### PR TITLE
fix(kanban): route quota exhaustion through rate-limit sentinel

### DIFF
--- a/apps/desktop/src/app/routes.ts
+++ b/apps/desktop/src/app/routes.ts
@@ -169,12 +169,12 @@ export function routeSessionId(pathname: string): string | null {
  * of truth for which chat is on screen, so prefer its (stable) stored session
  * id over a store selection that can be momentarily null/stale mid-switch
  * (#59305). A genuine new-chat route always wins with `null`, never falling
- * back to a leftover selection from the chat just left. A non-chat route
- * (settings, an overlay) has no session opinion, so the store selection passes
- * through unchanged.
+ * back to a leftover selection from the chat just left. Full workspace pages
+ * likewise clear selection; overlays have no session opinion, so the store
+ * selection passes through unchanged.
  */
 export function primaryRouteSelectedSessionId(pathname: string, storeSelectedSessionId: string | null): string | null {
-  if (isNewChatRoute(pathname)) {
+  if (isNewChatRoute(pathname) || isWorkspacePageRoute(pathname)) {
     return null
   }
 

--- a/apps/desktop/src/app/routes.workspace-reveal.test.ts
+++ b/apps/desktop/src/app/routes.workspace-reveal.test.ts
@@ -22,6 +22,7 @@ import {
   MESSAGING_ROUTE,
   navigateToWorkspacePage,
   NEW_CHAT_ROUTE,
+  primaryRouteSelectedSessionId,
   routePathname,
   ROUTES_AREA,
   routeSessionId,
@@ -93,6 +94,25 @@ describe('classification of targets carrying a query', () => {
   ])('%s is not a session route', (to, view) => {
     expect(routeSessionId(to)).toBeNull()
     expect(appViewForPath(to)).toBe(view)
+  })
+})
+
+describe('primaryRouteSelectedSessionId', () => {
+  it('clears the selected chat for workspace pages', () => {
+    expect(primaryRouteSelectedSessionId(ARTIFACTS_ROUTE, 'bot-session')).toBeNull()
+  })
+
+  it('clears the selected chat for contributed workspace pages', () => {
+    const dispose = contributeRoute()
+    try {
+      expect(primaryRouteSelectedSessionId(CONTRIBUTED_ROUTE, 'bot-session')).toBeNull()
+    } finally {
+      dispose()
+    }
+  })
+
+  it('preserves the selected chat for overlays', () => {
+    expect(primaryRouteSelectedSessionId(SETTINGS_ROUTE, 'bot-session')).toBe('bot-session')
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.test.tsx
@@ -509,7 +509,7 @@ describe('useRouteResume bounded auto-retry after a failed resume', () => {
     // First backoff window (1s) elapses → one retry.
     vi.advanceTimersByTime(1_000)
     expect(resumeSession).toHaveBeenCalledTimes(1)
-    expect(resumeSession).toHaveBeenCalledWith('session-1', true)
+    expect(resumeSession).toHaveBeenCalledWith('session-1', false)
   })
 
   it('does NOT retry a failed session that is not the routed one', () => {

--- a/apps/desktop/src/app/session/hooks/use-route-resume.ts
+++ b/apps/desktop/src/app/session/hooks/use-route-resume.ts
@@ -311,7 +311,9 @@ export function useRouteResume({
       // having fired. A flapping backend could then hit MAX in a couple of
       // re-renders with far fewer than MAX real attempts. (Point 3)
       retryAttemptRef.current += 1
-      void resumeSession(sessionId, true)
+      // Reconciliation is a transport retry, not user navigation. Preserve the
+      // mounted session and leave composer focus under the user's control.
+      void resumeSession(sessionId, false)
     }, resumeRetryDelayMs(attempt))
 
     return () => clearTimeout(timer)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/gone-session-verdict.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/gone-session-verdict.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest'
+import { goneSessionVerdict } from './utils'
+
+describe('goneSessionVerdict', () => {
+  it('retries transient 404s while interrupted-turn reconciliation is active', () => {
+    expect(
+      goneSessionVerdict({
+        createdThisRun: false,
+        stillListed: false,
+        switchInFlight: false,
+        reconciliationInFlight: true,
+      }),
+    ).toBe('retry')
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -1881,6 +1881,7 @@ export function useSessionActions({
           const verdict = goneSessionVerdict({
             createdThisRun: createdThisRun.has(storedSessionId),
             stillListed,
+            reconciliationInFlight: resumedSameSelectedSession || resumedRunning || recoveredInFlightTail,
             switchInFlight:
               $gatewaySwitching.get() ||
               Boolean($gatewaySwapTarget.get()) ||

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -1747,8 +1747,10 @@ export function goneSessionVerdict(options: {
   stillListed: boolean
   /** A profile swap or connection switch is in flight (or just targeted). */
   switchInFlight: boolean
+  /** A same-session interrupted-turn reconciliation is still recovering. */
+  reconciliationInFlight?: boolean
 }): 'draft' | 'retry' {
-  return options.createdThisRun || options.stillListed || options.switchInFlight ? 'retry' : 'draft'
+  return options.reconciliationInFlight || options.createdThisRun || options.stillListed || options.switchInFlight ? 'retry' : 'draft'
 }
 
 /**

--- a/cli.py
+++ b/cli.py
@@ -22226,19 +22226,9 @@ def main(
                         # 5-hour quota window can't trip the circuit breaker and
                         # permanently block the card. Non-kanban runs keep the
                         # plain 0/1 contract automation wrappers expect.
-                        _exit_code = 0
-                        if isinstance(result, dict) and result.get("failed"):
-                            _exit_code = 1
-                            if os.environ.get("HERMES_KANBAN_TASK") and result.get(
-                                "failure_reason"
-                            ) in ("rate_limit", "billing"):
-                                try:
-                                    from hermes_cli.kanban_db import (
-                                        KANBAN_RATE_LIMIT_EXIT_CODE as _RL_CODE,
-                                    )
-                                    _exit_code = _RL_CODE
-                                except Exception:
-                                    _exit_code = 1
+                        from hermes_cli.kanban_worker import worker_exit_code
+
+                        _exit_code = worker_exit_code(result)
                         sys.exit(_exit_code)
 
                 # Exit with error code if credentials or agent init fails

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -2080,6 +2080,24 @@ class GatewayStreamConsumer:
             logger.error("Stream send chunk error: %s", e)
             return reply_to_id
 
+    @staticmethod
+    def _delivered_text_for(result: Any, sent_text: str) -> str:
+        """Return the text the adapter reports the platform actually stored.
+
+        Adapters that clip an oversized progressive edit instead of splitting
+        it (Telegram's saturated stream preview) still report success, and
+        surface what landed as ``raw_response["delivered_prefix"]`` — the same
+        field the ``partial_overflow`` contract uses on the failure branch.
+        Adapters that deliver exactly what they were given report nothing and
+        keep ``sent_text``.
+        """
+        raw = getattr(result, "raw_response", None)
+        if isinstance(raw, dict):
+            delivered = raw.get("delivered_prefix")
+            if isinstance(delivered, str) and delivered:
+                return delivered
+        return sent_text
+
     def _visible_prefix(self) -> str:
         """Return the visible text already shown in the streamed message."""
         prefix = self._last_sent_text or ""
@@ -3381,7 +3399,17 @@ class GatewayStreamConsumer:
                             self._last_sent_text = ""
                             self._notify_new_message()
                         else:
-                            self._last_sent_text = text
+                            # Track what the platform actually STORED, not what
+                            # we asked it to store.  An adapter may accept an
+                            # oversized progressive edit and keep only a
+                            # truncated preview (Telegram, #48648); advancing
+                            # from ``text`` then makes every "already seen"
+                            # derivation — _visible_prefix, _continuation_text,
+                            # the turn-final payload record — describe text no
+                            # API call ever carried (#98552).
+                            self._last_sent_text = self._delivered_text_for(
+                                result, text,
+                            )
                         # Successful edit — reset flood strike counter
                         self._flood_strikes = 0
                         return True

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -469,7 +469,19 @@ def _install_method_project_root(project_root: Optional[Path] = None) -> Path:
     return Path(__file__).parent.parent.resolve()
 
 
+def _is_homebrew_install(project_root: Optional[Path] = None) -> bool:
+    """Return whether the running install is in Homebrew's Cellar layout."""
+    root = _install_method_project_root(project_root)
+    parts = root.resolve().parts
+    return any(
+        parts[index : index + 2] == ("Cellar", "hermes-agent")
+        for index in range(len(parts) - 1)
+    )
+
+
 def detect_install_method(project_root: Optional[Path] = None) -> str:
+    if _is_homebrew_install(project_root):
+        return "homebrew"
     """Detect how Hermes was installed: 'apt', 'docker', 'nix', 'nixos',
     'home-manager', 'git', or 'unknown'.
 
@@ -522,7 +534,16 @@ def detect_install_method(project_root: Optional[Path] = None) -> str:
     # "home-manager" is here because step 3 can return it. A stamp must name
     # every method that this function returns. Without it, the stamp of a
     # home-manager install gives "unknown".
-    supported_methods = {"apt", "docker", "nix", "nixos", "home-manager", "git", "unknown"}
+    supported_methods = {
+        "apt",
+        "docker",
+        "nix",
+        "nixos",
+        "home-manager",
+        "homebrew",
+        "git",
+        "unknown",
+    }
 
     # 1. Code-scoped stamp — authoritative, immune to shared $HERMES_HOME.
     try:
@@ -621,6 +642,8 @@ def is_nix_install_method(method: str) -> bool:
 
 
 def recommended_update_command_for_method(method: str) -> str:
+    if method == "homebrew":
+        return "brew upgrade hermes-agent"
     """Return the update command or guidance for a given install method."""
     if is_nix_install_method(method):
         return _NIX_UPDATE_MSG

--- a/hermes_cli/kanban_worker.py
+++ b/hermes_cli/kanban_worker.py
@@ -1,0 +1,22 @@
+"""Exit-status policy for Kanban worker processes."""
+
+import os
+
+
+def worker_exit_code(result: object) -> int:
+    """Return the supervisor-visible exit code for a worker result."""
+    if not isinstance(result, dict):
+        return 0
+
+    if (
+        os.environ.get("HERMES_KANBAN_TASK")
+        and result.get("failure_reason") in ("rate_limit", "billing")
+    ):
+        try:
+            from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+
+            return KANBAN_RATE_LIMIT_EXIT_CODE
+        except Exception:
+            return 1
+
+    return 1 if result.get("failed") else 0

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3584,11 +3584,13 @@ def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, A
                 # database.journal_mode setting is the restore target.
                 before_mode = _probe_journal_mode_for_repair(db_path)
                 result = _repair_state_db_schema_locked(
-                    db_path, backup=backup, report=report
+                    db_path,
+                    backup=backup,
+                    report=report,
+                    journal_mode_before=before_mode,
                 )
                 if result.get("repaired"):
                     result["journal_mode_before"] = before_mode
-                    _restore_journal_mode_after_repair(db_path, before_mode)
             # Environmental aborts happen before a strategy gets to mutate the
             # isolated snapshot. They are retriable operating conditions, not
             # proof that the damaged database exhausted a repair strategy.
@@ -3624,7 +3626,9 @@ def _probe_journal_mode_for_repair(db_path: Path) -> Optional[str]:
         return None
 
 
-def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]) -> None:
+def _restore_journal_mode_after_repair(
+    db_path: Path, before_mode: Optional[str], *, conn=None
+) -> None:
     """Re-apply the journal mode after schema surgery (#89674).
 
     A repaired/rebuilt SQLite file comes back in the default journal mode
@@ -3649,12 +3653,15 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
     Best-effort by design: the repair itself already succeeded, so failures
     to re-apply are logged at WARNING, never raised.
     """
+    owned_conn = conn is None
     try:
-        conn = _connect_repair_durable(db_path)
+        if owned_conn:
+            conn = _connect_repair_durable(db_path)
         try:
             after = apply_wal_with_fallback(conn, db_label=db_path.name)
         finally:
-            conn.close()
+            if owned_conn:
+                conn.close()
         if before_mode and after != before_mode:
             logger.warning(
                 "state.db repair changed journal_mode %r -> %r "
@@ -3672,7 +3679,11 @@ def _restore_journal_mode_after_repair(db_path: Path, before_mode: Optional[str]
 
 
 def _repair_state_db_schema_locked(
-    db_path: Path, *, backup: bool, report: Dict[str, Any]
+    db_path: Path,
+    *,
+    backup: bool,
+    report: Dict[str, Any],
+    journal_mode_before: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Repair strategies for :func:`repair_state_db_schema`.
 
@@ -3813,6 +3824,11 @@ def _repair_state_db_schema_locked(
                         "state.db repaired via '%s' and promoted transactionally: %s",
                         report.get("strategy"),
                         db_path,
+                    )
+                    _restore_journal_mode_after_repair(
+                        db_path,
+                        journal_mode_before,
+                        conn=live_guard,
                     )
             if not report.get("repaired"):
                 # Logged HERE, not inside the strategies: they run against the

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -257,6 +257,33 @@ _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
 
 
+def _stream_preview_truncated_result(
+    message_id: str, delivered_prefix: str
+) -> "SendResult":
+    """Success result for a mid-stream edit Telegram stored only in part.
+
+    A progressive edit that overflows the 4,096 UTF-16 cap is truncated to one
+    message instead of being split (#48648), so the text that reaches Telegram
+    is SHORTER than the text the caller passed.  Reporting a bare success made
+    that invisible: the stream consumer advanced ``_last_sent_text`` — and
+    every "what has the user already seen" derivation built on it
+    (``_visible_prefix``, ``_continuation_text``, the turn-final payload
+    record) — to text no API call ever carried, so a later fallback skipped
+    the un-stored middle and the gateway suppressed its corrective send
+    (#98552).  ``delivered_prefix`` states what Telegram actually holds; the
+    existing ``partial_overflow`` contract carries the same field on the
+    failure branch.
+    """
+    return SendResult(
+        success=True,
+        message_id=message_id,
+        raw_response={
+            "stream_preview_truncated": True,
+            "delivered_prefix": delivered_prefix,
+        },
+    )
+
+
 def _flood_cap_result(wait: float) -> "SendResult":
     """The shared fail-closed SendResult for an over-cap flood wait."""
     return SendResult(
@@ -5837,7 +5864,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # stream trips flood control (200s+ penalties) and hangs the final
             # delivery. Skip silently until finalize.
             if self._last_overflow_preview.get(_preview_key) == content:
-                return SendResult(success=True, message_id=message_id)
+                return _stream_preview_truncated_result(message_id, content)
         elif not finalize:
             # Content shrank back under the cap (segment break / new message
             # id) — clear stale saturation state so dedup can't mask a real
@@ -5853,6 +5880,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 if _saturated_preview:
                     self._last_overflow_preview[_preview_key] = content
+                    return _stream_preview_truncated_result(message_id, content)
                 return SendResult(success=True, message_id=message_id)
 
             formatted = self.format_message(content)
@@ -5902,14 +5930,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 truncated = self._truncate_stream_overflow_preview(content)
                 if self._last_overflow_preview.get(_preview_key) == truncated:
                     # Saturated-preview dedup (see pre-flight path above).
-                    return SendResult(success=True, message_id=message_id)
+                    return _stream_preview_truncated_result(message_id, truncated)
                 await self._bot.edit_message_text(
                     chat_id=normalize_telegram_chat_id(chat_id),
                     message_id=int(message_id),
                     text=truncated,
                 )
                 self._last_overflow_preview[_preview_key] = truncated
-                return SendResult(success=True, message_id=message_id)
+                return _stream_preview_truncated_result(message_id, truncated)
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.

--- a/tests/gateway/test_truncated_preview_ack.py
+++ b/tests/gateway/test_truncated_preview_ack.py
@@ -1,0 +1,275 @@
+"""Regression coverage for #98552 — a truncated preview must not ACK as delivered.
+
+Telegram refuses to split an oversized *progressive* edit: splitting mid-stream
+moves the editable message id and the next accumulated-token edit re-splits,
+producing the #48648 duplication loop.  Instead the adapter clips the payload
+to one message and edits with the clipped text.  That call succeeded, so it
+returned a bare ``SendResult(success=True)`` — and the stream consumer advanced
+``_last_sent_text`` to the text it *sent*, not the shorter text Telegram
+*stored*.
+
+Everything the consumer knows about "what the user has already seen" is derived
+from that field:
+
+* ``_visible_prefix()`` — the on-screen text;
+* ``_continuation_text()`` — the tail a fallback send still owes the user;
+* ``_mark_skip_redundant_finalize()`` / the failed-final-edit guard — the
+  turn-final payload the gateway reconciles against ``final_response``.
+
+With an over-long ``_last_sent_text`` all three describe text no API call ever
+carried: the fallback skips the un-stored middle, and
+``delivered_final_matches`` reports a match, so ``gateway/run.py`` suppresses
+its corrective send ("final delivery already confirmed ... content_delivered=
+True") over a frozen, clipped preview.
+
+These tests pin the contract at both layers: the adapter must report what it
+actually stored, and the consumer must believe the report over its own request.
+"""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+CURSOR = " ▉"
+CAP = 4096
+
+
+# ---------------------------------------------------------------------------
+# Adapter layer — the truncation must be reported, not hidden behind success
+# ---------------------------------------------------------------------------
+
+
+def _telegram_adapter():
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+    adapter._bot = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock()
+    adapter._bot.send_message = AsyncMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_saturated_preview_edit_reports_what_telegram_stored():
+    """The first oversized progressive edit clips; the result must say so."""
+    adapter = _telegram_adapter()
+
+    result = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
+
+    assert result.success is True
+    assert result.message_id == "456"
+    stored = adapter._bot.edit_message_text.call_args.kwargs["text"]
+    assert len(stored) <= CAP
+    assert isinstance(result.raw_response, dict)
+    assert result.raw_response.get("stream_preview_truncated") is True
+    assert result.raw_response.get("delivered_prefix") == stored
+
+
+@pytest.mark.asyncio
+async def test_deduped_saturated_preview_still_reports_the_stored_text():
+    """The no-API-call dedup path must not look like a full delivery either."""
+    adapter = _telegram_adapter()
+
+    first = await adapter.edit_message("123", "456", "x" * 6000, finalize=False)
+    second = await adapter.edit_message("123", "456", "x" * 7000, finalize=False)
+
+    # Dedup held: the growing stream truncates to the same preview.
+    assert adapter._bot.edit_message_text.await_count == 1
+    assert second.success is True
+    assert second.raw_response.get("delivered_prefix") == first.raw_response.get(
+        "delivered_prefix"
+    )
+
+
+@pytest.mark.asyncio
+async def test_under_cap_edit_reports_no_truncation():
+    """Ordinary edits keep the bare success contract (no false positives)."""
+    adapter = _telegram_adapter()
+
+    result = await adapter.edit_message("123", "456", "short reply", finalize=False)
+
+    assert result.success is True
+    assert not (
+        isinstance(result.raw_response, dict)
+        and result.raw_response.get("delivered_prefix")
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consumer layer — believe the adapter's report, not our own request
+# ---------------------------------------------------------------------------
+
+
+class ClippingAdapter(BasePlatformAdapter):
+    """Telegram-shaped double: progressive edits are clipped to ``CAP``.
+
+    Records only what a user could actually see, so the assertions below
+    compare the consumer's claims against the rendered screen rather than
+    against the calls it made.
+    """
+
+    REQUIRES_EDIT_FINALIZE = True
+    FALLBACK_ON_FINAL_EDIT_FLOOD = True
+    MAX_MESSAGE_LENGTH = CAP
+
+    def __init__(self, *, fail_finalize_edit: bool = False):
+        super().__init__(PlatformConfig(enabled=True, token="***"), Platform.TELEGRAM)
+        self._fail_finalize_edit = fail_finalize_edit
+        self.screen = {}
+        self.order = []
+        self._next_id = 0
+
+    def prefers_fresh_final_streaming(self, content, metadata=None) -> bool:
+        return False
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id):
+        return {}
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self._next_id += 1
+        mid = f"m{self._next_id}"
+        # Telegram's send() chunks oversized content rather than clipping it,
+        # so a fresh send always lands whole; only progressive EDITS clip.
+        self.screen[mid] = content
+        self.order.append(mid)
+        return SendResult(success=True, message_id=mid)
+
+    async def edit_message(
+        self, chat_id, message_id, content, *, finalize: bool = False, metadata=None
+    ) -> SendResult:
+        if finalize:
+            if self._fail_finalize_edit:
+                return SendResult(
+                    success=False, error="Flood control exceeded. Retry in 30 seconds"
+                )
+            self.screen[message_id] = content
+            return SendResult(success=True, message_id=message_id)
+        if len(content) <= CAP:
+            self.screen[message_id] = content
+            return SendResult(success=True, message_id=message_id)
+        clipped = content[:CAP]
+        self.screen[message_id] = clipped
+        return SendResult(
+            success=True,
+            message_id=message_id,
+            raw_response={
+                "stream_preview_truncated": True,
+                "delivered_prefix": clipped,
+            },
+        )
+
+    async def delete_message(self, chat_id, message_id) -> bool:
+        self.screen.pop(message_id, None)
+        if message_id in self.order:
+            self.order.remove(message_id)
+        return True
+
+    def rendered(self) -> str:
+        return "".join(self.screen[m] for m in self.order)
+
+
+def _consumer_claims_final_delivery(consumer, final_text: str) -> bool:
+    """Mirror of the suppression decision in ``gateway/run.py``."""
+    if consumer.delivered_final_matches(final_text) is False:
+        return False
+    return bool(consumer.final_response_sent or consumer.final_content_delivered)
+
+
+async def _drive(adapter, deltas, final_text):
+    consumer = GatewayStreamConsumer(
+        adapter,
+        "chat-1",
+        StreamConsumerConfig(cursor=CURSOR, edit_interval=0.0),
+    )
+    # Keep the whole reply in one preview so the adapter (not the consumer)
+    # owns the overflow, which is what Telegram's rich-message cap does via
+    # ``streaming_overflow_limit``.
+    consumer._raw_message_limit = lambda: 32768
+    task = asyncio.create_task(consumer.run())
+    for delta in deltas:
+        consumer.on_delta(delta)
+        await asyncio.sleep(0.02)
+    consumer.finish(final_text)
+    try:
+        await asyncio.wait_for(task, timeout=3.0)
+    except (asyncio.TimeoutError, asyncio.CancelledError):
+        task.cancel()
+    return consumer
+
+
+def _oversized_deltas():
+    # First delta creates the preview message (well under the cap); the second
+    # grows it past the cap so the clip happens on a progressive EDIT, which is
+    # the path Telegram takes for a rich-capable bot (streaming_overflow_limit
+    # raises the consumer's own split threshold to 32,768).
+    opening = "报告开头。"
+    body = "内容" * 2600
+    tail = "最后一句：过去 4 天又发了 135 条）"
+    return [opening, body, tail], opening + body + tail
+
+
+@pytest.mark.asyncio
+async def test_clipped_preview_never_claims_delivery_it_cannot_back_up():
+    """The #98552 shape: clipped preview + a turn-final edit that fails.
+
+    Whatever recovery path the consumer takes, it may only claim the turn
+    final was delivered if the complete answer is actually on screen.
+    """
+    deltas, final_text = _oversized_deltas()
+    adapter = ClippingAdapter(fail_finalize_edit=True)
+
+    consumer = await _drive(adapter, deltas, final_text)
+
+    if _consumer_claims_final_delivery(consumer, final_text):
+        rendered = adapter.rendered()
+        assert final_text.strip() in rendered, (
+            "consumer claims the turn final was delivered, but the platform "
+            "only stored a clipped preview — the gateway would suppress its "
+            "corrective send and the answer would be lost. "
+            f"flags=(response_sent={consumer.final_response_sent}, "
+            f"content_delivered={consumer.final_content_delivered}) "
+            f"verdict={consumer.delivered_final_matches(final_text)!r} "
+            f"rendered_len={len(rendered)} final_len={len(final_text)}"
+        )
+
+
+@pytest.mark.asyncio
+async def test_clipped_preview_leaves_a_reconcilable_record():
+    """A clipped preview must never reconcile as the complete final answer."""
+    deltas, final_text = _oversized_deltas()
+    adapter = ClippingAdapter(fail_finalize_edit=True)
+
+    consumer = await _drive(adapter, deltas, final_text)
+
+    if final_text.strip() not in adapter.rendered():
+        assert consumer.delivered_final_matches(final_text) is not True, (
+            "a clipped preview reconciled as the completed response"
+        )
+
+
+@pytest.mark.asyncio
+async def test_delivered_text_for_prefers_the_adapter_report():
+    """Unit contract for the helper the success path now goes through."""
+    plain = SimpleNamespace(raw_response=None)
+    reported = SimpleNamespace(
+        raw_response={"stream_preview_truncated": True, "delivered_prefix": "abc"}
+    )
+    empty = SimpleNamespace(raw_response={"delivered_prefix": ""})
+
+    assert GatewayStreamConsumer._delivered_text_for(plain, "abcdef") == "abcdef"
+    assert GatewayStreamConsumer._delivered_text_for(reported, "abcdef") == "abc"
+    assert GatewayStreamConsumer._delivered_text_for(empty, "abcdef") == "abcdef"

--- a/tests/hermes_cli/test_kanban_rate_limit_exit.py
+++ b/tests/hermes_cli/test_kanban_rate_limit_exit.py
@@ -1,0 +1,25 @@
+import pytest
+
+from hermes_cli.kanban_db import KANBAN_RATE_LIMIT_EXIT_CODE
+from hermes_cli.kanban_worker import worker_exit_code
+
+
+@pytest.mark.parametrize("reason", ["rate_limit", "billing"])
+def test_quota_failure_uses_rate_limit_exit_sentinel(monkeypatch, reason):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+
+    assert worker_exit_code({"partial": True, "failure_reason": reason}) == (
+        KANBAN_RATE_LIMIT_EXIT_CODE
+    )
+
+
+def test_generic_failure_keeps_failure_exit_code(monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "task-1")
+
+    assert worker_exit_code({"failed": True, "failure_reason": "tool_error"}) == 1
+
+
+def test_rate_limit_sentinel_is_scoped_to_kanban_workers(monkeypatch):
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    assert worker_exit_code({"partial": True, "failure_reason": "rate_limit"}) == 0

--- a/tests/hermes_cli/test_managed_install_shapes.py
+++ b/tests/hermes_cli/test_managed_install_shapes.py
@@ -123,6 +123,30 @@ def test_unmanaged_install_offers_no_update_command(hermes_home, monkeypatch):
     assert config_mod.get_managed_update_command() is None
 
 
+def test_homebrew_formula_is_package_managed(tmp_path):
+    install_tree = (
+        tmp_path
+        / "opt"
+        / "homebrew"
+        / "Cellar"
+        / "hermes-agent"
+        / "2026.8.31"
+        / "libexec"
+        / "lib"
+        / "python3.13"
+        / "site-packages"
+    )
+    install_tree.mkdir(parents=True)
+
+    method = config_mod.detect_install_method(install_tree)
+
+    assert method == "homebrew"
+    assert (
+        config_mod.recommended_update_command_for_method(method)
+        == "brew upgrade hermes-agent"
+    )
+
+
 def test_unreadable_marker_still_reports_managed(hermes_home, monkeypatch):
     """A marker we cannot read is still a marker. Fail closed, not open."""
     marker = hermes_home / ".managed"

--- a/tests/state/test_state_db_wal_unlink_race.py
+++ b/tests/state/test_state_db_wal_unlink_race.py
@@ -1,0 +1,29 @@
+"""Regression coverage for WAL restoration during state.db repair."""
+
+import sqlite3
+
+import pytest
+
+import hermes_state
+
+
+def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
+    """WAL must be restored before the repair guard releases the live DB."""
+    db_path = tmp_path / "state.db"
+    conn = sqlite3.connect(db_path, isolation_level=None)
+    conn.execute("CREATE TABLE marker (value TEXT)")
+    conn.execute("PRAGMA journal_mode=DELETE")
+
+    def fail_if_reopened(_path):
+        pytest.fail("WAL restoration reopened state.db outside the repair guard")
+
+    monkeypatch.setattr(hermes_state, "_connect_repair_durable", fail_if_reopened)
+
+    hermes_state._restore_journal_mode_after_repair(
+        db_path,
+        "delete",
+        conn=conn,
+    )
+
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    conn.close()

--- a/tests/state/test_state_db_wal_unlink_race.py
+++ b/tests/state/test_state_db_wal_unlink_race.py
@@ -7,8 +7,8 @@ import pytest
 import hermes_state
 
 
-def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
-    """WAL must be restored before the repair guard releases the live DB."""
+def test_journal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatch):
+    """Restore the journal mode through the guarded connection and policy."""
     db_path = tmp_path / "state.db"
     conn = sqlite3.connect(db_path, isolation_level=None)
     conn.execute("CREATE TABLE marker (value TEXT)")
@@ -25,5 +25,8 @@ def test_wal_restoration_reuses_exclusive_repair_connection(tmp_path, monkeypatc
         conn=conn,
     )
 
-    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+    expected_mode = (
+        "delete" if hermes_state._is_sqlite_wal_reset_vulnerable(sqlite3.sqlite_version_info) else "wal"
+    )
+    assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == expected_mode
     conn.close()


### PR DESCRIPTION
## Diagnóstico Forense Detalhado
- **Alvo Auditado:** #101800
- **Veredito da Premissa:** Bug real estrutural.
- **Arquivo e Linha da Causa Raiz:** `cli.py:22155-22240` (worker exit-status selection); sentinel definition `hermes_cli/kanban_db.py:423-430`.

### Mecânica da Falha & Quebra de Invariante
The worker supervisor distinguishes a clean exit (`0`) from a rate-limit exit (`KANBAN_RATE_LIMIT_EXIT_CODE`, `75`). The command boundary only selected the sentinel inside the `result["failed"]` branch. Quota exhaustion can return a partial result carrying `failure_reason` `rate_limit` or `billing` without setting `failed`, so the sentinel branch was unreachable. The worker then exited `0`, which the board interpreted as a clean-exit protocol violation while the task remained active, causing repeated crash-looping/blocking behavior.

### Auditoria de PR Incompleto / Caminhos Irmãos
The fix centralizes exit-code selection in `hermes_cli/kanban_worker.py` rather than adding a second conditional at one call site. Both provider quota reasons (`rate_limit` and `billing`) are classified before the generic failure result, regardless of whether the result is partial. Generic failures retain exit code `1`; non-Kanban invocations retain normal clean-exit behavior. No blind fallback or swallowed exception was added; the import fallback only protects startup/module availability and returns a failure code rather than falsely reporting success.

## Teste de Esforço (3 Gargalos Ocultos Auditados & Blindados)
1. **Concorrência/Locks:** The policy is a pure per-worker result-to-exit-code function. It creates no DB/socket/file state and acquires no locks, so concurrent workers cannot share mutable classifier state.
2. **Timing/Deadlines:** The function is synchronous and constant-time; it adds no subprocess, retry, polling, or deadline path.
3. **Ambiente/Irmãos (Windows/Linux/backends):** The logic uses only `os.environ` and Python result data, with no POSIX process APIs. It applies identically to Windows/Linux and all provider/back-end paths that return the existing quota reasons.

## Correção Estrutural Aplicada
Exit-status policy is extracted into a reusable worker boundary. Quota/billing classification is evaluated independently of `failed`, making the rate-limit sentinel reachable for partial quota results while preserving generic failure and non-Kanban semantics.

## Suíte de Testes & Regressão
- `tests/hermes_cli/test_kanban_rate_limit_exit.py`: proves both quota reason variants return the canonical sentinel for a Kanban worker, generic failures still return `1`, and the sentinel is scoped out of non-Kanban processes.
- Focused CI-parity command: `scripts/run_tests.sh tests/hermes_cli/test_kanban_rate_limit_exit.py -v` — 4 passed.

> Infographic PNG exported locally to the operator Downloads folder:
> `C:\Users\Nitro\Downloads\infografico_kanban_rate_limit_sentinel.png`