### PR TITLE
fix(acp): report request-sized context usage

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -996,6 +996,39 @@ class HermesACPAgent(acp.Agent):
         return target_provider, new_model
 
     @staticmethod
+    def _build_prompt_response_usage(result: dict[str, Any], agent: Any) -> Usage | None:
+        """Build client-facing usage from the latest provider request.
+
+        ``run_conversation`` returns cumulative session counters.  Those are
+        appropriate for billing, but clients such as AionUi use
+        ``PromptResponse.usage.total_tokens`` as current context pressure and
+        divide it by the model context window.  Sending cumulative counters
+        therefore makes a healthy long-running session appear to exceed its
+        window (for example, 5.2M / 1M = 521.6%).
+
+        The conversation loop stores the latest provider response's canonical
+        usage in ``agent._last_turn_usage``.  Use only that request-sized
+        snapshot.  If a turn produced no provider usage (early failure or
+        interrupt), return ``None`` so the client keeps its previous valid
+        reading instead of replacing it with cumulative session totals.
+        """
+        last_usage = getattr(agent, "_last_turn_usage", None)
+        if isinstance(last_usage, dict) and any(
+            last_usage.get(key) is not None
+            for key in ("prompt_tokens", "completion_tokens", "total_tokens")
+        ):
+            return Usage(
+                input_tokens=last_usage.get("prompt_tokens", 0) or 0,
+                output_tokens=last_usage.get("completion_tokens", 0) or 0,
+                total_tokens=last_usage.get("total_tokens", 0) or 0,
+                thought_tokens=last_usage.get("reasoning_tokens"),
+                cached_read_tokens=last_usage.get("cache_read_tokens"),
+                cached_write_tokens=last_usage.get("cache_write_tokens"),
+            )
+
+        return None
+
+    @staticmethod
     def _build_usage_update(state: SessionState) -> UsageUpdate | None:
         """Build ACP native context-usage data for clients like Zed.
 
@@ -2203,15 +2236,7 @@ class HermesACPAgent(acp.Agent):
                 session_id=session_id,
             )
 
-        usage = None
-        if any(result.get(key) is not None for key in ("prompt_tokens", "completion_tokens", "total_tokens")):
-            usage = Usage(
-                input_tokens=result.get("prompt_tokens", 0),
-                output_tokens=result.get("completion_tokens", 0),
-                total_tokens=result.get("total_tokens", 0),
-                thought_tokens=result.get("reasoning_tokens"),
-                cached_read_tokens=result.get("cache_read_tokens"),
-            )
+        usage = self._build_prompt_response_usage(result, state.agent)
 
         await self._send_usage_update(state)
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -260,6 +260,53 @@ class TestSessionOps:
         assert help_cmd.input is None
 
 
+    def test_prompt_response_usage_prefers_latest_request_over_session_totals(self, agent):
+        agent._last_turn_usage = {
+            "prompt_tokens": 180_000,
+            "completion_tokens": 2_000,
+            "total_tokens": 182_000,
+            "input_tokens": 180_000,
+            "output_tokens": 2_000,
+            "cache_read_tokens": 160_000,
+            "cache_write_tokens": 500,
+            "reasoning_tokens": 750,
+        }
+        cumulative_result = {
+            "prompt_tokens": 5_200_000,
+            "completion_tokens": 40_000,
+            "total_tokens": 5_240_000,
+            "cache_read_tokens": 4_800_000,
+            "cache_write_tokens": 9_000,
+            "reasoning_tokens": 22_300,
+        }
+
+        usage = agent._build_prompt_response_usage(cumulative_result, agent)
+
+        assert usage is not None
+        assert usage.input_tokens == 180_000
+        assert usage.output_tokens == 2_000
+        assert usage.total_tokens == 182_000
+        assert usage.cached_read_tokens == 160_000
+        assert usage.cached_write_tokens == 500
+        assert usage.thought_tokens == 750
+
+    def test_prompt_response_usage_ignores_session_totals_without_turn_usage(self, agent):
+        agent._last_turn_usage = None
+        cumulative_result = {
+            "prompt_tokens": 5_200_000,
+            "completion_tokens": 40_000,
+            "total_tokens": 5_240_000,
+            "cache_read_tokens": 4_800_000,
+            "reasoning_tokens": 22_300,
+        }
+
+        assert agent._build_prompt_response_usage(cumulative_result, agent) is None
+
+    def test_prompt_response_usage_absent_without_any_usage(self, agent):
+        agent._last_turn_usage = None
+
+        assert agent._build_prompt_response_usage({}, agent) is None
+
     def test_build_usage_update_for_zed_context_indicator(self, agent, mock_manager):
         state = mock_manager.create_session(cwd="/tmp")
         state.history = [{"role": "user", "content": "hello"}]


### PR DESCRIPTION
## Summary

Fix ACP context meters showing cumulative lifetime usage as current context pressure.

Hermes currently returns cumulative `session_*_tokens` in `PromptResponse.usage`. AionUi stores `usage.totalTokens` as `context_usage.used`, so a healthy long-running session can display values such as `5.2M / 1M = 521.6%` even though the actual request fits the model window and compression is functioning.

This change:

- builds `PromptResponse.usage` from the latest provider request's canonical `agent._last_turn_usage` snapshot;
- preserves input/output/cache-read/cache-write/reasoning buckets;
- omits usage when a failed or interrupted turn never received provider usage, allowing the client to retain its previous valid reading;
- leaves Hermes' cumulative session accounting and context-compression logic unchanged.

## Root cause

`run_conversation()` returns cumulative session counters, but the ACP desktop context indicator consumes the response as current context pressure. This is a reporting-contract mismatch, not a compression failure.

## Tests

- `python -m pytest tests/acp/test_server.py -o 'addopts=' -q` — 33 passed
- `python -m pytest tests/acp/ tests/acp_adapter/ -o 'addopts=' -q` — 154 passed
- `ruff check acp_adapter/server.py tests/acp/test_server.py` — passed
- `git diff --check origin/main...HEAD` — passed

Fixes #101817
