### PR TITLE
fix(email): cron deliveries use job name as email subject

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -3482,6 +3482,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 route_metadata = {
                     "direct_messages_topic_id": str(thread_id),
                     "job_id": job["id"],
+                    "subject": job.get("name") or job["id"],
                 }
                 # Media metadata mirrors the text routing so attachments land in
                 # the same DM topic instead of the General lane (#22773).
@@ -3496,7 +3497,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # anchor, so the metadata key bypasses that check and lets the
                 # adapter route via a plain message_thread_id.
                 route_thread_id = str(thread_id) if thread_id is not None else None
-                route_metadata = {"job_id": job["id"]}
+                route_metadata = {"job_id": job["id"], "subject": job.get("name") or job["id"]}
                 if route_thread_id:
                     route_metadata["thread_id"] = route_thread_id
                 media_metadata = {"thread_id": thread_id} if thread_id else None
@@ -3826,7 +3827,8 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 delivery_errors.extend(target_errors)
                 continue
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            job_subject = job.get("name") or job.get("id")
+            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, subject=job_subject)
             try:
                 result = asyncio.run(coro)
             except RuntimeError as run_err:
@@ -3855,7 +3857,7 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 try:
                     pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
                     try:
-                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                        future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files, subject=job_subject))
                         result = future.result(timeout=30)
                     finally:
                         pool.shutdown(wait=False)

--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1139,8 +1139,9 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email reply to the given address."""
         try:
             loop = asyncio.get_running_loop()
+            subject_override = (metadata or {}).get("subject")
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, self._send_email, chat_id, content, reply_to, subject_override
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1162,6 +1163,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
@@ -1170,9 +1172,13 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Thread context for reply
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if subject_override:
+            # Cron/standalone deliveries: use the job name verbatim, no Re:
+            subject = subject_override
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
         # Threading headers
@@ -1277,6 +1283,7 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
@@ -1284,9 +1291,12 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if subject_override:
+            subject = subject_override
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
         original_msg_id = ctx.get("message_id")
@@ -1338,6 +1348,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Send a file as an email attachment."""
         try:
             loop = asyncio.get_running_loop()
+            subject_override = (kwargs.get("metadata") or {}).get("subject") if kwargs.get("metadata") else None
             message_id = await loop.run_in_executor(
                 None,
                 self._send_email_with_attachment,
@@ -1345,6 +1356,7 @@ class EmailAdapter(BasePlatformAdapter):
                 caption or "",
                 file_path,
                 file_name,
+                subject_override,
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1357,6 +1369,7 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
@@ -1364,9 +1377,12 @@ class EmailAdapter(BasePlatformAdapter):
         msg["To"] = to_addr
 
         ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if subject_override:
+            subject = subject_override
+        else:
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
         original_msg_id = ctx.get("message_id")
@@ -1434,6 +1450,7 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    subject=None,
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
@@ -1458,7 +1475,7 @@ async def _standalone_send(
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        msg["Subject"] = subject or "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
         server = smtplib.SMTP(smtp_host, smtp_port)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1109,7 +1109,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None, subject=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1489,7 +1489,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
-            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id, subject=subject)
         elif platform == Platform.SMS:
             result = await _registry_standalone_send("sms", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.DINGTALK:
@@ -1880,7 +1880,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None, subject=None):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1893,6 +1893,12 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
+    # Pass subject through only to senders that accept it (signature-compatible
+    # downgrade): email's _standalone_send takes subject; other platforms
+    # (feishu/slack/whatsapp/...) do not, and would TypeError on the kwarg.
+    import inspect
+    if "subject" in inspect.signature(entry.standalone_sender_fn).parameters:
+        return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id, subject=subject)
     return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
 
 


### PR DESCRIPTION
## Problem

Every cron email delivery arrives with the subject `Re: Hermes Agent` regardless of which job produced it, making mailbox triage impossible for users with many scheduled jobs. Root cause: job names are never propagated to the email adapter, so `_send_email`/`_standalone_send` fall back to the reply-threading default (`"Hermes Agent"` + forced `Re:` prefix).

## Fix

Stamp the job name into the delivery path and have the email adapter honor it verbatim (no `Re:` prefix — that stays reserved for reply threading):

1. **`cron/scheduler.py`** — live path: add `"subject": job.get("name") or job["id"]` to `route_metadata` (2 sites). Standalone path: pass `subject=job name` to `_send_to_platform` (2 sites, incl. the thread-pool fallback).
2. **`plugins/platforms/email/adapter.py`** — `send()` reads `metadata["subject"]`; `_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment` accept a `subject_override` and use it as-is; `_standalone_send` accepts a `subject` kwarg instead of hardcoding `"Hermes Agent"`.
3. **`tools/send_message_tool.py`** — `_send_to_platform` / `_registry_standalone_send` accept and forward `subject`, with a **signature-compatible downgrade** (`inspect.signature` check) so non-email platforms whose `standalone_sender_fn` does not accept `subject` (feishu/slack/whatsapp/...) are unaffected.

## Verification

5-scenario unit test (FakeSMTP interception) all pass:
- override → subject used verbatim, no `Re:`
- no override, no thread ctx → `Re: Hermes Agent` (unchanged default)
- no override, reply thread ctx → `Re: <thread subject>` (reply threading preserved)
- standalone + subject → subject used
- standalone, no subject → `Hermes Agent` (unchanged)

Live cron delivery confirmed: after restart, emails arrive titled with the job name (e.g. `系统|吸星大法信号 | 每日08:30`).

## Notes

- Conversation-reply emails are untouched: `subject_override` is only present on cron/standalone deliveries; the `Re:` reply-threading logic is preserved when no override is supplied.
- Companion user-side guard (auto re-patch + watchdog) exists locally to survive updates until this lands; not part of this PR.