### PR TITLE
fix(memory): spill oversized external prefetch

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1271,7 +1271,7 @@ def _init_memory(agent, _agent_cfg, skip_memory, platform):
                 agent._memory_manager = _MemoryManager()
                 _mp = _load_mem(_mem_provider_name)
                 if _mp and _mp.is_available():
-                    agent._memory_manager.add_provider(_mp)
+                    agent._memory_manager.add_provider(_mp, is_builtin=False)
                 elif _mp is not None and _mem_provider_name not in _warned_unavailable_providers:
                     # unavailable_reason() reads config/probes importlib — skip it once warned.
                     _unavailable_reason = ""

--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -18,6 +18,7 @@ from typing import Any, Callable, Dict, List, Optional
 
 from agent.memory_provider import MemoryProvider, PRE_COMPRESS_CHECKPOINT_API_VERSION
 from agent.skill_commands import extract_user_instruction_from_skill_message
+from tools.hook_output_spill import get_spill_config, spill_if_oversized
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -295,6 +296,8 @@ class MemoryManager:
     def __init__(self, *, external_prefetch_timeout: Optional[float] = None) -> None:
         self._providers: List[MemoryProvider] = []
         self._tool_to_provider: Dict[str, MemoryProvider] = {}
+        self._builtin_provider_ids: set[int] = set()
+        self._external_prefetch_spill_config: Optional[Dict[str, Any]] = None
         self._has_external: bool = False
         timeout = external_prefetch_timeout
         timeout = _EXTERNAL_PREFETCH_TIMEOUT_S if timeout is None else float(timeout)
@@ -327,11 +330,19 @@ class MemoryManager:
                 logger.log(level, "Memory provider '%s' %s: %s", provider.name, label, e, exc_info=exc_info)
         return results
 
-    def add_provider(self, provider: MemoryProvider) -> None:
-        """Register a provider; builtin always accepted, only ONE external allowed."""
-        if provider.name != "builtin":
+    def _is_builtin_provider(self, provider: MemoryProvider) -> bool:
+        return id(provider) in self._builtin_provider_ids
+
+    def add_provider(self, provider: MemoryProvider, *, is_builtin: bool = False) -> None:
+        """Trust comes from registration, never the provider-controlled name.
+        Reject duplicate instances so their trust cannot change retroactively.
+        """
+        if any(existing is provider for existing in self._providers):
+            logger.warning("Rejected duplicate memory provider instance '%s'", provider.name)
+            return
+        if not is_builtin:
             if self._has_external:
-                existing = next((p.name for p in self._providers if p.name != "builtin"), "unknown")
+                existing = next((p.name for p in self._providers if not self._is_builtin_provider(p)), "unknown")
                 logger.warning(
                     "Rejected memory provider '%s' — external provider '%s' is "
                     "already registered. Only one external memory provider is "
@@ -340,8 +351,11 @@ class MemoryManager:
                 )
                 return
             self._has_external = True
+            self._external_prefetch_spill_config = get_spill_config()
 
         self._providers.append(provider)
+        if is_builtin:
+            self._builtin_provider_ids.add(id(provider))
 
         # Core tool names are reserved: built-ins always win at agent init, so a shadowing
         # provider tool would linger in ``_tool_to_provider`` and hijack dispatch.
@@ -401,7 +415,7 @@ class MemoryManager:
     def _prefetch_provider(self, provider: MemoryProvider, query: str, *, session_id: str = "") -> str:
         """Run one provider's prefetch; external providers are bounded by a timeout. A stuck external
         call keeps running on its daemon thread and the provider is skipped on later turns until it returns."""
-        if provider.name == "builtin":
+        if self._is_builtin_provider(provider):
             return provider.prefetch(query, session_id=session_id)
 
         result_box: Dict[str, Any] = {}
@@ -434,7 +448,13 @@ class MemoryManager:
                 self._external_prefetch_threads.pop(provider.name, None)
         if "error" in result_box:
             raise result_box["error"]
-        return result_box.get("value", "")
+        result = result_box.get("value", "")
+        if result and result.strip():
+            result = spill_if_oversized(
+                result, session_id=session_id, source=f"{provider.name} memory prefetch",
+                config=self._external_prefetch_spill_config,
+            )
+        return result
 
     def describe_recall(self) -> str:
         """Deterministic recall indicator line (e.g. ``"🧠 Provider — recalled 3 memories"``); ``""`` if none.
@@ -709,7 +729,7 @@ class MemoryManager:
             else:
                 provider.on_memory_write(action, target, content, metadata=dict(metadata or {}))
 
-        external = [p for p in self._providers if p.name != "builtin"]
+        external = [p for p in self._providers if not self._is_builtin_provider(p)]
         self._each_provider("on_memory_write failed", _notify, providers=external)
 
     # Actions mirrored to external providers; non-mutating results (errors, staged) are

--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -680,7 +680,7 @@ def _memory_turn_start_and_prefetch(agent: Any, original_user_message: Any) -> s
     ext_prefetch_cache = ""
     with suppress(Exception):
         if not is_trivial_prompt(_query):
-            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query) or ""
+            ext_prefetch_cache = agent._memory_manager.prefetch_all(_query, session_id=agent.session_id) or ""
     # Deterministic recall indicator via _emit_status so the model can't silently
     # drop injected memory.
     if ext_prefetch_cache:

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -3,9 +3,10 @@
 import json
 import threading
 import time
-import pytest
 from types import SimpleNamespace
 from unittest.mock import MagicMock
+
+import pytest
 
 from agent.memory_provider import MemoryProvider
 from agent.memory_manager import MemoryManager, inject_memory_provider_tools
@@ -145,6 +146,23 @@ class TestMemoryProviderABC:
 
 
 class TestMemoryManager:
+    @staticmethod
+    def _set_spill_config(monkeypatch, tmp_path, *, max_chars):
+        load_config = MagicMock(
+            return_value={
+                "enabled": True,
+                "max_chars": max_chars,
+                "preview_head": 12,
+                "preview_tail": 12,
+                "directory": str(tmp_path),
+            }
+        )
+        monkeypatch.setattr(
+            "agent.memory_manager.get_spill_config",
+            load_config,
+        )
+        return load_config
+
     def test_empty_manager(self):
         mgr = MemoryManager()
         assert mgr.providers == []
@@ -177,7 +195,7 @@ class TestMemoryManager:
         p1._prefetch_result = "Memory from builtin"
         p2 = FakeMemoryProvider("external")
         p2._prefetch_result = "Memory from external"
-        mgr.add_provider(p1)
+        mgr.add_provider(p1, is_builtin=True)
         mgr.add_provider(p2)
 
         result = mgr.prefetch_all("what do you know?")
@@ -186,12 +204,86 @@ class TestMemoryManager:
         assert p1.prefetch_queries == ["what do you know?"]
         assert p2.prefetch_queries == ["what do you know?"]
 
+    def test_oversized_external_prefetch_is_spilled(self, tmp_path, monkeypatch):
+        self._set_spill_config(monkeypatch, tmp_path, max_chars=40)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        provider._prefetch_result = "recalled " * 20
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-1")
+
+        assert "external memory prefetch output truncated" in result
+        spill_files = list((tmp_path / "session-1").glob("*.txt"))
+        assert len(spill_files) == 1
+        assert spill_files[0].read_text() == provider._prefetch_result + "\n"
+
+    def test_external_prefetch_under_limit_is_unchanged(self, tmp_path, monkeypatch):
+        load_config = self._set_spill_config(monkeypatch, tmp_path, max_chars=100)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        provider._prefetch_result = "remember this exactly"
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-2")
+        repeated = mgr.prefetch_all("what else?", session_id="session-2")
+
+        assert result == repeated == provider._prefetch_result
+        load_config.assert_called_once_with()
+        assert not list(tmp_path.rglob("*.txt"))
+
+    def test_builtin_prefetch_keeps_its_existing_budget(self, tmp_path, monkeypatch):
+        self._set_spill_config(monkeypatch, tmp_path, max_chars=10)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("builtin")
+        provider._prefetch_result = "built-in memory has its own configured limit"
+        mgr.add_provider(provider, is_builtin=True)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-3")
+
+        assert result == provider._prefetch_result
+        assert not list(tmp_path.rglob("*.txt"))
+
+    def test_external_provider_cannot_claim_builtin_spill_exemption(
+        self, tmp_path, monkeypatch
+    ):
+        self._set_spill_config(monkeypatch, tmp_path, max_chars=40)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("builtin")
+        provider._prefetch_result = "external recall " * 20
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-4")
+
+        assert "builtin memory prefetch output truncated" in result
+        spill_files = list((tmp_path / "session-4").glob("*.txt"))
+        assert len(spill_files) == 1
+        assert spill_files[0].read_text() == provider._prefetch_result + "\n"
+
+    def test_duplicate_registration_cannot_promote_external_provider(
+        self, tmp_path, monkeypatch
+    ):
+        self._set_spill_config(monkeypatch, tmp_path, max_chars=40)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("external")
+        provider._prefetch_result = "external recall " * 20
+        mgr.add_provider(provider)
+        mgr.add_provider(provider, is_builtin=True)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-5")
+
+        assert mgr.providers == [provider]
+        assert "external memory prefetch output truncated" in result
+        spill_files = list((tmp_path / "session-5").glob("*.txt"))
+        assert len(spill_files) == 1
+        assert spill_files[0].read_text() == provider._prefetch_result + "\n"
+
 
     def test_queue_prefetch_all(self):
         mgr = MemoryManager()
         p1 = FakeMemoryProvider("builtin")
         p2 = FakeMemoryProvider("external")
-        mgr.add_provider(p1)
+        mgr.add_provider(p1, is_builtin=True)
         mgr.add_provider(p2)
 
         mgr.queue_prefetch_all("next turn")
@@ -208,7 +300,7 @@ class TestMemoryManager:
         p1 = FakeMemoryProvider("builtin")
         p1.sync_turn = MagicMock(side_effect=RuntimeError("boom"))
         p2 = FakeMemoryProvider("external")
-        mgr.add_provider(p1)
+        mgr.add_provider(p1, is_builtin=True)
         mgr.add_provider(p2)
 
         mgr.sync_all("user", "assistant")
@@ -250,7 +342,7 @@ class TestMemoryManager:
         p2 = FakeMemoryProvider("external", tools=[
             {"name": "ext_tool", "description": "External", "parameters": {}}
         ])
-        mgr.add_provider(p1)
+        mgr.add_provider(p1, is_builtin=True)
         mgr.add_provider(p2)
 
         r1 = json.loads(mgr.handle_tool_call("builtin_tool", {"a": 1}))
@@ -274,7 +366,7 @@ class TestMemoryManager:
         builtin._prefetch_result = "builtin memory"
         external = BlockingPrefetchProvider("hy-memory")
         external._prefetch_result = "late external memory"
-        mgr.add_provider(builtin)
+        mgr.add_provider(builtin, is_builtin=True)
         mgr.add_provider(external)
 
         started = time.monotonic()
@@ -736,7 +828,7 @@ class TestSequentialDispatchRouting:
             {"name": "ext_recall", "description": "E1", "parameters": {}},
             {"name": "ext_retain", "description": "E2", "parameters": {}},
         ])
-        mgr.add_provider(builtin)
+        mgr.add_provider(builtin, is_builtin=True)
         mgr.add_provider(external)
 
         names = mgr.get_all_tool_names()
@@ -921,7 +1013,7 @@ class TestCommitMemorySessionRouting:
         mgr = MemoryManager()
         builtin = _CommitRecorder("builtin")
         external = _CommitRecorder("openviking")
-        mgr.add_provider(builtin)
+        mgr.add_provider(builtin, is_builtin=True)
         mgr.add_provider(external)
 
         msgs = [{"role": "user", "content": "hi"}]
@@ -935,7 +1027,7 @@ class TestCommitMemorySessionRouting:
         builtin = FakeMemoryProvider("builtin")
         bad = _CommitRecorder("bad-provider")
         bad.on_session_end = lambda m: (_ for _ in ()).throw(RuntimeError("boom"))
-        mgr.add_provider(builtin)
+        mgr.add_provider(builtin, is_builtin=True)
         mgr.add_provider(bad)
 
         mgr.on_session_end([])  # must not raise
@@ -1008,7 +1100,7 @@ class TestOnMemoryWriteBridge:
         bad = FakeMemoryProvider("builtin")
         bad.on_memory_write = MagicMock(side_effect=RuntimeError("boom"))
         good = FakeMemoryProvider("good")
-        mgr.add_provider(bad)
+        mgr.add_provider(bad, is_builtin=True)
         mgr.add_provider(good)
 
         mgr.on_memory_write("add", "user", "test")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -278,6 +278,22 @@ class TestMemoryManager:
         assert len(spill_files) == 1
         assert spill_files[0].read_text() == provider._prefetch_result + "\n"
 
+    def test_duplicate_registration_preserves_initial_builtin_trust(
+        self, tmp_path, monkeypatch
+    ):
+        self._set_spill_config(monkeypatch, tmp_path, max_chars=40)
+        mgr = MemoryManager()
+        provider = FakeMemoryProvider("builtin")
+        provider._prefetch_result = "built-in memory keeps its own configured budget " * 3
+        mgr.add_provider(provider, is_builtin=True)
+        mgr.add_provider(provider)
+
+        result = mgr.prefetch_all("what do you remember?", session_id="session-6")
+
+        assert mgr.providers == [provider]
+        assert result == provider._prefetch_result
+        assert not list(tmp_path.rglob("*.txt"))
+
 
     def test_queue_prefetch_all(self):
         mgr = MemoryManager()

--- a/tests/agent/test_memory_recall_indicator.py
+++ b/tests/agent/test_memory_recall_indicator.py
@@ -72,10 +72,11 @@ def test_zero_count_renders_generic():
 
 
 def test_aggregates_multiple_providers():
-    # builtin is always accepted first; a second external is rejected, so use
-    # builtin + one external to exercise the join path.
+    # Use the trusted builtin slot plus one external to exercise the join path.
     mgr = MemoryManager()
-    mgr.add_provider(_FakeProvider("builtin", RecallStatus("Notes", 2)))
+    mgr.add_provider(
+        _FakeProvider("builtin", RecallStatus("Notes", 2)), is_builtin=True
+    )
     mgr.add_provider(_FakeProvider("hindsight", RecallStatus("Hindsight", 5)))
     result = mgr.describe_recall()
     assert "🧠 Notes — recalled 2 memories" in result
@@ -84,7 +85,7 @@ def test_aggregates_multiple_providers():
 
 def test_failing_provider_is_skipped_not_fatal():
     mgr = MemoryManager()
-    mgr.add_provider(_FakeProvider("builtin", None, raises=True))
+    mgr.add_provider(_FakeProvider("builtin", None, raises=True), is_builtin=True)
     mgr.add_provider(_FakeProvider("hindsight", RecallStatus("Hindsight", 1)))
     # The raising provider is swallowed; the healthy one still surfaces.
     assert mgr.describe_recall() == "🧠 Hindsight — recalled 1 memory"

--- a/tests/agent/test_memory_session_switch.py
+++ b/tests/agent/test_memory_session_switch.py
@@ -94,10 +94,10 @@ class _MinimalProvider(MemoryProvider):
 
 def test_manager_fans_out_to_all_providers():
     mm = MemoryManager()
-    # Only one external provider is allowed; use the builtin slot for p1.
+    # Only one external provider is allowed; use the trusted builtin slot for p1.
     p1 = _RecordingProvider(name="builtin")
     p2 = _RecordingProvider(name="hindsight")
-    mm.add_provider(p1)
+    mm.add_provider(p1, is_builtin=True)
     mm.add_provider(p2)
 
     mm.on_session_switch("new-sid", parent_session_id="old-sid", reset=False, reason="resume")
@@ -125,7 +125,7 @@ def test_manager_isolates_provider_failures():
     # (builtin slot) with a good external one.
     broken = _Broken(name="builtin")
     good = _RecordingProvider(name="good")
-    mm.add_provider(broken)
+    mm.add_provider(broken, is_builtin=True)
     mm.add_provider(good)
 
     # Must not raise — exceptions in one provider are swallowed + logged

--- a/tests/agent/test_memory_user_id.py
+++ b/tests/agent/test_memory_user_id.py
@@ -82,10 +82,10 @@ class TestMemoryManagerUserIdThreading:
 
     def test_multiple_providers_all_receive_user_id(self):
         mgr = MemoryManager()
-        # Use one provider named "builtin" (always accepted) and one external
+        # Register one trusted built-in provider and one external provider.
         p1 = RecordingProvider("builtin")
         p2 = RecordingProvider("external")
-        mgr.add_provider(p1)
+        mgr.add_provider(p1, is_builtin=True)
         mgr.add_provider(p2)
 
         mgr.initialize_all(

--- a/tests/agent/test_turn_context.py
+++ b/tests/agent/test_turn_context.py
@@ -288,7 +288,7 @@ def test_prefetch_runs_for_substantive_user_message():
     agent, mm = _agent_with_memory_manager()
     query = "what did we decide about the deploy pipeline?"
     ctx = _build(agent, user_message=query)
-    mm.prefetch_all.assert_called_once_with(query)
+    mm.prefetch_all.assert_called_once_with(query, session_id=agent.session_id)
     assert ctx.ext_prefetch_cache == "REMEMBERED CONTEXT"
 
 

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -130,6 +130,16 @@ class MyMemoryProvider(MemoryProvider):
 | `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
 | `shutdown()` | Process exit | Clean up connections |
 
+### Oversized prefetch results
+
+External `prefetch()` results above the configured spill threshold are written
+to a private spill file and replaced with the configured head/tail preview.
+The preview includes the path so the agent can read the full result when it is
+actually needed. Results at or below the threshold are returned unchanged.
+
+This uses the shared `hooks.output_spill` settings (`10,000` characters by
+default); see [Plugins — oversized-context spill](/developer-guide/plugins/#oversized-context-spill).
+
 ## Pre-Compress Checkpoints (fail-closed)
 
 `on_pre_compress()` is best-effort by default: if your provider raises, the


### PR DESCRIPTION
## What does this PR do?

When output spilling is enabled, bounds oversized context returned by external `MemoryProvider.prefetch()` implementations before it is injected into the current request and persisted in `api_content` for later replay.

External providers can return arbitrarily large strings. Without a shared manager-level bound, a single result can consume substantial context on the current turn and then be replayed on every later turn until compaction. The fix reuses Hermes' existing private, symlink-safe output-spill mechanism instead of introducing another storage path.

Built-in behavior and external results at or below the configured threshold remain unchanged. Administrators retain the existing `hooks.output_spill.enabled: false` opt-out, which also leaves oversized results unchanged. The trusted registration call, rather than a plugin-controlled provider name, determines whether a provider receives the built-in exemption.

## Related Issue

N/A — searches for the prefetch-size and spill behavior found adjacent memory-provider work, but no issue or PR implementing this manager-boundary size limit. In particular, #84263 and #85135 concern timeout/cancellation behavior rather than result size; #84360 and #64288 concern trust framing and prompt delimiters rather than replay growth.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/memory_manager.py`
  - pass external prefetch results through the existing `spill_if_oversized()` helper, preserving its configured enable/disable behavior;
  - classify built-in providers from trusted registration state;
  - reject duplicate provider-instance registration so trust cannot change retroactively.
- `agent/turn_context.py`
  - forward the active session ID so spill files remain isolated per conversation.
- `agent/agent_init.py`
  - explicitly register the configured plugin as external; built-in exemption is available only through trusted registration.
- `tests/agent/test_memory_provider.py` and related memory/turn-context tests
  - cover threshold boundaries, built-in/external classification, duplicate registration, session isolation, and unchanged under-threshold behavior.
- `website/docs/developer-guide/memory-provider-plugin.md`
  - document spill-threshold semantics and the separate preview-size setting.

## How to Test

Run:

```bash
scripts/run_tests.sh tests/agent/test_memory*.py tests/agent/test_turn_context.py tests/tools/test_hook_output_spill.py
scripts/run_tests.sh tests/run_agent/test_memory_provider_init.py tests/agent/test_builtin_memory_disabled_surface.py tests/gateway/test_73297_memory_flush_on_reset.py
```

Verified after rebasing onto `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`:

- 142 memory/turn-context/spill tests and 25 initialization/built-in/reset tests passed on head `5e2070ace9cc426ae31dff344bc4ec83de99f52a`.
- Oversized external output remains unbounded on the base and is spilled by this revision. The baseline probe allows the new configuration seam to be absent so the failure is the output assertion, not a missing attribute.
- Boundary, opt-out, duplicate-instance trust, provider identity and session-isolation coverage is retained.
- Ruff and `git diff --check` passed.
- The current threaded prefetch timeout, context-variable propagation and fan-out structure are preserved; spilling occurs after a successful external prefetch and before its result reaches the turn context.

The repository-wide suite was not run for this revision. Local results are not a claim that GitHub Actions passed.

## Current GitHub status

After the update GitHub reports `MERGEABLE` against `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`. [Exact-head CI run](https://github.com/NousResearch/hermes-agent/actions/runs/33911673708) is `action_required`; the external-fork workflows require maintainer approval. The PR remains `BLOCKED` pending repository gates, so conflict-free and locally tested does not yet mean CI-green or merge-ready.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed issues and PRs for overlapping memory-prefetch size, spill, timeout, and trust-boundary work
- [x] My PR contains **only** changes related to this fix (including its tests and documentation)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full repository suite is not claimed; current affected-suite evidence is listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon / arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/memory-provider-plugin.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, no contributor workflow changed
- [x] I've considered cross-platform impact — the shared spill helper and path-safety behavior are existing cross-platform surfaces; no platform-specific process or terminal behavior was added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed

## Screenshots / Logs

N/A — this is a backend context-accounting and storage-boundary fix with no UI change. Test results are included above.

