### PR TITLE
fix(auth): persist first profile OAuth row with empty root

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -2990,14 +2990,28 @@ class CredentialPool:
         with self._lock:
             entry = replace(entry, priority=_next_priority(self._entries))
             self._entries.append(entry)
-            borrowed_ids = getattr(self, "_borrowed_root_ids", None)
-            if borrowed_ids:
+            borrowed_ids = set(getattr(self, "_borrowed_root_ids", ()) or ())
+            # A named profile adding its FIRST single-use OAuth credential
+            # must claim the row in its own store even when root has no row to
+            # borrow.  In that empty-root case ``_borrowed_root_ids`` is empty,
+            # but the generic ``_persist`` path still classifies the profile as
+            # a borrower and sends the payload through persist_pool_entries'
+            # update-only root merge.  With no matching root id the new row is
+            # dropped while ``hermes auth add`` reports success.
+            profile_claims_first_single_use_row = (
+                self.provider in SINGLE_USE_REFRESH_POOL_PROVIDERS
+                and not _profile_owns_pool_provider(self.provider)
+                and _borrowed_single_use_pool_root() is not None
+            )
+            if borrowed_ids or profile_claims_first_single_use_row:
                 # ``hermes -p <profile> auth add <single-use provider>``: the
                 # profile is claiming its OWN credential. Persist only the
                 # profile-owned rows locally — copying the borrowed root
                 # grant alongside them would fork its single-use refresh
-                # token (#100339). Once the profile owns rows, the root
-                # fallback for this provider is shadowed (existing contract).
+                # token (#100339).  The same local-claim path is required when
+                # root and profile are both empty. Once the profile
+                # owns rows, the root fallback for this provider is shadowed
+                # (existing contract).
                 write_credential_pool(
                     self.provider,
                     [e.to_dict() for e in self._entries if e.id not in borrowed_ids],

--- a/tests/agent/test_credential_pool_profile_oauth_fork.py
+++ b/tests/agent/test_credential_pool_profile_oauth_fork.py
@@ -254,6 +254,37 @@ def test_profile_auth_add_owns_only_its_own_rows(fleet):
     assert [e["id"] for e in fleet["rows"](fleet["root"])] == ["abc123"]
 
 
+def test_profile_auth_add_persists_when_root_and_profile_are_empty(fleet):
+    """A named-profile OAuth login must not report success then
+    discard the new row when neither the root nor profile has that provider.
+
+    With no borrowed root ids, add_entry previously used _persist(); the
+    borrowed-root safety path is update-only and therefore ignored the brand-
+    new id.  This is the exact empty-store state after a lost shared auth.json.
+    """
+    from agent.credential_pool import AUTH_TYPE_OAUTH, PooledCredential, load_pool
+
+    root = fleet["root"]
+    store = json.loads((root / "auth.json").read_text())
+    del store["credential_pool"]["anthropic"]
+    (root / "auth.json").write_text(json.dumps(store))
+
+    kid = _profile(fleet, "empty-kid")
+    fleet["use"](kid)
+    pool = load_pool("anthropic")
+    assert pool.entries() == []
+    assert pool._borrowed_root_ids == set()
+
+    pool.add_entry(PooledCredential(
+        provider="anthropic", id="own-empty", label="mine", auth_type=AUTH_TYPE_OAUTH,
+        priority=0, source="manual:hermes_pkce", access_token="at-mine-empty",
+        refresh_token="rt-mine-empty",
+    ))
+
+    assert [e["id"] for e in fleet["rows"](kid)] == ["own-empty"]
+    assert fleet["rows"](root) is None
+
+
 def test_classic_mode_persist_is_unchanged(fleet):
     from agent.credential_pool import load_pool
 


### PR DESCRIPTION
## Summary

- make a named profile claim its first single-use OAuth row locally even when the global root has no row
- preserve existing borrowed-root behavior: borrowed rows are never copied into the profile
- add a real temp-store regression for the empty-root + empty-profile state

## Root cause

`CredentialPool.add_entry()` only took the local-claim path when `_borrowed_root_ids` was non-empty. When both stores lacked the provider, it called `_persist()`. `persist_pool_entries()` correctly treats such a named profile as a root borrower and performs an update-only merge; because the new row ID did not exist at root, it persisted nothing even though `hermes --profile <name> auth add` reported success.

## Tests

- pre-fix negative control: the new test fails with `NoneType is not iterable` because no profile row is written
- patched: `python3 -m pytest -o addopts= -q tests/agent/test_credential_pool_profile_oauth_fork.py` -> 20 passed
