### PR TITLE
fix(tools): scope output limit caches by profile

### DIFF
--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -722,12 +722,12 @@ class TestConfigOverride(unittest.TestCase):
         _read_tracker.clear()
         # Reset the cached value so each test gets a fresh lookup
         import tools.file_tools as _ft
-        _ft._max_read_chars_cached = None
+        _ft._reset_max_read_chars_cache()
 
     def tearDown(self):
         _read_tracker.clear()
         import tools.file_tools as _ft
-        _ft._max_read_chars_cached = None
+        _ft._reset_max_read_chars_cache()
 
     @patch("tools.file_tools._get_file_ops")
     @patch("hermes_cli.config.load_config", return_value={"file_read_max_chars": 50})

--- a/tests/tools/test_terminal_truncation_spill.py
+++ b/tests/tools/test_terminal_truncation_spill.py
@@ -12,9 +12,12 @@ from tools.terminal_tool import terminal_tool
 @pytest.fixture
 def small_cap(tmp_path, monkeypatch):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from hermes_constants import hermes_home_key
     import tools.tool_output_limits as lim
     monkeypatch.setattr(lim, "_cached_limits", {
-        "max_bytes": 2000, "max_lines": 2000, "max_line_length": 2000,
+        hermes_home_key(): {
+            "max_bytes": 2000, "max_lines": 2000, "max_line_length": 2000,
+        },
     })
     return tmp_path
 

--- a/tests/tools/test_tool_output_limits.py
+++ b/tests/tools/test_tool_output_limits.py
@@ -139,3 +139,76 @@ class TestIntegrationReadPagination:
         # Clamped to default MAX_LINES (2000).
         assert limit == tol.DEFAULT_MAX_LINES
         assert offset == 10
+
+
+@pytest.mark.parametrize("order", [("a", "b", "a"), ("b", "a", "b")])
+def test_limits_follow_active_profile_across_switches(tmp_path, order):
+    """A shared gateway must retain independent limits for each profile."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+    from tools import file_tools
+    from tools.file_operations import normalize_read_pagination
+
+    expected = {
+        "a": (11_111, 33_333, 111, 1_111),
+        "b": (22_222, 44_444, 222, 2_222),
+    }
+    homes = {}
+    for name, (read_chars, max_bytes, max_lines, max_line_length) in expected.items():
+        home = tmp_path / name
+        home.mkdir()
+        (home / "config.yaml").write_text(
+            "\n".join(
+                [
+                    f"file_read_max_chars: {read_chars}",
+                    "tool_output:",
+                    f"  max_bytes: {max_bytes}",
+                    f"  max_lines: {max_lines}",
+                    f"  max_line_length: {max_line_length}",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        homes[name] = home
+
+    tol._reset_tool_output_limits_cache()
+    file_tools._reset_max_read_chars_cache()
+    try:
+        for name in order:
+            token = set_hermes_home_override(str(homes[name]))
+            try:
+                read_chars, max_bytes, max_lines, max_line_length = expected[name]
+                assert file_tools._get_max_read_chars() == read_chars
+                assert tol.get_max_bytes() == max_bytes
+                assert tol.get_max_lines() == max_lines
+                assert tol.get_max_line_length() == max_line_length
+                assert normalize_read_pagination(1, 99_999) == (1, max_lines)
+            finally:
+                reset_hermes_home_override(token)
+    finally:
+        tol._reset_tool_output_limits_cache()
+        file_tools._reset_max_read_chars_cache()
+
+
+def test_limit_caches_are_bypassed_when_profile_key_is_unavailable():
+    """A key-resolution failure must not create a shared fallback cache."""
+    from tools import file_tools
+
+    configs = [
+        {"file_read_max_chars": 111},
+        {"file_read_max_chars": 222},
+        {"tool_output": {"max_bytes": 333}},
+        {"tool_output": {"max_bytes": 444}},
+    ]
+    file_tools._reset_max_read_chars_cache()
+    try:
+        with (
+            patch("hermes_constants.hermes_home_key", side_effect=RuntimeError("unavailable")),
+            patch("hermes_cli.config.load_config", side_effect=configs) as load_config,
+        ):
+            assert file_tools._get_max_read_chars() == 111
+            assert file_tools._get_max_read_chars() == 222
+            assert tol.get_max_bytes() == 333
+            assert tol.get_max_bytes() == 444
+        assert load_config.call_count == 4
+    finally:
+        file_tools._reset_max_read_chars_cache()

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -45,21 +45,36 @@ _EXPECTED_WRITE_ERRNOS = {errno.EACCES, errno.EPERM, errno.EROFS}
 # Read-size guard. Model-agnostic, so characters proxy tokens: 100K chars is
 # ~25-35K tokens across typical tokenisers. Configurable: file_read_max_chars.
 _DEFAULT_MAX_READ_CHARS = 100_000
-_max_read_chars_cached: int | None = None
+_max_read_chars_by_home: dict[str, int] = {}
 
 
 def _get_max_read_chars() -> int:
-    """Return ``file_read_max_chars`` from config.yaml (cached per process; default on missing/invalid)."""
-    global _max_read_chars_cached
-    if _max_read_chars_cached is None:
-        try:
-            from hermes_cli.config import load_config
-            val = load_config().get("file_read_max_chars")
-        except Exception:
-            val = None
-        valid = isinstance(val, (int, float)) and val > 0
-        _max_read_chars_cached = int(val) if valid else _DEFAULT_MAX_READ_CHARS
-    return _max_read_chars_cached
+    """Return ``file_read_max_chars`` (cached per active profile; default on invalid)."""
+    try:
+        from hermes_constants import hermes_home_key
+        cache_key = hermes_home_key()
+    except Exception:
+        cache_key = None
+
+    if cache_key is not None:
+        cached = _max_read_chars_by_home.get(cache_key)
+        if cached is not None:
+            return cached
+    try:
+        from hermes_cli.config import load_config
+        val = load_config().get("file_read_max_chars")
+    except Exception:
+        val = None
+    valid = isinstance(val, (int, float)) and val > 0
+    resolved = int(val) if valid else _DEFAULT_MAX_READ_CHARS
+    if cache_key is not None:
+        _max_read_chars_by_home[cache_key] = resolved
+    return resolved
+
+
+def _reset_max_read_chars_cache() -> None:
+    """Clear cached read limits for every profile (tests/config hot-reload)."""
+    _max_read_chars_by_home.clear()
 
 
 def _truncate_to_char_budget(content: str, max_chars: int) -> tuple[str, int, bool]:

--- a/tools/tool_output_limits.py
+++ b/tools/tool_output_limits.py
@@ -11,7 +11,8 @@ from typing import Any, Dict
 DEFAULT_MAX_BYTES = 50_000       # terminal_tool.MAX_OUTPUT_CHARS
 DEFAULT_MAX_LINES = 2000         # file_operations.MAX_LINES
 DEFAULT_MAX_LINE_LENGTH = 2000   # file_operations.MAX_LINE_LENGTH
-_cached_limits: dict | None = None  # process-lifetime: no config.yaml re-read per tool call
+
+_cached_limits: dict[str, Dict[str, int]] = {}  # process-lifetime, keyed by active profile
 
 
 def _coerce_int(value: Any, default: int, minimum: int) -> int:
@@ -28,11 +29,15 @@ def _coerce_positive_int(value: Any, default: int) -> int:
 
 
 def get_tool_output_limits() -> Dict[str, int]:
-    """Resolved ``{max_bytes, max_lines, max_line_length}``; never raises. Cached for the
-    process — ``_reset_tool_output_limits_cache()`` forces a fresh read."""
-    global _cached_limits
-    if _cached_limits is not None:
-        return _cached_limits
+    """Resolved limits; never raises. Cached per active profile for the process."""
+    try:
+        from hermes_constants import hermes_home_key
+        cache_key = hermes_home_key()
+    except Exception:
+        cache_key = None
+
+    if cache_key is not None and cache_key in _cached_limits:
+        return _cached_limits[cache_key]
     try:
         from hermes_cli.config import load_config
         cfg = load_config() or {}
@@ -41,18 +46,20 @@ def get_tool_output_limits() -> Dict[str, int]:
         section = None
     if not isinstance(section, dict):
         section = {}
-    _cached_limits = {
+
+    limits = {
         "max_bytes": _coerce_positive_int(section.get("max_bytes"), DEFAULT_MAX_BYTES),
         "max_lines": _coerce_positive_int(section.get("max_lines"), DEFAULT_MAX_LINES),
         "max_line_length": _coerce_positive_int(
             section.get("max_line_length"), DEFAULT_MAX_LINE_LENGTH)}
-    return _cached_limits
+    if cache_key is not None:
+        _cached_limits[cache_key] = limits
+    return limits
 
 
 def _reset_tool_output_limits_cache() -> None:
     """Reset the cached limits — for tests or after config hot-reload."""
-    global _cached_limits
-    _cached_limits = None
+    _cached_limits.clear()
 
 
 def get_max_bytes() -> int: return get_tool_output_limits()["max_bytes"]


### PR DESCRIPTION
## What does this PR do?

The shared gateway changes the active Hermes home when it serves different profiles, but the `file_read_max_chars` and `tool_output` readers cached the first resolved values process-wide. After profile A used either reader, profile B could silently inherit A limits until the process restarted.

This changes both caches to use the established normalized `hermes_home_key()` identity. If that identity cannot be resolved, the readers preserve their non-raising behavior but skip caching for that call instead of sharing a fallback slot.

## Related Issue

No matching open or merged issue/PR was found.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/tool_output_limits.py`: cache resolved output limits per Hermes home
- `tools/file_tools.py`: cache the file-read character limit per Hermes home
- affected tests: reset the new cache shape and exercise real profile switches
- regression coverage: verify A → B → A and B → A → B using real temporary `config.yaml` files, plus the key-resolution failure path

## How to Test

1. Give two profiles different `file_read_max_chars` and `tool_output` values.
2. Alternate the active Hermes-home override in one process.
3. Confirm each profile retains its own file, terminal, and pagination limits.

Validation on macOS 26.5:

- Python 3.13.12: `scripts/run_tests.sh tests/tools/test_tool_output_limits.py tests/tools/test_file_read_guards.py tests/tools/test_terminal_truncation_spill.py` — 62 passed
- Python 3.11.15 with the CI extras: full `scripts/run_tests.sh` — 44,543 passed, 49 failed, 474 skipped
- baseline check at current upstream `main` (`db23c79b`): rerunning those 28 failing files with the same canonical runner produced the exact same 49 failures (1,247 passed, 61 skipped); none of the PR's three changed test files is in the failure set
- `ruff check` on all five changed files
- `git diff --check`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; no user-facing behavior or config key changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no workflow or architecture changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — cache identity and dictionary behavior are platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; schemas are unchanged

## Screenshots / Logs

N/A — covered by deterministic profile-switch regression tests.
