### PR TITLE
fix(mattermost): close replaced websocket connections

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -469,23 +469,30 @@ class MattermostAdapter(BasePlatformAdapter):
         """Single WebSocket session: connect, authenticate, process events."""
         ws_url = re.sub(r"^http", "ws", self._base_url) + "/api/v4/websocket"  # https→wss, http→ws
         logger.info("Mattermost: connecting to %s", ws_url)
-        self._ws = await self._session.ws_connect(ws_url, heartbeat=30.0)
-        await self._ws.send_json({"seq": 1, "action": "authentication_challenge", "data": {"token": self._token}})
-        logger.info("Mattermost: WebSocket connected and authenticated")
-
-        async for raw_msg in self._ws:
-            if self._closing:
-                return
-            kind = raw_msg.type
-            if kind in {kind.TEXT, kind.BINARY}:
-                try:
-                    event = json.loads(raw_msg.data)
-                except (json.JSONDecodeError, TypeError):
-                    continue
-                await self._handle_ws_event(event)
-            elif kind in {kind.ERROR, kind.CLOSE, kind.CLOSING, kind.CLOSED}:
-                logger.info("Mattermost: WebSocket closed (%s)", kind)
-                break
+        ws = await self._session.ws_connect(ws_url, heartbeat=30.0)
+        self._ws = ws
+        try:
+            await ws.send_json({"seq": 1, "action": "authentication_challenge", "data": {"token": self._token}})
+            logger.info("Mattermost: WebSocket connected and authenticated")
+            async for raw_msg in ws:
+                if self._closing:
+                    return
+                kind = raw_msg.type
+                if kind in {kind.TEXT, kind.BINARY}:
+                    try:
+                        event = json.loads(raw_msg.data)
+                    except (json.JSONDecodeError, TypeError):
+                        continue
+                    await self._handle_ws_event(event)
+                elif kind in {kind.ERROR, kind.CLOSE, kind.CLOSING, kind.CLOSED}:
+                    logger.info("Mattermost: WebSocket closed (%s)", kind)
+                    break
+        finally:
+            try:
+                await ws.close()
+            finally:
+                if self._ws is ws:
+                    self._ws = None
 
     def _extra_or_env(self, key: str, env: str, default: str = "") -> Any:
         """config.yaml ``mattermost.<key>`` (PlatformConfig.extra) first, env var fallback."""

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -1,9 +1,13 @@
 """Tests for Mattermost platform adapter."""
+import asyncio
 import json
 import os
 import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
 import pytest
-from unittest.mock import MagicMock, patch, AsyncMock
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import MessageType
@@ -265,6 +269,92 @@ class TestMattermostSend:
 # ---------------------------------------------------------------------------
 # WebSocket event parsing
 # ---------------------------------------------------------------------------
+
+
+class _FakeMattermostWebSocket:
+    def __init__(self, messages=(), *, block_when_empty=False):
+        self._messages = list(messages)
+        self._block_when_empty = block_when_empty
+        self._unblock = asyncio.Event()
+        self.iteration_started = asyncio.Event()
+        self.closed = False
+        self.close_calls = 0
+        self.sent_json = []
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        self.iteration_started.set()
+        if self._messages:
+            return self._messages.pop(0)
+        if self._block_when_empty:
+            await self._unblock.wait()
+        raise StopAsyncIteration
+
+    async def send_json(self, message):
+        self.sent_json.append(message)
+
+    async def close(self):
+        self.close_calls += 1
+        self.closed = True
+        self._unblock.set()
+
+
+class TestMattermostWebSocketLifecycle:
+    @pytest.mark.asyncio
+    async def test_handler_error_closes_socket_before_reconnect(self, monkeypatch):
+        from plugins.platforms.mattermost import adapter as mattermost_adapter
+
+        adapter = _make_adapter()
+        first_ws = _FakeMattermostWebSocket([
+            SimpleNamespace(
+                type=aiohttp.WSMsgType.TEXT,
+                data=json.dumps({"event": "test"}),
+            )
+        ])
+        second_ws = _FakeMattermostWebSocket()
+        sockets = iter([first_ws, second_ws])
+        first_closed_before_reconnect = []
+
+        async def ws_connect(*_args, **_kwargs):
+            ws = next(sockets)
+            if ws is second_ws:
+                first_closed_before_reconnect.append(first_ws.closed)
+                adapter._closing = True
+            return ws
+
+        adapter._session = MagicMock()
+        adapter._session.ws_connect = AsyncMock(side_effect=ws_connect)
+        adapter._handle_ws_event = AsyncMock(side_effect=RuntimeError("handler failed"))
+        monkeypatch.setattr(mattermost_adapter, "_RECONNECT_BASE_DELAY", 0)
+        monkeypatch.setattr(mattermost_adapter, "_RECONNECT_JITTER", 0)
+
+        await adapter._ws_loop()
+
+        assert first_closed_before_reconnect == [True]
+        assert first_ws.close_calls == 1
+        assert second_ws.close_calls == 1
+        assert adapter._ws is None
+
+    @pytest.mark.asyncio
+    async def test_cancelled_listener_closes_current_socket(self):
+        adapter = _make_adapter()
+        ws = _FakeMattermostWebSocket(block_when_empty=True)
+        adapter._session = MagicMock()
+        adapter._session.ws_connect = AsyncMock(return_value=ws)
+
+        listener = asyncio.create_task(adapter._ws_connect_and_listen())
+        await asyncio.wait_for(ws.iteration_started.wait(), timeout=5)
+        assert adapter._ws is ws
+
+        listener.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await listener
+
+        assert ws.close_calls == 1
+        assert adapter._ws is None
+
 
 class TestMattermostWebSocketParsing:
     def setup_method(self):
@@ -708,4 +798,3 @@ class TestMultiplexProfileScope:
             # skipped -- writing here would leak into every other profile's
             # os.environ.
             assert "MATTERMOST_REQUIRE_MENTION" not in os.environ
-


### PR DESCRIPTION
## What does this PR do?

Mattermost reconnects when its WebSocket event handler raises, but the previous connection was only stored in `self._ws`; the next connection overwrote that reference without closing the old socket. Repeated handler failures could therefore leave replaced connections open until process exit.

The listener now owns each connection in a local variable, closes it in `finally` on normal completion, errors, and cancellation, and clears the shared reference only when it still points to that same connection.

## Related Issue

No matching open or merged issue/PR was found. #19756 changes proxy handling in the same method but does not manage connection cleanup; #35645 changes error classification and fatal-state reporting.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: close the connection owned by each listener invocation in `finally`
- `tests/gateway/test_mattermost.py`: verify the first socket is closed before reconnect and the current socket is closed on task cancellation

## How to Test

1. Let a Mattermost event handler raise after receiving a WebSocket message.
2. Confirm the failed connection is closed before the reconnect attempt begins.
3. Cancel an active listener and confirm its socket is closed and `_ws` is cleared.

Validation on macOS 26.5 with Python 3.13.12:

- `scripts/run_tests.sh tests/gateway/test_mattermost.py` — 27 passed
- `ruff check plugins/platforms/mattermost/adapter.py tests/gateway/test_mattermost.py`
- `git diff --check`

Both new lifecycle tests were also verified to fail against the pre-fix implementation.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; internal lifecycle bug fix
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no workflow or architecture changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — asyncio lifecycle behavior is OS-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool surface changed

## Screenshots / Logs

N/A — covered by deterministic reconnect and cancellation tests.
