### PR TITLE
fix(agent): stop identical-tool spam loops from resetting across turns

### DIFF
--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -415,6 +415,18 @@ class ToolCallGuardrailController:
 
     def __init__(self, config: ToolCallGuardrailConfig | None = None):
         self.config = config or ToolCallGuardrailConfig()
+        # Cross-turn idempotent-call / identical-streak state. These persist
+        # across turns (unlike the per-turn failure counters below) so that a
+        # model repeating the same tool call with the same result across
+        # multiple turns is detected rather than having the streak reset every
+        # turn. They self-reset on any change in tool name, args, or result
+        # hash, so carrying them forward is safe.
+        self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
+        self._identical_streak_sig: ToolCallSignature | None = None
+        self._identical_streak_result_hash: str = ""
+        self._identical_streak_count: int = 0
+        self._identical_streak_first_call_id: str = ""
+        self._persisted_result_paths: dict[str, str] = {}
         self.reset_for_turn()
 
     def reset_for_turn(self) -> None:
@@ -422,28 +434,7 @@ class ToolCallGuardrailController:
         self._same_tool_failure_counts: dict[str, int] = {}
         # signature -> a mutating call succeeded since its last failure
         self._progress_since_failure: dict[ToolCallSignature, bool] = {}
-        self._no_progress: dict[ToolCallSignature, tuple[str, int]] = {}
         self._halt_decision: ToolGuardrailDecision | None = None
-        # Identical-call loop-breaker state (agent.stall_guards): tracks the
-        # CONSECUTIVE streak of identical (tool, canonical args) calls whose
-        # results were also identical. Any different call — or a different
-        # result — resets the streak, so legitimate re-reads after edits and
-        # varied polling are never flagged. Per-turn, like everything else here.
-        # NOTE: open PR #85352 (patrykkopycinski) tracks no-progress loops
-        # ACROSS turns via a detection window — a different mechanism from
-        # this per-turn consecutive streak. Coordinate future work there.
-        self._identical_streak_sig: ToolCallSignature | None = None
-        self._identical_streak_result_hash: str = ""
-        self._identical_streak_count: int = 0
-        # tool_call_id of the FIRST call in the current streak, so a
-        # result-reference stub can point at the message that carries the
-        # full payload.
-        self._identical_streak_first_call_id: str = ""
-        # tool_call_id -> spillover file path for results that were persisted
-        # out of context (persisted-output preview). Lets a reference stub
-        # carry the file path so the reference can't dangle when the first
-        # occurrence entered context as a preview.
-        self._persisted_result_paths: dict[str, str] = {}
         # Per-turn runaway-loop cap counters. Reset every turn (this method
         # runs at the start of each run_conversation), so the caps bound a
         # single agent loop rather than accumulating across the session.

--- a/tests/agent/test_tool_guardrails_cross_turn.py
+++ b/tests/agent/test_tool_guardrails_cross_turn.py
@@ -1,0 +1,40 @@
+"""Regression test: guardrails must detect identical-tool spam across turns."""
+
+from agent.tool_guardrails import ToolCallGuardrailConfig, ToolCallGuardrailController
+
+
+def test_identical_terminal_call_across_turns_halts_under_hard_stop():
+    """Regression: a model calling the same terminal command each turn
+    and getting the same result must be halted, not loop forever.
+
+    Before the fix, reset_for_turn() cleared the identical-call streak
+    every turn, so the model could spam the same tail command indefinitely
+    without ever hitting the stall-guard threshold.
+    """
+    controller = ToolCallGuardrailController(
+        ToolCallGuardrailConfig(hard_stop_enabled=True, no_progress_block_after=3)
+    )
+    args = {"command": "tail -5 /tmp/build.log"}
+    result = "still building\\n"
+
+    # Turn 1: first call, no halt.
+    controller.reset_for_turn()
+    controller.after_call("terminal", args, result, failed=False)
+    controller.observe_call("terminal", args, result, failed=False)
+    assert controller.halt_decision is None
+
+    # Turn 2: second identical call — streak persists across turns.
+    controller.reset_for_turn()
+    controller.after_call("terminal", args, result, failed=False)
+    controller.observe_call("terminal", args, result, failed=False)
+    assert controller.halt_decision is None
+
+    # Turn 3: third identical call — now at threshold, must halt.
+    controller.reset_for_turn()
+    controller.after_call("terminal", args, result, failed=False)
+    controller.observe_call("terminal", args, result, failed=False)
+    halt = controller.halt_decision
+    assert halt is not None and halt.should_halt
+    assert halt.code == "identical_call_streak_halt"
+    assert halt.tool_name == "terminal"
+    assert halt.count == 3


### PR DESCRIPTION
## Summary

- **Root cause:** `ToolCallGuardrailController.reset_for_turn()` cleared the identical-call streak (`_identical_streak_*`) and no-progress counters (`_no_progress`) every turn. A model repeating the same tool call with the same result across multiple turns never accumulated enough count to trigger the stall warning or hard-stop halt — each turn restarted the streak at 1, and the agent kept polling forever.
- **Fix:** Move `_no_progress`, `_identical_streak_*`, and `_persisted_result_paths` to `__init__` so they persist across turns. They already self-reset on any change in tool name, args, or result hash, so carrying them forward is safe. The per-turn failure counters and halt decision still reset each turn.
- **Test:** New regression test simulates three turns of identical terminal calls and asserts the hard-stop halt fires on the third turn. Fails on unpatched code because `reset_for_turn()` clears the streak each turn.

## Validation

### Automated tests
- [x] `tests/agent/test_tool_guardrails.py` — 19/19 pass (existing)
- [x] `tests/agent/test_tool_guardrails_cross_turn.py` — 1/1 pass (new regression; fails on unpatched main)

### Refs
- The in-turn no-progress block (`idempotent_no_progress_block`) covers read-only idempotent tools but NOT mutating tools like `terminal`. The identical-call streak (`identical_call_streak_halt`, added in #89069/#100849) was the tool-agnostic backstop — but it was also cleared every turn, defeating it for cross-turn spam.
