### PR TITLE
fix(desktop): set MSYS_NO_PATHCONV in embedded terminal env

### DIFF
--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -166,6 +166,18 @@ export function registerTerminalIpc({
     // which marks the agent *backend* and gates cron/gateway behavior.
     env.HERMES_DESKTOP_TERMINAL = '1'
 
+    // On Windows, disable MSYS argv path conversion for any MSYS2/Git Bash subprocesses.
+    // Without this, commands like `tasklist /FI` or `schtasks /Create` get their
+    // slash-prefixed flags rewritten to C:/... paths (e.g. /FI -> C:/.../git/FI),
+    // matching the Python terminal tool's _apply_windows_msys_bash_env_defaults
+    // in tools/environments/local.py. Set both vars for coverage:
+    // MSYS_NO_PATHCONV for Git for Windows bash, MSYS2_ARG_CONV_EXCL=* as fallback
+    // for MSYS2/Cygwin bash. Preserve any user-specified values.
+    if (process.platform === 'win32') {
+      env.MSYS_NO_PATHCONV = env.MSYS_NO_PATHCONV || '1'
+      env.MSYS2_ARG_CONV_EXCL = env.MSYS2_ARG_CONV_EXCL || '*'
+    }
+
     return env
   }
 


### PR DESCRIPTION
## Fix: MSYS argv path conversion in Desktop embedded terminal

**Closes #101826**

### Problem

On Windows, bash sessions in the Desktop embedded terminal were not setting
`MSYS_NO_PATHCONV` / `MSYS2_ARG_CONV_EXCL`. Native Windows CLI commands with
slash-prefixed flags (`tasklist /FI`, `schtasks /Create`) had their arguments
mangled into bogus paths (e.g. `/FI` → `C:/.../git/FI`) by MSYS path conversion.

### Fix

Inject both environment variables in `terminalShellEnv()` in `terminal-ipc.ts`
before the PTY spawn, mirroring the existing
`_apply_windows_msys_bash_env_defaults()` pattern already used by the Python
terminal tool in `tools/environments/local.py`.

### Changes

- `apps/desktop/electron/terminal-ipc.ts`: +12 lines in `terminalShellEnv()`

### Testing

The fix mirrors the working Python pattern (verified across 6 prior MSYS path
PRs in this repo). Manual test: open embedded terminal in Desktop on Windows,
run `tasklist /FI "IMAGENAME eq python.exe"` — should succeed without path
mangling.
