### PR TITLE
fix(tui): don't auto-submit composer draft when a chat message lands

### DIFF
--- a/ui-tui/README.md
+++ b/ui-tui/README.md
@@ -187,7 +187,7 @@ Notes:
 
 - Plain text entered while the agent is busy is queued instead of sent immediately.
 - Slash commands and `!cmd` do not queue; they execute immediately even while a run is active.
-- Queue auto-drains after each assistant response, unless a queued item is currently being edited.
+- Queue auto-drains after each assistant response, unless a queued item is currently being edited **or the composer still has unsent text**.
 - `Up/Down` prioritizes queued-message editing over history. History only activates when there is no queue to edit.
 - Queued drafts keep their original `!cmd` and `{!cmd}` text while you edit them. Shell commands and interpolation run when the queued item is actually sent.
 - If you load a queued item into the input and resubmit plain text, that queue item is replaced, removed from the queue preview, and promoted to send next. If the agent is still busy, the edited item is moved to the front of the queue and sent after the current run completes.

--- a/ui-tui/src/__tests__/composerSubmitGuard.test.ts
+++ b/ui-tui/src/__tests__/composerSubmitGuard.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  hasComposerDraft,
+  isComposerSubmitLocked,
+  lockComposerSubmit,
+  resetComposerSubmitGuard,
+  shouldDrainQueuedFollowUp
+} from '../app/composerSubmitGuard.js'
+
+describe('composer submit guard', () => {
+  afterEach(() => {
+    resetComposerSubmitGuard()
+  })
+
+  it('locks user-enter submit after an incoming chat row', () => {
+    const now = 1_000
+
+    expect(isComposerSubmitLocked(now)).toBe(false)
+
+    lockComposerSubmit(now, 120)
+
+    expect(isComposerSubmitLocked(now)).toBe(true)
+    expect(isComposerSubmitLocked(now + 119)).toBe(true)
+    expect(isComposerSubmitLocked(now + 120)).toBe(false)
+  })
+
+  it('extends an existing lock rather than shortening it', () => {
+    lockComposerSubmit(1_000, 200)
+    lockComposerSubmit(1_050, 20)
+
+    expect(isComposerSubmitLocked(1_199)).toBe(true)
+    expect(isComposerSubmitLocked(1_200)).toBe(false)
+  })
+})
+
+describe('hasComposerDraft', () => {
+  it('treats typed text or a multiline buffer as a live draft', () => {
+    expect(hasComposerDraft('', [])).toBe(false)
+    expect(hasComposerDraft('   ', [])).toBe(false)
+    expect(hasComposerDraft('half finished', [])).toBe(true)
+    expect(hasComposerDraft('', ['line one'])).toBe(true)
+  })
+})
+
+describe('shouldDrainQueuedFollowUp', () => {
+  const ready = {
+    busy: false,
+    composerDraft: false,
+    queueEdit: null,
+    queueLength: 1,
+    sid: 'sess-1'
+  }
+
+  it('drains when idle with a queued follow-up and an empty composer', () => {
+    expect(shouldDrainQueuedFollowUp(ready)).toBe(true)
+  })
+
+  it('does not drain while the user still has text in the input', () => {
+    expect(shouldDrainQueuedFollowUp({ ...ready, composerDraft: true })).toBe(false)
+  })
+
+  it('does not drain while a queued item is being edited', () => {
+    expect(shouldDrainQueuedFollowUp({ ...ready, queueEdit: 0 })).toBe(false)
+  })
+
+  it('does not drain while the agent is still working', () => {
+    expect(shouldDrainQueuedFollowUp({ ...ready, busy: true })).toBe(false)
+  })
+})

--- a/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
+++ b/ui-tui/src/__tests__/createGatewayEventHandler.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+import { resetComposerSubmitGuard } from '../app/composerSubmitGuard.js'
 import { createGatewayEventHandler } from '../app/createGatewayEventHandler.js'
 import { getOverlayState, patchOverlayState, resetOverlayState } from '../app/overlayStore.js'
 import { turnController } from '../app/turnController.js'
@@ -64,6 +65,7 @@ describe('createGatewayEventHandler', () => {
     resetUiState()
     resetTurnState()
     turnController.fullReset()
+    resetComposerSubmitGuard()
     patchUiState({ showReasoning: true })
   })
 

--- a/ui-tui/src/app/composerSubmitGuard.ts
+++ b/ui-tui/src/app/composerSubmitGuard.ts
@@ -1,0 +1,44 @@
+import { COMPOSER_SUBMIT_LOCK_MS } from '../config/timing.js'
+
+let lockedUntil = 0
+
+/**
+ * Incoming transcript rows (assistant reply, interim bubble, bg/btw notice)
+ * remount/reflow the composer. That redraw can flush a leftover CR into
+ * TextInput as Enter and send whatever the user was still typing.
+ *
+ * Lock user-Enter submit for a short window after those events. Voice,
+ * slash, and billing go through submitRef, not TextInput, so they stay live.
+ */
+export function lockComposerSubmit(now = Date.now(), ms = COMPOSER_SUBMIT_LOCK_MS): void {
+  lockedUntil = Math.max(lockedUntil, now + ms)
+}
+
+export function isComposerSubmitLocked(now = Date.now()): boolean {
+  return now < lockedUntil
+}
+
+export function resetComposerSubmitGuard(): void {
+  lockedUntil = 0
+}
+
+export function hasComposerDraft(input: string, inputBuf: readonly string[]): boolean {
+  return Boolean(input.trim() || inputBuf.length)
+}
+
+/**
+ * Queue auto-drain fires on busy → false (a chat message just settled).
+ * Skip it while the composer still has unsent text — that's the user
+ * mid-draft, not a ready follow-up.
+ */
+export function shouldDrainQueuedFollowUp(opts: {
+  busy: boolean
+  composerDraft: boolean
+  queueEdit: number | null
+  queueLength: number
+  sid: string | null | undefined
+}): boolean {
+  return Boolean(
+    opts.sid && !opts.busy && opts.queueEdit === null && opts.queueLength > 0 && !opts.composerDraft
+  )
+}

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -25,6 +25,7 @@ import { bootSeededPin, invalidateBootBackground, writeBootTheme } from '../lib/
 import { defaultThemeForCurrentBackground, fromSkin, skinIsLight, type Theme, themeToneHex } from '../theme.js'
 import type { Msg, SubagentProgress, SubagentStatus, Usage } from '../types.js'
 
+import { lockComposerSubmit } from './composerSubmitGuard.js'
 import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
 import { getOverlayState, patchOverlayState } from './overlayStore.js'
@@ -824,6 +825,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'message.start':
         resetAgentsNudgeTurnState()
         turnController.startMessage()
+        lockComposerSubmit()
 
         return
       case 'status.update': {
@@ -1300,11 +1302,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
       case 'background.complete':
         dropBgTask(ev.payload.task_id)
         sys(`[bg ${ev.payload.task_id}] ${ev.payload.text}`)
+        lockComposerSubmit()
 
         return
 
       case 'btw.complete':
         sys(`[btw${ev.payload.question ? ` "${ev.payload.question}"` : ''}] ${ev.payload.text}`)
+        lockComposerSubmit()
 
         return
       case 'review.summary': {
@@ -1317,6 +1321,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (text) {
           sys(text)
+          lockComposerSubmit()
         }
 
         return
@@ -1430,12 +1435,14 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (typeof text === 'string' && text.trim()) {
           turnController.recordInterimMessage(text)
+          lockComposerSubmit()
         }
 
         return
       }
 
       case 'message.complete': {
+        lockComposerSubmit()
         const { finalMessages, finalText, wasInterrupted } = turnController.recordMessageComplete(ev.payload ?? {})
 
         if (!wasInterrupted) {

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -46,6 +46,7 @@ import { estimatedMsgHeight, messageHeightKey } from '../lib/virtualHeights.js'
 import { onUserWidgets } from '../sdk/userWidgets.js'
 import type { Msg, PanelSection, SlashCatalog } from '../types.js'
 
+import { hasComposerDraft, shouldDrainQueuedFollowUp } from './composerSubmitGuard.js'
 import { createGatewayEventHandler } from './createGatewayEventHandler.js'
 import { createSlashHandler } from './createSlashHandler.js'
 import { planGatewayRecovery } from './gatewayRecovery.js'
@@ -799,12 +800,19 @@ export function useMainApp(gw: GatewayClient) {
   // session first comes up with pre-queued messages. Without this, shell.exec
   // and error paths never emit message.complete, so anything enqueued while
   // `!sleep` / a failed turn was running would stay stuck forever.
+  //
+  // Do not drain while the composer still has unsent text. A chat row landing
+  // (busy → false) would otherwise fire a half-finished follow-up the user
+  // queued with Enter-while-busy, or a leftover CR from the redraw.
   useEffect(() => {
     if (
-      !ui.sid ||
-      ui.busy ||
-      composerRefs.queueEditRef.current !== null ||
-      composerRefs.queueRef.current.length === 0
+      !shouldDrainQueuedFollowUp({
+        busy: ui.busy,
+        composerDraft: hasComposerDraft(composerState.input, composerState.inputBuf),
+        queueEdit: composerRefs.queueEditRef.current,
+        queueLength: composerRefs.queueRef.current.length,
+        sid: ui.sid
+      })
     ) {
       return
     }
@@ -815,7 +823,15 @@ export function useMainApp(gw: GatewayClient) {
       patchUiState({ busy: true, status: 'running…' })
       sendQueued(next)
     }
-  }, [ui.sid, ui.busy, composerActions, composerRefs, sendQueued])
+  }, [
+    composerActions,
+    composerRefs,
+    composerState.input,
+    composerState.inputBuf,
+    sendQueued,
+    ui.busy,
+    ui.sid
+  ])
 
   const { pagerPageSize } = useInputHandlers({
     actions: {

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -5,6 +5,7 @@ import { AlternateScreen, Box, NoSelect, ScrollBox, Text } from '@hermes/ink'
 import { useStore } from '@nanostores/react'
 import { Fragment, memo, useEffect, useMemo, useRef } from 'react'
 
+import { isComposerSubmitLocked } from '../app/composerSubmitGuard.js'
 import { useGateway } from '../app/gatewayContext.js'
 import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
@@ -424,7 +425,13 @@ const ComposerPane = memo(function ComposerPane({
                   mouseApiRef={inputMouseRef}
                   onChange={composer.updateInput}
                   onPaste={composer.handleTextPaste}
-                  onSubmit={composer.submit}
+                  onSubmit={value => {
+                    if (isComposerSubmitLocked()) {
+                      return
+                    }
+
+                    composer.submit(value)
+                  }}
                   placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}
                   // Exactly the "(and N more toolsets…)" tone. `muted` is a
                   // MID-luminance family tone, so it reads receded on both

--- a/ui-tui/src/config/timing.ts
+++ b/ui-tui/src/config/timing.ts
@@ -3,6 +3,11 @@ export const STREAM_IDLE_BATCH_MS = 16
 export const STREAM_SCROLL_BATCH_MS = 96
 export const STREAM_TYPING_BATCH_MS = 80
 export const TYPING_IDLE_MS = 250
+
+// Incoming chat rows reflow the composer. A leftover CR from that redraw
+// can look like Enter. Hold user-submit this long so a new message can't
+// fire the half-finished draft. Voice/slash/billing do not use this path.
+export const COMPOSER_SUBMIT_LOCK_MS = 120
 export const REASONING_PULSE_MS = 700
 
 // A drag-resize fires a burst of SIGWINCH events (one per pixel step in some


### PR DESCRIPTION
## What does this PR do?

Incoming TUI transcript rows (assistant reply, interim bubble, bg/btw notice, review summary) were sending whatever the user still had in the composer.

Two paths:

1. **Queue auto-drain.** Default `busyInputMode` is `queue` until config hydrates. Enter-while-busy parks a fragment, then `busy → false` (a message landing) dequeues and sends it even if the user is still typing the rest.
2. **Spurious Enter.** Those rows reflow/remount the composer. A leftover CR can look like Return and call `TextInput` `onSubmit` with the live draft.

This is not voice. Voice `submit_mode: draft` is unrelated; voice/slash/billing still go through `submitRef` and are not locked.

The fix:

- Skip queue auto-drain while the composer still has unsent text (empty composer still drains as before).
- Lock user-Enter submit for 120ms after `message.start`, `message.complete`, `message.interim`, `background.complete`, `btw.complete`, and `review.summary` (`message.delta` and `voice.transcript` are not locked).

## Related Issue

No existing issue. Closest open PR is #46342 (preserve draft on prompt-overlay unmount), which is a different failure mode.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/app/composerSubmitGuard.ts` — `lockComposerSubmit`, `isComposerSubmitLocked`, `hasComposerDraft`, `shouldDrainQueuedFollowUp`
- `ui-tui/src/config/timing.ts` — `COMPOSER_SUBMIT_LOCK_MS = 120`
- `ui-tui/src/app/createGatewayEventHandler.ts` — lock on incoming transcript-row events
- `ui-tui/src/app/useMainApp.ts` — skip auto-drain while the composer has unsent text
- `ui-tui/src/components/appLayout.tsx` — ignore `TextInput` submit while locked (keeps the draft)
- `ui-tui/README.md` — auto-drain also skipped when the composer still has unsent text
- `ui-tui/src/__tests__/composerSubmitGuard.test.ts` — unit coverage for the lock, draft detection, and drain guard
- `ui-tui/src/__tests__/createGatewayEventHandler.test.ts` — reset the lock between cases

## How to Test

1. `hermes --tui`. Send a prompt so a turn is running.
2. Type a half-finished follow-up in the composer. Do not mean to send it.
3. When the assistant reply (or an interim / bg / btw row) lands, the draft should stay in the composer.
4. Clear the composer, queue a follow-up with Enter-while-busy, and let the turn finish: the queued item should still auto-drain.
5. After the 120ms lock, Enter should still submit normally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Arch Linux (kernel 7.1.9-arch1-2)

Python `pytest tests/ -q` is N/A for this TUI-only TypeScript change. JS CI path:

```bash
cd ui-tui
npx vitest run src/__tests__/composerSubmitGuard.test.ts src/__tests__/createGatewayEventHandler.test.ts src/__tests__/textInputSubmitClear.test.tsx
# 3 files, 114 tests passed

npx tsc --noEmit -p tsconfig.json
# passed

npx eslint src/app/composerSubmitGuard.ts src/__tests__/composerSubmitGuard.test.ts src/app/createGatewayEventHandler.ts src/app/useMainApp.ts src/components/appLayout.tsx src/config/timing.ts src/__tests__/createGatewayEventHandler.test.ts
# passed
```

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

No new config keys. Ink composer path is shared across Linux/macOS/Windows terminals.

## Screenshots / Logs

Hit this live in `hermes --tui`: an incoming chat row submitted a half-typed composer draft. Not voice.

Made with [Cursor](https://cursor.com)