### PR TITLE
fix(tools): reload permanent allowlist by replacement

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -569,6 +569,26 @@ class TestPatternKeyUniqueness:
             assert is_approved("legacy-find", key_delete) is True
 
 
+class TestPermanentAllowlistReload:
+    def test_load_permanent_replaces_stale_entries(self):
+        with mock_patch.object(approval_module, "_permanent_approved", set()):
+            load_permanent({"old-pattern"})
+            assert is_approved("reload", "old-pattern") is True
+
+            load_permanent({"new-pattern"})
+
+            assert is_approved("reload", "old-pattern") is False
+            assert is_approved("reload", "new-pattern") is True
+
+    def test_load_permanent_allowlist_clears_when_config_is_empty(self):
+        with mock_patch.object(approval_module, "_permanent_approved", {"stale-pattern"}):
+            with mock_patch("hermes_cli.config.load_config_readonly", return_value={"command_allowlist": []}):
+                assert approval_module.load_permanent_allowlist() == set()
+
+            assert approval_module._permanent_approved == set()
+            assert is_approved("reload", "stale-pattern") is False
+
+
 class TestFullCommandAlwaysShown:
     """The full command is always shown in the approval prompt (no truncation).
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -3062,6 +3062,7 @@ def approve_permanent(pattern_key: str):
 def load_permanent(patterns: set):
     """Bulk-load permanent allowlist entries from config."""
     with _lock:
+        _permanent_approved.clear()
         _permanent_approved.update(patterns)
 
 
@@ -3186,8 +3187,7 @@ def load_permanent_allowlist() -> set:
         from hermes_cli.config import load_config_readonly
         config = load_config_readonly()
         patterns = set(config.get("command_allowlist", []) or [])
-        if patterns:
-            load_permanent(patterns)
+        load_permanent(patterns)
         return patterns
     except Exception as e:
         logger.warning("Failed to load permanent allowlist: %s", e)


### PR DESCRIPTION
## Summary
- reload the in-memory permanent allowlist by replacement instead of merge
- clear stale approvals when `command_allowlist` becomes empty
- add regression coverage for both stale-entry replacement and revoke-all reloads

## Testing
- `scripts/run_tests.sh tests/tools/test_approval.py -q -k 'TestPermanentAllowlistReload or test_legacy_find_key_still_approves_both_variants'`
- `scripts/run_tests.sh tests/tools/test_approval.py -q` *(currently fails on an unrelated pre-existing assertion in `TestDetectDangerousRm.test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`)*

Closes #101741.
