### PR TITLE
fix(desktop): prevent remote updates from breaking agent startup

### DIFF
--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -8,7 +8,7 @@ import { SearchField } from '@/components/ui/search-field'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { ResponsiveTabs } from '@/components/ui/tab-dropdown'
 import { Tip } from '@/components/ui/tooltip'
-import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway, updateHermes } from '@/hermes'
+import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway } from '@/hermes'
 import type { ActionStatusResponse, AnalyticsResponse, SessionInfo, StatusResponse } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
@@ -31,6 +31,7 @@ import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $sessions, sessionPinId } from '@/store/session'
+import { startActiveUpdate } from '@/store/updates'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -264,11 +265,11 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   }, [logQuery, logs])
 
   const runSystemAction = useCallback(
-    async (kind: 'restart' | 'update') => {
+    async () => {
       setSystemError('')
 
       try {
-        const started = kind === 'restart' ? await restartGateway() : await updateHermes()
+        const started = await restartGateway()
         let nextStatus: ActionStatusResponse | null = null
 
         for (let attempt = 0; attempt < 18; attempt += 1) {
@@ -442,10 +443,10 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                         </div>
                       </div>
                       <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 whitespace-nowrap max-[47.5rem]:whitespace-normal">
-                        <Button onClick={() => void runSystemAction('restart')} size="xs" variant="text">
+                        <Button onClick={() => void runSystemAction()} size="xs" variant="text">
                           {cc.restartGateway}
                         </Button>
-                        <Button onClick={() => void runSystemAction('update')} size="xs" variant="textStrong">
+                        <Button onClick={() => startActiveUpdate('backend')} size="xs" variant="textStrong">
                           {cc.updateHermes}
                         </Button>
                       </div>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -788,6 +788,75 @@ describe('client nudge after a backend update', () => {
   })
 })
 
+describe('managed SSH backend update', () => {
+  const updateManagedMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    reconnectGatewaySpy.mockClear()
+    updateHermesSpy.mockReset()
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    updateManagedMock.mockReset().mockResolvedValue({
+      connectionId: 'homelab',
+      correlationId: '12345678-1234-4678-9234-567812345678',
+      message: 'Updated and restored 1 SSH scope.',
+      ok: true,
+      outcome: 'success',
+      receipt: null,
+      restoreOk: true,
+      scopes: [{ profile: 'default', restored: true }],
+      updateOk: true
+    })
+    resetUpdateApplyState()
+    $backendUpdateStatus.set(status({ behind: 1 }))
+    $mockConnectionsRegistry.set({
+      version: 2,
+      primary: 'homelab',
+      secureTokenStorage: true,
+      connections: [{ id: 'homelab', kind: 'ssh', label: 'Homelab', host: 'box' }]
+    })
+    setConnection({
+      baseUrl: 'http://127.0.0.1:9119',
+      connectionId: 'homelab',
+      isFullscreen: false,
+      logs: [],
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      windowButtonPosition: null,
+      wsUrl: 'ws://127.0.0.1:9119'
+    })
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { connections: { updateManaged: updateManagedMock } }
+    }
+  })
+
+  afterEach(() => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(null)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('drains and restores the active isolated backend instead of updating through the stale serve', async () => {
+    const result = await applyBackendUpdate()
+
+    expect(result.ok).toBe(true)
+    expect(updateManagedMock).toHaveBeenCalledWith('homelab')
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect(reconnectGatewaySpy).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('applyUpdates terminal state', () => {
   const applyMock = vi.fn()
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -19,6 +19,7 @@ import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connections'
 import { reconnectGateway } from '@/store/gateway-reconnect'
+import { runManagedUpdate } from '@/store/managed-updates'
 import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
@@ -658,6 +659,24 @@ function legacyBackendReachedTarget(
 
 let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
 
+async function activeManagedSshConnectionId(): Promise<string | null> {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const connectionId = $connection.get()?.connectionId
+  const updateManaged = window.hermesDesktop?.connections?.updateManaged
+
+  if (!connectionId || !updateManaged) {
+    return null
+  }
+
+  const registry = $connectionsRegistry.get() ?? (await refreshConnectionsRegistry().catch(() => null))
+  const connection = registry?.connections.find(entry => entry.id === connectionId)
+
+  return connection?.kind === 'ssh' ? connectionId : null
+}
+
 async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
@@ -668,6 +687,27 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   })
 
   try {
+    const managedConnectionId = await activeManagedSshConnectionId()
+
+    if (managedConnectionId) {
+      const managed = await runManagedUpdate(managedConnectionId)
+
+      if (managed.status === 'updated') {
+        return finishBackendApply(true)
+      }
+
+      const message = managed.message || translateNow('updates.applyStatus.failed')
+      $backendUpdateApply.set({
+        ...$backendUpdateApply.get(),
+        applying: false,
+        stage: 'error',
+        error: 'apply-failed',
+        message
+      })
+
+      return { ok: false, error: 'apply-failed', message }
+    }
+
     const previousStatus = $backendUpdateStatus.get()
     const requestedTargetSha = previousStatus?.commits?.at(0)?.sha
 


### PR DESCRIPTION
## What does this PR do?

Remote Desktop sessions now update Desktop-managed SSH backends through the existing transactional drain/update/restore lifecycle. This prevents the active `hermes serve --isolated` process from surviving an update with stale Python modules while newer code is written beneath it.

### Symptom

After updating a remote Hermes checkout from Desktop, later agent initialization can fail with `cannot import name '_read_text_with_timeout' from 'agent.prompt_builder'`, even though the symbol exists in the clean checkout on disk.

### Impact

Windows Desktop users connected to a Linux backend over managed SSH can lose the ability to initialize agents until the Desktop-owned isolated backend exits and is recreated.

### Bug Cause

**Trigger:** `apps/desktop/src/store/updates.ts` / `runBackendUpdate()` when the active connection is a registered SSH connection.

**Causal chain:**
1. An active-backend update affordance called `updateHermes()` through the currently running isolated backend.
2. The update replaced files in the remote checkout, but the Desktop-owned isolated serve was outside the system-service restart set and retained old modules in `sys.modules`.
3. A later agent initialization combined those stale modules with newly loaded files and failed imports.

**Why it is wrong:** The renderer bypassed the managed SSH update bridge that owns the isolated process lifecycle, so a file update did not imply a runtime recycle.

**Working sibling / contrast:** The Managed Updates section and connection fan-out already use `connections.updateManaged()`, which gates dials, drains exact Desktop-owned scopes, performs the update externally, and restores those scopes.

**Ruled out:** The reported checkout was clean and contained the missing symbol; recycling only the Desktop-owned isolated backend restored operation without modifying source files.

### Fix

Detect when the active backend is a registered Desktop-managed SSH connection and delegate its update to `runManagedUpdate()`. The Command Center backend update button now enters the same central update flow instead of calling the stale backend API directly. A regression test proves that managed SSH selects `connections.updateManaged()`, bypasses `updateHermes()`, and reconnects after restoration.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/updates.ts` - route the active managed SSH backend through transactional update orchestration.
- `apps/desktop/src/store/updates.test.ts` - cover selection of the managed lifecycle and rejection of the stale-serve path.
- `apps/desktop/src/app/command-center/index.tsx` - use the central backend update entry point.

## How to Test

1. Configure Desktop with an active registered SSH connection.
2. Start a backend update and verify the managed SSH bridge drains and restores the isolated scope.
3. Run the focused renderer tests, lint, and TypeScript checks:

```bash
cd apps/desktop
npx vitest run src/store/updates.test.ts src/app/command-center/delete-confirm.test.tsx
npx eslint src/store/updates.ts src/store/updates.test.ts src/app/command-center/index.tsx
npm run typecheck
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant Desktop test entry and all tests pass
- [x] I've added tests for my changes
- [x] I've tested the renderer logic on Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not applicable
- [x] Configuration example update is not applicable
- [x] Architecture guide update is not applicable
- [x] I've considered cross-platform impact; the renderer selection is platform-neutral
- [x] Tool description/schema updates are not applicable

## Screenshots / Logs

Not applicable; this fixes backend lifecycle selection and is covered by behavior tests.
