### PR TITLE
fix(desktop): set MSYS path-conversion guards in embedded terminal

### DIFF
--- a/apps/desktop/electron/terminal-ipc.ts
+++ b/apps/desktop/electron/terminal-ipc.ts
@@ -14,6 +14,7 @@ import { resolveTerminalConnectionForSender } from './connection-apply'
 import { ensureSpawnHelperExecutable } from './spawn-helper-perms'
 import { buildInteractiveSshArgs } from './ssh-connection'
 import { createTerminalOutputGate } from './terminal-output-gate'
+import { applyWindowsMsysBashEnvDefaults } from './windows-msys-bash-env'
 import { buildWindowsInteractiveCommand } from './windows-remote-lifecycle'
 
 export interface TerminalIpcDeps {
@@ -166,7 +167,7 @@ export function registerTerminalIpc({
     // which marks the agent *backend* and gates cron/gateway behavior.
     env.HERMES_DESKTOP_TERMINAL = '1'
 
-    return env
+    return applyWindowsMsysBashEnvDefaults(env, isWindows)
   }
 
   function terminalChannel(id, suffix) {

--- a/apps/desktop/electron/windows-msys-bash-env.test.ts
+++ b/apps/desktop/electron/windows-msys-bash-env.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { applyWindowsMsysBashEnvDefaults } from './windows-msys-bash-env'
+
+test('applyWindowsMsysBashEnvDefaults sets both MSYS opt-outs on Windows when unset', () => {
+  const env: NodeJS.ProcessEnv = { FOO: 'bar' }
+  const result = applyWindowsMsysBashEnvDefaults(env, true)
+
+  assert.equal(result, env)
+  assert.equal(env.MSYS_NO_PATHCONV, '1')
+  assert.equal(env.MSYS2_ARG_CONV_EXCL, '*')
+  assert.equal(env.FOO, 'bar')
+})
+
+test('applyWindowsMsysBashEnvDefaults preserves an existing MSYS_NO_PATHCONV on Windows', () => {
+  const env: NodeJS.ProcessEnv = { MSYS_NO_PATHCONV: '0' }
+  applyWindowsMsysBashEnvDefaults(env, true)
+
+  assert.equal(env.MSYS_NO_PATHCONV, '0')
+  assert.equal(env.MSYS2_ARG_CONV_EXCL, '*')
+})
+
+test('applyWindowsMsysBashEnvDefaults preserves an existing MSYS2_ARG_CONV_EXCL on Windows', () => {
+  const env: NodeJS.ProcessEnv = { MSYS2_ARG_CONV_EXCL: '/custom' }
+  applyWindowsMsysBashEnvDefaults(env, true)
+
+  assert.equal(env.MSYS_NO_PATHCONV, '1')
+  assert.equal(env.MSYS2_ARG_CONV_EXCL, '/custom')
+})
+
+test('applyWindowsMsysBashEnvDefaults preserves both existing MSYS opt-outs on Windows', () => {
+  const env: NodeJS.ProcessEnv = { MSYS_NO_PATHCONV: '', MSYS2_ARG_CONV_EXCL: '/FO' }
+  applyWindowsMsysBashEnvDefaults(env, true)
+
+  assert.equal(env.MSYS_NO_PATHCONV, '')
+  assert.equal(env.MSYS2_ARG_CONV_EXCL, '/FO')
+})
+
+test('applyWindowsMsysBashEnvDefaults is a no-op off Windows', () => {
+  const env: NodeJS.ProcessEnv = { FOO: 'bar' }
+  const result = applyWindowsMsysBashEnvDefaults(env, false)
+
+  assert.equal(result, env)
+  assert.deepEqual(env, { FOO: 'bar' })
+})
+
+test('applyWindowsMsysBashEnvDefaults leaves existing MSYS opt-outs unchanged off Windows', () => {
+  const env: NodeJS.ProcessEnv = { MSYS_NO_PATHCONV: '0', MSYS2_ARG_CONV_EXCL: '/custom' }
+  applyWindowsMsysBashEnvDefaults(env, false)
+
+  assert.deepEqual(env, { MSYS_NO_PATHCONV: '0', MSYS2_ARG_CONV_EXCL: '/custom' })
+})
+
+test('applyWindowsMsysBashEnvDefaults defaults isWindows from process.platform when omitted', () => {
+  const env: NodeJS.ProcessEnv = {}
+  applyWindowsMsysBashEnvDefaults(env)
+
+  if (process.platform === 'win32') {
+    assert.equal(env.MSYS_NO_PATHCONV, '1')
+    assert.equal(env.MSYS2_ARG_CONV_EXCL, '*')
+  } else {
+    assert.equal(Object.hasOwn(env, 'MSYS_NO_PATHCONV'), false)
+    assert.equal(Object.hasOwn(env, 'MSYS2_ARG_CONV_EXCL'), false)
+  }
+})
+
+test('applyWindowsMsysBashEnvDefaults does not throw on a shallow clone of process.env', () => {
+  assert.doesNotThrow(() => {
+    applyWindowsMsysBashEnvDefaults({ ...process.env }, true)
+  })
+})

--- a/apps/desktop/electron/windows-msys-bash-env.ts
+++ b/apps/desktop/electron/windows-msys-bash-env.ts
@@ -1,0 +1,20 @@
+// Git Bash/MSYS rewrite slash-prefixed native flags (`/FI`) into paths.
+// Set these two opt-outs on Windows unless already present.
+export function applyWindowsMsysBashEnvDefaults(
+  env: NodeJS.ProcessEnv,
+  isWindows: boolean = process.platform === 'win32'
+): NodeJS.ProcessEnv {
+  if (!isWindows) {
+    return env
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(env, 'MSYS_NO_PATHCONV')) {
+    env.MSYS_NO_PATHCONV = '1'
+  }
+
+  if (!Object.prototype.hasOwnProperty.call(env, 'MSYS2_ARG_CONV_EXCL')) {
+    env.MSYS2_ARG_CONV_EXCL = '*'
+  }
+
+  return env
+}


### PR DESCRIPTION
## What does this PR do?

On native Windows, the Desktop embedded terminal's Git Bash / MSYS2 PTY env did not set `MSYS_NO_PATHCONV` or `MSYS2_ARG_CONV_EXCL`. Slash-prefixed native flags such as `tasklist /FI` and `tasklist /FO` were rewritten into bogus paths (`C:/.../git/FI`) and the commands failed.

The Python `terminal` tool already setdefaults those two variables (`_apply_windows_msys_bash_env_defaults`, #57006 / #56700). This PR applies the same defaults in `terminalShellEnv()` so node-pty spawn matches that behavior. Existing user values are preserved.

## Related Issue

Fixes #101826

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/windows-msys-bash-env.ts` — dependency-free helper that setdefaults `MSYS_NO_PATHCONV=1` and `MSYS2_ARG_CONV_EXCL=*` on Windows; no-op off Windows; caller-supplied values kept
- `apps/desktop/electron/terminal-ipc.ts` — `terminalShellEnv()` applies the helper with the injected `isWindows` flag used by node-pty spawn
- `apps/desktop/electron/windows-msys-bash-env.test.ts` — injected-`isWindows` coverage for setdefault, overrides (including empty string), and the off-Windows no-op

## How to Test

1. On native Windows, open Hermes Desktop's embedded terminal, switch to bash, and run `tasklist /FO CSV` (or `tasklist /FI "IMAGENAME eq explorer.exe"`).
2. Before this change, Git Bash rewrites `/FO` / `/FI` (e.g. `ERROR: Invalid argument/option - 'C:/Program Files/Git/FO'`). After, the native flag is passed through.
3. Automated: `npm --prefix apps/desktop run test:desktop:platforms -- electron/windows-msys-bash-env.test.ts` — 8 passed.

Local repro (Git Bash without vs with the two env vars) confirmed the mangling and the opt-out on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this Desktop-only TypeScript change; Desktop suite is listed above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows-only env setdefault; no-op on other platforms
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Contract

- issue: NousResearch/hermes-agent#101826
- type: bug
- claim: Desktop embedded terminal PTY env on Windows setdefaults `MSYS_NO_PATHCONV` / `MSYS2_ARG_CONV_EXCL` unless the user already provided them
- evidence: https://github.com/NousResearch/hermes-agent/issues/101826 ; prior art https://github.com/NousResearch/hermes-agent/pull/57006
