### PR TITLE
fix(cron): inject previous response for continuity

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4759,6 +4759,26 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+def _declared_job_prompt(job: dict, *, extra_prompt: Optional[str] = None) -> str:
+    """Return the prompt declared on the job itself, without injected context."""
+    user_prompt = str(job.get("prompt") or "")
+    if extra_prompt:
+        user_prompt = f"{user_prompt}\n\n## Run Context\n{extra_prompt}"
+    return user_prompt
+
+
+def _extract_context_from_output_doc(raw_output: str) -> str:
+    """Return the previous response body from a cron output doc when present."""
+    text = str(raw_output or "").strip()
+    if not text:
+        return ""
+    parts = re.split(r"^## Response\s*$", text, maxsplit=1, flags=re.MULTILINE)
+    if len(parts) != 2:
+        return text
+    response = parts[1].strip()
+    return response or text
+
+
 def _build_job_prompt(
     job: dict,
     prerun_script: Optional[tuple] = None,
@@ -4778,9 +4798,7 @@ def _build_job_prompt(
             stored prompt under a ``## Run Context`` header for this single
             fire only — never persisted to the job definition.
     """
-    user_prompt = str(job.get("prompt") or "")
-    if extra_prompt:
-        user_prompt = f"{user_prompt}\n\n## Run Context\n{extra_prompt}"
+    user_prompt = _declared_job_prompt(job, extra_prompt=extra_prompt)
     prompt = user_prompt
     skills = job.get("skills")
     # True when runtime-collected DATA (script stdout, upstream-job output)
@@ -4858,7 +4876,9 @@ def _build_job_prompt(
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_context_from_output_doc(
+                    output_files[0].read_text(encoding="utf-8")
+                ).strip()
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:
@@ -6024,6 +6044,7 @@ def run_job(
             )
             return True, silent_doc, SILENT_MARKER, None
 
+    declared_prompt = _declared_job_prompt(job, extra_prompt=extra_prompt)
     try:
         prompt = _build_job_prompt(
             job, prerun_script=prerun_script, extra_prompt=extra_prompt
@@ -7002,7 +7023,7 @@ def run_job(
 
 ## Prompt
 
-{prompt}
+{declared_prompt}
 
 ## Response
 
@@ -7059,7 +7080,7 @@ def run_job(
 
 ## Prompt
 
-{prompt}
+{declared_prompt}
 
 ## Error
 

--- a/tests/cron/test_cron_context_from.py
+++ b/tests/cron/test_cron_context_from.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -287,6 +288,28 @@ class TestSelfContext:
         assert "prev output" in prompt
         assert "previous run" in prompt.lower()
 
+    def test_self_prefers_previous_response_section(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(
+            prompt="Summarize what changed", schedule="every 1h", context_from="self"
+        )
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            "# Cron Job: nested\n\n"
+            "## Prompt\n\n"
+            "PROMPT-NESTING-SHOULD-NOT-REAPPEAR\n\n"
+            "## Response\n\n"
+            "carry forward only this response",
+            encoding="utf-8",
+        )
+
+        prompt = _build_job_prompt(job)
+        assert "carry forward only this response" in prompt
+        assert "PROMPT-NESTING-SHOULD-NOT-REAPPEAR" not in prompt
+
     def test_tool_create_accepts_self(self, cron_env):
         from tools.cronjob_tools import cronjob
         from cron.jobs import get_job
@@ -315,6 +338,54 @@ class TestSelfContext:
         ))
         assert result["success"] is True
         assert get_job(job["id"])["context_from"] == ["self"]
+
+
+class TestRunJobContinuityOutput:
+    def test_output_doc_keeps_declared_prompt_not_augmented_context(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import run_job
+
+        job = create_job(
+            prompt="Summarize what changed", schedule="every 1h", context_from="self"
+        )
+        out_dir = OUTPUT_DIR / job["id"]
+        out_dir.mkdir(parents=True, exist_ok=True)
+        (out_dir / "2026-08-01_10-00-00.md").write_text(
+            "# Cron Job: previous\n\n"
+            "## Prompt\n\n"
+            "OLD-PROMPT-SHOULD-NOT-BE-RECORDED\n\n"
+            "## Response\n\n"
+            "previous response context",
+            encoding="utf-8",
+        )
+
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        mock_agent = MagicMock()
+        mock_agent.run_conversation.return_value = {"final_response": "fresh response"}
+
+        with patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.get_shared_session_db", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("tools.mcp_tool.discover_mcp_tools", return_value=[]), \
+             patch("run_agent.AIAgent", return_value=mock_agent):
+            success, output, final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        assert final_response == "fresh response"
+        assert "## Prompt\n\nSummarize what changed" in output
+        assert "OLD-PROMPT-SHOULD-NOT-BE-RECORDED" not in output
 
 
 class TestContinuityFlag:
@@ -438,5 +509,4 @@ class TestContinuityFlag:
         prompt = _build_job_prompt(job)
         assert "Reported: story A" in prompt
         assert "previous run" in prompt.lower()
-
 


### PR DESCRIPTION
## Summary
- inject the latest `## Response` body for `context_from` / `--continuity` instead of the whole prior output document
- keep backwards compatibility for old plain-text output files by falling back to their raw contents
- record the declared prompt in cron output docs so future runs do not re-nest injected context

## Testing
- `HERMES_PYTHON=/Users/bytedance/Documents/trae_projects/repostew/hermes-agent-audit/.venv/bin/python scripts/run_tests.sh tests/cron/test_cron_context_from.py -q -k 'self_prefers_previous_response_section or output_doc_keeps_declared_prompt_not_augmented_context'`

Closes #101623.
