### PR TITLE
fix(desktop): keep Windows absolute paths intact in local preview targets

### DIFF
--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -169,6 +169,34 @@ describe('remote HTML previews', () => {
   })
 })
 
+describe('Windows preview targets', () => {
+  it('keeps Windows drive-letter paths absolute instead of joining the cwd', () => {
+    expect(localPreviewTarget('C:\\Users\\someone\\notes\\spec.md', 'C:\\Users\\someone')).toMatchObject({
+      path: 'C:\\Users\\someone\\notes\\spec.md',
+      language: 'markdown',
+      previewKind: 'text'
+    })
+  })
+
+  it('keeps lower-case Windows drive-letter paths absolute', () => {
+    expect(localPreviewTarget('c:/users/someone/notes/spec.md', 'C:\\Users\\someone')).toMatchObject({
+      path: 'c:/users/someone/notes/spec.md'
+    })
+  })
+
+  it('keeps UNC share paths absolute', () => {
+    expect(localPreviewTarget('\\\\server\\share\\spec.md', 'C:\\Users\\someone')).toMatchObject({
+      path: '\\\\server\\share\\spec.md'
+    })
+  })
+
+  it('still resolves relative paths against the cwd', () => {
+    expect(localPreviewTarget('notes/spec.md', 'C:\\Users\\someone')).toMatchObject({
+      path: 'C:\\Users\\someone/notes/spec.md'
+    })
+  })
+})
+
 describe('PDF previews', () => {
   it('classifies PDF files as PDF previews', () => {
     expect(localPreviewTarget('/tmp/spec.pdf')).toMatchObject({

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -197,7 +197,7 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
     } catch {
       path = raw.replace(/^file:\/\//i, '')
     }
-  } else if (!raw.startsWith('/') && cwd) {
+  } else if (!raw.startsWith('/') && !/^[a-z]:[/\\]/i.test(raw) && !raw.startsWith('\\\\') && cwd) {
     path = joinPath(cwd, raw)
   }
 


### PR DESCRIPTION
## Problem

`localPreviewTarget` only treats paths starting with `/` as absolute. On Windows, a drive-letter path like `C:\...` or a UNC path like `\\server\share` does not start with `/`, so the renderer-side fallback joins them onto the `cwd`, producing a doubled path. Example:

```
C:\Users\<user>/C:\Users\<user>\AppData\... (broken)
```

This is the fallback used when the Electron IPC `normalizePreviewTarget` does not produce a target (returns null / no bridge / error). When that happens on Windows, the preview cannot load the file.

## Fix

Add a check for Windows drive-letter (`/^[a-z]:[/\\]/i`) and UNC (`\\`) prefixes alongside the existing `/` check. Relative paths still resolve against the `cwd` as before.

## Verification

- 4 new unit tests covering Windows drive-letter, lower-case, UNC, and relative paths
- Existing 17 tests still pass (21 total)
- Reproduced the original broken URL from the observed doubled tab path and confirmed the fix produces the correct single path

## Related

- Test file: `apps/desktop/src/lib/local-preview.test.ts`