### PR TITLE
fix(agent): resolve profile name from symlink-farm overlay homes

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -270,14 +270,84 @@ def raise_if_read_blocked(path: str) -> None:
         raise ValueError(blocked)
 
 
+def _profile_name_from_overlay_links(home: Path, root: Path) -> Optional[str]:
+    """Recover a profile name from a symlink-farm overlay HERMES_HOME (#93862).
+
+    Multi-agent orchestrators isolate sessions/logs in a per-task directory
+    while sharing a named profile's content via symlinks (SOUL.md,
+    plugins/, cron/, ... -> ``<root>/profiles/<name>/...``). Such a home is
+    neither the root nor ``<root>/profiles/<name>``, so path-prefix
+    derivation reports "default". Readlink the well-known members instead
+    and recover the ``profiles/<name>`` segment from their targets.
+
+    Candidates are anchored on both the resolved root and the
+    platform-native home: for an overlay HERMES_HOME,
+    ``get_default_hermes_root()`` returns the overlay itself, while the
+    link targets live under the native root's ``profiles/``.
+
+    Returns None when no member points into a named profile, or when members
+    disagree (a mixed farm names no single profile) — callers fall back to
+    "default". Never raises.
+    """
+    try:
+        from hermes_constants import _get_platform_default_hermes_home
+
+        native_home = _get_platform_default_hermes_home()
+    except Exception:
+        native_home = None
+    candidates: list[Path] = []
+    for base in (root, native_home):
+        if base is None:
+            continue
+        try:
+            profiles_dir = base.resolve() / "profiles"
+        except (OSError, RuntimeError):
+            continue
+        if profiles_dir not in candidates:
+            candidates.append(profiles_dir)
+    if not candidates:
+        return None
+    members = ("SOUL.md", "skills", "plugins", "cron", "hooks", "memories", "sessions")
+    names: list[str] = []
+    for member in members:
+        try:
+            target = home / member
+            if not target.is_symlink():
+                continue
+            resolved = target.resolve()
+        except (OSError, RuntimeError):
+            continue
+        for profiles_dir in candidates:
+            try:
+                rel = resolved.relative_to(profiles_dir)
+            except ValueError:
+                continue
+            if rel.parts:
+                names.append(rel.parts[0])
+            break
+    if names and len(set(names)) == 1:
+        return names[0]
+    return None
+
+
 def _resolve_active_profile_name() -> str:
     """Active profile name from HERMES_HOME: ``~/.hermes`` -> ``"default"``,
-    ``~/.hermes/profiles/X`` -> ``"X"``; ``"default"`` on any resolution failure."""
+    ``~/.hermes/profiles/X`` -> ``"X"``; overlay farm into profiles/X -> ``"X"``
+    (see :func:`_profile_name_from_overlay_links`); ``"default"`` on any
+    resolution failure."""
     try:
-        parts = _hermes_home_path().resolve().relative_to(_hermes_root_path().resolve() / "profiles").parts
-    except (OSError, RuntimeError, ValueError):
+        home = _hermes_home_path()
+        home_real = home.resolve()
+        root_real = _hermes_root_path().resolve()
+    except (OSError, RuntimeError):
         return "default"
-    return parts[0] if parts else "default"
+    try:
+        parts = home_real.relative_to(root_real / "profiles").parts
+        if parts:
+            return parts[0]
+    except ValueError:
+        pass
+    return _profile_name_from_overlay_links(home, root_real) or "default"
 
 
 # --- Sandbox-mirror write guard ---

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -257,15 +257,26 @@ def _agent_skills_dir(agent: Any) -> Optional[Path]:
 
 
 def _profile_name_for_home(home: Path) -> str:
-    """``<root>/profiles/X`` -> ``"X"``; anything else -> ``"default"``.
+    """``<root>/profiles/X`` -> ``"X"``; a symlink-farm overlay into
+    ``<root>/profiles/X`` -> ``"X"`` (#93862); anything else -> ``"default"``.
     Uses ``get_default_hermes_root()`` (NOT ``get_hermes_home()``): on a bound
     profile session the ambient home IS the profile dir, so every profile
     would misreport as "default"."""
     try:
         from hermes_constants import get_default_hermes_root
-        rel = home.resolve().relative_to((get_default_hermes_root() / "profiles").resolve())
+        root = get_default_hermes_root()
+    except Exception:
+        return "default"
+    try:
+        rel = home.resolve().relative_to((root / "profiles").resolve())
         return rel.parts[0] if rel.parts else "default"
     except (ValueError, OSError):
+        pass
+    try:
+        from agent.file_safety import _profile_name_from_overlay_links
+
+        return _profile_name_from_overlay_links(home, root) or "default"
+    except Exception:
         return "default"
 
 

--- a/tests/agent/test_overlay_profile_name.py
+++ b/tests/agent/test_overlay_profile_name.py
@@ -1,0 +1,90 @@
+"""Regression: symlink-farm overlay HERMES_HOME resolves its profile (#93862).
+
+Multi-agent orchestrators isolate sessions/logs in a per-task directory while
+sharing a named profile's content via symlinks (SOUL.md, plugins/, cron/ ->
+``<root>/profiles/<name>/...``). Such a home is neither the root nor
+``<root>/profiles/<name>``, so both resolvers reported "default".
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _make_farm(tmp_path: Path, monkeypatch, name: str = "evaluator"):
+    """Build native root + named profile + overlay farm; bind HERMES_HOME."""
+    home_parent = tmp_path / "home"
+    native = home_parent / ".hermes"
+    profile = native / "profiles" / name
+    (profile / "plugins").mkdir(parents=True)
+    (profile / "cron").mkdir(parents=True)
+    (profile / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+    overlay = tmp_path / "overlay"
+    overlay.mkdir()
+    for member in ("SOUL.md", "plugins", "cron"):
+        (overlay / member).symlink_to(
+            profile / member, target_is_directory=(member != "SOUL.md")
+        )
+    monkeypatch.setattr(Path, "home", lambda: home_parent)
+    monkeypatch.setenv("HERMES_HOME", str(overlay))
+    # hermes_constants memoizes the root on (native, env) — distinct tmp
+    # paths per test keep the memo key fresh without manual resets.
+    return native, profile, overlay
+
+
+def test_profile_name_for_home_overlay(tmp_path, monkeypatch):
+    from agent import system_prompt
+
+    _, _, overlay = _make_farm(tmp_path, monkeypatch)
+    assert system_prompt._profile_name_for_home(overlay) == "evaluator"
+
+
+def test_resolve_active_profile_name_overlay(tmp_path, monkeypatch):
+    from agent.file_safety import _resolve_active_profile_name
+
+    _make_farm(tmp_path, monkeypatch)
+    assert _resolve_active_profile_name() == "evaluator"
+
+
+def test_overlay_mixed_farm_falls_back_to_default(tmp_path, monkeypatch):
+    from agent import system_prompt
+    from agent.file_safety import (
+        _resolve_active_profile_name,
+        _profile_name_from_overlay_links,
+    )
+    from hermes_constants import get_default_hermes_root
+
+    native, _, overlay = _make_farm(tmp_path, monkeypatch, name="one")
+    other = native / "profiles" / "two"
+    (other / "plugins").mkdir(parents=True)
+    (overlay / "plugins").unlink()
+    (overlay / "plugins").symlink_to(other / "plugins", target_is_directory=True)
+    root = get_default_hermes_root()
+    assert _profile_name_from_overlay_links(overlay, root) is None
+    assert system_prompt._profile_name_for_home(overlay) == "default"
+    assert _resolve_active_profile_name() == "default"
+
+
+def test_plain_dir_still_default(tmp_path, monkeypatch):
+    from agent import system_prompt
+    from agent.file_safety import _resolve_active_profile_name
+
+    home_parent = tmp_path / "home"
+    monkeypatch.setattr(Path, "home", lambda: home_parent)
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(plain))
+    assert system_prompt._profile_name_for_home(plain) == "default"
+    assert _resolve_active_profile_name() == "default"
+
+
+def test_real_profile_dir_unchanged(tmp_path, monkeypatch):
+    from agent import system_prompt
+    from agent.file_safety import _resolve_active_profile_name
+
+    native, profile, _ = _make_farm(tmp_path, monkeypatch)
+    monkeypatch.setenv("HERMES_HOME", str(profile))
+    assert system_prompt._profile_name_for_home(profile) == "evaluator"
+    assert _resolve_active_profile_name() == "evaluator"
+    assert os.environ["HERMES_HOME"] == str(profile)


### PR DESCRIPTION
## What does this PR do?

When `HERMES_HOME` is a symlink-farm overlay (per-task isolation dir whose
`SOUL.md`/`plugins/`/`cron/` are symlinks into `<root>/profiles/<name>/`),
both profile-name resolvers reported `default`: the home is neither the root
nor `<root>/profiles/<name>`, so path-prefix derivation gave up. The agent
then conflated the overlay session with the default profile in its system
prompt, and the cross-profile tool guard misattributed the active profile.

New shared helper `agent/file_safety._profile_name_from_overlay_links()`
readlinks the well-known members and recovers the `profiles/<name>` segment
from their targets (anchored on both the resolved root and the
platform-native home, since an overlay home makes `get_default_hermes_root()`
return the overlay itself). Mixed farms (members disagree) and plain dirs
still resolve to `default`; the helper never raises. Both
`_resolve_active_profile_name()` and `system_prompt._profile_name_for_home()`
use it as a fallback, keeping the single derivation both surfaces share.

## Related Issue

Fixes #93862

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/file_safety.py`: new `_profile_name_from_overlay_links()` + fallback
  wiring in `_resolve_active_profile_name()`.
- `agent/system_prompt.py`: `_profile_name_for_home()` falls back to the
  shared helper (also fixes unbound-`root` edge when the root lookup fails).
- `tests/agent/test_overlay_profile_name.py`: 5 tests — overlay resolves via
  both entry points, mixed farm → default, plain dir → default, real profile
  dir unchanged.

## How to Test

1. `pytest tests/agent/test_overlay_profile_name.py -q` — 5/5 pass.
2. Regression proof: with the production changes stashed, the overlay tests
   fail (both resolvers return `default`); with the fix they pass.
3. Neighboring suites green: `test_profile_home_override_precedence.py`,
   `test_cross_profile_guard.py`, `test_file_safety_cross_profile.py`
   (24 passed).
4. `scripts/check.sh --project hermes-agent --worktree worktrees/hermes-agent/93862`
   — all blocking gates passed.
5. Manual shape from the issue: named profile + overlay farm of symlinks →
   prompt reports the profile name instead of `default`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (changed-area: 5/5 + 24 neighboring via `scripts/check.sh`; full ~17k suite runs in CI per profile Resources & cleanup)
- [x] I've added tests for my changes (5 new regression tests, positive tests fail on base)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper + resolver docstrings cover the overlay contract; no user docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A (no config change)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pathlib readlink/relative_to only; no platform branches; symlink tests use target_is_directory for Windows)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
5 passed — tests/agent/test_overlay_profile_name.py
24 passed — neighboring profile/guard suites
✓ All blocking gates passed. (scripts/check.sh)
```