### PR TITLE
fix(desktop): three Windows SSH remote probe/spawn failures found on a live host

### DIFF
--- a/apps/desktop/electron/windows-remote-lifecycle.ts
+++ b/apps/desktop/electron/windows-remote-lifecycle.ts
@@ -63,7 +63,7 @@ async function probeWindowsRemote(ssh, explicitHermesPath = '') {
     '$python=[IO.Path]::Combine([IO.Path]::GetDirectoryName($hermes), "python.exe")',
     'Assert-NoReparse $python $false',
     '[ordered]@{os="Windows";arch=$env:PROCESSOR_ARCHITECTURE;hermesHome=$hermesHome;hermesPath=$hermes;python=$python}|ConvertTo-Json -Compress'
-  ].join(';')
+  ].join('\n')
 
   return JSON.parse((await ssh.exec(powerShellCommand(script))).trim())
 }
@@ -97,9 +97,9 @@ public static class HermesMarkerNoFollow {
     '$parent=$item.Parent.FullName;if(-not $parent -or $parent -eq $current){break};$current=$parent;$first=$false',
     '}',
     '}',
-    `$home=${psLiteral(hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    `$hHome=${psLiteral(hermesHome)}`,
+    '$installRoot=$hHome',
+    '$parent=Split-Path -Parent $hHome',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$result="UNCERTAIN"',
@@ -127,7 +127,7 @@ public static class HermesMarkerNoFollow {
     '}',
     '}}catch [IO.FileNotFoundException]{$result="CLEAR"}catch{$result="UNCERTAIN"}finally{if($memory){$memory.Dispose()};if($stream){$stream.Dispose()}}',
     'Write-Output $result'
-  ].join(';')
+  ].join('\n')
 
   return powerShellCommand(script)
 }
@@ -252,9 +252,9 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
 
   const script = [
     '$ErrorActionPreference="Stop"',
-    `$home=${psLiteral(runtime.hermesHome)}`,
-    '$installRoot=$home',
-    '$parent=Split-Path -Parent $home',
+    `$hHome=${psLiteral(runtime.hermesHome)}`,
+    '$installRoot=$hHome',
+    '$parent=Split-Path -Parent $hHome',
     'if((Split-Path -Leaf $parent) -ieq "profiles"){$installRoot=Split-Path -Parent $parent}',
     '$marker=Join-Path $installRoot ".hermes-update-in-progress"',
     '$mutexPath=$marker+".mutex"',
@@ -277,13 +277,13 @@ function atomicWindowsSpawnCommand(runtime, reservation: any = {}) {
       : '  if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}',
     reservation.ownershipId
       ? `  $spawned=$spawnLines[-1]|ConvertFrom-Json; $lock=[ordered]@{schemaVersion=2;protocolVersion=1;ownershipId=${psLiteral(reservation.ownershipId)};spawnNonce=${psLiteral(reservation.spawnNonce)};pid=[int]$spawned.pid;creationTimeNs=[string]$spawned.creationTimeNs;port=0;profile=${psLiteral(reservation.profile)};hermesPath=${psLiteral(reservation.hermesPath)};hermesHome=${psLiteral(reservation.hermesHome)};tokenFingerprint=${psLiteral(reservation.tokenFingerprint)};startedAt=${psLiteral(reservation.startedAt)}}|ConvertTo-Json -Compress; ` +
-        `  & ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)} $lock|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
+        `  $lock|& ${helper('write-lock').map(psLiteral).join(' ')} ${psLiteral(reservation.ownershipId)}|Out-Null; if($LASTEXITCODE -ne 0){exit $LASTEXITCODE}; $spawnLines|Write-Output`
       : '',
     '  if([IO.File]::Exists($marker)){throw "remote update marker claimed during backend spawn"}',
     '}finally{try{$mutex.Unlock(0,1)}catch{};$mutex.Dispose()}'
   ]
     .filter(line => line !== '')
-    .join(';')
+    .join('\n')
 
   return powerShellCommand(script)
 }


### PR DESCRIPTION
## Summary

Desktop SSH to a real Windows remote (Windows 11, OpenSSH default shell `cmd.exe`, Windows PowerShell 5.1, zh-CN code page) failed at three independent points in `windows-remote-lifecycle.ts`. All three were reproduced on the live host and the fixes verified there end-to-end: platform probe returns the runtime JSON, the update-marker probe returns `CLEAR`, the atomic spawn writes a readable lockfile, and the Desktop app connects.

## The three bugs

### 1. `join(';')` splits try/catch across array elements

The scripts are built as arrays of one-line fragments joined with `;`. Any `try{...}` and its `catch` landing in separate elements become `try {...}; catch {...}` — a PowerShell **parse error** (`MissingCatchOrFinally`), not a runtime failure, so the whole EncodedCommand dies before executing anything. Joined with `'\n'` instead: a newline is a legal statement separator, and `}` followed by a newline followed by `catch` is a valid try/catch. The base64 EncodedCommand remains a single argv element, so this does not re-trigger the cmd.exe 8191-char limit.

### 2. Assigning the read-only `/Users/hahahexiaobai` automatic variable

The update-marker and spawn-wrapper scripts started with `='<path>'`. `/Users/hahahexiaobai` is a read-only automatic variable; under `='Stop'` the marker probe died immediately with `VariableNotWritable` before it could emit `CLEAR`, failing every Windows connect with "Could not prove that the remote Hermes install is clear for SSH startup". Renamed to `` at both sites.

### 3. Lock JSON passed as a native-command argument in `atomicWindowsSpawnCommand`

`& <python> -m hermes_cli.windows_ssh_runtime write-lock '<ownershipId>' $lock` — PowerShell 5.1 does not quote native argv, so the JSON's embedded double quotes shredded it into multiple broken tokens. The remote runtime received an invalid arity for `write-lock` and returned `{"error":"invalid operation"}`. Worse, the wrapper reported spawn failure **after** the backend had already started, so every connect attempt orphaned one `serve` process (observed: 65 orphans over ~10 minutes on the test host). Fixed by piping the lock JSON to write-lock's stdin — the contract `dispatch()` already implements for the main connect path's `helper(..., 'write-lock', [id], json)`.

## Verification

- Reproduced each failure against the live Windows host before fixing (probe: '命令行太长'/parse error/`VariableNotWritable`/`invalid operation`)
- After the fix: probe JSON ✓, marker `CLEAR` ✓, spawn writes lockfile readable via `read-lock` ✓, Desktop app connects and serves sessions ✓
- `vitest`: 320 passed across connection/ssh-lifecycle suites

## Related PRs

- #98515 moves these scripts over **stdin** to bypass the cmd.exe 8191-char limit — complementary transport fix; the script bodies themselves still hit bugs 1–3 as written there
- #99027 silences/tolerates CLIXML progress-stream noise on stderr — independent

