### PR TITLE
feat(model-picker): quick-switch /model allow-list + openrouter.show_all_models

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1814,6 +1814,7 @@ class GatewaySlashCommandsMixin:
         excluded_provs = []
         _explicit_only = True
         _picker_providers = None
+        _quick_switch_models = None
         config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
             cfg = _load_gateway_config(config_path=config_path)
@@ -1838,6 +1839,9 @@ class GatewaySlashCommandsMixin:
                 _pp = cfg.get("model_catalog", {}).get("picker_providers")
                 if isinstance(_pp, list) and _pp:
                     _picker_providers = [str(s) for s in _pp]
+                _qs = cfg.get("model_catalog", {}).get("quick_switch_models")
+                if isinstance(_qs, list) and _qs:
+                    _quick_switch_models = [str(s) for s in _qs]
         except Exception:
             pass
 
@@ -1884,6 +1888,7 @@ class GatewaySlashCommandsMixin:
                         excluded_providers=excluded_provs,
                         explicit_only=_explicit_only,
                         picker_providers=_picker_providers,
+                        quick_switch_models=_quick_switch_models,
                     )
                 except Exception:
                     providers = []
@@ -2199,6 +2204,7 @@ class GatewaySlashCommandsMixin:
                     excluded_providers=excluded_provs,
                     explicit_only=_explicit_only,
                     picker_providers=_picker_providers,
+                    quick_switch_models=_quick_switch_models,
                 )
                 for p in providers:
                     tag = t("gateway.model.current_tag") if p["is_current"] else ""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1812,8 +1812,6 @@ class GatewaySlashCommandsMixin:
         user_provs = None
         custom_provs = None
         excluded_provs = []
-        _explicit_only = True
-        _picker_providers = None
         _quick_switch_models = None
         config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
@@ -1833,12 +1831,6 @@ class GatewaySlashCommandsMixin:
                 _excl = cfg.get("model_catalog", {}).get("excluded_providers")
                 if isinstance(_excl, list):
                     excluded_provs = _excl
-                _explicit_only = bool(
-                    cfg.get("model_catalog", {}).get("explicit_only_pickers", True)
-                )
-                _pp = cfg.get("model_catalog", {}).get("picker_providers")
-                if isinstance(_pp, list) and _pp:
-                    _picker_providers = [str(s) for s in _pp]
                 _qs = cfg.get("model_catalog", {}).get("quick_switch_models")
                 if isinstance(_qs, list) and _qs:
                     _quick_switch_models = [str(s) for s in _qs]
@@ -1886,8 +1878,6 @@ class GatewaySlashCommandsMixin:
                         max_models=50,
                         include_moa=True,
                         excluded_providers=excluded_provs,
-                        explicit_only=_explicit_only,
-                        picker_providers=_picker_providers,
                         quick_switch_models=_quick_switch_models,
                     )
                 except Exception:
@@ -2202,8 +2192,6 @@ class GatewaySlashCommandsMixin:
                     custom_providers=custom_provs,
                     max_models=5,
                     excluded_providers=excluded_provs,
-                    explicit_only=_explicit_only,
-                    picker_providers=_picker_providers,
                     quick_switch_models=_quick_switch_models,
                 )
                 for p in providers:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1813,6 +1813,7 @@ class GatewaySlashCommandsMixin:
         custom_provs = None
         excluded_provs = []
         _explicit_only = True
+        _picker_providers = None
         config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
             cfg = _load_gateway_config(config_path=config_path)
@@ -1834,6 +1835,9 @@ class GatewaySlashCommandsMixin:
                 _explicit_only = bool(
                     cfg.get("model_catalog", {}).get("explicit_only_pickers", True)
                 )
+                _pp = cfg.get("model_catalog", {}).get("picker_providers")
+                if isinstance(_pp, list) and _pp:
+                    _picker_providers = [str(s) for s in _pp]
         except Exception:
             pass
 
@@ -1879,6 +1883,7 @@ class GatewaySlashCommandsMixin:
                         include_moa=True,
                         excluded_providers=excluded_provs,
                         explicit_only=_explicit_only,
+                        picker_providers=_picker_providers,
                     )
                 except Exception:
                     providers = []
@@ -2193,6 +2198,7 @@ class GatewaySlashCommandsMixin:
                     max_models=5,
                     excluded_providers=excluded_provs,
                     explicit_only=_explicit_only,
+                    picker_providers=_picker_providers,
                 )
                 for p in providers:
                     tag = t("gateway.model.current_tag") if p["is_current"] else ""

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -1812,6 +1812,7 @@ class GatewaySlashCommandsMixin:
         user_provs = None
         custom_provs = None
         excluded_provs = []
+        _explicit_only = True
         config_path = (_command_profile_home or _hermes_home) / "config.yaml"
         try:
             cfg = _load_gateway_config(config_path=config_path)
@@ -1830,6 +1831,9 @@ class GatewaySlashCommandsMixin:
                 _excl = cfg.get("model_catalog", {}).get("excluded_providers")
                 if isinstance(_excl, list):
                     excluded_provs = _excl
+                _explicit_only = bool(
+                    cfg.get("model_catalog", {}).get("explicit_only_pickers", True)
+                )
         except Exception:
             pass
 
@@ -1874,6 +1878,7 @@ class GatewaySlashCommandsMixin:
                         max_models=50,
                         include_moa=True,
                         excluded_providers=excluded_provs,
+                        explicit_only=_explicit_only,
                     )
                 except Exception:
                     providers = []
@@ -2187,6 +2192,7 @@ class GatewaySlashCommandsMixin:
                     custom_providers=custom_provs,
                     max_models=5,
                     excluded_providers=excluded_provs,
+                    explicit_only=_explicit_only,
                 )
                 for p in providers:
                     tag = t("gateway.model.current_tag") if p["is_current"] else ""

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3152,6 +3152,13 @@ DEFAULT_CONFIG = {
         # to pin /model to the providers you actually cycle through.
         # Example: ["deepseek", "openrouter"]
         "picker_providers": [],
+        # Quick-switch allow-list mirroring the desktop model pill's
+        # "Edit models..." selection (localStorage hermes.desktop.visible-
+        # models). When non-empty, chat-surface /model pickers show ONLY
+        # these models (formatted "<provider>::<model-id>"), grouped under
+        # their providers — the same set the desktop pill offers.
+        # Example: ["deepseek::deepseek-v4-flash", "openrouter::google/gemini-3.5-flash"]
+        "quick_switch_models": [],
     },
 
     # Per-model metadata overrides — manually declare context_window,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3146,6 +3146,12 @@ DEFAULT_CONFIG = {
         # from the inline picker; set False to surface every provider that has
         # credentials.
         "explicit_only_pickers": True,
+        # Hard allow-list for chat-surface /model pickers: when non-empty,
+        # only these provider slugs are listed (the current provider is always
+        # kept as a safety net). Stricter than explicit_only_pickers — use it
+        # to pin /model to the providers you actually cycle through.
+        # Example: ["deepseek", "openrouter"]
+        "picker_providers": [],
     },
 
     # Per-model metadata overrides — manually declare context_window,

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3139,19 +3139,6 @@ DEFAULT_CONFIG = {
         #     openrouter:
         #       url: https://example.com/my-curation.json
         "providers": {},
-        # When True, chat-surface /model pickers (Telegram/Discord) list only
-        # providers the user explicitly configured for Hermes — the same
-        # narrowing the desktop ModelPickerDialog applies (explicit_only,
-        # #56974). Ambient credentials (e.g. GitHub CLI -> Copilot) stay hidden
-        # from the inline picker; set False to surface every provider that has
-        # credentials.
-        "explicit_only_pickers": True,
-        # Hard allow-list for chat-surface /model pickers: when non-empty,
-        # only these provider slugs are listed (the current provider is always
-        # kept as a safety net). Stricter than explicit_only_pickers — use it
-        # to pin /model to the providers you actually cycle through.
-        # Example: ["deepseek", "openrouter"]
-        "picker_providers": [],
         # Quick-switch allow-list mirroring the desktop model pill's
         # "Edit models..." selection (localStorage hermes.desktop.visible-
         # models). When non-empty, chat-surface /model pickers show ONLY

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1117,6 +1117,11 @@ DEFAULT_CONFIG = {
         "response_cache": True,
         "response_cache_ttl": 300,
         "min_coding_score": 0.65,
+        # When True, the OpenRouter picker lists every live-catalog model that
+        # advertises tool support instead of the curated subset. Intended for
+        # power users who want the full catalog reachable from /model and the
+        # CLI picker; leave False for the hand-picked agentic list.
+        "show_all_models": False,
     },
 
     # AWS Bedrock provider configuration.
@@ -3134,6 +3139,13 @@ DEFAULT_CONFIG = {
         #     openrouter:
         #       url: https://example.com/my-curation.json
         "providers": {},
+        # When True, chat-surface /model pickers (Telegram/Discord) list only
+        # providers the user explicitly configured for Hermes — the same
+        # narrowing the desktop ModelPickerDialog applies (explicit_only,
+        # #56974). Ambient credentials (e.g. GitHub CLI -> Copilot) stay hidden
+        # from the inline picker; set False to surface every provider that has
+        # credentials.
+        "explicit_only_pickers": True,
     },
 
     # Per-model metadata overrides — manually declare context_window,

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2965,6 +2965,7 @@ def list_authenticated_providers(
     for_picker: bool = False,
     excluded_providers: list | None = None,
     explicit_only: bool = False,
+    picker_providers: list | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -4336,7 +4337,25 @@ def list_authenticated_providers(
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
-    if explicit_only:
+    if picker_providers:
+        # Hard allow-list: when the user names specific providers, the picker
+        # shows only those (plus the current provider as a safety net so the
+        # active model stays visible). This is stricter than explicit_only —
+        # it hides even explicitly-configured providers the user does not
+        # want to cycle through on chat surfaces.
+        wanted = {
+            str(slug).strip().lower()
+            for slug in picker_providers
+            if str(slug).strip()
+        }
+        if current_provider:
+            wanted.add(str(current_provider).strip().lower())
+        results = [
+            row
+            for row in results
+            if str(row.get("slug", "")).strip().lower() in wanted
+        ]
+    elif explicit_only:
         # Narrow to providers the user explicitly configured — the same
         # semantic the desktop ModelPickerDialog applies via inventory's
         # _filter_explicit_provider_rows (#56974). Ambient / auto-seeded
@@ -4397,6 +4416,7 @@ def list_picker_providers(
     include_moa: bool = False,
     excluded_providers: list | None = None,
     explicit_only: bool = False,
+    picker_providers: list | None = None,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -4429,6 +4449,7 @@ def list_picker_providers(
         for_picker=True,
         excluded_providers=excluded_providers,
         explicit_only=explicit_only,
+        picker_providers=picker_providers,
     )
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3286,6 +3286,26 @@ def list_authenticated_providers(
         # disk caching to keep the picker open snappy. Falls back to the
         # curated static list when the live fetcher returns nothing.
         model_ids = cached_provider_model_ids(hermes_id)
+        if hermes_id == "openrouter":
+            # [openrouter.show_all_models] Optional expansion for every
+            # surface that reads list_authenticated_providers (CLI, desktop
+            # /model.options, text /model fallback): list the full live
+            # catalog instead of the curated subset.
+            # fetch_openrouter_models applies the expansion and falls back
+            # to the curated snapshot when the live catalog is unreachable.
+            try:
+                from hermes_cli.config import load_config
+
+                if bool(
+                    (load_config().get("openrouter") or {}).get("show_all_models", False)
+                ):
+                    from hermes_cli.models import fetch_openrouter_models
+
+                    _expanded = [mid for mid, _ in fetch_openrouter_models()]
+                    if _expanded:
+                        model_ids = _expanded
+            except Exception:
+                pass
         if not model_ids:
             model_ids = curated.get(hermes_id, [])
             if hermes_id in _MODELS_DEV_PREFERRED:

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2977,17 +2977,13 @@ def _apply_quick_switch_filter(
         wanted = qs_by_slug.get(slug)
         if wanted is None:
             continue
-        kept = [m for m in (row.get("models") or []) if m in wanted]
-        if not kept:
-            # The user explicitly named these models ("provider::model") — keep
-            # them even when the row's curated/live list does not carry them
-            # (e.g. a model that exists on the provider but is not in the
-            # curated picker snapshot). The named provider row exists, so the
-            # model is selectable through it.
-            kept = list(wanted)
+        # The user explicitly named these models ("provider::model") — show
+        # all of them as long as the provider row exists. Intersecting with
+        # the row's curated/live list would drop models the catalog happens
+        # not to carry on this fetch (e.g. a transient live-catalog miss).
         row = dict(row)
-        row["models"] = kept
-        row["total_models"] = len(kept)
+        row["models"] = list(wanted)
+        row["total_models"] = len(wanted)
         narrowed.append(row)
     return narrowed
 

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2950,6 +2950,48 @@ def _collect_authed_provider_slugs(
     return [s for s in slugs if s != "nous"]
 
 
+def _apply_quick_switch_filter(
+    rows: List[dict], quick_switch_models: list | None
+) -> List[dict]:
+    """Keep only the models named in ``quick_switch_models`` ("<provider>::<model>").
+
+    Rows whose provider is not named are dropped; within a kept provider,
+    models not in the allow-list are removed. Entries that no longer exist in
+    the provider's catalog drop out silently. ``None`` / empty passes rows
+    through unchanged.
+    """
+    if not quick_switch_models:
+        return rows
+    qs_by_slug: dict[str, list[str]] = {}
+    for entry in quick_switch_models:
+        if not isinstance(entry, str) or "::" not in entry:
+            continue
+        slug, _, model_id = entry.partition("::")
+        slug = slug.strip().lower()
+        model_id = model_id.strip()
+        if slug and model_id:
+            qs_by_slug.setdefault(slug, []).append(model_id)
+    narrowed: List[dict] = []
+    for row in rows:
+        slug = str(row.get("slug", "")).strip().lower()
+        wanted = qs_by_slug.get(slug)
+        if wanted is None:
+            continue
+        kept = [m for m in (row.get("models") or []) if m in wanted]
+        if not kept:
+            # The user explicitly named these models ("provider::model") — keep
+            # them even when the row's curated/live list does not carry them
+            # (e.g. a model that exists on the provider but is not in the
+            # curated picker snapshot). The named provider row exists, so the
+            # model is selectable through it.
+            kept = list(wanted)
+        row = dict(row)
+        row["models"] = kept
+        row["total_models"] = len(kept)
+        narrowed.append(row)
+    return narrowed
+
+
 def list_authenticated_providers(
     current_provider: str = "",
     current_base_url: str = "",
@@ -2966,6 +3008,7 @@ def list_authenticated_providers(
     excluded_providers: list | None = None,
     explicit_only: bool = False,
     picker_providers: list | None = None,
+    quick_switch_models: list | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -4357,6 +4400,8 @@ def list_authenticated_providers(
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
+    results = _apply_quick_switch_filter(results, quick_switch_models)
+
     if picker_providers:
         # Hard allow-list: when the user names specific providers, the picker
         # shows only those (plus the current provider as a safety net so the
@@ -4437,6 +4482,7 @@ def list_picker_providers(
     excluded_providers: list | None = None,
     explicit_only: bool = False,
     picker_providers: list | None = None,
+    quick_switch_models: list | None = None,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -4492,5 +4538,9 @@ def list_picker_providers(
         if not has_models and not is_custom_endpoint:
             continue
         filtered.append(p)
+
+    # Quick-switch narrowing must run AFTER the OpenRouter live-catalog swap
+    # above (that swap would otherwise re-expand the row to the full list).
+    filtered = _apply_quick_switch_filter(filtered, quick_switch_models)
 
     return filtered

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3002,8 +3002,6 @@ def list_authenticated_providers(
     probe_current_custom_provider: bool = False,
     for_picker: bool = False,
     excluded_providers: list | None = None,
-    explicit_only: bool = False,
-    picker_providers: list | None = None,
     quick_switch_models: list | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
@@ -3022,12 +3020,6 @@ def list_authenticated_providers(
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
-    ``explicit_only`` further narrows the list to providers the user explicitly
-    configured for Hermes (config ``providers:``, the current provider, OAuth /
-    external-process sign-ins, keyless providers, or a provider-specific API-key
-    env var) — the same semantic desktop chat pickers apply (#56974). Ambient
-    credentials such as GitHub CLI's Copilot token stay hidden unless the flag
-    is off.
     ``force_fresh_nous_tier`` bypasses the short Nous tier cache for explicit
     account-sensitive flows. UI picker opens should leave it false so they do
     not block on fresh Portal/account checks every time.
@@ -4398,52 +4390,6 @@ def list_authenticated_providers(
 
     results = _apply_quick_switch_filter(results, quick_switch_models)
 
-    if picker_providers:
-        # Hard allow-list: when the user names specific providers, the picker
-        # shows only those (plus the current provider as a safety net so the
-        # active model stays visible). This is stricter than explicit_only —
-        # it hides even explicitly-configured providers the user does not
-        # want to cycle through on chat surfaces.
-        wanted = {
-            str(slug).strip().lower()
-            for slug in picker_providers
-            if str(slug).strip()
-        }
-        if current_provider:
-            wanted.add(str(current_provider).strip().lower())
-        results = [
-            row
-            for row in results
-            if str(row.get("slug", "")).strip().lower() in wanted
-        ]
-    elif explicit_only:
-        # Narrow to providers the user explicitly configured — the same
-        # semantic the desktop ModelPickerDialog applies via inventory's
-        # _filter_explicit_provider_rows (#56974). Ambient / auto-seeded
-        # credentials (e.g. GitHub CLI -> Copilot) stay hidden from /model
-        # pickers unless the user opts into the full list. Best-effort:
-        # a filter failure falls back to the full list rather than breaking
-        # the picker.
-        try:
-            from hermes_cli.inventory import (
-                ConfigContext,
-                _filter_explicit_provider_rows,
-            )
-
-            results = _filter_explicit_provider_rows(
-                results,
-                ConfigContext(
-                    current_provider=current_provider,
-                    current_model=current_model,
-                    current_base_url=current_base_url,
-                    user_providers=user_providers or {},
-                    custom_providers=custom_providers or [],
-                    excluded_providers=excluded_providers,
-                ),
-            )
-        except Exception:
-            pass
-
     return results
 
 
@@ -4476,8 +4422,6 @@ def list_picker_providers(
     current_model: str = "",
     include_moa: bool = False,
     excluded_providers: list | None = None,
-    explicit_only: bool = False,
-    picker_providers: list | None = None,
     quick_switch_models: list | None = None,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
@@ -4510,8 +4454,6 @@ def list_picker_providers(
         current_model=current_model,
         for_picker=True,
         excluded_providers=excluded_providers,
-        explicit_only=explicit_only,
-        picker_providers=picker_providers,
     )
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -2964,6 +2964,7 @@ def list_authenticated_providers(
     probe_current_custom_provider: bool = False,
     for_picker: bool = False,
     excluded_providers: list | None = None,
+    explicit_only: bool = False,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -2981,6 +2982,12 @@ def list_authenticated_providers(
       - source: str — "built-in", "models.dev", "user-config"
 
     Only includes providers that have API keys set or are user-defined endpoints.
+    ``explicit_only`` further narrows the list to providers the user explicitly
+    configured for Hermes (config ``providers:``, the current provider, OAuth /
+    external-process sign-ins, keyless providers, or a provider-specific API-key
+    env var) — the same semantic desktop chat pickers apply (#56974). Ambient
+    credentials such as GitHub CLI's Copilot token stay hidden unless the flag
+    is off.
     ``force_fresh_nous_tier`` bypasses the short Nous tier cache for explicit
     account-sensitive flows. UI picker opens should leave it false so they do
     not block on fresh Portal/account checks every time.
@@ -4329,6 +4336,34 @@ def list_authenticated_providers(
     # Sort: current provider first, then by model count descending
     results.sort(key=lambda r: (not r["is_current"], -r["total_models"]))
 
+    if explicit_only:
+        # Narrow to providers the user explicitly configured — the same
+        # semantic the desktop ModelPickerDialog applies via inventory's
+        # _filter_explicit_provider_rows (#56974). Ambient / auto-seeded
+        # credentials (e.g. GitHub CLI -> Copilot) stay hidden from /model
+        # pickers unless the user opts into the full list. Best-effort:
+        # a filter failure falls back to the full list rather than breaking
+        # the picker.
+        try:
+            from hermes_cli.inventory import (
+                ConfigContext,
+                _filter_explicit_provider_rows,
+            )
+
+            results = _filter_explicit_provider_rows(
+                results,
+                ConfigContext(
+                    current_provider=current_provider,
+                    current_model=current_model,
+                    current_base_url=current_base_url,
+                    user_providers=user_providers or {},
+                    custom_providers=custom_providers or [],
+                    excluded_providers=excluded_providers,
+                ),
+            )
+        except Exception:
+            pass
+
     return results
 
 
@@ -4361,6 +4396,7 @@ def list_picker_providers(
     current_model: str = "",
     include_moa: bool = False,
     excluded_providers: list | None = None,
+    explicit_only: bool = False,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -4392,6 +4428,7 @@ def list_picker_providers(
         current_model=current_model,
         for_picker=True,
         excluded_providers=excluded_providers,
+        explicit_only=explicit_only,
     )
     if include_moa:
         providers = _prepend_moa_picker_provider(providers, current_provider=current_provider)

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2196,6 +2196,29 @@ def fetch_openrouter_models(
     if not curated:
         return list(_openrouter_catalog_cache or fallback)
 
+    # [openrouter.show_all_models] Optional expansion: surface every
+    # live-catalog model that advertises tool support, not just the curated
+    # subset. Curated entries stay first (they carry the default/free
+    # badges); the rest follow in catalog order with no badge.
+    try:
+        from hermes_cli.config import load_config
+
+        _or_cfg = load_config().get("openrouter") or {}
+        _show_all_models = bool(_or_cfg.get("show_all_models", False))
+    except Exception:
+        _show_all_models = False
+    if _show_all_models:
+        curated_ids = {mid for mid, _ in curated}
+        for live_item in live_items:
+            if not isinstance(live_item, dict):
+                continue
+            mid = str(live_item.get("id") or "").strip()
+            if not mid or mid in curated_ids:
+                continue
+            if not _openrouter_model_supports_tools(live_item):
+                continue
+            curated.append((mid, ""))
+
     first_id, first_desc = curated[0]
     if not first_desc:
         curated[0] = (first_id, "recommended")


### PR DESCRIPTION
## Summary

Two config-gated controls so chat surfaces (Telegram/Discord `/model`) show exactly what the user picked — instead of every ambient provider and every curated model.

### 1. `model_catalog.quick_switch_models` (default empty)

Mirrors the desktop composer model pill's "Edit models..." selection (persisted renderer-side as `hermes.desktop.visible-models`, a list of `"<provider>::<model>"`). When non-empty, chat `/model` pickers show ONLY those models, grouped under their providers — the same set the desktop pill offers. A shared `_apply_quick_switch_filter` helper narrows both the interactive picker (after the OpenRouter live-catalog swap, which would otherwise re-expand the row) and the text fallback. Named models are shown as long as the provider row exists — intersecting with the curated/live snapshot would drop models the catalog happens not to carry on a given fetch.

### 2. `openrouter.show_all_models` (default **False**)

Opt-in expansion of the OpenRouter picker beyond the curated subset to every live-catalog model advertising tool support. Applied both inside `fetch_openrouter_models()` and at the built-in openrouter row assembly site in `list_authenticated_providers()`, so CLI, desktop `/model.options`, and text `/model` fallback all honor it. Curated entries keep their badges and stay first; network failures degrade to the curated snapshot.

## Motivation

User-reported: `/model` on Telegram lists far more than the models the user configured/uses on desktop, making switches noisy. `quick_switch_models` gives chat surfaces the same "only what I chose" list the desktop pill shows; `show_all_models` is the formal config-gated opt-in for users who want the full OpenRouter catalog reachable everywhere.

## Testing

- `python -m py_compile` on all touched files.
- Import/signature checks: both list functions expose `quick_switch_models`; `DEFAULT_CONFIG` carries both new keys with documented defaults.
- Behavior: `_apply_quick_switch_filter` narrows a mock row set to exactly the named models (and drops unlisted providers); `show_all_models` toggles the OpenRouter row between 49 (curated) and 358 (expanded) live-catalog entries; end-to-end `/model` simulation on a 17-model config shows only those models across 5 providers.

No conversation-context or system-prompt changes — prompt cache unaffected. All changes are config gates (no new env vars).

Follow-up (separate PR): desktop-side write-through of the pill's selection into `model_catalog.quick_switch_models` so the two surfaces stay in sync without manual config edits.