### PR TITLE
fix(desktop): paste in the terminal on Ctrl+V (Windows) and Shift+Insert

### DIFF
--- a/apps/desktop/src/app/right-sidebar/terminal/clipboard.test.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/clipboard.test.ts
@@ -11,44 +11,122 @@ const key = (init: Partial<KeyboardEvent> & { key: string }) =>
   ({ altKey: false, ctrlKey: false, metaKey: false, shiftKey: false, type: 'keydown', ...init }) as KeyboardEvent
 
 describe('terminalClipboardIntent', () => {
-  it('never claims a bare Ctrl+C with nothing selected, on either platform', () => {
-    for (const isMac of [true, false]) {
-      expect(terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: false, isMac })).toBeNull()
+  it('never claims a bare Ctrl+C with nothing selected, on any platform', () => {
+    for (const [isMac, isWindows] of [
+      [true, false],
+      [false, true],
+      [false, false]
+    ]) {
+      expect(
+        terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: false, isMac, isWindows })
+      ).toBeNull()
     }
   })
 
   it('copies on Ctrl+C when text is selected, so a selection is never lost to SIGINT', () => {
-    expect(terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: true, isMac: false })).toBe('copy')
+    expect(
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: true, isMac: false, isWindows: false })
+    ).toBe('copy')
   })
 
   it('reserves plain Ctrl+C for the shell on macOS, where ⌘C is the copy chord', () => {
-    expect(terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: true, isMac: true })).toBeNull()
-    expect(terminalClipboardIntent(key({ key: 'c', metaKey: true }), { hasSelection: true, isMac: true })).toBe('copy')
+    expect(
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'c' }), { hasSelection: true, isMac: true, isWindows: false })
+    ).toBeNull()
+    expect(
+      terminalClipboardIntent(key({ key: 'c', metaKey: true }), { hasSelection: true, isMac: true, isWindows: false })
+    ).toBe('copy')
   })
 
   it('only claims copy when there is something to copy', () => {
-    expect(terminalClipboardIntent(key({ key: 'c', metaKey: true }), { hasSelection: false, isMac: true })).toBeNull()
     expect(
-      terminalClipboardIntent(key({ ctrlKey: true, key: 'c', shiftKey: true }), { hasSelection: false, isMac: false })
+      terminalClipboardIntent(key({ key: 'c', metaKey: true }), { hasSelection: false, isMac: true, isWindows: false })
+    ).toBeNull()
+    expect(
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'c', shiftKey: true }), {
+        hasSelection: false,
+        isMac: false,
+        isWindows: false
+      })
     ).toBeNull()
   })
 
   it('claims paste regardless of selection, since paste has nothing to do with one', () => {
-    expect(terminalClipboardIntent(key({ key: 'v', metaKey: true }), { hasSelection: false, isMac: true })).toBe(
-      'paste'
-    )
     expect(
-      terminalClipboardIntent(key({ ctrlKey: true, key: 'v', shiftKey: true }), { hasSelection: false, isMac: false })
+      terminalClipboardIntent(key({ key: 'v', metaKey: true }), { hasSelection: false, isMac: true, isWindows: false })
+    ).toBe('paste')
+    expect(
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'v', shiftKey: true }), {
+        hasSelection: false,
+        isMac: false,
+        isWindows: false
+      })
     ).toBe('paste')
   })
 
-  it('leaves shell chords alone: bare Ctrl+V, Alt combos, and keyup', () => {
-    expect(terminalClipboardIntent(key({ ctrlKey: true, key: 'v' }), { hasSelection: false, isMac: false })).toBeNull()
+  // Windows has no application menu (main.ts installs one on macOS only), so
+  // Chromium never turns Ctrl+V or Shift+Insert into a Paste editor command and
+  // xterm's helper-textarea `paste` listener never fires. Whatever this map
+  // declines on Windows is a dead key, which is why these two are claimed.
+  it('pastes on bare Ctrl+V on Windows, where VS Code binds it as the primary chord', () => {
     expect(
-      terminalClipboardIntent(key({ altKey: true, ctrlKey: true, key: 'c' }), { hasSelection: true, isMac: false })
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'v' }), { hasSelection: false, isMac: false, isWindows: true })
+    ).toBe('paste')
+  })
+
+  it('pastes on Shift+Insert on every platform, since no shell binds it', () => {
+    for (const [isMac, isWindows] of [
+      [true, false],
+      [false, true],
+      [false, false]
+    ]) {
+      expect(
+        terminalClipboardIntent(key({ key: 'Insert', shiftKey: true }), { hasSelection: false, isMac, isWindows })
+      ).toBe('paste')
+    }
+  })
+
+  it('leaves a bare or Ctrl-modified Insert to the shell — only Shift+Insert is paste', () => {
+    expect(
+      terminalClipboardIntent(key({ key: 'Insert' }), { hasSelection: false, isMac: false, isWindows: true })
     ).toBeNull()
     expect(
-      terminalClipboardIntent(key({ key: 'c', metaKey: true, type: 'keyup' }), { hasSelection: true, isMac: true })
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'Insert', shiftKey: true }), {
+        hasSelection: false,
+        isMac: false,
+        isWindows: true
+      })
+    ).toBeNull()
+    expect(
+      terminalClipboardIntent(key({ altKey: true, key: 'Insert', shiftKey: true }), {
+        hasSelection: false,
+        isMac: false,
+        isWindows: true
+      })
+    ).toBeNull()
+  })
+
+  it('leaves shell chords alone: bare Ctrl+V off Windows, Alt combos, and keyup', () => {
+    expect(
+      terminalClipboardIntent(key({ ctrlKey: true, key: 'v' }), {
+        hasSelection: false,
+        isMac: false,
+        isWindows: false
+      })
+    ).toBeNull()
+    expect(
+      terminalClipboardIntent(key({ altKey: true, ctrlKey: true, key: 'c' }), {
+        hasSelection: true,
+        isMac: false,
+        isWindows: false
+      })
+    ).toBeNull()
+    expect(
+      terminalClipboardIntent(key({ key: 'c', metaKey: true, type: 'keyup' }), {
+        hasSelection: true,
+        isMac: true,
+        isWindows: false
+      })
     ).toBeNull()
   })
 })

--- a/apps/desktop/src/app/right-sidebar/terminal/clipboard.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/clipboard.ts
@@ -8,21 +8,44 @@
 // right-click menu all work).
 //
 // The chords follow VS Code (terminal.clipboard.contribution.ts): ⌘C/⌘V on
-// macOS, Ctrl+Shift+C/V elsewhere, plus plain Ctrl+C as copy ONLY when text is
+// macOS, Ctrl+Shift+C/V everywhere, plus plain Ctrl+C as copy ONLY when text is
 // selected — the "intelligent Ctrl-C" of Windows Terminal and Tabby. With no
 // selection Ctrl+C stays SIGINT, so interrupting a process never breaks.
+//
+// This map is the ONLY paste route on Windows, so its gaps are dead keys rather
+// than fallbacks. Electron installs an application menu on macOS alone
+// (main.ts: `IS_MAC ? setApplicationMenu(buildApplicationMenu()) :
+// setApplicationMenu(null)`), and — the same trap the Edit submenu's
+// `pasteAndMatchStyle` comment records — an accelerator with no menu entry is
+// never translated into an editor command. Without a `role: 'paste'` on
+// Windows/Linux, Chromium never runs Paste for Ctrl+V or Shift+Insert, so no
+// `paste` event ever reaches the listener xterm puts on its helper textarea.
+// Anything this function returns null for is a keystroke that lands on nothing.
+//
+// Hence the two chords below beyond VS Code's Linux row:
+//   • Shift+Insert — every platform. xterm deliberately declines it
+//     (Keyboard.ts case 45: "used to copy-paste on some systems") expecting the
+//     host to paste, and no shell binds it. Dictation tools reach for it first.
+//   • Ctrl+V — Windows only, matching VS Code, whose terminal binds Ctrl+V as
+//     the PRIMARY paste there with Ctrl+Shift+V secondary; the Ctrl+Shift-only
+//     row is Linux's, where Ctrl+V stays readline's quoted-insert.
 
 export type TerminalClipboardIntent = 'copy' | 'paste' | null
 
 export function terminalClipboardIntent(
   event: KeyboardEvent,
-  { hasSelection, isMac }: { hasSelection: boolean; isMac: boolean }
+  { hasSelection, isMac, isWindows }: { hasSelection: boolean; isMac: boolean; isWindows: boolean }
 ): TerminalClipboardIntent {
   if (event.type !== 'keydown' || event.altKey) {
     return null
   }
 
   const key = event.key.toLowerCase()
+
+  // Ahead of every Ctrl gate: Shift+Insert carries no Ctrl to gate on.
+  if (key === 'insert' && event.shiftKey && !event.ctrlKey && !event.metaKey) {
+    return 'paste'
+  }
 
   if (isMac) {
     if (!event.metaKey || event.ctrlKey || event.shiftKey) {
@@ -40,6 +63,12 @@ export function terminalClipboardIntent(
 
   if (event.shiftKey) {
     return key === 'c' ? (hasSelection ? 'copy' : null) : key === 'v' ? 'paste' : null
+  }
+
+  // Bare Ctrl+V: paste on Windows (VS Code's primary chord there), left to the
+  // shell on Linux so readline keeps quoted-insert.
+  if (isWindows && key === 'v') {
+    return 'paste'
   }
 
   // Bare Ctrl+C: copy only when there's a selection to copy, else SIGINT.

--- a/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-agent-terminal.ts
@@ -7,6 +7,7 @@ import { useEffect, useRef } from 'react'
 import { writeClipboardText } from '@/components/ui/copy-button'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { triggerHaptic } from '@/lib/haptics'
+import { isWindowsPlatform } from '@/lib/platform'
 import { useTheme } from '@/themes/context'
 
 import { observeActiveTerminalResize } from './active-resize'
@@ -94,9 +95,13 @@ export function useAgentTerminal({ active, id, procId }: { active: boolean; id: 
     })
 
     term.attachCustomKeyEventHandler(event => {
+      // Real platform flags rather than hardcoded falses: only 'copy' is acted
+      // on here (this mirror has no PTY, so every paste chord is inert either
+      // way), and a lie would bite whoever gives this handler a paste branch.
       const intent = terminalClipboardIntent(event, {
         hasSelection: Boolean(term.getSelection()),
-        isMac: isMacPlatform()
+        isMac: isMacPlatform(),
+        isWindows: isWindowsPlatform()
       })
 
       if (intent !== 'copy') {

--- a/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
+++ b/apps/desktop/src/app/right-sidebar/terminal/use-terminal-session.ts
@@ -10,6 +10,7 @@ import { writeClipboardText } from '@/components/ui/copy-button'
 import { markRightPanePerf } from '@/debug/right-pane-events'
 import { triggerHaptic } from '@/lib/haptics'
 import { isComposerChord } from '@/lib/keybinds/chords'
+import { isWindowsPlatform } from '@/lib/platform'
 import { $previewTarget } from '@/store/preview'
 import { useTheme } from '@/themes/context'
 
@@ -815,7 +816,8 @@ export function useTerminalSession({
     term.attachCustomKeyEventHandler(event => {
       const intent = terminalClipboardIntent(event, {
         hasSelection: Boolean(term.getSelection()),
-        isMac: isMacPlatform()
+        isMac: isMacPlatform(),
+        isWindows: isWindowsPlatform()
       })
 
       if (!intent) {


### PR DESCRIPTION
## What does this PR do?

Pasting into a Desktop terminal pane only worked with Ctrl+Shift+V — plain **Ctrl+V** and **Shift+Insert** did nothing at all on Windows. That also breaks anything that pastes by synthesizing a keystroke; a dictation tool is how I ran into it.

There's no fallback underneath, which is the part that surprised me: we install an application menu on macOS only, and an accelerator with no menu entry is never translated into an editor command — the same trap the Edit submenu's `pasteAndMatchStyle` comment already records. With no `role: 'paste'` on Windows/Linux, Chromium never runs Paste, so the `paste` event xterm listens for on its helper textarea never fires. That makes the chord map in `clipboard.ts` the only paste route there, so anything it declines is a dead key.

Its header says it follows VS Code, but it applies VS Code's *Linux* row to Windows — VS Code binds Ctrl+V as the **primary** terminal paste on Windows, with Ctrl+Shift+V secondary.

## Related Issue

Couldn't find an existing one. Happy to open an issue first if you'd rather have it tracked that way.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/right-sidebar/terminal/clipboard.ts` — `terminalClipboardIntent` takes an `isWindows` flag; **Ctrl+V** (Windows only) and **Shift+Insert** (all platforms) now mean paste
- `.../terminal/use-terminal-session.ts`, `.../terminal/use-agent-terminal.ts` — pass the flag through
- `.../terminal/clipboard.test.ts` — cover both new chords, and that a bare or Ctrl-modified Insert still goes to the shell

Left alone on purpose: Ctrl+V stays readline's quoted-insert on Linux, and bare Ctrl+C still SIGINTs when nothing is selected.

## How to Test

1. On Windows, copy some text, then focus a terminal pane.
2. **Ctrl+V** pastes, and **Shift+Insert** pastes — neither did before.
3. Ctrl+Shift+V still pastes, and Ctrl+C with no selection still interrupts the running process.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] `pytest tests/ -q` — N/A, this is a renderer-only TS change. Ran `npx vitest run src/app/right-sidebar/terminal` (72 passing) and `tsc -p . --noEmit` (clean) against current `main`
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the reasoning lives in the `clipboard.ts` header comment)
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — yes, that's the crux: the new Ctrl+V binding is Windows-only so Linux keeps quoted-insert, and Shift+Insert is safe everywhere since no shell binds it
- [x] I've updated tool descriptions/schemas — N/A

https://claude.ai/code/session_01RRNzijhS55Fa5qADkFAGK4
