### PR TITLE
feat(discord): log require_mention drops at DEBUG

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -8283,6 +8283,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
             if require_mention and not is_free_channel and not in_bot_thread:
                 if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
+                    # Without this the drop is invisible: an unmentioned guild
+                    # message and one the gateway never received produce
+                    # identical logs (none), which sends operators hunting
+                    # through intents, permissions and the websocket.
+                    logger.debug(
+                        "[%s] Ignoring unmentioned message in channel: %s (require_mention is on)",
+                        self.name,
+                        channel_keys,
+                    )
                     return False
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -3,6 +3,7 @@
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+import logging
 import sys
 
 import pytest
@@ -882,3 +883,59 @@ class TestNonConversationalTrackerOffload:
         assert sorted(writes[-1]) == ["1", "2"]
 
 
+
+@pytest.mark.asyncio
+async def test_discord_require_mention_drop_is_logged(adapter, monkeypatch, caplog):
+    """An unmentioned guild message must leave a DEBUG trace when it is dropped.
+
+    The sibling ``allowed_channels`` / ``ignored_channels`` rejections above this
+    gate both log before returning; this one used to return silently, so a
+    dropped message and an event the gateway never received looked identical in
+    the logs.
+    """
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=4242),
+        content="no mention here",
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=discord_platform.logger.name):
+        await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+    drops = [
+        record.getMessage()
+        for record in caplog.records
+        if "Ignoring unmentioned message" in record.getMessage()
+    ]
+    assert drops, "require_mention drop emitted no log line"
+    assert "4242" in drops[0]
+    assert "require_mention is on" in drops[0]
+
+
+@pytest.mark.asyncio
+async def test_discord_mentioned_message_logs_no_drop(adapter, monkeypatch, caplog):
+    """The drop log must not fire for a message that is actually processed."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    bot_user = adapter._client.user
+    message = make_message(
+        channel=FakeTextChannel(channel_id=4242),
+        content=f"<@{bot_user.id}> hello",
+        mentions=[bot_user],
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=discord_platform.logger.name):
+        await adapter._handle_message(message)
+
+    adapter.handle_message.assert_awaited_once()
+    assert not [
+        record for record in caplog.records
+        if "Ignoring unmentioned message" in record.getMessage()
+    ]


### PR DESCRIPTION
## What does this PR do?

An unmentioned guild message is dropped in `_handle_message` with **no log line at any level**, while the `allowed_channels` and `ignored_channels` rejections immediately above it both `logger.debug` before returning:

```python
allowed_channels = self._get_allowed_channels()
if allowed_channels:
    if "*" not in allowed_channels and not (channel_keys & allowed_channels):
        logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_keys)
        return False

ignored_channels = self._get_ignored_channels()
if "*" in ignored_channels or (channel_keys & ignored_channels):
    logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_keys)
    return False

...

if require_mention and not is_free_channel and not in_bot_thread:
    if not self._self_is_explicitly_mentioned(message) and not mention_prefix:
        return False        # <-- silent
```

The consequence is that **a dropped message and an event the gateway never received look identical in the logs** — both produce nothing.

That matters because DMs skip this whole block (it sits inside `if not isinstance(message.channel, discord.DMChannel):`), so the failure presents as "the bot answers DMs but is completely dead in server channels". With no log either way, that sends operators through intents, permissions, bot token and websocket health before they can even establish that the event arrived. I lost several hours to exactly this and only got unstuck by patching in temporary instrumentation to confirm `MESSAGE_CREATE` was being delivered.

This adds the missing `logger.debug`, matching the two branches above it in format and arguments. `DEBUG` keeps it opt-in so active servers don't get log spam.

## Related Issue

Not filed for Discord. The Telegram equivalent is #57290 ("Telegram: group messages/attachments dropped by `require_mention` leave no log trace"), which proposes the same metadata-only DEBUG trace for `plugins/platforms/telegram/adapter.py`. This is the Discord sibling of that gap.

Happy to open a tracking issue first if maintainers prefer that order.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

Typed as a feature to match how #57290 is labelled (`type/feature`), since no behaviour changes — only observability.

## Changes Made

- `plugins/platforms/discord/adapter.py` — emit `logger.debug` at the `require_mention` drop before `return False`, naming the resolved channel keys and the gating condition.
- `tests/gateway/test_discord_free_response.py` — two regression tests.

### On classification

The triage note on #57290 flags that both Telegram PRs "mislabel every `_should_process_message()` rejection as an unmentioned/require-mention drop". This site does not have that problem: it is already specific to the mention gate, since the channel-list rejections return earlier and log their own reasons. The message names that condition explicitly (`require_mention is on`), and the second test asserts the line does **not** fire for a message that is actually processed.

## How to Test

Reproduce the silence first:

1. Set `discord.require_mention: true` (the default) and run the gateway in a guild.
2. Send a message in a channel **without** mentioning the bot.
3. `gateway.log` shows nothing — no inbound line, no drop reason. Now compare against `DISCORD_IGNORED_CHANNELS=<that channel>` and the same message, which logs `Ignoring message in ignored channel`.

With this PR, step 2 logs at DEBUG:

```
[Discord] Ignoring unmentioned message in channel: {'123456789'} (require_mention is on)
```

Automated:

```bash
scripts/run_tests.sh tests/gateway/test_discord_free_response.py -q
```

Red-green verified — reverting the `logger.debug` fails `test_discord_require_mention_drop_is_logged` and leaves the other 24 in that file passing.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15, discord.py 2.7.1

On the full-suite box: I could not complete `tests/` end to end in this environment — several files fail collection on optional dependencies unrelated to this change. What I did run, with `scripts/run_tests.sh` (per-file isolation, matching CI):

```
tests/gateway/test_discord_*.py
=== Summary: 46 files, 267 tests passed, 0 failed, 1 skipped (100% complete) ===
```

I also confirmed the unrelated failures I saw before installing `aiohttp` were identical with and without this change (8 failed / 16 passed either way), so they are pre-existing and not caused by it.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

No config keys, no schema changes, no platform-specific code — a single logging call.

## Screenshots / Logs

The instrumentation run that located the original problem, showing the event arriving and then vanishing at this exact gate:

```
[TRACE] gateway event: MESSAGE_CREATE
[TRACE] on_message guild=… chan=…(TextChannel) author=…  bot=False
        type=MessageType.default content='<@&…> test' mentions=[] self_mentioned=False
[TRACE] admission admitted=True role_authorized=False
[TRACE] DROP require_mention chan=… free=False in_bot_thread=False
```

Only the last line is new information, and today nothing like it reaches the log.
