### PR TITLE
feat(desktop): add manual ordering within Bot roster sections

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -95,6 +95,7 @@ type BotsMessages = {
     removeFromSection: string
     deleted: (name: string, count: number) => string
     undo: string
+    resetOrder: string
   }
   /** Creating, editing and removing a bot. */
   bot: {
@@ -326,7 +327,8 @@ const en: BotsMessages = {
       count === 0
         ? `Deleted “${name}”`
         : `Deleted “${name}” — ${count} ${count === 1 ? 'bot' : 'bots'} moved to Unassigned`,
-    undo: 'Undo'
+    undo: 'Undo',
+    resetOrder: 'Reset custom order'
   },
   bot: {
     newTitle: 'New bot',
@@ -543,7 +545,8 @@ const ja: BotsMessages = {
       count === 0
         ? `「${name}」を削除しました`
         : `「${name}」を削除しました — ${count} 件のボットを未分類に移動しました`,
-    undo: '元に戻す'
+    undo: '元に戻す',
+    resetOrder: 'カスタム順序をリセット'
   },
   bot: {
     newTitle: '新しいボット',
@@ -756,7 +759,8 @@ const zh: BotsMessages = {
     newSectionEllipsis: '新建分区…',
     removeFromSection: '移出分区',
     deleted: (name, count) => (count === 0 ? `已删除“${name}”` : `已删除“${name}” — ${count} 个机器人已移至未分类`),
-    undo: '撤销'
+    undo: '撤销',
+    resetOrder: '重置自定义排序'
   },
   bot: {
     newTitle: '新建机器人',
@@ -969,7 +973,8 @@ const zhHant: BotsMessages = {
     newSectionEllipsis: '新增分區…',
     removeFromSection: '移出分區',
     deleted: (name, count) => (count === 0 ? `已刪除「${name}」` : `已刪除「${name}」— ${count} 個機器人已移至未分類`),
-    undo: '復原'
+    undo: '復原',
+    resetOrder: '重設自訂排序'
   },
   bot: {
     newTitle: '新增機器人',

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -60,6 +60,7 @@ import { BOTS_LOCALES } from './i18n'
 import { displayName } from './labels'
 import { startBotRelay, stopBotRelay } from './relay'
 import { $activityToasts } from './roster-actions'
+import { loadRosterOrder } from './roster-order'
 import {
   botChatOwnsWorkspace,
   BotsPane,
@@ -96,9 +97,10 @@ export default {
     'Bot Mode — a one-chat-per-agent roster with avatars, routines, group chats, and bot-to-bot messaging. Ships with the app; disable here if unwanted.',
   register(ctx: PluginContext) {
     setPluginCtx(ctx)
-    // The user's own roster sections. Read once at register; every mutation
+    // The user's own roster sections and custom order. Read once at register; every mutation
     // writes through.
     loadBotSections()
+    loadRosterOrder()
     const disposeLocales = ctx.i18n.register(BOTS_LOCALES)
     setGroupChatSyncDisposed(false)
     startFaceClock()

--- a/apps/desktop/src/plugins/hermes-bots/roster-order-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-order-row.tsx
@@ -1,0 +1,102 @@
+/**
+ * Visual drop wrapper for reorderable roster rows.
+ *
+ * Handles dragover detection and renders an insertion line indicator
+ * when another bot in the same section and pinned band is dragged above or below this row.
+ */
+
+import { cn, useValue } from '@hermes/plugin-sdk'
+import type { DragEvent, ReactNode } from 'react'
+import { useEffect, useState } from 'react'
+
+import { $draggingBot, $draggingBotPinned, $draggingBotScope, BOT_DRAG_MIME } from './roster-order'
+
+interface ReorderableRosterRowProps {
+  children: ReactNode
+  itemKey: string
+  onReorder: (sourceKey: string, targetKey: string, position: 'before' | 'after') => void
+  pinned: boolean
+  scopeKey: string
+}
+
+export function ReorderableRosterRow({ children, itemKey, onReorder, pinned, scopeKey }: ReorderableRosterRowProps) {
+  const draggingBot = useValue($draggingBot)
+  const draggingScope = useValue($draggingBotScope)
+  const draggingPinned = useValue($draggingBotPinned)
+  const [dropPosition, setDropPosition] = useState<null | 'before' | 'after'>(null)
+
+  useEffect(() => {
+    if (!draggingBot) {
+      setDropPosition(null)
+    }
+  }, [draggingBot])
+
+  const accepts = (event: DragEvent) => {
+    return (
+      Boolean(draggingBot) &&
+      draggingBot !== itemKey &&
+      draggingScope === scopeKey &&
+      draggingPinned === pinned &&
+      event.dataTransfer.types.includes(BOT_DRAG_MIME)
+    )
+  }
+
+  return (
+    <div
+      className={cn(
+        'relative transition-all duration-75',
+        dropPosition === 'before' &&
+          'before:absolute before:-top-0.5 before:left-2 before:right-2 before:h-0.5 before:rounded-full before:bg-(--ui-accent) before:z-10',
+        dropPosition === 'after' &&
+          'after:absolute after:-bottom-0.5 after:left-2 after:right-2 after:h-0.5 after:rounded-full after:bg-(--ui-accent) after:z-10'
+      )}
+      data-roster-item-key={itemKey}
+      onDragLeave={event => {
+        if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+          setDropPosition(null)
+        }
+      }}
+      onDragOver={event => {
+        if (!accepts(event)) {
+          return
+        }
+
+        event.preventDefault()
+        event.dataTransfer.dropEffect = 'move'
+
+        const rect = event.currentTarget.getBoundingClientRect()
+        const midY = rect.top + rect.height / 2
+        const nextPos = event.clientY < midY ? 'before' : 'after'
+
+        if (dropPosition !== nextPos) {
+          setDropPosition(nextPos)
+        }
+      }}
+      onDrop={event => {
+        const wasPosition = dropPosition
+        setDropPosition(null)
+
+        if (!accepts(event)) {
+          return
+        }
+
+        const sourceKey = event.dataTransfer.getData(BOT_DRAG_MIME) || draggingBot
+
+        if (!sourceKey || sourceKey === itemKey) {
+          return
+        }
+
+        event.preventDefault()
+        event.stopPropagation()
+
+        const rect = event.currentTarget.getBoundingClientRect()
+        const midY = rect.top + rect.height / 2
+        const position = wasPosition || (event.clientY < midY ? 'before' : 'after')
+
+        onReorder(sourceKey, itemKey, position)
+      }}
+    >
+      {children}
+    </div>
+  )
+}

--- a/apps/desktop/src/plugins/hermes-bots/roster-order.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-order.test.ts
@@ -1,0 +1,308 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $rosterOrder,
+  clearRosterOrder,
+  hasAnyCustomRosterOrder,
+  hasCustomRosterOrder,
+  loadRosterOrder,
+  moveRosterItem,
+  normalizeRosterOrderMap,
+  orderRosterRows,
+  persistRosterOrder,
+  pruneRosterOrder,
+  removeBotFromRosterOrder,
+  rosterRowKey,
+  rosterSectionScope
+} from './roster-order'
+import { setPluginCtx } from './shared'
+import type { RosterRow } from './types'
+
+describe('roster-order (section-scoped manual ordering)', () => {
+  let mockStorage: Record<string, unknown> = {}
+
+  beforeEach(() => {
+    mockStorage = {}
+    setPluginCtx({
+      storage: {
+        get: (key: string, fallback: unknown) => (key in mockStorage ? mockStorage[key] : fallback),
+        set: (key: string, val: unknown) => {
+          mockStorage[key] = val
+        }
+      }
+    } as any)
+    $rosterOrder.set({})
+  })
+
+  describe('normalizeRosterOrderMap', () => {
+    it('handles non-object inputs gracefully', () => {
+      expect(normalizeRosterOrderMap(null)).toEqual({})
+      expect(normalizeRosterOrderMap(undefined)).toEqual({})
+      expect(normalizeRosterOrderMap('invalid')).toEqual({})
+      expect(normalizeRosterOrderMap(123)).toEqual({})
+      expect(normalizeRosterOrderMap(['array', 'not', 'map'])).toEqual({})
+    })
+
+    it('deduplicates, trims keys, and drops empty lists', () => {
+      const input = {
+        'local::sec-a': ['bot-1', ' bot-2 ', 'bot-1', '', '  ', 'bot-3'],
+        'local::empty': ['', '   '],
+        'local::invalid': 'not-an-array'
+      }
+
+      expect(normalizeRosterOrderMap(input)).toEqual({
+        'local::sec-a': ['bot-1', 'bot-2', 'bot-3']
+      })
+    })
+  })
+
+  describe('rosterSectionScope', () => {
+    it('formats connection and section identity', () => {
+      expect(rosterSectionScope('sec-123', 'remote-gw')).toBe('remote-gw::sec-123')
+    })
+
+    it('defaults connection to local when absent', () => {
+      expect(rosterSectionScope('sec-123', null)).toBe('local::sec-123')
+      expect(rosterSectionScope('sec-123', '')).toBe('local::sec-123')
+    })
+
+    it('defaults section to unassigned when null or empty', () => {
+      expect(rosterSectionScope(null, 'remote-gw')).toBe('remote-gw::unassigned')
+      expect(rosterSectionScope('', 'local')).toBe('local::unassigned')
+      expect(rosterSectionScope(null, null)).toBe('local::unassigned')
+    })
+  })
+
+  describe('rosterRowKey', () => {
+    it('formats bot row key with connection and name', () => {
+      const bot: RosterRow = {
+        name: 'secops',
+        connectionId: 'local'
+      }
+
+      expect(rosterRowKey({ bot })).toBe('local::secops')
+      expect(rosterRowKey(bot)).toBe('local::secops')
+    })
+
+    it('formats bot on remote gateway with remote connectionId', () => {
+      const bot: RosterRow = {
+        name: 'triage',
+        connectionId: 'cloud-gw-1'
+      }
+
+      expect(rosterRowKey(bot)).toBe('cloud-gw-1::triage')
+    })
+  })
+
+  describe('orderRosterRows', () => {
+    const mockRows = [
+      { key: 'bot-1', activity: 100, created: 1000, pinned: false },
+      { key: 'bot-2', activity: 200, created: 2000, pinned: false },
+      { key: 'bot-3', activity: 50, created: 3000, pinned: false },
+      { key: 'bot-pinned', activity: 10, created: 500, pinned: true }
+    ]
+
+    it('defaults to pinned first, then activity descending when orderKeys is empty', () => {
+      const sorted = orderRosterRows(mockRows, r => r.key, [])
+      expect(sorted.map(r => r.key)).toEqual(['bot-pinned', 'bot-2', 'bot-1', 'bot-3'])
+    })
+
+    it('respects custom manual order while keeping pinned items at top', () => {
+      const sorted = orderRosterRows(mockRows, r => r.key, ['bot-3', 'bot-1'])
+      expect(sorted.map(r => r.key)).toEqual(['bot-pinned', 'bot-3', 'bot-1', 'bot-2'])
+    })
+
+    it('orders multiple pinned items according to custom order', () => {
+      const rowsWithTwoPinned = [
+        { key: 'pin-a', activity: 10, created: 100, pinned: true },
+        { key: 'pin-b', activity: 50, created: 200, pinned: true },
+        { key: 'normal-1', activity: 100, created: 300, pinned: false }
+      ]
+
+      const sortedAB = orderRosterRows(rowsWithTwoPinned, r => r.key, ['pin-a', 'pin-b'])
+      expect(sortedAB.map(r => r.key)).toEqual(['pin-a', 'pin-b', 'normal-1'])
+
+      const sortedBA = orderRosterRows(rowsWithTwoPinned, r => r.key, ['pin-b', 'pin-a'])
+      expect(sortedBA.map(r => r.key)).toEqual(['pin-b', 'pin-a', 'normal-1'])
+    })
+
+    it('places unranked newly discovered bots deterministically without activity churn', () => {
+      const rowsWithNewBots = [
+        { key: 'ranked-1', activity: 100, created: 1000, pinned: false },
+        { key: 'ranked-2', activity: 200, created: 2000, pinned: false },
+        { key: 'unranked-older', activity: 50, created: 3000, pinned: false },
+        { key: 'unranked-newer', activity: 10, created: 4000, pinned: false }
+      ]
+
+      const sorted1 = orderRosterRows(rowsWithNewBots, r => r.key, ['ranked-1', 'ranked-2'])
+      // Ranked items follow custom order; unranked follow created timestamp desc (newer first)
+      expect(sorted1.map(r => r.key)).toEqual(['ranked-1', 'ranked-2', 'unranked-newer', 'unranked-older'])
+
+      // Activity spike on unranked-older does NOT reorder unranked bots (prevents chat activity churn)
+      const rowsAfterChatSpike = [
+        { key: 'ranked-1', activity: 100, created: 1000, pinned: false },
+        { key: 'ranked-2', activity: 200, created: 2000, pinned: false },
+        { key: 'unranked-older', activity: 99999, created: 3000, pinned: false },
+        { key: 'unranked-newer', activity: 10, created: 4000, pinned: false }
+      ]
+
+      const sorted2 = orderRosterRows(rowsAfterChatSpike, r => r.key, ['ranked-1', 'ranked-2'])
+      expect(sorted2.map(r => r.key)).toEqual(['ranked-1', 'ranked-2', 'unranked-newer', 'unranked-older'])
+    })
+  })
+
+  describe('moveRosterItem', () => {
+    const allBots = ['a', 'b', 'c', 'd']
+
+    it('moves item before target', () => {
+      const next = moveRosterItem(['a', 'b', 'c', 'd'], allBots, 'd', 'b', 'before')
+      expect(next).toEqual(['a', 'd', 'b', 'c'])
+    })
+
+    it('moves item after target', () => {
+      const next = moveRosterItem(['a', 'b', 'c', 'd'], allBots, 'a', 'c', 'after')
+      expect(next).toEqual(['b', 'c', 'a', 'd'])
+    })
+
+    it('returns unchanged order if fromKey equals toKey', () => {
+      const next = moveRosterItem(['a', 'b', 'c'], allBots, 'b', 'b', 'before')
+      expect(next).toEqual(['a', 'b', 'c'])
+    })
+
+    it('seeds full section bots on first drag when current order is empty', () => {
+      const next = moveRosterItem([], ['x', 'y', 'z'], 'z', 'x', 'before')
+      expect(next).toEqual(['z', 'x', 'y'])
+    })
+
+    it('preserves filtered/hidden bots in durable order during search projection', () => {
+      const currentOrder = ['a', 'b', 'c', 'd']
+      // Search matches only 'a' and 'd'
+      // User moves 'd' before 'a'
+      const next = moveRosterItem(currentOrder, allBots, 'd', 'a', 'before')
+      // 'b' and 'c' are retained and not lost
+      expect(next).toEqual(['d', 'a', 'b', 'c'])
+    })
+  })
+
+  describe('interaction with #101290 sections', () => {
+    it('scopes ordering to section: reordering Section A leaves Section B and Unassigned unchanged', () => {
+      const scopeA = rosterSectionScope('sec-A', 'local')
+      const scopeB = rosterSectionScope('sec-B', 'local')
+      const scopeUnassigned = rosterSectionScope(null, 'local')
+
+      const initialMap = {
+        [scopeA]: ['bot-a1', 'bot-a2', 'bot-a3'],
+        [scopeB]: ['bot-b1', 'bot-b2'],
+        [scopeUnassigned]: ['bot-u1', 'bot-u2']
+      }
+
+      persistRosterOrder(initialMap)
+
+      // Reorder inside Section A
+      const nextOrderA = moveRosterItem(
+        initialMap[scopeA],
+        ['bot-a1', 'bot-a2', 'bot-a3'],
+        'bot-a3',
+        'bot-a1',
+        'before'
+      )
+      persistRosterOrder({
+        ...$rosterOrder.get(),
+        [scopeA]: nextOrderA
+      })
+
+      const state = $rosterOrder.get()
+      expect(state[scopeA]).toEqual(['bot-a3', 'bot-a1', 'bot-a2'])
+      // Section B and Unassigned are completely untouched
+      expect(state[scopeB]).toEqual(['bot-b1', 'bot-b2'])
+      expect(state[scopeUnassigned]).toEqual(['bot-u1', 'bot-u2'])
+    })
+
+    it('supports reordering inside Unassigned section', () => {
+      const scopeUnassigned = rosterSectionScope(null, 'local')
+      const unassignedBots = ['u1', 'u2', 'u3']
+
+      const next = moveRosterItem([], unassignedBots, 'u3', 'u1', 'before')
+      persistRosterOrder({
+        [scopeUnassigned]: next
+      })
+
+      expect($rosterOrder.get()[scopeUnassigned]).toEqual(['u3', 'u1', 'u2'])
+    })
+
+    it('prunes bot from old section order on move so it does not leak into new section', () => {
+      const scopeA = rosterSectionScope('sec-A', 'local')
+      const scopeB = rosterSectionScope('sec-B', 'local')
+
+      persistRosterOrder({
+        [scopeA]: ['bot-1', 'bot-2', 'bot-3'],
+        [scopeB]: ['bot-4', 'bot-5']
+      })
+
+      // Move bot-1 out of Section A
+      removeBotFromRosterOrder('bot-1', scopeA)
+
+      const state = $rosterOrder.get()
+      expect(state[scopeA]).toEqual(['bot-2', 'bot-3'])
+      // Section B does not have bot-1 in its order yet
+      expect(state[scopeB]).toEqual(['bot-4', 'bot-5'])
+    })
+
+    it('prunes deleted bots across all section scopes without leaving stale entries', () => {
+      const scopeA = rosterSectionScope('sec-A', 'local')
+      const scopeB = rosterSectionScope('sec-B', 'local')
+
+      persistRosterOrder({
+        [scopeA]: ['live-1', 'deleted-bot', 'live-2'],
+        [scopeB]: ['live-3', 'deleted-bot']
+      })
+
+      const liveKeys = new Set(['live-1', 'live-2', 'live-3'])
+      pruneRosterOrder(liveKeys)
+
+      const state = $rosterOrder.get()
+      expect(state[scopeA]).toEqual(['live-1', 'live-2'])
+      expect(state[scopeB]).toEqual(['live-3'])
+    })
+
+    it('resets section custom order back to default recency sort', () => {
+      const scopeA = rosterSectionScope('sec-A', 'local')
+      const scopeB = rosterSectionScope('sec-B', 'local')
+
+      persistRosterOrder({
+        [scopeA]: ['bot-a2', 'bot-a1'],
+        [scopeB]: ['bot-b2', 'bot-b1']
+      })
+
+      expect(hasCustomRosterOrder(scopeA)).toBe(true)
+      expect(hasAnyCustomRosterOrder()).toBe(true)
+
+      // Reset only Section A
+      clearRosterOrder(scopeA)
+
+      expect(hasCustomRosterOrder(scopeA)).toBe(false)
+      expect($rosterOrder.get()[scopeA]).toBeUndefined()
+      // Section B is still customized
+      expect(hasCustomRosterOrder(scopeB)).toBe(true)
+      expect($rosterOrder.get()[scopeB]).toEqual(['bot-b2', 'bot-b1'])
+
+      // Global reset
+      clearRosterOrder()
+      expect(hasAnyCustomRosterOrder()).toBe(false)
+      expect($rosterOrder.get()).toEqual({})
+    })
+
+    it('preserves persistence across loadRosterOrder', () => {
+      const scopeA = rosterSectionScope('sec-A', 'local')
+      persistRosterOrder({
+        [scopeA]: ['bot-1', 'bot-2']
+      })
+
+      // Simulate app reload
+      $rosterOrder.set({})
+      loadRosterOrder()
+
+      expect($rosterOrder.get()[scopeA]).toEqual(['bot-1', 'bot-2'])
+    })
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-order.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-order.ts
@@ -1,0 +1,309 @@
+/**
+ * Roster Section Manual Ordering and Drag Reorder.
+ *
+ * Provides persistent manual ordering scoped to individual roster sections.
+ * Composes with user-made sections (#101290) by scoping order to each section/connection
+ * context, preserving pinned-first semantics, deterministic unranked bot placement,
+ * and isolated per-section resets.
+ */
+
+import { atom } from 'nanostores'
+
+import { botRosterKey } from './data'
+import { getPluginCtx } from './shared'
+import type { RosterRow } from './types'
+import { $draggingBot, BOT_DRAG_MIME, onBotMovedToSection } from './user-sections'
+
+export { $draggingBot, BOT_DRAG_MIME }
+
+export const BOT_ROSTER_ORDER_KEY = 'bot-roster-order-v1'
+
+/** Map of sectionScopeKey -> array of bot roster keys in manual order. */
+export type RosterOrderMap = Record<string, string[]>
+
+export const $rosterOrder = atom<RosterOrderMap>({})
+
+/** Section scope of the bot currently in flight. */
+export const $draggingBotScope = atom<null | string>(null)
+
+/** Pinned status of the bot currently in flight. */
+export const $draggingBotPinned = atom<null | boolean>(null)
+
+/**
+ * Scope key for a section context, combining connection and section identity.
+ * Unassigned uses 'unassigned'.
+ */
+export function rosterSectionScope(sectionId: null | string, connectionId?: string | null): string {
+  const conn = String(connectionId || 'local').trim() || 'local'
+  const sec = sectionId ? String(sectionId).trim() : 'unassigned'
+
+  return `${conn}::${sec}`
+}
+
+export function normalizeRosterOrderMap(value: unknown): RosterOrderMap {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {}
+  }
+
+  const out: RosterOrderMap = {}
+
+  for (const [scope, list] of Object.entries(value)) {
+    if (!Array.isArray(list)) {
+      continue
+    }
+
+    const seen = new Set<string>()
+    const cleanList: string[] = []
+
+    for (const item of list) {
+      const key = String(item || '').trim()
+
+      if (!key || seen.has(key)) {
+        continue
+      }
+
+      seen.add(key)
+      cleanList.push(key)
+    }
+
+    if (cleanList.length > 0) {
+      out[scope] = cleanList
+    }
+  }
+
+  return out
+}
+
+export function persistRosterOrder(next: RosterOrderMap): void {
+  const clean = normalizeRosterOrderMap(next)
+  $rosterOrder.set(clean)
+
+  try {
+    getPluginCtx()?.storage?.set?.(BOT_ROSTER_ORDER_KEY, clean)
+  } catch {
+    // Storage unavailable - order persists for this window session
+  }
+}
+
+export function loadRosterOrder(): void {
+  try {
+    const raw = getPluginCtx()?.storage?.get?.(BOT_ROSTER_ORDER_KEY, {})
+    $rosterOrder.set(normalizeRosterOrderMap(raw))
+  } catch {
+    $rosterOrder.set({})
+  }
+}
+
+/** Clear custom order for a specific section scope, or all scopes if none passed. */
+export function clearRosterOrder(scopeKey?: string): void {
+  if (!scopeKey) {
+    persistRosterOrder({})
+
+    return
+  }
+
+  const current = { ...$rosterOrder.get() }
+  delete current[scopeKey]
+  persistRosterOrder(current)
+}
+
+/** Check whether a section scope has a custom manual order. */
+export function hasCustomRosterOrder(scopeKey: string, orderMap: RosterOrderMap = $rosterOrder.get()): boolean {
+  return Boolean(orderMap[scopeKey]?.length)
+}
+
+/** Check whether any section scope has a custom manual order. */
+export function hasAnyCustomRosterOrder(orderMap: RosterOrderMap = $rosterOrder.get()): boolean {
+  return Object.values(orderMap).some(list => list.length > 0)
+}
+
+/** Remove a bot key from a specific section's order, or all sections if scope omitted. */
+export function removeBotFromRosterOrder(botKey: string, scopeKey?: string): void {
+  const current = $rosterOrder.get()
+  const next: RosterOrderMap = {}
+  let changed = false
+
+  for (const [scope, list] of Object.entries(current)) {
+    if (scopeKey && scope !== scopeKey) {
+      next[scope] = list
+
+      continue
+    }
+
+    const filtered = list.filter(k => k !== botKey)
+
+    if (filtered.length !== list.length) {
+      changed = true
+
+      if (filtered.length > 0) {
+        next[scope] = filtered
+      }
+    } else if (list.length > 0) {
+      next[scope] = list
+    }
+  }
+
+  if (changed) {
+    persistRosterOrder(next)
+  }
+}
+
+/** Prune deleted or stale keys no longer in the active roster. */
+export function pruneRosterOrder(liveRosterKeys: Set<string>): void {
+  const current = $rosterOrder.get()
+  const next: RosterOrderMap = {}
+  let changed = false
+
+  for (const [scope, list] of Object.entries(current)) {
+    const filtered = list.filter(k => liveRosterKeys.has(k))
+
+    if (filtered.length !== list.length) {
+      changed = true
+    }
+
+    if (filtered.length > 0) {
+      next[scope] = filtered
+    }
+  }
+
+  if (changed) {
+    persistRosterOrder(next)
+  }
+}
+
+export function rosterRowKey(row: { bot?: RosterRow } | RosterRow): string {
+  const bot = ('bot' in row && row.bot ? row.bot : row) as RosterRow
+
+  return botRosterKey(bot)
+}
+
+export interface OrderableRosterRow {
+  activity: number
+  bot?: RosterRow
+  created?: number
+  pinned: boolean
+}
+
+/**
+ * Reorder rows within a section.
+ * Pinned rows stay at the top.
+ * When orderKeys is empty or undefined, falls back to default recency sort.
+ * When orderKeys is present:
+ *   - Ranked rows sort by their index in orderKeys.
+ *   - Unranked rows (newly discovered bots) sort deterministically by (created, key)
+ *     to prevent churn on chat activity, appended after ranked rows in each band.
+ */
+export function orderRosterRows<T extends OrderableRosterRow>(
+  rows: T[],
+  getRowKey: (row: T) => string,
+  orderKeys?: string[]
+): T[] {
+  if (!orderKeys || !orderKeys.length) {
+    return rows.slice().sort((a, b) => {
+      const pa = a.pinned ? 1 : 0
+      const pb = b.pinned ? 1 : 0
+
+      if (pa !== pb) {
+        return pb - pa
+      }
+
+      return b.activity - a.activity
+    })
+  }
+
+  const orderIndexMap = new Map<string, number>()
+  orderKeys.forEach((key, index) => {
+    orderIndexMap.set(key, index)
+  })
+
+  const sortBucket = (bucket: T[]): T[] => {
+    return bucket.slice().sort((a, b) => {
+      const keyA = getRowKey(a)
+      const keyB = getRowKey(b)
+      const idxA = orderIndexMap.has(keyA) ? orderIndexMap.get(keyA)! : -1
+      const idxB = orderIndexMap.has(keyB) ? orderIndexMap.get(keyB)! : -1
+
+      if (idxA >= 0 && idxB >= 0) {
+        return idxA - idxB
+      }
+
+      if (idxA >= 0) {
+        return -1
+      }
+
+      if (idxB >= 0) {
+        return 1
+      }
+
+      // Unranked rows: deterministic placement based on creation time then key.
+      // Avoids activity churn.
+      const ca = a.created || 0
+      const cb = b.created || 0
+
+      if (ca !== cb) {
+        return cb - ca
+      }
+
+      return keyA.localeCompare(keyB)
+    })
+  }
+
+  const pinnedRows = rows.filter(r => r.pinned)
+  const unpinnedRows = rows.filter(r => !r.pinned)
+
+  return [...sortBucket(pinnedRows), ...sortBucket(unpinnedRows)]
+}
+
+/**
+ * Move fromKey before or after toKey within a section scope.
+ * Preserves all existing keys (including hidden/filtered rows).
+ */
+export function moveRosterItem(
+  currentOrder: string[],
+  allSectionBotKeys: string[],
+  fromKey: string,
+  toKey: string,
+  position: 'before' | 'after'
+): string[] {
+  if (fromKey === toKey) {
+    return currentOrder
+  }
+
+  let baseOrder: string[]
+
+  if (currentOrder.length > 0) {
+    baseOrder = [...currentOrder]
+    const existing = new Set(baseOrder)
+
+    for (const key of allSectionBotKeys) {
+      if (!existing.has(key)) {
+        baseOrder.push(key)
+        existing.add(key)
+      }
+    }
+  } else {
+    baseOrder = [...allSectionBotKeys]
+  }
+
+  const fromIndex = baseOrder.indexOf(fromKey)
+
+  if (fromIndex >= 0) {
+    baseOrder.splice(fromIndex, 1)
+  }
+
+  const targetIndex = baseOrder.indexOf(toKey)
+
+  if (targetIndex < 0) {
+    baseOrder.push(fromKey)
+  } else {
+    const insertIndex = position === 'before' ? targetIndex : targetIndex + 1
+    baseOrder.splice(insertIndex, 0, fromKey)
+  }
+
+  return baseOrder
+}
+
+// Automatically purge bot from old section order whenever moved across sections
+onBotMovedToSection(bot => {
+  removeBotFromRosterOrder(botRosterKey(bot))
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -66,6 +66,20 @@ import { displayName } from './labels'
 import { deleteBot, mergeServerMeta, pullServerAvatars } from './profile-ops'
 import { $activityToasts, setActivityToasts, trackInboundActivity } from './roster-actions'
 import {
+  $draggingBotPinned,
+  $draggingBotScope,
+  $rosterOrder,
+  clearRosterOrder,
+  hasAnyCustomRosterOrder,
+  moveRosterItem,
+  orderRosterRows,
+  persistRosterOrder,
+  pruneRosterOrder,
+  removeBotFromRosterOrder,
+  rosterSectionScope
+} from './roster-order'
+import { ReorderableRosterRow } from './roster-order-row'
+import {
   botNeedsHandleLabel,
   filterBotsByGateway,
   GatewayKindGlyph,
@@ -83,6 +97,7 @@ import type { BotMeta, GatewaySource, GroupMember, RosterActivityFilter, RosterK
 import {
   $botSections,
   $draggingBot,
+  botSectionId,
   createBotSection,
   deleteBotSection,
   groupRowsBySection,
@@ -294,6 +309,7 @@ export function BotsPane() {
   const rosterHydrated = useValue($rosterHydrated)
   const selectionHydrated = useValue($selectedRosterHydrated)
   const selectedRosterKey = useValue($selectedRosterKey)
+  const rosterOrder = useValue($rosterOrder)
 
   // The socket opening (boot, SSH reconnect, sleep/wake) is the signal to
   // retry immediately instead of waiting out the poll interval.
@@ -338,6 +354,23 @@ export function BotsPane() {
 
     return activityOf(b) - activityOf(a)
   })
+
+  useEffect(() => {
+    if (!dragging) {
+      $draggingBotScope.set(null)
+      $draggingBotPinned.set(null)
+
+      return
+    }
+
+    const dragged = roster.find(bot => botRosterKey(bot) === dragging)
+
+    if (dragged) {
+      const sectionId = botSectionId(dragged, allMeta)
+      $draggingBotScope.set(rosterSectionScope(sectionId, dragged.connectionId))
+      $draggingBotPinned.set(isBotPinned(dragged, allMeta))
+    }
+  }, [dragging, roster, allMeta])
 
   // React Query can briefly report neither loading nor data while the plugin
   // and the persisted connection registry hydrate. Keep that transition in a
@@ -515,6 +548,7 @@ export function BotsPane() {
     pullServerAvatars(activeSourceRoster)
     trackInboundActivity(roster)
     backfillMessagingProtocol(activeSourceRoster)
+    pruneRosterOrder(new Set(roster.map(botRosterKey)))
     // React Query owns the stable server snapshot; derived arrays intentionally
     // follow that snapshot rather than retriggering on their own atom writes.
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -554,31 +588,64 @@ export function BotsPane() {
     return <GroupChatWorkspace group={groupChatName} members={groupChatMembers} />
   }
 
-  const renderBotRow = (bot: RosterRow, keyPrefix = '') => (
-    <BotRow
-      bot={bot}
-      key={`${keyPrefix}${botRosterKey(bot)}`}
-      onDelete={setDeleting}
-      onEdit={setEditing}
-      onGroup={setGrouping}
-      onNewSection={target => setSectionDialog({ bot: target, mode: 'create' })}
-      showHandle={botNeedsHandleLabel(bot, roster, allMeta)}
-    />
-  )
+  const renderBotRow = (
+    bot: RosterRow,
+    keyPrefix = '',
+    scopeKey?: string,
+    onReorder?: (sourceKey: string, targetKey: string, position: 'before' | 'after') => void
+  ) => {
+    const itemKey = botRosterKey(bot)
+    const pinned = isPinned(bot)
 
-  const renderGroupRow = (row: { members: GroupMember[]; name: string }) => (
-    <GroupRow
-      active={groupChatName === row.name}
-      group={row.name}
-      key={`group:${row.name}`}
-      members={row.members}
-      needsYou={Boolean(groupNeedsYou[row.name])}
-      onDisband={setDeletingGroup}
-      onOpen={openGroupChat}
-    />
-  )
+    const row = (
+      <BotRow
+        bot={bot}
+        onDelete={setDeleting}
+        onEdit={setEditing}
+        onGroup={setGrouping}
+        onNewSection={target => setSectionDialog({ bot: target, mode: 'create' })}
+        showHandle={botNeedsHandleLabel(bot, roster, allMeta)}
+      />
+    )
 
-  const removeSection = (id: string) => {
+    if (!scopeKey || !onReorder) {
+      return <div key={`${keyPrefix}${itemKey}`}>{row}</div>
+    }
+
+    return (
+      <ReorderableRosterRow
+        itemKey={itemKey}
+        key={`${keyPrefix}${itemKey}`}
+        onReorder={onReorder}
+        pinned={pinned}
+        scopeKey={scopeKey}
+      >
+        {row}
+      </ReorderableRosterRow>
+    )
+  }
+
+  const renderGroupRow = (row: { members: GroupMember[]; name: string }) => {
+    const itemKey = `group:${row.name}`
+
+    return (
+      <GroupRow
+        active={groupChatName === row.name}
+        group={row.name}
+        key={itemKey}
+        members={row.members}
+        needsYou={Boolean(groupNeedsYou[row.name])}
+        onDisband={setDeletingGroup}
+        onOpen={openGroupChat}
+      />
+    )
+  }
+
+  const removeSection = (id: string, scopeKey?: string) => {
+    if (scopeKey) {
+      clearRosterOrder(scopeKey)
+    }
+
     const name = userSections.find(section => section.id === id)?.name || ''
     const { members, undo } = deleteBotSection(id, roster)
 
@@ -602,9 +669,49 @@ export function BotsPane() {
   type UserSectionRow = { bot: RosterRow; kind?: 'bot' } | RosterGroupRow
 
   const renderUserSections = (rows: UserSectionRow[], keyPrefix = '') => {
-    // No sections made: the plain list, exactly as before this feature.
+    const connectionId = keyPrefix
+      ? keyPrefix.replace(/:$/, '')
+      : gatewayFilter !== 'all'
+        ? gatewayFilter
+        : gatewayOptions[0]?.connectionId || 'local'
+
+    // No sections made: the plain list, reorderable within Unassigned
     if (!userSections.length) {
-      return rows.map(row => (row.kind === 'group' ? renderGroupRow(row) : renderBotRow(row.bot, keyPrefix)))
+      const scopeKey = rosterSectionScope(null, connectionId)
+      const sectionOrderKeys = rosterOrder[scopeKey] || []
+
+      const plainGroupRows = rows.filter((r): r is RosterGroupRow => r.kind === 'group')
+      const plainBotRows = rows.filter((r): r is { bot: RosterRow; kind?: 'bot' } => r.kind !== 'group')
+
+      const allSectionBots = roster.filter(
+        b =>
+          botSectionId(b, allMeta) === null &&
+          (!connectionId || connectionId === 'all' || b.connectionId === connectionId)
+      )
+
+      const allSectionBotKeys = allSectionBots.map(botRosterKey)
+
+      const orderableBotRows = plainBotRows.map(r => ({
+        ...r,
+        pinned: isPinned(r.bot),
+        activity: activityOf(r.bot),
+        created: botRosterMeta(r.bot, allMeta)?.created || r.bot.ui_meta?.['hermes-bots']?.created || 0
+      }))
+
+      const orderedBotRows = orderRosterRows(orderableBotRows, row => botRosterKey(row.bot), sectionOrderKeys)
+
+      const handleReorder = (sourceKey: string, targetKey: string, position: 'before' | 'after') => {
+        const nextOrder = moveRosterItem(sectionOrderKeys, allSectionBotKeys, sourceKey, targetKey, position)
+        persistRosterOrder({
+          ...rosterOrder,
+          [scopeKey]: nextOrder
+        })
+      }
+
+      return [
+        ...plainGroupRows.map(renderGroupRow),
+        ...orderedBotRows.map(row => renderBotRow(row.bot, keyPrefix, scopeKey, handleReorder))
+      ]
     }
 
     const nested = Boolean(keyPrefix)
@@ -623,6 +730,41 @@ export function BotsPane() {
           const key = `${keyPrefix}${block.id ? `user-section:${block.id}` : UNASSIGNED_SECTION_KEY}`
           const collapsed = rosterSectionCollapsed(key)
           const order = userSections.findIndex(section => section.id === block.id)
+          const scopeKey = rosterSectionScope(block.id, connectionId)
+          const sectionOrderKeys = rosterOrder[scopeKey] || []
+          const hasCustomOrder = sectionOrderKeys.length > 0
+
+          const allSectionBots = roster.filter(
+            b =>
+              botSectionId(b, allMeta) === (block.id ?? null) &&
+              (!connectionId || connectionId === 'all' || b.connectionId === connectionId)
+          )
+
+          const allSectionBotKeys = allSectionBots.map(botRosterKey)
+
+          const blockGroupRows = block.rows.filter((r): r is RosterGroupRow => r.kind === 'group')
+          const blockBotRows = block.rows.filter((r): r is { bot: RosterRow; kind?: 'bot' } => r.kind !== 'group')
+
+          const orderableBotRows = blockBotRows.map(r => ({
+            ...r,
+            pinned: isPinned(r.bot),
+            activity: activityOf(r.bot),
+            created: botRosterMeta(r.bot, allMeta)?.created || r.bot.ui_meta?.['hermes-bots']?.created || 0
+          }))
+
+          const orderedBotRows = orderRosterRows(orderableBotRows, row => botRosterKey(row.bot), sectionOrderKeys)
+
+          const handleReorder = (sourceKey: string, targetKey: string, position: 'before' | 'after') => {
+            const nextOrder = moveRosterItem(sectionOrderKeys, allSectionBotKeys, sourceKey, targetKey, position)
+            persistRosterOrder({
+              ...rosterOrder,
+              [scopeKey]: nextOrder
+            })
+          }
+
+          const resetSectionOrder = () => {
+            clearRosterOrder(scopeKey)
+          }
 
           return (
             <SectionDropZone
@@ -637,6 +779,9 @@ export function BotsPane() {
                 // `block.id` is null for Unassigned, which is exactly the value
                 // moveBotsToSection wants for "clear the assignment".
                 if (bot) {
+                  const oldSectionId = botSectionId(bot, allMeta)
+                  const oldScopeKey = rosterSectionScope(oldSectionId, bot.connectionId)
+                  removeBotFromRosterOrder(rosterKey, oldScopeKey)
                   void moveBotsToSection([bot], block.id)
                 }
               }}
@@ -646,18 +791,23 @@ export function BotsPane() {
                 canMoveUp={order > 0}
                 collapsed={collapsed}
                 count={block.rows.length}
+                hasCustomOrder={hasCustomOrder}
                 id={block.id}
                 name={block.name}
-                onDelete={() => block.id && removeSection(block.id)}
+                onDelete={() => {
+                  if (block.id) {
+                    removeSection(block.id, scopeKey)
+                  }
+                }}
                 onMove={delta => block.id && moveBotSection(block.id, delta)}
                 onRename={() => block.id && setSectionDialog({ id: block.id, mode: 'rename', name: block.name })}
+                onResetOrder={hasCustomOrder ? resetSectionOrder : undefined}
                 onToggle={() => toggleRosterSection(key)}
               />
               {collapsed ? null : block.rows.length ? (
                 <div className="grid min-w-0 gap-0.5">
-                  {block.rows.map(row =>
-                    row.kind === 'group' ? renderGroupRow(row) : renderBotRow(row.bot, `${key}:`)
-                  )}
+                  {blockGroupRows.map(renderGroupRow)}
+                  {orderedBotRows.map(row => renderBotRow(row.bot, `${key}:`, scopeKey, handleReorder))}
                 </div>
               ) : (
                 // Empty section: a quiet dashed slot that says what it is for,
@@ -769,6 +919,15 @@ export function BotsPane() {
                 <Codicon className="mr-1.5" name="new-folder" />
                 {b.sections.newSection}
               </DropdownMenuItem>
+              {hasAnyCustomRosterOrder(rosterOrder) ? (
+                <>
+                  <DropdownMenuSeparator />
+                  <DropdownMenuItem onSelect={() => clearRosterOrder()}>
+                    <Codicon className="mr-1.5" name="clear-all" />
+                    {b.sections.resetOrder}
+                  </DropdownMenuItem>
+                </>
+              ) : null}
             </DropdownMenuContent>
           </DropdownMenu>
         </div>
@@ -1046,6 +1205,7 @@ export function BotsPane() {
           }
 
           const name = deleting.name
+          removeBotFromRosterOrder(botRosterKey(deleting))
           await deleteBot(deleting)
           await refetch()
           host.notify({

--- a/apps/desktop/src/plugins/hermes-bots/user-sections-ui.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/user-sections-ui.tsx
@@ -118,12 +118,14 @@ interface UserSectionHeaderProps {
   canMoveUp: boolean
   collapsed: boolean
   count: number
+  hasCustomOrder?: boolean
   /** null for Unassigned, which has no record and therefore no menu. */
   id: null | string
   name: string
   onDelete: () => void
   onMove: (delta: number) => void
   onRename: () => void
+  onResetOrder?: () => void
   onToggle: () => void
 }
 
@@ -132,28 +134,79 @@ export function UserSectionHeader({
   canMoveUp,
   collapsed,
   count,
+  hasCustomOrder,
   id,
   name,
   onDelete,
   onMove,
   onRename,
+  onResetOrder,
   onToggle
 }: UserSectionHeaderProps) {
   const b = useBots()
   const { t } = useI18n()
 
-  // Unassigned has no record to rename, reorder or delete — it is whatever is
-  // left over — so it gets the plain heading rather than a menu of disabled
-  // items.
+  // Unassigned has no record to rename, reorder or delete - it is whatever is
+  // left over - but when it has a custom order, offer Reset custom order.
   if (!id) {
+    if (!hasCustomOrder || !onResetOrder) {
+      return (
+        <RosterSectionHeader
+          collapsed={collapsed}
+          count={count}
+          icon="inbox"
+          label={b.sections.unassigned}
+          onToggle={onToggle}
+        />
+      )
+    }
+
+    const unassignedItems = [{ icon: 'clear-all', label: b.sections.resetOrder, onSelect: onResetOrder }]
+
+    const unassignedAction = (
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            aria-label={b.sections.options(b.sections.unassigned)}
+            className="shrink-0 rounded-md p-0.5 text-(--ui-text-quaternary) opacity-0 transition hover:text-foreground group-hover/section:opacity-100 focus-visible:opacity-100 data-[state=open]:opacity-100"
+            type="button"
+          >
+            <Codicon name="ellipsis" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          {unassignedItems.map(item => (
+            <DropdownMenuItem key={item.label} onSelect={item.onSelect}>
+              <Codicon className="mr-1.5" name={item.icon} />
+              {item.label}
+            </DropdownMenuItem>
+          ))}
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+
     return (
-      <RosterSectionHeader
-        collapsed={collapsed}
-        count={count}
-        icon="inbox"
-        label={b.sections.unassigned}
-        onToggle={onToggle}
-      />
+      <ContextMenu>
+        <ContextMenuTrigger asChild>
+          <div data-section-id="unassigned" data-slot="bots-section-heading">
+            <RosterSectionHeader
+              action={unassignedAction}
+              collapsed={collapsed}
+              count={count}
+              icon="inbox"
+              label={b.sections.unassigned}
+              onToggle={onToggle}
+            />
+          </div>
+        </ContextMenuTrigger>
+        <ContextMenuContent>
+          {unassignedItems.map(item => (
+            <ContextMenuItem key={item.label} onSelect={item.onSelect}>
+              {item.label}
+            </ContextMenuItem>
+          ))}
+        </ContextMenuContent>
+      </ContextMenu>
     )
   }
 
@@ -163,7 +216,10 @@ export function UserSectionHeader({
   const items = [
     { icon: 'edit', label: b.sections.rename, onSelect: onRename },
     { disabled: !canMoveUp, icon: 'arrow-up', label: b.sections.moveUp, onSelect: () => onMove(-1) },
-    { disabled: !canMoveDown, icon: 'arrow-down', label: b.sections.moveDown, onSelect: () => onMove(1) }
+    { disabled: !canMoveDown, icon: 'arrow-down', label: b.sections.moveDown, onSelect: () => onMove(1) },
+    ...(hasCustomOrder && onResetOrder
+      ? [{ icon: 'clear-all', label: b.sections.resetOrder, onSelect: onResetOrder }]
+      : [])
   ]
 
   const action = (

--- a/apps/desktop/src/plugins/hermes-bots/user-sections.ts
+++ b/apps/desktop/src/plugins/hermes-bots/user-sections.ts
@@ -165,6 +165,15 @@ export function moveBotSection(id: string, delta: number): void {
   persistBotSections(next)
 }
 
+export type BotMoveListener = (bot: RosterRow, targetSectionId: null | string) => void
+const botMoveListeners = new Set<BotMoveListener>()
+
+export function onBotMovedToSection(listener: BotMoveListener): () => void {
+  botMoveListeners.add(listener)
+
+  return () => botMoveListeners.delete(listener)
+}
+
 /**
  * `null` clears the assignment (back to Unassigned). One `saveBotMeta` per
  * bot — membership is a field on each bot's own profile, so that IS one write
@@ -174,6 +183,14 @@ export function moveBotSection(id: string, delta: number): void {
 export async function moveBotsToSection(bots: RosterRow[], sectionId: null | string): Promise<void> {
   for (const bot of bots || []) {
     if (bot && botSectionId(bot, $botMeta.get()) !== (sectionId || null)) {
+      for (const listener of botMoveListeners) {
+        try {
+          listener(bot, sectionId || null)
+        } catch {
+          // best-effort listener notification
+        }
+      }
+
       await saveBotMeta(bot, { sectionId: sectionId || null })
     }
   }


### PR DESCRIPTION
## Summary

Adds manual ordering for bots within individual roster sections in Bot Mode.

Upstream PR #101290 introduced user-created roster sections with drag-and-drop filing. Earlier manual-ordering PR #92634 was closed in favor of #101290, with maintainer guidance from @teknium1 inviting focused follow-ups for functionality not covered by sections, specifically manual ordering within a section.

This PR is that focused follow-up. It narrows PR #101870 strictly to manual ordering within sections and Unassigned. Unrelated group chat description schema and UI changes have been removed.

## Design and Composition with #101290

1. **Scoped Persistence**
   - Manual order is scoped to section context: `${connectionId}::${sectionId || 'unassigned'}`.
   - Reordering inside Section A leaves Section B and Unassigned completely untouched.

2. **Drag Gesture Disambiguation**
   - In-section drops: dragging between rows within the same section and pinned band targets row insertion lines (`before` / `after`) and stops event propagation to reorder.
   - Cross-section drops: dragging across sections ignores intra-row drop targets, bubbling to `SectionDropZone` to execute section filing as introduced in #101290.

3. **Pinned Bands and Deterministic Placement**
   - Pinned bots remain in the pinned band at the top; unpinned bots remain in the unpinned band.
   - Newly discovered or unranked bots sort deterministically by creation timestamp and key rather than jumping on chat activity updates.

4. **Projection Stability and Lifecycle Cleanup**
   - Filtering or searching does not truncate durable order; non-visible bots are preserved during reorder operations.
   - Moving a bot to another section or unassigning it prunes its entry from the previous section order, preventing order leakage into the destination section.
   - Deleting a section or bot prunes stale keys across all section scopes.

5. **Reset Custom Order**
   - Added `Reset custom order` to each section header menu (when customized), Unassigned header menu, and the Bots pane top menu.
   - Reverts immediately to default pinned recency sorting.

## Verification

- `npx vitest run --project ui src/plugins/hermes-bots/roster-order.test.ts`: 22/22 tests passing covering scoped isolation, unassigned reorder, cross-section move pruning, unranked determinism, filter projection preservation, section deletion, and reload persistence.
- Full plugin suite: `npx vitest run --project ui src/plugins/hermes-bots/`: 594/594 tests passing across 62 test files.
- TypeScript check: `npm run typecheck` passed with zero errors across core, Electron, and E2E configs.
- Code quality: `npx eslint` and `npx prettier --check` passed cleanly with zero warnings/errors.
- Clean diff: `git diff --check` passed.
