### PR TITLE
fix(slack): ack skill slash commands — matcher now includes skill slugs

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1103,6 +1103,33 @@ def _is_slack_voice_clip(file_obj: Dict[str, Any]) -> bool:
     return name.startswith("audio_message")
 
 
+def _slash_command_pattern() -> re.Pattern:
+    """Regex matching every native slash the gateway dispatcher can serve.
+
+    Built from ``slack_native_slashes()`` (COMMAND_REGISTRY + plugin commands)
+    plus the skill slash slugs. Skills dispatch like any gateway command but
+    live outside COMMAND_REGISTRY, so without them here slack_bolt logs
+    "Unhandled request", never acks, and Slack shows "app did not respond"
+    even though the manifest declares the slash and the gateway could serve
+    it. Only manifest-declared slashes ever arrive, so matching every skill
+    slug over-approves nothing.
+    """
+    from hermes_cli.commands import slack_native_slashes
+
+    names = [name for name, _d, _h in slack_native_slashes()]
+    try:
+        from agent.skill_commands import get_skill_commands
+
+        names += [k.lstrip("/") for k in get_skill_commands()]
+    except Exception:  # noqa: BLE001 - a failed skill scan must not stop Slack
+        logger.warning(
+            "[Slack] could not add skill slugs to the slash matcher", exc_info=True
+        )
+    if not names:  # pragma: no cover - registry always non-empty
+        return re.compile(r"^/hermes$")
+    return re.compile(r"^/(?:" + "|".join(re.escape(n) for n in names) + r")$")
+
+
 class SlackAdapter(BasePlatformAdapter):
     """
     Slack bot adapter using Socket Mode.
@@ -2324,18 +2351,7 @@ class SlackAdapter(BasePlatformAdapter):
             # routes the command event through the socket regardless of the
             # manifest's request URL, but it will not deliver an event for
             # a slash command the manifest doesn't declare.
-            from hermes_cli.commands import slack_native_slashes
-            import re as _re
-
-            _slash_names = [name for name, _d, _h in slack_native_slashes()]
-            if _slash_names:
-                _slash_pattern = _re.compile(
-                    r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
-                )
-            else:  # pragma: no cover - registry always non-empty
-                _slash_pattern = _re.compile(r"^/hermes$")
-
-            @self._app.command(_slash_pattern)
+            @self._app.command(_slash_command_pattern())
             async def handle_hermes_command(ack, command):
                 slash = (command.get("command") or "").lstrip("/")
                 await ack(
@@ -2369,7 +2385,7 @@ class SlackAdapter(BasePlatformAdapter):
             # Choice buttons use indexed action IDs so each ID is unique within
             # its actions block, as required by Slack's Block Kit schema.
             self._app.action(
-                _re.compile(r"^hermes_clarify_choice_\d+$")
+                re.compile(r"^hermes_clarify_choice_\d+$")
             )(self._handle_clarify_action)
             self._app.action("hermes_clarify_other")(self._handle_clarify_action)
 

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -303,6 +303,41 @@ class TestSlackWorkspaceCollisionIsolation:
 
 
 # ---------------------------------------------------------------------------
+# Slash matcher
+# ---------------------------------------------------------------------------
+
+
+class TestSlashCommandPattern:
+    """The bolt slash matcher must accept every slash the gateway can dispatch."""
+
+    def test_includes_skill_slugs(self):
+        """A skill slash (/<skill-name>) reaches slack_bolt only if the matcher
+        lists it; otherwise bolt logs "Unhandled request", never acks, and Slack
+        shows "app did not respond" even though gateway dispatch would serve it."""
+        with patch(
+            "agent.skill_commands.get_skill_commands",
+            return_value={"/my-skill": {"name": "my-skill"}},
+        ):
+            pattern = _slack_mod._slash_command_pattern()
+
+        assert pattern.match("/my-skill")
+        assert pattern.match("/btw"), "registry slashes must still match"
+        assert not pattern.match("/my-skill-extra"), "must be anchored"
+        assert not pattern.match("/unknown")
+
+    def test_skill_scan_failure_keeps_registry_slashes(self):
+        """A broken skills dir must not take the whole slash surface down."""
+        with patch(
+            "agent.skill_commands.get_skill_commands",
+            side_effect=RuntimeError("boom"),
+        ):
+            pattern = _slack_mod._slash_command_pattern()
+
+        assert pattern.match("/btw")
+        assert not pattern.match("/my-skill")
+
+
+# ---------------------------------------------------------------------------
 # TestAppMentionHandler
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What does this PR do?

Makes the Slack adapter acknowledge and dispatch **skill** slash commands (`/<skill-name>`).

The bolt `@app.command()` regex matcher was built from `slack_native_slashes()` only (COMMAND_REGISTRY + plugin commands). A skill slash declared in the Slack app manifest reached slack_bolt with no listener, so bolt logged `Unhandled request`, never acked, and Slack showed "failed because the app did not respond" — even though `_handle_slash_command` → gateway dispatch already resolves `/<skill>` for CLI, Telegram and Discord.

The fix extracts the matcher into a module-level `_slash_command_pattern()` and adds the skill slugs from `agent.skill_commands.get_skill_commands()`. This deliberately touches only the **matcher**, not `slack_native_slashes()` / the manifest list: the manifest is clamped at Slack's 50-slash cap (already full), and which skill slashes to declare is the workspace admin's decision. Only manifest-declared slashes are ever delivered, so accepting every skill slug over-approves nothing. A failed skill scan is logged and falls back to the registry slashes, so it cannot take Slack down.

## Related Issue

Fixes #101871

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/platforms/slack/adapter.py` — new `_slash_command_pattern()`; `connect()` uses it. Also drops the local `import re as _re` in favour of the module-level `re` (one other use in `connect()` updated).
- `tests/gateway/test_slack.py` — `TestSlashCommandPattern`: skill slug matches, registry slashes still match, anchoring, and scan-failure fallback.

## How to Test

1. Install a skill (`~/.hermes/skills/my-skill/SKILL.md`, `name: my-skill`) and add `/my-skill` to the Slack app manifest (`features.slash_commands`).
2. Restart the gateway. Before this PR: `/my-skill` in Slack → "app did not respond", `errors.log` shows `slack_bolt.AsyncApp: Unhandled request ({'type': None, 'command': '/my-skill'})`.
3. After this PR: Slack shows `Running /my-skill…` and the skill runs, same as on Telegram/Discord.
4. `scripts/run_tests.sh tests/gateway/test_slack.py tests/hermes_cli/test_commands.py -q` → 297 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#32211 covers bundles via the manifest list; this covers skills via the matcher)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` on the affected test files and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian 13, Python 3.11 — running in production Slack workspace since 2026-08-27 as a local patch

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```
WARNING slack_bolt.AsyncApp: Unhandled request ({'type': None, 'command': '/trixie2-short-analyse'})
```

After (same slash, same gateway):

```
INFO gateway.run: inbound message: platform=slack ... msg='[IMPORTANT: The user has invoked the "trixie2-short-analyse" skill ...'
```
