### PR TITLE
fix(discord): stabilize slash command reconciliation

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -77,6 +77,8 @@ _DISCORD_NONCONVERSATIONAL_STATE_FILENAME = "discord_nonconversational_messages.
 
 _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS = 4.5
 _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS = 30.0
+_DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS = 30.0
+_DISCORD_COMMAND_SYNC_MAX_ATTEMPTS = 3
 # Discord enforces a hard cap of 100 global application (slash) commands per
 # app. Registering more makes the ENTIRE sync fail with error 30032
 # ("Maximum number of application commands reached"), which silently breaks
@@ -1426,6 +1428,7 @@ class DiscordAdapter(BasePlatformAdapter):
             # on reconnect (see #18187). Without this, the old client remains
             # connected to Discord gateway and both fire on_message, causing
             # double responses.
+            await self._cancel_post_connect_initialization()
             if self._client is not None:
                 try:
                     if not self._client.is_closed():
@@ -1453,11 +1456,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._resolve_allowed_usernames()
                 adapter_self._ready_event.set()
 
-                if adapter_self._post_connect_task and not adapter_self._post_connect_task.done():
-                    adapter_self._post_connect_task.cancel()
-                adapter_self._post_connect_task = asyncio.create_task(
-                    adapter_self._run_post_connect_initialization()
-                )
+                adapter_self._start_post_connect_initialization()
                 if adapter_self._missed_message_backfill_enabled():
                     adapter_self._ensure_missed_message_backfill_task()
 
@@ -2247,12 +2246,7 @@ class DiscordAdapter(BasePlatformAdapter):
             except Exception as e:  # pragma: no cover - defensive logging
                 logger.warning("[%s] Error during disconnect: %s", self.name, e, exc_info=True)
 
-        if self._post_connect_task and not self._post_connect_task.done():
-            self._post_connect_task.cancel()
-            try:
-                await self._post_connect_task
-            except asyncio.CancelledError:
-                pass
+        await self._cancel_post_connect_initialization()
         if self._missed_message_backfill_task and not self._missed_message_backfill_task.done():
             self._missed_message_backfill_task.cancel()
             try:
@@ -2314,24 +2308,23 @@ class DiscordAdapter(BasePlatformAdapter):
         payload = json.dumps(desired, sort_keys=True, separators=(",", ":"))
         return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
-    def _command_sync_skip_reason(self, app_id: Any, fingerprint: str) -> Optional[str]:
+    def _command_sync_already_synced(self, app_id: Any, fingerprint: str) -> bool:
         entry = self._read_command_sync_state().get(self._command_sync_state_key(app_id))
         if not isinstance(entry, dict):
-            return None
-        now = time.time()
-        retry_after_until = float(entry.get("retry_after_until") or 0)
-        if retry_after_until > now:
-            remaining = max(1, int(retry_after_until - now))
-            return f"Discord asked us to wait before syncing slash commands; retry in {remaining}s"
+            return False
         last_success_at = float(entry.get("last_success_at") or 0)
         last_attempt_at = float(entry.get("last_attempt_at") or 0)
-        if (
+        return bool(
             entry.get("fingerprint") == fingerprint
             and last_success_at
             and last_success_at >= last_attempt_at
-        ):
-            return "same slash-command fingerprint already synced"
-        return None
+        )
+
+    def _command_sync_cooldown_remaining(self, app_id: Any) -> float:
+        entry = self._read_command_sync_state().get(self._command_sync_state_key(app_id))
+        if not isinstance(entry, dict):
+            return 0.0
+        return max(0.0, float(entry.get("retry_after_until") or 0) - time.time())
 
     def _record_command_sync_attempt(self, app_id: Any, fingerprint: str) -> None:
         state = self._read_command_sync_state()
@@ -2463,6 +2456,32 @@ class DiscordAdapter(BasePlatformAdapter):
         if interval > 0:
             await asyncio.sleep(interval)
 
+    async def _sleep_for_command_sync_retry(self, seconds: float) -> None:
+        """Sleep between bounded post-connect synchronization attempts."""
+        if seconds > 0:
+            await asyncio.sleep(seconds)
+
+    def _start_post_connect_initialization(self) -> None:
+        """Start deferred initialization once per active Discord client."""
+        task = self._post_connect_task
+        if task and not task.done():
+            return
+        self._post_connect_task = asyncio.create_task(
+            self._run_post_connect_initialization()
+        )
+
+    async def _cancel_post_connect_initialization(self) -> None:
+        """Cancel and await deferred initialization before replacing its client."""
+        task = self._post_connect_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
+        if self._post_connect_task is task:
+            self._post_connect_task = None
+
     async def _run_post_connect_initialization(self) -> None:
         """Finish non-critical startup work after Discord is connected."""
         if not self._client:
@@ -2480,43 +2499,79 @@ class DiscordAdapter(BasePlatformAdapter):
 
             app_id = getattr(self._client, "application_id", None) or getattr(getattr(self._client, "user", None), "id", None)
             fingerprint = self._desired_command_sync_fingerprint()
-            skip_reason = self._command_sync_skip_reason(app_id, fingerprint)
-            if skip_reason:
-                logger.info("[%s] Skipping Discord slash command sync: %s", self.name, skip_reason)
-                return
-            self._record_command_sync_attempt(app_id, fingerprint)
-
-            http = getattr(self._client, "http", None)
-            has_ratelimit_timeout = http is not None and hasattr(http, "max_ratelimit_timeout")
-            previous_ratelimit_timeout = getattr(http, "max_ratelimit_timeout", None) if has_ratelimit_timeout else None
-            if has_ratelimit_timeout:
-                http.max_ratelimit_timeout = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
-
-            try:
-                # Discord's per-app command-management bucket is small, and
-                # discord.py can otherwise sit inside one long retry sleep
-                # before surfacing the 429. Keep the whole sync bounded and
-                # persist Discord's retry-after when it refuses the batch.
-                summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
-            except Exception as e:
-                if not self._is_discord_rate_limit(e):
-                    raise
-                retry_after = self._extract_discord_retry_after(e)
-                if retry_after is None:
-                    # Rate-limited but no retry-after signal — back off for a
-                    # conservative default so we don't slam the bucket again.
-                    retry_after = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
-                self._record_command_sync_rate_limit(app_id, fingerprint, retry_after)
-                logger.warning(
-                    "[%s] Discord rate-limited slash command sync; retrying after %.0fs",
+            if self._command_sync_already_synced(app_id, fingerprint):
+                logger.info(
+                    "[%s] Skipping Discord slash command sync: same slash-command fingerprint already synced",
                     self.name,
-                    retry_after,
                 )
                 return
-            finally:
-                if has_ratelimit_timeout:
-                    http.max_ratelimit_timeout = previous_ratelimit_timeout
+            cooldown = self._command_sync_cooldown_remaining(app_id)
+            if cooldown > 0:
+                logger.info(
+                    "[%s] Waiting %.0fs for Discord slash-command rate-limit cooldown",
+                    self.name,
+                    cooldown,
+                )
+                await self._sleep_for_command_sync_retry(cooldown)
+            summary: Optional[Dict[str, int]] = None
+            for attempt in range(_DISCORD_COMMAND_SYNC_MAX_ATTEMPTS):
+                self._record_command_sync_attempt(app_id, fingerprint)
 
+                http = getattr(self._client, "http", None)
+                has_ratelimit_timeout = http is not None and hasattr(http, "max_ratelimit_timeout")
+                previous_ratelimit_timeout = getattr(http, "max_ratelimit_timeout", None) if has_ratelimit_timeout else None
+                if has_ratelimit_timeout and http is not None:
+                    http.max_ratelimit_timeout = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
+
+                retry_after = None
+                try:
+                    # Discord's per-app command-management bucket is small, and
+                    # discord.py can otherwise sit inside one long retry sleep
+                    # before surfacing the 429. Keep each attempt bounded and
+                    # persist Discord's retry-after when it refuses the batch.
+                    summary = await asyncio.wait_for(self._safe_sync_slash_commands(), timeout=600)
+                except asyncio.TimeoutError:
+                    retry_after = _DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS
+                    if attempt + 1 < _DISCORD_COMMAND_SYNC_MAX_ATTEMPTS:
+                        logger.warning(
+                            "[%s] Slash command sync timed out — Discord rate-limit bucket "
+                            "may be saturated; retrying after %.0fs",
+                            self.name,
+                            retry_after,
+                        )
+                except Exception as e:
+                    if not self._is_discord_rate_limit(e):
+                        raise
+                    retry_after = self._extract_discord_retry_after(e)
+                    if retry_after is None:
+                        # Rate-limited but no retry-after signal — back off for a
+                        # conservative default so we don't slam the bucket again.
+                        retry_after = _DISCORD_COMMAND_SYNC_MAX_RATE_LIMIT_SLEEP_SECONDS
+                    self._record_command_sync_rate_limit(app_id, fingerprint, retry_after)
+                    if attempt + 1 < _DISCORD_COMMAND_SYNC_MAX_ATTEMPTS:
+                        logger.warning(
+                            "[%s] Discord rate-limited slash command sync; retrying after %.0fs",
+                            self.name,
+                            retry_after,
+                        )
+                finally:
+                    if has_ratelimit_timeout and http is not None:
+                        http.max_ratelimit_timeout = previous_ratelimit_timeout
+
+                if retry_after is None:
+                    break
+                if attempt + 1 >= _DISCORD_COMMAND_SYNC_MAX_ATTEMPTS:
+                    logger.warning(
+                        "[%s] Slash command sync exhausted %d attempts; "
+                        "will retry on next reconnect",
+                        self.name,
+                        _DISCORD_COMMAND_SYNC_MAX_ATTEMPTS,
+                    )
+                    return
+                await self._sleep_for_command_sync_retry(retry_after)
+
+            if summary is None:  # pragma: no cover - loop exits only after success
+                raise RuntimeError("Discord slash command sync completed without a summary")
             self._record_command_sync_success(app_id, fingerprint, summary)
             logger.info(
                 "[%s] Safely reconciled %d slash command(s): unchanged=%d updated=%d recreated=%d created=%d deleted=%d",
@@ -3363,6 +3418,15 @@ class DiscordAdapter(BasePlatformAdapter):
             current_existing_payload = self._existing_command_to_payload(current)
             current_payload = self._canonicalize_app_command_payload(current_existing_payload)
             desired_payload = self._canonicalize_app_command_payload(desired)
+            # Discord expands omitted install/context policy fields to the
+            # application's defaults. Treat those server-filled values as
+            # unchanged when Hermes did not explicitly manage the field.
+            for defaulted_field in ("contexts", "integration_types"):
+                if (
+                    desired.get(defaulted_field) is None
+                    and defaulted_field in current_payload
+                ):
+                    desired_payload[defaulted_field] = current_payload[defaulted_field]
             if current_payload == desired_payload:
                 unchanged += 1
                 continue

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -329,6 +329,51 @@ async def test_disconnect_cancels_running_bot_task(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_start_post_connect_initialization_reuses_running_task(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    entered = asyncio.Event()
+    release = asyncio.Event()
+
+    async def _blocking_initialization():
+        entered.set()
+        await release.wait()
+
+    monkeypatch.setattr(adapter, "_run_post_connect_initialization", _blocking_initialization)
+
+    adapter._start_post_connect_initialization()
+    first_task = adapter._post_connect_task
+    assert first_task is not None
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    adapter._start_post_connect_initialization()
+
+    assert adapter._post_connect_task is first_task
+    release.set()
+    await first_task
+
+
+@pytest.mark.asyncio
+async def test_cancel_post_connect_initialization_awaits_running_task(monkeypatch):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    entered = asyncio.Event()
+
+    async def _blocking_initialization():
+        entered.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(adapter, "_run_post_connect_initialization", _blocking_initialization)
+    adapter._start_post_connect_initialization()
+    task = adapter._post_connect_task
+    assert task is not None
+    await asyncio.wait_for(entered.wait(), timeout=1)
+
+    await adapter._cancel_post_connect_initialization()
+
+    assert task.cancelled()
+    assert adapter._post_connect_task is None
+
+
+@pytest.mark.asyncio
 async def test_safe_sync_slash_commands_only_mutates_diffs():
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
 
@@ -440,7 +485,9 @@ async def test_safe_sync_slash_commands_only_mutates_diffs():
 
 
 @pytest.mark.asyncio
-async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp_path, monkeypatch):
+async def test_post_connect_initialization_retries_timeout_in_same_connection(
+    tmp_path, monkeypatch
+):
     adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
     monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
 
@@ -489,17 +536,15 @@ async def test_post_connect_initialization_retries_fingerprint_after_timeout(tmp
     }
     sync = AsyncMock(side_effect=[asyncio.TimeoutError(), summary])
     monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
-
-    await adapter._run_post_connect_initialization()
-
-    timed_out_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
-    assert timed_out_entry["fingerprint"] == desired_fingerprint
-    assert "last_success_at" not in timed_out_entry
-    assert "summary" not in timed_out_entry
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
 
     await adapter._run_post_connect_initialization()
 
     assert sync.await_count == 2
+    sleep.assert_awaited_once_with(
+        discord_platform._DISCORD_COMMAND_SYNC_TIMEOUT_BACKOFF_SECONDS
+    )
     recovered_entry = json.loads(state_path.read_text(encoding="utf-8"))["999"]
     assert recovered_entry["last_success_at"] >= recovered_entry["last_attempt_at"]
     assert recovered_entry["summary"] == summary
@@ -599,6 +644,277 @@ async def test_safe_sync_reads_permission_attrs_from_existing_command():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_not_awaited()
     fake_http.upsert_global_command.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_safe_sync_ignores_expanded_defaults_but_preserves_explicit_restrictions():
+    """Server defaults are ignored only while the local policy is unspecified."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+    desired = {
+        "name": "new",
+        "description": "Start a new conversation",
+        "type": 1,
+        "options": [],
+        "nsfw": False,
+        "dm_permission": True,
+        "default_member_permissions": None,
+        "contexts": None,
+        "integration_types": None,
+    }
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return dict(desired)
+
+    class _ExistingCommand:
+        id = 42
+        name = "new"
+        description = desired["description"]
+        type = SimpleNamespace(value=1)
+        nsfw = False
+        guild_only = False
+        default_member_permissions = None
+
+        def to_dict(self):
+            return {
+                "id": self.id,
+                "application_id": 999,
+                **desired,
+                "contexts": [0, 1, 2],
+                "integration_types": [0, 1],
+            }
+
+    fake_http = SimpleNamespace(
+        upsert_global_command=AsyncMock(),
+        edit_global_command=AsyncMock(),
+        delete_global_command=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(
+            get_commands=lambda: [_DesiredCommand()],
+            fetch_commands=AsyncMock(return_value=[_ExistingCommand()]),
+        ),
+        http=fake_http,
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    summary = await adapter._safe_sync_slash_commands()
+
+    assert summary == {
+        "total": 1,
+        "unchanged": 1,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    fake_http.edit_global_command.assert_not_awaited()
+    fake_http.delete_global_command.assert_not_awaited()
+    fake_http.upsert_global_command.assert_not_awaited()
+
+    desired["contexts"] = [0]
+    restricted_summary = await adapter._safe_sync_slash_commands()
+
+    assert restricted_summary == {
+        "total": 1,
+        "unchanged": 0,
+        "updated": 0,
+        "recreated": 1,
+        "created": 0,
+        "deleted": 0,
+    }
+    fake_http.delete_global_command.assert_awaited_once_with(999, 42)
+    fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_retries_rate_limit_in_same_connection(
+    tmp_path, monkeypatch
+):
+    """A logged retry must happen without waiting for a reconnect."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "status",
+                "description": "Show Hermes status",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    class _DiscordRateLimit(RuntimeError):
+        retry_after = 2.0
+
+    summary = {
+        "total": 1,
+        "unchanged": 1,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    sync = AsyncMock(side_effect=[_DiscordRateLimit("rate limited"), summary])
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+
+    await adapter._run_post_connect_initialization()
+
+    assert sync.await_count == 2
+    sleep.assert_awaited_once_with(2.0)
+    entry = adapter._read_command_sync_state()["999"]
+    assert entry["last_success_at"] >= entry["last_attempt_at"]
+    assert "retry_after_until" not in entry
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_retry_cancels_cleanly(
+    tmp_path, monkeypatch
+):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "status",
+                "description": "Show Hermes status",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    class _DiscordRateLimit(RuntimeError):
+        retry_after = 2.0
+
+    sync = AsyncMock(side_effect=_DiscordRateLimit("rate limited"))
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    entered_backoff = asyncio.Event()
+
+    async def _blocking_sleep(_seconds):
+        entered_backoff.set()
+        await asyncio.sleep(3600)
+
+    monkeypatch.setattr(adapter, "_sleep_for_command_sync_retry", _blocking_sleep)
+
+    task = asyncio.create_task(adapter._run_post_connect_initialization())
+    await asyncio.wait_for(entered_backoff.wait(), timeout=1)
+    task.cancel()
+
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert sync.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_stops_after_three_rate_limits(
+    tmp_path, monkeypatch, caplog
+):
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "status",
+                "description": "Show Hermes status",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+
+    class _DiscordRateLimit(RuntimeError):
+        retry_after = 2.0
+
+    sync = AsyncMock(
+        side_effect=[
+            _DiscordRateLimit("rate limited"),
+            _DiscordRateLimit("rate limited"),
+            _DiscordRateLimit("rate limited"),
+            AssertionError("slash command sync exceeded its retry budget"),
+        ]
+    )
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+
+    await adapter._run_post_connect_initialization()
+
+    assert sync.await_count == 3
+    assert [call.args[0] for call in sleep.await_args_list] == [2.0, 2.0]
+    entry = adapter._read_command_sync_state()["999"]
+    assert entry["last_attempt_at"]
+    assert entry["retry_after_until"] > entry["last_attempt_at"]
+    assert "last_success_at" not in entry
+    assert sum("retrying after" in message for message in caplog.messages) == 2
+    assert sum("exhausted 3 attempts" in message for message in caplog.messages) == 1
+
+
+@pytest.mark.asyncio
+async def test_post_connect_initialization_waits_out_persisted_cooldown(
+    tmp_path, monkeypatch
+):
+    """A reconnect must wait out a prior 429 and then reconcile."""
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    monkeypatch.setattr("hermes_constants.get_hermes_home", lambda: tmp_path)
+
+    class _DesiredCommand:
+        def to_dict(self, tree):
+            return {
+                "name": "status",
+                "description": "Show Hermes status",
+                "type": 1,
+                "options": [],
+            }
+
+    adapter._client = SimpleNamespace(
+        tree=SimpleNamespace(get_commands=lambda: [_DesiredCommand()]),
+        application_id=999,
+        user=SimpleNamespace(id=999),
+    )
+    fingerprint = adapter._desired_command_sync_fingerprint()
+    adapter._record_command_sync_rate_limit(999, fingerprint, 2.0)
+
+    summary = {
+        "total": 1,
+        "unchanged": 1,
+        "updated": 0,
+        "recreated": 0,
+        "created": 0,
+        "deleted": 0,
+    }
+    sync = AsyncMock(return_value=summary)
+    monkeypatch.setattr(adapter, "_safe_sync_slash_commands", sync)
+    sleep = AsyncMock()
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", sleep)
+
+    await adapter._run_post_connect_initialization()
+
+    sync.assert_awaited_once()
+    sleep.assert_awaited_once()
+    assert sleep.await_args_list[0].args[0] > 0
+    entry = adapter._read_command_sync_state()["999"]
+    assert entry["last_success_at"] >= entry["last_attempt_at"]
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- treat Discord-expanded `contexts` and `integration_types` defaults as semantically unchanged when Hermes leaves those policies unspecified
- retry HTTP 429 and outer-timeout failures during the same live gateway connection instead of merely logging a retry and returning
- honor a persisted Discord cooldown after reconnect, then continue synchronization without requiring another reconnect
- bound synchronization to three attempts per connection and preserve the final 429 cooldown for the next connection
- keep one post-connect initializer per active Discord client and cancel/await it before client replacement or disconnect

Closes #17157.
Closes #68963.

## Root cause

Two independent behaviors combine into the recurring slash-command failure:

1. Discord expands omitted install/context policies in fetched command payloads, while discord.py may serialize the desired policy as `None`. Literal comparison falsely marks unchanged commands as different and consumes Discord's small command-mutation bucket.
2. When synchronization encounters HTTP 429 or the outer timeout, Hermes records/logs the condition but abandons reconciliation until an unrelated reconnect. A healthy long-lived gateway can therefore retain a partially reconciled command registry indefinitely.

## Approach

The safe reconciler now copies Discord's fetched `contexts` and `integration_types` values into the comparison payload only when the desired value is unspecified. Explicit local restrictions remain authoritative and still cause a mutation.

Post-connect synchronization waits out persisted Discord cooldowns and retries in the current connection. Retries are capped at three total attempts, cancellation propagates, and the final failed attempt no longer falsely logs that another retry will occur.

Repeated `on_ready` events for the same client reuse the active initializer. Actual client replacement and disconnect cancel and await the owned task before proceeding, preventing overlapping command mutations or stale application-ID/fingerprint ownership.

## Prior work and credit

This combines and forward-ports the relevant ideas from:

- #95120 by @bertholomus — Discord-expanded default-field normalization
- #68967 by @PRATHAMESH75 — same-connection retry, persisted cooldown waiting, and cancellation-safe retry structure

Both PR branches are substantially behind current `main`. This PR narrows the work to slash-command reconciliation on current `main` and adds bounded retries plus explicit post-connect task ownership.

## Verification

TDD regressions cover:

- Discord-expanded defaults do not recreate unchanged commands
- explicit context restrictions still mutate
- HTTP 429 retries in the same connection
- persisted cooldown is waited after reconnect
- outer timeout backs off and retries
- cancellation during retry backoff propagates
- retries stop after three attempts with no false final retry log
- repeated readiness events reuse one initializer
- client replacement/disconnect cancels and awaits initialization

Commands run after rebasing onto current `origin/main`:

```text
scripts/run_tests.sh tests/gateway/test_discord_connect.py tests/gateway/test_discord_sync_limit.py tests/gateway/test_discord_slash_commands.py -q
35 passed, 0 failed

scripts/run_tests.sh tests/gateway/test_discord*.py -q
272 passed, 1 skipped, 0 failed across 46 files

uv run ruff check plugins/platforms/discord/adapter.py tests/gateway/test_discord_connect.py
All checks passed!

git diff --check
clean
```

Standalone Grok Build independently reran the same gates and returned `APPROVE` with no blocking findings after adversarial review of retry limits, task ownership, cancellation, cooldown persistence, and explicit default handling.

## Runtime scope

This branch was developed and tested in an isolated Git worktree. It was intentionally **not** applied to a live Hermes runtime and did not perform live Discord command mutations during validation; that avoids consuming the production application's command-management rate-limit bucket merely to exercise the patch.
