### PR TITLE
fix(retry): adaptive long backoff for Anthropic overloaded_error (HTTP 200 stream envelope)

### DIFF
--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -25,6 +25,18 @@ _jitter_lock = threading.Lock()
 _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# Anthropic surfaces capacity dips as an `overloaded_error` delivered *inside*
+# a streaming HTTP 200 body — no 429/529 status, no Retry-After header. Field
+# logs show whole 2-5 minute windows in which every request fails regardless of
+# context size (a fresh 9K-token session fails alongside a 168K one), then the
+# window clears on its own. The default 3-retry budget (~25s of 2s-base
+# exponential backoff) always expires inside such a window, so the turn dies
+# with "API call failed after 3 retries: HTTP 200: Overloaded" even though a
+# slightly wider wait would have succeeded. Same remedy as the Z.AI overload
+# above: a few short retries, then a widening long tier.
+_ANTHROPIC_OVERLOAD_LONG_BACKOFF = (15.0, 30.0, 60.0, 120.0)
+_ANTHROPIC_OVERLOAD_SHORT_ATTEMPTS = 3
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value (numeric / HTTP-date) or a headers mapping (both casings tried) into
@@ -97,19 +109,76 @@ def is_zai_coding_overload_error(*, base_url: str | None, model: str | None, err
     )
 
 
+def is_anthropic_overload_error(*, base_url: str | None, model: str | None, error: Any) -> bool:
+    """Return True for Anthropic-wire transient capacity overloads.
+
+    Anthropic reports these as ``{"type": "overloaded_error"}``. On the
+    streaming path the envelope is an HTTP 200 whose body carries the error, so
+    matching on status alone misses them entirely — which is precisely why the
+    generic 503/529 handling never fires for them.
+
+    Deliberately *not* scoped to ``api.anthropic.com``. Anthropic-compatible
+    endpoints reached through ``ANTHROPIC_BASE_URL`` — proxies, gateways, and
+    third-party models served over the Anthropic wire format — emit the same
+    error type and dead-end for the same reason; the endpoint in #55540 is
+    exactly such a proxy. Scoping by host would reintroduce the same class of
+    blind spot this function exists to close. ``overloaded_error`` is a
+    distinctive Anthropic-wire token, so matching the body rather than the host
+    does not sweep in other providers' free-text wording, and Z.AI's own
+    429/1305 overload is matched earlier in ``adaptive_rate_limit_backoff`` and
+    keeps its dedicated schedule.
+
+    ``base_url`` and ``model`` are accepted for call-site symmetry with
+    ``is_zai_coding_overload_error`` and are intentionally unused.
+    """
+    return "overloaded_error" in _error_text(error)
+
+
+def _overload_long_backoff(
+    attempt: int,
+    *,
+    short_attempts: int,
+    table: tuple[float, ...],
+    label: str,
+    default_wait: float,
+) -> tuple[float, str]:
+    """Short retries first, then walk ``table`` one entry per later attempt."""
+    if attempt <= short_attempts:
+        return default_wait, f"{label}_short"
+
+    idx = min(attempt - short_attempts - 1, len(table) - 1)
+    base_delay = table[idx]
+    # A smaller jitter ratio keeps long waits readable while still avoiding
+    # synchronized retry storms across concurrent Hermes sessions.
+    wait = jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2)
+    return wait, f"{label}_long"
+
+
 def adaptive_rate_limit_backoff(
     attempt: int, *, base_url: str | None, model: str | None, error: Any, default_wait: float,
     short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS,
 ) -> tuple[float, str | None]:
     """``(wait_seconds, reason_label)``: ``default_wait`` for most providers; Z.AI Coding GLM-5.2 overloads keep
-    ``short_attempts`` short retries, then 30→60→90→120s with light jitter. ``attempt`` is 1-based."""
-    if not is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
-        return default_wait, None
-    if attempt <= short_attempts:
-        return default_wait, "zai_coding_overload_short"
-    idx = min(attempt - short_attempts - 1, len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) - 1)
-    base_delay = _ZAI_CODING_OVERLOAD_LONG_BACKOFF[idx]
-    return jittered_backoff(1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2), "zai_coding_overload_long"
+    ``short_attempts`` short retries, then 30→60→90→120s with light jitter; Anthropic
+    ``overloaded_error`` (streaming HTTP 200 envelope) gets the same treatment on 15/30/60/120s.
+    ``attempt`` is 1-based."""
+    if is_zai_coding_overload_error(base_url=base_url, model=model, error=error):
+        return _overload_long_backoff(
+            attempt,
+            short_attempts=short_attempts,
+            table=_ZAI_CODING_OVERLOAD_LONG_BACKOFF,
+            label="zai_coding_overload",
+            default_wait=default_wait,
+        )
+    if is_anthropic_overload_error(base_url=base_url, model=model, error=error):
+        return _overload_long_backoff(
+            attempt,
+            short_attempts=_ANTHROPIC_OVERLOAD_SHORT_ATTEMPTS,
+            table=_ANTHROPIC_OVERLOAD_LONG_BACKOFF,
+            label="anthropic_overload",
+            default_wait=default_wait,
+        )
+    return default_wait, None
 
 
 def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS) -> int:
@@ -117,3 +186,15 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     because the loop gives up when ``retry_count >= ceiling`` BEFORE computing the attempt's
     backoff (the default ``api_max_retries`` of 3 equals ``short_attempts``)."""
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+def anthropic_overload_retry_ceiling(short_attempts: int = _ANTHROPIC_OVERLOAD_SHORT_ATTEMPTS) -> int:
+    """Retry-loop ceiling needed for the full Anthropic overload schedule.
+
+    Same rationale as ``zai_coding_overload_retry_ceiling``: the loop gives up
+    once ``retry_count >= ceiling``, and that check runs before the attempt's
+    backoff is computed, so the ceiling must sit one past the final long-backoff
+    entry. With the default ``api_max_retries`` (3) the long tier is otherwise
+    unreachable and a capacity window that lasts minutes kills the turn.
+    """
+    return short_attempts + len(_ANTHROPIC_OVERLOAD_LONG_BACKOFF) + 1

--- a/agent/turn_api_error.py
+++ b/agent/turn_api_error.py
@@ -172,6 +172,7 @@ def handle_api_error(
     is_rate_limited = _ce.is_rate_limited
     _wrapped_output_cap_budget = _ce.wrapped_output_cap_budget
     _is_zai_coding_overload = _ce.is_zai_coding_overload
+    _is_anthropic_overload = _ce.is_anthropic_overload
     if _ce.provider_overflow_recovery_pending:
         _provider_overflow_recovery_pending = True
     if _ce.action != "fallthrough":
@@ -201,6 +202,7 @@ def handle_api_error(
         agent, api_error=api_error, classified=classified, _retry=_retry, status_code=status_code,
         error_msg=error_msg, is_context_length_error=is_context_length_error,
         is_rate_limited=is_rate_limited, _is_zai_coding_overload=_is_zai_coding_overload,
+        _is_anthropic_overload=_is_anthropic_overload,
         _provider=_provider, _base=_base, _model=_model, messages=messages,
         api_messages=api_messages, api_kwargs=api_kwargs, active_system_prompt=active_system_prompt,
         conversation_history=conversation_history, approx_tokens=approx_tokens,
@@ -250,6 +252,7 @@ class UnrecoveredErrorVerdict:
 def settle_unrecovered_error(
     agent: Any, *, api_error: Any, classified: Any, _retry: Any, status_code: Any, error_msg: Any,
     is_context_length_error: Any, is_rate_limited: Any, _is_zai_coding_overload: Any,
+    _is_anthropic_overload: Any,
     _provider: Any, _base: Any, _model: Any, messages: Any, api_messages: Any, api_kwargs: Any,
     active_system_prompt: Any, conversation_history: Any, approx_tokens: Any, retry_count: Any,
     max_retries: Any, compression_attempts: Any, api_call_count: Any,
@@ -351,7 +354,7 @@ def settle_unrecovered_error(
     wait_time = compute_error_backoff(
         agent, api_error, retry_count=retry_count, max_retries=max_retries,
         is_rate_limited=is_rate_limited, is_zai_coding_overload=_is_zai_coding_overload,
-        base_url=_base, model=_model,
+        is_anthropic_overload=_is_anthropic_overload, base_url=_base, model=_model,
     )
     # Same preserve-redirect rule as the invalid-response wait: a steering correction
     # must survive backoff, not die as "Operation interrupted".

--- a/agent/turn_recovery.py
+++ b/agent/turn_recovery.py
@@ -17,7 +17,10 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from agent.conversation_compression import COMPRESSION_RETRY_CONTEXT_REDUCED_STATUS_TEMPLATE
 from agent.model_metadata import is_output_cap_error, parse_available_output_tokens_from_error
-from agent.retry_utils import is_zai_coding_overload_error, zai_coding_overload_retry_ceiling
+from agent.retry_utils import (
+    anthropic_overload_retry_ceiling, is_anthropic_overload_error,
+    is_zai_coding_overload_error, zai_coding_overload_retry_ceiling,
+)
 from agent.error_classifier import FailoverReason
 from agent.message_sanitization import (
     _looks_like_image_content_rejection, _sanitize_messages_non_ascii,
@@ -964,21 +967,23 @@ def interruptible_backoff_sleep(
     return None
 
 
-_ZAI_POLICY_NOTES = {
+_POLICY_NOTES = {
     "zai_coding_overload_long": " (Z.AI Coding overload adaptive long backoff)",
     "zai_coding_overload_short": " (Z.AI Coding overload short retry)",
+    "anthropic_overload_long": " (Anthropic overload adaptive long backoff)",
+    "anthropic_overload_short": " (Anthropic overload short retry)",
 }
 
 
 def compute_error_backoff(
     agent: Any, api_error: Exception, *, retry_count: int, max_retries: int, is_rate_limited: bool,
-    is_zai_coding_overload: bool, base_url: Any, model: Any,
+    is_zai_coding_overload: bool, is_anthropic_overload: bool, base_url: Any, model: Any,
 ) -> float:
     """Pick the wait before the next API retry and announce it. Retry-After wins for
     rate limits and any other retryable error (capped at 600s: Anthropic Tier 1 buckets
     reset in ~171s, so a 120s cap re-tripped the limit); otherwise jittered backoff,
-    replaced by the adaptive policy for 429s / Z.AI overloads. Normal retries are
-    buffered; long Z.AI Coding waits surface immediately."""
+    replaced by the adaptive policy for 429s / Z.AI overloads / Anthropic overloaded_error.
+    Normal retries are buffered; long overload waits surface immediately."""
     # Imported lazily so tests that patch ``agent.retry_utils.jittered_backoff`` /
     # ``adaptive_rate_limit_backoff`` (incl. the run_agent conftest fast-backoff fixture) intercept.
     from agent.retry_utils import adaptive_rate_limit_backoff, jittered_backoff, parse_retry_after_seconds
@@ -1010,16 +1015,17 @@ def compute_error_backoff(
             _retry_after = None
     wait_time = _retry_after if _retry_after is not None else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
     _backoff_policy = None
-    _adaptive = is_rate_limited or is_zai_coding_overload
+    _is_capacity_overload = is_zai_coding_overload or is_anthropic_overload
+    _adaptive = is_rate_limited or _is_capacity_overload
     if _adaptive and _retry_after is None:
         wait_time, _backoff_policy = adaptive_rate_limit_backoff(
             retry_count, base_url=str(base_url), model=model, error=api_error, default_wait=wait_time,
         )
     if _adaptive:
-        _policy_note = _ZAI_POLICY_NOTES.get(_backoff_policy or "", "")
-        _wait_reason = "Provider overloaded" if is_zai_coding_overload and not is_rate_limited else "Rate limited"
+        _policy_note = _POLICY_NOTES.get(_backoff_policy or "", "")
+        _wait_reason = "Provider overloaded" if _is_capacity_overload and not is_rate_limited else "Rate limited"
         _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
-        if _backoff_policy == "zai_coding_overload_long":
+        if _backoff_policy in ("zai_coding_overload_long", "anthropic_overload_long"):
             agent._emit_status(_rate_limit_status)
         else:
             agent._buffer_status(_rate_limit_status)
@@ -1174,6 +1180,7 @@ class ClassifiedErrorVerdict:
     is_rate_limited: bool
     wrapped_output_cap_budget: Optional[int]
     is_zai_coding_overload: bool
+    is_anthropic_overload: bool
 
 
 _OVERFLOW_REASONS = frozenset({
@@ -1276,6 +1283,7 @@ def route_classified_error(
     is_rate_limited = False
     _wrapped_output_cap_budget = None
     _is_zai_coding_overload = False
+    _is_anthropic_overload = False
     status_code = getattr(api_error, "status_code", None)
 
     def _verdict(action: str, result: Optional[Dict[str, Any]] = None) -> ClassifiedErrorVerdict:
@@ -1286,7 +1294,7 @@ def route_classified_error(
             compression_attempts=compression_attempts,
             provider_overflow_recovery_pending=_provider_overflow_recovery_pending,
             is_rate_limited=is_rate_limited, wrapped_output_cap_budget=_wrapped_output_cap_budget,
-            is_zai_coding_overload=_is_zai_coding_overload,
+            is_zai_coding_overload=_is_zai_coding_overload, is_anthropic_overload=_is_anthropic_overload,
         )
 
     def _fallback_break() -> ClassifiedErrorVerdict:
@@ -1382,6 +1390,13 @@ def route_classified_error(
     _is_zai_coding_overload = is_zai_coding_overload_error(base_url=str(base_url), model=model, error=api_error)
     if _is_zai_coding_overload:
         max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+    # Anthropic capacity dips arrive as `overloaded_error` inside a streaming 200 —
+    # no status code, so `is_rate_limited` is False and the default 3-retry budget
+    # (~25s) expires well inside a window that routinely lasts minutes. Raise the
+    # ceiling so the adaptive long tier is reachable.
+    _is_anthropic_overload = is_anthropic_overload_error(base_url=str(base_url), model=model, error=api_error)
+    if _is_anthropic_overload:
+        max_retries = max(max_retries, anthropic_overload_retry_ceiling())
     _should_fallback = (
         (is_rate_limited and _wrapped_output_cap_budget is None)
         or (_is_transport_failure and retry_count >= 2)

--- a/tests/test_retry_utils.py
+++ b/tests/test_retry_utils.py
@@ -5,7 +5,12 @@ import threading
 import agent.retry_utils as retry_utils
 from types import SimpleNamespace
 
-from agent.retry_utils import adaptive_rate_limit_backoff, is_zai_coding_overload_error, jittered_backoff
+from agent.retry_utils import (
+    adaptive_rate_limit_backoff,
+    is_anthropic_overload_error,
+    is_zai_coding_overload_error,
+    jittered_backoff,
+)
 
 
 def test_backoff_is_exponential():
@@ -167,6 +172,134 @@ def test_zai_overload_ceiling_makes_long_tier_reachable(monkeypatch):
 
     assert long_waits, "long-backoff tier never reached within the retry ceiling"
     assert long_waits == [30.0, 60.0, 90.0, 120.0]
+
+
+def _anthropic_overload_error(status_code=200):
+    """Anthropic capacity dip as seen on the streaming path.
+
+    The envelope is HTTP 200 — the error rides in the body — so anything that
+    keys off the status code alone will miss it.
+    """
+    return SimpleNamespace(
+        status_code=status_code,
+        body={"type": "error", "error": {"type": "overloaded_error", "message": "Overloaded"}},
+    )
+
+
+def test_anthropic_overload_detected_despite_http_200():
+    """The streaming path delivers `overloaded_error` inside a 200 body."""
+    assert is_anthropic_overload_error(
+        base_url="https://api.anthropic.com",
+        model="claude-opus-5",
+        error=_anthropic_overload_error(),
+    )
+
+
+def test_anthropic_overload_covers_anthropic_compatible_proxies():
+    """`ANTHROPIC_BASE_URL` proxies emit the same error type and must qualify.
+
+    Host-scoping would reintroduce the blind spot this detection exists to
+    close — the endpoint reported in #55540 is exactly such a proxy.
+    """
+    assert is_anthropic_overload_error(
+        base_url="https://my-gateway.internal/v1",
+        model="glm-5.2",
+        error=_anthropic_overload_error(),
+    )
+
+
+def test_overload_detection_requires_the_anthropic_wire_token():
+    """Free-text 'overloaded' from some other provider must not qualify.
+
+    Matching the body is only safe because `overloaded_error` is a distinctive
+    Anthropic-wire token; a generic phrase must stay out.
+    """
+    generic = SimpleNamespace(
+        status_code=503,
+        body={"error": {"message": "Server is overloaded, please try again"}},
+    )
+    assert not is_anthropic_overload_error(
+        base_url="https://api.example.com/v1", model="some-model", error=generic
+    )
+
+
+def test_zai_overload_keeps_its_own_schedule():
+    """Z.AI is matched first and must not be captured by the Anthropic tier."""
+    monkey_err = _zai_overload_error()
+    _wait, policy = adaptive_rate_limit_backoff(
+        4,
+        base_url="https://api.z.ai/api/coding/paas/v4",
+        model="glm-5.2",
+        error=monkey_err,
+        default_wait=1.0,
+    )
+    assert policy == "zai_coding_overload_long"
+
+
+def test_non_overload_anthropic_error_uses_default_wait():
+    """Ordinary Anthropic failures keep the default exponential schedule."""
+    err = SimpleNamespace(status_code=500, body={"error": {"type": "api_error"}})
+    wait, policy = adaptive_rate_limit_backoff(
+        1,
+        base_url="https://api.anthropic.com",
+        model="claude-opus-5",
+        error=err,
+        default_wait=2.0,
+    )
+    assert (wait, policy) == (2.0, None)
+
+
+def test_anthropic_overload_ceiling_makes_long_tier_reachable(monkeypatch):
+    """With the extended ceiling the full 15/30/60/120s schedule executes.
+
+    Without it, `api_max_retries` (3) equals the short-attempt count, so the
+    long tier is dead code and a multi-minute capacity window kills the turn.
+    """
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    from agent.retry_utils import anthropic_overload_retry_ceiling
+
+    err = _anthropic_overload_error()
+    ceiling = anthropic_overload_retry_ceiling()
+
+    long_waits = []
+    # The loop computes backoff for attempts 1..ceiling-1 (it gives up at ceiling).
+    for attempt in range(1, ceiling):
+        wait, policy = adaptive_rate_limit_backoff(
+            attempt,
+            base_url="https://api.anthropic.com",
+            model="claude-opus-5",
+            error=err,
+            default_wait=1.0,
+        )
+        if policy == "anthropic_overload_long":
+            long_waits.append(wait)
+
+    assert long_waits, "long-backoff tier never reached within the retry ceiling"
+    assert long_waits == [15.0, 30.0, 60.0, 120.0]
+
+
+def test_anthropic_overload_outlasts_a_multi_minute_window(monkeypatch):
+    """The observed failure mode: capacity windows lasting minutes.
+
+    Total wait across the ceiling must exceed the ~2 min window seen in the
+    field, where the stock 3-retry budget spent only ~25s.
+    """
+    monkeypatch.setattr(retry_utils, "jittered_backoff", lambda *a, **kw: kw["base_delay"])
+    from agent.retry_utils import anthropic_overload_retry_ceiling
+
+    err = _anthropic_overload_error()
+    ceiling = anthropic_overload_retry_ceiling()
+    total = sum(
+        adaptive_rate_limit_backoff(
+            attempt,
+            base_url="https://api.anthropic.com",
+            model="claude-opus-5",
+            error=err,
+            default_wait=2.0,
+        )[0]
+        for attempt in range(1, ceiling)
+    )
+    assert total >= 180.0, f"only {total}s of retry budget — a 2 min window still kills the turn"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Anthropic capacity dips arrive as `overloaded_error` delivered **inside a streaming HTTP 200 body** — no 429/529 status, no `Retry-After` header:

```
provider=anthropic base_url=https://api.anthropic.com model=claude-opus-5
summary=HTTP 200: Overloaded
error={'type': 'error', 'error': {'type': 'overloaded_error', 'message': 'Overloaded'}}
```

Because there is no overload status code, `is_rate_limited` is False and the request falls through to the default schedule: `api_max_retries` 3 on a 2s-base exponential backoff — **~25s of total retry budget**. The turn then dies with `API call failed after 3 retries: HTTP 200: Overloaded`.

Two things from production logs sized the fix:

1. **The window lasts minutes, not seconds.** In one span from 13:26:52 to 13:28:50, 43 requests were attempted and every single one failed with `overloaded_error` — zero successes. The stock ~25s budget expires deep inside such a window, and the endpoint recovers shortly after.

2. **It is independent of request shape.** In that same window a brand-new session (`msgs=2`, ~9.5K tokens) failed identically to a long one (`msgs=170`, ~168K tokens). This is pure upstream capacity — not context size, tool count, or prompt content — so retrying the *same* request after a longer wait is the correct recovery and no request-side mitigation helps.

**Why this approach:** the repo already solved this exact problem shape for Z.AI Coding overload 429s, including the subtle part — `zai_coding_overload_retry_ceiling()` exists because a long-backoff table is dead code when `api_max_retries` equals the short-attempt count. Rather than add a second parallel mechanism, this reuses that shape and factors the shared walk into one helper so the two schedules cannot drift apart.

Detection matches the `overloaded_error` body rather than the host, so Anthropic-compatible endpoints reached through `ANTHROPIC_BASE_URL` are covered too — the endpoint in #55540 is exactly such a proxy, and host-scoping would reintroduce the same class of blind spot this change exists to close. `overloaded_error` is a distinctive Anthropic-wire token, so other providers' free-text "overloaded" wording stays out, and Z.AI's 429/1305 is matched earlier and keeps its dedicated schedule.

## Related Issue

Relates to #55540 — that issue asks for exactly this parity, but it and #56037 both route on HTTP status, which cannot reach the streaming-200 shape described above. This PR is complementary and does not overlap #56037's configurability work: #56037 makes the numbers tunable, this makes the Anthropic wire shape reach the overload path at all.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/retry_utils.py`
  - `is_anthropic_overload_error()` — matches the `overloaded_error` body; catches the HTTP 200 streaming envelope.
  - `_ANTHROPIC_OVERLOAD_LONG_BACKOFF = (15, 30, 60, 120)` and `_ANTHROPIC_OVERLOAD_SHORT_ATTEMPTS = 3`.
  - `anthropic_overload_retry_ceiling()` — sizes the retry loop so every long-tier entry is reachable.
  - `_overload_long_backoff()` — extracted shared walk, now used by both the Z.AI and Anthropic paths.
  - `adaptive_rate_limit_backoff()` — dispatches to whichever overload policy matches; Z.AI is checked first and is behaviourally unchanged.
- `agent/conversation_loop.py`
  - Raises the retry ceiling on an Anthropic overload, mirroring the existing Z.AI branch.
  - Status/log decoration for the new policy labels; the long-wait path emits immediately rather than buffering, so the TUI does not look frozen during a multi-minute wait.
- `tests/test_retry_utils.py` — six added (see below).

## How to Test

1. Unit tests: `pytest tests/test_retry_utils.py -q` → 18 passed.
2. Verify against a real SDK exception rather than a hand-rolled stub — this is the part most likely to silently not fire, since `str(err)` for this error is just `"Overloaded"` and the token lives in `.body`:
   ```python
   import httpx, anthropic
   from agent.retry_utils import is_anthropic_overload_error, adaptive_rate_limit_backoff
   body = {'type':'error','error':{'type':'overloaded_error','message':'Overloaded'}}
   resp = httpx.Response(200, request=httpx.Request("POST","https://api.anthropic.com/v1/messages"))
   err = anthropic.APIStatusError("Overloaded", response=resp, body=body)
   assert is_anthropic_overload_error(base_url="https://api.anthropic.com", model="claude-opus-5", error=err)
   print(adaptive_rate_limit_backoff(4, base_url="https://api.anthropic.com",
                                     model="claude-opus-5", error=err, default_wait=2.0))
   # -> (16.1, 'anthropic_overload_long')
   ```
   Same call with `base_url="https://my-proxy.internal/v1"` also qualifies, covering the `ANTHROPIC_BASE_URL` case.
3. Confirm the Z.AI path is untouched: same call with the Z.AI base URL and a 429/1305 body still returns `zai_coding_overload_long`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — see the note below
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 25.2.0), Python 3.11

Note on the full suite: `scripts/run_tests.sh` gives **44,591 passed / 111 failed across 33 files** on this branch in my environment. None of them touch `retry_utils` or `conversation_loop`. I re-ran those same 33 files against unmodified `main` to check attribution:

- **29 files fail identically on `main`** — `tests/plugins/`, `tests/tools/`, packaging, and CLI tests that need optional deps and provider credentials I don't have locally.
- **4 files** (`test_compression_attempt_lifecycle`, `test_compression_stall_fallback_78981`, `gateway/test_compress_command`, `gateway/test_gateway_shutdown`) are **load-dependent timing flakes**, not regressions: they fail under full-suite parallel load and pass on this branch when run on their own (48/48). I also saw `test_compression_attempt_lifecycle` fail on unmodified `main` when run individually, so the flakiness is not branch-specific. The failing assertions are all grace-period / join-timeout style.

Every test that exercises the changed code passes.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new functions explain the trade-off; no user-facing docs affected
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no new config keys
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, no platform-specific calls; pure timing arithmetic
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

The failure this fixes, from `~/.hermes/logs/agent.log`:

```
13:26:52 WARNING API call failed (attempt 1/3) error_type=APIStatusError provider=anthropic
         base_url=https://api.anthropic.com model=claude-opus-5 summary=HTTP 200: Overloaded
13:26:52 WARNING Retrying API call in 2.82s (attempt 1/3) policy=default
13:26:58 WARNING Retrying API call in 5.41s (attempt 2/3) policy=default
13:27:09 ERROR   API call failed after 3 retries. HTTP 200: Overloaded
                 | provider=anthropic model=claude-opus-5 msgs=169 tokens=~167,955
13:27:09 INFO    tui turn finished: status=error failure_reason=overloaded
```

Total elapsed before giving up: 17 seconds. The next successful request in that session was minutes later.
