### PR TITLE
fix(desktop): invalidate stale profile fetches after gateway switch

### DIFF
--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx
@@ -26,7 +26,7 @@ import {
   recoverActiveSourceAfterFailedGatewaySwitch
 } from '@/store/gateway-switch'
 import { notifyError } from '@/store/notifications'
-import { $activeGatewayProfile, $profiles, ensureGatewayProfile } from '@/store/profile'
+import { $activeGatewayProfile, $profiles, ensureGatewayProfile, refreshProfiles } from '@/store/profile'
 import {
   $activeSessionId,
   $awaitingResponse,
@@ -404,6 +404,56 @@ describe('useGatewayBoot remote reconnect loop (real hook, fake socket)', () => 
     expect(beforeConnectionSwitch).toHaveBeenCalledTimes(1)
     await flushAsync()
     expect($gatewayState.get()).toBe('open')
+  })
+
+  it('restarts a profile-list fetch that refills during a same-profile gateway switch', async () => {
+    const desktop = fakeDesktop()
+
+    const nextConnection = {
+      ...primaryConn,
+      baseUrl: 'https://next-vps.example.com',
+      connectionId: 'next-vps',
+      wsUrl: 'wss://next-vps.example.com/api/ws?token=t'
+    }
+
+    const nextDescriptor = deferred<typeof nextConnection>()
+    const staleProfiles = deferred<{ profiles: Array<{ is_default: boolean; name: string }> }>()
+
+    const api = vi.fn(async (request: { connectionId?: string; path: string }) => {
+      if (request.path === '/api/profiles/active') {
+        return { active: 'default', current: 'default' }
+      }
+
+      if (request.connectionId === nextConnection.connectionId) {
+        return { profiles: [{ is_default: true, name: 'default' }, { is_default: false, name: 'thanos' }] }
+      }
+
+      return staleProfiles.promise
+    })
+
+    ;(desktop as typeof desktop & { api: typeof api }).api = api
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+    desktop.getConnection.mockImplementationOnce(() => nextDescriptor.promise)
+
+    act(() => connectionApplied?.())
+    expect($gatewaySwitching.get()).toBe(true)
+
+    // A background refresh can start after beginGatewaySwitch invalidates the
+    // old slot but before the new route publishes. The commit must strand it.
+    const staleRefresh = refreshProfiles()
+    nextDescriptor.resolve(nextConnection)
+    await flushAsync()
+    await flushAsync()
+
+    await vi.waitFor(() => expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'thanos']))
+
+    staleProfiles.resolve({ profiles: [{ is_default: true, name: 'default' }, { is_default: false, name: 'mali' }] })
+    await staleRefresh
+
+    expect($profiles.get().map(profile => profile.name)).toEqual(['default', 'thanos'])
   })
 
   it('a stale failed Settings switch cannot publish failure or disarm the newer switch owner', async () => {

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -48,6 +48,7 @@ import { checkLocalRuntimeUpdate, watchLocalRuntimeJobs } from '@/store/local-ru
 import { notify, notifyError } from '@/store/notifications'
 import {
   $activeGatewayProfile,
+  invalidateProfileListFetches,
   normalizeProfileKey,
   refreshActiveProfile,
   touchActiveGatewayBackend
@@ -771,6 +772,12 @@ export function useGatewayBoot({
       // #89206 "Waking up… → retries gave up" wake failure, while the bot's
       // own backend sat healthy and idle.
       onActiveRouteChanged: profile => {
+        // A refresh can refill the slot after beginGatewaySwitch clears it but
+        // before activation. Strand it again at publication, even for default → default.
+        if ($gatewaySwitching.get()) {
+          invalidateProfileListFetches()
+        }
+
         const key = normalizeProfileKey(profile)
 
         if (normalizeProfileKey($activeGatewayProfile.get()) !== key) {


### PR DESCRIPTION
## What does this PR do?

Desktop could show the previous gateway's profiles after switching between gateways whose active profile names match, such as `default` to `default`. A profile-list refresh could start after the switch began but before the new route was published, allowing its late response to overwrite the new gateway's list.

This invalidates profile-list fetches again when the registry publishes the active route during a gateway switch. The existing generation guard then ignores any late response from the previous gateway.

## Related Issue

None. Reproduced locally in Desktop while switching gateways.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts`: invalidate outstanding profile-list fetches when the active route is published during a switch.
- `apps/desktop/src/app/gateway/hooks/use-gateway-boot.test.tsx`: reproduce a late response from the previous gateway and verify that it cannot replace the new gateway's profiles.

## How to Test

1. Run `cd apps/desktop`.
2. Run `npx vitest run --project ui src/app/gateway/hooks/use-gateway-boot.test.tsx src/store/profile.test.ts src/store/gateway-switch.test.ts src/store/connections.test.ts`.
3. Run `npm run typecheck` and `npx eslint src/app/gateway/hooks/use-gateway-boot.ts src/app/gateway/hooks/use-gateway-boot.test.tsx`.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass (not run; this is a Desktop TypeScript-only change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings): N/A; behavior fix with regression coverage
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys: N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows: N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility): renderer state only; no platform API changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior: N/A

## Screenshots / Logs

- Focused Desktop suite: 4 files passed, 100 tests passed.
- TypeScript typecheck and ESLint passed.
- Manual macOS verification: repeated local-to-remote gateway switches kept `default`, `thanos`, and `vultr` visible, and each profile's model settings loaded.
