### PR TITLE
perf(state): stop taking the state.db write lock to open a database that needs no writes

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6440,14 +6440,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         token = uuid.uuid4().hex
         try:
             with self._lock:
-                self._conn.execute(
-                    "INSERT OR IGNORE INTO state_meta (key, value) VALUES (?, ?)",
-                    (_STATE_DB_GENERATION_KEY, token),
-                )
+                # Read before writing. The stamp is minted once per FILE, so
+                # every open after the first one used to issue an
+                # INSERT OR IGNORE that could not insert anything — and a
+                # write statement takes the database write lock even when it
+                # changes nothing. With a sibling process holding that lock
+                # the no-op INSERT blocks for the full busy timeout (~1s at
+                # the timeout=1.0 this connection is opened with) and the
+                # whole block is then abandoned by the handler below, so the
+                # stamp was LOST precisely when contention made it slowest.
+                # state_meta is keyed by TEXT PRIMARY KEY, so the probe is a
+                # primary-key seek. First opener still wins via
+                # INSERT OR IGNORE, and racers still converge on the winner's
+                # token through the re-read.
                 row = self._conn.execute(
                     "SELECT value FROM state_meta WHERE key = ?",
                     (_STATE_DB_GENERATION_KEY,),
                 ).fetchone()
+                if not (row and row[0]):
+                    self._conn.execute(
+                        "INSERT OR IGNORE INTO state_meta (key, value) VALUES (?, ?)",
+                        (_STATE_DB_GENERATION_KEY, token),
+                    )
+                    row = self._conn.execute(
+                        "SELECT value FROM state_meta WHERE key = ?",
+                        (_STATE_DB_GENERATION_KEY,),
+                    ).fetchone()
                 if row and row[0]:
                     token = str(row[0])
                 self._db_file_generation_token = token

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -1262,10 +1262,27 @@ class SessionSchemaMixin:
         # active=1 explicitly; this idempotent repair un-hides rows written
         # before the fix.  It was previously gated at ``current_version <
         # 12`` which never re-ran for already-v12+ databases.
+        #
+        # The repair is still CONSIDERED on every startup; only the write is
+        # gated, on a read proving there is something to repair.  An UPDATE
+        # takes the database write lock even when it matches no rows, so the
+        # unconditional form made every read-write open block on a sibling
+        # process's write transaction for a full busy timeout.  The probe is
+        # served by ``idx_messages_active_null`` (created by the
+        # DEFERRED_INDEX_SQL executescript above) on legacy default-less
+        # columns, and short-circuits as an unsatisfiable constraint on the
+        # modern ``active INTEGER NOT NULL DEFAULT 1`` column: ~5us either
+        # way.  Deliberately NOT ``INDEXED BY`` — that hint raises
+        # OperationalError("no query solution") against the NOT NULL column
+        # and the handler below would silently swallow it, disabling the
+        # repair forever.
         try:
-            cursor.execute(
-                "UPDATE messages SET active = 1 WHERE active IS NULL"
-            )
+            if cursor.execute(
+                "SELECT 1 FROM messages WHERE active IS NULL LIMIT 1"
+            ).fetchone() is not None:
+                cursor.execute(
+                    "UPDATE messages SET active = 1 WHERE active IS NULL"
+                )
         except sqlite3.OperationalError:
             pass
 
@@ -1581,9 +1598,21 @@ class SessionSchemaMixin:
                 and not self._has_fts_trash(cursor)
                 and not self._fts_external_index_empty_with_messages(cursor)
             ):
-                self.set_meta(
-                    "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
-                )
+                # Stamp only when it would change something. On a
+                # fully-optimized DB every condition above is already true, so
+                # this used to re-write the same value on every single open —
+                # and a write takes the database write lock even when the value
+                # is unchanged, blocking behind any sibling process's write
+                # transaction for a full busy timeout. Reading the marker first
+                # is a primary-key seek on state_meta.
+                if cursor.execute(
+                    "SELECT 1 FROM state_meta WHERE key = 'fts_storage_version' "
+                    "AND value = ? LIMIT 1",
+                    (str(FTS_STORAGE_VERSION),),
+                ).fetchone() is None:
+                    self.set_meta(
+                        "fts_storage_version", str(FTS_STORAGE_VERSION), cursor=cursor
+                    )
 
             # Advance schema_version to current for ALL non-FTS-layout
             # migrations. This is deliberately NOT gated on the FTS opt-in —

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -613,6 +613,77 @@ class TestMessageStorage:
 
 
 
+    def test_open_does_not_take_the_write_lock_when_nothing_needs_writing(self, tmp_path):
+        """A read-write open must not block on a sibling's write transaction.
+
+        Opening used to issue two unconditional writes — the generation
+        stamp's ``INSERT OR IGNORE`` and the NULL-``active`` repair ``UPDATE``
+        — and a write statement takes the database write lock even when it
+        changes nothing. With another process holding that lock, each one
+        blocked for a full busy timeout, so a plain open cost ~2s on a
+        database that needed no repair at all. Both are now gated on a read.
+        """
+        db_path = tmp_path / "state.db"
+        # Open until the file has settled: the first opens legitimately mint
+        # the generation stamp and the FTS layout marker. From then on a
+        # healthy DB needs no writes at all to be opened.
+        SessionDB(db_path=db_path).close()
+        SessionDB(db_path=db_path).close()
+
+        holder = sqlite3.connect(db_path, timeout=60)
+        holder.execute("PRAGMA busy_timeout=60000")
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
+        try:
+            started = time.perf_counter()
+            session_db = SessionDB(db_path=db_path)
+            elapsed = time.perf_counter() - started
+            session_db.close()
+        finally:
+            holder.rollback()
+            holder.close()
+
+        # One busy timeout is ~1s (the connection is opened with timeout=1.0);
+        # on the pre-fix code this took two of them. A generous bound keeps
+        # this from flaking on a loaded CI box while still failing loudly if a
+        # write creeps back onto the open path.
+        assert elapsed < 0.5, f"open blocked on the write lock for {elapsed:.3f}s"
+
+    def test_generation_stamp_survives_write_lock_contention(self, tmp_path):
+        """The stamp must be readable even when the write lock is held.
+
+        The stamp is minted once per file, so every later open only needs to
+        READ it. While the whole block was write-first, a held write lock made
+        it raise, the handler swallowed it, and the process ended up with no
+        generation token at all — losing the deleted-WAL/replaced-file guard
+        exactly when contention made it most likely to matter.
+        """
+        db_path = tmp_path / "state.db"
+        SessionDB(db_path=db_path).close()  # settle the FTS layout marker too
+        first = SessionDB(db_path=db_path)
+        try:
+            on_disk = first._conn.execute(
+                "SELECT value FROM state_meta WHERE key = ?",
+                (hermes_state._STATE_DB_GENERATION_KEY,),
+            ).fetchone()[0]
+        finally:
+            first.close()
+        assert on_disk
+
+        holder = sqlite3.connect(db_path, timeout=60)
+        holder.execute("PRAGMA busy_timeout=60000")
+        holder.execute("BEGIN IMMEDIATE")
+        holder.execute("UPDATE state_meta SET value = value WHERE key = 'nonexistent'")
+        try:
+            session_db = SessionDB(db_path=db_path)
+            try:
+                assert session_db._db_file_generation_token == on_disk
+            finally:
+                session_db.close()
+        finally:
+            holder.rollback()
+            holder.close()
+
     def test_startup_heals_null_active_rows(self, tmp_path):
         """Rows written as active=NULL before the fix are un-hidden on startup.
 


### PR DESCRIPTION
## What does this PR do?

Stops a read-write `SessionDB` open from taking the state.db **write lock** when it has nothing to write. On a machine where several Hermes processes share one profile — a gateway, a `hermes serve` backend, the dashboard, plus every `hermes` CLI invocation — opening the database currently blocks behind whichever process happens to be writing.

### The three writes

A write statement takes the database write lock **even when it matches no rows**. Three ran unconditionally on every read-write open:

| where | statement | why it is almost always a no-op |
|---|---|---|
| `hermes_state.py`, `_ensure_db_file_generation` | `INSERT OR IGNORE INTO state_meta …` | the stamp is minted once per **file**, so every open after the first inserts nothing |
| `hermes_state_schema.py`, the NULL-`active` heal | `UPDATE messages SET active = 1 WHERE active IS NULL` | matches nothing on a healthy database |
| `hermes_state_schema.py`, the FTS layout stamp | `INSERT … ON CONFLICT DO UPDATE` | re-writes the identical value on every open of an already-optimized database |

The connection is opened with `timeout=1.0` ("Short timeout — application-level retry with random jitter handles contention"), so each blocked write costs a full busy timeout, and the open path's patience loop can ultimately give up and raise.

### Measured

Real 99 MB `state.db` copy, 239 sessions / 6,470 messages, macOS arm64, Python 3.11 / SQLite 3.53. Every number below is from this branch versus a pristine `origin/main` export, same database, same box.

**A sibling holds the write lock and does not release it** (3 opens):

```
origin/main   2117.3 / 2127.2 / 2136.0 ms      <- two full busy timeouts
this branch      7.1 /    3.6 /    3.6 ms
```

**Same test on an already-optimized database** (the population that hits the FTS stamp):

```
origin/main   sqlite3.OperationalError: database is locked   <- the open FAILS
this branch      6.8 / 3.7 / 4.0 ms
```

**A sibling running 200 ms write transactions in a loop**, n=20 opens:

```
origin/main   min 208.0  p50 894.6  p90 1094.7  max 1098.7 ms
this branch   min   4.8  p50   9.6  p90   13.9  max   14.9 ms      p50 93x, p90 79x
```

**A settled database now issues zero main-database write statements to open** (traced via `set_trace_callback`; `temp.` statements excluded, they do not touch the main write lock).

### The added reads cost nothing

```
state_meta primary-key seek                       min 2.0 us   p50 2.2 us
messages active-IS-NULL probe, modern schema      min 1.7 us   p50 1.8 us
  plan: unsatisfiable constraint against `active INTEGER NOT NULL DEFAULT 1`, short-circuited
messages probe, legacy default-less column, 300k rows, no NULL rows
                                                  min 0.4 us   p50 0.5 us
  plan: SEARCH messages USING COVERING INDEX idx_messages_active_null (active=?)
```

That index is created by the `DEFERRED_INDEX_SQL` executescript twelve lines above the heal, so it is always in place before the probe runs. Uncontended open is unchanged: `min 3.65 → 3.94 ms`, a delta ~100× larger than the ~4 µs actually added, i.e. box noise on a loaded machine.

### Semantics preserved

- `INSERT OR IGNORE` still resolves the first-opener race **inside SQLite**, and racers still converge on the winner's token through the re-read.
- The `application_id` gate and the PASSIVE-only checkpoint (#45383) are untouched.
- The heal is still **considered on every startup**, which is the deliberate decision from #60108 — the comment explains it was previously gated at `current_version < 12` and so never re-ran for v12+ databases. Only the *write* is now conditional, on a read proving there is something to repair. `test_startup_heals_null_active_rows` passes unchanged.
- The probe is deliberately **not** `INDEXED BY`: I measured that `INDEXED BY idx_messages_active_null` raises `OperationalError: no query solution` against the modern NOT NULL column, and the existing `except sqlite3.OperationalError: pass` would swallow it — silently disabling the repair forever.

### Correctness bonus

Read-first is not only faster, it fixes two silent failures under contention:

- The generation block was abandoned by its `except sqlite3.Error` handler, so a process ended up with **no generation token at all** even though the value was on disk and a plain read would have returned it. That token feeds the deleted-WAL / replaced-file guards added by merged #101221.
- The heal's `except sqlite3.OperationalError: pass` skipped the repair silently, so the unconditional form did not deliver the unconditional repair it advertised precisely when contention made it slowest.

## Related Issue

Related: **#93799** ("SessionDB write-lock contention stalls concurrent Hermes processes") — that issue is about the *writer* side (autocheckpoint, FTS write amplification, busy_timeout); this PR removes three writers from the **open** path, so it is complementary rather than overlapping.

Merge-adjacent, disclosed for the reviewer, no semantic conflict:
- **#101042** (open) adds `busy_timeout` PRAGMAs in `hermes_state.py`; different lines, and it confirms the writer stays around 1 s.
- **#101729** (open) bumps `FTS_STORAGE_VERSION` to 2 and touches `hermes_state_schema.py`. My gate compares against the **constant**, not a literal, so under that bump a database stamped `1` correctly fails the probe and gets re-stamped. Textual conflict in that file is possible; the semantics compose.
- **#94894** (open) touches `_fts_external_index_empty_with_messages`, a sibling condition in the same `if`, but in `hermes_state_search.py`.

## Type of Change

- [x] ⚡ Performance improvement (non-breaking)

## Changes Made

- `hermes_state.py` — `_ensure_db_file_generation` reads the stamp before inserting
- `hermes_state_schema.py` — the NULL-`active` heal is gated on an existence probe; the FTS layout stamp is gated on a value comparison
- `tests/test_hermes_state.py` — two tests: an open must not block on a sibling's write transaction, and the generation stamp must survive write-lock contention

## How to Test

1. `pytest tests/test_hermes_state.py tests/hermes_state -q` — 548 passed on this branch. One unrelated failure, `TestFTS5Search::test_search_projection_skips_context_enrichment_queries`, **reproduces identically on pristine `origin/main`** (verified by running that single test in a clean `git archive` export), so it is pre-existing.
2. Both new tests **fail on `origin/main`** with `sqlite3.OperationalError: database is locked` after exhausting the open path's write patience, and pass here — that is the regression proof, not just a timing assertion.
3. To see it end to end: hold the write lock from a second connection (`BEGIN IMMEDIATE` plus any write) and time `SessionDB(path)` on a settled database.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — `_ensure_db_file_generation`, `fts_storage_version`, `INSERT OR IGNORE state_meta`, "state.db write lock open", "heal NULL active startup"; the only hits are the merge-adjacent PRs disclosed above
- [x] My PR contains **only** changes related to this improvement
- [x] Ran the state suites, `ruff check`, and `scripts/check-windows-footguns.py --all`; relying on CI for the full matrix
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 arm64, Python 3.11, SQLite 3.53

### Documentation & Housekeeping

- [x] Documentation — the rationale lives in comments at each of the three sites, next to the existing load-bearing ones
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure SQLite/Python; no platform APIs; footgun linter clean
- [x] Tool descriptions/schemas — N/A
