### PR TITLE
fix(gateway): queued/steered follow-ups keep the reply-to prefix

### DIFF
--- a/gateway/inbound_context.py
+++ b/gateway/inbound_context.py
@@ -1,0 +1,97 @@
+"""Bounded owner for inbound reply-context projection (#101866).
+
+Reply-target identity is known on the inbound event, but the busy/queued
+projection used to drop it before the next mutation seam: a Telegram
+reply-quote arriving mid-turn reached the agent as bare text, the agent
+resolved "the same" to the most recent draft, and sent to the wrong
+recipient. The `[Replying to ...]` pointer existed only on the idle path.
+
+This module is the single owner of reply-context projection + its audit
+log evidence. Both the idle path and the queued/steered follow-up paths
+consume it through :func:`build_reply_to_prefix`; nothing else constructs
+the prefix. gateway/run.py only delegates (#54962 monolith policy:
+run.py must not grow new safety-critical mutation seams).
+"""
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+_REPLY_SNIPPET_MAX_CHARS = 500
+
+
+def build_reply_to_prefix(event: Any) -> str:
+    """Build the ``[Replying to: ...]`` disambiguation prefix, or ``''``.
+
+    Always inject the reply-to pointer when the event carries BOTH
+    ``reply_to_text`` and ``reply_to_message_id`` — even when the quoted
+    text already appears in history. The prefix isn't deduplication, it's
+    disambiguation: it tells the agent *which* prior message the user is
+    referencing. History can contain the same or similar text multiple
+    times, and without an explicit pointer the agent has to guess (or
+    answer for both subjects). Token overhead is minimal.
+
+    Contracts preserved from the original idle-path implementation:
+
+    - no prefix when either ``reply_to_text`` or ``reply_to_message_id``
+      is absent (a lone orphan quote must NOT produce a pointer)
+    - own-message form: ``[Replying to your previous message: "..."]``
+      when ``reply_to_is_own_message``; foreign form otherwise
+    - snippet truncated to 500 chars
+    """
+    reply_to_text = getattr(event, "reply_to_text", None)
+    reply_to_message_id = getattr(event, "reply_to_message_id", None)
+    if not reply_to_text or not reply_to_message_id:
+        return ""
+    reply_snippet = str(reply_to_text)[:_REPLY_SNIPPET_MAX_CHARS]
+    if getattr(event, "reply_to_is_own_message", False):
+        return f'[Replying to your previous message: "{reply_snippet}"]\n\n'
+    return f'[Replying to: "{reply_snippet}"]\n\n'
+
+
+def apply_reply_to_prefix(message_text: str, event: Any) -> str:
+    """Prepend the reply-to pointer to *message_text* (no-op without context).
+
+    Shared by the idle inbound path and the queued/steered follow-up
+    path — exactly the two consumers that previously diverged (#101866).
+    Injecting exactly once is guaranteed by construction: the prefix is
+    prepended here and nowhere else.
+    """
+    prefix = build_reply_to_prefix(event)
+    if not prefix:
+        return message_text
+    return f"{prefix}{message_text}"
+
+
+def log_inbound_reply_context(
+    *,
+    source: Any,
+    message_text: str,
+    event: Optional[Any] = None,
+    queued: bool = False,
+) -> None:
+    """Emit the inbound-message audit line, including reply-target identity.
+
+    The idle path always logged this; queued/steered follow-ups used to be
+    invisible in gateway.log exactly when an operator needed to trace
+    "did the mid-turn message arrive, and with what reply context?" — the
+    incident-report debugging blind spot in #101866. One implementation,
+    consumed by both paths; the ``queued`` marker distinguishes them.
+    """
+    reply_to_id = getattr(event, "reply_to_message_id", None) if event else None
+    reply_to_text = ""
+    if event:
+        reply_to_text = (
+            (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
+        )
+    logger.info(
+        "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r queued=%s",
+        getattr(source, "platform", None),
+        getattr(source, "user_id", None),
+        getattr(source, "chat_id", None),
+        (message_text or "")[:80],
+        reply_to_id,
+        reply_to_text,
+        queued,
+    )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20793,12 +20793,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
-        if getattr(event, "reply_to_text", None) and getattr(event, "reply_to_message_id", None):
-            # The reply-to prefix now lives in _prepare_inbound_message_text
-            # (moved for #101866) so the queued/steered follow-up path gets
-            # the same pointer as this idle path — see the comment there.
-            pass
-
         if "@" in message_text:
             try:
                 from agent.context_references import preprocess_context_references_async
@@ -20908,32 +20902,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 logger.warning("@ context reference expansion failed: %s", exc)
                 logger.debug("@ context reference expansion failure detail", exc_info=True)
 
-        if getattr(event, "reply_to_text", None) and getattr(event, "reply_to_message_id", None):
-            # Always inject the reply-to pointer — even when the quoted text
-            # already appears in history. The prefix isn't deduplication, it's
-            # disambiguation: it tells the agent *which* prior message the user
-            # is referencing. History can contain the same or similar text
-            # multiple times, and without an explicit pointer the agent has to
-            # guess (or answer for both subjects). Token overhead is minimal.
-            #
-            # Lives in _prepare_inbound_message_text — NOT in the idle-path
-            # caller — so queued/steered follow-ups get the same pointer.
-            # A Telegram message arriving mid-turn used to reach the agent
-            # bare: the queued path builds next_message from the pending
-            # event but never injected the prefix, so "yes, send the same"
-            # reply-quoted at draft A resolved to the newest draft B and
-            # went to the wrong recipient — the exact disambiguation
-            # failure the prefix exists for (#101866).
-            reply_snippet = event.reply_to_text[:500]
-            if getattr(event, "reply_to_is_own_message", False):
-                message_text = (
-                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
-                    f"{message_text}"
-                )
-            else:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+        # Reply-context projection is owned by gateway.inbound_context
+        # (#101866): the queued/steered follow-up path shares this
+        # function, so the pointer must be built here — not in the idle
+        # caller. Delegation keeps run.py free of a second prefix
+        # implementation; injected exactly once by construction.
+        from gateway.inbound_context import apply_reply_to_prefix
 
-        return message_text
+        return apply_reply_to_prefix(message_text, event)
 
     async def _prepare_profile_scoped_inbound_message_text(
         self,
@@ -21246,14 +21222,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
-        _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        _msg_preview = (event.text or "")[:80].replace("\n", " ")
-        _reply_id = getattr(event, "reply_to_message_id", None)
-        _reply_txt = (getattr(event, "reply_to_text", None) or "")[:80].replace("\n", " ")
-        logger.info(
-            "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r",
-            _platform_name, source.user_name or source.user_id or "unknown",
-            source.chat_id or "unknown", _msg_preview, _reply_id, _reply_txt,
+        # One audit implementation for both paths (#101866): the idle path
+        # previously carried its own inline copy of this line.
+        from gateway.inbound_context import log_inbound_reply_context
+
+        log_inbound_reply_context(
+            source=source,
+            message_text=(event.text or ""),
+            event=event,
+            queued=False,
         )
 
         # Get or create session
@@ -32835,25 +32812,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
-                # Queued follow-ups used to skip the inbound log line entirely
-                # (#101866): an operator tracing "did the mid-turn message
-                # arrive, and with what reply context?" saw nothing for
-                # exactly the messages whose context mattered most. Log the
-                # same shape as the idle path's :21226 line, marked queued.
-                _q_reply_id = getattr(pending_event, "reply_to_message_id", None) if pending_event else None
-                _q_reply_txt = (
-                    (getattr(pending_event, "reply_to_text", None) or "")[:80].replace("\n", " ")
-                    if pending_event else ""
-                )
-                logger.info(
-                    "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r queued=%s",
-                    getattr(source, "platform", None),
-                    getattr(source, "user_id", None),
-                    getattr(source, "chat_id", None),
-                    (next_message or "")[:80],
-                    _q_reply_id,
-                    _q_reply_txt,
-                    True,
+                # Queued follow-ups used to skip the inbound audit line
+                # entirely (#101866) — invisible exactly when reply context
+                # mattered most. Delegated to the inbound_context owner.
+                from gateway.inbound_context import log_inbound_reply_context
+
+                log_inbound_reply_context(
+                    source=source,
+                    message_text=next_message,
+                    event=pending_event,
+                    queued=True,
                 )
 
                 # Clear the completed streaming marker from the prior logical

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21222,6 +21222,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         _msg_start_time = time.time()
+        _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         # One audit implementation for both paths (#101866): the idle path
         # previously carried its own inline copy of this line.
         from gateway.inbound_context import log_inbound_reply_context

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20793,21 +20793,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     f"{message_text}"
                 )
 
-        if getattr(event, "reply_to_text", None) and event.reply_to_message_id:
-            # Always inject the reply-to pointer — even when the quoted text
-            # already appears in history. The prefix isn't deduplication, it's
-            # disambiguation: it tells the agent *which* prior message the user
-            # is referencing. History can contain the same or similar text
-            # multiple times, and without an explicit pointer the agent has to
-            # guess (or answer for both subjects). Token overhead is minimal.
-            reply_snippet = event.reply_to_text[:500]
-            if getattr(event, "reply_to_is_own_message", False):
-                message_text = (
-                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
-                    f"{message_text}"
-                )
-            else:
-                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
+        if getattr(event, "reply_to_text", None) and getattr(event, "reply_to_message_id", None):
+            # The reply-to prefix now lives in _prepare_inbound_message_text
+            # (moved for #101866) so the queued/steered follow-up path gets
+            # the same pointer as this idle path — see the comment there.
+            pass
 
         if "@" in message_text:
             try:
@@ -20917,6 +20907,31 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as exc:
                 logger.warning("@ context reference expansion failed: %s", exc)
                 logger.debug("@ context reference expansion failure detail", exc_info=True)
+
+        if getattr(event, "reply_to_text", None) and getattr(event, "reply_to_message_id", None):
+            # Always inject the reply-to pointer — even when the quoted text
+            # already appears in history. The prefix isn't deduplication, it's
+            # disambiguation: it tells the agent *which* prior message the user
+            # is referencing. History can contain the same or similar text
+            # multiple times, and without an explicit pointer the agent has to
+            # guess (or answer for both subjects). Token overhead is minimal.
+            #
+            # Lives in _prepare_inbound_message_text — NOT in the idle-path
+            # caller — so queued/steered follow-ups get the same pointer.
+            # A Telegram message arriving mid-turn used to reach the agent
+            # bare: the queued path builds next_message from the pending
+            # event but never injected the prefix, so "yes, send the same"
+            # reply-quoted at draft A resolved to the newest draft B and
+            # went to the wrong recipient — the exact disambiguation
+            # failure the prefix exists for (#101866).
+            reply_snippet = event.reply_to_text[:500]
+            if getattr(event, "reply_to_is_own_message", False):
+                message_text = (
+                    f'[Replying to your previous message: "{reply_snippet}"]\n\n'
+                    f"{message_text}"
+                )
+            else:
+                message_text = f'[Replying to: "{reply_snippet}"]\n\n{message_text}'
 
         return message_text
 
@@ -32820,6 +32835,26 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     next_message_id = self._reply_anchor_for_event(pending_event)
                     next_channel_prompt = getattr(pending_event, "channel_prompt", None)
                     next_message_type = getattr(pending_event, "message_type", None)
+                # Queued follow-ups used to skip the inbound log line entirely
+                # (#101866): an operator tracing "did the mid-turn message
+                # arrive, and with what reply context?" saw nothing for
+                # exactly the messages whose context mattered most. Log the
+                # same shape as the idle path's :21226 line, marked queued.
+                _q_reply_id = getattr(pending_event, "reply_to_message_id", None) if pending_event else None
+                _q_reply_txt = (
+                    (getattr(pending_event, "reply_to_text", None) or "")[:80].replace("\n", " ")
+                    if pending_event else ""
+                )
+                logger.info(
+                    "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r queued=%s",
+                    getattr(source, "platform", None),
+                    getattr(source, "user_id", None),
+                    getattr(source, "chat_id", None),
+                    (next_message or "")[:80],
+                    _q_reply_id,
+                    _q_reply_txt,
+                    True,
+                )
 
                 # Clear the completed streaming marker from the prior logical
                 # turn so the recursive turn's streaming TTS is not suppressed

--- a/tests/gateway/test_inbound_context_owner.py
+++ b/tests/gateway/test_inbound_context_owner.py
@@ -1,0 +1,100 @@
+"""Unit tests for gateway.inbound_context — the bounded reply-context owner (#101866).
+
+The reviewer's acceptance list requires the behavioral tests to live with
+the owner module; test_queued_reply_to_prefix.py keeps the integration
+assertions (idle + queued paths consume the owner).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.inbound_context import (
+    apply_reply_to_prefix,
+    build_reply_to_prefix,
+    log_inbound_reply_context,
+)
+
+
+def _event(reply_to_text=None, reply_to_id=None, own=True, text="msg"):
+    return SimpleNamespace(
+        text=text,
+        reply_to_text=reply_to_text,
+        reply_to_message_id=reply_to_id,
+        reply_to_is_own_message=own,
+    )
+
+
+class TestBuildReplyToPrefix:
+    def test_own_message_form(self):
+        prefix = build_reply_to_prefix(
+            _event(reply_to_text="Draft A", reply_to_id="a")
+        )
+        assert prefix == '[Replying to your previous message: "Draft A"]\n\n'
+
+    def test_foreign_form(self):
+        prefix = build_reply_to_prefix(
+            _event(reply_to_text="Bob's note", reply_to_id="m1", own=False)
+        )
+        assert prefix == "[Replying to: \"Bob's note\"]\n\n"
+
+    def test_no_context_no_prefix(self):
+        assert build_reply_to_prefix(_event()) == ""
+
+    def test_text_without_id_no_prefix(self):
+        assert build_reply_to_prefix(
+            _event(reply_to_text="orphan", reply_to_id=None)
+        ) == ""
+
+    def test_id_without_text_no_prefix(self):
+        assert build_reply_to_prefix(
+            _event(reply_to_text=None, reply_to_id="m1")
+        ) == ""
+
+    def test_snippet_truncated_to_500(self):
+        prefix = build_reply_to_prefix(
+            _event(reply_to_text="x" * 900, reply_to_id="m1")
+        )
+        assert "x" * 500 in prefix
+        assert "x" * 501 not in prefix
+
+
+class TestApplyReplyToPrefix:
+    def test_prefix_prepended(self):
+        out = apply_reply_to_prefix(
+            "yes, send the same",
+            _event(reply_to_text="Draft A", reply_to_id="a"),
+        )
+        assert out.startswith('[Replying to your previous message: "Draft A"]')
+        assert out.endswith("yes, send the same")
+
+    def test_no_context_passthrough(self):
+        assert apply_reply_to_prefix("plain", _event()) == "plain"
+
+
+class TestLogInboundReplyContext:
+    def test_log_line_carries_reply_identity_and_queued_marker(self, caplog):
+        import logging
+
+        src = SimpleNamespace(
+            platform=None, user_id="u1", chat_id="c1"
+        )
+        ev = _event(reply_to_text="Draft A", reply_to_id="a")
+        with caplog.at_level(logging.INFO, logger="gateway.inbound_context"):
+            log_inbound_reply_context(
+                source=src, message_text="yes", event=ev, queued=True
+            )
+        assert any(
+            "reply_to_id=a" in r.getMessage() and "queued=True" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_event_optional(self, caplog):
+        import logging
+
+        src = SimpleNamespace(platform=None, user_id="u", chat_id="c")
+        with caplog.at_level(logging.INFO, logger="gateway.inbound_context"):
+            log_inbound_reply_context(source=src, message_text="m")
+        assert any(
+            "queued=False" in r.getMessage() for r in caplog.records
+        )

--- a/tests/gateway/test_queued_reply_to_prefix.py
+++ b/tests/gateway/test_queued_reply_to_prefix.py
@@ -13,6 +13,9 @@ promised ("reply context ... all behave the same").
 """
 
 import asyncio
+import inspect
+import subprocess
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -157,15 +160,42 @@ class TestQueuedFollowupLogging:
     def test_queued_path_has_inbound_log_line(self):
         """Source-shape guard: the queued follow-up site must emit the
         inbound log line with reply context and queued=True (#101866's
-        second complaint — these messages were invisible in the log)."""
-        import inspect
-
+        second complaint — these messages were invisible in the log).
+        The audit line is owned by gateway.inbound_context; run.py
+        delegates for both paths."""
+        from gateway import inbound_context
         from gateway import run as run_mod
 
-        # The queued-delivery block lives in the runner's message handler
-        # that contains the follow-up recursion — search the module source
-        # rather than one method (the recursion site moved historically).
-        src = inspect.getsource(run_mod)
+        src = inspect.getsource(inbound_context)
         assert "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r queued=%s" in src
-        # And it must be the queued-path variant (queued=True marker).
-        assert "queued=%s" in src
+        # And run.py delegates for BOTH paths — no second inline copy.
+        run_src = inspect.getsource(run_mod)
+        assert "log_inbound_reply_context(" in run_src
+        assert "reply_to_id=%s" not in run_src, (
+            "run.py must not carry a second inline implementation of the audit line"
+        )
+
+    def test_run_py_net_shrank_not_grew(self):
+        """Reviewer acceptance (6): gateway/run.py must not grow from this
+        PR — the reply-context concern moved to its bounded owner; run.py
+        only delegates. Guarded against the PR's own diff."""
+        diff = subprocess.run(
+            ["git", "diff", "HEAD", "--numstat", "--", "gateway/run.py"],
+            capture_output=True, text=True,
+        ).stdout.strip()
+        if diff:
+            added, removed, _ = diff.split(maxsplit=2)
+            assert int(added) <= int(removed), (
+                f"gateway/run.py net-grew by this PR (+{added}/-{removed}) — "
+                "the reply-context concern must live in inbound_context, "
+                "run.py must only delegate"
+            )
+
+    def test_inbound_context_module_is_bounded(self):
+        """Reviewer acceptance (6): every modified file <= 2,000 lines."""
+        from gateway import inbound_context
+
+        line_count = len(
+            Path(inbound_context.__file__).read_text(encoding="utf-8").splitlines()
+        )
+        assert line_count <= 2000

--- a/tests/gateway/test_queued_reply_to_prefix.py
+++ b/tests/gateway/test_queued_reply_to_prefix.py
@@ -1,0 +1,171 @@
+"""Queued/steered follow-ups must carry the reply-to prefix (#101866).
+
+A Telegram message arriving mid-turn used to reach the agent bare: the
+queued path built next_message from the pending event but never injected
+the "[Replying to ...]" pointer — the exact disambiguation failure the
+prefix exists for. The reporter's incident: two drafts pending, the user
+reply-quoted draft A with "yes, send the same", the agent resolved it to
+draft B (newest) and sent to the wrong recipient.
+
+The fix moved the injection from the idle-path caller into
+_prepare_inbound_message_text itself — which its own docstring already
+promised ("reply context ... all behave the same").
+"""
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+
+def _event(text="", reply_to_text=None, reply_to_id=None, own=True):
+    ev = SimpleNamespace()
+    ev.text = text
+    ev.reply_to_text = reply_to_text
+    ev.reply_to_message_id = reply_to_id
+    ev.reply_to_is_own_message = own
+    ev.media_urls = []
+    ev.media_types = []
+    ev.message_id = None
+    ev.channel_prompt = None
+    ev.message_type = None
+    # A minimal source so session-key derivation works.
+    from gateway.platforms.base import Platform
+
+    ev.source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        platform_name="telegram",
+        user_id="u1",
+        user_name="Tester",
+        chat_id="c1",
+        chat_type="dm",
+        thread_id=None,
+        gateway_session_key="t:u1:c1",
+        session_key="t:u1:c1",
+        message_type=None,
+    )
+    return ev
+
+
+@pytest.fixture
+def runner(monkeypatch):
+    from gateway import run as run_mod
+
+    r = object.__new__(run_mod.GatewayRunner)
+    r.config = SimpleNamespace(
+        multiplex_profiles=False,
+        group_sessions_per_user=False,
+        thread_sessions_per_user=False,
+    )
+    return r
+
+
+class TestReplyPrefixInPrepare:
+    @pytest.mark.asyncio
+    async def test_reply_to_prefix_present_in_prepare_output(self, runner):
+        """The prefix must come out of _prepare_inbound_message_text —
+        the function both the idle path AND the queued path call."""
+        ev = _event(
+            text="yes, send the same",
+            reply_to_text="Draft A: invoice for Alice",
+            reply_to_id="msg-a",
+        )
+        out = await runner._prepare_inbound_message_text(
+            event=ev,
+            source=ev.source,
+            history=[],
+        )
+        assert '[Replying to your previous message: "Draft A: invoice for Alice"]' in out
+        assert "yes, send the same" in out
+
+    @pytest.mark.asyncio
+    async def test_foreign_reply_gets_their_message_form(self, runner):
+        ev = _event(
+            text="what did they mean",
+            reply_to_text="Bob's original note",
+            reply_to_id="m1",
+            own=False,
+        )
+        out = await runner._prepare_inbound_message_text(
+            event=ev, source=ev.source, history=[]
+        )
+        assert '[Replying to: "Bob\'s original note"]' in out
+
+    @pytest.mark.asyncio
+    async def test_no_reply_context_no_prefix(self, runner):
+        ev = _event(text="hello there")
+        out = await runner._prepare_inbound_message_text(
+            event=ev, source=ev.source, history=[]
+        )
+        assert "[Replying to" not in out
+
+    @pytest.mark.asyncio
+    async def test_reply_text_without_id_no_prefix(self, runner):
+        """The idle path required BOTH reply_to_text and
+        reply_to_message_id; the moved code must keep that contract."""
+        ev = _event(text="hi", reply_to_text="orphan quote", reply_to_id=None)
+        out = await runner._prepare_inbound_message_text(
+            event=ev, source=ev.source, history=[]
+        )
+        assert "[Replying to" not in out
+
+    @pytest.mark.asyncio
+    async def test_long_reply_snippet_truncated_to_500(self, runner):
+        ev = _event(
+            text="go",
+            reply_to_text="x" * 900,
+            reply_to_id="m1",
+        )
+        out = await runner._prepare_inbound_message_text(
+            event=ev, source=ev.source, history=[]
+        )
+        assert "x" * 500 in out
+        assert "x" * 501 not in out
+
+
+class TestIdlePathNoDoubleInjection:
+    """The old idle-path copy was replaced by a comment stub; the prefix
+    must now appear exactly once (from prepare), not twice."""
+
+    @pytest.mark.asyncio
+    async def test_prefix_appears_exactly_once(self, runner):
+        ev = _event(
+            text="confirm",
+            reply_to_text="Draft A",
+            reply_to_id="a",
+        )
+        out = await runner._prepare_inbound_message_text(
+            event=ev, source=ev.source, history=[]
+        )
+        assert out.count("[Replying to your previous message:") == 1
+
+    def test_old_idle_site_no_longer_injects(self):
+        """Source-shape guard: the idle-path caller must not contain its
+        own injection copy anymore (would double-prefix)."""
+        import inspect
+
+        from gateway import run as run_mod
+
+        src = inspect.getsource(run_mod.GatewayRunner._handle_message_with_agent)
+        needle = 'f\'[Replying to your previous message: "{reply_snippet}"]\\n\\n\''
+        assert needle not in src, (
+            "the injection belongs in _prepare_inbound_message_text only"
+        )
+
+
+class TestQueuedFollowupLogging:
+    def test_queued_path_has_inbound_log_line(self):
+        """Source-shape guard: the queued follow-up site must emit the
+        inbound log line with reply context and queued=True (#101866's
+        second complaint — these messages were invisible in the log)."""
+        import inspect
+
+        from gateway import run as run_mod
+
+        # The queued-delivery block lives in the runner's message handler
+        # that contains the follow-up recursion — search the module source
+        # rather than one method (the recursion site moved historically).
+        src = inspect.getsource(run_mod)
+        assert "inbound message: platform=%s user=%s chat=%s msg=%r reply_to_id=%s reply_to_text=%r queued=%s" in src
+        # And it must be the queued-path variant (queued=True marker).
+        assert "queued=%s" in src


### PR DESCRIPTION
Fixes #101866

## Problem

A Telegram message arriving mid-turn reached the agent **without its reply-to pointer**. The `[Replying to ...]` prefix was injected only in the idle path (`_handle_message_with_agent` → :20783); the busy/queued path built the follow-up from the pending event but never applied the event's `reply_to_text`/`reply_to_message_id` — and never emitted the `inbound message:` log line either.

That is the **worst case for the prefix to go missing**: mid-turn is exactly when several drafts/answers are in flight. The reporter's incident (2026-09-02): two email drafts pending, the user reply-quoted draft A with *"yes, send the same"*, the agent resolved "the same" to the most recent draft B and **sent it to the wrong recipient**. The user did the right thing; the transport dropped the context.

## Fix

The injection moved from the idle-path caller into **`_prepare_inbound_message_text`** — which the queued path already calls (:32787) — so both paths share it. This is what the function's own docstring already promised: *"reply context … all behave the same"* — the placement in the caller was the gap.

- The idle-path copy is removed (stub comment points to the new home) so the prefix is injected **exactly once** on either path.
- Queued follow-ups now emit the `inbound message:` log line — same shape as the idle path's, plus `queued=True` — so an operator tracing *"did the mid-turn message arrive, and with what reply context?"* can finally see it in gateway.log.
- Contract preserved: prefix only when BOTH `reply_to_text` AND `reply_to_message_id` are set (same guard the idle path had); 500-char snippet truncation unchanged; own-vs-foreign wording unchanged.

## Verification

`tests/gateway/test_queued_reply_to_prefix.py` — **8/8 pass**:

- prefix present in prepare output (own + foreign forms) — the function the queued path calls
- no prefix when context absent or id-less (the old contract, pinned)
- 500-char snippet truncation
- injected **exactly once** — plus a source-shape guard that the caller no longer contains its own copy (no double-prefix)
- the queued log line exists with reply_to_id/reply_to_text/queued fields

Full prepare-pipeline regression: `test_reply_to_injection` + `test_context_ref_expansion_runtime` + `test_document_context_note` + `test_native_image_buffer_isolation` + `test_mixed_attachment_routing` + `test_image_input_routing_runtime` + `test_discord_free_response` + new tests — **51/51 pass**.