### PR TITLE
fix(update): prevent Desktop relaunches from blocking Windows rebuilds

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7757,11 +7757,15 @@ def _stop_desktop_processes_locking_build(desktop_dir: Path) -> list[int]:
         # Wait for the handles (and thus the file locks) to actually release.
         try:
             _, alive = psutil.wait_procs(victims, timeout=5)
+            killed = []
             for proc in alive:
                 try:
                     proc.kill()
+                    killed.append(proc)
                 except Exception:
                     continue
+            if killed:
+                psutil.wait_procs(killed, timeout=5)
         except Exception:
             pass
     return stopped

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7118,7 +7118,12 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         if live_root.exists():
             # The app can relaunch while the staged pack is being built. Clear
             # that fresh Windows executable lock at the promotion boundary.
-            _stop_desktop_processes_locking_build(desktop_dir)
+            stopped = _stop_desktop_processes_locking_build(desktop_dir)
+            if stopped:
+                logger.info(
+                    "stopped desktop processes before staged app promotion (pid %s)",
+                    ", ".join(map(str, stopped)),
+                )
             os.rename(live_root, previous)
             moved_aside = True
         try:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7116,6 +7116,9 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         shutil.rmtree(previous, ignore_errors=True)
         moved_aside = False
         if live_root.exists():
+            # The app can relaunch while the staged pack is being built. Clear
+            # that fresh Windows executable lock at the promotion boundary.
+            _stop_desktop_processes_locking_build(desktop_dir)
             os.rename(live_root, previous)
             moved_aside = True
         try:

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -428,6 +428,28 @@ class _FakeProc:
         self.killed = True
 
 
+def test_stop_desktop_build_lock_waits_after_force_kill(tmp_path, monkeypatch):
+    desktop_dir = tmp_path / "apps" / "desktop"
+    locker_exe = desktop_dir / "release" / "win-unpacked" / "Hermes.exe"
+    locker_exe.parent.mkdir(parents=True)
+    locker_exe.write_text("", encoding="utf-8")
+    monkeypatch.setattr(cli_main.sys, "platform", "win32")
+
+    locker = _FakeProc(101, str(locker_exe))
+    with patch("psutil.process_iter", return_value=[locker]), patch(
+        "psutil.wait_procs", side_effect=[([], [locker]), ([locker], [])]
+    ) as wait_procs:
+        stopped = cli_main._stop_desktop_processes_locking_build(desktop_dir)
+
+    assert stopped == [101]
+    assert locker.terminated is True
+    assert locker.killed is True
+    assert wait_procs.call_args_list == [
+        (([locker],), {"timeout": 5}),
+        (([locker],), {"timeout": 5}),
+    ]
+
+
 
 
 

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1365,7 +1365,9 @@ def test_swap_staged_desktop_app_promotes_staged_tree_and_drops_previous(tmp_pat
     assert sorted(p.name for p in (desktop_dir / "release").iterdir()) == [_packaged_exe_rel().parts[0]]
 
 
-def test_swap_staged_desktop_app_releases_lock_acquired_during_pack(tmp_path, monkeypatch):
+def test_swap_staged_desktop_app_releases_lock_acquired_during_pack(
+    tmp_path, monkeypatch, caplog
+):
     """A desktop relaunched during the long pack is stopped at promotion time."""
     root = _make_desktop_tree(tmp_path)
     desktop_dir = root / "apps" / "desktop"
@@ -1400,6 +1402,7 @@ def test_swap_staged_desktop_app_releases_lock_acquired_during_pack(tmp_path, mo
 
     assert promoted == live_exe
     assert live_exe.read_text(encoding="utf-8") == "new"
+    assert "staged app promotion (pid 1234)" in caplog.text
 
 
 def test_swap_staged_desktop_app_without_staged_exe_keeps_live_app(tmp_path):

--- a/tests/hermes_cli/test_gui_command.py
+++ b/tests/hermes_cli/test_gui_command.py
@@ -1365,6 +1365,43 @@ def test_swap_staged_desktop_app_promotes_staged_tree_and_drops_previous(tmp_pat
     assert sorted(p.name for p in (desktop_dir / "release").iterdir()) == [_packaged_exe_rel().parts[0]]
 
 
+def test_swap_staged_desktop_app_releases_lock_acquired_during_pack(tmp_path, monkeypatch):
+    """A desktop relaunched during the long pack is stopped at promotion time."""
+    root = _make_desktop_tree(tmp_path)
+    desktop_dir = root / "apps" / "desktop"
+    live_exe = desktop_dir / "release" / _packaged_exe_rel()
+    live_exe.parent.mkdir(parents=True)
+    live_exe.write_text("old", encoding="utf-8")
+    staging = cli_main._desktop_staging_dir(desktop_dir)
+    staged_exe = staging / _packaged_exe_rel()
+    staged_exe.parent.mkdir(parents=True)
+    staged_exe.write_text("new", encoding="utf-8")
+
+    locked = True
+    real_rename = cli_main.os.rename
+
+    def stop_locking_processes(path):
+        nonlocal locked
+        assert path == desktop_dir
+        locked = False
+        return [1234]
+
+    def rename_unless_locked(src, dst):
+        if Path(src) == live_exe.parent and locked:
+            raise PermissionError("[WinError 32] file is in use")
+        return real_rename(src, dst)
+
+    monkeypatch.setattr(
+        cli_main, "_stop_desktop_processes_locking_build", stop_locking_processes
+    )
+    monkeypatch.setattr(cli_main.os, "rename", rename_unless_locked)
+
+    promoted = cli_main._swap_staged_desktop_app(desktop_dir, staging)
+
+    assert promoted == live_exe
+    assert live_exe.read_text(encoding="utf-8") == "new"
+
+
 def test_swap_staged_desktop_app_without_staged_exe_keeps_live_app(tmp_path):
     """Zero-exit pack that produced nothing: live app untouched, staging gone."""
     root = _make_desktop_tree(tmp_path)


### PR DESCRIPTION
## What does this PR do?

Windows Desktop rebuilds can now promote a verified staged app even when Hermes relaunches during the packaging window. The promotion path stops processes executing from the live release tree immediately before the first rename, while preserving the existing stage-and-swap rollback behavior.

### Symptom

`hermes update` or `hermes desktop --build-only` can finish packaging but fail to install the rebuilt app with a WinError 32 directory rename failure. The previous app remains intact, but the freshly built app is not promoted.

### Impact

Windows users can be unable to complete a Desktop rebuild when `release/win-unpacked/Hermes.exe` starts again during the one-to-two-minute packaging window.

### Bug Cause

**Trigger:** `hermes_cli/main.py:7119` / `_swap_staged_desktop_app` renames the live unpacked directory after packaging.

**Causal chain:**
1. `cmd_gui` stops Desktop processes before starting the staged package build.
2. Hermes can relaunch while that build is running and lock the live `Hermes.exe` again.
3. The later `live_root -> previous` rename encounters WinError 32 and the verified staged build cannot be installed.

**Why it is wrong:** Process cleanup occurred before a long packaging operation rather than at the promotion boundary where the live executable must be unlocked.

**Working sibling / contrast:** A Desktop process that is already running before packaging is handled by the existing pre-build cleanup. Only a process started during packaging escaped that cleanup.

**Ruled out:** The staged output itself is not being built in place over the live app. The existing stage-and-swap tests confirm that failed builds preserve the live tree and that a failed second rename restores `.previous`.

### Fix

Call the existing narrowly scoped Desktop process cleanup immediately before moving the live unpacked directory aside. Add a regression test that simulates a lock acquired during packaging and makes the first rename fail unless promotion-time cleanup runs.

## Related Issue

Closes #101878

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` - release live Desktop executable locks at the stage-and-swap promotion boundary.
- `tests/hermes_cli/test_gui_command.py` - cover a Desktop lock acquired after packaging begins.

## How to Test

1. On Windows, keep an existing `apps/desktop/release/win-unpacked` app and start `Hermes.exe` after packaging begins but before promotion.
2. Confirm the process is stopped at promotion and the staged app replaces the live unpacked directory.
3. Run the focused automated checks:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gui_command.py -k swap_staged_desktop_app -v
scripts/run_tests.sh tests/hermes_cli/test_desktop_exe_integrity.py
```

The focused checks passed locally: 4 stage-and-swap tests and 5 Desktop executable integrity tests. The complete `test_gui_command.py` file has the same three pre-existing Windows failures on this branch and `hermes/main`; those tests create zero-byte or nine-byte fake executables that the existing PE integrity gate rejects.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; behavior is internal and covered by the helper docstring and regression test
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - cleanup remains a no-op off Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

The regression test fails before the fix with `[WinError 32] file is in use` at the first live-directory rename and passes after cleanup is moved to the promotion boundary.
