### PR TITLE
fix(update): re-stop desktop lockers right before the staged swap

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7116,6 +7116,18 @@ def _swap_staged_desktop_app(desktop_dir: Path, staging_dir: Path) -> Optional[P
         shutil.rmtree(previous, ignore_errors=True)
         moved_aside = False
         if live_root.exists():
+            # The pre-pack stop ran minutes ago (the npm pack takes 1-2 min),
+            # and a desktop instance re-launched inside that window (autostart,
+            # updater relaunch, stray shortcut) re-locks ``release/<unpacked>``;
+            # the rename below then dies with WinError 32 and aborts the whole
+            # update over a verified staged build (#101878). Stop again right
+            # before promoting; off-Windows the stopper is a no-op.
+            stopped = _stop_desktop_processes_locking_build(desktop_dir)
+            if stopped:
+                print(
+                    "  ⚠ Stopped re-launched desktop app before installing the "
+                    f"rebuild (pid {', '.join(map(str, stopped))})"
+                )
             os.rename(live_root, previous)
             moved_aside = True
         try:

--- a/tests/hermes_cli/test_desktop_exe_integrity.py
+++ b/tests/hermes_cli/test_desktop_exe_integrity.py
@@ -332,3 +332,86 @@ def test_build_only_fails_when_pack_produces_corrupt_exe(tmp_path, monkeypatch, 
     mock_stamp.assert_not_called()
     out = capsys.readouterr().out
     assert "integrity check" in out
+
+
+# ─── stage-and-swap promotion vs. re-locked release trees (#101878) ─────────
+
+
+def _unpacked_exe_rel() -> Path:
+    """The platform's unpacked-tree exe layout, as electron-builder emits it."""
+    if sys.platform == "darwin":
+        return Path("mac/Hermes.app/Contents/MacOS/Hermes")
+    if sys.platform == "win32":
+        return Path("win-unpacked/Hermes.exe")
+    return Path("linux-unpacked/hermes")
+
+
+def _make_unpacked_tree(base: Path, payload: str) -> Path:
+    exe = base / _unpacked_exe_rel()
+    exe.parent.mkdir(parents=True, exist_ok=True)
+    exe.write_text(payload, encoding="utf-8")
+    return exe
+
+
+def test_swap_restops_relaunched_desktop_before_promoting(tmp_path, capsys):
+    """The pack window between the pre-pack stop and the swap is minutes
+    long; a desktop instance re-launched inside it (autostart, updater
+    relaunch) re-locks ``release/<unpacked>`` and the promote rename dies
+    with WinError 32, aborting the whole update over a verified staged build
+    (#101878). The swap must re-stop lockers right before promoting."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    staging_dir = desktop_dir / ".staging-1-0"
+    _make_unpacked_tree(staging_dir, "staged")
+    live_exe = _make_unpacked_tree(desktop_dir / "release", "live")
+
+    with patch(
+        "hermes_cli.main._stop_desktop_processes_locking_build",
+        return_value=[4242, 4243],
+    ) as mock_stop:
+        promoted = cli_main._swap_staged_desktop_app(desktop_dir, staging_dir)
+
+    assert promoted == live_exe
+    mock_stop.assert_called_once_with(desktop_dir)
+    assert live_exe.read_text(encoding="utf-8") == "staged"
+    assert not staging_dir.exists()
+    out = capsys.readouterr().out
+    assert "Stopped re-launched desktop app" in out
+    assert "4242, 4243" in out
+
+
+def test_swap_keeps_failsafe_when_the_relock_survives_the_restop(tmp_path):
+    """A re-lock the re-stop cannot clear (e.g. a third-party process keeping
+    ``release/`` as its working directory) must still land in the stage-and-
+    swap failsafe: live app untouched, staging discarded, ``None`` returned."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    staging_dir = desktop_dir / ".staging-1-0"
+    _make_unpacked_tree(staging_dir, "staged")
+    live_exe = _make_unpacked_tree(desktop_dir / "release", "live")
+
+    with patch(
+        "hermes_cli.main._stop_desktop_processes_locking_build", return_value=[]
+    ) as mock_stop, patch(
+        "hermes_cli.main.os.rename",
+        side_effect=PermissionError(32, "The process cannot access the file"),
+    ):
+        promoted = cli_main._swap_staged_desktop_app(desktop_dir, staging_dir)
+
+    assert promoted is None
+    mock_stop.assert_called_once_with(desktop_dir)
+    assert live_exe.read_text(encoding="utf-8") == "live"
+    assert not staging_dir.exists()
+
+
+def test_swap_skips_the_restop_on_fresh_install(tmp_path):
+    """No live tree to promote over means no needless process-table sweep."""
+    desktop_dir = tmp_path / "apps" / "desktop"
+    staging_dir = desktop_dir / ".staging-1-0"
+    _make_unpacked_tree(staging_dir, "staged")
+
+    with patch(
+        "hermes_cli.main._stop_desktop_processes_locking_build"
+    ) as mock_stop:
+        promoted = cli_main._swap_staged_desktop_app(desktop_dir, staging_dir)
+
+    assert promoted == desktop_dir / "release" / _unpacked_exe_rel()
+    mock_stop.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

The stage-and-swap Desktop rebuild (#86443, commit 1398c0f5ca) stops processes locking `release/` once — **before** the npm pack starts. The pack then runs for 1–2 minutes, and a desktop instance re-launched inside that window (OS autostart, updater relaunch, a stray shortcut) re-locks `release/win-unpacked`. When `_swap_staged_desktop_app` then runs `os.rename(live_root, previous)`, Windows fails the rename with `PermissionError: [WinError 32]`, the swap returns `None`, and the whole update aborts with "Could not install the rebuilt desktop app" — over a fully verified staged build.

This PR makes `_swap_staged_desktop_app` re-call `_stop_desktop_processes_locking_build(desktop_dir)` immediately before the promote rename, closing the pack-window gap. The approach reuses the existing narrow-scoped stopper (Windows-only, only processes whose executable lives inside the release tree, waits for handle release), so:

- off-Windows nothing changes (the stopper is already a no-op there);
- a re-lock the re-stop cannot clear (e.g. a third-party process keeping `release/` as its working directory) still lands in the existing stage-and-swap failsafe: live app untouched, staging discarded, `None` returned.

## Related Issue

Fixes #101878

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py` — in `_swap_staged_desktop_app`, re-call `_stop_desktop_processes_locking_build(desktop_dir)` right before `os.rename(live_root, previous)` when a live tree exists, printing which re-launched PIDs were stopped (mirrors the existing pre-pack stop UX). Fresh installs with no live tree skip the sweep.
- `tests/hermes_cli/test_desktop_exe_integrity.py` — three regression tests: the re-stop fires before promoting (with stdout notice), the failsafe is preserved when the re-lock survives the re-stop, and a fresh-install swap performs no process sweep.

## How to Test

1. `python -m pytest tests/hermes_cli/test_desktop_exe_integrity.py -q` → `4 passed, 4 skipped` (the skips are the pre-existing `windows_only` chain tests on macOS); the three new swap tests run on every platform.
2. `python -m pytest tests/hermes_cli/test_desktop_local_flag.py tests/hermes_cli/test_gui_command.py tests/hermes_cli/test_subcommands_batch.py -q` → `53 passed, 8 skipped` — the surrounding `cmd_gui` suites are unaffected.
3. `python -m ruff check` on both changed files → clean.
4. Windows repro from the issue (cannot be exercised on this macOS host): run `hermes desktop --build-only` while a desktop instance re-launches during the pack window; Observed result after the fix: the swap re-stops the re-launched instance (pid notice printed) and the staged build is promoted instead of aborting with WinError 32.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(update):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the related `hermes_cli` test suites and they pass (integrity + cmd_gui suites listed above; full-tree run not possible on this host due to environment-only failures unrelated to this change)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (Darwin 25.4.0, arm64); the changed path is Windows-gated via the existing stopper's `sys.platform != "win32"` guard, covered by mocked unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the re-stop is a no-op off-Windows by the stopper's existing guard
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/hermes_cli/test_desktop_exe_integrity.py -q
4 passed, 4 skipped in 0.45s
```
