### PR TITLE
fix(packaging): include hermes_state_registry in py-modules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ py-modules = [
   "hermes_state",
   "hermes_state_common",
   "hermes_state_portability",
+  "hermes_state_registry",
   "hermes_state_schema",
   "hermes_state_search",
   "hermes_startup_watchdog",


### PR DESCRIPTION
## Bug Description

`hermes_state.py` imports from `hermes_state_registry` (introduced in the state-registry refactor), but the new top-level module is missing from the `[tool.setuptools] py-modules` list in `pyproject.toml`. Editable installs and sealed venvs (uv2nix) generate an import finder that enumerates only the listed top-level modules, so `hermes_state_registry` ends up unmapped.

## Root Cause

`py-modules` enumerates every top-level single-file module (`hermes_state`, `hermes_state_common`, `hermes_state_portability`, `hermes_state_schema`, `hermes_state_search`, …), but `hermes_state_registry` was never added when `hermes_state.py` began importing it.

## Fix

Add `"hermes_state_registry"` to `py-modules` (alphabetical order, between `hermes_state_portability` and `hermes_state_schema`).

## How to Verify

1. `uv pip install -e .` into a fresh venv (or any editable install).
2. Run in `-P` isolated mode from a non-repo cwd:

   ```
   python -P -c "from hermes_state import is_sqlite_wal_reset_vulnerable"
   ```

   Before: `ModuleNotFoundError: No module named 'hermes_state_registry'`
   After: imports cleanly.

## Impact

Anything that imports `hermes_state` without the repo cwd on `sys.path` currently crashes. Concretely, this breaks the Hermes overnight update's SQLite runtime-safety probes (which run `python -P` and import `hermes_state.is_sqlite_wal_reset_vulnerable`), causing the overnight update to false-fail with exit=1 and a misleading red failure notification.

## Risk Assessment

Low — adds a missing name to an existing packaging list; no runtime behavior change.