### PR TITLE
fix(profiles): keep new bots runnable when config already exists

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -773,22 +773,23 @@ def _read_config_model(profile_dir: Path) -> tuple:
 def _seed_model_config(profile_dir: Path) -> None:
     """Give a profile created without a clone source a usable model block.
 
-    Such a profile gets its directory tree but no ``config.yaml`` at all, so it
-    resolves no provider and its first turn dies with "No LLM provider
-    configured" — created, but unable to run. Copy the active profile's
-    ``model`` block over at creation time.
+    Copy the active profile's ``model`` block over at creation time, merging it
+    into a config file another creation surface may already have written.
+    Existing config and an explicitly present ``model`` key always win.
 
     This is a copy, not a link: profiles remain independent islands, and
     editing either one afterwards never touches the other. "Fresh" means fresh
     skills and SOUL, not unreachable.
     """
     config_path = profile_dir / "config.yaml"
-    if config_path.exists():
-        return
     try:
         import yaml
         from hermes_constants import get_hermes_home
         from hermes_cli.config import read_user_config_raw
+
+        existing = read_user_config_raw(config_path)
+        if "model" in existing:
+            return
 
         source = get_hermes_home() / "config.yaml"
         if not source.is_file():
@@ -796,8 +797,9 @@ def _seed_model_config(profile_dir: Path) -> None:
         model_cfg = read_user_config_raw(source).get("model")
         if not model_cfg:
             return
+        existing["model"] = model_cfg
         config_path.write_text(
-            yaml.safe_dump({"model": model_cfg}, sort_keys=False),
+            yaml.safe_dump(existing, sort_keys=False),
             encoding="utf-8",
         )
     except Exception:

--- a/tests/hermes_cli/test_profiles.py
+++ b/tests/hermes_cli/test_profiles.py
@@ -39,6 +39,7 @@ from hermes_cli.profiles import (
     import_profile,
     _get_profiles_root,
     _get_default_hermes_home,
+    _seed_model_config,
     seed_profile_skills,
     has_bundled_skills_opt_out,
     NO_BUNDLED_SKILLS_MARKER,
@@ -171,6 +172,48 @@ class TestCreateProfile:
         cfg = yaml.safe_load((profile_dir / "config.yaml").read_text())
         assert cfg["model"]["provider"] == "nous"
         assert cfg["model"]["default"] == "some/model"
+
+
+    def test_model_seed_preserves_existing_config(self, profile_env):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "model:\n  provider: nous\n  default: some/model\n"
+        )
+        profile_dir = default_home / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(
+            "display:\n  skin: slate\nagent:\n  max_iterations: 42\n"
+        )
+
+        _seed_model_config(profile_dir)
+
+        cfg = yaml.safe_load((profile_dir / "config.yaml").read_text())
+        assert cfg == {
+            "display": {"skin": "slate"},
+            "agent": {"max_iterations": 42},
+            "model": {"provider": "nous", "default": "some/model"},
+        }
+
+
+    def test_model_seed_does_not_replace_existing_model(self, profile_env):
+        default_home = profile_env / ".hermes"
+        (default_home / "config.yaml").write_text(
+            "model:\n  provider: nous\n  default: inherited/model\n"
+        )
+        profile_dir = default_home / "profiles" / "coder"
+        profile_dir.mkdir(parents=True)
+        (profile_dir / "config.yaml").write_text(
+            "model:\n  provider: custom\n  default: chosen/model\n"
+            "display:\n  skin: mono\n"
+        )
+
+        _seed_model_config(profile_dir)
+
+        cfg = yaml.safe_load((profile_dir / "config.yaml").read_text())
+        assert cfg == {
+            "model": {"provider": "custom", "default": "chosen/model"},
+            "display": {"skin": "mono"},
+        }
 
 
 


### PR DESCRIPTION
## What does this PR do?

A fresh bot can keep the metadata already written to its `config.yaml` while inheriting the active profiles model assignment. Without this merge, `_seed_model_config` exits as soon as the target config exists, leaving the bot without a provider and making its first turn fail.

### Symptom

A bot creation surface that writes profile metadata before model seeding leaves the new profile with no `model` block.

### Impact

The new bot cannot start a model turn until the user manually configures a provider and model.

### Bug Cause

**Trigger:** `hermes_cli/profiles.py:773` / `_seed_model_config` / target `config.yaml` already exists without a `model` key

**Causal chain:**
1. A creation surface writes non-model profile configuration.
2. `_seed_model_config` treats any existing config file as fully configured and returns.
3. The profile has no inherited provider or model, so its first model turn cannot run.

**Why it is wrong:** File existence does not imply that the model key exists. The guard conflates unrelated profile metadata with an explicit model assignment.

**Working sibling / contrast:** A profile with no target config already receives the inherited model block; a profile with an explicit model must keep that choice.

**Ruled out:** Source model resolution is not the failure. The same source model is copied successfully when the target file is absent.

### Fix

Read the targets raw config, preserve all existing keys, and add the inherited model only when the `model` key is absent. An explicitly present model key remains authoritative.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/profiles.py` - merge inherited model configuration into an existing target config without replacing an explicit model.
- `tests/hermes_cli/test_profiles.py` - cover metadata preservation and existing-model precedence.

## How to Test

1. Create source and target profile configs where the target has metadata but no model.
2. Seed the model and verify the metadata and inherited model both remain.
3. Repeat with an explicit target model and verify it is unchanged.

```bash
scripts/run_tests.sh tests/hermes_cli/test_profiles.py -k "fresh_profile_inherits_a_usable_model or fresh_profile_model_is_copied_not_linked or model_seed_preserves_existing_config or model_seed_does_not_replace_existing_model" -q
```

Result: 4 passed.

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I ran the relevant repository test entry and all selected tests pass
- [x] I added regression tests for the change
- [x] I tested on Windows 11

### Documentation & Housekeeping

- [x] I updated the affected docstring
- [x] Config examples are N/A because no config key changed
- [x] Architecture documentation is N/A
- [x] I considered cross-platform impact; the change uses existing pathlib and YAML primitives
- [x] Tool descriptions and schemas are N/A

## Screenshots / Logs

The focused model-seeding suite passes 4 tests. The complete `test_profiles.py` file also has four unrelated pre-existing Windows failures from POSIX-only permission and wrapper-name expectations.