### PR TITLE
fix(desktop): scope deferred MCP discovery

### DIFF
--- a/hermes_cli/mcp_startup.py
+++ b/hermes_cli/mcp_startup.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import threading
 from contextlib import nullcontext
 from typing import Optional
@@ -222,6 +223,20 @@ def defer_background_mcp_discovery(*, logger, thread_name: str, delay: float) ->
     the late-binding refresh behave exactly as if it had been started eagerly.
     """
     global _mcp_discovery_deferred
+    # Desktop ``serve`` resolves and validates its environment toolsets in the
+    # TUI gateway. Reuse that exact result for process-level MCP spawning so an
+    # invalid env list and the agent schema cannot drift apart. Resolution
+    # uncertainty and an explicit empty schema fail closed for MCP processes.
+    if os.environ.get("HERMES_DESKTOP") == "1":
+        try:
+            from tui_gateway.server import _load_enabled_toolsets
+
+            resolved_toolsets = _load_enabled_toolsets("desktop")
+            set_mcp_server_filter(
+                ["no_mcp"] if resolved_toolsets == [] else resolved_toolsets
+            )
+        except Exception:
+            set_mcp_server_filter(["no_mcp"])
     with _mcp_discovery_lock:
         if _mcp_discovery_started or _mcp_discovery_deferred is not None:
             return

--- a/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
+++ b/tests/hermes_cli/test_serve_mcp_discovery_after_bind.py
@@ -12,6 +12,7 @@ import threading
 
 import hermes_cli.mcp_startup as mcp_startup
 import hermes_cli.web_server as web_server
+import tui_gateway.server as tui_server
 from tests.hermes_cli.test_dashboard_auth_gate import _stub_uvicorn_run
 
 
@@ -19,6 +20,9 @@ def _reset_discovery_state(monkeypatch):
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_started", False)
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_thread", None)
     monkeypatch.setattr(mcp_startup, "_mcp_discovery_deferred", None)
+    monkeypatch.setattr(mcp_startup, "_mcp_server_filter", None)
+    monkeypatch.delenv("HERMES_DESKTOP", raising=False)
+    monkeypatch.delenv("HERMES_TUI_TOOLSETS", raising=False)
 
 
 def test_desktop_serve_arms_mcp_discovery_only_after_ready_sentinel(monkeypatch):
@@ -68,3 +72,40 @@ def test_deferred_discovery_fires_once_and_is_idempotent(monkeypatch):
     mcp_startup._start_deferred_mcp_discovery_now()
     assert calls == ["t"]
     assert first is not None and mcp_startup._mcp_discovery_deferred is None
+
+
+def test_desktop_deferred_discovery_uses_resolved_toolset_filter(monkeypatch):
+    _reset_discovery_state(monkeypatch)
+    monkeypatch.setenv("HERMES_DESKTOP", "1")
+    monkeypatch.setattr(
+        tui_server,
+        "_load_enabled_toolsets",
+        lambda _platform: ["terminal", "desktop_ui", "ivc_macbook_control"],
+    )
+
+    mcp_startup.defer_background_mcp_discovery(
+        logger=logging.getLogger("test"), thread_name="desktop", delay=60
+    )
+    timer = mcp_startup._mcp_discovery_deferred
+    assert mcp_startup.get_mcp_server_filter() == [
+        "terminal", "desktop_ui", "ivc_macbook_control"
+    ]
+    assert isinstance(timer, threading.Timer)
+    timer.cancel()
+
+
+def test_desktop_empty_or_failed_resolution_denies_mcp(monkeypatch):
+    for resolver in (
+        lambda _platform: [],
+        lambda _platform: (_ for _ in ()).throw(RuntimeError("boom")),
+    ):
+        _reset_discovery_state(monkeypatch)
+        monkeypatch.setenv("HERMES_DESKTOP", "1")
+        monkeypatch.setattr(tui_server, "_load_enabled_toolsets", resolver)
+        mcp_startup.defer_background_mcp_discovery(
+            logger=logging.getLogger("test"), thread_name="desktop", delay=60
+        )
+        timer = mcp_startup._mcp_discovery_deferred
+        assert mcp_startup.get_mcp_server_filter() == ["no_mcp"]
+        assert isinstance(timer, threading.Timer)
+        timer.cancel()


### PR DESCRIPTION
## Summary

Make Desktop `hermes serve` apply its resolved agent toolset list to the existing process-level MCP spawn filter before deferred discovery starts.

Desktop backends receive scoped toolsets through `HERMES_TUI_TOOLSETS`, not CLI `-t/--toolsets`. Without this bridge, the agent schema can expose a narrow MCP selection while deferred startup still spawns every configured MCP server.

## Behaviour

- Reuses `tui_gateway.server._load_enabled_toolsets("desktop")`, so validation, disabled-server handling, plugin toolsets and invalid-env fallback stay identical to the model-facing schema.
- A resolved empty toolset list maps to `no_mcp` and starts no MCP process.
- Resolver failures fail closed for MCP spawning.
- `None` retains the existing all-enabled behaviour.
- Ordinary CLI and explicit `-t/--toolsets` semantics are unchanged.

## Verification

- `ruff check` passed.
- `tests/hermes_cli/test_mcp_startup.py` and `tests/hermes_cli/test_serve_mcp_discovery_after_bind.py`: 18 passed.
- `git diff --check` passed.

No profile-specific names, paths, adapters or configuration are included.
