### PR TITLE
fix: resolve 1M context for opencode-free and muse-spark family

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -543,7 +543,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek-chat": 1_000_000,
     "deepseek-reasoner": 1_000_000,
     "deepseek": 128000,
-    # Meta
+    # Meta — Muse Spark family ships with a 1M context window
+    # (1,048,576 tokens, Standard and Contributor tiers alike).
+    # Source: https://dev.meta.ai/docs/overview/ (verified 2026-09-03).
+    # models.dev has no muse-spark entry under any provider id and the
+    # opencode /models endpoint omits context metadata entirely, so without
+    # this the family falls through to the 256K fallback on every provider.
+    "muse-spark": 1_048_576,
     "llama": 131072,
     # Thinking Machines — Inkling family ships with a 1M context window
     # (max output 256K).  Verified against OpenRouter live metadata
@@ -3463,6 +3469,15 @@ def get_model_context_length(
     if effective_provider == "gmi" and base_url:
         # GMI exposes authoritative context_length via /models, but it is not
         # in models.dev yet. Preserve that higher-fidelity endpoint lookup.
+        ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
+        if ctx is not None:
+            return ctx
+    if effective_provider in {"commandcode", "commandcode-anthropic"} and base_url:
+        # commandcode (api.commandcode.ai) exposes authoritative
+        # context_length via /models (e.g. muse-spark 1M) but is a
+        # known provider so step 2's custom-endpoint probe is skipped
+        # and models.dev has no muse-spark entry — without this the
+        # model fell through to the 256K fallback.
         ctx = _resolve_endpoint_context_length(model, base_url, api_key=api_key)
         if ctx is not None:
             return ctx

--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -188,6 +188,10 @@ PROVIDER_TO_MODELS_DEV: Dict[str, str] = {
     "ai-gateway": "vercel",
     "opencode-zen": "opencode",
     "opencode-go": "opencode-go",
+    # opencode-free is the free-tier transport for the same opencode-go
+    # catalog — without this alias the models.dev lookup misses for every
+    # model on opencode-free and falls through to the 256K default.
+    "opencode-free": "opencode-go",
     "kilocode": "kilo",
     "fireworks": "fireworks-ai",
     "huggingface": "huggingface",

--- a/tests/agent/test_opencode_free_mapping.py
+++ b/tests/agent/test_opencode_free_mapping.py
@@ -1,0 +1,13 @@
+"""opencode-free resolves through the opencode-go catalog; muse-spark is 1M."""
+
+from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+from agent.models_dev import PROVIDER_TO_MODELS_DEV
+
+
+def test_opencode_free_maps_to_opencode_go():
+    assert PROVIDER_TO_MODELS_DEV.get("opencode-free") == "opencode-go"
+    assert PROVIDER_TO_MODELS_DEV.get("opencode-go") == "opencode-go"
+
+
+def test_muse_spark_catalog_is_1m():
+    assert DEFAULT_CONTEXT_LENGTHS.get("muse-spark") == 1_048_576


### PR DESCRIPTION
## Summary
- Map `opencode-free` to the `opencode-go` models.dev catalog. The opencode `/models` endpoint omits context metadata for all 66 models and `opencode-free` had no models.dev alias, so every model on that route survived only via the hardcoded catalog and muse-spark fell through to the 256K fallback.
- Add `muse-spark=1048576` to `DEFAULT_CONTEXT_LENGTHS` (Meta docs: Standard and Contributor tiers share the 1,048,576-token window; verified 2026-09-03; missing from models.dev under every provider id and opencode exposes no metadata to probe).
- Route `commandcode`/`commandcode-anthropic` through the live `/models` endpoint, which reports authoritative `context_length` (e.g. 1048576) but was skipped as a known provider.

## Test plan
- `get_model_context_length` now returns 1048576 for `muse-spark-1.3-contributor-free` / `muse-spark-1.2` on `opencode-free` and `meta/muse-spark-1.3-contributor` on commandcode (was 256000); spot-checked qwen/deepseek/claude/gpt on opencode-free unchanged (provider-catalog values).
- `tests/agent/test_model_metadata.py`, `test_models_dev.py`, `test_models_dev_meta_mapping.py`: 185 passed.
- New `tests/agent/test_opencode_free_mapping.py`: 3 passed (with meta-mapping test file).

## Note
- `qwen3.6-plus` on opencode-free now resolves via the provider catalog (1000000) instead of the DashScope hardcoded value (1048576); provider-specific catalog wins by design (safe direction).