### PR TITLE
fix(desktop): recycle managed SSH backend on update

### DIFF
--- a/apps/desktop/src/app/command-center/index.tsx
+++ b/apps/desktop/src/app/command-center/index.tsx
@@ -8,7 +8,7 @@ import { SearchField } from '@/components/ui/search-field'
 import { SegmentedControl } from '@/components/ui/segmented-control'
 import { ResponsiveTabs } from '@/components/ui/tab-dropdown'
 import { Tip } from '@/components/ui/tooltip'
-import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway, updateHermes } from '@/hermes'
+import { getActionStatus, getLogs, getStatus, getUsageAnalytics, restartGateway } from '@/hermes'
 import type { ActionStatusResponse, AnalyticsResponse, SessionInfo, StatusResponse } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { sessionTitle } from '@/lib/chat-runtime'
@@ -31,6 +31,7 @@ import { cn } from '@/lib/utils'
 import { upsertDesktopActionTask } from '@/store/activity'
 import { $pinnedSessionIds, pinSession, unpinSession } from '@/store/layout'
 import { $sessions, sessionPinId } from '@/store/session'
+import { startActiveUpdate } from '@/store/updates'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import { useRouteEnumParam } from '../hooks/use-route-enum-param'
@@ -264,11 +265,11 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
   }, [logQuery, logs])
 
   const runSystemAction = useCallback(
-    async (kind: 'restart' | 'update') => {
+    async () => {
       setSystemError('')
 
       try {
-        const started = kind === 'restart' ? await restartGateway() : await updateHermes()
+        const started = await restartGateway()
         let nextStatus: ActionStatusResponse | null = null
 
         for (let attempt = 0; attempt < 18; attempt += 1) {
@@ -442,10 +443,10 @@ export function CommandCenterView({ initialSection, onClose, onDeleteSession, on
                         </div>
                       </div>
                       <div className="flex shrink-0 flex-wrap items-center gap-x-3 gap-y-1 whitespace-nowrap max-[47.5rem]:whitespace-normal">
-                        <Button onClick={() => void runSystemAction('restart')} size="xs" variant="text">
+                        <Button onClick={() => void runSystemAction()} size="xs" variant="text">
                           {cc.restartGateway}
                         </Button>
-                        <Button onClick={() => void runSystemAction('update')} size="xs" variant="textStrong">
+                        <Button onClick={() => startActiveUpdate('backend')} size="xs" variant="textStrong">
                           {cc.updateHermes}
                         </Button>
                       </div>

--- a/apps/desktop/src/store/updates.test.ts
+++ b/apps/desktop/src/store/updates.test.ts
@@ -788,6 +788,75 @@ describe('client nudge after a backend update', () => {
   })
 })
 
+describe('managed SSH backend update', () => {
+  const updateManagedMock = vi.fn()
+
+  beforeEach(() => {
+    storage.clear()
+    notifySpy.mockClear()
+    dismissSpy.mockClear()
+    reconnectGatewaySpy.mockClear()
+    updateHermesSpy.mockReset()
+    checkHermesUpdateSpy.mockReset().mockResolvedValue({
+      install_method: 'git',
+      current_version: '0.4.2',
+      behind: 0,
+      update_available: false,
+      can_apply: true,
+      update_command: null,
+      message: null
+    })
+    updateManagedMock.mockReset().mockResolvedValue({
+      connectionId: 'homelab',
+      correlationId: '12345678-1234-4678-9234-567812345678',
+      message: 'Updated and restored 1 SSH scope.',
+      ok: true,
+      outcome: 'success',
+      receipt: null,
+      restoreOk: true,
+      scopes: [{ profile: 'default', restored: true }],
+      updateOk: true
+    })
+    resetUpdateApplyState()
+    $backendUpdateStatus.set(status({ behind: 1 }))
+    $mockConnectionsRegistry.set({
+      version: 2,
+      primary: 'homelab',
+      secureTokenStorage: true,
+      connections: [{ id: 'homelab', kind: 'ssh', label: 'Homelab', host: 'box' }]
+    })
+    setConnection({
+      baseUrl: 'http://127.0.0.1:9119',
+      connectionId: 'homelab',
+      isFullscreen: false,
+      logs: [],
+      mode: 'remote',
+      nativeOverlayWidth: 0,
+      token: 't',
+      windowButtonPosition: null,
+      wsUrl: 'ws://127.0.0.1:9119'
+    })
+    ;(globalThis as unknown as { window: unknown }).window = {
+      hermesDesktop: { connections: { updateManaged: updateManagedMock } }
+    }
+  })
+
+  afterEach(() => {
+    setRemote(false)
+    $mockConnectionsRegistry.set(null)
+    delete (globalThis as unknown as { window?: unknown }).window
+  })
+
+  it('drains and restores the active isolated backend instead of updating through the stale serve', async () => {
+    const result = await applyBackendUpdate()
+
+    expect(result.ok).toBe(true)
+    expect(updateManagedMock).toHaveBeenCalledWith('homelab')
+    expect(updateHermesSpy).not.toHaveBeenCalled()
+    expect(reconnectGatewaySpy).toHaveBeenCalledTimes(1)
+  })
+})
+
 describe('applyUpdates terminal state', () => {
   const applyMock = vi.fn()
 

--- a/apps/desktop/src/store/updates.ts
+++ b/apps/desktop/src/store/updates.ts
@@ -19,6 +19,7 @@ import { translateNow } from '@/i18n'
 import { persistString, storedString } from '@/lib/storage'
 import { $connectionsRegistry, refreshConnectionsRegistry } from '@/store/connections'
 import { reconnectGateway } from '@/store/gateway-reconnect'
+import { runManagedUpdate } from '@/store/managed-updates'
 import { dismissNotification, notify } from '@/store/notifications'
 import { $connection } from '@/store/session'
 import type { BackendUpdateCheckResponse } from '@/types/hermes'
@@ -658,6 +659,24 @@ function legacyBackendReachedTarget(
 
 let backendUpdateInFlight: Promise<DesktopUpdateApplyResult> | null = null
 
+async function activeManagedSshConnectionId(): Promise<string | null> {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const connectionId = $connection.get()?.connectionId
+  const updateManaged = window.hermesDesktop?.connections?.updateManaged
+
+  if (!connectionId || !updateManaged) {
+    return null
+  }
+
+  const registry = $connectionsRegistry.get() ?? (await refreshConnectionsRegistry().catch(() => null))
+  const connection = registry?.connections.find(entry => entry.id === connectionId)
+
+  return connection?.kind === 'ssh' ? connectionId : null
+}
+
 async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   dismissNotification(UPDATE_TOAST_ID)
   $backendUpdateApply.set({
@@ -668,6 +687,27 @@ async function runBackendUpdate(): Promise<DesktopUpdateApplyResult> {
   })
 
   try {
+    const managedConnectionId = await activeManagedSshConnectionId()
+
+    if (managedConnectionId) {
+      const managed = await runManagedUpdate(managedConnectionId)
+
+      if (managed.status === 'updated') {
+        return finishBackendApply(true)
+      }
+
+      const message = managed.message || translateNow('updates.applyStatus.failed')
+      $backendUpdateApply.set({
+        ...$backendUpdateApply.get(),
+        applying: false,
+        stage: 'error',
+        error: 'apply-failed',
+        message
+      })
+
+      return { ok: false, error: 'apply-failed', message }
+    }
+
     const previousStatus = $backendUpdateStatus.get()
     const requestedTargetSha = previousStatus?.commits?.at(0)?.sha
 


### PR DESCRIPTION
## What does this PR do?

Fixes #101822. When Desktop updates the checkout behind an active, registered SSH backend, the running `hermes serve --isolated` process can retain stale Python modules in memory while newer files are written on disk. The next agent initialization can then fail with an `ImportError` even though the checkout contains the imported symbol.

The active managed-SSH backend update path now uses the existing transactional drain/update/restore lifecycle instead of calling the update API through the live isolated backend. The Command Center's backend update action now enters that central path as well, so Desktop stops and later recreates the exact owned SSH scope around the remote update.

## Changes made

- `apps/desktop/src/store/updates.ts`: detect an active registered SSH connection and delegate backend updates to `runManagedUpdate()`.
- `apps/desktop/src/store/updates.test.ts`: add a behavioral regression proving the managed bridge is used, the stale backend update API is not called, and the gateway reconnects after restoration.
- `apps/desktop/src/app/command-center/index.tsx`: route the backend update button through the central update flow.

## Verification

- `npx vitest run src/store/updates.test.ts --project ui` — 66 passed.
- `npx vitest run src/store/updates.test.ts src/app/command-center/delete-confirm.test.tsx --project ui` — 69 passed.
- `npm run typecheck` — passed across renderer, Electron, and E2E TypeScript projects.
- `npx eslint src/store/updates.ts src/store/updates.test.ts src/app/command-center/index.tsx` — passed.
- `git diff --check` — passed.

The full Desktop dependency install initially required restoring the sparse checkout's workspace manifests and shared package sources; the focused checks above were run after the supported `npm ci --workspace apps/desktop --ignore-scripts --no-audit --no-fund` install completed.

## Checklist

- [x] Focused regression tests added and passed
- [x] TypeScript checks passed
- [x] ESLint passed
- [x] `git diff --check` passed
- [x] Existing managed SSH lifecycle reused; no new backend lifecycle protocol added
