### PR TITLE
feat(slack): add current message tool

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -4474,6 +4474,33 @@ class SlackAdapter(BasePlatformAdapter):
             logger.debug("[Slack] reactions.remove failed (%s): %s", emoji, e)
             return False
 
+    async def react_to_current_message(
+        self, *, channel: str, timestamp: str, emoji: str, team_id: str
+    ) -> bool:
+        """React to a caller-bound Slack message without target resolution.
+
+        The Slack tool passes IDs only from task-local inbound context; it never
+        accepts model-controlled channel/message/workspace identifiers.
+        """
+        return await self._add_reaction(channel, timestamp, emoji, team_id)
+
+    async def current_message_permalink(
+        self, *, channel: str, timestamp: str, team_id: str
+    ) -> Optional[str]:
+        """Return Slack's canonical permalink for a caller-bound message."""
+        if not self._app:
+            return None
+        try:
+            response = await self._get_client(
+                channel, team_id=team_id or None
+            ).chat_getPermalink(channel=channel, message_ts=timestamp)
+            payload = _slack_response_payload(response)
+            permalink = payload.get("permalink") if payload.get("ok", True) else None
+            return str(permalink) if isinstance(permalink, str) and permalink else None
+        except Exception as exc:
+            logger.debug("[Slack] chat.getPermalink failed: %s", exc)
+            return None
+
     def _reactions_enabled(self) -> bool:
         """Check if message reactions are enabled via config/env."""
         return os.getenv("SLACK_REACTIONS", "true").lower() not in {"false", "0", "no"}
@@ -9887,6 +9914,9 @@ def _build_adapter(config):
 
 def register(ctx) -> None:
     """Plugin entry point — called by the Hermes plugin system."""
+    from .tools import register_tools
+
+    register_tools(ctx)
     ctx.register_platform(
         name="slack",
         label="Slack",

--- a/plugins/platforms/slack/tools.py
+++ b/plugins/platforms/slack/tools.py
@@ -1,0 +1,115 @@
+"""Current-message-only Slack tools.
+
+The model never supplies Slack identifiers.  Each call is bound to the inbound
+message that started this turn through task-local gateway session context.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+_CURRENT_MESSAGE_SCHEMA = {
+    "name": "slack_current_message",
+    "description": "React to the Slack message that triggered this turn, or return that exact message's canonical Slack permalink. This tool cannot target any other message, thread, channel, or workspace.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["react", "permalink"],
+                "description": "'react' adds an emoji to the current inbound Slack message; 'permalink' returns its canonical Slack URL.",
+            },
+            "emoji": {
+                "type": "string",
+                "description": "Slack emoji name for action='react', optionally colon-wrapped (for example ':beer:' or 'eyes').",
+            },
+        },
+        "required": ["action"],
+        "additionalProperties": False,
+    },
+}
+_EMOJI_NAME_RE = re.compile(r"^[a-z0-9_+\-]{1,128}$")
+
+
+def _bound_current_message() -> tuple[str, str, str] | tuple[None, None, str]:
+    from gateway.session_context import get_session_env
+
+    if get_session_env("HERMES_SESSION_PLATFORM", "").strip().lower() != "slack":
+        return None, None, "This tool is available only while handling a Slack message."
+    channel = get_session_env("HERMES_SESSION_CHAT_ID", "").strip()
+    message_id = get_session_env("HERMES_SESSION_MESSAGE_ID", "").strip()
+    team_id = get_session_env("HERMES_SESSION_SCOPE_ID", "").strip()
+    if not channel or not message_id or not team_id:
+        return None, None, "Current Slack message context is unavailable; refusing to target a message."
+    return channel, message_id, team_id
+
+
+def _current_slack_adapter():
+    try:
+        from gateway.config import Platform
+        from gateway.run import _gateway_runner_ref
+
+        runner = _gateway_runner_ref()
+        adapter = runner.adapters.get(Platform.SLACK) if runner is not None else None
+    except Exception:
+        adapter = None
+    if adapter is None or not callable(getattr(adapter, "react_to_current_message", None)):
+        return None
+    return adapter
+
+
+def _handle_current_message(args: dict, **_: object) -> str:
+    action = str(args.get("action") or "").strip().lower()
+    channel, message_id, team_or_error = _bound_current_message()
+    if channel is None:
+        return json.dumps({"success": False, "error": team_or_error})
+    team_id = team_or_error
+    adapter = _current_slack_adapter()
+    if adapter is None:
+        return json.dumps({"success": False, "error": "A live Slack gateway adapter is required."})
+
+    from model_tools import _run_async
+
+    if action == "react":
+        emoji = str(args.get("emoji") or "").strip().strip(":").lower()
+        if not _EMOJI_NAME_RE.fullmatch(emoji):
+            return json.dumps({"success": False, "error": "emoji must be a Slack emoji name such as 'beer' or ':beer:'."})
+        try:
+            success = bool(_run_async(adapter.react_to_current_message(
+                channel=channel, timestamp=message_id, emoji=emoji, team_id=team_id,
+            )))
+        except Exception:
+            success = False
+        return json.dumps({"success": success, "action": "react", "emoji": emoji})
+
+    if action == "permalink":
+        try:
+            permalink = _run_async(adapter.current_message_permalink(
+                channel=channel, timestamp=message_id, team_id=team_id,
+            ))
+        except Exception:
+            permalink = None
+        if not isinstance(permalink, str) or not permalink:
+            return json.dumps({"success": False, "error": "Slack could not resolve the current message permalink."})
+        return json.dumps({"success": True, "action": "permalink", "permalink": permalink})
+
+    return json.dumps({"success": False, "error": "action must be 'react' or 'permalink'."})
+
+
+def _check_slack_tool_available() -> bool:
+    try:
+        from agent.secret_scope import get_secret
+        return bool((get_secret("SLACK_BOT_TOKEN", "") or "").strip())
+    except Exception:
+        return False
+
+
+def register_tools(ctx) -> None:
+    ctx.register_tool(
+        name="slack_current_message",
+        toolset="slack",
+        schema=_CURRENT_MESSAGE_SCHEMA,
+        handler=_handle_current_message,
+        check_fn=_check_slack_tool_available,
+        emoji="💬",
+    )

--- a/tests/plugins/platforms/slack/test_current_message_tool.py
+++ b/tests/plugins/platforms/slack/test_current_message_tool.py
@@ -1,0 +1,82 @@
+import json
+from unittest.mock import patch
+
+from gateway.session_context import clear_session_vars, set_session_vars
+from plugins.platforms.slack.tools import _handle_current_message
+
+
+class _Adapter:
+    def __init__(self):
+        self.calls = []
+
+    async def react_to_current_message(self, **kwargs):
+        self.calls.append(("react", kwargs))
+        return True
+
+    async def current_message_permalink(self, **kwargs):
+        self.calls.append(("permalink", kwargs))
+        return "https://workspace.slack.com/archives/C1/p123"
+
+
+def _bound_slack():
+    return set_session_vars(
+        platform="slack", chat_id="C1", thread_id="111.0001",
+        message_id="123.0002", scope_id="T1",
+    )
+
+
+def test_react_uses_only_current_context_identifiers():
+    adapter = _Adapter()
+    tokens = _bound_slack()
+    try:
+        with patch("plugins.platforms.slack.tools._current_slack_adapter", return_value=adapter):
+            result = json.loads(_handle_current_message({"action": "react", "emoji": ":beer:"}))
+    finally:
+        clear_session_vars(tokens)
+    assert result == {"success": True, "action": "react", "emoji": "beer"}
+    assert adapter.calls == [("react", {
+        "channel": "C1", "timestamp": "123.0002", "emoji": "beer", "team_id": "T1",
+    })]
+
+
+def test_permalink_uses_current_reply_not_thread_root():
+    adapter = _Adapter()
+    tokens = _bound_slack()
+    try:
+        with patch("plugins.platforms.slack.tools._current_slack_adapter", return_value=adapter):
+            result = json.loads(_handle_current_message({"action": "permalink"}))
+    finally:
+        clear_session_vars(tokens)
+    assert result == {
+        "success": True, "action": "permalink",
+        "permalink": "https://workspace.slack.com/archives/C1/p123",
+    }
+    assert adapter.calls == [("permalink", {
+        "channel": "C1", "timestamp": "123.0002", "team_id": "T1",
+    })]
+
+
+def test_rejects_non_slack_or_missing_bound_context():
+    tokens = set_session_vars(platform="discord", chat_id="C1", message_id="123", scope_id="T1")
+    try:
+        result = json.loads(_handle_current_message({"action": "permalink"}))
+    finally:
+        clear_session_vars(tokens)
+    assert result["success"] is False
+    assert "Slack" in result["error"]
+
+
+def test_rejects_model_controlled_target_fields_at_schema_boundary():
+    # The schema has additionalProperties:false, and the handler never reads a target.
+    adapter = _Adapter()
+    tokens = _bound_slack()
+    try:
+        with patch("plugins.platforms.slack.tools._current_slack_adapter", return_value=adapter):
+            result = json.loads(_handle_current_message({
+                "action": "react", "emoji": "beer", "target": "slack:C-ATTACKER:999",
+            }))
+    finally:
+        clear_session_vars(tokens)
+    assert result["success"] is True
+    assert adapter.calls[0][1]["channel"] == "C1"
+    assert adapter.calls[0][1]["timestamp"] == "123.0002"


### PR DESCRIPTION
## Summary
- Add opt-in `slack_current_message` with current-message-only reaction and permalink actions.
- Bind target identifiers solely from task-local Slack inbound context.
- Use workspace-scoped Slack API clients and reject unbound contexts.

## Verification
- `python3 -m py_compile plugins/platforms/slack/adapter.py plugins/platforms/slack/tools.py tests/plugins/platforms/slack/test_current_message_tool.py`
- current-message handler, plugin registration, and workspace-scoped adapter smoke tests
- `git diff --check`

Focused pytest is blocked in this checkout by the existing invalid `exclude-newer = "14 days"` value and absent pytest environment.