### PR TITLE
fix(mcp-oauth): close the inner auth-flow generator in the owning task (fixes permanent OAuth MCP wedge)

### DIFF
--- a/tests/tools/test_mcp_oauth_bidirectional.py
+++ b/tests/tools/test_mcp_oauth_bidirectional.py
@@ -317,3 +317,101 @@ async def _noop_callback() -> tuple[str, str | None]:
     raise AssertionError(
         "callback handler should not be invoked in bidirectional-generator tests"
     )
+
+
+@pytest.mark.asyncio
+async def test_wrapper_closes_inner_generator_and_frees_the_lock(tmp_path, monkeypatch):
+    """Closing the wrapper MUST close the inner SDK generator, freeing the lock.
+
+    ``httpx`` closes the OUTER generator deterministically, but the bridge only
+    held ``inner`` in a local. Dropped rather than closed, ``inner`` is finalized
+    later by asyncio's async-generator hook, which runs ``athrow(GeneratorExit)``
+    in a **different task**. Its suspended ``async with self.context.lock`` then
+    calls ``anyio.Lock.release()``, which is task-affine — it raises *before*
+    clearing ``_owner_task``, so the lock stays owned by a task that no longer
+    exists.
+
+    Because :class:`MCPOAuthManager` caches one provider per server, every later
+    request for that server then deadlocks inside ``async with
+    self.context.lock`` **before issuing any HTTP**: the server retries, times
+    out, parks, and never recovers until the process restarts. Observed in
+    production as an 11-hour Composio outage whose logs showed reconnect
+    attempts with zero outbound requests (GH#101756).
+
+    A server that answers 405 to the streamable-HTTP GET stream reaches this on
+    every single connect, but any abandoned flow will do it.
+    """
+    import gc
+
+    from tools.mcp_tool import sdk_httpx
+    httpx = sdk_httpx()
+    from mcp.shared.auth import OAuthClientInformationFull, OAuthClientMetadata, OAuthToken
+    from pydantic import AnyUrl
+
+    from tools.mcp_oauth import HermesTokenStorage
+    from tools.mcp_oauth_manager import _HERMES_PROVIDER_CLS, reset_manager_for_tests
+
+    assert _HERMES_PROVIDER_CLS is not None
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    reset_manager_for_tests()
+
+    storage = HermesTokenStorage("srv")
+    await storage.set_tokens(
+        OAuthToken(
+            access_token="old_access",
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token="old_refresh",
+        )
+    )
+    await storage.set_client_info(
+        OAuthClientInformationFull(
+            client_id="test-client",
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            grant_types=["authorization_code", "refresh_token"],
+            response_types=["code"],
+            token_endpoint_auth_method="none",
+        )
+    )
+
+    provider = _HERMES_PROVIDER_CLS(
+        server_name="srv",
+        server_url="https://example.com/mcp",
+        client_metadata=OAuthClientMetadata(
+            redirect_uris=[AnyUrl("http://127.0.0.1:12345/callback")],
+            client_name="Hermes Agent",
+        ),
+        storage=storage,
+        redirect_handler=_noop_redirect,
+        callback_handler=_noop_callback,
+    )
+
+    req = httpx.Request("POST", "https://example.com/mcp")
+    flow = provider.async_auth_flow(req)
+
+    # Drive to the suspension point: the inner SDK generator has acquired
+    # context.lock and is parked at ``response = yield request``.
+    outbound = await flow.__anext__()
+    assert outbound is not None
+
+    # What httpx does when the request is torn down mid-flight (a cancelled
+    # call, or the GET stream against a server that answers 405).
+    await flow.aclose()
+
+    # Give an orphaned inner generator every chance to be finalized. With the
+    # bug, this is where the cross-task release fails and the lock is poisoned.
+    gc.collect()
+    await asyncio.sleep(0.1)
+
+    assert not provider.context.lock.locked(), (
+        "context.lock is still held after the flow was closed: the inner SDK "
+        "generator was abandoned instead of closed, so its release ran in a "
+        "foreign task and anyio refused it. Every subsequent request through "
+        "this cached provider will now deadlock before issuing any HTTP."
+    )
+
+    # And prove the provider is actually reusable, which is the property that
+    # was really lost — the lock being free is only the proxy for it.
+    await asyncio.wait_for(provider.context.lock.acquire(), timeout=2.0)
+    provider.context.lock.release()

--- a/tools/mcp_oauth_manager.py
+++ b/tools/mcp_oauth_manager.py
@@ -587,16 +587,35 @@ def _make_hermes_provider_class() -> Optional[type]:
                 self._persist_oauth_metadata_if_changed()
                 return
             finally:
+                import anyio
+
                 if resource_lock_released:
                     # Balance the SDK's surrounding ``async with`` even when
                     # HTTPX cancels or closes the flow while the resource
-                    # request is still in flight.  Shield only this local
-                    # bookkeeping; general inner-generator teardown remains
-                    # the separate concern tracked by the cleanup PR.
-                    import anyio
-
+                    # request is still in flight.
                     with anyio.CancelScope(shield=True):
                         await self.context.lock.acquire()
+                # Close the inner generator HERE, in the task that acquired
+                # the lock. HTTPX closes this OUTER generator deterministically,
+                # but ``inner`` was only held in a local -- dropped, it is
+                # finalized later by asyncio's async-generator hook, which runs
+                # ``athrow(GeneratorExit)`` in a DIFFERENT task. Its suspended
+                # ``async with self.context.lock`` then calls
+                # ``anyio.Lock.release()``, which is task-affine: it raises
+                # *before* clearing ``_owner_task``, leaving the lock owned by a
+                # task that no longer exists. Because MCPOAuthManager caches one
+                # provider per server, every later request for that server then
+                # deadlocks inside ``async with self.context.lock`` before
+                # issuing any HTTP -- the server retries, times out, parks, and
+                # never recovers for the life of the process (#101756).
+                #
+                # Closing it here throws GeneratorExit into ``inner`` from the
+                # owning task, so the release succeeds. Shielded so a cancelled
+                # flow still tears down cleanly. Idempotent: aclose() on an
+                # already-closed generator (the retry_after_concurrent_auth
+                # branch) is a no-op.
+                with anyio.CancelScope(shield=True):
+                    await inner.aclose()
 
             if retry_after_concurrent_auth:
                 yield request


### PR DESCRIPTION
Fixes #101756.

## The bug

`HermesMCPOAuthProvider.async_auth_flow` holds the SDK's inner generator in a local and never closes it. httpx closes the **outer** generator deterministically, but `inner` is simply dropped.

`inner` is suspended at `yield request` inside `async with self.context.lock`. Dropped rather than closed, it is finalized by asyncio's async-generator hook, which runs `athrow(GeneratorExit)` in a **different task**. `anyio.Lock.release()` is task-affine: it raises *before* clearing `_owner_task` (`anyio/_backends/_asyncio.py:1933`), so the lock is left owned by a task that no longer exists.

Because `MCPOAuthManager` caches one provider per server, every later request for that server then deadlocks inside `async with self.context.lock` **before issuing any HTTP**. The server retries, times out, parks, self-probes, and never recovers for the life of the process.

Note this is *not* a race — asyncio's finalizer always runs in a new task, so the cross-task release fails 100% of the time whenever the flow is abandoned.

## Why the recent lock-narrowing didn't close it

The current `main` releases `context.lock` around the resource request and re-acquires it in a shielded `finally`, with the comment that *"general inner-generator teardown remains the separate concern tracked by the cleanup PR."* That is exactly this PR — and the teardown path is still reachable today. Simulating the current bridge faithfully:

```
upstream main as-is            -> lock still held: True
upstream main + inner.aclose() -> lock still held: False
```

When the outer generator is closed at its `yield` while `resource_lock_released` is true, the `finally` re-acquires the lock and returns — but `inner` is still suspended inside its own `async with` and is never closed, so the poisoning proceeds as before.

## The fix

Close `inner` in the `finally`, in the task that acquired the lock:

```python
with anyio.CancelScope(shield=True):
    await inner.aclose()
```

Placed **after** the existing conditional re-acquire, so the inner generator's `async with` always has a lock owned by this task to release. Shielded so a cancelled flow still tears down cleanly, and idempotent — `aclose()` on the already-closed `retry_after_concurrent_auth` generator is a no-op.

## Reproduction, no server required

```python
import asyncio, gc, anyio

class Ctx:
    def __init__(self):
        self.lock = anyio.Lock()

async def sdk_auth_flow(ctx):              # mirrors oauth2.py:582
    async with ctx.lock:
        response = yield "request"         # oauth2.py:601
        if response == 401:
            yield "retry"

async def bridge(ctx, close_inner):        # mirrors the wrapper
    inner = sdk_auth_flow(ctx)
    try:
        outgoing = await inner.__anext__()
        while True:
            incoming = yield outgoing
            outgoing = await inner.asend(incoming)
    except StopAsyncIteration:
        return
    finally:
        if close_inner:
            await inner.aclose()

async def scenario(close_inner):
    ctx = Ctx()
    gen = bridge(ctx, close_inner)
    await gen.__anext__()
    await gen.aclose()                     # what httpx does
    gc.collect()
    await asyncio.sleep(0.3)
    return ctx.lock.locked()

async def main():
    print("without aclose ->", await scenario(False))   # True  (poisoned)
    print("with    aclose ->", await scenario(True))    # False (clean)

asyncio.run(main())
```

Emits the production traceback verbatim:

```
RuntimeError: The current task is not holding this lock
  File "anyio/_backends/_asyncio.py", line 1935, in release
without aclose -> True
with    aclose -> False
```

## Production evidence

Against `connect.composio.dev/mcp`, which answers **405 to the GET** stream opened after `initialize`, so `handle_get_stream` takes the exception path on **every connect**. An 11-hour outage:

```
22:21:18 GET  /mcp "405 Method Not Allowed"
22:21:18 mcp.client.streamable_http: GET stream disconnected, reconnecting in 1000ms...
22:21:19 ERROR asyncio: Task exception was never retrieved
         RuntimeError('The current task is not holding this lock')   <- oauth2.py:582
22:24:20 WARNING MCP server 'composio' failed after 5 reconnection attempts, parking
[repeats every ~5.5 min for 11 hours, with ZERO httpx2 request lines in between]
```

That silence is the signature: the reconnects never reach the network. A genuine network failure still logs requests.

After the fix, on the same host: **13** subsequent 405-GET teardowns, **0** poisonings, **0** parkings — against **75** poisonings and **233** parkings before.

Any OAuth MCP server can hit this; a 405-on-GET server hits it constantly. #84132 reports the same symptom against Linear.

## Test

Adds `test_wrapper_closes_inner_generator_and_frees_the_lock` to the existing bridge test file. It drives the wrapper to its suspension point, closes the outer generator the way httpx does, forces finalization, then asserts `context.lock` is free **and** that the provider is still usable — the reusability being the property actually lost.

## Testing caveat

I verified the mechanism with the standalone repro above (against the installed `anyio` and `mcp`), with an equivalent test driven through the real cached provider on the affected host, and in production over several hours. I was **not** able to run the repository's full pytest suite in that environment, so please treat the new test as needing a CI run.

## Related

- #84132, #81051 — same symptom, cause not identified
- modelcontextprotocol/python-sdk#2847 — the SDK-side issue (lock held across `yield`), still open; python-sdk#2858 narrows it upstream. The two fixes are independent: while the SDK holds a lock across a yield, **any** wrapper that drops the generator poisons it, so this teardown is worth having regardless. `mcp` 2.1.1 still holds `anyio.Lock` across the yield, so upgrading is not a workaround.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
