### PR TITLE
fix(vision): fall through to configured chain on request-time errors

### DIFF
--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -1121,3 +1121,176 @@ class TestVisionCpuBurstCap:
             f"analyses were serialized to the cap (peak={calls_peak}); only the "
             "encode burst should be bounded, not the whole call"
         )
+
+
+# ---------------------------------------------------------------------------
+# Request-time fallback across auxiliary.vision.fallback_chain
+# ---------------------------------------------------------------------------
+
+
+_CHAIN_ENTRY = {
+    "provider": "custom",
+    "model": "qwen3.8-27b-vision",
+    "base_url": "http://127.0.0.1:8090/v1",
+    "api_key": "no-key-required",
+}
+
+
+def _resp(content):
+    mock = MagicMock()
+    mock.choices = [MagicMock()]
+    mock.choices[0].message.content = content
+    return mock
+
+
+class TestVisionRequestTimeFallback:
+    """A request-time failure on the resolved primary (removed hosted model,
+    quota 429, timeout) must walk auxiliary.vision.fallback_chain instead of
+    killing the tool call — the resolution-time chain only engages when a
+    client cannot be BUILT, so without this the configured local vision
+    fallback is unreachable from a dead primary."""
+
+    def _vision_cfg(self):
+        return {"auxiliary": {"vision": {}}}
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_chain_on_request_error(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG)
+
+        async def llm(**kwargs):
+            if "provider" not in kwargs:
+                raise RuntimeError(
+                    "Error code: 404 - Function 'abc': Not found for account")
+            return _resp("chain analysis")
+
+        with (
+            patch("tools.vision_tools._image_to_base64_data_url",
+                  return_value="data:image/png;base64,abc"),
+            patch("tools.vision_tools.async_call_llm",
+                  new_callable=AsyncMock, side_effect=llm) as mock_llm,
+            patch("tools.vision_tools._load_vision_fallback_chain",
+                  return_value=[_CHAIN_ENTRY]),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+
+        assert result["success"] is True
+        assert "chain analysis" in result["analysis"]
+        assert mock_llm.await_count == 2
+        primary_kwargs = mock_llm.await_args_list[0].kwargs
+        chain_kwargs = mock_llm.await_args_list[1].kwargs
+        assert "provider" not in primary_kwargs
+        assert chain_kwargs["provider"] == "custom"
+        assert chain_kwargs["model"] == "qwen3.8-27b-vision"
+        assert chain_kwargs["base_url"] == "http://127.0.0.1:8090/v1"
+        assert chain_kwargs["api_key"] == "no-key-required"
+        # Task/messages/timeout ride along from the primary call.
+        assert chain_kwargs["task"] == "vision"
+        assert chain_kwargs["messages"] == primary_kwargs["messages"]
+
+    @pytest.mark.asyncio
+    async def test_exhausted_chain_reraises_primary_error(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG)
+
+        with (
+            patch("tools.vision_tools._image_to_base64_data_url",
+                  return_value="data:image/png;base64,abc"),
+            patch("tools.vision_tools.async_call_llm",
+                  new_callable=AsyncMock,
+                  side_effect=RuntimeError("Error code: 404 - Not Found"),
+            ) as mock_llm,
+            patch("tools.vision_tools._load_vision_fallback_chain",
+                  return_value=[_CHAIN_ENTRY]),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+
+        assert result["success"] is False
+        assert "404" in result["error"]
+        # Primary + one chain entry; no retry on a hard provider failure.
+        assert mock_llm.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_successful_primary_never_touches_chain(self, tmp_path):
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG)
+
+        with (
+            patch("tools.vision_tools._image_to_base64_data_url",
+                  return_value="data:image/png;base64,abc"),
+            patch("tools.vision_tools.async_call_llm",
+                  new_callable=AsyncMock, return_value=_resp("ok")) as mock_llm,
+            patch("tools.vision_tools._load_vision_fallback_chain",
+                  return_value=[_CHAIN_ENTRY]) as mock_chain,
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+
+        assert result["success"] is True
+        assert mock_llm.await_count == 1
+        mock_chain.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_empty_content_retry_stays_on_serving_provider(self, tmp_path):
+        """The empty-content retry must re-serve from the provider that
+        actually answered — not bounce back to the dead primary."""
+        img = tmp_path / "test.png"
+        img.write_bytes(VALID_PNG)
+
+        async def llm(**kwargs):
+            if "provider" not in kwargs:
+                raise RuntimeError("Error code: 429 - quota exceeded")
+            if len(kwargs.get("base_url") or "") > 0:
+                return _resp("")  # chain serves, but empty content
+            return _resp("")
+
+        with (
+            patch("tools.vision_tools._image_to_base64_data_url",
+                  return_value="data:image/png;base64,abc"),
+            patch("tools.vision_tools.async_call_llm",
+                  new_callable=AsyncMock, side_effect=llm) as mock_llm,
+            patch("tools.vision_tools._load_vision_fallback_chain",
+                  return_value=[_CHAIN_ENTRY]),
+        ):
+            result = json.loads(await vision_analyze_tool(str(img), "describe"))
+
+        assert result["success"] is True
+        assert mock_llm.await_count == 3
+        retry_kwargs = mock_llm.await_args_list[2].kwargs
+        assert retry_kwargs["provider"] == "custom"
+        assert retry_kwargs["model"] == "qwen3.8-27b-vision"
+        assert retry_kwargs["base_url"] == "http://127.0.0.1:8090/v1"
+
+    @pytest.mark.asyncio
+    async def test_chain_helper_skips_unusable_entries(self):
+        """Entries without a provider, auto providers, and an already-failed
+        unspecified provider are skipped without a call."""
+        from tools import vision_tools as vt
+
+        calls = []
+
+        async def llm(**kwargs):
+            calls.append(kwargs)
+            return _resp("ok")
+
+        chain = [
+            {"model": "m"},                                   # no provider
+            {"provider": "auto", "model": "m"},               # auto sentinel
+            {"provider": "ollama-cloud"},                     # failed primary
+            {"provider": "custom", "model": "v", "api_key": "k"},
+        ]
+        with (
+            patch("tools.vision_tools.async_call_llm",
+                  new_callable=AsyncMock, side_effect=llm),
+            patch("tools.vision_tools._load_vision_fallback_chain",
+                  return_value=chain),
+        ):
+            served = await vt._call_vision_fallback_chain(
+                {"task": "vision", "provider": "ollama-cloud",
+                 "messages": []},
+                RuntimeError("boom"),
+            )
+
+        assert served is not None
+        assert len(calls) == 1
+        assert calls[0]["provider"] == "custom"
+        assert calls[0]["api_key"] == "k"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -63,6 +63,78 @@ def _load_auxiliary_client() -> None:
             extract_content_or_reasoning = _ecr
 
 
+
+def _load_vision_fallback_chain() -> list:
+    """Return ``auxiliary.vision.fallback_chain`` entries from config.yaml.
+
+    Kept as its own module-level function so tests can inject a chain without
+    touching on-disk user configuration.
+    """
+    try:
+        from hermes_cli.config import cfg_get, load_config
+        _cfg = load_config()
+        _vision_cfg = cfg_get(_cfg, "auxiliary", "vision", default={}) or {}
+        chain = _vision_cfg.get("fallback_chain")
+    except Exception:
+        return []
+    if not isinstance(chain, list):
+        return []
+    return [entry for entry in chain if isinstance(entry, dict)]
+
+
+async def _call_vision_fallback_chain(call_kwargs: dict, primary_error: Exception):
+    """Re-issue a failed vision request across ``auxiliary.vision.fallback_chain``.
+
+    The resolution-time fallback chain only engages when a client cannot be
+    BUILT (missing key, resolver failure); a request-time failure on a
+    healthy-looking primary — a 404 for a removed hosted model, a 429 quota
+    wall, a timeout — otherwise kills the tool call outright. This walks the
+    configured entries in order and returns ``(response, serving_kwargs)`` for
+    the first success, or ``None`` when every entry also fails (the caller
+    re-raises the primary error). ``serving_kwargs`` are the kwargs that
+    produced the response, so callers retrying on empty content stay on the
+    provider that actually served instead of bouncing back to the dead primary.
+    """
+    failed_provider = str(call_kwargs.get("provider") or "").strip().lower()
+    for entry in _load_vision_fallback_chain():
+        provider = str(entry.get("provider") or "").strip()
+        model = str(entry.get("model") or "").strip()
+        if not provider or provider.lower() == "auto":
+            continue
+        if provider.lower() == failed_provider and not model:
+            # Same unspecified provider that already failed.
+            continue
+        entry_kwargs = dict(call_kwargs)
+        entry_kwargs["provider"] = provider
+        if model:
+            entry_kwargs["model"] = model
+        base_url = str(entry.get("base_url") or "").strip()
+        if base_url:
+            entry_kwargs["base_url"] = base_url
+        try:
+            from hermes_cli.fallback_config import resolve_entry_api_key
+            api_key = resolve_entry_api_key(entry)
+        except Exception:
+            api_key = None
+        if api_key:
+            entry_kwargs["api_key"] = api_key
+        logger.warning(
+            "Vision request failed (%s: %.120s); trying fallback_chain "
+            "entry %s/%s",
+            type(primary_error).__name__, primary_error, provider,
+            model or "(default)",
+        )
+        try:
+            response = await async_call_llm(**entry_kwargs)
+        except Exception as _fb_err:
+            logger.warning(
+                "Vision fallback entry %s/%s failed: %s",
+                provider, model or "(default)", _fb_err,
+            )
+            continue
+        return response, entry_kwargs
+    return None
+
 from hermes_constants import get_hermes_dir
 from tools.debug_helpers import DebugSession
 from tools.website_policy import check_website_access
@@ -1625,6 +1697,7 @@ async def vision_analyze_tool(
         if model:
             call_kwargs["model"] = model
         _load_auxiliary_client()
+        _serving_kwargs = call_kwargs
         # Try full-size image first; on size-related rejection, downscale and retry.
         try:
             response = await async_call_llm(**call_kwargs)
@@ -1644,15 +1717,23 @@ async def vision_analyze_tool(
                 messages[0]["content"][1]["image_url"]["url"] = image_data_url
                 response = await async_call_llm(**call_kwargs)
             else:
-                raise
-        
+                # Request-time failure on the resolved primary (removed hosted
+                # model, quota wall, timeout). The resolution-time chain never
+                # sees this — walk auxiliary.vision.fallback_chain now.
+                _fallback = await _call_vision_fallback_chain(
+                    call_kwargs, _api_err)
+                if _fallback is None:
+                    raise
+                response, _serving_kwargs = _fallback
+
         # Extract the analysis — fall back to reasoning if content is empty
         analysis = extract_content_or_reasoning(response)
 
-        # Retry once on empty content (reasoning-only response)
+        # Retry once on empty content (reasoning-only response). Re-serve from
+        # whichever provider actually answered, not the failed primary.
         if not analysis:
             logger.warning("Vision LLM returned empty content, retrying once")
-            response = await async_call_llm(**call_kwargs)
+            response = await async_call_llm(**_serving_kwargs)
             analysis = extract_content_or_reasoning(response)
 
         analysis_length = len(analysis)


### PR DESCRIPTION
## Summary

`vision_analyze_tool` resolves its client through the configured vision routing, but the `auxiliary.vision.fallback_chain` entries were only consulted at **client-build time** (missing key, resolver failure — that build-time branch is what #29091 fixes). A **request-time** failure on a healthy-looking primary killed the tool call outright with the configured fallbacks unreachable.

Concrete failure observed in production: an ollama-hosted `kimi-k2.6` vision backend was removed server-side, so every `vision_analyze` call failed with `404 - Function '…': Not found for account '…'` while a fully working local `qwen3.8-27b-vision` entry sat configured in `fallback_chain` — 4 consecutive tool failures in one agent turn, none of which tried the fallback.

### Changes

- On a non-image-size request failure of the primary, `vision_analyze_tool` now walks `auxiliary.vision.fallback_chain` entries in order (skipping entries without a provider, `auto` sentinels, and the already-failed unspecified provider), resolving each entry's `api_key`/`key_env` through the same `resolve_entry_api_key` used by the main-agent fallback chain, and serves from the first healthy entry.
- Exhausted chains re-raise the **primary** error, preserving today's failure surface (the tool's error guidance still applies).
- The existing empty-content retry now re-serves from **whichever provider actually answered** (`serving_kwargs`), instead of bouncing back to a dead primary.
- Image-size resize/retry behavior is unchanged and stays on the primary.

## Tests

- `python -m pytest -o addopts='' tests/tools/test_vision_tools.py -q` — 42 passed (5 new: chain serves on request error with correct per-entry kwargs, exhausted chain re-raises, successful primary never touches the chain, empty-content retry stays on the serving provider, chain helper skips unusable entries).
- `python -m ruff check tools/vision_tools.py tests/tools/test_vision_tools.py`

Related: #29091 (build-time / no-client branch of the same gap).