### PR TITLE
fix(local-models): stop Windows GPU statusbar console flashes

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -35,6 +35,7 @@ import sys
 import time
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime.estimator import HardwareBudget
 
 logger = logging.getLogger(__name__)
@@ -192,7 +193,8 @@ def _nvidia_vram() -> tuple[int, int] | None:
         out = subprocess.run(
             [exe, "--query-gpu=memory.total,memory.free",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=10)
+            capture_output=True, text=True, timeout=10,
+            creationflags=windows_hide_flags())
         if out.returncode != 0 or not out.stdout.strip():
             return None
         total_mib, free_mib = (int(x) for x in out.stdout.strip().splitlines()[0].split(","))

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -28,6 +28,7 @@ from typing import Any, Dict, Optional
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime.endpoint import _state_endpoint
 
 logger = logging.getLogger(__name__)
@@ -465,7 +466,8 @@ def local_models_hardware():
         smi = subprocess.run(
             [smi_exe, "--query-gpu=name,utilization.gpu,memory.used",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=5) if smi_exe else None
+            capture_output=True, text=True, timeout=5,
+            creationflags=windows_hide_flags()) if smi_exe else None
         if smi and smi.returncode == 0 and smi.stdout.strip():
             name, util, used_mib = (x.strip() for x in smi.stdout.strip().splitlines()[0].split(","))
             out["gpu_name"] = name

--- a/tests/hermes_cli/test_local_model_windows_subprocess.py
+++ b/tests/hermes_cli/test_local_model_windows_subprocess.py
@@ -1,0 +1,60 @@
+"""Windowless subprocess contracts for local-model GPU polling."""
+
+from __future__ import annotations
+
+import subprocess
+from types import SimpleNamespace
+
+
+_CREATE_NO_WINDOW = 0x08000000
+
+
+def test_vram_probe_hides_short_lived_smi_console(monkeypatch):
+    import hermes_cli.local_runtime.hardware as hardware
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(argv, 0, "8192, 4096\n", "")
+
+    monkeypatch.setattr(hardware, "_nvidia_smi_path", lambda: "nvidia-smi")
+    monkeypatch.setattr(
+        hardware, "windows_hide_flags", lambda: _CREATE_NO_WINDOW, raising=False
+    )
+    monkeypatch.setattr(hardware.subprocess, "run", fake_run)
+
+    assert hardware._nvidia_vram() == (8192 << 20, 4096 << 20)
+    assert captured["creationflags"] == _CREATE_NO_WINDOW
+
+
+def test_hardware_route_hides_live_gpu_status_console(monkeypatch):
+    import hermes_cli.local_runtime.hardware as hardware
+    import hermes_cli.web_routers.local_models as local_models
+
+    captured = {}
+
+    def fake_run(argv, **kwargs):
+        captured.update(kwargs)
+        return subprocess.CompletedProcess(argv, 0, "Example GPU, 37, 2048\n", "")
+
+    budget = SimpleNamespace(
+        uma=False,
+        total_device_bytes=8192 << 20,
+        usable_vram_bytes=6144 << 20,
+    )
+    monkeypatch.setattr(hardware, "probe_budget", lambda: budget)
+    monkeypatch.setattr(hardware, "_nvidia_vram", lambda: (8192 << 20, 4096 << 20))
+    monkeypatch.setattr(hardware, "_ram_bytes", lambda: (32 << 30, 16 << 30))
+    monkeypatch.setattr(hardware, "_nvidia_smi_path", lambda: "nvidia-smi")
+    monkeypatch.setattr(
+        local_models, "windows_hide_flags", lambda: _CREATE_NO_WINDOW, raising=False
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    result = local_models.local_models_hardware()
+
+    assert result["gpu_name"] == "Example GPU"
+    assert result["gpu_util_percent"] == 37
+    assert result["vram_used_bytes"] == 2048 << 20
+    assert captured["creationflags"] == _CREATE_NO_WINDOW


### PR DESCRIPTION
## What does this PR do?

Stops the Windows Desktop GPU statusbar from flashing two console windows during each five-second hardware poll. Both short-lived `nvidia-smi` queries now use the shared window-hiding creation flags while preserving synchronous output capture and parsing.

### Symptom

With local models enabled on Windows, the system-resources statusbar triggers two visible black console flashes about every five seconds.

### Impact

Windows users with NVIDIA GPUs see repeated focus-disrupting console windows for as long as the statusbar resource item remains visible.

### Bug Cause

**Trigger:** `hermes_cli/local_runtime/hardware.py:_nvidia_vram` and `hermes_cli/web_routers/local_models.py:local_models_hardware`

**Causal chain:**
1. The Desktop statusbar polls `/api/local-models/hardware` every five seconds.
2. The endpoint runs two console-subsystem `nvidia-smi.exe` queries without `CREATE_NO_WINDOW`.
3. A windowless Desktop backend causes each query to allocate a visible console, producing two flashes per poll.

**Why it is wrong:** Short-lived background probes should remain attached for synchronous result collection but must not create visible Windows consoles.

**Working sibling / contrast:** Other short-lived Hermes subprocess probes use `windows_hide_flags()`, which returns `CREATE_NO_WINDOW` on Windows and `0` on other platforms without changing process-group behavior.

**Ruled out:** The client poll interval only determines how often the symptom appears. The two backend subprocess calls directly match the two observed `nvidia-smi.exe` children, and output parsing remains unchanged when the creation flag is supplied.

### Fix

Pass `windows_hide_flags()` to both `nvidia-smi` subprocess calls. Add behavior tests that exercise each real probe path, verify parsed hardware values, and require the windowless creation flag.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` - hide the VRAM budget query console on Windows.
- `hermes_cli/web_routers/local_models.py` - hide the live GPU status query console on Windows.
- `tests/hermes_cli/test_local_model_windows_subprocess.py` - cover both windowless polling contracts and unchanged result parsing.

## How to Test

1. On Windows with an NVIDIA GPU and local models enabled, open the Desktop app with the system-resources statusbar visible.
2. Leave the app open across multiple five-second polling intervals and confirm that no console windows appear.
3. Run the automated regression and neighboring route tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_local_model_windows_subprocess.py tests/hermes_cli/test_unified_pool_quirk.py tests/hermes_cli/test_local_models_routes.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the 33 relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested the changed Python paths on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; `windows_hide_flags()` returns `0` outside Windows
- [x] Tool description and schema updates are N/A because no model tool behavior changed

## Screenshots / Logs

N/A. The regression is a transient native console flash and is covered by the subprocess creation contract tests.
