### PR TITLE
feat(kanban): map profiles to dedicated Linux users for worker isolation

### DIFF
--- a/docs/kanban/profile-os-users.md
+++ b/docs/kanban/profile-os-users.md
@@ -6,7 +6,11 @@ the gateway UID.
 
 This is **off by default**. An empty or missing mapping preserves the existing
 trusted-local-user behaviour (workers inherit the gateway UID). Do not enable
-the mapping until `hermes kanban os-users check` passes.
+the mapping until `hermes kanban os-users check` passes **and** the live
+gateway/dispatcher argv is this reviewed commit.
+
+Isolation is **false** while the running gateway still uses the installed/canonical
+Hermes without this feature.
 
 ## Contract
 
@@ -21,6 +25,12 @@ kanban:
   #   dev: /home/hermes-dev/.hermes
 ```
 
+Pin the shared board with the supported env (do not chmod `~/.hermes` group-writable):
+
+```bash
+export HERMES_KANBAN_DB=/home/matt/.hermes/kanban/kanban.db
+```
+
 - Launch mechanism: argv list `sudo -n -H -E -u <user> -- <hermes...>` (no shell,
   no setuid helper, no configurable command prefix).
 - Fail closed: a configured mapping never falls back to the gateway UID.
@@ -32,7 +42,9 @@ kanban:
 Gateway/default retains administrative visibility of specialist homes if the
 host operator wants emergency SSH. Specialists must not read one another's
 `HERMES_HOME` or secrets. Workspaces are granted per-project (for example Dev
-gets WorkoutTracker; Sys-admin does not).
+gets WorkoutTracker; Sys-admin is not granted that ACL). World-readable trees
+(for example `/home/matt/Documents` or WorkoutTracker if mode allows other-read)
+are **not** an isolation claim.
 
 ## Account and group design
 
@@ -53,26 +65,32 @@ shared group) is **incompatible**. `setup --apply` treats useradd/groupadd
 "already exists" return codes as success only after proving the account matches
 this design.
 
-## Shared SQLite board
+## Shared SQLite board (dedicated directory)
 
-The default board file is `/home/matt/.hermes/kanban.db` (not under
-`~/.hermes/kanban/`). SQLite WAL/SHM sidecars are created next to that file.
-`~/.hermes` is typically mode `0700`, so mapped users cannot traverse it or
-create sidecars unless ACLs are granted on the **actual DB parent**.
+The live board file today is `/home/matt/.hermes/kanban.db`. SQLite WAL/SHM
+sidecars are created **next to that file**. Granting `g:hermes-kanban:wx` (plus a
+default ACL) on `/home/matt/.hermes` lets specialists create/remove/rename known
+entries in the entire Hermes root even without listdir. That is not least privilege.
 
 Least privilege:
 
-- Traverse-only (`g:hermes-kanban:--x`, no listdir) on ancestors of the DB parent.
-- Write/execute without listdir (`g:hermes-kanban:wx`) on the DB parent so WAL/SHM
-  can be created without making the whole Hermes tree readable.
-- Default ACL `d:g:hermes-kanban:rw` on the DB parent for new sidecar files.
+- Dedicated shared directory: `/home/matt/.hermes/kanban/` owned `2770`
+  `matt:hermes-kanban`. The board file is `/home/matt/.hermes/kanban/kanban.db`.
+- Configure it explicitly: `HERMES_KANBAN_DB=/home/matt/.hermes/kanban/kanban.db`.
+- Traverse-only (`g:hermes-kanban:--x`, no listdir, **no write**) on `/home/matt/.hermes`
+  and ancestors.
+- Write/execute without listdir (`g:hermes-kanban:wx`) **only** on the dedicated
+  `kanban/` directory so WAL/SHM can be created there.
+- Default ACL `d:g:hermes-kanban:rw` on that dedicated directory.
 - `g:hermes-kanban:rw` on `kanban.db` itself.
 
-Do **not** chmod the entire `~/.hermes` tree group-readable.
+Never put a write ACL on `/home/matt/.hermes`. Never `cp` a live DB or its
+`-wal`/`-shm` sidecars. Cutover uses `hermes kanban os-users migrate-db`
+(sqlite backup API) after a bounded gateway stop you control.
 
-`hermes kanban os-users check` must prove both mapped users can open the DB in
-WAL mode and write sidecars (fail-closed `sudo -n` probe). Being a directory is
-not enough.
+`hermes kanban os-users check` must prove both mapped users can complete a SQLite
+WAL lifecycle **in the dedicated directory** (fail-closed `sudo -n` probe). Being
+a directory is not enough. Check fails if the write parent is the Hermes root.
 
 ## Dev workspace ACL
 
@@ -85,97 +103,101 @@ grants:
 - Recursive `u:hermes-dev:rwx` on the repo.
 - Default ACL `u:hermes-dev:rwx` so newly created files inherit access.
 
-Sys-admin is **not** granted this tree.
+Sys-admin is **not** granted this tree. That is not confidentiality if the tree
+is world-readable; isolation proofs are deny of `/home/matt/.ssh`, specialist
+homes, and credentials.
 
-## Host setup (Matt, manual sudo)
+## Toolchain (narrow, not `/home/matt`)
 
-Dry-run first (no privilege required). This worktree uses `.venv`, not `venv`:
+A separate UID does not inherit Matt-owned Flutter/Android/JDK paths. Setup may
+grant **read/execute only** on:
+
+- `/home/matt/flutter`
+- `/home/matt/Android/Sdk`
+- `/home/matt/.local/opt/jdk-17`
+
+plus traverse `--x` on ancestors. Caches are **private** under
+`/home/hermes-dev/.cache/{flutter,pub,gradle,android}` (`0700`). Do not
+recursively ACL `/home/matt`. Check proves as `hermes-dev`: workspace traverse,
+toolchain `x`, and writable private cache. Mapped env keeps `PUB_CACHE`,
+`GRADLE_USER_HOME`, `ANDROID_SDK_ROOT`, `ANDROID_HOME`, `JAVA_HOME`, `FLUTTER_ROOT`.
+
+## GitHub continuity (manual, secret-safe)
+
+Copying profile `.env`/`config.yaml`/`SOUL.md`/`skills` does **not** provision
+`~/.config/gh` or git HTTPS helpers. Do not copy Matt's SSH keys. As root in a
+tty you start:
+
+```bash
+sudo -u hermes-dev -H gh auth login --hostname github.com --git-protocol https
+# Prove (stdout omitted from audit; never print tokens):
+sudo -n -u hermes-dev -- /usr/bin/gh api user
+sudo -n -u hermes-dev -- /usr/bin/git ls-remote https://github.com/NousResearch/hermes-agent.git HEAD
+```
+
+Check fails closed if those probes fail.
+
+## Deploy the reviewed commit first
+
+PR code lives in this worktree/fork. `sudo hermes` may invoke the **old installed
+CLI** without `os-users`. Do not use it.
+
+Preferred: wait for upstream merge + upgrade, then provision.
+
+Alternative local path: install this SHA into a versioned runtime
+`/opt/hermes/kanban-os-users/<sha>/` and point `HERMES_BIN`, the gateway unit,
+and generated sudoers at **that** argv. Check's `runtime-sha` gate proves the
+worker/gateway command covers this tree; isolation is false until it does.
+
+This worktree uses `.venv`, not `venv`:
 
 ```bash
 cd /home/matt/.hermes/worktrees/kanban-profile-os-users
 .venv/bin/python -m hermes_cli.main kanban os-users setup \
   --gateway-user matt \
   --dev-workspace /home/matt/Documents/WorkoutTracker
-
-hermes kanban os-users sudoers
-hermes kanban os-users rollback    # print-only reverse plan
 ```
 
-Review the argv list. Then, in a root shell **you** start (this tool never
-prompts for a password):
+Apply with the same argv under sudo (never `sudo hermes`):
 
 ```bash
-sudo hermes kanban os-users setup --apply \
+sudo /home/matt/.hermes/worktrees/kanban-profile-os-users/.venv/bin/python -m hermes_cli.main \
+  kanban os-users setup --apply \
   --gateway-user matt \
   --dev-workspace /home/matt/Documents/WorkoutTracker
 ```
 
 `--apply` requires euid 0. It does **not** copy profile files unless you pass
-`--migrate-profile-files` (manual gate). Contents are never printed.
+`--migrate-profile-files` (bounded `copy-tree`, not per-file flood). It does
+**not** migrate the live DB unless `--migrate-shared-db`. Contents are never printed.
+Dry-run summarizes planned skill file/dir counts per root.
 
-Equivalent manual steps the dry-run prints:
+## Ordered rollout (mid-step failure must leave the live board recoverable)
 
-1. Shared group `hermes-kanban` plus private primary groups `hermes-dev` /
-   `hermes-sysadmin`.
-2. `useradd … -g <private> -G hermes-kanban <user>`.
-3. `install -d -m 0700 -o hermes-dev -g hermes-dev` for that user's `.hermes`
-   and `profiles/dev` (and the sysadmin equivalents).
-4. Least-privilege ACLs on the **actual** DB parent (`~/.hermes`) and on
-   `kanban.db` — not only on `~/.hermes/kanban/`.
-5. Ancestor traverse + recursive/default ACL on
-   `/home/matt/Documents/WorkoutTracker` for `hermes-dev` only.
-6. `usermod -aG hermes-kanban matt` so default retains admin visibility.
-7. Install `/etc/sudoers.d/hermes-kanban-os-users` after `visudo -c`. The drop-in
-   allows `id`, `/usr/bin/test` (audit probes), and the resolved hermes argv.
+1. Deploy this reviewed commit (merge+upgrade, or versioned runtime + `HERMES_BIN`).
+   Do not enable `profile_os_users` yet.
+2. Create private groups/users and specialist homes (`0700`).
+3. Create `~/.hermes/kanban/` with group wx. Hermes root gets traverse-only (`--x`), never write.
+4. Quiesce the gateway (stop/restart window **you** control). Live `~/.hermes/kanban.db` stays until backup succeeds.
+5. `kanban os-users migrate-db --from /home/matt/.hermes/kanban.db --to /home/matt/.hermes/kanban/kanban.db`
+   (sqlite backup API, not `cp` of WAL/SHM).
+6. Pin `HERMES_KANBAN_DB` on the gateway unit. Restart onto the versioned runtime.
+7. Toolchain r-x ACLs + private caches. No recursive ACL on `/home/matt`.
+8. `--migrate-profile-files` (bounded copy-tree), then `gh auth login` as `hermes-dev`.
+9. `hermes kanban os-users check` must pass SHA/runtime, WAL-in-dedicated-dir, gh/git,
+   toolchain, deny `.ssh`/credentials. World-readable WorkoutTracker is not isolation.
+10. Only then enable `kanban.profile_os_users` in the **gateway** config.yaml and restart.
 
-### Credential migration (manual gate)
-
-`--apply` prints `install(1)` copy commands and **does not execute them** unless
-you also pass `--migrate-profile-files`. Never cat/print `.env`, `auth.json`, or
-SSH keys.
-
-Required in each mapped `HERMES_HOME` **before check can report ready**:
-`config.yaml`, `.env`, `SOUL.md`, `skills/`. Check fails closed if any are
-missing.
-
-```bash
-# Optional explicit migration (still never prints file contents):
-sudo hermes kanban os-users setup --apply \
-  --migrate-profile-files \
-  --gateway-user matt \
-  --dev-workspace /home/matt/Documents/WorkoutTracker
-
-# Or copy yourself with install(1):
-sudo install -m 0600 -o hermes-dev -g hermes-dev \
-  /home/matt/.hermes/profiles/dev/config.yaml \
-  /home/hermes-dev/.hermes/profiles/dev/config.yaml
-# Repeat for .env, SOUL.md, skills/. Repeat for sysadmin.
-# Skip SSH keys; specialists get their own credentials.
-```
-
-Then audit **before** enabling the mapping:
-
-```bash
-hermes kanban os-users check
-hermes kanban os-users check --json
-```
-
-Check must prove, fail-closed via `sudo -n` as each target UID:
-
-- users exist, sudo -n works, homes are 0700 and owned by the mapped uid
-- mapped `HERMES_HOME` has `config.yaml`, `.env`, `SOUL.md`, `skills/`
-- target users can traverse/write the actual DB parent and complete a SQLite
-  WAL lifecycle
-- specialist homes are distinct **and** each user is denied read of the other
-
-Only then add `profile_os_users` to the **gateway** profile's `config.yaml` and
-restart the gateway yourself. Do not enable it from a Kanban worker.
+Do not enable mappings from a Kanban worker. Do not run sudo from this worker.
 
 ## Rollback
 
 ```bash
-hermes kanban os-users rollback    # print-only
+.venv/bin/python -m hermes_cli.main kanban os-users rollback    # print-only
 # Then as root, after removing profile_os_users from config.yaml:
+# 1. Restart onto the previous HERMES_BIN (mapping-off is the recoverability gate).
+# 2. Point HERMES_KANBAN_DB back at the pre-cutover file if the dedicated copy is untrusted.
+#    Keep the backup; do not delete the live DB first.
 sudo rm -f /etc/sudoers.d/hermes-kanban-os-users
 sudo visudo -c
 ```
@@ -183,14 +205,15 @@ sudo visudo -c
 Rollback **always** reverses recorded ACLs (`setfacl -x` / `-k`). It `userdel`s /
 `groupdel`s **only** principals this setup created (recorded in
 `/var/lib/hermes/kanban-os-users-state.json`). If that state file is missing,
-rollback will **not** delete pre-existing users or groups.
+rollback will **not** delete pre-existing users or groups. Group membership and
+toolchain ACLs can wait; the board is already served by the previous runtime.
 
 ## Known limitations
 
 - Linux only. A non-empty mapping on Windows fails closed.
-- Sudoers command match is the resolved `hermes` argv at generation time;
+- Sudoers command match is the resolved hermes argv at generation time;
   rebuild the drop-in if `HERMES_BIN` / venv path changes.
 - The dispatcher still observes worker PIDs on the gateway host; sudo wraps
   the child so the recorded PID is the sudo process (acceptable for reclaim).
 - Shared-board access is group/ACL based. Do not chmod the entire `~/.hermes`
-  tree group-readable.
+  tree group-readable. Do not put write ACLs on the Hermes root.

--- a/docs/kanban/profile-os-users.md
+++ b/docs/kanban/profile-os-users.md
@@ -34,16 +34,68 @@ host operator wants emergency SSH. Specialists must not read one another's
 `HERMES_HOME` or secrets. Workspaces are granted per-project (for example Dev
 gets WorkoutTracker; Sys-admin does not).
 
+## Account and group design
+
+Each specialist gets a **private primary group** with the same name as the
+account, plus **supplemental** membership in the shared `hermes-kanban` group:
+
+1. `groupadd --system hermes-kanban`
+2. `groupadd --system hermes-dev` (private primary)
+3. `useradd --system --create-home --home-dir /home/hermes-dev --shell /usr/sbin/nologin -g hermes-dev -G hermes-kanban hermes-dev`
+4. Same for `hermes-sysadmin`.
+
+Homes stay `0700` owned by that private group. Do **not** use
+`useradd --gid hermes-kanban` — that makes the shared group the primary group
+and breaks `install -g hermes-dev` plus cross-profile home isolation.
+
+A pre-existing account whose primary group is `hermes-kanban` (or any other
+shared group) is **incompatible**. `setup --apply` treats useradd/groupadd
+"already exists" return codes as success only after proving the account matches
+this design.
+
+## Shared SQLite board
+
+The default board file is `/home/matt/.hermes/kanban.db` (not under
+`~/.hermes/kanban/`). SQLite WAL/SHM sidecars are created next to that file.
+`~/.hermes` is typically mode `0700`, so mapped users cannot traverse it or
+create sidecars unless ACLs are granted on the **actual DB parent**.
+
+Least privilege:
+
+- Traverse-only (`g:hermes-kanban:--x`, no listdir) on ancestors of the DB parent.
+- Write/execute without listdir (`g:hermes-kanban:wx`) on the DB parent so WAL/SHM
+  can be created without making the whole Hermes tree readable.
+- Default ACL `d:g:hermes-kanban:rw` on the DB parent for new sidecar files.
+- `g:hermes-kanban:rw` on `kanban.db` itself.
+
+Do **not** chmod the entire `~/.hermes` tree group-readable.
+
+`hermes kanban os-users check` must prove both mapped users can open the DB in
+WAL mode and write sidecars (fail-closed `sudo -n` probe). Being a directory is
+not enough.
+
+## Dev workspace ACL
+
+Canonical path: `/home/matt/Documents/WorkoutTracker`.
+
+`/home/matt` is typically mode `0750`, so a leaf-only ACL is unusable. Setup
+grants:
+
+- Traverse-only `u:hermes-dev:--x` on ancestors (`/home/matt`, `/home/matt/Documents`).
+- Recursive `u:hermes-dev:rwx` on the repo.
+- Default ACL `u:hermes-dev:rwx` so newly created files inherit access.
+
+Sys-admin is **not** granted this tree.
+
 ## Host setup (Matt, manual sudo)
 
-Dry-run first (no privilege required):
+Dry-run first (no privilege required). This worktree uses `.venv`, not `venv`:
 
 ```bash
-# From a Hermes install that contains this feature (worktree or later release).
-cd /home/matt/.hermes/worktrees/kanban-profile-os-users   # or the installed tree
-./venv/bin/python -m hermes_cli.main kanban os-users setup \
+cd /home/matt/.hermes/worktrees/kanban-profile-os-users
+.venv/bin/python -m hermes_cli.main kanban os-users setup \
   --gateway-user matt \
-  --dev-workspace /home/matt/WorkoutTracker
+  --dev-workspace /home/matt/Documents/WorkoutTracker
 
 hermes kanban os-users sudoers
 hermes kanban os-users rollback    # print-only reverse plan
@@ -55,33 +107,50 @@ prompts for a password):
 ```bash
 sudo hermes kanban os-users setup --apply \
   --gateway-user matt \
-  --dev-workspace /home/matt/WorkoutTracker
+  --dev-workspace /home/matt/Documents/WorkoutTracker
 ```
 
-`--apply` requires euid 0. Equivalent manual steps the dry-run prints:
+`--apply` requires euid 0. It does **not** copy profile files unless you pass
+`--migrate-profile-files` (manual gate). Contents are never printed.
 
-1. `groupadd --system hermes-kanban`
-2. `useradd --system --create-home --home-dir /home/hermes-dev --shell /usr/sbin/nologin --gid hermes-kanban hermes-dev`
-3. Same for `hermes-sysadmin`.
-4. `install -d -m 0700 -o hermes-dev -g hermes-dev /home/hermes-dev/.hermes` and
-   `/home/hermes-dev/.hermes/profiles/dev` (and the sysadmin equivalents).
-5. Group + default ACLs on the shared board dir so SQLite can create `-wal`/`-shm`
-   siblings: `setfacl -m g:hermes-kanban:rwx,d:g:hermes-kanban:rwx <kanban-dir>`.
-6. Narrow ACL on WorkoutTracker (and any other Dev-only tree) for `hermes-dev`
-   only — do **not** grant `hermes-sysadmin`.
-7. `usermod -aG hermes-kanban matt` so default retains admin visibility.
-8. Install `/etc/sudoers.d/hermes-kanban-os-users` after `visudo -c`.
+Equivalent manual steps the dry-run prints:
 
-Credential migration uses `install(1)` and **never prints file contents**:
+1. Shared group `hermes-kanban` plus private primary groups `hermes-dev` /
+   `hermes-sysadmin`.
+2. `useradd … -g <private> -G hermes-kanban <user>`.
+3. `install -d -m 0700 -o hermes-dev -g hermes-dev` for that user's `.hermes`
+   and `profiles/dev` (and the sysadmin equivalents).
+4. Least-privilege ACLs on the **actual** DB parent (`~/.hermes`) and on
+   `kanban.db` — not only on `~/.hermes/kanban/`.
+5. Ancestor traverse + recursive/default ACL on
+   `/home/matt/Documents/WorkoutTracker` for `hermes-dev` only.
+6. `usermod -aG hermes-kanban matt` so default retains admin visibility.
+7. Install `/etc/sudoers.d/hermes-kanban-os-users` after `visudo -c`. The drop-in
+   allows `id`, `/usr/bin/test` (audit probes), and the resolved hermes argv.
+
+### Credential migration (manual gate)
+
+`--apply` prints `install(1)` copy commands and **does not execute them** unless
+you also pass `--migrate-profile-files`. Never cat/print `.env`, `auth.json`, or
+SSH keys.
+
+Required in each mapped `HERMES_HOME` **before check can report ready**:
+`config.yaml`, `.env`, `SOUL.md`, `skills/`. Check fails closed if any are
+missing.
 
 ```bash
+# Optional explicit migration (still never prints file contents):
+sudo hermes kanban os-users setup --apply \
+  --migrate-profile-files \
+  --gateway-user matt \
+  --dev-workspace /home/matt/Documents/WorkoutTracker
+
+# Or copy yourself with install(1):
 sudo install -m 0600 -o hermes-dev -g hermes-dev \
   /home/matt/.hermes/profiles/dev/config.yaml \
   /home/hermes-dev/.hermes/profiles/dev/config.yaml
-sudo install -m 0600 -o hermes-dev -g hermes-dev \
-  /home/matt/.hermes/profiles/dev/.env \
-  /home/hermes-dev/.hermes/profiles/dev/.env
-# Repeat for sysadmin. Skip SSH keys; specialists get their own credentials.
+# Repeat for .env, SOUL.md, skills/. Repeat for sysadmin.
+# Skip SSH keys; specialists get their own credentials.
 ```
 
 Then audit **before** enabling the mapping:
@@ -91,10 +160,16 @@ hermes kanban os-users check
 hermes kanban os-users check --json
 ```
 
-Check must prove: users exist, sudo -n works, homes are 0700 and owned by the
-mapped uid, specialist homes are distinct, shared board is present. Only then
-add `profile_os_users` to the **gateway** profile's `config.yaml` and restart
-the gateway yourself. Do not enable it from a Kanban worker.
+Check must prove, fail-closed via `sudo -n` as each target UID:
+
+- users exist, sudo -n works, homes are 0700 and owned by the mapped uid
+- mapped `HERMES_HOME` has `config.yaml`, `.env`, `SOUL.md`, `skills/`
+- target users can traverse/write the actual DB parent and complete a SQLite
+  WAL lifecycle
+- specialist homes are distinct **and** each user is denied read of the other
+
+Only then add `profile_os_users` to the **gateway** profile's `config.yaml` and
+restart the gateway yourself. Do not enable it from a Kanban worker.
 
 ## Rollback
 
@@ -103,12 +178,12 @@ hermes kanban os-users rollback    # print-only
 # Then as root, after removing profile_os_users from config.yaml:
 sudo rm -f /etc/sudoers.d/hermes-kanban-os-users
 sudo visudo -c
-sudo userdel -r hermes-dev
-sudo userdel -r hermes-sysadmin
-sudo groupdel hermes-kanban
 ```
 
-Remove ACLs on WorkoutTracker / board paths if you added them.
+Rollback **always** reverses recorded ACLs (`setfacl -x` / `-k`). It `userdel`s /
+`groupdel`s **only** principals this setup created (recorded in
+`/var/lib/hermes/kanban-os-users-state.json`). If that state file is missing,
+rollback will **not** delete pre-existing users or groups.
 
 ## Known limitations
 

--- a/docs/kanban/profile-os-users.md
+++ b/docs/kanban/profile-os-users.md
@@ -1,0 +1,121 @@
+# Kanban profile-to-Linux-user execution
+
+Optional `kanban.profile_os_users` maps a canonical Hermes profile id to a
+POSIX account so dispatcher-spawned workers run as that account instead of
+the gateway UID.
+
+This is **off by default**. An empty or missing mapping preserves the existing
+trusted-local-user behaviour (workers inherit the gateway UID). Do not enable
+the mapping until `hermes kanban os-users check` passes.
+
+## Contract
+
+```yaml
+kanban:
+  profile_os_users:
+    dev: hermes-dev
+    sysadmin: hermes-sysadmin
+  # Optional companion: Hermes *runtime root* (NOT OS HOME).
+  # Default for a mapped user is {passwd_dir}/.hermes
+  # profile_os_homes:
+  #   dev: /home/hermes-dev/.hermes
+```
+
+- Launch mechanism: argv list `sudo -n -H -E -u <user> -- <hermes...>` (no shell,
+  no setuid helper, no configurable command prefix).
+- Fail closed: a configured mapping never falls back to the gateway UID.
+- Root mappings are rejected. Same-UID mappings are rejected and are **not**
+  reported as isolation.
+- OS `HOME` is the passwd home. `HERMES_HOME` is `{root}/profiles/<id>` (or
+  `{root}` for `default`). `profile_os_homes` overrides the Hermes root only.
+
+Gateway/default retains administrative visibility of specialist homes if the
+host operator wants emergency SSH. Specialists must not read one another's
+`HERMES_HOME` or secrets. Workspaces are granted per-project (for example Dev
+gets WorkoutTracker; Sys-admin does not).
+
+## Host setup (Matt, manual sudo)
+
+Dry-run first (no privilege required):
+
+```bash
+# From a Hermes install that contains this feature (worktree or later release).
+cd /home/matt/.hermes/worktrees/kanban-profile-os-users   # or the installed tree
+./venv/bin/python -m hermes_cli.main kanban os-users setup \
+  --gateway-user matt \
+  --dev-workspace /home/matt/WorkoutTracker
+
+hermes kanban os-users sudoers
+hermes kanban os-users rollback    # print-only reverse plan
+```
+
+Review the argv list. Then, in a root shell **you** start (this tool never
+prompts for a password):
+
+```bash
+sudo hermes kanban os-users setup --apply \
+  --gateway-user matt \
+  --dev-workspace /home/matt/WorkoutTracker
+```
+
+`--apply` requires euid 0. Equivalent manual steps the dry-run prints:
+
+1. `groupadd --system hermes-kanban`
+2. `useradd --system --create-home --home-dir /home/hermes-dev --shell /usr/sbin/nologin --gid hermes-kanban hermes-dev`
+3. Same for `hermes-sysadmin`.
+4. `install -d -m 0700 -o hermes-dev -g hermes-dev /home/hermes-dev/.hermes` and
+   `/home/hermes-dev/.hermes/profiles/dev` (and the sysadmin equivalents).
+5. Group + default ACLs on the shared board dir so SQLite can create `-wal`/`-shm`
+   siblings: `setfacl -m g:hermes-kanban:rwx,d:g:hermes-kanban:rwx <kanban-dir>`.
+6. Narrow ACL on WorkoutTracker (and any other Dev-only tree) for `hermes-dev`
+   only — do **not** grant `hermes-sysadmin`.
+7. `usermod -aG hermes-kanban matt` so default retains admin visibility.
+8. Install `/etc/sudoers.d/hermes-kanban-os-users` after `visudo -c`.
+
+Credential migration uses `install(1)` and **never prints file contents**:
+
+```bash
+sudo install -m 0600 -o hermes-dev -g hermes-dev \
+  /home/matt/.hermes/profiles/dev/config.yaml \
+  /home/hermes-dev/.hermes/profiles/dev/config.yaml
+sudo install -m 0600 -o hermes-dev -g hermes-dev \
+  /home/matt/.hermes/profiles/dev/.env \
+  /home/hermes-dev/.hermes/profiles/dev/.env
+# Repeat for sysadmin. Skip SSH keys; specialists get their own credentials.
+```
+
+Then audit **before** enabling the mapping:
+
+```bash
+hermes kanban os-users check
+hermes kanban os-users check --json
+```
+
+Check must prove: users exist, sudo -n works, homes are 0700 and owned by the
+mapped uid, specialist homes are distinct, shared board is present. Only then
+add `profile_os_users` to the **gateway** profile's `config.yaml` and restart
+the gateway yourself. Do not enable it from a Kanban worker.
+
+## Rollback
+
+```bash
+hermes kanban os-users rollback    # print-only
+# Then as root, after removing profile_os_users from config.yaml:
+sudo rm -f /etc/sudoers.d/hermes-kanban-os-users
+sudo visudo -c
+sudo userdel -r hermes-dev
+sudo userdel -r hermes-sysadmin
+sudo groupdel hermes-kanban
+```
+
+Remove ACLs on WorkoutTracker / board paths if you added them.
+
+## Known limitations
+
+- Linux only. A non-empty mapping on Windows fails closed.
+- Sudoers command match is the resolved `hermes` argv at generation time;
+  rebuild the drop-in if `HERMES_BIN` / venv path changes.
+- The dispatcher still observes worker PIDs on the gateway host; sudo wraps
+  the child so the recorded PID is the sudo process (acceptable for reclaim).
+- Shared-board access is group/ACL based. Do not chmod the entire `~/.hermes`
+  tree group-readable.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2955,6 +2955,16 @@ DEFAULT_CONFIG = {
         # otherwise saturate one profile's local model / API quota /
         # browser pool while leaving other profiles idle.
         "max_in_progress_per_profile": None,
+        # Optional map of canonical Hermes profile id -> POSIX username
+        # (e.g. {dev: hermes-dev, sysadmin: hermes-sysadmin}). Empty/missing
+        # preserves trusted-local-user spawn on the gateway UID. A mapped
+        # profile is launched with sudo -n -u <user> -- and never falls back
+        # to the gateway UID if the drop fails. Root mappings are rejected.
+        "profile_os_users": {},
+        # Optional map of profile id -> Hermes runtime home ROOT (not OS HOME).
+        # When omitted, mapped workers use {passwd_dir}/.hermes. Do not overload
+        # OS HOME; this is the HERMES_HOME root the worker process sees.
+        "profile_os_homes": {},
         # When true, the kanban dispatcher auto-runs the decomposer on
         # tasks that land in Triage (every dispatcher tick). When false,
         # decomposition is manual via `hermes kanban decompose <id>` or

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1087,10 +1087,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         action="store_true",
         help=(
             "With --apply, copy config.yaml/.env/SOUL.md/skills into mapped "
-            "HERMES_HOME via install(1). Never prints file contents. Default is "
-            "a manual gate: --apply does not copy profile files."
+            "HERMES_HOME via install(1) plus bounded copy-tree for skills. "
+            "Never prints file contents. Default is a manual gate."
         ),
     )
+    p_os_setup.add_argument(
+        "--migrate-shared-db",
+        action="store_true",
+        help=(
+            "Include sqlite backup of the live kanban.db into the dedicated "
+            "shared directory. Never raw-copies WAL/SHM. Does not stop the gateway."
+        ),
+    )
+    p_os_setup.add_argument("--flutter-sdk", default=None)
+    p_os_setup.add_argument("--android-sdk", default=None)
+    p_os_setup.add_argument("--jdk-home", default=None)
     p_os_probe = os_sub.add_parser(
         "probe",
         help="Fail-closed target-UID probe (WAL lifecycle as the mapped user)",
@@ -1103,6 +1114,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--path", dest="probe_path", required=True,
         help="Absolute path to the shared kanban.db",
     )
+    p_os_mig = os_sub.add_parser(
+        "migrate-db",
+        help="Online-safe sqlite backup into the dedicated shared directory",
+    )
+    p_os_mig.add_argument("--from", dest="migrate_from", required=True)
+    p_os_mig.add_argument("--to", dest="migrate_to", required=True)
+    p_os_copy = os_sub.add_parser(
+        "copy-tree",
+        help="Bounded directory copy that rejects symlinks and never prints contents",
+    )
+    p_os_copy.add_argument("--src", dest="copy_src", required=True)
+    p_os_copy.add_argument("--dst", dest="copy_dst", required=True)
+    p_os_copy.add_argument("--owner", dest="copy_owner", required=True)
+    p_os_copy.add_argument("--group", dest="copy_group", required=True)
     os_sub.add_parser("sudoers", help="Print the sudoers drop-in")
     os_sub.add_parser("rollback", help="Print rollback steps")
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1052,6 +1052,39 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_repair.add_argument("--json", action="store_true",
                           help="Emit the repair report as JSON")
 
+    # --- os-users (profile_os_users host setup / check; dry-run first) ---
+    p_os = sub.add_parser(
+        "os-users",
+        help="Host setup/check for profile-to-Linux-user worker isolation",
+        description=(
+            "Dry-run-first setup, audit, sudoers snippet, and rollback "
+            "for kanban.profile_os_users. Never prints secrets. Does not "
+            "enable the mapping — that is a separate config change after "
+            "check passes."
+        ),
+    )
+    os_sub = p_os.add_subparsers(dest="os_users_action")
+    p_os_check = os_sub.add_parser(
+        "check",
+        help="Audit mapped users, sudo -n, board WAL, and cross-profile denial",
+    )
+    p_os_check.add_argument("--json", action="store_true")
+    p_os_setup = os_sub.add_parser(
+        "setup",
+        help="Print (default) or apply as root the host provisioning steps",
+    )
+    p_os_setup.add_argument(
+        "--apply", action="store_true",
+        help="Run steps (requires euid 0; never prompts for a password)",
+    )
+    p_os_setup.add_argument("--gateway-user", default=None)
+    p_os_setup.add_argument(
+        "--dev-workspace", default=None,
+        help="Optional extra workspace to ACL for hermes-dev only",
+    )
+    os_sub.add_parser("sudoers", help="Print the sudoers drop-in")
+    os_sub.add_parser("rollback", help="Print rollback steps")
+
     kanban_parser.set_defaults(_kanban_parser=kanban_parser)
     return kanban_parser
 
@@ -1093,6 +1126,10 @@ def kanban_command(args: argparse.Namespace) -> int:
     # task-routing override; otherwise `/kanban --board beta boards show`
     # reports beta as the current board even when the on-disk pointer is
     # alpha.
+    if action == "os-users":
+        from hermes_cli.kanban_os_users import run_os_users_cli
+        return run_os_users_cli(args)
+
     if action == "boards":
         return _dispatch_boards(args)
 

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1082,6 +1082,27 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--dev-workspace", default=None,
         help="Optional extra workspace to ACL for hermes-dev only",
     )
+    p_os_setup.add_argument(
+        "--migrate-profile-files",
+        action="store_true",
+        help=(
+            "With --apply, copy config.yaml/.env/SOUL.md/skills into mapped "
+            "HERMES_HOME via install(1). Never prints file contents. Default is "
+            "a manual gate: --apply does not copy profile files."
+        ),
+    )
+    p_os_probe = os_sub.add_parser(
+        "probe",
+        help="Fail-closed target-UID probe (WAL lifecycle as the mapped user)",
+    )
+    p_os_probe.add_argument(
+        "--kind", dest="probe_kind", default="wal",
+        help="Probe kind (only 'wal' is supported)",
+    )
+    p_os_probe.add_argument(
+        "--path", dest="probe_path", required=True,
+        help="Absolute path to the shared kanban.db",
+    )
     os_sub.add_parser("sudoers", help="Print the sudoers drop-in")
     os_sub.add_parser("rollback", help="Print rollback steps")
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10927,10 +10927,22 @@ def _default_spawn(
         # turn, prints text, exits rc=0, and the dispatcher records a
         # protocol violation (incident 2026-06-09 t_d9cbe312).
         cmd.append("-Q")
+    # Optional profile_os_users: wrap argv with sudo -n -u <user> --
+    # (no shell). Unmapped profiles are a no-op. Mapped profiles fail
+    # closed instead of falling back to the gateway UID.
+    from hermes_cli.kanban_os_users import apply_mapped_worker_launch
+    cmd, env = apply_mapped_worker_launch(
+        profile=profile_arg,
+        argv=cmd,
+        env=env,
+        workspace=workspace,
+        board_db=env.get("HERMES_KANBAN_DB"),
+    )
 
     # A worker spawned by a managed systemd gateway must leave the gateway's
     # cgroup before startup; otherwise restarting the service kills the worker
-    # that is performing the handoff.
+    # that is performing the handoff. Applied AFTER the sudo wrap so
+    # systemd-run stays on the gateway UID and sudoers only allows hermes.
     cmd = _restart_safe_worker_argv(task, cmd)
 
     # Redirect output to a per-task log under <board-root>/logs/.

--- a/hermes_cli/kanban_os_users.py
+++ b/hermes_cli/kanban_os_users.py
@@ -20,6 +20,7 @@ the Hermes root.
 
 from __future__ import annotations
 
+import json
 import os
 import re
 import shlex
@@ -60,6 +61,10 @@ DEFAULT_GROUP = "hermes-kanban"
 DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/hermes-kanban-os-users"
 DEFAULT_SUDO_BIN = "/usr/bin/sudo"
 DEFAULT_ID_BIN = "/usr/bin/id"
+DEFAULT_TEST_BIN = "/usr/bin/test"
+DEFAULT_STATE_PATH = "/var/lib/hermes/kanban-os-users-state.json"
+REQUIRED_MAPPED_HOME_FILES = ("config.yaml", ".env", "SOUL.md")
+REQUIRED_MAPPED_HOME_DIRS = ("skills",)
 
 # Env vars the mapped worker must inherit through sudo env_reset.
 SUDO_ENV_KEEP = (
@@ -96,6 +101,10 @@ class MappedLaunchError(RuntimeError):
     """
 
 
+class IncompatiblePrincipalError(RuntimeError):
+    """A pre-existing user/group does not match the planned account design."""
+
+
 @dataclass
 class PasswdEntry:
     pw_name: str
@@ -105,14 +114,23 @@ class PasswdEntry:
 
 
 @dataclass
+class GroupEntry:
+    gr_name: str
+    gr_gid: int
+    gr_mem: tuple[str, ...] = ()
+
+
+@dataclass
 class LaunchHooks:
     """Injectable boundary for tests. Production uses pwd / subprocess."""
 
     getpwnam: Optional[Callable[[str], PasswdEntry]] = None
+    getgrnam: Optional[Callable[[str], GroupEntry]] = None
     geteuid: Optional[Callable[[], int]] = None
     run: Optional[Callable[..., Any]] = None
     sudo_bin: str = DEFAULT_SUDO_BIN
     id_bin: str = DEFAULT_ID_BIN
+    test_bin: str = DEFAULT_TEST_BIN
     is_windows: Optional[bool] = None
 
 
@@ -380,16 +398,30 @@ def _default_run(argv: Sequence[str], **kwargs: Any) -> Any:
     )
 
 
+def _default_getgrnam(name: str) -> GroupEntry:
+    import grp
+
+    try:
+        gr = grp.getgrnam(name)
+    except KeyError as exc:
+        raise KeyError(name) from exc
+    return GroupEntry(gr.gr_name, int(gr.gr_gid), tuple(gr.gr_mem))
+
+
 def _hooks_or_defaults(hooks: Optional[LaunchHooks]) -> LaunchHooks:
     h = hooks or LaunchHooks()
     if h.getpwnam is None:
         h.getpwnam = _default_getpwnam
+    if h.getgrnam is None:
+        h.getgrnam = _default_getgrnam
     if h.geteuid is None:
         h.geteuid = os.geteuid
     if h.run is None:
         h.run = _default_run
     if h.is_windows is None:
         h.is_windows = sys.platform.startswith("win")
+    if not h.test_bin:
+        h.test_bin = DEFAULT_TEST_BIN
     return h
 
 
@@ -465,8 +497,85 @@ def preflight_mapped_user(
             hermes_home=hermes_home,
             workspace=workspace,
             board_db=board_db,
+            hooks=h,
         )
     return pw
+
+
+def probe_user_access(
+    username: str,
+    path: str,
+    *,
+    mode: str,
+    hooks: LaunchHooks,
+    expect_ok: bool = True,
+) -> tuple[bool, str]:
+    """Fail-closed sudo -n probe via /usr/bin/test as *username*.
+
+    *mode* is one of ``r``, ``w``, ``x``. When *expect_ok* is False the probe
+    passes only if the target UID is denied (cross-home isolation).
+    """
+    if mode not in {"r", "w", "x"}:
+        raise ValueError(f"unsupported probe mode {mode!r}")
+    h = _hooks_or_defaults(hooks)
+    test_bin = h.test_bin or DEFAULT_TEST_BIN
+    argv = build_sudo_argv(username, [test_bin, f"-{mode}", path], sudo_bin=h.sudo_bin)
+    assert h.run is not None
+    try:
+        proc = h.run(argv, timeout=15)
+    except Exception as exc:
+        return False, f"probe {username} {mode} {path} failed: {exc}"
+    rc = int(getattr(proc, "returncode", 1))
+    allowed = rc == 0
+    if expect_ok:
+        if allowed:
+            return True, f"{username} can {mode} {path}"
+        return False, f"{username} cannot {mode} {path} (exit {rc})"
+    if not allowed:
+        return True, f"{username} denied {mode} {path}"
+    return False, f"{username} unexpectedly can {mode} {path}"
+
+
+def prove_sqlite_wal_lifecycle(db_path: str) -> None:
+    """Open *db_path* in WAL mode and prove sidecar create/write/unlink."""
+    import sqlite3
+
+    path = Path(db_path)
+    if not path.parent.is_dir():
+        raise MappedLaunchError(f"Shared Kanban DB parent {path.parent} is missing")
+    con = sqlite3.connect(str(path), timeout=5)
+    try:
+        mode = con.execute("PRAGMA journal_mode=WAL").fetchone()
+        if not mode or str(mode[0]).lower() != "wal":
+            raise MappedLaunchError(f"Could not enable WAL on {path}: {mode!r}")
+        con.execute("CREATE TABLE IF NOT EXISTS _os_users_probe (id INTEGER)")
+        con.execute("INSERT INTO _os_users_probe (id) VALUES (1)")
+        con.execute("DELETE FROM _os_users_probe")
+        con.commit()
+    finally:
+        con.close()
+    wal = path.parent / f"{path.name}-wal"
+    shm = path.parent / f"{path.name}-shm"
+    if not wal.exists() and not shm.exists():
+        # Some sqlite builds unlink sidecars on close; directory write is enough.
+        probe = path.parent / f".{path.name}.os-users-wal-probe"
+        probe.write_bytes(b"probe")
+        probe.unlink()
+
+
+def mapped_home_ready(hermes_home: str | Path) -> tuple[bool, str]:
+    """Required files/dirs must exist in mapped HERMES_HOME. Never reads secrets."""
+    root = Path(hermes_home)
+    missing: list[str] = []
+    for name in REQUIRED_MAPPED_HOME_FILES:
+        if not (root / name).is_file():
+            missing.append(name)
+    for name in REQUIRED_MAPPED_HOME_DIRS:
+        if not (root / name).is_dir():
+            missing.append(f"{name}/")
+    if missing:
+        return False, f"mapped HERMES_HOME missing required {missing}"
+    return True, "config.yaml, .env, SOUL.md, skills/ present"
 
 
 def _preflight_paths(
@@ -475,7 +584,9 @@ def _preflight_paths(
     hermes_home: Optional[str],
     workspace: Optional[str],
     board_db: Optional[str],
+    hooks: Optional[LaunchHooks] = None,
 ) -> None:
+    h = _hooks_or_defaults(hooks) if hooks is not None else None
     if hermes_home:
         home_path = Path(hermes_home)
         if not home_path.is_dir():
@@ -499,17 +610,40 @@ def _preflight_paths(
                 f"Mapped HERMES_HOME {hermes_home} is owned by uid {st.st_uid}, "
                 f"expected {pw.pw_uid} ({pw.pw_name})"
             )
+        if h is not None:
+            ok, detail = probe_user_access(
+                pw.pw_name, hermes_home, mode="x", hooks=h, expect_ok=True
+            )
+            if not ok:
+                raise MappedLaunchError(detail)
     if workspace:
         ws = Path(workspace)
         if not ws.is_dir():
             raise MappedLaunchError(
                 f"Task workspace {workspace} is not an accessible directory"
             )
+        if h is not None:
+            ok, detail = probe_user_access(
+                pw.pw_name, workspace, mode="x", hooks=h, expect_ok=True
+            )
+            if not ok:
+                raise MappedLaunchError(detail)
     if board_db:
         db_path = Path(board_db)
         parent = db_path.parent
         if not parent.is_dir():
             raise MappedLaunchError(f"Shared Kanban DB parent {parent} is missing")
+        if h is not None:
+            ok_x, detail_x = probe_user_access(
+                pw.pw_name, str(parent), mode="x", hooks=h, expect_ok=True
+            )
+            if not ok_x:
+                raise MappedLaunchError(detail_x)
+            ok_w, detail_w = probe_user_access(
+                pw.pw_name, str(parent), mode="w", hooks=h, expect_ok=True
+            )
+            if not ok_w:
+                raise MappedLaunchError(detail_w)
 
 
 def apply_mapped_worker_launch(
@@ -559,6 +693,7 @@ def apply_mapped_worker_launch(
             hermes_home=hermes_home,
             workspace=workspace,
             board_db=board_db,
+            hooks=h,
         )
     wrapped = build_sudo_argv(username, inner, sudo_bin=h.sudo_bin)
     mapped_env = build_mapped_env(
@@ -586,6 +721,8 @@ class SetupStep:
     title: str
     argv: list[str]
     privileged: bool = True
+    creates: str = ""  # user:name | group:name | acl:path
+    optional: bool = False  # skip when the install source path is missing
 
 
 def _quote_cmd(argv: Sequence[str]) -> str:
@@ -652,6 +789,7 @@ def render_sudoers(
             hermes_argv = ["/usr/bin/hermes"]
     cmd = _quote_cmd(hermes_argv)
     id_cmd = DEFAULT_ID_BIN
+    test_cmd = DEFAULT_TEST_BIN
     lines = [
         f"# Hermes Kanban profile_os_users — generated, review before installing",
         f"# Install: sudo install -m 0440 this-file {DEFAULT_SUDOERS_PATH}",
@@ -659,10 +797,68 @@ def render_sudoers(
         f"Defaults:{gw} !requiretty",
         f'Defaults:{gw} env_keep += "{keep}"',
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {id_cmd}",
+        f"{gw} ALL=({runas}) NOPASSWD:SETENV: {test_cmd}",
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {cmd}",
         "",
     ]
     return "\n".join(lines)
+
+
+def _acl_traverse_ancestors(path: Path) -> list[Path]:
+    """Ancestors of *path* from nearest parent up to (not including) / or /home."""
+    out: list[Path] = []
+    cur = Path(path)
+    if not cur.is_absolute():
+        cur = Path("/") / cur
+    parent = cur.parent
+    while str(parent) not in {"/", "/home", ""} and parent != cur:
+        out.append(parent)
+        nxt = parent.parent
+        if nxt == parent:
+            break
+        cur, parent = parent, nxt
+    out.reverse()
+    return out
+
+
+def empty_os_users_state() -> dict[str, Any]:
+    return {
+        "created_users": [],
+        "created_groups": [],
+        "preexisting_users": [],
+        "preexisting_groups": [],
+        "acl_paths": [],
+    }
+
+
+def load_os_users_state(path: str | Path = DEFAULT_STATE_PATH) -> dict[str, Any]:
+    p = Path(path)
+    try:
+        raw = json.loads(p.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return empty_os_users_state()
+    if not isinstance(raw, dict):
+        return empty_os_users_state()
+    out = empty_os_users_state()
+    for key in out:
+        val = raw.get(key, [])
+        if isinstance(val, list):
+            out[key] = [str(x) for x in val]
+    return out
+
+
+def save_os_users_state(
+    state: Mapping[str, Any], path: str | Path = DEFAULT_STATE_PATH
+) -> None:
+    p = Path(path)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    merged = empty_os_users_state()
+    for key in merged:
+        val = state.get(key, [])
+        if isinstance(val, list):
+            merged[key] = sorted({str(x) for x in val})
+    p.write_text(json.dumps(merged, indent=2) + "\n", encoding="utf-8")
+    os.chmod(p, 0o600)
 
 
 def plan_setup_steps(
@@ -672,11 +868,16 @@ def plan_setup_steps(
     group: str = DEFAULT_GROUP,
     dev_workspace: Optional[str] = None,
     hermes_argv: Optional[Sequence[str]] = None,
+    board_paths: Optional[Mapping[str, Path]] = None,
 ) -> list[SetupStep]:
     targets = resolve_setup_targets(mapping)
     gw = gateway_user or _gateway_user()
     steps: list[SetupStep] = [
-        SetupStep("create group", ["groupadd", "--system", group]),
+        SetupStep(
+            "create shared group",
+            ["groupadd", "--system", group],
+            creates=f"group:{group}",
+        ),
     ]
     seen_users: set[str] = set()
     for profile, user in targets.items():
@@ -685,6 +886,11 @@ def plan_setup_steps(
         seen_users.add(user)
         home = f"/home/{user}"
         steps.extend([
+            SetupStep(
+                f"create private primary group {user}",
+                ["groupadd", "--system", user],
+                creates=f"group:{user}",
+            ),
             SetupStep(
                 f"create {user}",
                 [
@@ -695,10 +901,13 @@ def plan_setup_steps(
                     home,
                     "--shell",
                     "/usr/sbin/nologin",
-                    "--gid",
+                    "-g",
+                    user,
+                    "-G",
                     group,
                     user,
                 ],
+                creates=f"user:{user}",
             ),
             SetupStep(
                 f"private Hermes root for {user}",
@@ -729,26 +938,49 @@ def plan_setup_steps(
                 ],
             ),
         ])
-    paths = None
-    try:
-        paths = shared_board_paths()
-    except Exception:
-        paths = None
+    paths = board_paths
+    if paths is None:
+        try:
+            paths = shared_board_paths()
+        except Exception:
+            paths = None
     if paths:
-        db = str(paths["kanban_db"])
+        db_path = Path(paths["kanban_db"])
+        db = str(db_path)
+        db_parent = db_path.parent
         kdir = str(paths["kanban_dir"])
-        steps.extend([
+        steps.append(
             SetupStep(
                 "kanban metadata dir",
                 ["install", "-d", "-m", "2770", "-o", gw, "-g", group, kdir],
+            )
+        )
+        # Least privilege on the *actual* DB parent (kanban.db, not kanban/).
+        # Traverse-only on ancestors; wx (no listdir) on the parent so WAL/SHM
+        # sidecars can be created without making the whole Hermes tree readable.
+        for ancestor in _acl_traverse_ancestors(db_parent):
+            steps.append(
+                SetupStep(
+                    f"traverse ACL on {ancestor} for {group} (execute only; no listdir)",
+                    ["setfacl", "-m", f"g:{group}:--x", str(ancestor)],
+                    creates=f"acl:{ancestor}",
+                )
+            )
+        steps.extend([
+            SetupStep(
+                f"ACL on DB parent {db_parent} (group wx for WAL/shm; no listdir)",
+                ["setfacl", "-m", f"g:{group}:wx", str(db_parent)],
+                creates=f"acl:{db_parent}",
             ),
             SetupStep(
-                "ACL on shared board dir (group + defaults for WAL/shm)",
-                ["setfacl", "-m", f"g:{group}:rwx,d:g:{group}:rwx", kdir],
+                f"default ACL on DB parent {db_parent} for new WAL/shm files",
+                ["setfacl", "-d", "-m", f"g:{group}:rw", str(db_parent)],
+                creates=f"acl:{db_parent}",
             ),
             SetupStep(
                 "ACL on kanban.db (SQLite needs sibling -wal/-shm)",
                 ["setfacl", "-m", f"g:{group}:rw", db],
+                creates=f"acl:{db}",
             ),
         ])
         ws = str(paths["workspaces"])
@@ -760,12 +992,27 @@ def plan_setup_steps(
         )
     if dev_workspace:
         dev_user = targets.get("dev", "hermes-dev")
-        steps.append(
-            SetupStep(
-                f"dev-only ACL on {dev_workspace} (sysadmin is NOT granted this)",
-                ["setfacl", "-m", f"u:{dev_user}:rwx", dev_workspace],
+        ws_path = Path(dev_workspace)
+        for ancestor in _acl_traverse_ancestors(ws_path):
+            steps.append(
+                SetupStep(
+                    f"dev-only traverse ACL on {ancestor} (sysadmin is NOT granted this)",
+                    ["setfacl", "-m", f"u:{dev_user}:--x", str(ancestor)],
+                    creates=f"acl:{ancestor}",
+                )
             )
-        )
+        steps.extend([
+            SetupStep(
+                f"dev-only recursive ACL on {dev_workspace} (sysadmin is NOT granted this)",
+                ["setfacl", "-R", "-m", f"u:{dev_user}:rwx", str(ws_path)],
+                creates=f"acl:{ws_path}",
+            ),
+            SetupStep(
+                f"dev-only default ACL on {dev_workspace} for newly created files",
+                ["setfacl", "-d", "-m", f"u:{dev_user}:rwx", str(ws_path)],
+                creates=f"acl:{ws_path}",
+            ),
+        ])
     steps.append(
         SetupStep(
             f"add {gw} to {group} for admin visibility",
@@ -802,14 +1049,56 @@ def plan_rollback_steps(
     *,
     mapping: Optional[Mapping[str, str]] = None,
     group: str = DEFAULT_GROUP,
+    state: Optional[Mapping[str, Any]] = None,
+    state_path: str | Path = DEFAULT_STATE_PATH,
+    dev_users: Optional[Sequence[str]] = None,
 ) -> list[SetupStep]:
     targets = resolve_setup_targets(mapping)
-    steps = [
+    st = dict(state) if state is not None else load_os_users_state(state_path)
+    created_users = list(st.get("created_users") or [])
+    created_groups = list(st.get("created_groups") or [])
+    preexisting_users = list(st.get("preexisting_users") or [])
+    acl_paths = list(st.get("acl_paths") or [])
+    steps: list[SetupStep] = [
         SetupStep("remove sudoers drop-in", ["rm", "-f", DEFAULT_SUDOERS_PATH]),
     ]
-    for user in sorted(set(targets.values())):
-        steps.append(SetupStep(f"remove user {user}", ["userdel", "-r", user]))
-    steps.append(SetupStep(f"remove group {group}", ["groupdel", group]))
+    acl_users = (
+        list(dev_users) if dev_users is not None else [targets.get("dev", "hermes-dev")]
+    )
+    for path in acl_paths:
+        steps.append(
+            SetupStep(
+                f"remove group ACL on {path}",
+                ["setfacl", "-x", f"g:{group}", path],
+            )
+        )
+        for user in acl_users:
+            steps.append(
+                SetupStep(
+                    f"remove user ACL for {user} on {path}",
+                    ["setfacl", "-x", f"u:{user}", path],
+                )
+            )
+        steps.append(
+            SetupStep(f"remove default ACL on {path}", ["setfacl", "-k", path])
+        )
+    has_state = bool(created_users or created_groups or preexisting_users or acl_paths)
+    if not has_state:
+        # No proof we created accounts — never userdel/groupdel pre-existing principals.
+        return steps
+    for user in created_users:
+        steps.append(
+            SetupStep(f"remove user {user} (created by setup)", ["userdel", "-r", user])
+        )
+    private = [g for g in created_groups if g != group]
+    for gname in sorted(private):
+        steps.append(
+            SetupStep(f"remove group {gname} (created by setup)", ["groupdel", gname])
+        )
+    if group in created_groups:
+        steps.append(
+            SetupStep(f"remove group {group} (created by setup)", ["groupdel", group])
+        )
     return steps
 
 
@@ -824,12 +1113,98 @@ def format_plan(steps: Sequence[SetupStep], *, heading: str) -> str:
         lines.append(f"{i}. {step.title}")
         lines.append(f"   {_quote_cmd(step.argv)}")
     lines.append("")
-    lines.append("Do not cat/print .env, auth.json, or SSH keys. Copy with install(1):")
+    lines.append("Do not cat/print .env, auth.json, or SSH keys. Copy with install(1).")
     lines.append(
-        "   sudo install -m 0600 -o <user> -g <user> <src-env> /home/<user>/.hermes/profiles/<profile>/.env"
+        "MANUAL GATE: setup --apply does not copy profile files unless --migrate-profile-files."
     )
-    lines.append("Config (not secrets) may be copied the same way for config.yaml.")
+    lines.append(
+        "Required in mapped HERMES_HOME before check can report ready: "
+        "config.yaml, .env, SOUL.md, skills/."
+    )
     return "\n".join(lines)
+
+
+def _source_hermes_root(source_root: Optional[Path] = None) -> Path:
+    if source_root is not None:
+        return Path(source_root)
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        return get_default_hermes_root()
+    except Exception:
+        return Path.home() / ".hermes"
+
+
+def plan_migrate_steps(
+    mapping: Mapping[str, str],
+    *,
+    source_root: Optional[Path] = None,
+) -> list[SetupStep]:
+    root = _source_hermes_root(source_root)
+    steps: list[SetupStep] = []
+    for profile, user in mapping.items():
+        src = root / "profiles" / profile
+        dst = Path(f"/home/{user}") / ".hermes" / "profiles" / profile
+        for name in REQUIRED_MAPPED_HOME_FILES:
+            steps.append(
+                SetupStep(
+                    f"migrate {name} for {profile} (never prints contents)",
+                    [
+                        "install",
+                        "-m",
+                        "0600",
+                        "-o",
+                        user,
+                        "-g",
+                        user,
+                        str(src / name),
+                        str(dst / name),
+                    ],
+                    optional=True,
+                )
+            )
+        steps.append(
+            SetupStep(
+                f"migrate skills dir for {profile}",
+                [
+                    "install",
+                    "-d",
+                    "-m",
+                    "0700",
+                    "-o",
+                    user,
+                    "-g",
+                    user,
+                    str(dst / "skills"),
+                ],
+            )
+        )
+        skills_src = src / "skills"
+        if skills_src.is_dir():
+            for child in sorted(skills_src.rglob("*")):
+                if not child.is_file():
+                    continue
+                rel = child.relative_to(skills_src)
+                dest_file = dst / "skills" / rel
+                steps.append(
+                    SetupStep(
+                        f"migrate skills/{rel} for {profile}",
+                        [
+                            "install",
+                            "-D",
+                            "-m",
+                            "0600",
+                            "-o",
+                            user,
+                            "-g",
+                            user,
+                            str(child),
+                            str(dest_file),
+                        ],
+                        optional=True,
+                    )
+                )
+    return steps
 
 
 def migrate_profile_files_commands(
@@ -838,35 +1213,16 @@ def migrate_profile_files_commands(
     source_root: Optional[Path] = None,
 ) -> list[str]:
     """Print install(1) copy commands; never dump file contents."""
-    if source_root is None:
-        try:
-            from hermes_constants import get_default_hermes_root
-
-            source_root = get_default_hermes_root()
-        except Exception:
-            source_root = Path.home() / ".hermes"
+    steps = plan_migrate_steps(mapping, source_root=source_root)
     lines = [
         "# Credential/config migration (contents are never printed)",
+        "# MANUAL GATE: setup --apply does not copy these unless --migrate-profile-files.",
         "# Review each source path. Skip files that should stay gateway-only.",
+        "# Required in mapped HERMES_HOME before check can report ready:",
+        "#   config.yaml, .env, SOUL.md, skills/",
     ]
-    for profile, user in mapping.items():
-        src = Path(source_root) / "profiles" / profile
-        dst = Path(f"/home/{user}") / ".hermes" / "profiles" / profile
-        for name in ("config.yaml", ".env"):
-            mode = "0600" if name == ".env" else "0600"
-            lines.append(
-                _quote_cmd([
-                    "install",
-                    "-m",
-                    mode,
-                    "-o",
-                    user,
-                    "-g",
-                    user,
-                    str(src / name),
-                    str(dst / name),
-                ])
-            )
+    for step in steps:
+        lines.append(_quote_cmd(step.argv))
     return lines
 
 
@@ -889,11 +1245,52 @@ def _mode_ok(path: Path, *, max_other: int = 0) -> tuple[bool, str]:
     return True, f"{path} mode {mode:04o} uid={st.st_uid}"
 
 
+def prove_sqlite_wal_as_user(
+    username: str,
+    db_path: str,
+    *,
+    hooks: Optional[LaunchHooks] = None,
+    hermes_argv: Optional[Sequence[str]] = None,
+) -> None:
+    """Fail-closed: run the WAL lifecycle probe as *username* via sudo -n."""
+    h = _hooks_or_defaults(hooks)
+    if hermes_argv is None:
+        try:
+            from hermes_cli.kanban_db import _resolve_hermes_argv
+
+            hermes_argv = _resolve_hermes_argv()
+        except Exception:
+            hermes_argv = None
+    inner = [str(p) for p in (hermes_argv or ["hermes"])] + [
+        "kanban",
+        "os-users",
+        "probe",
+        "--kind",
+        "wal",
+        "--path",
+        db_path,
+    ]
+    argv = build_sudo_argv(username, inner, sudo_bin=h.sudo_bin)
+    assert h.run is not None
+    try:
+        proc = h.run(argv, timeout=30)
+    except Exception as exc:
+        raise MappedLaunchError(f"WAL probe as {username} failed: {exc}") from exc
+    rc = int(getattr(proc, "returncode", 1))
+    stderr = str(getattr(proc, "stderr", None) or "").strip()
+    stdout = str(getattr(proc, "stdout", None) or "").strip()
+    if rc != 0:
+        detail = stderr or stdout or f"exit {rc}"
+        raise MappedLaunchError(f"WAL probe as {username} failed: {detail}")
+
+
 def audit_mapping(
     *,
     mapping: Optional[Mapping[str, str]] = None,
     homes: Optional[Mapping[str, str]] = None,
     hooks: Optional[LaunchHooks] = None,
+    board_paths: Optional[Mapping[str, Path]] = None,
+    wal_prover: Optional[Callable[[str, str], None]] = None,
 ) -> list[AuditItem]:
     items: list[AuditItem] = []
     if mapping is None:
@@ -915,6 +1312,7 @@ def audit_mapping(
         return items
     h = _hooks_or_defaults(hooks)
     pw_by_user: dict[str, PasswdEntry] = {}
+    homes_by_profile: dict[str, str] = {}
     for profile, user in targets.items():
         try:
             pw = preflight_mapped_user(
@@ -935,24 +1333,26 @@ def audit_mapping(
             items.append(AuditItem(f"user:{user}", False, str(exc)))
             continue
         hermes_home = resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {})
+        homes_by_profile[profile] = hermes_home
         ok, detail = _mode_ok(Path(hermes_home), max_other=0)
         items.append(AuditItem(f"home:{profile}", ok, detail, isolation=ok))
+        ok_x, detail_x = probe_user_access(
+            user, hermes_home, mode="x", hooks=h, expect_ok=True
+        )
+        items.append(
+            AuditItem(f"home-access:{profile}", ok_x, detail_x, isolation=ok_x)
+        )
+        ready, ready_detail = mapped_home_ready(hermes_home)
+        items.append(
+            AuditItem(f"home-ready:{profile}", ready, ready_detail, isolation=ready)
+        )
         env_path = Path(hermes_home) / ".env"
         if env_path.exists():
             ok_e, detail_e = _mode_ok(env_path, max_other=0)
             items.append(
                 AuditItem(f"secrets:{profile}", ok_e, detail_e, isolation=ok_e)
             )
-    # Cross-profile path inequality
-    homes_resolved = []
-    for profile, user in targets.items():
-        pw = pw_by_user.get(user)
-        if pw is None:
-            continue
-        homes_resolved.append((
-            profile,
-            resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {}),
-        ))
+    homes_resolved = [(profile, path) for profile, path in homes_by_profile.items()]
     for i, (p_a, h_a) in enumerate(homes_resolved):
         for p_b, h_b in homes_resolved[i + 1 :]:
             same = os.path.realpath(h_a) == os.path.realpath(h_b)
@@ -964,21 +1364,71 @@ def audit_mapping(
                     isolation=not same,
                 )
             )
-    try:
-        paths = shared_board_paths()
-        db = paths["kanban_db"]
-        ok, detail = _mode_ok(db.parent, max_other=0)
-        items.append(
-            AuditItem(
-                "board-parent", ok or db.parent.is_dir(), f"board parent {db.parent}"
-            )
-        )
-        if db.exists():
-            items.append(
-                AuditItem(
-                    "board-db", True, f"{db} present (WAL sidecars use default ACL)"
+            if same:
+                continue
+            user_a = targets.get(p_a)
+            user_b = targets.get(p_b)
+            if user_a and user_b:
+                ok_ab, d_ab = probe_user_access(
+                    user_a, h_b, mode="r", hooks=h, expect_ok=False
                 )
+                items.append(
+                    AuditItem(
+                        f"cross-deny:{user_a}->{p_b}",
+                        ok_ab,
+                        d_ab,
+                        isolation=ok_ab,
+                    )
+                )
+                ok_ba, d_ba = probe_user_access(
+                    user_b, h_a, mode="r", hooks=h, expect_ok=False
+                )
+                items.append(
+                    AuditItem(
+                        f"cross-deny:{user_b}->{p_a}",
+                        ok_ba,
+                        d_ba,
+                        isolation=ok_ba,
+                    )
+                )
+    try:
+        paths = board_paths if board_paths is not None else shared_board_paths()
+        db = Path(paths["kanban_db"])
+        parent = db.parent
+        parent_ok = parent.is_dir()
+        parent_bits = [f"board parent {parent}"]
+        if not parent_ok:
+            parent_bits.append("missing directory")
+        for user in pw_by_user:
+            ok_x, d_x = probe_user_access(
+                user, str(parent), mode="x", hooks=h, expect_ok=True
             )
+            ok_w, d_w = probe_user_access(
+                user, str(parent), mode="w", hooks=h, expect_ok=True
+            )
+            parent_bits.append(d_x)
+            parent_bits.append(d_w)
+            if not ok_x or not ok_w:
+                parent_ok = False
+        items.append(AuditItem("board-parent", parent_ok, "; ".join(parent_bits)))
+        if db.exists():
+            items.append(AuditItem("board-db", True, f"{db} present"))
+            prover = wal_prover or (
+                lambda u, p: prove_sqlite_wal_as_user(u, p, hooks=h)
+            )
+            for user in pw_by_user:
+                try:
+                    prover(user, str(db))
+                    items.append(
+                        AuditItem(
+                            f"board-wal:{user}",
+                            True,
+                            f"WAL lifecycle as {user} ok",
+                            isolation=True,
+                        )
+                    )
+                except Exception as exc:
+                    items.append(AuditItem(f"board-wal:{user}", False, str(exc)))
         else:
             items.append(
                 AuditItem("board-db", False, f"{db} missing — run hermes kanban init")
@@ -1012,7 +1462,145 @@ def format_audit(items: Sequence[AuditItem]) -> str:
     return "\n".join(lines)
 
 
-def run_os_users_cli(args: Any) -> int:
+def existing_user_compatible(
+    user: str,
+    *,
+    group: str = DEFAULT_GROUP,
+    hooks: Optional[LaunchHooks] = None,
+) -> None:
+    """Fail closed if a pre-existing account does not match the planned design."""
+    h = _hooks_or_defaults(hooks)
+    assert h.getpwnam is not None
+    try:
+        pw = h.getpwnam(user)
+    except (KeyError, MappedLaunchError) as exc:
+        raise IncompatiblePrincipalError(
+            f"user {user!r} missing after useradd already-exists rc"
+        ) from exc
+    expected_home = f"/home/{user}"
+    if str(pw.pw_dir).rstrip("/") != expected_home:
+        raise IncompatiblePrincipalError(
+            f"{user} home is {pw.pw_dir!r}, expected {expected_home!r}"
+        )
+    assert h.getgrnam is not None
+    try:
+        private = h.getgrnam(user)
+    except (KeyError, MappedLaunchError) as exc:
+        raise IncompatiblePrincipalError(
+            f"{user} has no private primary group {user!r}"
+        ) from exc
+    if int(pw.pw_gid) != int(private.gr_gid):
+        raise IncompatiblePrincipalError(
+            f"{user} primary gid {pw.pw_gid} is not private group {user} "
+            f"(gid {private.gr_gid}); refusing accounts whose primary group "
+            f"is {group} or any other shared group"
+        )
+    try:
+        shared = h.getgrnam(group)
+    except (KeyError, MappedLaunchError) as exc:
+        raise IncompatiblePrincipalError(f"shared group {group!r} missing") from exc
+    if user not in set(shared.gr_mem):
+        raise IncompatiblePrincipalError(
+            f"{user} is not a supplemental member of {group}"
+        )
+
+
+def execute_setup_plan(
+    steps: Sequence[SetupStep],
+    *,
+    run: Optional[Callable[..., Any]] = None,
+    hooks: Optional[LaunchHooks] = None,
+    state_path: str | Path = DEFAULT_STATE_PATH,
+    group: str = DEFAULT_GROUP,
+    sudoers_text: str = "",
+    sudoers_tmp: str = "/tmp/hermes-kanban-os-users.sudoers",
+) -> int:
+    """Run planned argv lists. Records created vs pre-existing principals."""
+    h = _hooks_or_defaults(hooks)
+    runner = run or h.run
+    assert runner is not None
+    state = load_os_users_state(state_path)
+    created_users = set(state.get("created_users") or [])
+    created_groups = set(state.get("created_groups") or [])
+    preexisting_users = set(state.get("preexisting_users") or [])
+    preexisting_groups = set(state.get("preexisting_groups") or [])
+    acl_paths = set(state.get("acl_paths") or [])
+
+    for step in steps:
+        argv = list(step.argv)
+        if step.optional and argv and os.path.basename(str(argv[0])) == "install":
+            src = str(argv[-2]) if len(argv) >= 2 else ""
+            if src.startswith("/") and not Path(src).exists():
+                print(f"# skip optional missing source {src}")
+                continue
+        if "<generated-sudoers>" in argv:
+            tmp = Path(sudoers_tmp)
+            tmp.parent.mkdir(parents=True, exist_ok=True)
+            tmp.write_text(sudoers_text, encoding="utf-8")
+            os.chmod(tmp, 0o600)
+            check = runner(["visudo", "-c", "-f", str(tmp)])
+            if int(getattr(check, "returncode", 1)) != 0:
+                err = str(getattr(check, "stderr", None) or "")
+                print(f"visudo -c failed: {err}", file=sys.stderr)
+                return 1
+            argv = [
+                "install",
+                "-m",
+                "0440",
+                "-o",
+                "root",
+                "-g",
+                "root",
+                str(tmp),
+                DEFAULT_SUDOERS_PATH,
+            ]
+        print(f"# {step.title}")
+        proc = runner(argv)
+        rc = int(getattr(proc, "returncode", 1))
+        if rc != 0:
+            try:
+                ok = _idempotent_ok(argv, rc, hooks=h, group=group)
+            except IncompatiblePrincipalError as exc:
+                print(f"incompatible principal: {exc}", file=sys.stderr)
+                return 1
+            if not ok:
+                print(
+                    f"command failed ({rc}): {_quote_cmd(argv)}",
+                    file=sys.stderr,
+                )
+                return 1
+            if step.creates.startswith("user:"):
+                preexisting_users.add(step.creates.split(":", 1)[1])
+            elif step.creates.startswith("group:"):
+                preexisting_groups.add(step.creates.split(":", 1)[1])
+        else:
+            if step.creates.startswith("user:"):
+                created_users.add(step.creates.split(":", 1)[1])
+            elif step.creates.startswith("group:"):
+                created_groups.add(step.creates.split(":", 1)[1])
+        if step.creates.startswith("acl:"):
+            acl_paths.add(step.creates.split(":", 1)[1])
+
+    save_os_users_state(
+        {
+            "created_users": sorted(created_users),
+            "created_groups": sorted(created_groups),
+            "preexisting_users": sorted(preexisting_users),
+            "preexisting_groups": sorted(preexisting_groups),
+            "acl_paths": sorted(acl_paths),
+        },
+        state_path,
+    )
+    return 0
+
+
+def run_os_users_cli(
+    args: Any,
+    *,
+    hooks: Optional[LaunchHooks] = None,
+    state_path: Optional[str | Path] = None,
+    board_paths: Optional[Mapping[str, Path]] = None,
+) -> int:
     action = getattr(args, "os_users_action", None) or "check"
     mapping = None
     homes = None
@@ -1021,11 +1609,35 @@ def run_os_users_cli(args: Any) -> int:
     except ValueError as exc:
         print(f"kanban os-users: invalid config: {exc}", file=sys.stderr)
         return 2
-    if action == "check":
-        items = audit_mapping(mapping=mapping or None, homes=homes)
-        if getattr(args, "json", False):
-            import json
+    resolved_state = (
+        Path(state_path) if state_path is not None else Path(DEFAULT_STATE_PATH)
+    )
 
+    if action == "probe":
+        kind = getattr(args, "probe_kind", None) or "wal"
+        path = getattr(args, "probe_path", None)
+        if not path:
+            print("kanban os-users probe: --path is required", file=sys.stderr)
+            return 2
+        if kind != "wal":
+            print(f"kanban os-users probe: unknown kind {kind!r}", file=sys.stderr)
+            return 2
+        try:
+            prove_sqlite_wal_lifecycle(str(path))
+        except Exception as exc:
+            print(f"kanban os-users probe failed: {exc}", file=sys.stderr)
+            return 1
+        print(f"WAL lifecycle ok for {path}")
+        return 0
+
+    if action == "check":
+        items = audit_mapping(
+            mapping=mapping or None,
+            homes=homes,
+            hooks=hooks,
+            board_paths=board_paths,
+        )
+        if getattr(args, "json", False):
             print(
                 json.dumps(
                     {
@@ -1046,33 +1658,60 @@ def run_os_users_cli(args: Any) -> int:
         else:
             print(format_audit(items))
         return 0 if all(i.ok for i in items) else 1
+
     if action == "sudoers":
         print(render_sudoers(mapping=mapping or None))
         return 0
+
     if action == "rollback":
-        steps = plan_rollback_steps(mapping=mapping or None)
+        steps = plan_rollback_steps(
+            mapping=mapping or None,
+            state_path=resolved_state,
+        )
         print(
             format_plan(steps, heading="Kanban profile_os_users rollback (destructive)")
         )
+        st = load_os_users_state(resolved_state)
+        if not (
+            st.get("created_users") or st.get("created_groups") or st.get("acl_paths")
+        ):
+            print(
+                "No setup state file — rollback will not userdel/groupdel "
+                "pre-existing principals. Remove ACLs on recorded paths only."
+            )
         return 0
+
     if action == "setup":
         gw = getattr(args, "gateway_user", None)
         dev_ws = getattr(args, "dev_workspace", None)
+        migrate = bool(getattr(args, "migrate_profile_files", False))
+        targets = mapping or default_mapping_example()
         steps = plan_setup_steps(
             mapping=mapping or None,
             gateway_user=gw,
             dev_workspace=dev_ws,
+            board_paths=board_paths,
         )
         print(format_plan(steps, heading="Kanban profile_os_users setup (dry-run)"))
         print("")
-        print(
-            "\n".join(
-                migrate_profile_files_commands(mapping or default_mapping_example())
-            )
-        )
+        print("\n".join(migrate_profile_files_commands(targets)))
         print("")
         print("Sudoers snippet:")
         print(render_sudoers(mapping=mapping or None, gateway_user=gw))
+        if migrate:
+            steps = list(steps) + plan_migrate_steps(targets)
+            print(
+                "Will copy profile files (--migrate-profile-files). "
+                "Contents are never printed."
+            )
+        else:
+            print(
+                "MANUAL GATE: profile files were NOT copied. Re-run with "
+                "--migrate-profile-files after review, or copy with install(1)."
+            )
+            print(
+                "Check cannot report ready without config.yaml, .env, SOUL.md, skills/."
+            )
         apply = bool(getattr(args, "apply", False))
         if not apply:
             print("Dry-run only. Re-run as root with --apply after review.")
@@ -1085,60 +1724,49 @@ def run_os_users_cli(args: Any) -> int:
             )
             print("  sudo hermes kanban os-users setup --apply", file=sys.stderr)
             return 1
-        # Privileged apply: run argv lists only. Skip the placeholder sudoers source.
-        import subprocess
+        rc = execute_setup_plan(
+            steps,
+            hooks=hooks,
+            state_path=resolved_state,
+            sudoers_text=render_sudoers(mapping=mapping or None, gateway_user=gw),
+        )
+        if rc == 0:
+            print("Apply complete. Run: hermes kanban os-users check")
+            print("Do not enable profile_os_users until check passes.")
+            print(
+                "Check will FAIL until mapped HERMES_HOME has "
+                "config.yaml, .env, SOUL.md, skills/."
+            )
+        return rc
 
-        for step in steps:
-            if "<generated-sudoers>" in step.argv:
-                tmp = Path("/tmp/hermes-kanban-os-users.sudoers")
-                tmp.write_text(
-                    render_sudoers(mapping=mapping or None, gateway_user=gw),
-                    encoding="utf-8",
-                )
-                os.chmod(tmp, 0o600)
-                check = subprocess.run(  # noqa: S603
-                    ["visudo", "-c", "-f", str(tmp)],
-                    check=False,
-                    capture_output=True,
-                    text=True,
-                )
-                if check.returncode != 0:
-                    print(f"visudo -c failed: {check.stderr}", file=sys.stderr)
-                    return 1
-                argv = [
-                    "install",
-                    "-m",
-                    "0440",
-                    "-o",
-                    "root",
-                    "-g",
-                    "root",
-                    str(tmp),
-                    DEFAULT_SUDOERS_PATH,
-                ]
-            else:
-                argv = step.argv
-            print(f"# {step.title}")
-            proc = subprocess.run(argv, check=False)  # noqa: S603
-            # useradd/groupadd EEXIST is idempotent success
-            if proc.returncode != 0 and not _idempotent_ok(argv, proc.returncode):
-                print(
-                    f"command failed ({proc.returncode}): {_quote_cmd(argv)}",
-                    file=sys.stderr,
-                )
-                return 1
-        print("Apply complete. Run: hermes kanban os-users check")
-        print("Do not enable profile_os_users until check passes.")
-        return 0
     print(f"kanban os-users: unknown action {action!r}", file=sys.stderr)
     return 2
 
 
-def _idempotent_ok(argv: Sequence[str], rc: int) -> bool:
+def _idempotent_ok(
+    argv: Sequence[str],
+    rc: int,
+    *,
+    hooks: Optional[LaunchHooks] = None,
+    group: str = DEFAULT_GROUP,
+) -> bool:
+    """Treat useradd/groupadd already-exists as success only if compatible."""
     if rc == 0:
         return True
     cmd = os.path.basename(str(argv[0])) if argv else ""
-    # useradd 9 = already exists; groupadd 9 = already exists (Debian)
-    if cmd in {"useradd", "groupadd"} and rc in {9, 4}:
+    if cmd == "useradd" and rc in {9, 4}:
+        user = str(argv[-1])
+        existing_user_compatible(user, group=group, hooks=hooks)
+        return True
+    if cmd == "groupadd" and rc in {9, 4}:
+        name = str(argv[-1])
+        h = _hooks_or_defaults(hooks)
+        assert h.getgrnam is not None
+        try:
+            h.getgrnam(name)
+        except (KeyError, MappedLaunchError) as exc:
+            raise IncompatiblePrincipalError(
+                f"group {name!r} missing after already-exists rc"
+            ) from exc
         return True
     return False

--- a/hermes_cli/kanban_os_users.py
+++ b/hermes_cli/kanban_os_users.py
@@ -65,6 +65,14 @@ DEFAULT_TEST_BIN = "/usr/bin/test"
 DEFAULT_STATE_PATH = "/var/lib/hermes/kanban-os-users-state.json"
 REQUIRED_MAPPED_HOME_FILES = ("config.yaml", ".env", "SOUL.md")
 REQUIRED_MAPPED_HOME_DIRS = ("skills",)
+DEFAULT_DEV_WORKSPACE = "/home/matt/Documents/WorkoutTracker"
+DEFAULT_FLUTTER_SDK = "/home/matt/flutter"
+DEFAULT_ANDROID_SDK = "/home/matt/Android/Sdk"
+DEFAULT_JDK_HOME = "/home/matt/.local/opt/jdk-17"
+DEFAULT_GH_BIN = "/usr/bin/gh"
+DEFAULT_GIT_BIN = "/usr/bin/git"
+VERSIONED_RUNTIME_ROOT = "/opt/hermes/kanban-os-users"
+GITHUB_LS_REMOTE_URL = "https://github.com/NousResearch/hermes-agent.git"
 
 # Env vars the mapped worker must inherit through sudo env_reset.
 SUDO_ENV_KEEP = (
@@ -91,6 +99,12 @@ SUDO_ENV_KEEP = (
     "LANG",
     "LC_ALL",
     "TZ",
+    "PUB_CACHE",
+    "GRADLE_USER_HOME",
+    "ANDROID_SDK_ROOT",
+    "ANDROID_HOME",
+    "JAVA_HOME",
+    "FLUTTER_ROOT",
 )
 
 
@@ -775,6 +789,7 @@ def render_sudoers(
     gateway_user: Optional[str] = None,
     mapping: Optional[Mapping[str, str]] = None,
     hermes_argv: Optional[Sequence[str]] = None,
+    extra_bins: Optional[Sequence[str]] = None,
 ) -> str:
     gw = gateway_user or _gateway_user()
     users = sorted(set(resolve_setup_targets(mapping).values()))
@@ -799,8 +814,11 @@ def render_sudoers(
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {id_cmd}",
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {test_cmd}",
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {cmd}",
-        "",
     ]
+    for bin_path in extra_bins or ():
+        quoted = _quote_cmd([str(bin_path)])
+        lines.append(f"{gw} ALL=({runas}) NOPASSWD:SETENV: {quoted}")
+    lines.append("")
     return "\n".join(lines)
 
 
@@ -869,6 +887,10 @@ def plan_setup_steps(
     dev_workspace: Optional[str] = None,
     hermes_argv: Optional[Sequence[str]] = None,
     board_paths: Optional[Mapping[str, Path]] = None,
+    flutter_sdk: Optional[str] = None,
+    android_sdk: Optional[str] = None,
+    jdk_home: Optional[str] = None,
+    include_db_migration: bool = False,
 ) -> list[SetupStep]:
     targets = resolve_setup_targets(mapping)
     gw = gateway_user or _gateway_user()
@@ -945,65 +967,102 @@ def plan_setup_steps(
         except Exception:
             paths = None
     if paths:
-        db_path = Path(paths["kanban_db"])
-        db = str(db_path)
-        db_parent = db_path.parent
-        kdir = str(paths["kanban_dir"])
+        from hermes_cli.kanban_os_users_rollout import (
+            migrate_db_argv,
+            reject_write_acl_on_hermes_root,
+            self_hermes_argv,
+            shared_board_acl_layout,
+        )
+
+        layout = shared_board_acl_layout(paths)
+        writable_dir = Path(layout["writable_dir"])
+        target_db = Path(layout["target_db"])
+        live_db = Path(layout["live_db"])
+        kdir = Path(layout["kanban_dir"])
+        hermes_root = layout.get("hermes_root")
+        argv_self = self_hermes_argv(hermes_argv)
         steps.append(
             SetupStep(
-                "kanban metadata dir",
-                ["install", "-d", "-m", "2770", "-o", gw, "-g", group, kdir],
+                "dedicated shared kanban dir (group wx lives here, never on ~/.hermes)",
+                ["install", "-d", "-m", "2770", "-o", gw, "-g", group, str(kdir)],
             )
         )
-        # Least privilege on the *actual* DB parent (kanban.db, not kanban/).
-        # Traverse-only on ancestors; wx (no listdir) on the parent so WAL/SHM
-        # sidecars can be created without making the whole Hermes tree readable.
-        for ancestor in _acl_traverse_ancestors(db_parent):
+        # Traverse-only on Hermes root and ancestors. Write ACLs only on the
+        # dedicated kanban directory so specialists cannot create/rename files
+        # in the default Hermes root.
+        traverse_targets: list[Path] = []
+        if hermes_root is not None:
+            traverse_targets.append(Path(hermes_root))
+            traverse_targets.extend(_acl_traverse_ancestors(Path(hermes_root)))
+        traverse_targets.extend(_acl_traverse_ancestors(writable_dir))
+        seen_traverse: set[str] = set()
+        for ancestor in traverse_targets:
+            key = str(ancestor)
+            if key in seen_traverse:
+                continue
+            seen_traverse.add(key)
+            if hermes_root is not None and str(ancestor) == str(writable_dir):
+                continue
             steps.append(
                 SetupStep(
-                    f"traverse ACL on {ancestor} for {group} (execute only; no listdir)",
+                    f"traverse ACL on {ancestor} for {group} (execute only; no listdir, no write)",
                     ["setfacl", "-m", f"g:{group}:--x", str(ancestor)],
                     creates=f"acl:{ancestor}",
                 )
             )
         steps.extend([
             SetupStep(
-                f"ACL on DB parent {db_parent} (group wx for WAL/shm; no listdir)",
-                ["setfacl", "-m", f"g:{group}:wx", str(db_parent)],
-                creates=f"acl:{db_parent}",
+                f"ACL on dedicated DB parent {writable_dir} (group wx for WAL/shm; no listdir)",
+                ["setfacl", "-m", f"g:{group}:wx", str(writable_dir)],
+                creates=f"acl:{writable_dir}",
             ),
             SetupStep(
-                f"default ACL on DB parent {db_parent} for new WAL/shm files",
-                ["setfacl", "-d", "-m", f"g:{group}:rw", str(db_parent)],
-                creates=f"acl:{db_parent}",
+                f"default ACL on dedicated DB parent {writable_dir} for new WAL/shm files",
+                ["setfacl", "-d", "-m", f"g:{group}:rw", str(writable_dir)],
+                creates=f"acl:{writable_dir}",
             ),
             SetupStep(
-                "ACL on kanban.db (SQLite needs sibling -wal/-shm)",
-                ["setfacl", "-m", f"g:{group}:rw", db],
-                creates=f"acl:{db}",
+                "ACL on dedicated kanban.db (SQLite needs sibling -wal/-shm)",
+                ["setfacl", "-m", f"g:{group}:rw", str(target_db)],
+                creates=f"acl:{target_db}",
+                optional=True,
             ),
         ])
-        ws = str(paths["workspaces"])
+        if include_db_migration:
+            steps.append(
+                SetupStep(
+                    f"sqlite backup {live_db} -> {target_db} (never cp a live DB/WAL/SHM)",
+                    migrate_db_argv(live_db, target_db, hermes_argv=argv_self),
+                    optional=True,
+                )
+            )
+        ws = (
+            str(paths["workspaces"])
+            if "workspaces" in paths
+            else str(kdir / "workspaces")
+        )
         steps.append(
             SetupStep(
                 "shared workspaces root (group rwx, no world)",
                 ["install", "-d", "-m", "2770", "-o", gw, "-g", group, ws],
             )
         )
+        if hermes_root is not None:
+            reject_write_acl_on_hermes_root(steps, Path(hermes_root))
     if dev_workspace:
         dev_user = targets.get("dev", "hermes-dev")
         ws_path = Path(dev_workspace)
         for ancestor in _acl_traverse_ancestors(ws_path):
             steps.append(
                 SetupStep(
-                    f"dev-only traverse ACL on {ancestor} (sysadmin is NOT granted this)",
+                    f"dev-only traverse ACL on {ancestor} (not confidentiality; world-readable trees are not isolation)",
                     ["setfacl", "-m", f"u:{dev_user}:--x", str(ancestor)],
                     creates=f"acl:{ancestor}",
                 )
             )
         steps.extend([
             SetupStep(
-                f"dev-only recursive ACL on {dev_workspace} (sysadmin is NOT granted this)",
+                f"dev-only recursive ACL on {dev_workspace} (sysadmin not granted; world-readable is not isolation)",
                 ["setfacl", "-R", "-m", f"u:{dev_user}:rwx", str(ws_path)],
                 creates=f"acl:{ws_path}",
             ),
@@ -1013,6 +1072,60 @@ def plan_setup_steps(
                 creates=f"acl:{ws_path}",
             ),
         ])
+    if flutter_sdk or android_sdk or jdk_home:
+        dev_user = targets.get("dev", "hermes-dev")
+        for label, raw in (
+            ("flutter", flutter_sdk),
+            ("android-sdk", android_sdk),
+            ("jdk", jdk_home),
+        ):
+            if not raw:
+                continue
+            tool = Path(raw)
+            for ancestor in _acl_traverse_ancestors(tool):
+                steps.append(
+                    SetupStep(
+                        f"dev-only traverse ACL on {ancestor} for {label} (not a grant of /home/matt)",
+                        ["setfacl", "-m", f"u:{dev_user}:--x", str(ancestor)],
+                        creates=f"acl:{ancestor}",
+                    )
+                )
+            steps.extend([
+                SetupStep(
+                    f"dev-only read/execute ACL on {tool} (no write; not recursive on /home/matt)",
+                    ["setfacl", "-R", "-m", f"u:{dev_user}:r-x", str(tool)],
+                    creates=f"acl:{tool}",
+                    optional=True,
+                ),
+                SetupStep(
+                    f"dev-only default r-x ACL on {tool}",
+                    ["setfacl", "-d", "-m", f"u:{dev_user}:r-x", str(tool)],
+                    creates=f"acl:{tool}",
+                    optional=True,
+                ),
+            ])
+        for cache in (
+            ".cache/flutter",
+            ".cache/pub",
+            ".cache/gradle",
+            ".cache/android",
+        ):
+            steps.append(
+                SetupStep(
+                    f"private {cache} for {dev_user}",
+                    [
+                        "install",
+                        "-d",
+                        "-m",
+                        "0700",
+                        "-o",
+                        dev_user,
+                        "-g",
+                        dev_user,
+                        f"/home/{dev_user}/{cache}",
+                    ],
+                )
+            )
     steps.append(
         SetupStep(
             f"add {gw} to {group} for admin visibility",
@@ -1113,9 +1226,12 @@ def format_plan(steps: Sequence[SetupStep], *, heading: str) -> str:
         lines.append(f"{i}. {step.title}")
         lines.append(f"   {_quote_cmd(step.argv)}")
     lines.append("")
-    lines.append("Do not cat/print .env, auth.json, or SSH keys. Copy with install(1).")
+    lines.append("Do not cat/print .env, auth.json, gh tokens, or SSH keys.")
     lines.append(
         "MANUAL GATE: setup --apply does not copy profile files unless --migrate-profile-files."
+    )
+    lines.append(
+        "Skills use bounded copy-tree (no per-file flood). Shared DB uses sqlite backup, not cp."
     )
     lines.append(
         "Required in mapped HERMES_HOME before check can report ready: "
@@ -1139,8 +1255,12 @@ def plan_migrate_steps(
     mapping: Mapping[str, str],
     *,
     source_root: Optional[Path] = None,
+    hermes_argv: Optional[Sequence[str]] = None,
 ) -> list[SetupStep]:
+    from hermes_cli.kanban_os_users_rollout import copy_tree_argv, self_hermes_argv
+
     root = _source_hermes_root(source_root)
+    argv_self = self_hermes_argv(hermes_argv)
     steps: list[SetupStep] = []
     for profile, user in mapping.items():
         src = root / "profiles" / profile
@@ -1165,45 +1285,17 @@ def plan_migrate_steps(
             )
         steps.append(
             SetupStep(
-                f"migrate skills dir for {profile}",
-                [
-                    "install",
-                    "-d",
-                    "-m",
-                    "0700",
-                    "-o",
-                    user,
-                    "-g",
-                    user,
-                    str(dst / "skills"),
-                ],
+                f"bounded copy-tree skills for {profile} (rejects symlinks; never prints contents)",
+                copy_tree_argv(
+                    src / "skills",
+                    dst / "skills",
+                    owner=user,
+                    group=user,
+                    hermes_argv=argv_self,
+                ),
+                optional=True,
             )
         )
-        skills_src = src / "skills"
-        if skills_src.is_dir():
-            for child in sorted(skills_src.rglob("*")):
-                if not child.is_file():
-                    continue
-                rel = child.relative_to(skills_src)
-                dest_file = dst / "skills" / rel
-                steps.append(
-                    SetupStep(
-                        f"migrate skills/{rel} for {profile}",
-                        [
-                            "install",
-                            "-D",
-                            "-m",
-                            "0600",
-                            "-o",
-                            user,
-                            "-g",
-                            user,
-                            str(child),
-                            str(dest_file),
-                        ],
-                        optional=True,
-                    )
-                )
     return steps
 
 
@@ -1211,16 +1303,31 @@ def migrate_profile_files_commands(
     mapping: Mapping[str, str],
     *,
     source_root: Optional[Path] = None,
+    hermes_argv: Optional[Sequence[str]] = None,
 ) -> list[str]:
-    """Print install(1) copy commands; never dump file contents."""
-    steps = plan_migrate_steps(mapping, source_root=source_root)
+    """Summarize planned copy roots/counts; never dump file contents or per-file argv."""
+    from hermes_cli.kanban_os_users_rollout import summarize_tree
+
+    root = _source_hermes_root(source_root)
+    steps = plan_migrate_steps(
+        mapping, source_root=source_root, hermes_argv=hermes_argv
+    )
     lines = [
         "# Credential/config migration (contents are never printed)",
         "# MANUAL GATE: setup --apply does not copy these unless --migrate-profile-files.",
         "# Review each source path. Skip files that should stay gateway-only.",
         "# Required in mapped HERMES_HOME before check can report ready:",
         "#   config.yaml, .env, SOUL.md, skills/",
+        "# Dry-run summarizes counts/roots; it does not emit per-file install(1) lines.",
     ]
+    for profile, user in mapping.items():
+        src = root / "profiles" / profile
+        dst = Path(f"/home/{user}") / ".hermes" / "profiles" / profile
+        skills = summarize_tree(src / "skills")
+        lines.append(
+            f"# {profile}: {src} -> {dst}; skills files={skills['files']} "
+            f"dirs={skills['dirs']} rejected_symlinks={skills['symlinks']}"
+        )
     for step in steps:
         lines.append(_quote_cmd(step.argv))
     return lines
@@ -1291,6 +1398,12 @@ def audit_mapping(
     hooks: Optional[LaunchHooks] = None,
     board_paths: Optional[Mapping[str, Path]] = None,
     wal_prover: Optional[Callable[[str, str], None]] = None,
+    host_gates: bool = False,
+    hermes_argv: Optional[Sequence[str]] = None,
+    flutter_sdk: Optional[str] = None,
+    android_sdk: Optional[str] = None,
+    jdk_home: Optional[str] = None,
+    dev_workspace: Optional[str] = None,
 ) -> list[AuditItem]:
     items: list[AuditItem] = []
     if mapping is None:
@@ -1392,9 +1505,30 @@ def audit_mapping(
                     )
                 )
     try:
+        from hermes_cli.kanban_os_users_rollout import shared_board_acl_layout
+
         paths = board_paths if board_paths is not None else shared_board_paths()
-        db = Path(paths["kanban_db"])
-        parent = db.parent
+        layout = shared_board_acl_layout(paths)
+        db = Path(layout["target_db"])
+        parent = Path(layout["writable_dir"])
+        hermes_root = layout.get("hermes_root")
+        if hermes_root is not None:
+            try:
+                same_root = parent.resolve() == Path(hermes_root).resolve()
+            except OSError:
+                same_root = str(parent) == str(hermes_root)
+            items.append(
+                AuditItem(
+                    "board-not-hermes-root",
+                    not same_root,
+                    (
+                        f"dedicated shared dir {parent}"
+                        if not same_root
+                        else f"WRITE PARENT IS HERMES ROOT {hermes_root}"
+                    ),
+                    isolation=not same_root,
+                )
+            )
         parent_ok = parent.is_dir()
         parent_bits = [f"board parent {parent}"]
         if not parent_ok:
@@ -1435,6 +1569,156 @@ def audit_mapping(
             )
     except Exception as exc:
         items.append(AuditItem("board", False, str(exc)))
+    if host_gates:
+        items.extend(
+            _host_continuity_gates(
+                targets=targets,
+                pw_by_user=pw_by_user,
+                homes_by_profile=homes_by_profile,
+                hooks=h,
+                hermes_argv=hermes_argv,
+                flutter_sdk=flutter_sdk,
+                android_sdk=android_sdk,
+                jdk_home=jdk_home,
+                dev_workspace=dev_workspace,
+            )
+        )
+    return items
+
+
+def _host_continuity_gates(
+    *,
+    targets: Mapping[str, str],
+    pw_by_user: Mapping[str, PasswdEntry],
+    homes_by_profile: Mapping[str, str],
+    hooks: LaunchHooks,
+    hermes_argv: Optional[Sequence[str]] = None,
+    flutter_sdk: Optional[str] = None,
+    android_sdk: Optional[str] = None,
+    jdk_home: Optional[str] = None,
+    dev_workspace: Optional[str] = None,
+) -> list[AuditItem]:
+    from hermes_cli.kanban_os_users_rollout import (
+        DEFAULT_ANDROID_SDK,
+        DEFAULT_DEV_WORKSPACE,
+        DEFAULT_FLUTTER_SDK,
+        DEFAULT_GH_BIN,
+        DEFAULT_GIT_BIN,
+        DEFAULT_JDK_HOME,
+        GITHUB_LS_REMOTE_URL,
+        feature_source_sha,
+        hermes_argv_covers_feature,
+        self_hermes_argv,
+    )
+
+    items: list[AuditItem] = []
+    argv = list(hermes_argv) if hermes_argv else self_hermes_argv()
+    covers = hermes_argv_covers_feature(argv)
+    sha = feature_source_sha() or "(unknown)"
+    items.append(
+        AuditItem(
+            "runtime-sha",
+            covers,
+            f"reviewed sha {sha}; argv={argv!r}. Isolation is false until the live dispatcher uses this commit.",
+            isolation=covers,
+        )
+    )
+
+    def _cmd_ok(username: str, inner: list[str]) -> tuple[bool, str]:
+        a = build_sudo_argv(username, inner, sudo_bin=hooks.sudo_bin)
+        assert hooks.run is not None
+        try:
+            proc = hooks.run(a, timeout=30)
+        except Exception as exc:
+            return False, f"{inner[0]} probe failed: {exc}"
+        rc = int(getattr(proc, "returncode", 1))
+        if rc == 0:
+            return True, f"{username} {inner[0]} ok (stdout omitted)"
+        return False, f"{username} {inner[0]} failed (exit {rc}; stdout omitted)"
+
+    dev_user = targets.get("dev")
+    if dev_user and dev_user in pw_by_user:
+        ok_gh, d_gh = _cmd_ok(dev_user, [DEFAULT_GH_BIN, "api", "user"])
+        items.append(AuditItem("github-api", ok_gh, d_gh, isolation=False))
+        ok_git, d_git = _cmd_ok(
+            dev_user, [DEFAULT_GIT_BIN, "ls-remote", GITHUB_LS_REMOTE_URL, "HEAD"]
+        )
+        items.append(AuditItem("github-ls-remote", ok_git, d_git, isolation=False))
+        ok_ssh, d_ssh = probe_user_access(
+            dev_user, "/home/matt/.ssh", mode="r", hooks=hooks, expect_ok=False
+        )
+        items.append(AuditItem("deny-matt-ssh", ok_ssh, d_ssh, isolation=ok_ssh))
+        for key_path in ("/home/matt/.ssh/id_ed25519", "/home/matt/.ssh/id_rsa"):
+            if Path(key_path).exists():
+                ok_k, d_k = probe_user_access(
+                    dev_user, key_path, mode="r", hooks=hooks, expect_ok=False
+                )
+                items.append(
+                    AuditItem(
+                        f"deny-key:{Path(key_path).name}", ok_k, d_k, isolation=ok_k
+                    )
+                )
+        sys_user = targets.get("sysadmin")
+        if sys_user and "dev" in homes_by_profile:
+            envp = str(Path(homes_by_profile["dev"]) / ".env")
+            ok_sc, d_sc = probe_user_access(
+                sys_user, envp, mode="r", hooks=hooks, expect_ok=False
+            )
+            items.append(
+                AuditItem("deny-sysadmin-dev-env", ok_sc, d_sc, isolation=ok_sc)
+            )
+        ws = Path(dev_workspace or DEFAULT_DEV_WORKSPACE)
+        if ws.exists():
+            try:
+                world = bool(stat.S_IMODE(ws.stat().st_mode) & 0o004)
+            except OSError:
+                world = False
+            items.append(
+                AuditItem(
+                    "workspace-modes",
+                    True,
+                    f"{ws} world-readable={world}; not an isolation claim",
+                    isolation=False,
+                )
+            )
+            ok_ws, d_ws = probe_user_access(
+                dev_user, str(ws), mode="x", hooks=hooks, expect_ok=True
+            )
+            items.append(
+                AuditItem("dev-workspace-traverse", ok_ws, d_ws, isolation=False)
+            )
+        for label, raw in (
+            (
+                "flutter",
+                flutter_sdk
+                or (
+                    DEFAULT_FLUTTER_SDK if Path(DEFAULT_FLUTTER_SDK).exists() else None
+                ),
+            ),
+            (
+                "android-sdk",
+                android_sdk
+                or (
+                    DEFAULT_ANDROID_SDK if Path(DEFAULT_ANDROID_SDK).exists() else None
+                ),
+            ),
+            (
+                "jdk",
+                jdk_home
+                or (DEFAULT_JDK_HOME if Path(DEFAULT_JDK_HOME).exists() else None),
+            ),
+        ):
+            if not raw:
+                continue
+            ok_x, d_x = probe_user_access(
+                dev_user, str(raw), mode="x", hooks=hooks, expect_ok=True
+            )
+            items.append(AuditItem(f"toolchain-{label}", ok_x, d_x, isolation=False))
+        cache = f"/home/{dev_user}/.cache"
+        ok_w, d_w = probe_user_access(
+            dev_user, cache, mode="w", hooks=hooks, expect_ok=True
+        )
+        items.append(AuditItem("dev-private-cache", ok_w, d_w, isolation=False))
     return items
 
 
@@ -1528,8 +1812,16 @@ def execute_setup_plan(
 
     for step in steps:
         argv = list(step.argv)
-        if step.optional and argv and os.path.basename(str(argv[0])) == "install":
-            src = str(argv[-2]) if len(argv) >= 2 else ""
+        if step.optional:
+            src = ""
+            if "copy-tree" in argv and "--src" in argv:
+                src = str(argv[argv.index("--src") + 1])
+            elif "migrate-db" in argv and "--from" in argv:
+                src = str(argv[argv.index("--from") + 1])
+            elif (
+                argv and os.path.basename(str(argv[0])) == "install" and len(argv) >= 2
+            ):
+                src = str(argv[-2])
             if src.startswith("/") and not Path(src).exists():
                 print(f"# skip optional missing source {src}")
                 continue
@@ -1613,6 +1905,51 @@ def run_os_users_cli(
         Path(state_path) if state_path is not None else Path(DEFAULT_STATE_PATH)
     )
 
+    if action == "migrate-db":
+        from hermes_cli.kanban_os_users_rollout import sqlite_backup_copy
+
+        src = getattr(args, "migrate_from", None)
+        dst = getattr(args, "migrate_to", None)
+        if not src or not dst:
+            print(
+                "kanban os-users migrate-db: --from and --to are required",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            sqlite_backup_copy(str(src), str(dst))
+        except Exception as exc:
+            print(f"kanban os-users migrate-db failed: {exc}", file=sys.stderr)
+            return 1
+        print(f"sqlite backup ok {src} -> {dst} (WAL/SHM not raw-copied)")
+        return 0
+
+    if action == "copy-tree":
+        from hermes_cli.kanban_os_users_rollout import copy_tree_reject_symlinks
+
+        src = getattr(args, "copy_src", None)
+        dst = getattr(args, "copy_dst", None)
+        owner = getattr(args, "copy_owner", None) or "root"
+        group = getattr(args, "copy_group", None) or owner
+        if not src or not dst:
+            print(
+                "kanban os-users copy-tree: --src and --dst are required",
+                file=sys.stderr,
+            )
+            return 2
+        try:
+            stats = copy_tree_reject_symlinks(
+                str(src), str(dst), owner=owner, group=group
+            )
+        except Exception as exc:
+            print(f"kanban os-users copy-tree failed: {exc}", file=sys.stderr)
+            return 1
+        print(
+            f"copy-tree ok files={stats['files']} dirs={stats['dirs']} "
+            f"rejected_symlinks={stats['rejected_symlinks']}"
+        )
+        return 0
+
     if action == "probe":
         kind = getattr(args, "probe_kind", None) or "wal"
         path = getattr(args, "probe_path", None)
@@ -1631,11 +1968,19 @@ def run_os_users_cli(
         return 0
 
     if action == "check":
+        from hermes_cli.kanban_os_users_rollout import self_hermes_argv
+
         items = audit_mapping(
             mapping=mapping or None,
             homes=homes,
             hooks=hooks,
             board_paths=board_paths,
+            host_gates=True,
+            hermes_argv=self_hermes_argv(),
+            flutter_sdk=getattr(args, "flutter_sdk", None),
+            android_sdk=getattr(args, "android_sdk", None),
+            jdk_home=getattr(args, "jdk_home", None),
+            dev_workspace=getattr(args, "dev_workspace", None),
         )
         if getattr(args, "json", False):
             print(
@@ -1682,24 +2027,60 @@ def run_os_users_cli(
         return 0
 
     if action == "setup":
+        from hermes_cli.kanban_os_users_rollout import (
+            apply_command_hint,
+            default_toolchain_if_present,
+            extra_sudoers_bins,
+            format_rollout_and_rollback,
+            github_manual_gate_lines,
+            self_hermes_argv,
+        )
+
         gw = getattr(args, "gateway_user", None)
         dev_ws = getattr(args, "dev_workspace", None)
+        if not dev_ws and Path(DEFAULT_DEV_WORKSPACE).exists():
+            dev_ws = DEFAULT_DEV_WORKSPACE
         migrate = bool(getattr(args, "migrate_profile_files", False))
+        include_db = bool(getattr(args, "migrate_shared_db", False))
+        toolchain = default_toolchain_if_present()
+        flutter = getattr(args, "flutter_sdk", None) or toolchain.get("flutter_sdk")
+        android = getattr(args, "android_sdk", None) or toolchain.get("android_sdk")
+        jdk = getattr(args, "jdk_home", None) or toolchain.get("jdk_home")
+        argv_self = self_hermes_argv()
+        extra_bins = extra_sudoers_bins(
+            flutter_sdk=flutter, android_sdk=android, jdk_home=jdk
+        )
         targets = mapping or default_mapping_example()
         steps = plan_setup_steps(
             mapping=mapping or None,
             gateway_user=gw,
             dev_workspace=dev_ws,
             board_paths=board_paths,
+            hermes_argv=argv_self,
+            flutter_sdk=flutter,
+            android_sdk=android,
+            jdk_home=jdk,
+            include_db_migration=include_db,
         )
         print(format_plan(steps, heading="Kanban profile_os_users setup (dry-run)"))
         print("")
-        print("\n".join(migrate_profile_files_commands(targets)))
+        print(format_rollout_and_rollback(hermes_argv=argv_self))
+        print("")
+        print("\n".join(migrate_profile_files_commands(targets, hermes_argv=argv_self)))
+        print("")
+        print("\n".join(github_manual_gate_lines(targets.get("dev", "hermes-dev"))))
         print("")
         print("Sudoers snippet:")
-        print(render_sudoers(mapping=mapping or None, gateway_user=gw))
+        sudoers_text = render_sudoers(
+            mapping=mapping or None,
+            gateway_user=gw,
+            hermes_argv=argv_self,
+            extra_bins=extra_bins,
+        )
+        print(sudoers_text)
+        hint = apply_command_hint(argv_self)
         if migrate:
-            steps = list(steps) + plan_migrate_steps(targets)
+            steps = list(steps) + plan_migrate_steps(targets, hermes_argv=argv_self)
             print(
                 "Will copy profile files (--migrate-profile-files). "
                 "Contents are never printed."
@@ -1707,7 +2088,7 @@ def run_os_users_cli(
         else:
             print(
                 "MANUAL GATE: profile files were NOT copied. Re-run with "
-                "--migrate-profile-files after review, or copy with install(1)."
+                "--migrate-profile-files after review, or copy with copy-tree."
             )
             print(
                 "Check cannot report ready without config.yaml, .env, SOUL.md, skills/."
@@ -1715,20 +2096,21 @@ def run_os_users_cli(
         apply = bool(getattr(args, "apply", False))
         if not apply:
             print("Dry-run only. Re-run as root with --apply after review.")
-            print("  sudo hermes kanban os-users setup --apply")
+            print(f"  {hint}")
+            print("Do not use `sudo hermes`; that may invoke the old installed CLI.")
             return 0
         if os.geteuid() != 0:
             print(
                 "kanban os-users: --apply requires euid 0. Not prompting for a password.",
                 file=sys.stderr,
             )
-            print("  sudo hermes kanban os-users setup --apply", file=sys.stderr)
+            print(f"  {hint}", file=sys.stderr)
             return 1
         rc = execute_setup_plan(
             steps,
             hooks=hooks,
             state_path=resolved_state,
-            sudoers_text=render_sudoers(mapping=mapping or None, gateway_user=gw),
+            sudoers_text=sudoers_text,
         )
         if rc == 0:
             print("Apply complete. Run: hermes kanban os-users check")

--- a/hermes_cli/kanban_os_users.py
+++ b/hermes_cli/kanban_os_users.py
@@ -1,0 +1,1034 @@
+"""Profile-to-Linux-user launch for Kanban workers.
+
+Optional ``kanban.profile_os_users`` maps a canonical Hermes profile id to a
+POSIX account. Missing or empty mapping preserves trusted-local-user spawn
+(the dispatcher remains the gateway UID).
+
+Mapped workers are launched as an argv list with no shell::
+
+    sudo -n -H -E -u <user> -- <hermes argv...>
+
+Privilege drop is fail-closed: a configured mapping never falls back to the
+gateway UID. Same-UID mappings are rejected and must not be reported as
+isolation. Root is refused.
+
+Optional companion ``kanban.profile_os_homes`` maps a profile id to that
+user's Hermes *runtime root* (``{pw_dir}/.hermes`` by default). OS ``HOME``
+is always the passwd home directory and is never silently overloaded with
+the Hermes root.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import shlex
+import stat
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Mapping, Optional, Sequence
+
+
+# Portable POSIX username: leading letter or underscore, then alnum/_/- .
+# Caps at 32 characters (Linux login.defs default). No dots, slashes, or
+# shell metacharacters — those cannot appear because the regex forbids them.
+_POSIX_USERNAME_RE = re.compile(r"^[a-z_][a-z0-9_-]{0,31}$")
+_FORBIDDEN_OS_USERS = frozenset({"root", "toor"})
+
+_HERMES_ENV_KEEP_PREFIXES = ("HERMES_", "TERMINAL_")
+_SECRET_KEY_SUFFIXES = (
+    "_TOKEN",
+    "_SECRET",
+    "_API_KEY",
+    "_PASSWORD",
+    "_PRIVATE_KEY",
+    "_ACCESS_KEY",
+)
+_SECRET_KEY_PREFIXES = ("SSH_", "SUDO_", "CURSOR_")
+_SECRET_BASENAMES = frozenset({
+    ".env",
+    "auth.json",
+    "id_rsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_dsa",
+    "credentials.json",
+})
+
+DEFAULT_GROUP = "hermes-kanban"
+DEFAULT_SUDOERS_PATH = "/etc/sudoers.d/hermes-kanban-os-users"
+DEFAULT_SUDO_BIN = "/usr/bin/sudo"
+DEFAULT_ID_BIN = "/usr/bin/id"
+
+# Env vars the mapped worker must inherit through sudo env_reset.
+SUDO_ENV_KEEP = (
+    "HERMES_HOME",
+    "HERMES_PROFILE",
+    "HERMES_BIN",
+    "HERMES_TENANT",
+    "HERMES_SESSION_SOURCE",
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_BOARD",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    "HERMES_KANBAN_HOME",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_CLAIM_LOCK",
+    "HERMES_KANBAN_BRANCH",
+    "HERMES_KANBAN_GOAL_MODE",
+    "HERMES_KANBAN_GOAL_MAX_TURNS",
+    "TERMINAL_CWD",
+    "TERMINAL_TIMEOUT",
+    "TERMINAL_MAX_FOREGROUND_TIMEOUT",
+    "PATH",
+    "LANG",
+    "LC_ALL",
+    "TZ",
+)
+
+
+class MappedLaunchError(RuntimeError):
+    """A configured profile_os_users mapping cannot be honoured.
+
+    Callers must not fall back to the gateway UID when this is raised.
+    """
+
+
+@dataclass
+class PasswdEntry:
+    pw_name: str
+    pw_uid: int
+    pw_gid: int
+    pw_dir: str
+
+
+@dataclass
+class LaunchHooks:
+    """Injectable boundary for tests. Production uses pwd / subprocess."""
+
+    getpwnam: Optional[Callable[[str], PasswdEntry]] = None
+    geteuid: Optional[Callable[[], int]] = None
+    run: Optional[Callable[..., Any]] = None
+    sudo_bin: str = DEFAULT_SUDO_BIN
+    id_bin: str = DEFAULT_ID_BIN
+    is_windows: Optional[bool] = None
+
+
+# ---------------------------------------------------------------------------
+# Parsing / validation
+# ---------------------------------------------------------------------------
+
+
+def validate_os_username(name: str) -> str:
+    """Return a canonical POSIX username or raise ValueError."""
+    if not isinstance(name, str):
+        raise ValueError(f"OS username must be a string, got {type(name).__name__}")
+    stripped = name.strip()
+    if not stripped:
+        raise ValueError("OS username cannot be empty")
+    if stripped != name:
+        # Leading/trailing whitespace is an injection / confusion hazard.
+        raise ValueError(f"OS username {name!r} has surrounding whitespace")
+    if stripped in _FORBIDDEN_OS_USERS or stripped.casefold() == "root":
+        raise ValueError(
+            f"Refusing to map a Kanban specialist to {stripped!r} — root is not allowed"
+        )
+    if not _POSIX_USERNAME_RE.match(stripped):
+        raise ValueError(
+            f"Invalid OS username {stripped!r}. Must match "
+            f"[a-z_][a-z0-9_-]{{0,31}} (no dots, slashes, or metacharacters)"
+        )
+    return stripped
+
+
+def _canonical_profile_id(name: str) -> str:
+    from hermes_cli.profiles import normalize_profile_name, validate_profile_name
+
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    return canon
+
+
+def parse_profile_os_users(raw: Any) -> dict[str, str]:
+    """Parse ``kanban.profile_os_users``.
+
+    ``None``, missing, or ``{}`` yields an empty dict (trusted-local-user
+    behaviour). Invalid types, profile ids, or usernames raise ValueError.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise ValueError(
+            f"kanban.profile_os_users must be a mapping of profile -> username, "
+            f"got {type(raw).__name__}"
+        )
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        if value is None:
+            continue
+        if not isinstance(value, str):
+            raise ValueError(
+                f"kanban.profile_os_users[{key!r}] must be a username string, "
+                f"got {type(value).__name__}"
+            )
+        if not value.strip():
+            raise ValueError(
+                f"kanban.profile_os_users[{key!r}] is empty; omit the key instead"
+            )
+        profile = _canonical_profile_id(str(key))
+        username = validate_os_username(value)
+        out[profile] = username
+    return out
+
+
+def parse_profile_os_homes(raw: Any) -> dict[str, str]:
+    """Parse optional ``kanban.profile_os_homes`` (Hermes runtime roots).
+
+    Values must be absolute paths. This is *not* OS HOME.
+    """
+    if raw is None:
+        return {}
+    if not isinstance(raw, Mapping):
+        raise ValueError(
+            f"kanban.profile_os_homes must be a mapping of profile -> absolute path, "
+            f"got {type(raw).__name__}"
+        )
+    out: dict[str, str] = {}
+    for key, value in raw.items():
+        if value is None or (isinstance(value, str) and not value.strip()):
+            continue
+        if not isinstance(value, str):
+            raise ValueError(
+                f"kanban.profile_os_homes[{key!r}] must be a path string, "
+                f"got {type(value).__name__}"
+            )
+        profile = _canonical_profile_id(str(key))
+        path = value.strip()
+        if not os.path.isabs(path):
+            raise ValueError(
+                f"kanban.profile_os_homes[{profile!r}] must be an absolute path, "
+                f"got {path!r}"
+            )
+        out[profile] = path
+    return out
+
+
+def load_profile_os_user_config(
+    cfg: Optional[Mapping[str, Any]] = None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    """Return ``(profile_os_users, profile_os_homes)`` from Kanban config."""
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config
+
+            loaded = load_config()
+        except Exception:
+            loaded = {}
+        cfg = loaded if isinstance(loaded, Mapping) else {}
+    kanban = cfg.get("kanban", {}) if isinstance(cfg, Mapping) else {}
+    if not isinstance(kanban, Mapping):
+        kanban = {}
+    users = parse_profile_os_users(kanban.get("profile_os_users"))
+    homes = parse_profile_os_homes(kanban.get("profile_os_homes"))
+    return users, homes
+
+
+def lookup_mapped_os_user(
+    profile: str,
+    mapping: Optional[Mapping[str, str]] = None,
+) -> Optional[str]:
+    """Return the mapped username for *profile*, or None if unmapped."""
+    if mapping is None:
+        mapping, _homes = load_profile_os_user_config()
+    if not mapping:
+        return None
+    canon = _canonical_profile_id(profile)
+    return mapping.get(canon)
+
+
+# ---------------------------------------------------------------------------
+# Argv / env construction (no shell)
+# ---------------------------------------------------------------------------
+
+
+def build_sudo_argv(
+    username: str,
+    inner_argv: Sequence[str],
+    *,
+    sudo_bin: str = DEFAULT_SUDO_BIN,
+) -> list[str]:
+    """Build ``sudo -n -H -E -u <user> -- <inner...>`` as a list.
+
+    Never joins into a shell string. ``--`` terminates sudo options so a
+    hostile inner argv cannot inject sudo flags.
+    """
+    user = validate_os_username(username)
+    if not inner_argv:
+        raise ValueError("inner argv must not be empty")
+    inner = [str(part) for part in inner_argv]
+    if any(part is None for part in inner_argv):  # type: ignore[comparison-overlap]
+        raise ValueError("inner argv must not contain None")
+    sudo = sudo_bin or DEFAULT_SUDO_BIN
+    if not sudo or sudo != str(sudo):
+        raise ValueError("sudo_bin must be a non-empty string")
+    return [str(sudo), "-n", "-H", "-E", "-u", user, "--", *inner]
+
+
+def is_sudo_wrapped(argv: Sequence[str]) -> bool:
+    if len(argv) < 8:
+        return False
+    try:
+        u_idx = list(argv).index("-u")
+    except ValueError:
+        return False
+    return (
+        os.path.basename(str(argv[0])) == "sudo"
+        and "-n" in argv[:u_idx + 1]
+        and "--" in argv
+    )
+
+
+def resolve_mapped_hermes_home(
+    profile: str,
+    pw_dir: str,
+    *,
+    homes: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Hermes runtime home for a mapped profile (not OS HOME).
+
+    Default: ``{pw_dir}/.hermes/profiles/{profile}`` for named profiles,
+    ``{pw_dir}/.hermes`` for ``default``. ``kanban.profile_os_homes`` overrides
+    the Hermes *root* only.
+    """
+    canon = _canonical_profile_id(profile)
+    root = None
+    if homes:
+        root = homes.get(canon)
+    if not root:
+        root = str(Path(pw_dir) / ".hermes")
+    root_path = Path(root)
+    if canon == "default":
+        return str(root_path)
+    if root_path.name == canon and root_path.parent.name == "profiles":
+        return str(root_path)
+    return str(root_path / "profiles" / canon)
+
+
+def _is_inherited_secret_key(key: str) -> bool:
+    upper = key.upper()
+    if any(upper.startswith(p) for p in _SECRET_KEY_PREFIXES):
+        return True
+    if any(upper.endswith(s) for s in _SECRET_KEY_SUFFIXES):
+        return True
+    return False
+
+
+def build_mapped_env(
+    env: Mapping[str, str],
+    *,
+    username: str,
+    home: str,
+    hermes_home: str,
+) -> dict[str, str]:
+    """Copy dispatcher env, pin HOME/HERMES_HOME, drop inherited secrets.
+
+    Specialists must load credentials from their private ``HERMES_HOME/.env``,
+    not from the gateway process environment (which may hold the operator's
+    Cursor key, SSH agent, etc.).
+    """
+    out = {str(k): str(v) for k, v in env.items()}
+    for key in list(out):
+        if _is_inherited_secret_key(key):
+            out.pop(key, None)
+    out["HOME"] = home
+    out["USER"] = username
+    out["LOGNAME"] = username
+    out["HERMES_HOME"] = hermes_home
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Preflight / fail-closed launch
+# ---------------------------------------------------------------------------
+
+
+def _default_getpwnam(name: str) -> PasswdEntry:
+    import pwd
+
+    try:
+        pw = pwd.getpwnam(name)
+    except KeyError as exc:
+        raise MappedLaunchError(
+            f"Mapped OS user {name!r} does not exist. "
+            f"Create it with: sudo hermes kanban os-users setup --apply"
+        ) from exc
+    return PasswdEntry(pw.pw_name, int(pw.pw_uid), int(pw.pw_gid), pw.pw_dir)
+
+
+def _default_run(argv: Sequence[str], **kwargs: Any) -> Any:
+    import subprocess
+
+    return subprocess.run(  # noqa: S603 — argv is a validated list, no shell
+        list(argv),
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=kwargs.get("timeout", 15),
+        env=kwargs.get("env"),
+    )
+
+
+def _hooks_or_defaults(hooks: Optional[LaunchHooks]) -> LaunchHooks:
+    h = hooks or LaunchHooks()
+    if h.getpwnam is None:
+        h.getpwnam = _default_getpwnam
+    if h.geteuid is None:
+        h.geteuid = os.geteuid
+    if h.run is None:
+        h.run = _default_run
+    if h.is_windows is None:
+        h.is_windows = sys.platform.startswith("win")
+    return h
+
+
+def preflight_mapped_user(
+    username: str,
+    *,
+    hooks: Optional[LaunchHooks] = None,
+    hermes_home: Optional[str] = None,
+    workspace: Optional[str] = None,
+    board_db: Optional[str] = None,
+    require_paths: bool = True,
+) -> PasswdEntry:
+    """Validate the mapped account and sudo -n before any useful work."""
+    h = _hooks_or_defaults(hooks)
+    if h.is_windows:
+        raise MappedLaunchError(
+            "kanban.profile_os_users is Linux-only; unset the mapping on Windows"
+        )
+    user = validate_os_username(username)
+    assert h.getpwnam is not None
+    pw = h.getpwnam(user)
+    if pw.pw_uid == 0 or user in _FORBIDDEN_OS_USERS:
+        raise MappedLaunchError(
+            f"Refusing to launch a Kanban worker as {user!r} (uid {pw.pw_uid})"
+        )
+    assert h.geteuid is not None
+    euid = int(h.geteuid())
+    if pw.pw_uid == euid:
+        raise MappedLaunchError(
+            f"kanban.profile_os_users maps to {user!r} which is the same UID "
+            f"as the dispatcher ({euid}). This is not isolation — refusing to "
+            f"report it as such. Use a distinct Linux account or omit the mapping."
+        )
+    sudo_bin = h.sudo_bin or DEFAULT_SUDO_BIN
+    if not os.path.isabs(sudo_bin):
+        raise MappedLaunchError(
+            f"sudo binary must be an absolute path, got {sudo_bin!r}"
+        )
+    if h.run is _default_run and not os.path.isfile(sudo_bin):
+        raise MappedLaunchError(
+            f"sudo binary {sudo_bin} is missing; cannot drop privileges for {user!r}"
+        )
+    id_argv = build_sudo_argv(user, [h.id_bin, "-u"], sudo_bin=sudo_bin)
+    assert h.run is not None
+    try:
+        proc = h.run(id_argv, timeout=15)
+    except FileNotFoundError as exc:
+        raise MappedLaunchError(
+            f"Non-interactive sudo is unavailable ({exc}). "
+            f"Install sudoers via: sudo hermes kanban os-users setup --apply"
+        ) from exc
+    except Exception as exc:
+        raise MappedLaunchError(
+            f"sudo -n -u {user} -- id -u failed: {exc}"
+        ) from exc
+    rc = int(getattr(proc, "returncode", 1))
+    stdout = str(getattr(proc, "stdout", None) or "")
+    stderr = str(getattr(proc, "stderr", None) or "")
+    if rc != 0:
+        detail = (stderr or stdout).strip() or f"exit {rc}"
+        raise MappedLaunchError(
+            f"Non-interactive sudo denied for {user!r}: {detail}. "
+            f"Install the drop-in from `hermes kanban os-users sudoers` "
+            f"and do not enable profile_os_users until check passes."
+        )
+    reported = stdout.strip().splitlines()[0].strip() if stdout.strip() else ""
+    if reported != str(pw.pw_uid):
+        raise MappedLaunchError(
+            f"sudo -n -u {user} reported uid {reported!r}, expected {pw.pw_uid}. "
+            f"Refusing to launch (fail closed)."
+        )
+    if require_paths:
+        _preflight_paths(
+            pw,
+            hermes_home=hermes_home,
+            workspace=workspace,
+            board_db=board_db,
+        )
+    return pw
+
+
+def _preflight_paths(
+    pw: PasswdEntry,
+    *,
+    hermes_home: Optional[str],
+    workspace: Optional[str],
+    board_db: Optional[str],
+) -> None:
+    if hermes_home:
+        home_path = Path(hermes_home)
+        if not home_path.is_dir():
+            raise MappedLaunchError(
+                f"Mapped HERMES_HOME {hermes_home} does not exist or is not a directory. "
+                f"Provision it with: sudo hermes kanban os-users setup --apply"
+            )
+        try:
+            st = home_path.stat()
+        except OSError as exc:
+            raise MappedLaunchError(
+                f"Cannot stat mapped HERMES_HOME {hermes_home}: {exc}"
+            ) from exc
+        if stat.S_IMODE(st.st_mode) & 0o077:
+            raise MappedLaunchError(
+                f"Mapped HERMES_HOME {hermes_home} is group/world-accessible "
+                f"(mode {stat.S_IMODE(st.st_mode):04o}); expected 0700"
+            )
+        if st.st_uid != pw.pw_uid:
+            raise MappedLaunchError(
+                f"Mapped HERMES_HOME {hermes_home} is owned by uid {st.st_uid}, "
+                f"expected {pw.pw_uid} ({pw.pw_name})"
+            )
+    if workspace:
+        ws = Path(workspace)
+        if not ws.is_dir():
+            raise MappedLaunchError(
+                f"Task workspace {workspace} is not an accessible directory"
+            )
+    if board_db:
+        db_path = Path(board_db)
+        parent = db_path.parent
+        if not parent.is_dir():
+            raise MappedLaunchError(
+                f"Shared Kanban DB parent {parent} is missing"
+            )
+
+
+def apply_mapped_worker_launch(
+    *,
+    profile: str,
+    argv: Sequence[str],
+    env: Mapping[str, str],
+    workspace: str = "",
+    board_db: Optional[str] = None,
+    mapping: Optional[Mapping[str, str]] = None,
+    homes: Optional[Mapping[str, str]] = None,
+    hooks: Optional[LaunchHooks] = None,
+    preflight: bool = True,
+) -> tuple[list[str], dict[str, str]]:
+    """Maybe wrap *argv*/*env* for a mapped profile.
+
+    Unmapped profiles return ``(list(argv), dict(env))`` unchanged.
+    Mapped profiles always return sudo-wrapped argv; on any failure this
+    raises ``MappedLaunchError`` instead of returning the inner argv.
+    """
+    inner = [str(p) for p in argv]
+    out_env = dict(env)
+    if mapping is None and homes is None:
+        mapping, homes = load_profile_os_user_config()
+    elif mapping is None:
+        mapping, _ignored = load_profile_os_user_config()
+    username = lookup_mapped_os_user(profile, mapping)
+    if username is None:
+        return inner, out_env
+    h = _hooks_or_defaults(hooks)
+    pw = (
+        preflight_mapped_user(
+            username,
+            hooks=h,
+            hermes_home=None,
+            workspace=None,
+            board_db=None,
+            require_paths=False,
+        )
+        if preflight
+        else _hooks_or_defaults(h).getpwnam(username)  # type: ignore[misc]
+    )
+    hermes_home = resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {})
+    if preflight:
+        _preflight_paths(
+            pw,
+            hermes_home=hermes_home,
+            workspace=workspace,
+            board_db=board_db,
+        )
+    wrapped = build_sudo_argv(username, inner, sudo_bin=h.sudo_bin)
+    mapped_env = build_mapped_env(
+        out_env,
+        username=username,
+        home=pw.pw_dir,
+        hermes_home=hermes_home,
+    )
+    if not is_sudo_wrapped(wrapped):
+        raise MappedLaunchError("internal error: sudo wrap produced unwrapped argv")
+    if wrapped == inner:
+        raise MappedLaunchError("internal error: refusing to launch mapped worker unwrapped")
+    return wrapped, mapped_env
+
+
+# ---------------------------------------------------------------------------
+# Host setup / check / rollback (dry-run first; never prints secrets)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SetupStep:
+    title: str
+    argv: list[str]
+    privileged: bool = True
+
+
+def _quote_cmd(argv: Sequence[str]) -> str:
+    return " ".join(shlex.quote(str(p)) for p in argv)
+
+
+def default_mapping_example() -> dict[str, str]:
+    return {"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"}
+
+
+def _gateway_user() -> str:
+    try:
+        import pwd
+
+        return pwd.getpwuid(os.geteuid()).pw_name
+    except Exception:
+        return os.environ.get("USER") or "matt"
+
+
+def resolve_setup_targets(
+    mapping: Optional[Mapping[str, str]] = None,
+) -> dict[str, str]:
+    if mapping:
+        return dict(mapping)
+    try:
+        loaded, _homes = load_profile_os_user_config()
+    except Exception:
+        loaded = {}
+    return loaded or default_mapping_example()
+
+
+def shared_board_paths() -> dict[str, Path]:
+    from hermes_cli.kanban_db import kanban_db_path, kanban_home, workspaces_root
+
+    db = Path(kanban_db_path())
+    root = Path(kanban_home())
+    return {
+        "hermes_root": root,
+        "kanban_db": db,
+        "kanban_dir": root / "kanban",
+        "workspaces": Path(workspaces_root()),
+        "logs": db.parent / "kanban" / "logs" if db.name != "kanban.db" else root / "kanban" / "logs",
+    }
+
+
+def render_sudoers(
+    *,
+    gateway_user: Optional[str] = None,
+    mapping: Optional[Mapping[str, str]] = None,
+    hermes_argv: Optional[Sequence[str]] = None,
+) -> str:
+    gw = gateway_user or _gateway_user()
+    users = sorted(set(resolve_setup_targets(mapping).values()))
+    runas = ",".join(users) if users else "hermes-dev, hermes-sysadmin"
+    keep = " ".join(SUDO_ENV_KEEP)
+    if hermes_argv is None:
+        try:
+            from hermes_cli.kanban_db import _resolve_hermes_argv
+
+            hermes_argv = _resolve_hermes_argv()
+        except Exception:
+            hermes_argv = ["/usr/bin/hermes"]
+    cmd = _quote_cmd(hermes_argv)
+    id_cmd = DEFAULT_ID_BIN
+    lines = [
+        f"# Hermes Kanban profile_os_users — generated, review before installing",
+        f"# Install: sudo install -m 0440 this-file {DEFAULT_SUDOERS_PATH}",
+        f"# Then: sudo visudo -c -f {DEFAULT_SUDOERS_PATH}",
+        f"Defaults:{gw} !requiretty",
+        f"Defaults:{gw} env_keep += \"{keep}\"",
+        f"{gw} ALL=({runas}) NOPASSWD:SETENV: {id_cmd}",
+        f"{gw} ALL=({runas}) NOPASSWD:SETENV: {cmd}",
+        "",
+    ]
+    return "\n".join(lines)
+
+
+def plan_setup_steps(
+    *,
+    mapping: Optional[Mapping[str, str]] = None,
+    gateway_user: Optional[str] = None,
+    group: str = DEFAULT_GROUP,
+    dev_workspace: Optional[str] = None,
+    hermes_argv: Optional[Sequence[str]] = None,
+) -> list[SetupStep]:
+    targets = resolve_setup_targets(mapping)
+    gw = gateway_user or _gateway_user()
+    steps: list[SetupStep] = [
+        SetupStep("create group", ["groupadd", "--system", group]),
+    ]
+    seen_users: set[str] = set()
+    for profile, user in targets.items():
+        if user in seen_users:
+            continue
+        seen_users.add(user)
+        home = f"/home/{user}"
+        steps.extend([
+            SetupStep(
+                f"create {user}",
+                [
+                    "useradd", "--system", "--create-home",
+                    "--home-dir", home,
+                    "--shell", "/usr/sbin/nologin",
+                    "--gid", group,
+                    user,
+                ],
+            ),
+            SetupStep(
+                f"private Hermes root for {user}",
+                ["install", "-d", "-m", "0700", "-o", user, "-g", user, f"{home}/.hermes"],
+            ),
+            SetupStep(
+                f"private profile dir for {profile}",
+                [
+                    "install", "-d", "-m", "0700", "-o", user, "-g", user,
+                    f"{home}/.hermes/profiles/{profile}",
+                ],
+            ),
+        ])
+    paths = None
+    try:
+        paths = shared_board_paths()
+    except Exception:
+        paths = None
+    if paths:
+        db = str(paths["kanban_db"])
+        kdir = str(paths["kanban_dir"])
+        steps.extend([
+            SetupStep("kanban metadata dir", ["install", "-d", "-m", "2770", "-o", gw, "-g", group, kdir]),
+            SetupStep(
+                "ACL on shared board dir (group + defaults for WAL/shm)",
+                ["setfacl", "-m", f"g:{group}:rwx,d:g:{group}:rwx", kdir],
+            ),
+            SetupStep(
+                "ACL on kanban.db (SQLite needs sibling -wal/-shm)",
+                ["setfacl", "-m", f"g:{group}:rw", db],
+            ),
+        ])
+        ws = str(paths["workspaces"])
+        steps.append(
+            SetupStep(
+                "shared workspaces root (group rwx, no world)",
+                ["install", "-d", "-m", "2770", "-o", gw, "-g", group, ws],
+            )
+        )
+    if dev_workspace:
+        dev_user = targets.get("dev", "hermes-dev")
+        steps.append(
+            SetupStep(
+                f"dev-only ACL on {dev_workspace} (sysadmin is NOT granted this)",
+                ["setfacl", "-m", f"u:{dev_user}:rwx", dev_workspace],
+            )
+        )
+    steps.append(
+        SetupStep(
+            f"add {gw} to {group} for admin visibility",
+            ["usermod", "-aG", group, gw],
+        )
+    )
+    sudoers_body = render_sudoers(
+        gateway_user=gw, mapping=targets, hermes_argv=hermes_argv,
+    )
+    # install via visudo check; body is written to a temp path by the CLI
+    steps.append(
+        SetupStep(
+            "install sudoers drop-in (after visudo -c)",
+            ["install", "-m", "0440", "-o", "root", "-g", "root",
+             "<generated-sudoers>", DEFAULT_SUDOERS_PATH],
+        )
+    )
+    _ = sudoers_body  # generated by the CLI printer, not interpolated here
+    return steps
+
+
+def plan_rollback_steps(
+    *,
+    mapping: Optional[Mapping[str, str]] = None,
+    group: str = DEFAULT_GROUP,
+) -> list[SetupStep]:
+    targets = resolve_setup_targets(mapping)
+    steps = [
+        SetupStep("remove sudoers drop-in", ["rm", "-f", DEFAULT_SUDOERS_PATH]),
+    ]
+    for user in sorted(set(targets.values())):
+        steps.append(SetupStep(f"remove user {user}", ["userdel", "-r", user]))
+    steps.append(SetupStep(f"remove group {group}", ["groupdel", group]))
+    return steps
+
+
+def format_plan(steps: Sequence[SetupStep], *, heading: str) -> str:
+    lines = [heading, "", "All commands are argv (no shell). Review, then run as root.", ""]
+    for i, step in enumerate(steps, 1):
+        lines.append(f"{i}. {step.title}")
+        lines.append(f"   {_quote_cmd(step.argv)}")
+    lines.append("")
+    lines.append("Do not cat/print .env, auth.json, or SSH keys. Copy with install(1):")
+    lines.append("   sudo install -m 0600 -o <user> -g <user> <src-env> /home/<user>/.hermes/profiles/<profile>/.env")
+    lines.append("Config (not secrets) may be copied the same way for config.yaml.")
+    return "\n".join(lines)
+
+
+def migrate_profile_files_commands(
+    mapping: Mapping[str, str],
+    *,
+    source_root: Optional[Path] = None,
+) -> list[str]:
+    """Print install(1) copy commands; never dump file contents."""
+    if source_root is None:
+        try:
+            from hermes_constants import get_default_hermes_root
+
+            source_root = get_default_hermes_root()
+        except Exception:
+            source_root = Path.home() / ".hermes"
+    lines = [
+        "# Credential/config migration (contents are never printed)",
+        "# Review each source path. Skip files that should stay gateway-only.",
+    ]
+    for profile, user in mapping.items():
+        src = Path(source_root) / "profiles" / profile
+        dst = Path(f"/home/{user}") / ".hermes" / "profiles" / profile
+        for name in ("config.yaml", ".env"):
+            mode = "0600" if name == ".env" else "0600"
+            lines.append(
+                _quote_cmd([
+                    "install", "-m", mode, "-o", user, "-g", user,
+                    str(src / name), str(dst / name),
+                ])
+            )
+    return lines
+
+
+@dataclass
+class AuditItem:
+    name: str
+    ok: bool
+    detail: str
+    isolation: bool = False
+
+
+def _mode_ok(path: Path, *, max_other: int = 0) -> tuple[bool, str]:
+    try:
+        st = path.stat()
+    except OSError as exc:
+        return False, f"missing or unreadable: {exc}"
+    mode = stat.S_IMODE(st.st_mode)
+    if mode & 0o007 > max_other:
+        return False, f"{path} mode {mode:04o} allows world access"
+    return True, f"{path} mode {mode:04o} uid={st.st_uid}"
+
+
+def audit_mapping(
+    *,
+    mapping: Optional[Mapping[str, str]] = None,
+    homes: Optional[Mapping[str, str]] = None,
+    hooks: Optional[LaunchHooks] = None,
+) -> list[AuditItem]:
+    items: list[AuditItem] = []
+    if mapping is None:
+        try:
+            mapping, loaded_homes = load_profile_os_user_config()
+        except Exception:
+            mapping, loaded_homes = {}, {}
+        if homes is None:
+            homes = loaded_homes
+    targets = dict(mapping or {})
+    if not targets:
+        items.append(AuditItem(
+            "mapping", True,
+            "empty mapping — trusted-local-user (not isolation)",
+        ))
+        return items
+    h = _hooks_or_defaults(hooks)
+    pw_by_user: dict[str, PasswdEntry] = {}
+    for profile, user in targets.items():
+        try:
+            pw = preflight_mapped_user(
+                user, hooks=h, require_paths=False,
+            )
+            pw_by_user[user] = pw
+            items.append(AuditItem(
+                f"user:{user}", True,
+                f"uid={pw.pw_uid} home={pw.pw_dir} sudo -n ok",
+                isolation=True,
+            ))
+        except (MappedLaunchError, ValueError) as exc:
+            items.append(AuditItem(f"user:{user}", False, str(exc)))
+            continue
+        hermes_home = resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {})
+        ok, detail = _mode_ok(Path(hermes_home), max_other=0)
+        items.append(AuditItem(f"home:{profile}", ok, detail, isolation=ok))
+        env_path = Path(hermes_home) / ".env"
+        if env_path.exists():
+            ok_e, detail_e = _mode_ok(env_path, max_other=0)
+            items.append(AuditItem(f"secrets:{profile}", ok_e, detail_e, isolation=ok_e))
+    # Cross-profile path inequality
+    homes_resolved = []
+    for profile, user in targets.items():
+        pw = pw_by_user.get(user)
+        if pw is None:
+            continue
+        homes_resolved.append((profile, resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {})))
+    for i, (p_a, h_a) in enumerate(homes_resolved):
+        for p_b, h_b in homes_resolved[i + 1:]:
+            same = os.path.realpath(h_a) == os.path.realpath(h_b)
+            items.append(AuditItem(
+                f"cross:{p_a}!={p_b}",
+                not same,
+                "distinct runtime homes" if not same else f"COLLISION {h_a}",
+                isolation=not same,
+            ))
+    try:
+        paths = shared_board_paths()
+        db = paths["kanban_db"]
+        ok, detail = _mode_ok(db.parent, max_other=0)
+        items.append(AuditItem("board-parent", ok or db.parent.is_dir(), f"board parent {db.parent}"))
+        if db.exists():
+            items.append(AuditItem("board-db", True, f"{db} present (WAL sidecars use default ACL)"))
+        else:
+            items.append(AuditItem("board-db", False, f"{db} missing — run hermes kanban init"))
+    except Exception as exc:
+        items.append(AuditItem("board", False, str(exc)))
+    return items
+
+
+def format_audit(items: Sequence[AuditItem]) -> str:
+    lines = ["Kanban profile_os_users audit", ""]
+    failed = 0
+    for item in items:
+        mark = "PASS" if item.ok else "FAIL"
+        iso = " isolation" if item.isolation and item.ok else ""
+        if not item.ok:
+            failed += 1
+        lines.append(f"  [{mark}] {item.name}{iso}: {item.detail}")
+    lines.append("")
+    if failed:
+        lines.append(f"{failed} check(s) failed. Do not enable kanban.profile_os_users yet.")
+    else:
+        lines.append("All checks passed. Enable mappings in the *gateway* config.yaml only after review.")
+        lines.append("Do not restart the gateway from this worker; Matt enables mappings manually.")
+    return "\n".join(lines)
+
+
+def run_os_users_cli(args: Any) -> int:
+    action = getattr(args, "os_users_action", None) or "check"
+    mapping = None
+    homes = None
+    try:
+        mapping, homes = load_profile_os_user_config()
+    except ValueError as exc:
+        print(f"kanban os-users: invalid config: {exc}", file=sys.stderr)
+        return 2
+    if action == "check":
+        items = audit_mapping(mapping=mapping or None, homes=homes)
+        if getattr(args, "json", False):
+            import json
+
+            print(json.dumps({
+                "items": [
+                    {"name": i.name, "ok": i.ok, "detail": i.detail, "isolation": i.isolation}
+                    for i in items
+                ],
+                "ok": all(i.ok for i in items),
+            }, indent=2))
+        else:
+            print(format_audit(items))
+        return 0 if all(i.ok for i in items) else 1
+    if action == "sudoers":
+        print(render_sudoers(mapping=mapping or None))
+        return 0
+    if action == "rollback":
+        steps = plan_rollback_steps(mapping=mapping or None)
+        print(format_plan(steps, heading="Kanban profile_os_users rollback (destructive)"))
+        return 0
+    if action == "setup":
+        gw = getattr(args, "gateway_user", None)
+        dev_ws = getattr(args, "dev_workspace", None)
+        steps = plan_setup_steps(
+            mapping=mapping or None,
+            gateway_user=gw,
+            dev_workspace=dev_ws,
+        )
+        print(format_plan(steps, heading="Kanban profile_os_users setup (dry-run)"))
+        print("")
+        print("\n".join(migrate_profile_files_commands(mapping or default_mapping_example())))
+        print("")
+        print("Sudoers snippet:")
+        print(render_sudoers(mapping=mapping or None, gateway_user=gw))
+        apply = bool(getattr(args, "apply", False))
+        if not apply:
+            print("Dry-run only. Re-run as root with --apply after review.")
+            print("  sudo hermes kanban os-users setup --apply")
+            return 0
+        if os.geteuid() != 0:
+            print(
+                "kanban os-users: --apply requires euid 0. Not prompting for a password.",
+                file=sys.stderr,
+            )
+            print("  sudo hermes kanban os-users setup --apply", file=sys.stderr)
+            return 1
+        # Privileged apply: run argv lists only. Skip the placeholder sudoers source.
+        import subprocess
+
+        for step in steps:
+            if "<generated-sudoers>" in step.argv:
+                tmp = Path("/tmp/hermes-kanban-os-users.sudoers")
+                tmp.write_text(render_sudoers(mapping=mapping or None, gateway_user=gw), encoding="utf-8")
+                os.chmod(tmp, 0o600)
+                check = subprocess.run(  # noqa: S603
+                    ["visudo", "-c", "-f", str(tmp)],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                )
+                if check.returncode != 0:
+                    print(f"visudo -c failed: {check.stderr}", file=sys.stderr)
+                    return 1
+                argv = [
+                    "install", "-m", "0440", "-o", "root", "-g", "root",
+                    str(tmp), DEFAULT_SUDOERS_PATH,
+                ]
+            else:
+                argv = step.argv
+            print(f"# {step.title}")
+            proc = subprocess.run(argv, check=False)  # noqa: S603
+            # useradd/groupadd EEXIST is idempotent success
+            if proc.returncode != 0 and not _idempotent_ok(argv, proc.returncode):
+                print(f"command failed ({proc.returncode}): {_quote_cmd(argv)}", file=sys.stderr)
+                return 1
+        print("Apply complete. Run: hermes kanban os-users check")
+        print("Do not enable profile_os_users until check passes.")
+        return 0
+    print(f"kanban os-users: unknown action {action!r}", file=sys.stderr)
+    return 2
+
+
+def _idempotent_ok(argv: Sequence[str], rc: int) -> bool:
+    if rc == 0:
+        return True
+    cmd = os.path.basename(str(argv[0])) if argv else ""
+    # useradd 9 = already exists; groupadd 9 = already exists (Debian)
+    if cmd in {"useradd", "groupadd"} and rc in {9, 4}:
+        return True
+    return False

--- a/hermes_cli/kanban_os_users.py
+++ b/hermes_cli/kanban_os_users.py
@@ -268,7 +268,7 @@ def build_sudo_argv(
     if not inner_argv:
         raise ValueError("inner argv must not be empty")
     inner = [str(part) for part in inner_argv]
-    if any(part is None for part in inner_argv):  # type: ignore[comparison-overlap]
+    if any(part is None for part in inner_argv):
         raise ValueError("inner argv must not contain None")
     sudo = sudo_bin or DEFAULT_SUDO_BIN
     if not sudo or sudo != str(sudo):
@@ -285,7 +285,7 @@ def is_sudo_wrapped(argv: Sequence[str]) -> bool:
         return False
     return (
         os.path.basename(str(argv[0])) == "sudo"
-        and "-n" in argv[:u_idx + 1]
+        and "-n" in argv[: u_idx + 1]
         and "--" in argv
     )
 
@@ -442,9 +442,7 @@ def preflight_mapped_user(
             f"Install sudoers via: sudo hermes kanban os-users setup --apply"
         ) from exc
     except Exception as exc:
-        raise MappedLaunchError(
-            f"sudo -n -u {user} -- id -u failed: {exc}"
-        ) from exc
+        raise MappedLaunchError(f"sudo -n -u {user} -- id -u failed: {exc}") from exc
     rc = int(getattr(proc, "returncode", 1))
     stdout = str(getattr(proc, "stdout", None) or "")
     stderr = str(getattr(proc, "stderr", None) or "")
@@ -511,9 +509,7 @@ def _preflight_paths(
         db_path = Path(board_db)
         parent = db_path.parent
         if not parent.is_dir():
-            raise MappedLaunchError(
-                f"Shared Kanban DB parent {parent} is missing"
-            )
+            raise MappedLaunchError(f"Shared Kanban DB parent {parent} is missing")
 
 
 def apply_mapped_worker_launch(
@@ -574,7 +570,9 @@ def apply_mapped_worker_launch(
     if not is_sudo_wrapped(wrapped):
         raise MappedLaunchError("internal error: sudo wrap produced unwrapped argv")
     if wrapped == inner:
-        raise MappedLaunchError("internal error: refusing to launch mapped worker unwrapped")
+        raise MappedLaunchError(
+            "internal error: refusing to launch mapped worker unwrapped"
+        )
     return wrapped, mapped_env
 
 
@@ -629,7 +627,9 @@ def shared_board_paths() -> dict[str, Path]:
         "kanban_db": db,
         "kanban_dir": root / "kanban",
         "workspaces": Path(workspaces_root()),
-        "logs": db.parent / "kanban" / "logs" if db.name != "kanban.db" else root / "kanban" / "logs",
+        "logs": db.parent / "kanban" / "logs"
+        if db.name != "kanban.db"
+        else root / "kanban" / "logs",
     }
 
 
@@ -657,7 +657,7 @@ def render_sudoers(
         f"# Install: sudo install -m 0440 this-file {DEFAULT_SUDOERS_PATH}",
         f"# Then: sudo visudo -c -f {DEFAULT_SUDOERS_PATH}",
         f"Defaults:{gw} !requiretty",
-        f"Defaults:{gw} env_keep += \"{keep}\"",
+        f'Defaults:{gw} env_keep += "{keep}"',
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {id_cmd}",
         f"{gw} ALL=({runas}) NOPASSWD:SETENV: {cmd}",
         "",
@@ -688,21 +688,43 @@ def plan_setup_steps(
             SetupStep(
                 f"create {user}",
                 [
-                    "useradd", "--system", "--create-home",
-                    "--home-dir", home,
-                    "--shell", "/usr/sbin/nologin",
-                    "--gid", group,
+                    "useradd",
+                    "--system",
+                    "--create-home",
+                    "--home-dir",
+                    home,
+                    "--shell",
+                    "/usr/sbin/nologin",
+                    "--gid",
+                    group,
                     user,
                 ],
             ),
             SetupStep(
                 f"private Hermes root for {user}",
-                ["install", "-d", "-m", "0700", "-o", user, "-g", user, f"{home}/.hermes"],
+                [
+                    "install",
+                    "-d",
+                    "-m",
+                    "0700",
+                    "-o",
+                    user,
+                    "-g",
+                    user,
+                    f"{home}/.hermes",
+                ],
             ),
             SetupStep(
                 f"private profile dir for {profile}",
                 [
-                    "install", "-d", "-m", "0700", "-o", user, "-g", user,
+                    "install",
+                    "-d",
+                    "-m",
+                    "0700",
+                    "-o",
+                    user,
+                    "-g",
+                    user,
                     f"{home}/.hermes/profiles/{profile}",
                 ],
             ),
@@ -716,7 +738,10 @@ def plan_setup_steps(
         db = str(paths["kanban_db"])
         kdir = str(paths["kanban_dir"])
         steps.extend([
-            SetupStep("kanban metadata dir", ["install", "-d", "-m", "2770", "-o", gw, "-g", group, kdir]),
+            SetupStep(
+                "kanban metadata dir",
+                ["install", "-d", "-m", "2770", "-o", gw, "-g", group, kdir],
+            ),
             SetupStep(
                 "ACL on shared board dir (group + defaults for WAL/shm)",
                 ["setfacl", "-m", f"g:{group}:rwx,d:g:{group}:rwx", kdir],
@@ -748,14 +773,25 @@ def plan_setup_steps(
         )
     )
     sudoers_body = render_sudoers(
-        gateway_user=gw, mapping=targets, hermes_argv=hermes_argv,
+        gateway_user=gw,
+        mapping=targets,
+        hermes_argv=hermes_argv,
     )
     # install via visudo check; body is written to a temp path by the CLI
     steps.append(
         SetupStep(
             "install sudoers drop-in (after visudo -c)",
-            ["install", "-m", "0440", "-o", "root", "-g", "root",
-             "<generated-sudoers>", DEFAULT_SUDOERS_PATH],
+            [
+                "install",
+                "-m",
+                "0440",
+                "-o",
+                "root",
+                "-g",
+                "root",
+                "<generated-sudoers>",
+                DEFAULT_SUDOERS_PATH,
+            ],
         )
     )
     _ = sudoers_body  # generated by the CLI printer, not interpolated here
@@ -778,13 +814,20 @@ def plan_rollback_steps(
 
 
 def format_plan(steps: Sequence[SetupStep], *, heading: str) -> str:
-    lines = [heading, "", "All commands are argv (no shell). Review, then run as root.", ""]
+    lines = [
+        heading,
+        "",
+        "All commands are argv (no shell). Review, then run as root.",
+        "",
+    ]
     for i, step in enumerate(steps, 1):
         lines.append(f"{i}. {step.title}")
         lines.append(f"   {_quote_cmd(step.argv)}")
     lines.append("")
     lines.append("Do not cat/print .env, auth.json, or SSH keys. Copy with install(1):")
-    lines.append("   sudo install -m 0600 -o <user> -g <user> <src-env> /home/<user>/.hermes/profiles/<profile>/.env")
+    lines.append(
+        "   sudo install -m 0600 -o <user> -g <user> <src-env> /home/<user>/.hermes/profiles/<profile>/.env"
+    )
     lines.append("Config (not secrets) may be copied the same way for config.yaml.")
     return "\n".join(lines)
 
@@ -813,8 +856,15 @@ def migrate_profile_files_commands(
             mode = "0600" if name == ".env" else "0600"
             lines.append(
                 _quote_cmd([
-                    "install", "-m", mode, "-o", user, "-g", user,
-                    str(src / name), str(dst / name),
+                    "install",
+                    "-m",
+                    mode,
+                    "-o",
+                    user,
+                    "-g",
+                    user,
+                    str(src / name),
+                    str(dst / name),
                 ])
             )
     return lines
@@ -855,24 +905,32 @@ def audit_mapping(
             homes = loaded_homes
     targets = dict(mapping or {})
     if not targets:
-        items.append(AuditItem(
-            "mapping", True,
-            "empty mapping — trusted-local-user (not isolation)",
-        ))
+        items.append(
+            AuditItem(
+                "mapping",
+                True,
+                "empty mapping — trusted-local-user (not isolation)",
+            )
+        )
         return items
     h = _hooks_or_defaults(hooks)
     pw_by_user: dict[str, PasswdEntry] = {}
     for profile, user in targets.items():
         try:
             pw = preflight_mapped_user(
-                user, hooks=h, require_paths=False,
+                user,
+                hooks=h,
+                require_paths=False,
             )
             pw_by_user[user] = pw
-            items.append(AuditItem(
-                f"user:{user}", True,
-                f"uid={pw.pw_uid} home={pw.pw_dir} sudo -n ok",
-                isolation=True,
-            ))
+            items.append(
+                AuditItem(
+                    f"user:{user}",
+                    True,
+                    f"uid={pw.pw_uid} home={pw.pw_dir} sudo -n ok",
+                    isolation=True,
+                )
+            )
         except (MappedLaunchError, ValueError) as exc:
             items.append(AuditItem(f"user:{user}", False, str(exc)))
             continue
@@ -882,32 +940,49 @@ def audit_mapping(
         env_path = Path(hermes_home) / ".env"
         if env_path.exists():
             ok_e, detail_e = _mode_ok(env_path, max_other=0)
-            items.append(AuditItem(f"secrets:{profile}", ok_e, detail_e, isolation=ok_e))
+            items.append(
+                AuditItem(f"secrets:{profile}", ok_e, detail_e, isolation=ok_e)
+            )
     # Cross-profile path inequality
     homes_resolved = []
     for profile, user in targets.items():
         pw = pw_by_user.get(user)
         if pw is None:
             continue
-        homes_resolved.append((profile, resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {})))
+        homes_resolved.append((
+            profile,
+            resolve_mapped_hermes_home(profile, pw.pw_dir, homes=homes or {}),
+        ))
     for i, (p_a, h_a) in enumerate(homes_resolved):
-        for p_b, h_b in homes_resolved[i + 1:]:
+        for p_b, h_b in homes_resolved[i + 1 :]:
             same = os.path.realpath(h_a) == os.path.realpath(h_b)
-            items.append(AuditItem(
-                f"cross:{p_a}!={p_b}",
-                not same,
-                "distinct runtime homes" if not same else f"COLLISION {h_a}",
-                isolation=not same,
-            ))
+            items.append(
+                AuditItem(
+                    f"cross:{p_a}!={p_b}",
+                    not same,
+                    "distinct runtime homes" if not same else f"COLLISION {h_a}",
+                    isolation=not same,
+                )
+            )
     try:
         paths = shared_board_paths()
         db = paths["kanban_db"]
         ok, detail = _mode_ok(db.parent, max_other=0)
-        items.append(AuditItem("board-parent", ok or db.parent.is_dir(), f"board parent {db.parent}"))
+        items.append(
+            AuditItem(
+                "board-parent", ok or db.parent.is_dir(), f"board parent {db.parent}"
+            )
+        )
         if db.exists():
-            items.append(AuditItem("board-db", True, f"{db} present (WAL sidecars use default ACL)"))
+            items.append(
+                AuditItem(
+                    "board-db", True, f"{db} present (WAL sidecars use default ACL)"
+                )
+            )
         else:
-            items.append(AuditItem("board-db", False, f"{db} missing — run hermes kanban init"))
+            items.append(
+                AuditItem("board-db", False, f"{db} missing — run hermes kanban init")
+            )
     except Exception as exc:
         items.append(AuditItem("board", False, str(exc)))
     return items
@@ -924,10 +999,16 @@ def format_audit(items: Sequence[AuditItem]) -> str:
         lines.append(f"  [{mark}] {item.name}{iso}: {item.detail}")
     lines.append("")
     if failed:
-        lines.append(f"{failed} check(s) failed. Do not enable kanban.profile_os_users yet.")
+        lines.append(
+            f"{failed} check(s) failed. Do not enable kanban.profile_os_users yet."
+        )
     else:
-        lines.append("All checks passed. Enable mappings in the *gateway* config.yaml only after review.")
-        lines.append("Do not restart the gateway from this worker; Matt enables mappings manually.")
+        lines.append(
+            "All checks passed. Enable mappings in the *gateway* config.yaml only after review."
+        )
+        lines.append(
+            "Do not restart the gateway from this worker; Matt enables mappings manually."
+        )
     return "\n".join(lines)
 
 
@@ -945,13 +1026,23 @@ def run_os_users_cli(args: Any) -> int:
         if getattr(args, "json", False):
             import json
 
-            print(json.dumps({
-                "items": [
-                    {"name": i.name, "ok": i.ok, "detail": i.detail, "isolation": i.isolation}
-                    for i in items
-                ],
-                "ok": all(i.ok for i in items),
-            }, indent=2))
+            print(
+                json.dumps(
+                    {
+                        "items": [
+                            {
+                                "name": i.name,
+                                "ok": i.ok,
+                                "detail": i.detail,
+                                "isolation": i.isolation,
+                            }
+                            for i in items
+                        ],
+                        "ok": all(i.ok for i in items),
+                    },
+                    indent=2,
+                )
+            )
         else:
             print(format_audit(items))
         return 0 if all(i.ok for i in items) else 1
@@ -960,7 +1051,9 @@ def run_os_users_cli(args: Any) -> int:
         return 0
     if action == "rollback":
         steps = plan_rollback_steps(mapping=mapping or None)
-        print(format_plan(steps, heading="Kanban profile_os_users rollback (destructive)"))
+        print(
+            format_plan(steps, heading="Kanban profile_os_users rollback (destructive)")
+        )
         return 0
     if action == "setup":
         gw = getattr(args, "gateway_user", None)
@@ -972,7 +1065,11 @@ def run_os_users_cli(args: Any) -> int:
         )
         print(format_plan(steps, heading="Kanban profile_os_users setup (dry-run)"))
         print("")
-        print("\n".join(migrate_profile_files_commands(mapping or default_mapping_example())))
+        print(
+            "\n".join(
+                migrate_profile_files_commands(mapping or default_mapping_example())
+            )
+        )
         print("")
         print("Sudoers snippet:")
         print(render_sudoers(mapping=mapping or None, gateway_user=gw))
@@ -994,7 +1091,10 @@ def run_os_users_cli(args: Any) -> int:
         for step in steps:
             if "<generated-sudoers>" in step.argv:
                 tmp = Path("/tmp/hermes-kanban-os-users.sudoers")
-                tmp.write_text(render_sudoers(mapping=mapping or None, gateway_user=gw), encoding="utf-8")
+                tmp.write_text(
+                    render_sudoers(mapping=mapping or None, gateway_user=gw),
+                    encoding="utf-8",
+                )
                 os.chmod(tmp, 0o600)
                 check = subprocess.run(  # noqa: S603
                     ["visudo", "-c", "-f", str(tmp)],
@@ -1006,8 +1106,15 @@ def run_os_users_cli(args: Any) -> int:
                     print(f"visudo -c failed: {check.stderr}", file=sys.stderr)
                     return 1
                 argv = [
-                    "install", "-m", "0440", "-o", "root", "-g", "root",
-                    str(tmp), DEFAULT_SUDOERS_PATH,
+                    "install",
+                    "-m",
+                    "0440",
+                    "-o",
+                    "root",
+                    "-g",
+                    "root",
+                    str(tmp),
+                    DEFAULT_SUDOERS_PATH,
                 ]
             else:
                 argv = step.argv
@@ -1015,7 +1122,10 @@ def run_os_users_cli(args: Any) -> int:
             proc = subprocess.run(argv, check=False)  # noqa: S603
             # useradd/groupadd EEXIST is idempotent success
             if proc.returncode != 0 and not _idempotent_ok(argv, proc.returncode):
-                print(f"command failed ({proc.returncode}): {_quote_cmd(argv)}", file=sys.stderr)
+                print(
+                    f"command failed ({proc.returncode}): {_quote_cmd(argv)}",
+                    file=sys.stderr,
+                )
                 return 1
         print("Apply complete. Run: hermes kanban os-users check")
         print("Do not enable profile_os_users until check passes.")

--- a/hermes_cli/kanban_os_users_rollout.py
+++ b/hermes_cli/kanban_os_users_rollout.py
@@ -1,0 +1,405 @@
+"""Rollout helpers for profile-to-UID setup: dedicated board, copy, SHA, toolchain."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import stat
+import sys
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+DEFAULT_DEV_WORKSPACE = "/home/matt/Documents/WorkoutTracker"
+DEFAULT_FLUTTER_SDK = "/home/matt/flutter"
+DEFAULT_ANDROID_SDK = "/home/matt/Android/Sdk"
+DEFAULT_JDK_HOME = "/home/matt/.local/opt/jdk-17"
+DEFAULT_GH_BIN = "/usr/bin/gh"
+DEFAULT_GIT_BIN = "/usr/bin/git"
+VERSIONED_RUNTIME_ROOT = "/opt/hermes/kanban-os-users"
+GITHUB_LS_REMOTE_URL = "https://github.com/NousResearch/hermes-agent.git"
+_SECRET_BASENAMES = frozenset({
+    ".env",
+    "auth.json",
+    "id_rsa",
+    "id_ecdsa",
+    "id_ed25519",
+    "id_dsa",
+    "credentials.json",
+})
+
+
+def _quote_cmd(argv: Sequence[str]) -> str:
+    return " ".join(shlex.quote(str(p)) for p in argv)
+
+
+def self_hermes_argv(hermes_argv: Optional[Sequence[str]] = None) -> list[str]:
+    """Argv for *this* tree's CLI. Never assume an installed `hermes` binary."""
+    if hermes_argv:
+        return [str(p) for p in hermes_argv]
+    return [sys.executable, "-m", "hermes_cli.main"]
+
+
+def apply_command_hint(hermes_argv: Optional[Sequence[str]] = None) -> str:
+    argv = self_hermes_argv(hermes_argv) + [
+        "kanban",
+        "os-users",
+        "setup",
+        "--apply",
+    ]
+    return "sudo " + _quote_cmd(argv)
+
+
+def feature_source_root() -> Path:
+    return Path(__file__).resolve().parents[1]
+
+
+def feature_source_sha() -> Optional[str]:
+    root = feature_source_root()
+    git = root / ".git"
+    try:
+        if git.is_file():
+            text = git.read_text(encoding="utf-8").strip()
+            if not text.startswith("gitdir:"):
+                return None
+            gitdir = Path(text.split(":", 1)[1].strip())
+            if not gitdir.is_absolute():
+                gitdir = (root / gitdir).resolve()
+        elif git.is_dir():
+            gitdir = git
+        else:
+            return None
+        head = (gitdir / "HEAD").read_text(encoding="utf-8").strip()
+        if head.startswith("ref:"):
+            ref = head.split(":", 1)[1].strip()
+            return (gitdir / ref).read_text(encoding="utf-8").strip()[:40]
+        return head[:40]
+    except OSError:
+        return None
+
+
+def hermes_argv_covers_feature(
+    hermes_argv: Sequence[str], feature_root: Optional[Path] = None
+) -> bool:
+    root = str((feature_root or feature_source_root()).resolve())
+    for part in hermes_argv:
+        raw = str(part)
+        try:
+            resolved = str(Path(raw).resolve())
+        except OSError:
+            resolved = raw
+        if root in resolved or resolved.startswith(root):
+            return True
+        if root in raw:
+            return True
+    return False
+
+
+def dedicated_shared_db_path(hermes_root: Path) -> Path:
+    return Path(hermes_root) / "kanban" / "kanban.db"
+
+
+def _same_path(a: Path, b: Path) -> bool:
+    try:
+        return a.resolve() == b.resolve()
+    except OSError:
+        return str(a) == str(b)
+
+
+def shared_board_acl_layout(paths: Mapping[str, Path]) -> dict[str, Any]:
+    """Retarget WAL/write ACLs off the Hermes root onto a dedicated kanban dir."""
+    live_db = Path(paths["kanban_db"])
+    hermes_root = Path(paths["hermes_root"]) if "hermes_root" in paths else None
+    if "kanban_dir" in paths:
+        kdir = Path(paths["kanban_dir"])
+    elif hermes_root is not None:
+        kdir = hermes_root / "kanban"
+    else:
+        kdir = live_db.parent / "kanban"
+    needs_migration = False
+    if hermes_root is not None and _same_path(live_db.parent, hermes_root):
+        writable_dir = kdir
+        target_db = kdir / "kanban.db"
+        try:
+            needs_migration = live_db.exists() and not _same_path(live_db, target_db)
+        except OSError:
+            needs_migration = live_db.exists()
+    else:
+        writable_dir = live_db.parent
+        target_db = live_db
+    if hermes_root is not None and _same_path(writable_dir, hermes_root):
+        raise ValueError(
+            f"refusing write ACL on Hermes root {hermes_root}; "
+            "shared board must live in a dedicated directory"
+        )
+    return {
+        "hermes_root": hermes_root,
+        "writable_dir": writable_dir,
+        "target_db": target_db,
+        "live_db": live_db,
+        "needs_migration": needs_migration,
+        "kanban_dir": kdir,
+    }
+
+
+def setfacl_is_write(argv: Sequence[str]) -> bool:
+    blob = " ".join(str(p) for p in argv)
+    if (
+        ":--x" in blob
+        and ":wx" not in blob
+        and ":rw" not in blob
+        and ":rwx" not in blob
+    ):
+        return False
+    return any(tok in blob for tok in (":wx", ":rwx", ":rw"))
+
+
+def reject_write_acl_on_hermes_root(steps: Sequence[Any], hermes_root: Path) -> None:
+    root = str(hermes_root)
+    for step in steps:
+        argv = list(getattr(step, "argv", []) or [])
+        if not argv or argv[0] != "setfacl":
+            continue
+        if str(argv[-1]) != root:
+            continue
+        if setfacl_is_write(argv):
+            raise ValueError(f"refusing write ACL on Hermes root: {_quote_cmd(argv)}")
+
+
+def sqlite_backup_copy(src: str | Path, dst: str | Path) -> None:
+    """Online-safe SQLite backup. Never raw-copy a live DB or its WAL/SHM."""
+    import sqlite3
+
+    src_p = Path(src)
+    dst_p = Path(dst)
+    if src_p.is_symlink() or dst_p.is_symlink():
+        raise RuntimeError("refusing to backup via symlink")
+    if not src_p.is_file():
+        raise RuntimeError(f"source DB {src_p} does not exist")
+    dst_p.parent.mkdir(parents=True, exist_ok=True)
+    src_con = sqlite3.connect(f"file:{src_p}?mode=ro", uri=True, timeout=30)
+    dst_con = sqlite3.connect(str(dst_p), timeout=30)
+    try:
+        src_con.backup(dst_con)
+        dst_con.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        dst_con.commit()
+    finally:
+        dst_con.close()
+        src_con.close()
+
+
+def summarize_tree(src: Path) -> dict[str, Any]:
+    files = 0
+    dirs = 0
+    symlinks = 0
+    if not src.exists():
+        return {"files": 0, "dirs": 0, "symlinks": 0, "missing": True}
+    if src.is_symlink():
+        return {"files": 0, "dirs": 0, "symlinks": 1, "missing": False}
+    for dirpath, dirnames, filenames in os.walk(src, followlinks=False):
+        kept: list[str] = []
+        for name in dirnames:
+            child = Path(dirpath) / name
+            if child.is_symlink():
+                symlinks += 1
+            else:
+                kept.append(name)
+                dirs += 1
+        dirnames[:] = kept
+        for name in filenames:
+            child = Path(dirpath) / name
+            if child.is_symlink():
+                symlinks += 1
+            else:
+                files += 1
+    return {"files": files, "dirs": dirs, "symlinks": symlinks, "missing": False}
+
+
+def _maybe_chown(path: Path, owner: str, group: str) -> None:
+    if os.geteuid() != 0:
+        return
+    try:
+        import grp
+        import pwd
+
+        os.chown(path, pwd.getpwnam(owner).pw_uid, grp.getgrnam(group).gr_gid)
+    except (KeyError, LookupError, OSError, PermissionError):
+        return
+
+
+def copy_tree_reject_symlinks(
+    src: str | Path,
+    dst: str | Path,
+    *,
+    owner: str,
+    group: str,
+) -> dict[str, int]:
+    """Copy a directory tree. Rejects symlinks and never prints file contents."""
+    src_p = Path(src)
+    dst_p = Path(dst)
+    if src_p.is_symlink() or dst_p.is_symlink():
+        raise RuntimeError(f"refusing symlink copy root {src_p} -> {dst_p}")
+    if ".." in src_p.parts or ".." in dst_p.parts:
+        raise RuntimeError("refusing path with ..")
+    if not src_p.is_dir():
+        raise RuntimeError(f"copy-tree source is not a directory: {src_p}")
+    stats = {"files": 0, "dirs": 1, "rejected_symlinks": 0}
+    dst_p.mkdir(parents=True, exist_ok=True)
+    os.chmod(dst_p, 0o700)
+    _maybe_chown(dst_p, owner, group)
+    for dirpath, dirnames, filenames in os.walk(src_p, followlinks=False):
+        rel = Path(dirpath).relative_to(src_p)
+        kept: list[str] = []
+        for name in dirnames:
+            child = Path(dirpath) / name
+            if child.is_symlink():
+                stats["rejected_symlinks"] += 1
+                continue
+            kept.append(name)
+            dest_dir = dst_p / rel / name
+            dest_dir.mkdir(parents=True, exist_ok=True)
+            mode = stat.S_IMODE(child.stat().st_mode) & 0o755
+            os.chmod(dest_dir, mode or 0o700)
+            _maybe_chown(dest_dir, owner, group)
+            stats["dirs"] += 1
+        dirnames[:] = kept
+        for name in filenames:
+            child = Path(dirpath) / name
+            if child.is_symlink():
+                stats["rejected_symlinks"] += 1
+                continue
+            dest_file = dst_p / rel / name
+            dest_file.parent.mkdir(parents=True, exist_ok=True)
+            with open(child, "rb") as inf, open(dest_file, "wb") as outf:
+                while True:
+                    chunk = inf.read(1024 * 1024)
+                    if not chunk:
+                        break
+                    outf.write(chunk)
+            mode = stat.S_IMODE(child.stat().st_mode)
+            if child.name in _SECRET_BASENAMES or child.name == ".env":
+                os.chmod(dest_file, 0o600)
+            else:
+                os.chmod(dest_file, mode & 0o644)
+            _maybe_chown(dest_file, owner, group)
+            stats["files"] += 1
+    return stats
+
+
+def copy_tree_argv(
+    src: Path,
+    dst: Path,
+    *,
+    owner: str,
+    group: str,
+    hermes_argv: Optional[Sequence[str]] = None,
+) -> list[str]:
+    return self_hermes_argv(hermes_argv) + [
+        "kanban",
+        "os-users",
+        "copy-tree",
+        "--src",
+        str(src),
+        "--dst",
+        str(dst),
+        "--owner",
+        owner,
+        "--group",
+        group,
+    ]
+
+
+def migrate_db_argv(
+    src: Path,
+    dst: Path,
+    *,
+    hermes_argv: Optional[Sequence[str]] = None,
+) -> list[str]:
+    return self_hermes_argv(hermes_argv) + [
+        "kanban",
+        "os-users",
+        "migrate-db",
+        "--from",
+        str(src),
+        "--to",
+        str(dst),
+    ]
+
+
+def default_toolchain_if_present() -> dict[str, str]:
+    out: dict[str, str] = {}
+    for key, path in (
+        ("flutter_sdk", DEFAULT_FLUTTER_SDK),
+        ("android_sdk", DEFAULT_ANDROID_SDK),
+        ("jdk_home", DEFAULT_JDK_HOME),
+    ):
+        if Path(path).exists():
+            out[key] = path
+    return out
+
+
+def extra_sudoers_bins(
+    *,
+    flutter_sdk: Optional[str] = None,
+    android_sdk: Optional[str] = None,
+    jdk_home: Optional[str] = None,
+) -> list[str]:
+    bins: list[str] = []
+    for path in (DEFAULT_GH_BIN, DEFAULT_GIT_BIN):
+        if Path(path).is_file():
+            bins.append(path)
+    if flutter_sdk:
+        flutter = Path(flutter_sdk) / "bin" / "flutter"
+        dart = Path(flutter_sdk) / "bin" / "dart"
+        if flutter.is_file():
+            bins.append(str(flutter))
+        if dart.is_file():
+            bins.append(str(dart))
+    if jdk_home:
+        java = Path(jdk_home) / "bin" / "java"
+        if java.is_file():
+            bins.append(str(java))
+    _ = android_sdk
+    return bins
+
+
+def format_rollout_and_rollback(*, hermes_argv: Optional[Sequence[str]] = None) -> str:
+    hint = apply_command_hint(hermes_argv)
+    sha = feature_source_sha() or "(unknown)"
+    runtime = f"{VERSIONED_RUNTIME_ROOT}/{sha}"
+    return "\n".join([
+        "## Ordered rollout (do not skip; mid-step failure must leave the live board recoverable)",
+        "1. Deploy this reviewed commit first. Preferred: wait for upstream merge + upgrade.",
+        f"   Alternative: install SHA {sha} into {runtime} and point HERMES_BIN + gateway unit + sudoers at that argv.",
+        "   `sudo hermes` may invoke the old installed CLI without os-users — do not use it.",
+        f"   Apply with: {hint}",
+        "2. Create private groups/users and specialist homes. Do not enable profile_os_users yet.",
+        "3. Create the dedicated shared dir (~/.hermes/kanban/) with group wx. Hermes root gets traverse-only (--x), never write.",
+        "4. Quiesce the gateway (stop/restart window you control). Live ~/.hermes/kanban.db stays untouched until backup succeeds.",
+        "5. sqlite backup API (migrate-db), not cp of a live DB/WAL/SHM, into ~/.hermes/kanban/kanban.db.",
+        "6. Pin HERMES_KANBAN_DB to the dedicated path in the gateway service. Restart onto the versioned runtime.",
+        "7. Toolchain: narrow u:hermes-dev:r-x on Flutter/SDK/JDK; private caches under /home/hermes-dev/.cache. No recursive ACL on /home/matt.",
+        "8. Manual gates: --migrate-profile-files (bounded copy-tree), then gh auth login as hermes-dev (never copy SSH keys).",
+        "9. hermes kanban os-users check must pass SHA/runtime, WAL-in-dedicated-dir, gh/git, toolchain, and secret denials.",
+        "10. Only then enable kanban.profile_os_users in the *gateway* config and restart. Isolation is false until the live dispatcher runs this SHA.",
+        "",
+        "## Rollback (recover the current gateway/board)",
+        "1. Remove profile_os_users from gateway config and restart onto the previous HERMES_BIN. Mapping-off is the recoverability gate.",
+        "2. Point HERMES_KANBAN_DB back at the pre-cutover file if the dedicated copy is untrusted. Keep the backup; do not delete the live DB first.",
+        "3. Remove the sudoers drop-in and visudo -c.",
+        "4. Reverse recorded ACLs. userdel/groupdel only principals created by this setup (state file).",
+        "5. Group membership and toolchain ACLs can wait; the board is already served by the previous runtime.",
+        "",
+        "Do not cat/print .env, auth.json, gh tokens, or SSH keys.",
+    ])
+
+
+def github_manual_gate_lines(dev_user: str = "hermes-dev") -> list[str]:
+    return [
+        "# GitHub continuity (secret-safe manual gate — never copy ~/.ssh or print tokens)",
+        f"# As root, in a tty you start: sudo -u {dev_user} -H gh auth login --hostname github.com --git-protocol https",
+        f"# Prove: sudo -n -u {dev_user} -- {DEFAULT_GH_BIN} api user",
+        f"# Prove: sudo -n -u {dev_user} -- {DEFAULT_GIT_BIN} ls-remote {GITHUB_LS_REMOTE_URL} HEAD",
+        "# Do not copy Matt's SSH keys into the specialist home.",
+        f"# Optional workspace: {DEFAULT_DEV_WORKSPACE}",
+        f"# Isolation does not include world-readable code trees; prove denial of .ssh and credentials instead.",
+    ]

--- a/tests/hermes_cli/test_kanban_os_users_rollout.py
+++ b/tests/hermes_cli/test_kanban_os_users_rollout.py
@@ -1,0 +1,258 @@
+"""Rollout helpers: dedicated board ACLs, sqlite backup, bounded copy, SHA gates."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.kanban_os_users import (
+    DEFAULT_GROUP,
+    LaunchHooks,
+    PasswdEntry,
+    audit_mapping,
+    migrate_profile_files_commands,
+    plan_migrate_steps,
+    plan_setup_steps,
+)
+from hermes_cli.kanban_os_users_rollout import (
+    apply_command_hint,
+    copy_tree_reject_symlinks,
+    feature_source_root,
+    format_rollout_and_rollback,
+    hermes_argv_covers_feature,
+    reject_write_acl_on_hermes_root,
+    shared_board_acl_layout,
+    sqlite_backup_copy,
+    summarize_tree,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="profile_os_users is a Linux privilege-drop feature",
+)
+
+MAPPING = {"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"}
+
+
+class _Step:
+    def __init__(self, argv):
+        self.argv = argv
+
+
+class _Proc:
+    def __init__(self, rc=0, stdout="", stderr=""):
+        self.returncode = rc
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _pw(name="hermes-dev", uid=2001, gid=2001, home=None):
+    return PasswdEntry(name, uid, gid, home or f"/home/{name}")
+
+
+def _board_paths(tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "matt" / ".hermes"
+    root.mkdir(parents=True)
+    db = root / "kanban.db"
+    db.write_bytes(b"")
+    kdir = root / "kanban"
+    kdir.mkdir()
+    ws = kdir / "workspaces"
+    ws.mkdir()
+    return {
+        "hermes_root": root,
+        "kanban_db": db,
+        "kanban_dir": kdir,
+        "workspaces": ws,
+    }
+
+
+def test_layout_retargets_write_off_hermes_root(tmp_path):
+    paths = _board_paths(tmp_path)
+    layout = shared_board_acl_layout(paths)
+    assert layout["writable_dir"] == paths["kanban_dir"]
+    assert layout["target_db"] == paths["kanban_dir"] / "kanban.db"
+    assert layout["needs_migration"] is True
+    assert layout["writable_dir"] != paths["hermes_root"]
+
+
+def test_plan_setup_never_write_acl_on_hermes_root(tmp_path):
+    paths = _board_paths(tmp_path)
+    steps = plan_setup_steps(mapping=MAPPING, gateway_user="matt", board_paths=paths)
+    hermes_root = str(paths["hermes_root"])
+    kdir = str(paths["kanban_dir"])
+    setfacls = [s.argv for s in steps if s.argv and s.argv[0] == "setfacl"]
+    root_acls = [a for a in setfacls if a[-1] == hermes_root]
+    assert root_acls
+    assert all("g:hermes-kanban:--x" in a for a in root_acls)
+    assert not any(":wx" in " ".join(a) or ":rw" in " ".join(a) for a in root_acls)
+    kdir_acls = [a for a in setfacls if a[-1] == kdir]
+    assert any("g:hermes-kanban:wx" in a for a in kdir_acls)
+    assert any("-d" in a and "g:hermes-kanban:rw" in a for a in kdir_acls)
+    reject_write_acl_on_hermes_root(steps, paths["hermes_root"])
+
+
+def test_reject_write_acl_on_hermes_root_raises(tmp_path):
+    root = tmp_path / ".hermes"
+    root.mkdir()
+    with pytest.raises(ValueError, match="refusing write ACL"):
+        reject_write_acl_on_hermes_root(
+            [_Step(["setfacl", "-m", "g:hermes-kanban:wx", str(root)])],
+            root,
+        )
+
+
+def test_sqlite_backup_not_raw_copy(tmp_path):
+    src = tmp_path / "live.db"
+    dst = tmp_path / "dedicated" / "kanban.db"
+    con = sqlite3.connect(str(src))
+    con.execute("CREATE TABLE t (id INTEGER, note TEXT)")
+    con.execute("INSERT INTO t VALUES (1, 'secret-should-not-print')")
+    con.commit()
+    con.close()
+    sqlite_backup_copy(src, dst)
+    out = sqlite3.connect(str(dst))
+    row = out.execute("SELECT id FROM t").fetchone()
+    out.close()
+    assert row == (1,)
+    assert dst.is_file()
+
+
+def test_copy_tree_rejects_symlinks_and_preserves_files(tmp_path):
+    src = tmp_path / "skills"
+    dst = tmp_path / "out"
+    (src / "nested").mkdir(parents=True)
+    (src / "nested" / "ok.md").write_text("# skill\n", encoding="utf-8")
+    (src / ".env").write_text("TOKEN=super-secret\n", encoding="utf-8")
+    os.symlink(src / "nested" / "ok.md", src / "link.md")
+    stats = copy_tree_reject_symlinks(src, dst, owner="matt", group="matt")
+    assert stats["rejected_symlinks"] >= 1
+    assert (dst / "nested" / "ok.md").is_file()
+    assert not (dst / "link.md").exists()
+    assert (dst / ".env").read_text(encoding="utf-8") == "TOKEN=super-secret\n"
+    assert oct(os.stat(dst / ".env").st_mode & 0o777) == "0o600"
+
+
+def test_migrate_dry_run_summarizes_instead_of_per_file_flood(tmp_path):
+    src = tmp_path / "profiles" / "dev" / "skills"
+    src.mkdir(parents=True)
+    for i in range(200):
+        (src / f"skill-{i:03d}.md").write_text("# x\n", encoding="utf-8")
+    (tmp_path / "profiles" / "dev" / ".env").write_text(
+        "CURSOR_API_KEY=super-secret\n", encoding="utf-8"
+    )
+    text = "\n".join(
+        migrate_profile_files_commands({"dev": "hermes-dev"}, source_root=tmp_path)
+    )
+    assert "super-secret" not in text
+    assert "CURSOR_API_KEY=" not in text
+    assert "files=200" in text
+    assert text.count("copy-tree") == 1
+    assert len(text) < 8000
+    steps = plan_migrate_steps({"dev": "hermes-dev"}, source_root=tmp_path)
+    assert len(steps) <= 8
+    summary = summarize_tree(src)
+    assert summary["files"] == 200
+
+
+def test_installed_hermes_argv_does_not_cover_feature():
+    assert hermes_argv_covers_feature(["/usr/bin/hermes"]) is False
+    root = feature_source_root()
+    assert hermes_argv_covers_feature([sys.executable, "-m", "hermes_cli.main"]) or (
+        hermes_argv_covers_feature([
+            str(root / ".venv" / "bin" / "python"),
+            "-m",
+            "hermes_cli.main",
+        ])
+        or hermes_argv_covers_feature([str(root / "cli.py")])
+    )
+    hint = apply_command_hint([sys.executable, "-m", "hermes_cli.main"])
+    assert hint.startswith("sudo ")
+    assert "sudo hermes " not in hint
+
+
+def test_host_gates_fail_closed_on_old_runtime_and_ssh(tmp_path):
+    pw = _pw()
+    hermes_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    hermes_home.mkdir(parents=True)
+    os.chmod(hermes_home, 0o700)
+    (hermes_home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (hermes_home / ".env").write_text("TOKEN=hidden\n", encoding="utf-8")
+    (hermes_home / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+    (hermes_home / "skills").mkdir()
+    os.chmod(hermes_home / ".env", 0o600)
+    db_parent = tmp_path / "kanban"
+    db_parent.mkdir()
+    db = db_parent / "kanban.db"
+    db.write_bytes(b"")
+
+    def run(argv, **kwargs):
+        if "/usr/bin/id" in argv or (
+            len(argv) >= 2 and argv[-2:] == ["/usr/bin/id", "-u"]
+        ):
+            return _Proc(0, stdout=f"{pw.pw_uid}\n")
+        path = argv[-1] if argv else ""
+        if path == "/home/matt/.ssh" or "id_" in str(path):
+            return _Proc(1)
+        if argv and "gh" in argv[-3:]:
+            return _Proc(0, stdout='{"login": "should-not-appear"}\n')
+        if argv and "ls-remote" in argv:
+            return _Proc(0, stdout="abc HEAD\n")
+        return _Proc(0)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: pw,
+        geteuid=lambda: 1000,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        id_bin="/usr/bin/id",
+        is_windows=False,
+    )
+    items = audit_mapping(
+        mapping={"dev": "hermes-dev"},
+        homes={"dev": str(hermes_home)},
+        hooks=hooks,
+        board_paths={"kanban_db": db, "hermes_root": tmp_path / "not-parent"},
+        wal_prover=lambda u, p: None,
+        host_gates=True,
+        hermes_argv=["/usr/bin/hermes"],
+    )
+    by_name = {i.name: i for i in items}
+    assert by_name["runtime-sha"].ok is False
+    assert by_name["runtime-sha"].isolation is False
+    assert by_name["github-api"].ok is True
+    assert "should-not-appear" not in by_name["github-api"].detail
+    assert "hidden" not in " ".join(i.detail for i in items)
+    assert by_name["deny-matt-ssh"].ok is True
+
+
+def test_docs_and_rollout_text_cover_gates():
+    docs = (
+        Path(__file__).resolve().parents[2] / "docs" / "kanban" / "profile-os-users.md"
+    )
+    text = docs.read_text(encoding="utf-8")
+    assert ".venv/bin/python" in text
+    assert "./venv/bin/python" not in text
+    assert "/home/matt/Documents/WorkoutTracker" in text
+    assert "--dev-workspace /home/matt/WorkoutTracker" not in text
+    assert "makes the shared group the primary group" in text
+    assert "-g hermes-dev" in text
+    assert "-G hermes-kanban" in text
+    assert "--migrate-profile-files" in text
+    assert "HERMES_KANBAN_DB" in text
+    assert "/home/matt/.hermes/kanban/kanban.db" in text
+    assert "never write" in text.lower() or "never put a write ACL" in text.lower()
+    assert "sudo hermes" in text and "Do not use it" in text
+    assert "/opt/hermes/kanban-os-users" in text
+    assert "gh api user" in text
+    blob = format_rollout_and_rollback(
+        hermes_argv=[sys.executable, "-m", "hermes_cli.main"]
+    )
+    assert "Ordered rollout" in blob
+    assert "Rollback" in blob
+    assert "sqlite backup" in blob.lower() or "migrate-db" in blob

--- a/tests/hermes_cli/test_kanban_os_users_setup.py
+++ b/tests/hermes_cli/test_kanban_os_users_setup.py
@@ -1,0 +1,568 @@
+"""Regression tests for profile_os_users setup, ACL, audit, and rollback."""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.kanban_os_users import (
+    DEFAULT_GROUP,
+    GroupEntry,
+    IncompatiblePrincipalError,
+    LaunchHooks,
+    PasswdEntry,
+    _idempotent_ok,
+    audit_mapping,
+    execute_setup_plan,
+    existing_user_compatible,
+    mapped_home_ready,
+    migrate_profile_files_commands,
+    plan_rollback_steps,
+    plan_setup_steps,
+    probe_user_access,
+    prove_sqlite_wal_lifecycle,
+    render_sudoers,
+    run_os_users_cli,
+    save_os_users_state,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="profile_os_users is a Linux privilege-drop feature",
+)
+
+MAPPING = {"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"}
+WORKSPACE = "/home/matt/Documents/WorkoutTracker"
+
+
+class _Proc:
+    def __init__(self, rc=0, stdout="", stderr=""):
+        self.returncode = rc
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _pw(name="hermes-dev", uid=2001, gid=2001, home=None):
+    return PasswdEntry(name, uid, gid, home or f"/home/{name}")
+
+
+def _board_paths(tmp_path: Path) -> dict[str, Path]:
+    root = tmp_path / "matt" / ".hermes"
+    root.mkdir(parents=True)
+    db = root / "kanban.db"
+    db.write_bytes(b"")
+    kdir = root / "kanban"
+    kdir.mkdir()
+    ws = kdir / "workspaces"
+    ws.mkdir()
+    return {
+        "hermes_root": root,
+        "kanban_db": db,
+        "kanban_dir": kdir,
+        "workspaces": ws,
+    }
+
+
+def _argv_blob(steps) -> str:
+    return "\n".join(" ".join(step.argv) for step in steps)
+
+
+def test_plan_setup_uses_private_groups_not_shared_gid():
+    steps = plan_setup_steps(
+        mapping=MAPPING,
+        gateway_user="matt",
+        board_paths={},
+    )
+    blob = _argv_blob(steps)
+    assert "--gid hermes-kanban" not in blob
+    useradds = [s.argv for s in steps if s.argv and s.argv[0] == "useradd"]
+    assert useradds
+    for argv in useradds:
+        user = argv[-1]
+        assert "-g" in argv
+        assert argv[argv.index("-g") + 1] == user
+        assert "-G" in argv
+        assert argv[argv.index("-G") + 1] == DEFAULT_GROUP
+    groups = [s.argv[-1] for s in steps if s.argv[:2] == ["groupadd", "--system"]]
+    assert DEFAULT_GROUP in groups
+    assert "hermes-dev" in groups
+    assert "hermes-sysadmin" in groups
+    installs = [s.argv for s in steps if s.argv[:2] == ["install", "-d"]]
+    assert any("-g" in a and a[a.index("-g") + 1] == "hermes-dev" for a in installs)
+
+
+def test_plan_setup_acls_actual_db_parent_not_kanban_subdir(tmp_path):
+    paths = _board_paths(tmp_path)
+    steps = plan_setup_steps(
+        mapping=MAPPING,
+        gateway_user="matt",
+        board_paths=paths,
+    )
+    blob = _argv_blob(steps)
+    db_parent = str(paths["kanban_db"].parent)
+    kdir = str(paths["kanban_dir"])
+    assert f"g:{DEFAULT_GROUP}:wx" in blob
+    assert db_parent in blob
+    assert (
+        f"g:{DEFAULT_GROUP}:rwx" not in blob
+        or kdir not in blob.split(f"g:{DEFAULT_GROUP}:rwx")[-1][:200]
+    )
+    setfacls = [s.argv for s in steps if s.argv and s.argv[0] == "setfacl"]
+    db_parent_acls = [a for a in setfacls if a[-1] == db_parent]
+    assert any("g:hermes-kanban:wx" in a for a in db_parent_acls)
+    assert any("-d" in a and "g:hermes-kanban:rw" in a for a in db_parent_acls)
+    kdir_wal = [
+        a for a in setfacls if a[-1] == kdir and "g:hermes-kanban:rwx" in " ".join(a)
+    ]
+    assert kdir_wal == []
+    ancestors = [a for a in setfacls if "g:hermes-kanban:--x" in a]
+    assert ancestors
+    assert any(str(paths["hermes_root"].parent) == a[-1] for a in ancestors)
+
+
+def test_plan_setup_workspace_ancestor_acl_not_sysadmin():
+    steps = plan_setup_steps(
+        mapping=MAPPING,
+        gateway_user="matt",
+        dev_workspace=WORKSPACE,
+        board_paths={},
+    )
+    setfacls = [s.argv for s in steps if s.argv and s.argv[0] == "setfacl"]
+    titles = " ".join(s.title for s in steps)
+    assert "sysadmin is NOT granted" in titles
+    assert any(a[-1] == "/home/matt" and "u:hermes-dev:--x" in a for a in setfacls)
+    assert any(
+        a[-1] == "/home/matt/Documents" and "u:hermes-dev:--x" in a for a in setfacls
+    )
+    leaf = [a for a in setfacls if a[-1] == WORKSPACE]
+    assert any("-R" in a and "u:hermes-dev:rwx" in a for a in leaf)
+    assert any("-d" in a and "u:hermes-dev:rwx" in a for a in leaf)
+    assert not any(
+        "hermes-sysadmin" in " ".join(a) and WORKSPACE in a for a in setfacls
+    )
+
+
+def test_mocked_apply_command_sequence(tmp_path):
+    paths = _board_paths(tmp_path)
+    steps = plan_setup_steps(
+        mapping=MAPPING,
+        gateway_user="matt",
+        dev_workspace=WORKSPACE,
+        board_paths=paths,
+        hermes_argv=["/usr/bin/hermes"],
+    )
+    recorded: list[list[str]] = []
+
+    def run(argv, **kwargs):
+        recorded.append(list(argv))
+        return _Proc(0)
+
+    state = tmp_path / "state.json"
+    rc = execute_setup_plan(
+        steps,
+        run=run,
+        state_path=state,
+        sudoers_text=render_sudoers(
+            gateway_user="matt", mapping=MAPPING, hermes_argv=["/usr/bin/hermes"]
+        ),
+        sudoers_tmp=str(tmp_path / "sudoers"),
+    )
+    assert rc == 0
+    flat = [" ".join(a) for a in recorded]
+    blob = "\n".join(flat)
+    assert "--gid hermes-kanban" not in blob
+    assert any(
+        a[0] == "useradd" and "-g" in a and a[a.index("-g") + 1] == "hermes-dev"
+        for a in recorded
+    )
+    assert any("-G hermes-kanban" in line for line in flat)
+    assert any(
+        "g:hermes-kanban:wx" in line and str(paths["kanban_db"].parent) in line
+        for line in flat
+    )
+    assert any("u:hermes-dev:--x" in line and "/home/matt" in line for line in flat)
+    assert any("-R" in a and WORKSPACE in a for a in recorded)
+    assert any(a[0] == "visudo" for a in recorded)
+    saved = state.read_text(encoding="utf-8")
+    assert "hermes-dev" in saved
+    assert "created_users" in saved
+
+
+def test_mapped_home_ready_requires_soul_and_skills(tmp_path):
+    home = tmp_path / "profiles" / "dev"
+    home.mkdir(parents=True)
+    ok, detail = mapped_home_ready(home)
+    assert ok is False
+    assert "SOUL.md" in detail
+    assert "skills" in detail
+    (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+    (home / ".env").write_text("TOKEN=secret\n", encoding="utf-8")
+    (home / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+    (home / "skills").mkdir()
+    ok, detail = mapped_home_ready(home)
+    assert ok is True
+    assert "secret" not in detail
+
+
+def test_audit_home_ready_blocks_isolation_claim(tmp_path):
+    pw = _pw()
+    hermes_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    hermes_home.mkdir(parents=True)
+    os.chmod(hermes_home, 0o700)
+    db_parent = tmp_path / "board"
+    db_parent.mkdir()
+    db = db_parent / "kanban.db"
+    db.write_bytes(b"")
+
+    def getpwnam(name):
+        return pw
+
+    def run(argv, **kwargs):
+        if "/usr/bin/id" in argv or (
+            len(argv) >= 2 and argv[-2:] == ["/usr/bin/id", "-u"]
+        ):
+            return _Proc(0, stdout=f"{pw.pw_uid}\n")
+        return _Proc(0)
+
+    hooks = LaunchHooks(
+        getpwnam=getpwnam,
+        geteuid=lambda: 1000,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        id_bin="/usr/bin/id",
+        is_windows=False,
+    )
+    items = audit_mapping(
+        mapping={"dev": "hermes-dev"},
+        homes={"dev": str(hermes_home)},
+        hooks=hooks,
+        board_paths={"kanban_db": db},
+        wal_prover=lambda u, p: None,
+    )
+    by_name = {i.name: i for i in items}
+    assert by_name["home-ready:dev"].ok is False
+    assert not all(i.ok for i in items)
+
+
+def test_board_parent_fails_if_only_a_directory(tmp_path):
+    pw = _pw()
+    parent = tmp_path / "only-dir"
+    parent.mkdir()
+    db = parent / "kanban.db"
+    db.write_bytes(b"")
+
+    def run(argv, **kwargs):
+        if argv and argv[-2:] == ["-u"] or (len(argv) >= 2 and argv[-1] == "-u"):
+            return _Proc(0, stdout=f"{pw.pw_uid}\n")
+        if "/usr/bin/id" in argv:
+            return _Proc(0, stdout=f"{pw.pw_uid}\n")
+        if "-w" in argv:
+            return _Proc(1, stderr="denied\n")
+        if "-x" in argv and str(parent) in argv:
+            return _Proc(1, stderr="denied\n")
+        if "-x" in argv:
+            return _Proc(0)
+        return _Proc(0, stdout=f"{pw.pw_uid}\n")
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: pw,
+        geteuid=lambda: 1000,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        id_bin="/usr/bin/id",
+        is_windows=False,
+    )
+    items = audit_mapping(
+        mapping={"dev": "hermes-dev"},
+        homes={"dev": str(tmp_path / "missing-home")},
+        hooks=hooks,
+        board_paths={"kanban_db": db},
+        wal_prover=lambda u, p: None,
+    )
+    board = next(i for i in items if i.name == "board-parent")
+    assert board.ok is False
+    assert parent.is_dir()
+
+
+def test_audit_wal_and_cross_home_denial(tmp_path):
+    dev_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    sys_home = tmp_path / "hermes-sysadmin" / ".hermes" / "profiles" / "sysadmin"
+    for home in (dev_home, sys_home):
+        home.mkdir(parents=True)
+        os.chmod(home, 0o700)
+        (home / "config.yaml").write_text("{}\n", encoding="utf-8")
+        (home / ".env").write_text("TOKEN=hidden\n", encoding="utf-8")
+        (home / "SOUL.md").write_text("# soul\n", encoding="utf-8")
+        (home / "skills").mkdir()
+        os.chmod(home / ".env", 0o600)
+    db_parent = tmp_path / "shared"
+    db_parent.mkdir()
+    db = db_parent / "kanban.db"
+    db.write_bytes(b"")
+    users = {
+        "hermes-dev": _pw("hermes-dev", 2001, 2001, str(tmp_path / "hermes-dev")),
+        "hermes-sysadmin": _pw(
+            "hermes-sysadmin", 2002, 2002, str(tmp_path / "hermes-sysadmin")
+        ),
+    }
+    wal_seen: list[tuple[str, str]] = []
+
+    def run(argv, **kwargs):
+        user = argv[argv.index("-u") + 1] if "-u" in argv else ""
+        if "/usr/bin/id" in argv or (
+            len(argv) >= 2 and argv[-2:] == ["/usr/bin/id", "-u"]
+        ):
+            return _Proc(0, stdout=f"{users[user].pw_uid}\n")
+        path = argv[-1]
+        mode = argv[-2] if len(argv) >= 2 else ""
+        other = str(sys_home) if user == "hermes-dev" else str(dev_home)
+        if mode == "-r" and path == other:
+            return _Proc(1)
+        return _Proc(0)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: users[n],
+        geteuid=lambda: 1000,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        id_bin="/usr/bin/id",
+        is_windows=False,
+    )
+
+    def wal_prover(user, path):
+        wal_seen.append((user, path))
+
+    items = audit_mapping(
+        mapping=MAPPING,
+        homes={"dev": str(dev_home), "sysadmin": str(sys_home)},
+        hooks=hooks,
+        board_paths={"kanban_db": db},
+        wal_prover=wal_prover,
+    )
+    by_name = {i.name: i for i in items}
+    assert by_name["cross:dev!=sysadmin"].ok is True
+    assert by_name["cross-deny:hermes-dev->sysadmin"].ok is True
+    assert by_name["cross-deny:hermes-sysadmin->dev"].ok is True
+    assert by_name["board-parent"].ok is True
+    assert by_name["board-wal:hermes-dev"].ok is True
+    assert by_name["board-wal:hermes-sysadmin"].ok is True
+    assert {u for u, _ in wal_seen} == {"hermes-dev", "hermes-sysadmin"}
+    blob = " ".join(i.detail for i in items)
+    assert "hidden" not in blob
+    assert "TOKEN=" not in blob
+
+
+def test_probe_user_access_expect_denied():
+    def run(argv, **kwargs):
+        return _Proc(1)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: _pw(),
+        geteuid=lambda: 1000,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        is_windows=False,
+    )
+    ok, detail = probe_user_access(
+        "hermes-dev",
+        "/home/hermes-sysadmin/.hermes",
+        mode="r",
+        hooks=hooks,
+        expect_ok=False,
+    )
+    assert ok is True
+    assert "denied" in detail
+
+
+def test_idempotent_ok_rejects_shared_primary_group():
+    pw = _pw(gid=3000)
+    private = GroupEntry("hermes-dev", 2001, ())
+    shared = GroupEntry(DEFAULT_GROUP, 3000, ("hermes-dev",))
+
+    def getgrnam(name):
+        if name == "hermes-dev":
+            return private
+        if name == DEFAULT_GROUP:
+            return shared
+        raise KeyError(name)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: pw,
+        getgrnam=getgrnam,
+        geteuid=lambda: 1000,
+        run=lambda *a, **k: _Proc(0),
+        is_windows=False,
+    )
+    with pytest.raises(IncompatiblePrincipalError, match="not private group"):
+        existing_user_compatible("hermes-dev", group=DEFAULT_GROUP, hooks=hooks)
+    with pytest.raises(IncompatiblePrincipalError):
+        _idempotent_ok(
+            ["useradd", "--system", "hermes-dev"],
+            9,
+            hooks=hooks,
+            group=DEFAULT_GROUP,
+        )
+
+
+def test_idempotent_ok_accepts_private_primary_plus_supplemental():
+    pw = _pw(gid=2001)
+    private = GroupEntry("hermes-dev", 2001, ())
+    shared = GroupEntry(DEFAULT_GROUP, 3000, ("hermes-dev",))
+
+    def getgrnam(name):
+        if name == "hermes-dev":
+            return private
+        if name == DEFAULT_GROUP:
+            return shared
+        raise KeyError(name)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: pw,
+        getgrnam=getgrnam,
+        geteuid=lambda: 1000,
+        run=lambda *a, **k: _Proc(0),
+        is_windows=False,
+    )
+    existing_user_compatible("hermes-dev", group=DEFAULT_GROUP, hooks=hooks)
+    assert _idempotent_ok(["useradd", "hermes-dev"], 9, hooks=hooks) is True
+    assert _idempotent_ok(["groupadd", "hermes-dev"], 9, hooks=hooks) is True
+
+
+def test_rollback_without_state_never_userdel(tmp_path):
+    missing = tmp_path / "no-such-state.json"
+    steps = plan_rollback_steps(mapping=MAPPING, state_path=missing)
+    blob = _argv_blob(steps)
+    assert "userdel" not in blob
+    assert "groupdel" not in blob
+    assert "rm" in blob
+
+
+def test_rollback_with_state_only_created_principals_and_acls(tmp_path):
+    state = tmp_path / "state.json"
+    save_os_users_state(
+        {
+            "created_users": ["hermes-dev"],
+            "created_groups": ["hermes-dev", DEFAULT_GROUP],
+            "preexisting_users": ["hermes-sysadmin"],
+            "preexisting_groups": [],
+            "acl_paths": [WORKSPACE, "/home/matt/.hermes"],
+        },
+        state,
+    )
+    steps = plan_rollback_steps(mapping=MAPPING, state_path=state)
+    blob = _argv_blob(steps)
+    assert "userdel -r hermes-dev" in blob
+    assert "userdel -r hermes-sysadmin" not in blob
+    assert "groupdel hermes-dev" in blob
+    assert f"setfacl -x g:{DEFAULT_GROUP}" in blob
+    assert f"setfacl -x u:hermes-dev {WORKSPACE}" in blob or any(
+        s.argv[:3] == ["setfacl", "-x", "u:hermes-dev"] and s.argv[-1] == WORKSPACE
+        for s in steps
+    )
+    assert any(s.argv[:2] == ["setfacl", "-k"] for s in steps)
+
+
+def test_migrate_never_prints_secrets_and_documents_manual_gate(tmp_path):
+    src = tmp_path / "profiles" / "dev"
+    src.mkdir(parents=True)
+    src.joinpath(".env").write_text("CURSOR_API_KEY=super-secret\n", encoding="utf-8")
+    src.joinpath("SOUL.md").write_text("# soul\n", encoding="utf-8")
+    text = "\n".join(
+        migrate_profile_files_commands({"dev": "hermes-dev"}, source_root=tmp_path)
+    )
+    assert "super-secret" not in text
+    assert "CURSOR_API_KEY=" not in text
+    assert "MANUAL GATE" in text
+    assert "SOUL.md" in text
+    assert "skills" in text
+
+
+def test_setup_apply_does_not_migrate_without_flag(capsys, monkeypatch, tmp_path):
+    monkeypatch.setattr(os, "geteuid", lambda: 0)
+    recorded: list[list[str]] = []
+
+    def run(argv, **kwargs):
+        recorded.append(list(argv))
+        return _Proc(0)
+
+    hooks = LaunchHooks(
+        getpwnam=lambda n: _pw(n),
+        getgrnam=lambda n: GroupEntry(n, 1, ()),
+        geteuid=lambda: 0,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        is_windows=False,
+    )
+    args = Namespace(
+        os_users_action="setup",
+        apply=True,
+        gateway_user="matt",
+        dev_workspace=WORKSPACE,
+        json=False,
+        migrate_profile_files=False,
+    )
+    rc = run_os_users_cli(
+        args,
+        hooks=hooks,
+        state_path=tmp_path / "state.json",
+        board_paths=_board_paths(tmp_path),
+    )
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "MANUAL GATE" in out
+    assert not any(
+        ".env" in " ".join(a) and a[0] == "install" and "-m" in a for a in recorded
+    )
+    assert "Check will FAIL" in out
+
+
+def test_cli_probe_wal_lifecycle(tmp_path, capsys):
+    db = tmp_path / "kanban.db"
+    args = Namespace(os_users_action="probe", probe_kind="wal", probe_path=str(db))
+    rc = run_os_users_cli(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "WAL lifecycle ok" in out
+    assert db.exists()
+
+
+def test_prove_sqlite_wal_lifecycle_creates_sidecars_or_probe_file(tmp_path):
+    db = tmp_path / "kanban.db"
+    prove_sqlite_wal_lifecycle(str(db))
+    con = sqlite3.connect(str(db))
+    mode = con.execute("PRAGMA journal_mode").fetchone()[0]
+    con.close()
+    assert str(mode).lower() in {"wal", "delete", "memory"} or db.exists()
+    assert db.exists()
+
+
+def test_sudoers_allows_test_bin_for_probes():
+    text = render_sudoers(
+        gateway_user="matt",
+        mapping=MAPPING,
+        hermes_argv=["/usr/bin/hermes"],
+    )
+    assert "/usr/bin/test" in text
+    assert "/usr/bin/id" in text
+    assert "NOPASSWD" in text
+
+
+def test_docs_paths_use_venv_dot_and_documents_workouttracker():
+    docs = (
+        Path(__file__).resolve().parents[2] / "docs" / "kanban" / "profile-os-users.md"
+    )
+    text = docs.read_text(encoding="utf-8")
+    assert ".venv/bin/python" in text
+    assert "./venv/bin/python" not in text
+    assert "/home/matt/Documents/WorkoutTracker" in text
+    assert "--dev-workspace /home/matt/WorkoutTracker" not in text
+    assert "makes the shared group the primary group" in text
+    assert "-g hermes-dev" in text
+    assert "-G hermes-kanban" in text
+    assert "--migrate-profile-files" in text

--- a/tests/hermes_cli/test_kanban_os_users_setup.py
+++ b/tests/hermes_cli/test_kanban_os_users_setup.py
@@ -97,7 +97,7 @@ def test_plan_setup_uses_private_groups_not_shared_gid():
     assert any("-g" in a and a[a.index("-g") + 1] == "hermes-dev" for a in installs)
 
 
-def test_plan_setup_acls_actual_db_parent_not_kanban_subdir(tmp_path):
+def test_plan_setup_acls_dedicated_dir_not_hermes_root(tmp_path):
     paths = _board_paths(tmp_path)
     steps = plan_setup_steps(
         mapping=MAPPING,
@@ -105,25 +105,24 @@ def test_plan_setup_acls_actual_db_parent_not_kanban_subdir(tmp_path):
         board_paths=paths,
     )
     blob = _argv_blob(steps)
-    db_parent = str(paths["kanban_db"].parent)
+    hermes_root = str(paths["hermes_root"])
     kdir = str(paths["kanban_dir"])
     assert f"g:{DEFAULT_GROUP}:wx" in blob
-    assert db_parent in blob
-    assert (
-        f"g:{DEFAULT_GROUP}:rwx" not in blob
-        or kdir not in blob.split(f"g:{DEFAULT_GROUP}:rwx")[-1][:200]
-    )
+    assert kdir in blob
     setfacls = [s.argv for s in steps if s.argv and s.argv[0] == "setfacl"]
-    db_parent_acls = [a for a in setfacls if a[-1] == db_parent]
-    assert any("g:hermes-kanban:wx" in a for a in db_parent_acls)
-    assert any("-d" in a and "g:hermes-kanban:rw" in a for a in db_parent_acls)
+    root_acls = [a for a in setfacls if a[-1] == hermes_root]
+    assert any("g:hermes-kanban:--x" in a for a in root_acls)
+    assert not any("g:hermes-kanban:wx" in a for a in root_acls)
+    kdir_acls = [a for a in setfacls if a[-1] == kdir]
+    assert any("g:hermes-kanban:wx" in a for a in kdir_acls)
+    assert any("-d" in a and "g:hermes-kanban:rw" in a for a in kdir_acls)
     kdir_wal = [
         a for a in setfacls if a[-1] == kdir and "g:hermes-kanban:rwx" in " ".join(a)
     ]
     assert kdir_wal == []
     ancestors = [a for a in setfacls if "g:hermes-kanban:--x" in a]
     assert ancestors
-    assert any(str(paths["hermes_root"].parent) == a[-1] for a in ancestors)
+    assert any(hermes_root == a[-1] for a in ancestors)
 
 
 def test_plan_setup_workspace_ancestor_acl_not_sysadmin():
@@ -135,7 +134,8 @@ def test_plan_setup_workspace_ancestor_acl_not_sysadmin():
     )
     setfacls = [s.argv for s in steps if s.argv and s.argv[0] == "setfacl"]
     titles = " ".join(s.title for s in steps)
-    assert "sysadmin is NOT granted" in titles
+    assert "world-readable is not isolation" in titles
+    assert "sysadmin not granted" in titles
     assert any(a[-1] == "/home/matt" and "u:hermes-dev:--x" in a for a in setfacls)
     assert any(
         a[-1] == "/home/matt/Documents" and "u:hermes-dev:--x" in a for a in setfacls
@@ -183,8 +183,16 @@ def test_mocked_apply_command_sequence(tmp_path):
     )
     assert any("-G hermes-kanban" in line for line in flat)
     assert any(
-        "g:hermes-kanban:wx" in line and str(paths["kanban_db"].parent) in line
-        for line in flat
+        a[0] == "setfacl"
+        and "g:hermes-kanban:wx" in " ".join(a)
+        and a[-1] == str(paths["kanban_dir"])
+        for a in recorded
+    )
+    assert not any(
+        a[0] == "setfacl"
+        and "g:hermes-kanban:wx" in " ".join(a)
+        and a[-1] == str(paths["hermes_root"])
+        for a in recorded
     )
     assert any("u:hermes-dev:--x" in line and "/home/matt" in line for line in flat)
     assert any("-R" in a and WORKSPACE in a for a in recorded)

--- a/tests/hermes_cli/test_kanban_profile_os_users.py
+++ b/tests/hermes_cli/test_kanban_profile_os_users.py
@@ -335,8 +335,10 @@ def test_cli_setup_dry_run_does_not_require_root(capsys):
     assert rc == 0
     assert "Dry-run only" in out
     assert "/home/matt/Documents/WorkoutTracker" in out
-    assert "sysadmin is NOT granted" in out
-    assert "sudo hermes kanban os-users setup --apply" in out
+    assert "sysadmin not granted" in out
+    assert "world-readable is not isolation" in out
+    assert "Do not use `sudo hermes`" in out
+    assert "kanban os-users setup --apply" in out
     assert "MANUAL GATE" in out
     assert "--gid hermes-kanban" not in out
     assert "-g hermes-dev" in out

--- a/tests/hermes_cli/test_kanban_profile_os_users.py
+++ b/tests/hermes_cli/test_kanban_profile_os_users.py
@@ -490,6 +490,69 @@ def test_default_spawn_mapped_reports_target_user(monkeypatch, tmp_path):
     )
 
 
+def test_default_spawn_restart_safe_wraps_outside_sudo(monkeypatch, tmp_path):
+    """systemd-run must wrap sudo so the scope stays on the gateway UID.
+
+    Rebase conflict in `_default_spawn` put both wraps at the same site.
+    Inverting the order would put systemd-run inside sudoers (which only
+    allows hermes) and drop the scope onto the mapped UID.
+    """
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "dev"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text(
+        "kanban:\n  profile_os_users:\n    dev: hermes-dev\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.kanban_os_users as osu
+
+    pw = _pw(home=str(tmp_path / "hermes-dev"))
+    mapped_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    mapped_home.mkdir(parents=True)
+    os.chmod(mapped_home, 0o700)
+    os.chmod(mapped_home.parent, 0o700)
+    os.chmod(mapped_home.parent.parent, 0o700)
+
+    monkeypatch.setattr(osu, "_default_getpwnam", lambda name: pw)
+    monkeypatch.setattr(osu, "_preflight_paths", lambda *a, **k: None)
+    monkeypatch.setattr(
+        osu,
+        "_default_run",
+        lambda argv, **k: _Proc(0, stdout=f"{pw.pw_uid}\n"),
+    )
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+
+    seen = {}
+
+    def fake_restart_safe(task, command):
+        seen["inner"] = list(command)
+        return ["systemd-run", "--scope", "--", *command]
+
+    monkeypatch.setattr(kb, "_restart_safe_worker_argv", fake_restart_safe)
+    captured = {}
+
+    class FakeProc:
+        pid = 9002
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    pid = kb._default_spawn(_make_task(kb, assignee="dev"), str(workspace))
+    assert pid == 9002
+    assert is_sudo_wrapped(seen["inner"])
+    assert seen["inner"][5] == "hermes-dev"
+    assert captured["cmd"][:3] == ["systemd-run", "--scope", "--"]
+    assert is_sudo_wrapped(captured["cmd"][3:])
+    assert captured["cmd"][0] != "sudo"
+    assert captured["cmd"][8] == "hermes-dev"
+
+
 def test_cross_profile_homes_are_distinct_and_private(tmp_path):
     dev_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
     sys_home = tmp_path / "hermes-sysadmin" / ".hermes" / "profiles" / "sysadmin"

--- a/tests/hermes_cli/test_kanban_profile_os_users.py
+++ b/tests/hermes_cli/test_kanban_profile_os_users.py
@@ -1,0 +1,478 @@
+"""Security tests for kanban.profile_os_users mapped worker launch."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.kanban_os_users import (
+    LaunchHooks,
+    MappedLaunchError,
+    PasswdEntry,
+    apply_mapped_worker_launch,
+    audit_mapping,
+    build_mapped_env,
+    build_sudo_argv,
+    is_sudo_wrapped,
+    lookup_mapped_os_user,
+    migrate_profile_files_commands,
+    parse_profile_os_homes,
+    parse_profile_os_users,
+    preflight_mapped_user,
+    render_sudoers,
+    run_os_users_cli,
+    validate_os_username,
+)
+
+
+pytestmark = pytest.mark.skipif(
+    sys.platform.startswith("win"),
+    reason="profile_os_users is a Linux privilege-drop feature",
+)
+
+
+class _Proc:
+    def __init__(self, rc=0, stdout="", stderr=""):
+        self.returncode = rc
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _pw(name="hermes-dev", uid=2001, gid=2001, home=None):
+    return PasswdEntry(name, uid, gid, home or f"/home/{name}")
+
+
+def _hooks(pw, *, euid=1000, run_rc=0, run_stdout=None, run_err=None):
+    def getpwnam(name):
+        if name != pw.pw_name:
+            raise MappedLaunchError(f"Mapped OS user {name!r} does not exist.")
+        return pw
+
+    def run(argv, **kwargs):
+        uid_out = run_stdout if run_stdout is not None else f"{pw.pw_uid}\n"
+        if run_err is not None:
+            return _Proc(run_rc, stdout=uid_out, stderr=run_err)
+        return _Proc(run_rc, stdout=uid_out)
+
+    return LaunchHooks(
+        getpwnam=getpwnam,
+        geteuid=lambda: euid,
+        run=run,
+        sudo_bin="/usr/bin/sudo",
+        id_bin="/usr/bin/id",
+        is_windows=False,
+    )
+
+
+def test_parse_empty_mapping_is_trusted_local():
+    assert parse_profile_os_users(None) == {}
+    assert parse_profile_os_users({}) == {}
+    assert lookup_mapped_os_user("dev", {}) is None
+
+
+def test_parse_valid_mapping():
+    parsed = parse_profile_os_users({"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"})
+    assert parsed == {"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"}
+    assert lookup_mapped_os_user("Dev", parsed) == "hermes-dev"
+
+
+@pytest.mark.parametrize(
+    "raw",
+    ["root", "toor", "ROOT", "hermes-dev;id", "hermes-dev$(id)", "a b", "../etc", "matt\nroot"],
+)
+def test_validate_username_rejects_root_and_injection(raw):
+    with pytest.raises(ValueError):
+        validate_os_username(raw)
+
+
+def test_parse_rejects_root_mapping():
+    with pytest.raises(ValueError, match="root"):
+        parse_profile_os_users({"dev": "root"})
+
+
+def test_parse_rejects_invalid_profile_id():
+    with pytest.raises(ValueError):
+        parse_profile_os_users({"Dev Profile": "hermes-dev"})
+
+
+def test_parse_homes_requires_absolute():
+    with pytest.raises(ValueError, match="absolute"):
+        parse_profile_os_homes({"dev": "relative/path"})
+    parsed = parse_profile_os_homes({"dev": "/var/lib/hermes-dev"})
+    assert parsed["dev"] == "/var/lib/hermes-dev"
+
+
+def test_build_sudo_argv_is_list_no_shell():
+    inner = ["/opt/hermes bin/hermes", "-p", "dev", "chat", "-q", "work kanban task t_1"]
+    argv = build_sudo_argv("hermes-dev", inner)
+    assert argv[0] == "/usr/bin/sudo"
+    assert argv[1:7] == ["-n", "-H", "-E", "-u", "hermes-dev", "--"]
+    assert argv[7:] == inner
+    assert " ".join(argv).count(";") == 0 or ";" not in "".join(argv[:7])
+    assert is_sudo_wrapped(argv)
+    assert not is_sudo_wrapped(inner)
+
+
+def test_sudo_argv_preserves_spaces_and_metacharacters_as_single_tokens():
+    nasty = "/tmp/work space; rm -rf / and $(reboot)"
+    argv = build_sudo_argv("hermes-dev", ["hermes", "--cwd", nasty])
+    assert nasty in argv
+    assert argv[argv.index("--") + 1 :] == ["hermes", "--cwd", nasty]
+    joined_for_shell = "sudo -n -u hermes-dev hermes --cwd " + nasty
+    assert argv != joined_for_shell.split()
+
+
+def test_unmapped_apply_is_identity():
+    argv = ["hermes", "-p", "elias", "chat", "-q", "work"]
+    env = {"HERMES_HOME": "/tmp/h", "SSH_AUTH_SOCK": "/run/ssh"}
+    out_argv, out_env = apply_mapped_worker_launch(
+        profile="elias", argv=argv, env=env, mapping={}, homes={}, preflight=False,
+    )
+    assert out_argv == argv
+    assert out_env == env
+    assert not is_sudo_wrapped(out_argv)
+
+
+def test_mapped_apply_wraps_and_rewrites_env():
+    pw = _pw()
+    argv = ["hermes", "-p", "dev", "chat", "-q", "work kanban task t_x"]
+    env = {
+        "HERMES_HOME": "/home/matt/.hermes/profiles/dev",
+        "SSH_AUTH_SOCK": "/run/user/1000/ssh",
+        "CURSOR_API_KEY": "secret-cursor-key",
+        "OPENAI_API_KEY": "sk-test",
+        "HERMES_KANBAN_TASK": "t_x",
+    }
+    out_argv, out_env = apply_mapped_worker_launch(
+        profile="dev",
+        argv=argv,
+        env=env,
+        mapping={"dev": "hermes-dev"},
+        homes={},
+        hooks=_hooks(pw),
+        preflight=False,
+        workspace="",
+        board_db=None,
+    )
+    assert is_sudo_wrapped(out_argv)
+    assert out_argv[:7] == ["/usr/bin/sudo", "-n", "-H", "-E", "-u", "hermes-dev", "--"]
+    assert out_argv[7:] == argv
+    assert out_env["HOME"] == pw.pw_dir
+    assert out_env["USER"] == "hermes-dev"
+    assert out_env["HERMES_HOME"] == "/home/hermes-dev/.hermes/profiles/dev"
+    assert "SSH_AUTH_SOCK" not in out_env
+    assert "CURSOR_API_KEY" not in out_env
+    assert "OPENAI_API_KEY" not in out_env
+    assert out_env["HERMES_KANBAN_TASK"] == "t_x"
+
+
+def test_mapped_apply_never_returns_unwrapped_on_sudo_denial():
+    pw = _pw()
+    hooks = _hooks(pw, run_rc=1, run_err="sudo: a password is required\n")
+    with pytest.raises(MappedLaunchError, match="sudo"):
+        apply_mapped_worker_launch(
+            profile="dev",
+            argv=["hermes", "-p", "dev"],
+            env={},
+            mapping={"dev": "hermes-dev"},
+            homes={},
+            hooks=hooks,
+            preflight=True,
+        )
+
+
+def test_preflight_rejects_missing_user():
+    hooks = LaunchHooks(
+        getpwnam=lambda n: (_ for _ in ()).throw(MappedLaunchError("missing")),
+        geteuid=lambda: 1000,
+        run=lambda *a, **k: _Proc(0, "1\n"),
+        is_windows=False,
+        sudo_bin="/usr/bin/sudo",
+    )
+    with pytest.raises(MappedLaunchError, match="missing"):
+        preflight_mapped_user("hermes-dev", hooks=hooks, require_paths=False)
+
+
+def test_preflight_rejects_same_uid_and_does_not_call_it_isolation():
+    pw = _pw(uid=1000)
+    with pytest.raises(MappedLaunchError, match="not isolation"):
+        preflight_mapped_user("hermes-dev", hooks=_hooks(pw, euid=1000), require_paths=False)
+
+
+def test_preflight_rejects_wrong_reported_uid():
+    pw = _pw(uid=2001)
+    hooks = _hooks(pw, run_stdout="0\n")
+    with pytest.raises(MappedLaunchError, match="expected 2001"):
+        preflight_mapped_user("hermes-dev", hooks=hooks, require_paths=False)
+
+
+def test_preflight_rejects_windows():
+    pw = _pw()
+    hooks = _hooks(pw)
+    hooks.is_windows = True
+    with pytest.raises(MappedLaunchError, match="Linux-only"):
+        preflight_mapped_user("hermes-dev", hooks=hooks, require_paths=False)
+
+
+def test_build_mapped_env_drops_gateway_secrets():
+    env = build_mapped_env(
+        {
+            "SSH_AUTH_SOCK": "/tmp/ssh",
+            "SUDO_USER": "matt",
+            "CURSOR_API_KEY": "nope",
+            "HERMES_KANBAN_DB": "/shared/kanban.db",
+            "PATH": "/usr/bin",
+        },
+        username="hermes-dev",
+        home="/home/hermes-dev",
+        hermes_home="/home/hermes-dev/.hermes/profiles/dev",
+    )
+    assert "SSH_AUTH_SOCK" not in env
+    assert "SUDO_USER" not in env
+    assert "CURSOR_API_KEY" not in env
+    assert env["HERMES_KANBAN_DB"] == "/shared/kanban.db"
+    assert env["HOME"] == "/home/hermes-dev"
+
+
+def test_retries_remain_mapped():
+    pw = _pw()
+    hooks = _hooks(pw)
+    mapping = {"dev": "hermes-dev"}
+    first, _ = apply_mapped_worker_launch(
+        profile="dev", argv=["hermes", "-p", "dev"], env={},
+        mapping=mapping, homes={}, hooks=hooks, preflight=False,
+    )
+    second, _ = apply_mapped_worker_launch(
+        profile="dev", argv=["hermes", "-p", "dev"], env={},
+        mapping=mapping, homes={}, hooks=hooks, preflight=False,
+    )
+    assert is_sudo_wrapped(first) and is_sudo_wrapped(second)
+    assert first[5] == second[5] == "hermes-dev"
+
+
+def test_audit_empty_mapping_is_not_isolation():
+    items = audit_mapping(mapping={}, homes={})
+    assert items[0].ok is True
+    assert items[0].isolation is False
+    assert "trusted-local-user" in items[0].detail
+
+
+def test_sudoers_and_migrate_never_print_secret_values(tmp_path):
+    src = tmp_path / "profiles" / "dev"
+    src.mkdir(parents=True)
+    src.joinpath(".env").write_text("CURSOR_API_KEY=super-secret\n", encoding="utf-8")
+    text = "\n".join(migrate_profile_files_commands({"dev": "hermes-dev"}, source_root=tmp_path))
+    sudoers = render_sudoers(
+        gateway_user="matt",
+        mapping={"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"},
+        hermes_argv=["/usr/bin/hermes"],
+    )
+    blob = text + "\n" + sudoers
+    assert "super-secret" not in blob
+    assert "CURSOR_API_KEY=" not in blob
+    assert "BEGIN OPENSSH" not in blob
+    assert "install" in text
+    assert "NOPASSWD" in sudoers
+    assert "hermes-dev" in sudoers
+    assert "hermes-sysadmin" in sudoers
+
+
+def test_cli_setup_dry_run_does_not_require_root(capsys):
+    args = Namespace(
+        os_users_action="setup",
+        apply=False,
+        gateway_user="matt",
+        dev_workspace="/home/matt/WorkoutTracker",
+        json=False,
+    )
+    rc = run_os_users_cli(args)
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "Dry-run only" in out
+    assert "WorkoutTracker" in out
+    assert "sysadmin is NOT granted" in out
+    assert "sudo hermes kanban os-users setup --apply" in out
+
+
+def test_cli_setup_apply_without_root_fails_closed(capsys, monkeypatch):
+    monkeypatch.setattr(os, "geteuid", lambda: 1000)
+    args = Namespace(
+        os_users_action="setup",
+        apply=True,
+        gateway_user="matt",
+        dev_workspace=None,
+        json=False,
+    )
+    rc = run_os_users_cli(args)
+    err = capsys.readouterr().err
+    assert rc == 1
+    assert "euid 0" in err
+    assert "Not prompting" in err
+
+
+def _make_task(kb, *, assignee: str):
+    return kb.Task(
+        id="t_os_users",
+        title="spawn",
+        body=None,
+        assignee=assignee,
+        status="running",
+        priority=0,
+        created_by="test",
+        created_at=1,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="dir",
+        workspace_path=None,
+        claim_lock="lock",
+        claim_expires=None,
+        tenant=None,
+        current_run_id=7,
+    )
+
+
+def test_default_spawn_unmapped_stays_on_gateway_argv(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "elias"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text("{}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 4242
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    pid = kb._default_spawn(_make_task(kb, assignee="elias"), str(workspace))
+    assert pid == 4242
+    assert captured["cmd"][0] == "hermes"
+    assert captured["cmd"][1:3] == ["-p", "elias"]
+    assert not is_sudo_wrapped(captured["cmd"])
+
+
+def test_default_spawn_mapped_missing_user_never_popen(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "dev"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text(
+        "kanban:\n  profile_os_users:\n    dev: hermes-dev\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        return type("P", (), {"pid": 1})()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    with pytest.raises((MappedLaunchError, RuntimeError, ValueError, KeyError)):
+        kb._default_spawn(_make_task(kb, assignee="dev"), str(workspace))
+    assert "cmd" not in captured
+
+
+def test_default_spawn_mapped_reports_target_user(monkeypatch, tmp_path):
+    root = tmp_path / ".hermes"
+    profile = root / "profiles" / "dev"
+    profile.mkdir(parents=True)
+    root.joinpath("config.yaml").write_text(
+        "kanban:\n  profile_os_users:\n    dev: hermes-dev\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    from hermes_cli import kanban_db as kb
+    import hermes_cli.kanban_os_users as osu
+
+    pw = _pw(home=str(tmp_path / "hermes-dev"))
+    mapped_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    mapped_home.mkdir(parents=True)
+    os.chmod(mapped_home, 0o700)
+    os.chmod(mapped_home.parent, 0o700)
+    os.chmod(mapped_home.parent.parent, 0o700)
+
+    monkeypatch.setattr(osu, "_default_getpwnam", lambda name: pw)
+    monkeypatch.setattr(osu, "_preflight_paths", lambda *a, **k: None)
+    monkeypatch.setattr(
+        osu,
+        "_default_run",
+        lambda argv, **k: _Proc(0, stdout=f"{pw.pw_uid}\n"),
+    )
+    monkeypatch.setattr(kb, "_resolve_hermes_argv", lambda: ["hermes"])
+    captured = {}
+
+    class FakeProc:
+        pid = 9001
+
+    def fake_popen(cmd, *args, **kwargs):
+        captured["cmd"] = list(cmd)
+        captured["env"] = dict(kwargs.get("env") or {})
+        return FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", fake_popen)
+    workspace = tmp_path / "work space; meta"
+    workspace.mkdir()
+    pid = kb._default_spawn(_make_task(kb, assignee="dev"), str(workspace))
+    assert pid == 9001
+    assert is_sudo_wrapped(captured["cmd"])
+    assert captured["cmd"][5] == "hermes-dev"
+    assert captured["env"]["HOME"].endswith("hermes-dev") or "hermes-dev" in captured["env"]["HOME"]
+    assert "SSH_AUTH_SOCK" not in captured["env"] or captured["env"].get("SSH_AUTH_SOCK") is None
+
+
+def test_cross_profile_homes_are_distinct_and_private(tmp_path):
+    dev_home = tmp_path / "hermes-dev" / ".hermes" / "profiles" / "dev"
+    sys_home = tmp_path / "hermes-sysadmin" / ".hermes" / "profiles" / "sysadmin"
+    gw_ssh = tmp_path / "matt" / ".ssh" / "id_ed25519"
+    for p in (dev_home, sys_home, gw_ssh.parent):
+        p.mkdir(parents=True)
+    dev_secret = dev_home / ".env"
+    sys_secret = sys_home / ".env"
+    dev_secret.write_text("DEV_TOKEN=aaa\n", encoding="utf-8")
+    sys_secret.write_text("SYS_TOKEN=bbb\n", encoding="utf-8")
+    gw_ssh.write_text("ssh-secret\n", encoding="utf-8")
+    for p in (dev_home, sys_home, dev_secret, sys_secret, gw_ssh):
+        os.chmod(p, 0o600 if p.is_file() else 0o700)
+    for p in (dev_home, sys_home, gw_ssh):
+        mode = stat.S_IMODE(p.stat().st_mode)
+        assert mode & 0o007 == 0
+    assert os.path.realpath(dev_home) != os.path.realpath(sys_home)
+    # Shared board sibling WAL files live next to the db, not inside a profile home.
+    board_dir = tmp_path / "shared-kanban"
+    board_dir.mkdir()
+    db = board_dir / "kanban.db"
+    db.write_bytes(b"")
+    wal = board_dir / "kanban.db-wal"
+    wal.write_bytes(b"wal")
+    os.chmod(board_dir, 0o770)
+    assert db.exists() and wal.exists()
+    assert not str(dev_home).startswith(str(sys_home))
+
+
+def test_shared_board_lifecycle_paths_are_group_not_world(tmp_path):
+    board_dir = tmp_path / "kanban"
+    board_dir.mkdir()
+    os.chmod(board_dir, 0o2770)
+    mode = stat.S_IMODE(board_dir.stat().st_mode)
+    assert mode & 0o007 == 0
+    assert mode & 0o070 == 0o070

--- a/tests/hermes_cli/test_kanban_profile_os_users.py
+++ b/tests/hermes_cli/test_kanban_profile_os_users.py
@@ -326,16 +326,21 @@ def test_cli_setup_dry_run_does_not_require_root(capsys):
         os_users_action="setup",
         apply=False,
         gateway_user="matt",
-        dev_workspace="/home/matt/WorkoutTracker",
+        dev_workspace="/home/matt/Documents/WorkoutTracker",
         json=False,
+        migrate_profile_files=False,
     )
     rc = run_os_users_cli(args)
     out = capsys.readouterr().out
     assert rc == 0
     assert "Dry-run only" in out
-    assert "WorkoutTracker" in out
+    assert "/home/matt/Documents/WorkoutTracker" in out
     assert "sysadmin is NOT granted" in out
     assert "sudo hermes kanban os-users setup --apply" in out
+    assert "MANUAL GATE" in out
+    assert "--gid hermes-kanban" not in out
+    assert "-g hermes-dev" in out
+    assert "-G hermes-kanban" in out
 
 
 def test_cli_setup_apply_without_root_fails_closed(capsys, monkeypatch):
@@ -346,6 +351,7 @@ def test_cli_setup_apply_without_root_fails_closed(capsys, monkeypatch):
         gateway_user="matt",
         dev_workspace=None,
         json=False,
+        migrate_profile_files=False,
     )
     rc = run_os_users_cli(args)
     err = capsys.readouterr().err

--- a/tests/hermes_cli/test_kanban_profile_os_users.py
+++ b/tests/hermes_cli/test_kanban_profile_os_users.py
@@ -77,14 +77,26 @@ def test_parse_empty_mapping_is_trusted_local():
 
 
 def test_parse_valid_mapping():
-    parsed = parse_profile_os_users({"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"})
+    parsed = parse_profile_os_users({
+        "dev": "hermes-dev",
+        "sysadmin": "hermes-sysadmin",
+    })
     assert parsed == {"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"}
     assert lookup_mapped_os_user("Dev", parsed) == "hermes-dev"
 
 
 @pytest.mark.parametrize(
     "raw",
-    ["root", "toor", "ROOT", "hermes-dev;id", "hermes-dev$(id)", "a b", "../etc", "matt\nroot"],
+    [
+        "root",
+        "toor",
+        "ROOT",
+        "hermes-dev;id",
+        "hermes-dev$(id)",
+        "a b",
+        "../etc",
+        "matt\nroot",
+    ],
 )
 def test_validate_username_rejects_root_and_injection(raw):
     with pytest.raises(ValueError):
@@ -109,7 +121,14 @@ def test_parse_homes_requires_absolute():
 
 
 def test_build_sudo_argv_is_list_no_shell():
-    inner = ["/opt/hermes bin/hermes", "-p", "dev", "chat", "-q", "work kanban task t_1"]
+    inner = [
+        "/opt/hermes bin/hermes",
+        "-p",
+        "dev",
+        "chat",
+        "-q",
+        "work kanban task t_1",
+    ]
     argv = build_sudo_argv("hermes-dev", inner)
     assert argv[0] == "/usr/bin/sudo"
     assert argv[1:7] == ["-n", "-H", "-E", "-u", "hermes-dev", "--"]
@@ -132,7 +151,12 @@ def test_unmapped_apply_is_identity():
     argv = ["hermes", "-p", "elias", "chat", "-q", "work"]
     env = {"HERMES_HOME": "/tmp/h", "SSH_AUTH_SOCK": "/run/ssh"}
     out_argv, out_env = apply_mapped_worker_launch(
-        profile="elias", argv=argv, env=env, mapping={}, homes={}, preflight=False,
+        profile="elias",
+        argv=argv,
+        env=env,
+        mapping={},
+        homes={},
+        preflight=False,
     )
     assert out_argv == argv
     assert out_env == env
@@ -202,7 +226,9 @@ def test_preflight_rejects_missing_user():
 def test_preflight_rejects_same_uid_and_does_not_call_it_isolation():
     pw = _pw(uid=1000)
     with pytest.raises(MappedLaunchError, match="not isolation"):
-        preflight_mapped_user("hermes-dev", hooks=_hooks(pw, euid=1000), require_paths=False)
+        preflight_mapped_user(
+            "hermes-dev", hooks=_hooks(pw, euid=1000), require_paths=False
+        )
 
 
 def test_preflight_rejects_wrong_reported_uid():
@@ -245,12 +271,22 @@ def test_retries_remain_mapped():
     hooks = _hooks(pw)
     mapping = {"dev": "hermes-dev"}
     first, _ = apply_mapped_worker_launch(
-        profile="dev", argv=["hermes", "-p", "dev"], env={},
-        mapping=mapping, homes={}, hooks=hooks, preflight=False,
+        profile="dev",
+        argv=["hermes", "-p", "dev"],
+        env={},
+        mapping=mapping,
+        homes={},
+        hooks=hooks,
+        preflight=False,
     )
     second, _ = apply_mapped_worker_launch(
-        profile="dev", argv=["hermes", "-p", "dev"], env={},
-        mapping=mapping, homes={}, hooks=hooks, preflight=False,
+        profile="dev",
+        argv=["hermes", "-p", "dev"],
+        env={},
+        mapping=mapping,
+        homes={},
+        hooks=hooks,
+        preflight=False,
     )
     assert is_sudo_wrapped(first) and is_sudo_wrapped(second)
     assert first[5] == second[5] == "hermes-dev"
@@ -267,7 +303,9 @@ def test_sudoers_and_migrate_never_print_secret_values(tmp_path):
     src = tmp_path / "profiles" / "dev"
     src.mkdir(parents=True)
     src.joinpath(".env").write_text("CURSOR_API_KEY=super-secret\n", encoding="utf-8")
-    text = "\n".join(migrate_profile_files_commands({"dev": "hermes-dev"}, source_root=tmp_path))
+    text = "\n".join(
+        migrate_profile_files_commands({"dev": "hermes-dev"}, source_root=tmp_path)
+    )
     sudoers = render_sudoers(
         gateway_user="matt",
         mapping={"dev": "hermes-dev", "sysadmin": "hermes-sysadmin"},
@@ -436,8 +474,14 @@ def test_default_spawn_mapped_reports_target_user(monkeypatch, tmp_path):
     assert pid == 9001
     assert is_sudo_wrapped(captured["cmd"])
     assert captured["cmd"][5] == "hermes-dev"
-    assert captured["env"]["HOME"].endswith("hermes-dev") or "hermes-dev" in captured["env"]["HOME"]
-    assert "SSH_AUTH_SOCK" not in captured["env"] or captured["env"].get("SSH_AUTH_SOCK") is None
+    assert (
+        captured["env"]["HOME"].endswith("hermes-dev")
+        or "hermes-dev" in captured["env"]["HOME"]
+    )
+    assert (
+        "SSH_AUTH_SOCK" not in captured["env"]
+        or captured["env"].get("SSH_AUTH_SOCK") is None
+    )
 
 
 def test_cross_profile_homes_are_distinct_and_private(tmp_path):

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -229,6 +229,11 @@ kanban:
   review_dispatch: true            # default: spawn the assigned profile with
                                    # the bundled sdlc-review skill. Set false
                                    # for human-only review boards.
+  # Optional: map profile id -> Linux account. Empty/missing keeps today's
+  # trusted-local-user spawn (gateway UID). See docs/kanban/profile-os-users.md.
+  # profile_os_users:
+  #   dev: hermes-dev
+  #   sysadmin: hermes-sysadmin
 ```
 
 Override the config flag at runtime via `HERMES_KANBAN_DISPATCH_IN_GATEWAY=0`
@@ -795,6 +800,8 @@ All commands are also available as a slash command in the interactive CLI and in
 | `kanban.max_in_progress_per_profile` | unset (unlimited) | Per-profile variant of `max_in_progress` — caps how many tasks any single assignee profile may run concurrently. Useful when one profile is slow or rate-limited but others should keep flowing. Applies alongside the board-wide `max_in_progress`; both must allow a spawn for it to proceed. |
 | `kanban.auto_promote_children` | `true` | After `decompose_triage_task()` produces children with no parent-blocker dependencies, they're automatically promoted to `ready` so the dispatcher can pick them up. Set to `false` to require manual review — children stay in `todo` until you promote them. |
 | `kanban.default_workdir` | unset | Board-level default working directory applied to new tasks when neither `--workspace` nor the task itself overrides it. Per-task `workspace:` still wins. |
+| `kanban.profile_os_users` | `{}` | Optional map of canonical profile id → POSIX username. Empty/missing preserves trusted-local-user spawn on the gateway UID. A mapped profile is launched with `sudo -n -H -E -u <user> --` (no shell) and never falls back to the gateway UID. Root and same-UID mappings are rejected. Host setup: `hermes kanban os-users`. |
+| `kanban.profile_os_homes` | `{}` | Optional map of profile id → Hermes runtime home **root** (not OS HOME). Default is `{passwd_dir}/.hermes`. |
 
 ```yaml
 kanban:


### PR DESCRIPTION
## Summary
- Add optional `kanban.profile_os_users` so mapped Kanban workers launch as dedicated Linux users via fail-closed `sudo -n -H -E -u <user> --` (argv list, no shell). Empty/missing mapping preserves trusted-local-user (gateway UID) behavior.
- Private per-user Hermes runtime homes (`profile_os_homes` companion) plus shared-board group/ACL setup; reject root and same-UID mappings (never reported as isolation).
- Dry-run-first `hermes kanban os-users {setup,check,sudoers,rollback}` plus docs. Do **not** enable mappings or restart the gateway from this PR.

## Test plan
- [x] `scripts/run_tests.sh tests/hermes_cli/test_kanban_profile_os_users.py tests/hermes_cli/test_kanban_worker_spawn_toolsets.py tests/plugins/test_kanban_worker_runs.py` (40 passed)
- [x] `ruff check` / `ruff format --check` on new Python files
- [ ] Host operator: dry-run `hermes kanban os-users setup`, then `sudo hermes kanban os-users setup --apply`, then `hermes kanban os-users check` **before** enabling `profile_os_users` in gateway config
