### PR TITLE
fix(whatsapp): honor HTTPS_PROXY for Baileys socket and fetch

### DIFF
--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -48,6 +48,19 @@ import {
   pollUpdateForAggregation,
 } from './bridge_helpers.js';
 
+// Proxy support for environments behind an HTTP proxy (e.g., mainland China)
+const PROXY_URL = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy;
+let proxyAgent = null;
+if (PROXY_URL) {
+  try {
+    const { HttpsProxyAgent } = await import('https-proxy-agent');
+    proxyAgent = new HttpsProxyAgent(PROXY_URL);
+    console.log(`🔗 Using proxy: ${PROXY_URL}`);
+  } catch (e) {
+    console.warn(`⚠️  Could not load https-proxy-agent, falling back to direct connection: ${e.message}`);
+  }
+}
+
 // Parse CLI args
 const args = process.argv.slice(2);
 function getArg(name, defaultVal) {
@@ -410,6 +423,8 @@ async function startSocket() {
     browser: ['Hermes Agent', 'Chrome', '120.0'],
     syncFullHistory: false,
     markOnlineOnConnect: false,
+    agent: proxyAgent || undefined,
+    fetchAgent: proxyAgent || undefined,
     // Required for Baileys 7.x: without this, incoming messages that need
     // E2EE session re-establishment are silently dropped (msg.message === null)
     getMessage: async (key) => {

--- a/scripts/whatsapp-bridge/bridge.js
+++ b/scripts/whatsapp-bridge/bridge.js
@@ -50,12 +50,19 @@ import {
 
 // Proxy support for environments behind an HTTP proxy (e.g., mainland China)
 const PROXY_URL = process.env.HTTPS_PROXY || process.env.HTTP_PROXY || process.env.https_proxy || process.env.http_proxy;
+// Mask credentials in any logged proxy URL (user:pass@host -> user:***@host).
+// Greedy password match up to the LAST '@' so passwords containing '@' are fully masked.
+function maskProxyUrl(url) {
+  return typeof url === 'string'
+    ? url.replace(/(\/\/[^:@/]+):(.+)@/, '$1:***@')
+    : url;
+}
 let proxyAgent = null;
 if (PROXY_URL) {
   try {
     const { HttpsProxyAgent } = await import('https-proxy-agent');
     proxyAgent = new HttpsProxyAgent(PROXY_URL);
-    console.log(`🔗 Using proxy: ${PROXY_URL}`);
+    console.log(`🔗 Using proxy: ${maskProxyUrl(PROXY_URL)}`);
   } catch (e) {
     console.warn(`⚠️  Could not load https-proxy-agent, falling back to direct connection: ${e.message}`);
   }

--- a/scripts/whatsapp-bridge/package-lock.json
+++ b/scripts/whatsapp-bridge/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@whiskeysockets/baileys": "7.0.0-rc13",
         "express": "^4.21.0",
+        "https-proxy-agent": "^9.1.0",
         "pino": "^9.0.0",
         "qrcode-terminal": "^0.12.0"
       }
@@ -806,6 +807,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-9.0.0.tgz",
+      "integrity": "sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
@@ -1285,6 +1295,43 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/https-proxy-agent": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
+      "integrity": "sha512-ag87y7cJJ9/3+GxFr8Oy4O5faDsGRGnBGsJj/YjOSsSx/5eadKLYTMPlzuR6obgoCDDm0abAAZitXXQkMOPSpA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "9.0.0",
+        "debug": "^4.3.4",
+        "proxy-agent-negotiate": "1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.4.24",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
@@ -1684,6 +1731,23 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-agent-negotiate": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-agent-negotiate/-/proxy-agent-negotiate-1.1.0.tgz",
+      "integrity": "sha512-N8IBcM3UgCVzz2L2Lqv8DVntDnnC8/hiV4nEDUPkqq72TPUgYWjQc+bdZlBPZK9LzPAvOY//gAt0S0DApoOXWQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "peerDependencies": {
+        "kerberos": "^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "kerberos": {
+          "optional": true
+        }
       }
     },
     "node_modules/qified": {

--- a/scripts/whatsapp-bridge/package.json
+++ b/scripts/whatsapp-bridge/package.json
@@ -10,8 +10,9 @@
   "dependencies": {
     "@whiskeysockets/baileys": "7.0.0-rc13",
     "express": "^4.21.0",
-    "qrcode-terminal": "^0.12.0",
-    "pino": "^9.0.0"
+    "https-proxy-agent": "^9.1.0",
+    "pino": "^9.0.0",
+    "qrcode-terminal": "^0.12.0"
   },
   "overrides": {
     "protobufjs": "^7.5.5",


### PR DESCRIPTION
## Summary

Baileys ignores proxy environment variables entirely. On hosts whose only egress path is an HTTP proxy (mainland China being the canonical case), `makeWASocket` can never reach WhatsApp's servers: the gateway logs `whatsapp connect timed out after 30s` and retries forever with backoff.

This PR teaches the bridge to honor the proxy environment:

- Read `HTTPS_PROXY` / `HTTP_PROXY` (and lowercase variants) at startup
- Build an `HttpsProxyAgent` and pass it to `makeWASocket` via `agent` / `fetchAgent`
- Add `https-proxy-agent` to `scripts/whatsapp-bridge/package.json`

## Behavior matrix

| Environment | Before | After |
|---|---|---|
| No proxy env set | direct connection | direct connection (unchanged) |
| Proxy env set, dep installed | **connect timeout after 30s** | proxied connection |
| Proxy env set, dep missing | connect timeout after 30s | direct fallback + console warning |

## Testing

- [x] Proxy env set → bridge connects through proxy (macOS, HTTPS_PROXY=http://127.0.0.1:10808)

```
2026-09-02 10:57:04 INFO gateway.run: Connecting to whatsapp...
2026-09-02 10:57:33 INFO gateway.run: ✓ whatsapp connected
```

- [x] No proxy env → unchanged direct behavior (no agent passed)
- [ ] Docker/CI matrix

## Notes

- The dynamic `await import('https-proxy-agent')` with try/catch keeps the failure mode soft: if the dependency is somehow absent the bridge falls back to today's direct-connection behavior instead of crashing.
- The gateway already propagates `HTTP_PROXY`/`HTTPS_PROXY` into the bridge subprocess environment on hosts that need it (via launchd `EnvironmentVariables` or shell env), so no gateway-side changes are required.


Fixes #43603