### PR TITLE
fix(agent): adopt router-resolved model/provider in implicit-runtime path

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1369,9 +1369,43 @@ def init_agent(
         else:
             # No explicit creds — use the centralized provider router
             from agent.auxiliary_client import resolve_provider_client
-            _routed_client, _ = resolve_provider_client(
+            _routed_client, _routed_model = resolve_provider_client(
                 agent.provider or "auto", model=agent.model, raw_codex=True)
             if _routed_client is not None:
+                # ``auto`` routing can resolve the configured main runtime even
+                # when a direct AIAgent caller omitted both provider and model
+                # (notably ``python run_agent.py``).  The router has always
+                # returned the concrete model, but this path discarded it and
+                # later sent ``model: \"\"`` to an otherwise valid endpoint.
+                # Adopt both pieces of resolved runtime identity before any
+                # request kwargs or context limits are built.
+                if not str(agent.model or "").strip():
+                    agent.model = str(_routed_model or "").strip()
+                if not str(agent.provider or "").strip():
+                    _routed_provider = str(
+                        getattr(
+                            _routed_client,
+                            "_hermes_aux_effective_provider",
+                            "",
+                        )
+                        or ""
+                    ).strip().lower()
+                    if _routed_provider:
+                        agent.provider = _routed_provider
+                        agent.requested_provider = _routed_provider
+                if not str(agent.model or "").strip():
+                    raise RuntimeError(
+                        "LLM provider resolved successfully but did not supply a "
+                        "model name. Set model.default in config.yaml or pass "
+                        "model= explicitly."
+                    )
+                # The first lookup ran before auto-routing had a concrete
+                # provider/model. Re-resolve now so provider-specific timeout
+                # settings also apply to this implicit-runtime path.
+                _provider_timeout = get_provider_request_timeout(
+                    agent.provider,
+                    agent.model,
+                )
                 client_kwargs = {
                     "api_key": _routed_client.api_key,
                     "base_url": str(_routed_client.base_url),

--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -533,6 +533,41 @@ def _refuse_checkpoint_required_on_codex_app_server(
         )
 
 
+def _adopt_implicit_runtime(agent, routed_client, routed_model) -> None:
+    """Adopt the provider router's resolved runtime identity.
+
+    ``auto`` routing can resolve the configured main runtime even when a
+    direct AIAgent caller omitted both provider and model (notably
+    ``python run_agent.py``).  The router has always returned the concrete
+    model, but this path used to discard it and later send ``model: ""``
+    to an otherwise valid endpoint.  Adopt both pieces of resolved runtime
+    identity before any request kwargs or context limits are built.
+
+    Raises:
+        RuntimeError: routing succeeded but supplied no model name.
+    """
+    if not str(agent.model or "").strip():
+        agent.model = str(routed_model or "").strip()
+    if not str(agent.provider or "").strip():
+        _routed_provider = str(
+            getattr(
+                routed_client,
+                "_hermes_aux_effective_provider",
+                "",
+            )
+            or ""
+        ).strip().lower()
+        if _routed_provider:
+            agent.provider = _routed_provider
+            agent.requested_provider = _routed_provider
+    if not str(agent.model or "").strip():
+        raise RuntimeError(
+            "LLM provider resolved successfully but did not supply a "
+            "model name. Set model.default in config.yaml or pass "
+            "model= explicitly."
+        )
+
+
 def init_agent(
     agent,
     base_url: str = None,
@@ -1372,33 +1407,10 @@ def init_agent(
             _routed_client, _routed_model = resolve_provider_client(
                 agent.provider or "auto", model=agent.model, raw_codex=True)
             if _routed_client is not None:
-                # ``auto`` routing can resolve the configured main runtime even
-                # when a direct AIAgent caller omitted both provider and model
-                # (notably ``python run_agent.py``).  The router has always
-                # returned the concrete model, but this path discarded it and
-                # later sent ``model: \"\"`` to an otherwise valid endpoint.
                 # Adopt both pieces of resolved runtime identity before any
-                # request kwargs or context limits are built.
-                if not str(agent.model or "").strip():
-                    agent.model = str(_routed_model or "").strip()
-                if not str(agent.provider or "").strip():
-                    _routed_provider = str(
-                        getattr(
-                            _routed_client,
-                            "_hermes_aux_effective_provider",
-                            "",
-                        )
-                        or ""
-                    ).strip().lower()
-                    if _routed_provider:
-                        agent.provider = _routed_provider
-                        agent.requested_provider = _routed_provider
-                if not str(agent.model or "").strip():
-                    raise RuntimeError(
-                        "LLM provider resolved successfully but did not supply a "
-                        "model name. Set model.default in config.yaml or pass "
-                        "model= explicitly."
-                    )
+                # request kwargs or context limits are built (see
+                # _adopt_implicit_runtime).
+                _adopt_implicit_runtime(agent, _routed_client, _routed_model)
                 # The first lookup ran before auto-routing had a concrete
                 # provider/model. Re-resolve now so provider-specific timeout
                 # settings also apply to this implicit-runtime path.

--- a/tests/agent/test_agent_init_implicit_runtime.py
+++ b/tests/agent/test_agent_init_implicit_runtime.py
@@ -1,0 +1,91 @@
+"""Regression tests for the implicit-runtime path in init_agent (#101916).
+
+When a direct ``AIAgent`` caller omits both ``provider`` and ``model``
+(notably ``python run_agent.py``), the ``auto`` provider router resolves
+the configured main runtime correctly — but the implicit-runtime branch
+in ``init_agent`` historically discarded the concrete model the router
+returned, then sent ``model: ""`` to an otherwise valid endpoint.
+
+These tests pin the fixed behaviors of ``_adopt_implicit_runtime``:
+
+1. the router-resolved model is adopted onto ``agent.model``
+2. the client's effective provider is adopted onto
+   ``agent.provider`` / ``agent.requested_provider``
+3. routing success without a model name raises a clear RuntimeError
+   instead of a silent empty-model request
+"""
+
+import pytest
+from unittest.mock import MagicMock, patch
+
+
+class _FakeAgent:
+    """Minimal AIAgent stand-in exposing the fields init_agent touches."""
+
+    def __init__(self, provider=None, model=None):
+        self.provider = provider
+        self.model = model
+        self.requested_provider = provider
+
+
+class TestAdoptImplicitRuntime:
+    """_adopt_implicit_runtime adopts router-resolved identity."""
+
+    def test_routed_model_and_provider_adopted_when_caller_omitted(self):
+        from agent.agent_init import _adopt_implicit_runtime
+
+        agent = _FakeAgent(provider=None, model=None)
+        routed = MagicMock()
+        routed._hermes_aux_effective_provider = "custom"
+
+        _adopt_implicit_runtime(agent, routed, "glm-5_3")
+
+        assert agent.model == "glm-5_3"
+        assert agent.provider == "custom"
+        assert agent.requested_provider == "custom"
+
+    def test_explicit_model_not_overwritten(self):
+        from agent.agent_init import _adopt_implicit_runtime
+
+        agent = _FakeAgent(provider=None, model="explicit-model")
+        routed = MagicMock()
+        routed._hermes_aux_effective_provider = "custom"
+
+        _adopt_implicit_runtime(agent, routed, "glm-5_3")
+
+        assert agent.model == "explicit-model"
+
+    def test_explicit_provider_not_overwritten(self):
+        from agent.agent_init import _adopt_implicit_runtime
+
+        agent = _FakeAgent(provider="openrouter", model=None)
+        routed = MagicMock()
+        routed._hermes_aux_effective_provider = "custom"
+
+        _adopt_implicit_runtime(agent, routed, "glm-5_3")
+
+        assert agent.provider == "openrouter"
+        assert agent.model == "glm-5_3"
+
+    def test_router_success_without_model_raises(self):
+        from agent.agent_init import _adopt_implicit_runtime
+
+        agent = _FakeAgent(provider=None, model=None)
+        routed = MagicMock()
+        routed._hermes_aux_effective_provider = "custom"
+
+        with pytest.raises(RuntimeError, match="did not supply a model name"):
+            _adopt_implicit_runtime(agent, routed, "")
+
+    def test_missing_effective_provider_attribute_keeps_none(self):
+        """Routed clients without the marker attribute are fine — provider
+        stays unset and only the model is adopted."""
+        from agent.agent_init import _adopt_implicit_runtime
+
+        agent = _FakeAgent(provider=None, model=None)
+        routed = MagicMock(spec=[])  # no _hermes_aux_effective_provider
+
+        _adopt_implicit_runtime(agent, routed, "glm-5_3")
+
+        assert agent.model == "glm-5_3"
+        assert agent.provider is None


### PR DESCRIPTION
## Summary

When a direct `AIAgent` caller omits both `provider` and `model` (notably `python run_agent.py`), the `auto` provider router resolves the configured main runtime correctly — but `init_agent`'s implicit-runtime path discards the concrete model the router returns, then proceeds to send `model: ""` to an otherwise valid endpoint.

This PR makes the path adopt both pieces of resolved runtime identity:

- `agent.model` ← router-resolved model (when the caller omitted it)
- `agent.provider` / `agent.requested_provider` ← the client's effective provider (when omitted)
- Raise a clear `RuntimeError` when routing succeeded but supplied no model name (previously: silent empty-model request)
- Re-resolve `get_provider_request_timeout` after the concrete provider is known, so provider-specific timeout settings apply to the implicit path too

## Before / After

```python
# before: routed identity discarded, later sends model: ""
_routed_client, _ = resolve_provider_client(...)

# after: adopt it
_routed_client, _routed_model = resolve_provider_client(...)
if not str(agent.model or "").strip():
    agent.model = str(_routed_model or "").strip()
```

## Testing

- [x] `python run_agent.py` with configured `model.default`, no explicit model/provider on the call site → requests now carry the concrete model name
- [x] Router returns no model → clear RuntimeError instead of empty-model request
- [ ] Explicit provider+model callers → byte-identical behavior (no code path change)

## Notes

The router (`resolve_provider_client`) has returned the concrete model since it was written; this path simply never consumed the second tuple element.
