### PR TITLE
feat(agent): recognize Vertex AI Express Mode base URL in Gemini native adapter

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -90,6 +90,10 @@ def is_native_gemini_base_url(base_url: str) -> bool:
     normalized = str(base_url or "").strip().rstrip("/").lower()
     if not normalized:
         return False
+    # Vertex AI Express Mode
+    if normalized == "https://aiplatform.googleapis.com/v1/publishers/google":
+        return True
+    # Google AI Studio
     if "generativelanguage.googleapis.com" not in normalized:
         return False
     return not normalized.endswith("/openai")

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,18 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+def test_is_native_gemini_base_url():
+    """Verify is_native_gemini_base_url detects AI Studio and Vertex Express Mode endpoints."""
+    from agent.gemini_native_adapter import is_native_gemini_base_url
+
+    assert is_native_gemini_base_url("https://generativelanguage.googleapis.com") is True
+    assert is_native_gemini_base_url("https://generativelanguage.googleapis.com/v1beta") is True
+    assert is_native_gemini_base_url("https://generativelanguage.googleapis.com/v1beta/openai") is False
+    assert is_native_gemini_base_url("https://aiplatform.googleapis.com/v1/publishers/google") is True
+    assert is_native_gemini_base_url("https://aiplatform.googleapis.com/v1/publishers/google/") is True
+    assert is_native_gemini_base_url("https://api.openai.com/v1") is False
+    assert is_native_gemini_base_url("") is False
+    assert is_native_gemini_base_url(None) is False
+


### PR DESCRIPTION
## What does this PR do?

Adds `https://aiplatform.googleapis.com/v1/publishers/google` (Google Cloud Vertex AI Express Mode base URL) to `is_native_gemini_base_url()`.

When users configure a custom provider with Vertex AI Express Mode (Google's API-key path for Vertex AI, without requiring service accounts or OAuth2 tokens) or pass `--base-url https://aiplatform.googleapis.com/v1/publishers/google`, Hermes previously treated the endpoint as generic OpenAI-compatible instead of native Gemini REST. This caused calls to route through the OpenAI client, which appends a trailing slash to `base_url` and results in HTTP 404 on `:generateContent` endpoints (as reported in #30152).

By recognizing this base URL in `is_native_gemini_base_url()`, requests are automatically dispatched to `GeminiNativeClient`, enabling zero-config Express Mode usage with existing `x-goog-api-key` authentication.

## Related Issue

Relates to #30152, #13484

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `agent/gemini_native_adapter.py`: Added check for `https://aiplatform.googleapis.com/v1/publishers/google` in `is_native_gemini_base_url()`.
- `tests/agent/test_gemini_native_adapter.py`: Added `test_is_native_gemini_base_url()` covering Google AI Studio and Vertex Express Mode base URLs.

## How to Test

1. Run unit tests:
   ```bash
   uv run pytest tests/agent/test_gemini_native_adapter.py -k test_is_native_gemini_base_url
   ```
2. Verify with Vertex AI Express Mode key:
   Configure a provider with `base_url: https://aiplatform.googleapis.com/v1/publishers/google` and run a query with `--model gemini-2.5-flash`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
