### PR TITLE
fix(streaming): stop raw tool markup from corrupting interrupted turns

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -393,6 +393,82 @@ def _provider_stream_text_may_be_sse(text: str) -> bool:
     return saw_sse_field
 
 
+_TEXT_TOOL_CALL_OPEN_RE = re.compile(
+    r'<(?P<tag>tool_call|tool_calls|function_call|function_calls)\b[^>]*>',
+    re.IGNORECASE,
+)
+_TEXT_NAMED_FUNCTION_OPEN_RE = re.compile(
+    r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*'
+    r'<(?P<named>function)\b[^>]*\bname\s*=[^>]*>',
+    re.IGNORECASE,
+)
+_TEXT_TOOL_ARG_TAG_RE = re.compile(r'</?arg_(?:key|value)\b[^>]*>', re.IGNORECASE)
+_TEXT_TOOL_TAG_PARTIAL_RE = re.compile(
+    r'</?(?:tool(?:_calls?)?|function_calls?|arg_(?:key|value))[^>]*$',
+    re.IGNORECASE,
+)
+_TEXT_NAMED_FUNCTION_PARTIAL_RE = re.compile(
+    r'(?:(?<=^)|(?<=[\n\r.!?:]))[ \t]*<function\b[^>]*$',
+    re.IGNORECASE,
+)
+
+
+def _unterminated_text_tool_call_start(text: str) -> Optional[int]:
+    """Return where an incomplete text-channel tool serialization starts.
+
+    Some OpenAI-compatible models serialize a tool call as XML in ``content``
+    and can report ``finish_reason=stop`` after the stream cuts inside that
+    serialization. A provider terminal flag is not sufficient proof that an
+    unclosed tool envelope is safe assistant prose.
+    """
+    if not isinstance(text, str) or not text:
+        return None
+
+    complete_spans: list[tuple[int, int]] = []
+    open_matches = sorted(
+        [
+            *_TEXT_TOOL_CALL_OPEN_RE.finditer(text),
+            *_TEXT_NAMED_FUNCTION_OPEN_RE.finditer(text),
+        ],
+        key=lambda item: item.start(),
+    )
+    for match in open_matches:
+        tag = (match.group("tag") or match.group("named") or "").lower()
+        close = f"</{tag}>"
+        close_at = text.lower().find(close, match.end())
+        if close_at == -1:
+            return match.start()
+        complete_spans.append((match.start(), close_at + len(close)))
+
+    for match in _TEXT_TOOL_ARG_TAG_RE.finditer(text):
+        if not any(start <= match.start() < end for start, end in complete_spans):
+            # A leading argument value may precede the first surviving close
+            # tag after a stream cut. Drop that whole line, not merely the tag.
+            line_start = text.rfind("\n", 0, match.start()) + 1
+            return line_start
+
+    partial = (
+        _TEXT_TOOL_TAG_PARTIAL_RE.search(text)
+        or _TEXT_NAMED_FUNCTION_PARTIAL_RE.search(text)
+    )
+    if partial:
+        return partial.start()
+    return None
+
+
+def _provider_stream_text_may_be_tool_markup(text: str) -> bool:
+    """Hold text that may be model-serialized tool markup out of live UI."""
+    if not isinstance(text, str) or not text:
+        return False
+    return bool(
+        _TEXT_TOOL_CALL_OPEN_RE.search(text)
+        or _TEXT_NAMED_FUNCTION_OPEN_RE.search(text)
+        or _TEXT_TOOL_ARG_TAG_RE.search(text)
+        or _TEXT_TOOL_TAG_PARTIAL_RE.search(text)
+        or _TEXT_NAMED_FUNCTION_PARTIAL_RE.search(text)
+    )
+
+
 def _provider_stream_error_from_text(
     text: str,
     finish_reason: Optional[str],
@@ -4412,6 +4488,10 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 return
             pending_parts = list(pending_text_parts)
             pending_text_parts.clear()
+            pending_text = "".join(pending_parts)
+            if _provider_stream_text_may_be_tool_markup(pending_text):
+                visible_text = agent._strip_think_blocks(pending_text)
+                pending_parts = [visible_text] if visible_text else []
             if not tool_calls_acc:
                 for text in pending_parts:
                     _fire_first_delta()
@@ -4562,10 +4642,17 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             if delta_content:
                 content_parts.append(delta_content)
                 if not tool_calls_acc:
-                    if pending_text_parts or _provider_stream_text_may_be_sse(delta_content):
+                    if (
+                        pending_text_parts
+                        or _provider_stream_text_may_be_sse(delta_content)
+                        or _provider_stream_text_may_be_tool_markup(delta_content)
+                    ):
                         pending_text_parts.append(delta_content)
                         pending_text = "".join(pending_text_parts)
-                        if _provider_stream_text_may_be_sse(pending_text):
+                        if (
+                            _provider_stream_text_may_be_sse(pending_text)
+                            or _provider_stream_text_may_be_tool_markup(pending_text)
+                        ):
                             continue
                         _flush_pending_stream_text()
                         continue
@@ -4850,6 +4937,29 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 role, full_content,
                 "".join(reasoning_parts) or None,
                 model_name, usage_obj,
+            )
+
+        # A provider ``stop`` is not authoritative when the text channel ends
+        # inside model-serialized tool XML. The missing bytes cannot be
+        # reconstructed, so discard the markup tail and use the existing
+        # bounded partial-stream continuation path instead of persisting it as
+        # ordinary assistant prose (#101899).
+        _text_tool_cut_at = _unterminated_text_tool_call_start(full_content or "")
+        if _text_tool_cut_at is not None:
+            _visible_prefix = agent._strip_think_blocks(
+                (full_content or "")[:_text_tool_cut_at]
+            ).strip() or None
+            logger.warning(
+                "Stream ended inside text-channel tool-call markup despite "
+                "finish_reason=%r; discarding the incomplete serialization.",
+                finish_reason,
+            )
+            return _build_partial_stream_stub(
+                role,
+                _visible_prefix,
+                "".join(reasoning_parts) or None,
+                model_name,
+                usage_obj,
             )
 
         effective_finish_reason = finish_reason or "stop"

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -53,6 +53,28 @@ def _make_empty_chunk(model=None, usage=None):
     return SimpleNamespace(choices=[], model=model, usage=usage)
 
 
+def _run_nous_text_stream(mock_create, chunks):
+    """Run a mocked Nous chat stream and capture visible text deltas."""
+    from run_agent import AIAgent
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = iter(chunks)
+    mock_create.return_value = mock_client
+    delivered = []
+    agent = AIAgent(
+        api_key="test-key",
+        base_url="https://portal.nousresearch.com/v1",
+        model="zai-org/GLM-4.5-Air",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        stream_delta_callback=delivered.append,
+    )
+    agent.api_mode = "chat_completions"
+    agent._interrupt_requested = False
+    return agent._interruptible_streaming_api_call({}), delivered
+
+
 # ── Test: Streaming Accumulator ──────────────────────────────────────────
 
 
@@ -95,6 +117,82 @@ class TestStreamingAccumulator:
         assert response.choices[0].finish_reason == "stop"
         assert response.usage is not None
         assert response.usage.completion_tokens == 3
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_stop_with_unterminated_tool_markup_uses_partial_stream_recovery(
+        self, mock_close, mock_create
+    ):
+        """A provider ``stop`` cannot bless a cut text-channel tool call."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        fragments = [
+            "<tool_call><arg_key>action</arg_key><arg_value>wa</arg_value>",
+            "wa</arg_value><arg_key>timeout</arg_key><arg_value>59",
+            "<function_call>{\"name\": \"process_manage\"",
+        ]
+        for leaked in fragments:
+            response, delivered = _run_nous_text_stream(mock_create, [
+                _make_stream_chunk(leaked, finish_reason="stop", model="test-model")
+            ])
+            assert response.id == PARTIAL_STREAM_STUB_ID
+            assert response.choices[0].finish_reason == "length"
+            assert response.choices[0].message.content is None
+            assert response.choices[0].message.tool_calls is None
+            assert delivered == []
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_split_tool_markup_prefix_never_reaches_stream_callback(
+        self, mock_close, mock_create
+    ):
+        """Tool markup detection is invariant to provider chunk boundaries."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        response, delivered = _run_nous_text_stream(mock_create, [
+            _make_stream_chunk(content="<"),
+            _make_stream_chunk(
+                content="tool_call><arg_key>action</arg_key><arg_value>wa</arg_value>",
+                finish_reason="stop",
+            ),
+        ])
+        assert response.id == PARTIAL_STREAM_STUB_ID
+        assert delivered == []
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_complete_text_tool_block_is_hidden_without_marking_stream_partial(
+        self, mock_close, mock_create
+    ):
+        """A complete leaked block stays on the existing sanitizer path."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        leaked = (
+            "<tool_call><arg_key>action</arg_key>"
+            "<arg_value>wait</arg_value></tool_call>Done."
+        )
+        response, delivered = _run_nous_text_stream(mock_create, [
+            _make_stream_chunk(leaked, finish_reason="stop", model="test-model")
+        ])
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.content == leaked
+        assert delivered == ["Done."]
+
+    @patch("run_agent.AIAgent._create_request_openai_client")
+    @patch("run_agent.AIAgent._close_request_openai_client")
+    def test_inline_named_function_prose_is_not_treated_as_partial_tool_markup(
+        self, mock_close, mock_create
+    ):
+        """The named-function detector keeps the stripper's boundary guard."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        prose = 'Use <function name="demo"> in the documentation.'
+        response, delivered = _run_nous_text_stream(mock_create, [
+            _make_stream_chunk(prose, finish_reason="stop", model="test-model")
+        ])
+        assert response.id != PARTIAL_STREAM_STUB_ID
+        assert response.choices[0].message.content == prose
+        assert delivered == [prose]
 
     @patch("run_agent.AIAgent._create_request_openai_client")
     @patch("run_agent.AIAgent._close_request_openai_client")


### PR DESCRIPTION
## What does this PR do?

Prevents a cut text-channel tool serialization from being persisted or displayed as ordinary assistant prose when an OpenAI-compatible provider incorrectly ends the stream with `finish_reason=stop`. The accumulator now recognizes incomplete tool XML, withholds suspicious markup from live callbacks, discards the unrecoverable fragment, and routes the response through the bounded partial-stream continuation path.

### Symptom

After a background tool result, a long-context Nous/GLM stream can stop while the model is serializing its next tool call. The incomplete argument markup is then stored as assistant content even though no valid tool call arrived.

### Impact

Users can see raw internal tool-call markup, and the durable session records a malformed assistant turn instead of an honest interrupted-stream recovery. The missing tool arguments cannot be reconstructed and the intended action is not executed.

### Bug Cause

**Trigger:** `agent/chat_completion_helpers.py` / `interruptible_streaming_api_call` / a text-only stream with incomplete tool XML and `finish_reason=stop`

**Causal chain:**
1. A model emits tool-call XML through the text channel and the stream ends before the serialization closes.
2. The accumulator trusts the provider stop flag because existing drop detection only covers a missing finish reason or incomplete structured `tool_calls` JSON.
3. The incomplete XML becomes a normal assistant message and reaches live display and durable session storage.

**Why it is wrong:** A terminal flag does not make an unclosed tool serialization valid prose. No complete action exists to execute or persist.

**Working sibling / contrast:** Streams with incomplete structured `tool_calls` arguments already produce a `PARTIAL_STREAM_STUB_ID` response and enter bounded continuation. Complete text-channel tool blocks are also removed by the existing assistant-content sanitizer.

**Ruled out:** The desktop renderer and turn assembly are not the source. The malformed value already exists in persisted assistant content with `tool_calls=NULL`.

### Fix

Detect unclosed tool/function envelopes, dangling argument tags, and partial tag tails after stream accumulation. Buffer suspected markup before live delivery, preserve only any visible prefix, and return the existing partial-stream stub so the tool is never executed with missing arguments. Named-function detection retains the existing sentence-boundary guard so ordinary inline documentation remains visible.

## Related Issue

Closes #101899

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/chat_completion_helpers.py` - detect incomplete text-channel tool markup, sanitize live delivery, and route it to bounded stream recovery.
- `tests/run_agent/test_streaming.py` - cover false stop, dangling argument tags, split chunk boundaries, complete blocks, and inline named-function prose.

## How to Test

```bash
scripts/run_tests.sh tests/run_agent/test_streaming.py -q
scripts/run_tests.sh tests/run_agent/test_run_agent.py tests/run_agent/test_strip_reasoning_tags_cli.py -q
```

## Checklist

### Code

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this is not a duplicate
- [x] My PR contains only changes related to this fix
- [x] I have run the relevant test suites and all tests pass
- [x] I have added tests for my changes
- [x] I have tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation updates are N/A; behavior and rationale are documented in code and tests
- [x] Config example updates are N/A; no config keys changed
- [x] Contributor or architecture guide updates are N/A
- [x] I have considered cross-platform impact; the change is pure Python stream parsing
- [x] Tool descriptions and schema updates are N/A; no tool contract changed

## Screenshots / Logs

N/A - automated regression tests exercise the stream accumulator and callback boundary directly.