### PR TITLE
fix(agent): word-bound intent-ack action and workspace markers (#101868)

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -29,8 +29,9 @@ import re
 import threading
 import time
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from hermes_cli.timeouts import get_provider_request_timeout
 from agent.message_sanitization import (
@@ -4683,6 +4684,49 @@ def sanitize_api_messages(messages: List[Dict[str, Any]]) -> List[Dict[str, Any]
 
 
 
+_VERB_SUFFIX_RE = r"(?:e?|s|es|ed|d|ing|en|er|ers|ion|ions|is|ance|ence|ability|able)?"
+_NOUN_SUFFIX_RE = r"(?:s|es)?"
+
+
+@lru_cache(maxsize=256)
+def _bounded_marker_re(marker: str, verb_inflections: bool) -> "re.Pattern":
+    """Word-bounded pattern for one action/workspace marker.
+
+    ``text`` is already lowercased by the caller. Multi-word markers keep
+    their internal spacing. Single-word verb markers get a small inflection
+    suffix group (plus an optional repeat of the marker's final letter for
+    doubled-consonant forms like ``scanning``/``running``) so ``reading``,
+    ``checking``, and ``analyzing`` still match while ``bread``/``thread``
+    (no boundary before ``read``) do not (#101868). Noun markers take a
+    plural suffix only.
+    """
+    body = re.escape(marker)
+    if " " not in marker:
+        if verb_inflections:
+            if marker[-1].isalpha():
+                body = body + f"(?:{re.escape(marker[-1])})?"
+            body = body + _VERB_SUFFIX_RE
+        else:
+            body = body + _NOUN_SUFFIX_RE
+    return re.compile(r"(?<![a-z0-9])" + body + r"(?![a-z0-9])")
+
+
+def _mentions_bounded_marker(
+    text: str, markers: "Sequence[str]", verb_inflections: bool = False
+) -> bool:
+    """Whether ``text`` mentions any of ``markers`` as whole word(s).
+
+    Replaces raw substring matching (``marker in text``) in the intent-ack
+    detector: substring matching fired on intra-word collisions like
+    ``"read" in "bread"``, ``"repo" in "report"``, and ``"path" in
+    "empathy"``, misclassifying complete replies as intermediate acks and
+    suppressing their delivery (#101868).
+    """
+    return any(
+        _bounded_marker_re(m, verb_inflections).search(text) for m in markers
+    )
+
+
 def looks_like_codex_intermediate_ack(
     agent,
     user_message: Any,
@@ -4755,7 +4799,9 @@ def looks_like_codex_intermediate_ack(
         "path",
     )
 
-    assistant_mentions_action = any(marker in assistant_text for marker in action_markers)
+    assistant_mentions_action = _mentions_bounded_marker(
+        assistant_text, action_markers, verb_inflections=True
+    )
     if not assistant_mentions_action:
         return False
 
@@ -4774,12 +4820,12 @@ def looks_like_codex_intermediate_ack(
 
     user_text = _summarize_user_message_for_log(user_message).strip().lower()
     user_targets_workspace = (
-        any(marker in user_text for marker in workspace_markers)
+        _mentions_bounded_marker(user_text, workspace_markers)
         or "~/" in user_text
         or "/" in user_text
     )
-    assistant_targets_workspace = any(
-        marker in assistant_text for marker in workspace_markers
+    assistant_targets_workspace = _mentions_bounded_marker(
+        assistant_text, workspace_markers
     )
     return user_targets_workspace or assistant_targets_workspace
 

--- a/tests/agent/test_intent_ack_continuation.py
+++ b/tests/agent/test_intent_ack_continuation.py
@@ -119,6 +119,120 @@ def test_all_path_drops_workspace_requirement():
 # ── detector: guardrails that hold regardless of workspace ───────────────────
 
 
+# The #101868 repro: a complete gateway answer whose product list contains
+# "bread" (a substring collision with the "read" action marker) plus a closing
+# future-tense offer. The reply is substantive and must NOT be treated as an
+# intermediate ack, or the gateway delivers only the synthetic continuation.
+REPRO_101868_USER = "List four products."
+REPRO_101868_REPLY = (
+    "Here are four options:\n"
+    "1. Bread maker.\n"
+    "2. Coffee grinder.\n"
+    "3. Electric kettle.\n"
+    "4. Stand mixer.\n"
+    "\n"
+    "These are the available options. If useful, I'll provide a comparison table."
+)
+
+
+def test_substantive_reply_with_marker_substring_is_not_an_ack():
+    """#101868: ``"read" in "bread"`` must not make a complete reply an ack.
+
+    On the opted-in gateway path (``require_workspace=False``) the substring
+    collision combined with the closing ``I'll`` offer misclassified the whole
+    answer as an action announcement, so the first, substantive response was
+    never delivered.
+    """
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": REPRO_101868_USER}]
+    assert not looks_like_codex_intermediate_ack(
+        a, REPRO_101868_USER, REPRO_101868_REPLY, msgs, require_workspace=False
+    )
+
+
+def test_substantive_reply_with_thread_substring_is_not_an_ack():
+    """Sibling collision from the same marker tuple: ``"read" in "thread"``."""
+    a = _agent(True, "chat_completions")
+    reply = (
+        "Here is the summary you asked for.\n"
+        "The discussion thread converged on two designs.\n"
+        "If you want, I'll provide the full transcript."
+    )
+    msgs = [{"role": "user", "content": "Summarize the discussion."}]
+    assert not looks_like_codex_intermediate_ack(
+        a, "Summarize the discussion.", reply, msgs, require_workspace=False
+    )
+
+
+def test_workspace_substring_collisions_do_not_satisfy_codex_scope():
+    """#101868 bug class, workspace markers: ``"repo" in "report"``,
+    ``"path" in "empathy"``, ``"files" in "profiles"`` must not target a
+    workspace on the codex_only path."""
+    a = _agent("auto", "codex_responses")
+    user = "Give me a status report with empathy."
+    reply = "I'll draft the report now."
+    msgs = [{"role": "user", "content": user}]
+    assert not looks_like_codex_intermediate_ack(
+        a, user, reply, msgs, require_workspace=True
+    )
+
+    # Assistant-side only: the ack mentions "profiles"/"report" but no real
+    # workspace word, and the user targets none either.
+    reply2 = "I'll review the profiles section now."
+    assert not looks_like_codex_intermediate_ack(
+        a, "Describe the layout.", reply2, msgs, require_workspace=True
+    )
+
+
+def test_word_bounded_actions_still_fire():
+    """Positive side of #101868: inflected action mentions governed by a
+    future-ack keep triggering continuation in ``all`` mode."""
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": "Get the log summary."}]
+    for ack in (
+        "I'll read the file now.",
+        "I'll start reading the file.",
+        "Let me check the logs.",
+        "I'll begin analyzing the results.",
+        "I'll keep scanning the records.",
+        "Let me look into it.",
+        "I'll report back shortly.",
+    ):
+        assert looks_like_codex_intermediate_ack(
+            a, "Get the log summary.", ack, msgs, require_workspace=False
+        ), ack
+
+
+def test_word_bounded_workspace_markers_still_fire():
+    """Positive side of the workspace-marker fix: genuine repo/path/file-tree
+    references still satisfy the codex workspace scope."""
+    a = _agent("auto", "codex_responses")
+    msgs = [{"role": "user", "content": "check the failing build"}]
+    for ack in (
+        "Let me inspect the repository files first.",
+        "I'll scan the codebase next.",
+        "I'll check the current directory.",
+        "Let me look at the file tree.",
+    ):
+        assert looks_like_codex_intermediate_ack(
+            a, "check the failing build", ack, msgs, require_workspace=True
+        ), ack
+
+
+def test_plain_offers_of_optional_future_action_are_not_acks():
+    """Completed conversational answers that merely offer an optional next
+    step must be delivered as-is (#101868 "negative/substantive" cases)."""
+    a = _agent(True, "chat_completions")
+    msgs = [{"role": "user", "content": "What are my options?"}]
+    for reply in (
+        "You can pick A or B. I can do that for you if you want.",
+        "The answer is 42. Let me know if you'd like details.",
+    ):
+        assert not looks_like_codex_intermediate_ack(
+            a, "What are my options?", reply, msgs, require_workspace=False
+        ), reply
+
+
 
 
 


### PR DESCRIPTION
## What

`looks_like_codex_intermediate_ack()` matched action/workspace markers as raw substrings, so a complete gateway reply containing an intra-word collision (`"read" in "bread"`, `"repo" in "report"`, `"path" in "empathy"`) could satisfy the action test, be classified as an intermediate ack, and never be delivered — the user only saw the synthetic continuation (\#101868).

All three raw-substring sites now go through `_mentions_bounded_marker()`: word-bounded regexes (`(?<![a-z0-9])…(?![a-z0-9])`) with a small inflection suffix group for single-word verb markers (plus an optional doubled final consonant for `scanning`/`running`), so inflections (`reading`, `checking`, `analyzing`) still match while `bread`/`thread`/`empathy`/`profiles` do not. Noun (workspace) markers take a plural suffix only; multi-word markers (`look into`, `report back`, `file tree`) are unaffected. The match is a strict subset of the old substring behavior, so no new positives are possible.

## Verification

- RED: 3 new negative regression tests fail on pristine upstream/main (`935c1e8962`) — the #101868 repro (`bread`), a `thread` sibling collision, and workspace collisions (`report`/`empathy`/`profiles`) in both `require_workspace` modes
- GREEN: 11/11 in `tests/agent/test_intent_ack_continuation.py`; focused + nearby suites (intent-ack, codex_responses, verification continuation budget, wecom double send): 99 passed, 1 xfailed — re-verified by the reviewer after rebase onto current main (`77adb80d52`)
- Positive coverage: all four issue-suggested intent acks plus `scanning`, `look into`, `report back`, genuine repo/path/file-tree workspace references

## Competitor analysis

Open PRs touching the same detector (\#55916, \#55681, \#55670 — CJK future-acks; \#76013 — progress narration; \#45016 — preamble stalls; \#59638 — loop guards; \#69779 — false-negative revival in tool-using sessions) address different defect classes; none bound the marker matching, so the substring false positive remains on their diffs.

Closes #101868

Auto-published by Moonsong via Path B automated pipeline.