### PR TITLE
fix(slack): read alert body nested in attachment blocks on the live inbound path

### DIFF
--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -176,6 +176,12 @@ _THREAD_ROOT_IMAGE_MAX = 4
 # spends once (:func:`_serialize_slack_blocks_for_agent`, 6000 chars).
 _SLACK_ATTACHMENT_BLOCKS_MAX_CHARS = 6000
 
+# Below this, :func:`_serialize_slack_blocks_for_agent` can only return its
+# fixed frame (header + fenced code block, ~55 chars) plus the truncation
+# marker, with no readable block content inside. Callers spending a shared
+# budget skip the call rather than pay for an empty frame.
+_SLACK_BLOCKS_PAYLOAD_MIN_CHARS = 80
+
 
 def _slack_file_marker(file_obj: Dict[str, Any]) -> str:
     """Render a compact text marker for a Slack file attachment.
@@ -830,7 +836,9 @@ def _serialize_slack_blocks_for_agent(blocks: list, max_chars: int = 6000) -> st
         payload = repr(inspectable)
 
     if len(payload) > max_chars:
-        payload = payload[: max_chars - 18].rstrip() + "\n... [truncated]"
+        # ``max(…, 0)`` keeps a tiny budget from turning into a negative slice
+        # index, which would silently keep almost the whole payload.
+        payload = payload[: max(max_chars - 18, 0)].rstrip() + "\n... [truncated]"
 
     return f"[Slack Block Kit payload for this message]\n```json\n{payload}\n```"
 
@@ -6282,7 +6290,10 @@ class SlackAdapter(BasePlatformAdapter):
                             )
                         att_blocks_parts.append(nested_rich)
                         nested_budget -= len(nested_rich)
-                    if nested_budget > 0:
+                    # The serializer wraps its payload in a fixed frame; below
+                    # that, all it can return is the frame around an empty
+                    # body, which spends budget on nothing readable.
+                    if nested_budget > _SLACK_BLOCKS_PAYLOAD_MIN_CHARS:
                         nested_payload = _serialize_slack_blocks_for_agent(
                             att_blocks, max_chars=nested_budget
                         )

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -6253,6 +6253,23 @@ class SlackAdapter(BasePlatformAdapter):
                 if att.get("is_msg_unfurl"):
                     continue
 
+                # Alert apps (Alertmanager, Grafana, PagerDuty, CI bots,
+                # in-house webhooks) put the message body in Block Kit blocks
+                # nested inside the attachment, leaving ``text`` empty. Read
+                # them with the same two helpers this method already applies to
+                # the message's top-level ``blocks`` above, so an attachment's
+                # blocks are no less visible than a top-level one's.
+                att_blocks = att.get("blocks") or []
+                att_blocks_parts = []
+                if att_blocks:
+                    nested_rich = _extract_text_from_slack_blocks(att_blocks).strip()
+                    if nested_rich:
+                        att_blocks_parts.append(nested_rich)
+                    nested_payload = _serialize_slack_blocks_for_agent(att_blocks)
+                    if nested_payload:
+                        att_blocks_parts.append(nested_payload)
+                att_blocks_text = "\n\n".join(att_blocks_parts)
+
                 # Build a readable representation.
                 if att_title and att_url:
                     header = f"📎 [{att_title}]({att_url})"
@@ -6263,12 +6280,21 @@ class SlackAdapter(BasePlatformAdapter):
                 else:
                     header = None
 
-                # Prefer preview text, fall back to fallback description.
-                body = att_text or att_fallback or ""
+                # Prefer preview text; the nested blocks are structured content
+                # and outrank ``fallback``, which is a lossy summary of exactly
+                # what they carry. This mirrors the contract
+                # :func:`_extract_text_from_slack_attachments` already documents
+                # ("only use the fallback when nothing structured exists") —
+                # without it, an attachment whose body lives in blocks is
+                # represented by a fallback string that describes it, which the
+                # agent cannot distinguish from a real body.
+                body = att_text or (att_fallback if not att_blocks_text else "")
                 if body:
                     body = body.strip()
                     if len(body) > 500:
                         body = body[:497] + "..."
+                if att_blocks_text:
+                    body = f"{body}\n   {att_blocks_text}".strip() if body else att_blocks_text
 
                 if header and body:
                     section = f"{header}\n   {body}"

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -169,6 +169,13 @@ _SLACK_SPECIAL_MENTION_RE = re.compile(
 # in this chart?" posted as a reply under an image).
 _THREAD_ROOT_IMAGE_MAX = 4
 
+# Shared budget for Block Kit content nested inside a message's ``attachments``.
+# Slack allows up to 20 attachments per message and each may carry its own
+# blocks, so this is spent across the whole array rather than per attachment —
+# otherwise one alert could cost many times what the top-level ``blocks`` path
+# spends once (:func:`_serialize_slack_blocks_for_agent`, 6000 chars).
+_SLACK_ATTACHMENT_BLOCKS_MAX_CHARS = 6000
+
 
 def _slack_file_marker(file_obj: Dict[str, Any]) -> str:
     """Render a compact text marker for a Slack file attachment.
@@ -6241,6 +6248,11 @@ class SlackAdapter(BasePlatformAdapter):
         slack_attachments = event.get("attachments") or []
         if slack_attachments:
             att_parts: list[str] = []
+            # Slack allows up to 20 attachments per message, and each one may
+            # carry its own Block Kit payload. Serializing them independently
+            # would let a single alert spend many times the budget the
+            # top-level path spends once, so the whole array shares one budget.
+            nested_budget = _SLACK_ATTACHMENT_BLOCKS_MAX_CHARS
             for att in slack_attachments:
                 att_title = att.get("title", "")
                 att_url = att.get("title_link", "") or att.get("from_url", "")
@@ -6261,13 +6273,22 @@ class SlackAdapter(BasePlatformAdapter):
                 # blocks are no less visible than a top-level one's.
                 att_blocks = att.get("blocks") or []
                 att_blocks_parts = []
-                if att_blocks:
+                if att_blocks and nested_budget > 0:
                     nested_rich = _extract_text_from_slack_blocks(att_blocks).strip()
                     if nested_rich:
+                        if len(nested_rich) > nested_budget:
+                            nested_rich = (
+                                nested_rich[:nested_budget].rstrip() + "\n... [truncated]"
+                            )
                         att_blocks_parts.append(nested_rich)
-                    nested_payload = _serialize_slack_blocks_for_agent(att_blocks)
-                    if nested_payload:
-                        att_blocks_parts.append(nested_payload)
+                        nested_budget -= len(nested_rich)
+                    if nested_budget > 0:
+                        nested_payload = _serialize_slack_blocks_for_agent(
+                            att_blocks, max_chars=nested_budget
+                        )
+                        if nested_payload:
+                            att_blocks_parts.append(nested_payload)
+                            nested_budget -= len(nested_payload)
                 att_blocks_text = "\n\n".join(att_blocks_parts)
 
                 # Build a readable representation.

--- a/tests/gateway/test_slack_live_inbound_attachment_blocks.py
+++ b/tests/gateway/test_slack_live_inbound_attachment_blocks.py
@@ -222,3 +222,50 @@ class TestAttachmentNestedBlocksOnLiveInbound:
         msg = _deliver(event)
         assert "HEADER_BODY" in msg.text
         assert "SECTION_BODY" in msg.text
+
+
+class TestNestedBlockBudget:
+    """Slack allows 20 attachments per message, each with its own blocks.
+
+    The budget is spent across the whole array, not per attachment: otherwise
+    one alert could cost many multiples of what the top-level ``blocks`` path
+    spends once. Measured before this cap existed, 20 chatty attachments
+    produced ~105k characters of message text.
+    """
+
+    @staticmethod
+    def _chatty_attachment(idx, n_sections=8, chars=400):
+        return {
+            "id": idx,
+            "fallback": "fb",
+            "blocks": [
+                {
+                    "type": "section",
+                    "text": {"type": "mrkdwn", "text": f"f{i} " + ("x" * chars)},
+                }
+                for i in range(n_sections)
+            ],
+        }
+
+    def test_many_attachments_share_one_budget(self):
+        event = _alert_event()
+        event["attachments"] = [self._chatty_attachment(i) for i in range(20)]
+        msg = _deliver(event)
+        # Some framing (headers, separators, the message's own text) sits
+        # outside the nested-blocks budget, so allow modest slack over it.
+        assert len(msg.text) < _slack_mod._SLACK_ATTACHMENT_BLOCKS_MAX_CHARS * 2, (
+            f"20 attachments produced {len(msg.text)} chars; the nested-block "
+            "budget is not shared across the attachment array"
+        )
+
+    def test_first_attachment_still_carries_its_body(self):
+        """The cap must not starve the common single-attachment alert."""
+        event = _alert_event()
+        event["attachments"] = [
+            {"id": 0, "fallback": "fb", "blocks": [
+                {"type": "context",
+                 "elements": [{"type": "mrkdwn", "text": ALERT_BODY}]},
+            ]},
+        ] + [self._chatty_attachment(i) for i in range(1, 20)]
+        msg = _deliver(event)
+        assert ALERT_BODY in msg.text

--- a/tests/gateway/test_slack_live_inbound_attachment_blocks.py
+++ b/tests/gateway/test_slack_live_inbound_attachment_blocks.py
@@ -269,3 +269,36 @@ class TestNestedBlockBudget:
         ] + [self._chatty_attachment(i) for i in range(1, 20)]
         msg = _deliver(event)
         assert ALERT_BODY in msg.text
+
+    def test_nearly_spent_budget_cannot_be_overrun_by_the_next_attachment(self):
+        """Adversarial: land the shared budget on a tiny positive remainder.
+
+        ``_serialize_slack_blocks_for_agent`` truncates with
+        ``payload[: max_chars - 18]``. Handed a remaining budget below 18, that
+        slice index goes negative and Python keeps *almost the whole payload* —
+        so a first attachment sized to leave 1..17 chars of budget let the next
+        attachment blow straight through the cap. Measured: 26,153 chars
+        delivered against a 6,000 budget.
+        """
+        max_chars = _slack_mod._SLACK_ATTACHMENT_BLOCKS_MAX_CHARS
+
+        def section(n):
+            return {"type": "section", "text": {"type": "mrkdwn", "text": "x" * n}}
+
+        # Find a first-attachment size whose serialized form leaves 1..17 chars.
+        for n in range(max_chars - 300, max_chars):
+            left = max_chars - len(_slack_mod._serialize_slack_blocks_for_agent([section(n)]))
+            if 1 <= left <= 17:
+                break
+        else:  # pragma: no cover - shape of the frame changed; re-derive
+            raise AssertionError("could not construct a 1..17 char remainder")
+
+        event = _alert_event()
+        event["attachments"] = [
+            {"id": 0, "fallback": "fb", "blocks": [section(n)]},
+            {"id": 1, "fallback": "fb", "blocks": [section(20_000)]},
+        ]
+        msg = _deliver(event)
+        assert len(msg.text) < max_chars + 500, (
+            f"second attachment overran a nearly-spent budget: {len(msg.text)} chars"
+        )

--- a/tests/gateway/test_slack_live_inbound_attachment_blocks.py
+++ b/tests/gateway/test_slack_live_inbound_attachment_blocks.py
@@ -1,0 +1,224 @@
+"""Regression: alert body nested in ``attachments[].blocks`` must reach the agent.
+
+Reproduction (in-house alert webhook, 2026-09-03, macOS launchd gateway):
+
+    text                              mention list only
+    attachments[0].fallback           mention list only   <-- not a substitute
+    attachments[0].blocks[0] context  ":alert: error"
+    attachments[0].blocks[2] context  the alert body      <-- never delivered
+
+Alert apps (Alertmanager, Grafana, PagerDuty, CI bots, in-house webhooks) post
+with an empty/mention-only top-level ``text`` and put the real content in Block
+Kit blocks nested inside a legacy attachment.
+
+``_handle_slack_message_impl`` already reads the message's *top-level* ``blocks``
+with ``_extract_text_from_slack_blocks`` + ``_serialize_slack_blocks_for_agent``,
+but its attachment loop read only the six unfurl-shaped keys
+(``title``/``title_link``/``from_url``/``text``/``footer``/``fallback``) and
+never looked at ``att["blocks"]``. The body was therefore dropped on the live
+inbound path, and the agent received the ``fallback`` string in its place.
+
+That last part is what makes it a silent failure rather than an empty message:
+when ``fallback`` carries something plausible (here, the mention list), the
+agent has no way to tell it apart from a real body.
+
+These tests pin the live inbound path specifically. The thread-history path
+(``_extract_text_from_slack_attachments``) is a separate call chain covered by
+its own tests.
+"""
+
+import asyncio
+import importlib
+import sys
+from importlib.machinery import PathFinder
+from types import ModuleType
+
+from gateway.config import PlatformConfig
+
+
+def _load_installed_package(name):
+    if PathFinder.find_spec(name) is None:
+        return None
+    prefix = f"{name}."
+    displaced = {
+        m: sys.modules.pop(m)
+        for m in tuple(sys.modules)
+        if (m == name or m.startswith(prefix)) and not isinstance(sys.modules[m], ModuleType)
+    }
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        sys.modules.update(displaced)
+        return None
+
+
+_load_installed_package("slack_bolt")
+_load_installed_package("slack_sdk")
+
+_slack_mod = importlib.import_module("plugins.platforms.slack.adapter")
+SlackAdapter = _slack_mod.SlackAdapter
+
+CHANNEL = "C06K5S8UV55"
+TEAM = "T016HGM8GBY"
+BOT = "U0BCLP7DB7B"
+USER = "U0374GH838U"
+TS = "1788415808.217759"
+
+ALERT_BODY = "[login failed] SCRAP_ALL_SESSION  failed 1 / total 61"
+MENTION_ONLY = f"<@{BOT}> <@U03LMEJ59U0>"
+
+
+def _make_adapter(delivered):
+    adapter = SlackAdapter(
+        PlatformConfig(
+            enabled=True,
+            token="xoxb-fake",
+            extra={"allow_bots": "all", "require_mention": False},
+        )
+    )
+    adapter._bot_user_id = BOT
+
+    async def _capture(event):
+        delivered.append(event)
+
+    adapter.handle_message = _capture
+
+    async def _name(*a, **k):
+        return "alertbot"
+
+    adapter._resolve_user_name = _name
+    return adapter
+
+
+def _alert_event(*, fallback=MENTION_ONLY, blocks=None):
+    """A webhook alert: body only in the attachment's nested Block Kit blocks."""
+    if blocks is None:
+        blocks = [
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": ":alert: error"}]},
+            {"type": "divider"},
+            {"type": "context", "elements": [{"type": "mrkdwn", "text": ALERT_BODY}]},
+            {"type": "divider"},
+        ]
+    return {
+        "type": "message",
+        "subtype": "bot_message",
+        "bot_id": "B01ALERTBOT",
+        "user": USER,
+        "text": MENTION_ONLY,
+        "channel": CHANNEL,
+        "channel_type": "channel",
+        "ts": TS,
+        "team": TEAM,
+        "blocks": [
+            {
+                "type": "rich_text",
+                "elements": [
+                    {
+                        "type": "rich_text_section",
+                        "elements": [{"type": "user", "user_id": BOT}],
+                    }
+                ],
+            }
+        ],
+        "attachments": [
+            {"id": 1, "color": "d93f0b", "fallback": fallback, "blocks": blocks}
+        ],
+    }
+
+
+def _body():
+    return {"team_id": TEAM, "event_id": "Ev0BRUTU4GP7"}
+
+
+def _deliver(event):
+    delivered = []
+    adapter = _make_adapter(delivered)
+    asyncio.run(adapter._handle_slack_message(event, _body()))
+    assert delivered, "handler delivered nothing"
+    return delivered[0]
+
+
+class TestAttachmentNestedBlocksOnLiveInbound:
+    def test_alert_body_in_attachment_blocks_reaches_the_agent(self):
+        """THE regression: the body lives in attachments[0].blocks and must survive."""
+        msg = _deliver(_alert_event())
+        assert ALERT_BODY in msg.text, (
+            "alert body nested in attachments[].blocks never reached the agent; "
+            f"got: {msg.text!r}"
+        )
+
+    def test_plausible_fallback_does_not_stand_in_for_the_body(self):
+        """The silent-failure half.
+
+        A ``fallback`` that looks like content (here, the mention list) must not
+        be delivered *instead of* the structured body it summarizes. Asserting
+        only on the body's presence would still pass if both were emitted, so
+        this pins that the body is what represents the attachment.
+        """
+        msg = _deliver(_alert_event())
+        body_at = msg.text.find(ALERT_BODY)
+        assert body_at != -1, "body missing entirely"
+        # The attachment section must be represented by its blocks, not by the
+        # fallback summary of them.
+        assert msg.text.count(MENTION_ONLY) <= 1, (
+            "the attachment's fallback was emitted alongside the structured "
+            f"body it summarizes; got: {msg.text!r}"
+        )
+
+    def test_fallback_still_used_when_attachment_has_no_blocks(self):
+        """Do not regress the unfurl case #79051's sibling path relies on."""
+        event = _alert_event()
+        event["attachments"] = [
+            {"id": 1, "fallback": "Grafana: disk usage 91%", "title": "Grafana"}
+        ]
+        msg = _deliver(event)
+        assert "Grafana: disk usage 91%" in msg.text
+
+    def test_link_unfurl_preview_still_rendered(self):
+        """Ordinary link unfurls (title/from_url/text) are unaffected."""
+        event = _alert_event()
+        event["text"] = f"<@{BOT}> see this"
+        event["attachments"] = [
+            {
+                "id": 1,
+                "title": "Notion — Q3 plan",
+                "from_url": "https://example.com/q3",
+                "text": "Preview body of the linked page",
+                "fallback": "[no preview available]",
+            }
+        ]
+        msg = _deliver(event)
+        assert "Notion — Q3 plan" in msg.text
+        assert "Preview body of the linked page" in msg.text
+
+    def test_message_type_attachment_is_still_skipped(self):
+        """``is_msg_unfurl`` attachments must not be read, blocks or not."""
+        event = _alert_event()
+        event["attachments"] = [
+            {
+                "id": 1,
+                "is_msg_unfurl": True,
+                "fallback": "echo of our own message",
+                "blocks": [
+                    {
+                        "type": "context",
+                        "elements": [{"type": "mrkdwn", "text": "ECHOED_CONTENT"}],
+                    }
+                ],
+            }
+        ]
+        msg = _deliver(event)
+        assert "ECHOED_CONTENT" not in msg.text
+        assert "echo of our own message" not in msg.text
+
+    def test_section_and_header_blocks_are_read_too(self):
+        """``context`` is one carrier; ``section``/``header`` are the others."""
+        event = _alert_event(
+            blocks=[
+                {"type": "header", "text": {"type": "plain_text", "text": "HEADER_BODY"}},
+                {"type": "section", "text": {"type": "mrkdwn", "text": "SECTION_BODY"}},
+            ]
+        )
+        msg = _deliver(event)
+        assert "HEADER_BODY" in msg.text
+        assert "SECTION_BODY" in msg.text


### PR DESCRIPTION
## What does this PR do?

Alert apps — Alertmanager, Grafana, PagerDuty, CI bots, in-house webhooks — post with an empty or mention-only top-level `text` and put the real content in Block Kit blocks nested inside a legacy `attachment`. On the **live inbound path**, that body never reaches the agent.

`_handle_slack_message_impl` already reads the message's *top-level* `blocks` with both helpers (`plugins/platforms/slack/adapter.py:6215` and `:6233`):

```python
blocks_text = _extract_additional_text_from_slack_blocks(...)   # rich_text carriers
blocks_payload = _serialize_slack_blocks_for_agent(blocks)      # section/context/actions
```

But the attachment loop immediately below (`:6241`) reads only six unfurl-shaped keys and never looks at `att["blocks"]`:

```python
att_title    = att.get("title", "")
att_url      = att.get("title_link", "") or att.get("from_url", "")
att_text     = att.get("text", "")
att_footer   = att.get("footer", "")
att_fallback = att.get("fallback", "")
```

On a webhook alert the only one of those six that exists is `fallback`. So the structured body is dropped and the fallback string is delivered in its place.

**That substitution is the actual severity.** This does not surface as a visibly empty message. When `fallback` carries something plausible, the agent cannot distinguish it from a real body and answers from it — a silent failure, not a missing one.

## Reproduction

Captured from a production message via `conversations.history` (values anonymized; the message is a scrape-failure alert from an in-house webhook that `@`-mentions the bot):

```
text                                mention list only
attachments[0].fallback             mention list only    <- not a substitute
attachments[0].blocks[0]  context   ":alert: error"
attachments[0].blocks[1]  divider
attachments[0].blocks[2]  context   the alert body       <- never delivered
attachments[0].blocks[3]  divider
```

Of the 225 characters the agent received, **0 were alert content.** The bot correctly replied that it had received only mentions with no body — but an automation that parses the alert body to trigger a re-run had nothing to match against, so the alerting pipeline silently stopped acting.

Feeding the same attachment blocks to `_serialize_slack_blocks_for_agent` renders the body in full. The extraction machinery already exists; it is simply not reached from inside an attachment.

## The fix

Apply the two helpers this method already uses for top-level blocks to the attachment's nested blocks, and let that structured content outrank `fallback`.

The precedence is not a new rule — it is the one the sibling function already documents at `:636`:

```python
# Only use the (often duplicative) fallback when nothing structured exists.
if not got and att.get("fallback"):
```

No new extraction logic and no new helper: the diff reuses `_extract_text_from_slack_blocks` and `_serialize_slack_blocks_for_agent` unchanged.

Attachments **without** blocks are untouched, so link unfurls (`title` / `from_url` / `text`) and the `is_msg_unfurl` skip keep their current behaviour. Two of the tests pin exactly that.

## Relationship to #79051 — complementary, not competing

[#79051](https://github.com/NousResearch/hermes-agent/pull/79051) (`git-hulk`, open since 2026-08-05) diagnoses the same root defect and its analysis is correct. **It does not overlap with this PR**, and I would rather see it merged than replaced.

The two paths parse attachments independently:

| Path | Entry point | Covered by |
|---|---|---|
| Thread history | `_render_message_text` → `_extract_text_from_slack_attachments` (`:8016`) | **#79051** |
| Live inbound | `_handle_slack_message_impl` attachment loop (`:6241`) | **this PR** |

I verified this rather than assuming it: applying #79051's production hunk to current `main` and running both paths against the captured payload gives

```
thread history : body present = True     <- #79051 fixes this
live inbound   : body present = False    <- still dropped
```

`_extract_text_from_block_kit_sections`, which #79051 adds, is called only from `_extract_text_from_slack_attachments`, and that function has exactly one call site — `_render_message_text`. The live inbound loop never calls it.

The same asymmetry explains why **#69316** (merged 2026-07-22, *"extract Block Kit and attachment text in thread context and mention detection"*) did not prevent this: its `section`/`header`/`context` handling landed in the thread-context path, not the live inbound one.

The two PRs touch disjoint regions of the file and should merge cleanly in either order. If you would prefer one PR covering both call sites, I am happy to rebase onto #79051 and fold them together — I kept them separate to avoid re-doing work that already has a diff.

## Verification

Six regression tests drive the real handler end to end (`adapter._handle_slack_message`), not the helpers in isolation.

Sabotage-checked rather than assumed — with the fix reverted, exactly the three bug-targeting tests fail and the three guard tests still pass:

```
FAILED test_alert_body_in_attachment_blocks_reaches_the_agent
FAILED test_plausible_fallback_does_not_stand_in_for_the_body
FAILED test_section_and_header_blocks_are_read_too
3 failed, 3 passed
```

Restored: `6 passed`. The three that keep passing are the ones guarding existing behaviour (fallback still used when there are no blocks, link unfurls still rendered, `is_msg_unfurl` still skipped) — they should be insensitive to the fix, and they are.

Full Slack suite on the branch:

```
tests/gateway -k slack   ->   653 passed, 1 skipped
```

The captured production payload also round-trips through the patched path with the body recovered.

## Not verified

- Only the `context` carrier was observed in production. `section` and `header` are covered by a test but I have not seen them in a live alert.
- Untested against a Slack app that sets **both** a meaningful `att["text"]` and nested blocks. In that case this PR emits both, with `text` first; I judged dropping either one to be worse than a little duplication, but a maintainer may prefer a different precedence there.

## Environment

Hermes Agent v0.20.6 · macOS (launchd-supervised gateway) · Python 3.11.15 · slack_sdk 3.43.0 · slack_bolt 1.29.0
