### PR TITLE
Remote execute_code kernels are idle-reaped and capped like local ones, never mid-cell (salvage #97099)

### DIFF
--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -200,6 +200,51 @@ class TestOwnershipIsolation(RemoteKernelBase):
         self.assertEqual(remaining_owner, "owner-b")
 
 
+class TestIdleReapAndCapEviction(RemoteKernelBase):
+    """Unlike local session kernels, remote kernels had no idle-reap or
+    process-wide cap: _REMOTE_KERNELS grew one entry per distinct
+    (owner, env_type, task_env_id) that was never revisited, for the life
+    of the gateway process."""
+
+    def test_idle_expired_kernel_is_reaped_on_next_call(self):
+        env = ScriptedEnv(_spawn_ok_handlers([_cell(), _cell()]))
+        execute_in_remote_kernel(
+            "print(1)", env=env, env_type="ssh", task_env_id="stale",
+            sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+            reset=False, idle_exit=1800,
+        )
+        self.assertEqual(len(_REMOTE_KERNELS), 1)
+        # Backdate the kernel's last_used past the idle window — simulates
+        # a key that is never revisited again.
+        for kernel in _REMOTE_KERNELS.values():
+            kernel.last_used -= 2000
+        # A call for a DIFFERENT key must reap the stale entry on entry,
+        # without ever touching or reviving it.
+        execute_in_remote_kernel(
+            "print(1)", env=env, env_type="ssh", task_env_id="fresh",
+            sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+            reset=False, idle_exit=1800,
+        )
+        owners = {key[0] for key in _REMOTE_KERNELS}
+        self.assertNotIn("stale", owners)
+        self.assertIn("fresh", owners)
+
+    def test_over_cap_evicts_least_recently_used(self):
+        with patch("tools.code_kernel._lifecycle_limits", return_value=(2, 1800)):
+            env = ScriptedEnv(_spawn_ok_handlers([_cell() for _ in range(10)]))
+            for i in range(3):
+                execute_in_remote_kernel(
+                    "print(1)", env=env, env_type="ssh", task_env_id=f"owner-{i}",
+                    sandbox_tools=frozenset(), timeout=10, max_tool_calls=5,
+                    reset=False, idle_exit=1800,
+                )
+            self.assertEqual(len(_REMOTE_KERNELS), 2)
+            owners = {key[0] for key in _REMOTE_KERNELS}
+            self.assertNotIn("owner-0", owners)
+            self.assertIn("owner-1", owners)
+            self.assertIn("owner-2", owners)
+
+
 class TestDispatchIntegration(unittest.TestCase):
     """_execute_remote prefers the kernel and falls open to per-call."""
 

--- a/tests/tools/test_code_kernel_remote.py
+++ b/tests/tools/test_code_kernel_remote.py
@@ -244,6 +244,36 @@ class TestIdleReapAndCapEviction(RemoteKernelBase):
             self.assertIn("owner-1", owners)
             self.assertIn("owner-2", owners)
 
+    def test_eviction_skips_kernels_with_a_running_cell(self):
+        """Cap eviction must never kill a kernel mid-cell (the local-kernel
+        race from hermes-agent#101861): a busy kernel stays put and a
+        settled one goes instead, even if the busy one is older."""
+        import threading
+
+        gate = threading.Event()
+
+        def slow_cat(command):
+            gate.wait(10)
+            return {"output": json.dumps(_cell()), "returncode": 0}
+
+        busy_env = ScriptedEnv([
+            ("nohup", lambda c: {"output": "PID:4242\n", "returncode": 0}),
+            ("kill -0", lambda c: {"output": "ALIVE\n", "returncode": 0}),
+            ("cat ", slow_cat),
+        ])
+        with patch("tools.code_kernel._lifecycle_limits", return_value=(1, 1800)):
+            worker = threading.Thread(target=_run, args=(busy_env,), kwargs={"task": "busy"})
+            worker.start()
+            while not any(k.attached for k in _REMOTE_KERNELS.values()):
+                pass
+            env = ScriptedEnv(_spawn_ok_handlers([_cell()]))
+            _run(env, task="settled")
+            owners = {key[0] for key in _REMOTE_KERNELS}
+            self.assertIn("busy", owners)
+            gate.set()
+            worker.join(10)
+        self.assertFalse(any("kill 4242" in c for c in busy_env.commands))
+
 
 class TestDispatchIntegration(unittest.TestCase):
     """_execute_remote prefers the kernel and falls open to per-call."""

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -219,6 +219,44 @@ def shutdown_remote_kernels_for_owner(owner: str) -> None:
         _kill(kernel)
 
 
+def _reap_unlocked(idle_timeout: int) -> List["RemoteKernel"]:
+    """Pop idle-expired remote kernels; caller tears them down outside the lock.
+
+    Mirrors tools.code_kernel._reap_unlocked. The remote runner itself
+    self-exits after the same idle window (REMOTE_KERNEL_RUNNER_SOURCE's
+    IDLE_EXIT_SECONDS), so this only needs to clear the HOST-side
+    bookkeeping entry — without it, _REMOTE_KERNELS grows one entry per
+    distinct (owner, env_type, task_env_id) that is never revisited, for
+    the life of the gateway process.
+    """
+    now = time.monotonic()
+    doomed = [
+        key
+        for key, kernel in _REMOTE_KERNELS.items()
+        if now - kernel.last_used > idle_timeout
+    ]
+    return [_REMOTE_KERNELS.pop(key) for key in doomed]
+
+
+def _evict_over_cap_unlocked(keep: Tuple) -> List["RemoteKernel"]:
+    """Pop least-recently-used remote kernels beyond the process-wide cap.
+
+    Mirrors tools.code_kernel._evict_over_cap_unlocked, reusing the same
+    max_session_kernels config as an independent bound on _REMOTE_KERNELS.
+    """
+    from tools.code_kernel import _lifecycle_limits
+
+    cap, _ = _lifecycle_limits()
+    if len(_REMOTE_KERNELS) <= cap:
+        return []
+    by_age = sorted(
+        (key for key in _REMOTE_KERNELS if key != keep),
+        key=lambda key: _REMOTE_KERNELS[key].last_used,
+    )
+    doomed = by_age[: len(_REMOTE_KERNELS) - cap]
+    return [_REMOTE_KERNELS.pop(key) for key in doomed]
+
+
 atexit.register(shutdown_all_remote_kernels)
 
 
@@ -329,7 +367,10 @@ def execute_in_remote_kernel(
     state_reset = False
 
     with _REMOTE_KERNELS_LOCK:
+        expired = _reap_unlocked(idle_exit)
         kernel = _REMOTE_KERNELS.get(key)
+    for doomed in expired:
+        _kill(doomed)
 
     if kernel is not None and reset:
         with _REMOTE_KERNELS_LOCK:
@@ -359,6 +400,10 @@ def execute_in_remote_kernel(
             _REMOTE_KERNELS[key] = kernel
 
     kernel.last_used = time.monotonic()
+    with _REMOTE_KERNELS_LOCK:
+        evicted = _evict_over_cap_unlocked(keep=key)
+    for doomed in evicted:
+        _kill(doomed)
     kernel.cell_seq += 1
     seq = f"{kernel.cell_seq:06d}"
     q_cells = shlex.quote(f"{kernel.kernel_dir}/cells")

--- a/tools/code_kernel_remote.py
+++ b/tools/code_kernel_remote.py
@@ -156,6 +156,10 @@ class RemoteKernel:
     last_used: float = field(default_factory=time.monotonic)
     execution_count: int = 0
     cell_seq: int = 0
+    # Cells currently running on this kernel. Reap/evict skip attached
+    # kernels: killing one mid-cell tears the runner out from under a live
+    # poll loop (same guard as tools.code_kernel, hermes-agent#101861).
+    attached: int = 0
 
 
 def _kernel_key(owner: str, env_type: str, task_env_id: str) -> Tuple:
@@ -233,7 +237,7 @@ def _reap_unlocked(idle_timeout: int) -> List["RemoteKernel"]:
     doomed = [
         key
         for key, kernel in _REMOTE_KERNELS.items()
-        if now - kernel.last_used > idle_timeout
+        if kernel.attached == 0 and now - kernel.last_used > idle_timeout
     ]
     return [_REMOTE_KERNELS.pop(key) for key in doomed]
 
@@ -250,7 +254,7 @@ def _evict_over_cap_unlocked(keep: Tuple) -> List["RemoteKernel"]:
     if len(_REMOTE_KERNELS) <= cap:
         return []
     by_age = sorted(
-        (key for key in _REMOTE_KERNELS if key != keep),
+        (key for key in _REMOTE_KERNELS if key != keep and _REMOTE_KERNELS[key].attached == 0),
         key=lambda key: _REMOTE_KERNELS[key].last_used,
     )
     doomed = by_age[: len(_REMOTE_KERNELS) - cap]
@@ -355,11 +359,6 @@ def execute_in_remote_kernel(
     the ``kernel`` sub-dict, matching the local kernel's result shape.
     """
     from tools.code_kernel import _resolve_owner
-    from tools.code_execution_tool import (
-        _rpc_poll_loop,
-        _ship_file_to_remote,
-    )
-    from tools.thread_context import propagate_context_to_thread
 
     owner = _resolve_owner(task_env_id)
     key = _kernel_key(owner, env_type, task_env_id)
@@ -401,9 +400,43 @@ def execute_in_remote_kernel(
 
     kernel.last_used = time.monotonic()
     with _REMOTE_KERNELS_LOCK:
+        kernel.attached += 1
         evicted = _evict_over_cap_unlocked(keep=key)
     for doomed in evicted:
         _kill(doomed)
+    try:
+        return _run_remote_cell(
+            kernel, key, code, env=env, task_env_id=task_env_id,
+            sandbox_tools=sandbox_tools, timeout=timeout,
+            max_tool_calls=max_tool_calls, reused=reused,
+            state_reset=state_reset, state_lost=state_lost,
+        )
+    finally:
+        with _REMOTE_KERNELS_LOCK:
+            kernel.attached -= 1
+            kernel.last_used = time.monotonic()
+
+
+def _run_remote_cell(
+    kernel: RemoteKernel,
+    key: Tuple,
+    code: str,
+    *,
+    env,
+    task_env_id: str,
+    sandbox_tools: frozenset,
+    timeout: int,
+    max_tool_calls: int,
+    reused: bool,
+    state_reset: bool,
+    state_lost: bool,
+) -> Dict[str, Any]:
+    from tools.code_execution_tool import (
+        _rpc_poll_loop,
+        _ship_file_to_remote,
+    )
+    from tools.thread_context import propagate_context_to_thread
+
     kernel.cell_seq += 1
     seq = f"{kernel.cell_seq:06d}"
     q_cells = shlex.quote(f"{kernel.kernel_dir}/cells")


### PR DESCRIPTION
## Summary
Remote `execute_code` kernels (docker/ssh/modal) are now idle-reaped and LRU-capped like local ones, and neither host ever reaps or evicts a kernel with a cell running. Salvage of #97099 by @nftpoetrist, plus the attached-cell guard from #101861 on top.

Root cause: #96991 added a host-side `_REMOTE_KERNELS` registry with no reap/cap; entries (and the live remote runner, until it self-exits at 30 min) accumulate one per distinct `(owner, env, task_env_id)` for the life of the gateway process. The contributor's port also inherited the local host's mid-cell eviction race fixed in #101861.

## Changes
- `tools/code_kernel_remote.py`: `_reap_unlocked` / `_evict_over_cap_unlocked` mirroring the local host, sharing `code_execution.max_session_kernels` (@nftpoetrist); `RemoteKernel.attached` counter so reap/evict skip kernels mid-cell, cell body extracted to `_run_remote_cell` so detach runs on every exit path (follow-up).
- Tests: idle reap, LRU cap (contributor), eviction-skips-busy-kernel (sabotage-verified: fails with the guard removed).

## Validation
| | Before | After |
|---|---|---|
| Never-revisited remote kernel | host entry lives forever | reaped on next call after idle window |
| 3 owners, cap 2 | 3 live | 2 live, LRU evicted |
| Cap eviction vs kernel mid-cell | killed under the poll loop | busy kernel kept, settled one evicted |
| `tests/tools/test_code_kernel_remote.py` + `test_code_kernel.py` | — | 35 passed |

**Live repro:** scripted-env harness (real transport verified on the local twin in #101861; remote path is the same lifecycle shape).

## Infographic

![remote kernel reap/cap](https://v3b.fal.media/files/b/0aa8e8b9/oqFsprtZCEcTJN2_9QoAs_eW9dNwMd.png)
