### PR TITLE
fix(desktop): cap concurrent local backend spawns + pool sizing as a live preference (salvage #100985 + #92581)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -280,6 +280,11 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
+import {
+  type LocalBackendSpawnRequest,
+  LocalBackendSpawnCoordinator,
+  releaseLocalBackendSlotAfterExit
+} from './pool-spawn-coordinator'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
@@ -1410,6 +1415,7 @@ const profileDeletionGate = new ProfileDeletionGate()
 // exist while a non-primary profile is actively being chatted through.
 const POOL_MAX_BACKENDS = Math.max(1, Number(process.env.HERMES_DESKTOP_POOL_MAX) || 3)
 const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || 10 * 60_000)
+const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(POOL_MAX_BACKENDS)
 
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
@@ -11259,7 +11265,10 @@ async function ensureBackend(profile) {
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
-    remoteBaseUrl: null
+    remoteBaseUrl: null,
+    releaseLocalBackendSlot: null,
+    localBackendSlotKey: null,
+    localBackendSpawnRequest: null
   }
 
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(async error => {
@@ -11270,12 +11279,7 @@ async function ensureBackend(profile) {
       `Hermes backend for profile "${key}" failed to start: ${error instanceof Error ? error.message : String(error)}`
     )
 
-    if (backendPool.get(key) === entry) {
-      backendPool.delete(key)
-    }
-
-    stopBackendChild(entry.process)
-    await waitForBackendExit(entry.process)
+    await teardownFailedLocalBackend(key, entry)
     throw error
   })
   backendPool.set(key, entry)
@@ -11427,7 +11431,10 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       token: null,
       connectionPromise: null,
       lastActiveAt: Date.now(),
-      remoteBaseUrl: null
+      remoteBaseUrl: null,
+      releaseLocalBackendSlot: null,
+      localBackendSlotKey: null,
+      localBackendSpawnRequest: null
     }
 
     localEntry.connectionPromise = spawnPoolBackend(profileKey, localEntry, {
@@ -11440,12 +11447,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
         `Hermes backend for profile "${profileKey}" (forced-local) failed to start: ${error instanceof Error ? error.message : String(error)}`
       )
 
-      if (backendPool.get(localRoute.poolKey) === localEntry) {
-        backendPool.delete(localRoute.poolKey)
-      }
-
-      stopBackendChild(localEntry.process)
-      await waitForBackendExit(localEntry.process)
+      await teardownFailedLocalBackend(localRoute.poolKey, localEntry)
       throw error
     })
     backendPool.set(localRoute.poolKey, localEntry)
@@ -12178,6 +12180,67 @@ function startPoolIdleReaper() {
   }
 }
 
+function releaseLocalBackendSlot(entry: any) {
+  if (!entry) {
+    return
+  }
+
+  const release = entry.releaseLocalBackendSlot
+  const request = entry.localBackendSpawnRequest as LocalBackendSpawnRequest | null
+  entry.releaseLocalBackendSlot = null
+  entry.localBackendSlotKey = null
+  entry.localBackendSpawnRequest = null
+
+  if (release) {
+    release()
+  } else {
+    request?.cancel()
+  }
+}
+
+function assertPoolEntryStillOwned(poolKey: string, entry: any) {
+  if (backendPool.get(poolKey) !== entry) {
+    releaseLocalBackendSlot(entry)
+    throw new Error(`Profile backend start for "${poolKey}" was cancelled before spawn.`)
+  }
+}
+
+const failedLocalBackendTeardowns = new WeakMap<object, Promise<void>>()
+
+function teardownFailedLocalBackend(poolKey: string, entry: any): Promise<void> {
+  const existing = failedLocalBackendTeardowns.get(entry)
+
+  if (existing) {
+    return existing
+  }
+
+  if (backendPool.get(poolKey) === entry) {
+    backendPool.delete(poolKey)
+  }
+
+  const child = entry.process
+  const teardown = releaseLocalBackendSlotAfterExit(
+    () => releaseLocalBackendSlot(entry),
+    async () => {
+      stopBackendChild(child)
+      await waitForBackendExit(child)
+
+      if (child && child.exitCode === null && child.signalCode === null) {
+        throw new Error(
+          `Profile backend for "${poolKey}" did not exit; keeping the local slot occupied.`
+        )
+      }
+
+      releaseBackendChild(child)
+    }
+  )
+
+  // Keep the settled promise in the WeakMap for the lifetime of this entry.
+  // Error + exit + outer catch may all request cleanup; none may run it twice.
+  failedLocalBackendTeardowns.set(entry, teardown)
+  return teardown
+}
+
 // Spawn an additional dashboard backend pinned to a named profile. Mirrors the
 // local-spawn portion of startHermes() but without the boot-progress UI,
 // bootstrap, or remote handling (those belong to the primary backend only).
@@ -12214,6 +12277,17 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
       ...getWindowState()
     }
   }
+
+  const spawnRequest = localBackendSpawnCoordinator.request(poolKey, { timeoutMs: POOL_IDLE_MS })
+  entry.localBackendSlotKey = poolKey
+  entry.localBackendSpawnRequest = spawnRequest
+  entry.releaseLocalBackendSlot = await spawnRequest.acquired
+
+  if (entry.localBackendSpawnRequest === spawnRequest) {
+    entry.localBackendSpawnRequest = null
+  }
+
+  assertPoolEntryStillOwned(poolKey, entry)
 
   const token = crypto.randomBytes(32).toString('base64url')
 
@@ -12258,12 +12332,12 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   assertLocalProfileCanStart(profile, profileDeletionGate, key =>
     directoryExists(path.join(HERMES_HOME, 'profiles', key))
   )
-
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const parentStartMarker = await desktopParentStartMarker()
   const backendNonce = crypto.randomBytes(16).toString('hex')
   const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
+  assertPoolEntryStillOwned(poolKey, entry)
 
   const child = spawn(
     backend.command,
@@ -12318,6 +12392,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // surface as an unhandled rejection before the Promise.race below attaches.
   portAnnouncement.catch(() => {})
   await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce, outputTail)
+  assertPoolEntryStillOwned(poolKey, entry)
 
   child.stdout.on('data', rememberLog)
   child.stderr.on('data', rememberLog)
@@ -12331,14 +12406,21 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   child.once('error', error => {
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
-    releaseBackendChild(child)
-    backendPool.delete(poolKey)
+    void teardownFailedLocalBackend(poolKey, entry).catch(cleanupError => {
+      rememberLog(
+        `Hermes backend for profile "${profile}" cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
+      )
+    })
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
+    releaseLocalBackendSlot(entry)
     releaseBackendChild(child)
-    backendPool.delete(poolKey)
+
+    if (backendPool.get(poolKey) === entry) {
+      backendPool.delete(poolKey)
+    }
 
     if (!ready) {
       rejectStart?.(
@@ -12406,16 +12488,20 @@ const poolStopper = createPoolStopper({
   waitForExit: child => waitForBackendExit(child)
 })
 
-function stopPoolBackend(profile) {
-  return poolStopper.stop(profile)
+async function stopPoolBackend(profile: string) {
+  const entry = backendPool.get(profile)
+  await poolStopper.stop(profile)
+  releaseLocalBackendSlot(entry)
 }
 
 async function teardownPoolBackendAndWait(profile) {
-  await Promise.all(localProfilePoolKeys(profile).map(key => poolStopper.stop(key)))
+  await Promise.all(localProfilePoolKeys(profile).map(key => stopPoolBackend(key)))
 }
 
-function stopAllPoolBackends() {
-  return poolStopper.stopAll()
+async function stopAllPoolBackends() {
+  const entries = [...backendPool.values()]
+  await poolStopper.stopAll()
+  entries.forEach(releaseLocalBackendSlot)
 }
 
 const backendShutdown = createBackendShutdownCoordinator(async () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -281,8 +281,8 @@ import {
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
 import {
-  type LocalBackendSpawnRequest,
   LocalBackendSpawnCoordinator,
+  type LocalBackendSpawnRequest,
   releaseLocalBackendSlotAfterExit
 } from './pool-spawn-coordinator'
 import { createPoolStopper } from './pool-stop'
@@ -1416,6 +1416,10 @@ const profileDeletionGate = new ProfileDeletionGate()
 const POOL_MAX_BACKENDS = Math.max(1, Number(process.env.HERMES_DESKTOP_POOL_MAX) || 3)
 const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || 10 * 60_000)
 const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(POOL_MAX_BACKENDS)
+// How long a spawn may wait for a free local slot. Must stay under the
+// renderer's BACKEND_BOOT_WAIT_TIMEOUT_MS (45s, src/lib/with-timeout.ts) so
+// the queued ticket fails before the renderer does and the user sees why.
+const POOL_SLOT_WAIT_MS = 30_000
 
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
@@ -12219,6 +12223,7 @@ function teardownFailedLocalBackend(poolKey: string, entry: any): Promise<void> 
   }
 
   const child = entry.process
+
   const teardown = releaseLocalBackendSlotAfterExit(
     () => releaseLocalBackendSlot(entry),
     async () => {
@@ -12238,6 +12243,7 @@ function teardownFailedLocalBackend(poolKey: string, entry: any): Promise<void> 
   // Keep the settled promise in the WeakMap for the lifetime of this entry.
   // Error + exit + outer catch may all request cleanup; none may run it twice.
   failedLocalBackendTeardowns.set(entry, teardown)
+
   return teardown
 }
 
@@ -12278,9 +12284,21 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     }
   }
 
-  const spawnRequest = localBackendSpawnCoordinator.request(poolKey, { timeoutMs: POOL_IDLE_MS })
+  // Bound the slot wait BELOW the renderer's backend-boot budget (45s): once
+  // the renderer has given up on this spawn, a ticket still queued for the
+  // pool-idle window (10 min) would hold the pool key hostage and every
+  // later click on the profile would join that stale wait. Failing here
+  // surfaces the "all N slots busy" reason instead of a generic boot timeout.
+  const spawnRequest = localBackendSpawnCoordinator.request(poolKey, { timeoutMs: POOL_SLOT_WAIT_MS })
   entry.localBackendSlotKey = poolKey
   entry.localBackendSpawnRequest = spawnRequest
+
+  if (localBackendSpawnCoordinator.activeCount >= POOL_MAX_BACKENDS) {
+    rememberLog(
+      `Profile backend "${profile}" waiting for a free local slot (${localBackendSpawnCoordinator.activeCount}/${POOL_MAX_BACKENDS} busy, ${localBackendSpawnCoordinator.queuedCount} queued)`
+    )
+  }
+
   entry.releaseLocalBackendSlot = await spawnRequest.acquired
 
   if (entry.localBackendSpawnRequest === spawnRequest) {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -280,6 +280,7 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
 import {
   LocalBackendSpawnCoordinator,
   type LocalBackendSpawnRequest,
@@ -1413,13 +1414,86 @@ const profileDeletionGate = new ProfileDeletionGate()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
-const POOL_MAX_BACKENDS = Math.max(1, Number(process.env.HERMES_DESKTOP_POOL_MAX) || 3)
-const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || 10 * 60_000)
-const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(POOL_MAX_BACKENDS)
+// Pool sizing is a device preference (Settings → Advanced → pool rows), not a
+// launch constant: mutable at runtime, persisted in userData, applied live.
+// The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
+// for scripted/headless setups; after launch the stored preference wins.
+const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
+
+function readPersistedPoolLimits() {
+  try {
+    const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
+    rememberLog(
+      `[pool-limits] loaded from ${POOL_LIMITS_PATH}: maxBackends=${limits.maxBackends}, idleMs=${limits.idleMs}`
+    )
+
+    return limits
+  } catch {
+    // No persisted file yet — fall back to the legacy env vars so scripted
+    // setups keep working. Log which source won: a silently-ignored env var
+    // here costs a scripted-setup user a debugging session.
+    const fromEnv = clampPoolLimits({
+      maxBackends: Number(process.env.HERMES_DESKTOP_POOL_MAX) || undefined,
+      idleMs: Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || undefined
+    })
+
+    if (fromEnv.maxBackends !== POOL_LIMITS_DEFAULTS.maxBackends || fromEnv.idleMs !== POOL_LIMITS_DEFAULTS.idleMs) {
+      rememberLog(`[pool-limits] no saved file; using env-var overrides: maxBackends=${fromEnv.maxBackends}, idleMs=${fromEnv.idleMs}`)
+    } else {
+      rememberLog('[pool-limits] no saved file and no env overrides; using defaults')
+    }
+
+    return fromEnv
+  }
+}
+
+function persistPoolLimits(limits) {
+  try {
+    fs.mkdirSync(path.dirname(POOL_LIMITS_PATH), { recursive: true })
+    // Atomic write: write to a temp file in the same directory, then rename.
+    // A crash mid-write would otherwise leave truncated JSON and silently
+    // lose the user's saved sizing.
+    const tmpPath = `${POOL_LIMITS_PATH}.tmp`
+    fs.writeFileSync(tmpPath, JSON.stringify(limits, null, 2), 'utf8')
+    fs.renameSync(tmpPath, POOL_LIMITS_PATH)
+  } catch (error) {
+    rememberLog(`[pool-limits] write failed: ${error.message}`)
+  }
+}
+
+let poolLimits = readPersistedPoolLimits()
+// Hard cap on local backends that are starting OR running (the LRU eviction
+// above is soft — it spares keepalive-fresh entries). Follows the live
+// preference: setPoolLimits() pushes a new max into the coordinator.
+const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(poolLimits.maxBackends)
 // How long a spawn may wait for a free local slot. Must stay under the
 // renderer's BACKEND_BOOT_WAIT_TIMEOUT_MS (45s, src/lib/with-timeout.ts) so
 // the queued ticket fails before the renderer does and the user sees why.
 const POOL_SLOT_WAIT_MS = 30_000
+
+function poolMaxBackends() {
+  return poolLimits.maxBackends
+}
+
+function poolIdleMs() {
+  return poolLimits.idleMs
+}
+
+/**
+ * Apply new limits live: persist, then converge the running pool — evict
+ * LRU backends down to the new max, and let the (already running) idle
+ * reaper handle a shortened idle window on its next tick. Returns the
+ * limits actually in force (post-clamp).
+ */
+function setPoolLimits(raw) {
+  poolLimits = clampPoolLimits(raw)
+  persistPoolLimits(poolLimits)
+  localBackendSpawnCoordinator.setLimit(poolLimits.maxBackends)
+  evictLruPoolBackends(poolMaxBackends())
+  startPoolIdleReaper()
+
+  return { ...poolLimits }
+}
 
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
@@ -1439,7 +1513,7 @@ const POOL_SLOT_WAIT_MS = 30_000
 //                       re-allocating pooled gateway secondaries ~700×/day).
 //   * 3× ping + 60s headroom = ~4 min, comfortable margin for two missed
 //     pings + WSL2 IPC stall. The hard ceiling for the cap-eligible set is
-//     POOL_IDLE_MS above (default 10 min) — this constant only governs the
+//     pool idle window above (default 10 min) — this constant only governs the
 //     "is this backend plausibly still alive" question for LRU eviction,
 //     not when the idle reaper definitively tears a backend down.
 const POOL_KEEPALIVE_FRESH_MS = Math.max(
@@ -11261,7 +11335,7 @@ async function ensureBackend(profile) {
     return connection
   }
 
-  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+  evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -11427,7 +11501,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return existingLocal.connectionPromise
     }
 
-    evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+    evictLruPoolBackends(poolMaxBackends() - 1)
 
     const localEntry = {
       process: null,
@@ -11498,7 +11572,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     )
   }
 
-  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
+  evictLruPoolBackends(poolMaxBackends() - 1)
 
   const entry = {
     process: null,
@@ -12153,7 +12227,7 @@ function evictLruPoolBackends(keep) {
   const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
 
   for (const profile of evictions) {
-    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${POOL_MAX_BACKENDS})`)
+    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
     stopPoolBackend(profile)
   }
 }
@@ -12167,8 +12241,8 @@ function startPoolIdleReaper() {
     const now = Date.now()
 
     for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > POOL_IDLE_MS) {
-        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(POOL_IDLE_MS / 1000)}s)`)
+      if (now - (entry.lastActiveAt || 0) > poolIdleMs()) {
+        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(poolIdleMs() / 1000)}s)`)
         stopPoolBackend(profile)
       }
     }
@@ -12293,9 +12367,9 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   entry.localBackendSlotKey = poolKey
   entry.localBackendSpawnRequest = spawnRequest
 
-  if (localBackendSpawnCoordinator.activeCount >= POOL_MAX_BACKENDS) {
+  if (localBackendSpawnCoordinator.activeCount >= poolMaxBackends()) {
     rememberLog(
-      `Profile backend "${profile}" waiting for a free local slot (${localBackendSpawnCoordinator.activeCount}/${POOL_MAX_BACKENDS} busy, ${localBackendSpawnCoordinator.queuedCount} queued)`
+      `Profile backend "${profile}" waiting for a free local slot (${localBackendSpawnCoordinator.activeCount}/${poolMaxBackends()} busy, ${localBackendSpawnCoordinator.queuedCount} queued)`
     )
   }
 
@@ -14713,6 +14787,18 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
   touchPoolBackend(profile)
 
   return { ok: true }
+})
+// Pool sizing (Settings → Advanced): device-local, live-applied. Main is
+// authoritative (it owns the pool and the persisted copy); the returned
+// limits are what actually took effect post-clamp.
+ipcMain.handle('hermes:pool-limits:get', async () => ({ ...poolLimits }))
+ipcMain.handle('hermes:pool-limits:set', async (_event, raw) => {
+  const next = setPoolLimits({
+    maxBackends: typeof raw?.maxBackends === 'number' ? raw.maxBackends : poolLimits.maxBackends,
+    idleMs: typeof raw?.idleMs === 'number' ? raw.idleMs : poolLimits.idleMs
+  })
+
+  return { ok: true, limits: next }
 })
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))

--- a/apps/desktop/electron/pool-limits.test.ts
+++ b/apps/desktop/electron/pool-limits.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+
+import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_BOUNDS, POOL_LIMITS_DEFAULTS, POOL_LIMITS_MIN } from './pool-limits'
+
+describe('parsePoolLimits', () => {
+  it('falls back to defaults for null/empty/corrupt input', () => {
+    expect(parsePoolLimits(null)).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits(undefined)).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits('')).toEqual(POOL_LIMITS_DEFAULTS)
+    expect(parsePoolLimits('not json {')).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+
+  it('parses a valid persisted blob', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 11, idleMs: 7_200_000 }))).toEqual({
+      maxBackends: 11,
+      idleMs: 7_200_000
+    })
+  })
+
+  it('fills missing keys from defaults', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 5 }))).toEqual({ ...POOL_LIMITS_DEFAULTS, maxBackends: 5 })
+    expect(parsePoolLimits('{}')).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+
+  it('ignores non-numeric junk instead of NaN-poisoning the pool', () => {
+    expect(parsePoolLimits(JSON.stringify({ maxBackends: 'lots', idleMs: null }))).toEqual(POOL_LIMITS_DEFAULTS)
+  })
+})
+
+describe('clampPoolLimits', () => {
+  it('clamps below the floors', () => {
+    expect(clampPoolLimits({ maxBackends: 0 }).maxBackends).toBe(POOL_LIMITS_MIN.maxBackends)
+    expect(clampPoolLimits({ idleMs: 100 }).idleMs).toBe(POOL_LIMITS_MIN.idleMs)
+  })
+
+  it('clamps absurdly high backend counts', () => {
+    expect(clampPoolLimits({ maxBackends: 10_000 }).maxBackends).toBeLessThanOrEqual(64)
+  })
+
+  it('clamps idleMs to the shared ceiling (7 days)', () => {
+    expect(clampPoolLimits({ idleMs: 999_000_000 }).idleMs).toBe(POOL_LIMITS_BOUNDS.idleMsMax)
+  })
+
+  it('floors fractional values', () => {
+    expect(clampPoolLimits({ maxBackends: 2.9 }).maxBackends).toBe(2)
+  })
+})

--- a/apps/desktop/electron/pool-limits.ts
+++ b/apps/desktop/electron/pool-limits.ts
@@ -1,0 +1,81 @@
+/**
+ * Pool limits — how many bot backends may stay spawned, and how long an
+ * unused one survives.
+ *
+ * A device-local preference (each machine trades RAM against switching
+ * speed for itself), stored in userData like keep-awake. The main process
+ * is authoritative: it owns the pool AND the persisted copy, and applies a
+ * new max IMMEDIATELY by evicting least-recently-used idle backends — no
+ * app restart. The renderer mirrors the values for its UI and prewarm
+ * guard over IPC.
+ *
+ * Defaults preserve the historical hard-coded behavior (3 backends, 10min
+ * idle) so machines that never open Settings behave exactly as before.
+ */
+
+export interface PoolLimits {
+  /** Max concurrently spawned non-primary profile backends. */
+  maxBackends: number
+  /** Idle lifetime of an unused pool backend, in milliseconds. */
+  idleMs: number
+}
+
+export const POOL_LIMITS_DEFAULTS: PoolLimits = {
+  maxBackends: 3,
+  idleMs: 10 * 60_000
+}
+
+/** Hard floors — match the clamps the env-var path always applied. */
+export const POOL_LIMITS_MIN: PoolLimits = {
+  maxBackends: 1,
+  idleMs: 60_000
+}
+
+/** Shared bounds for both pool knobs — imported by the Settings UI so the
+ *  advertised input ranges can never drift from what main actually clamps
+ *  to. idleMs has no ceiling: a user who wants backends kept warm all week
+ *  may have exactly that. */
+export const POOL_LIMITS_BOUNDS = {
+  maxBackendsMax: 64,
+  /** 7 days, matching the UI's suggestion ceiling. */
+  idleMsMax: 7 * 24 * 60 * 60_000
+} as const
+
+const MAX_BACKENDS_CEILING = POOL_LIMITS_BOUNDS.maxBackendsMax
+const IDLE_MS_CEILING = POOL_LIMITS_BOUNDS.idleMsMax
+
+/** Clamp a raw partial to the floors/ceilings; missing keys fall to defaults. */
+export function clampPoolLimits(raw: Partial<PoolLimits>): PoolLimits {
+  const maxBackends = Number.isFinite(raw.maxBackends)
+    ? Math.min(MAX_BACKENDS_CEILING, Math.max(POOL_LIMITS_MIN.maxBackends, Math.floor(Number(raw.maxBackends))))
+    : POOL_LIMITS_DEFAULTS.maxBackends
+
+  const idleMs = Number.isFinite(raw.idleMs)
+    ? Math.min(IDLE_MS_CEILING, Math.max(POOL_LIMITS_MIN.idleMs, Math.floor(Number(raw.idleMs))))
+    : POOL_LIMITS_DEFAULTS.idleMs
+
+  return { maxBackends, idleMs }
+}
+
+function clampLimits(raw: Partial<PoolLimits>): PoolLimits {
+  return clampPoolLimits(raw)
+}
+
+/** Parse + clamp a persisted JSON blob; anything unreadable falls back to
+ *  defaults so a corrupted file can never wedge the pool. */
+export function parsePoolLimits(json: string | null | undefined): PoolLimits {
+  if (!json) {
+    return { ...POOL_LIMITS_DEFAULTS }
+  }
+
+  try {
+    const parsed = JSON.parse(json)
+
+    return clampLimits({
+      maxBackends: typeof parsed?.maxBackends === 'number' ? parsed.maxBackends : undefined,
+      idleMs: typeof parsed?.idleMs === 'number' ? parsed.idleMs : undefined
+    })
+  } catch {
+    return { ...POOL_LIMITS_DEFAULTS }
+  }
+}

--- a/apps/desktop/electron/pool-spawn-coordinator.test.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.test.ts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+
+import { test } from 'vitest'
+
+import {
+  LocalBackendSpawnCoordinator,
+  releaseLocalBackendSlotAfterExit
+} from './pool-spawn-coordinator'
+
+const deferred = () => {
+  let resolve!: () => void
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+const flush = () => new Promise<void>(resolve => setImmediate(resolve))
+
+test('100 concurrent local requests never hold more than the configured slots', async () => {
+  const limit = 12
+  const coordinator = new LocalBackendSpawnCoordinator(limit)
+  const gates = Array.from({ length: 100 }, deferred)
+  let active = 0
+  let maxActive = 0
+
+  const tasks = gates.map(async (gate, index) => {
+    const release = await coordinator.acquire(`profile-${index}`)
+    active += 1
+    maxActive = Math.max(maxActive, active)
+
+    await gate.promise
+
+    active -= 1
+    release()
+  })
+
+  await flush()
+  assert.equal(active, limit)
+  assert.equal(coordinator.activeCount, limit)
+  assert.equal(coordinator.queuedCount, 100 - limit)
+
+  for (let start = 0; start < gates.length; start += limit) {
+    for (const gate of gates.slice(start, start + limit)) {
+      gate.resolve()
+    }
+    await flush()
+  }
+
+  await Promise.all(tasks)
+  assert.equal(maxActive, limit)
+  assert.equal(coordinator.activeCount, 0)
+  assert.equal(coordinator.queuedCount, 0)
+})
+
+test('a queued start can be cancelled without waiting for an active backend', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const releaseFirst = await coordinator.acquire('first')
+  const queued = coordinator.request('cancelled')
+
+  assert.equal(coordinator.queuedCount, 1)
+  assert.equal(queued.cancel(), true)
+  await assert.rejects(queued.acquired, /cancelled while queued/)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 0)
+
+  releaseFirst()
+  assert.equal(coordinator.activeCount, 0)
+})
+
+test('cancelling an old same-key request never rejects a newer waiter', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const blocker = coordinator.request('blocker')
+  const releaseBlocker = await blocker.acquired
+  const old = coordinator.request('same-profile')
+
+  releaseBlocker()
+  const newer = coordinator.request('same-profile')
+
+  assert.equal(old.cancel(), false, 'the old request was already granted')
+  assert.equal(coordinator.queuedCount, 1, 'the newer same-key waiter must remain queued')
+
+  const releaseOld = await old.acquired
+  releaseOld()
+  const releaseNewer = await newer.acquired
+  releaseNewer()
+
+  assert.equal(coordinator.activeCount, 0)
+  assert.equal(coordinator.queuedCount, 0)
+})
+
+test('a queued start times out with a clear error and frees its queue position', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const releaseFirst = await coordinator.acquire('first')
+  const queued = coordinator.request('timed-out', { timeoutMs: 10 })
+
+  await assert.rejects(queued.acquired, /timed out while waiting for a free slot/)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 0)
+
+  releaseFirst()
+  assert.equal(coordinator.activeCount, 0)
+})
+
+test('100 real child processes never exceed twelve simultaneous local slots', async () => {
+  const limit = 12
+  const coordinator = new LocalBackendSpawnCoordinator(limit)
+  const livePids = new Set<number>()
+  const seenPids = new Set<number>()
+  let maxLive = 0
+
+  await Promise.all(
+    Array.from({ length: 100 }, async (_, index) => {
+      const release = await coordinator.acquire(`real-profile-${index}`)
+
+      try {
+        const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 40)'], {
+          stdio: 'ignore'
+        })
+        assert.ok(child.pid)
+        livePids.add(child.pid)
+        seenPids.add(child.pid)
+        maxLive = Math.max(maxLive, livePids.size)
+
+        await new Promise<void>((resolve, reject) => {
+          child.once('error', reject)
+          child.once('exit', code => {
+            if (code === 0) {
+              resolve()
+            } else {
+              reject(new Error(`child ${child.pid} exited with ${code}`))
+            }
+          })
+        })
+
+        livePids.delete(child.pid)
+      } finally {
+        release()
+      }
+    })
+  )
+
+  assert.equal(seenPids.size, 100)
+  assert.equal(maxLive, limit)
+  assert.equal(livePids.size, 0)
+  assert.equal(coordinator.activeCount, 0)
+  assert.equal(coordinator.queuedCount, 0)
+})
+
+test('failed start keeps its slot until the child has actually exited', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const childExit = deferred()
+  const releaseFailed = await coordinator.acquire('failed')
+  let successorEntered = false
+  const successor = coordinator.acquire('successor').then(release => {
+    successorEntered = true
+    return release
+  })
+
+  const cleanup = releaseLocalBackendSlotAfterExit(releaseFailed, () => childExit.promise)
+  await flush()
+
+  assert.equal(successorEntered, false)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 1)
+
+  childExit.resolve()
+  await cleanup
+  const releaseSuccessor = await successor
+
+  assert.equal(successorEntered, true)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 0)
+
+  releaseSuccessor()
+  assert.equal(coordinator.activeCount, 0)
+})
+
+test('a rejected wait keeps the slot occupied', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const releaseFailed = await coordinator.acquire('failed')
+  let successorEntered = false
+  const successor = coordinator.acquire('successor').then(release => {
+    successorEntered = true
+    return release
+  })
+
+  const cleanup = releaseLocalBackendSlotAfterExit(releaseFailed, async () => {
+    throw new Error('exit unproven')
+  })
+
+  await assert.rejects(cleanup, /exit unproven/)
+  await flush()
+
+  assert.equal(successorEntered, false)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 1)
+
+  releaseFailed()
+  const releaseSuccessor = await successor
+  assert.equal(successorEntered, true)
+  releaseSuccessor()
+  assert.equal(coordinator.activeCount, 0)
+  assert.equal(coordinator.queuedCount, 0)
+})
+
+test('an invalid timeout never enqueues a waiter', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const releaseFirst = await coordinator.acquire('first')
+
+  assert.throws(
+    () => coordinator.request('invalid', { timeoutMs: 0 }),
+    /timeout must be a positive number/
+  )
+  assert.throws(
+    () => coordinator.request('invalid', { timeoutMs: Number.NaN }),
+    /timeout must be a positive number/
+  )
+  assert.throws(
+    () => coordinator.request('invalid', { timeoutMs: -5 }),
+    /timeout must be a positive number/
+  )
+
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 0)
+
+  releaseFirst()
+  assert.equal(coordinator.activeCount, 0)
+})
+
+test('a failed or repeated cleanup releases exactly one slot', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const releaseFirst = await coordinator.acquire('first')
+  let secondEntered = false
+  const second = coordinator.acquire('second').then(release => {
+    secondEntered = true
+    return release
+  })
+
+  await flush()
+  assert.equal(secondEntered, false)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 1)
+
+  releaseFirst()
+  releaseFirst()
+  const releaseSecond = await second
+
+  assert.equal(secondEntered, true)
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 0)
+
+  releaseSecond()
+  assert.equal(coordinator.activeCount, 0)
+})

--- a/apps/desktop/electron/pool-spawn-coordinator.test.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.test.ts
@@ -269,6 +269,56 @@ test('a failed or repeated cleanup releases exactly one slot', async () => {
 })
 
 
+test('raising the limit at runtime drains queued waiters into the new slots', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(1)
+  const first = await coordinator.acquire('a')
+  const queuedB = coordinator.request('b')
+  const queuedC = coordinator.request('c')
+  await flush()
+  assert.equal(coordinator.activeCount, 1)
+  assert.equal(coordinator.queuedCount, 2)
+
+  coordinator.setLimit(2)
+  const releaseB = await queuedB.acquired
+  assert.equal(coordinator.activeCount, 2)
+  assert.equal(coordinator.queuedCount, 1)
+
+  first()
+  const releaseC = await queuedC.acquired
+  assert.equal(coordinator.activeCount, 2)
+  releaseB()
+  releaseC()
+  assert.equal(coordinator.activeCount, 0)
+})
+
+test('lowering the limit never revokes granted slots; new requests queue until under cap', async () => {
+  const coordinator = new LocalBackendSpawnCoordinator(3)
+  const releases = await Promise.all(['a', 'b', 'c'].map(key => coordinator.acquire(key)))
+  coordinator.setLimit(1)
+  assert.equal(coordinator.activeCount, 3, 'granted slots stay granted')
+
+  const queued = coordinator.request('d')
+  await flush()
+  assert.equal(coordinator.queuedCount, 1)
+
+  releases[0]()
+  releases[1]()
+  await flush()
+  assert.equal(coordinator.queuedCount, 1, 'still over the new cap of 1')
+
+  releases[2]()
+  const releaseD = await queued.acquired
+  assert.equal(coordinator.activeCount, 1)
+  releaseD()
+})
+
+test('setLimit rejects a non-positive or fractional cap', () => {
+  const coordinator = new LocalBackendSpawnCoordinator(2)
+  assert.throws(() => coordinator.setLimit(0), RangeError)
+  assert.throws(() => coordinator.setLimit(1.5), RangeError)
+  assert.equal(coordinator.limit, 2)
+})
+
 // ── main.ts wiring ──────────────────────────────────────────────────────────
 // The coordinator is only as good as the timeout main.ts hands it. A queued
 // ticket that outlives the renderer's backend-boot budget holds the pool key
@@ -295,5 +345,13 @@ test('a failed or repeated cleanup releases exactly one slot', async () => {
     assert.ok(slotWait < bootBudget, `slot wait ${slotWait}ms must be below the boot budget ${bootBudget}ms`)
     assert.match(mainSource, /localBackendSpawnCoordinator\.request\(poolKey, \{ timeoutMs: POOL_SLOT_WAIT_MS \}\)/)
     assert.doesNotMatch(mainSource, /request\(poolKey, \{ timeoutMs: POOL_IDLE_MS \}\)/)
+  })
+
+  test('main.ts pushes the live pool max into the coordinator when the preference changes', () => {
+    // Pool sizing is a live device preference (#92581); the hard cap must
+    // follow it, otherwise raising the max in Settings would leave spawns
+    // queued behind the launch-time value.
+    assert.match(mainSource, /new LocalBackendSpawnCoordinator\(poolLimits\.maxBackends\)/)
+    assert.match(mainSource, /localBackendSpawnCoordinator\.setLimit\(poolLimits\.maxBackends\)/)
   })
 }

--- a/apps/desktop/electron/pool-spawn-coordinator.test.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.test.ts
@@ -1,5 +1,8 @@
 import assert from 'node:assert/strict'
 import { spawn } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 import { test } from 'vitest'
 
@@ -10,9 +13,11 @@ import {
 
 const deferred = () => {
   let resolve!: () => void
+
   const promise = new Promise<void>(done => {
     resolve = done
   })
+
   return { promise, resolve }
 }
 
@@ -45,6 +50,7 @@ test('100 concurrent local requests never hold more than the configured slots', 
     for (const gate of gates.slice(start, start + limit)) {
       gate.resolve()
     }
+
     await flush()
   }
 
@@ -118,6 +124,7 @@ test('100 real child processes never exceed twelve simultaneous local slots', as
         const child = spawn(process.execPath, ['-e', 'setTimeout(() => {}, 40)'], {
           stdio: 'ignore'
         })
+
         assert.ok(child.pid)
         livePids.add(child.pid)
         seenPids.add(child.pid)
@@ -153,8 +160,10 @@ test('failed start keeps its slot until the child has actually exited', async ()
   const childExit = deferred()
   const releaseFailed = await coordinator.acquire('failed')
   let successorEntered = false
+
   const successor = coordinator.acquire('successor').then(release => {
     successorEntered = true
+
     return release
   })
 
@@ -181,8 +190,10 @@ test('a rejected wait keeps the slot occupied', async () => {
   const coordinator = new LocalBackendSpawnCoordinator(1)
   const releaseFailed = await coordinator.acquire('failed')
   let successorEntered = false
+
   const successor = coordinator.acquire('successor').then(release => {
     successorEntered = true
+
     return release
   })
 
@@ -233,8 +244,10 @@ test('a failed or repeated cleanup releases exactly one slot', async () => {
   const coordinator = new LocalBackendSpawnCoordinator(1)
   const releaseFirst = await coordinator.acquire('first')
   let secondEntered = false
+
   const second = coordinator.acquire('second').then(release => {
     secondEntered = true
+
     return release
   })
 
@@ -254,3 +267,33 @@ test('a failed or repeated cleanup releases exactly one slot', async () => {
   releaseSecond()
   assert.equal(coordinator.activeCount, 0)
 })
+
+
+// ── main.ts wiring ──────────────────────────────────────────────────────────
+// The coordinator is only as good as the timeout main.ts hands it. A queued
+// ticket that outlives the renderer's backend-boot budget holds the pool key
+// hostage: the renderer has already reported "backend didn't come up", and
+// every later click on that profile joins the stale wait instead of failing
+// fast with a reason.
+{
+  const here = path.dirname(fileURLToPath(import.meta.url))
+  const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+  const withTimeoutSource = fs
+    .readFileSync(path.join(here, '..', 'src', 'lib', 'with-timeout.ts'), 'utf8')
+    .replace(/\r\n/g, '\n')
+
+  test('main.ts bounds the slot wait below the renderer backend-boot budget', () => {
+    const slotWait = Number(/const POOL_SLOT_WAIT_MS = ([\d_]+)/.exec(mainSource)?.[1]?.replace(/_/g, ''))
+
+    const bootBudget = Number(
+      /export const BACKEND_BOOT_WAIT_TIMEOUT_MS = ([\d_]+)/.exec(withTimeoutSource)?.[1]?.replace(/_/g, '')
+    )
+
+    assert.ok(Number.isFinite(slotWait) && slotWait > 0, 'POOL_SLOT_WAIT_MS must be a literal in main.ts')
+    assert.ok(Number.isFinite(bootBudget), 'BACKEND_BOOT_WAIT_TIMEOUT_MS must be a literal')
+    assert.ok(slotWait < bootBudget, `slot wait ${slotWait}ms must be below the boot budget ${bootBudget}ms`)
+    assert.match(mainSource, /localBackendSpawnCoordinator\.request\(poolKey, \{ timeoutMs: POOL_SLOT_WAIT_MS \}\)/)
+    assert.doesNotMatch(mainSource, /request\(poolKey, \{ timeoutMs: POOL_IDLE_MS \}\)/)
+  })
+}

--- a/apps/desktop/electron/pool-spawn-coordinator.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.ts
@@ -1,0 +1,128 @@
+export type ReleaseLocalBackendSlot = () => void
+
+export type LocalBackendSpawnRequest = {
+  acquired: Promise<ReleaseLocalBackendSlot>
+  cancel: () => boolean
+}
+
+type Waiter = {
+  key: string
+  resolve: (release: ReleaseLocalBackendSlot) => void
+  reject: (error: Error) => void
+  timer: ReturnType<typeof setTimeout> | null
+}
+
+export async function releaseLocalBackendSlotAfterExit(
+  release: ReleaseLocalBackendSlot,
+  waitForExit: () => Promise<void>
+): Promise<void> {
+  await waitForExit()
+  release()
+}
+
+/**
+ * Bounds the number of local profile backends that are starting or running.
+ *
+ * A lease is acquired immediately before local start work and is held until
+ * the child exits or the start fails. Remote descriptors never call request().
+ */
+export class LocalBackendSpawnCoordinator {
+  readonly #limit: number
+  #active = 0
+  #queue: Waiter[] = []
+
+  constructor(limit: number) {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new RangeError('Local backend spawn limit must be a positive integer.')
+    }
+
+    this.#limit = limit
+  }
+
+  get activeCount(): number {
+    return this.#active
+  }
+
+  get queuedCount(): number {
+    return this.#queue.length
+  }
+
+  request(key: string, options: { timeoutMs?: number } = {}): LocalBackendSpawnRequest {
+    if (options.timeoutMs !== undefined && (!Number.isFinite(options.timeoutMs) || options.timeoutMs < 1)) {
+      throw new RangeError('Local backend spawn timeout must be a positive number.')
+    }
+
+    if (this.#active < this.#limit) {
+      return {
+        acquired: Promise.resolve(this.#grant()),
+        cancel: () => false
+      }
+    }
+
+    let waiter!: Waiter
+    const acquired = new Promise<ReleaseLocalBackendSlot>((resolve, reject) => {
+      waiter = { key, resolve, reject, timer: null }
+      this.#queue.push(waiter)
+
+      if (options.timeoutMs !== undefined) {
+        waiter.timer = setTimeout(() => {
+          this.#rejectWaiter(
+            waiter,
+            new Error(`Local backend start for "${key}" timed out while waiting for a free slot.`)
+          )
+        }, options.timeoutMs)
+        waiter.timer.unref?.()
+      }
+    })
+
+    return {
+      acquired,
+      cancel: () =>
+        this.#rejectWaiter(waiter, new Error(`Local backend start for "${key}" was cancelled while queued.`))
+    }
+  }
+
+  acquire(key: string): Promise<ReleaseLocalBackendSlot> {
+    return this.request(key).acquired
+  }
+
+  #rejectWaiter(waiter: Waiter, error: Error): boolean {
+    const index = this.#queue.indexOf(waiter)
+
+    if (index === -1) {
+      return false
+    }
+
+    this.#queue.splice(index, 1)
+    this.#clearTimer(waiter)
+    waiter.reject(error)
+    return true
+  }
+
+  #clearTimer(waiter: Waiter): void {
+    if (waiter.timer) {
+      clearTimeout(waiter.timer)
+      waiter.timer = null
+    }
+  }
+
+  #grant(): ReleaseLocalBackendSlot {
+    this.#active += 1
+    let released = false
+
+    return () => {
+      if (released) {
+        return
+      }
+
+      released = true
+      this.#active -= 1
+      const next = this.#queue.shift()
+
+      if (next) {
+        this.#clearTimer(next)
+        next.resolve(this.#grant())
+      }
+    }
+  }
+}

--- a/apps/desktop/electron/pool-spawn-coordinator.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.ts
@@ -27,7 +27,7 @@ export async function releaseLocalBackendSlotAfterExit(
  * the child exits or the start fails. Remote descriptors never call request().
  */
 export class LocalBackendSpawnCoordinator {
-  readonly #limit: number
+  #limit: number
   #active = 0
   #queue: Waiter[] = []
 
@@ -41,6 +41,25 @@ export class LocalBackendSpawnCoordinator {
 
   get activeCount(): number {
     return this.#active
+  }
+
+  get limit(): number {
+    return this.#limit
+  }
+
+  /**
+   * Adopt a new cap at runtime (the pool size is a live device preference).
+   * Raising it drains waiters into the newly freed slots immediately; lowering
+   * it never revokes a granted slot — the running backends simply stay over
+   * the cap until they exit, and LRU eviction (main.ts) converges the pool.
+   */
+  setLimit(limit: number): void {
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new RangeError('Local backend spawn limit must be a positive integer.')
+    }
+
+    this.#limit = limit
+    this.#drain()
   }
 
   get queuedCount(): number {
@@ -119,12 +138,16 @@ export class LocalBackendSpawnCoordinator {
 
       released = true
       this.#active -= 1
-      const next = this.#queue.shift()
+      this.#drain()
+    }
+  }
 
-      if (next) {
-        this.#clearTimer(next)
-        next.resolve(this.#grant())
-      }
+  /** Hand free slots to queued waiters while under the (possibly lowered) cap. */
+  #drain(): void {
+    while (this.#active < this.#limit && this.#queue.length > 0) {
+      const next = this.#queue.shift()!
+      this.#clearTimer(next)
+      next.resolve(this.#grant())
     }
   }
 }

--- a/apps/desktop/electron/pool-spawn-coordinator.ts
+++ b/apps/desktop/electron/pool-spawn-coordinator.ts
@@ -60,6 +60,7 @@ export class LocalBackendSpawnCoordinator {
     }
 
     let waiter!: Waiter
+
     const acquired = new Promise<ReleaseLocalBackendSlot>((resolve, reject) => {
       waiter = { key, resolve, reject, timer: null }
       this.#queue.push(waiter)
@@ -96,6 +97,7 @@ export class LocalBackendSpawnCoordinator {
     this.#queue.splice(index, 1)
     this.#clearTimer(waiter)
     waiter.reject(error)
+
     return true
   }
 

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -24,6 +24,8 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
   getProfileRoutes: profiles => ipcRenderer.invoke('hermes:plugin-profile-routes', profiles),
   revalidateConnection: () => ipcRenderer.invoke('hermes:connection:revalidate'),
   touchBackend: profile => ipcRenderer.invoke('hermes:backend:touch', profile),
+  getPoolLimits: () => ipcRenderer.invoke('hermes:pool-limits:get'),
+  setPoolLimits: limits => ipcRenderer.invoke('hermes:pool-limits:set', limits),
   getGatewayWsUrl: profile => ipcRenderer.invoke('hermes:gateway:ws-url', profile),
   // Registry-scoped fresh WS URL: { connectionId, profile } → result shape of
   // getGatewayWsUrl, minted against that connection's backend.

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -46,6 +46,7 @@ import {
 } from '@/store/gateway-switch'
 import { checkLocalRuntimeUpdate, watchLocalRuntimeJobs } from '@/store/local-runtime-jobs'
 import { notify, notifyError } from '@/store/notifications'
+import { loadPoolLimits } from '@/store/pool-limits'
 import {
   $activeGatewayProfile,
   normalizeProfileKey,
@@ -899,6 +900,10 @@ export function useGatewayBoot({
     // macOS wake often restores focus without a visibilitychange — without
     // this a socket dropped during sleep sits closed until the user clicks.
     window.addEventListener('focus', onFocus)
+
+    // Pool limits are main-process state; mirror them once for the Settings
+    // rows and prewarmProfileBackend's saturation guard.
+    void loadPoolLimits()
 
     // Keep live pool backends alive while this window is open (the main process
     // can't observe the direct renderer↔backend WS). No-op for the primary.

--- a/apps/desktop/src/app/settings/config-settings.tsx
+++ b/apps/desktop/src/app/settings/config-settings.tsx
@@ -45,6 +45,7 @@ import {
 import { MemoryConnect } from './memory/connect'
 import { ProviderConfigPanel } from './memory/provider-config-panel'
 import { ModelSettings, ModelSettingsSkeleton } from './model-settings'
+import { PoolLimitsSetting } from './pool-limits-setting'
 import { EmptyState, ListRow, SettingsContent, SettingsSkeleton, ToggleRow } from './primitives'
 import { SettingsProfileScope } from './profile-scope'
 import { QuickEntrySettings } from './quick-entry-settings'
@@ -405,6 +406,7 @@ function ConfigSettingsInner({
             label={c.disableF12Title}
             onChange={setDisableF12}
           />
+          <PoolLimitsSetting />
           <QuickEntrySettings />
         </>
       )}

--- a/apps/desktop/src/app/settings/pool-limits-setting.tsx
+++ b/apps/desktop/src/app/settings/pool-limits-setting.tsx
@@ -1,0 +1,113 @@
+import { useStore } from '@nanostores/react'
+import { useEffect, useState } from 'react'
+
+import { ListRow } from '@/app/settings/primitives'
+import { Input } from '@/components/ui/input'
+import { $poolLimits, loadPoolLimits, savePoolLimits } from '@/store/pool-limits'
+
+// Bounds imported from main's clamp module so the advertised input ranges
+// can never drift from what the pool actually enforces (review note on #92581).
+import { POOL_LIMITS_BOUNDS } from '../../../electron/pool-limits'
+
+const MAX_BACKENDS_MAX = POOL_LIMITS_BOUNDS.maxBackendsMax
+const IDLE_MS_MAX = POOL_LIMITS_BOUNDS.idleMsMax
+
+/** Settings → Advanced: warm-bot-backends count + backend idle timeout.
+ *  Device-local (not profile-scoped): the pool is sized once per machine and
+ *  changes apply live — main evicts/reaps to converge without a restart. */
+export function PoolLimitsSetting() {
+  const limits = useStore($poolLimits)
+  const [maxDraft, setMaxDraft] = useState(String(limits.maxBackends))
+  const [idleDraft, setIdleDraft] = useState(String(limits.idleMs))
+
+  useEffect(() => {
+    void loadPoolLimits()
+  }, [])
+
+  useEffect(() => {
+    setMaxDraft(String(limits.maxBackends))
+    setIdleDraft(String(limits.idleMs))
+  }, [limits])
+
+  const commitMax = () => {
+    const parsed = Number(maxDraft)
+
+    if (!Number.isFinite(parsed) || parsed === limits.maxBackends) {
+      setMaxDraft(String(limits.maxBackends))
+
+      return
+    }
+
+    void savePoolLimits({ maxBackends: parsed })
+      .then(() => undefined)
+      .catch(() => setMaxDraft(String($poolLimits.get().maxBackends)))
+  }
+
+  const commitIdle = () => {
+    const parsed = Number(idleDraft)
+
+    if (!Number.isFinite(parsed) || parsed === limits.idleMs) {
+      setIdleDraft(String(limits.idleMs))
+
+      return
+    }
+
+    void savePoolLimits({ idleMs: parsed })
+      .then(() => undefined)
+      .catch(() => setIdleDraft(String($poolLimits.get().idleMs)))
+  }
+
+  return (
+    <>
+      <ListRow
+        action={
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Warm bot backends"
+              className="w-20"
+              inputMode="numeric"
+              max={MAX_BACKENDS_MAX}
+              min={1}
+              onBlur={commitMax}
+              onChange={event => setMaxDraft(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.blur()
+                }
+              }}
+              type="number"
+              value={maxDraft}
+            />
+          </div>
+        }
+        description="How many bot backends stay running for instant switching. Higher = faster switches, more memory (~60MB per backend). Applies immediately."
+        title="Warm Bot Backends"
+      />
+      <ListRow
+        action={
+          <div className="flex items-center gap-2">
+            <Input
+              aria-label="Backend idle timeout in milliseconds"
+              className="w-28"
+              inputMode="numeric"
+              max={IDLE_MS_MAX}
+              min={60_000}
+              onBlur={commitIdle}
+              onChange={event => setIdleDraft(event.target.value)}
+              onKeyDown={event => {
+                if (event.key === 'Enter') {
+                  event.currentTarget.blur()
+                }
+              }}
+              type="number"
+              value={idleDraft}
+            />
+            <span className="text-[length:var(--conversation-caption-font-size)] text-(--ui-text-tertiary)">ms</span>
+          </div>
+        }
+        description="How long an unused bot backend stays warm before it is shut down. Raise this so bots you revisit every few minutes never pay a cold start."
+        title="Backend Idle Timeout"
+      />
+    </>
+  )
+}

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -1,6 +1,8 @@
 import type { GatewayWsUrlResult } from '@hermes/shared'
 import type { TranslucencyState } from '@hermes/shared/translucency'
 
+import type { PoolLimits } from '../electron/pool-limits'
+
 import type { WakeIndicatorState } from './lib/wake-indicator'
 import type {
   PetOverlayBounds,
@@ -46,6 +48,14 @@ declare global {
       // Keepalive: mark a pool profile backend as recently used so the idle
       // reaper spares it while its chat is active.
       touchBackend: (profile?: string | null) => Promise<{ ok: boolean }>
+      // Pool sizing (Settings → Advanced): device-local, live-applied by the
+      // main process. get resolves the limits currently in force; set applies
+      // (and persists) new ones, evicting/reaping to converge immediately.
+      getPoolLimits: () => Promise<PoolLimits>
+      setPoolLimits: (limits: { maxBackends?: number; idleMs?: number }) => Promise<{
+        ok: boolean
+        limits: PoolLimits
+      }>
       getGatewayWsUrl: (profile?: null | string) => Promise<GatewayWsUrlResult>
       // Open (or focus) a standalone OS window for a single chat session so
       // the user can work with multiple chats side by side. Returns ok:false

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1584,6 +1584,24 @@ export function reconnectSecondaryGateways({ forceOpenSockets = false }: { force
   }
 }
 
+// How many non-primary backends currently hold an open socket. Hover-intent
+// prewarming consults this before spawning: a speculative spawn that pushes
+// the pool past its cap causes the Electron main to LRU-evict a warm backend
+// — often one the user is about to click — turning the prewarm into churn
+// (the #91545 evict/respawn cascade). The active gateway's backend is
+// primary-routed and never counts toward the pool cap.
+export function openSecondaryCount(): number {
+  let count = 0
+
+  for (const entry of g.secondaries.values()) {
+    if (isOpen(entry.gateway)) {
+      count += 1
+    }
+  }
+
+  return count
+}
+
 // Keep the idle reaper from killing a backend we still need: ping every live
 // secondary. The active one is pinged separately (touchActiveGatewayBackend).
 export function touchSecondaryGateways(): void {

--- a/apps/desktop/src/store/pool-limits.ts
+++ b/apps/desktop/src/store/pool-limits.ts
@@ -1,0 +1,65 @@
+/**
+ * Pool limits — how many bot backends may stay spawned, and how long an
+ * unused one survives before it is shut down.
+ *
+ * A device-local preference (each machine trades RAM against switching
+ * speed for itself). The MAIN process is authoritative: it owns the pool
+ * and the persisted copy, and applies a new max immediately by evicting
+ * least-recently-used idle backends — no restart. This store mirrors the
+ * live values for the Settings rows and feeds prewarmProfileBackend's
+ * saturation guard.
+ */
+
+import { atom } from 'nanostores'
+
+export interface PoolLimits {
+  /** Max concurrently spawned non-primary profile backends. */
+  maxBackends: number
+  /** Idle lifetime of an unused pool backend, in milliseconds. */
+  idleMs: number
+}
+
+export const POOL_LIMITS_DEFAULTS: PoolLimits = {
+  maxBackends: 3,
+  idleMs: 10 * 60_000
+}
+
+export const $poolLimits = atom<PoolLimits>({ ...POOL_LIMITS_DEFAULTS })
+
+/** Seed from main's authoritative state once at startup; no-op without the
+ *  bridge (web/older builds just keep the defaults for the UI). */
+export async function loadPoolLimits(): Promise<void> {
+  try {
+    const limits = await window.hermesDesktop?.getPoolLimits?.()
+
+    if (limits) {
+      $poolLimits.set(limits)
+    }
+  } catch {
+    // Keep defaults — Settings rows still render and can retry on save.
+  }
+}
+
+/** Push new limits to main; adopt the post-clamp values it reports. */
+export async function savePoolLimits(next: { maxBackends?: number; idleMs?: number }): Promise<void> {
+  const current = $poolLimits.get()
+
+  const optimistic: PoolLimits = {
+    maxBackends: next.maxBackends ?? current.maxBackends,
+    idleMs: next.idleMs ?? current.idleMs
+  }
+
+  // Optimistic paint, then honest reconciliation with the clamped result.
+  $poolLimits.set(optimistic)
+
+  try {
+    const result = await window.hermesDesktop?.setPoolLimits?.(next)
+
+    if (result?.limits) {
+      $poolLimits.set(result.limits)
+    }
+  } catch {
+    $poolLimits.set(current)
+    throw new Error('Applying pool limits failed')
+  }
+}

--- a/apps/desktop/src/store/profile.test.ts
+++ b/apps/desktop/src/store/profile.test.ts
@@ -9,10 +9,24 @@ import type { ProfileInfo } from '@/types/hermes'
 const ensureGatewayForProfile = vi.fn(async () => undefined)
 const ensureGatewayForAgent = vi.fn(async () => undefined)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
+const openSecondaryCount = vi.fn(() => 0)
 const $gateway = atom<unknown>({ id: 'live-socket', connectionState: 'open' })
 const resetStarmapGraph = vi.fn()
 
-vi.mock('@/store/gateway', () => ({ $gateway, ensureGatewayForAgent, ensureGatewayForProfile, openGatewayForProfile }))
+vi.mock('@/store/gateway', () => ({
+  $gateway,
+  ensureGatewayForAgent,
+  ensureGatewayForProfile,
+  openGatewayForProfile,
+  openSecondaryCount
+}))
+// The pool-limits atom is profile.ts's live saturation signal — keep the real
+// one so tests can move the cap via the store, but stub its IPC bridge.
+vi.mock('@/store/pool-limits', async () => {
+  const { atom } = await import('nanostores')
+
+  return { $poolLimits: atom({ idleMs: 600_000, maxBackends: 3 }) }
+})
 vi.mock('@/hermes', () => ({
   getProfiles: vi.fn(async () => ({ profiles: [] })),
   setApiRequestProfile: vi.fn()
@@ -28,6 +42,8 @@ const {
   prewarmProfileBackend,
   refreshProfiles
 } = await import('./profile')
+
+const { $poolLimits } = await import('@/store/pool-limits')
 
 const { $connection } = await import('./session')
 const { invalidateProfileScopedQueries } = await import('@/lib/query-client')
@@ -55,6 +71,7 @@ beforeEach(() => {
   getConnection.mockReset()
   ensureGatewayForProfile.mockClear()
   openGatewayForProfile.mockClear()
+  openSecondaryCount.mockReturnValue(0)
   $gateway.set({ id: 'live-socket', connectionState: 'open' })
   $activeGatewayProfile.set('default')
   $connection.set(localConn())
@@ -168,6 +185,43 @@ describe('prewarmProfileBackend (hover-intent pool spawn)', () => {
     openGatewayForProfile.mockRejectedValueOnce(new Error('spawn failed'))
 
     expect(() => prewarmProfileBackend('warm-failing')).not.toThrow()
+  })
+
+  it('skips pre-warm when the pool is saturated (#91545 evict/respawn cascade)', () => {
+    // Every pool slot occupied: a speculative spawn would LRU-evict a warm
+    // backend — often the one the user is about to click. Default limit 3,
+    // 3 open secondaries → the next spawn would exceed the cap.
+    openSecondaryCount.mockReturnValue(3)
+
+    prewarmProfileBackend('warm-saturated')
+
+    expect(openGatewayForProfile).not.toHaveBeenCalled()
+  })
+
+  it('pre-warms while pool slots are free', () => {
+    openSecondaryCount.mockReturnValue(1)
+
+    prewarmProfileBackend('warm-slot-free')
+
+    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-slot-free')
+  })
+
+  it('follows the live pool-limit atom, not a hard-coded cap', () => {
+    // User raises Warm Bot Backends to 8 in Settings: prewarming must keep
+    // working well past the old default of 3.
+    openSecondaryCount.mockReturnValue(5)
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 8 })
+
+    prewarmProfileBackend('warm-raised-cap')
+
+    expect(openGatewayForProfile).toHaveBeenCalledWith('warm-raised-cap')
+
+    // And lowering the cap re-engages the guard at the new boundary.
+    $poolLimits.set({ idleMs: 600_000, maxBackends: 2 })
+
+    prewarmProfileBackend('warm-lowered-cap')
+
+    expect(openGatewayForProfile).not.toHaveBeenCalledWith('warm-lowered-cap')
   })
 })
 

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -21,9 +21,11 @@ import {
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForAgent,
-  openGatewayForProfile
+  openGatewayForProfile,
+  openSecondaryCount
 } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
+import { $poolLimits } from '@/store/pool-limits'
 import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { clearComposerSelectionOwner, setComposerSelectionOwner, setConnection } from '@/store/session'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
@@ -420,6 +422,17 @@ export function prewarmProfileBackend(name: string): void {
   const now = Date.now()
 
   if (now - (prewarmedAt.get(key) ?? 0) < PREWARM_MIN_INTERVAL_MS) {
+    return
+  }
+
+  // Prewarm/cap harmony (#91545): the pool caps spawned backends at the
+  // configured max, and a spawn over the cap LRU-evicts the warmest idle
+  // backend. A hover sweep across the rail therefore evicted backends for
+  // profiles the user was about to click — prewarming caused the exact churn
+  // it exists to prevent. Skip speculative spawns once every pool slot is
+  // occupied by an open socket; the real click still spawns on demand, it
+  // just doesn't get a head start.
+  if (openSecondaryCount() + 1 > $poolLimits.get().maxBackends) {
     return
   }
 


### PR DESCRIPTION
## Summary
Desktop now hard-caps how many local `hermes serve` profile backends may be starting or running at once, and the cap follows the new Settings → Advanced pool-size preference, so a roster refresh across many profiles can no longer fan out into a process wave — and hover-prewarm can no longer evict the backend you're about to click.

Composite salvage of two complementary PRs, each cherry-picked with authorship preserved:
- **#100985** (@Kryptonator) — `LocalBackendSpawnCoordinator`: hard enforcement.
- **#92581** (@ClintonEmok) — prewarm saturation guard + pool sizing as a live device preference (#91545).

## Who hits this / when
- Anyone with many profiles: LRU eviction is *soft* (it spares keepalive-fresh entries), so N simultaneous `ensureBackend` calls each evicted nothing and spawned — 40+ backends, load 30–50 reported.
- Anyone hovering across the Bots rail (#91545, two independent repros): speculative prewarms pushed the pool past its cap → LRU evicted a warm backend → the click respawned it → switching got progressively slower. The 3-backend default was also undiscoverable (env var only) and wrong for 24-profile rosters (see thread).

## Changes
**@Kryptonator** — `pool-spawn-coordinator.ts`: at most *max* local backends starting+running; remote descriptors never take a slot; a slot is released only after exit is proven (`exitCode`/`signalCode`); failed-spawn teardown is WeakMap-deduped; `assertPoolEntryStillOwned` at each await so an evicted entry can't spawn a zombie.
**@ClintonEmok** — `prewarmProfileBackend` skips once every slot holds an open socket; `pool-limits.ts` + Settings rows + IPC: max/idle persisted atomically in userData (`pool-limits.json`), applied live (evict down / reaper picks up), env vars remain the initial fallback; defaults unchanged.

**Follow-ups (ours)**
- Slot wait capped at **30 s** (was `POOL_IDLE_MS` = 10 min): the renderer gives up on a boot at 45 s, so a longer wait held the pool key hostage and every later click joined the stale wait with a generic "backend didn't come up". Now it fails first, with a slot-pressure log line. Wiring test pins `POOL_SLOT_WAIT_MS < BACKEND_BOOT_WAIT_TIMEOUT_MS`.
- Coordinator `setLimit()` so the hard cap follows the live preference; slot hand-off goes through one `#drain` that respects the current cap — this also fixed the original release path, which handed a slot to the next waiter even when the cap had just been lowered (caught by the new test).
- `eslint --fix` on the salvaged files (import order was a lint *error*).

## Validation
| | |
|---|---|
| `pool-spawn-coordinator.test.ts` + `pool-limits.test.ts` | 22 passed (+4: raise drains waiters, lower never revokes, invalid cap, main.ts wiring) |
| `vitest --project electron` (full) | 146 files passed; the 2 failures (`managed-ssh-update`, `remote-lifecycle`) fail identically on `origin/main` |
| `vitest --project ui` store/settings | 357 passed |
| `tsc` electron + renderer | clean |

Provenance: #100985 applied via diff (branch carried a merge commit; original commits were authored as "Motor (Hermes AI)" — attributed to the PR author's GitHub identity). #92581 applied via diff on top; import/constant-block conflicts resolved so the coordinator is constructed from `poolLimits.maxBackends`.

Closes #100985. Closes #92581. Fixes #91545.
