### PR TITLE
fix(config): accept symlink for HERMES_HOME (#101900)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1062,7 +1062,16 @@ def ensure_hermes_home():
         finally:
             os.umask(old_umask)
     else:
-        home.mkdir(parents=True, exist_ok=True)
+        # ~/.hermes may be a symlink to a real hermes directory (e.g. git-managed
+        # dotfiles). In that case home.is_dir() is True but mkdir would try to
+        # create the symlink itself and raise FileExistsError on some Python/
+        # pathlib versions (notably 3.13). Accept a symlink to a directory as
+        # valid and skip mkdir on the link.
+        if home.is_symlink():
+            if not home.is_dir():
+                raise RuntimeError(f"HERMES_HOME {home} is a broken symlink")
+        else:
+            home.mkdir(parents=True, exist_ok=True)
         _secure_dir(home)
         for subdir in (
             "cron", "sessions", "logs", "logs/curator", "memories",


### PR DESCRIPTION
Fixes #101900

HERMES_HOME may be a symlink to a real hermes directory (e.g. dotfiles kept under Git). On Python 3.13, `Path.mkdir(parents=True, exist_ok=True)` on a symlink-to-dir raises `FileExistsError` instead of honouring `exist_ok`, causing `hermes --tui` to crash in `ensure_hermes_home()` with:

```
FileNotFound → os.mkdir(self, mode) → FileExistsError on the symlink path
```

Accept a symlink that resolves to an existing directory as valid and skip `mkdir` on the link itself. Broken symlinks still raise a clear `RuntimeError`. Subdirectories inside the symlinked home continue to be created normally via the symlink path.

Verified: symlinked HERMES_HOME now passes `ensure_hermes_home()` and creates `SOUL.md`/`cron` etc. inside the target; broken symlink case tested; existing `test_hermes_constants` suite green.