### PR TITLE
fix(agent): guard vars() on __dict__-less invalid responses (#6133)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3874,8 +3874,22 @@ def run_conversation(
                     
                     # Check for x-openrouter-provider or similar metadata
                     if provider_name == "Unknown" and response:
-                        # Log all response attributes for debugging
-                        resp_attrs = {k: str(v)[:100] for k, v in vars(response).items() if not k.startswith('_')}
+                        # Log all response attributes for debugging. Some SDK
+                        # response shapes (slotted classes, some Pydantic
+                        # models) don't expose __dict__, so vars() would raise
+                        # TypeError — fall back to model_dump(), then to a
+                        # plain type-name repr (#6133).
+                        try:
+                            _resp_dict = getattr(response, "__dict__", None)
+                            if _resp_dict is None and hasattr(response, "model_dump"):
+                                _resp_dict = response.model_dump()
+                            resp_attrs = {
+                                k: str(v)[:100]
+                                for k, v in _resp_dict.items()
+                                if not k.startswith('_')
+                            }
+                        except (TypeError, AttributeError):
+                            resp_attrs = {type(response).__name__: str(response)[:200]}
                         if agent.verbose_logging:
                             logging.debug(f"Response attributes for invalid response: {resp_attrs}")
                     

--- a/tests/agent/test_6133_invalid_response_vars.py
+++ b/tests/agent/test_6133_invalid_response_vars.py
@@ -1,0 +1,105 @@
+"""Regression test for #6133 — vars() on response objects without __dict__.
+
+The invalid-response debug-logging path in ``agent.conversation_loop``
+called ``vars(response)`` bare. SDK response shapes that don't expose
+``__dict__`` (slotted classes, some Pydantic models) made that raise
+``TypeError: vars() argument must have dict attribute``, crashing the
+retry loop instead of degrading the debug log. The fix falls back
+through ``__dict__`` -> ``model_dump()`` -> a plain type-name repr.
+
+Scenario (mirrors the reporter's: intermittent, shape-dependent):
+  1. First API call returns a slotted response object with no
+     choices/error/message/model attributes — invalid, and the provider
+     name stays "Unknown", so the loop enters the resp_attrs logging
+     branch that used to call ``vars(response)``.
+  2. Before this fix, the turn died with TypeError at that point.
+     With the fix, the turn retries and the second call returns a valid
+     chat-completions response, so the conversation completes.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agent.conversation_loop as conversation_loop
+from run_agent import AIAgent
+
+
+def _dummy_credential() -> str:
+    # Placeholder shaped like a key but built at runtime — no real secret.
+    return "t" + "0" * 23
+
+
+def _make_tool_defs():
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": "web_search",
+                "description": "search",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ]
+
+
+def _make_agent():
+    """Build a minimal chat-completions AIAgent (mock client, no fallback)."""
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs()),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI", return_value=MagicMock()),
+    ):
+        agent = AIAgent(
+            api_key=_dummy_credential(),
+            base_url="https://api.test.internal/v1",
+            provider="test",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+class _SlotsResponse:
+    """SDK response shape with no ``__dict__`` and no recognisable fields."""
+
+    __slots__ = ()
+
+    def __repr__(self):  # stable payload for the fallback logging path
+        return "<_SlotsResponse invalid>"
+
+
+def _valid_response(content: str):
+    msg = SimpleNamespace(content=content, tool_calls=None, reflections=None)
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    usage = SimpleNamespace(prompt_tokens=1, completion_tokens=1, total_tokens=2)
+    return SimpleNamespace(
+        choices=[choice], model="test/model", usage=usage, id="resp_ok"
+    )
+
+
+def test_invalid_slots_response_does_not_crash_retry(monkeypatch):
+    agent = _make_agent()
+    calls = {"n": 0}
+
+    def _fake_api(api_kwargs):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return _SlotsResponse()
+        return _valid_response("Recovered")
+
+    monkeypatch.setattr(agent, "_interruptible_api_call", _fake_api)
+    # Collapse the retry backoff so the invalid->valid sequence is instant.
+    monkeypatch.setattr(
+        conversation_loop, "jittered_backoff", lambda *a, **kw: 0.0
+    )
+
+    result = agent.run_conversation("ping")
+
+    assert calls["n"] >= 2
+    assert result["completed"] is True
+    assert result["final_response"] == "Recovered"


### PR DESCRIPTION
## What does this PR do?

Fixes a crash in the invalid-response debug-logging path of the conversation loop: `agent/conversation_loop.py` called `vars(response)` bare, and SDK response shapes that don't expose `__dict__` (slotted classes, some Pydantic models) raise `TypeError: vars() argument must have dict attribute` there — killing the retry loop instead of degrading the log. This is the exact crash reported in #6133 (originally at `run_agent.py:7479`; the code was later moved into `agent/conversation_loop.py`).

The fix falls back through `__dict__` → `model_dump()` → a plain `{type name: stringified response}` repr, so the debug logging always degrades gracefully and the turn keeps its retry budget.

Note for triage: two earlier attempts at this fix (#6228, superseded by #12584) were closed by their author in July 2026 after a `duplicate` mislabel ("Likely duplicate of #6228" — but #6228 had been self-closed as superseded by #12584). Neither was rejected by maintainers on its merits; this PR re-lands the same safe-extraction approach at the current code location, off today's `main`.

## Related Issue

Fixes #6133

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/conversation_loop.py` — wrap the `resp_attrs` extraction in a try/except with a `__dict__` → `model_dump()` fallback chain and a type-name repr as the last resort, instead of bare `vars(response)`
- `tests/agent/test_6133_invalid_response_vars.py` — new regression test driving `run_conversation` end-to-end with a slotted invalid response followed by a valid one

## How to Test

1. `pytest tests/agent/test_6133_invalid_response_vars.py -q`
2. Observed result on this branch: `1 passed` — the turn retries past the slotted response and completes with `final_response == "Recovered"`
3. Observed result with the fix reverted (test against unpatched `agent/conversation_loop.py`): the test fails with `TypeError: vars() argument must have __dict__ attribute` surfacing in the API-call error log — exactly the crash from the issue
4. Neighboring suites still green: `pytest tests/agent/test_conversation_loop_interpreter_shutdown.py tests/agent/test_empty_tool_name_loop_dampening.py -q` → `14 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26 (arm64)

### Documentation & Housekeeping

- [x] N/A — no docs changes needed for this bug fix
- [x] N/A — no config keys added or changed
- [x] N/A — no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] N/A — no tool behavior changes

## Screenshots / Logs

Before (unpatched), the invalid-response path crashes the turn:

```
⚠️  API call failed (attempt 2/3): TypeError
   📝 Error: vars() argument must have __dict__ attribute
```

After the fix, the same slotted response is logged via the fallback repr and the turn retries to completion.

