### PR TITLE
fix(config): refuse migration on malformed or non-mapping config.yaml (salvage #101778)

### DIFF
--- a/contributors/emails/emanuele.cornaggia@gmail.com
+++ b/contributors/emails/emanuele.cornaggia@gmail.com
@@ -1,0 +1,2 @@
+EmanueleCornaggia
+# PR #101778 salvage

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2272,7 +2272,7 @@ def _raw_config_has_explicit_version() -> bool:
     return isinstance(raw, dict) and "_config_version" in raw
 
 
-def check_config_version() -> Tuple[int, int]:
+def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, int]:
     """
     Check the raw on-disk config schema version.
 
@@ -2282,7 +2282,10 @@ def check_config_version() -> Tuple[int, int]:
     raw ``_config_version`` must remain visible as legacy instead of inheriting
     the latest default version in memory.
 
-    Returns (current_version, latest_version).
+    Returns (current_version, latest_version). Tolerant runtime status callers
+    retain the historical latest/latest fallback for malformed YAML. Mutation
+    and explicit validation paths can set ``raise_on_parse_error`` so a parse
+    failure cannot be mistaken for an up-to-date config.
     """
     latest = _coerce_config_version(DEFAULT_CONFIG.get("_config_version", 1)) or 1
     config_path = get_config_path()
@@ -2296,6 +2299,10 @@ def check_config_version() -> Tuple[int, int]:
         # Invalid YAML needs a parse warning, not an automatic schema rewrite
         # that could replace the user's broken file with defaults.
         _warn_config_parse_failure(config_path, e)
+        if raise_on_parse_error:
+            raise InvalidUserConfigError(
+                f"Cannot inspect {config_path}: config.yaml is not valid YAML ({e})"
+            ) from e
         return latest, latest
 
     if not isinstance(config, dict):
@@ -2659,6 +2666,11 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
     """
     results = {"env_added": [], "config_added": [], "warnings": []}
 
+    # Validate config.yaml before any migration side effect. In particular,
+    # sanitize_env_file() can rewrite .env, which must not happen when the
+    # migration will be refused for malformed YAML.
+    current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
+
     # ── Always: normalize safe .env line formatting ──
     try:
         fixes = sanitize_env_file()
@@ -2666,9 +2678,6 @@ def migrate_config(interactive: bool = True, quiet: bool = False) -> Dict[str, A
             print(f"  ✓ Normalized .env line formatting ({fixes} line(s) changed)")
     except Exception:
         pass  # best-effort; don't block migration on sanitize failure
-
-    # Check config version
-    current_ver, latest_ver = check_config_version()
 
     # ── Auto-migration support floor (policy: v12, July 2026) ──
     # A config with an EXPLICIT on-disk ``_config_version`` below the floor is
@@ -6366,7 +6375,7 @@ def config_command(args):
         # Check what's missing
         missing_env = get_missing_env_vars(required_only=False)
         missing_config = get_missing_config_fields()
-        current_ver, latest_ver = check_config_version()
+        current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
         
         if not missing_env and not missing_config and current_ver >= latest_ver:
             print(color("✓ Configuration is up to date!", Colors.GREEN))
@@ -6420,7 +6429,7 @@ def config_command(args):
         print(color("📋 Configuration Status", Colors.CYAN, Colors.BOLD))
         print()
         
-        current_ver, latest_ver = check_config_version()
+        current_ver, latest_ver = check_config_version(raise_on_parse_error=True)
         if current_ver >= latest_ver:
             print(f"  Config version: {current_ver} ✓")
         else:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2285,7 +2285,7 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
     Returns (current_version, latest_version). Tolerant runtime status callers
     retain the historical latest/latest fallback for malformed YAML. Mutation
     and explicit validation paths can set ``raise_on_parse_error`` so a parse
-    failure cannot be mistaken for an up-to-date config.
+    failure or a non-mapping root cannot be mistaken for an up-to-date config.
     """
     latest = _coerce_config_version(DEFAULT_CONFIG.get("_config_version", 1)) or 1
     config_path = get_config_path()
@@ -2294,7 +2294,7 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
 
     try:
         with open(config_path, encoding="utf-8") as f:
-            config = fast_safe_load(f) or {}
+            config = fast_safe_load(f)
     except Exception as e:
         # Invalid YAML needs a parse warning, not an automatic schema rewrite
         # that could replace the user's broken file with defaults.
@@ -2305,6 +2305,8 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
             ) from e
         return latest, latest
 
+    if config is None:
+        config = {}  # empty file / bare document: valid first-run state
     if not isinstance(config, dict):
         # A list/scalar root parses fine but is just as unusable as broken
         # YAML: save_config() would refuse it later, after .env was already

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2306,6 +2306,14 @@ def check_config_version(*, raise_on_parse_error: bool = False) -> Tuple[int, in
         return latest, latest
 
     if not isinstance(config, dict):
+        # A list/scalar root parses fine but is just as unusable as broken
+        # YAML: save_config() would refuse it later, after .env was already
+        # rewritten. Strict callers must see it up front too.
+        if raise_on_parse_error:
+            raise InvalidUserConfigError(
+                f"Cannot inspect {config_path}: config.yaml top-level value must be "
+                f"a mapping, got {type(config).__name__}"
+            )
         config = {}
     current = _coerce_config_version(config.get("_config_version"))
     return current, latest

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -227,7 +227,7 @@ def _run_config_check_fresh() -> tuple:
     _reload_config_modules()
     from hermes_cli.config import check_config_version
 
-    return check_config_version()
+    return check_config_version(raise_on_parse_error=True)
 
 
 def _run_migrate_config_fresh(*, interactive: bool = False, quiet: bool = False) -> dict:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -786,13 +786,22 @@ class TestConfigVersionDetection:
             assert load_config()["_config_version"] == DEFAULT_CONFIG["_config_version"]
             assert check_config_version() == (0, DEFAULT_CONFIG["_config_version"])
 
+    _LATEST = DEFAULT_CONFIG["_config_version"]
+    # (bytes, strict match, tolerant return): tolerant malformed YAML keeps
+    # the historical latest/latest fallback; a parseable non-mapping root is
+    # reported as legacy (0).
     _INVALID_CONFIG_CASES = [
-        pytest.param(b"model: [unterminated\n", "not valid YAML", id="malformed-yaml"),
-        pytest.param(b"- just_a_list\n", "must be a mapping", id="list-root"),
+        pytest.param(
+            b"model: [unterminated\n", "not valid YAML", (_LATEST, _LATEST), id="malformed-yaml"
+        ),
+        pytest.param(b"- just_a_list\n", "must be a mapping", (0, _LATEST), id="list-root"),
+        pytest.param(b"[]\n", "must be a mapping", (0, _LATEST), id="empty-list-root"),
     ]
 
-    @pytest.mark.parametrize("config_bytes, match", _INVALID_CONFIG_CASES)
-    def test_strict_check_rejects_invalid_config(self, tmp_path, config_bytes, match):
+    @pytest.mark.parametrize("config_bytes, match, tolerant", _INVALID_CONFIG_CASES)
+    def test_strict_check_rejects_invalid_config(
+        self, tmp_path, config_bytes, match, tolerant
+    ):
         config_path = tmp_path / "config.yaml"
         config_path.write_bytes(config_bytes)
 
@@ -800,11 +809,11 @@ class TestConfigVersionDetection:
             with pytest.raises(InvalidUserConfigError, match=match):
                 check_config_version(raise_on_parse_error=True)
             # Tolerant callers keep the historical non-raising behavior.
-            check_config_version()
+            assert check_config_version() == tolerant
 
-    @pytest.mark.parametrize("config_bytes, match", _INVALID_CONFIG_CASES)
+    @pytest.mark.parametrize("config_bytes, match, _tolerant", _INVALID_CONFIG_CASES)
     def test_migration_rejects_invalid_config_before_sanitizing_env(
-        self, tmp_path, config_bytes, match
+        self, tmp_path, config_bytes, match, _tolerant
     ):
         config_path = tmp_path / "config.yaml"
         config_path.write_bytes(config_bytes)

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -10,6 +10,7 @@ import yaml
 
 from hermes_cli.config import (
     DEFAULT_CONFIG,
+    InvalidUserConfigError,
     check_config_version,
     get_hermes_home,
     ensure_hermes_home,
@@ -738,7 +739,9 @@ class TestConfigMigrationSecretPrompts:
         saved = {}
 
         monkeypatch.setattr(cfg_mod, "sanitize_env_file", lambda: 0)
-        monkeypatch.setattr(cfg_mod, "check_config_version", lambda: (999, 999))
+        monkeypatch.setattr(
+            cfg_mod, "check_config_version", lambda **_kwargs: (999, 999)
+        )
         monkeypatch.setattr(cfg_mod, "get_missing_config_fields", lambda: [])
         monkeypatch.setattr(cfg_mod, "get_missing_skill_config_vars", lambda: [])
         monkeypatch.setattr(
@@ -782,6 +785,29 @@ class TestConfigVersionDetection:
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
             assert load_config()["_config_version"] == DEFAULT_CONFIG["_config_version"]
             assert check_config_version() == (0, DEFAULT_CONFIG["_config_version"])
+
+    def test_strict_check_rejects_malformed_yaml(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text("model: [unterminated\n", encoding="utf-8")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+                check_config_version(raise_on_parse_error=True)
+
+    def test_migration_rejects_malformed_yaml_before_sanitizing_env(self, tmp_path):
+        config_path = tmp_path / "config.yaml"
+        config_bytes = b"model: [unterminated\n"
+        config_path.write_bytes(config_bytes)
+        env_path = tmp_path / ".env"
+        env_bytes = b"OPENAI_API_KEY=test-without-final-newline"
+        env_path.write_bytes(env_bytes)
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+                migrate_config(interactive=False, quiet=True)
+
+        assert config_path.read_bytes() == config_bytes
+        assert env_path.read_bytes() == env_bytes
 
 
 class TestConfigSupportFloor:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -786,24 +786,34 @@ class TestConfigVersionDetection:
             assert load_config()["_config_version"] == DEFAULT_CONFIG["_config_version"]
             assert check_config_version() == (0, DEFAULT_CONFIG["_config_version"])
 
-    def test_strict_check_rejects_malformed_yaml(self, tmp_path):
+    _INVALID_CONFIG_CASES = [
+        pytest.param(b"model: [unterminated\n", "not valid YAML", id="malformed-yaml"),
+        pytest.param(b"- just_a_list\n", "must be a mapping", id="list-root"),
+    ]
+
+    @pytest.mark.parametrize("config_bytes, match", _INVALID_CONFIG_CASES)
+    def test_strict_check_rejects_invalid_config(self, tmp_path, config_bytes, match):
         config_path = tmp_path / "config.yaml"
-        config_path.write_text("model: [unterminated\n", encoding="utf-8")
+        config_path.write_bytes(config_bytes)
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+            with pytest.raises(InvalidUserConfigError, match=match):
                 check_config_version(raise_on_parse_error=True)
+            # Tolerant callers keep the historical non-raising behavior.
+            check_config_version()
 
-    def test_migration_rejects_malformed_yaml_before_sanitizing_env(self, tmp_path):
+    @pytest.mark.parametrize("config_bytes, match", _INVALID_CONFIG_CASES)
+    def test_migration_rejects_invalid_config_before_sanitizing_env(
+        self, tmp_path, config_bytes, match
+    ):
         config_path = tmp_path / "config.yaml"
-        config_bytes = b"model: [unterminated\n"
         config_path.write_bytes(config_bytes)
         env_path = tmp_path / ".env"
         env_bytes = b"OPENAI_API_KEY=test-without-final-newline"
         env_path.write_bytes(env_bytes)
 
         with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
-            with pytest.raises(InvalidUserConfigError, match="not valid YAML"):
+            with pytest.raises(InvalidUserConfigError, match=match):
                 migrate_config(interactive=False, quiet=True)
 
         assert config_path.read_bytes() == config_bytes

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -91,7 +91,7 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_main, "_restore_stashed_changes", lambda *a, **kw: True)
     monkeypatch.setattr(hermes_config, "get_missing_env_vars", lambda required_only=True: [])
     monkeypatch.setattr(hermes_config, "get_missing_config_fields", lambda: [])
-    monkeypatch.setattr(hermes_config, "check_config_version", lambda: (5, 5))
+    monkeypatch.setattr(hermes_config, "check_config_version", lambda **_kwargs: (5, 5))
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
     monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)


### PR DESCRIPTION
## Summary
Config migration now refuses to run — and leaves `.env` and `config.yaml` byte-for-byte untouched — when `config.yaml` is unparseable **or** has a non-mapping (list/scalar) root, instead of reporting the broken file as "up to date" and rewriting `.env` first.

Salvage of #101778 by @EmanueleCornaggia (cherry-picked, authorship preserved) plus one follow-up commit closing the sibling case the original missed.

Root cause: `check_config_version()` returned `(latest, latest)` on a YAML parse failure, so `migrate_config()` treated the config as current and continued; `sanitize_env_file()` had already rewritten `.env` before anything surfaced the error.

## Changes
- `hermes_cli/config.py`: `check_config_version(*, raise_on_parse_error=False)` — strict mode raises `InvalidUserConfigError` on parse failure (#101778) **and** on a non-mapping root (follow-up). Tolerant callers (doctor, profiles, setup, web_server `/api/status`, docker boot script) keep the historical fallback.
- `hermes_cli/config.py` `migrate_config()`: strict check moved **before** `sanitize_env_file()` so no side effect precedes the refusal.
- `hermes_cli/config.py` `config_command` (`hermes config check` / `migrate`) and `hermes_cli/update_cmd.py` `_run_config_check_fresh`: strict. Every one of these sites sits under an existing `RuntimeError`/`Exception` handler (`main.cmd_config`, `console_engine._capture_output`, all 3 `_run_config_check_fresh` callers) — clean message, no traceback.
- `tests/hermes_cli/test_config.py`: the two regression tests parametrized over `malformed-yaml`, `list-root` and `empty-list-root`; assert the tolerant call's return per shape (`(latest, latest)` for malformed, `(0, latest)` for non-mapping).
- Second follow-up (post-review fold): `fast_safe_load(f) or {}` collapsed a falsy `[]` root to `{}` before the strict check — only a `None` document (empty file) maps to `{}` now; docstring updated to name non-mapping roots.
- `tests/hermes_cli/test_update_autostash.py`: `check_config_version` mock made kwarg-tolerant (same fix the author applied in `test_config.py`).
- `contributors/emails/`: attribution entry for @EmanueleCornaggia (commit 1 so attribution CI is green per-commit).

## Why the follow-up
E2E on the PR head: a `config.yaml` whose root is a YAML list parses fine, so the strict check returned `(0, latest)`, migration proceeded, `.env` was rewritten, and only then `save_config()`'s fail-closed guard raised `RuntimeError("top-level YAML must be a mapping")` — the exact ".env mutated before the invalid config is surfaced" pattern the PR set out to fix. Same bug class, second shape; fixed in the same PR rather than filed as a follow-up.

## Validation
| | main | this PR |
|---|---|---|
| malformed YAML → `migrate_config()` | returns normally, `.env` rewritten | `InvalidUserConfigError`, `.env` + `config.yaml` byte-identical |
| list-root YAML → `migrate_config()` | `.env` rewritten, then late `RuntimeError` from `save_config` | `InvalidUserConfigError` up front, both files byte-identical |
| tolerant `check_config_version()` on either | `(latest, latest)` / `(0, latest)` | unchanged |

- `tests/hermes_cli/test_config.py`: 120 passed. Mutation check: reverting only the non-mapping strict raise fails exactly the 4 `list-root`/`empty-list-root` cases; the `malformed-yaml` pair stays green (binds to the original fix).
- Targeted sweep of 12 test files touching `check_config_version`/`migrate_config`: 255 passed; the 20 failures (`test_cmd_update`, `test_update_autostash`, `test_update_yes_flag`) reproduce identically on `upstream/main` on this host (`SystemExit: 1` from the gateway-fleet-restart guard, launchd env) — pre-existing, unrelated.
- `ruff check` clean on all touched files.

Closes #101778
