### PR TITLE
fix(desktop): Bot Mode @mention handoffs resolve on every active gateway (#97678, salvage #97683)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -253,11 +253,15 @@ describe('the mention middleware', () => {
     expect(hostMock.requestProfile).not.toHaveBeenCalled()
   })
 
-  it('hands the agent the connection-qualified message_agent target', async () => {
+  it('hands the agent a relay-resolvable canonical target', async () => {
     const { handler } = await contributions()
     const result = await handler({ text: 'ping @default-vera' })
 
-    expect(result.text).toMatch(/message_agent target: "default-vera@vera"/)
+    // The UI alias ('default-vera') is not a relay identity: resolve_remote_target()
+    // accepts only a roster row's handle/profile, optionally @connection-qualified.
+    // The annotation must carry the canonical profile@connection form (#97678).
+    expect(result.text).toMatch(/message_agent target: "default@vera"/)
+    expect(result.text).not.toMatch(/message_agent target: "default-vera/)
     expect(result.text).toMatch(/on Vera/)
   })
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -265,6 +265,25 @@ describe('the mention middleware', () => {
     expect(result.text).toMatch(/on Vera/)
   })
 
+  it('annotates the resolvable handle for a local row whose UI alias differs', async () => {
+    // The reporter's shape (#97678 / Discord video): the LOCAL twin carries
+    // the 'default-this-device' alias when the remote gateway is active.
+    // The local resolver only knows bare profile names / 'hermes'.
+    const { handler } = await contributions({
+      focused: 'ops',
+      profiles: [
+        { connectionId: 'local', connectionKind: 'local', handle: 'default-this-device', name: 'default' },
+        { name: 'ops' }
+      ]
+    })
+
+    const result = await handler({ text: 'ping @default-this-device' })
+
+    expect(result.text).toMatch(/@default-this-device = agent profile "default"/)
+    expect(result.text).toMatch(/message_agent target: "hermes"/)
+    expect(result.text).not.toMatch(/message_agent target: "default-this-device/)
+  })
+
   it('passes a draft with no mention straight through', async () => {
     const { handler } = await contributions()
     const draft = { text: 'no tags here' }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -734,7 +734,13 @@ export default {
               botRosterMeta(bot, $botMeta.get())?.title || bot.ui_meta?.['hermes-bots']?.title || bot.title || ''
             ).trim()
 
-            const target = bot.remoteSource && bot.connectionId ? `${handle}@${bot.connectionId}` : handle
+            // message_agent only resolves canonical identities: the relay
+            // matches a roster row's handle/profile (± @connection-id), the
+            // local path a bare profile name or 'hermes'. botHandle() prefers
+            // the row's source-qualified UI alias ('default-vera'), which
+            // neither resolver accepts — annotate the canonical form instead.
+            const target =
+              bot.remoteSource && bot.connectionId ? `${bot.name}@${bot.connectionId}` : botHandle(bot.name)
 
             const where = bot.remoteSource
               ? ` — on ${bot.connectionLabel || bot.connectionId} (message_agent target: "${target}")`

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -742,9 +742,15 @@ export default {
             const target =
               bot.remoteSource && bot.connectionId ? `${bot.name}@${bot.connectionId}` : botHandle(bot.name)
 
+            // Local rows get the same annotation whenever their UI alias
+            // ('default-this-device') differs from the resolvable handle —
+            // otherwise the agent has only the alias to go on and the local
+            // path rejects it the same way (#97678).
             const where = bot.remoteSource
               ? ` — on ${bot.connectionLabel || bot.connectionId} (message_agent target: "${target}")`
-              : ''
+              : handle !== target
+                ? ` (message_agent target: "${target}")`
+                : ''
 
             return `@${handle} = agent profile "${bot.name}"${title ? ` ("${title}")` : ''}${where}`
           })

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -84,6 +84,9 @@ def test_resolve_remote_target_forms(root):
     assert bot_relay.resolve_remote_target("default", roster)["connection_id"] == "cloud-1"
     # exact connection-qualified form
     assert bot_relay.resolve_remote_target("hermes@cloud-1", roster)["profile"] == "default"
+    # profile@connection — the form Desktop's mention middleware annotates
+    # for remote bots (#97678); the UI alias form must not be required
+    assert bot_relay.resolve_remote_target("default@cloud-1", roster)["profile"] == "default"
     assert bot_relay.resolve_remote_target("hermes@nope", roster) is None
     assert bot_relay.resolve_remote_target("ghost", roster) is None
 


### PR DESCRIPTION
## Summary
Desktop `@mention` handoffs to a bot on another connection (and to the local twin while a remote gateway is active) no longer die with `No teammate named ...` — the hidden annotation now hands the agent a target `message_agent` can actually resolve. Salvages #97683 by @liuhao1024 (fixes #97678; Discord report: A2A works or not depending on which gateway is active).

Root cause: the mention middleware built the `message_agent` target from `botHandle()`, which prefers the roster row's source-qualified **UI alias** (`default-vera`, `default-this-device`). Neither resolver accepts that: `resolve_remote_target()` matches only handle/profile ± `@connection-id`, and the local path only a bare profile name or `hermes`.

## Changes
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` (contributor): remote rows annotate `profile@connection-id`; local rows the canonical handle. The visible `@alias` line is unchanged.
- `plugin.tsx` (follow-up): the local twin also gets the `(message_agent target: "...")` annotation whenever its alias differs from the resolvable handle — the reporter's exact shape (`default-this-device` with the remote gateway active), which the remote-only fix left uncovered.
- `plugin.mentions.test.ts`: pins `default@vera` for remote, `hermes` for the aliased local row; asserts the alias never leaks into the target.
- `tests/tools/test_bot_relay.py` (contributor): pins that `default@cloud-1` (profile@connection) resolves.

## Validation
| | Before | After |
|---|---|---|
| remote `@default-vera` → target | `default-vera@vera` → `resolve_remote_target` = None | `default@vera` → row |
| local `@default-this-device` → target | none annotated; alias → `_resolve_local_name` = None | `hermes` → `default` |
| vitest `plugin.mentions.test.ts` + `contrib/plugin.test.ts` | — | 22/22 (new local test fails without the follow-up: sabotage-verified) |
| `pytest tests/tools/test_bot_relay.py` | — | 27 passed |
| `tsc --noEmit`, eslint, prettier | — | clean |

Dupes: #97862 (@loulanyue, same fix, later) and #97685 (closed as dupe) — close after merge with credit.

## Infographic

![mention-to-resolvable-target](https://v3b.fal.media/files/b/0aa8e927/bFL1M4_O9E4XdiuHwJAps_vBzFb2Fc.png)
