### PR TITLE
fix(desktop): push resolved backend connection to renderer on 'hermes:backend-ready' (#96743 item 1)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1950,6 +1950,26 @@ function broadcastBootProgress() {
   webContents.send('hermes:boot-progress', bootProgressState)
 }
 
+// #96743 item 1: push the resolved primary connection to the renderer the
+// moment the backend is ready. The renderer's boot loop can then consume it
+// directly when its own getConnection() call lost the race (bounded retries
+// exhausted while main was gating on a remote update / install). This runs
+// in PARALLEL with (never replacing) the pull-based handshake — the pull path
+// is preserved as the compatibility fallback.
+function broadcastBackendReady(connection: unknown) {
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return
+  }
+
+  const { webContents } = mainWindow
+
+  if (!webContents || webContents.isDestroyed()) {
+    return
+  }
+
+  webContents.send('hermes:backend-ready', { connection })
+}
+
 // Bootstrap-event broadcast channel + state. The bootstrap runner emits a
 // stream of events (manifest, stage, log, complete, failed) that the renderer
 // install overlay subscribes to. We also keep a running snapshot:
@@ -12831,7 +12851,14 @@ async function startHermes() {
         error: null
       })
 
-      return createPrimaryRemoteConnection(remote, hermesLog.slice(-80), getWindowState())
+      const remoteConnection = createPrimaryRemoteConnection(remote, hermesLog.slice(-80), getWindowState())
+
+      // #96743 item 1: push the resolved connection to the renderer NOW.
+      // The pull (getConnection IPC) can lose the race when the boot
+      // retry budget exhausts during a long update gate.
+      broadcastBackendReady(remoteConnection)
+
+      return remoteConnection
     }
 
     await advanceBootProgress('backend.resolve', 'Resolving Hermes backend', 8)
@@ -13106,7 +13133,7 @@ async function startHermes() {
     // Surface it once (per distinct set of affected plugins) after the window is up; never block boot.
     setTimeout(() => void showPluginCompatNoticeOnce(), 1500)
 
-    return {
+    const localConnection = {
       baseUrl,
       mode: 'local',
       source: 'local',
@@ -13116,6 +13143,13 @@ async function startHermes() {
       logs: hermesLog.slice(-80),
       ...getWindowState()
     }
+
+    // #96743 item 1: push the resolved connection to the renderer NOW.
+    // The pull (getConnection IPC) can lose the race when the boot
+    // retry budget exhausts during a long install/bootstrap gate.
+    broadcastBackendReady(localConnection)
+
+    return localConnection
   })().catch(async error => {
     if (!backendConnectionState.clearPromiseForAttempt(connectionAttempt)) {
       throw error

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -475,6 +475,16 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:boot-progress', listener)
   },
+  // #96743 item 1: main pushes the resolved connection descriptor once the
+  // primary backend is actually ready — the missing half of the handshake.
+  // Boot uses it to recover when its own getConnection() IPC call lost the
+  // race against a long-running gate (remote update, install, etc.).
+  onBackendReady: callback => {
+    const listener = (_event, payload) => callback(payload)
+    ipcRenderer.on('hermes:backend-ready', listener)
+
+    return () => ipcRenderer.removeListener('hermes:backend-ready', listener)
+  },
   // First-launch bootstrap progress -- emitted by the install.ps1 stage
   // runner in main.ts (apps/desktop/electron/bootstrap-runner.ts).
   // Renderer's install overlay subscribes to live events and queries the

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-backend-ready-push.test.tsx
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-backend-ready-push.test.tsx
@@ -1,0 +1,319 @@
+import { act, cleanup, render } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { $desktopBoot } from '@/store/boot'
+import { _resetConnectionsForTests } from '@/store/connections'
+import { closeSecondaryGateways } from '@/store/gateway'
+import { endGatewaySwitch } from '@/store/gateway-switch'
+import { notifyError } from '@/store/notifications'
+import { $activeGatewayProfile } from '@/store/profile'
+import {
+  $awaitingResponse,
+  $busy,
+  $connection,
+  $currentCwd,
+  $gatewayState,
+  setActiveSessionId,
+  setSelectedStoredSessionId
+} from '@/store/session'
+
+import { takeGatewaySurvivor } from './gateway-hmr-survivor'
+import { useGatewayBoot } from './use-gateway-boot'
+
+vi.mock(import('@/store/notifications'), async importOriginal => ({
+  ...(await importOriginal()),
+  notifyError: vi.fn()
+}))
+
+// #96743 item 1: main pushes a `hermes:backend-ready` event the MOMENT the
+// primary connection is resolved, carrying the full connection descriptor.
+// The renderer's boot loop subscribes and uses the pushed descriptor as the
+// connection for the in-flight boot when one is pending — instead of relying
+// exclusively on its own getConnection() IPC round-trip, which can lose the
+// race against main settling the promise after the renderer's retry budget
+// ran out during a long remote-update gate.
+
+type Listener = (ev: unknown) => void
+
+class FakeWebSocket {
+  static OPEN = 1
+  static CLOSED = 3
+  static mode: 'open' | 'fail' = 'open'
+  static instances: FakeWebSocket[] = []
+
+  readyState = 0
+  private listeners: Record<string, Set<Listener>> = {}
+
+  constructor(public url: string) {
+    FakeWebSocket.instances.push(this)
+    const willOpen = FakeWebSocket.mode === 'open'
+
+    setTimeout(() => {
+      if (willOpen) {
+        this.readyState = FakeWebSocket.OPEN
+        this.emit('open', {})
+      } else {
+        this.readyState = FakeWebSocket.CLOSED
+        this.emit('error', {})
+      }
+    }, 0)
+  }
+
+  addEventListener(type: string, fn: Listener) {
+    ;(this.listeners[type] ??= new Set()).add(fn)
+  }
+
+  removeEventListener(type: string, fn: Listener) {
+    this.listeners[type]?.delete(fn)
+  }
+
+  close() {
+    this.readyState = FakeWebSocket.CLOSED
+    this.emit('close', {})
+  }
+
+  send(_data: string) {}
+
+  private emit(type: string, ev: unknown) {
+    for (const fn of this.listeners[type] ?? []) {
+      fn(ev)
+    }
+  }
+}
+
+const primaryConn = {
+  authMode: 'token' as const,
+  baseUrl: 'https://vps.example.com',
+  connectionId: 'primary-vps',
+  profile: 'default',
+  token: 't',
+  wsUrl: 'wss://vps.example.com/api/ws?token=t'
+}
+
+function fakeDesktop() {
+  let bootProgressHandler: ((payload: Record<string, unknown>) => void) | null = null
+  let backendReadyHandler: ((payload: Record<string, unknown>) => void) | null = null
+
+  return {
+    getConnection: vi.fn(async () => primaryConn),
+    getGatewayWsUrl: vi.fn(async (conn?: { wsUrl?: string }) => conn?.wsUrl ?? primaryConn.wsUrl),
+    getBootProgress: vi.fn(async () => ({
+      error: null as null | string,
+      fakeMode: false,
+      message: '',
+      phase: 'init',
+      progress: 0,
+      retryable: false as boolean,
+      running: true as boolean,
+      timestamp: Date.now()
+    })),
+    onBootProgress: vi.fn(callback => {
+      bootProgressHandler = callback
+
+      return () => {
+        bootProgressHandler = null
+      }
+    }),
+    emitBootProgress(payload: Record<string, unknown>) {
+      bootProgressHandler?.(payload)
+    },
+    // Item 1's new push channel: main → renderer, fires once per successful
+    // primary connect, carrying the full connection descriptor.
+    onBackendReady: vi.fn(callback => {
+      backendReadyHandler = callback
+
+      return () => {
+        backendReadyHandler = null
+      }
+    }),
+    emitBackendReady(payload: Record<string, unknown>) {
+      backendReadyHandler?.(payload)
+    },
+    onBackendExit: vi.fn(() => () => undefined),
+    onConnectionApplied: vi.fn(() => () => undefined),
+    onPowerResume: vi.fn(() => () => undefined),
+    revalidateConnection: vi.fn(async () => ({ ok: true, rebuilt: false })),
+    onWindowStateChanged: vi.fn(() => () => undefined),
+    touchBackend: vi.fn(async () => undefined),
+    profile: { get: vi.fn(async () => ({ profile: 'default' })) }
+  }
+}
+
+function Harness() {
+  useGatewayBoot({
+    beforeConnectionSwitch: () => undefined,
+    handleGatewayEvent: () => undefined,
+    onConnectionReady: () => undefined,
+    onGatewayReady: () => undefined,
+    refreshHermesConfig: async () => undefined,
+    refreshSessions: async () => undefined
+  })
+
+  return null
+}
+
+const originalWebSocket = globalThis.WebSocket
+
+beforeEach(() => {
+  const leftover = takeGatewaySurvivor()
+
+  if (leftover) {
+    try {
+      leftover.gateway.close()
+    } catch {
+      // ignore
+    }
+  }
+
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
+  vi.useFakeTimers()
+  FakeWebSocket.mode = 'open'
+  FakeWebSocket.instances = []
+  vi.mocked(notifyError).mockReset()
+  ;(globalThis as { WebSocket: unknown }).WebSocket = FakeWebSocket
+  $gatewayState.set('idle')
+  $busy.set(false)
+  $awaitingResponse.set(false)
+  $desktopBoot.set({
+    error: null,
+    fakeMode: false,
+    message: '',
+    phase: 'init',
+    progress: 0,
+    running: true,
+    timestamp: Date.now(),
+    visible: true
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  const survivor = takeGatewaySurvivor()
+
+  if (survivor) {
+    try {
+      survivor.gateway.close()
+    } catch {
+      // ignore
+    }
+  }
+
+  closeSecondaryGateways()
+  $activeGatewayProfile.set('default')
+  $connection.set(null)
+  _resetConnectionsForTests()
+  setActiveSessionId(null)
+  setSelectedStoredSessionId(null)
+  endGatewaySwitch()
+  vi.useRealTimers()
+  ;(globalThis as { WebSocket: unknown }).WebSocket = originalWebSocket
+  delete (window as { hermesDesktop?: unknown }).hermesDesktop
+  window.localStorage.removeItem('hermes.desktop.workspace-cwd')
+  $currentCwd.set('')
+  $busy.set(false)
+  $awaitingResponse.set(false)
+})
+
+async function flushAsync() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(0)
+  })
+}
+
+describe('#96743 item 1 — main pushes backend-ready with the resolved connection', () => {
+  it('a boot stuck behind getConnection() unblocks when main pushes the resolved connection', async () => {
+    const updateError = new Error('Remote Hermes update process 4242 is still running; SSH startup is paused.')
+    const desktop = fakeDesktop()
+    let updateFinished = false
+
+    desktop.getConnection = vi.fn(async () => {
+      if (!updateFinished) {
+        throw updateError
+      }
+
+      return primaryConn
+    })
+    desktop.getBootProgress = vi.fn(async () => ({
+      error: updateError.message,
+      fakeMode: false,
+      message: `Desktop boot failed: ${updateError.message}`,
+      phase: 'backend.error',
+      progress: 24,
+      retryable: true,
+      running: false,
+      timestamp: Date.now()
+    }))
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await flushAsync()
+
+    // Retry budget exhausts — the boot overlay is latched, no further
+    // attempts are scheduled. Nothing yet can recover this except main
+    // pushing the resolved connection.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(500_000)
+    })
+
+    const dialsBeforePush = vi.mocked(desktop.getConnection).mock.calls.length
+
+    expect($gatewayState.get()).not.toBe('open')
+    expect($desktopBoot.get().visible).toBe(true)
+    expect(dialsBeforePush).toBeGreaterThan(1)
+
+    // Main finished the remote update, resolved the connection, and PUSHED
+    // it to the renderer with the full descriptor. boot() must consume it
+    // directly — without waiting on a new getConnection() round-trip.
+    updateFinished = true
+    await act(async () => {
+      desktop.emitBackendReady({
+        connection: primaryConn
+      })
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    // Boot completed via the PUSHED connection, no extra dial. The
+    // FakeWebSocket for the gateway handshake is the proof the boot
+    // proceeded past getConnection all the way to gateway.connect().
+    expect(FakeWebSocket.instances.length).toBeGreaterThan(0)
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().visible).toBe(false)
+    expect($desktopBoot.get().error).toBeNull()
+    // Emphasize the point: the boot did NOT need a fresh dial to recover.
+    expect(vi.mocked(desktop.getConnection).mock.calls.length).toBe(dialsBeforePush)
+  }, 30_000)
+
+  it('a dark push after a completed boot is ignored (post-boot stability)', async () => {
+    const desktop = fakeDesktop()
+
+    ;(window as { hermesDesktop?: unknown }).hermesDesktop = desktop
+
+    render(<Harness />)
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect($gatewayState.get()).toBe('open')
+    expect($desktopBoot.get().visible).toBe(false)
+    const dialsAfterBoot = vi.mocked(desktop.getConnection).mock.calls.length
+
+    // A late backend-ready push (e.g. a profile-handoff re-emit) must NOT
+    // disrupt the healthy boot. The renderer already owns a live connection;
+    // parroting an older descriptor would be a regression.
+    await act(async () => {
+      desktop.emitBackendReady({
+        connection: {
+          ...primaryConn,
+          token: 'stale-token',
+          wsUrl: 'wss://vps.example.com/api/ws?token=stale-token'
+        }
+      })
+      await vi.advanceTimersByTimeAsync(1_000)
+    })
+
+    expect($gatewayState.get()).toBe('open')
+    expect(vi.mocked(desktop.getConnection).mock.calls.length).toBe(dialsAfterBoot)
+  }, 30_000)
+})

--- a/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
+++ b/apps/desktop/src/app/gateway/hooks/use-gateway-boot.ts
@@ -713,6 +713,42 @@ export function useGatewayBoot({
       applyDesktopBootProgress(payload)
     })
 
+    // #96743 item 1: main ALSO pushes the resolved connection descriptor the
+    // moment the primary backend is actually ready, on the
+    // `hermes:backend-ready` channel. The pull handshake (getConnection IPC)
+    // can lose its race when the renderer's retry budget exhausts while main
+    // is parked inside a long gate (remote update, installer); the pushed
+    // connection lets a pending boot continue directly from the descriptor,
+    // no second dial needed.
+    let standbyPushedConnection: Awaited<
+      ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>
+    > | null = null
+
+    const offBackendReady = desktop.onBackendReady?.(payload => {
+      // Pull-based handoff stays canonical: boot, soft-switch, reconnect, and
+      // retries all complete through their own getConnection() await. The
+      // push is the recovery escape hatch: it only matters when the pull
+      // pipeline gave up — i.e. boot failed AND its retry budget is
+      // exhausted (no retry timer armed). Any other moment (in-flight boot,
+      // pending retry, completed boot, in-progress switch) is a normal path
+      // that must not be disturbed; swallow the push there too.
+      if (cancelled || bootCompleted || $gatewaySwitching.get() || bootRetryTimer) {
+        return
+      }
+
+      const connection = (payload as { connection?: unknown } | null | undefined)?.connection
+
+      if (!connection || typeof connection !== 'object') {
+        return
+      }
+
+      standbyPushedConnection =
+        connection as Awaited<ReturnType<NonNullable<typeof window.hermesDesktop>['getConnection']>>
+
+      resumeDesktopBootForRetry(translateNow('boot.steps.retryingRemoteBackend'))
+      void boot()
+    })
+
     void desktop
       .getBootProgress()
       .then(snapshot => applyDesktopBootProgress(snapshot))
@@ -988,11 +1024,20 @@ export function useGatewayBoot({
         // round-trip must not hang "Starting Hermes…" forever. Initial boot
         // rides out a full backend cold spawn, so it gets the shared 45s
         // backend-boot budget, not the 20s reconnect budget.
-        const conn = await withTimeout(
+        //
+        // #96743 item 1: when main has already PUSHED the resolved connection
+        // on `hermes:backend-ready` (the boot was triggered from the push
+        // after retries exhausted), skip this dial entirely and consume the
+        // pushed descriptor directly — the pull was already lost once; asking
+        // again just re-awaits the same gate.
+        const pushed = standbyPushedConnection
+        standbyPushedConnection = null
+
+        const conn = pushed ?? (await withTimeout(
           desktop.getConnection(windowProfileOverride() ?? undefined),
           BACKEND_BOOT_WAIT_TIMEOUT_MS,
           'Timed out connecting to Hermes backend'
-        )
+        ))
 
         if (cancelled) {
           return
@@ -1173,6 +1218,7 @@ export function useGatewayBoot({
       offExit()
       offWindowState?.()
       offBootProgress()
+      offBackendReady?.()
 
       // HMR teardown vs. real unmount. On a hot update we must NOT close the
       // socket — that's the whole bug. Detach this instance's listeners (their

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -507,6 +507,7 @@ declare global {
       getOnBattery?: () => Promise<boolean>
       onBatteryChanged?: (callback: (onBattery: boolean) => void) => () => void
       onBootProgress: (callback: (payload: DesktopBootProgress) => void) => () => void
+      onBackendReady?: (callback: (payload: { connection: unknown }) => void) => () => void
       getBootstrapState: () => Promise<DesktopBootstrapState>
       continueBootstrapLocal: () => Promise<{ ok: boolean }>
       recycleBackend?: (profile?: null | string) => Promise<{ ok: boolean }>


### PR DESCRIPTION
## Summary

Closes item 1 of #96743 — push the resolved backend connection from main to the renderer instead of relying on a renderer-driven pull loop.

The boot handshake today is pull-only: `boot()` calls `getConnection()`, waits up to 45 s, on failure retries up to 5 times with backoff (~1 min total), then latches the failure overlay. That works for transient blips, but not for the long external gate in the issue: the one-click update can hold main inside the remote-update marker for 10+ minutes. The renderer exhausts its retries while main is still working; when main finally resolves, nobody is left awaiting — the window sits on the failure overlay until a manual relaunch. This PR adds the missing push leg so a resolved connection reaches the renderer directly.

## What changes, exactly

**main.ts (electron):**
- New `broadcastBackendReady(connection)` — `webContents.send('hermes:backend-ready', { connection })` with the standard destroyed-window guards.
- Called from both ready paths: the remote branch (`connectRemote`, after `Remote Hermes backend is ready`) and the local spawn branch, just before each returns its resolved descriptor. The push rides the same state the pull path would return, so they cannot disagree.

**preload.ts + global.d.ts:**
- Expose `onBackendReady(callback)` to the renderer, mirroring the existing `onBootProgress` shape. Unsubscribes cleanly.

**use-gateway-boot.ts (renderer):**
- New `standbyPushedConnection` slot.
- `onBackendReady` handler consumes the push ONLY when the pull pipeline has genuinely given up: `!cancelled && !bootCompleted && !$gatewaySwitching.get() && !bootRetryTimer`. Under any other state (in-flight boot, armed retry, post-boot, mid-switch) the push is ignored — the pull remains canonical everywhere it already works.
- When the push does recover, the handler parks the descriptor into the standby slot and re-invokes `boot()`.
- `boot()` now prefers a non-null standby connection over a fresh `desktop.getConnection()` dial, then clears the slot so a second push can't double-drive boot.

## Why this shape (and not a bigger rewrite)

I considered three alternative designs and rejected them here:

1. **Make the pull infinite** (remove the 5-attempt cap) — turns a real, misconfigured-remote failure into an infinite spinner; the bounded retry is deliberate (#82679).
2. **Publish through `broadcastBootProgress` with a new phase** — conflates progress UI with connection state, requires consumers to know which phases carry a connection descriptor, and pollutes `bootProgressState` with a field that isn't about progress.
3. **Rework the whole handshake to push-only** — a larger refactor that would churn every call site of `boot()`/`softSwitch()`/`getConnection()`. Not the right scope for a P2 bug fix; this PR is the surgical addition that closes the observability-to-recovery gap.

The pull leg stays as the canonical fast path; the push leg is the bounded-retry escape hatch.

## Test plan

New file `apps/desktop/src/app/gateway/hooks/use-gateway-backend-ready-push.test.tsx` (dedicated to this fix, per project convention):

- **RED→GREEN reproduction of the issue's exact timeline**: every `getConnection()` rejects with the remote-update-in-progress error, retries exhaust (fake timers advance the full ~8-min retry budget), the boot overlay latches. Then main pushes `hermes:backend-ready` with the resolved connection. The hook must consume the pushed descriptor directly — no new `getConnection()` call — and complete the boot (gateway opens, overlay clears). Failed RED before the hook change, passes GREEN with it.
- **Push after a healthy boot is ignored**: a late `hermes:backend-ready` (profile handoff re-emit, stale broadcast) with a stale token DOES NOT disrupt the open gateway. Guards against regressing the post-boot push to a visible reconnect.

Existing coverage:
- 42 tests in `use-gateway-boot.test.tsx` pass unchanged.
- 3 tests in `use-gateway-boot-late-ready.test.tsx` (the sibling PR's reproduction + guards) also pass unchanged — the two mechanisms compose, they don't collide.

Local:
- `npx vitest run src/app/gateway/hooks/use-gateway-boot{,-late-ready,-backend-ready-push}.test.tsx` — 47/47
- `npx tsc --noEmit -p tsconfig.json` — clean
- `npx eslint` on every touched file — clean (0 errors, 0 warnings)

## Risk

- One new IPC event name, additive only. No existing channel changes shape.
- The push is consumed at exactly one point in the renderer (`use-gateway-boot.ts`), with four explicit guards (`cancelled` / `bootCompleted` / `$gatewaySwitching.get()` / `bootRetryTimer`) that mirror the existing boot-progress guards.
- No env vars, no config keys, no schema changes. Renders identically on Windows, macOS, and Linux; no platform-specific code.
- Worst-case regression: a push is ignored (the same behavior as before, where no push existed) and the user still sees the failure overlay with the manual Retry button.

## Coordination with the other #96743 PRs

- **#101879** (re-drive boot on late `backend.ready`) lives in the same handler and is the small-t sibling of this one. Together they cover the "progress event is enough" case (101879) and the "need the resolved descriptor, not a hint" case (this PR).
- **#101896** (transition logging) is unaffected; this PR just adds one new producer of pushed state that the logger will see too.
