### PR TITLE
fix(desktop): declare rememberLog state before the top-level pool-limits read

### DIFF
--- a/apps/desktop/electron/main-init-order.test.ts
+++ b/apps/desktop/electron/main-init-order.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression: the desktop main process must finish initializing rememberLog()
+ * state before any top-level statement that logs.
+ *
+ * `readPersistedPoolLimits()` runs at module top level and logs on BOTH code
+ * paths (persisted file / env-var-or-defaults fallback). `rememberLog()`
+ * pushes onto `hermesLog` and appends to `desktopLogBuffer`, so those
+ * declarations must execute first. When they were declared ~110 lines below
+ * the top-level call, every desktop launch died during ESM module evaluation
+ * with `TypeError: Cannot read properties of undefined (reading 'push')` —
+ * esbuild lowers `const`/`let` TDZ to `undefined` instead of throwing, so the
+ * packaged app crashed at `hermesLog.push(...)` and the window never appeared
+ * (#101941).
+ *
+ * main.ts cannot be imported in unit tests (it needs Electron's `app` at
+ * module scope), so this locks the source-level ordering contract instead:
+ * the log-state declarations exist exactly once and precede the top-level
+ * `readPersistedPoolLimits()` call.
+ */
+
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { test } from 'vitest'
+
+const MAIN_TS = path.join(__dirname, 'main.ts')
+
+function mainSource(): string {
+  return fs.readFileSync(MAIN_TS, 'utf8')
+}
+
+// Returns the index of `needle`, asserting it appears exactly once so a
+// pasted duplicate cannot silently satisfy the ordering check.
+function uniqueIndexOf(source: string, needle: string): number {
+  const first = source.indexOf(needle)
+  assert.notStrictEqual(first, -1, `expected exactly one occurrence of ${needle}`)
+
+  assert.strictEqual(
+    source.indexOf(needle, first + 1),
+    -1,
+    `expected exactly one occurrence of ${needle}`
+  )
+
+  return first
+}
+
+test('log buffer state is declared before the top-level readPersistedPoolLimits() call', () => {
+  const source = mainSource()
+
+  const poolLimitsCall = uniqueIndexOf(source, 'let poolLimits = readPersistedPoolLimits()')
+
+  for (const declaration of [
+    'const hermesLog = []',
+    "let desktopLogBuffer = ''",
+    'let desktopLogFlushTimer = null',
+    'let desktopLogFlushPromise = Promise.resolve()'
+  ]) {
+    const at = uniqueIndexOf(source, declaration)
+
+    assert.ok(
+      at < poolLimitsCall,
+      `${declaration} must be declared before \`let poolLimits = readPersistedPoolLimits()\` — rememberLog() touches it during module evaluation (#101941)`
+    )
+  }
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1462,6 +1462,15 @@ function persistPoolLimits(limits) {
   }
 }
 
+// rememberLog() state. Declared here, before the top-level
+// readPersistedPoolLimits() call below, because that call logs during module
+// evaluation; declaring these later crashed launch with `undefined.push` in
+// the packaged build (esbuild lowers the TDZ to undefined instead of throwing).
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
+
 let poolLimits = readPersistedPoolLimits()
 // Hard cap on local backends that are starting OR running (the LRU eviction
 // above is soft — it spares keepalive-fresh entries). Follows the live
@@ -1572,12 +1581,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## What does this PR do?

Fixes a desktop main-process launch crash introduced by `c401756a6a` (#91545). `readPersistedPoolLimits()` runs at module top level and calls `rememberLog()` on **both** code paths (persisted file / env-var-or-defaults fallback), but the log state that `rememberLog()` touches (`hermesLog`, `desktopLogBuffer`, `desktopLogFlushTimer`, `desktopLogFlushPromise`) was declared ~110 lines below the call. In the packaged build esbuild lowers the `const`/`let` TDZ to `undefined`, so `hermesLog.push(...)` threw `TypeError: Cannot read properties of undefined (reading 'push')` during ESM module evaluation and the window never appeared (#101941).

Moving the `readPersistedPoolLimits()` call down (the issue's option 1) is not possible as written: `localBackendSpawnCoordinator` is constructed from `poolLimits` immediately below the call. So this moves the four log-state declarations **up**, just before the call, with a comment pinning the ordering constraint. That keeps the pool-limits read where it is and makes `rememberLog()` safe for any current or future early caller (addressing the "hides other early callers" concern the issue raised about a guard-based fix).

## Related Issue

Fixes #101941

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — moved `const hermesLog = []`, `let desktopLogBuffer = ''`, `let desktopLogFlushTimer = null`, `let desktopLogFlushPromise = Promise.resolve()` from the misc-state block (~L1575) to directly above the top-level `let poolLimits = readPersistedPoolLimits()` call, plus a comment explaining why the ordering is load-bearing. No behavior change for any code path that runs after module evaluation.
- `apps/desktop/electron/main-init-order.test.ts` — new regression test (source-contract style, following the `desktop-electron-pin.test.ts` precedent) asserting each log-state declaration appears exactly once and precedes the top-level call. `main.ts` cannot be imported in unit tests (it needs Electron's `app` at module scope), so the source-level contract is the only unit-testable seam for this init-order class of bug.

## How to Test

1. `cd apps/desktop && npx vitest run electron/main-init-order.test.ts` — passes with the fix (1 test).
2. Negative control (verified locally): revert only `apps/desktop/electron/main.ts` and re-run — the test fails with `AssertionError: const hermesLog = [] must be declared before `let poolLimits = readPersistedPoolLimits()``, i.e. the test actually locks the regression.
3. `cd apps/desktop && npx vitest run electron/` — Observed result: 2030 passed, 6 skipped; the single failure (`managed-ssh-update.test.ts`, POSIX launcher exits 127) reproduces identically on a clean `upstream/main` checkout without this change (local-environment flake, unrelated to this PR).
4. `npx esbuild electron/main.ts --format=esm` — Observed result: transforms cleanly; the module now initializes the log state before the first statement that can log.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (touches only `apps/desktop` TypeScript); ran `npx vitest run electron/` instead (results above)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (ordering constraint documented as an inline comment at the moved declarations)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (declaration reordering, no platform-conditional code touched)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

`npx vitest run electron/main-init-order.test.ts electron/pool-limits.test.ts` with the fix:

```
 ✓ |electron| electron/main-init-order.test.ts (1 test) 2ms
 ✓ |electron| electron/pool-limits.test.ts (8 tests) 2ms

 Test Files  2 passed (2)
      Tests  9 passed (9)
```
