### PR TITLE
fix(acp): canonicalize named custom model IDs

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -737,10 +737,23 @@ class HermesACPAgent(acp.Agent):
         """
         model = str(state.model or getattr(state.agent, "model", "") or "").strip()
         provider = getattr(state.agent, "provider", None) or detect_provider() or "openrouter"
+        requested_provider = getattr(state.agent, "requested_provider", None)
+        requested_provider_id = (
+            requested_provider.strip().lower()
+            if isinstance(requested_provider, str)
+            else ""
+        )
+        if not requested_provider_id.startswith("custom:"):
+            requested_provider_id = ""
 
         try:
             from hermes_cli.inventory import build_models_payload, load_picker_context
-            from hermes_cli.models import normalize_provider, provider_label
+            from hermes_cli.models import (
+                CANONICAL_PROVIDERS,
+                normalize_provider,
+                provider_label,
+            )
+            from hermes_cli.runtime_provider import canonical_custom_identity
 
             normalized_provider = normalize_provider(provider)
             context = load_picker_context().with_overrides(
@@ -764,9 +777,24 @@ class HermesACPAgent(acp.Agent):
 
             available_models: list[ModelInfo] = []
             seen_ids: set[str] = set()
-            current_choice_provider = str(provider or "").strip().lower()
-            if current_choice_provider == "ollama":
-                current_choice_provider = "custom:ollama"
+            canonical_provider_ids = {entry.slug for entry in CANONICAL_PROVIDERS}
+
+            def canonical_choice_provider(provider_id: str) -> str:
+                raw = str(provider_id or "").strip().lower()
+                if raw == "ollama":
+                    return "custom:ollama"
+                if raw == "custom" and requested_provider_id:
+                    return requested_provider_id
+                if raw.startswith("custom:"):
+                    return raw
+                normalized = normalize_provider(raw)
+                if normalized in canonical_provider_ids:
+                    return normalized
+                return canonical_custom_identity(config_provider=raw) or normalized
+
+            current_choice_provider = canonical_choice_provider(
+                requested_provider_id or provider
+            )
             current_base_url = str(
                 getattr(state.agent, "base_url", "") or ""
             ).strip().rstrip("/").lower()
@@ -801,6 +829,7 @@ class HermesACPAgent(acp.Agent):
                 provider_name = str(row.get("name") or "").strip() or provider_label(
                     row_provider
                 )
+                encoded_provider = canonical_choice_provider(raw_row_provider)
                 row_models = row.get("models")
                 if not isinstance(row_models, (list, tuple)):
                     continue
@@ -816,15 +845,6 @@ class HermesACPAgent(acp.Agent):
                         rendered_model = str(model_entry or "").strip()
                     if not rendered_model:
                         continue
-                    encoded_provider = (
-                        "custom:ollama"
-                        if raw_row_provider == "ollama"
-                        else raw_row_provider
-                        if raw_row_provider == "custom:ollama"
-                        else raw_row_provider
-                        if raw_row_provider.startswith("custom:")
-                        else row_provider
-                    )
                     choice_id = self._encode_model_choice(
                         encoded_provider, rendered_model
                     )

--- a/tests/acp/test_named_provider_catalogs.py
+++ b/tests/acp/test_named_provider_catalogs.py
@@ -277,3 +277,116 @@ class TestModelStateIncludesNamedProviders:
             )
         assert provider == "custom:local-127.0.0.1:11434"
         assert model == "qwen3:1.7b"
+
+    @pytest.mark.parametrize(
+        (
+            "current_provider",
+            "requested_provider",
+            "inventory_provider",
+            "current_model",
+            "expected_current_id",
+        ),
+        [
+            ("openai-codex", None, "9router", "gpt-5.4", "openai-codex:gpt-5.4"),
+            (
+                "custom",
+                "custom:9router",
+                "custom",
+                "tflow/gpt-5.6-sol",
+                "custom:9router:tflow/gpt-5.6-sol",
+            ),
+        ],
+    )
+    def test_named_provider_inventory_slug_uses_canonical_choice_id(
+        self,
+        monkeypatch,
+        tmp_path,
+        current_provider,
+        requested_provider,
+        inventory_provider,
+        current_model,
+        expected_current_id,
+    ):
+        """ACP must advertise one round-trippable ID for a named endpoint."""
+        import yaml
+
+        from hermes_cli.models import parse_model_input
+
+        model = "tflow/gpt-5.6-sol"
+        config = {
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
+            "providers": {
+                "9router": {
+                    "name": "9Router",
+                    "base_url": "https://router.example/v1",
+                    "api_key": "x",
+                    "default_model": model,
+                    "discover_models": False,
+                }
+            },
+        }
+        (tmp_path / "config.yaml").write_text(
+            yaml.safe_dump(config), encoding="utf-8"
+        )
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model=current_model,
+                provider=current_provider,
+                requested_provider=requested_provider,
+                base_url="https://router.example/v1"
+                if current_provider == "custom"
+                else None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd=str(tmp_path))
+        inventory = {
+            "providers": [
+                {
+                    "slug": inventory_provider,
+                    "name": "9Router",
+                    "api_url": "https://router.example/v1",
+                    "models": [{"id": model}],
+                }
+            ]
+        }
+
+        with patch(
+            "hermes_cli.inventory.build_models_payload", return_value=inventory
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        canonical_id = f"custom:9router:{model}"
+        ids = [item.model_id for item in model_state.available_models]
+        assert ids.count(canonical_id) == 1
+        assert f"{inventory_provider}:{model}" not in ids
+        assert model_state.current_model_id == expected_current_id
+
+        provider, parsed_model = parse_model_input(canonical_id, "custom")
+        assert provider == "custom:9router"
+        assert parsed_model == model
+
+    def test_auto_request_keeps_resolved_provider_id(self):
+        manager = SessionManager(
+            agent_factory=lambda: SimpleNamespace(
+                model="anthropic/claude-sonnet-4.5",
+                provider="openrouter",
+                requested_provider="auto",
+                base_url=None,
+            )
+        )
+        acp_agent = HermesACPAgent(session_manager=manager)
+        state = manager.create_session(cwd="/tmp")
+
+        with patch(
+            "acp_adapter.server._named_custom_provider_catalogs", return_value=[]
+        ):
+            model_state = acp_agent._build_model_state(state)
+
+        assert isinstance(model_state, SessionModelState)
+        assert model_state.current_model_id == (
+            "openrouter:anthropic/claude-sonnet-4.5"
+        )


### PR DESCRIPTION
## What does this PR do?

ACP now returns one canonical model ID for each named custom provider.

For a provider named `9router`, clients receive
`custom:9router:<model>` instead of receiving both that ID and
`9router:<model>`.

The fix reuses Hermes' existing named-provider identity lookup. Built-in
providers, Ollama, and auto provider selection keep their existing behavior.

Builds on the withdrawn #97242 by @turingcat.

## Related Issue

Fixes #97233

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Canonicalize named provider slugs before building ACP model IDs.
- Use the same identity for de-duplication and the current model.
- Add regression coverage for named providers and auto selection.

## How to Test

```bash
scripts/run_tests.sh tests/acp/test_named_provider_catalogs.py -q
scripts/run_tests.sh tests/acp/ -q
scripts/run_tests.sh \
  tests/hermes_cli/test_canonical_custom_identity.py \
  tests/hermes_cli/test_custom_provider_identity.py \
  tests/hermes_cli/test_runtime_provider_resolution.py -q
uvx ruff==0.15.10 check \
  acp_adapter/server.py \
  tests/acp/test_named_provider_catalogs.py
python scripts/check-windows-footguns.py \
  acp_adapter/server.py \
  tests/acp/test_named_provider_catalogs.py
git diff --check

# Full suite; see the local environment note below.
scripts/run_tests.sh
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — Windows footgun scan passed
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Before:
`9router:<model>` and `custom:9router:<model>`

After:
`custom:9router:<model>`

Focused verification passed: 14 named-provider tests, 139 ACP tests, and 83
related provider-identity tests.

GitHub CI passed all required checks, including Python tests, E2E, Ruff and
type checks, macOS, Windows, Docker, and Nix.

The full repository suite did not pass in this local shared virtual environment:
44,202 passed, 316 failed, and 454 skipped. None of the failing files are in the
ACP/provider paths changed here. Representative failures also reproduced on a
clean `origin/main`: the environment is missing `snowballstemmer`, and the
live-system guard blocks `os.kill` in the process timeout test.
