### PR TITLE
fix(vision): providers that reject images in tool results no longer get the multimodal envelope — meta-ai/Muse Spark 400 (#101668, salvages #89987)

### DIFF
--- a/plugins/model-providers/meta-ai/__init__.py
+++ b/plugins/model-providers/meta-ai/__init__.py
@@ -121,6 +121,9 @@ meta_ai = MetaAIProfile(
     api_mode="codex_responses",
     # Muse Spark is natively multimodal (image/video/pdf/audio in, text out).
     supports_vision=True,
+    # ...but only on user turns: an image envelope inside a role:tool message
+    # 400s "messages[N].content did not match any supported type" (#101668).
+    supports_vision_tool_messages=False,
     # Cheap contributor tier is a good default for auxiliary tasks
     # (compaction, title generation, vision) when this is the main provider.
     default_aux_model="muse-spark-1.2-contributor",

--- a/tests/providers/test_meta_ai_profile.py
+++ b/tests/providers/test_meta_ai_profile.py
@@ -28,6 +28,8 @@ class TestMetaAIProfile:
         assert p.api_mode == "codex_responses"
         assert "MODEL_API_KEY" in p.env_vars
         assert p.supports_vision is True
+        # Images are accepted on user turns only; tool-result envelopes 400 (#101668).
+        assert p.supports_vision_tool_messages is False
         assert p.default_aux_model == "muse-spark-1.2-contributor"
         assert p.default_max_tokens == 16384
         assert p.fallback_models == ("muse-spark-1.2",)

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -90,6 +90,30 @@ class TestSupportsMediaInToolResults:
         assert _supports_media_in_tool_results("", "anything") is False
         assert _supports_media_in_tool_results(None, "anything") is False  # type: ignore[arg-type]
 
+    def test_profile_tool_message_veto_overrides_supports_vision(self):
+        """supports_vision_tool_messages=False is a hard veto even when the
+        profile declares supports_vision=True (xiaomi/MiMo 400s on list-type
+        tool-result content, #89981)."""
+        assert _supports_media_in_tool_results("xiaomi", "mimo-v2.5") is False
+
+    def test_profile_veto_applies_even_when_vision_capable_lookup_agrees(self):
+        """A capability source marking the model vision-capable must not
+        re-open the native fast path for a provider that rejects it."""
+        from tools.vision_tools import _should_use_native_vision_fast_path
+        from agent.auxiliary_client import set_runtime_main, clear_runtime_main
+        from agent import image_routing
+
+        set_runtime_main("xiaomi", "mimo-v2.5")
+        try:
+            with patch.object(
+                image_routing, "decide_image_input_mode", return_value="native"
+            ), patch.object(
+                image_routing, "_lookup_supports_vision", return_value=True
+            ):
+                assert _should_use_native_vision_fast_path() is False
+        finally:
+            clear_runtime_main()
+
 
 # ─── _build_native_vision_tool_result ────────────────────────────────────────
 

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -1077,6 +1077,22 @@ def _resize_image_for_vision(image_path: Path, mime_type: Optional[str] = None,
 # ---------------------------------------------------------------------------
 
 
+def _profile_rejects_tool_media(provider: str) -> bool:
+    """Hard veto: the provider's ``ProviderProfile`` declares
+    ``supports_vision_tool_messages=False`` — images are accepted in user
+    messages but list-type tool-result content is rejected with 400
+    (xiaomi/MiMo "text is not set"). ``supports_vision`` alone must not
+    override this, or the multimodal tool-result envelope 400s every turn
+    and the image never enters context (#89981).
+    """
+    try:
+        from providers import get_provider_profile
+        profile = get_provider_profile(str(provider or "").strip().lower())
+        return profile is not None and profile.supports_vision_tool_messages is False
+    except Exception:
+        return False
+
+
 def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     """Whether the given provider+model combination accepts image content
     inside a tool-result message.
@@ -1100,7 +1116,7 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if not isinstance(provider, str):
         return False
     p = provider.strip().lower()
-    if not p:
+    if not p or _profile_rejects_tool_media(p):
         return False
 
     # Aggregators that route to multiple vendors — assume support since
@@ -1169,6 +1185,11 @@ def _should_use_native_vision_fast_path() -> bool:
         model = _read_main_model()
         cfg = load_config()
         if decide_image_input_mode(provider, model, cfg) != "native":
+            return False
+        # The profile veto applies ahead of the capability lookup too: a
+        # model marked vision-capable by models.dev / custom_providers must
+        # not re-open the multimodal-envelope route the profile rejects.
+        if _profile_rejects_tool_media(provider):
             return False
         return (
             _supports_media_in_tool_results(provider, model)


### PR DESCRIPTION
Providers whose profile declares `supports_vision_tool_messages=False` no longer receive the `vision_analyze` multimodal envelope inside a `role:tool` message — and the bundled meta-ai profile now declares it, fixing the Muse Spark HTTP 400 `messages[N].content did not match any supported type` (#101668).

## Changes

- **`tools/vision_tools.py`** — new `_profile_rejects_tool_media(provider)` predicate (profile exists and `supports_vision_tool_messages is False`). Both fast-path gates route through it: `_supports_media_in_tool_results()` returns False up front (so `supports_vision=True` can no longer override the veto), and `_should_use_native_vision_fast_path()` checks it ahead of the `_lookup_supports_vision(...)` arm (so a models.dev / `custom_providers` capability hit can't re-open the path either). Cherry-picked from #89987 by @liuhao1024; the two inline try/except blocks in the original were collapsed into the single shared predicate.
- **`plugins/model-providers/meta-ai/__init__.py`** — `supports_vision_tool_messages=False` with a one-line comment citing the 400. `supports_vision=True` is unchanged, so user-turn image input stays native; only the tool-result envelope falls back to the aux-LLM text path (same mechanism xiaomi already uses).
- **Tests** — contributor's two tests kept, trimmed: profile veto beats `supports_vision=True`; veto still holds when the capability lookup says vision-capable. One assertion added to the existing `test_profile_registered` in `tests/providers/test_meta_ai_profile.py`.

On current `main` nothing in `tools/` read `supports_vision_tool_messages` — only `run_agent.py`'s post-hoc summary path did, and the vision fast path built the envelope before that ever ran.

## Validation

| Check | Result |
|---|---|
| `pytest tests/tools/test_vision_native_fast_path.py tests/providers/test_meta_ai_profile.py` | 29 passed |
| Same + `tests/run_agent/test_vision_tool_messages.py` + `tests/hermes_cli/test_cli_custom_provider_vision.py` | 38 passed |
| New veto tests with `tools/vision_tools.py` reverted to `main` | both FAIL (pin the bug) |
| Real-import probe, fresh temp `HERMES_HOME`: `_supports_media_in_tool_results("meta-ai","muse-spark-1.2")` | main **True** → branch **False** |
| Same probe, `("xiaomi","mimo-v2.5")` | main **True** → branch **False** |
| Same probe, `("anthropic","claude-opus-4-6")` (control) | True → True |
| `ruff check` on touched files | clean |
| `scripts/audit_pr_attribution.py --fix` | all emails mapped |

Live repro: the Meta wire-level 400 was **not** reproduced live (no `META_API_KEY` available here); the reporter's trace in #101668 is relied on for the API behavior. The gate flip above was verified with real imports against the registered provider profiles.

Fixes #101668
Refs #47742 #89981

Credits: @liuhao1024 — cherry-picked from #89987 with authorship preserved.

## Infographic

![vision-tool-message-veto](https://v3b.fal.media/files/b/0aa8e97b/rqdfBagKPwYc99c0Iyekk_Q8z7mVXG.png)
