### PR TITLE
feat(models): Muse Spark 1.3 family selectable across OpenRouter, OpenCode Zen/Go/Free (salvages #101631, #93073)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -545,6 +545,13 @@ DEFAULT_CONTEXT_LENGTHS = {
     "deepseek": 128000,
     # Meta
     "llama": 131072,
+    # Muse Spark family (1.1/1.2/1.3 + contributor tiers) ships with a 1M
+    # context window: 1,048,576 per OpenRouter live metadata (verified
+    # 2026-09-02). The family key covers every checkpoint; live endpoint /
+    # models.dev metadata still wins when available. Substring match also
+    # covers -contributor and provider-prefixed ids (meta/...).
+    "muse-spark-1.3": 1_048_576,
+    "muse-spark": 1_048_576,
     # Thinking Machines — Inkling family ships with a 1M context window
     # (max output 256K).  Verified against OpenRouter live metadata
     # (context_length 1,048,576 for inkling, inkling-small, and the
@@ -2304,6 +2311,8 @@ def _model_name_suggests_minimax_m3(model: str) -> bool:
 # catch-all can never be listed here.
 _PRE_CATALOG_STALE_KEYS = frozenset({
     "minimax-m3",    # 1M; older builds persisted the "minimax" catch-all (204,800)
+    "muse-spark-1.3",  # 1M; builds before this entry fell through to the 256K fallback
+    "muse-spark",      # 1M; 1.1/1.2 builds fell through to the 256K fallback
     "grok-4.3",      # 1M; pre-2026-05-15 builds persisted the "grok-4" catch-all (256,000)
     "grok-4.6",      # 500K; pre-catalog builds persisted the "grok-4" catch-all (256,000)
     "grok-4-fast",   # 2M; pre-2026-04-10 builds fell through to the 256K probe fallback

--- a/contributors/emails/csreyes92@gmail.com
+++ b/contributors/emails/csreyes92@gmail.com
@@ -1,0 +1,1 @@
+csreyes

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -134,6 +134,8 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     # Meta
     ("meta/muse-spark-1.2",                    ""),
     ("meta/muse-spark-1.2-contributor",        ""),
+    ("meta/muse-spark-1.3",                    ""),
+    ("meta/muse-spark-1.3-contributor",        ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers
@@ -577,6 +579,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
+        "muse-spark-1.3-contributor-free",
     ],
     # OpenCode free tier — keyless (no OpenCode account needed). This is the
     # OFFLINE FLOOR only: provider_model_ids("opencode-free") revalidates live
@@ -597,6 +600,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nemotron-3-ultra-free",
         "nemotron-3.5-lightning-free",
         "muse-spark-1.2-contributor-free",
+        "muse-spark-1.3-contributor-free",
     ],
     # Synced against https://opencode.ai/docs/go/ + live GET /zen/go/v1/models
     # (2026-08-20).
@@ -629,6 +633,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "hy3",
         "hy3-preview",
         "muse-spark-1.2-contributor",
+        "muse-spark-1.3-contributor",
         # Go-subscription twin of the Zen keyless Ox Alpha (live go/v1
         # catalog 2026-08-21; NOT keyless — Go relay requires a Go key).
         "ox-alpha-free",

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -133,6 +133,7 @@ OPENROUTER_MODELS: list[tuple[str, str]] = [
     ("nvidia/nemotron-3-super-120b-a12b",      ""),
     # Meta
     ("meta/muse-spark-1.2",                    ""),
+    ("meta/muse-spark-1.2-contributor",        ""),
     # Sakana
     ("sakana/fugu-ultra",                      ""),
     # OpenRouter routers

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -112,7 +112,7 @@ _DEFAULT_PROVIDER_MODELS = {
     "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
     "kilocode": ["anthropic/claude-sonnet-5", "anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
     "opencode-zen": ["x-preview-f-free", "gpt-5.6-sol", "gpt-5.4", "gpt-5.3-codex", "claude-opus-5", "claude-sonnet-5", "gemini-3.7-flash", "glm-5.2", "kimi-k3", "minimax-m3"],
-    "opencode-free": ["deepseek-v4-flash-free", "hy3-free", "mimo-v2.5-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free"],
+    "opencode-free": ["deepseek-v4-flash-free", "hy3-free", "mimo-v2.5-free", "laguna-s-2.1-free", "nemotron-3-ultra-free", "nemotron-3.5-lightning-free", "muse-spark-1.2-contributor-free", "muse-spark-1.3-contributor-free"],
     "opencode-go": ["kimi-k3", "kimi-k2.7-code", "kimi-k2.6", "gpt-5.6-luna", "grok-4.5", "glm-5.3", "glm-5.3-flash", "glm-5.2", "mimo-v2.5-pro", "mimo-v2.5", "minimax-m3", "minimax-m2.7", "qwen3.8-max", "qwen3.7-max", "deepseek-v4-pro", "hy3"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1631,6 +1631,18 @@ class TestGrok43StaleCacheGuard:
             assert ctx == 256_000, f"{slug} should stay 256000, got {ctx}"
 
 
+class TestMuseSparkStaleCacheGuard:
+    """Muse Spark (1M window per OpenRouter live metadata) had no catalog
+    entry, so older builds persisted the 256K default fallback. The cache
+    guard must flag that stale value and keep correct/probed values."""
+
+    def test_stale_muse_spark_detected_by_generic_guard(self):
+        from agent.model_metadata import _stale_pre_catalog_cache_entry
+        for slug in ("muse-spark-1.3", "meta/muse-spark-1.3-contributor", "muse-spark-1.2-contributor"):
+            assert _stale_pre_catalog_cache_entry(slug, 256_000), slug
+            assert not _stale_pre_catalog_cache_entry(slug, 1_048_576), slug
+
+
 class TestGrok46StaleCacheGuard:
     """Pre-catalog builds resolved grok-4.6 via the generic 'grok-4' catch-all
     (256,000) and persisted it before the 500K catalog entry existed.

--- a/tests/hermes_cli/test_opencode_free_live_catalog.py
+++ b/tests/hermes_cli/test_opencode_free_live_catalog.py
@@ -41,6 +41,7 @@ _LIVE_FREE_MODELS = [
     "nemotron-3-ultra-free",
     "nemotron-3.5-lightning-free",
     "muse-spark-1.2-contributor-free",
+    "muse-spark-1.3-contributor-free",
 ]
 
 # The raw live /zen/v1/models dump also lists paid/subscription + KEYED-free IDs

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -329,7 +329,7 @@ model:
 Base URLs can be overridden with `NOVITA_BASE_URL`, `GLM_BASE_URL`, `KIMI_BASE_URL`, `MINIMAX_BASE_URL`, `MINIMAX_CN_BASE_URL`, `DASHSCOPE_BASE_URL`, `XIAOMI_BASE_URL`, `GMI_BASE_URL`, `META_BASE_URL`, or `TOKENHUB_BASE_URL` environment variables.
 
 :::note Meta contributor tier
-`muse-spark-1.2-contributor` is Meta's contributor tier — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using it. For current pricing and rate limits, see [Meta Model API pricing and rate limits](https://dev.meta.ai/docs/pricing-rate-limits/). Use `muse-spark-1.2` (standard variant, no training) for confidential work.
+`muse-spark-1.2-contributor` and `muse-spark-1.3-contributor` are Meta's contributor tiers — Meta may train on your prompts and completions, so [interactive model selection asks for confirmation](../user-guide/configuring-models.md) before using either. For current pricing and rate limits, see [Meta Model API pricing and rate limits](https://dev.meta.ai/docs/pricing-rate-limits/). Use the standard `muse-spark-1.2` / `muse-spark-1.3` (no training) for confidential work.
 :::
 
 :::note Z.AI Endpoint Auto-Detection

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -57,7 +57,7 @@ Prompt caches are keyed to the model serving the request, so any mid-conversatio
 
 ### Unattended data-training tiers
 
-Models such as `muse-spark-1.2-contributor` are discounted because the vendor may train on your prompts and completions. Interactive model selection always shows a confirmation prompt. Non-interactive startup paths such as Kanban workers and cron agents fail closed because they cannot ask that question.
+Models with a `-contributor` suffix (e.g. `muse-spark-1.2-contributor`, `muse-spark-1.3-contributor`) are discounted because the vendor may train on your prompts and completions. Interactive model selection always shows a confirmation prompt. Non-interactive startup paths such as Kanban workers and cron agents fail closed because they cannot ask that question.
 
 If training on the unattended workload's data is acceptable, record a persistent acknowledgement:
 

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-03T07:08:10Z",
+  "updated_at": "2026-09-03T07:08:39Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -167,6 +167,14 @@
         },
         {
           "id": "meta/muse-spark-1.2-contributor",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.3",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.3-contributor",
           "description": ""
         },
         {

--- a/website/static/api/model-catalog.json
+++ b/website/static/api/model-catalog.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "updated_at": "2026-09-02T16:31:43Z",
+  "updated_at": "2026-09-03T07:08:10Z",
   "metadata": {
     "source": "hermes-agent repo",
     "docs": "https://hermes-agent.nousresearch.com/docs/reference/model-catalog"
@@ -163,6 +163,10 @@
         },
         {
           "id": "meta/muse-spark-1.2",
+          "description": ""
+        },
+        {
+          "id": "meta/muse-spark-1.2-contributor",
           "description": ""
         },
         {


### PR DESCRIPTION
Makes the Meta Muse Spark 1.3 family (standard + contributor tier) and `muse-spark-1.2-contributor` selectable from Hermes' curated OpenRouter list and the OpenCode Zen / Go / Free offline floors, with a 1M-context metadata entry — salvaging #101631 (@am423) and #93073 (@csreyes) onto current `main` with authorship preserved.

## Changes

- **OpenRouter curated list** (`hermes_cli/models.py`): `meta/muse-spark-1.2-contributor` (from #93073), `meta/muse-spark-1.3`, `meta/muse-spark-1.3-contributor` (from #101631).
- **OpenCode offline floors** (`hermes_cli/models.py`): `muse-spark-1.3-contributor-free` in `opencode-zen` / `opencode-free`; `muse-spark-1.3-contributor` in `opencode-go`. Setup-wizard `opencode-free` shortlist (`hermes_cli/setup.py`) gains the same free slug; the live-catalog mirror test (`tests/hermes_cli/test_opencode_free_live_catalog.py`) gains it too.
- **Context window** (`agent/model_metadata.py`): `muse-spark` family key → 1,048,576 in `DEFAULT_CONTEXT_LENGTHS` (live endpoint / models.dev still win), plus `_PRE_CATALOG_STALE_KEYS` entries so sessions that persisted the 256K fallback self-heal to 1M. One test class (2 assertions per slug, 3 slugs) pins the stale-detect / keep-correct contract.
- **Docs**: `providers.md` Meta note and `configuring-models.md` "Unattended data-training tiers" now cover both 1.2 and 1.3 contributor tiers; no hardcoded prices (keeps the pricing link from #101503).
- **Hosted catalog**: `website/static/api/model-catalog.json` regenerated via `scripts/build_model_catalog.py` (not hand-merged).
- `contributors/emails/csreyes92@gmail.com` added for attribution CI.

### Dropped from #101631 (deliberately)

- `plugins/model-providers/meta-ai/__init__.py` `fallback_models` additions — #101503 made `meta-ai` live-first with a single-entry fallback; Meta's `/v1/models` is authoritative for the direct provider.
- `hermes_cli/model_data_policy_guard.py` + its test + per-version price tables — the guard was rewritten model-agnostic in #101503 and already covers `muse-spark-1.3-contributor` via the `-contributor` suffix predicate.
- The redundant `muse-spark-1.3` context key (the family key already matches) and the `HERMES_HOME`-reloading re-resolve test (contract already pinned by the guard test).

## Validation

| Check | Result |
|---|---|
| `curl https://openrouter.ai/api/v1/models` | `meta/muse-spark-1.2-contributor`, `meta/muse-spark-1.3`, `meta/muse-spark-1.3-contributor` all present, `context_length=1048576`, `tools` in `supported_parameters` |
| models.dev `api.json` | `opencode:muse-spark-1.3-contributor-free` and `opencode-go:muse-spark-1.3-contributor` present, context 1048576 (OpenCode relay returns 403 to plain curl) |
| `pytest tests/agent/test_model_metadata.py tests/hermes_cli/test_opencode_free_live_catalog.py tests/hermes_cli/test_model_data_policy_guard.py tests/hermes_cli/test_model_catalog.py` | 154 passed |
| `pytest tests/hermes_cli/test_catalog_json.py tests/hermes_cli/test_catalog_variants.py tests/hermes_cli/test_configured_builtin_models.py` | 18 passed |
| `ruff check` on touched Python files | clean |
| `scripts/audit_pr_attribution.py` | all contributor emails mapped |

Live repro: `curl -s https://openrouter.ai/api/v1/models | jq '.data[] | select(.id|test("muse-spark-1.3|muse-spark-1.2-contributor")) | {id, context_length, tools: (.supported_parameters|index("tools")!=null)}'` → three ids, 1048576, tools=true; before this PR none of them appear in `hermes model` picker's OpenRouter curated list or the OpenCode floors.

## Credits

Cherry-picked with authorship preserved: @am423 (#101631 — 1.3 family across OpenRouter / OpenCode floors / setup shortlist / metadata / docs) and @csreyes (#93073 — first to submit the OpenRouter `meta/muse-spark-1.2-contributor` slug, Aug 23).

## Infographic

![muse-spark-1.3-catalog](https://v3b.fal.media/files/b/0aa8e96e/C_0pAxah8dGfYYVWgeB_Y_Nx5CNCNR.png)
