### PR TITLE
fix(desktop): init log buffers before pool-limits boot read

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1419,6 +1419,15 @@ const profileDeletionGate = new ProfileDeletionGate()
 // launch constant: mutable at runtime, persisted in userData, applied live.
 // The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
 // for scripted/headless setups; after launch the stored preference wins.
+//
+// Desktop log ring buffer and pending flush buffer. Declared BEFORE the
+// pool-limits section: readPersistedPoolLimits() below logs through
+// rememberLog() at module top level, and pushing into an uninitialized
+// buffer crashed every boot (TypeError: Cannot read properties of
+// undefined (reading 'push')). Keep any future module-top-level
+// rememberLog() call after these declarations.
+const hermesLog = []
+let desktopLogBuffer = ''
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
 function readPersistedPoolLimits() {
@@ -1572,10 +1581,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
 let desktopLogFlushTimer = null
 let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false


### PR DESCRIPTION
## Symptom
Hermes Desktop 0.17.0 crashes at launch, before any window renders, with:

```
Uncaught Exception:
TypeError: Cannot read properties of undefined (reading 'push')
at rememberLog (electron-main.mjs:23176)
at readPersistedPoolLimits (electron-main.mjs:23009)
```

Regression from #91545 (pool sizing as a live device preference).

## Root cause
Module top-level execution order in `apps/desktop/electron/main.ts`:

1. `let poolLimits = readPersistedPoolLimits()` — before the log buffers exist
2. `readPersistedPoolLimits` unconditionally calls `rememberLog` (both the
   'loaded from file' and the 'no saved file' branches)
3. `rememberLog` does `hermesLog.push(...)` — `hermesLog` is still
   undefined (bundled build) / in TDZ (source), so every boot throws.

`hermesLog = []` and `desktopLogBuffer = ''` were declared ~110 lines
below the call site.

## Fix
Move the two buffer declarations above the pool-limits section with a
comment stating the ordering requirement, so future module-top-level
`rememberLog()` callers don't reintroduce it.

## Verification
- `tsc -p tsconfig.electron.json --noEmit` passes
- `node scripts/bundle-electron-main.mjs` output shows
  `var hermesLog = [];` / `var desktopLogBuffer = \"\";` emitted before
  `var poolLimits = readPersistedPoolLimits();`
- Applied as a two-line move to a broken 0.17.0 install (app.asar.unpacked
  bundle): app boots, backend starts, and `~/.hermes/logs/desktop.log`
  records the previously-crashing `[pool-limits] no saved file and no env
  overrides; using defaults` line.