### PR TITLE
feat(desktop): summon the HUD globally and dismiss with Escape

### DIFF
--- a/apps/desktop/electron/hud-summon-shortcut.test.ts
+++ b/apps/desktop/electron/hud-summon-shortcut.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { createHudSummonShortcut, DEFAULT_HUD_SUMMON_SHORTCUT, resolveHudSummon } from './hud-summon-shortcut'
+import type { GlobalShortcutLike } from './quick-entry'
+
+function fakeGlobalShortcut(options: { register?: boolean; taken?: string[] } = {}) {
+  const held = new Set(options.taken ?? [])
+  const callbacks = new Map<string, () => void>()
+
+  const globalShortcut: GlobalShortcutLike = {
+    isRegistered: vi.fn((accelerator: string) => held.has(accelerator)),
+    register: vi.fn((accelerator: string, callback: () => void) => {
+      if (options.register === false || held.has(accelerator)) {
+        return false
+      }
+
+      held.add(accelerator)
+      callbacks.set(accelerator, callback)
+
+      return true
+    }),
+    unregister: vi.fn((accelerator: string) => {
+      held.delete(accelerator)
+      callbacks.delete(accelerator)
+    })
+  }
+
+  return { globalShortcut, held, press: (accelerator: string) => callbacks.get(accelerator)?.() }
+}
+
+describe('resolveHudSummon', () => {
+  it('dismisses when the HUD is already up — the chord is a toggle', () => {
+    expect(resolveHudSummon({ hudOpen: true, hermesFocused: true })).toBe('close')
+    expect(resolveHudSummon({ hudOpen: true, hermesFocused: false })).toBe('close')
+  })
+
+  it('opens like the titlebar toggle when a Hermes window has focus', () => {
+    expect(resolveHudSummon({ hudOpen: false, hermesFocused: true })).toBe('open-in-app')
+  })
+
+  it('opens as a companion — no focus steal, no hiding the app — when summoned from another app', () => {
+    expect(resolveHudSummon({ hudOpen: false, hermesFocused: false })).toBe('open-external')
+  })
+})
+
+describe('createHudSummonShortcut', () => {
+  it('registers CommandOrControl+Shift+H for the life of the app', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    expect(controller.register()).toBe(true)
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(true)
+    expect(controller.current()).toBe(DEFAULT_HUD_SUMMON_SHORTCUT)
+  })
+
+  it('invokes the summon callback when the chord fires', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut, press } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    controller.register()
+    press(DEFAULT_HUD_SUMMON_SHORTCUT)
+
+    expect(summon).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports taken and leaves the in-app keybind to do the job', () => {
+    // Another app owns ⌘⇧H. Registration must fail loudly (false), not
+    // silently claim a chord it does not hold.
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut({ taken: [DEFAULT_HUD_SUMMON_SHORTCUT] })
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    expect(controller.register()).toBe(false)
+    expect(controller.current()).toBeNull()
+  })
+
+  it('survives an OS that refuses the registration', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut({ register: false })
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    expect(controller.register()).toBe(false)
+    expect(controller.current()).toBeNull()
+  })
+
+  it('dispose releases the accelerator and is idempotent', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    controller.register()
+    controller.dispose()
+    controller.dispose()
+
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(false)
+    expect(controller.current()).toBeNull()
+    expect(globalShortcut.unregister).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-registering releases the old accelerator first', () => {
+    const summon = vi.fn<() => void>()
+    const { globalShortcut } = fakeGlobalShortcut()
+    const controller = createHudSummonShortcut(globalShortcut, summon)
+
+    controller.register()
+    controller.register()
+
+    expect(globalShortcut.unregister).toHaveBeenCalledTimes(1)
+    expect(globalShortcut.isRegistered(DEFAULT_HUD_SUMMON_SHORTCUT)).toBe(true)
+  })
+})

--- a/apps/desktop/electron/hud-summon-shortcut.ts
+++ b/apps/desktop/electron/hud-summon-shortcut.ts
@@ -1,0 +1,97 @@
+/**
+ * HUD summon — a global OS chord that brings the HUD up from ANY app.
+ *
+ * Before this, the only ways into HUD mode were the in-app keybind and the
+ * titlebar button — both of which need Hermes to have focus first. That is
+ * three context switches (Alt-Tab to Hermes, toggle, Alt-Tab back) to use a
+ * surface whose whole point is staying in the app you were already in.
+ *
+ * Registered for the life of the app (unlike the snap chord, which lives only
+ * while the HUD is up). Main owns registration — same authority split as
+ * Quick Entry and snap. Electron's globalShortcut is press-only.
+ *
+ * The chord is deliberately the SAME as the in-app `view.toggleHud` keybind
+ * (⌘⇧H). While the global registration holds, it intercepts the press before
+ * the renderer sees it and does the same toggle; if another app already owns
+ * the chord, registration fails (logged, never silent) and the in-app keybind
+ * keeps working exactly as before — graceful degradation, not a dead key.
+ */
+
+import type { GlobalShortcutLike } from './quick-entry'
+
+export const DEFAULT_HUD_SUMMON_SHORTCUT = 'CommandOrControl+Shift+H'
+
+/** How a summon should behave, decided from where the user pressed it. */
+export type HudSummonMode = 'close' | 'open-external' | 'open-in-app'
+
+/**
+ * Pure decision for a summon press.
+ *
+ * - HUD already up → the chord is a toggle, so dismiss it. One gesture does
+ *   exactly one thing in both directions (the Quick Entry convention).
+ * - HUD down and a Hermes window has focus → the user is IN the app; open the
+ *   HUD the way the titlebar toggle does (take focus, step the app aside).
+ * - HUD down and focus is elsewhere → the user is in Figma / a browser / a
+ *   terminal. Open the HUD WITHOUT stealing focus and WITHOUT hiding the main
+ *   window: they summoned a companion, not a mode switch.
+ */
+export function resolveHudSummon(state: { hermesFocused: boolean; hudOpen: boolean }): HudSummonMode {
+  if (state.hudOpen) {
+    return 'close'
+  }
+
+  return state.hermesFocused ? 'open-in-app' : 'open-external'
+}
+
+export interface HudSummonShortcutController {
+  /** Register the global chord. Returns false when another app owns it. */
+  register(): boolean
+  /** Release the chord (quit). Idempotent. */
+  dispose(): void
+  /** The accelerator currently held, or null when unregistered/taken. */
+  current(): null | string
+}
+
+export function createHudSummonShortcut(
+  globalShortcut: GlobalShortcutLike,
+  onSummon: () => void
+): HudSummonShortcutController {
+  let active: null | string = null
+
+  const release = () => {
+    if (active) {
+      try {
+        globalShortcut.unregister(active)
+      } catch {
+        // Best effort — a dead accelerator must not block re-register.
+      }
+
+      active = null
+    }
+  }
+
+  return {
+    register() {
+      release()
+
+      const accelerator = DEFAULT_HUD_SUMMON_SHORTCUT
+      let ok = false
+
+      try {
+        ok = globalShortcut.isRegistered(accelerator) ? false : globalShortcut.register(accelerator, onSummon)
+      } catch {
+        ok = false
+      }
+
+      active = ok ? accelerator : null
+
+      return ok
+    },
+    dispose() {
+      release()
+    },
+    current() {
+      return active
+    }
+  }
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -229,6 +229,7 @@ import { registerHudIpc } from './hud-ipc'
 import { applyHudElectronOverlay, promoteHudOverlay } from './hud-overlay'
 import { snapHudBounds } from './hud-snap'
 import { createHudSnapShortcut } from './hud-snap-shortcut'
+import { createHudSummonShortcut, resolveHudSummon } from './hud-summon-shortcut'
 import { buildHudWindowUrl } from './hud-url'
 import { resolveHudWindowing } from './hud-windowing'
 import { createLinkTitleWindow, guardLinkTitleSession, readLinkTitleWindowTitle } from './link-title-window'
@@ -13804,6 +13805,40 @@ function registerHudSnapShortcut() {
 }
 
 /**
+ * Global HUD summon (⌘⇧H from ANY app). Registered for the app's whole life —
+ * unlike snap, which lives only while the HUD is up — so the HUD can be called
+ * up from Figma or a terminal without visiting Hermes first. Which flavour of
+ * open it does is decided by where focus is at the press (see
+ * `resolveHudSummon`): from inside Hermes it behaves exactly like the titlebar
+ * toggle; from another app it appears as a companion — no focus steal, and the
+ * main window is left alone.
+ */
+function onHudSummon() {
+  const focused = BrowserWindow.getFocusedWindow()
+  const hermesFocused = focused !== null && !focused.isDestroyed()
+  const hudOpen = Boolean(hudWindow && !hudWindow.isDestroyed())
+  const mode = resolveHudSummon({ hermesFocused, hudOpen })
+
+  if (mode === 'close') {
+    closeHudWindow()
+
+    return
+  }
+
+  openHudWindow(hudSessionId, hudProfile, mode === 'open-external' ? { summon: 'external' } : {})
+}
+
+const hudSummonShortcut = createHudSummonShortcut(globalShortcut, onHudSummon)
+
+function registerHudSummonShortcut() {
+  if (!hudSummonShortcut.register()) {
+    rememberLog(
+      '[hud] summon shortcut unavailable — CommandOrControl+Shift+H may be owned by another app; the in-app keybind still works'
+    )
+  }
+}
+
+/**
  * Feed the HUD renderer the cursor position on Linux.
  *
  * Everywhere else the renderer learns this from mousemove, which keeps arriving
@@ -13974,7 +14009,9 @@ function broadcastHudState(open) {
   }
 }
 
-function spawnHudWindow(sessionId, profile) {
+function spawnHudWindow(sessionId, profile, summon = 'in-app') {
+  const external = summon === 'external'
+
   const win = new BrowserWindow({
     ...hudBounds(),
     minWidth: 380,
@@ -14045,12 +14082,23 @@ function spawnHudWindow(sessionId, profile) {
 
   wireWindowReveal(win, {
     show: () => {
+      if (external) {
+        // Summoned from another app: appear WITHOUT taking focus, so the user
+        // stays in the app they were working in. showInactive keeps
+        // always-on-top; the composer takes focus only when clicked.
+        win.showInactive()
+
+        return
+      }
+
       win.show()
       win.focus()
     },
     onRevealed: () => {
-      // Step the app aside: the HUD IS the surface now.
-      if (hudRestoreMainWindow && mainWindow && !mainWindow.isDestroyed()) {
+      // Step the app aside: the HUD IS the surface now. Not for an external
+      // summon — the user asked for a companion over their current app, and
+      // hiding Hermes' main window behind it is neither wanted nor visible.
+      if (!external && hudRestoreMainWindow && mainWindow && !mainWindow.isDestroyed()) {
         mainWindow.hide()
       }
 
@@ -14099,8 +14147,11 @@ function restoreMainWindowFromHud() {
   }
 }
 
-function openHudWindow(sessionId, profile) {
+function openHudWindow(sessionId, profile, options: { summon?: 'external' | 'in-app' } = {}) {
   const profileKey = typeof profile === 'string' && profile.trim() ? profile.trim() : null
+  // 'external' = summoned by the global chord while another app had focus.
+  // Everything else (titlebar, in-app keybind, pet launcher, IPC) is 'in-app'.
+  const summon = options.summon === 'external' ? 'external' : 'in-app'
 
   if (hudWindow && !hudWindow.isDestroyed()) {
     // Pointed at another PROFILE: the live renderer is bound to the old
@@ -14115,7 +14166,7 @@ function openHudWindow(sessionId, profile) {
 
       hudSessionId = sessionId || null
       hudProfile = profileKey
-      hudWindow = spawnHudWindow(sessionId, profileKey)
+      hudWindow = spawnHudWindow(sessionId, profileKey, summon)
       broadcastHudState(true)
       registerHudSnapShortcut()
 
@@ -14133,15 +14184,29 @@ function openHudWindow(sessionId, profile) {
       broadcastHudState(true)
     }
 
-    focusWindow(hudWindow)
+    if (summon === 'external') {
+      // Companion summon onto an already-open HUD: raise it without stealing
+      // focus from the app the user is in.
+      if (!hudWindow.isVisible()) {
+        hudWindow.showInactive()
+      }
+
+      hudWindow.moveTop?.()
+    } else {
+      focusWindow(hudWindow)
+    }
 
     return hudWindow
   }
 
-  hudRestoreMainWindow = Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible())
+  // An external summon never hides the main window (there is nothing to
+  // "step aside" from — the user is in another app), so there is nothing to
+  // restore when the HUD closes either.
+  hudRestoreMainWindow =
+    summon !== 'external' && Boolean(mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible())
   hudSessionId = sessionId || null
   hudProfile = profileKey
-  hudWindow = spawnHudWindow(sessionId, profileKey)
+  hudWindow = spawnHudWindow(sessionId, profileKey, summon)
   broadcastHudState(true)
   registerHudSnapShortcut()
 
@@ -17904,6 +17969,9 @@ app.whenReady().then(() => {
   // it without the renderer visiting Settings. A failed registration is logged
   // here and surfaced in Settings via the IPC state (never silent).
   applyQuickEntrySettings(readQuickEntrySettings())
+  // HUD summon chord — same lifetime as Quick Entry's: the whole app run, so
+  // the HUD is reachable from any app without visiting Hermes first.
+  registerHudSummonShortcut()
 
   if (IS_MAC) {
     const reposition = () => wakeIndicatorController.reposition()
@@ -18116,6 +18184,7 @@ app.on('before-quit', event => {
   // closeHudWindow(): that also re-shows the main window, which is wrong on the
   // way out (and `hudRestoreMainWindow` may still be armed from entering HUD).
   hudSnapShortcut.dispose()
+  hudSummonShortcut.dispose()
 
   if (hudWindow && !hudWindow.isDestroyed()) {
     hudWindow.removeAllListeners('closed')

--- a/apps/desktop/src/app/hud/escape-interaction.test.tsx
+++ b/apps/desktop/src/app/hud/escape-interaction.test.tsx
@@ -1,0 +1,121 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { Dialog } from 'radix-ui'
+import { useRef, useState } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { closeHud } from '@/store/hud'
+
+import { useHudEscape } from './escape'
+
+vi.mock('@/store/hud', () => ({ closeHud: vi.fn() }))
+
+function HudFixture({ autocomplete = false, dialog = false }) {
+  const rootRef = useRef<HTMLDivElement>(null)
+  const [suggestionsOpen, setSuggestionsOpen] = useState(autocomplete)
+  useHudEscape(rootRef)
+
+  return (
+    <div ref={rootRef}>
+      <input
+        aria-label="Composer"
+        onKeyDown={event => {
+          // Match the composer's autocomplete contract: consume Escape and
+          // close suggestions while keyboard focus stays in the editor.
+          if (event.key === 'Escape' && suggestionsOpen) {
+            event.preventDefault()
+            setSuggestionsOpen(false)
+          }
+        }}
+      />
+      {suggestionsOpen && <div aria-label="Suggestions" role="listbox" />}
+      {dialog && (
+        <Dialog.Root>
+          <Dialog.Trigger>Open picker</Dialog.Trigger>
+          <Dialog.Portal>
+            <Dialog.Content aria-describedby={undefined}>
+              <Dialog.Title>Picker</Dialog.Title>
+              <input aria-label="Picker search" />
+            </Dialog.Content>
+          </Dialog.Portal>
+        </Dialog.Root>
+      )}
+    </div>
+  )
+}
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('HUD Escape interaction', () => {
+  it('dismisses the HUD once when its focused composer has nothing to dismiss', () => {
+    render(<HudFixture />)
+    const composer = screen.getByRole('textbox', { name: 'Composer' })
+    composer.focus()
+
+    fireEvent.keyDown(composer, { key: 'Escape' })
+
+    expect(closeHud).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets autocomplete consume the first Escape and dismisses the HUD on the next', () => {
+    render(<HudFixture autocomplete />)
+    const composer = screen.getByRole('textbox', { name: 'Composer' })
+    composer.focus()
+
+    fireEvent.keyDown(composer, { key: 'Escape' })
+
+    expect(screen.queryByRole('listbox')).toBeNull()
+    expect(window.document.activeElement).toBe(composer)
+    expect(closeHud).not.toHaveBeenCalled()
+
+    fireEvent.keyDown(composer, { key: 'Escape' })
+
+    expect(closeHud).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes a real portalled dialog before allowing Escape to dismiss the HUD', async () => {
+    render(<HudFixture dialog />)
+    const trigger = screen.getByRole('button', { name: 'Open picker' })
+    fireEvent.click(trigger)
+    const search = screen.getByRole('textbox', { name: 'Picker search' })
+    search.focus()
+
+    fireEvent.keyDown(search, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).toBeNull())
+    expect(closeHud).not.toHaveBeenCalled()
+    await waitFor(() => expect(window.document.activeElement).toBe(trigger))
+
+    fireEvent.keyDown(trigger, { key: 'Escape' })
+
+    expect(closeHud).toHaveBeenCalledTimes(1)
+  })
+
+  it('leaves Escape to a focused portal even when it does not preventDefault', () => {
+    render(<HudFixture />)
+    const portal = window.document.createElement('input')
+    window.document.body.appendChild(portal)
+
+    try {
+      portal.focus()
+      fireEvent.keyDown(portal, { key: 'Escape' })
+      expect(closeHud).not.toHaveBeenCalled()
+    } finally {
+      portal.remove()
+    }
+  })
+
+  it('ignores other keys and removes its listener on unmount', () => {
+    const { unmount } = render(<HudFixture />)
+    const composer = screen.getByRole('textbox', { name: 'Composer' })
+    composer.focus()
+    fireEvent.keyDown(composer, { key: 'Enter' })
+    expect(closeHud).not.toHaveBeenCalled()
+
+    unmount()
+    fireEvent.keyDown(window, { key: 'Escape' })
+    expect(closeHud).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/hud/escape.test.ts
+++ b/apps/desktop/src/app/hud/escape.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+
+import { hudEscapeAction } from './escape'
+
+function shell() {
+  const root = document.createElement('div')
+  const composer = document.createElement('div')
+  composer.setAttribute('data-slot', 'composer-rich-input')
+  root.appendChild(composer)
+  document.body.appendChild(root)
+
+  const overlay = document.createElement('div')
+  overlay.setAttribute('role', 'dialog')
+  document.body.appendChild(overlay)
+
+  return { root, composer, overlay }
+}
+
+describe('hudEscapeAction', () => {
+  it('closes the HUD when focus is inside the shell', () => {
+    const { root, composer } = shell()
+
+    expect(hudEscapeAction(root, composer, false)).toBe('close')
+  })
+
+  it('closes the HUD when nothing has focus', () => {
+    const { root } = shell()
+
+    expect(hudEscapeAction(root, null, false)).toBe('close')
+    expect(hudEscapeAction(root, document.body, false)).toBe('close')
+  })
+
+  it('steps back when a portalled overlay holds focus — Escape belongs to it', () => {
+    const { root, overlay } = shell()
+
+    expect(hudEscapeAction(root, overlay, false)).toBe('ignore')
+  })
+
+  it('honours a press another handler already consumed', () => {
+    const { root, composer } = shell()
+
+    expect(hudEscapeAction(root, composer, true)).toBe('ignore')
+  })
+})

--- a/apps/desktop/src/app/hud/escape.ts
+++ b/apps/desktop/src/app/hud/escape.ts
@@ -1,0 +1,68 @@
+import { type RefObject, useEffect } from 'react'
+
+import { closeHud } from '@/store/hud'
+
+/** What an Escape press inside the HUD window should do. */
+export type HudEscapeAction = 'close' | 'ignore'
+
+/**
+ * Decide whether Escape dismisses the HUD.
+ *
+ * Escape is the gesture people reach for to put a floating thing away, and
+ * the HUD had no answer to it — dismissal was ⌘W or the composer's exit
+ * button. But Escape also belongs to whatever is stacked ON TOP of the shell:
+ *
+ * - Focus BESIDE the shell is a portalled dialog, popover, menu or the model
+ *   picker (same test `hudIgnoresMouse` uses). That surface owns the press —
+ *   Escape closes IT, not the HUD under it — so the HUD steps back.
+ * - A press some handler already consumed (`defaultPrevented`) stays consumed;
+ *   the composer's own editor may claim Escape to clear an autocomplete.
+ *
+ * Everything else — focus inside the shell, or nowhere — closes the HUD.
+ */
+export function hudEscapeAction(root: Element, active: Element | null, defaultPrevented: boolean): HudEscapeAction {
+  if (defaultPrevented) {
+    return 'ignore'
+  }
+
+  const overlayFocused = active !== null && !root.contains(active) && !active.contains(root)
+
+  return overlayFocused ? 'ignore' : 'close'
+}
+
+/**
+ * Escape dismisses the HUD.
+ *
+ * Listens on the window in the capture phase so a press reaches the decision
+ * before any bubbling handler, but defers to anything that has already claimed
+ * it (see `hudEscapeAction`). Closing goes through the store so main restores
+ * the app window exactly as it does for ⌘W and the exit button.
+ */
+export function useHudEscape(rootRef: RefObject<HTMLElement | null>): void {
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') {
+        return
+      }
+
+      const root = rootRef.current
+
+      if (!root) {
+        return
+      }
+
+      if (hudEscapeAction(root, document.activeElement, event.defaultPrevented) !== 'close') {
+        return
+      }
+
+      event.preventDefault()
+      closeHud()
+    }
+
+    // Bubble phase, not capture: a portalled overlay's own Escape handler runs
+    // first and can preventDefault, which `hudEscapeAction` then honours.
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [rootRef])
+}

--- a/apps/desktop/src/app/hud/escape.ts
+++ b/apps/desktop/src/app/hud/escape.ts
@@ -33,10 +33,10 @@ export function hudEscapeAction(root: Element, active: Element | null, defaultPr
 /**
  * Escape dismisses the HUD.
  *
- * Listens on the window in the capture phase so a press reaches the decision
- * before any bubbling handler, but defers to anything that has already claimed
- * it (see `hudEscapeAction`). Closing goes through the store so main restores
- * the app window exactly as it does for ⌘W and the exit button.
+ * Listens on the window in the bubble phase so editor and overlay handlers
+ * can consume the press first (see `hudEscapeAction`). Closing goes through
+ * the store so main restores the app window exactly as it does for ⌘W and
+ * the exit button.
  */
 export function useHudEscape(rootRef: RefObject<HTMLElement | null>): void {
   useEffect(() => {

--- a/apps/desktop/src/app/hud/hud-shell.tsx
+++ b/apps/desktop/src/app/hud/hud-shell.tsx
@@ -10,6 +10,7 @@ import { RICH_INPUT_SLOT } from '../chat/composer/rich-editor'
 import { WiredPane } from '../contrib/wiring'
 
 import { useHudClickThrough } from './click-through'
+import { useHudEscape } from './escape'
 import { useHudGameOverlay } from './game-overlay'
 import { useHudGlass } from './glass'
 import { useHudGoto, useReportHudSession } from './handoff'
@@ -284,6 +285,10 @@ export function HudShell() {
   useHudGlass(rootRef, filled)
   useHudClickThrough(rootRef)
   useHudThreadFocus(rootRef)
+  // Escape puts the HUD away — the gesture people reach for first, and the one
+  // dismissal the HUD lacked (it was ⌘W or the exit button). Defers to any
+  // portalled overlay that owns the press (see `hudEscapeAction`).
+  useHudEscape(rootRef)
 
   // Edge/corner resize frame. The window is created non-resizable so dragging can
   // never be misread as a resize gesture (the Windows transparent-frameless

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -314,7 +314,7 @@ export const en: Translations = {
       'view.toggleTabStrip': 'Toggle tabs',
       'view.showFiles': 'Show file browser',
       'view.showBrowser': 'Open browser',
-      'view.toggleHud': 'Toggle HUD mode',
+      'view.toggleHud': 'Toggle HUD mode (global — works from any app)',
       'hud.snapToPointer': 'Move HUD to pointer (global, while HUD is open)',
       'view.showTerminal': 'Toggle terminal',
       'view.newTerminal': 'New terminal',


### PR DESCRIPTION
Adds the smallest HUD usability slice: summon the floating HUD from any app with the same shortcut already used in-app, and dismiss it with Escape without stealing Escape from an open dialog or picker.

How to try it

1. Start Hermes Desktop.
2. From another app, press `Ctrl/Command+Shift+H` to open the HUD without focusing or hiding the app underneath.
3. Press the shortcut again to toggle it, or focus the HUD and press Escape to dismiss it.

Tested on Windows 11

- `npm run typecheck`
- `npm run lint` (0 errors; existing repository warnings remain)
- `npx vitest run --project electron electron/hud-summon-shortcut.test.ts` (9 passed)
- `npx vitest run --project ui src/app/hud/escape.test.ts` (4 passed)

The original feature was built and used on Windows 11. macOS and Linux are untested in this split.

Reviewer pushback is welcome on the global shortcut choice, focus-preservation behavior, and Escape ownership around portalled overlays.