### PR TITLE
fix(memory): recognize the new OpenViking ROOT-request permission error shape

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -367,7 +367,13 @@ class _VikingClient:
         API-key permission denials non-retriable.
         """
         message = str(exc)
-        if "Trusted mode requests must include" not in message:
+        # Two error shapes across OpenViking versions:
+        #   old: "Trusted mode requests must include X-OpenViking-Account..."
+        #   new: "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account..."
+        if (
+            "Trusted mode requests must include" not in message
+            and "ROOT requests" not in message
+        ):
             return False
         if "X-OpenViking-Account" not in message and "X-OpenViking-User" not in message:
             return False

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -1925,3 +1925,49 @@ class TestOpenVikingEnvWriter:
         assert env.read_text(encoding="utf-8").splitlines() == [
             "A=1", "OPENAI_API_KEY=new", "B=2",
         ]
+
+
+def test_needs_trusted_identity_retry_matches_legacy_and_root_error_shapes():
+    """Trusted-mode missing-identity denials must stay retriable across both
+    OpenViking error shapes; the short-circuit needs to recognize ``ROOT
+    requests`` in addition to the legacy ``Trusted mode requests`` prefix."""
+    from plugins.memory.openviking import _VikingClient
+
+    legacy = "Trusted mode requests must include X-OpenViking-Account (400)"
+    legacy_user = "Trusted mode requests must include X-OpenViking-User (400)"
+    modern = "ROOT requests to tenant-scoped APIs must include X-OpenViking-Account (400)"
+    modern_user = "ROOT requests to tenant-scoped APIs must include X-OpenViking-User (400)"
+
+    assert _VikingClient._needs_trusted_identity_retry(Exception(legacy)) is True
+    assert _VikingClient._needs_trusted_identity_retry(Exception(legacy_user)) is True
+    assert _VikingClient._needs_trusted_identity_retry(Exception(modern)) is True
+    assert _VikingClient._needs_trusted_identity_retry(Exception(modern_user)) is True
+
+
+def test_needs_trusted_identity_retry_rejects_unrelated_errors():
+    """A generic API error is not a missing-identity denial and must not be
+    marked retriable via the trusted-identity path."""
+    from plugins.memory.openviking import _VikingClient
+
+    assert _VikingClient._needs_trusted_identity_retry(Exception("401 Unauthorized")) is False
+    assert _VikingClient._needs_trusted_identity_retry(Exception("connection reset")) is False
+
+
+def test_needs_trusted_identity_retry_requires_identity_header_in_message():
+    """The trusted-mode wording alone is insufficient — the error must name a
+    missing identity header, otherwise the denial is not retriable."""
+    from plugins.memory.openviking import _VikingClient
+
+    assert _VikingClient._needs_trusted_identity_retry(Exception("Trusted mode requests must not apply here")) is False
+    assert _VikingClient._needs_trusted_identity_retry(Exception("ROOT requests are not allowed (400)")) is False
+
+
+def test_needs_trusted_identity_retry_rejects_non_400_status():
+    """Only HTTP 400 maps to a missing-identity denial; a 401 for the same
+    wording is an auth error and stays non-retriable."""
+    from plugins.memory.openviking import _VikingClient
+
+    class _Exc(Exception):
+        status_code = 401
+
+    assert _VikingClient._needs_trusted_identity_retry(_Exc("Trusted mode requests must include X-OpenViking-Account")) is False


### PR DESCRIPTION
## Problem

The OpenViking memory provider has changed the error string it returns for a tenant-scoped permission denial:

- old: `Trusted mode requests must include X-OpenViking-Account...`
- new: `ROOT requests to tenant-scoped APIs must include X-OpenViking-Account...`

`_VikingClient._needs_trusted_identity_retry` matches the legacy prefix exactly, so the new shape falls through and the denial is marked **non-retriable** — Hermes fails fast on a 400 that would previously be retried. The retry path was intended to cover missing-identity denials; the new phrasing no longer triggers it.

## Fix

Match both shapes so these errors stay in the trusted-identity retry path:

```python
if (
    "Trusted mode requests must include" not in message
    and "ROOT requests" not in message
):
    return False
```

No behavior changes for other errors; this only widens the retriable set that the legacy branch already covered.

## Verification

- Confirmed the OpenViking server now emits the `ROOT requests ...` phrasing.
- Added unit tests covering: legacy + ROOT error shapes (retriable), unrelated errors (non-retriable), missing identity header (non-retriable), and non-400 status (non-retriable).

Co-authored-by: Sisyphus <clio-agent@sisyphuslabs.ai>