### PR TITLE
feat(telegram): emit InputRichMessage.is_rtl for RTL rich messages

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -534,6 +534,41 @@ def _rich_normalize_linebreaks(text: str) -> str:
     return ''.join(out)
 
 
+_RTL_CODEPOINTS = frozenset(
+    cp
+    for lo, hi in (
+        (0x0590, 0x05FF),  # Hebrew
+        (0x0600, 0x06FF),  # Arabic
+        (0x0700, 0x074F),  # Syriac
+        (0x0750, 0x077F),  # Arabic Supplement
+        (0x08A0, 0x08FF),  # Arabic Extended-A
+        (0xFB50, 0xFDFF),  # Arabic Presentation Forms-A
+        (0xFDF0, 0xFDCF),  # Arabic ligatures
+        (0xFE70, 0xFEFC),  # Arabic Presentation Forms-B
+    )
+    for cp in range(lo, hi + 1)
+)
+
+
+def _is_rtl_text(text: str) -> bool:
+    """True when >30% of the alphabetic characters are Hebrew/Arabic-script.
+
+    Heuristic mirrors the Teams adapter's RTL detection: a message that is
+    predominantly RTL-script should be flagged so Telegram renders it
+    right-to-left (Bot API 10.1 ``InputRichMessage.is_rtl``).
+    """
+    if not text:
+        return False
+    rtl = letters = 0
+    for ch in text:
+        if not ch.isalpha():
+            continue
+        letters += 1
+        if ord(ch) in _RTL_CODEPOINTS:
+            rtl += 1
+    return letters > 0 and rtl / letters > 0.3
+
+
 # Watchdog bound for `await updater.stop()`. When the underlying TCP socket is
 # in CLOSE-WAIT the PTB polling task is blocked on epoll on the dead socket and
 # never wakes, so an unguarded stop() hangs indefinitely and wedges the whole
@@ -725,6 +760,11 @@ class TelegramAdapter(BasePlatformAdapter):
         # reply still lands through sendRichMessage so tables are not flattened
         # by the MarkdownV2 formatter.
         self._rich_drafts_enabled: bool = self._coerce_bool_extra("rich_drafts", False)
+        # RTL rich messages (Bot API 10.1 InputRichMessage.is_rtl): opt-in via
+        # platforms.telegram.extra.rich_rtl; when on, payloads with >30%
+        # Hebrew/Arabic alphabetic content get is_rtl=True so Telegram renders
+        # them right-to-left.
+        self._rich_rtl_enabled: bool = self._coerce_bool_extra("rich_rtl", False)
         # Latched off after a capability failure on sendRichMessage /
         # sendRichMessageDraft (e.g. older python-telegram-bot without the
         # endpoint) so later sends skip the doomed rich attempt entirely.
@@ -2204,6 +2244,12 @@ class TelegramAdapter(BasePlatformAdapter):
         payload: Dict[str, Any] = {"markdown": _rich_normalize_linebreaks(content)}
         if skip_entity_detection:
             payload["skip_entity_detection"] = True
+        # Bot API 10.1 InputRichMessage.is_rtl: "Pass True if the rich message
+        # must be shown right-to-left" (Hebrew/Arabic). Opt-in via
+        # platforms.telegram.extra.rich_rtl + auto-detection when >30% of the
+        # alphabetic characters are RTL (mirrors the Teams adapter heuristic).
+        if getattr(self, "_rich_rtl_enabled", False) and _is_rtl_text(content):
+            payload["is_rtl"] = True
         return payload
 
     def _is_rich_capability_error(self, exc: Exception) -> bool:

--- a/tests/gateway/test_telegram_rich_rtl.py
+++ b/tests/gateway/test_telegram_rich_rtl.py
@@ -1,0 +1,111 @@
+"""Tests for RTL rich messages (Bot API 10.1 InputRichMessage.is_rtl).
+
+When ``platforms.telegram.extra.rich_rtl`` is enabled, rich-message payloads
+whose content is predominantly Hebrew/Arabic (>30% of alphabetic characters)
+carry ``is_rtl: True`` so Telegram renders them right-to-left. English or
+mixed-LTR content stays untouched, and the flag is off by default.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+from plugins.platforms.telegram.adapter import TelegramAdapter, _is_rtl_text
+
+ARABIC_CONTENT = "## تقرير السوق\n\n| السهم | الحالة |\n|---|---|\n| أرامكو | صاعد |"
+HEBREW_CONTENT = "## דוח השוק\n\n| מניה | מצב |\n|---|---|\n| טבע | עולה |"
+ENGLISH_CONTENT = "## Market report\n\n| Ticker | Status |\n|---|---|\n| SPY | up |"
+
+
+def _make_adapter(extra=None):
+    """Build a TelegramAdapter with a mock bot wired for the rich path."""
+    from gateway.config import PlatformConfig
+
+    config = PlatformConfig(
+        enabled=True,
+        token="fake-token",
+        extra={"rich_messages": True, **(extra or {})},
+    )
+    adapter = TelegramAdapter(config)
+    bot = MagicMock()
+    bot.do_api_request = AsyncMock(return_value=SimpleNamespace(message_id=123))
+    bot.send_message = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.send_chat_action = AsyncMock()
+    bot.send_message_draft = AsyncMock(return_value=True)
+    bot.edit_message_text = AsyncMock(return_value=MagicMock(message_id=1))
+    bot.delete_message = AsyncMock(return_value=True)
+    adapter._bot = bot
+    return adapter
+
+
+class TestIsRtlText:
+    def test_arabic_dominant_true(self):
+        assert _is_rtl_text("هذا تقرير السوق اليومي: SPY ارتفع 1.2%") is True
+
+    def test_hebrew_dominant_true(self):
+        assert _is_rtl_text("דוח השוק: SPY עלה היום") is True
+
+    def test_english_false(self):
+        assert _is_rtl_text("Market report: SPY rose 1.2% today") is False
+
+    def test_empty_false(self):
+        assert _is_rtl_text("") is False
+
+    def test_no_letters_false(self):
+        assert _is_rtl_text("12345 !@# 67890") is False
+
+    def test_minority_rtl_false(self):
+        # Two Arabic words buried in English prose stay LTR.
+        text = "The term انت appears once and قيمة twice in this English text"
+        assert _is_rtl_text(text) is False
+
+
+class TestRichRtlPayload:
+    def test_rtl_extra_off_by_default(self):
+        adapter = _make_adapter()
+        payload = adapter._rich_message_payload(ARABIC_CONTENT)
+        assert "is_rtl" not in payload
+
+    def test_rtl_extra_on_arabic_sets_flag(self):
+        adapter = _make_adapter(extra={"rich_rtl": True})
+        payload = adapter._rich_message_payload(ARABIC_CONTENT)
+        assert payload["is_rtl"] is True
+        assert "markdown" in payload
+
+    def test_rtl_extra_on_hebrew_sets_flag(self):
+        adapter = _make_adapter(extra={"rich_rtl": True})
+        payload = adapter._rich_message_payload(HEBREW_CONTENT)
+        assert payload["is_rtl"] is True
+
+    def test_rtl_extra_on_english_no_flag(self):
+        adapter = _make_adapter(extra={"rich_rtl": True})
+        payload = adapter._rich_message_payload(ENGLISH_CONTENT)
+        assert "is_rtl" not in payload
+
+    def test_rtl_extra_string_true_coerced(self):
+        adapter = _make_adapter(extra={"rich_rtl": "true"})
+        payload = adapter._rich_message_payload(ARABIC_CONTENT)
+        assert payload["is_rtl"] is True
+
+    def test_forwarded_in_send_payload(self):
+        adapter = _make_adapter(extra={"rich_rtl": True})
+        import asyncio
+
+        asyncio.run(adapter._try_send_rich("123", ARABIC_CONTENT, None, None))
+        _, kwargs = adapter._bot.do_api_request.call_args
+        assert kwargs["api_kwargs"]["rich_message"]["is_rtl"] is True
+
+    def test_not_forwarded_when_english(self):
+        adapter = _make_adapter(extra={"rich_rtl": True})
+        import asyncio
+
+        asyncio.run(adapter._try_send_rich("123", ENGLISH_CONTENT, None, None))
+        _, kwargs = adapter._bot.do_api_request.call_args
+        assert "is_rtl" not in kwargs["api_kwargs"]["rich_message"]
+
+    def test_not_forwarded_when_disabled(self):
+        adapter = _make_adapter()
+        import asyncio
+
+        asyncio.run(adapter._try_send_rich("123", ARABIC_CONTENT, None, None))
+        _, kwargs = adapter._bot.do_api_request.call_args
+        assert "is_rtl" not in kwargs["api_kwargs"]["rich_message"]


### PR DESCRIPTION
## What does this PR do?

Bot API 10.1 `InputRichMessage` documents `is_rtl`: "Pass True if the rich message must be shown right-to-left". The adapter never emits it — the payload is markdown-only — so Hebrew/Arabic rich messages always render LTR: bullets on the wrong side, punctuation and mixed Latin tokens mis-ordered.

When the composed payload's content is predominantly RTL-script (>30% of alphabetic characters) and the operator opts in via `platforms.telegram.extra.rich_rtl`, the payload now carries `is_rtl: true`.

Closes #78746.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/telegram/adapter.py`:
  - `_is_rtl_text()` — module-level detection: true when >30% of the alphabetic characters fall in the Hebrew/Arabic-script Unicode ranges (mirrors the Teams adapter's threshold from #101205).
  - `_rich_rtl_enabled` — opt-in config extra read through the existing `_coerce_bool_extra` pattern (`platforms.telegram.extra.rich_rtl`, default **false** — nothing changes for existing operators).
  - `_rich_message_payload()` — sets `is_rtl: True` when enabled + RTL detected. `getattr` guard used because tests construct adapters via `object.__new()` (no `__init__`), matching the existing rich flags' defensive style.
- `tests/gateway/test_telegram_rich_rtl.py` (new): detection table (Arabic/Hebrew dominant → true; English, minority-RTL mixed, empty, digits-only → false) and payload wiring (off by default, set on RTL content when enabled, string coercion, forwarded through the raw `sendRichMessage` `api_kwargs`).

Because the flag is applied in `_rich_message_payload()`, all three call sites pick it up: `_try_send_rich`, `_try_edit_rich` (streamed previews finalize RTL), and `_try_send_rich_draft`.

## How to Test

1. Set `platforms.telegram.extra.rich_messages: true` and `platforms.telegram.extra.rich_rtl: true` in config.yaml
2. Ask the bot a question in Arabic/Hebrew → the rich message renders right-to-left (bullets/punctuation on the right)
3. Ask in English → renders unchanged
4. Without `rich_rtl` → behavior byte-identical to main

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#101205 is the Teams-side fix with a parallel heuristic; #78746 tracks this Telegram gap with no open PR)
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run `pytest tests/gateway/test_telegram_rich_rtl.py` — 14/14 pass
- [x] I've added tests for my changes
- [x] Tested on my platform: macOS 26.5 (arm64), verified live against a real Telegram chat

### Documentation & Housekeeping
- [x] Documentation N/A (config extra follows the documented `telegram.extra.*` pattern; no new top-level key)