### PR TITLE
fix(desktop): stop completed messages rendering twice after compression

### DIFF
--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -39,6 +39,67 @@ describe('useRuntimeMessageRepository', () => {
     expect(ids).toEqual(['user-1', 'assistant-1'])
   })
 
+  it('emits one settled message when live and durable ids differ after compaction', () => {
+    const live: ChatMessage = {
+      id: 'assistant-stream-1',
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Finished the work.' },
+        { type: 'tool-call', toolCallId: 'call-1', toolName: 'terminal', args: {}, argsText: '' }
+      ] as ChatMessage['parts'],
+      timestamp: 1_700_000_000,
+      pending: false
+    }
+    const durable: ChatMessage = {
+      ...live,
+      id: '1700000000-42-assistant',
+      rowId: 42
+    }
+
+    const { result } = renderHook(() => useRuntimeMessageRepository([live, durable]))
+
+    expect(result.current.messages.map(item => item.message.id)).toEqual(['assistant-stream-1'])
+  })
+
+  it('does not content-dedupe messages that are still streaming', () => {
+    const partial = {
+      ...text('assistant-stream-1', 'assistant', 'same partial'),
+      timestamp: 1_700_000_000,
+      pending: true
+    }
+
+    const { result } = renderHook(() =>
+      useRuntimeMessageRepository([partial, { ...partial, id: 'assistant-stream-2' }])
+    )
+
+    expect(result.current.messages.map(item => item.message.id)).toEqual([
+      'assistant-stream-1',
+      'assistant-stream-2'
+    ])
+  })
+
+  it('keeps settled tool messages with different call identities', () => {
+    const settledToolMessage = (id: string, toolCallId: string): ChatMessage => ({
+      id,
+      role: 'assistant',
+      parts: [
+        { type: 'text', text: 'Finished.' },
+        { type: 'tool-call', toolCallId, toolName: 'terminal', args: {}, argsText: '' }
+      ] as ChatMessage['parts'],
+      timestamp: 1_700_000_000,
+      pending: false
+    })
+
+    const { result } = renderHook(() =>
+      useRuntimeMessageRepository([
+        settledToolMessage('assistant-1', 'call-1'),
+        settledToolMessage('assistant-2', 'call-2')
+      ])
+    )
+
+    expect(result.current.messages.map(item => item.message.id)).toEqual(['assistant-1', 'assistant-2'])
+  })
+
   it('builds a repository the runtime can link without throwing', () => {
     const { result } = renderHook(() =>
       useRuntimeMessageRepository([

--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -50,6 +50,7 @@ describe('useRuntimeMessageRepository', () => {
       timestamp: 1_700_000_000,
       pending: false
     }
+
     const durable: ChatMessage = {
       ...live,
       id: '1700000000-42-assistant',

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -2,14 +2,28 @@ import { fromThreadMessageLike, getAutoStatus } from '@assistant-ui/core/interna
 import type { ExportedMessageRepository, ThreadMessage } from '@assistant-ui/react'
 import { useMemo, useRef } from 'react'
 
-import type { ChatMessage } from '@/lib/chat-messages'
-import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
+import { type ChatMessage, chatMessageText, withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
 
 // The exact fallback status ExportedMessageRepository.fromBranchableArray uses.
 // Normalization happens HERE, once per message, so the cached record below is
 // already the final ThreadMessage the runtime consumes.
 const FALLBACK_STATUS = getAutoStatus(false, false, false, false, undefined)
+
+const settledMessageKey = (message: ChatMessage): string | null => {
+  // Compression can leave a completed live copy beside the same rehydrated
+  // durable row. Their renderer ids differ, but persisted identity fields do
+  // not. Never apply this fallback to a still-streaming row: repeated partial
+  // snapshots are updates, not settled duplicates.
+  if (message.timestamp === undefined || message.pending === true) {
+    return null
+  }
+
+  const firstToolCallId = message.parts.find(part => part.type === 'tool-call')?.toolCallId ?? ''
+  const normalizedText = chatMessageText(message).replace(/\s+/g, ' ').trim()
+
+  return JSON.stringify([message.role, normalizedText, message.timestamp, firstToolCallId])
+}
 
 /**
  * ChatMessage[] -> assistant-ui message repository, with a WeakMap identity
@@ -32,6 +46,7 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
     const items: { message: ThreadMessage; parentId: string | null }[] = []
     const branchParentByGroup = new Map<string, string | null>()
     const seenIds = new Set<string>()
+    const seenSettledMessages = new Set<string>()
     let visibleParentId: string | null = null
     let headId: string | null = null
 
@@ -45,7 +60,17 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
         continue
       }
 
+      const settledKey = settledMessageKey(message)
+
+      if (settledKey !== null && seenSettledMessages.has(settledKey)) {
+        continue
+      }
+
       seenIds.add(message.id)
+
+      if (settledKey !== null) {
+        seenSettledMessages.add(settledKey)
+      }
 
       let parentId = visibleParentId
 


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop from rendering a completed assistant message twice after context compression when the live and durable copies have different renderer ids. The runtime repository now uses persisted message identity as a settled-only fallback while leaving in-progress stream snapshots independent.

### Symptom

After context compression, a completed assistant message and its tool timeline can appear twice in the Desktop transcript.

### Impact

Affected Desktop sessions show duplicate completed work, tool calls, and timestamps, making the transcript misleading and harder to follow.

### Bug Cause

**Trigger:** `apps/desktop/src/app/chat/runtime-repository.ts` / `useRuntimeMessageRepository`

**Causal chain:**
1. Context compression rehydrates a durable copy of a completed message while a settled live copy can still be present in the renderer store.
2. The two copies describe the same persisted message but use different renderer ids.
3. The repository's id-only duplicate guard accepts both, so assistant-ui renders both copies.

**Why it is wrong:** Renderer ids describe the source copy, not the logical persisted message, so they are insufficient at the live-to-durable reconciliation boundary.

**Working sibling / contrast:** Repeated copies with the same renderer id are already filtered by `seenIds`.

**Ruled out:** SessionDB display projection duplication is not the remaining renderer cause. Current display reads already share `_dedupe_display_generations`, and carried-forward tail originals are excluded from display and recall through `tail_count` semantics.

### Fix

Add a fallback key for timestamp-bearing settled messages based on role, normalized text, timestamp, and first tool-call id. Apply it after tool-only assistant coalescing and alongside the existing id guard. Pending stream rows bypass the fallback, and different tool-call identities remain distinct.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/runtime-repository.ts` - deduplicate settled live and durable copies by persisted message identity.
- `apps/desktop/src/app/chat/runtime-repository.test.ts` - cover the compression collision, pending streams, and distinct tool-call identities.

## How to Test

1. Run the focused Desktop repository tests.
2. Confirm the live/durable regression emits one repository message.
3. Confirm pending copies and settled messages with different tool-call ids remain separate.

```bash
cd apps/desktop
npx vitest run src/app/chat/runtime-repository.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Vitest target and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - no user-facing contract changed
- [x] `cli-config.yaml.example` update: N/A - no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: renderer logic is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed

## Screenshots / Logs

Focused Vitest result: 9 tests passed.

