### PR TITLE
fix(desktop): initialize hermesLog before pool limits

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1404,6 +1404,9 @@ const backendDialClaims = new BackendDialClaims()
 // True while connection-config:apply soft-rehomes the primary — suppresses the
 // backend-exit toast so an intentional kill doesn't look like a crash.
 let softRehomeInProgress = false
+// Keep the in-memory log available before any startup preference is read.
+// readPersistedPoolLimits() records its outcome through rememberLog().
+const hermesLog = []
 // Additional per-profile backends, keyed by profile name. The PRIMARY backend
 // (the desktop's launch profile) stays managed by backendConnectionState +
 // startHermes(); this pool only holds EXTRA profile
@@ -1574,7 +1577,6 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
 let desktopLogBuffer = ''


### PR DESCRIPTION
## Summary

Fix an Electron main-process crash during Desktop startup when persisted pool limits are read.

## Background

`readPersistedPoolLimits()` logs its result through `rememberLog()` during ESM module evaluation. Before this change, `hermesLog` was declared later in the module, so `rememberLog()` attempted to call `.push()` on `undefined`. This prevented Hermes Desktop from launching.

## Changes

- Initialize `hermesLog` before `readPersistedPoolLimits()` can run.
- Preserve the existing startup logging behavior.

## Verification

- `git diff --check`
- `npm run test:desktop:platforms -- --run electron/pool-limits.test.ts` — 8 tests passed
- `npm run typecheck` — passed

Fixes #101960
Fixes #101941