### PR TITLE
fix(approval): isolate long command classification

### DIFF
--- a/tests/tools/test_command_guard_worker.py
+++ b/tests/tools/test_command_guard_worker.py
@@ -1,0 +1,50 @@
+import subprocess
+
+from tools import approval
+
+
+def test_long_commands_are_classified_once_outside_parent(monkeypatch) -> None:
+    safe = "; ".join(["printf λ"] * 500)
+    monkeypatch.setenv("LC_ALL", "C")
+    monkeypatch.setenv("PYTHONUTF8", "0")
+    monkeypatch.setattr(
+        approval, "detect_dangerous_command",
+        lambda _command: (_ for _ in ()).throw(AssertionError("parent reparsed long command")),
+    )
+
+    assert approval.check_dangerous_command(safe, "local")["approved"] is True
+
+    hardline = safe + "; rm -rf /"
+    result = approval.check_all_command_guards(hardline, "local")
+    assert result["approved"] is False
+    assert "hardline" in result["message"].lower()
+
+
+def test_long_command_worker_timeout_fails_closed(monkeypatch) -> None:
+    from tools import approval_guard_worker
+
+    completed = subprocess.CompletedProcess(
+        [], 0, stdout='{"kind":"dangerous","pattern_key":"x","description":"x"}', stderr="",
+    )
+    monkeypatch.setattr(approval_guard_worker.subprocess, "run", lambda *_args, **_kwargs: completed)
+    try:
+        approval_guard_worker.classify_long_command("x" * 5000, full=False)
+    except ValueError:
+        pass
+    else:
+        raise AssertionError("user-deny worker accepted a full-mode verdict")
+    for check in (approval.check_all_command_guards, approval.check_dangerous_command):
+        result = check("x" * 5000, "docker")
+        assert result["approved"] is False
+        assert result["guard_error"] is True
+
+    def timeout(*_args, **_kwargs):
+        raise subprocess.TimeoutExpired("guard", 10)
+
+    monkeypatch.setattr(approval_guard_worker, "classify_long_command", timeout)
+    monkeypatch.setattr(approval, "_YOLO_MODE_FROZEN", True)
+
+    result = approval.check_all_command_guards("x" * 5000, "local")
+    assert result["approved"] is False
+    assert result["guard_timeout"] is True
+    assert "Do NOT retry" in result["message"]

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -16,6 +16,7 @@ import hashlib
 import importlib
 import logging
 import os
+import subprocess
 import threading
 from typing import Optional
 
@@ -500,7 +501,9 @@ def _unattended_contexts() -> list[_Unattended]:
     return contexts
 
 
-def _unattended_deny(command: str, ctx: _Unattended) -> dict | None:
+def _unattended_deny(
+    command: str, ctx: _Unattended, dangerous_verdict: tuple | None = None,
+) -> dict | None:
     """Deny-mode handling for one unattended context (cron / -q / webhook); None = allow.
 
     Pattern detection first, then tirith so content-level threats (homograph URLs,
@@ -516,7 +519,7 @@ def _unattended_deny(command: str, ctx: _Unattended) -> dict | None:
             subject, noun="dangerous commands",
             advice="Find an alternative approach that avoids this command.")}
 
-    is_dangerous, _pk, description = detect_dangerous_command(command)
+    is_dangerous, _pk, description = dangerous_verdict or detect_dangerous_command(command)
     if is_dangerous:
         result = block(f"Command flagged as dangerous ({description})")
         if ctx.name == "single_query":
@@ -901,22 +904,64 @@ def _floor_block(command: str, *, sudo_guard: bool = False) -> dict | None:
     return _user_deny_block(command)
 
 
+def _guard_worker_failure(*, timed_out: bool) -> dict:
+    description = ("command security inspection timed out" if timed_out
+                   else "command security inspection failed")
+    result = _hardline_block_result(description)
+    result["guard_timeout" if timed_out else "guard_error"] = True
+    result["message"] += (
+        " The command was not executed. Do NOT retry the same inline command; "
+        "write large content with write_file/patch and execute only a short reviewable command."
+    )
+    return result
+
+
+def _isolated_guard(command: str, *, full: bool) -> tuple[dict | None, tuple | None, bool]:
+    """Return ``(block, dangerous verdict, isolated)`` for long commands."""
+    from tools.approval_guard_worker import classify_long_command
+
+    try:
+        verdict = classify_long_command(command, full=full)
+    except subprocess.TimeoutExpired:
+        logger.error("isolated command guard timed out")
+        return _guard_worker_failure(timed_out=True), None, True
+    except Exception:
+        logger.exception("isolated command guard failed")
+        return _guard_worker_failure(timed_out=False), None, True
+    if verdict is None:
+        return None, None, False
+    kind = verdict["kind"]
+    if kind == "hardline":
+        return _hardline_block_result(verdict["description"], command), None, True
+    if kind == "sudo_stdin":
+        return _sudo_stdin_block_result(verdict["description"]), None, True
+    if kind == "user_deny":
+        return _user_deny_block_result(verdict["pattern"]), None, True
+    if kind == "dangerous":
+        return None, (True, verdict["pattern_key"], verdict["description"]), True
+    return None, (False, None, None) if full else None, True
+
+
 def check_dangerous_command(command: str, env_type: str,
                             approval_callback=None,
                             has_host_access: bool = False) -> dict:
     """Detect a dangerous command and handle approval (pattern layer only). ``has_host_access``:
     a Docker sandbox that bind-mounts host paths must not skip approval.
     Returns ``{"approved": True/False, "message": str or None, ...}``."""
-    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _user_deny_block(command) or _approved()
-    blocked = _floor_block(command)
+    skip_floors = _should_skip_container_guards(env_type, has_host_access=has_host_access)
+    blocked, dangerous_verdict, isolated = _isolated_guard(command, full=not skip_floors)
+    if blocked is not None:
+        return blocked
+    if skip_floors:
+        return _approved() if isolated else (_user_deny_block(command) or _approved())
+    blocked = None if isolated else _floor_block(command)
     if blocked is not None:
         return blocked
     if _yolo_active():
         return _approved()
     if _command_matches_permanent_allowlist(command):
         return _approved()
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    is_dangerous, pattern_key, description = dangerous_verdict or detect_dangerous_command(command)
     if not is_dangerous:
         return _approved()
     return _run_approval_gate(
@@ -998,10 +1043,14 @@ def check_all_command_guards(command: str, env_type: str,
     dangerous-command findings are presented as ONE combined approval request, so a gateway
     force=True replay cannot bypass one check when only the other was shown to the user.
     ``has_host_access``: a Docker sandbox with bind-mounted host paths takes the normal flow."""
-    if _should_skip_container_guards(env_type, has_host_access=has_host_access):
-        return _user_deny_block(command) or _approved()
+    skip_floors = _should_skip_container_guards(env_type, has_host_access=has_host_access)
+    blocked, dangerous_verdict, isolated = _isolated_guard(command, full=not skip_floors)
+    if blocked is not None:
+        return blocked
+    if skip_floors:
+        return _approved() if isolated else (_user_deny_block(command) or _approved())
 
-    blocked = _floor_block(command, sudo_guard=True)
+    blocked = None if isolated else _floor_block(command, sudo_guard=True)
     if blocked is not None:
         return blocked
 
@@ -1016,7 +1065,7 @@ def check_all_command_guards(command: str, env_type: str,
     # unattended context applies its configured deny/approve mode, else allow.
     if not is_cli and not is_gateway and not is_ask:
         for ctx in _unattended_contexts():
-            result = _unattended_deny(command, ctx)
+            result = _unattended_deny(command, ctx, dangerous_verdict)
             if result is not None:
                 return result
         return _approved()
@@ -1024,7 +1073,7 @@ def check_all_command_guards(command: str, env_type: str,
     # Gather findings: warnings = [(pattern_key, description, is_tirith)]. Tirith block AND warn both go through the
     # approval flow (block used to be a hard stop) so users can inspect the findings and approve.
     tirith_result = _tirith_scan(command)
-    is_dangerous, pattern_key, description = detect_dangerous_command(command)
+    is_dangerous, pattern_key, description = dangerous_verdict or detect_dangerous_command(command)
     warnings = []
     session_key = get_current_session_key()
     if tirith_result["action"] in {"block", "warn"}:

--- a/tools/approval_detection.py
+++ b/tools/approval_detection.py
@@ -160,11 +160,19 @@ def _mask_quoted_prose(command: str) -> str:
 _SUDO_STDIN_RE = re.compile(r'(?:^|[;&|`\n]|&&|\|\||\$\()\s*sudo\s+-S\b', re.IGNORECASE)
 
 
-def _check_sudo_stdin_guard(command: str) -> tuple:
+def _check_sudo_stdin_guard(
+    command: str, sudo_password_configured: bool | None = None,
+) -> tuple:
     """Detect ``sudo -S`` without configured SUDO_PASSWORD -> (is_blocked, description). When
     SUDO_PASSWORD is set, ``_transform_sudo_command`` injects ``-S`` itself, so this guard only
     fires when the LLM wrote it explicitly."""
-    if "SUDO_PASSWORD" not in os.environ and _SUDO_STDIN_RE.search(_normalize_command_for_detection(command).lower()):
+    if sudo_password_configured is None:
+        try:
+            from agent.secret_scope import get_secret
+            sudo_password_configured = bool(get_secret("SUDO_PASSWORD", ""))
+        except Exception:
+            sudo_password_configured = False
+    if not sudo_password_configured and _SUDO_STDIN_RE.search(_normalize_command_for_detection(command).lower()):
         return (True, "sudo password guessing via stdin (sudo -S)")
     return (False, None)
 

--- a/tools/approval_floors.py
+++ b/tools/approval_floors.py
@@ -31,6 +31,11 @@ def _match_user_deny_rule(command: str) -> str | None:
         deny_patterns = _ctx._get_approval_config().get("deny") or []
     except Exception:
         return None
+    return _match_user_deny_globs(command, deny_patterns)
+
+
+def _match_user_deny_globs(command: str, deny_patterns) -> str | None:
+    """Pure deny-glob matcher shared with the isolated classifier."""
     globs = [p.strip() for p in deny_patterns if isinstance(p, str) and p.strip()]
     if not globs:
         return None

--- a/tools/approval_guard_worker.py
+++ b/tools/approval_guard_worker.py
@@ -1,0 +1,72 @@
+"""Parent-side protocol for isolated long-command classification."""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+
+from hermes_cli._subprocess_compat import windows_hide_flags
+
+MIN_COMMAND_CHARS = 4096
+TIMEOUT_SECONDS = 10.0
+
+
+def classify_long_command(command: str, *, full: bool) -> dict | None:
+    """Return a validated worker verdict, or None for the in-process short path."""
+    if len(command) < MIN_COMMAND_CHARS:
+        return None
+    from hermes_constants import get_hermes_home
+    from tools import approval_context
+
+    try:
+        patterns = approval_context._get_approval_config().get("deny") or []
+    except Exception:
+        patterns = []
+    try:
+        from agent.secret_scope import get_secret
+        has_sudo_password = bool(get_secret("SUDO_PASSWORD", ""))
+    except Exception:
+        has_sudo_password = False
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(get_hermes_home())
+    env["PYTHONIOENCODING"] = "utf-8"
+    completed = subprocess.run(
+        [sys.executable, "-m", "tools.command_guard_worker"],
+        input=json.dumps({
+            "mode": "full" if full else "user_deny",
+            "command": command,
+            "sudo_password_configured": has_sudo_password,
+            "deny_patterns": patterns,
+        }, ensure_ascii=False),
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="strict",
+        timeout=TIMEOUT_SECONDS,
+        cwd=os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+        env=env,
+        creationflags=windows_hide_flags(),
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(f"command guard worker exited {completed.returncode}")
+    result = json.loads(completed.stdout)
+    required = {
+        "allow": (),
+        "hardline": ("description",),
+        "sudo_stdin": ("description",),
+        "user_deny": ("pattern",),
+        "dangerous": ("pattern_key", "description"),
+    }
+    kind = result.get("kind") if isinstance(result, dict) else None
+    allowed_kinds = (
+        {"allow", "hardline", "sudo_stdin", "user_deny", "dangerous"}
+        if full else {"allow", "user_deny"}
+    )
+    if kind not in allowed_kinds:
+        raise ValueError("invalid command guard worker response")
+    fields = required.get(kind) if isinstance(kind, str) else None
+    if fields is None or any(not isinstance(result.get(key), str) or not result[key] for key in fields):
+        raise ValueError("invalid command guard worker response")
+    return result

--- a/tools/command_guard_worker.py
+++ b/tools/command_guard_worker.py
@@ -1,0 +1,59 @@
+"""Killable subprocess entry point for long command classification."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+
+def _classify(request: dict) -> dict:
+    from tools.approval_detection import (
+        _check_sudo_stdin_guard,
+        detect_dangerous_command,
+        detect_hardline_command,
+    )
+    from tools.approval_floors import _match_user_deny_globs
+
+    command = request["command"]
+    mode = request["mode"]
+    patterns = request["deny_patterns"]
+    sudo_password_configured = request.get("sudo_password_configured")
+    if not isinstance(mode, str) or not isinstance(sudo_password_configured, bool):
+        raise TypeError("invalid request")
+    if mode == "full":
+        matched, description = detect_hardline_command(command)
+        if matched:
+            return {"kind": "hardline", "description": description}
+        matched, description = _check_sudo_stdin_guard(
+            command, sudo_password_configured,
+        )
+        if matched:
+            return {"kind": "sudo_stdin", "description": description}
+    elif mode != "user_deny":
+        raise ValueError("unknown mode")
+    pattern = _match_user_deny_globs(command, patterns)
+    if pattern is not None:
+        return {"kind": "user_deny", "pattern": pattern}
+    if mode == "full":
+        matched, pattern_key, description = detect_dangerous_command(command)
+        if matched:
+            return {"kind": "dangerous", "pattern_key": pattern_key, "description": description}
+    return {"kind": "allow"}
+
+
+def main() -> int:
+    try:
+        request = json.loads(sys.stdin.read())
+        if not isinstance(request, dict) or not isinstance(request.get("command"), str):
+            raise TypeError("invalid request")
+        if not isinstance(request.get("deny_patterns"), list):
+            raise TypeError("invalid request")
+        sys.stdout.write(json.dumps(_classify(request), ensure_ascii=False))
+        return 0
+    except Exception as exc:
+        sys.stderr.write(f"command guard worker failed: {type(exc).__name__}\n")
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## What does this PR do?

Long shell commands can drive command normalization and dangerous-command detection through expensive Python parser/regex paths. In a single-process gateway, a pathological input can monopolize the interpreter and stall unrelated messaging work.

This change moves only the pure classification of long commands into a subprocess with a 10-second hard deadline. Approval prompts, session state, YOLO/mode decisions, and the final allow/block decision remain in the parent process. Worker timeout, process failure, malformed JSON, and invalid per-verdict schemas all fail closed.

The existing parent-side parser cap remains the first cheap rejection step. Commands shorter than 4,096 characters keep the existing in-process path.

This is adjacent to, but does not duplicate:

- #44473, which bounds dangerous-command regex input. This PR does not add the competing 8,192-byte multiline cap from the local incident fix.
- #72500, which adds watchdogs around other internal timeout surfaces. It does not isolate CPU/GIL-bound command classification.

## Related Issue

Related: #7485, #44473, #72500

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `tools/approval_guard_worker.py` for the parent-side subprocess protocol and `tools/command_guard_worker.py` for classification over stdin.
- Classify commands of at least 4,096 characters in a subprocess with a 10-second deadline. Short commands retain the in-process path.
- Integrate the worker through `tools/approval.py`, `tools/approval_detection.py`, and `tools/approval_floors.py`; approval decisions and mutable session state remain in the parent.
- Snapshot profile-scoped sudo-password presence and deny patterns; propagate the active Hermes home. Use explicit UTF-8 for the protocol.
- Validate verdict fields and restrict verdict kinds by full/user-deny mode. Operational and protocol errors block rather than falling back to inline classification.
- Add regression tests for a real Unicode subprocess round trip, avoiding parent-side reclassification, mode-invalid verdicts, and timeout blocking even with YOLO enabled.

## Review follow-up

The earlier automated review referenced an older revision. The current parent error includes only the worker exit code, not captured stderr; the worker reports only the exception type. No persistent-worker or caching architecture has been added.

## Validation for the current revision

Current head: `6fee02dce4cab50b801eafdd0325eb16a3f59350`.

The commands below have been updated to paths present at this head. They are **commands to run, not new passing results**. Tests, lint, and compilation were not rerun as part of this description-only update. Previously reported pass counts and root E2E results belong to earlier validation and must not be treated as evidence for this head.

```bash
scripts/run_tests.sh tests/tools/test_command_guard_worker.py tests/tools/test_approval.py tests/tools/test_approval_deny_rules.py tests/tools/test_approval_mode_parity.py tests/tools/test_approval_outcome_parity.py tests/tools/test_single_query_approval_mode.py tests/tools/test_cron_approval_mode.py tests/tools/test_smart_approval_policy.py
ruff check tests/tools/test_command_guard_worker.py tools/approval.py tools/approval_detection.py tools/approval_floors.py tools/approval_guard_worker.py tools/command_guard_worker.py
python -m py_compile tests/tools/test_command_guard_worker.py tools/approval.py tools/approval_detection.py tools/approval_floors.py tools/approval_guard_worker.py tools/command_guard_worker.py
git diff --check
```

At the latest status check, this head had no check runs or commit-status results. The repository requires `All required checks pass`, which is not yet satisfied; absence of results is not a confirmed test failure. Full-suite success is not claimed. Earlier local full-suite collection was blocked by the optional ACP dependency.
