### PR TITLE
fix(terminal): break exact retries after timeouts

### DIFF
--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import contextlib
+import copy
 import json
 from pathlib import Path
 import logging
@@ -450,6 +451,49 @@ class _ToolCancelledResult(str):
     post_tool_call was already emitted, so a late-finishing abandoned worker must not report."""
 
 
+class _DispatchCommit:
+    """Linearize actual dispatch against an outer runner abandoning the call."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._abandoned = False
+        self._args: dict[str, Any] | None = None
+
+    def commit(self, args: dict[str, Any]) -> bool:
+        with self._lock:
+            if self._abandoned:
+                return False
+            self._args = copy.deepcopy(args)
+            return True
+
+    def abandon_and_snapshot(self) -> dict[str, Any] | None:
+        with self._lock:
+            self._abandoned = True
+            return None if self._args is None else copy.deepcopy(self._args)
+
+
+def _is_terminal_timeout_result(tool_name: str, result: Any) -> bool:
+    if tool_name != "terminal":
+        return False
+    try:
+        payload = result if isinstance(result, dict) else json.loads(result)
+    except (TypeError, ValueError):
+        return False
+    return (
+        isinstance(payload, dict)
+        and payload.get("status") == "timeout"
+        and payload.get("error_type") == "terminal_timeout"
+    )
+
+
+def _record_terminal_timeout(agent, args: dict) -> None:
+    try:
+        from agent.tool_timeout_circuit import record_tool_timeout
+        record_tool_timeout("terminal", args, getattr(agent, "session_id", "") or "")
+    except Exception:
+        logger.exception("could not record terminal timeout circuit")
+
+
 class _ConcurrentToolAuthorizationGate:
     """Serialize policy prompts and exclude human approval waits from batch deadlines.
 
@@ -640,6 +684,7 @@ def _dispatch_authorized_once(
     display_index: int | None,
     begin_execution,
     authorization_gate: _ConcurrentToolAuthorizationGate | None,
+    dispatch_commit: _DispatchCommit,
 ) -> Any:
     """Hermes policy (scope → plugin pre-hooks → guardrails) then the one real dispatch.
 
@@ -679,8 +724,44 @@ def _dispatch_authorized_once(
     elif ref.name == "skill_manage":
         agent._iters_since_skill = 0
 
-    _advance_start_order(lambda: _begin_tool_execution(agent, ref, display_index))
-    return _run_with_activity_heartbeat(agent, ref.name, lambda: execute(ref.args))
+    admitted = False
+
+    def _begin() -> None:
+        nonlocal admitted
+        if ref.name == "terminal":
+            from agent.tool_timeout_circuit import try_admit_tool_call
+
+            admitted = try_admit_tool_call(
+                ref.name,
+                ref.args,
+                getattr(agent, "session_id", "") or "",
+                lambda: dispatch_commit.commit(ref.args),
+            )
+        else:
+            admitted = dispatch_commit.commit(ref.args)
+        if admitted:
+            _begin_tool_execution(agent, ref, display_index)
+
+    _advance_start_order(_begin)
+    if not admitted:
+        state.blocked = True
+        state.dispatched = False
+        return _blocked_tool_result(
+            agent,
+            ref,
+            block_message=(
+                "Identical terminal call timed out recently in this session and is temporarily "
+                "circuit-broken, or this call was abandoned before dispatch. Its prior side effects "
+                "may be UNKNOWN. Do NOT retry unchanged; inspect external state first, then use a "
+                "different bounded approach or wait for the circuit to expire."
+            ),
+            block_error_type="tool_timeout_retry_circuit",
+            guardrail_decision=None,
+        )
+    result = _run_with_activity_heartbeat(agent, ref.name, lambda: execute(ref.args))
+    if _is_terminal_timeout_result(ref.name, result):
+        _record_terminal_timeout(agent, ref.args)
+    return result
 
 
 def _run_agent_tool_execution_middleware(
@@ -696,6 +777,7 @@ def _run_agent_tool_execution_middleware(
     middleware_trace: list[dict[str, Any]] | None = None,
     begin_execution=None,
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
+    dispatch_commit: _DispatchCommit | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
     from agent import relay_tools
@@ -706,6 +788,7 @@ def _run_agent_tool_execution_middleware(
 
     trace = middleware_trace if middleware_trace is not None else []
     state = _ManagedToolResult(result=None, args=function_args, middleware_trace=trace, blocked=False, dispatched=False)
+    dispatch_commit = dispatch_commit or _DispatchCommit()
     dispatch_lock = threading.Lock()
 
     def _authorized_dispatch(final_args: dict[str, Any]) -> Any:
@@ -724,6 +807,7 @@ def _run_agent_tool_execution_middleware(
             display_index=display_index,
             begin_execution=begin_execution,
             authorization_gate=authorization_gate,
+            dispatch_commit=dispatch_commit,
         )
 
     def _hermes_pipeline(relay_args: dict[str, Any]) -> Any:
@@ -839,11 +923,16 @@ def _run_sequential_tool_execution_middleware(
 
     authorization_gate = _ConcurrentToolAuthorizationGate()
     worker_tid: list[int] = []
+    dispatch_commit = _DispatchCommit()
 
     def _run() -> _ManagedToolResult:
         with _registered_tool_worker(agent) as tid:
             worker_tid.append(tid)
-            return _run_agent_tool_execution_middleware(agent, authorization_gate=authorization_gate, **kwargs)
+            return _run_agent_tool_execution_middleware(
+                agent, authorization_gate=authorization_gate,
+                dispatch_commit=dispatch_commit,
+                **kwargs,
+            )
 
     if ref.trace is None:
         ref.trace = []
@@ -863,6 +952,7 @@ def _run_sequential_tool_execution_middleware(
             concurrent.futures.wait([future], timeout=3.0)
             if future.done() and not future.cancelled():
                 return future.result()
+            dispatch_commit.abandon_and_snapshot()
             interrupt_reason = getattr(agent, "_tool_interrupt_reason", None) or "interrupt requested"
             message = f"[Tool execution cancelled — {function_name} was abandoned: {interrupt_reason}]"
             logger.info(
@@ -877,6 +967,9 @@ def _run_sequential_tool_execution_middleware(
             assert timeout_s is not None  # only reachable when a deadline exists
             message = f"Error executing tool '{function_name}': timed out after {timeout_s:.1f}s"
             logger.warning("sequential tool %s timed out after %.1fs", function_name, timeout_s)
+            dispatched_args = dispatch_commit.abandon_and_snapshot()
+            if function_name == "terminal" and dispatched_args is not None:
+                _record_terminal_timeout(agent, dispatched_args)
             result_cls, outcome = _ToolTimeoutResult, dict(
                 duration_ms=int(timeout_s * 1000), status="timeout", error_type="tool_timeout", error_message=message,
             )
@@ -1158,6 +1251,7 @@ class _ConcurrentBatch:
         self.gate = _StartOrderGate(_start_order_gate_timeout(timeout_s))
         self.authorization_gate = _ConcurrentToolAuthorizationGate()
         self.timed_out_indices: set[int] = set()
+        self.dispatch_commits = [_DispatchCommit() for _ in parsed_calls]
 
     def _dispatch_worker(self, index: int, ref: _ToolCallRef, scope_block, start_gate: _WorkerStartOnce) -> Optional[_ToolOutcome]:
         """Run one call through the middleware and synthesize its slot outcome; ``None`` when
@@ -1184,6 +1278,7 @@ class _ConcurrentBatch:
                 display_index=index + 1,
                 begin_execution=start_gate.advance,
                 authorization_gate=self.authorization_gate,
+                dispatch_commit=self.dispatch_commits[index],
             )
             result, ref.args, ref.trace = managed.result, managed.args, managed.middleware_trace
             blocked, dispatched = managed.blocked, managed.dispatched
@@ -1302,6 +1397,16 @@ class _ConcurrentBatch:
                 continue
             for f in not_done:
                 f.cancel()
+            # Atomically prevent calls that have not crossed the dispatch boundary
+            # from starting after the batch result is synthesized. Calls that did
+            # commit expose an immutable args snapshot for timeout recording.
+            for f in not_done:
+                index = future_to_index.get(f)
+                if index is None:
+                    continue
+                dispatched_args = self.dispatch_commits[index].abandon_and_snapshot()
+                if timed_out and self.parsed_calls[index].name == "terminal" and dispatched_args is not None:
+                    _record_terminal_timeout(agent, dispatched_args)
             # Release gate-parked workers BEFORE interrupt fan-out so none later
             # dispatches a tool the turn already reported as timed out / interrupted.
             self.gate.abandon()

--- a/agent/tool_timeout_circuit.py
+++ b/agent/tool_timeout_circuit.py
@@ -1,0 +1,257 @@
+"""Privacy-preserving circuit for exact retries after terminal timeouts.
+
+Every process keeps a bounded in-memory circuit. POSIX profiles additionally
+persist HMAC fingerprints and expiry times behind a cross-process file lock;
+tool arguments and session identifiers never touch disk in plaintext. When
+secure persistence or locking is unavailable, the circuit degrades to the
+process-local map instead of performing an unlocked shared read/modify/write.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import threading
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, Callable, Iterator
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+_TIMEOUT_RETRY_TTL_SECONDS = 15 * 60
+_MAX_ENTRIES = 256
+_lock = threading.Lock()
+_ephemeral_key = secrets.token_bytes(32)
+_memory_entries: dict[str, float] = {}
+
+
+def _ledger_path() -> Path:
+    return get_hermes_home() / "cache" / "tool-timeout-circuit.json"
+
+
+def _key_path() -> Path:
+    return _ledger_path().with_name("tool-timeout-circuit.key")
+
+
+def _lock_path() -> Path:
+    return _ledger_path().with_name("tool-timeout-circuit.lock")
+
+
+def _persistent_storage_supported() -> bool:
+    # chmod/open modes do not establish an owner-only DACL on Windows. Keep the
+    # circuit process-local there rather than writing sensitive correlation data
+    # with permissions we cannot guarantee.
+    return os.name == "posix"
+
+
+def _secure_cache_dir() -> Path:
+    directory = _ledger_path().parent
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    os.chmod(directory, 0o700)
+    return directory
+
+
+def _fingerprint_payload(tool_name: str, args: dict[str, Any], session_id: str) -> bytes:
+    fingerprint_args = dict(args)
+    if tool_name == "terminal":
+        # Timeout length and the internal approval replay bit do not change the
+        # shell operation or its possible side effects.
+        fingerprint_args.pop("timeout", None)
+        fingerprint_args.pop("force", None)
+    return json.dumps(
+        {"session_id": session_id or "", "tool_name": tool_name, "args": fingerprint_args},
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=repr,
+    ).encode("utf-8")
+
+
+def _fingerprint(payload: bytes, key: bytes) -> str:
+    return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+
+def _persistent_key() -> bytes:
+    """Load or atomically create the profile-local key while the ledger lock is held."""
+    path = _key_path()
+    _secure_cache_dir()
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        key = path.read_bytes()
+    else:
+        key = secrets.token_bytes(32)
+        with os.fdopen(fd, "wb") as handle:
+            handle.write(key)
+            handle.flush()
+            os.fsync(handle.fileno())
+    os.chmod(path, 0o600)
+    if len(key) != 32:
+        raise ValueError("invalid timeout circuit key length")
+    return key
+
+
+def tool_call_fingerprint(tool_name: str, args: dict[str, Any], session_id: str) -> str:
+    """Return the stable process-local fingerprint used by the fallback circuit."""
+    return _fingerprint(_fingerprint_payload(tool_name, args, session_id), _ephemeral_key)
+
+
+@contextmanager
+def _process_ledger_lock() -> Iterator[bool]:
+    """Yield whether the POSIX cross-process lock was acquired."""
+    if not _persistent_storage_supported():
+        yield False
+        return
+    fd: int | None = None
+    locked = False
+    try:
+        _secure_cache_dir()
+        fd = os.open(_lock_path(), os.O_RDWR | os.O_CREAT, 0o600)
+        os.chmod(_lock_path(), 0o600)
+        import fcntl
+
+        fcntl.flock(fd, fcntl.LOCK_EX)
+        locked = True
+    except OSError as exc:
+        logger.debug("could not lock tool timeout circuit: %s", exc)
+    try:
+        yield locked
+    finally:
+        if fd is not None:
+            if locked:
+                try:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except OSError:
+                    pass
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _load_live_entries(now: float) -> dict[str, float]:
+    try:
+        path = _ledger_path()
+        os.chmod(path, 0o600)
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(payload, dict) or payload.get("version") != 1:
+            return {}
+        entries = payload.get("entries")
+        if not isinstance(entries, dict):
+            return {}
+        return {
+            key: float(expiry)
+            for key, expiry in entries.items()
+            if isinstance(key, str)
+            and len(key) == 64
+            and isinstance(expiry, (int, float))
+            and not isinstance(expiry, bool)
+            and float(expiry) > now
+        }
+    except (OSError, ValueError, TypeError):
+        return {}
+
+
+def _save_entries(entries: dict[str, float]) -> None:
+    path = _ledger_path()
+    tmp: Path | None = None
+    try:
+        _secure_cache_dir()
+        bounded = dict(sorted(entries.items(), key=lambda item: item[1])[-_MAX_ENTRIES:])
+        tmp = path.with_suffix(f".{os.getpid()}.{threading.get_ident()}.tmp")
+        fd = os.open(tmp, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump({"version": 1, "entries": bounded}, handle, separators=(",", ":"))
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp, path)
+        os.chmod(path, 0o600)
+    except OSError as exc:
+        logger.debug("could not persist tool timeout circuit: %s", exc)
+        if tmp is not None:
+            try:
+                tmp.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def _prune_memory(now: float) -> None:
+    live = {key: expiry for key, expiry in _memory_entries.items() if expiry > now}
+    _memory_entries.clear()
+    _memory_entries.update(dict(sorted(live.items(), key=lambda item: item[1])[-_MAX_ENTRIES:]))
+
+
+def _persistent_fingerprint(payload: bytes) -> str | None:
+    try:
+        return _fingerprint(payload, _persistent_key())
+    except (OSError, ValueError):
+        return None
+
+
+def _blocked_locked(payload: bytes, now: float, process_locked: bool) -> bool:
+    process_fp = _fingerprint(payload, _ephemeral_key)
+    _prune_memory(now)
+    if process_fp in _memory_entries:
+        return True
+    if not process_locked:
+        return False
+    persistent_fp = _persistent_fingerprint(payload)
+    return persistent_fp is not None and persistent_fp in _load_live_entries(now)
+
+
+def is_tool_timeout_blocked(tool_name: str, args: dict[str, Any], session_id: str) -> bool:
+    payload = _fingerprint_payload(tool_name, args, session_id)
+    now = time.time()
+    with _lock:
+        with _process_ledger_lock() as process_locked:
+            return _blocked_locked(payload, now, process_locked)
+
+
+def try_admit_tool_call(
+    tool_name: str,
+    args: dict[str, Any],
+    session_id: str,
+    commit: Callable[[], bool],
+) -> bool:
+    """Atomically order circuit admission against timeout records, then commit dispatch.
+
+    ``commit`` must be quick and side-effect free apart from marking the per-call
+    lifecycle. It is invoked while the circuit locks are held, making either the
+    timeout record or the dispatch commitment win deterministically.
+    """
+    payload = _fingerprint_payload(tool_name, args, session_id)
+    now = time.time()
+    with _lock:
+        with _process_ledger_lock() as process_locked:
+            if _blocked_locked(payload, now, process_locked):
+                return False
+            return bool(commit())
+
+
+def record_tool_timeout(tool_name: str, args: dict[str, Any], session_id: str) -> None:
+    payload = _fingerprint_payload(tool_name, args, session_id)
+    now = time.time()
+    expiry = now + _TIMEOUT_RETRY_TTL_SECONDS
+    with _lock:
+        process_fp = _fingerprint(payload, _ephemeral_key)
+        _prune_memory(now)
+        _memory_entries[process_fp] = expiry
+        _prune_memory(now)
+        with _process_ledger_lock() as process_locked:
+            if not process_locked:
+                return
+            persistent_fp = _persistent_fingerprint(payload)
+            if persistent_fp is None:
+                return
+            entries = _load_live_entries(now)
+            entries[persistent_fp] = expiry
+            _save_entries(entries)

--- a/tests/run_agent/test_timeout_retry_circuit_integration.py
+++ b/tests/run_agent/test_timeout_retry_circuit_integration.py
@@ -1,0 +1,189 @@
+"""Exact terminal timeout retries are recorded and blocked."""
+
+import json
+import threading
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agent.tool_timeout_circuit as circuit
+from agent.tool_executor import _DispatchCommit, _run_agent_tool_execution_middleware
+from tools.terminal_tool import _ExecPlan, _run_foreground
+
+
+def _agent():
+    return SimpleNamespace(
+        session_id="session-a",
+        quiet_mode=True,
+        verbose_logging=False,
+        log_prefix="",
+        log_prefix_chars=120,
+        tool_progress_mode="off",
+        tool_progress_callback=None,
+        tool_start_callback=None,
+        _checkpoint_mgr=SimpleNamespace(enabled=False),
+        _subagent_id=None,
+        _current_turn_id="turn",
+        _current_api_request_id="request",
+        _touch_activity=MagicMock(),
+        _tool_guardrails=SimpleNamespace(
+            before_call=lambda *_args: SimpleNamespace(allows_execution=True)
+        ),
+    )
+
+
+def _reset_memory(monkeypatch, tmp_path) -> None:
+    circuit._memory_entries.clear()
+    monkeypatch.setattr(circuit, "_ephemeral_key", b"m" * 32)
+    monkeypatch.setattr(circuit, "_ledger_path", lambda: tmp_path / "cache" / "tool-timeout-circuit.json")
+
+
+def test_timeout_circuit_private_exact_and_safe_storage_fallbacks(tmp_path, monkeypatch) -> None:
+    _reset_memory(monkeypatch, tmp_path)
+    ledger = circuit._ledger_path()
+    args = {"command": "SECRET_PAYLOAD", "timeout": 1}
+
+    circuit.record_tool_timeout("terminal", args, "session-a")
+
+    assert circuit.is_tool_timeout_blocked(
+        "terminal", {**args, "timeout": 9, "force": True}, "session-a"
+    )
+    assert not circuit.is_tool_timeout_blocked("terminal", args, "session-b")
+    assert "SECRET_PAYLOAD" not in ledger.read_text(encoding="utf-8")
+    assert ledger.stat().st_mode & 0o777 == 0o600
+
+    @contextmanager
+    def unlocked():
+        yield False
+
+    # Lock failure must never perform an unlocked shared write; the process-local
+    # circuit still blocks the immediate retry.
+    fallback_ledger = tmp_path / "unlocked" / "tool-timeout-circuit.json"
+    monkeypatch.setattr(circuit, "_ledger_path", lambda: fallback_ledger)
+    monkeypatch.setattr(circuit, "_process_ledger_lock", unlocked)
+    fallback_args = {"command": "fallback-only"}
+    circuit.record_tool_timeout("terminal", fallback_args, "session-a")
+    assert circuit.is_tool_timeout_blocked("terminal", fallback_args, "session-a")
+    assert not fallback_ledger.exists()
+
+    # Platforms without enforceable owner-only permissions also stay in memory.
+    unsupported_ledger = tmp_path / "unsupported" / "tool-timeout-circuit.json"
+    monkeypatch.setattr(circuit, "_ledger_path", lambda: unsupported_ledger)
+    monkeypatch.setattr(circuit, "_persistent_storage_supported", lambda: False)
+    platform_args = {"command": "platform-fallback"}
+    circuit.record_tool_timeout("terminal", platform_args, "session-a")
+    assert circuit.is_tool_timeout_blocked("terminal", platform_args, "session-a")
+    assert not unsupported_ledger.exists()
+
+    # An unrelated backend exception containing the word timeout is not an
+    # explicit execution timeout and therefore cannot poison the circuit.
+    env = SimpleNamespace(execute=MagicMock(side_effect=RuntimeError("connection timeout negotiating TLS")))
+    plan = _ExecPlan(
+        config={},
+        env_type="local",
+        effective_task_id="task",
+        image="",
+        cwd=str(tmp_path),
+        host_cwd=None,
+        effective_timeout=3,
+    )
+    with patch("tools.terminal_tool._resolve_command_cwd", return_value=str(tmp_path)), patch(
+        "tools.terminal_tool._yield_kwargs", return_value={}
+    ):
+        result = json.loads(
+            _run_foreground(
+                "printf safe",
+                env,
+                plan,
+                task_id="task",
+                session_id="session-a",
+                session_key="session-a",
+                workdir=None,
+                approval_note=None,
+                clear_interrupt=False,
+            )
+        )
+    assert result["exit_code"] == 124
+    assert result.get("status") != "timeout"
+    assert result.get("error_type") != "terminal_timeout"
+
+
+def test_dispatch_boundary_linearizes_timeout_record_and_abandonment(tmp_path, monkeypatch) -> None:
+    _reset_memory(monkeypatch, tmp_path)
+    agent = _agent()
+    final_args = {"command": "sleep 9", "timeout": 1}
+
+    # Native structured timeouts record the hook-modified final arguments and
+    # the immediate exact retry is blocked before execute.
+    with patch("hermes_cli.plugins._dispatch_pre_tool_call_hooks", return_value=(None, final_args)):
+        first = _run_agent_tool_execution_middleware(
+            agent,
+            function_name="terminal",
+            function_args={"command": "original"},
+            effective_task_id="task",
+            tool_call_id="call-1",
+            execute=lambda _args: json.dumps(
+                {"status": "timeout", "error_type": "terminal_timeout", "exit_code": 124}
+            ),
+        )
+        exact_dispatch = MagicMock(return_value="must not run")
+        second = _run_agent_tool_execution_middleware(
+            agent,
+            function_name="terminal",
+            function_args=final_args,
+            effective_task_id="task",
+            tool_call_id="call-2",
+            execute=exact_dispatch,
+        )
+    assert "terminal_timeout" in first.result
+    assert second.blocked is True
+    exact_dispatch.assert_not_called()
+
+    # Deterministic race: a second call has passed policy and is parked at the
+    # start gate when another worker records the first timeout. Admission is
+    # rechecked at dispatch, so the parked call never executes.
+    raced_args = {"command": "sleep 10", "timeout": 1}
+    parked = threading.Event()
+    release = threading.Event()
+    raced_dispatch = MagicMock(return_value="must not run")
+    outcome = []
+
+    def delayed_begin(callback):
+        parked.set()
+        assert release.wait(5)
+        callback()
+
+    def run_raced_call():
+        outcome.append(
+            _run_agent_tool_execution_middleware(
+                agent,
+                function_name="terminal",
+                function_args=raced_args,
+                effective_task_id="task",
+                tool_call_id="call-race",
+                execute=raced_dispatch,
+                begin_execution=delayed_begin,
+            )
+        )
+
+    worker = threading.Thread(target=run_raced_call)
+    worker.start()
+    assert parked.wait(5)
+    circuit.record_tool_timeout("terminal", raced_args, "session-a")
+    release.set()
+    worker.join(5)
+    assert not worker.is_alive()
+    assert outcome[0].blocked is True
+    raced_dispatch.assert_not_called()
+
+    # The per-call lifecycle has one linearization point: abandonment before
+    # commit prevents dispatch; commitment before abandonment yields a snapshot.
+    abandoned = _DispatchCommit()
+    assert abandoned.abandon_and_snapshot() is None
+    assert abandoned.commit({"command": "late"}) is False
+    committed = _DispatchCommit()
+    nested_args = {"command": "started", "notify": ["ready"]}
+    assert committed.commit(nested_args) is True
+    snapshot = committed.abandon_and_snapshot()
+    nested_args["notify"].append("mutated-after-commit")
+    assert snapshot == {"command": "started", "notify": ["ready"]}

--- a/tests/tools/test_managed_modal_environment.py
+++ b/tests/tools/test_managed_modal_environment.py
@@ -189,5 +189,6 @@ def test_managed_modal_execute_times_out_and_cancels(monkeypatch):
     assert result == {
         "output": "Managed Modal exec timed out after 2s",
         "returncode": 124,
+        "timed_out": True,
     }
     assert any(call[0] == "POST" and call[1].endswith("/cancel") for call in calls)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -400,7 +400,7 @@ class BaseEnvironment(ABC):
                     rendered = output.render(suffix=f"\n[Command timed out after {timeout}s]")
                     if output.total_chars == 0:
                         rendered = rendered.lstrip()
-                    return self._finalize_wait_result(output, rendered, 124)
+                    return self._finalize_wait_result(output, rendered, 124, timed_out=True)
                 touch_activity_if_due(_activity_state, "terminal command running")
                 trace.heartbeat()
                 time.sleep(_poll_sleep)
@@ -559,7 +559,7 @@ class BaseEnvironment(ABC):
             raise
 
         result = (
-            {"output": f"[Command timed out after {effective_timeout}s]", "returncode": 124}
+            {"output": f"[Command timed out after {effective_timeout}s]", "returncode": 124, "timed_out": True}
             if bounded.timed_out else bounded.value)
         self._update_cwd(result)
         return result

--- a/tools/environments/base_output.py
+++ b/tools/environments/base_output.py
@@ -198,9 +198,13 @@ def _new_output_collector(proc, bounded_capture: bool) -> _BoundedOutputCollecto
     return _BoundedOutputCollector(capture_limit, spill_path=spill_path)
 
 
-def _finalize_wait_result(collector: _BoundedOutputCollector, rendered: str, returncode: int | None) -> dict:
+def _finalize_wait_result(
+    collector: _BoundedOutputCollector, rendered: str, returncode: int | None, *, timed_out: bool = False,
+) -> dict:
     """Assemble a wait result, attaching spill metadata when overflow occurred."""
     result = {"output": rendered, "returncode": returncode}
+    if timed_out:
+        result["timed_out"] = True
     spill = collector.close_spill()
     if spill:
         result["output_total_chars"] = collector.total_chars

--- a/tools/environments/managed_modal.py
+++ b/tools/environments/managed_modal.py
@@ -38,8 +38,11 @@ def _request_timeout_env(name: str, default: float) -> float:
     return value if value > 0 else default
 
 
-def _result(output: str, returncode: int = 1) -> dict:
-    return {"output": output, "returncode": returncode}
+def _result(output: str, returncode: int = 1, *, timed_out: bool = False) -> dict:
+    result = {"output": output, "returncode": returncode}
+    if timed_out:
+        result["timed_out"] = True
+    return result
 
 
 class ManagedModalEnvironment(BaseEnvironment):
@@ -117,7 +120,7 @@ class ManagedModalEnvironment(BaseEnvironment):
                 return _result(f"Managed Modal exec failed: {exc}")
             if time.monotonic() >= deadline:
                 self._cancel_exec(exec_id)
-                return _result(f"Managed Modal exec timed out after {timeout}s", 124)
+                return _result(f"Managed Modal exec timed out after {timeout}s", 124, timed_out=True)
             # Periodic activity touch so the gateway knows we're alive (lazy import:
             # tests stub tools.environments.base with only BaseEnvironment)
             try:
@@ -131,7 +134,10 @@ class ManagedModalEnvironment(BaseEnvironment):
     def _result_from_body(body: dict) -> dict | None:
         """Final result dict if the exec body reports a terminal status, else ``None``."""
         if body.get("status") in _TERMINAL_EXEC_STATUSES:
-            return _result(body.get("output", ""), body.get("returncode", 1))
+            return _result(
+                body.get("output", ""), body.get("returncode", 1),
+                timed_out=body.get("status") == "timeout",
+            )
 
     def _poll_exec(self, exec_id: str) -> dict | None:
         try:

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1087,7 +1087,16 @@ def _run_foreground(
             break
         except Exception as e:
             if "timeout" in str(e).lower():
-                return _error_json(f"Command timed out after {effective_timeout} seconds", exit_code=124)
+                # Backend/setup exceptions that merely mention "timeout" are not
+                # proof that the command ran until its execution deadline. Keep the
+                # legacy exit code, but do not emit the explicit terminal-timeout
+                # markers that poison the exact-retry circuit.
+                return _error_json(
+                    _redact_terminal_error_text(
+                        f"Command execution failed: {type(e).__name__}: {e}"
+                    ),
+                    exit_code=124,
+                )
             # Retry on transient errors
             if retry_count < max_retries:
                 wait_time = 2 ** (retry_count + 1)

--- a/tools/terminal_tool_result.py
+++ b/tools/terminal_tool_result.py
@@ -247,6 +247,8 @@ def finalize_foreground_result(
         approval_note = approval_note.rstrip(".") + ", then interrupted."
 
     result_dict = {"output": output, "exit_code": returncode, "error": None}
+    if result.get("timed_out") is True:
+        result_dict.update(status="timeout", error_type="terminal_timeout")
     # Optional fields in observable JSON key order; None means "omit". Spill
     # metadata is present only when output overflowed the capture window.
     optional_fields: list[tuple[str, Any]] = [


### PR DESCRIPTION
## What does this PR do?

A terminal timeout does not prove that the command had no side effects. Retrying the exact call automatically can repeat a partially completed deployment, write, or remote operation.

This change records a profile-local HMAC fingerprint only after a terminal command was actually dispatched and timed out. For 15 minutes, an unchanged retry in the same session is blocked with an explicit `UNKNOWN` side-effect warning. The fingerprint uses the final middleware-mutated arguments; raw commands and session IDs are not persisted.

Queued calls, pre-tool-hook timeouts, guardrail blocks, and start-gate-abandoned calls are not recorded. Natural process exit code 124 is kept distinct from a real timeout.

This is adjacent to, but does not duplicate:

- #69346, which handles repeated pre-dispatch hardline blocks within one conversation. This PR handles real post-dispatch timeouts with unknown side effects and can survive process restarts when secure POSIX persistence is available.
- #72500, which prevents several internal timeout surfaces from freezing the turn. It does not prevent replay of a terminal call that may already have produced side effects.

## Related Issue

Related: #69346, #72500

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add `agent/tool_timeout_circuit.py` with HMAC fingerprints, a 15-minute TTL, and bounded state. Raw commands and session IDs are not persisted.
- Keep a process-local circuit on all platforms. Persist profile-local state on supported POSIX systems with owner-only storage, atomic replacement, and cross-process locking; fall back to memory when secure persistence or locking is unavailable.
- Check the final middleware-mutated arguments at the dispatch boundary and record explicit post-dispatch timeouts. Keep pre-dispatch abandonment distinct from a dispatched operation with unknown side effects.
- Preserve natural exit code 124 as distinct from an explicit execution timeout and propagate structured timeout markers through terminal and environment result paths.
- Add integration coverage for private fingerprints, storage fallbacks, middleware argument rewrites, dispatch races, and abandonment snapshots.

## Validation for the current revision

Current head: `78c18130c4201cbff7b27b6a7a30d7ff42eebbf6`.

The commands below have been updated to paths present at this head. They are **commands to run, not new passing results**. Tests, lint, and compilation were not rerun as part of this description-only update. Previously reported pass counts and root E2E results belong to earlier validation and must not be treated as evidence for this head.

```bash
scripts/run_tests.sh tests/run_agent/test_timeout_retry_circuit_integration.py tests/run_agent/test_sequential_tool_timeout.py tests/run_agent/test_start_order_gate.py tests/tools/test_managed_modal_environment.py tests/tools/test_terminal_timeout_output.py tests/tools/test_terminal_tool.py
ruff check agent/tool_executor.py agent/tool_timeout_circuit.py tests/run_agent/test_timeout_retry_circuit_integration.py tests/tools/test_managed_modal_environment.py tools/environments/base.py tools/environments/base_output.py tools/environments/managed_modal.py tools/terminal_tool.py tools/terminal_tool_result.py
python -m py_compile agent/tool_executor.py agent/tool_timeout_circuit.py tests/run_agent/test_timeout_retry_circuit_integration.py tests/tools/test_managed_modal_environment.py tools/environments/base.py tools/environments/base_output.py tools/environments/managed_modal.py tools/terminal_tool.py tools/terminal_tool_result.py
git diff --check
```

At the latest status check, this head had no check runs or commit-status results. The repository requires `All required checks pass`, which is not yet satisfied; absence of results is not a confirmed test failure. Full-suite success is not claimed. Earlier local full-suite collection was blocked by the optional ACP dependency.
