### PR TITLE
fix(desktop): read pool limits after the log buffer exists

### DIFF
--- a/apps/desktop/electron/main-boot-order.test.ts
+++ b/apps/desktop/electron/main-boot-order.test.ts
@@ -1,0 +1,29 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url))
+
+// Regression guard for the boot crash introduced by c401756a6: the pool-limits
+// read runs at module evaluation and logs through rememberLog(), which pushes
+// into hermesLog. esbuild lowers both top-level consts to `var`, so ordering
+// them the wrong way around does not throw a ReferenceError at build time --
+// it ships a packaged app that dies on every launch with
+// "TypeError: Cannot read properties of undefined (reading 'push')".
+// Nothing else in the file catches this, so assert the order on the source.
+test('pool limits are read after the log buffer they write into is initialized', () => {
+  const source = fs.readFileSync(path.join(__dirname, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+  const logBufferInit = source.indexOf('\nconst hermesLog = []')
+  const poolLimitsInit = source.indexOf('\nlet poolLimits = readPersistedPoolLimits()')
+
+  assert.notEqual(logBufferInit, -1, 'hermesLog must be declared at module scope in main.ts')
+  assert.notEqual(poolLimitsInit, -1, 'poolLimits must be initialized at module scope in main.ts')
+  assert.ok(
+    logBufferInit < poolLimitsInit,
+    'readPersistedPoolLimits() logs through rememberLog(): it must run after hermesLog is initialized'
+  )
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1464,11 +1464,6 @@ function persistPoolLimits(limits) {
   }
 }
 
-let poolLimits = readPersistedPoolLimits()
-// Hard cap on local backends that are starting OR running (the LRU eviction
-// above is soft — it spares keepalive-fresh entries). Follows the live
-// preference: setPoolLimits() pushes a new max into the coordinator.
-const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(poolLimits.maxBackends)
 // How long a spawn may wait for a free local slot. Must stay under the
 // renderer's BACKEND_BOOT_WAIT_TIMEOUT_MS (45s, src/lib/with-timeout.ts) so
 // the queued ticket fails before the renderer does and the user sees why.
@@ -1749,6 +1744,16 @@ function rememberLog(chunk) {
 }
 
 installCrashForensics({ flush: flushDesktopLogBufferSync, log: rememberLog })
+
+// Read here, not next to readPersistedPoolLimits(): that read logs through
+// rememberLog(), which needs hermesLog/desktopLogBuffer to already exist.
+// Placed above them, this module-eval read kills the main process on launch
+// with "Cannot read properties of undefined (reading 'push')".
+let poolLimits = readPersistedPoolLimits()
+// Hard cap on local backends that are starting OR running (the LRU eviction
+// is soft — it spares keepalive-fresh entries). Follows the live preference:
+// setPoolLimits() pushes a new max into the coordinator.
+const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(poolLimits.maxBackends)
 
 // A rejected loadURL leaves a blank window and, unhandled, no trace anywhere
 // the user can send us. `label` names the surface so the log says which one.


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop main-process crash on every launch introduced by `c401756a6` (*pool sizing as a live device preference in Settings*, #91545). The app dies during ESM evaluation of `electron-main.mjs`, before the first window:

```
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog (electron-main.mjs:23176:13)
    at readPersistedPoolLimits (electron-main.mjs:23009:7)
    at electron-main.mjs:23024:18
    at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
```

**Root cause.** `let poolLimits = readPersistedPoolLimits()` is a module-eval statement sitting at `main.ts:1465`. That read logs through `rememberLog()`, which does `hermesLog.push(...)` — but `const hermesLog = []` is declared ~110 lines further down (`main.ts:1575`). esbuild lowers both top-level `const`s to `var` in the bundle, so instead of a TDZ `ReferenceError` at build time we ship a packaged app where `hermesLog` is `undefined` at call time.

Both branches of the `try`/`catch` in `readPersistedPoolLimits()` log, so **every** launch hits it — with or without a persisted `pool-limits.json`, on every platform.

**The fix** moves the read (and the `LocalBackendSpawnCoordinator` it sizes) below `installCrashForensics(...)`, where the logging state is initialized. Nothing between the old and new position touches `poolLimits` at module-eval time, so there is no behavior change beyond the crash going away — and the `[pool-limits] ...` boot line now actually reaches `desktop.log`, which it never could from the old position.

I kept the change to the ordering only: the Settings-side pool sizing feature is untouched.

## Related Issue

Fixes #101941
Fixes #101960

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/main.ts` — move `let poolLimits = readPersistedPoolLimits()` and `const localBackendSpawnCoordinator = ...` from above the logging block to just after `installCrashForensics(...)`; comment says why the position matters.
- `apps/desktop/electron/main-boot-order.test.ts` (new) — source-order regression guard, in the style of the existing `main.ts` source-shape assertions in `hardening.test.ts`. Neither `tsc` nor `eslint` can catch this class of bug, since the wrong order builds cleanly.

## How to Test

1. On `main` (before this patch), launch the packaged desktop app — or complete an in-app update so it rebuilds and relaunches. The main process dies with the trace above and no `desktop.log` line is written for that launch.
2. Apply this PR, rebuild (`hermes desktop --force-build`), launch.
3. The window comes up, and `~/.hermes/logs/desktop.log` gets the line that was previously lost:
   `[pool-limits] no saved file and no env overrides; using defaults`
4. Regression guard: `npx vitest run --project electron electron/main-boot-order.test.ts` passes here, and fails when run against the pre-patch source order.

Verified end-to-end on macOS arm64 (git install, `~/.hermes/hermes-agent`), packaged build via `hermes desktop --force-build`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs to make sure this isn't a duplicate — two open issues (#101941, #101960) report this crash, no PR yet
- [x] My PR contains **only** changes related to this fix (no unrelated commits, no drive-by formatting)
- [ ] I've run `pytest tests/ -q` — **not run**: this change touches only `apps/desktop/electron`, no Python. I ran the desktop suites instead (see below).
- [x] I've added tests for my changes — `apps/desktop/electron/main-boot-order.test.ts`
- [x] I've tested on my platform: macOS 15 (arm64, Apple Silicon)

`npx vitest run --project electron` on this branch: **2106 passed, 1 failed, 6 skipped**. The single failure is `managed-ssh-update.test.ts > POSIX managed launcher executes the updater command and atomically publishes its status`, which fails identically on a clean `origin/main` checkout — pre-existing and unrelated to this change.

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — the crash and the fix are platform-independent (reported on macOS arm64, Windows 11 x64 and Linux); the patch is pure statement ordering.
- [x] I've updated tool descriptions/schemas — N/A
