### PR TITLE
fix(prompt): Muse Spark no longer ends the turn in prose with 0 tool calls on default guidance settings (#96550, salvages #96549)

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -467,7 +467,9 @@ TOOL_USE_ENFORCEMENT_GUIDANCE = (
 
 # Model name substrings that trigger tool-use enforcement guidance.
 # Add new patterns here when a model family needs explicit steering.
-TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek")
+# "muse" = Meta Muse Spark: on defaults it answers in prose with 0 tool calls
+# and the turn closes on finish_reason=stop (#96550).
+TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm", "qwen", "deepseek", "muse")
 
 # Model name substrings whose sessions receive OPENAI_MODEL_EXECUTION_GUIDANCE
 # (execution discipline: tool persistence, mandatory tool use for arithmetic,
@@ -479,13 +481,14 @@ TOOL_USE_ENFORCEMENT_MODELS = ("gpt", "codex", "gemini", "gemma", "grok", "glm",
 # failure modes on those families (financial math in prose, no read-back after
 # external writes, identifier "repair", completeness claims despite count
 # mismatches). GLM's tool-calls-as-plain-text stall (#53847) and MiMo (#41874)
-# are covered here too. Gemini/Gemma are excluded — they get the more specific
+# are covered here too. Muse Spark (#96550) stops after a chat-only turn on
+# defaults. Gemini/Gemma are excluded — they get the more specific
 # GOOGLE_MODEL_OPERATIONAL_GUIDANCE block instead. Claude is excluded because
 # it does not exhibit these failure modes; users can opt any model in via
 # config.yaml `agent.execution_guidance: true` or a substring list.
 EXECUTION_GUIDANCE_MODELS = (
     "gpt", "codex", "grok",
-    "deepseek", "kimi", "qwen", "glm", "minimax", "mimo", "mistral",
+    "deepseek", "kimi", "qwen", "glm", "minimax", "mimo", "mistral", "muse",
 )
 
 # Universal "finish the job" guidance — applied to ALL models, not gated

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1108,6 +1108,13 @@ class TestExecutionGuidanceModels:
         for fam in ("deepseek", "kimi", "qwen", "glm", "minimax", "mimo", "mistral"):
             assert fam in EXECUTION_GUIDANCE_MODELS
 
+    def test_muse_spark_gets_both_guidance_blocks(self):
+        # Muse Spark closes the turn after a chat-only response on defaults
+        # (#96550) — it needs tool-use enforcement AND execution guidance.
+        from agent.prompt_builder import EXECUTION_GUIDANCE_MODELS
+        assert any(p in "meta/muse-spark-1.3-contributor" for p in TOOL_USE_ENFORCEMENT_MODELS)
+        assert any(p in "meta/muse-spark-1.3-contributor" for p in EXECUTION_GUIDANCE_MODELS)
+
     def test_excludes_google_and_claude(self):
         # Gemini/Gemma get GOOGLE_MODEL_OPERATIONAL_GUIDANCE instead;
         # Claude doesn't exhibit the targeted failure modes.

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1741,7 +1741,7 @@ agent:
 
 | Value | Behavior |
 |-------|----------|
-| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `gemini`, `gemma`, `grok`, `glm`, `qwen`, `deepseek`. Disabled for all others (e.g. Claude). |
+| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `gemini`, `gemma`, `grok`, `glm`, `qwen`, `deepseek`, `muse`. Disabled for all others (e.g. Claude). |
 | `true` | Always enabled, regardless of model. Useful if you notice your current model describing actions instead of performing them. |
 | `false` | Always disabled, regardless of model. |
 | `["gpt", "codex", "qwen", "llama"]` | Enabled only when the model name contains one of the listed substrings (case-insensitive). |
@@ -1776,7 +1776,7 @@ agent:
 
 | Value | Behavior |
 |-------|----------|
-| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `grok`, `deepseek`, `kimi`, `qwen`, `glm`, `minimax`, `mimo`, `mistral`. |
+| `"auto"` (default) | Enabled for models matching: `gpt`, `codex`, `grok`, `deepseek`, `kimi`, `qwen`, `glm`, `minimax`, `mimo`, `mistral`, `muse`. |
 | `true` | Always enabled, regardless of model. |
 | `false` | Always disabled, regardless of model. |
 | `["deepseek", "my-custom-model"]` | Enabled only when the model name contains one of the listed substrings (case-insensitive). |


### PR DESCRIPTION
## Summary
Muse Spark now receives tool-use enforcement and execution-discipline guidance on default settings, so it stops answering agentic requests in prose with zero tool calls (#96550).

Root cause: `agent.tool_use_enforcement` / `agent.execution_guidance` default to `"auto"`, which keys off two model-substring tuples in `agent/prompt_builder.py`; `muse-spark-*` was in neither, so it got only the universal finish-the-job block and the turn closed on `finish_reason=stop`.

## Changes
- `agent/prompt_builder.py`: add `"muse"` to `TOOL_USE_ENFORCEMENT_MODELS` and `EXECUTION_GUIDANCE_MODELS` (+ one-line rationale comments)
- `website/docs/user-guide/configuration.md`: both `"auto"` tables list `muse`
- `tests/agent/test_prompt_builder.py`: one invariant test — a Muse Spark id matches both tuples

Salvages the intent of #96549 by @EdderTalmor (co-authored). That PR redefined `"auto"` as inject-for-every-model, which would also flip Claude (intentionally excluded) and grow every user's system prompt; this lands the two-substring fix instead.

## Validation
Real `AIAgent.build_system_prompt()` on a fresh temp `HERMES_HOME`:

| model | before: enforcement / exec guidance | after |
|---|---|---|
| `muse-spark-1.2-contributor` | False / False (prompt 4,359 chars) | True / True (9,072 chars) |
| `meta/muse-spark-1.3` | False / False | True / True |
| `anthropic/claude-opus-4.6` | False / False | False / False (unchanged) |

`tests/agent/test_prompt_builder.py`: 76 passed. ruff clean.

Fixes #96550

## Infographic

![Muse Spark guidance before/after](https://v3b.fal.media/files/b/0aa8ea03/Z0T3xZOWQAh615bT1sQYP_so01tw1O.png)
