### PR TITLE
fix(desktop): model-switch confirm toast has a real button, not a hairline text link (#96563, salvages #96562)

### DIFF
--- a/apps/desktop/src/components/notifications.tsx
+++ b/apps/desktop/src/components/notifications.tsx
@@ -236,9 +236,9 @@ function NotificationItem({ notification }: { notification: AppNotification }) {
                 notification.action?.onClick()
                 dismissNotification(notification.id)
               }}
-              size="xs"
+              size="sm"
               type="button"
-              variant="textStrong"
+              variant="default"
             >
               {notification.action.label}
             </Button>


### PR DESCRIPTION
## Summary

The notification action in `NotificationItem` (`apps/desktop/src/components/notifications.tsx`) rendered as `variant="textStrong" size="xs"`: an 11px, underlined, muted-grey text link with a ~44×20 px hit target. Every toast action in the desktop shares this one element — including the data-training / expensive-model **confirm** toast that `surfaceModelSwitchConfirm` (composer + Bots) and `confirmModelWarning` (Settings → Model) raise when the gateway answers `confirm_required` (e.g. picking `muse-spark-1.2-contributor`). On that toast the only action the toast exists for read as a footnote under ~870 chars of warning copy, and users reported not being able to "press to accept".

This promotes the action to the SDK's existing `default` variant at `size="sm"`: a filled primary button, ~66×24 px, obvious affordance. No new styles.

Salvaged from #96562 by @EdderTalmor (authorship preserved). Refs #96563.

## What was verified live (real desktop app, real backend, over CDP)

**Live repro:** launched the desktop from this branch's worktree against the real `hermes serve` backend with an OpenRouter key; drove Settings → Model's `setMainModelAssignment({ model: 'muse-spark-1.2-contributor-free', provider: 'opencode-free' })` — the backend returned `confirm_required: true` and the warning toast appeared.

| | Before (`origin/main`) | After (this PR) |
|---|---|---|
| Confirm button box | 44.5 × 20.0 px | 65.6 × 24.0 px |
| font / decoration | 11px, `underline` | 12px, none |
| background | transparent | `bg-primary` (filled) |
| color | muted-foreground @ 54% | `primary-foreground` (white) |
| single click applies switch | yes | yes |

Both callers were exercised end-to-end after the change: the Settings REST path (`set_model_assignment` → `config.yaml` now `model.default: muse-spark-1.2-contributor-free`) and the composer's shared `surfaceModelSwitchConfirm` gateway path (`config.set` with `--session` → resend with `confirm_expensive_model: true` → `confirm_required: false`). One click on the button applied the switch in both.

### Before
![before — hairline text link](https://files.catbox.moe/u7dwi1.png)

### After
![after — filled button](https://files.catbox.moe/3w4fkv.png)

## What was dropped from #96562 and why

1. **`e.stopPropagation()` before `action.onClick()`** — dropped. The React fiber walk over the live toast shows **no ancestor with an `onClick`/`onPointer*`/`onMouse*` handler** between the button and the portal root (`ancestorsWithClick: []`); the notification region is `pointer-events-none` with the card `pointer-events-auto`. There is nothing to swallow the click, and the original link *did* apply the switch on a single click when hit. The bug is affordance/hit-area, not bubbling.
2. **`model-visibility.ts` hardcoding `muse-spark` into `expandProviderDefaults` / `effectiveVisibleKeys`** — dropped, wrong direction. The visibility store is generic: aggregators get `featured_models` (newest-per-lab, derived from models.dev), everything else gets the top-N collapsed families, and search spans every family regardless. Live on `origin/main` with a fresh profile, the default picker grid already shows `Muse Spark 1.2 Contributor Free` and `Muse Spark 1.3 Contributor Free` (OpenCode Free rows 2–3) and `Muse Spark 1.2` under OpenRouter (it is in `featured_models`). A per-model vendor hardcode in the store is not a fix for anything that reproduces.

## Changes

- `apps/desktop/src/components/notifications.tsx` — action `Button`: `variant="textStrong" size="xs"` → `variant="default" size="sm"` (+2/−2)

## Validation

- `npx vitest run --environment jsdom src/components/notifications.test.tsx src/store/model-visibility.test.ts src/app/session/hooks/use-model-controls.test.tsx` → 3 files, 52 passed
- `npx tsc -p . --noEmit` → clean
- `npx eslint src/components/notifications.tsx` / `prettier --check` → clean
- `python3 scripts/audit_pr_attribution.py --fix` → all contributor emails mapped

## Infographic

![toast-action-real-button](https://v3b.fal.media/files/b/0aa8ea1f/XyuPLFWoHhNkYR315fE0m_3WvnU7Q7.png)
