### PR TITLE
fix(google-workspace): preserve broader OAuth scopes

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -145,10 +145,17 @@ later, even on headless systems:
 $GSETUP --auth-code "THE_URL_OR_CODE_THE_USER_PASTED" --format json
 ```
 
-If `--auth-code` fails because the code expired, was already used, or came from
-an older browser tab, it now returns a fresh `fresh_auth_url`. In that case,
-immediately send the new URL to the user and have them retry with the newest
-browser redirect only.
+Each `--auth-code` attempt consumes its pending OAuth session. If it fails
+because the code expired, was already used, or came from an older browser tab,
+run `--auth-url` again and retry with the newest browser redirect only.
+
+Hermes preserves an existing token when a new grant would reduce its effective
+capabilities. To intentionally replace it with a narrower grant, start a fresh
+authorization session, then complete it explicitly:
+
+```bash
+$GSETUP --auth-code "THE_NEW_URL_OR_CODE" --allow-scope-downgrade
+```
 
 ### Step 5: Verify
 

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -9,6 +9,7 @@ Commands:
   setup.py --client-secret /path/to.json    # Store OAuth client credentials
   setup.py --auth-url                       # Print the OAuth URL for user to visit
   setup.py --auth-code CODE                 # Exchange auth code for token
+  setup.py --auth-code CODE --allow-scope-downgrade  # Intentionally reduce access
   setup.py --revoke                         # Revoke and delete stored token
   setup.py --install-deps                   # Install Python dependencies only
 
@@ -55,6 +56,31 @@ SCOPES = [
     "https://www.googleapis.com/auth/documents",
 ]
 
+# Google can return a broader scope instead of a requested narrow scope.  Scope
+# downgrade checks therefore compare the capabilities each scope represents,
+# while retaining the original scope itself so unknown scopes remain distinct.
+_SCOPE_IMPLICATIONS = {
+    "https://www.googleapis.com/auth/gmail.modify": {
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+    },
+    "https://www.googleapis.com/auth/calendar": {
+        "https://www.googleapis.com/auth/calendar.readonly",
+    },
+    "https://www.googleapis.com/auth/drive": {
+        "https://www.googleapis.com/auth/drive.readonly",
+    },
+    "https://www.googleapis.com/auth/contacts": {
+        "https://www.googleapis.com/auth/contacts.readonly",
+    },
+    "https://www.googleapis.com/auth/spreadsheets": {
+        "https://www.googleapis.com/auth/spreadsheets.readonly",
+    },
+    "https://www.googleapis.com/auth/documents": {
+        "https://www.googleapis.com/auth/documents.readonly",
+    },
+}
+
 # Exact pins: keep in sync with pyproject.toml [project.optional-dependencies].google
 # and tools/lazy_deps.py LAZY_DEPS['skill.google_workspace'].
 # Pinning all protects against version drift and ensures the security floors
@@ -94,17 +120,24 @@ def _missing_scopes_from_payload(payload: dict) -> list[str]:
     raw = payload.get("scopes") or payload.get("scope")
     if not raw:
         return []
-    granted = {s.strip() for s in (raw.split() if isinstance(raw, str) else raw) if s.strip()}
+    granted = _effective_scope_capabilities(raw)
     return sorted(scope for scope in SCOPES if scope not in granted)
 
 
-def _format_missing_scopes(missing_scopes: list[str]) -> str:
-    bullets = "\n".join(f"  - {scope}" for scope in missing_scopes)
-    return (
-        "Token is valid but missing required Google Workspace scopes:\n"
-        f"{bullets}\n"
-        "Run the Google Workspace setup again from this same Hermes profile to refresh consent."
-    )
+def _scope_values(payload: dict) -> set[str]:
+    raw = payload.get("scopes") or payload.get("scope")
+    if not raw:
+        return set()
+    values = raw.split() if isinstance(raw, str) else raw
+    return {str(value).strip() for value in values if str(value).strip()}
+
+
+def _effective_scope_capabilities(scopes) -> set[str]:
+    values = scopes.split() if isinstance(scopes, str) else scopes
+    effective = {str(value).strip() for value in (values or []) if str(value).strip()}
+    for scope in tuple(effective):
+        effective.update(_SCOPE_IMPLICATIONS.get(scope, ()))
+    return effective
 
 
 def _missing_required_packages() -> list[str]:
@@ -240,8 +273,6 @@ def check_auth(quiet: bool = False):
         missing_scopes = _missing_scopes_from_payload(payload)
         if missing_scopes:
             print(f"AUTHENTICATED (partial): Token valid but missing {len(missing_scopes)} scopes:")
-            for s in missing_scopes:
-                print(f"  - {s}")
         if not quiet:
             print(f"AUTHENTICATED: Token valid at {TOKEN_PATH}")
         return True
@@ -258,8 +289,6 @@ def check_auth(quiet: bool = False):
             missing_scopes = _missing_scopes_from_payload(_load_token_payload(TOKEN_PATH))
             if missing_scopes:
                 print(f"AUTHENTICATED (partial): Token refreshed but missing {len(missing_scopes)} scopes:")
-                for s in missing_scopes:
-                    print(f"  - {s}")
             if not quiet:
                 print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
             return True
@@ -377,19 +406,24 @@ def get_auth_url():
     auth_url, state = flow.authorization_url(
         access_type="offline",
         prompt="consent",
+        include_granted_scopes="true",
     )
     _save_pending_auth(state=state, code_verifier=flow.code_verifier)
     # Print just the URL so the agent can extract it cleanly
     print(auth_url)
 
 
-def exchange_auth_code(code: str):
+def exchange_auth_code(code: str, *, allow_scope_downgrade: bool = False):
     """Exchange the authorization code for a token and save it."""
     if not CLIENT_SECRET_PATH.exists():
         print("ERROR: No client secret stored. Run --client-secret first.")
         sys.exit(1)
 
     pending_auth = _load_pending_auth()
+    # An auth-code completion attempt consumes its PKCE state.  Retaining it
+    # after any outcome would let a stale callback be retried against the same
+    # local session.
+    PENDING_AUTH_PATH.unlink(missing_ok=True)
     raw_callback = code
     code, returned_state = _extract_code_and_state(code)
     if returned_state and returned_state != pending_auth["state"]:
@@ -420,9 +454,9 @@ def exchange_auth_code(code: str):
         # Accept partial scopes — user may deselect some permissions in the consent screen
         os.environ["OAUTHLIB_RELAX_TOKEN_SCOPE"] = "1"
         flow.fetch_token(code=code)
-    except Exception as e:
-        print(f"ERROR: Token exchange failed: {e}")
-        print("The code may have expired. Run --auth-url to get a fresh URL.")
+    except Exception:
+        print("ERROR: Token exchange failed.")
+        print("The pending session was consumed. Run --auth-url to get a new authorization URL.")
         sys.exit(1)
 
     creds = flow.credentials
@@ -438,13 +472,31 @@ def exchange_auth_code(code: str):
         # granted_scopes was extracted from the callback URL
         token_payload["scopes"] = granted_scopes
 
+    old_payload = _load_token_payload(TOKEN_PATH) if TOKEN_PATH.exists() else {}
+    old_capabilities = _effective_scope_capabilities(_scope_values(old_payload))
+    new_capabilities = _effective_scope_capabilities(_scope_values(token_payload))
+    if (
+        old_capabilities
+        and new_capabilities < old_capabilities
+        and not allow_scope_downgrade
+    ):
+        print(
+            "SCOPE_DOWNGRADE_BLOCKED: The new authorization grants fewer "
+            "capabilities than the existing token."
+        )
+        print("The existing token was left unchanged. Run --auth-url for a new authorization URL.")
+        print(
+            "To intentionally reduce access, start a new authorization URL "
+            "and pass --allow-scope-downgrade with its --auth-code."
+        )
+        sys.exit(1)
+
     missing_scopes = _missing_scopes_from_payload(token_payload)
     if missing_scopes:
-        print(f"WARNING: Token missing some Google Workspace scopes: {', '.join(missing_scopes)}")
+        print(f"WARNING: Token is missing {len(missing_scopes)} Google Workspace scopes.")
         print("Some services may not be available.")
 
     TOKEN_PATH.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
-    PENDING_AUTH_PATH.unlink(missing_ok=True)
     print(f"OK: Authenticated. Token saved to {TOKEN_PATH}")
     print(f"Profile-scoped token location: {display_hermes_home()}/google_token.json")
 
@@ -492,7 +544,15 @@ def main():
     group.add_argument("--auth-code", metavar="CODE", help="Exchange auth code for token")
     group.add_argument("--revoke", action="store_true", help="Revoke and delete stored token")
     group.add_argument("--install-deps", action="store_true", help="Install Python dependencies")
+    parser.add_argument(
+        "--allow-scope-downgrade",
+        action="store_true",
+        help="Allow --auth-code to replace an existing token with fewer capabilities",
+    )
     args = parser.parse_args()
+
+    if args.allow_scope_downgrade and not args.auth_code:
+        parser.error("--allow-scope-downgrade is only valid with --auth-code")
 
     if args.check:
         sys.exit(0 if check_auth() else 1)
@@ -503,7 +563,10 @@ def main():
     elif args.auth_url:
         get_auth_url()
     elif args.auth_code:
-        exchange_auth_code(args.auth_code)
+        exchange_auth_code(
+            args.auth_code,
+            allow_scope_downgrade=args.allow_scope_downgrade,
+        )
     elif args.revoke:
         revoke()
     elif args.install_deps:

--- a/tests/skills/test_google_workspace_setup.py
+++ b/tests/skills/test_google_workspace_setup.py
@@ -3,8 +3,12 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import sys
+import types
 from importlib.metadata import PackageNotFoundError
 from pathlib import Path
+from urllib.parse import parse_qs, urlencode, urlparse
 
 import pytest
 
@@ -14,9 +18,95 @@ SETUP_PATH = (
     / "skills/productivity/google-workspace/scripts/setup.py"
 )
 
+CONTACTS_READONLY = "https://www.googleapis.com/auth/contacts.readonly"
+CONTACTS_WRITE = "https://www.googleapis.com/auth/contacts"
+DRIVE_READONLY = "https://www.googleapis.com/auth/drive.readonly"
+DRIVE_WRITE = "https://www.googleapis.com/auth/drive"
+CALENDAR_READONLY = "https://www.googleapis.com/auth/calendar.readonly"
+CALENDAR_WRITE = "https://www.googleapis.com/auth/calendar"
+GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly"
+GMAIL_SEND = "https://www.googleapis.com/auth/gmail.send"
+GMAIL_MODIFY = "https://www.googleapis.com/auth/gmail.modify"
+
+
+class FakeCredentials:
+    def __init__(self, payload, granted_scopes=None):
+        self._payload = payload
+        self.granted_scopes = granted_scopes
+
+    def to_json(self):
+        return json.dumps(self._payload)
+
+
+class FakeFlow:
+    created = []
+    credentials_payload = None
+    granted_scopes = None
+    fetch_error = None
+
+    def __init__(
+        self,
+        client_secrets_file,
+        scopes,
+        *,
+        redirect_uri=None,
+        state=None,
+        code_verifier=None,
+        autogenerate_code_verifier=False,
+    ):
+        self.client_secrets_file = client_secrets_file
+        self.scopes = scopes
+        self.redirect_uri = redirect_uri
+        self.state = state or "generated-state"
+        self.code_verifier = code_verifier or "generated-code-verifier"
+        self.autogenerate_code_verifier = autogenerate_code_verifier
+        self.authorization_kwargs = None
+        self.fetch_token_calls = []
+        payload = self.credentials_payload or {
+            "token": "new-access-token",
+            "refresh_token": "new-refresh-token",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "scopes": list(scopes),
+        }
+        self.credentials = FakeCredentials(payload, self.granted_scopes)
+
+    @classmethod
+    def reset(cls):
+        cls.created = []
+        cls.credentials_payload = None
+        cls.granted_scopes = None
+        cls.fetch_error = None
+
+    @classmethod
+    def from_client_secrets_file(cls, client_secrets_file, scopes, **kwargs):
+        flow = cls(client_secrets_file, scopes, **kwargs)
+        cls.created.append(flow)
+        return flow
+
+    def authorization_url(self, **kwargs):
+        self.authorization_kwargs = kwargs
+        query = urlencode({"state": self.state, **kwargs})
+        return f"https://auth.example/authorize?{query}", self.state
+
+    def fetch_token(self, **kwargs):
+        self.fetch_token_calls.append(kwargs)
+        if self.fetch_error:
+            raise self.fetch_error
+
 
 @pytest.fixture()
-def setup_module():
+def setup_module(monkeypatch, tmp_path):
+    FakeFlow.reset()
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    google_auth_module = types.ModuleType("google_auth_oauthlib")
+    flow_module = types.ModuleType("google_auth_oauthlib.flow")
+    flow_module.Flow = FakeFlow
+    google_auth_module.flow = flow_module
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
+    monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+
     spec = importlib.util.spec_from_file_location(
         "test_google_workspace_setup_module",
         SETUP_PATH,
@@ -24,7 +114,42 @@ def setup_module():
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
+    monkeypatch.setattr(module, "_ensure_deps", lambda: None)
+    module.CLIENT_SECRET_PATH.write_text(
+        json.dumps(
+            {
+                "installed": {
+                    "client_id": "client-id",
+                    "client_secret": "client-secret",
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
     return module
+
+
+def _write_pending(module, *, state="saved-state"):
+    module.PENDING_AUTH_PATH.write_text(
+        json.dumps(
+            {
+                "state": state,
+                "code_verifier": "saved-code-verifier",
+                "redirect_uri": module.REDIRECT_URI,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+
+def _new_token(scopes):
+    return {
+        "token": "new-access-token",
+        "refresh_token": "new-refresh-token",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "scopes": scopes,
+    }
 
 
 def test_stale_google_transitives_are_reported_missing(setup_module, monkeypatch):
@@ -88,3 +213,183 @@ def test_installer_repairs_stale_transitives(setup_module, monkeypatch):
             "pyasn1==0.6.4",
         ]
     ]
+
+
+def test_contacts_write_satisfies_contacts_readonly(setup_module):
+    missing = setup_module._missing_scopes_from_payload(
+        {"scopes": [CONTACTS_WRITE]}
+    )
+    assert CONTACTS_READONLY not in missing
+
+
+@pytest.mark.parametrize(
+    ("broader", "narrower"),
+    [
+        (GMAIL_MODIFY, GMAIL_READONLY),
+        (GMAIL_MODIFY, GMAIL_SEND),
+        (DRIVE_WRITE, DRIVE_READONLY),
+        (CALENDAR_WRITE, CALENDAR_READONLY),
+    ],
+)
+def test_known_broader_scopes_satisfy_narrower_capabilities(
+    setup_module, broader, narrower
+):
+    effective = setup_module._effective_scope_capabilities([broader])
+    assert narrower in effective
+
+
+def test_write_to_readonly_downgrade_preserves_existing_bytes(
+    setup_module, capsys
+):
+    old_bytes = (
+        b'{"token":"old-access-token","scopes":["'
+        + CONTACTS_WRITE.encode()
+        + b'"]}\n'
+    )
+    setup_module.TOKEN_PATH.write_bytes(old_bytes)
+    _write_pending(setup_module)
+    FakeFlow.credentials_payload = _new_token([CONTACTS_READONLY])
+
+    with pytest.raises(SystemExit) as exc:
+        setup_module.exchange_auth_code("new-auth-code")
+
+    assert exc.value.code == 1
+    assert setup_module.TOKEN_PATH.read_bytes() == old_bytes
+    assert not setup_module.PENDING_AUTH_PATH.exists()
+    assert "SCOPE_DOWNGRADE_BLOCKED" in capsys.readouterr().out
+
+
+def test_readonly_to_write_upgrade_saves(setup_module):
+    setup_module.TOKEN_PATH.write_text(
+        json.dumps({"token": "old-access-token", "scopes": [CONTACTS_READONLY]}),
+        encoding="utf-8",
+    )
+    _write_pending(setup_module)
+    FakeFlow.credentials_payload = _new_token([CONTACTS_WRITE])
+
+    setup_module.exchange_auth_code("new-auth-code")
+
+    saved = json.loads(setup_module.TOKEN_PATH.read_text(encoding="utf-8"))
+    assert saved["scopes"] == [CONTACTS_WRITE]
+    assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+def test_partial_token_without_existing_token_saves_with_warning(
+    setup_module, capsys
+):
+    _write_pending(setup_module)
+    FakeFlow.credentials_payload = _new_token([DRIVE_READONLY])
+
+    setup_module.exchange_auth_code("new-auth-code")
+
+    assert setup_module.TOKEN_PATH.exists()
+    assert "WARNING" in capsys.readouterr().out
+    assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+def test_explicit_flag_permits_scope_downgrade(setup_module, monkeypatch):
+    setup_module.TOKEN_PATH.write_text(
+        json.dumps({"token": "old-access-token", "scopes": [CONTACTS_WRITE]}),
+        encoding="utf-8",
+    )
+    _write_pending(setup_module)
+    FakeFlow.credentials_payload = _new_token([CONTACTS_READONLY])
+
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "setup.py",
+            "--auth-code",
+            "new-auth-code",
+            "--allow-scope-downgrade",
+        ],
+    )
+    setup_module.main()
+
+    saved = json.loads(setup_module.TOKEN_PATH.read_text(encoding="utf-8"))
+    assert saved["scopes"] == [CONTACTS_READONLY]
+
+
+def test_scope_downgrade_flag_is_invalid_without_auth_code(
+    setup_module, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        ["setup.py", "--auth-url", "--allow-scope-downgrade"],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        setup_module.main()
+
+    assert exc.value.code == 2
+    assert "only valid with --auth-code" in capsys.readouterr().err
+
+
+def test_callback_scopes_build_flow_and_granted_scopes_are_saved(setup_module):
+    _write_pending(setup_module)
+    FakeFlow.credentials_payload = _new_token([CONTACTS_READONLY])
+    FakeFlow.granted_scopes = [CONTACTS_WRITE]
+    callback = (
+        "http://localhost:1/?code=new-auth-code&state=saved-state&scope="
+        + CONTACTS_READONLY
+    )
+
+    setup_module.exchange_auth_code(callback)
+
+    assert FakeFlow.created[-1].scopes == [CONTACTS_READONLY]
+    saved = json.loads(setup_module.TOKEN_PATH.read_text(encoding="utf-8"))
+    assert saved["scopes"] == [CONTACTS_WRITE]
+
+
+def test_state_mismatch_consumes_pending_session(setup_module, capsys):
+    _write_pending(setup_module)
+
+    with pytest.raises(SystemExit) as exc:
+        setup_module.exchange_auth_code(
+            "http://localhost:1/?code=secret-code&state=wrong-secret-state"
+        )
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "state mismatch" in output.lower()
+    assert "secret-code" not in output
+    assert "wrong-secret-state" not in output
+    assert not setup_module.PENDING_AUTH_PATH.exists()
+
+    with pytest.raises(SystemExit) as retry_exc:
+        setup_module.exchange_auth_code("another-code")
+    assert retry_exc.value.code == 1
+    assert "run --auth-url first" in capsys.readouterr().out.lower()
+
+
+def test_exchange_failure_redacts_secrets_and_requires_new_url(
+    setup_module, capsys
+):
+    _write_pending(setup_module)
+    FakeFlow.fetch_error = RuntimeError(
+        "auth-code-secret refresh-token-secret client-secret"
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        setup_module.exchange_auth_code("auth-code-secret")
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert "auth-code-secret" not in output
+    assert "refresh-token-secret" not in output
+    assert "client-secret" not in output
+    assert "run --auth-url" in output.lower()
+    assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+def test_auth_url_enables_incremental_authorization(setup_module, capsys):
+    setup_module.get_auth_url()
+
+    auth_url = capsys.readouterr().out.strip()
+    query = parse_qs(urlparse(auth_url).query)
+    assert query["include_granted_scopes"] == ["true"]
+    assert FakeFlow.created[-1].authorization_kwargs[
+        "include_granted_scopes"
+    ] == "true"


### PR DESCRIPTION
## What does this PR do?

Prevents a Google Workspace re-authorization from silently replacing an existing profile token with a strict subset of its effective OAuth capabilities.

The fix preserves partial grants for first-time setup, models documented broader-to-narrower scope relationships, enables Google incremental authorization, and requires an explicit auth-code-only flag for an intentional downgrade. It also consumes pending PKCE state after one completion attempt and avoids printing credential-bearing token-exchange exceptions.

Base verified before implementation: `b9dc79033203704841f64e381d564a99299cb3bf`.

## Related Issue

Fixes #101969

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `skills/productivity/google-workspace/scripts/setup.py`
  - compare scopes by effective capabilities instead of literal URLs only
  - treat known write scopes as satisfying their documented read-only counterparts
  - request incremental authorization with `include_granted_scopes=true`
  - block strict effective-capability downgrades with `SCOPE_DOWNGRADE_BLOCKED`
  - preserve the existing token file byte-for-byte when blocked
  - allow an intentional downgrade only via `--auth-code ... --allow-scope-downgrade`
  - consume pending OAuth state on every auth-code attempt and redact exchange failures
- `tests/skills/test_google_workspace_setup.py`
  - add temp-`HERMES_HOME`, credentialless behavior coverage for scope inclusion, downgrade blocking, upgrade/partial saves, explicit downgrade, callback scopes, state consumption, redaction, and incremental auth
- `skills/productivity/google-workspace/SKILL.md`
  - document one-shot pending sessions and the explicit downgrade flow

## How to Test

1. Run the focused Google Workspace suite:

   ```bash
   scripts/run_tests.sh tests/skills/test_google_workspace_setup.py tests/skills/test_google_workspace_setup_deps.py tests/skills/test_google_workspace_credential_files.py tests/skills/test_google_workspace_api.py tests/skills/test_google_workspace_daily_brief_reference.py -q
   ```

   Expected: 34 passed.

2. Run static and portability checks:

   ```bash
   ruff check skills/productivity/google-workspace/scripts/setup.py tests/skills/test_google_workspace_setup.py
   python3 -m compileall -q skills/productivity/google-workspace/scripts/setup.py
   python3 scripts/check-windows-footguns.py skills/productivity/google-workspace/scripts/setup.py tests/skills/test_google_workspace_setup.py
   git diff --check
   ```

3. Full-suite context: `scripts/run_tests.sh` was attempted and manually stopped for runtime at approximately 6.6% (2,796 tests passed). Two compression timing failures appeared during interrupt/shutdown; both affected files reran cleanly (23/23). No change-related failure remains.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5, Python 3.9.6

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config key changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — no platform-specific code; footgun scan passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool schema changed

## Screenshots / Logs

Not applicable. Tests use synthetic payloads and a temporary `HERMES_HOME`; no live account, OAuth code, token, contact identifier, or provider log is included.
