### PR TITLE
fix(terminal): prompt on case-sensitive path conflicts

### DIFF
--- a/docs/case-sensitive-path-conflicts.md
+++ b/docs/case-sensitive-path-conflicts.md
@@ -1,0 +1,29 @@
+# Case-sensitive path conflict handling
+
+Hermes checks simple terminal write targets (`mkdir`, `touch`, `cp`, `mv`, and
+`install`) before execution. The check runs inside the target terminal
+environment, so it uses the mounted or remote filesystem rather than assuming
+the host operating system's behavior.
+
+Hermes first probes whether that filesystem distinguishes case. If it does not,
+Hermes skips the extra check because the filesystem already treats `Desktop` and
+`desktop` as the same path. If it does distinguish case and the requested target
+has an existing case-only variant, Hermes returns a `case_conflict` result and
+does not execute the command.
+
+The caller must then explicitly choose one of:
+
+- `case_resolution: "use_existing"` — use the existing path spelling.
+- `case_resolution: "create_variant"` — intentionally create/use the requested
+  differently-cased path.
+
+Hermes does not choose between these options. This is particularly important
+when speech-to-text is used: spoken file and directory names do not reliably
+encode capitalization, so a dictated `desktop` can be intended to refer to an
+existing `Desktop` directory. Surfacing the conflict prevents Hermes from
+silently creating or targeting the wrong case variant.
+
+The check is deliberately limited to commands with unambiguous, directly
+identifiable write destinations. Arbitrary shell programs and compound shell
+syntax remain the user's responsibility; Hermes does not rewrite unknown shell
+commands.

--- a/tests/tools/test_path_case.py
+++ b/tests/tools/test_path_case.py
@@ -1,0 +1,81 @@
+"""Regression tests for case-sensitive filesystem path conflicts."""
+
+from pathlib import Path
+
+from tools.path_case import (
+    case_conflict_for_path,
+    check_case_conflicts,
+    extract_write_targets,
+    filesystem_is_case_sensitive,
+    rewrite_target_path,
+)
+
+
+def test_probe_reports_case_sensitive_filesystem(tmp_path):
+    assert filesystem_is_case_sensitive(tmp_path) is True
+
+
+def test_case_conflict_detects_existing_parent_with_different_case(tmp_path):
+    existing = tmp_path / "Desktop"
+    existing.mkdir()
+
+    conflict = case_conflict_for_path(existing.parent / "desktop" / "plan.md")
+
+    assert conflict == existing / "plan.md"
+
+
+def test_case_conflict_is_not_reported_when_target_filesystem_is_case_insensitive(
+    tmp_path, monkeypatch
+):
+    existing = tmp_path / "Desktop"
+    existing.mkdir()
+    requested = existing.parent / "desktop" / "plan.md"
+    monkeypatch.setattr("tools.path_case.filesystem_is_case_sensitive", lambda _: False)
+
+    assert case_conflict_for_path(requested) is None
+
+
+def test_extracts_move_destination_for_case_check():
+    targets = extract_write_targets("mv '/tmp/source.md' '/home/r/Desktop/'", "/")
+
+    assert targets == [Path("/home/r/Desktop/")]
+
+
+def test_rewrites_case_variant_destination_with_trailing_slash(tmp_path):
+    command = "mv '/tmp/source.md' '/home/r/desktop/'"
+    requested = Path("/home/r/desktop")
+    existing = Path("/home/r/Desktop")
+
+    assert rewrite_target_path(command, requested, existing) == (
+        "mv '/tmp/source.md' '/home/r/Desktop/'"
+    )
+
+
+def test_terminal_schema_exposes_case_resolution_choice():
+    from tools.terminal_tool import TERMINAL_SCHEMA
+
+    property_schema = TERMINAL_SCHEMA["parameters"]["properties"]["case_resolution"]
+
+    assert property_schema["enum"] == ["use_existing", "create_variant"]
+    assert "Omit to ask the user" in property_schema["description"]
+
+
+def test_remote_check_runs_probe_in_target_environment(tmp_path):
+    existing = tmp_path / "Desktop"
+    existing.mkdir()
+    calls = []
+
+    class FakeEnvironment:
+        def execute(self, command, cwd=""):
+            calls.append((command, cwd))
+            return {"returncode": 0, "output": repr([{
+                "requested_path": str(tmp_path / "desktop" / "plan.md"),
+                "existing_path": str(existing / "plan.md"),
+            }])}
+
+    conflicts = check_case_conflicts(
+        FakeEnvironment(), "mkdir desktop", str(tmp_path)
+    )
+
+    assert conflicts[0]["existing_path"].endswith("Desktop/plan.md")
+    assert calls and calls[0][1] == str(tmp_path)

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -420,9 +420,9 @@ _TOOL_STUBS = {
     ),
     "terminal": (
         "terminal",
-        "command: str, timeout: int = None, workdir: str = None",
+        "command: str, timeout: int = None, workdir: str = None, case_resolution: str = None",
         '"""Run a shell command (foreground only). Returns dict with "output" and "exit_code"."""',
-        '{"command": command, "timeout": timeout, "workdir": workdir}',
+        '{"command": command, "timeout": timeout, "workdir": workdir, "case_resolution": case_resolution}',
     ),
 }
 

--- a/tools/path_case.py
+++ b/tools/path_case.py
@@ -1,0 +1,188 @@
+"""Case-sensitivity probes and case-only write-target detection."""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import shlex
+import tempfile
+from pathlib import Path
+from typing import Any, Optional
+
+
+def filesystem_is_case_sensitive(directory: Path) -> bool:
+    """Return the actual case behavior of the filesystem containing *directory*."""
+    directory = Path(directory)
+    while not directory.exists() and directory != directory.parent:
+        directory = directory.parent
+    if not directory.is_dir():
+        return True
+    fd, first_name = tempfile.mkstemp(prefix=".hermes-case-probe-", dir=directory)
+    os.close(fd)
+    first = Path(first_name)
+    second = first.with_name(first.name.swapcase())
+    try:
+        return not second.exists()
+    finally:
+        if second.exists() and second != first:
+            second.unlink()
+        first.unlink(missing_ok=True)
+
+
+def _case_variant(path: Path) -> Optional[Path]:
+    """Return the existing spelling of a missing path component, if any."""
+    if path.exists():
+        return None
+    current = Path(path.anchor)
+    parts = path.parts[1:]
+    for index, component in enumerate(parts):
+        if not current.is_dir():
+            return None
+        exact = current / component
+        if exact.exists():
+            current = exact
+            continue
+        matches = [entry for entry in current.iterdir()
+                   if entry.name.casefold() == component.casefold()]
+        if len(matches) != 1 or matches[0].name == component:
+            return None
+        return matches[0].joinpath(*parts[index + 1:])
+    return None
+
+
+def case_conflict_for_path(path: Path) -> Optional[Path]:
+    """Return a case-only existing path when a write target is ambiguous."""
+    path = Path(path)
+    if path.exists() or not filesystem_is_case_sensitive(path.parent):
+        return None
+    return _case_variant(path)
+
+
+def _path_arg(value: str, cwd: str) -> Path:
+    path = Path(value).expanduser()
+    return path if path.is_absolute() else Path(cwd) / path
+
+
+def extract_write_targets(command: str, cwd: str) -> list[Path]:
+    """Extract destinations for simple commands with unambiguous targets."""
+    # Do not tokenize arbitrary commands. Besides avoiding unnecessary work,
+    # this preserves the terminal security parser's fail-closed handling for
+    # oversized or malformed command strings.
+    if not re.match(
+        r"^\s*(?:/[^\s;|]+/)?(?:mkdir|touch|install|mv|cp)(?:\s|$)",
+        command,
+    ):
+        return []
+    try:
+        tokens = shlex.split(command, posix=True)
+    except ValueError:
+        return []
+    if not tokens:
+        return []
+    command_name = Path(tokens[0]).name
+    candidates = [token for token in tokens[1:] if not token.startswith("-")]
+    if command_name == "mkdir":
+        return [_path_arg(token, cwd) for token in candidates]
+    if command_name in {"touch", "install"}:
+        return [_path_arg(candidates[-1], cwd)] if candidates else []
+    if command_name in {"mv", "cp"}:
+        return [_path_arg(candidates[-1], cwd)] if len(candidates) >= 2 else []
+    return []
+
+
+def _case_conflict_script(targets: list[Path]) -> str:
+    """Build a self-contained probe for execution inside the target backend."""
+    payload = repr([str(path) for path in targets])
+    return f"""
+import os, pathlib, tempfile
+items = {payload}
+out = []
+for raw in items:
+    p = pathlib.Path(raw)
+    if p.exists():
+        continue
+    parent = p.parent
+    while not parent.exists() and parent != parent.parent:
+        parent = parent.parent
+    if not parent.is_dir():
+        continue
+    try:
+        fd, probe_name = tempfile.mkstemp(prefix='.hermes-case-probe-', dir=str(parent))
+        os.close(fd)
+        probe = pathlib.Path(probe_name)
+        variant = probe.with_name(probe.name.swapcase())
+        insensitive = variant.exists()
+        if variant.exists() and variant != probe:
+            variant.unlink()
+        probe.unlink(missing_ok=True)
+    except OSError:
+        continue
+    if insensitive:
+        continue
+    current = pathlib.Path(p.anchor)
+    parts = p.parts[1:]
+    for index, component in enumerate(parts):
+        if not current.is_dir():
+            break
+        exact = current / component
+        if exact.exists():
+            current = exact
+            continue
+        matches = [entry for entry in current.iterdir()
+                   if entry.name.casefold() == component.casefold()]
+        if len(matches) == 1 and matches[0].name != component:
+            existing = matches[0].joinpath(*parts[index + 1:])
+            out.append({{'requested_path': str(p), 'existing_path': str(existing)}})
+        break
+print(repr(out))
+"""
+
+
+def check_case_conflicts(env: Any, command: str, cwd: str) -> list[dict[str, str]]:
+    """Check simple write targets inside the target terminal environment.
+
+    The probe runs inside *env*, so remote and container filesystems are tested
+    where the command will execute. Unknown shell syntax is left unchanged.
+    """
+    targets = extract_write_targets(command, cwd)
+    if not targets:
+        return []
+    result = env.execute(
+        f"python3 -c {shlex.quote(_case_conflict_script(targets))}",
+        cwd=cwd,
+    )
+    if result.get("returncode", 1) != 0:
+        return []
+    try:
+        findings = ast.literal_eval(result.get("output", "").strip())
+    except (SyntaxError, TypeError, ValueError):
+        return []
+    return findings if isinstance(findings, list) else []
+
+
+def rewrite_target_path(
+    command: str, requested: Path, existing: Path, cwd: Optional[str] = None
+) -> str:
+    """Replace one destination spelling with the existing spelling."""
+    candidates = [os.fspath(requested)]
+    if cwd:
+        try:
+            relative = requested.relative_to(Path(cwd))
+            candidates.extend((os.fspath(relative), f"./{relative}"))
+        except ValueError:
+            pass
+    for candidate in candidates:
+        for spelling in (candidate, candidate + os.sep):
+            if spelling not in command:
+                continue
+            replacement = os.fspath(existing)
+            if not spelling.startswith(("/", "\\")):
+                try:
+                    replacement = os.fspath(existing.relative_to(Path(cwd)))
+                except (ValueError, TypeError):
+                    pass
+            if spelling.endswith(os.sep):
+                replacement += os.sep
+            return command.replace(spelling, replacement, 1)
+    return command

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -50,6 +50,7 @@ from pathlib import Path
 from typing import Optional, Dict, Any, List
 
 from utils import env_var_enabled
+from tools.path_case import check_case_conflicts, rewrite_target_path
 
 logger = logging.getLogger(__name__)
 
@@ -2876,6 +2877,7 @@ def terminal_tool(
     notify_on_complete: bool = False,
     watch_patterns: Optional[List[str]] = None,
     _host_local: bool = False,
+    case_resolution: Optional[str] = None,
 ) -> str:
     """
     Execute a command in the configured terminal environment.
@@ -2891,6 +2893,7 @@ def terminal_tool(
         pty: If True, use pseudo-terminal for interactive CLI tools (local backend only)
         notify_on_complete: If True and background=True, you'll be notified exactly once when the process exits. The right choice for almost every long task. MUTUALLY EXCLUSIVE with watch_patterns.
         watch_patterns: List of strings to watch for in background output. HARD rate limit: 1 notification per 15s per process. After 3 strike windows in a row — or after a small lifetime cap of delivered matches, however cleanly spaced — watch_patterns is disabled and the session is auto-promoted to notify_on_complete. Use ONLY for rare, one-shot mid-process signals on long-lived processes (server readiness, migration-done markers). NEVER use in loops/batch jobs — error patterns there will hit the strike limit and get disabled. MUTUALLY EXCLUSIVE with notify_on_complete — set one, not both.
+        case_resolution: Resolution for a case-only write-target conflict reported on a case-sensitive filesystem. Omit to return a user prompt; use_existing rewrites the target to the existing spelling; create_variant intentionally keeps the requested spelling.
 
     Returns:
         str: JSON string with output, exit_code, and error fields
@@ -3115,6 +3118,46 @@ def terminal_tool(
                     logger.info("%s environment ready for task %s", env_type, effective_task_id[:8])
 
         assert env is not None  # all creation failure paths return above
+
+        # Avoid parsing commands that the security parser will reject for size.
+        # This preserves the existing fail-closed oversized-command behavior.
+        from tools.approval import _command_parser_limit_exceeded
+        parser_budget_exceeded = _command_parser_limit_exceeded(command)
+
+        if case_resolution not in (None, "use_existing", "create_variant"):
+            return tool_error(
+                "case_resolution must be 'use_existing' or 'create_variant'."
+            )
+
+        # The actual environment is required: its filesystem semantics may
+        # differ from the host running Hermes (SSH/container/mounted volume).
+        if not parser_budget_exceeded and (
+            case_resolution is None or case_resolution == "use_existing"
+        ):
+            conflicts = check_case_conflicts(env, command, cwd)
+            if conflicts:
+                conflict = conflicts[0]
+                if case_resolution is None:
+                    return json.dumps({
+                        "output": "",
+                        "exit_code": -1,
+                        "status": "case_conflict",
+                        "case_conflict": True,
+                        "requested_path": conflict["requested_path"],
+                        "existing_path": conflict["existing_path"],
+                        "choices": ["use_existing", "create_variant"],
+                        "error": (
+                            f"The requested path {conflict['requested_path']} differs "
+                            f"only by case from existing path {conflict['existing_path']}. "
+                            "Choose use_existing or create_variant."
+                        ),
+                    }, ensure_ascii=False)
+                command = rewrite_target_path(
+                    command,
+                    Path(conflict["requested_path"]),
+                    Path(conflict["existing_path"]),
+                    cwd,
+                )
 
         # The session key that drives cwd records: get_current_session_key()'s
         # contextvar doesn't cross tool-worker threads, so fall back to the raw
@@ -4207,6 +4250,11 @@ TERMINAL_SCHEMA = {
                     {"type": "boolean"},
                     {"type": "array", "items": {"type": "string"}}
                 ]
+            },
+            "case_resolution": {
+                "type": "string",
+                "enum": ["use_existing", "create_variant"],
+                "description": "When a case-only path conflict is reported on a case-sensitive filesystem, choose the existing spelling or explicitly create the requested case variant. Omit to ask the user."
             }
             # Legacy aliases (unadvertised, still accepted): notify_on_complete
             # (bool) and watch_patterns (list). notify=true|[...] maps onto
@@ -4273,6 +4321,7 @@ def _handle_terminal(args, **kw):
         pty=args.get("pty", False),
         notify_on_complete=notify_on_complete,
         watch_patterns=watch_patterns,
+        case_resolution=args.get("case_resolution"),
     )
 
 


### PR DESCRIPTION
## Summary

- Probe the filesystem where simple terminal write commands will execute instead of assuming behavior from the host OS.
- Detect case-only conflicts for unambiguous `mkdir`, `touch`, `cp`, `mv`, and `install` destinations.
- Return a structured `case_conflict` response without executing the command, exposing the existing spelling and the two explicit choices `use_existing` and `create_variant`.
- Keep case-insensitive filesystems on the existing path with no extra prompt.

## Why

When Hermes is used with speech-to-text, capitalization is not reliably represented in dictated paths. A request such as `desktop` can therefore be intended to refer to an existing `Desktop` directory. Previously, a case-sensitive filesystem could allow Hermes to create or target a separate case variant without surfacing the ambiguity.

Hermes must not choose the user's intent. Omitting `case_resolution` asks the user; `use_existing` rewrites the destination to the reported existing spelling; `create_variant` explicitly preserves the requested spelling.

The probe runs inside the target terminal environment, so SSH, container, and mounted-volume semantics are evaluated at the execution site. Unknown or compound shell syntax is left unchanged rather than being guessed at.

## Tests

- `uv run --locked --extra dev pytest -q tests/tools/test_path_case.py` — 7 passed
- `uv run --locked --extra dev pytest -q tests/tools/test_file_tools.py tests/tools/test_path_case.py` — 53 passed, 2 skipped
- `uv run --locked --extra dev ruff check tools/path_case.py tools/terminal_tool.py tests/tools/test_path_case.py` — passed
- `python3 -m py_compile tools/path_case.py tools/terminal_tool.py tests/tools/test_path_case.py` — passed
- `git diff --check` — passed

A broader terminal-requirements run has three existing failures in check-function grace-period tests; none involve this change.

## Scope

This covers Hermes-managed terminal execution. It does not attempt to parse arbitrary shell programs or override filesystem semantics.
