### PR TITLE
fix(desktop): stop SSH dispatch probe killing healthy tunnels

### DIFF
--- a/apps/desktop/electron/remote-liveness.test.ts
+++ b/apps/desktop/electron/remote-liveness.test.ts
@@ -260,7 +260,7 @@ describe('revalidateRemoteConnection', () => {
 })
 
 describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
-  it('retires a dead cached descriptor and gives dispatch the replacement', async () => {
+  it('retires a dead cached descriptor and gives dispatch the replacement on transport failure', async () => {
     const stale = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
     const replacement = { baseUrl: 'http://127.0.0.1:53968', mode: 'remote' }
     const stalePromise = Promise.resolve(stale)
@@ -292,11 +292,171 @@ describe('ensureHealthyPooledRemoteBackendForDispatch', () => {
       })
     ).resolves.toBe(replacement)
 
-    expect(probe).toHaveBeenCalledWith(stale, '/api/status', {
+    expect(probe).toHaveBeenCalledWith(stale, '/api/health', {
       timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
     })
     expect(retire).toHaveBeenCalledOnce()
     expect(reconnect).toHaveBeenCalledOnce()
+  })
+
+  it('preserves the descriptor on a single transient timeout, returning existing connection', async () => {
+    const active = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const activePromise = Promise.resolve(active)
+
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+
+    const probe = vi.fn(async () => {
+      throw new Error('Timed out connecting to Hermes backend after 10000ms')
+    })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: activePromise,
+        currentConnectionPromise: () => activePromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(active)
+
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
+  })
+
+  it('retires and reconnects when timeouts repeat consecutively on a wedged backend', async () => {
+    const wedged = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const replacement = { baseUrl: 'http://127.0.0.1:53968', mode: 'remote' }
+    const wedgedPromise = Promise.resolve(wedged)
+    let currentPromise: Promise<typeof wedged> | null = wedgedPromise
+
+    const retire = vi.fn(async () => {
+      currentPromise = null
+    })
+    const reconnect = vi.fn(async () => {
+      currentPromise = Promise.resolve(replacement)
+
+      return replacement
+    })
+
+    const probe = vi.fn(async () => {
+      throw new Error('Timed out connecting to Hermes backend after 10000ms')
+    })
+
+    // First timeout: transient miss, preserved without retire
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: wedgedPromise,
+        currentConnectionPromise: () => currentPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(wedged)
+
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
+
+    // Second consecutive timeout: repeated timeout exceeds tolerance, retires and reconnects
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: wedgedPromise,
+        currentConnectionPromise: () => currentPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(replacement)
+
+    expect(retire).toHaveBeenCalledOnce()
+    expect(reconnect).toHaveBeenCalledOnce()
+  })
+
+  it('resets consecutive timeout count after a successful probe', async () => {
+    const flaky = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const flakyPromise = Promise.resolve(flaky)
+
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+
+    let shouldTimeout = true
+    const probe = vi.fn(async () => {
+      if (shouldTimeout) {
+        throw new Error('Timed out connecting to Hermes backend after 10000ms')
+      }
+    })
+
+    // 1st dispatch: times out (count = 1) -> tolerated
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: flakyPromise,
+        currentConnectionPromise: () => flakyPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(flaky)
+    expect(retire).not.toHaveBeenCalled()
+
+    // 2nd dispatch: succeeds -> resets count
+    shouldTimeout = false
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: flakyPromise,
+        currentConnectionPromise: () => flakyPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(flaky)
+    expect(retire).not.toHaveBeenCalled()
+
+    // 3rd dispatch: times out again (count = 1 again, since reset) -> still tolerated
+    shouldTimeout = true
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: flakyPromise,
+        currentConnectionPromise: () => flakyPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(flaky)
+    expect(retire).not.toHaveBeenCalled()
+  })
+
+  it('falls back to /api/status when /api/health returns 404 on older backends', async () => {
+    const legacy = { baseUrl: 'http://127.0.0.1:49525', mode: 'remote' }
+    const legacyPromise = Promise.resolve(legacy)
+
+    const retire = vi.fn()
+    const reconnect = vi.fn()
+
+    const probe = vi.fn(async (_connection, path) => {
+      if (path === '/api/health') {
+        throw new Error('404: Not Found')
+      }
+      // /api/status succeeds
+    })
+
+    await expect(
+      ensureHealthyPooledRemoteBackendForDispatch({
+        connectionPromise: legacyPromise,
+        currentConnectionPromise: () => legacyPromise,
+        probe,
+        reconnect,
+        retire
+      })
+    ).resolves.toBe(legacy)
+
+    expect(probe).toHaveBeenCalledWith(legacy, '/api/health', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(probe).toHaveBeenCalledWith(legacy, '/api/status', {
+      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+    })
+    expect(retire).not.toHaveBeenCalled()
+    expect(reconnect).not.toHaveBeenCalled()
   })
 })
 

--- a/apps/desktop/electron/remote-liveness.ts
+++ b/apps/desktop/electron/remote-liveness.ts
@@ -1,9 +1,12 @@
+import { isMissingHealthEndpointError } from './backend-health'
+
 export const REMOTE_LIVENESS_TIMEOUT_MS = 10_000
-// Dispatch is synchronous user intent: a cached descriptor must prove its
-// forwarded endpoint is alive before it can be returned. Keep this probe much
-// shorter than the background liveness budget so a dead tunnel reconnects
-// promptly instead of making the click feel hung.
-export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 2_500
+// Dispatch is synchronous user intent, but a newly established SSH forward can
+// take several seconds before the remote HTTP server responds. Use the same
+// 10s budget as background liveness: a 2.5s /api/status probe false-fails on
+// Tailscale userspace and then kills a healthy ControlMaster.
+export const POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS = 10_000
+export const DEFAULT_POOLED_REMOTE_DISPATCH_TIMEOUT_LIMIT = 1
 export const REMOTE_LIVENESS_FAILURE_LIMIT = 3
 // Even at the capped retry path, consecutive liveness observations are at most
 // about 48s apart (ticket mint + socket open + backoff + the next status probe).
@@ -74,6 +77,25 @@ interface EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection extends
   probe: (connection: TConnection, path: string, options: { timeoutMs: number }) => Promise<unknown>
   reconnect: () => Promise<TConnection>
   retire: (error: unknown) => Promise<void> | void
+  maxConsecutiveTimeouts?: number
+}
+
+const dispatchProbeTimeoutsByConnection = new WeakMap<object, number>()
+
+export function isDispatchProbeTimeoutError(error: unknown): boolean {
+  if (!error) {
+    return false
+  }
+
+  const err = error as any
+  if (err.name === 'AbortError' || err.name === 'TimeoutError' || err.code === 'ETIMEDOUT') {
+    return true
+  }
+
+  const message = error instanceof Error ? error.message : String(error ?? '')
+  const lower = message.toLowerCase()
+
+  return lower.includes('timed out') || lower.includes('timeout')
 }
 
 /**
@@ -89,9 +111,10 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
   currentConnectionPromise,
   probe,
   reconnect,
-  retire
+  retire,
+  maxConsecutiveTimeouts = DEFAULT_POOLED_REMOTE_DISPATCH_TIMEOUT_LIMIT
 }: EnsureHealthyPooledRemoteBackendForDispatchOptions<TConnection>): Promise<TConnection> {
-  let connection: TConnection
+  let connection: TConnection | undefined
 
   try {
     connection = await connectionPromise
@@ -100,10 +123,47 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
       return reconnect()
     }
 
-    await probe(connection, '/api/status', {
-      timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
-    })
+    try {
+      await probe(connection, '/api/health', {
+        timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+      })
+    } catch (healthError) {
+      // Fallback for older remote backends that predated /api/health (returns 404)
+      if (isMissingHealthEndpointError(healthError)) {
+        await probe(connection, '/api/status', {
+          timeoutMs: POOLED_REMOTE_DISPATCH_PROBE_TIMEOUT_MS
+        })
+      } else {
+        throw healthError
+      }
+    }
+
+    if (connection && typeof connection === 'object') {
+      dispatchProbeTimeoutsByConnection.delete(connection)
+    }
   } catch (error) {
+    // An ambiguous HTTP timeout does not immediately retire the descriptor: healthy
+    // backends can exceed the probe budget while an active turn is streaming over the
+    // live WebSocket. A single transient miss is preserved, but repeated timeouts on a
+    // wedged backend are bounded: exceeding maxConsecutiveTimeouts falls through to
+    // retire and reconnect. Conclusive transport failures (refused, dropped socket, 5xx)
+    // retire the pooled backend immediately.
+    if (connection && typeof connection === 'object' && isDispatchProbeTimeoutError(error)) {
+      const timeouts = (dispatchProbeTimeoutsByConnection.get(connection) ?? 0) + 1
+      dispatchProbeTimeoutsByConnection.set(connection, timeouts)
+
+      if (timeouts <= maxConsecutiveTimeouts) {
+        if (currentConnectionPromise() !== connectionPromise) {
+          return reconnect()
+        }
+        return connection
+      }
+    }
+
+    if (connection && typeof connection === 'object') {
+      dispatchProbeTimeoutsByConnection.delete(connection)
+    }
+
     if (currentConnectionPromise() === connectionPromise) {
       await retire(error)
     }
@@ -115,7 +175,7 @@ export async function ensureHealthyPooledRemoteBackendForDispatch<TConnection ex
     return reconnect()
   }
 
-  return connection
+  return connection!
 }
 
 /**

--- a/apps/desktop/electron/ssh-connection.test.ts
+++ b/apps/desktop/electron/ssh-connection.test.ts
@@ -113,6 +113,8 @@ test('baseSshOptions carries the house ControlMaster/BatchMode/accept-new policy
   assert.match(joined, /BatchMode=yes/)
   assert.match(joined, /StrictHostKeyChecking=accept-new/)
   assert.match(joined, /ExitOnForwardFailure=yes/)
+  assert.match(joined, /ServerAliveInterval=15/)
+  assert.match(joined, /ServerAliveCountMax=3/)
   assert.match(joined, /ConnectTimeout=15/)
   assert.ok(!joined.includes('StrictHostKeyChecking=no'), 'never disables host-key checking')
 })

--- a/apps/desktop/electron/ssh-connection.ts
+++ b/apps/desktop/electron/ssh-connection.ts
@@ -227,6 +227,10 @@ function baseSshOptions(controlPath, connectTimeoutMs?) {
     '-o',
     'ExitOnForwardFailure=yes',
     '-o',
+    'ServerAliveInterval=15',
+    '-o',
+    'ServerAliveCountMax=3',
+    '-o',
     `ConnectTimeout=${connectSecs}`
   ]
 }


### PR DESCRIPTION
## What does this PR do?

Stops Desktop SSH from tearing down a live ControlMaster because the **dispatch** probe is too heavy and too short.

On a Tailscale userspace hop, a newly forwarded `/api/status` routinely misses a 2.5s budget. `ensureHealthyPooledRemoteBackendForDispatch` then retires the pooled backend, cancels the forward, and opens a new master. Logs on Air → Pro showed hundreds of `Timed out connecting to Hermes backend after 2500ms` followed by `cancelled forward` / `control master closed`.

## Related Issue

Related to #97914 (same `/api/health` dispatch probe; that PR uses a 5s budget), #100700 / #100040 (reconnect-storm family), and #62800 (ServerAlive on the CLI SSH environment, not Desktop ControlMaster). Does not close those.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/remote-liveness.ts` — dispatch probe path `/api/health`, timeout 10s (same budget as background liveness). Background probes stay on `/api/status`.
- `apps/desktop/electron/ssh-connection.ts` — `ServerAliveInterval=15` + `ServerAliveCountMax=3` on every Desktop ControlMaster so a silent Tailscale hop is detected instead of left half-open.
- Matching unit tests in `remote-liveness.test.ts` and `ssh-connection.test.ts`.

## How to Test

1. `cd apps/desktop && npx vitest run electron/remote-liveness.test.ts electron/ssh-connection.test.ts`
2. Desktop → SSH gateway over Tailscale userspace. After a cold spawn, dispatch should not log `after 2500ms` then immediately `cancelled forward` / `control master closed`.
3. `ps` on the ControlMaster should include `ServerAliveInterval=15`. `GET /api/health` on the local forward should stay well under 10s (typically ~20–300ms).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Hermes Desktop SSH Air → Pro over Tailscale userspace (`npx vitest`: 91 passed; live ControlMaster now carries ServerAlive)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `.env.example` if I added/changed environment variables — or N/A
- [x] I am not adding a dependency — or N/A
- [x] `git diff --check` is clean (no whitespace errors)