### PR TITLE
fix(plugins): skip foreign-harness manifest dirs during discovery

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -682,6 +682,21 @@ def _get_enabled_plugins() -> Optional[set]:
 
 _VALID_PLUGIN_KINDS: Set[str] = {"standalone", "backend", "exclusive", "platform", "model-provider"}
 
+# Per-harness manifest directories that plugin repos ship for OTHER agent
+# harnesses (Claude Code, Codex, Cursor, Devin, Kimi — e.g. obra/superpowers
+# keeps one plugin.json per harness inside them). Their plugin.json is not an
+# Agent Plugins v1 manifest and can never validate, so attempting it on every
+# discovery pass only spams warnings (#101962). Directory discovery skips
+# them; a plugin's real Hermes manifest (.hermes-plugin/plugin.yaml or a
+# top-level plugin.yaml/plugin.json) is unaffected.
+_FOREIGN_HARNESS_MANIFEST_DIRS = frozenset({
+    ".claude-plugin",
+    ".codex-plugin",
+    ".cursor-plugin",
+    ".devin-plugin",
+    ".kimi-plugin",
+})
+
 
 def _portable_skill_namespace(key: str) -> str:
     """Return a readable, collision-resistant namespace for a portable plugin."""
@@ -4708,6 +4723,11 @@ class PluginManager:
             if not child.is_dir():
                 continue
             if depth == 0 and skip_names and child.name in skip_names:
+                continue
+            if child.name in _FOREIGN_HARNESS_MANIFEST_DIRS:
+                logger.debug(
+                    "Skipping %s (foreign-harness manifest convention)", child
+                )
                 continue
             manifest_file = child / "plugin.yaml"
             if not manifest_file.exists():

--- a/tests/hermes_cli/test_plugin_scanner_recursion.py
+++ b/tests/hermes_cli/test_plugin_scanner_recursion.py
@@ -8,6 +8,7 @@ still opt-in; exclusive kind skipped; unknown kinds → standalone warning).
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from typing import Any, Dict
 
@@ -111,6 +112,74 @@ class TestCategoryNamespaceRecursion:
             if p.manifest.source != "bundled"
         ]
         assert non_bundled == []
+
+
+# ── Foreign-harness manifest dirs (#101962) ────────────────────────────────
+
+
+class TestForeignHarnessManifestDirs:
+    def test_foreign_harness_dirs_skipped_without_warnings(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        """Multi-harness plugin repos (e.g. obra/superpowers) ship one
+        ``plugin.json`` per OTHER agent harness inside ``.claude-plugin/``,
+        ``.codex-plugin/`` etc. Those manifests can never satisfy the Agent
+        Plugins v1 schema, so scanning them warned on every discovery pass.
+        They must be skipped silently; the plugin's real Hermes manifest
+        (``.hermes-plugin/plugin.yaml``) is still discovered."""
+        import os
+        hermes_home = Path(os.environ["HERMES_HOME"])  # set by hermetic conftest fixture
+        sp = hermes_home / "plugins" / "superpowers"
+        (sp / ".hermes-plugin").mkdir(parents=True)
+        (sp / ".hermes-plugin" / "plugin.yaml").write_text(
+            yaml.dump(
+                {
+                    "name": "superpowers",
+                    "version": "6.3.0",
+                    "description": "multi-harness plugin",
+                }
+            )
+        )
+        for harness in (
+            ".claude-plugin",
+            ".codex-plugin",
+            ".cursor-plugin",
+            ".devin-plugin",
+            ".kimi-plugin",
+        ):
+            harness_dir = sp / harness
+            harness_dir.mkdir(parents=True)
+            (harness_dir / "plugin.json").write_text(
+                json.dumps({"name": "superpowers", "version": "6.3.0"})
+            )
+
+        with caplog.at_level("WARNING", logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert "superpowers/.hermes-plugin" in mgr._plugins
+        parse_warnings = [
+            r for r in caplog.records if "Failed to parse" in r.getMessage()
+        ]
+        assert parse_warnings == []
+
+    def test_broken_portable_plugin_still_warns(self, tmp_path, monkeypatch, caplog):
+        """A genuinely broken portable plugin.json (not a foreign-harness
+        convention directory) must still surface its parse warning."""
+        import os
+        hermes_home = Path(os.environ["HERMES_HOME"])  # set by hermetic conftest fixture
+        broken = hermes_home / "plugins" / "broken-portable"
+        broken.mkdir(parents=True)
+        (broken / "plugin.json").write_text(json.dumps({"name": "broken"}))
+
+        with caplog.at_level("WARNING", logger="hermes_cli.plugins"):
+            mgr = PluginManager()
+            mgr.discover_and_load()
+
+        assert any(
+            "Failed to parse" in r.getMessage() and "broken-portable" in r.getMessage()
+            for r in caplog.records
+        )
 
 
 


### PR DESCRIPTION
## What does this PR do?

Multi-harness plugin repos (e.g. [obra/superpowers](https://github.com/obra/superpowers)) ship one `plugin.json` per *other* agent harness inside `.claude-plugin/`, `.codex-plugin/`, `.cursor-plugin/`, `.devin-plugin/` and `.kimi-plugin/`. Those manifests are per-harness conventions and can never satisfy the Agent Plugins v1 `$schema`, so every plugin-discovery pass tried each one, rejected it, and logged a warning — on the reporter's install that is 5 warnings per discovery cycle, ~1,500/day in `errors.log`.

This PR makes directory discovery skip these well-known foreign-harness manifest directories (option 1 from the issue). A plugin's real Hermes manifest (`.hermes-plugin/plugin.yaml` or a top-level `plugin.yaml`/`plugin.json`) is unaffected, and a genuinely broken portable `plugin.json` outside these convention directories still surfaces its parse warning.

## Related Issue

Fixes #101962

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/plugins.py`: added `_FOREIGN_HARNESS_MANIFEST_DIRS` (`.claude-plugin`, `.codex-plugin`, `.cursor-plugin`, `.devin-plugin`, `.kimi-plugin`) and skip these directory names at any scan depth in `_scan_directory_level`, with a DEBUG log explaining the skip. No functional change: those `plugin.json` files could never validate, so nothing that was loadable before is lost.
- `tests/hermes_cli/test_plugin_scanner_recursion.py`: regression tests — a superpowers-style layout produces zero `Failed to parse` warnings while the real `.hermes-plugin/plugin.yaml` is still discovered; a genuinely broken portable `plugin.json` still warns.

## How to Test

1. `python -m pytest tests/hermes_cli/test_plugin_scanner_recursion.py -q` — 14 passed (12 existing + 2 new).
2. `python -m pytest tests/hermes_cli/ -q -k plugin` — 625 passed, 1 unrelated pre-existing failure (`test_relay_shared_metrics_runtime.py`, fails identically on clean `upstream/main`; `nemo_relay` module issue, unrelated to plugin scanning).
3. Manual repro on the fix branch: create `~/.hermes/plugins/superpowers/{.hermes-plugin,.claude-plugin,.codex-plugin,.cursor-plugin,.devin-plugin,.kimi-plugin}` with a `plugin.yaml` in the first and a schema-less `plugin.json` in each of the others, then run discovery. Observed result: before the fix, 5 × `WARNING hermes_cli.plugins: Failed to parse ...: plugin.json declares an unsupported or missing Agent Plugins schema` per pass; after the fix, 0 warnings and `superpowers/.hermes-plugin` still discovered.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure directory-name match, no path handling changes)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

Before (per discovery pass, ×5 dirs):

```
WARNING hermes_cli.plugins: Failed to parse .../superpowers/.claude-plugin/plugin.json: plugin.json declares an unsupported or missing Agent Plugins schema
```

After: no warnings; discovery debug log shows `Skipping .../superpowers/.claude-plugin (foreign-harness manifest convention)`.
