### PR TITLE
fix(desktop): declare rememberLog state before readPersistedPoolLimits() runs

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1419,6 +1419,15 @@ const profileDeletionGate = new ProfileDeletionGate()
 // launch constant: mutable at runtime, persisted in userData, applied live.
 // The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
 // for scripted/headless setups; after launch the stored preference wins.
+// rememberLog() state. Declared here, ahead of readPersistedPoolLimits(),
+// because that runs at module load and logs which limits source won; the
+// bundler lowers these to `var`, so a later declaration is `undefined` at
+// that point instead of a TDZ error, and the first push() crashes the app.
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
+
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
 function readPersistedPoolLimits() {
@@ -1574,12 +1583,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## What

The packaged desktop app crashes on every launch since c3e9b28a42 (persisted pool limits):

```
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog (app.asar/dist/electron-main.mjs:23178:13)
    at readPersistedPoolLimits (app.asar/dist/electron-main.mjs:23011:7)
    at app.asar/dist/electron-main.mjs:23026:18
```

## Why

`readPersistedPoolLimits()` is called at module load (`let poolLimits = readPersistedPoolLimits()`) and logs which limits source won via `rememberLog()`. `rememberLog()` pushes into `hermesLog` and appends to `desktopLogBuffer`, but both were declared ~110 lines later. The bundler lowers top-level `const`/`let` to `var`, so instead of a TDZ `ReferenceError` the value is `undefined` at that point and the first `push()` throws. Both branches of the try/catch log, so it fails whether or not `pool-limits.json` exists.

Fix: move the four `rememberLog` state declarations (`hermesLog`, `desktopLogBuffer`, `desktopLogFlushTimer`, `desktopLogFlushPromise`) above the pool-limits block, with a comment explaining the ordering constraint.

## How to test

1. On current `main`, `hermes desktop --force-build` on macOS: the error dialog above appears and the main process dies.
2. With this patch, the app boots and `~/.hermes/logs/desktop.log` contains the line that used to crash, e.g. `[pool-limits] no saved file and no env overrides; using defaults`, followed by `HERMES_BACKEND_READY`.
3. `cd apps/desktop && npx tsc -p tsconfig.electron.json --noEmit` passes.
4. `npx vitest run --project electron electron/pool-spawn-coordinator.test.ts electron/pool-limits.test.ts` passes (22 passed, 1 skipped).

## Platforms tested

macOS 26 (arm64), packaged build via `hermes desktop --build-only --force-build`. Not tested on Windows or Linux, but the change is pure declaration order in `main.ts` with no platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gUYmpHUqzNjLnHuDMHcSz