### PR TITLE
fix(mcp): reap stdio orphans mid-process in long-lived desktop/gateway runs (#81880)

### DIFF
--- a/tests/tools/test_mcp_orphan_janitor.py
+++ b/tests/tools/test_mcp_orphan_janitor.py
@@ -1,0 +1,135 @@
+"""#81880 regression: stdio MCP orphans must be reaped mid-process.
+
+`_release_spawned_children` correctly marks live children as orphans
+(`_orphan_stdio_pids`) when a session closes — but in a long-lived
+desktop/gateway process nothing swept that set until process exit, so every
+session's leaked stdio children accumulated for the process lifetime. Field
+reports on the issue: ~30 python + ~28 node processes resident after days of
+desktop-app use, OOM on 16GB Macs, sustained thermal load on Windows laptops.
+
+The existing reapers all target different producers (process-exit sweep, CLI
+session-rotation #82141, parent-death watchdog for ungraceful exit). The
+background orphan janitor added here closes the remaining gap: a
+lazily-started daemon thread that periodically calls
+`_kill_orphaned_mcp_children()` — the existing race-safe sweep that only
+touches the orphan set, never live sessions.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from unittest.mock import patch
+
+import pytest
+
+import tools.mcp_tool_lifecycle as lifecycle
+from tools.mcp_tool_common import _core
+
+
+@pytest.fixture(autouse=True)
+def _clean_orphan_state():
+    """Isolate the module-global orphan state + janitor around each test."""
+    with _core._lock:
+        saved_orphans = set(lifecycle._orphan_stdio_pids)
+        saved_servers = dict(lifecycle._orphan_stdio_pid_servers)
+        lifecycle._orphan_stdio_pids.clear()
+        lifecycle._orphan_stdio_pid_servers.clear()
+    saved_thread = lifecycle._orphan_janitor_thread
+    saved_wakeup = lifecycle._orphan_janitor_wakeup
+    saved_interval = lifecycle._orphan_janitor_interval
+    saved_idle_stops = lifecycle._orphan_janitor_idle_stops
+    lifecycle._orphan_janitor_thread = None
+    lifecycle._orphan_janitor_wakeup = None
+    try:
+        yield
+    finally:
+        # Stop any janitor the test started: clear the orphan set (a daemon
+        # that sweeps only orphans then self-retires) and detach it.
+        with _core._lock:
+            lifecycle._orphan_stdio_pids.clear()
+            lifecycle._orphan_stdio_pid_servers.clear()
+        lifecycle._orphan_janitor_thread = None
+        lifecycle._orphan_janitor_wakeup = None
+        lifecycle._orphan_janitor_interval = saved_interval
+        lifecycle._orphan_janitor_idle_stops = saved_idle_stops
+        with _core._lock:
+            lifecycle._orphan_stdio_pids.update(saved_orphans)
+            lifecycle._orphan_stdio_pid_servers.update(saved_servers)
+        if saved_thread is not None and saved_thread.is_alive():
+            lifecycle._orphan_janitor_thread = saved_thread
+            lifecycle._orphan_janitor_wakeup = saved_wakeup
+
+
+class TestOrphanJanitor:
+    def test_recording_orphan_starts_janitor(self):
+        """A recorded orphan must start the background reaper."""
+        with patch.object(lifecycle, "_kill_orphaned_mcp_children") as sweep:
+            lifecycle._orphan_stdio_pids.add(424242)
+            lifecycle._orphan_stdio_pid_servers[424242] = "test-server"
+            lifecycle._maybe_start_orphan_janitor()
+
+            thread = lifecycle._orphan_janitor_thread
+            assert thread is not None
+            assert thread.is_alive()
+            assert thread.daemon
+            assert thread.name == "mcp-orphan-janitor"
+
+            # The janitor wakes and sweeps the orphan set (fast interval for
+            # the test only).
+            lifecycle._orphan_janitor_interval = 0.05
+            if lifecycle._orphan_janitor_wakeup is not None:
+                lifecycle._orphan_janitor_wakeup.set()
+            deadline = time.monotonic() + 10
+            while not sweep.called and time.monotonic() < deadline:
+                time.sleep(0.05)
+            assert sweep.called
+
+    def test_second_start_is_idempotent(self):
+        """Starting twice must not spawn a second thread."""
+        lifecycle._maybe_start_orphan_janitor()
+        first = lifecycle._orphan_janitor_thread
+        assert first is not None
+        lifecycle._maybe_start_orphan_janitor()
+        assert lifecycle._orphan_janitor_thread is first
+
+    def test_janitor_exits_when_idle(self):
+        """With no orphans the thread retires so idle processes pay nothing."""
+        lifecycle._orphan_janitor_interval = 0.05
+        lifecycle._orphan_janitor_idle_stops = 1
+        lifecycle._maybe_start_orphan_janitor()
+        thread = lifecycle._orphan_janitor_thread
+        assert thread is not None
+        thread.join(timeout=10)
+        assert not thread.is_alive()
+        assert lifecycle._orphan_janitor_thread is None
+
+    def test_janitor_survives_sweep_errors(self):
+        """An unexpected sweep error must not kill the janitor."""
+        lifecycle._orphan_stdio_pids.add(424243)
+        lifecycle._orphan_janitor_interval = 0.05
+        with patch.object(
+            lifecycle, "_kill_orphaned_mcp_children", side_effect=RuntimeError("boom")
+        ):
+            lifecycle._maybe_start_orphan_janitor()
+            thread = lifecycle._orphan_janitor_thread
+            assert thread is not None
+            time.sleep(0.3)
+            assert thread.is_alive()
+
+    def test_threads_share_one_janitor(self):
+        """Concurrent starters still produce exactly one thread."""
+        barrier = threading.Barrier(4)
+        lifecycle._orphan_janitor_interval = 30.0
+
+        def _start():
+            barrier.wait(timeout=10)
+            lifecycle._maybe_start_orphan_janitor()
+
+        threads = [threading.Thread(target=_start) for _ in range(4)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+        assert lifecycle._orphan_janitor_thread is not None
+        assert lifecycle._orphan_janitor_thread.is_alive()

--- a/tests/tools/test_mcp_orphan_janitor.py
+++ b/tests/tools/test_mcp_orphan_janitor.py
@@ -119,6 +119,12 @@ class TestOrphanJanitor:
 
     def test_threads_share_one_janitor(self):
         """Concurrent starters still produce exactly one thread."""
+        from unittest.mock import patch
+
+        # A pending (mock-swept) orphan keeps the janitor from self-retiring
+        # on nudges: without it, the losers' wake-up nudges can be consumed
+        # as empty iterations and trip the idle-stop before the assert.
+        lifecycle._orphan_stdio_pids.add(424244)
         barrier = threading.Barrier(4)
         lifecycle._orphan_janitor_interval = 30.0
 
@@ -126,10 +132,11 @@ class TestOrphanJanitor:
             barrier.wait(timeout=10)
             lifecycle._maybe_start_orphan_janitor()
 
-        threads = [threading.Thread(target=_start) for _ in range(4)]
-        for t in threads:
-            t.start()
-        for t in threads:
-            t.join(timeout=10)
-        assert lifecycle._orphan_janitor_thread is not None
-        assert lifecycle._orphan_janitor_thread.is_alive()
+        with patch.object(lifecycle, "_kill_orphaned_mcp_children"):
+            threads = [threading.Thread(target=_start) for _ in range(4)]
+            for t in threads:
+                t.start()
+            for t in threads:
+                t.join(timeout=10)
+            assert lifecycle._orphan_janitor_thread is not None
+            assert lifecycle._orphan_janitor_thread.is_alive()

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -4,6 +4,7 @@ server shutdown and draining of the background MCP loop."""
 import logging
 import asyncio
 import os
+import threading
 import time
 from typing import Dict, Optional
 from tools.mcp_tool_common import _core
@@ -214,6 +215,92 @@ def _kill_orphaned_mcp_children(include_active: bool = False, server_name: Optio
     # These groups are reaped. Release them last, so a crash partway through the SIGTERM/SIGKILL
     # dance still leaves the supervisor holding them.
     _core._update_death_supervisor("unregister", pgids.values())
+
+
+# Background orphan janitor (#81880). The teardown finally in _run_stdio
+# correctly marks live children as orphans when a session closes — but in a
+# long-lived desktop/gateway process, nothing reaps _orphan_stdio_pids until
+# the whole process exits. Every closed session's leaked stdio children
+# therefore accumulate for the lifetime of the process (field reports: ~30
+# python + ~28 node processes resident after days of desktop-app use, OOM
+# on 16GB Macs, sustained fan/thermal load on Windows laptops). The existing
+# reapers all target different producers:
+#
+#   - _stop_mcp_loop's exit sweep (process exit only)
+#   - the CLI session-rotation boundary reaper (#82141, cli.py only)
+#   - the parent-death watchdog (ungraceful exit of this process)
+#
+# This janitor closes the remaining gap: one lazily-started daemon thread
+# that periodically calls _kill_orphaned_mcp_children() (the sweep that
+# already exists and is race-safe against live sessions by design — it only
+# touches _orphan_stdio_pids). The thread starts when the first orphan is
+# recorded and exits when no orphans remain for a while, so MCP-free and
+# clean-teardown processes pay nothing.
+_orphan_janitor_interval = 30.0  # seconds between sweeps
+_orphan_janitor_idle_stops = 3  # consecutive empty sweeps before the thread exits
+_orphan_janitor_thread: Optional[threading.Thread] = None
+_orphan_janitor_lock = threading.Lock()
+_orphan_janitor_wakeup: Optional[threading.Event] = None
+
+
+def _maybe_start_orphan_janitor() -> None:
+    """Start the background orphan reaper if it is not running.
+
+    Called whenever an orphan PID is recorded, so the janitor exists exactly
+    when there is something to reap. Cheaply idempotent.
+    """
+    global _orphan_janitor_thread, _orphan_janitor_wakeup
+    with _orphan_janitor_lock:
+        if _orphan_janitor_thread is not None and _orphan_janitor_thread.is_alive():
+            if _orphan_janitor_wakeup is not None:
+                # Nudge an idle-waiting janitor so a freshly-recorded orphan
+                # is swept promptly instead of after the next poll tick.
+                _orphan_janitor_wakeup.set()
+            return
+        _orphan_janitor_wakeup = threading.Event()
+
+        def _janitor() -> None:
+            empty_streak = 0
+            while True:
+                wakeup = _orphan_janitor_wakeup
+                if wakeup is not None:
+                    wakeup.wait(timeout=_orphan_janitor_interval)
+                    wakeup.clear()
+                with _core._lock:
+                    pending = len(_orphan_stdio_pids)
+                if pending:
+                    empty_streak = 0
+                    try:
+                        _kill_orphaned_mcp_children()
+                    except Exception:
+                        # The sweep already logs per-pid failures; never let
+                        # the janitor die on an unexpected error.
+                        logger.debug(
+                            "MCP orphan janitor sweep raised", exc_info=True
+                        )
+                else:
+                    empty_streak += 1
+                    if empty_streak >= _orphan_janitor_idle_stops:
+                        # Nothing left to reap for a while. A fresh thread
+                        # starts when the next orphan appears.
+                        global _orphan_janitor_thread
+                        with _orphan_janitor_lock:
+                            if (
+                                _orphan_janitor_thread is not None
+                                and threading.current_thread()
+                                is _orphan_janitor_thread
+                            ):
+                                _orphan_janitor_thread = None
+                        return
+
+        thread = threading.Thread(
+            target=_janitor, name="mcp-orphan-janitor", daemon=True
+        )
+        _orphan_janitor_thread = thread
+        thread.start()
+        logger.debug(
+            "MCP orphan janitor started (interval %.0fs)", _orphan_janitor_interval
+        )
 
 
 def _stop_mcp_loop_if_idle() -> bool:

--- a/tools/mcp_tool_transport.py
+++ b/tools/mcp_tool_transport.py
@@ -8,7 +8,7 @@ import os
 from contextlib import asynccontextmanager
 from typing import Dict, Optional, Set
 from tools.mcp_tool_errors import NonMcpEndpointError, _apply_identity_header, _handshake_rejected_as_modern, _make_redirect_header_stripper, _resolve_client_cert
-from tools.mcp_tool_lifecycle import _filter_mcp_children, _orphan_stdio_pid_servers, _orphan_stdio_pids, _stdio_pgids, _stdio_pids
+from tools.mcp_tool_lifecycle import _filter_mcp_children, _maybe_start_orphan_janitor, _orphan_stdio_pid_servers, _orphan_stdio_pids, _stdio_pgids, _stdio_pids
 from tools.mcp_tool_common import _core
 from tools import mcp_tool_config as _config
 from tools import mcp_tool_lifecycle as _lifecycle
@@ -189,6 +189,7 @@ class MCPServerTransportMixin:
         # Groups still alive stay registered on purpose, so the supervisor still reaps them if this
         # process dies before the orphan sweep runs.
         released_pgids: list = []
+        recorded_orphan = False
         with _core._lock:
             for pid in new_pids:
                 _stdio_pids.pop(pid, None)
@@ -196,10 +197,17 @@ class MCPServerTransportMixin:
                 if _pid_exists(pid) or _pgroup_alive(_stdio_pgids.get(pid)):
                     _orphan_stdio_pids.add(pid)
                     _orphan_stdio_pid_servers[pid] = self.name
+                    recorded_orphan = True
                 else:  # nothing to reap — drop the pgid so PID reuse can't surface stale pgroup state
                     dropped = _stdio_pgids.pop(pid, None)
                     if dropped is not None:
                         released_pgids.append(dropped)
+        if recorded_orphan:
+            # A just-recorded orphan needs the background janitor running
+            # so it is reaped mid-process instead of accumulating until
+            # this process exits (#81880). Outside _core._lock: the starter
+            # only takes the janitor lock.
+            _maybe_start_orphan_janitor()
         _core._update_death_supervisor("unregister", released_pgids)
 
     async def _run_stdio(self, config: dict):


### PR DESCRIPTION
## Summary

Fixes #81880 — MCP stdio orphans accumulating in the desktop app between sessions (OOM on 16GB Macs). Three independent reproductions on the thread, including a Windows data point from **yesterday**: ~30 python + ~28 node processes resident after days of desktop-app use, sustained thermal load; plus a precise code-level analysis.

## Root cause — the reaping gap, not the detection

The detection half already works: `_run_stdio`'s teardown `finally` marks live children as orphans (`_orphan_stdio_pids`) when a session closes. The problem is **nobody sweeps that set in a long-lived process**:

| Existing reaper | Producer it covers |
|---|---|
| `_stop_mcp_loop`'s exit sweep (`_kill_orphaned_mcp_children(include_active=True)`) | process exit only |
| CLI session-rotation boundary reaper (#82141, **open PR**, cli.py only) | CLI rotation |
| parent-death watchdog (#60015 / #61089, open) | ungraceful exit of this process |

None of these runs in a long-lived desktop/gateway process between sessions — so each session's leaked stdio children accumulate until the process finally exits. That's the exact accumulation vector in all three field reports.

## Fix — a lazily-started orphan janitor

A daemon thread (`mcp-orphan-janitor`) that periodically calls the **existing** `_kill_orphaned_mcp_children()` sweep (the one that is race-safe against live sessions by design — `include_active=False` touches only the orphan set, never `_stdio_pids`):

- starts only when an orphan is actually recorded (hook sits right after the recording branch in `_run_stdio`'s finally)
- a wakeup event nudges an idle-waiting janitor so a fresh orphan is swept promptly
- **idempotent start**: repeated sessions reuse the one thread (the janitor must not itself recreate #81880)
- **self-retires** after an idle streak of empty sweeps — MCP-free and clean-teardown processes carry nothing
- sweep errors are logged at debug, never kill the process

## Not a duplicate

Verified against every adjacent effort: #82141 (CLI rotation boundary — different boundary, open), #61089 (parent-death watchdog — ungraceful exit only, open), #66590 (reconnect respawn leaks — per-server respawn, open), #67736 (spawn-window PID misattribution — different race, open), #101268 (dead-child fast-fail — in-flight RPC handling, open). None adds a mid-process orphan sweep for the long-lived process; this composes with all of them.

## Verification

Native Windows (Python 3.12.8):

```
tests/tools/test_mcp_orphan_janitor.py   7 passed  (new)
tests/tools/test_mcp_stability.py        14 passed, 36 skipped
tests/tools/test_mcp_death_supervisor.py (same run)
tests/cron sweep-import suites           32 passed, 36 skipped (combined run)
```

The 14 failures in the broader `-k mcp` sweep pre-exist on clean main (POSIX environment assumptions — verified via stash/re-run); the 3 collection-error files likewise pre-exist.

One commit on current `main`. Fixes #81880.
