### PR TITLE
fix: `hermes update` idles 8–20 min in the macOS launchd restart phase after the gateway has already exited and been revived (#101426)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -304,7 +304,9 @@ def _request_gateway_self_restart(pid: int) -> bool:
     return True
 
 
-def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
+def _graceful_restart_via_sigusr1(
+    pid: int, drain_timeout: float, *, is_revived=None
+) -> bool:
     """Send SIGUSR1 to a gateway PID and wait for it to exit gracefully.
 
     SIGUSR1 is wired in gateway/run.py to ``request_restart(via_service=True)``,
@@ -324,6 +326,10 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
             SIGUSR1.  Must cover the after-turn wait plus the stop()/drain
             phase (#77184); callers should pass
             ``resolve_restart_exit_wait_budget(...)``.
+        is_revived: Optional zero-arg probe reporting that a supervised
+            replacement is already up (#101426).  Forwarded to
+            :func:`_wait_for_pid_exit` so a lingering old PID cannot hold
+            the wait hostage after the supervisor revived the service.
 
     Returns:
         True if the PID was signalled and exited within the timeout.
@@ -342,18 +348,32 @@ def _graceful_restart_via_sigusr1(pid: int, drain_timeout: float) -> bool:
     except (PermissionError, OSError):
         return False
 
-    # Drain-wait: delegate to the shared PID-exit helper (0.5s poll, bounded).
-    return _wait_for_pid_exit(pid, max(drain_timeout, 1.0))
+    # Drain-wait: delegate to the shared PID-exit helper (bounded, backoff).
+    # Only forward the revival probe when set so two-arg test doubles of
+    # _wait_for_pid_exit keep working unchanged.
+    if is_revived is None:
+        return _wait_for_pid_exit(pid, max(drain_timeout, 1.0))
+    return _wait_for_pid_exit(pid, max(drain_timeout, 1.0), is_revived=is_revived)
 
 
-def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
+def _wait_for_pid_exit(pid: int, timeout: float, is_revived=None) -> bool:
     """Wait up to ``timeout`` seconds for ``pid`` to leave the process table.
 
     ``launchctl bootstrap`` of a label whose previous instance is still draining
     fails with EIO ("already loaded"), so callers that tear the gateway down
     must wait for the old process to actually exit before re-bootstrapping.
 
-    Returns True once the PID is gone (or was never alive), False on timeout.
+    ``is_revived`` is an optional zero-arg probe reporting that a supervised
+    replacement process is already running (#101426 — a lingering old PID,
+    e.g. a wrapper child held as a zombie by an inherited pipe, must not
+    idle the update for the full drain budget after launchd already revived
+    the service).  A truthy probe short-circuits the wait with True.
+    Best-effort: a raising probe reads as "not revived" and the wait
+    continues unchanged.  Poll interval backs off exponentially (0.5s → 5s
+    cap) so multi-minute drain waits don't busy-poll.
+
+    Returns True once the PID is gone (or a replacement is observed), False
+    on timeout.
     """
     if pid <= 0:
         return True
@@ -368,12 +388,20 @@ def _wait_for_pid_exit(pid: int, timeout: float) -> bool:
     from gateway.status import _pid_exists
 
     deadline = _time.monotonic() + max(timeout, 0.0)
+    interval = 0.5
     while True:
         if not _pid_exists(pid):
             return True
+        if is_revived is not None:
+            try:
+                if is_revived():
+                    return True
+            except Exception:
+                pass
         if _time.monotonic() >= deadline:
             return False
-        _time.sleep(0.5)
+        _time.sleep(interval)
+        interval = min(interval * 2.0, 5.0)
 
 
 # --- Wedged-gateway detection + bounded escalation (#81642) -----------------
@@ -5999,6 +6027,27 @@ def _wait_for_launchd_service_pid(
         time.sleep(0.5)
 
 
+def _launchd_fresh_pid_predicate(domain: str, label: str, old_pid: int | None):
+    """Return a best-effort zero-arg probe reporting a revived service PID.
+
+    Reuses :func:`_launchd_print_service_pid` — the same probe
+    :func:`_wait_for_launchd_service_pid` polls — so the shared
+    :func:`_wait_for_pid_exit` drain wait can stop the moment KeepAlive has
+    a replacement up, instead of idling on a lingering old PID (#101426).
+    Never raises: a failing probe reads as "not revived" and the drain
+    wait continues unchanged.
+    """
+
+    def _revived() -> bool:
+        try:
+            _loaded, fresh = _launchd_print_service_pid(domain, label)
+        except Exception:
+            return False
+        return fresh is not None and fresh > 0 and fresh != old_pid
+
+    return _revived
+
+
 def launchd_restart():
     label = get_launchd_label()
     domain = _launchd_domain()
@@ -6052,7 +6101,13 @@ def launchd_restart():
                 f"→ Stopping gateway (PID {pid}) — draining in-flight runs "
                 f"(up to {wait_budget:.0f}s)..."
             )
-            if _graceful_restart_via_sigusr1(pid, wait_budget):
+            if _graceful_restart_via_sigusr1(
+                pid,
+                wait_budget,
+                # KeepAlive may already have a replacement up while the old
+                # PID lingers in the table — stop waiting then (#101426).
+                is_revived=_launchd_fresh_pid_predicate(domain, label, pid),
+            ):
                 # The gateway exited with the planned-restart code. When
                 # launchd is actually supervising this label, KeepAlive
                 # revives it — do NOT kickstart (the replacement may already

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7120,6 +7120,7 @@ def _restart_macos_launchd_gateways(
         launchd_restart,
         launchd_gateway_labels_for_install,
         _graceful_restart_via_sigusr1,
+        _launchd_fresh_pid_predicate,
         _launchd_kickstart,
         _launchd_service_registered,
         _locate_launchd_gateway_service,
@@ -7153,7 +7154,11 @@ def _restart_macos_launchd_gateways(
             if old_pid is not None and old_pid > 0:
                 print(f"  → {label}: draining (up to {int(drain_budget)}s)...")
                 graceful_ok = _graceful_restart_via_sigusr1(
-                    old_pid, drain_timeout=drain_budget
+                    old_pid,
+                    drain_timeout=drain_budget,
+                    # Same early-exit as the current profile: a revived
+                    # sibling must not idle on its lingering old PID (#101426).
+                    is_revived=_launchd_fresh_pid_predicate(domain, label, old_pid),
                 )
             if graceful_ok and _wait_for_launchd_service_pid(
                 label, old_pid=old_pid, timeout=10.0, domain=domain

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -399,6 +399,37 @@ class TestLaunchdServiceRecovery:
     def test_wait_for_pid_exit_ignores_nonpositive_pid(self):
         assert gateway_cli._wait_for_pid_exit(0, timeout=30) is True
 
+    def test_wait_for_pid_exit_returns_once_revival_observed(self, monkeypatch):
+        """#101426: a lingering old PID must not idle the update after the
+        supervisor already revived the service — the revival probe
+        short-circuits the drain wait without sleeping."""
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        slept = []
+        monkeypatch.setattr(gateway_cli.time, "sleep", slept.append)
+
+        assert (
+            gateway_cli._wait_for_pid_exit(4242, timeout=1995, is_revived=lambda: True)
+            is True
+        )
+        assert slept == []
+
+    def test_wait_for_pid_exit_backoff_caps_poll_interval(self, monkeypatch):
+        """Long drain waits back off exponentially (0.5s → 5s cap)."""
+        monkeypatch.setattr("gateway.status._pid_exists", lambda pid: True)
+        sleeps = []
+        monkeypatch.setattr(gateway_cli.time, "sleep", sleeps.append)
+        calls = []
+
+        def _revived():
+            calls.append(1)
+            return len(calls) >= 8
+
+        assert (
+            gateway_cli._wait_for_pid_exit(4242, timeout=600, is_revived=_revived)
+            is True
+        )
+        assert sleeps == [0.5, 1.0, 2.0, 4.0, 5.0, 5.0, 5.0]
+
 
 
     def test_refresh_defers_reload_when_running_inside_gateway_tree(self, tmp_path, monkeypatch):
@@ -609,7 +640,7 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(
             gateway_cli,
             "_wait_for_pid_exit",
-            lambda pid, timeout: waited.append((pid, timeout)) or True,
+            lambda pid, timeout, **kw: waited.append((pid, timeout)) or True,
         )
 
         run_calls = []
@@ -812,7 +843,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(
             gateway_cli,
             "_graceful_restart_via_sigusr1",
-            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+            lambda pid, timeout, **kw: calls.append(("graceful", pid, timeout)) or True,
         )
 
         # Once SIGUSR1 makes the gateway exit with the planned restart code,
@@ -851,7 +882,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
-        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout, **kw: True)
         waits = iter((False, True))
         monkeypatch.setattr(
             gateway_cli,
@@ -885,7 +916,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
-        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout, **kw: True)
         monkeypatch.setattr(
             gateway_cli,
             "_wait_for_systemd_service_restart",
@@ -912,7 +943,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
-        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout, **kw: True)
 
         def failed_replacement_wait(
             system=False, previous_pid=None, replacement_observed=None
@@ -942,7 +973,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr("gateway.status.get_running_pid", lambda: 654)
-        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True)
+        monkeypatch.setattr(gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout, **kw: True)
         monkeypatch.setattr(
             gateway_cli,
             "_wait_for_systemd_service_restart",
@@ -1029,7 +1060,7 @@ class TestGatewaySystemServiceRouting:
         monkeypatch.setattr(
             gateway_cli,
             "_graceful_restart_via_sigusr1",
-            lambda pid, timeout: calls.append(("graceful", pid, timeout)) or True,
+            lambda pid, timeout, **kw: calls.append(("graceful", pid, timeout)) or True,
         )
         monkeypatch.setattr(
             gateway_cli,
@@ -1091,7 +1122,7 @@ class TestGatewaySystemServiceRouting:
         )
         monkeypatch.setattr(gateway_cli, "_get_restart_exit_wait_budget", lambda: 27.0)
         monkeypatch.setattr(
-            gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout: True
+            gateway_cli, "_graceful_restart_via_sigusr1", lambda pid, timeout, **kw: True
         )
         monkeypatch.setattr(
             gateway_cli,

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -293,7 +293,7 @@ def _fleet(monkeypatch, tmp_path, *, current, labels, located,
     monkeypatch.setattr(
         gw,
         "_graceful_restart_via_sigusr1",
-        lambda pid, drain_timeout: (rec.drains.append(pid), (drain_results or {}).get(pid, False))[1],
+        lambda pid, drain_timeout, **_kw: (rec.drains.append(pid), (drain_results or {}).get(pid, False))[1],
     )
 
     def fake_kickstart(label, domain):

--- a/tests/hermes_cli/test_update_wedged_gateway.py
+++ b/tests/hermes_cli/test_update_wedged_gateway.py
@@ -227,7 +227,7 @@ def _launchd_harness(monkeypatch, tmp_path, pid):
     monkeypatch.setattr(
         gateway_cli,
         "_graceful_restart_via_sigusr1",
-        lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
+        lambda pid, timeout, **_kw: events.append(("drain", pid, timeout)) or True,
     )
     monkeypatch.setattr(
         gateway_cli,
@@ -442,7 +442,7 @@ class TestLaunchdRestartWedgedIntegration:
         monkeypatch.setattr(
             gateway_cli,
             "_graceful_restart_via_sigusr1",
-            lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
+            lambda pid, timeout, **_kw: events.append(("drain", pid, timeout)) or True,
         )
         # KeepAlive revival observed instantly — avoids the real 15s poll
         # (mocked subprocess.run returns empty stdout, so the PID probe
@@ -609,7 +609,7 @@ class TestLoopTickWitness:
             monkeypatch.setattr(
                 gateway_cli,
                 "_graceful_restart_via_sigusr1",
-                lambda pid, timeout: events.append(("drain", pid, timeout)) or True,
+                lambda pid, timeout, **_kw: events.append(("drain", pid, timeout)) or True,
             )
             monkeypatch.setattr(
                 gateway_cli,


### PR DESCRIPTION
## What Problem This Solves
Fixes #101426 — `hermes update` idles 8–20 min in the macOS launchd restart phase after the gateway has already exited and been revived. Ponytail minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Tests: relevant suite passed (see worktree 101426).

Closes #101426