### PR TITLE
fix(desktop): init boot log buffers before readPersistedPoolLimits()

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1421,6 +1421,15 @@ const profileDeletionGate = new ProfileDeletionGate()
 // for scripted/headless setups; after launch the stored preference wins.
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
+// Boot-time log buffers. Declared before readPersistedPoolLimits() so the
+// rememberLog() calls it emits at module top-level (see `let poolLimits =
+// readPersistedPoolLimits()` below) append into initialized buffers instead
+// of crashing on an uninitialized `hermesLog`.
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
+
 function readPersistedPoolLimits() {
   try {
     const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
@@ -1574,12 +1583,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## Problem

On a cold boot (no `pool-limits.json` in userData), the desktop app crashes at startup:

```
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog (electron-main.mjs)
    at readPersistedPoolLimits (electron-main.mjs)
```

## Root cause

`readPersistedPoolLimits()` runs at module top-level (`let poolLimits = readPersistedPoolLimits()`) and calls `rememberLog()`, which does `hermesLog.push(...)`. But `hermesLog` (and the other boot log buffers `desktopLogBuffer` / `desktopLogFlushTimer` / `desktopLogFlushPromise`) are declared *after* that call site. Once esbuild transpiles `const`/`let` to `var`, `hermesLog` is `undefined` at that point, so the push throws.

## Fix

Move the boot log buffer declarations above `readPersistedPoolLimits()` so the earliest boot logs append into initialized buffers.

## Verification

- Reproduced the crash by deleting `pool-limits.json` and relaunching (before fix).
- After the fix, a cold boot proceeds normally and the `[pool-limits] no saved file and no env overrides; using defaults` line is written to the log instead of crashing.
