### PR TITLE
fix(desktop): tables follow RTL message direction

### DIFF
--- a/apps/desktop/src/components/assistant-ui/markdown-table.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-table.tsx
@@ -164,6 +164,7 @@ export function ResizableMarkdownTable({ children, className, ...props }: Compon
         onDoubleClick={onDoubleClick}
         onPointerDown={onPointerDown}
         ref={tableRef}
+        dir="auto"
         {...props}
       >
         {widths && (
@@ -183,7 +184,7 @@ export function ResizableMarkdownTh({ children, className, ...props }: Component
   return (
     <th
       className={cn(
-        'relative px-2.5 py-1.5 text-left align-middle text-[0.75rem] font-medium text-muted-foreground',
+        'relative px-2.5 py-1.5 text-start align-middle text-[0.75rem] font-medium text-muted-foreground',
         // The trailing column has no seam: its right edge is the table's edge,
         // and there is nothing on the far side to trade width with.
         '[&:last-child_[data-md-col-handle]]:hidden',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1544,6 +1544,29 @@ body.guest-pointer-lock :is(webview, iframe) {
   text-align: left;
 }
 
+/* Table cells follow the table's single resolved direction. The <table>
+   carries dir="auto" (markdown-table.tsx) so the browser derives that one
+   direction, and the column order, from the cells' content (in practice the
+   column headers). plaintext keeps each cell's inline content in its authored
+   order, so a value like "18 ₪", "-3%" or "123 units" is never reordered by
+   the surrounding RTL run. :dir() then pins every header and cell to the
+   table's resolved edge, so a column's header and values stay on the same
+   side instead of splitting (an RTL header right, a numeric value left).
+   Physical right/left is deliberate here: the side is chosen by the table's
+   resolved direction, not the cell's own. Out-specifies the prose cell
+   defaults. */
+[data-slot='aui_assistant-message-content'] .aui-md :where(th, td) {
+  unicode-bidi: plaintext;
+}
+
+[data-slot='aui_assistant-message-content'] .aui-md table:dir(rtl) :where(th, td) {
+  text-align: right;
+}
+
+[data-slot='aui_assistant-message-content'] .aui-md table:dir(ltr) :where(th, td) {
+  text-align: left;
+}
+
 [data-slot='aui_user-message-root'] {
   top: var(--sticky-human-top);
 }

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -118,6 +118,12 @@ export default defineConfig(({ command }) => ({
     postcss: { plugins: [] }
   },
   build: {
+    // Renderer CSS targets the bundled Chromium (Electron 40 ≈ Chrome 132), not
+    // the web-default baseline. Without this, LightningCSS downlevels modern
+    // selectors — e.g. `table:dir(rtl)` compiles to a `:lang()` list that
+    // never matches (no lang attribute is ever set) — silently breaking
+    // RTL table alignment. Chrome 132 supports :dir() natively.
+    cssTarget: 'chrome132',
     // The renderer intentionally ships FEW chunks (not one, not thousands):
     //   · `codeSplitting: false` (the old setup) inlines every `lazy()` /
     //     dynamic import into the entry, so heavyweight lazy-only deps


### PR DESCRIPTION
## What does this PR do?

A markdown table's column order is its box `direction`, which the `unicode-bidi: plaintext` rules (#44150) that resolve per-block text direction never touch. An RTL table (Arabic/Hebrew — the common case for RTL-language operators) keeps LTR columns: the first-read column ends up stranded on the left and every row reads in mirrored column order.

Salvages the approach of #47911 (open, no recent activity) — same `dir="auto"` + `:dir()` hook — plus fixes the silent root cause that would have defeated it: the renderer's CSS target.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes a bug)

## Changes Made

- `apps/desktop/src/components/assistant-ui/markdown-table.tsx`
  - `dir="auto"` on the rendered `<table>`: lets the browser derive the box direction from the cells' content (in practice the headers). No CSS selector can read direction off the cells' script, so the attribute is the minimal hook. Content-driven, so English tables are untouched (they resolve LTR and everything renders as today).
  - `th` alignment `text-left` → `text-start` so headers follow the resolved direction.
- `apps/desktop/src/styles.css`
  - Table cells get `unicode-bidi: plaintext` — values like `33% = 5/15` or `-3%` keep their authored order inside an RTL run.
  - `table:dir(rtl)` / `table:dir(ltr)` pin every header and cell to the table's resolved edge, so a column's header and values stay on the same side instead of splitting (RTL header right, numeric value left).
- `apps/desktop/vite.config.ts`
  - **`build.cssTarget: 'chrome132'`** — without this, LightningCSS downlevels `:dir()` into a `:lang()` list (verified in the shipped bundle: `table:is(:lang(ar),...)`), which never matches because no `lang` attribute is ever set. The :dir() rules silently compile to dead selectors. The renderer runs on the bundled Chromium (Electron 40 ≈ Chrome 132), which supports `:dir()` natively. **This is the root cause any future modern-selector CSS in this stylesheet will hit.**

## How to Test

1. Ask the agent for an Arabic/Hebrew markdown table → columns render right-to-left with the first-read column on the right; header and values of each column stay on the same side; numeric cells keep their authored order.
2. Ask for an English table → renders byte-identically to before (dir="auto" resolves LTR).
3. Resize a column (drag the header seam) → still works; the existing RTL-aware drag math reads `getComputedStyle(table).direction`, which dir="auto" now actually resolves.
4. `grep table:dir apps/desktop/dist/assets/index-*.css` → both :dir(rtl) and :dir(ltr) rules present as-is (not downleveled).

Verified live on macOS 26.5 (arm64) in the packaged app: Arabic tables now read right-to-left end to end; mixed values (`5/15 = 33%`, `~12–15`, `[19–59%]`) stay in order inside RTL cells.

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — #47911 targets the same bug with the same approach and has no recent activity; this PR salvages it and adds the cssTarget fix without which the CSS never matches
- [x] My PR contains **only** changes related to this fix
- [x] I've added/verified tests where practical (jsdom does not resolve dir="auto"; contract verified via built-bundle inspection + live rendering)
- [x] I've tested on my platform: macOS 26.5 arm64, packaged Hermes.app

### Documentation & Housekeeping
- [x] Documentation N/A (renderer-only change)
