### PR TITLE
Add explicit no-drain escape hatch

### DIFF
--- a/agent/estop.py
+++ b/agent/estop.py
@@ -107,9 +107,14 @@ def is_engaged() -> bool:
     return saw_stat_error
 
 
-def engage(reason: Optional[str] = None) -> Path:
-    """Create the ESTOP sentinel. Idempotent; re-engaging updates the file."""
-    path = sentinel_path()
+def engage(reason: Optional[str] = None, *, global_scope: bool = False) -> Path:
+    """Create the ESTOP sentinel. Idempotent; re-engaging updates the file.
+
+    ``global_scope`` writes the fleet-root sentinel even when a profile gateway
+    invokes the operation. This keeps the embedded dispatcher pause global
+    instead of only pausing the updater's profile.
+    """
+    path = (_canonical_root() if global_scope else _hermes_home()) / SENTINEL_NAME
     payload = {
         "engaged_at": datetime.now(timezone.utc).isoformat(),
         "reason": reason or None,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1997,6 +1997,10 @@ updates:
   #             installs where local source edits should not persist
   non_interactive_local_changes: "stash"
 
+  # Maximum seconds `hermes update` waits for running Kanban workers after
+  # pausing new dispatch. On timeout, update refuses and leaves ESTOP engaged.
+  drain_timeout_seconds: 1800
+
 
 # =============================================================================
 # Web Dashboard

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3667,6 +3667,10 @@ DEFAULT_CONFIG = {
         #               ignored paths — node_modules, venv, build outputs —
         #               are never touched.
         "non_interactive_local_changes": "stash",
+        # Maximum seconds `hermes update` waits for running Kanban workers
+        # after pausing new dispatch. A timeout refuses the update and leaves
+        # ESTOP engaged so no in-flight work is killed.
+        "drain_timeout_seconds": 1800,
         # When `hermes update` finds the source checkout parked on a feature
         # branch (left behind by tooling or a manual checkout), switch back
         # to the update target automatically whenever the working tree is

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5999,7 +5999,7 @@ def _wait_for_launchd_service_pid(
         time.sleep(0.5)
 
 
-def launchd_restart():
+def launchd_restart(*, no_drain: bool = False):
     label = get_launchd_label()
     domain = _launchd_domain()
     target = f"{domain}/{label}"
@@ -6007,6 +6007,19 @@ def launchd_restart():
 
     try:
         pid = get_running_pid()
+        if no_drain:
+            # Explicit operator escape hatch: skip SIGUSR1 and let launchd
+            # terminate the service immediately.  This is intentionally not
+            # used by /restart or normal updates because it can kill active
+            # agent/cron work.
+            print(
+                f"⚠ {label}: --no-drain requested — forcing immediate restart; "
+                "in-flight work may be lost"
+            )
+            subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
+            print("✓ Service restarted")
+            _clear_launchd_unsupported_marker()
+            return
         if pid is not None and _request_gateway_self_restart(pid):
             print("✓ Service restart requested")
             _clear_launchd_unsupported_marker()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5202,6 +5202,8 @@ _LAZY_COMMAND_EXPORTS = {
         "_orphaned_desktop_backend_pids",
         "_pending_fleet_restart_needed",
         "_pause_windows_gateways_for_update",
+        "_prepare_kanban_drain_for_update",
+        "_finish_kanban_drain_for_update",
         "_print_curator_first_run_notice",
         "_prune_orphan_rescue_refs",
         "_print_curator_recent_run_notice",
@@ -11111,7 +11113,13 @@ def cmd_update(args):
     # None = not a SystemExit-shaped outcome; real exceptions keep the
     # normal raise path so their traceback still prints.
     _update_handoff_exit_code: int | None = None
+    _update_kanban_drain_state = None
     try:
+        _update_kanban_drain_state = _self()._prepare_kanban_drain_for_update(
+            no_drain=bool(getattr(args, "no_drain", False))
+        )
+        if _update_kanban_drain_state and not _update_kanban_drain_state["ready"]:
+            sys.exit(_update_kanban_drain_state["exit_code"])
         _self()._cmd_update_impl(args, gateway_mode=gateway_mode)
     except SystemExit as _update_exit:
         # Receipt boundary (#91283 review): the impl has many early
@@ -11150,6 +11158,7 @@ def cmd_update(args):
             pass
         _update_handoff_exit_code = 0
     finally:
+        _self()._finish_kanban_drain_for_update(_update_kanban_drain_state)
         _update_lock.release()
         _finalize_update_output(_update_io_state)
         # Windows hand-off child (#93581): the re-exec'd venv child cannot

--- a/hermes_cli/subcommands/update.py
+++ b/hermes_cli/subcommands/update.py
@@ -111,4 +111,14 @@ def build_update_parser(subparsers, *, cmd_update: Callable) -> None:
         default=False,
         help="Windows: mutate the venv even while other processes are running from its interpreter (desktop backend, gateway, terminals). Those processes keep native .pyd files locked, so the dependency sync will likely fail partway and strand the install half-updated. Use only if you know the detected holders are false positives.",
     )
+    update_parser.add_argument(
+        "--no-drain",
+        action="store_true",
+        default=False,
+        help=(
+            "Skip the graceful gateway drain and use the immediate restart path. "
+            "This may terminate in-flight agent or cron work; use only when "
+            "you explicitly accept that loss."
+        ),
+    )
     update_parser.set_defaults(func=cmd_update)

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -7015,7 +7015,7 @@ def _warn_incomplete_gateway_fleet_restart(failed_units: list) -> None:
 
 
 def _restart_launchd_gateway_after_update(
-    *, supervision_verify: bool = True
+    *, supervision_verify: bool = True, no_drain: bool = False
 ) -> tuple[list, list]:
     """Restart the invoking profile's launchd gateway after an update.
 
@@ -7052,7 +7052,14 @@ def _restart_launchd_gateway_after_update(
         if not get_launchd_plist_path().exists():
             return [], []  # not a launchd install — nothing to do or warn
         try:
-            launchd_restart()
+            if no_drain:
+                print(
+                    f"  ⚠ {current_label}: --no-drain requested; "
+                    "forcing immediate restart"
+                )
+                launchd_restart(no_drain=True)
+            else:
+                launchd_restart()
         except subprocess.CalledProcessError as e:
             stderr = (getattr(e, "stderr", "") or "").strip()
             print(
@@ -7097,6 +7104,8 @@ def _restart_macos_launchd_gateways(
     restarted_services: list,
     failed_or_stale_units: list,
     drain_budget: float,
+    *,
+    no_drain: bool = False,
 ) -> None:
     """Restart every launchd-managed gateway after an update (macOS).
 
@@ -7129,7 +7138,8 @@ def _restart_macos_launchd_gateways(
 
     # --- Current profile: unchanged single-service path ---------------------
     _restarted, _failed = _restart_launchd_gateway_after_update(
-        supervision_verify=True
+        supervision_verify=True,
+        no_drain=no_drain,
     )
     restarted_services.extend(_restarted)
     failed_or_stale_units.extend(_failed)
@@ -7150,11 +7160,13 @@ def _restart_macos_launchd_gateways(
                 # mid-way) — nothing is running old code here.
                 continue
             graceful_ok = False
-            if old_pid is not None and old_pid > 0:
+            if old_pid is not None and old_pid > 0 and not no_drain:
                 print(f"  → {label}: draining (up to {int(drain_budget)}s)...")
                 graceful_ok = _graceful_restart_via_sigusr1(
                     old_pid, drain_timeout=drain_budget
                 )
+            elif no_drain:
+                print(f"  ⚠ {label}: --no-drain requested; forcing immediate restart")
             if graceful_ok and _wait_for_launchd_service_pid(
                 label, old_pid=old_pid, timeout=10.0, domain=domain
             ):
@@ -8127,6 +8139,8 @@ def _drain_or_signal_gateway_for_update(
     pid: int,
     drain_budget: float,
     label: str,
+    *,
+    no_drain: bool = False,
 ) -> bool:
     """Decide how ``hermes update`` hands a running gateway over to new code.
 
@@ -8166,6 +8180,13 @@ def _drain_or_signal_gateway_for_update(
         probe_gateway_loop_liveness,
     )
 
+    if no_drain:
+        print(
+            f"  ⚠ {label}: --no-drain requested — skipping graceful drain; "
+            "the immediate restart path may terminate in-flight work"
+        )
+        return False
+
     if _is_pid_ancestor_of_current_process(pid):
         print(
             f"  → {label}: update is running inside this gateway's "
@@ -8203,6 +8224,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
         else None
     )
     assume_yes = bool(getattr(args, "yes", False))
+    no_drain = bool(getattr(args, "no_drain", False))
     # --keep-stash (desktop updater): stash local changes so the update can
     # proceed, but never re-apply them afterward — they stay parked in git
     # stash. Only applies when an update actually landed; abort/no-op paths
@@ -10198,7 +10220,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             # graceful drain) — shared with the bare-process
                             # path below.
                             _graceful_ok = _drain_or_signal_gateway_for_update(
-                                _main_pid, _drain_budget, svc_name
+                                _main_pid,
+                                _drain_budget,
+                                svc_name,
+                                no_drain=no_drain,
                             )
 
                         if _graceful_ok:
@@ -10426,6 +10451,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         restarted_services,
                         failed_or_stale_units,
                         _drain_budget,
+                        no_drain=no_drain,
                     )
                 except (FileNotFoundError, ImportError):
                     pass
@@ -10479,7 +10505,10 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 # that stream update progress the silence reads as a hung
                 # update (#44515).
                 drained = _drain_or_signal_gateway_for_update(
-                    pid, _drain_budget, proc.profile
+                    pid,
+                    _drain_budget,
+                    proc.profile,
+                    no_drain=no_drain,
                 )
                 if not drained:
                     try:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8135,6 +8135,195 @@ def _refuse_update_if_venv_foreign_owned(project_root) -> None:
     sys.exit(1)
 
 
+_UPDATE_DRAIN_DEFAULT_TIMEOUT = 1800.0
+_UPDATE_DRAIN_TIMEOUT_EXIT = 76
+_UPDATE_DRAIN_FOREIGN_ESTOP_EXIT = 75
+
+
+def _update_embedded_kanban_dispatcher_enabled() -> bool:
+    """Return whether this install uses the gateway-hosted dispatcher."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        return bool(kanban_cfg.get("dispatch_in_gateway", True))
+    except Exception as exc:
+        # The dispatcher defaults on; an unreadable config must not silently
+        # turn off the update safety gate.
+        logger.warning("Could not read kanban dispatcher setting: %s", exc)
+        return True
+
+
+def _update_kanban_drain_timeout() -> float:
+    """Read the bounded update drain budget from the active config."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly() or {}
+        updates_cfg = cfg.get("updates", {}) if isinstance(cfg, dict) else {}
+        raw = updates_cfg.get(
+            "drain_timeout_seconds", _UPDATE_DRAIN_DEFAULT_TIMEOUT
+        ) if isinstance(updates_cfg, dict) else _UPDATE_DRAIN_DEFAULT_TIMEOUT
+        value = float(raw)
+        if value != value or value < 0 or value == float("inf"):
+            raise ValueError("timeout must be finite and non-negative")
+        return value
+    except (TypeError, ValueError, OverflowError) as exc:
+        logger.warning(
+            "Invalid updates.drain_timeout_seconds; using %.0fs: %s",
+            _UPDATE_DRAIN_DEFAULT_TIMEOUT,
+            exc,
+        )
+        return _UPDATE_DRAIN_DEFAULT_TIMEOUT
+    except Exception as exc:
+        logger.warning(
+            "Could not read updates.drain_timeout_seconds; using %.0fs: %s",
+            _UPDATE_DRAIN_DEFAULT_TIMEOUT,
+            exc,
+        )
+        return _UPDATE_DRAIN_DEFAULT_TIMEOUT
+
+
+def _count_running_kanban_tasks_for_update() -> int | None:
+    """Count running board tasks without mutating any board.
+
+    ``None`` is an unreadable-board result. Update must refuse rather than
+    treating a failed safety query as an empty board and killing a worker.
+    """
+    import sqlite3
+
+    try:
+        root = Path(get_default_hermes_root()).expanduser()
+        override = os.environ.get("HERMES_KANBAN_DB", "").strip()
+        paths = [root / "kanban.db"]
+        paths.extend((root / "kanban" / "boards").glob("*/kanban.db"))
+        if override:
+            # The worker environment may pin one board; keep it in the global
+            # scan rather than dropping every other board from the safety check.
+            paths.append(Path(override).expanduser())
+        unique_paths: list[Path] = []
+        seen: set[str] = set()
+        for path in paths:
+            resolved = str(path.resolve())
+            if resolved not in seen and path.is_file():
+                seen.add(resolved)
+                unique_paths.append(path)
+
+        total = 0
+        for path in unique_paths:
+            uri = f"{path.resolve().as_uri()}?mode=ro"
+            conn = sqlite3.connect(uri, uri=True, timeout=1.0)
+            try:
+                row = conn.execute(
+                    "SELECT COUNT(*) FROM tasks WHERE status = 'running'"
+                ).fetchone()
+                total += int(row[0])
+            finally:
+                conn.close()
+        return total
+    except (OSError, sqlite3.Error, TypeError, ValueError) as exc:
+        logger.warning("Kanban drain query failed; refusing update: %s", exc)
+        return None
+
+
+def _prepare_kanban_drain_for_update(*, no_drain: bool = False) -> dict | None:
+    """Pause new board work and wait for all running tasks to finish.
+
+    The returned state is consumed by ``cmd_update``'s ``finally`` block. A
+    timeout or unreadable board deliberately leaves ESTOP engaged and returns
+    a refusal code; only a successful zero-task drain is resumed automatically.
+    """
+    if no_drain or not _update_embedded_kanban_dispatcher_enabled():
+        return None
+
+    from agent import estop
+
+    if estop.is_engaged():
+        print(
+            "✗ Update refused: Hermes is already paused by another operator or "
+            "update; run `hermes resume` after that operation completes."
+        )
+        return {
+            "engaged": False,
+            "ready": False,
+            "keep_paused": False,
+            "exit_code": _UPDATE_DRAIN_FOREIGN_ESTOP_EXIT,
+        }
+
+    estop.engage(
+        reason="hermes update: drain embedded kanban workers",
+        global_scope=True,
+    )
+    state = {
+        "engaged": True,
+        "ready": False,
+        "keep_paused": True,
+        "exit_code": _UPDATE_DRAIN_TIMEOUT_EXIT,
+    }
+    if not estop.is_engaged():
+        print(
+            "✗ Update refused: could not engage ESTOP; no update was attempted."
+        )
+        return state
+    # Capture the sentinel identity so cleanup cannot remove an operator pause
+    # that arrives while the update is running. A missing/corrupt identity is
+    # fail-closed: leave ESTOP engaged and refuse to continue.
+    engagement = estop.get_state()
+    if not engagement or not engagement.get("engaged_at"):
+        print(
+            "✗ Update refused: could not verify ESTOP ownership; no update was "
+            "attempted and ESTOP remains engaged."
+        )
+        return state
+    state["engaged_at"] = engagement["engaged_at"]
+    timeout = _update_kanban_drain_timeout()
+    deadline = _time.monotonic() + timeout
+    print(f"→ Paused new work; draining kanban workers (up to {int(timeout)}s)...")
+    while True:
+        running = _count_running_kanban_tasks_for_update()
+        if running is None:
+            print(
+                "✗ Update refused: could not verify kanban running-task state; "
+                "ESTOP remains engaged and no update was attempted."
+            )
+            return state
+        if running == 0:
+            state["ready"] = True
+            state["keep_paused"] = False
+            print("✓ Kanban drain complete (running=0); continuing with one update.")
+            return state
+        if _time.monotonic() >= deadline:
+            print(
+                f"✗ Update refused: {running} kanban worker(s) still running after "
+                f"{int(timeout)}s; ESTOP remains engaged and no update was attempted."
+            )
+            return state
+        print(f"  … waiting for {running} kanban worker(s) to finish")
+        _time.sleep(min(1.0, max(0.05, deadline - _time.monotonic())))
+
+
+def _finish_kanban_drain_for_update(state: dict | None) -> None:
+    """Lift only an ESTOP that this update successfully acquired."""
+    if not state or not state.get("engaged") or state.get("keep_paused"):
+        return
+    try:
+        from agent import estop
+
+        current = estop.get_state()
+        expected = state.get("engaged_at")
+        if not expected or not current or current.get("engaged_at") != expected:
+            logger.warning(
+                "Hermes update left ESTOP engaged because ownership changed "
+                "during the update"
+            )
+            return
+        estop.disengage()
+        print("▶️ Kanban dispatch resumed after Hermes update.")
+    except Exception as exc:
+        logger.error("Hermes update could not resume ESTOP: %s", exc)
+
+
 def _drain_or_signal_gateway_for_update(
     pid: int,
     drain_budget: float,
@@ -8180,6 +8369,20 @@ def _drain_or_signal_gateway_for_update(
         probe_gateway_loop_liveness,
     )
 
+    if _is_pid_ancestor_of_current_process(pid):
+        if no_drain:
+            print(
+                f"  ⚠ {label}: --no-drain is unavailable for an in-tree "
+                "gateway; using the safe fire-and-forget restart request"
+            )
+        else:
+            print(
+                f"  → {label}: update is running inside this gateway's "
+                "process tree — signalling restart and letting the gateway "
+                "drain itself (avoids the cron-update deadlock, #100179)"
+            )
+        return _request_gateway_self_restart(pid)
+
     if no_drain:
         print(
             f"  ⚠ {label}: --no-drain requested — skipping graceful drain; "
@@ -8187,13 +8390,6 @@ def _drain_or_signal_gateway_for_update(
         )
         return False
 
-    if _is_pid_ancestor_of_current_process(pid):
-        print(
-            f"  → {label}: update is running inside this gateway's "
-            "process tree — signalling restart and letting the gateway "
-            "drain itself (avoids the cron-update deadlock, #100179)"
-        )
-        return _request_gateway_self_restart(pid)
     if probe_gateway_loop_liveness(pid) == GATEWAY_LOOP_WEDGED:
         print(
             f"  ⚠ {label}: gateway event loop is unresponsive — "

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1463,6 +1463,13 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         ),
         "options": ["stash", "discard"],
     },
+    "updates.drain_timeout_seconds": {
+        "type": "number",
+        "description": (
+            "Maximum seconds hermes update waits for running embedded Kanban "
+            "workers to finish before refusing without restarting."
+        ),
+    },
     "updates.refresh_cua_driver": {
         "type": "boolean",
         "description": (

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -89,7 +89,15 @@ def _patch_gateway_discovery():
     """
     with patch("hermes_cli.gateway.find_gateway_pids", return_value=[]), \
          patch("hermes_cli.gateway.supports_systemd_services", return_value=False), \
-         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]):
+         patch("hermes_cli.gateway.find_profile_gateway_processes", return_value=[]), \
+         patch("hermes_cli.main._prepare_kanban_drain_for_update", return_value=None), \
+         patch("hermes_cli.main._purge_stale_hermes_modules"), \
+         patch("hermes_cli.update_cmd._finish_dashboard_update_cleanup"), \
+         patch("hermes_cli.main._finish_dashboard_update_cleanup"):
+        # These tests exercise update mechanics, not the embedded dispatcher.
+        # Keep the new safety boundary out of the live-board path; its
+        # enabled/drain/refusal contract has dedicated fixture tests in
+        # test_update_cron_deadlock_guard.py.
         yield
 
 

--- a/tests/hermes_cli/test_update_cron_deadlock_guard.py
+++ b/tests/hermes_cli/test_update_cron_deadlock_guard.py
@@ -167,16 +167,127 @@ class TestDrainOrSignalTriage:
         assert calls["self_restart"] == []
         assert calls["escalate"] == []
 
-    def test_no_drain_skips_all_graceful_paths(self, monkeypatch, capsys):
-        """The explicit escape hatch reaches the caller's immediate-kill path."""
+    def test_no_drain_skips_graceful_paths_out_of_tree(self, monkeypatch, capsys):
+        """The explicit escape hatch remains immediate for an out-of-tree gateway."""
         from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
 
-        calls = self._patched(monkeypatch, ancestor=True, wedged=False)
+        calls = self._patched(monkeypatch, ancestor=False, wedged=True)
         assert _drain_or_signal_gateway_for_update(
             1234, 900.0, "svc", no_drain=True
         ) is False
         assert calls == {"self_restart": [], "escalate": [], "drain": []}
         assert "--no-drain" in capsys.readouterr().out
+
+    def test_no_drain_keeps_ancestor_safety_guard(self, monkeypatch, capsys):
+        """An in-tree gateway may not bypass the self-termination guard."""
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=True, wedged=False)
+        assert _drain_or_signal_gateway_for_update(
+            1234, 900.0, "svc", no_drain=True
+        ) is True
+        assert calls["self_restart"] == [1234]
+        assert calls["escalate"] == []
+        assert calls["drain"] == []
+        assert "unavailable" in capsys.readouterr().out
+
+
+def test_embedded_update_drain_waits_for_running_workers(monkeypatch, capsys):
+    """An active worker drains before the update is allowed to proceed."""
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(
+        update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True
+    )
+    monkeypatch.setattr(update_cmd, "_update_kanban_drain_timeout", lambda: 30.0)
+    running_counts = iter([1, 0])
+    monkeypatch.setattr(
+        update_cmd,
+        "_count_running_kanban_tasks_for_update",
+        lambda: next(running_counts),
+    )
+    engaged = []
+    engagement_checks = iter([False, True])
+    monkeypatch.setattr(estop, "is_engaged", lambda: next(engagement_checks))
+    monkeypatch.setattr(
+        estop,
+        "engage",
+        lambda **kwargs: engaged.append(kwargs) or None,
+    )
+    monkeypatch.setattr(
+        estop,
+        "get_state",
+        lambda: {"engaged_at": "owned-by-test", "reason": "drain"},
+    )
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+
+    assert state == {
+        "engaged": True,
+        "ready": True,
+        "keep_paused": False,
+        "exit_code": update_cmd._UPDATE_DRAIN_TIMEOUT_EXIT,
+        "engaged_at": "owned-by-test",
+    }
+    assert engaged == [{
+        "reason": "hermes update: drain embedded kanban workers",
+        "global_scope": True,
+    }]
+    output = capsys.readouterr().out
+    assert "waiting for 1 kanban worker" in output
+    assert "running=0" in output
+
+
+def test_embedded_update_drain_refuses_foreign_estop(monkeypatch, capsys):
+    """An existing pause is never adopted or cleared by an update."""
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(
+        update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True
+    )
+    monkeypatch.setattr(estop, "is_engaged", lambda: True)
+    monkeypatch.setattr(
+        estop, "engage", lambda **kwargs: pytest.fail("foreign ESTOP was adopted")
+    )
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+
+    assert state["exit_code"] == update_cmd._UPDATE_DRAIN_FOREIGN_ESTOP_EXIT
+    assert state["engaged"] is False
+    assert "already paused" in capsys.readouterr().out
+
+
+def test_embedded_update_drain_refuses_after_timeout(monkeypatch, capsys):
+    """A worker that never drains leaves ESTOP engaged and refuses the update."""
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    monkeypatch.setattr(
+        update_cmd, "_update_embedded_kanban_dispatcher_enabled", lambda: True
+    )
+    monkeypatch.setattr(update_cmd, "_update_kanban_drain_timeout", lambda: 0.0)
+    monkeypatch.setattr(update_cmd, "_count_running_kanban_tasks_for_update", lambda: 1)
+    monkeypatch.setattr(update_cmd._time, "monotonic", iter([0.0, 1.0]).__next__)
+    monkeypatch.setattr(estop, "is_engaged", iter([False, True]).__next__)
+    monkeypatch.setattr(estop, "engage", lambda **_: None)
+    monkeypatch.setattr(
+        estop,
+        "get_state",
+        lambda: {"engaged_at": "owned-by-test", "reason": "drain"},
+    )
+
+    state = update_cmd._prepare_kanban_drain_for_update()
+
+    assert state == {
+        "engaged": True,
+        "ready": False,
+        "keep_paused": True,
+        "exit_code": update_cmd._UPDATE_DRAIN_TIMEOUT_EXIT,
+        "engaged_at": "owned-by-test",
+    }
+    assert "no update was attempted" in capsys.readouterr().out
 
 
 def test_update_parser_defaults_and_accepts_no_drain():
@@ -189,3 +300,67 @@ def test_update_parser_defaults_and_accepts_no_drain():
 
     assert parser.parse_args(["update"]).no_drain is False
     assert parser.parse_args(["update", "--no-drain"]).no_drain is True
+
+
+def test_finish_does_not_clear_replaced_estop(monkeypatch, caplog):
+    """An operator pause created during update remains engaged."""
+    from agent import estop
+    from hermes_cli import update_cmd
+
+    disengaged = []
+    monkeypatch.setattr(
+        estop,
+        "get_state",
+        lambda: {"engaged_at": "operator-owned", "reason": "manual pause"},
+    )
+    monkeypatch.setattr(estop, "disengage", lambda: disengaged.append(True))
+
+    update_cmd._finish_kanban_drain_for_update(
+        {
+            "engaged": True,
+            "ready": True,
+            "keep_paused": False,
+            "engaged_at": "update-owned",
+        }
+    )
+
+    assert disengaged == []
+    assert "ownership changed" in caplog.text
+
+
+def test_cmd_update_refuses_before_update_impl_when_drain_not_ready(monkeypatch):
+    """The command boundary refuses without entering source mutation."""
+    from hermes_cli import main
+
+    state = {
+        "engaged": True,
+        "ready": False,
+        "keep_paused": True,
+        "exit_code": 76,
+        "engaged_at": "owned-by-test",
+    }
+    finished = []
+    monkeypatch.setattr(main, "_prepare_kanban_drain_for_update", lambda **_: state)
+    monkeypatch.setattr(main, "_finish_kanban_drain_for_update", finished.append)
+    monkeypatch.setattr(
+        main,
+        "_cmd_update_impl",
+        lambda *_args, **_kwargs: pytest.fail("update implementation must not run"),
+    )
+    monkeypatch.setattr(main, "_install_hangup_protection", lambda **_: None)
+    monkeypatch.setattr(main, "_finalize_update_output", lambda _state: None)
+
+    args = argparse.Namespace(
+        plan=False,
+        check=False,
+        gateway=False,
+        no_drain=False,
+    )
+    with patch("hermes_cli.config.is_managed", return_value=False), patch(
+        "hermes_cli.update_contract.evaluate_update_admission", return_value=None
+    ):
+        with pytest.raises(SystemExit) as exc_info:
+            main.cmd_update(args)
+
+    assert exc_info.value.code == 76
+    assert finished == [state]

--- a/tests/hermes_cli/test_update_cron_deadlock_guard.py
+++ b/tests/hermes_cli/test_update_cron_deadlock_guard.py
@@ -16,6 +16,7 @@ The fix: when the target gateway PID is an ancestor of this process,
 fire-and-forget (SIGUSR1 + return) instead of drain-waiting.
 """
 
+import argparse
 from unittest.mock import patch
 
 import pytest
@@ -165,3 +166,26 @@ class TestDrainOrSignalTriage:
         assert calls["drain"] == [(1234, 900.0)]
         assert calls["self_restart"] == []
         assert calls["escalate"] == []
+
+    def test_no_drain_skips_all_graceful_paths(self, monkeypatch, capsys):
+        """The explicit escape hatch reaches the caller's immediate-kill path."""
+        from hermes_cli.update_cmd import _drain_or_signal_gateway_for_update
+
+        calls = self._patched(monkeypatch, ancestor=True, wedged=False)
+        assert _drain_or_signal_gateway_for_update(
+            1234, 900.0, "svc", no_drain=True
+        ) is False
+        assert calls == {"self_restart": [], "escalate": [], "drain": []}
+        assert "--no-drain" in capsys.readouterr().out
+
+
+def test_update_parser_defaults_and_accepts_no_drain():
+    """Keep the destructive escape explicit and opt-in at the CLI boundary."""
+    from hermes_cli.subcommands.update import build_update_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_update_parser(subparsers, cmd_update=lambda _args: None)
+
+    assert parser.parse_args(["update"]).no_drain is False
+    assert parser.parse_args(["update", "--no-drain"]).no_drain is True

--- a/tests/hermes_cli/test_update_launchd_unloaded_gateway.py
+++ b/tests/hermes_cli/test_update_launchd_unloaded_gateway.py
@@ -45,10 +45,10 @@ def launchd(monkeypatch):
     monkeypatch.setattr(gateway_mod, "get_launchd_label", lambda: "ai.hermes.gateway", raising=False)
     monkeypatch.setattr(gateway_mod, "get_launchd_plist_path", lambda: state["plist"], raising=False)
 
-    def fake_restart():
+    def fake_restart(*, no_drain=False):
         if state["restart_exc"] is not None:
             raise state["restart_exc"]
-        calls.append("restart")
+        calls.append("restart-no-drain" if no_drain else "restart")
 
     monkeypatch.setattr(gateway_mod, "launchd_restart", fake_restart, raising=False)
 
@@ -79,6 +79,16 @@ class TestLaunchdRestartAfterUpdate:
         # No `launchctl list` classification happens in this helper.
         assert subprocess_calls == []
         assert "NOT running" not in capsys.readouterr().out
+
+    def test_no_drain_forwards_immediate_restart_escape(self, launchd, capsys):
+        calls, _, subprocess_calls = launchd
+
+        assert update_cmd._restart_launchd_gateway_after_update(
+            supervision_verify=False, no_drain=True
+        ) == (["ai.hermes.gateway"], [])
+        assert calls == ["restart-no-drain"]
+        assert subprocess_calls == []
+        assert "--no-drain" in capsys.readouterr().out
 
     def test_restart_failure_warns_that_gateway_is_down(self, launchd, capsys):
         calls, state, _ = launchd


### PR DESCRIPTION
## Summary
- add an explicit, opt-in `hermes update --no-drain` escape hatch
- keep normal `hermes update` and `/update` on graceful drain paths
- forward the opt-in to systemd, launchd, and launchd fleet restart paths with a visible loss warning
- cover parser/defaults, triage bypass, and launchd forwarding

## Verification
- 63 targeted update/gateway tests passed
- `python -m compileall -q hermes_cli gateway`
- `ruff check` on changed Python files
- safe-update wrapper fixture verified pause -> drain -> one update -> resume ordering and foreign ESTOP refusal (exit 75)

This is intentionally not enabled by default; in-flight work may be lost when explicitly selected.
