### PR TITLE
fix(desktop): hoist hermesLog decl above module-eval pool-limits read

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1421,6 +1421,15 @@ const profileDeletionGate = new ProfileDeletionGate()
 // for scripted/headless setups; after launch the stored preference wins.
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
+// Desktop-shell log state. Declared here (not next to the other window/cache
+// state below) because readPersistedPoolLimits() runs at module-eval time and
+// calls rememberLog(); after transpile `const` loses its TDZ, so a later
+// declaration left `hermesLog` undefined and crashed boot on `.push`.
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
+
 function readPersistedPoolLimits() {
   try {
     const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
@@ -1574,12 +1583,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
Move desktop-shell log state (hermesLog, desktopLogBuffer, desktopLogFlushTimer, desktopLogFlushPromise) above readPersistedPoolLimits() in apps/desktop/electron/main.ts so it is initialized before any module-eval-time rememberLog() call.

App crashed on launch after update: TypeError: Cannot read properties of undefined (reading 'push') at rememberLog / readPersistedPoolLimits. `let poolLimits = readPersistedPoolLimits()` runs at module eval; both branches call rememberLog() -> hermesLog.push(). esbuild lowers top-level const/let to var; the later `var hermesLog = []` is hoisted but undefined at that point, so .push throws and boot aborts every launch.

Regression from c401756a6a (#91545). No logic change - declaration hoist only. Rebuilt dist:mac locally: bundle now emits `var hermesLog = []` before the readPersistedPoolLimits() call; app launches.

Generated with Claude Code