### PR TITLE
fix(aux): honor explicit base_url/api_key for named custom providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -7206,6 +7206,17 @@ def resolve_provider_client(
         if custom_entry:
             custom_base = (custom_entry.get("base_url") or "").strip()
             custom_key = (custom_entry.get("api_key") or "").strip()
+            # A per-task base_url/api_key (auxiliary.<task>.base_url, resolved
+            # by _resolve_task_provider_model and passed as explicit_base_url)
+            # must win over the named provider entry's own endpoint — the
+            # PROVIDER_REGISTRY and anonymous-custom branches already honour
+            # this override, and without it a task-level override (e.g.
+            # routing one aux task through a local translator shim) is
+            # silently dropped for named custom providers (#task-base-url).
+            if explicit_base_url:
+                custom_base = explicit_base_url.strip()
+            if explicit_api_key:
+                custom_key = explicit_api_key.strip() or custom_key
             custom_key_env = (custom_entry.get("key_env") or custom_entry.get("api_key_env") or "").strip()
             if not custom_key and custom_key_env:
                 custom_key = _scoped_key_env(custom_key_env)


### PR DESCRIPTION
## Problem

`resolve_provider_client()` accepts `explicit_base_url` / `explicit_api_key`
so that per-task auxiliary configuration (`auxiliary.<task>.base_url` in
config.yaml, resolved by `_resolve_task_provider_model`) can override the
endpoint of the provider a task uses. Every routing branch honors the
override **except** the named custom provider branch (`providers:` /
`custom_providers:` entries): it builds the client from the entry's own
`base_url` and silently drops the explicit one.

Repro:

```python
from agent.auxiliary_client import resolve_provider_client
# config.yaml:
#   providers:
#     my-custom:
#       base_url: https://upstream.example.com/v1
#       key_env: MY_CUSTOM_API_KEY
#   auxiliary:
#     title_generation:
#       provider: my-custom
#       model: some-model
#       base_url: http://localhost:9000    # task-level override
client, _ = resolve_provider_client(
    provider="my-custom", model="some-model",
    explicit_base_url="http://localhost:9000", task="title_generation")
print(client.base_url)
# Expected: http://localhost:9000
# Actual:   https://upstream.example.com/v1   (override silently dropped)
```

Note that `_resolve_task_provider_model` correctly resolves the override —
the returned tuple contains the task-level URL, and the debug log line
("Auxiliary <task>: using <provider> (<model>) at <url>") even shows the
task URL, while the actual client still targets the provider's endpoint.
This makes the misrouting very hard to spot.

The documented "the task block's base_url wins" behavior (per-task endpoint
overrides, e.g. routing one aux task through a local rewriting proxy while
keeping other tasks on the upstream endpoint) currently works for registry
providers and anonymous `custom` endpoints but not for named custom
providers.

## Fix

In the named custom provider branch, apply the explicit overrides before
falling back to the entry's own values — mirroring the precedence the
PROVIDER_REGISTRY branch (`raw_base_url` / `api_key`) and the
anonymous-custom branch already use:

- `explicit_base_url` replaces the entry's `base_url`
- `explicit_api_key` replaces the entry's `api_key`; when no explicit key
  is given, existing env / key_cmd resolution is unchanged

+11 lines, no behavior change when no override is passed.

## Testing

- `resolve_provider_client(provider=<named>, explicit_base_url=X)` →
  client `base_url` is X ✓
- `resolve_provider_client(provider=<named>)` (no override) → entry's own
  URL (unchanged) ✓
- `resolve_provider_client(provider=<named>, explicit_base_url=Y,
  task='compression')` where the task's config sets Y → Y ✓
- End-to-end `call_llm(task=...)` against an override endpoint succeeds ✓
