### PR TITLE
fix(desktop): clicking an already-open bot no longer shows a stale transcript (#101430, salvage #101431)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -71,6 +71,24 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     })
   })
 
+  it('fronting an already-open Bot Chat refreshes its transcript in place', async () => {
+    // The front is presentation-only: the pane keeps whatever transcript it
+    // last painted, which can predate rows the bot wrote while the user was
+    // elsewhere (a cron delivery, a teammate's message_agent, another bot's
+    // turn). Fronting must force a registry open so forceResume re-pulls the
+    // latest rows instead of leaving a stale snapshot until the next turn
+    // (#99393 class; #95600 only covered the not-yet-open path).
+    host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>
+      only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
+    ) as never
+    $selectedStoredSessionId.set('bot-chat-tip')
+
+    await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
+
+    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
+    $selectedStoredSessionId.set(null)
+  })
+
   it('resolves the registry when only a side thread is open', async () => {
     // The shell would happily front 'side-thread' — the allowlist excludes it.
     host.focusOpenWorkspaceSession = vi.fn((_key: string, _probe: unknown, only?: readonly string[]) =>

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -246,6 +246,14 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // the roster-activity refresh treat it exactly like a registry open.
     $openBotChat.set({ key, openedRegistryId: fronted.registryId, openedSessionId: fronted.storedSessionId })
 
+    // Fronting is presentation-only: the pane keeps whatever transcript it
+    // last painted, which can predate rows the bot wrote while the user was
+    // elsewhere (another bot's turn, a cron delivery, a teammate's
+    // message_agent). Force a registry open so forceResume re-pulls the
+    // latest transcript instead of leaving a stale snapshot until the next
+    // user turn (#99393 class; #95600 only covered the not-yet-open path).
+    refreshOpenBotChat(bot)
+
     return true
   }
 


### PR DESCRIPTION
## Summary
Clicking a bot in the Bot Mode roster whose Bot Chat tab is already open now re-pulls the latest transcript instead of leaving the last-painted (possibly several turns stale) snapshot until the next user message.

Root cause: the fronted branch of `openRosterBot` was presentation-only. Rows the bot received while the user was elsewhere (cron `bot-chat:` delivery, a teammate's `message_agent`, a CLI turn) never arrive on this window's live stream, and `forceResume` (#95600) only ran on the not-yet-open registry path.

Salvage of #101431 by @cmyyy (authorship preserved via cherry-pick). Fixes #101430.

## Changes
- `plugins/hermes-bots/roster-actions.ts`: fronted branch calls the existing `refreshOpenBotChat(bot)` (#99393 reclaim mechanism) after recording the claim; it re-runs the registry open with `forceResume`, gated to the focused session and never mid-turn.
- `plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts`: one regression — fronting an already-open Bot Chat requests the canonical registry open.

## Validation
| | main | this PR |
|---|---|---|
| `bot-row-opens-canonical-chat.test.ts` + `roster-actions.test.ts` | new case fails (contributor sabotage run) | 15/15 pass |

Companion to #101955 (pane visibility on the same click path): that one makes the "already open" claim honest; this one makes the fronted path refresh.

## Infographic

![Bot Chat re-syncs on click](https://v3b.fal.media/files/b/0aa8ea82/1FrDPHJNuGseqVgQqzqQU_nlTgkBSC.png)
