### PR TITLE
fix(buzz): WebSocket liveness + persistent-socket presence + reaction lifecycle (combined #101166 + #99451)

### DIFF
--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -27,6 +27,7 @@ Configuration in config.yaml::
             allowed_users: []          # empty = allow all; entries are hex pubkeys or npubs
             reply_in_thread: true      # false = post replies flat to the channel timeline
             reaction_only_users: []    # acknowledge explicit tags without dispatching; allowed_users wins on overlap
+            reactions: true             # emoji reaction lifecycle (👀 received → 🧠 working → ✅/❌ done); false disables
 
 Or via environment variables (overrides config.yaml):
     BUZZ_RELAY_URL, BUZZ_CHANNELS, BUZZ_HOME_CHANNEL, BUZZ_POLL_INTERVAL,

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -1967,10 +1967,6 @@ class BuzzAdapter(BasePlatformAdapter):
                                     # A clean close racing the liveness probe is
                                     # normal relay lifecycle, not a failure.
                                     break
-                                except asyncio.TimeoutError:
-                                    raise ConnectionError(
-                                        "WebSocket liveness probe timed out"
-                                    ) from None
                                 try:
                                     message = json.loads(raw)
                                 except (ValueError, TypeError):

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -308,24 +308,11 @@ _WS_AUTH_TIMEOUT = 20.0
 # never completes, so a manual ping round-trip times out and forces the
 # normal reconnect path. A quiet-but-healthy relay answers the ping and the
 # connection is kept — silence alone is not death.
-_WS_LIVENESS_INTERVAL = 60.0
-_WS_LIVENESS_TIMEOUT = 45.0
+_WS_LIVENESS_INTERVAL = 300.0
+_WS_LIVENESS_TIMEOUT = 15.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
-
-
-def _ws_clean_close_error():
-    """The websockets clean-close exception class (version-portable).
-
-    websockets 15.x raises ``ConnectionClosedOK`` when the server closes
-    cleanly — normally surfaced as the iterator ending, but a close racing
-    the liveness ping instead raises it from ``ping()``/``recv()``.
-    Resolved lazily so adapter import never needs websockets present.
-    """
-    from websockets.exceptions import ConnectionClosedOK
-
-    return ConnectionClosedOK
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -1891,36 +1878,62 @@ class BuzzAdapter(BasePlatformAdapter):
 
     async def _probe_liveness(self, websocket) -> None:
         """Require proof of transport life via a ping/pong round-trip."""
-        ping_fn = getattr(websocket, "ping", None)
-        if not callable(ping_fn):
-            return
-        pong_waiter = await ping_fn()
+        pong_waiter = await websocket.ping()
         if pong_waiter is not None:
             await pong_waiter
 
     async def _read_frame_or_probe(self, frame_iter, websocket) -> str:
-        """Read a frame, probing the connection while it remains quiet."""
+        """Read a frame, probing the connection while it remains quiet.
+
+        The pending read is kept across idle/probe cycles — cancelling and
+        re-creating it per cycle would drop frames that arrive while the
+        probe is in flight.
+        """
         read_task = asyncio.ensure_future(frame_iter.__anext__())
+        probe_task = None
         try:
             while True:
-                done, _ = await asyncio.wait({read_task}, timeout=_WS_LIVENESS_INTERVAL)
+                done, _ = await asyncio.wait(
+                    {read_task}, timeout=_WS_LIVENESS_INTERVAL
+                )
                 if done:
                     return read_task.result()
-                try:
-                    await asyncio.wait_for(
-                        self._probe_liveness(websocket), timeout=_WS_LIVENESS_TIMEOUT
-                    )
-                except asyncio.TimeoutError:
+                probe_task = asyncio.ensure_future(
+                    self._probe_liveness(websocket)
+                )
+                done, _ = await asyncio.wait(
+                    {read_task, probe_task},
+                    timeout=_WS_LIVENESS_TIMEOUT,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:
                     raise ConnectionError(
                         "relay did not answer a liveness ping within "
                         f"{_WS_LIVENESS_TIMEOUT:.0f}s; assuming the connection went silent"
                     ) from None
+                if probe_task in done:
+                    # A failed probe wins even when a frame also completed:
+                    # the transport error must reach the reconnect path.
+                    probe_task.result()
+                    if read_task in done:
+                        return read_task.result()
+                    probe_task = None
+                    continue
+                # Only the frame is ready: return it without waiting for the
+                # pong; the finally block cancels and settles the probe.
+                return read_task.result()
         finally:
-            read_task.cancel()
-            try:
-                await read_task
-            except (asyncio.CancelledError, Exception):
-                pass
+            for task in (read_task, probe_task):
+                if task is None or task.done():
+                    continue
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):
+                    pass
+            for task in (read_task, probe_task):
+                if task is not None and not task.cancelled():
+                    task.exception()  # retrieve, so nothing is left un-retrieved
 
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
@@ -1929,6 +1942,7 @@ class BuzzAdapter(BasePlatformAdapter):
         from the last observed timestamps (same-second overlap de-duped by
         event id)."""
         import websockets
+        from websockets.exceptions import ConnectionClosedOK
 
         backoff = 1.0
         try:
@@ -1963,9 +1977,9 @@ class BuzzAdapter(BasePlatformAdapter):
                                     )
                                 except StopAsyncIteration:
                                     break
-                                except _ws_clean_close_error():
-                                    # A clean close racing the liveness probe is
-                                    # normal relay lifecycle, not a failure.
+                                # A clean close racing the liveness probe is
+                                # normal relay lifecycle, not a failure.
+                                except ConnectionClosedOK:
                                     break
                                 try:
                                     message = json.loads(raw)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -300,16 +300,32 @@ def _attachment_origin(value: str) -> Optional[tuple[str, int]]:
 # WebSocket transport (NIP-42 authenticated Nostr subscription).
 # kind 44100 is Buzz's channel-membership event — used for live DM discovery.
 _WS_AUTH_TIMEOUT = 20.0
-# Last-resort bound on how long the read loop may wait for a frame. The
-# library keepalive (ping_interval/ping_timeout below) should catch a dead
-# relay first, but a relay-side close the transport never surfaces (observed
-# as a CLOSE_WAIT socket with the loop parked on recv, #98097) leaves the
-# gateway "connected" while inbound stops; this timeout forces the normal
-# reconnect path instead.
-_WS_READ_IDLE_TIMEOUT = 300.0
+# Last-resort liveness probe for the read loop. The library keepalive
+# (ping_interval/ping_timeout below) should catch a dead relay first, but a
+# relay-side close the transport never surfaces (observed as a CLOSE_WAIT
+# socket with the loop parked on recv, #98097) leaves the gateway
+# "connected" while inbound stops: in that state the pending pong waiter
+# never completes, so a manual ping round-trip times out and forces the
+# normal reconnect path. A quiet-but-healthy relay answers the ping and the
+# connection is kept — silence alone is not death.
+_WS_LIVENESS_INTERVAL = 60.0
+_WS_LIVENESS_TIMEOUT = 45.0
 _WS_MAX_MESSAGE_BYTES = 2_000_000
 _WS_MEMBERSHIP_KIND = 44100
 _WS_MEMBERSHIP_SUB_ID = "hermes-buzz-membership"
+
+
+def _ws_clean_close_error():
+    """The websockets clean-close exception class (version-portable).
+
+    websockets 15.x raises ``ConnectionClosedOK`` when the server closes
+    cleanly — normally surfaced as the iterator ending, but a close racing
+    the liveness ping instead raises it from ``ping()``/``recv()``.
+    Resolved lazily so adapter import never needs websockets present.
+    """
+    from websockets.exceptions import ConnectionClosedOK
+
+    return ConnectionClosedOK
 
 # Where to look for a credentials JSON (keys: nsec / private_key_hex) when
 # BUZZ_PRIVATE_KEY is not set.  Module-level so tests can point it at a tmpdir.
@@ -1873,6 +1889,39 @@ class BuzzAdapter(BasePlatformAdapter):
             except Exception:
                 logger.warning("Buzz: WebSocket discovery sweep failed", exc_info=True)
 
+    async def _probe_liveness(self, websocket) -> None:
+        """Require proof of transport life via a ping/pong round-trip."""
+        ping_fn = getattr(websocket, "ping", None)
+        if not callable(ping_fn):
+            return
+        pong_waiter = await ping_fn()
+        if pong_waiter is not None:
+            await pong_waiter
+
+    async def _read_frame_or_probe(self, frame_iter, websocket) -> str:
+        """Read a frame, probing the connection while it remains quiet."""
+        read_task = asyncio.ensure_future(frame_iter.__anext__())
+        try:
+            while True:
+                done, _ = await asyncio.wait({read_task}, timeout=_WS_LIVENESS_INTERVAL)
+                if done:
+                    return read_task.result()
+                try:
+                    await asyncio.wait_for(
+                        self._probe_liveness(websocket), timeout=_WS_LIVENESS_TIMEOUT
+                    )
+                except asyncio.TimeoutError:
+                    raise ConnectionError(
+                        "relay did not answer a liveness ping within "
+                        f"{_WS_LIVENESS_TIMEOUT:.0f}s; assuming the connection went silent"
+                    ) from None
+        finally:
+            read_task.cancel()
+            try:
+                await read_task
+            except (asyncio.CancelledError, Exception):
+                pass
+
     async def _websocket_loop(self) -> None:
         """Persistent authenticated subscription with bounded reconnect
         backoff. Events route through _handle_event() — identical semantics
@@ -1909,16 +1958,18 @@ class BuzzAdapter(BasePlatformAdapter):
                             frame_iter = websocket.__aiter__()
                             while True:
                                 try:
-                                    raw = await asyncio.wait_for(
-                                        frame_iter.__anext__(),
-                                        timeout=_WS_READ_IDLE_TIMEOUT,
+                                    raw = await self._read_frame_or_probe(
+                                        frame_iter, websocket
                                     )
                                 except StopAsyncIteration:
                                     break
+                                except _ws_clean_close_error():
+                                    # A clean close racing the liveness probe is
+                                    # normal relay lifecycle, not a failure.
+                                    break
                                 except asyncio.TimeoutError:
                                     raise ConnectionError(
-                                        f"no WebSocket frame for {_WS_READ_IDLE_TIMEOUT:.0f}s; "
-                                        "assuming the connection went silent"
+                                        "WebSocket liveness probe timed out"
                                     ) from None
                                 try:
                                     message = json.loads(raw)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -241,8 +241,30 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
-# Buzz presence records expire, so refresh comfortably before the relay TTL.
-_PRESENCE_INTERVAL = 60.0
+# Buzz relays document a 180-second expiry for presence records. Refresh at
+# most once a minute, leaving a two-minute margin even if the relay's clock or
+# delivery is delayed.
+_PRESENCE_EXPIRY = 180.0
+_PRESENCE_REFRESH_MARGIN = 120.0
+_PRESENCE_INTERVAL = min(60.0, _PRESENCE_EXPIRY - _PRESENCE_REFRESH_MARGIN)
+_REACTION_CLEANUP_INTERVAL = 60.0
+_REACTION_CLEANUP_TTL = 300.0
+
+
+def _presence_refresh_interval(refresh: float, expiry: float, margin: float) -> float:
+    """Effective presence-refresh interval for a relay TTL of ``expiry``.
+
+    The relay expires presence records after ``expiry`` seconds; the
+    effective cadence is the configured ``refresh`` clamped so every
+    refresh (including the first, scheduled right after the connect-time
+    ``online`` publish) lands at least ``margin`` seconds before the
+    record would lapse. A degenerate ``margin >= expiry`` falls back to
+    half the expiry rather than a zero/negative sleep.
+    """
+    bounded = expiry - margin
+    if bounded <= 0:
+        bounded = expiry / 2.0
+    return max(0.0, min(refresh, bounded))
 
 # Mention-resolution caches: member lists are cheap to refetch but hit on
 # every publish containing "@", so a short TTL amortizes the CLI round-trip;
@@ -917,6 +939,8 @@ class BuzzAdapter(BasePlatformAdapter):
         self._ws_ready: Optional[asyncio.Event] = None
         self._presence_task: Optional[asyncio.Task] = None
         self._presence_interval = _PRESENCE_INTERVAL
+        self._presence_expiry = _PRESENCE_EXPIRY
+        self._presence_margin = _PRESENCE_REFRESH_MARGIN
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
         self._lock_key: Optional[str] = None
@@ -969,9 +993,12 @@ class BuzzAdapter(BasePlatformAdapter):
                 )
                 self._reactions_enabled_flag = True
         # (chat_id, message_id) -> {"emoji": str|None, "terminal": bool,
-        # "tail_task": asyncio.Task|None}
+        # "tail_task": asyncio.Task|None, "last_active": float}
         self._reaction_lifecycle: Dict[tuple, dict] = {}
         self._reaction_tasks: set = set()
+        self._reaction_cleanup_task: Optional[asyncio.Task] = None
+        self._reaction_cleanup_interval = _REACTION_CLEANUP_INTERVAL
+        self._reaction_cleanup_ttl = _REACTION_CLEANUP_TTL
 
     @property
     def name(self) -> str:
@@ -1022,10 +1049,22 @@ class BuzzAdapter(BasePlatformAdapter):
         return True
 
     async def _presence_loop(self) -> None:
-        """Refresh online presence until the adapter disconnects."""
+        """Refresh online presence until the adapter disconnects.
+
+        Each sleep uses the effective cadence — the configured interval
+        clamped by :func:`_presence_refresh_interval` — so every refresh
+        lands at least the margin before the relay's presence TTL lapses,
+        including the first refresh after the connect-time publish.
+        """
         try:
             while True:
-                await asyncio.sleep(self._presence_interval)
+                await asyncio.sleep(
+                    _presence_refresh_interval(
+                        self._presence_interval,
+                        self._presence_expiry,
+                        self._presence_margin,
+                    )
+                )
                 await self._set_presence("online")
         except asyncio.CancelledError:
             raise
@@ -1043,8 +1082,11 @@ class BuzzAdapter(BasePlatformAdapter):
         self._presence_task = None
         try:
             await asyncio.wait_for(self._set_presence("offline"), timeout=5)
-        except (asyncio.TimeoutError, TimeoutError, Exception):
-            pass  # best-effort: never let presence block shutdown
+        except Exception:
+            # Best-effort: never let presence block shutdown. (Timeouts are
+            # Exception subclasses on every supported Python, and
+            # CancelledError deliberately propagates.)
+            pass
 
     # ── Connection lifecycle ──────────────────────────────────────────────
 
@@ -1217,6 +1259,15 @@ class BuzzAdapter(BasePlatformAdapter):
             task.cancel()
         if pending:
             await asyncio.gather(*pending, return_exceptions=True)
+        # Stop the abandoned-state sweeper before clearing its state: it only
+        # runs while entries exist and restarts on the next enqueue.
+        if self._reaction_cleanup_task and not self._reaction_cleanup_task.done():
+            self._reaction_cleanup_task.cancel()
+            try:
+                await self._reaction_cleanup_task
+            except asyncio.CancelledError:
+                pass
+        self._reaction_cleanup_task = None
         self._reaction_tasks.clear()
         self._reaction_lifecycle = {}
         self._channel_state = {}
@@ -1264,6 +1315,15 @@ class BuzzAdapter(BasePlatformAdapter):
     # call happens in a background task — never awaited by message
     # processing or response delivery. Best-effort throughout: any failure
     # only means the user sees a stale emoji, never a broken reply.
+    #
+    # Abandoned-state cleanup: the terminal hook is the only normal way an
+    # entry leaves ``_reaction_lifecycle``, so a hung/hard-crashed turn
+    # would otherwise pin its entry until disconnect. A single shared
+    # sweeper task (started lazily with the first entry, self-terminating
+    # when the map empties — never one task per message) drops entries idle
+    # past ``_REACTION_CLEANUP_TTL`` and cancels wedged transitions at the
+    # same bound; sweeps never touch a valid in-flight transition younger
+    # than the TTL.
 
     _RECEIVED_EMOJI = "\N{EYES}"
     _WORKING_EMOJI = "\N{BRAIN}"
@@ -1281,8 +1341,55 @@ class BuzzAdapter(BasePlatformAdapter):
             return
         self._reaction_lifecycle[key] = {
             "emoji": None, "terminal": False, "tail_task": None,
+            "last_active": time.monotonic(),
         }
         self._reaction_transition_enqueue(key, self._RECEIVED_EMOJI)
+        self._ensure_reaction_cleanup()
+
+    def _ensure_reaction_cleanup(self) -> None:
+        """Run the abandoned-state sweeper while any lifecycle entry exists.
+
+        One shared task, (re)started lazily when state is created and ending
+        itself when the map empties — never one background task per message.
+        """
+        if self._reaction_cleanup_task is None or self._reaction_cleanup_task.done():
+            self._reaction_cleanup_task = asyncio.ensure_future(
+                self._reaction_cleanup_loop()
+            )
+
+    async def _reaction_cleanup_loop(self) -> None:
+        """Drop lifecycle entries whose terminal hook never arrives."""
+        try:
+            while self._reaction_lifecycle:
+                await asyncio.sleep(self._reaction_cleanup_interval)
+                await self._reaction_cleanup_once()
+        except asyncio.CancelledError:
+            raise
+
+    async def _reaction_cleanup_once(self) -> None:
+        """One sweep: expire idle entries; time out wedged transitions.
+
+        An entry is idle when its transition chain has been quiescent for
+        ``_reaction_cleanup_ttl`` — the tail task is done AND no new activity
+        happened within the TTL. A wedged (never-completing) transition is
+        cancelled at the TTL and its entry dropped: the tail's ``finally``
+        only pops terminal entries, so cleanup must drop non-terminal state
+        itself, and cancelling the tail stops the chain head from enqueuing
+        more work (each successor re-raises when its predecessor is
+        cancelled). Older links still draining a slow buzz-cli call finish
+        on their own ``_CLI_TIMEOUT`` and find the state gone. In-flight
+        work younger than the TTL is never touched.
+        """
+        now = time.monotonic()
+        stale: List[tuple] = []
+        for key, state in self._reaction_lifecycle.items():
+            tail = state.get("tail_task")
+            if now - state.get("last_active", 0) >= self._reaction_cleanup_ttl:
+                if tail is not None and not tail.done():
+                    tail.cancel()
+                stale.append(key)
+        for key in stale:
+            self._reaction_lifecycle.pop(key, None)
 
     def _reaction_transition_enqueue(
         self, key: tuple, desired: Optional[str], *, terminal: bool = False
@@ -1299,6 +1406,7 @@ class BuzzAdapter(BasePlatformAdapter):
             return
         if terminal:
             state["terminal"] = True
+        state["last_active"] = time.monotonic()
         task = asyncio.create_task(
             self._reaction_transition_run(
                 key, desired, state.get("tail_task"), terminal

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -240,6 +240,8 @@ _DM_DISCOVERY_EVERY = 5
 _DEFAULT_POLL_INTERVAL = 4.0
 _MIN_POLL_INTERVAL = 1.0
 _CLI_TIMEOUT = 30.0
+# Buzz presence records expire, so refresh comfortably before the relay TTL.
+_PRESENCE_INTERVAL = 60.0
 
 # Mention-resolution caches: member lists are cheap to refetch but hit on
 # every publish containing "@", so a short TTL amortizes the CLI round-trip;
@@ -912,6 +914,8 @@ class BuzzAdapter(BasePlatformAdapter):
         self._poll_task: Optional[asyncio.Task] = None
         self._ws_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
+        self._presence_task: Optional[asyncio.Task] = None
+        self._presence_interval = _PRESENCE_INTERVAL
         self._ws_active = False  # True while the WS loop owns inbound delivery
         self._membership_since = 0
         self._lock_key: Optional[str] = None
@@ -997,6 +1001,49 @@ class BuzzAdapter(BasePlatformAdapter):
             auth_tag=self._auth_tag,
             input_text=input_text,
         )
+
+    async def _set_presence(self, status: str) -> bool:
+        """Publish a best-effort presence state to the Buzz relay."""
+        try:
+            code, _out, err = await self._run_cli(
+                ["users", "set-presence", "--status", status]
+            )
+        except Exception as exc:
+            logger.debug("Buzz: presence update to %s failed — %s", status, exc)
+            return False
+        if code != 0:
+            logger.debug(
+                "Buzz: presence update to %s failed — %s",
+                status,
+                _cli_error_message(err, code),
+            )
+            return False
+        return True
+
+    async def _presence_loop(self) -> None:
+        """Refresh online presence until the adapter disconnects."""
+        try:
+            while True:
+                await asyncio.sleep(self._presence_interval)
+                await self._set_presence("online")
+        except asyncio.CancelledError:
+            raise
+
+    async def _start_presence(self) -> None:
+        """Publish online presence and start its expiry-refresh task."""
+        await self._set_presence("online")
+        self._presence_task = asyncio.create_task(self._presence_loop())
+
+    async def _stop_presence(self) -> None:
+        """Stop refreshing and publish offline presence best-effort."""
+        if self._presence_task and not self._presence_task.done():
+            self._presence_task.cancel()
+            await asyncio.gather(self._presence_task, return_exceptions=True)
+        self._presence_task = None
+        try:
+            await asyncio.wait_for(self._set_presence("offline"), timeout=5)
+        except (asyncio.TimeoutError, TimeoutError, Exception):
+            pass  # best-effort: never let presence block shutdown
 
     # ── Connection lifecycle ──────────────────────────────────────────────
 
@@ -1116,6 +1163,8 @@ class BuzzAdapter(BasePlatformAdapter):
                 return False
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
+        # Publish online presence and refresh it against relay expiry.
+        await self._start_presence()
         self._mark_connected()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
@@ -1156,6 +1205,9 @@ class BuzzAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+        # Presence: stop refreshing, then publish offline best-effort. A
+        # failed publish must not break shutdown (relay may already be gone).
+        await self._stop_presence()
         # Reaction lifecycle: cancel any in-flight transition tasks so
         # shutdown never leaks "task pending" warnings or hangs on a wedged
         # buzz-cli call.

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -938,6 +938,8 @@ class BuzzAdapter(BasePlatformAdapter):
         self._ws_task: Optional[asyncio.Task] = None
         self._ws_ready: Optional[asyncio.Event] = None
         self._presence_task: Optional[asyncio.Task] = None
+        self._ws_connection = None
+        self._ws_send_lock = asyncio.Lock()
         self._presence_interval = _PRESENCE_INTERVAL
         self._presence_expiry = _PRESENCE_EXPIRY
         self._presence_margin = _PRESENCE_REFRESH_MARGIN
@@ -1030,34 +1032,43 @@ class BuzzAdapter(BasePlatformAdapter):
             input_text=input_text,
         )
 
-    async def _set_presence(self, status: str) -> bool:
-        """Publish a best-effort presence state to the Buzz relay."""
-        try:
-            code, _out, err = await self._run_cli(
-                ["users", "set-presence", "--status", status]
-            )
-        except Exception as exc:
-            logger.debug("Buzz: presence update to %s failed — %s", status, exc)
-            return False
-        if code != 0:
-            logger.debug(
-                "Buzz: presence update to %s failed — %s",
-                status,
-                _cli_error_message(err, code),
-            )
-            return False
-        return True
+    async def _send_ws(self, websocket, payload: list) -> None:
+        """Serialize all frames sharing the authenticated connection."""
+        async with self._ws_send_lock:
+            await websocket.send(json.dumps(payload, separators=(",", ":")))
 
-    async def _presence_loop(self) -> None:
-        """Refresh online presence until the adapter disconnects.
+    async def _publish_presence(self, websocket, status: str) -> None:
+        """Sign and publish a kind-20001 event on the authenticated socket.
 
-        Each sleep uses the effective cadence — the configured interval
-        clamped by :func:`_presence_refresh_interval` — so every refresh
-        lands at least the margin before the relay's presence TTL lapses,
-        including the first refresh after the connect-time publish.
+        Ephemeral kinds (20000-29999) are rejected by the relay's HTTP
+        bridge, so presence always rides the authenticated WebSocket. The
+        pure-Python secp256k1 signature is CPU-bound (~50ms); it runs in
+        the default executor so the inbound frame pump is never stalled.
+        """
+        build_presence_event = _load_nostr_auth().build_presence_event
+        event = await asyncio.get_running_loop().run_in_executor(
+            None,
+            lambda: build_presence_event(private_key=self._private_key, status=status),
+        )
+        await self._send_ws(websocket, ["EVENT", event])
+
+    async def _presence_heartbeat(self, websocket) -> None:
+        """Publish online immediately, then at the effective cadence.
+
+        Best-effort: a failed sign/send is logged and retried on the next
+        tick — it must never take down message delivery. Each sleep uses
+        the cadence from :func:`_presence_refresh_interval`, so every
+        publish lands at least the margin before the relay's 180-second
+        presence TTL lapses.
         """
         try:
             while True:
+                try:
+                    await self._publish_presence(websocket, "online")
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    logger.warning("Buzz: presence publish failed", exc_info=True)
                 await asyncio.sleep(
                     _presence_refresh_interval(
                         self._presence_interval,
@@ -1065,27 +1076,28 @@ class BuzzAdapter(BasePlatformAdapter):
                         self._presence_margin,
                     )
                 )
-                await self._set_presence("online")
         except asyncio.CancelledError:
             raise
 
-    async def _start_presence(self) -> None:
-        """Publish online presence and start its expiry-refresh task."""
-        await self._set_presence("online")
-        self._presence_task = asyncio.create_task(self._presence_loop())
-
     async def _stop_presence(self) -> None:
-        """Stop refreshing and publish offline presence best-effort."""
+        """Stop the heartbeat, then publish offline on the live socket.
+
+        Called from disconnect() *before* the WebSocket task is cancelled,
+        so the offline event still has an open socket to travel on. A
+        failed publish must not break shutdown (relay may already be gone);
+        cancellation still propagates.
+        """
         if self._presence_task and not self._presence_task.done():
             self._presence_task.cancel()
             await asyncio.gather(self._presence_task, return_exceptions=True)
         self._presence_task = None
+        websocket = self._ws_connection
+        self._ws_connection = None
+        if websocket is None:
+            return
         try:
-            await asyncio.wait_for(self._set_presence("offline"), timeout=5)
+            await asyncio.wait_for(self._publish_presence(websocket, "offline"), timeout=5)
         except Exception:
-            # Best-effort: never let presence block shutdown. (Timeouts are
-            # Exception subclasses on every supported Python, and
-            # CancelledError deliberately propagates.)
             pass
 
     # ── Connection lifecycle ──────────────────────────────────────────────
@@ -1206,8 +1218,6 @@ class BuzzAdapter(BasePlatformAdapter):
                 return False
         if transport_used == "poll":
             self._poll_task = asyncio.create_task(self._poll_loop())
-        # Publish online presence and refresh it against relay expiry.
-        await self._start_presence()
         self._mark_connected()
         logger.info(
             "Buzz: connected to %s as %s, watching %d channel(s) via %s%s",
@@ -1234,6 +1244,12 @@ class BuzzAdapter(BasePlatformAdapter):
                 pass
             self._lock_key = None
         self._ws_active = False
+        # Presence: stop the heartbeat and publish offline on the live
+        # socket — this must happen BEFORE the WebSocket task is cancelled,
+        # because cancelling it closes the connection (the offline event
+        # needs the open socket to travel on). A failed publish must not
+        # break shutdown (relay may already be gone).
+        await self._stop_presence()
         if self._ws_task and not self._ws_task.done():
             self._ws_task.cancel()
             try:
@@ -1248,9 +1264,6 @@ class BuzzAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
-        # Presence: stop refreshing, then publish offline best-effort. A
-        # failed publish must not break shutdown (relay may already be gone).
-        await self._stop_presence()
         # Reaction lifecycle: cancel any in-flight transition tasks so
         # shutdown never leaks "task pending" warnings or hangs on a wedged
         # buzz-cli call.
@@ -2191,7 +2204,7 @@ class BuzzAdapter(BasePlatformAdapter):
             subscription_id,
             request_filter,
         ]
-        await websocket.send(json.dumps(request, separators=(",", ":")))
+        await self._send_ws(websocket, request)
 
     async def _subscribe_websocket(self, websocket) -> Dict[str, Optional[str]]:
         """Subscribe to every watched conversation plus membership events
@@ -2213,7 +2226,7 @@ class BuzzAdapter(BasePlatformAdapter):
                     "since": max(self._membership_since - 1, 0),
                 },
             ]
-            await websocket.send(json.dumps(request, separators=(",", ":")))
+            await self._send_ws(websocket, request)
             subscriptions[_WS_MEMBERSHIP_SUB_ID] = None
         return subscriptions
 
@@ -2344,6 +2357,29 @@ class BuzzAdapter(BasePlatformAdapter):
                         await self._authenticate_websocket(websocket)
                         subscriptions = await self._subscribe_websocket(websocket)
                         self._ws_active = True
+                        self._ws_connection = websocket
+                        # First online publish happens inline before the
+                        # connection is reported ready; the heartbeat keeps
+                        # it fresh afterwards. Inline = no barrier window in
+                        # which cancellation could strand the heartbeat task.
+                        try:
+                            await self._publish_presence(websocket, "online")
+                        except asyncio.CancelledError:
+                            raise
+                        except Exception:
+                            logger.warning("Buzz: initial presence publish failed", exc_info=True)
+                        # The publish's executor await can silently consume a
+                        # cancellation delivered mid-signing on Python 3.11
+                        # (the loop then resumes with a pending cancel that is
+                        # never observed as terminal — shutdown would wedge
+                        # with orphan heartbeat/discovery tasks). Re-arm it
+                        # here, before any child task is spawned.
+                        loop_task = asyncio.current_task()
+                        if loop_task is not None and loop_task.cancelling():
+                            raise asyncio.CancelledError()
+                        self._presence_task = asyncio.create_task(
+                            self._presence_heartbeat(websocket)
+                        )
                         if self._ws_ready is not None:
                             self._ws_ready.set()
                         backoff = 1.0
@@ -2420,13 +2456,36 @@ class BuzzAdapter(BasePlatformAdapter):
                                     logger.warning("Buzz: relay notice: %s", message[-1])
                         finally:
                             discovery_task.cancel()
-                            try:
-                                await discovery_task
-                            except (asyncio.CancelledError, Exception):
-                                pass
+                            # gather(return_exceptions=True) reaps the child
+                            # without swallowing OUR OWN cancellation — a
+                            # bare `except CancelledError: pass` here would
+                            # resurrect the reconnect loop after shutdown.
+                            await asyncio.gather(discovery_task, return_exceptions=True)
+                            # Retire the heartbeat with this connection; the
+                            # reconnect's first inline publish renews online
+                            # immediately. No offline here — a transient drop
+                            # must not flap presence offline, and the relay
+                            # clears the lease when the socket closes anyway.
+                            if self._presence_task is not None:
+                                self._presence_task.cancel()
+                                await asyncio.gather(
+                                    self._presence_task, return_exceptions=True
+                                )
+                                self._presence_task = None
+                            if self._ws_connection is websocket:
+                                self._ws_connection = None
                 except asyncio.CancelledError:
                     raise
                 except Exception as e:
+                    # On Python 3.11 a cancellation delivered inside
+                    # asyncio.wait_for() (e.g. mid-handshake) can surface as
+                    # TimeoutError instead of CancelledError (fixed in 3.12).
+                    # Retrying after that would resurrect this loop after
+                    # shutdown and wedge disconnect(); un-cancelling instead
+                    # propagates the shutdown.
+                    loop_task = asyncio.current_task()
+                    if loop_task is not None and loop_task.cancelling():
+                        raise asyncio.CancelledError() from e
                     self._ws_active = False
                     logger.warning("Buzz: WebSocket disconnected; retrying in %.1fs: %s", backoff, e)
                     await asyncio.sleep(backoff)

--- a/plugins/platforms/buzz/adapter.py
+++ b/plugins/platforms/buzz/adapter.py
@@ -173,6 +173,7 @@ from gateway.platforms.base import (
     SendResult,
     MessageEvent,
     MessageType,
+    ProcessingOutcome,
     cache_media_bytes_async,
 )
 from gateway.config import Platform
@@ -940,6 +941,33 @@ class BuzzAdapter(BasePlatformAdapter):
         # instead of opening a new thread under every reply (see _thread_root).
         self._thread_roots: "OrderedDict[str, Optional[str]]" = OrderedDict()
 
+        # ── Reaction lifecycle (👀 received → 🧠 working → ✅/❌) ──────────
+        # Best-effort visible progress: Buzz has no typing-indicator API, so
+        # reactions are the only pre-reply surface. Config gate:
+        #   gateway.platforms.buzz.extra.reactions (default true)
+        # Deliberately NOT an env var — behavioral config belongs in
+        # config.yaml (profile-scoped, so multiplex profiles stay isolated).
+        reactions_raw = extra.get("reactions", True)
+        if isinstance(reactions_raw, bool):
+            self._reactions_enabled_flag = reactions_raw
+        else:
+            _text = str(reactions_raw).strip().lower()
+            if _text in ("true", "1", "yes", "on"):
+                self._reactions_enabled_flag = True
+            elif _text in ("false", "0", "no", "off"):
+                self._reactions_enabled_flag = False
+            else:
+                logger.warning(
+                    "Buzz: invalid reactions value %r in platforms.buzz.extra; "
+                    "using default true",
+                    reactions_raw,
+                )
+                self._reactions_enabled_flag = True
+        # (chat_id, message_id) -> {"emoji": str|None, "terminal": bool,
+        # "tail_task": asyncio.Task|None}
+        self._reaction_lifecycle: Dict[tuple, dict] = {}
+        self._reaction_tasks: set = set()
+
     @property
     def name(self) -> str:
         return "Buzz"
@@ -1128,8 +1156,197 @@ class BuzzAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
         self._poll_task = None
+        # Reaction lifecycle: cancel any in-flight transition tasks so
+        # shutdown never leaks "task pending" warnings or hangs on a wedged
+        # buzz-cli call.
+        pending = [t for t in self._reaction_tasks if not t.done()]
+        for task in pending:
+            task.cancel()
+        if pending:
+            await asyncio.gather(*pending, return_exceptions=True)
+        self._reaction_tasks.clear()
+        self._reaction_lifecycle = {}
         self._channel_state = {}
         self._poll_count = 0
+
+    async def remove_reaction(self, chat_id: str, message_id: str, emoji: str) -> bool:
+        """Remove our emoji reaction from a message via buzz-cli.
+
+        Mirrors :meth:`send_reaction`: best-effort, returns True/False, never
+        raises into the message flow. Requires the exact emoji because the
+        CLI contract is ``reactions remove --event <id> --emoji <e>``.
+        """
+        if not self.cli_path or not emoji or not message_id:
+            return False
+        args = [
+            "reactions", "remove",
+            "--event", str(message_id),
+            "--emoji", emoji,
+        ]
+        try:
+            code, _out, err = await self._run_cli(args)
+        except Exception as exc:
+            logger.debug(
+                "Buzz: reaction remove failed for message %s in %s — %s",
+                message_id[:12], chat_id, exc,
+            )
+            return False
+        if code != 0:
+            logger.debug(
+                "Buzz: reaction remove failed for message %s in %s — %s",
+                message_id[:12], chat_id, _cli_error_message(err, code),
+            )
+            return False
+        return True
+
+    # ── Reaction lifecycle coordinator ────────────────────────────────────
+    #
+    # Buzz has no typing-indicator API, so reactions are the only visible
+    # pre-reply progress. State machine per inbound message, keyed
+    # (chat_id, message_id): 👀 queued at dispatch → 🧠 when background
+    # processing starts → ✅/❌ on the real outcome (CANCELLED removes the
+    # working reaction and adds nothing). Transitions are serialized per
+    # message behind a tail task so hooks can fire out of order / early
+    # without stacking or racing reactions on the relay, and every buzz-cli
+    # call happens in a background task — never awaited by message
+    # processing or response delivery. Best-effort throughout: any failure
+    # only means the user sees a stale emoji, never a broken reply.
+
+    _RECEIVED_EMOJI = "\N{EYES}"
+    _WORKING_EMOJI = "\N{BRAIN}"
+    _OK_EMOJI = "\N{WHITE HEAVY CHECK MARK}"
+    _FAIL_EMOJI = "\N{CROSS MARK}"
+
+    def _reactions_enabled(self) -> bool:
+        """Config gate: platforms.buzz.extra.reactions (default true)."""
+        return self._reactions_enabled_flag
+
+    def _reaction_begin(self, chat_id: str, message_id: str) -> None:
+        """Create lifecycle state and queue the 👀 transition (non-blocking)."""
+        key = (chat_id, message_id)
+        if key in self._reaction_lifecycle:
+            return
+        self._reaction_lifecycle[key] = {
+            "emoji": None, "terminal": False, "tail_task": None,
+        }
+        self._reaction_transition_enqueue(key, self._RECEIVED_EMOJI)
+
+    def _reaction_transition_enqueue(
+        self, key: tuple, desired: Optional[str], *, terminal: bool = False
+    ) -> None:
+        """Queue a transition behind the current tail; returns immediately.
+
+        ``terminal=True`` marks the lifecycle finished. The transition still
+        runs (chained behind its predecessors), but no further transitions
+        may be enqueued and the terminal task drops the lifecycle state when
+        it completes.
+        """
+        state = self._reaction_lifecycle.get(key)
+        if state is None or state["terminal"]:
+            return
+        if terminal:
+            state["terminal"] = True
+        task = asyncio.create_task(
+            self._reaction_transition_run(
+                key, desired, state.get("tail_task"), terminal
+            )
+        )
+        state["tail_task"] = task
+        self._reaction_tasks.add(task)
+        task.add_done_callback(self._reaction_tasks.discard)
+
+    async def _reaction_transition_run(
+        self,
+        key: tuple,
+        desired: Optional[str],
+        prev: Optional[asyncio.Task],
+        terminal: bool,
+    ) -> None:
+        """Serialized remove-gated replacement; see block comment above."""
+        try:
+            if prev is not None:
+                try:
+                    await prev
+                except asyncio.CancelledError:
+                    # Shutdown cancelled the chain ahead of us — stop here.
+                    raise
+                except Exception:
+                    pass  # predecessor failed; best-effort chain continues
+            state = self._reaction_lifecycle.get(key)
+            if state is None:
+                return
+            chat_id, message_id = key
+            current = state["emoji"]
+            if desired != current:
+                if current is not None:
+                    if not await self.remove_reaction(chat_id, message_id, current):
+                        # Keep the old reaction authoritative; skip the add
+                        # so two lifecycle reactions never stack on the relay.
+                        return
+                    state["emoji"] = None
+                if desired is not None and await self.send_reaction(
+                    chat_id, message_id, desired
+                ):
+                    state["emoji"] = desired
+        finally:
+            if terminal:
+                # The terminal task is the chain's last link (later enqueues
+                # are rejected), so dropping the state here cannot orphan a
+                # queued transition. Best-effort end regardless of I/O result.
+                self._reaction_lifecycle.pop(key, None)
+
+    def _reaction_eligible(self, event: MessageEvent) -> bool:
+        """True when this turn should carry lifecycle reactions.
+
+        Requires message ids, an enabled gate, a conversational (non-command)
+        message, and — when a gateway authorization callback is installed —
+        a positive authorization for the sender. ``on_processing_start`` runs
+        before the runner's central authorization check, so without this
+        gate unauthorized senders would earn a 👀 they can see.
+        """
+        if not getattr(event, "message_id", None):
+            return False
+        if not self._reactions_enabled():
+            return False
+        if not isinstance(getattr(event, "text", None), str) or event.is_command():
+            return False
+        user_id = getattr(event.source, "user_id", None)
+        if user_id and self._authorization_check is not None:
+            decision = self._is_sender_authorized(
+                user_id,
+                chat_type=getattr(event.source, "chat_type", None),
+                chat_id=getattr(event.source, "chat_id", None),
+            )
+            if decision is False:
+                return False
+        return True
+
+    async def on_processing_start(self, event: MessageEvent) -> None:
+        """👀 → 🧠 when background processing of the message begins."""
+        key = (
+            getattr(event.source, "chat_id", None),
+            getattr(event, "message_id", None),
+        )
+        if key in self._reaction_lifecycle:
+            self._reaction_transition_enqueue(key, self._WORKING_EMOJI)
+
+    async def on_processing_complete(
+        self, event: MessageEvent, outcome: ProcessingOutcome
+    ) -> None:
+        """🧠 → ✅/❌ on the real outcome; CANCELLED removes and adds nothing."""
+        key = (
+            getattr(event.source, "chat_id", None),
+            getattr(event, "message_id", None),
+        )
+        if key not in self._reaction_lifecycle:
+            return
+        if outcome == ProcessingOutcome.SUCCESS:
+            desired = self._OK_EMOJI
+        elif outcome == ProcessingOutcome.FAILURE:
+            desired = self._FAIL_EMOJI
+        else:
+            desired = None  # CANCELLED: remove current, add no terminal.
+        self._reaction_transition_enqueue(key, desired, terminal=True)
 
     # ── Sending ───────────────────────────────────────────────────────────
 
@@ -1404,7 +1621,14 @@ class BuzzAdapter(BasePlatformAdapter):
             "--event", str(message_id),
             "--emoji", emoji,
         ]
-        code, _out, err = await self._run_cli(args)
+        try:
+            code, _out, err = await self._run_cli(args)
+        except Exception as exc:
+            logger.debug(
+                "Buzz: reaction add failed for message %s in %s — %s",
+                message_id[:12], chat_id, exc,
+            )
+            return False
         if code != 0:
             logger.debug(
                 "Buzz: reaction add failed for message %s in %s — %s",
@@ -3060,6 +3284,11 @@ class BuzzAdapter(BasePlatformAdapter):
             thread_id=thread_id,
         )
 
+        # Reaction lifecycle: create state and queue 👀 as a tracked
+        # transition BEFORE handle_message (which spawns the background task
+        # that fires on_processing_start) so the states stay ordered.
+        # Skipped for commands / disabled gate / unauthorized senders / bad
+        # ids — see _reaction_eligible.
         event = MessageEvent(
             text=text,
             message_type=message_type,
@@ -3076,14 +3305,10 @@ class BuzzAdapter(BasePlatformAdapter):
             reply_to_is_own_message=reply_to_is_own_message,
         )
 
-        await self.handle_message(event)
+        if self._reaction_eligible(event):
+            self._reaction_begin(chat_id, message_id)
 
-        # Add a "seen" reaction after dispatching — signals to the user that
-        # their message was received and is being processed.
-        try:
-            await self.send_reaction(chat_id, message_id, "👀")
-        except Exception:
-            logger.debug("Buzz: reaction failed for message %s", message_id[:12], exc_info=True)
+        await self.handle_message(event)
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/platforms/buzz/nostr_auth.py
+++ b/plugins/platforms/buzz/nostr_auth.py
@@ -180,6 +180,51 @@ def schnorr_sign(
     return nonce_x + signature_scalar.to_bytes(32, "big")
 
 
+KIND_PRESENCE_UPDATE = 20001
+
+
+def build_presence_event(
+    *,
+    private_key: str,
+    status: str,
+    created_at: Optional[int] = None,
+    auxiliary_randomness: Optional[bytes] = None,
+) -> dict[str, Any]:
+    """Build a self-signed kind 20001 presence event.
+
+    ``status`` must be ``"online"``, ``"away"``, or ``"offline"``. The bare
+    status string is the content (the relay and Desktop read it there); a
+    ``["status", status]`` tag mirrors buzz-sdk's ``build_presence_update``
+    for structured access. No p-tags — the Desktop's live path trusts
+    author = subject.
+
+    Ephemeral kinds (20000-29999) are rejected by the relay's HTTP bridge,
+    so this event must be published over an authenticated WebSocket.
+    """
+    if status not in ("online", "away", "offline"):
+        raise ValueError("status must be online, away, or offline")
+    pubkey = public_key_hex(private_key)
+    timestamp = int(time.time()) if created_at is None else int(created_at)
+    tags = [["status", status]]
+    serialized = json.dumps(
+        [0, pubkey, timestamp, KIND_PRESENCE_UPDATE, tags, status],
+        separators=(",", ":"),
+        ensure_ascii=False,
+    ).encode()
+    event_id = hashlib.sha256(serialized).digest()
+    return {
+        "id": event_id.hex(),
+        "pubkey": pubkey,
+        "created_at": timestamp,
+        "kind": KIND_PRESENCE_UPDATE,
+        "tags": tags,
+        "content": status,
+        "sig": schnorr_sign(
+            event_id, private_key, auxiliary_randomness=auxiliary_randomness
+        ).hex(),
+    }
+
+
 def build_auth_event(
     *,
     private_key: str,

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -92,7 +92,7 @@ def _make_adapter(extra=None):
     adapter._self_pubkey = SELF_PUBKEY
     adapter._self_npub = SELF_NPUB
     adapter._display_name = "Chip"
-    adapter._private_key = "nsec1test"
+    adapter._private_key = "00" * 31 + "03"
     # GatewayRunner installs this callback before intake starts. Attachment
     # tests are authorized by default and override the callback at the boundary.
     adapter.set_authorization_check(lambda *_args: True)
@@ -3184,49 +3184,45 @@ class TestBuzzAdapterLifecycle:
         assert adapter._lock_key is None
 
     @pytest.mark.asyncio
-    async def test_connect_publishes_online_and_disconnect_publishes_offline(self, monkeypatch):
-        """A connected Buzz agent must have a visible presence record."""
+    async def test_presence_publishes_on_authenticated_websocket_without_cli(self):
+        """Presence uses the already-authenticated inbound socket."""
         adapter = _make_adapter()
         cli = _ScriptedCli()
-        cli.script("users", "get", [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}])
-        cli.script("channels", "list", [{"channel_id": CHANNEL, "name": "general"}])
         adapter._run_cli = cli
-        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
-        monkeypatch.setattr(adapter, "_seed_channel", AsyncMock())
-        monkeypatch.setattr(adapter, "_discover_dms", AsyncMock())
-        monkeypatch.setattr(adapter, "_start_websocket", AsyncMock(return_value=True))
+        sent = []
 
-        assert await adapter.connect() is True
-        assert [
-            args for args, _input in cli.calls
-            if args[:2] == ["users", "set-presence"]
-        ] == [["users", "set-presence", "--status", "online"]]
+        class WebSocket:
+            async def send(self, payload):
+                sent.append(json.loads(payload))
 
-        await adapter.disconnect()
-        assert [
-            args for args, _input in cli.calls
-            if args[:2] == ["users", "set-presence"]
-        ] == [
-            ["users", "set-presence", "--status", "online"],
-            ["users", "set-presence", "--status", "offline"],
-        ]
+        websocket = WebSocket()
+        await adapter._publish_presence(websocket, "online")
+
+        assert cli.calls == []
+        assert len(sent) == 1
+        assert sent[0][0] == "EVENT"
+        assert sent[0][1]["kind"] == 20001
+        assert sent[0][1]["content"] == "online"
+        # The event is self-authored: the signing key IS the subject.
+        assert sent[0][1]["pubkey"] == _buzz_mod._load_nostr_auth().public_key_hex(
+            "00" * 31 + "03"
+        )
 
     @pytest.mark.asyncio
-    async def test_presence_refreshes_until_cancelled(self):
+    async def test_presence_heartbeat_publishes_online_then_repeats(self):
         """The heartbeat republishes online presence before relay expiry."""
         adapter = _make_adapter()
         adapter._presence_interval = 0.001
         calls = []
         refreshed = asyncio.Event()
 
-        async def record_presence(status):
+        async def record_publish(websocket, status):
             calls.append(status)
             if len(calls) >= 2:
                 refreshed.set()
-            return True
 
-        adapter._set_presence = record_presence
-        task = asyncio.create_task(adapter._presence_loop())
+        adapter._publish_presence = record_publish
+        task = asyncio.create_task(adapter._presence_heartbeat(object()))
         try:
             await asyncio.wait_for(refreshed.wait(), timeout=1)
         finally:
@@ -3258,7 +3254,7 @@ class TestBuzzAdapterLifecycle:
 
     @pytest.mark.asyncio
     async def test_presence_first_and_repeat_refresh_lands_before_expiry(self):
-        """First refresh (and repeats) arrive before a short relay TTL lapses."""
+        """First publish (and repeats) arrive before a short relay TTL lapses."""
         adapter = _make_adapter()
         adapter._presence_interval = 0.05  # configured cadence would brush expiry
         adapter._presence_expiry = 0.06
@@ -3266,22 +3262,21 @@ class TestBuzzAdapterLifecycle:
         stamps = []
         done = asyncio.Event()
 
-        async def record_presence(status):
+        async def record_publish(websocket, status):
             stamps.append(time.monotonic())
             if len(stamps) >= 2:
                 done.set()
-            return True
 
-        adapter._set_presence = record_presence
+        adapter._publish_presence = record_publish
         start = time.monotonic()
-        task = asyncio.create_task(adapter._presence_loop())
+        task = asyncio.create_task(adapter._presence_heartbeat(object()))
         try:
             await asyncio.wait_for(done.wait(), timeout=2)
         finally:
             task.cancel()
             await asyncio.gather(task, return_exceptions=True)
 
-        # Effective cadence is expiry - margin = 0.02s; the first refresh
+        # Effective cadence is expiry - margin = 0.02s; the first publish
         # must land well before the 0.06s TTL, and the second on cadence.
         assert stamps[0] - start < adapter._presence_expiry
         assert 0 < stamps[1] - stamps[0] < 2 * (
@@ -3292,13 +3287,17 @@ class TestBuzzAdapterLifecycle:
     async def test_stop_presence_swallows_timeouts_but_not_cancellation(self):
         adapter = _make_adapter()
 
-        async def raise_cancelled(status):
+        async def raise_cancelled(websocket, status):
             raise asyncio.CancelledError()
 
         adapter._presence_task = None
-        adapter._set_presence = raise_cancelled
-        with pytest.raises(asyncio.CancelledError):
-            await adapter._stop_presence()
+        adapter._ws_connection = object()
+        adapter._publish_presence = raise_cancelled
+        try:
+            with pytest.raises(asyncio.CancelledError):
+                await adapter._stop_presence()
+        finally:
+            adapter._ws_connection = None
 
 
 # ── Credentials / requirements ────────────────────────────────────────────

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -83,7 +83,10 @@ def _event(event_id, pubkey=OTHER_PUBKEY, content="hello", created_at=1000, kind
 def _make_adapter(extra=None):
     from gateway.config import PlatformConfig
 
-    cfg = PlatformConfig(enabled=True, extra={"relay_url": "https://test.relay", **(extra or {})})
+    cfg = PlatformConfig(
+        enabled=True,
+        extra={"relay_url": "https://test.relay", "reactions": False, **(extra or {})},
+    )
     adapter = BuzzAdapter(cfg)
     adapter._self_pubkey = SELF_PUBKEY
     adapter._self_npub = SELF_NPUB

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3182,6 +3182,59 @@ class TestBuzzAdapterLifecycle:
         assert await adapter.connect() is False
         assert adapter._lock_key is None
 
+    @pytest.mark.asyncio
+    async def test_connect_publishes_online_and_disconnect_publishes_offline(self, monkeypatch):
+        """A connected Buzz agent must have a visible presence record."""
+        adapter = _make_adapter()
+        cli = _ScriptedCli()
+        cli.script("users", "get", [{"pubkey": SELF_PUBKEY, "display_name": "Chip"}])
+        cli.script("channels", "list", [{"channel_id": CHANNEL, "name": "general"}])
+        adapter._run_cli = cli
+        monkeypatch.setattr(_buzz_mod, "_resolve_private_key", lambda extra=None: "nsec1test")
+        monkeypatch.setattr(adapter, "_seed_channel", AsyncMock())
+        monkeypatch.setattr(adapter, "_discover_dms", AsyncMock())
+        monkeypatch.setattr(adapter, "_start_websocket", AsyncMock(return_value=True))
+
+        assert await adapter.connect() is True
+        assert [
+            args for args, _input in cli.calls
+            if args[:2] == ["users", "set-presence"]
+        ] == [["users", "set-presence", "--status", "online"]]
+
+        await adapter.disconnect()
+        assert [
+            args for args, _input in cli.calls
+            if args[:2] == ["users", "set-presence"]
+        ] == [
+            ["users", "set-presence", "--status", "online"],
+            ["users", "set-presence", "--status", "offline"],
+        ]
+
+    @pytest.mark.asyncio
+    async def test_presence_refreshes_until_cancelled(self):
+        """The heartbeat republishes online presence before relay expiry."""
+        adapter = _make_adapter()
+        adapter._presence_interval = 0.001
+        calls = []
+        refreshed = asyncio.Event()
+
+        async def record_presence(status):
+            calls.append(status)
+            if len(calls) >= 2:
+                refreshed.set()
+            return True
+
+        adapter._set_presence = record_presence
+        task = asyncio.create_task(adapter._presence_loop())
+        try:
+            await asyncio.wait_for(refreshed.wait(), timeout=1)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        assert calls[0] == "online"
+        assert len(calls) >= 2
+
 
 # ── Credentials / requirements ────────────────────────────────────────────
 

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import hashlib
 import json
+import time
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -3234,6 +3235,70 @@ class TestBuzzAdapterLifecycle:
 
         assert calls[0] == "online"
         assert len(calls) >= 2
+
+    def test_refresh_interval_clamps_to_leave_margin_before_expiry(self):
+        """Cadence invariants: never later than expiry-minus-margin, never zero."""
+        assert _buzz_mod._presence_refresh_interval(60.0, 180.0, 120.0) == 60.0
+        # A configured cadence that would brush expiry is pulled earlier.
+        assert _buzz_mod._presence_refresh_interval(90.0, 100.0, 60.0) == 40.0
+        # A degenerate margin that leaves no headroom falls back to half the
+        # expiry as the ceiling; the configured cadence still applies when
+        # it is already tighter.
+        assert _buzz_mod._presence_refresh_interval(60.0, 180.0, 200.0) == 60.0
+        assert _buzz_mod._presence_refresh_interval(120.0, 180.0, 200.0) == 90.0
+        # The default cadence always refreshes before the record lapses.
+        assert (
+            _buzz_mod._presence_refresh_interval(
+                _buzz_mod._PRESENCE_INTERVAL,
+                _buzz_mod._PRESENCE_EXPIRY,
+                _buzz_mod._PRESENCE_REFRESH_MARGIN,
+            )
+            < _buzz_mod._PRESENCE_EXPIRY
+        )
+
+    @pytest.mark.asyncio
+    async def test_presence_first_and_repeat_refresh_lands_before_expiry(self):
+        """First refresh (and repeats) arrive before a short relay TTL lapses."""
+        adapter = _make_adapter()
+        adapter._presence_interval = 0.05  # configured cadence would brush expiry
+        adapter._presence_expiry = 0.06
+        adapter._presence_margin = 0.04
+        stamps = []
+        done = asyncio.Event()
+
+        async def record_presence(status):
+            stamps.append(time.monotonic())
+            if len(stamps) >= 2:
+                done.set()
+            return True
+
+        adapter._set_presence = record_presence
+        start = time.monotonic()
+        task = asyncio.create_task(adapter._presence_loop())
+        try:
+            await asyncio.wait_for(done.wait(), timeout=2)
+        finally:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
+
+        # Effective cadence is expiry - margin = 0.02s; the first refresh
+        # must land well before the 0.06s TTL, and the second on cadence.
+        assert stamps[0] - start < adapter._presence_expiry
+        assert 0 < stamps[1] - stamps[0] < 2 * (
+            adapter._presence_expiry - adapter._presence_margin
+        )
+
+    @pytest.mark.asyncio
+    async def test_stop_presence_swallows_timeouts_but_not_cancellation(self):
+        adapter = _make_adapter()
+
+        async def raise_cancelled(status):
+            raise asyncio.CancelledError()
+
+        adapter._presence_task = None
+        adapter._set_presence = raise_cancelled
+        with pytest.raises(asyncio.CancelledError):
+            await adapter._stop_presence()
 
 
 # ── Credentials / requirements ────────────────────────────────────────────

--- a/tests/gateway/test_buzz_reaction_lifecycle.py
+++ b/tests/gateway/test_buzz_reaction_lifecycle.py
@@ -1,0 +1,572 @@
+"""Tests for the Buzz reaction lifecycle (👀 → 🧠 → ✅/❌).
+
+Behavioral contract (design spec, PM-owned):
+- Reaction lifecycle is Buzz-owned and serialized per inbound message.
+- 👀 is queued at dispatch of an authorized conversational message, before
+  handle_message runs; 🧠 when background processing starts; ✅/❌ on the
+  real outcome; CANCELLED removes the working reaction and adds nothing.
+- Replacement is remove-gated: a failed remove suppresses the replacement
+  add so lifecycle reactions never stack.
+- Gate: gateway.platforms.buzz.extra.reactions (default true). No env var.
+- Every reaction operation is best-effort: failures never affect the reply.
+"""
+
+import asyncio
+
+import pytest
+from unittest.mock import AsyncMock
+
+from tests.gateway._plugin_adapter_loader import load_plugin_adapter
+
+_buzz_mod = load_plugin_adapter("buzz")
+
+BuzzAdapter = _buzz_mod.BuzzAdapter
+
+SELF_PUBKEY = "9fd5c7ba6d3ef224da78f541e0fcb9c50f72cc63edb19aae76ac6a0474dfa860"
+SELF_NPUB = "npub1nl2u0wnd8mezfknc74q7pl9ec58h9nrrakce4tnk434qgaxl4psqe5twr6"
+OTHER_PUBKEY = "a" * 64
+CHANNEL = "ccc2bc1a-7a82-5a8f-8c4e-57a070cbe7cd"
+
+EYES = "\U0001f440"
+BRAIN = "\U0001f9e0"
+OK = "\U00002705"
+FAIL = "\U0000274c"
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch, tmp_path):
+    """Hermetic: no ambient Buzz env vars (the gate must be config-only)."""
+    for var in (
+        "BUZZ_RELAY_URL",
+        "BUZZ_PRIVATE_KEY",
+        "BUZZ_REACTIONS",  # must never be consulted
+        "BUZZ_CHANNELS",
+        "BUZZ_HOME_CHANNEL",
+        "BUZZ_ALLOWED_USERS",
+        "BUZZ_ALLOW_ALL_USERS",
+        "BUZZ_POLL_INTERVAL",
+        "BUZZ_AUTH_TAG",
+        "BUZZ_CLI_PATH",
+        "BUZZ_CREDENTIALS_FILE",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(_buzz_mod, "_DEFAULT_CREDENTIALS_DIR", tmp_path / "no-creds")
+    yield
+
+
+def _make_adapter(extra=None):
+    from gateway.config import PlatformConfig
+
+    cfg = PlatformConfig(
+        enabled=True, extra={"relay_url": "https://test.relay", **(extra or {})}
+    )
+    adapter = BuzzAdapter(cfg)
+    adapter._self_pubkey = SELF_PUBKEY
+    adapter._self_npub = SELF_NPUB
+    adapter._display_name = "Chip"
+    adapter._private_key = "nsec1test"
+    return adapter
+
+
+def _message_event(
+    adapter,
+    text="hello",
+    message_id="e1",
+    chat_id=CHANNEL,
+    chat_type="group",
+    user_id=OTHER_PUBKEY,
+):
+    from gateway.platforms.base import MessageEvent, MessageType
+
+    source = adapter.build_source(
+        chat_id=chat_id,
+        chat_name=chat_id,
+        chat_type=chat_type,
+        user_id=user_id,
+        user_name="other",
+    )
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=source,
+        message_id=message_id,
+    )
+
+
+class _RecordingCli:
+    """Fake ``_run_cli`` recording every call as (args, input_text).
+
+    Optional gate/event hooks let tests hold calls open to prove ordering.
+    Reaction failures are count-limited so a test can fail the FIRST
+    remove/add and let later retries succeed.
+    """
+
+    def __init__(self):
+        self.calls = []
+        self.release_first: asyncio.Event | None = None  # optional gate
+        self.fail_removes: dict = {}  # emoji -> remaining failure count
+        self.fail_adds: dict = {}  # emoji -> remaining failure count
+
+    def fail_remove(self, emoji, times=1):
+        self.fail_removes[emoji] = times
+
+    def fail_add(self, emoji, times=1):
+        self.fail_adds[emoji] = times
+
+    async def __call__(self, args, *, input_text=None):
+        args = list(args)
+        if args[0] == "reactions":
+            cmd = args[1]
+            emoji = args[args.index("--emoji") + 1]
+            fails = self.fail_removes if cmd == "remove" else self.fail_adds
+            if fails.get(emoji, 0) > 0:
+                fails[emoji] -= 1
+                self.calls.append((args, input_text))
+                return 2, "", "relay error"
+        if self.release_first is not None and not self.calls:
+            await self.release_first.wait()
+        self.calls.append((args, input_text))
+        return 0, '{"accepted": true, "event_id": "self-sent"}', ""
+
+    def reaction_ops(self):
+        """Reaction operations in issue order: ('add'|'remove', emoji)."""
+        ops = []
+        for args, _input in self.calls:
+            if args[0] == "reactions":
+                ops.append((args[1], args[args.index("--emoji") + 1]))
+        return ops
+
+
+async def _drain_reactions(adapter, rounds=6):
+    """Wait until no reaction tasks remain (terminal hooks enqueue async)."""
+    for _ in range(rounds):
+        tasks = [t for t in list(adapter._reaction_tasks) if not t.done()]
+        if not tasks:
+            break
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+
+async def _drain_sessions(adapter, rounds=8):
+    """Wait until no background session/reaction tasks remain.
+
+    ``handle_message`` spawns the handler in a background task, so callers
+    asserting handler-side effects must drain before asserting.
+    """
+    for _ in range(rounds):
+        session = [
+            t
+            for t in list(getattr(adapter, "_session_tasks", {}).values())
+            if not t.done()
+        ]
+        pending = [t for t in list(adapter._reaction_tasks) if not t.done()]
+        if not session and not pending:
+            break
+        await asyncio.gather(*(session + pending), return_exceptions=True)
+
+
+# ── Configuration gate ────────────────────────────────────────────────────
+
+
+class TestReactionGate:
+    def test_default_enabled_when_absent(self):
+        assert _make_adapter()._reactions_enabled() is True
+
+    @pytest.mark.parametrize("value", [False, "false", "False", "0", "no", "off"])
+    def test_disabled_values(self, value):
+        assert _make_adapter(extra={"reactions": value})._reactions_enabled() is False
+
+    @pytest.mark.parametrize("value", [True, "true", "yes", "on", "1"])
+    def test_enabled_values(self, value):
+        assert _make_adapter(extra={"reactions": value})._reactions_enabled() is True
+
+    def test_invalid_value_falls_back_to_default_true(self):
+        assert _make_adapter(extra={"reactions": "banana"})._reactions_enabled() is True
+
+    def test_gate_is_per_adapter_multiplex_safe(self):
+        off = _make_adapter(extra={"reactions": False})
+        on = _make_adapter(extra={})
+        assert off._reactions_enabled() is False and on._reactions_enabled() is True
+
+
+# ── Low-level CLI primitives ──────────────────────────────────────────────
+
+
+class TestReactionPrimitives:
+    @pytest.mark.asyncio
+    async def test_add_uses_event_and_emoji_no_channel(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        assert await adapter.send_reaction(CHANNEL, "e1", EYES) is True
+        assert cli.calls == [
+            (["reactions", "add", "--event", "e1", "--emoji", EYES], None)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_remove_uses_event_and_emoji_no_channel(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        assert await adapter.remove_reaction(CHANNEL, "e1", EYES) is True
+        assert cli.calls == [
+            (["reactions", "remove", "--event", "e1", "--emoji", EYES], None)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_remove_failure_returns_false(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        cli.fail_remove(EYES)
+        adapter._run_cli = cli
+        assert await adapter.remove_reaction(CHANNEL, "e1", EYES) is False
+
+
+# ── Transition coordinator (serialization + replacement algorithm) ───────
+
+
+class TestTransitionCoordinator:
+    def _seed(self, adapter, cli, message_id="e1", chat_id=CHANNEL):
+        adapter._run_cli = cli
+        adapter._reaction_begin(chat_id, message_id)
+        return (chat_id, message_id)
+
+    @pytest.mark.asyncio
+    async def test_success_sequence_ordered(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        key = self._seed(adapter, cli)
+        await adapter.on_processing_start(_evt_with(key))
+        await adapter.on_processing_complete(_evt_with(key), _outcome_success())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [
+            ("add", EYES),
+            ("remove", EYES),
+            ("add", BRAIN),
+            ("remove", BRAIN),
+            ("add", OK),
+        ]
+        # Terminal state is cleaned up.
+        assert key not in adapter._reaction_lifecycle
+
+    @pytest.mark.asyncio
+    async def test_failure_sequence_ordered(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        key = self._seed(adapter, cli)
+        await adapter.on_processing_start(_evt_with(key))
+        await adapter.on_processing_complete(_evt_with(key), _outcome_failure())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [
+            ("add", EYES),
+            ("remove", EYES),
+            ("add", BRAIN),
+            ("remove", BRAIN),
+            ("add", FAIL),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_cancelled_removes_without_terminal(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        key = self._seed(adapter, cli)
+        await adapter.on_processing_start(_evt_with(key))
+        await adapter.on_processing_complete(_evt_with(key), _outcome_cancelled())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [
+            ("add", EYES),
+            ("remove", EYES),
+            ("add", BRAIN),
+            ("remove", BRAIN),
+        ]
+        assert key not in adapter._reaction_lifecycle
+
+    @pytest.mark.asyncio
+    async def test_failed_remove_suppresses_replacement_add(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        cli.fail_remove(EYES)  # first remove fails; later removes succeed
+        key = self._seed(adapter, cli)
+        await adapter.on_processing_start(_evt_with(key))
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [("add", EYES), ("remove", EYES)]
+        # Old reaction stays authoritative; a later terminal still tries.
+        await adapter.on_processing_complete(_evt_with(key), _outcome_failure())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops()[-2:] == [("remove", EYES), ("add", FAIL)]
+
+    @pytest.mark.asyncio
+    async def test_initial_add_failure_then_direct_brain(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        cli.fail_add(EYES)
+        key = self._seed(adapter, cli)
+        await adapter.on_processing_start(_evt_with(key))
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [("add", EYES), ("add", BRAIN)]
+
+    @pytest.mark.asyncio
+    async def test_transitions_serialize_never_stack(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        cli.release_first = asyncio.Event()
+        key = self._seed(adapter, cli)
+
+        start_task = asyncio.create_task(adapter.on_processing_start(_evt_with(key)))
+        # Working + terminal are queued while the 👀 add is still held open.
+        await asyncio.sleep(0)
+        await adapter.on_processing_complete(_evt_with(key), _outcome_failure())
+        cli.release_first.set()
+        await asyncio.gather(start_task, return_exceptions=True)
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == [
+            ("add", EYES),
+            ("remove", EYES),
+            ("add", BRAIN),
+            ("remove", BRAIN),
+            ("add", FAIL),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_hooks_noop_for_unknown_event(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        await adapter.on_processing_start(_evt_with((CHANNEL, "unknown")))
+        await adapter.on_processing_complete(
+            _evt_with((CHANNEL, "unknown")), _outcome_success()
+        )
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == []
+
+    @pytest.mark.asyncio
+    async def test_hooks_noop_when_disabled(self):
+        adapter = _make_adapter(extra={"reactions": False})
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        key = (CHANNEL, "e1")
+        await adapter.on_processing_start(_evt_with(key))
+        await adapter.on_processing_complete(_evt_with(key), _outcome_success())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == []
+
+    @pytest.mark.asyncio
+    async def test_hooks_noop_without_ids(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        event = _message_event(adapter)
+        event.message_id = None
+        await adapter.on_processing_start(event)
+        await adapter.on_processing_complete(event, _outcome_success())
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == []
+
+    @pytest.mark.asyncio
+    async def test_unauthorized_sender_gets_no_lifecycle(self):
+        adapter = _make_adapter()
+        adapter.set_authorization_check(lambda user_id, chat_type, chat_id: False)
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        await adapter._dispatch_message(
+            text="hello",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="other",
+            message_id="e1",
+            created_at=1000,
+        )
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == []
+
+    @pytest.mark.asyncio
+    async def test_no_auth_callback_still_gets_lifecycle(self):
+        adapter = _make_adapter()  # no authorization callback installed
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        seen_at_handler = {}
+
+        async def handler(event):
+            seen_at_handler["called"] = True
+            seen_at_handler["tracked"] = (CHANNEL, "e1") in adapter._reaction_lifecycle
+            return "ok"
+
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text="hello",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="other",
+            message_id="e1",
+            created_at=1000,
+        )
+        # The 👀 must already be lifecycle-tracked before the handler ran
+        # (asserted inside the handler: terminal cleanup pops the state by
+        # the time the turn finishes).
+        await _drain_sessions(adapter)
+        assert seen_at_handler.get("called") is True
+        assert seen_at_handler["tracked"] is True
+        assert ("add", EYES) in cli.reaction_ops()
+
+
+# ── Dispatch wiring ───────────────────────────────────────────────────────
+
+
+class TestDispatchWiring:
+    @pytest.mark.asyncio
+    async def test_command_message_gets_no_reaction(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        adapter._message_handler = AsyncMock(return_value="ok")
+        await adapter._dispatch_message(
+            text="/status",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="other",
+            message_id="e1",
+            created_at=1000,
+        )
+        await _drain_reactions(adapter)
+        assert cli.reaction_ops() == []
+
+    @pytest.mark.asyncio
+    async def test_dispatch_queues_eyes_before_handler_and_no_duplicate(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+
+        seen_at_handler = {}
+
+        async def handler(event):
+            seen_at_handler["tracked"] = (CHANNEL, "e1") in adapter._reaction_lifecycle
+            return "ok"
+
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text="hello",
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="other",
+            message_id="e1",
+            created_at=1000,
+        )
+        await _drain_sessions(adapter)
+        assert seen_at_handler["tracked"] is True
+        # Exactly one 👀 add: the lifecycle one — the old post-dispatch
+        # duplicate must be gone.
+        assert cli.reaction_ops().count(("add", EYES)) == 1
+
+
+# ── Full base-class wiring (integration through handle_message) ──────────
+
+
+class TestBaseHookIntegration:
+    async def _run_turn(self, adapter, handler, text="hello"):
+        adapter._message_handler = handler
+        await adapter._dispatch_message(
+            text=text,
+            chat_id=CHANNEL,
+            chat_type="group",
+            user_id=OTHER_PUBKEY,
+            user_name="other",
+            message_id="e1",
+            created_at=1000,
+        )
+        for _ in range(8):
+            session = [
+                t
+                for t in list(getattr(adapter, "_session_tasks", {}).values())
+                if not t.done()
+            ]
+            pending = [t for t in list(adapter._reaction_tasks) if not t.done()]
+            if not session and not pending:
+                break
+            await asyncio.gather(*(session + pending), return_exceptions=True)
+
+    @pytest.mark.asyncio
+    async def test_real_flow_success_full_lifecycle(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+        await self._run_turn(adapter, AsyncMock(return_value="ok"))
+        assert cli.reaction_ops() == [
+            ("add", EYES),
+            ("remove", EYES),
+            ("add", BRAIN),
+            ("remove", BRAIN),
+            ("add", OK),
+        ]
+
+    @pytest.mark.asyncio
+    async def test_real_flow_handler_exception_marks_failure(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        adapter._run_cli = cli
+
+        async def boom(event):
+            raise RuntimeError("handler exploded")
+
+        await self._run_turn(adapter, boom)
+        assert cli.reaction_ops()[-1] == ("add", FAIL)
+        assert ("remove", BRAIN) in cli.reaction_ops()
+
+
+# ── Disconnect hygiene ────────────────────────────────────────────────────
+
+
+class TestDisconnectCleanup:
+    @pytest.mark.asyncio
+    async def test_disconnect_cancels_in_flight_reaction_tasks(self):
+        adapter = _make_adapter()
+        cli = _RecordingCli()
+        cli.release_first = asyncio.Event()
+        adapter._run_cli = cli
+        key = (CHANNEL, "e1")
+        adapter._reaction_begin(*key)
+        await adapter.on_processing_start(_evt_with(key))
+        await asyncio.sleep(0)  # let the task start and block on the CLI
+
+        await asyncio.wait_for(adapter.disconnect(), timeout=5)
+
+        assert not adapter._reaction_tasks or all(
+            t.done() for t in adapter._reaction_tasks
+        )
+        assert adapter._reaction_lifecycle == {}
+
+
+# ── helpers ───────────────────────────────────────────────────────────────
+
+
+def _evt_with(key):
+    """Minimal stand-in carrying (chat_id, message_id) for hook calls."""
+
+    class _Src:
+        chat_id = key[0]
+
+    class _Evt:
+        source = _Src()
+        message_id = key[1]
+
+    return _Evt()
+
+
+def _outcome_success():
+    from gateway.platforms.base import ProcessingOutcome
+
+    return ProcessingOutcome.SUCCESS
+
+
+def _outcome_failure():
+    from gateway.platforms.base import ProcessingOutcome
+
+    return ProcessingOutcome.FAILURE
+
+
+def _outcome_cancelled():
+    from gateway.platforms.base import ProcessingOutcome
+
+    return ProcessingOutcome.CANCELLED

--- a/tests/gateway/test_buzz_reaction_lifecycle.py
+++ b/tests/gateway/test_buzz_reaction_lifecycle.py
@@ -518,6 +518,100 @@ class TestBaseHookIntegration:
 # ── Disconnect hygiene ────────────────────────────────────────────────────
 
 
+class TestAbandonedLifecycleCleanup:
+    @pytest.mark.asyncio
+    async def test_stale_completed_chain_is_removed_without_terminal_hook(self):
+        adapter = _make_adapter()
+        adapter._reaction_cleanup_ttl = 0
+        key = (CHANNEL, "leaked")
+        adapter._reaction_begin(*key)
+        await _drain_reactions(adapter)
+
+        assert key in adapter._reaction_lifecycle
+        await adapter._reaction_cleanup_once()
+
+        assert key not in adapter._reaction_lifecycle
+
+    @pytest.mark.asyncio
+    async def test_cleanup_keeps_live_transition_until_timeout_cancels_it(self):
+        adapter = _make_adapter()
+        adapter._reaction_cleanup_ttl = 0
+        key = (CHANNEL, "in-flight")
+        blocker = asyncio.Event()
+
+        async def stuck(*_args, **_kwargs):
+            await blocker.wait()
+            return 0, "", ""
+
+        adapter._run_cli = stuck
+        adapter._reaction_begin(*key)
+        await asyncio.sleep(0)
+        task = adapter._reaction_lifecycle[key]["tail_task"]
+        assert not task.done()
+
+        await adapter._reaction_cleanup_once()
+        # Cancellation is delivered on the next loop pass; wait for the
+        # task to finish processing it.
+        await asyncio.gather(task, return_exceptions=True)
+
+        assert task.cancelled()
+        assert key not in adapter._reaction_lifecycle
+
+    @pytest.mark.asyncio
+    async def test_cleanup_does_not_touch_young_in_flight_state(self):
+        """A valid transition in flight must survive a sweep."""
+        adapter = _make_adapter()
+        adapter._reaction_cleanup_ttl = 300.0
+        key = (CHANNEL, "young")
+        blocker = asyncio.Event()
+
+        async def slow_but_fine(*_args, **_kwargs):
+            await blocker.wait()
+            return 0, "", ""
+
+        adapter._run_cli = slow_but_fine
+        adapter._reaction_begin(*key)
+        await asyncio.sleep(0)
+        task = adapter._reaction_lifecycle[key]["tail_task"]
+
+        await adapter._reaction_cleanup_once()
+
+        assert key in adapter._reaction_lifecycle
+        assert not task.cancelled()
+        blocker.set()
+        await _drain_reactions(adapter)
+
+    @pytest.mark.asyncio
+    async def test_single_shared_cleanup_task_starts_and_ends_with_state(self):
+        adapter = _make_adapter()
+        adapter._reaction_cleanup_interval = 0.001
+
+        key = (CHANNEL, "sweeper")
+        adapter._reaction_begin(*key)
+        first = adapter._reaction_cleanup_task
+        assert first is not None and not first.done()
+
+        # A second entry reuses the same sweeper task.
+        key2 = (CHANNEL, "sweeper2")
+        adapter._reaction_begin(*key2)
+        assert adapter._reaction_cleanup_task is first
+
+        # Terminal completion empties the map; the sweeper exits on its own.
+        await adapter.on_processing_complete(_evt_with(key2), _outcome_success())
+        await adapter.on_processing_complete(_evt_with(key), _outcome_success())
+        await _drain_reactions(adapter)
+        for _ in range(20):
+            if adapter._reaction_cleanup_task.done():
+                break
+            await asyncio.sleep(0.001)
+        assert adapter._reaction_cleanup_task.done()
+        # A fresh entry restarts it (done task is replaced).
+        adapter._reaction_begin(CHANNEL, "sweeper3")
+        assert adapter._reaction_cleanup_task is not first
+        await adapter.on_processing_complete(_evt_with((CHANNEL, "sweeper3")), _outcome_success())
+        await _drain_reactions(adapter)
+
+
 class TestDisconnectCleanup:
     @pytest.mark.asyncio
     async def test_disconnect_cancels_in_flight_reaction_tasks(self):

--- a/tests/gateway/test_buzz_reaction_lifecycle.py
+++ b/tests/gateway/test_buzz_reaction_lifecycle.py
@@ -123,7 +123,7 @@ class _RecordingCli:
                 fails[emoji] -= 1
                 self.calls.append((args, input_text))
                 return 2, "", "relay error"
-        if self.release_first is not None and not self.calls:
+        if self.release_first is not None and not self.calls and args[0] == "reactions":
             await self.release_first.wait()
         self.calls.append((args, input_text))
         return 0, '{"accepted": true, "event_id": "self-sent"}', ""

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -161,6 +161,93 @@ async def _unresolved_pong():
 
 
 @pytest.mark.asyncio
+async def test_frame_wins_over_pending_liveness_probe(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    frame_ready = asyncio.Event()
+    pong_started = asyncio.Event()
+    pong_waiter = None
+
+    async def anext_behavior():
+        await frame_ready.wait()
+        return "frame"
+
+    async def ping_behavior():
+        nonlocal pong_waiter
+        pong_waiter = asyncio.get_running_loop().create_future()
+        pong_started.set()
+        return pong_waiter
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    frame_task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(pong_started.wait(), 1)
+    frame_ready.set()
+
+    assert await asyncio.wait_for(frame_task, 1) == "frame"
+    assert pong_waiter.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_failed_probe_wins_simultaneous_frame_completion(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    frame_ready = asyncio.Event()
+    probe_started = asyncio.Event()
+    probe_failed = asyncio.Event()
+
+    async def anext_behavior():
+        await frame_ready.wait()
+        return "frame"
+
+    async def ping_behavior():
+        probe_started.set()
+        await asyncio.sleep(0)
+        probe_failed.set()
+        raise ConnectionError("transport failed")
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    frame_task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(probe_started.wait(), 1)
+    frame_ready.set()
+    await asyncio.wait_for(probe_failed.wait(), 1)
+    await asyncio.sleep(0)
+
+    with pytest.raises(ConnectionError, match="transport failed"):
+        await asyncio.wait_for(frame_task, 1)
+
+
+@pytest.mark.asyncio
+async def test_liveness_race_cancellation_settles_pending_tasks(monkeypatch):
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 1)
+    pong_waiter = None
+    probe_started = asyncio.Event()
+
+    async def anext_behavior():
+        await asyncio.Event().wait()
+
+    async def ping_behavior():
+        nonlocal pong_waiter
+        pong_waiter = asyncio.get_running_loop().create_future()
+        probe_started.set()
+        return pong_waiter
+
+    websocket = _ScriptedWebSocket(anext_behavior, ping_behavior)
+    task = asyncio.create_task(
+        BuzzAdapter._read_frame_or_probe(_make_adapter(), websocket.__aiter__(), websocket)
+    )
+    await asyncio.wait_for(probe_started.wait(), 1)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 1)
+    assert pong_waiter.cancelled()
+
+
+@pytest.mark.asyncio
 async def test_websocket_loop_keeps_a_quiet_healthy_connection(monkeypatch):
     adapter = _make_adapter()
     monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -116,10 +116,12 @@ class _ScriptedWebSocket(_FakeWebSocket):
     a clean close.
     """
 
-    def __init__(self, anext_behavior):
+    def __init__(self, anext_behavior, ping_behavior):
         super().__init__()
         self._anext_behavior = anext_behavior
+        self._ping_behavior = ping_behavior
         self.exited = False
+        self.ping_count = 0
 
     async def __aenter__(self):
         return self
@@ -128,40 +130,88 @@ class _ScriptedWebSocket(_FakeWebSocket):
         self.exited = True
 
     def __aiter__(self):
+        # Match websockets 15.x: the frame iterator is distinct from the
+        # connection and does not expose ping().
+        return _ScriptedFrameIterator(self._anext_behavior)
+
+    async def ping(self):
+        self.ping_count += 1
+        return await self._ping_behavior()
+
+
+class _ScriptedFrameIterator:
+    def __init__(self, anext_behavior):
+        self._anext_behavior = anext_behavior
+
+    def __aiter__(self):
         return self
 
     async def __anext__(self):
         return await self._anext_behavior()
 
 
+async def _resolved_pong():
+    waiter = asyncio.get_running_loop().create_future()
+    waiter.set_result(0.0)
+    return waiter
+
+
+async def _unresolved_pong():
+    return asyncio.get_running_loop().create_future()
+
+
 @pytest.mark.asyncio
-async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, caplog):
-    """A relay close the transport never surfaces must not park the loop.
-
-    Reproduces the #98097 shape: a socket stuck in CLOSE_WAIT yields no
-    frame and no error, so without a read-side bound the loop would wait
-    forever while the gateway keeps reporting "connected".
-    """
-    import logging
-
+async def test_websocket_loop_keeps_a_quiet_healthy_connection(monkeypatch):
     adapter = _make_adapter()
-    monkeypatch.setattr(_buzz_mod, "_WS_READ_IDLE_TIMEOUT", 0.05)
-    caplog.set_level(logging.WARNING)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.02)
 
     sockets = []
 
-    async def dead_anext():
-        await asyncio.Event().wait()  # never yields, never raises
+    async def quiet_anext():
+        await asyncio.Event().wait()
 
     def fake_connect(*args, **kwargs):
-        ws = _ScriptedWebSocket(dead_anext)
+        ws = _ScriptedWebSocket(quiet_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 
     import websockets as _ws_mod
 
     monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+    task = asyncio.create_task(adapter._websocket_loop())
+    await asyncio.sleep(0.2)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 5.0)
 
+    assert len(sockets) == 1
+    assert sockets[0].ping_count >= 2
+    assert sockets[0].exited
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_reconnects_when_liveness_ping_goes_silent(monkeypatch, caplog):
+    import logging
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.02)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.02)
+    caplog.set_level(logging.WARNING)
+
+    sockets = []
+
+    async def dead_anext():
+        await asyncio.Event().wait()
+
+    def fake_connect(*args, **kwargs):
+        ws = _ScriptedWebSocket(dead_anext, _unresolved_pong)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
     task = asyncio.create_task(adapter._websocket_loop())
     try:
         deadline = time.monotonic() + 5.0
@@ -174,9 +224,52 @@ async def test_websocket_loop_reconnects_when_read_goes_silent(monkeypatch, capl
         except (asyncio.CancelledError, asyncio.TimeoutError):
             pass
 
-    assert len(sockets) >= 2, "idle read watchdog did not force a reconnect"
-    assert sockets[0].exited, "the silent connection was not closed before reconnecting"
+    assert len(sockets) >= 2
+    assert sockets[0].exited
     assert any("went silent" in record.message for record in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_websocket_loop_clean_close_during_liveness_ping_is_quiet(
+    monkeypatch, caplog
+):
+    import logging
+
+    from websockets.exceptions import ConnectionClosedOK
+    from websockets.frames import Close
+
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_INTERVAL", 0.01)
+    monkeypatch.setattr(_buzz_mod, "_WS_LIVENESS_TIMEOUT", 0.01)
+    caplog.set_level(logging.WARNING)
+
+    async def quiet_anext():
+        await asyncio.Event().wait()
+
+    async def clean_ping_close():
+        raise ConnectionClosedOK(Close(1000, "normal closure"), None)
+
+    sockets = []
+    connects = []
+
+    def fake_connect(*args, **kwargs):
+        connects.append(1)
+        if len(connects) == 2:
+            raise asyncio.CancelledError()
+        ws = _ScriptedWebSocket(quiet_anext, clean_ping_close)
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+    task = asyncio.create_task(adapter._websocket_loop())
+    with pytest.raises(asyncio.CancelledError):
+        await asyncio.wait_for(task, 5.0)
+
+    assert len(connects) == 2
+    assert sockets[0].exited
+    assert not any("WebSocket disconnected" in record.message for record in caplog.records)
 
 
 @pytest.mark.asyncio
@@ -215,7 +308,7 @@ async def test_websocket_loop_dispatches_frames_and_closes_cleanly(monkeypatch):
         # loop's except-order, unlike a regular Exception which would retry.
         if len(sockets) == 1:
             raise asyncio.CancelledError()
-        ws = _ScriptedWebSocket(scripted_anext)
+        ws = _ScriptedWebSocket(scripted_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 
@@ -666,7 +759,7 @@ async def test_ws_discovery_task_cancelled_when_connection_exits(monkeypatch):
     def fake_connect(*args, **kwargs):
         if sockets:
             raise asyncio.CancelledError()
-        ws = _ScriptedWebSocket(closed_anext)
+        ws = _ScriptedWebSocket(closed_anext, _resolved_pong)
         sockets.append(ws)
         return ws
 

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -500,7 +500,12 @@ async def test_websocket_loop_drops_restricted_channel_without_reconnect():
         adapter._ws_ready.set()
         adapter._ws_active = True
         task = asyncio.create_task(adapter._websocket_loop())
-        await asyncio.sleep(0.1)
+        # Bounded poll, not a fixed settle: under full-suite load the inline
+        # presence publish (executor + ~50ms schnorr) precedes the first frame
+        # read, so the CLOSED frame can land after an arbitrary 0.1s.
+        deadline = time.monotonic() + 5.0
+        while CHANNEL not in adapter._restricted_channels and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
 
     assert CHANNEL in adapter._restricted_channels, (
         "restricted channel should be recorded in _restricted_channels"
@@ -573,7 +578,14 @@ async def test_websocket_loop_reconnects_on_non_restricted_closed():
         adapter._ws_ready.set()
         adapter._ws_active = True
         task = asyncio.create_task(adapter._websocket_loop())
-        await asyncio.sleep(0.1)
+        # Wait for the CLOSED frame to be consumed (idx advances past it),
+        # then confirm it did NOT restrict the channel — a negative assert
+        # needs a positive observation point first.
+        deadline = time.monotonic() + 5.0
+        while idx < len(messages) and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        # Give the handler a turn to (wrongly) restrict, if it were going to.
+        await asyncio.sleep(0.05)
 
     assert CHANNEL not in adapter._restricted_channels, (
         "non-restricted CLOSED must not add channel to _restricted_channels"
@@ -733,7 +745,11 @@ async def test_closed_membership_phrases_prune_without_reconnect(detail):
         adapter._ws_ready = asyncio.Event()
         adapter._ws_ready.set()
         task = asyncio.create_task(adapter._websocket_loop())
-        await asyncio.sleep(0.1)
+        # Bounded poll (see drops_restricted test): the CLOSED frame is only
+        # observed after the inline presence publish completes.
+        deadline = time.monotonic() + 5.0
+        while CHANNEL not in adapter._restricted_channels and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
 
     assert CHANNEL in adapter._restricted_channels
     assert CHANNEL not in adapter._channel_state
@@ -860,3 +876,405 @@ async def test_ws_discovery_task_cancelled_when_connection_exits(monkeypatch):
 
     assert started, "discovery task was never started with the connection"
     assert all(t.done() for t in started), "discovery task outlived its connection"
+
+
+# ── Presence heartbeat on the persistent socket ───────────────────────────
+
+
+def test_build_presence_event_shape():
+    event = nostr_auth.build_presence_event(
+        private_key=TEST_PRIVATE_KEY,
+        status="online",
+        created_at=1_700_000_000,
+        auxiliary_randomness=bytes(32),
+    )
+    assert event["kind"] == 20001
+    assert event["content"] == "online"
+    assert event["tags"] == [["status", "online"]]
+    assert event["pubkey"] == nostr_auth.public_key_hex(TEST_PRIVATE_KEY)
+    assert len(bytes.fromhex(event["sig"])) == 64
+    # No p-tags — the Desktop's live path trusts author = subject.
+    assert not any(tag[0] == "p" for tag in event["tags"])
+
+
+def test_build_presence_event_rejects_bad_status():
+    with pytest.raises(ValueError):
+        nostr_auth.build_presence_event(private_key=TEST_PRIVATE_KEY, status="brb")
+
+
+async def fail_cli(args, *, input_text=None):
+    raise AssertionError(f"presence must not shell out to buzz, got {args}")
+
+
+class _PresenceWebSocket(_ScriptedWebSocket):
+    """Authenticating WS whose outbound presence events are observable.
+
+    ``ping_behavior`` defaults to an always-answered pong: the liveness
+    probe (from the websocket-liveness series) also rides this socket, and
+    a healthy presence socket must survive its periodic probes.
+    """
+
+    def __init__(self, ping_behavior=None):
+        self.stream = asyncio.Queue()
+
+        async def behavior():
+            frame = await self.stream.get()
+            if frame is None:
+                raise StopAsyncIteration from None
+            return frame
+
+        if ping_behavior is None:
+            ping_behavior = _resolved_pong
+        super().__init__(behavior, ping_behavior)
+
+    @property
+    def presence_events(self):
+        return [
+            message[1]
+            for message in self.sent
+            if isinstance(message, list)
+            and message
+            and message[0] == "EVENT"
+            and isinstance(message[1], dict)
+            and message[1].get("kind") == 20001
+        ]
+
+
+def _heartbeat_tasks():
+    return [
+        task
+        for task in asyncio.all_tasks()
+        if task.get_coro().__qualname__ == "BuzzAdapter._presence_heartbeat"
+    ]
+
+
+async def _force_close(*sockets):
+    """Push a CLOSED frame so the adapter's reconnect loop parks in its
+    backoff sleep — a cancellation point that settles cleanly on every
+    code path (a cancel delivered inside the read-loop's cleanup during
+    an immediate reconnect can be swallowed and resurrect the loop)."""
+    for websocket in sockets:
+        websocket.stream.put_nowait(
+            json.dumps(["CLOSED", "hermes-buzz-membership", "error: connection reset"])
+        )
+    await asyncio.sleep(0.05)
+
+
+async def _settle(*tasks):
+    """Cancel tasks and await them so nothing leaks past a test."""
+    for task in tasks:
+        task.cancel()
+    await asyncio.wait_for(
+        asyncio.gather(*tasks, return_exceptions=True), timeout=5
+    )
+
+
+@pytest.mark.asyncio
+async def test_presence_heartbeat_runs_on_same_socket_without_cli(monkeypatch):
+    """Presence rides the authenticated inbound connection: no second
+    WebSocket, no ``buzz users set-presence`` subprocess."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_PRESENCE_INTERVAL", 0.02)
+    adapter._presence_interval = 0.02
+
+    adapter._run_cli = fail_cli
+
+    sockets = []
+
+    def fake_connect(*args, **kwargs):
+        ws = _PresenceWebSocket()
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while not sockets and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        while sockets and len(sockets[0].presence_events) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert len(sockets) == 1
+    finally:
+        await _settle(task)
+
+    assert len(sockets) == 1, "presence spawned a second WebSocket"
+    events = sockets[0].presence_events
+    assert len(events) >= 2, "presence did not repeat on the persistent socket"
+    online_events = [event for event in events if event["content"] == "online"]
+    assert len(online_events) >= 2
+    expected_pubkey = nostr_auth.public_key_hex(TEST_PRIVATE_KEY)
+    assert all(event["pubkey"] == expected_pubkey for event in online_events)
+    assert all(["status", "online"] in event["tags"] for event in online_events)
+
+
+@pytest.mark.asyncio
+async def test_presence_heartbeat_reconnect_replaces_task_exactly_once(monkeypatch):
+    """A reconnect retires the old heartbeat with the old socket and keeps
+    exactly one live heartbeat for the new connection."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_PRESENCE_INTERVAL", 0.02)
+    adapter._presence_interval = 0.02
+    adapter._run_cli = fail_cli
+
+    sockets = []
+
+    def fake_connect(*args, **kwargs):
+        ws = _PresenceWebSocket()
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while not sockets and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        while (
+            sockets
+            and len(sockets[0].presence_events) < 1
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.01)
+        assert sockets and sockets[0].presence_events, "first connection never heartbeated"
+        assert len(_heartbeat_tasks()) == 1, "duplicate heartbeats on one connection"
+
+        # Force a reconnect: CLOSED makes the read loop raise and back off.
+        await _force_close(sockets[0])
+        while len(sockets) < 2 and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert len(sockets) == 2, "relay CLOSED did not trigger a reconnect"
+        assert sockets[0].exited, "old socket was not closed before reconnecting"
+        # The retired heartbeat must not publish after its socket exited.
+        retired_count = len(sockets[0].presence_events)
+        await asyncio.sleep(0.1)
+        assert len(sockets[0].presence_events) == retired_count, (
+            "retired heartbeat kept publishing after its socket closed"
+        )
+        while (
+            len(sockets[1].presence_events) < 1
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.01)
+        assert len(_heartbeat_tasks()) == 1, "reconnect duplicated the heartbeat"
+    finally:
+        await _settle(task)
+
+    assert sockets[1].presence_events, "reconnected connection never heartbeated"
+    assert not _heartbeat_tasks(), "heartbeat task outlived its reconnect loop"
+
+
+@pytest.mark.asyncio
+async def test_cancel_during_first_presence_does_not_leak_heartbeat(monkeypatch):
+    """Cancelling the loop while the first online publish is still in flight
+    must not strand the heartbeat task (or any task) past shutdown."""
+    adapter = _make_adapter()
+    adapter._presence_interval = 0.02
+    adapter._run_cli = fail_cli
+
+    release = asyncio.Event()
+    original_publish = adapter._publish_presence
+
+    async def gated_publish(websocket, status):
+        if status == "online" and not release.is_set():
+            await release.wait()
+        return await original_publish(websocket, status)
+
+    monkeypatch.setattr(adapter, "_publish_presence", gated_publish)
+
+    sockets = []
+
+    def fake_connect(*args, **kwargs):
+        ws = _PresenceWebSocket()
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while not sockets and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        assert sockets, "connection never opened"
+        # The loop is now parked waiting for the first online publish.
+        # Cancel, then release the gate: the cancellation consumed at the
+        # executor boundary must be honored before child tasks spawn, so
+        # the loop settles promptly with no orphan heartbeat.
+        task.cancel()
+        release.set()
+        # (asyncio.wait, not wait_for: on Python 3.11 wait_for converts a
+        # completed-with-CancelledError gather into TimeoutError.)
+        await asyncio.wait([task], timeout=2)
+        assert task.done(), "websocket loop did not settle after cancel"
+    finally:
+        release.set()
+
+    await asyncio.sleep(0.05)
+    heartbeat = getattr(adapter, "_presence_task", None)
+    assert heartbeat is None or heartbeat.done(), "heartbeat task leaked past shutdown"
+    strays = [
+        t
+        for t in asyncio.all_tasks()
+        if t is not asyncio.current_task() and not t.done()
+    ]
+    assert not strays, f"leaked tasks: {[t.get_coro() for t in strays]}"
+
+
+@pytest.mark.asyncio
+async def test_presence_heartbeat_coexists_with_inbound_dispatch(monkeypatch):
+    """Heartbeats keep flowing while inbound frames dispatch to handlers."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(_buzz_mod, "_PRESENCE_INTERVAL", 0.02)
+    adapter._presence_interval = 0.02
+    adapter._run_cli = fail_cli
+    adapter._channel_state = {CHANNEL: {"chat_type": "group", "last_ts": 1, "seen": {}}}
+
+    handled = []
+
+    async def record_handle_event(channel_id, state, event):
+        handled.append(event["id"])
+
+    monkeypatch.setattr(adapter, "_handle_event", record_handle_event)
+
+    ws_refs = []
+
+    def fake_connect(*args, **kwargs):
+        ws = _PresenceWebSocket()
+        ws_refs.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    # Feed inbound frames continuously while heartbeats tick.
+    async def feed():
+        for index in range(20):
+            await asyncio.sleep(0.01)
+            for ws in list(ws_refs):
+                ws.stream.put_nowait(
+                    json.dumps(
+                        ["EVENT", "hermes-buzz-0", {"id": f"in-{index}", "kind": 9, "created_at": 2, "content": "hi"}]
+                    )
+                )
+
+    feeder = asyncio.create_task(feed())
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while not ws_refs and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        while (
+            ws_refs
+            and len(ws_refs[0].presence_events) < 3
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.01)
+    finally:
+        feeder.cancel()
+        await _force_close(*ws_refs)
+        await _settle(task, feeder)
+
+    assert len(ws_refs) == 1
+    assert len(ws_refs[0].presence_events) >= 3, "heartbeats stopped under inbound load"
+    assert handled, "inbound frames were not dispatched alongside heartbeats"
+
+
+@pytest.mark.asyncio
+async def test_presence_heartbeat_survives_failed_send_and_retries(monkeypatch):
+    """A failed sign/send is logged and retried on the next cadence; it must
+    not kill the heartbeat."""
+    adapter = _make_adapter()
+    adapter._presence_interval = 0.02
+    adapter._run_cli = fail_cli
+
+    attempts = []
+    sent = []
+    ready = asyncio.Event()
+
+    class FlakySend:
+        async def send(self, raw):
+            message = json.loads(raw)
+            if message[0] == "EVENT" and message[1].get("kind") == 20001:
+                attempts.append(message)
+                if len(attempts) == 1:
+                    raise ConnectionError("send failed")
+                sent.append(message)
+                ready.set()
+
+    websocket = FlakySend()
+    task = asyncio.create_task(adapter._presence_heartbeat(websocket))
+    try:
+        await asyncio.wait_for(ready.wait(), timeout=5)
+    finally:
+        await _settle(task)
+
+    assert len(attempts) >= 2, "heartbeat died after the first failed send"
+    assert len(sent) >= 1, "heartbeat never retried after the failed send"
+
+
+@pytest.mark.asyncio
+async def test_graceful_shutdown_publishes_offline_before_socket_close(monkeypatch):
+    """Adapter shutdown must push a final ``offline`` on the live socket
+    before the connection exits."""
+    adapter = _make_adapter()
+    adapter._presence_interval = 0.02
+    adapter._run_cli = fail_cli
+
+    sent_before_exit = {}
+
+    class OfflineWebSocket(_PresenceWebSocket):
+        async def __aexit__(self, *exc_info):
+            sent_before_exit["offline"] = any(
+                isinstance(message, list)
+                and message
+                and message[0] == "EVENT"
+                and isinstance(message[1], dict)
+                and message[1].get("content") == "offline"
+                for message in self.sent
+            )
+            return await _ScriptedWebSocket.__aexit__(self, *exc_info)
+
+    sockets = []
+
+    def fake_connect(*args, **kwargs):
+        ws = OfflineWebSocket()
+        sockets.append(ws)
+        return ws
+
+    import websockets as _ws_mod
+
+    monkeypatch.setattr(_ws_mod, "connect", fake_connect)
+
+    task = asyncio.create_task(adapter._websocket_loop())
+    try:
+        deadline = time.monotonic() + 5.0
+        while not sockets and time.monotonic() < deadline:
+            await asyncio.sleep(0.01)
+        while (
+            sockets
+            and len(sockets[0].presence_events) < 1
+            and time.monotonic() < deadline
+        ):
+            await asyncio.sleep(0.01)
+        assert sockets and sockets[0].presence_events, "online heartbeat never landed"
+        # Graceful shutdown through the adapter's own disconnect() — the same
+        # path the gateway runs — so offline lands while the socket is open.
+        await asyncio.wait_for(adapter.disconnect(), timeout=5)
+    finally:
+        await _settle(task)
+
+    assert sent_before_exit.get("offline") is True, (
+        "offline was not published before the socket exited"
+    )
+    heartbeat = getattr(adapter, "_presence_task", None)
+    assert heartbeat is None or heartbeat.done(), "heartbeat leaked past disconnect()"

--- a/tests/gateway/test_buzz_websocket.py
+++ b/tests/gateway/test_buzz_websocket.py
@@ -267,7 +267,14 @@ async def test_websocket_loop_keeps_a_quiet_healthy_connection(monkeypatch):
 
     monkeypatch.setattr(_ws_mod, "connect", fake_connect)
     task = asyncio.create_task(adapter._websocket_loop())
-    await asyncio.sleep(0.2)
+    # Event-driven wait for two liveness probes on the quiet connection: a
+    # fixed sleep window assumes a quiet runner, but the connect path signs
+    # the AUTH event (and presence publish) in the executor before the read
+    # loop starts — under parallel load that can consume a fixed window and
+    # starve the probe count.
+    deadline = time.monotonic() + 5.0
+    while (not sockets or sockets[0].ping_count < 2) and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await asyncio.wait_for(task, 5.0)

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -138,7 +138,7 @@ If a reply never finishes (the agent crashes or processing hangs), the working r
 
 ## Presence
 
-Buzz relays expire presence records after about 3 minutes unless they are republished. The adapter publishes `online` when it connects, refreshes it every minute — comfortably inside that expiry window — and publishes `offline` on graceful shutdown (best-effort: a slow or unreachable relay never blocks startup or shutdown).
+Buzz relays expire presence records after about 3 minutes unless they are republished, and they tie a presence record to the authenticated WebSocket that published it: when that socket closes, the relay drops the record. So the adapter publishes presence on its own already-authenticated persistent WebSocket — a signed kind-20001 `online` event right after the NIP-42 handshake (before the connection is reported ready), refreshed at a conservative cadence well inside the expiry window, and `offline` on graceful shutdown while the socket is still open (best-effort: a slow or unreachable relay never blocks startup or shutdown). A transient disconnect never publishes `offline` — the relay clears the record itself, and the reconnect's first publish restores it immediately.
 
 ## Access control
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -134,6 +134,10 @@ Buzz has no typing indicator, so the agent marks each conversational turn with e
 
 Only one reaction is shown at a time — each replaces the previous one. Commands (`/status`, `/stop`, …) don't get reactions, and senders who aren't authorized to talk to the agent never see any. Reactions are best-effort: if a reaction fails to update, the reply is unaffected. Set `reactions: false` in the `buzz` `extra` block to turn them off.
 
+## Presence
+
+Buzz presence expires unless republished, so the adapter publishes `online` when it connects and refreshes it every minute; on graceful shutdown it publishes `offline` (best-effort — a slow or unreachable relay never blocks startup or shutdown).
+
 ## Access control
 
 By default the allow-list is empty, which means every community member who mentions the agent gets a response only if `BUZZ_ALLOW_ALL_USERS=true`; otherwise restrict access by listing npubs or hex pubkeys in `BUZZ_ALLOWED_USERS` (or `allowed_users` in config.yaml). Community membership itself is enforced by the relay — only members can post.

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -85,6 +85,7 @@ gateway:
         allowed_users: []                 # empty = allow all if allow_all_users is true; otherwise restrict to listed npubs/hex pubkeys
         require_mention: true             # in channels: only respond when addressed (@name, npub, or hex pubkey); DMs always dispatch regardless
         allow_all_users: false            # set true for community mode (everyone can chat, only owner is admin); false for private mode (only allowed_users)
+        reactions: true                   # 👀 received → 🧠 working → ✅/❌ done reactions on each conversational turn
 ```
 
 **Why these defaults:**
@@ -121,6 +122,17 @@ gateway:
 ```
 
 The opt-out applies to **all** send paths — final answers, streamed updates, interim commentary, tool-progress bubbles, and out-of-process cron delivery (`deliver=buzz`).
+
+## Reaction lifecycle
+
+Buzz has no typing indicator, so the agent marks each conversational turn with emoji reactions on your message:
+
+- 👀 — received
+- 🧠 — working on it
+- ✅ — replied successfully
+- ❌ — failed (the error follows as a regular message)
+
+Only one reaction is shown at a time — each replaces the previous one. Commands (`/status`, `/stop`, …) don't get reactions, and senders who aren't authorized to talk to the agent never see any. Reactions are best-effort: if a reaction fails to update, the reply is unaffected. Set `reactions: false` in the `buzz` `extra` block to turn them off.
 
 ## Access control
 

--- a/website/docs/user-guide/messaging/buzz.md
+++ b/website/docs/user-guide/messaging/buzz.md
@@ -134,9 +134,11 @@ Buzz has no typing indicator, so the agent marks each conversational turn with e
 
 Only one reaction is shown at a time — each replaces the previous one. Commands (`/status`, `/stop`, …) don't get reactions, and senders who aren't authorized to talk to the agent never see any. Reactions are best-effort: if a reaction fails to update, the reply is unaffected. Set `reactions: false` in the `buzz` `extra` block to turn them off.
 
+If a reply never finishes (the agent crashes or processing hangs), the working reaction could otherwise stay on the message until restart. A periodic sweep retires these abandoned lifecycle reactions a few minutes after the last activity, and a wedged update is cancelled at the same bound — a slow relay that resumes after that simply finds nothing left to update. Normal replies always finish their ✅/❌ first; the sweep only catches turns whose terminal state never arrived.
+
 ## Presence
 
-Buzz presence expires unless republished, so the adapter publishes `online` when it connects and refreshes it every minute; on graceful shutdown it publishes `offline` (best-effort — a slow or unreachable relay never blocks startup or shutdown).
+Buzz relays expire presence records after about 3 minutes unless they are republished. The adapter publishes `online` when it connects, refreshes it every minute — comfortably inside that expiry window — and publishes `offline` on graceful shutdown (best-effort: a slow or unreachable relay never blocks startup or shutdown).
 
 ## Access control
 


### PR DESCRIPTION
## Summary

Combines two focused Buzz connection PRs into one complete mechanism so maintainers can adopt the whole story at once:

- WebSocket transport liveness (supersedes the mechanism in #101166): a quiet read loop now probes the connection with a ping/pong round-trip instead of a blind idle timeout — a quiet-but-healthy relay answers and the connection is kept; a wedged transport (pending pong never resolves) forces the normal reconnect path. Frames are raced with the pending probe, and a clean close racing a probe exits quietly.
- Persistent-socket presence (from #99451): the authenticated inbound socket now carries a kind-20001 Nostr presence heartbeat, so agents show online without a second CLI websocket per refresh.
- Reaction lifecycle (from #99451): begin/refresh with bounded cleanup, plus the `reactions` config key documented.

#101166 and #99451 remain the focused alternatives; this PR carries both series cherry-picked onto current `main` with both mechanisms coexisting on the same persistent authenticated socket (liveness probe **and** presence publishing).

## What changed

- `plugins/platforms/buzz/adapter.py` — liveness probe (`_probe_liveness` + `_read_frame_or_probe` racing frames with probes), presence publishing (`_publish_presence`, `_presence_heartbeat`, inline online publish, offline on graceful shutdown), reaction lifecycle with bounded cleanup.
- `plugins/platforms/buzz/nostr_auth.py` — `build_presence_event()` (kind 20001, self-signed).
- `tests/gateway/test_buzz_websocket.py` — union of both series' tests; the pre-liveness `test_websocket_loop_reconnects_when_read_goes_silent` is superseded by `test_websocket_loop_reconnects_when_liveness_ping_goes_silent` (same contract, probe semantics).
- `tests/gateway/test_buzz_reaction_lifecycle.py` — new (23 tests).
- `tests/gateway/test_buzz_adapter.py` — reaction + presence adapter tests.
- `website/docs/user-guide/messaging/buzz.md` — reactions config key + presence docs.

Cherry-picked series (normal commits, no rewrites):

| #101166 (liveness) | #99451 (reaction/presence) |
|---|---|
| `3370f48e5e` probe quiet websocket transport liveness | `58ada74a44` feat: add reaction lifecycle |
| `01aeae275b` drop unreachable probe timeout handler | `ba9b1bdd67` fix: publish presence so agents show online |
| `89b266fa59` race websocket frames with liveness probes | `f6b770bad4` docs: document reactions config key |
| | `96dd89acb1` fix: bound reaction lifecycle cleanup |
| | `ce59b60916` fix: maintain Nostr presence on the persistent authenticated socket |

Conflict resolution (semantic, both mechanisms preserved):

- `adapter.py` import block: upstream renamed `cache_media_bytes` → `cache_media_bytes_async` (#99451's CONFLICTING cause); kept main's rename and added `ProcessingOutcome`.
- `_PresenceWebSocket` test double: the liveness series made `ping_behavior` a required constructor arg; the presence subclass now defaults it to an always-answered pong so the probe and presence coexist on the same socket.

## Test plan

<details>
<summary>Local verification (exact commands and results)</summary>

All runs via `scripts/run_tests.sh` (per-file subprocess isolation) with `HERMES_PYTHON` pointed at the main checkout's venv (worktree shares no venv).

```
scripts/run_tests.sh tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_reaction_lifecycle.py tests/gateway/test_buzz_websocket.py tests/plugins/platforms/buzz/
=== Summary: 4 files, 265 tests passed, 0 failed (100% complete) in 5.6s (12 workers) ===

scripts/run_tests.sh tests/gateway/test_run_progress_topics.py tests/gateway/test_adapter_startup_secret_scope.py tests/gateway/test_multiplex_profile_authz.py
=== Summary: 3 files, 118 tests passed, 0 failed (100% complete) in 11.8s (12 workers) ===
```

Lints / static:

```
ruff check plugins/platforms/buzz/adapter.py plugins/platforms/buzz/nostr_auth.py tests/gateway/test_buzz_websocket.py tests/gateway/test_buzz_adapter.py tests/gateway/test_buzz_reaction_lifecycle.py
All checks passed!

python3 -m py_compile <the same five files>   # OK
git diff --check upstream/main..HEAD          # clean
```

An intermediate run caught a real cross-series break before publication: the presence tests failed with `_ScriptedWebSocket.__init__() missing 1 required positional argument: 'ping_behavior'` — resolved as described above and folded into the final commit.

</details>

- [x] Quiet healthy connection (pong resolves) stays on one connection across probes
- [x] Wedged transport (pong never resolves) closes and reconnects via the existing failure path
- [x] Clean close during a probe exits quietly (no warning/backoff)
- [x] Frames race probes correctly (frame wins; failed probe wins over simultaneous frame)
- [x] Presence maintained on the persistent authenticated socket; no `buzz users set-presence` subprocess
- [x] Reaction lifecycle begin/refresh/bounded cleanup; `reactions` config key documented
- [x] Existing Buzz dispatch behavior unchanged (progress-thread + secret-scope regressions pass)

## Scope & residuals

- Out of scope by design: #101184 (startup config gate) and unrelated main drift.
- The pre-liveness read-idle test (`test_websocket_loop_reconnects_when_read_goes_silent`) was superseded by its probe-based successor — same behavioral contract, updated mechanism; no assertion dropped.
- Infographic waived per user decision 2026-09-02.

Closes nothing — #101166 and #99451 remain open as the focused alternatives.
