### PR TITLE
fix(mcp): read readOnlyHint from the SDK's snake_case field (untrusted servers gate every tool)

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,47 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_real_sdk_tool_annotations_object(self):
+        """A genuine SDK ``ToolAnnotations`` must be read correctly.
+
+        Regression guard. ``ToolAnnotations`` declares the field as
+        ``read_only_hint`` with ``alias="readOnlyHint"``; the alias is a
+        serialization name, NOT an attribute. Reading only the camelCase
+        spelling therefore always missed, and EVERY tool on EVERY
+        ``trust: untrusted`` server was classified write-capable — including
+        pure-read tools like search, which then blocked on an approval that
+        non-interactive callers (gateway, cron) can never satisfy.
+
+        The pre-existing tests all passed dicts or SimpleNamespace stand-ins,
+        which is exactly why the bug survived them. This one uses the real
+        model so the regression cannot come back unnoticed.
+        """
+        from mcp.types import ToolAnnotations
+
+        read_only = ToolAnnotations.model_validate({"readOnlyHint": True})
+        # Guard the premise: the camelCase alias is not an attribute.
+        assert not hasattr(read_only, "readOnlyHint")
+        assert read_only.read_only_hint is True
+
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=read_only)
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(
+                annotations=ToolAnnotations.model_validate({"readOnlyHint": False})
+            )
+        ) is False
+        # Annotations present but hint omitted ⇒ fail closed.
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations=ToolAnnotations.model_validate({}))
+        ) is False
+
+    def test_snake_case_dict_annotations(self):
+        """``model_dump()`` without ``by_alias=True`` yields snake_case keys."""
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations={"read_only_hint": True})
+        ) is True
+        assert mcp_tool._annotation_read_only_hint(
+            SimpleNamespace(annotations={"read_only_hint": False})
+        ) is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4982,9 +4982,22 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if annotations is None:
         return False
     if isinstance(annotations, dict):
+        # Schema-cache JSON preserves the camelCase wire spelling. Accept the
+        # snake_case field name too, so a dict produced by ``model_dump()``
+        # without ``by_alias=True`` is not silently misread as write-capable.
         hint = annotations.get("readOnlyHint")
+        if hint is None:
+            hint = annotations.get("read_only_hint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        # The MCP Python SDK declares ``ToolAnnotations.read_only_hint`` with
+        # ``alias="readOnlyHint"``. The alias is a *serialization* name — it is
+        # not an attribute — so ``getattr(annotations, "readOnlyHint")`` always
+        # missed and every tool on an untrusted server was classified
+        # write-capable. Read the field name first, keeping the camelCase
+        # lookup as a fallback for duck-typed stand-ins.
+        hint = getattr(annotations, "read_only_hint", None)
+        if hint is None:
+            hint = getattr(annotations, "readOnlyHint", None)
     return hint is True
 
 


### PR DESCRIPTION
## Summary

`_annotation_read_only_hint` in `tools/mcp_tool.py` looked up the annotation as `getattr(annotations, "readOnlyHint", None)`. The MCP Python SDK declares it as:

```python
class ToolAnnotations(BaseModel):
    read_only_hint: bool | None = Field(default=None, alias="readOnlyHint")
```

The alias is a **serialization** name, not an attribute, so that `getattr` always returned `None`.

The gate is fail-closed, so `None` is treated as write-capable. The result: **every tool on every `trust: untrusted` server was classified write-capable**, including pure-read tools, and each invocation raised a dangerous-tool approval prompt.

## Impact

- **Non-interactive callers hang.** Gateway and cron paths cannot answer an approval prompt, so read-only calls block until timeout. Observed on a live instance: an Exa search tool advertising `readOnlyHint: true` blocked; after the fix the same call returns in 0.8s.
- **The bad verdict is cached.** `_record_tool_trust_metadata` persists it to `mcp_schema_cache.json`, so it survives restarts until the cache is purged.
- **Approval fatigue.** When demonstrably read-only tools prompt, operators learn to approve reflexively — eroding the signal for genuine writes.

## The fix

Read the snake_case field first, keeping the camelCase lookup as a fallback for duck-typed stand-ins.

The dict branch gets the same treatment: the schema cache stores the camelCase wire form, but `model_dump()` without `by_alias=True` emits snake_case, so both spellings must be accepted.

Fail-closed semantics are unchanged — missing annotations, missing key, or any non-`True` value is still write-capable. This only stops *misreading* a present `True`; it never widens the gate on absent metadata.

## Why the existing tests missed it

Every prior case passed a `dict` or a `SimpleNamespace`, never a real SDK model — so the camelCase `getattr` appeared to work.

`test_real_sdk_tool_annotations_object` uses an actual `ToolAnnotations` instance and asserts `not hasattr(read_only, "readOnlyHint")`, pinning the premise so the regression cannot return unnoticed.

## Verification

- Both new tests **fail before** this change, **pass after**.
- `tests/tools/test_mcp_trust_gating.py`: **13/13 pass**.
- Wider `-k mcp` suite: 46 failures identical on clean `origin/main` (pre-existing, unrelated — logging/reconnect); passing count moves 677 → 679, exactly the two added tests.
- On a live instance, gating now discriminates correctly rather than passing everything: GitHub 22 read tools free / 13 writes still gated (`merge_pull_request`, `push_files`, `create_branch`…), `firecrawl_crawl` correctly still gated.