### PR TITLE
fix(desktop): packaged app no longer crashes on launch with undefined.push in rememberLog (#101941, salvage #101945)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1464,6 +1464,15 @@ function persistPoolLimits(limits) {
   }
 }
 
+// rememberLog() state. Declared here, before the top-level
+// readPersistedPoolLimits() call below, because that call logs during module
+// evaluation; declaring these later crashed launch with `undefined.push` in
+// the packaged build (esbuild lowers the TDZ to undefined instead of throwing).
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
+
 let poolLimits = readPersistedPoolLimits()
 // Hard cap on local backends that are starting OR running (the LRU eviction
 // above is soft — it spares keepalive-fresh entries). Follows the live
@@ -1574,12 +1583,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## Summary
The packaged Hermes Desktop launches again on git installs: since c401756a6a (#91545) every launch died before the window with `TypeError: Cannot read properties of undefined (reading 'push')` in `rememberLog` ← `readPersistedPoolLimits` (#101941, #101960).

Root cause: `readPersistedPoolLimits()` runs at module top level and logs through `rememberLog()` on every branch, but `hermesLog` / `desktopLogBuffer` / `desktopLogFlushTimer` / `desktopLogFlushPromise` were declared ~110 lines later. esbuild lowers `const`/`let` to `var`, so the TDZ became `undefined.push` in the bundle.

Salvaged from #101945 by @liuhao1024 (authorship preserved). Same one-line reorder also submitted in #101950, #101958, #101964, #101967. Contributor test dropped: it pinned source-text ordering, and the Desktop E2E lane is `if: false` in CI.

## Changes
- `apps/desktop/electron/main.ts`: move the four rememberLog state declarations above `let poolLimits = readPersistedPoolLimits()` (+9/−4).

## Validation
Bundled `dist/electron-main.mjs` and launched headless Electron (`HERMES_DESKTOP_BOOT_FAKE=1`, fresh `HERMES_HOME`/userData):

| | main (37fd6eea975) | this branch |
|---|---|---|
| bundle order | `var poolLimits` L23026 → `var hermesLog` L23065 | `var hermesLog` L23026 → `var poolLimits` L23030 |
| launch | `App threw an error during load` / `undefined.push` at `rememberLog` ← `readPersistedPoolLimits` | boots; `desktop.log` opens with `[pool-limits] no saved file and no env overrides; using defaults` then `[boot] Resolving Hermes backend` |

## Infographic

![Desktop launches again](https://v3b.fal.media/files/b/0aa8eabf/QYB_7bJdgTuLFT1eMyX4q_h6SlYUD6.png)
