### PR TITLE
feat(discord): allow bounded opt-in split delivery batches

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1363,6 +1363,7 @@ platform_toolsets:
 # Discord-specific settings (config.yaml top-level, not under platforms:):
 #
 # discord:
+#   max_split_messages: 8           # 1-40; replies over 20 chunks use labelled, paced batches
 #   require_mention: true            # Require @mention in server channels (default: true)
 #   auto_thread: true                # Auto-create thread on @mention (default: true)
 #   free_response_channels: ""       # Channel IDs where no mention is needed

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2462,6 +2462,7 @@ DEFAULT_CONFIG = {
 
     # Discord platform settings (gateway mode)
     "discord": {
+        "max_split_messages": 8,       # 1-40; >20 delivered chunks use paced, labelled batches
         "require_mention": True,       # Require @mention to respond in server channels
         "free_response_channels": "",  # Comma-separated channel IDs where bot responds without mention
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1114,6 +1114,10 @@ class DiscordAdapter(BasePlatformAdapter):
     # incident delivered 60,698 chars as 31 messages).  Chunks beyond the
     # cap are replaced by a short notice.
     MAX_SPLIT_MESSAGES = 8
+    # Opt-in extended delivery stays bounded to two paced batches.
+    SPLIT_BATCH_SIZE = 20
+    MAX_CONFIGURED_SPLIT_MESSAGES = 2 * SPLIT_BATCH_SIZE
+    SPLIT_BATCH_DELAY_SECONDS = 2.0
 
     # Auto-disconnect from voice channel after this many seconds of inactivity.
     # Config key: discord.voice_channel_inactivity_timeout_seconds (0 disables)
@@ -1133,6 +1137,11 @@ class DiscordAdapter(BasePlatformAdapter):
 
     def __init__(self, config: PlatformConfig):
         super().__init__(config, Platform.DISCORD)
+        limit = self._config_value("max_split_messages", self.MAX_SPLIT_MESSAGES)
+        if type(limit) is not int or not 1 <= limit <= self.MAX_CONFIGURED_SPLIT_MESSAGES:
+            logger.warning("Invalid discord.max_split_messages; using default %s", self.MAX_SPLIT_MESSAGES)
+            limit = self.MAX_SPLIT_MESSAGES
+        self._max_split_messages = limit
         self._client: Optional[commands.Bot] = None
         self._ready_event = asyncio.Event()
         self._allowed_user_ids: set = set()  # For button approval authorization
@@ -3475,23 +3484,47 @@ class DiscordAdapter(BasePlatformAdapter):
 
         A degenerate turn can produce tens of thousands of characters; the
         #86581 incident delivered 60,698 chars as 31 back-to-back Discord
-        messages.  When ``chunks`` exceeds ``MAX_SPLIT_MESSAGES``, keep the
+        messages.  When ``chunks`` exceeds the configured limit, keep the
         first ``N-1`` chunks and replace the rest with a short notice so the
         user sees a clear signal instead of a flood.  The full response
         remains available in the gateway session history / logs.
         """
-        if len(chunks) <= self.MAX_SPLIT_MESSAGES:
+        if len(chunks) <= self._max_split_messages:
             return chunks
-        kept = chunks[: self.MAX_SPLIT_MESSAGES - 1]
-        dropped_chars = sum(len(c) for c in chunks[self.MAX_SPLIT_MESSAGES - 1 :])
+        kept = chunks[: self._max_split_messages - 1]
+        dropped_chars = sum(len(c) for c in chunks[self._max_split_messages - 1 :])
         notice = (
             f"\n\n⚠️ **Response truncated** — this reply exceeded the "
-            f"delivery limit ({self.MAX_SPLIT_MESSAGES} messages). "
+            f"delivery limit ({self._max_split_messages} messages). "
             f"{dropped_chars} characters were not delivered; the full "
             f"response is in the session logs."
         )
         kept.append(notice)
         return kept
+
+    def _prepare_split_chunks(self, formatted: str) -> List[str]:
+        """Keep the default delivery unchanged; label opt-in multi-batch replies."""
+        chunks = self._cap_split_chunks(
+            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        )
+        if len(chunks) <= self.SPLIT_BATCH_SIZE:
+            return chunks
+
+        # Reserve space before splitting so labels cannot exceed Discord's
+        # message limit or clip a code fence. Two batches of 20 is the ceiling.
+        label_reserve = len("**Part 2 of 2 — 20/20**\n")
+        chunks = self._cap_split_chunks(
+            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH - label_reserve)
+        )
+        parts = (len(chunks) + self.SPLIT_BATCH_SIZE - 1) // self.SPLIT_BATCH_SIZE
+        labelled = []
+        for i, chunk in enumerate(chunks):
+            part, offset = divmod(i, self.SPLIT_BATCH_SIZE)
+            count = min(self.SPLIT_BATCH_SIZE, len(chunks) - part * self.SPLIT_BATCH_SIZE)
+            # Replace only the splitter's trailing indicator, outside fences.
+            chunk = re.sub(r" \(\d+/\d+\)$", "", chunk)
+            labelled.append(f"**Part {part + 1} of {parts} — {offset + 1}/{count}**\n{chunk}")
+        return labelled
 
     async def send(
         self,
@@ -3579,15 +3612,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self._cap_split_chunks(
-                self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-            )
+            chunks = self._prepare_split_chunks(formatted)
 
             message_ids = []
             # Build the reference from ids — no fetch_message round trip.
             reference = self._reply_reference_for_send(reply_to, channel)
 
             for i, chunk in enumerate(chunks):
+                if i and i % self.SPLIT_BATCH_SIZE == 0:
+                    await asyncio.sleep(self.SPLIT_BATCH_DELAY_SECONDS)
                 if self._reply_to_mode == "all":
                     chunk_reference = reference
                 else:  # "first" (default) or "off"
@@ -3680,9 +3713,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # module — no cross-module import needed.
 
         formatted = self.format_message(content)
-        chunks = self._cap_split_chunks(
-            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-        )
+        chunks = self._prepare_split_chunks(formatted)
 
         thread_name = _derive_forum_thread_name(content)
 
@@ -3706,7 +3737,9 @@ class DiscordAdapter(BasePlatformAdapter):
         # per-chunk failures so the caller sees partial-send outcomes.
         message_ids = [message_id]
         warnings: list[str] = []
-        for chunk in chunks[1:]:
+        for i, chunk in enumerate(chunks[1:], start=1):
+            if i % self.SPLIT_BATCH_SIZE == 0:
+                await asyncio.sleep(self.SPLIT_BATCH_DELAY_SECONDS)
             try:
                 msg = await thread_channel.send(content=chunk)
                 message_ids.append(str(msg.id))
@@ -3949,9 +3982,7 @@ class DiscordAdapter(BasePlatformAdapter):
         returns ``success=False`` (a real adapter problem, not overflow).
         """
         formatted = self.format_message(content)
-        chunks = self._cap_split_chunks(
-            self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
-        )
+        chunks = self._prepare_split_chunks(formatted)
         if len(chunks) <= 1:
             # Defensive: caller's pre-flight should guarantee >1 chunk, but if
             # not, just edit normally.
@@ -3972,7 +4003,9 @@ class DiscordAdapter(BasePlatformAdapter):
         continuation_ids: list[str] = []
         delivered = 1
         prev_msg = msg
-        for chunk in chunks[1:]:
+        for i, chunk in enumerate(chunks[1:], start=1):
+            if i % self.SPLIT_BATCH_SIZE == 0:
+                await asyncio.sleep(self.SPLIT_BATCH_DELAY_SECONDS)
             reference = None
             if hasattr(prev_msg, "to_reference"):
                 try:
@@ -10517,6 +10550,9 @@ def _apply_yaml_config(yaml_cfg: dict, discord_cfg: dict) -> dict | None:
             if isinstance(candidate_extra, dict):
                 platform_extra_cfg = candidate_extra
     seeded_extra = {}
+    # Keep the delivery limit on the adapter's profile, never in process env.
+    if "max_split_messages" in discord_cfg:
+        seeded_extra["max_split_messages"] = discord_cfg["max_split_messages"]
     # Authorization gate keys are ALWAYS seeded into PlatformConfig.extra so
     # every adapter carries its own profile's allow/deny lists (issue #72348).
     # The os.environ writes below remain first-writer-wins for legacy env-only

--- a/tests/gateway/test_discord_split_batches.py
+++ b/tests/gateway/test_discord_split_batches.py
@@ -1,0 +1,115 @@
+"""Opt-in bounded delivery through real config loading and Discord adapter code."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+import plugins.platforms.discord.adapter as discord_platform
+from gateway.config import Platform, PlatformConfig, load_gateway_config
+from plugins.platforms.discord.adapter import DiscordAdapter
+
+
+@pytest.fixture(autouse=True)
+def isolated_home(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+
+def make_adapter(limit=40):
+    return DiscordAdapter(PlatformConfig(enabled=True, extra={"max_split_messages": limit}))
+
+
+def report(words=6000):
+    return " ".join(f"record-{i:05d}" for i in range(words))
+
+
+def test_yaml_limit_reaches_adapter_and_does_not_leak(tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text("discord:\n  max_split_messages: 40\n", encoding="utf-8")
+    config = load_gateway_config()
+    adapter = DiscordAdapter(config.platforms[Platform.DISCORD])
+    assert len(adapter._prepare_split_chunks(report())) > adapter.MAX_SPLIT_MESSAGES
+    config_path.write_text("discord:\n  require_mention: true\n", encoding="utf-8")
+    default = DiscordAdapter(load_gateway_config().platforms[Platform.DISCORD])
+    assert len(default._prepare_split_chunks(report())) == default.MAX_SPLIT_MESSAGES
+    assert len(adapter._prepare_split_chunks(report())) > default.MAX_SPLIT_MESSAGES
+
+
+@pytest.mark.parametrize("invalid", [True, False, 0, -1, 41, 1000000, 8.5, float("inf"), "40", [], {}])
+def test_invalid_limit_retains_default_flood_guard(invalid):
+    adapter = make_adapter(invalid)
+    chunks = adapter._prepare_split_chunks(report())
+    assert len(chunks) == adapter.MAX_SPLIT_MESSAGES
+    assert "Response truncated" in chunks[-1]
+    assert not chunks[0].startswith("**Part")
+
+
+@pytest.mark.parametrize("limit", [1, 8, 20, 21, 40])
+def test_configured_cap_includes_notice(limit):
+    chunks = make_adapter(limit)._prepare_split_chunks(report(10000))
+    assert len(chunks) == limit
+    assert "Response truncated" in chunks[-1]
+    assert all(len(chunk) <= DiscordAdapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+
+
+def test_short_replies_keep_existing_format():
+    adapter = make_adapter()
+    for content in ["hello", report(1000)]:
+        assert adapter._prepare_split_chunks(content) == adapter.truncate_message(
+            content, adapter.MAX_MESSAGE_LENGTH
+        )
+
+
+def test_labels_preserve_fences_order_and_partial_batch():
+    adapter = make_adapter()
+    content = "```text\n" + "\n".join(f"line-{i:05d}" for i in range(4500)) + "\n```"
+    chunks = adapter._prepare_split_chunks(content)
+    assert 20 < len(chunks) < 40
+    assert chunks[0].startswith("**Part 1 of 2 — 1/20**\n")
+    remaining = len(chunks) - 20
+    assert chunks[20].startswith(f"**Part 2 of 2 — 1/{remaining}**\n")
+    assert chunks[-1].startswith(f"**Part 2 of 2 — {remaining}/{remaining}**\n")
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in chunks)
+    assert all(chunk.count("```") == 2 for chunk in chunks)
+    actual = [line for chunk in chunks for line in chunk.splitlines() if line.startswith("line-")]
+    assert actual == [f"line-{i:05d}" for i in range(4500)]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("path", ["send", "forum", "edit"])
+@pytest.mark.parametrize("limit", [8, 40])
+async def test_real_delivery_paths_cap_and_pause_between_batches(monkeypatch, path, limit):
+    adapter = make_adapter(limit)
+    delivered = []
+    pauses = []
+
+    async def fake_send(*, content, reference=None):
+        delivered.append(content)
+        return SimpleNamespace(id=9000 + len(delivered))
+
+    async def pause(seconds):
+        pauses.append((len(delivered), seconds))
+
+    monkeypatch.setattr(discord_platform.asyncio, "sleep", pause)
+    channel = SimpleNamespace(id=555, send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(get_channel=lambda _: channel, fetch_channel=AsyncMock())
+    if path == "send":
+        result = await adapter.send("555", report(10000))
+    elif path == "forum":
+        async def create_thread(*, name, content):
+            first = await fake_send(content=content)
+            return SimpleNamespace(thread=channel, message=first)
+        forum = SimpleNamespace(id=666, create_thread=AsyncMock(side_effect=create_thread))
+        result = await adapter._send_to_forum(forum, report(10000))
+    else:
+        msg = SimpleNamespace(id=42, edit=AsyncMock(side_effect=fake_send))
+        result = await adapter._edit_overflow_split(channel, msg, "42", report(10000))
+    assert result.success
+    assert len(delivered) == limit
+    assert "Response truncated" in delivered[-1]
+    assert all(len(chunk) <= adapter.MAX_MESSAGE_LENGTH for chunk in delivered)
+    if limit > adapter.SPLIT_BATCH_SIZE:
+        assert pauses == [(adapter.SPLIT_BATCH_SIZE, adapter.SPLIT_BATCH_DELAY_SECONDS)]
+        assert delivered[20].startswith("**Part 2 of 2 — 1/20**\n")
+    else:
+        assert pauses == []

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -25,6 +25,29 @@ Before setup, here's the part most people want to know: how Hermes behaves once 
 If you want a normal bot-help channel where people can talk to Hermes without tagging it every time, add that channel to `DISCORD_FREE_RESPONSE_CHANNELS`.
 :::
 
+### Long responses
+
+By default, a reply is limited to eight messages to prevent channel flooding.
+If it exceeds the limit, the final message is a truncation notice; the full
+response remains in the session logs. For a dedicated channel where you want
+long reports inline, you can opt into a larger limit in `config.yaml`:
+
+```yaml
+discord:
+  max_split_messages: 40
+```
+
+Restart the gateway after changing this setting. It accepts integers from 1 to
+40, including any truncation notice; invalid values fall back to eight. The
+setting applies to all Discord conversations served by that profile, including
+DMs, channels, threads, forum posts, and oversized final edits.
+
+Replies longer than 20 messages use labels such as `Part 1 of 2 — 1/20`, with
+a two-second pause before the second batch. Each message still fits Discord's
+2,000-character limit. Replies up to 20 messages keep their usual formatting.
+The pause does not replace Discord's rate-limit handling. Larger limits can
+still create substantial channel traffic; the default remains eight.
+
 ### Discord Gateway Model
 
 Hermes on Discord is not a webhook that replies statelessly. It runs through the full messaging gateway, which means each incoming message goes through:


### PR DESCRIPTION
[gpt-5.6-sol] RESPONDING ON BEHALF OF PRAGGY

## What does this PR do?

Allow operators of dedicated Discord channels to receive long reports inline without changing the default flood guard. A reply that needs 30 messages currently becomes seven content messages plus a truncation notice. With `discord.max_split_messages: 40`, it can instead arrive in two labelled batches, with a two-second pause before the second batch.

The existing default stays at eight messages. This is an opt-in feature proposal; the original flood-protection behavior is intentional and remains the default.

## Related Issue

Related design context: #86581 and #86698 introduced the eight-message guard after a channel-flooding incident. This proposal does not claim to fix or close that incident, and it leaves the generation-side repetition protections unchanged.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Add `discord.max_split_messages` in YAML, accepting integers from 1 through 40. Invalid values fall back to the default. The truncation notice counts toward the limit.
- Carry the setting through the existing plugin config hook into per-adapter configuration, without a process environment variable.
- Apply the bounded limit to ordinary sends, forum posts and oversized final edits. More than 20 delivered messages get two labelled batches, with a two-second pause before message 21. Smaller replies retain their existing formatting.
- Reserve label space before the existing fence-aware splitter runs, preserving Discord's 2,000-character limit.
- Document the setting and add regression coverage for YAML propagation, profile isolation, invalid values, limits, code fences, ordering, delivery and pacing.

The upper limit is still substantial channel traffic; the batch pause is not a substitute for Discord rate-limit handling. The conservative default is unchanged.

## How to Test

1. Run `scripts/run_tests.sh -j 1 tests/gateway/test_discord_split_batches.py tests/gateway/test_discord_split_cap.py tests/gateway/test_discord_send.py tests/gateway/test_discord_edit_message_overflow.py --file-retries 0 -q`.
2. For a manual check in a dedicated test channel, add the following to `config.yaml` and restart the gateway:
   ```yaml
   discord:
     max_split_messages: 40
   ```
3. Request a long report exceeding 20 chunks. Check that the second labelled batch begins after a two-second pause. Remove the setting and restart to restore the default eight-message ceiling. A reply longer than the configured ceiling must end with a truncation notice.

Validation on macOS: **49 tests passed, zero failures**, using the canonical hermetic runner. New tests use real gateway config loading and adapter imports, with only Discord network operations replaced. The Windows footgun check passed for all three changed Python files; Ruff passed for the new test file; `git diff --check` passed.

No live Discord messages were sent during validation. The full standard Python suite was subsequently run; its complete result and upstream-baseline comparison are below. Linux/Windows runtime testing was not run. This contribution was prepared and self-reviewed with GPT-5.6-Sol in Codex; no independent reviewer was used.

## Checklist

- [x] Read the contributing guide and checked existing PRs.
- [x] Conventional commit; only this feature is included.
- [x] Added and ran focused regression tests.
- [x] Ran the full standard Python suite using the canonical runner (result below).
- [ ] Full suite is green on this PR revision — pending integration of the test-only companion [#102046](https://github.com/NousResearch/hermes-agent/pull/102046).
- [x] Updated the default config, config example and Discord documentation.
- [x] Considered cross-platform behavior; no OS-specific functionality or new dependencies.


## Full-suite validation — 2026-09-03

Completed the canonical full standard Python suite on macOS at PR commit
`cc66147f13d36a71ed51fb068635b824eb087195`:

```text
scripts/run_tests.sh -j 8
3,687 test files completed
44,764 passed, 39 failed, 451 skipped
969.6 seconds; exit status 1; no flaky passes reported
```

Dependencies were installed into a separate test environment using the same
locked dependency command as the upstream test workflow:

```sh
uv sync --locked --python 3.11 --extra all --extra dev --extra anthropic --extra mistral --extra fal --extra modal --extra daytona --extra hindsight --extra parallel-web
```

Re-ran every failing test file against untouched upstream base
`37fd6eea9753cb2b6de08b7ab83a9e385a97b144`, with the same interpreter and
dependencies. **All 39 exact failing test IDs reproduce on that base.**
No additional test failure attributable to this PR was observed. The Discord
regression tests also passed during the full run. The overall macOS suite is
not green, and these baseline failures are not hidden or patched in this PR.

The canonical runner excludes `tests/e2e`, `tests/integration` and `tests/docker`
for separate external-service CI jobs. Those suites, live Discord delivery and
Linux/Windows runtime tests were not run here.

<details>
<summary>Upstream-baseline failure comparison (39 failures in 22 files)</summary>

| Test file | Failures reproduced on upstream base |
|---|---:|
| `tests/computer_use/test_cua_no_overlay.py` | 1 |
| `tests/gateway/test_buzz_adapter.py` | 1 |
| `tests/gateway/test_readiness.py` | 1 |
| `tests/gateway/test_scale_to_zero.py` | 2 |
| `tests/gateway/test_systemd_notify.py` | 1 |
| `tests/hermes_cli/test_auth_commands.py` | 1 |
| `tests/hermes_cli/test_session_recovery_lost_and_found.py` | 1 |
| `tests/hermes_cli/test_update_launchd_fleet_restart.py` | 3 |
| `tests/hermes_cli/test_user_providers_model_switch.py` | 2 |
| `tests/scripts/test_contributor_map.py` | 1 |
| `tests/test_guest_durability_barriers.py` | 1 |
| `tests/test_hermes_state.py` | 1 |
| `tests/test_tui_gateway_server.py` | 1 |
| `tests/tools/test_approval.py` | 1 |
| `tests/tools/test_code_kernel.py` | 1 |
| `tests/tools/test_delegate.py` | 1 |
| `tests/tools/test_execution_flag_detection.py` | 3 |
| `tests/tools/test_file_tools.py` | 2 |
| `tests/tools/test_process_registry.py` | 8 |
| `tests/tools/test_transcription_tools.py` | 1 |
| `tests/tools/test_voice_mode.py` | 4 |
| `tests/tools/test_wake_word.py` | 1 |

</details>


## Skip audit and Discord follow-up — 2026-09-03

The original full-run **451 skips were reported across 136 files**. They include
Windows/Linux host-gated tests, optional SDKs (NumPy, Lark/Feishu, Honcho and
Discord), opt-in slow/live tests, unavailable local capabilities and two
explicit upstream persistence-test placeholders. Some skips happen at module
collection, so a reported skip can cover multiple uncollected test functions.
The separate e2e/integration/Docker suites were excluded by the standard runner
and are not part of the 451.

The exact CI extra set used for that run does not install `discord.py` or
NumPy. Added the versions already pinned by the repository (`discord.py[voice]
2.7.1` and `numpy 2.4.3`) to the isolated test environment and ran:

```sh
scripts/run_tests.sh -j 2 tests/gateway/test_discord_split_batches.py tests/gateway/test_discord_split_cap.py tests/gateway/test_discord_send.py tests/gateway/test_discord_edit_message_overflow.py tests/gateway/test_discord_voice_mixer.py tests/plugins/platforms/test_discord_gate_isolation.py --file-retries 0 -q
```

**79 passed, zero failures, zero skips.** This covers the previously skipped
Discord voice-mixer module and channel-gate check alongside the split-delivery
regressions, with the real optional libraries installed. Network sends remain
mocked; this is not a live Discord delivery test. The full-run totals above
remain the original full-run evidence, not a claim that all 451 skips have
been eliminated or that the full suite was rerun after adding these packages.


## Companion test-suite repair

The upstream baseline test failures have a separate test-only repair in [#102046](https://github.com/NousResearch/hermes-agent/pull/102046), commit `615d15d0959d17a6d5a10f60aa822e6116c4b3ba`. Its full standard macOS run completed with **44,766 passed, zero failed, 466 skipped**, all 3,686 files, retries disabled. That branch also repairs an additional watchdog-fixture race found during validation.

Those results belong to the companion revision, which does not contain this Discord feature. This PR's source remains unchanged; the green-suite checkbox remains pending until the repairs are incorporated and the combined revision is verified. Linux/Windows execution and upstream acceptance are not claimed from the macOS result.
