### PR TITLE
fix(desktop): declare hermesLog before init-time rememberLog callers

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1419,6 +1419,10 @@ const profileDeletionGate = new ProfileDeletionGate()
 // launch constant: mutable at runtime, persisted in userData, applied live.
 // The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
 // for scripted/headless setups; after launch the stored preference wins.
+// Declared before any init-time call to rememberLog() below (e.g.
+// readPersistedPoolLimits) — bundler flattening put this after its first use,
+// so `hermesLog.push` threw "Cannot read properties of undefined" at boot.
+const hermesLog = []
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
 function readPersistedPoolLimits() {
@@ -1574,7 +1578,6 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
 let desktopLogBuffer = ''


### PR DESCRIPTION
## Problem

After updating to `main` (which includes b9dc79033), the Windows desktop app crashes at every launch:

```
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog
    at readPersistedPoolLimits
```

## Root cause

b9dc79033 added `rememberLog(...)` calls inside `readPersistedPoolLimits()`. That function is invoked at **module init** (`let poolLimits = readPersistedPoolLimits()`), but `const hermesLog = []` is declared ~110 lines later in `electron/main.ts`.

In source order the `rememberLog` body runs only after `hermesLog` is initialized — but at init time the call site executes before the declaration. In the flattened bundle (`var` hoisting) `hermesLog` is `undefined` at that point, so `hermesLog.push(...lines)` throws and the Electron main process dies before creating any window.

## Fix

Move the `const hermesLog = []` declaration above the pool-limits block, with a comment explaining why it must stay ahead of any init-time `rememberLog()` caller.

## Testing

- Windows 11: app previously crashed 100% of launches with the dialog above; after this change the desktop app boots cleanly (main process alive, backend ready, no JS error).
- Verified the same fix applied to the built `electron-main.mjs` bundle stops the crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)