### PR TITLE
fix(titles): reject JSON-literal and code-fence title fragments

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -413,6 +413,17 @@ def generate_title(
         )
         content = response.choices[0].message.content or ""
         title = _clean_title(_extract_title_text(content))
+        # Reject structurally-unusable title fragments: providers that ignore
+        # response_format can stream a truncated JSON object/array or a markdown
+        # code fence whose leading token the loose prose-scan then stores verbatim
+        # (e.g. `{"title #2`, `["a"', a bare ``` fence). A session title is never
+        # a JSON literal or a code fence, so treat any such fragment as unusable
+        # and let the caller keep the instant derived title (#92473 regression
+        # guard).
+        if title is not None and title.startswith(("`", "{", '["', "[{")):
+            logger.debug("Rejecting structurally-invalid title fragment: %r", title)
+            return None
+
         # Answer-shaped output guard: titling is a 3-7 word task, so a title
         # with many words is a model that ignored the task and answered
         # the user's message instead ("I don't have context on X — that's


### PR DESCRIPTION
## Problem

When a provider ignores `response_format`, it can stream a truncated JSON
object/array or a markdown code fence whose leading token the loose prose-scan
then stores verbatim as the session title. Observed live titles included a bare
``` fence, ```json, and a truncated `{"title #2` fragment.

## Fix

Add a guard in `generate_title` that rejects a generated title which looks like
a structurally-unusable fragment, before it is persisted:

- starts with a backtick (a markdown code fence / inline code)
- starts with `{` (truncated JSON object)
- starts with `["` or `[{` (JSON array literal)

When rejected, `generate_title` returns `None` and the caller keeps the instant
derived title, matching the existing answer-shaped over-word guard's behaviour.

## Rationale

The earlier blanket `[` heuristic was intentionally **not** adopted: legitimate
titles such as `[TX] GitHub Fork 同步`, `[Feature] …`, and `[Bug] …` also start
with `[`. The guard targets only JSON array *literals* (`["`, `[{`) rather than
any square-bracket-prefixed prose.

## Tested

`title.startswith(("`", "{", '["', "[{"))` returns `True` for ```, ```json,
```json #2/3, `{"title #2`, `{"title": "foo"}`, `["a","b"]`, `[{"a":1}]`; and
`False` for `[TX] GitHub Fork 同步`, `[Feature] …`, `[Bug] …`, plain prose, and
`None`.
