### PR TITLE
fix(auth): make `hermes auth reset` clear a still-binding cooldown

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -863,8 +863,13 @@ def persist_pool_entries(
     payloads: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    merge_disk_status: bool = True,
 ) -> None:
     """Persist a provider's pool rows to the store that OWNS them.
+
+    ``merge_disk_status=False`` skips the ``_merge_disk_cooldown_state``
+    lost-update guard so an explicit status clear (``reset_statuses``) lands
+    on disk even while the on-disk cooldown is still binding.
 
     A named profile that sees a single-use-refresh provider (Anthropic,
     Codex, xAI OAuth) only through the global-root fallback must not
@@ -907,7 +912,11 @@ def persist_pool_entries(
                         if incoming is None:
                             merged.append(disk_entry)
                             continue
-                        updated = auth_mod._merge_disk_cooldown_state(incoming, disk_entry, provider)
+                        updated = (
+                            auth_mod._merge_disk_cooldown_state(incoming, disk_entry, provider)
+                            if merge_disk_status
+                            else incoming
+                        )
                         if updated != disk_entry:
                             changed = True
                         merged.append(updated)
@@ -925,7 +934,14 @@ def persist_pool_entries(
                     provider, exc,
                 )
                 return
-    write_credential_pool(provider, payloads, removed_ids=removed_ids)
+    if merge_disk_status:
+        # Keep the default call shape: test doubles and older callers replace
+        # write_credential_pool with a (provider, entries, *, removed_ids) stub.
+        write_credential_pool(provider, payloads, removed_ids=removed_ids)
+    else:
+        write_credential_pool(
+            provider, payloads, removed_ids=removed_ids, merge_disk_status=False
+        )
 
 
 class CredentialPool:
@@ -1058,7 +1074,12 @@ class CredentialPool:
                     self._entries[idx] = new
                     return
 
-    def _persist(self, *, removed_ids: Optional[List[str]] = None) -> None:
+    def _persist(
+        self,
+        *,
+        removed_ids: Optional[List[str]] = None,
+        merge_disk_status: bool = True,
+    ) -> None:
         # Self-locking (RLock): snapshotting self._entries must not race a
         # concurrent rotation when called from the deferred refresh path.
         with self._lock:
@@ -1066,6 +1087,7 @@ class CredentialPool:
                 self.provider,
                 [entry.to_dict() for entry in self._entries],
                 removed_ids=removed_ids,
+                merge_disk_status=merge_disk_status,
             )
 
     def _is_terminal_auth_failure(
@@ -2939,7 +2961,11 @@ class CredentialPool:
                     new_entries.append(entry)
             if count:
                 self._entries = new_entries
-                self._persist()
+                # The user asked for the clear: bypass the disk-boundary
+                # cooldown merge, which would otherwise treat the None'd
+                # status fields as a stale snapshot and re-adopt the
+                # still-binding on-disk cooldown (reset became a no-op).
+                self._persist(merge_disk_status=False)
             return count
 
     def remove_index(self, index: int) -> Optional[PooledCredential]:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2354,6 +2354,7 @@ def write_credential_pool(
     entries: List[Dict[str, Any]],
     *,
     removed_ids: Optional[Iterable[str]] = None,
+    merge_disk_status: bool = True,
 ) -> Path:
     """Persist one provider's credential pool under auth.json.
 
@@ -2371,7 +2372,10 @@ def write_credential_pool(
     snapshot cannot erase a cooldown/quarantine another process just wrote.
 
     Pass ``removed_ids`` for entries the caller intentionally removed, so the
-    merge does not resurrect them from the on-disk copy.
+    merge does not resurrect them from the on-disk copy. Pass
+    ``merge_disk_status=False`` when the caller is deliberately clearing
+    status fields (``hermes auth reset``); otherwise the recency merge
+    re-adopts an unexpired on-disk cooldown over the cleared row.
     """
     removed = {rid for rid in (removed_ids or ()) if rid}
     with _auth_store_lock():
@@ -2401,7 +2405,7 @@ def write_credential_pool(
             _merge_disk_cooldown_state(
                 entry, existing_by_id.get(entry.get("id")), provider_id
             )
-            if isinstance(entry, dict)
+            if merge_disk_status and isinstance(entry, dict)
             else entry
             for entry in sanitized_entries
         ]

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -2079,3 +2079,55 @@ class TestCredentialPoolQueryLocking:
             inner.release()
 
         assert done.wait(timeout=2.0), f"{method}() did not complete after lock release"
+
+
+def test_reset_statuses_clears_unexpired_cooldown_on_disk(tmp_path, monkeypatch):
+    """``hermes auth reset`` must clear a cooldown that is still binding.
+
+    ``reset_statuses()`` persists rows whose status fields are None. The
+    disk-boundary merge in ``write_credential_pool`` reads that as a stale
+    snapshot and re-adopts the on-disk cooldown whenever it has not expired,
+    so an explicit user reset silently became a no-op until the cooldown
+    lapsed on its own.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    monkeypatch.setattr("hermes_cli.auth._import_codex_cli_tokens", lambda: None)
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "still-cooling",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": "tok-1",
+                        "last_status": "exhausted",
+                        "last_status_at": time.time() - 60,
+                        "last_error_code": 400,
+                        "last_error_reason": "invalid_request_error",
+                        "last_error_reset_at": time.time() + 3600,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    assert pool.reset_statuses() == 1
+
+    on_disk = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    row = on_disk["credential_pool"]["openai-codex"][0]
+    assert row["last_status"] is None
+    assert row["last_status_at"] is None
+    assert row["last_error_code"] is None
+    assert row["last_error_reset_at"] is None
+
+    reloaded = load_pool("openai-codex")
+    entry = next(e for e in reloaded.entries() if e.id == "cred-1")
+    assert entry.last_status is None


### PR DESCRIPTION
## What

`hermes auth reset <provider>` prints "Reset status on 1 credentials" but leaves the credential exhausted whenever its cooldown has not expired yet:

```
$ hermes auth reset anthropic
Reset status on 1 anthropic credentials
$ hermes auth list
anthropic (1 credentials):
  #1  anthropic-oauth-1    oauth   hermes_pkce exhausted invalid_request_error (400) (50m 9s left)
```

## Why

`reset_statuses()` sets the six status fields to `None` and persists. The disk-boundary lost-update guard (`_merge_disk_cooldown_state`, applied in `write_credential_pool` and in the borrowed-root update-only path of `persist_pool_entries`) compares `last_status_at` recency, sees `None` (0) on the incoming row versus a real timestamp on disk, and re-adopts the on-disk cooldown because it is still binding. That guard is right for a stale snapshot from another process, but here the caller is deliberately clearing.

Fix: thread `merge_disk_status=False` from `reset_statuses()` through `_persist` -> `persist_pool_entries` -> `write_credential_pool` (and the borrowed-root branch). Every other persist keeps the merge. The default call shape into `write_credential_pool` is unchanged so existing test doubles with the `(provider, entries, *, removed_ids)` signature keep working.

## How to test

- New regression `tests/agent/test_credential_pool.py::test_reset_statuses_clears_unexpired_cooldown_on_disk`: on-disk row exhausted with `last_error_reset_at` an hour out, `reset_statuses()` returns 1, the on-disk row is cleared, and a fresh `load_pool()` shows it healthy. Fails on `main` with `assert 'exhausted' is None`, passes with this change.
- `scripts/run_tests.sh tests/agent/test_credential_pool.py tests/agent/test_credential_pool_anthropic_refresh_race.py tests/agent/test_credential_pool_profile_oauth_fork.py tests/hermes_cli/test_auth_commands.py -q` passes, except `test_seed_from_singletons_respects_hermes_pkce_suppression`, which also fails on unmodified `main` on this machine because it seeds the host's real Claude Code login (unrelated to this change).
- Manual: reproduce the transcript above on `main`, then with this patch the entry shows healthy immediately after reset.

## Platforms tested

macOS 26 (arm64), Python 3.11. Pure Python, no platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gUYmpHUqzNjLnHuDMHcSz