### PR TITLE
fix(anthropic): honour env-key suppression in resolve_anthropic_token()

### DIFF
--- a/agent/anthropic_credentials.py
+++ b/agent/anthropic_credentials.py
@@ -786,6 +786,18 @@ def _resolve_anthropic_pool_token() -> Optional[str]:
     return None
 
 
+def _is_env_source_suppressed(provider: str, source: str) -> bool:
+    """True when ``hermes auth remove`` suppressed *source* for *provider*."""
+    try:
+        from hermes_cli.auth import is_source_suppressed
+    except Exception:
+        return False
+    try:
+        return bool(is_source_suppressed(provider, source))
+    except Exception:
+        return False
+
+
 def resolve_anthropic_token() -> Optional[str]:
     """Resolve an Anthropic token from all available sources.
 
@@ -826,9 +838,13 @@ def resolve_anthropic_token() -> Optional[str]:
         return cc_token
 
     # 3. Regular API key. An explicit user-configured key must not be shadowed
-    # by auto-discovered Claude Code or credential-pool OAuth credentials.
+    # by auto-discovered Claude Code or credential-pool OAuth credentials —
+    # unless the user removed it with ``hermes auth remove``, which records
+    # ``env:ANTHROPIC_API_KEY`` as suppressed. ``load_pool()`` already skips
+    # the variable then; reading it here anyway sent every request out with
+    # the removed key as ``X-Api-Key`` while the healthy OAuth entry sat idle.
     api_key = _getenv("ANTHROPIC_API_KEY").strip()
-    if api_key:
+    if api_key and not _is_env_source_suppressed("anthropic", "env:ANTHROPIC_API_KEY"):
         return api_key
 
     # 4. Claude Code credential file

--- a/tests/agent/test_anthropic_credentials_suppressed_env_key.py
+++ b/tests/agent/test_anthropic_credentials_suppressed_env_key.py
@@ -1,0 +1,65 @@
+"""Regression: a suppressed ``ANTHROPIC_API_KEY`` must not shadow the pool.
+
+``hermes auth remove anthropic <env-key-entry>`` records
+``env:ANTHROPIC_API_KEY`` under ``suppressed_sources`` and tells the user
+"Hermes will ignore ANTHROPIC_API_KEY". ``load_pool()`` honours that, but
+``resolve_anthropic_token()`` read the variable straight from the environment
+ahead of the pool, so every request went out authenticated with the removed
+key (observed as ``HTTP 401: invalid x-api-key`` with a bogus value, and as
+the Console "credit balance is too low" 400 with a real one) while the
+healthy OAuth entry sat unused.
+"""
+
+import json
+
+import pytest
+
+
+def _write_store(tmp_path, *, suppressed: bool) -> None:
+    home = tmp_path / "hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    store = {
+        "version": 1,
+        "credential_pool": {
+            "anthropic": [
+                {
+                    "id": "oauth-1",
+                    "label": "anthropic-oauth-1",
+                    "auth_type": "oauth",
+                    "priority": 0,
+                    "source": "manual:hermes_pkce",
+                    "access_token": "pool-oauth-token",
+                }
+            ]
+        },
+    }
+    if suppressed:
+        store["suppressed_sources"] = {"anthropic": ["env:ANTHROPIC_API_KEY"]}
+    (home / "auth.json").write_text(json.dumps(store))
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    for var in ("ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-env-key")
+    # Keep the host's Claude Code login out of the resolver and the pool seed.
+    monkeypatch.setattr(
+        "agent.anthropic_credentials.read_claude_code_credentials", lambda: None
+    )
+    return tmp_path
+
+
+def test_suppressed_env_key_yields_to_pool_oauth(isolated_home):
+    _write_store(isolated_home, suppressed=True)
+    from agent.anthropic_credentials import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == "pool-oauth-token"
+
+
+def test_unsuppressed_env_key_still_wins(isolated_home):
+    _write_store(isolated_home, suppressed=False)
+    from agent.anthropic_credentials import resolve_anthropic_token
+
+    assert resolve_anthropic_token() == "sk-ant-env-key"


### PR DESCRIPTION
## What

After `hermes auth remove anthropic <ANTHROPIC_API_KEY entry>`, Hermes says:

```
The pool entry is now suppressed — Hermes will ignore ANTHROPIC_API_KEY until you run `hermes auth add anthropic`.
```

But while the variable is still exported, every Anthropic request goes out with that key as `X-Api-Key`, and the remaining healthy OAuth (Claude Max) entry is never used.

Reproduction on `main`, pool containing only the `hermes_pkce` OAuth entry, `env:ANTHROPIC_API_KEY` listed under `suppressed_sources`:

```
$ ANTHROPIC_API_KEY=sk-ant-bogus-test hermes -z "Reply with the single word OK."
HTTP 401: invalid x-api-key

$ env -u ANTHROPIC_API_KEY hermes -z "Reply with the single word OK."
OK
```

With a real key on a Console org that has no credits, the failure is instead `400 invalid_request_error: Your credit balance is too low`, which Hermes then reports as "your Claude subscription usage is exhausted" and puts the OAuth entry on a one-hour cooldown. That is how this was found: a working Max subscription looked exhausted.

## Why

`load_pool()` honours `suppressed_sources`, but `resolve_anthropic_token()` reads `ANTHROPIC_API_KEY` from the environment at step 3, ahead of the pool, with no suppression check. Step 3's comment says an explicit key must not be shadowed by discovered OAuth credentials; the user removing the key is the explicit opt-out.

Fix: skip step 3 when `is_source_suppressed("anthropic", "env:ANTHROPIC_API_KEY")`. An unsuppressed key keeps its precedence. The import from `hermes_cli.auth` is lazy and fails open, matching the pattern already used in `credential_pool.py`.

## How to test

- New `tests/agent/test_anthropic_credentials_suppressed_env_key.py`: with the source suppressed the resolver returns the pool OAuth token; without suppression the env key still wins. The first case fails on `main` (`assert 'sk-ant-env-key' == 'pool-oauth-token'`) and passes with this change.
- `scripts/run_tests.sh tests/agent/test_auxiliary_anthropic_pool_fallback_regression.py tests/agent/test_auxiliary_client.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_anthropic_pool_model_discovery.py tests/hermes_cli/test_model_switch_opencode_anthropic.py tests/test_hermetic_side_effect_guards.py -q` passes.
- Manual: the two commands above, both return `OK` with this patch.

## Platforms tested

macOS 26 (arm64), Python 3.11. Pure Python, no platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017gUYmpHUqzNjLnHuDMHcSz