### PR TITLE
fix(desktop): initialize desktop log buffers before top-level pool-limits read

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -1421,6 +1421,15 @@ const profileDeletionGate = new ProfileDeletionGate()
 // for scripted/headless setups; after launch the stored preference wins.
 const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
 
+// Logging buffers must be initialized BEFORE readPersistedPoolLimits() runs
+// at module top level (it calls rememberLog, which pushes into hermesLog).
+// Declaring them after the pool read crashed every launch with
+// "Cannot read properties of undefined (reading 'push')".
+const hermesLog: string[] = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer: ReturnType<typeof setTimeout> | null = null
+let desktopLogFlushPromise: Promise<void> = Promise.resolve()
+
 function readPersistedPoolLimits() {
   try {
     const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
@@ -1574,12 +1583,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## Problem

The desktop app crashes on every launch with an uncaught exception dialog:

```
TypeError: Cannot read properties of undefined (reading 'push')
  at rememberLog (electron-main.mjs:23178:13)
  at readPersistedPoolLimits (electron-main.mjs:23011:7)
```

`readPersistedPoolLimits()` runs at module top level and calls `rememberLog()`, which pushes into `hermesLog`. But the log buffers (`hermesLog`, `desktopLogBuffer`, `desktopLogFlushTimer`, `desktopLogFlushPromise`) were declared *after* the pool read in source order. When bundled, the `var`-hoisted `hermesLog` is `undefined` at the point of the call, so the first log line of a launch throws and the app shows the error box instead of starting.

## Fix

Move the log buffer declarations above `readPersistedPoolLimits()` so logging is safe during early module bootstrap. No behavior change otherwise.

## Verification

- `tsc -p tsconfig.electron.json --noEmit` passes
- Rebuilt `electron-main.mjs`, verified the bundled order: `hermesLog` (line 22994) now precedes the `readPersistedPoolLimits()` call (line 23030)
- Repacked `app.asar` and launched the app: full boot log appears in `desktop.log` and the window renders normally