### PR TITLE
perf(desktop): resolve the renderer bundle once per window, not twice

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -4656,7 +4656,15 @@ function resolveWebDist() {
   return fallback
 }
 
-function resolveRendererIndex() {
+// Same resolution as resolveRendererIndex, but also hands back the missing
+// asset list already computed for the copy it chose. The primary-window path
+// needs BOTH, and re-deriving the list means walking the whole renderer
+// generation a second time: missingRendererAssets follows index.html's
+// modulepreload refs and then every chunk's inline __vite__mapDeps table, so
+// on a release build it reads ~28 MiB across ~160 files synchronously on the
+// main thread — measured ~49 ms per walk, twice before loadWindowUrl().
+// Callers that only need the path keep using resolveRendererIndex below.
+function resolveRendererIndexWithMissing(): { index: string; missing: string[] } {
   const asarIndex = path.join(APP_ROOT, 'dist', 'index.html')
   const webDistIndex = path.join(resolveWebDist(), 'index.html')
 
@@ -4679,11 +4687,20 @@ function resolveRendererIndex() {
   // first lazy import with "Failed to fetch dynamically imported module" and
   // every restart reloads the same torn copy. Prefer a copy whose modules are
   // all present, so the intact generation heals the boot by itself.
+  // Remember the FIRST candidate's list: if every copy turns out to be torn we
+  // load present[0], and its list is already in hand — recomputing it there
+  // would reintroduce the very second walk this function exists to avoid.
+  let firstMissing: string[] | null = null
+
   for (const candidate of present) {
     const missing = missingRendererAssets(candidate)
 
     if (missing.length === 0) {
-      return candidate
+      return { index: candidate, missing: [] }
+    }
+
+    if (firstMissing === null) {
+      firstMissing = missing
     }
 
     rememberLog(
@@ -4703,7 +4720,9 @@ function resolveRendererIndex() {
         `Repair with: hermes desktop --force-build`
     )
 
-    return present[0]
+    // present[0]'s own list, captured on the first loop iteration — never the
+    // last candidate's, which would describe a bundle we are not loading.
+    return { index: present[0], missing: firstMissing ?? [] }
   }
 
   // Nothing on disk. A packaged build with no renderer bundle blank-pages with
@@ -4715,7 +4734,13 @@ function resolveRendererIndex() {
       `Rebuild with: hermes desktop --force-build`
   )
 
-  return candidates[0]
+  return { index: candidates[0], missing: [] }
+}
+
+// Path-only accessor: unchanged behaviour for the window loaders that do not
+// need the torn-asset list.
+function resolveRendererIndex() {
+  return resolveRendererIndexWithMissing().index
 }
 
 // True when `dir` lives inside the packaged app bundle / install tree.
@@ -14598,8 +14623,11 @@ function createWindow() {
   // copies; here we refuse to load one into the PRIMARY window and put the
   // visible repair page in it instead. The Reload button re-attempts the
   // bundle in case the file lock cleared since boot.
-  const rendererIndex = DEV_SERVER ? null : resolveRendererIndex()
-  const tornAssets = rendererIndex ? missingRendererAssets(rendererIndex) : []
+  // One resolution, not two: resolveRendererIndexWithMissing already computed
+  // this copy's missing list while choosing it.
+  const resolvedRenderer = DEV_SERVER ? null : resolveRendererIndexWithMissing()
+  const rendererIndex = resolvedRenderer?.index ?? null
+  const tornAssets = resolvedRenderer?.missing ?? []
 
   if (!DEV_SERVER && rendererIndex && tornAssets.length > 0) {
     rememberLog(


### PR DESCRIPTION
## What does this PR do?

`createMainWindow` walked the entire renderer generation **twice** before it could give the window its URL:

```js
const rendererIndex = DEV_SERVER ? null : resolveRendererIndex()
const tornAssets = rendererIndex ? missingRendererAssets(rendererIndex) : []
```

`resolveRendererIndex` already computes exactly that list while choosing the copy — it has to, in order to decide whether a copy is torn — and then discards it. So the second call recomputes what the first one just knew.

### Why this is expensive rather than trivial

`missingRendererAssets` is not a stat walk. It is a BFS that `readFileSync`s every present chunk **whole** and regex-scans it for the inline `__vite__mapDeps` table, following those refs transitively — so it reads the 19 MB shiki chunk and the 3 MB mermaid chunk too.

Measured against the real `apps/desktop/dist` on this machine (252 JS chunks, 28.7 MiB total, `index.html` carrying 108 refs), one walk costs:

```
readFileSync  162 calls
bytes read    28.23 MiB
existsSync    576 calls
wall clock    min 55.8 ms, median 56.6 ms   (9 reps, warm page cache, darwin-arm64)
```

Both walks are synchronous on the Electron main thread, ahead of `loadWindowUrl()`. Cold page cache — first launch after a reboot or right after an update, which is exactly when the torn-bundle check earns its keep — is worse, and a packaged build routes those reads through Electron's asar shim.

### The change

`resolveRendererIndexWithMissing()` holds the existing body and returns `{ index, missing }`. `resolveRendererIndex()` becomes a one-line wrapper over it, so the **nine other call sites are untouched**. The primary-window path takes one resolution and reads both values off it.

Semantics are identical in all three branches: same candidate chosen, same log lines, and the returned `missing` always describes the copy actually being loaded.

One subtlety worth calling out, because my own first draft got it wrong: in the all-copies-torn branch the loop variable holds the **last** candidate's list, not `present[0]`'s. Recomputing it for `present[0]` there would have reintroduced the second walk in the very case that matters most, and reusing the loop's value would have described a bundle we do not load. So the first candidate's list is captured on the first iteration and reused. Net result: **no branch walks twice**, and `main.ts` now contains exactly one `missingRendererAssets` call site.

### What this saves per primary-window boot

162 fewer `readFileSync` calls, 28.23 MiB less synchronous reading, 288 fewer `existsSync` calls, and roughly 57 ms of main-thread blocking removed before `loadURL`. `DEV_SERVER` skips the walk entirely, so `vite dev` is unaffected; the win lands on packaged and `--prod` launches, which is what users get.

### Deliberately not included

Memoizing the result across calls would also remove the ~57 ms that each *additional* window (session popout, HUD, pet overlay, quick entry, wake indicator) pays. I left it out on purpose: `onFailedLoadBudgetExhausted` re-resolves at failure time, so a process-lifetime cache would freeze the boot-time candidate choice even if the file lock cleared and the other copy became complete — which is precisely the recovery path #95575 added. That needs an explicit invalidation hook and its own review, not a quiet ride-along here.

## Related Issue

Fixes #111722

None filed. This is a pure duplicate-work removal on the boot path.

The correctness lineage this code serves is intact and must stay that way — #93479 and #95575 (the bugs), and #85887, #93669, #86377 (the fixes and the detector's unit coverage). Nothing about torn-bundle detection, its log wording, or the repair page changes here.

Merge-adjacent: #46661 is **superseded** — it edits `main.cjs` (since renamed to `main.ts`) and its "prefer unpacked dist" change is already in main.

## Type of Change

- [x] ⚡ Performance improvement (non-breaking)

## Changes Made

- `apps/desktop/electron/main.ts` — `resolveRendererIndexWithMissing()` returning `{ index, missing }`; `resolveRendererIndex()` reduced to a wrapper; the primary-window path takes one resolution; the all-torn branch reuses the first candidate's captured list

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/renderer-bundle.test.ts` — **17 passed** here. That file is the torn-bundle detector's lock (#86377) and covers intact, torn, lazy-chunk, cycle and per-copy cases; `renderer-bundle.ts` itself is untouched by this PR.
2. `npx tsc -p tsconfig.electron.json --noEmit` — the `main.ts` diagnostics are **byte-identical to unpacked `origin/main`** (7 on each, all pre-existing missing-`electron`-types noise in this checkout, only line numbers shifted). No new type error.
3. Static invariant: `grep -c 'missingRendererAssets(' apps/desktop/electron/main.ts` is now **1**, inside the resolver loop.
4. To reproduce the cost number: transpile `renderer-bundle.ts`, call `missingRendererAssets(dist/index.html)` with counting `readFileSync`/`existsSync` shims (the module already accepts a `RendererBundleDeps` shim, which is how its own tests inject), and time it.

**On tests, honestly:** `electron/main.ts` is the Electron entry point and no test imports it, so there is no seam to unit-test `resolveRendererIndexWithMissing` through without extracting it — a larger refactor than this fix. I also declined to add a source-parsing guard asserting "one call site": I removed exactly such an AST guard from another PR of mine this week after upstream moved a function and broke it while changing no behaviour, and I am not going to add a fresh one here. The behaviour that matters is covered by the 17 detector tests; the duplicate-work claim is covered by the measurement and the single remaining call site.

I did not run `npm run perf -- cold-start --spawn --prod`: the harness attaches to a live Electron instance over CDP, and this machine's desktop app runs from this repo's `dist/`, so driving it risked disturbing a running app for a number the per-walk measurement already establishes.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — `resolveRendererIndex`, `missingRendererAssets`, "renderer bundle walk cache", "torn renderer bundle boot cost"; no one has proposed removing the duplicate walk
- [x] My PR contains **only** changes related to this improvement
- [x] Ran the electron project's renderer-bundle suite and the electron typecheck; relying on CI for the full matrix
- [x] Tests — the existing detector suite covers the behaviour; see the honest note above on why no new unit test
- [x] I've tested on my platform: macOS 26 arm64, node 22, against a real 28.7 MiB `dist` tree

### Documentation & Housekeeping

- [x] Documentation — the rationale lives in comments at the resolver and the call site
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — no platform APIs; `DEV_SERVER` path unchanged
- [x] Tool descriptions/schemas — N/A