### PR TITLE
fix(desktop): declare rememberLog state before module-eval callers, with a regression guard

### DIFF
--- a/apps/desktop/electron/main-module-init-order.test.ts
+++ b/apps/desktop/electron/main-module-init-order.test.ts
@@ -1,0 +1,150 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { test } from 'vitest'
+
+// ── Regression guard: module-evaluation order vs. the desktop logger ────────
+//
+// Live repro (2026-09-03, Fedora, Electron 40.10.2): the app died on every
+// launch before it painted a window —
+//
+//   Uncaught Exception:
+//   TypeError: Cannot read properties of undefined (reading 'push')
+//       at rememberLog (dist/electron-main.mjs:23178)
+//       at readPersistedPoolLimits (dist/electron-main.mjs:23011)
+//
+// c401756a6a4a (#91545) turned two pure `const` computations into an eager
+// `let poolLimits = readPersistedPoolLimits()` at module scope. Every branch
+// of that function calls rememberLog(), but rememberLog()'s backing state was
+// declared 111 lines further down — inside the temporal dead zone at that
+// moment. The bundler lowers module-scope const/let to `var`, so the TDZ
+// ReferenceError degraded into `hermesLog` being plain `undefined` and `.push`
+// threw. Nothing reached desktop.log either, because the logger itself was
+// what died — the crash left no trace in the one file you would go looking in.
+//
+// The invariant: state that rememberLog() touches must be declared before any
+// module-level code that can log while the module is still evaluating.
+// Function *declarations* are hoisted and so are exempt; `const`/`let` are not.
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainTsSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8')
+
+/** Module-scope `const`/`let` bindings (column 0), name -> source offset. */
+function moduleBindings(source: string): Map<string, number> {
+  const found = new Map<string, number>()
+  const declaration = /^(?:const|let)\s+([A-Za-z_$][\w$]*)\s*=/gm
+  let match: RegExpExecArray | null
+
+  while ((match = declaration.exec(source))) {
+    if (!found.has(match[1])) {
+      found.set(match[1], match.index)
+    }
+  }
+
+  return found
+}
+
+/** Top-level `function foo(` declarations — hoisted, so order-exempt. */
+function localFunctions(source: string): Set<string> {
+  return new Set(Array.from(source.matchAll(/^function\s+([A-Za-z_$][\w$]*)\s*\(/gm), m => m[1]))
+}
+
+// Slice to the next top-level `function ` declaration — crude but stable for
+// the flat function layout main.ts uses, and matching the approach the other
+// main.ts source-scanning guards already take.
+function extractFunction(source: string, name: string): string {
+  const start = source.indexOf(`function ${name}(`)
+  assert.notEqual(start, -1, `function ${name} not found in main.ts`)
+
+  const rest = source.slice(start)
+  const next = rest.slice(1).search(/\nfunction /)
+
+  return next === -1 ? rest : rest.slice(0, next + 1)
+}
+
+function identifiersIn(body: string): Set<string> {
+  return new Set(body.match(/[A-Za-z_$][\w$]*/g) ?? [])
+}
+
+/**
+ * Module-scope bindings rememberLog() reaches, following the local functions
+ * it calls directly (scheduleDesktopLogFlush, flushDesktopLogBufferAsync, …).
+ * Derived rather than hard-coded so a new binding added to the logger is
+ * covered without anyone remembering to update this list.
+ */
+function loggerStateBindings(): string[] {
+  const bindings = moduleBindings(mainTsSource)
+  const functions = localFunctions(mainTsSource)
+  const body = extractFunction(mainTsSource, 'rememberLog')
+  const directCallees = Array.from(identifiersIn(body)).filter(name => functions.has(name) && name !== 'rememberLog')
+  const reachable = [body, ...directCallees.map(name => extractFunction(mainTsSource, name))].join('\n')
+
+  return Array.from(identifiersIn(reachable)).filter(name => bindings.has(name))
+}
+
+test('logger state is declared before readPersistedPoolLimits() runs at module scope', () => {
+  const bindings = moduleBindings(mainTsSource)
+  const poolLimitsInit = mainTsSource.search(/^let poolLimits = readPersistedPoolLimits\(\)/m)
+
+  assert.notEqual(
+    poolLimitsInit,
+    -1,
+    'expected a module-level `let poolLimits = readPersistedPoolLimits()` — if this moved, re-point the guard at whatever now logs during module evaluation'
+  )
+
+  // All four move together. Hoisting hermesLog alone stops the crash but
+  // leaves desktopLogBuffer undefined at that moment, so the pool-limits
+  // lines are dropped when its own initializer resets it to '' later in the
+  // same evaluation, and the pending flush timer handle is clobbered by
+  // desktopLogFlushTimer's initializer.
+  for (const name of ['hermesLog', 'desktopLogBuffer', 'desktopLogFlushTimer', 'desktopLogFlushPromise']) {
+    const declaredAt = bindings.get(name)
+
+    assert.notEqual(declaredAt, undefined, `expected a module-scope \`${name}\` in main.ts`)
+    assert.ok(
+      (declaredAt as number) < poolLimitsInit,
+      `${name} is declared after readPersistedPoolLimits() runs — that call logs during module ` +
+        `evaluation, and the bundler's const->var lowering turns the dead-zone read into undefined, ` +
+        `so the main process dies on boot with "Cannot read properties of undefined"`
+    )
+  }
+})
+
+test('no module-level initializer logs before the logger state it depends on exists', () => {
+  const bindings = moduleBindings(mainTsSource)
+  const functions = localFunctions(mainTsSource)
+  const loggerState = loggerStateBindings()
+
+  assert.ok(loggerState.includes('hermesLog'), 'sanity: rememberLog should reach hermesLog')
+
+  // Every `const|let X = someLocalFunction(...)` at module scope: if that
+  // function logs, it runs rememberLog() mid-evaluation and every binding the
+  // logger touches must already be initialized.
+  const initializer = /^(?:const|let)\s+[A-Za-z_$][\w$]*\s*=\s*([A-Za-z_$][\w$]*)\(/gm
+  let match: RegExpExecArray | null
+  const offenders: string[] = []
+
+  while ((match = initializer.exec(mainTsSource))) {
+    const callee = match[1]
+
+    if (!functions.has(callee) || !extractFunction(mainTsSource, callee).includes('rememberLog(')) {
+      continue
+    }
+
+    for (const name of loggerState) {
+      if ((bindings.get(name) as number) > match.index) {
+        offenders.push(`${callee}() runs at module scope before \`${name}\` is declared`)
+      }
+    }
+  }
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `module-eval logging reads uninitialized logger state:\n  ${offenders.join('\n  ')}\n` +
+      'Move the declaration above the initializer — a dead-zone read here becomes `undefined` ' +
+      'after bundling and crashes the main process on boot.'
+  )
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -883,6 +883,21 @@ const DESKTOP_LOG_MAX_BYTES = 10 * 1024 * 1024
 const DESKTOP_LOG_BACKUP_COUNT = 3
 const DESKTOP_LOG_DISCARD_BYTES = DESKTOP_LOG_MAX_BYTES * 4
 const desktopLogBackupPath = n => `${DESKTOP_LOG_PATH}.${n}`
+
+// rememberLog()'s backing state. It lives up here, beside the DESKTOP_LOG_*
+// constants, because module-level initializers further down this file call
+// rememberLog() while the module is still evaluating (readPersistedPoolLimits()
+// is the first, and will not be the last). Declared at their point of use these
+// were in the temporal dead zone at that moment; the bundler lowers module-scope
+// `const`/`let` to `var`, so the TDZ ReferenceError degraded into `hermesLog`
+// being plain `undefined` and the main process died on boot with
+// "Cannot read properties of undefined (reading 'push')" — no window, no log
+// line, because the logger itself was what crashed. Anything that logs during
+// module evaluation must be declared before the code that does the logging.
+const hermesLog = []
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
 const BOOT_FAKE_MODE = process.env.HERMES_DESKTOP_BOOT_FAKE === '1'
 const BOOT_FAKE_ERROR = process.env.HERMES_DESKTOP_BOOT_FAKE_ERROR || ''
 // Automated teardown (Playwright's app.close(), harness scripts) quits with
@@ -1574,12 +1589,8 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
-const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {


### PR DESCRIPTION
## What does this PR do?

Fixes the main-process boot crash that makes Hermes Desktop unlaunchable, and adds the regression guard the suite is missing.

```
Uncaught Exception:
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog (dist/electron-main.mjs:23178)
    at readPersistedPoolLimits (dist/electron-main.mjs:23011)
```

c401756a6a4a (#91545) replaced two pure `const` computations with an eager `let poolLimits = readPersistedPoolLimits()` at module scope. Every branch of that function calls `rememberLog()`, but `rememberLog()`'s backing state was declared 111 lines further down — inside the temporal dead zone at that moment. The bundler lowers module-scope `const`/`let` to `var`, so the TDZ `ReferenceError` degraded into `hermesLog` being plain `undefined` and `.push` threw before the app painted a window.

Nothing reached `desktop.log` either, because the logger itself was what died — the crash left no trace in the one file you would go looking in.

**Note on overlap:** #101988 already carries the same declaration hoist, and got there first. If it lands first, drop the `main.ts` hunk here — it is the same change and I have no claim on it. The regression test is the part this PR is actually for; neither PR had one, and CONTRIBUTING lists tests as required for bug fixes. Happy for the test to be cherry-picked into #101988 instead of merging this.

One substantive difference in the `main.ts` hunk: the declarations land beside the `DESKTOP_LOG_*` constants (~line 886) rather than immediately above `readPersistedPoolLimits()` (~line 1424). Same fix for this crash; the earlier placement also covers any *future* module-level initializer that logs, which is the shape that caused this.

## Related Issue

Fixes #101941

(Also reported as #101960, #101989, #101993, #101996, #101999, #102003 — seven duplicates in under 30 minutes, which is a fair signal of the blast radius.)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `apps/desktop/electron/main.ts` — move `hermesLog`, `desktopLogBuffer`, `desktopLogFlushTimer` and `desktopLogFlushPromise` up beside the `DESKTOP_LOG_*` constants, ahead of all module-level code that can log. Declaration hoist only; no logic change.

  All four have to move together. Hoisting `hermesLog` alone stops the crash but leaves `desktopLogBuffer` undefined at that point, so the three `[pool-limits]` lines are dropped when its own initializer resets it to `''` mid-evaluation, and the scheduled flush timer handle is clobbered by `desktopLogFlushTimer`'s initializer.

- `apps/desktop/electron/main-module-init-order.test.ts` (new) — two source-level guards, following the existing `main.ts` scanning tests (`backend-python-coherence.test.ts`), since `main.ts` cannot be imported under vitest:

  1. The specific regression: all four bindings are declared before `let poolLimits = readPersistedPoolLimits()`.
  2. The general invariant: no module-level `const|let X = fn()` whose callee calls `rememberLog()` may run before any module binding the logger reaches. The binding set is *derived* from `rememberLog()`'s body and the local functions it calls, so a new logger dependency is covered without anyone updating a list.

  Function declarations are hoisted and stay exempt; only `const`/`let` are checked — exactly the class the bundler's `const`→`var` lowering turns from a TDZ `ReferenceError` into a silent `undefined`.

## How to Test

1. Check out the parent commit's `main.ts` and run `npx vitest run electron/main-module-init-order.test.ts` from `apps/desktop` — **both tests fail**, with the crash explained in the assertion message.
2. Restore the fixed `main.ts` and re-run — **both pass** (2 passed, ~320ms).
3. End to end: `hermes desktop --build-only && hermes-desktop`. Before the fix the main process dies in ~2s with the trace above; after it, the app boots and `~/.hermes/logs/desktop.log` records the `[pool-limits]` line that previously killed the process, followed by `[boot] Hermes runtime is ready`.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate — found #101988, disclosed above
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — not run; this change is TypeScript-only and touches no Python. The relevant suite (`npx vitest run` in `apps/desktop`) is covered above.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Fedora (Linux 7.1.12), Wayland/XWayland, Electron 40.10.2, Node 20

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the bug is bundler-level, not platform-level, so it reproduces on macOS and Windows identically; the fix and both tests are platform-independent (pure source-order analysis, no `fs`/path behavior).
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before (every launch, ~2s after start, no window):

```
[hermes] install stamp: b9dc79033203 (main) from local
A JavaScript error occurred in the main process
Uncaught Exception:
TypeError: Cannot read properties of undefined (reading 'push')
    at rememberLog (.../resources/app.asar/dist/electron-main.mjs:23178:13)
    at readPersistedPoolLimits (.../resources/app.asar/dist/electron-main.mjs:23011:7)
    at .../resources/app.asar/dist/electron-main.mjs:23026:18
```

After, in `~/.hermes/logs/desktop.log` — the line that used to be fatal:

```
[2026-09-03T08:03:42.126Z] [hermes] [pool-limits] no saved file and no env overrides; using defaults
[2026-09-03T08:04:03.287Z] [hermes] [boot] Hermes runtime is ready
[2026-09-03T08:04:05.010Z] [hermes] Hermes backend listening on 127.0.0.1:44007
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KcFNRSvkhS6Hv7cT64Mr5A
