### PR TITLE
fix(cli): block model-version auto-correction (#101975)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -19,6 +19,7 @@ import urllib.request
 import urllib.error
 import time
 from difflib import get_close_matches
+import re
 from pathlib import Path
 from typing import Any, NamedTuple, Optional, TYPE_CHECKING
 
@@ -7037,6 +7038,35 @@ def validate_requested_model(
       - recognized: whether it matched a known provider catalog
       - message: optional warning / guidance for the user
     """
+
+    def _version_only_diff(requested: str, corrected: str) -> bool:
+        """Check if requested and corrected differ ONLY in version digits.
+        
+        Returns True if the sole difference is in numeric segments
+        (e.g. "gemini-3.8-flash" vs "gemini-3.6-flash"), indicating a
+        model-version substitution rather than a typo fix (e.g. "gpt-5.44" vs
+        "gpt-5.4" is a typo, not a version swap).
+        """
+        req_digits = re.findall(r'\d+', requested)
+        cor_digits = re.findall(r'\d+', corrected)
+        if not req_digits or not cor_digits or len(req_digits) != len(cor_digits):
+            return False
+        # Compare non-digit structure (case-insensitive)
+        req_stripped = re.sub(r'\d+', '', requested.lower())
+        cor_stripped = re.sub(r'\d+', '', corrected.lower())
+        if req_stripped != cor_stripped:
+            return False
+        # Check if all numeric diffs are small (version-like, not typo-like)
+        for r, c in zip(req_digits, cor_digits):
+            if r != c:
+                try:
+                    if abs(int(r) - int(c)) > 5:
+                        # Large numeric diff (e.g. 44→4) → likely a typo
+                        return False
+                except ValueError:
+                    pass
+        # At least one numeric segment must differ (otherwise not a diff at all)
+        return req_digits != cor_digits
     requested = (model_name or "").strip()
     normalized = normalize_provider(provider)
     if normalized == "openrouter" and base_url and not base_url_host_matches(base_url, "openrouter.ai"):
@@ -7269,13 +7299,17 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
-                }
+                if _version_only_diff(requested_for_lookup, auto[0]):
+                    # Version-only substitution: block auto-correction (#101975)
+                    pass
+                else:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": auto[0],
+                        "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                    }
 
             suggestions = get_close_matches(requested, api_models, n=3, cutoff=0.5)
             suggestion_text = ""
@@ -7375,13 +7409,16 @@ def validate_requested_model(
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, catalog_models, n=1, cutoff=0.9)
             if auto:
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
-                }
+                if _version_only_diff(requested_for_lookup, auto[0]):
+                    pass
+                else:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": auto[0],
+                        "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                    }
             suggestions = get_close_matches(requested_for_lookup, catalog_models, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
@@ -7450,14 +7487,17 @@ def validate_requested_model(
             catalog_lower_list = list(catalog_lower.keys())
             auto = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9)
             if auto:
-                corrected = catalog_lower[auto[0]]
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": corrected,
-                    "message": f"Auto-corrected `{requested}` → `{corrected}`",
-                }
+                if _version_only_diff(requested_for_lookup, catalog_lower[auto[0]]):
+                    pass
+                else:
+                    corrected = catalog_lower[auto[0]]
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": corrected,
+                        "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                    }
             suggestions = get_close_matches(requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
@@ -7495,13 +7535,16 @@ def validate_requested_model(
                 }
             auto = get_close_matches(requested_for_lookup, anthropic_models, n=1, cutoff=0.9)
             if auto:
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
-                }
+                if _version_only_diff(requested_for_lookup, auto[0]):
+                    pass
+                else:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": auto[0],
+                        "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                    }
             suggestions = get_close_matches(requested, anthropic_models, n=3, cutoff=0.5)
             suggestion_text = ""
             if suggestions:
@@ -7536,15 +7579,18 @@ def validate_requested_model(
                 }
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
             if auto:
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": auto[0],
-                    "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
-                }
+                if _version_only_diff(requested_for_lookup, auto[0]):
+                    pass
+                else:
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": auto[0],
+                        "message": f"Auto-corrected `{requested}` → `{auto[0]}`",
+                    }
         # Probe failed or model not found — accept anyway (proxy likely
-        # doesn't implement the Anthropic Models API).
+        # doesn't implement the Anthropic Messages API).
         return {
             "accepted": True,
             "persist": True,
@@ -7605,15 +7651,20 @@ def validate_requested_model(
 
             # Auto-correct if the top match is very similar (e.g. typo)
             auto = get_close_matches(requested_for_lookup, api_models, n=1, cutoff=0.9)
+            version_swap_blocked = False
             if auto:
-                corrected = _with_preset_suffix(auto[0])
-                return {
-                    "accepted": True,
-                    "persist": True,
-                    "recognized": True,
-                    "corrected_model": corrected,
-                    "message": f"Auto-corrected `{requested}` → `{corrected}`",
-                }
+                if _version_only_diff(requested_for_lookup, auto[0]):
+                    # Version-only substitution: block auto-correction (#101975)
+                    version_swap_blocked = True
+                else:
+                    corrected = _with_preset_suffix(auto[0])
+                    return {
+                        "accepted": True,
+                        "persist": True,
+                        "recognized": True,
+                        "corrected_model": corrected,
+                        "message": f"Auto-corrected `{requested}` → `{corrected}`",
+                    }
 
             suggestions = get_close_matches(
                 requested_for_lookup, api_models, n=3, cutoff=0.5
@@ -7688,6 +7739,19 @@ def validate_requested_model(
                             f"listing but is a current Nous Portal recommendation — accepted."
                         ),
                     }
+
+            # Non-OpenAI providers soft-accept version-swapped requests as-is
+            # with suggestions; OpenAI-official rejects them (authoritative listing).
+            if version_swap_blocked and normalized not in {"openai", "openai-api"}:
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": False,
+                    "message": (
+                        f"Note: `{requested}` was not found in this provider's model listing."
+                        f"{suggestion_text}"
+                    ),
+                }
 
         return {
             "accepted": False,
@@ -7780,17 +7844,20 @@ def validate_requested_model(
             requested_for_lookup.lower(), catalog_lower_list, n=1, cutoff=0.9
         )
         if auto:
-            corrected = catalog_lower[auto[0]]
-            corrected_with_suffix = _with_preset_suffix(corrected)
-            return {
-                "accepted": True,
-                "persist": True,
-                "recognized": True,
-                "corrected_model": corrected_with_suffix,
-                "message": (
-                    f"Auto-corrected `{requested}` → `{corrected_with_suffix}`"
-                ),
-            }
+            if _version_only_diff(requested_for_lookup, catalog_lower[auto[0]]):
+                pass
+            else:
+                corrected = catalog_lower[auto[0]]
+                corrected_with_suffix = _with_preset_suffix(corrected)
+                return {
+                    "accepted": True,
+                    "persist": True,
+                    "recognized": True,
+                    "corrected_model": corrected_with_suffix,
+                    "message": (
+                        f"Auto-corrected `{requested}` → `{corrected_with_suffix}`"
+                    ),
+                }
         suggestions = get_close_matches(
             requested_for_lookup.lower(), catalog_lower_list, n=3, cutoff=0.5
         )


### PR DESCRIPTION
**Closes #101975**

## Problem

When switching to a newly released model via `/model <model_name> --provider <provider>`, if the requested model is not yet in the provider's catalog, Hermes's fuzzy auto-correction (`get_close_matches` with `cutoff=0.9`) silently substitutes model versions that differ by a single digit (e.g. `gemini-3.8-flash` → `gemini-3.6-flash`, SequenceMatcher ratio ≈ 0.956 > 0.9).

This is dangerous: different model versions have distinct token pricing, context windows, and capability profiles. The user explicitly requested `3.8`, but inference runs on `3.6` with no opportunity to confirm or reject the substitution.

## Solution

1. Added `_version_only_diff(requested, corrected) -> bool` helper inside `validate_requested_model()` that detects version-number swaps (same structure, different digits, all numeric diffs ≤ 5 to exclude typos like `5.44` → `5.4`).
2. Modified all 7 auto-correction sites in `hermes_cli/models.py` to block `corrected_model` when `_version_only_diff()` returns `True`.
3. For non-OpenAI-authoritative providers (aggregators, proxies), version-swapped requests now soft-accept as-is with suggestions, preserving the user's explicit model choice. OpenAI-official endpoints still reject (their listing is authoritative).

## Testing

- `test_missing_dash_auto_corrects` (typo `gpt5.3-codex` → `gpt-5.3-codex`): ✅ PASS (ratio 0.96, legitimate correction)
- `test_combined_openrouter_preset_reference_preserves_suffix_on_autocorrect` (`gpt-5.44` → `gpt-5.4`): ✅ PASS (abs diff 40 > threshold, typo not version)
- `test_warning_includes_suggestions` (`claude-opus-4.5`, version-blocked): ✅ PASS (soft-accept with suggestions)
- All 68 `test_model_validation.py` + `test_openrouter_preset_validation.py` tests green

## Example (before → after)

**Before:**
```text
/model google/gemini-3.8-flash --provider vertex
→ Model switched to google/gemini-3.6-flash
   Warning: Auto-corrected google/gemini-3.8-flash → google/gemini-3.6-flash
```

**After:**
```text
/model google/gemini-3.8-flash --provider vertex
→ Model switched to google/gemini-3.8-flash
   Note: `google/gemini-3.8-flash` was not found in this provider's model listing.
   Similar models: `google/gemini-3.6-flash`, `google/gemini-3.6-pro`
```
The requested model name is preserved; if the provider doesn't serve it, the subsequent inference request will fail honestly with a 404, not silently run on a different version.
