### PR TITLE
fix(skills): validate writes before approval staging

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1,6 +1,9 @@
 """Tests for tools/skill_manager_tool.py — skill creation, editing, and deletion."""
 
 import json
+import os
+import shutil
+import tempfile
 from contextlib import contextmanager
 from contextvars import copy_context
 from pathlib import Path
@@ -1191,3 +1194,331 @@ class TestCuratorConsolidationDeleteGuard:
             assert allowed["success"] is True, allowed
 
         _reset_background_review_read_marks()
+
+
+# ---------------------------------------------------------------------------
+# Staging preflight — validate create/edit payloads before they become pending
+# ---------------------------------------------------------------------------
+
+
+@contextmanager
+def _approval_home(monkeypatch, enabled):
+    """HERMES_HOME on a temp dir with skills.write_approval set to ``enabled``.
+
+    Always writes the flag explicitly: reading the operator's real config would
+    make gate-on/gate-off assertions depend on the machine.
+    """
+    d = tempfile.mkdtemp(prefix="hermes_skill_gate_test_")
+    home = os.path.join(d, ".hermes")
+    os.makedirs(home)
+    monkeypatch.setenv("HERMES_HOME", home)
+    import hermes_cli.config as cfg
+    config = cfg.load_config()
+    config.setdefault("skills", {})["write_approval"] = enabled
+    cfg.save_config(config)
+    try:
+        yield home
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+def _desc_of_length(n):
+    """A one-sentence description padded to exactly ``n`` characters."""
+    head = "Use when staging a skill "
+    return head + "a" * (n - len(head) - 1) + "."
+
+
+def _desc_with_quoted_tail(budgeted_len):
+    """A plain-YAML description ending in a quote character.
+
+    YAML leaves the quote in the parsed value, but the budget check measures
+    ``desc.strip().strip("'\\"")`` — so the parsed value is one char longer
+    than the length the limit is actually applied to. Used to pin the reported
+    count to the measured one.
+    """
+    head = "Use when the user says "
+    return head + '"' + "a" * (budgeted_len - len(head) - 1) + '"'
+
+
+def _skill_md(desc, name="budget-skill"):
+    return f"---\nname: {name}\ndescription: {desc}\n---\n\n# Budget Skill\n\nStep 1.\n"
+
+
+def _skill_on_disk(tmp_path, name="budget-skill"):
+    """Materialize a valid skill so disk-state checks pass and payload
+    validation is what decides the outcome."""
+    skill = tmp_path / name
+    skill.mkdir(parents=True, exist_ok=True)
+    (skill / "SKILL.md").write_text(
+        _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT), name=name), encoding="utf-8"
+    )
+    return skill
+
+
+class TestStagedWritePreflight:
+    """An invalid write payload must be rejected before it is staged.
+
+    Staging defers the real write — and the validation inside the action
+    handlers — to approval replay, so validation that only runs there surfaces
+    the failure after the user already reviewed and approved the pending
+    record.
+    """
+
+    def test_over_budget_description_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        over = _desc_of_length(SKILL_PROMPT_DESC_LIMIT + 1)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result.get("success") is False, result
+            assert result.get("staged") is not True
+            assert wa.pending_count(wa.SKILLS) == 0
+            # The rejection must name the real count, the limit, and the fix.
+            error = result["error"]
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 1} chars" in error
+            assert f"{SKILL_PROMPT_DESC_LIMIT}-char system-prompt budget" in error
+            assert "Move detail into the skill body." in error
+
+    def test_at_budget_description_stages_normally(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        at_limit = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(at_limit),
+            ))
+            assert result["staged"] is True, result
+            assert result["pending_id"]
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_edit_over_budget_still_stages(self, tmp_path, monkeypatch):
+        """The 60-char rule is create-only, so edit must keep staging —
+        otherwise existing over-limit skills become uneditable."""
+        from tools import write_approval as wa
+        over = _desc_of_length(SKILL_PROMPT_DESC_LIMIT + 40)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="edit", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_patch_merged_result_is_not_preflighted(self, tmp_path, monkeypatch):
+        """A patch's merged result does not exist until replay, so approval-time
+        validation stays its only checkpoint — even for a patch that will break
+        the frontmatter once applied."""
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill",
+                old_string="name: budget-skill", new_string="",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_patch_on_missing_skill_still_stages(self, tmp_path, monkeypatch):
+        """Whether the skill exists is disk state, which can change between
+        staging and approval — so it stays a replay-time check."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill",
+                old_string="Step 1.", new_string="Step 2.",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_missing_content_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(action="create", name="budget-skill"))
+            assert result.get("success") is False, result
+            assert "content is required for 'create'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_invalid_category_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        ok = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(ok),
+                category="../escape",
+            ))
+            assert result.get("success") is False, result
+            assert "Invalid category '../escape'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_malformed_frontmatter_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content="# No frontmatter\n",
+            ))
+            assert result.get("success") is False, result
+            assert "must start with YAML frontmatter" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_gate_off_writes_through_unchanged(self, tmp_path, monkeypatch):
+        """With the gate off nothing stages and the create still lands."""
+        from tools import write_approval as wa
+        ok = _desc_of_length(SKILL_PROMPT_DESC_LIMIT)
+        with _approval_home(monkeypatch, False), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(ok),
+            ))
+            assert result["success"] is True, result
+            assert result.get("staged") is not True
+            assert wa.pending_count(wa.SKILLS) == 0
+        assert (tmp_path / "budget-skill" / "SKILL.md").exists()
+
+    def test_reported_count_is_the_measured_count(self, tmp_path, monkeypatch):
+        """The budget is applied to the quote-stripped description, so the
+        rejection must report that length — not the raw parsed one."""
+        over = _desc_with_quoted_tail(SKILL_PROMPT_DESC_LIMIT + 1)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="create", name="budget-skill", content=_skill_md(over),
+            ))
+            assert result.get("success") is False, result
+            error = result["error"]
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 1} chars" in error
+            assert f"Description is {SKILL_PROMPT_DESC_LIMIT + 2} chars" not in error
+
+    def test_patch_params_are_preflighted(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill", new_string="Step 2.",
+            ))
+            assert result.get("success") is False, result
+            assert "old_string is required for 'patch'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_patch_file_path_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill", file_path="../escape.md",
+                old_string="Step 1.", new_string="Step 2.",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="../escape.md", file_content="pwned\n",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_over_byte_limit_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        from tools.skill_manager_tool import MAX_SKILL_FILE_BYTES
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="references/big.md", file_content="a" * (MAX_SKILL_FILE_BYTES + 1),
+            ))
+            assert result.get("success") is False, result
+            assert "1 MiB" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_missing_content_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill", file_path="references/a.md",
+            ))
+            assert result.get("success") is False, result
+            assert "file_content is required for 'write_file'" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_write_file_empty_content_still_stages(self, tmp_path, monkeypatch):
+        """An empty supporting file is a legal write, so the preflight must not
+        be stricter than the handler it stands in for."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="write_file", name="budget-skill",
+                file_path="references/a.md", file_content="",
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_remove_file_traversal_is_not_staged(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="remove_file", name="budget-skill", file_path="../escape.md",
+            ))
+            assert result.get("success") is False, result
+            assert "Path traversal" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
+    def test_delete_stages_without_preflight(self, tmp_path, monkeypatch):
+        """Delete carries no payload beyond the name, whose existence is disk
+        state — nothing to preflight."""
+        from tools import write_approval as wa
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(action="delete", name="budget-skill"))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    @pytest.mark.parametrize("kwargs", [
+        pytest.param(
+            {"action": "create", "content": _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT + 1))},
+            id="create-over-budget",
+        ),
+        pytest.param({"action": "create"}, id="create-missing-content"),
+        pytest.param(
+            {"action": "create", "content": _skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT)),
+             "category": "../escape"},
+            id="create-bad-category",
+        ),
+        pytest.param(
+            {"action": "patch", "new_string": "Step 2."}, id="patch-missing-old-string",
+        ),
+        pytest.param(
+            {"action": "patch", "file_path": "../escape.md",
+             "old_string": "Step 1.", "new_string": "Step 2."},
+            id="patch-traversal",
+        ),
+        pytest.param(
+            {"action": "write_file", "file_path": "../escape.md", "file_content": "x"},
+            id="write-file-traversal",
+        ),
+        pytest.param(
+            {"action": "write_file", "file_path": "notes/a.md", "file_content": "x"},
+            id="write-file-bad-subdir",
+        ),
+        pytest.param({"action": "write_file", "file_path": "references/a.md"},
+                     id="write-file-missing-content"),
+        pytest.param({"action": "remove_file", "file_path": "../escape.md"},
+                     id="remove-file-traversal"),
+    ])
+    def test_gated_and_ungated_rejections_are_identical(self, tmp_path, monkeypatch, kwargs):
+        """The preflight must be the gate-off path's validation, not a parallel
+        copy of it: the same payload has to produce the same error either way.
+
+        Divergence is the real hazard here — a preflight that is stricter than
+        replay rejects writes approval would have accepted, and one that is
+        laxer re-introduces the round trip this exists to remove.
+        """
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            gated = json.loads(skill_manage(name="budget-skill", **kwargs))
+        with _approval_home(monkeypatch, False), _skill_dir(tmp_path):
+            ungated = json.loads(skill_manage(name="budget-skill", **kwargs))
+
+        assert gated.get("success") is False, gated
+        assert gated.get("staged") is not True, gated
+        assert ungated.get("success") is False, ungated
+        assert gated["error"] == ungated["error"]

--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -1329,6 +1329,31 @@ class TestStagedWritePreflight:
             assert result["staged"] is True, result
             assert wa.pending_count(wa.SKILLS) == 1
 
+    def test_full_rewrite_patch_stages(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        _skill_on_disk(tmp_path)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage(
+                action="patch", name="budget-skill",
+                content=_skill_md(_desc_of_length(SKILL_PROMPT_DESC_LIMIT)),
+            ))
+            assert result["staged"] is True, result
+            assert wa.pending_count(wa.SKILLS) == 1
+
+    def test_batch_rejects_invalid_create_before_staging(self, tmp_path, monkeypatch):
+        from tools import write_approval as wa
+        over = _desc_of_length(SKILL_PROMPT_DESC_LIMIT + 1)
+        with _approval_home(monkeypatch, True), _skill_dir(tmp_path):
+            result = json.loads(skill_manage("", "", operations=[{
+                "action": "create",
+                "name": "budget-skill",
+                "content": _skill_md(over),
+            }]))
+            assert result.get("success") is False, result
+            assert result.get("staged") is not True
+            assert "operations[0]" in result["error"]
+            assert wa.pending_count(wa.SKILLS) == 0
+
     def test_missing_content_is_not_staged(self, tmp_path, monkeypatch):
         from tools import write_approval as wa
         with _approval_home(monkeypatch, True), _skill_dir(tmp_path):

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -1564,10 +1564,16 @@ _REQUIRED_PARAM_ERRORS = {
         "content": "content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).",
     },
     "edit": {
-        "content": "content is required for 'edit'. Provide the full updated SKILL.md text.",
+        "content": "content is required for a full rewrite. Provide the full updated SKILL.md text.",
     },
     "patch": {
-        "old_string": "old_string is required for 'patch'. Provide the text to find.",
+        "old_string": (
+            "old_string is required for 'patch' and must be the EXACT text currently in the "
+            "file. Read the target file first (read_file on the skill's SKILL.md, or the file "
+            "named by file_path) and copy the snippet verbatim, then retry 'patch'. "
+            "Do NOT fall back to action='write_file' — that rewrites the entire file and "
+            "destroys unrelated content."
+        ),
         "new_string": "new_string is required for 'patch'. Use empty string to delete matched text.",
     },
     "write_file": {
@@ -1614,6 +1620,13 @@ def _preflight_staged_skill_write(action: str, name: str, payload: Dict[str, Any
         )
 
     if action == "patch":
+        if content:
+            if payload.get("old_string") or payload.get("new_string") is not None:
+                return (
+                    "Pass EITHER content (full SKILL.md rewrite) OR "
+                    "old_string/new_string (targeted replacement), not both."
+                )
+            return _validate_frontmatter(content) or _validate_content_size(content)
         if not payload.get("old_string"):
             return required["old_string"]
         if payload.get("new_string") is None:
@@ -1838,6 +1851,10 @@ def _skill_manage_batch(
             if decision.blocked:
                 return tool_error(decision.message, success=False)
             if not decision.allow:
+                for i, op in enumerate(operations):
+                    err = _preflight_staged_skill_write(op["action"], names[i], op)
+                    if err:
+                        return tool_error(f"operations[{i}]: {err}", success=False)
                 payload = {"action": "batch", "operations": operations}
                 acts = ", ".join(op["action"] for op in operations)
                 skills = ", ".join(sorted(set(names)))

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -652,9 +652,10 @@ def _validate_frontmatter(content: str, *, new_skill: bool = False) -> Optional[
     desc = str(parsed["description"])
     if len(desc) > MAX_DESCRIPTION_LENGTH:
         return f"Description exceeds {MAX_DESCRIPTION_LENGTH} characters."
-    if new_skill and len(desc.strip().strip("'\"")) > SKILL_PROMPT_DESC_LIMIT:
+    budgeted_desc = desc.strip().strip("'\"")
+    if new_skill and len(budgeted_desc) > SKILL_PROMPT_DESC_LIMIT:
         return (
-            f"Description is {len(desc.strip())} chars — new skills must fit the "
+            f"Description is {len(budgeted_desc)} chars — new skills must fit the "
             f"{SKILL_PROMPT_DESC_LIMIT}-char system-prompt budget (one sentence, "
             f"trigger first, ends with a period). The skill index truncates "
             f"longer descriptions to {SKILL_PROMPT_DESC_LIMIT - 3} chars + '...', "
@@ -679,6 +680,21 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
             f"(limit: {MAX_SKILL_CONTENT_CHARS:,}). "
             f"Consider splitting into a smaller SKILL.md with supporting files "
             f"in references/ or templates/."
+        )
+    return None
+
+
+def _validate_file_bytes(file_content: str) -> Optional[str]:
+    """Check a supporting file's encoded size against the per-file byte limit.
+
+    Returns an error message or None if within bounds.
+    """
+    content_bytes = len(file_content.encode("utf-8"))
+    if content_bytes > MAX_SKILL_FILE_BYTES:
+        return (
+            f"File content is {content_bytes:,} bytes "
+            f"(limit: {MAX_SKILL_FILE_BYTES:,} bytes / 1 MiB). "
+            f"Consider splitting into smaller files."
         )
     return None
 
@@ -1423,17 +1439,9 @@ def _write_file(name: str, file_path: str, file_content: str) -> Dict[str, Any]:
     if not file_content and file_content != "":
         return {"success": False, "error": "file_content is required."}
 
-    # Check size limits
-    content_bytes = len(file_content.encode("utf-8"))
-    if content_bytes > MAX_SKILL_FILE_BYTES:
-        return {
-            "success": False,
-            "error": (
-                f"File content is {content_bytes:,} bytes "
-                f"(limit: {MAX_SKILL_FILE_BYTES:,} bytes / 1 MiB). "
-                f"Consider splitting into smaller files."
-            ),
-        }
+    err = _validate_file_bytes(file_content)
+    if err:
+        return {"success": False, "error": err}
     err = _validate_content_size(file_content, label=file_path)
     if err:
         return {"success": False, "error": err}
@@ -1549,6 +1557,92 @@ _skill_gate_bypass: "_ctxvars.ContextVar[bool]" = _ctxvars.ContextVar(
 )
 
 
+# Missing-parameter messages, shared by skill_manage() and the staging preflight
+# so a gated write and an ungated one reject an incomplete payload identically.
+_REQUIRED_PARAM_ERRORS = {
+    "create": {
+        "content": "content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).",
+    },
+    "edit": {
+        "content": "content is required for 'edit'. Provide the full updated SKILL.md text.",
+    },
+    "patch": {
+        "old_string": "old_string is required for 'patch'. Provide the text to find.",
+        "new_string": "new_string is required for 'patch'. Use empty string to delete matched text.",
+    },
+    "write_file": {
+        "file_path": "file_path is required for 'write_file'. Example: 'references/api-guide.md'",
+        "file_content": "file_content is required for 'write_file'.",
+    },
+    "remove_file": {
+        "file_path": "file_path is required for 'remove_file'.",
+    },
+}
+
+
+def _preflight_staged_skill_write(action: str, name: str, payload: Dict[str, Any]) -> Optional[str]:
+    """Validate what is checkable about a write payload before it becomes pending.
+
+    Staging defers the real write — and with it every validation inside the
+    action handlers — until approval replay, so without this an invalid payload
+    sits in the pending queue and fails only after the user has reviewed and
+    approved it. Call the same validators the handlers call, not copies, so the
+    staged and replayed paths can never disagree, and run them in the handlers'
+    order so both paths report the same error for the same payload.
+
+    Only payload-intrinsic checks belong here. Anything that depends on the
+    state of the skill on disk — name collisions, the skill existing, the org
+    mirror and background-review guards, the security scan, and a patch's
+    merged result — stays a replay-time check: the disk can change between
+    staging and approval, so replay is the only correct place to evaluate it.
+    """
+    required = _REQUIRED_PARAM_ERRORS.get(action, {})
+    content = payload.get("content")
+    file_path = payload.get("file_path")
+    file_content = payload.get("file_content")
+
+    if action in ("create", "edit"):
+        if not content:
+            return required["content"]
+        if action == "create":
+            err = _validate_name(name) or _validate_category(payload.get("category"))
+            if err:
+                return err
+        return (
+            _validate_frontmatter(content, new_skill=(action == "create"))
+            or _validate_content_size(content)
+        )
+
+    if action == "patch":
+        if not payload.get("old_string"):
+            return required["old_string"]
+        if payload.get("new_string") is None:
+            return required["new_string"]
+        # Only the addressing is checkable: the merged result does not exist
+        # until replay, so _patch_skill stays the sole checkpoint for it.
+        return _validate_file_path(file_path) if file_path else None
+
+    if action == "write_file":
+        if not file_path:
+            return required["file_path"]
+        if file_content is None:
+            return required["file_content"]
+        return (
+            _validate_file_path(file_path)
+            or _validate_file_bytes(file_content)
+            or _validate_content_size(file_content, label=file_path)
+        )
+
+    if action == "remove_file":
+        if not file_path:
+            return required["file_path"]
+        return _validate_file_path(file_path)
+
+    # 'delete' carries no payload beyond the skill name, whose existence is a
+    # disk check.
+    return None
+
+
 def _apply_skill_write_gate(action, name, **payload_kwargs):
     """Evaluate the skill write gate. Returns a JSON tool-result string when the
     write should NOT proceed (blocked or staged), or None to perform the real
@@ -1569,6 +1663,10 @@ def _apply_skill_write_gate(action, name, **payload_kwargs):
         return None
     if decision.blocked:
         return tool_error(decision.message, success=False)
+
+    err = _preflight_staged_skill_write(action, name, payload_kwargs)
+    if err:
+        return tool_error(err, success=False)
 
     # stage — record the full skill_manage kwargs so approval can replay it.
     payload = {"action": action, "name": name}
@@ -2001,7 +2099,7 @@ def skill_manage(
 
     if action == "create":
         if not content:
-            return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["create"]["content"], success=False)
         result = _create_skill(name, content, category)
 
     elif action == "edit":
@@ -2034,14 +2132,14 @@ def skill_manage(
 
     elif action == "write_file":
         if not file_path:
-            return tool_error("file_path is required for 'write_file'. Example: 'references/api-guide.md'", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["write_file"]["file_path"], success=False)
         if file_content is None:
-            return tool_error("file_content is required for 'write_file'.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["write_file"]["file_content"], success=False)
         result = _write_file(name, file_path, file_content)
 
     elif action == "remove_file":
         if not file_path:
-            return tool_error("file_path is required for 'remove_file'.", success=False)
+            return tool_error(_REQUIRED_PARAM_ERRORS["remove_file"]["file_path"], success=False)
         result = _remove_file(name, file_path)
 
     else:


### PR DESCRIPTION
## What changed

- Validate payload-intrinsic `skill_manage` constraints before a write enters the pending approval queue.
- Keep disk/state-dependent checks at approval replay, where they remain authoritative.
- Cover current single-write, full-rewrite patch, and atomic batch shapes.
- Preserve the same actionable errors on gated and ungated paths.

## Why

With `skills.write_approval: true`, malformed or over-budget writes could be staged successfully and fail only after the user reviewed and approved them. That creates a guaranteed extra review round trip for payloads that were already known to be invalid.

This rematerializes #77325 on current `main`. The original implementation commit and authorship by @OU9999 are preserved; the second commit adapts it to the current batch/full-rewrite API. It addresses the validation gap described in #78519 (and its duplicate #94372).

## Validation

- Targeted suite passed before the final no-overlap rebase: `tests/tools/test_skill_manager_tool.py`, `tests/tools/test_skill_manage_batch.py`, and `tests/tools/test_write_approval.py` — 116 passed.
- Sabotage check: bypassing preflight makes the new over-budget staging regression test fail.
- Post-rebase `git range-diff` reports both commits unchanged; intervening upstream commits touched none of this PR's files.
- Post-rebase `ruff`, `py_compile`, and `git diff --check` pass.
- Manual isolated-`HERMES_HOME` acceptance verified: invalid single and batch writes create no pending record, while a valid create stages exactly once.

**Platform tested:** Linux, Python 3.11.
