### PR TITLE
fix(gateway): disarm the startup watchdog when `gateway run` hands off to s6

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8474,6 +8474,22 @@ def _maybe_redirect_run_to_s6_supervision(args) -> bool:
         return False
     if not _dispatch_via_service_manager_if_s6("start"):
         return False
+    # The supervised child owns the gateway from here; this process will
+    # never reach a GatewayRunner, so the startup-liveness watchdog armed
+    # by hermes_cli.main's argv fast-path (argv IS `gateway run`) has no
+    # disarm site left. On the execvp path that is academic — the image
+    # swap takes the watchdog thread with it — but the #36208 fallback
+    # parks in _block_until_terminated() with ~zero CPU and no progress
+    # lease, which is precisely the parked-deadlock signature: the
+    # watchdog fires on schedule and os._exit(75)s the container's CMD
+    # process, killing a container whose supervised gateway is healthy.
+    # Disarm at the handoff, before either heartbeat.
+    try:
+        from hermes_startup_watchdog import disarm_startup_watchdog
+
+        disarm_startup_watchdog()
+    except Exception:
+        pass
     # Loud breadcrumb: explain the upgrade and how to opt out. Print to
     # stderr so it doesn't pollute stdout-parsing scripts. The
     # supervised gateway's own logs are routed by s6-log to both

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -152,5 +152,105 @@ def test_redirect_falls_back_when_sleep_missing(
     assert "`sleep` is unavailable" in err
 
 
+def _arm_for_redirect(monkeypatch: pytest.MonkeyPatch):
+    """Arm the real startup watchdog the way the argv fast-path does.
+
+    ``hermes_cli.main`` arms whenever argv carries the adjacent tokens
+    ``gateway run`` — which is exactly the invocation the s6 redirect
+    intercepts. A long timeout keeps the deadline out of the test's way:
+    what is under test is the handle's state at handoff, not the timer.
+    """
+    import hermes_startup_watchdog as sw
+
+    monkeypatch.delenv(sw.ENV_STARTUP_WATCHDOG, raising=False)
+    monkeypatch.delenv(sw.ENV_STARTUP_WATCHDOG_TIMEOUT_S, raising=False)
+    sw._reset_for_tests()
+    handle = sw.arm_startup_watchdog(timeout_s=3600)
+    assert handle is not None and handle.is_alive()
+    return sw, handle
+
+
+def test_redirect_disarms_startup_watchdog_before_parking(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The #36208 in-process heartbeat must not park under an armed
+    startup watchdog.
+
+    The CMD process arms the OOF-298 watchdog (its argv is ``gateway
+    run``) and then hands the gateway to s6 — it never reaches a
+    GatewayRunner, so nothing downstream disarms. Parked on
+    ``signal.pause()`` it burns ~zero CPU and holds no progress lease,
+    reading exactly like the wedged startup the watchdog exists to kill:
+    it would ``os._exit(75)`` the container's main process on schedule
+    while the supervised gateway is perfectly healthy.
+    """
+    from hermes_cli import gateway as gw
+
+    sw, handle = _arm_for_redirect(monkeypatch)
+    try:
+        _stub_s6(monkeypatch, on_s6=True)
+        monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+
+        def missing_sleep(file: str, args: list[str]) -> None:
+            raise FileNotFoundError(2, "No such file or directory", file)
+
+        monkeypatch.setattr("hermes_cli.gateway.os.execvp", missing_sleep)
+        disarmed_at_park: list[bool] = []
+        monkeypatch.setattr(
+            "hermes_cli.gateway._block_until_terminated",
+            lambda: disarmed_at_park.append(handle.disarmed),
+        )
+
+        assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is True
+
+        assert disarmed_at_park == [True], (
+            "the CMD process parked forever with the startup watchdog still "
+            "armed — it will be hard-exited with code 75"
+        )
+        # The singleton is cleared too, so a later arm site cannot revive
+        # this handle's deadline.
+        assert sw._handle is None
+        # And the timer thread actually stands down rather than lingering.
+        handle.join(timeout=5)
+        assert not handle.is_alive()
+    finally:
+        sw._reset_for_tests()
+    capsys.readouterr()
+
+
+def test_redirect_disarms_startup_watchdog_before_exec(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same handoff, the normal ``sleep infinity`` path.
+
+    The exec replaces the process image (watchdog thread included), so
+    this arm is not a live hazard — but the disarm belongs to the
+    handoff, not to one of its two heartbeats. Pinning it here keeps a
+    future third heartbeat from inheriting the parked-process bug.
+    """
+    from hermes_cli import gateway as gw
+
+    sw, handle = _arm_for_redirect(monkeypatch)
+    try:
+        _stub_s6(monkeypatch, on_s6=True)
+        monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+        disarmed_at_exec: list[bool] = []
+        monkeypatch.setattr(
+            "hermes_cli.gateway.os.execvp",
+            lambda file, args: disarmed_at_exec.append(handle.disarmed),
+        )
+
+        assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is True
+
+        assert disarmed_at_exec == [True]
+    finally:
+        sw._reset_for_tests()
+    capsys.readouterr()
+
+
 
 


### PR DESCRIPTION
## Summary

`docker run <image> gateway run` arms the OOF-298 startup-liveness watchdog in `hermes_cli.main`'s argv fast-path — argv literally carries the adjacent `gateway run` tokens — and then `_maybe_redirect_run_to_s6_supervision()` hands the real gateway to s6 and keeps the CMD process alive as a heartbeat. That process never reaches a `GatewayRunner`, so the only production disarm site (`GatewayRunner.start()`) is unreachable for it.

On the `os.execvp("sleep", ...)` path the image swap takes the watchdog thread with it, so the leak is invisible. On the #36208 fallback it is fatal: `_block_until_terminated()` parks on `signal.pause()` with ~zero CPU and no progress lease — the exact parked-deadlock signature the watchdog exists to kill — so it fires on schedule and `os._exit(75)`s the container's main process. `/init` then tears the container down every deadline while the supervised gateway underneath is perfectly healthy, and the forensic record blames a startup that finished minutes earlier.

The fix disarms at the handoff, before either heartbeat: once s6 owns the gateway, this process has no pre-loop window left to cover.

Reproduced directly against the shipped module — arm exactly as the fast-path does, then run the verbatim body of `_block_until_terminated()`:

```
$ HERMES_STARTUP_WATCHDOG_TIMEOUT_S=30 python3 probe.py
Gateway startup did not reach a live event loop within 30s (elapsed 30s,
0 extension(s)), holds no progress lease and shows no CPU progress; ...
exiting with code 75 ... (OOF-298).
EXIT=75
```

Found while investigating #102000. It does **not** explain that report — the disarm site that issue describes as missing is present and identical in both builds it names (`gateway/run.py`, `disarm_startup_watchdog()` inside `GatewayRunner.start()`; `git diff 593aa74c e629c900` touches no watchdog code, and that reporter's firing record carries `state_db_data_migrations` leases the CMD process can never take). This is a sibling leak in the same class, reachable on any s6 image where `sleep` is not on `PATH`.

## Test plan

- `scripts/run_tests.sh tests/hermes_cli/test_gateway_s6_dispatch.py tests/gateway/test_startup_watchdog.py tests/hermes_cli/test_gateway_external_supervisor.py -q` → 63 passed.
- Both new tests fail on the unfixed handoff (`disarmed_at_park == [True]` / `disarmed_at_exec == [True]` assert False) and pass with it.
- The new tests arm the real watchdog rather than a mock, and additionally assert the singleton is cleared and the timer thread stands down, so a disarm that only flips state without releasing the handle would still fail.
- Pre-existing unrelated failure on this machine, present on a clean `main` too: `tests/hermes_cli/test_gateway.py::test_gateway_run_subprocess_preserves_daemon_exit_codes[True-systemexit:75-75]`.