### PR TITLE
fix(acp): honor configured agent.max_turns in ACP sessions

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -644,6 +644,18 @@ class SessionManager:
             "model": model or default_model,
         }
 
+        # Honor agent.max_turns from config.yaml the way the CLI does. Without
+        # this, ACP sessions ignored the configured cap entirely and rode the
+        # AIAgent constructor default instead (90 before, sys.maxsize now).
+        try:
+            from hermes_cli.config import resolve_turn_limit
+
+            kwargs["max_iterations"] = resolve_turn_limit(
+                (config.get("agent") or {}).get("max_turns")
+            )
+        except Exception:
+            pass  # fall back to the AIAgent default
+
         try:
             runtime = resolve_runtime_provider(requested=requested_provider or config_provider)
             kwargs.update(

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -110,6 +110,45 @@ class TestCreateSession:
 
         assert state.agent.session_cwd == "/tmp/project"
 
+    def test_make_agent_honors_configured_agent_max_turns(self, monkeypatch):
+        """ACP sessions must obey config agent.max_turns, not the AIAgent default.
+
+        Regression: the ACP agent factory never read agent.max_turns, so ACP
+        sessions silently ignored a configured cap that CLI and gateway
+        sessions both honor.
+        """
+        captured = {}
+
+        class FakeAgent:
+            model = "fake-model"
+
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        config = {
+            "model": {"default": "fake-model", "provider": "fake-provider"},
+            "mcp_servers": {},
+            "agent": {"max_turns": 1234},
+        }
+
+        monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+        monkeypatch.setattr("acp_adapter.session.load_config", lambda: config, raising=False)
+        monkeypatch.setattr("hermes_cli.config.load_config", lambda: config)
+        monkeypatch.setattr(
+            "hermes_cli.runtime_provider.resolve_runtime_provider",
+            lambda requested=None: {
+                "provider": requested,
+                "api_mode": "chat_completions",
+                "base_url": "https://example.invalid",
+                "api_key": "test-key",
+            },
+        )
+        monkeypatch.setattr("acp_adapter.session._register_task_cwd", lambda task_id, cwd: None)
+
+        SessionManager(db=None).create_session(cwd="/tmp/project")
+
+        assert captured.get("max_iterations") == 1234
+
 
 
 


### PR DESCRIPTION
The ACP agent factory (`SessionManager._make_agent`) constructs `AIAgent` without ever reading `agent.max_turns`, so **ACP sessions silently ignore the configured iteration cap** that the CLI and gateway both honor.

## Symptom

With `agent.max_turns: 2000` in `config.yaml`, an ACP session (Zed / IDE integration) still stopped mid-task at the `AIAgent` constructor default, reporting:

> Youʼve reached the maximum number of tool-calling iterations allowed.

The same config on the CLI or gateway behaved correctly. Since c32119b12c flipped the constructor default to unlimited, the user-visible shape changed but the bug did not: an *explicit finite* `agent.max_turns` is still unenforceable on ACP, so the setting is simply inert on that platform.

## Where it manifests

Both other construction paths resolve the config value; ACP is the only one that does not:

| Path | Reads `agent.max_turns`? |
|---|---|
| CLI — `hermes_cli/cli_agent_setup_mixin.py` (`max_iterations=self.max_turns`) | yes |
| Gateway — `gateway/run.py` (`_bridge_max_turns_from_config` → `HERMES_MAX_ITERATIONS`) | yes |
| **ACP — `acp_adapter/session.py` `_make_agent`** | **no** |

## Fix

Resolve the configured value through the existing `resolve_turn_limit()` helper and pass it as `max_iterations`, so ACP matches CLI parsing exactly — including the `inf` / `infinity` / `null` / `none` / `0` / `-1` unlimited spellings. Wrapped in a fail-open `try` so a malformed config falls back to the `AIAgent` default rather than breaking session creation.

## Test

`test_make_agent_honors_configured_agent_max_turns` captures the kwargs the factory passes to `AIAgent` and asserts the configured `1234` arrives as `max_iterations`. Verified RED/GREEN — the test fails on `main` without the one-hunk fix and passes with it.

```
tests/acp/ tests/acp_adapter/ ....... 152 passed
```

Authored-by: Terminus (AI Assistant)
