### PR TITLE
Finished subagents release their transcripts from the parent heap; subagent transcripts skip the trigram FTS index (schema v30)

### DIFF
--- a/agent/subagent_lifecycle.py
+++ b/agent/subagent_lifecycle.py
@@ -17,6 +17,7 @@ import math
 import secrets
 import threading
 import time
+import weakref
 from contextlib import contextmanager
 from concurrent.futures import Future, TimeoutError
 from typing import Any, Callable, Mapping, Optional
@@ -171,8 +172,19 @@ _ACTIVE_PARENT_AGENT: contextvars.ContextVar[Any] = contextvars.ContextVar(
 
 @contextmanager
 def bind_subagent_parent(parent_agent: Any):
-    """Bind the host-owned parent for the current agent turn."""
-    token = _ACTIVE_PARENT_AGENT.set(parent_agent)
+    """Bind the host-owned parent for the current agent turn.
+
+    Stored as a weakref: every asyncio Handle/Future scheduled from the turn
+    (LSP reader loops, kernel pipes, ...) snapshots the Context, and those
+    snapshots outlive the turn. A strong ref there pinned finished delegate
+    children — each of which binds itself here for its own turn — in the
+    parent process heap for the life of the background loop.
+    """
+    try:
+        ref = weakref.ref(parent_agent)
+    except TypeError:
+        ref = lambda: parent_agent  # noqa: E731 — non-weakrefable test doubles
+    token = _ACTIVE_PARENT_AGENT.set(ref)
     try:
         yield
     finally:
@@ -181,7 +193,8 @@ def bind_subagent_parent(parent_agent: Any):
 
 def get_active_subagent_parent() -> Any:
     """Return the parent bound to this execution context, if any."""
-    return _ACTIVE_PARENT_AGENT.get()
+    ref = _ACTIVE_PARENT_AGENT.get()
+    return ref() if ref is not None else None
 
 
 class SubagentLifecycleService:

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -354,7 +354,7 @@ def _sql_session_last_active_by_id(session_id_expr: str) -> str:
     )
 
 
-SCHEMA_VERSION = 29
+SCHEMA_VERSION = 30
 
 
 # FTS storage-layout version, tracked INDEPENDENTLY of SCHEMA_VERSION in the
@@ -782,12 +782,40 @@ END;
 # LIKE for the same reason. Structured ``tool_calls`` JSON likewise stays
 # searchable through ``messages_fts``; excluding it here avoids indexing
 # repetitive JSON syntax as trigrams (FTS_STORAGE_VERSION 2).
-FTS_TRIGRAM_SQL = """
+#
+# Delegate-child (subagent) transcripts are excluded the same way (v30):
+# on a fan-out-heavy install they were ~70% of all message bytes and
+# ``session_search`` hides ``source='subagent'`` sessions anyway. A child
+# is recognised by its source OR by the ``_delegate_from`` creation marker
+# (children spawned under a gateway turn inherit the gateway's source).
+# Compression/branch continuations of interactive sessions also carry
+# ``parent_session_id`` but NOT the marker, so they stay trigram-indexed.
+FTS_TRIGRAM_EXCLUDED_SOURCES = ("cron", "subagent")
+
+# Predicate over a ``sessions`` row (unqualified column names) selecting
+# sessions whose rows belong in the trigram index. Shared by the view, the
+# sync triggers, and the deferred-backfill INSERT ... SELECTs so they can
+# never disagree about the index boundary.
+FTS_TRIGRAM_SESSION_SQL = (
+    "source NOT IN ("
+    + ", ".join(f"'{src}'" for src in FTS_TRIGRAM_EXCLUDED_SOURCES)
+    + ") AND json_extract(COALESCE(model_config, '{}'), '$._delegate_from') IS NULL"
+)
+
+
+def fts_trigram_session_sql(alias: str) -> str:
+    """``FTS_TRIGRAM_SESSION_SQL`` with every column qualified by ``alias``."""
+    return FTS_TRIGRAM_SESSION_SQL.replace("source ", f"{alias}.source ").replace(
+        "COALESCE(model_config", f"COALESCE({alias}.model_config"
+    )
+
+
+FTS_TRIGRAM_SQL = f"""
 CREATE VIEW IF NOT EXISTS messages_fts_trigram_src AS
     SELECT m.id, m.role, m.content, m.tool_name
     FROM messages AS m
     JOIN sessions AS s ON s.id = m.session_id
-    WHERE m.role <> 'tool' AND s.source <> 'cron';
+    WHERE m.role <> 'tool' AND {fts_trigram_session_sql('s')};
 
 CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
     content,
@@ -800,7 +828,7 @@ CREATE VIRTUAL TABLE IF NOT EXISTS messages_fts_trigram USING fts5(
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_insert AFTER INSERT ON messages
 WHEN new.role <> 'tool'
    AND EXISTS (SELECT 1 FROM sessions
-               WHERE id = new.session_id AND source <> 'cron')
+               WHERE id = new.session_id AND {FTS_TRIGRAM_SESSION_SQL})
    AND (new.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                            WHERE key = 'fts_rebuild_high_water'), -1)
      OR new.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
@@ -813,7 +841,7 @@ END;
 CREATE TRIGGER IF NOT EXISTS messages_fts_trigram_delete AFTER DELETE ON messages
 WHEN old.role <> 'tool'
    AND EXISTS (SELECT 1 FROM sessions
-               WHERE id = old.session_id AND source <> 'cron')
+               WHERE id = old.session_id AND {FTS_TRIGRAM_SESSION_SQL})
    AND (old.id > COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
                            WHERE key = 'fts_rebuild_high_water'), -1)
      OR old.id <= COALESCE((SELECT CAST(value AS INTEGER) FROM state_meta
@@ -837,12 +865,12 @@ BEGIN
     SELECT 'delete', old.id, old.content, old.tool_name
     WHERE old.role <> 'tool'
       AND EXISTS (SELECT 1 FROM sessions
-                  WHERE id = old.session_id AND source <> 'cron');
+                  WHERE id = old.session_id AND {FTS_TRIGRAM_SESSION_SQL});
     INSERT INTO messages_fts_trigram(rowid, content, tool_name)
     SELECT new.id, new.content, new.tool_name
     WHERE new.role <> 'tool'
       AND EXISTS (SELECT 1 FROM sessions
-                  WHERE id = new.session_id AND source <> 'cron');
+                  WHERE id = new.session_id AND {FTS_TRIGRAM_SESSION_SQL});
 END;
 """
 

--- a/hermes_state_schema.py
+++ b/hermes_state_schema.py
@@ -415,7 +415,10 @@ class SessionSchemaMixin:
             )
 
     def _migrate_trigram_cron_exclusion(self, cursor: sqlite3.Cursor) -> bool:
-        """Install the cron-filtered trigram view and purge historical rows.
+        """Install the source-filtered trigram view and purge historical rows.
+
+        Covers the v29 cron exclusion and the v30 subagent exclusion — both
+        only change the view/trigger predicate and rebuild from it.
 
         Legacy inline indexes remain opt-in: their content is private to the
         virtual table and cannot adopt this external-content view. For an
@@ -1550,11 +1553,11 @@ class SessionSchemaMixin:
                 # rows, but clear migrated rows so future writes do not keep
                 # one large prompt copy per session.
                 self._dedupe_legacy_system_prompts(cursor)
-            if current_version < 29 and fts5_available:
-                # v29 (was v27 in the original PR; main had already reached
-                # v28 with column-reconciliation bumps, so a `< 27` gate would
-                # never fire on existing installs): cron sessions remain canonical and stay in the standard
+            if current_version < 30 and fts5_available:
+                # v29: cron sessions remain canonical and stay in the standard
                 # word index, but no longer inflate the trigram substring index.
+                # v30: delegate-child (subagent) transcripts get the same
+                # treatment (FTS_TRIGRAM_EXCLUDED_SOURCES + _delegate_from).
                 # Rebuild once so rows indexed by older trigger/view definitions
                 # do not survive indefinitely as stale matches and disk usage.
                 if not self._migrate_trigram_cron_exclusion(cursor):

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -24,7 +24,9 @@ from hermes_state_common import (
     FTS_STORAGE_VERSION,
     FTS_TOOL_CONTENT_PREFIX_CHARS,
     FTS_TOOL_FULL_CONTENT_HIGH_WATER_KEY,
+    FTS_TRIGRAM_EXCLUDED_SOURCES,
     FTS_TRIGRAM_SQL,
+    fts_trigram_session_sql,
     MAX_FTS5_QUERY_CHARS,
     SCHEMA_VERSION,
     _FTS_CJK_TRIGGERS,
@@ -169,7 +171,7 @@ class SessionSearchMixin:
                         "SELECT m.id, m.content, m.tool_name "
                         "FROM messages m JOIN sessions s ON s.id = m.session_id "
                         "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
-                        "AND s.source <> 'cron' "
+                        f"AND {fts_trigram_session_sql('s')} "
                         "AND NOT EXISTS (SELECT 1 FROM messages_fts_trigram_docsize d WHERE d.id = m.id)",
                         (lo, hi),
                     )
@@ -329,7 +331,7 @@ class SessionSearchMixin:
                     "SELECT m.id, m.content, m.tool_name "
                     "FROM messages m JOIN sessions s ON s.id = m.session_id "
                     "WHERE m.id > ? AND m.id <= ? AND m.role <> 'tool' "
-                    "AND s.source <> 'cron'",
+                    f"AND {fts_trigram_session_sql('s')}",
                     (progress, upper),
                 )
             # Publish progress in the same transaction as the rows it
@@ -1922,7 +1924,12 @@ class SessionSearchMixin:
             # query explicitly filtering on role='tool' must therefore use
             # the LIKE fallback, which scans the base table directly.
             _wants_tool_rows = bool(role_filter) and "tool" in role_filter
-            _wants_cron_rows = bool(source_filter) and "cron" in source_filter
+            # Cron and subagent transcripts are excluded too (see
+            # FTS_TRIGRAM_EXCLUDED_SOURCES); an explicit filter for them
+            # must likewise scan the base table.
+            _wants_cron_rows = bool(source_filter) and any(
+                src in FTS_TRIGRAM_EXCLUDED_SOURCES for src in source_filter
+            )
 
             # ── CJK-bigram route (messages_fts_cjk, cjk_unicode61) ──────
             # When the bigram index is available it serves EVERY CJK query

--- a/run_agent.py
+++ b/run_agent.py
@@ -5176,6 +5176,14 @@ class AIAgent:
         # still holds the closed agent (e.g. a draining background task).
         try:
             self._session_messages = []
+            # Shadow copies of the same transcript: the DB-flush settled-prefix
+            # snapshot (a shallow copy of the whole list, see
+            # _flush_session_to_db) and the streamed-text accumulator. On a
+            # closed delegate child these were the only remaining owners of
+            # every message dict, so a retained child kept its full history
+            # alive in the parent's heap.
+            self._db_flush_scan_prefix = None
+            self._streamed_assistant_text_parts = []
         except Exception:
             pass
 

--- a/tests/state/test_fts_trigram_subagent_exclusion.py
+++ b/tests/state/test_fts_trigram_subagent_exclusion.py
@@ -1,0 +1,161 @@
+"""Delegate-child (subagent) transcripts stay out of the trigram FTS index (v30).
+
+Mirrors ``test_fts_trigram_cron_exclusion.py``: children are canonical rows
+in ``messages`` and stay searchable through the standard ``messages_fts``
+word index; only the trigram (CJK substring) shadow index skips them.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_state import SCHEMA_VERSION, SessionDB
+from hermes_state_common import FTS_TRIGRAM_EXCLUDED_SOURCES, fts_trigram_session_sql
+
+
+@pytest.fixture
+def db(tmp_path):
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    if not session_db._trigram_available:
+        session_db.close()
+        pytest.skip("trigram tokenizer unavailable in this SQLite build")
+    yield session_db
+    session_db.close()
+
+
+def _trigram_rowids(db: SessionDB) -> set[int]:
+    return {
+        row[0]
+        for row in db._conn.execute("SELECT id FROM messages_fts_trigram_docsize").fetchall()
+    }
+
+
+def _fts_rowids(db: SessionDB) -> set[int]:
+    return {
+        row[0] for row in db._conn.execute("SELECT id FROM messages_fts_docsize").fetchall()
+    }
+
+
+def _seed(db: SessionDB) -> dict[str, int]:
+    db.create_session("root", source="cli")
+    # delegate_tool children: source='subagent' via platform, plus the
+    # _delegate_from creation marker.
+    db.create_session(
+        "kid", source="subagent", parent_session_id="root",
+        model_config={"_delegate_from": "root"},
+    )
+    # A child spawned under a gateway turn inherits the gateway's source but
+    # still carries the marker.
+    db.create_session(
+        "gw-kid", source="telegram", parent_session_id="root",
+        model_config={"_delegate_from": "root"},
+    )
+    # Compression continuation: parent_session_id but NO marker -> indexed.
+    db.create_session("cont", source="cli", parent_session_id="root")
+    return {
+        "root": db.append_message("root", role="user", content="交付状态正常 root-word"),
+        "kid": db.append_message("kid", role="assistant", content="子任务状态正常 kid-word"),
+        "gw-kid": db.append_message("gw-kid", role="assistant", content="网关子任务 gwkid-word"),
+        "cont": db.append_message("cont", role="assistant", content="继续会话内容 cont-word"),
+    }
+
+
+def test_subagent_rows_skip_trigram_but_stay_in_standard_fts(db: SessionDB):
+    ids = _seed(db)
+    assert _trigram_rowids(db) == {ids["root"], ids["cont"]}
+    assert _fts_rowids(db) >= set(ids.values())
+
+
+def test_subagent_rows_remain_word_searchable(db: SessionDB):
+    _seed(db)
+    assert [r["session_id"] for r in db.search_messages("kid-word")] == ["kid"]
+    assert [r["session_id"] for r in db.search_messages("gwkid-word")] == ["gw-kid"]
+    # Explicit CJK search scoped to the excluded source falls back to LIKE.
+    assert [
+        r["session_id"]
+        for r in db.search_messages("子任务状态", source_filter=["subagent"])
+    ] == ["kid"]
+    # Top-level CJK substring search unaffected.
+    assert [r["session_id"] for r in db.search_messages("交付状态")] == ["root"]
+
+
+def test_update_and_delete_of_unindexed_child_row_keep_trigram_consistent(db: SessionDB):
+    ids = _seed(db)
+    db._conn.execute(
+        "UPDATE messages SET content = ? WHERE id = ?", ("改写后的内容", ids["kid"])
+    )
+    db._conn.execute("DELETE FROM messages WHERE id = ?", (ids["kid"],))
+    db._conn.execute(
+        "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('integrity-check')"
+    )
+    assert _trigram_rowids(db) == {ids["root"], ids["cont"]}
+
+
+def test_deferred_rebuild_does_not_reintroduce_children(db: SessionDB):
+    ids = _seed(db)
+    with db._lock:
+        db._reset_fts_index_to_empty(db._conn)
+        db._seed_fts_rebuild_markers(db._conn, force=True)
+        db._conn.commit()
+    while db.fts_rebuild_step():
+        pass
+    assert _trigram_rowids(db) == {ids["root"], ids["cont"]}
+    assert _fts_rowids(db) >= set(ids.values())
+
+
+def test_full_rebuild_honours_exclusion(db: SessionDB):
+    ids = _seed(db)
+    db.rebuild_fts()
+    assert _trigram_rowids(db) == {ids["root"], ids["cont"]}
+
+
+def test_v29_install_purges_child_rows_on_upgrade(tmp_path):
+    db_path = tmp_path / "state.db"
+    old = SessionDB(db_path=db_path)
+    if not old._trigram_available:
+        old.close()
+        pytest.skip("trigram tokenizer unavailable in this SQLite build")
+    # Recreate the v29 (cron-only) view/trigger boundary.
+    old._conn.executescript(
+        """
+        DROP TRIGGER messages_fts_trigram_insert;
+        DROP TRIGGER messages_fts_trigram_delete;
+        DROP TRIGGER messages_fts_trigram_update;
+        DROP VIEW messages_fts_trigram_src;
+        CREATE VIEW messages_fts_trigram_src AS
+            SELECT m.id, m.role, m.content, m.tool_name
+            FROM messages AS m JOIN sessions AS s ON s.id = m.session_id
+            WHERE m.role <> 'tool' AND s.source <> 'cron';
+        CREATE TRIGGER messages_fts_trigram_insert AFTER INSERT ON messages
+        WHEN new.role <> 'tool'
+           AND EXISTS (SELECT 1 FROM sessions WHERE id = new.session_id AND source <> 'cron')
+        BEGIN
+            INSERT INTO messages_fts_trigram(rowid, content, tool_name)
+            VALUES (new.id, new.content, new.tool_name);
+        END;
+        """
+    )
+    ids = _seed(old)
+    assert _trigram_rowids(old) == set(ids.values())
+    old._conn.execute("UPDATE schema_version SET version = 29")
+    old._conn.commit()
+    old.close()
+
+    migrated = SessionDB(db_path=db_path)
+    try:
+        assert _trigram_rowids(migrated) == {ids["root"], ids["cont"]}
+        assert migrated._conn.execute(
+            "SELECT version FROM schema_version"
+        ).fetchone()[0] == SCHEMA_VERSION
+        migrated._conn.execute(
+            "INSERT INTO messages_fts_trigram(messages_fts_trigram) VALUES('integrity-check')"
+        )
+    finally:
+        migrated.close()
+
+
+def test_predicate_constants_agree():
+    assert "subagent" in FTS_TRIGRAM_EXCLUDED_SOURCES
+    assert "cron" in FTS_TRIGRAM_EXCLUDED_SOURCES
+    sql = fts_trigram_session_sql("s")
+    assert sql.startswith("s.source NOT IN (") and "s.model_config" in sql

--- a/tests/tools/test_delegate_child_transcript_release.py
+++ b/tests/tools/test_delegate_child_transcript_release.py
@@ -1,0 +1,145 @@
+"""Finished delegate children must not pin their transcripts in the parent heap.
+
+Profiled parent (1,320 children over 13h) reached 2.6 GB RSS: every closed
+child AIAgent stayed reachable, and each still owned a shallow copy of its
+full message list. Two retainers were proven with ``gc.get_referrers``:
+
+1. ``AIAgent.close()`` cleared ``_session_messages`` but not the
+   ``_db_flush_scan_prefix`` snapshot (``messages[:]``) or the streamed-text
+   accumulator, so every message dict stayed alive through the agent.
+2. ``bind_subagent_parent`` stored the agent (each child binds ITSELF for
+   its own turn) strongly in a ContextVar; asyncio Handles/Futures scheduled
+   during the turn snapshot that Context and live as long as the background
+   LSP / kernel loops do, so the child object itself was never collected.
+"""
+
+from __future__ import annotations
+
+import gc
+import json
+import weakref
+from unittest.mock import MagicMock
+
+from agent.subagent_lifecycle import (
+    _ACTIVE_PARENT_AGENT,
+    bind_subagent_parent,
+    get_active_subagent_parent,
+)
+from run_agent import AIAgent
+
+
+def _bare_agent() -> AIAgent:
+    agent = AIAgent.__new__(AIAgent)
+    agent._active_children = []
+    import threading
+
+    agent._active_children_lock = threading.Lock()
+    agent._session_db = None
+    agent.session_id = "child-x"
+    return agent
+
+
+def test_close_releases_transcript_shadow_copies():
+    agent = _bare_agent()
+
+    class Payload(str):  # weakref-able stand-in for a message content string
+        pass
+
+    payload = Payload("x" * 50_000)
+    big = {"role": "tool", "content": payload}
+    agent._session_messages = [big]
+    agent._db_flush_scan_prefix = agent._session_messages[:]
+    agent._streamed_assistant_text_parts = ["y" * 10_000]
+    probe = weakref.ref(payload)
+
+    agent.close()
+
+    assert agent._session_messages == []
+    assert agent._db_flush_scan_prefix is None
+    assert agent._streamed_assistant_text_parts == []
+    del big, payload
+    gc.collect()
+    assert probe() is None, "closed agent still owns its message dicts"
+
+
+def test_bind_subagent_parent_does_not_pin_agent():
+    agent = _bare_agent()
+    probe = weakref.ref(agent)
+    snapshots = []
+    with bind_subagent_parent(agent):
+        assert get_active_subagent_parent() is agent
+        import contextvars
+
+        # An asyncio Handle scheduled inside the turn keeps this snapshot.
+        snapshots.append(contextvars.copy_context())
+    assert get_active_subagent_parent() is None
+    assert snapshots[0][_ACTIVE_PARENT_AGENT] is not agent
+    del agent
+    gc.collect()
+    assert probe() is None, "Context snapshot still pins the agent"
+
+
+def test_bind_subagent_parent_accepts_non_weakrefable_doubles():
+    class Slots:
+        __slots__ = ()
+
+    double = Slots()
+    with bind_subagent_parent(double):
+        assert get_active_subagent_parent() is double
+
+
+def _fake_child(messages):
+    child = MagicMock()
+    child._credential_pool = None
+    child._delegate_role = "leaf"
+    child.session_estimated_cost_usd = 0.0123
+    child.session_cost_status = "estimated"
+    child.session_id = "child-sess"
+    child.run_conversation.return_value = {
+        "final_response": "the summary",
+        "completed": True,
+        "interrupted": False,
+        "api_calls": 3,
+        "messages": messages,
+    }
+    return child
+
+
+def test_run_single_child_result_json_unchanged_by_transcript_release():
+    """Pin: the parent-visible result entry is byte-identical whether or not
+    the child released its transcript at close() (the entry never carried
+    ``messages``; only summary/tool_trace/tokens/cost derive from them)."""
+    from tests.tools.test_delegate import _make_mock_parent
+    from tools.delegate_tool import _run_single_child
+
+    messages = [
+        {"role": "user", "content": "goal"},
+        {
+            "role": "assistant",
+            "content": None,
+            "tool_calls": [
+                {
+                    "id": "c1",
+                    "type": "function",
+                    "function": {"name": "read_file", "arguments": '{"path": "a.py"}'},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "c1", "content": "z" * 5000},
+        {"role": "assistant", "content": "the summary"},
+    ]
+    results = []
+    for _ in range(2):
+        child = _fake_child([dict(m) for m in messages])
+        entry = _run_single_child(
+            task_index=0, goal="goal", child=child, parent_agent=_make_mock_parent()
+        )
+        child.close.assert_called_once()
+        entry.pop("duration_seconds", None)
+        results.append(json.dumps(entry, sort_keys=True, default=str))
+    assert results[0] == results[1]
+    parsed = json.loads(results[0])
+    assert parsed["summary"] == "the summary"
+    assert parsed["tool_trace"][0]["tool"] == "read_file"
+    assert parsed["cost_usd"] == 0.0123
+    assert "messages" not in parsed

--- a/website/docs/developer-guide/session-storage.md
+++ b/website/docs/developer-guide/session-storage.md
@@ -169,6 +169,8 @@ The `schema_version` table stores a single integer. Simple column additions are 
 | 20 | Per-model usage attribution — seed `session_model_usage` rows from historical per-session aggregate totals |
 | 22 | Task-dimension usage attribution — rebuild `session_model_usage` so the `task` column participates in the PRIMARY KEY |
 | 23 | FTS storage redesign — external-content FTS tables replacing the v11 inline-mode copies (opt-in transition for existing DBs) |
+| 29 | Cron sessions leave the trigram (substring/CJK) index; `messages_fts_trigram_src` view + triggers filter on `sessions.source`, one-time rebuild purges historical rows |
+| 30 | Delegate-child (subagent) sessions leave the trigram index too — `source='subagent'` or the `$._delegate_from` marker (`FTS_TRIGRAM_SESSION_SQL`). Rows stay in `messages` and the standard `messages_fts` word index, so `session_search` still finds them; only the ~2.6× trigram shadow tables shrink. Same one-time rebuild as v29 |
 
 Versions not listed above were declarative column additions handled by `_reconcile_columns()` (version bump only, no data migration).
 


### PR DESCRIPTION
## Summary
Finished delegated children no longer pin their transcripts in the parent heap, and subagent transcripts are no longer written into the trigram FTS index (schema v30); `delegate_task` results and top-level `session_search` are unchanged.

Profiled session: 1.9 GB anonymous heap in the parent after 1,320 children; state.db 3.3 GB with 1,029 MB of trigram shadow tables, 70% of raw content from `source='subagent'`.

## Changes
- `agent/subagent_lifecycle.py`: `bind_subagent_parent` stores a `weakref` (gc proved the retention chain: child AIAgent <- Context <- asyncio Handle/Future from LSP reader / kernel pipe transports; 56 Context snapshots held children via the ContextVar).
- `run_agent.py` `AIAgent.close()`: also releases `_db_flush_scan_prefix` (a `messages[:]` snapshot per DB flush, 240 KB/child) and `_streamed_assistant_text_parts` (235 KB/child).
- `hermes_state_common.py` / `hermes_state_schema.py` / `hermes_state_search.py`: `FTS_TRIGRAM_EXCLUDED_SOURCES = ("cron", "subagent")` plus `_delegate_from` marker check, reusing the v29 cron-exclusion view/trigger mechanism; SCHEMA_VERSION 29 -> 30 with a one-time admitted rebuild that purges historical child postings. Explicit `source_filter=['subagent']` CJK queries route to LIKE (as cron already did).
- Tests: `tests/tools/test_delegate_child_transcript_release.py` (4, incl. byte-identical result-JSON pin; RED on main), `tests/state/test_fts_trigram_subagent_exclusion.py` (7, incl. v29->v30 migration + integrity check). 143 + 474 + 392 passed across delegate / state / search suites (one pre-existing red on main untouched).
- Docs: `website/docs/developer-guide/session-storage.md` migration table.

## Validation
| | before | after |
|---|---|---|
| live child AIAgents after 30-child fan-out (100 KB replies, gc.collect) | 15 | 2 |
| Contexts pinning children | 56 | 0 |
| RSS after fan-out | 229 MB | 178 MB |
| temp DB, 2,000 x 2 KB child messages | 22.4 MB (trigram shadow 10.1) | 12.5 MB (trigram shadow 0.02) |

Caveat: existing installs pay a one-time trigram rebuild on first open at v30 (same cost class as v29). Compression/branch continuations (parent_session_id without the subagent markers) intentionally stay indexed.

## Infographic

![child transcript footprint](https://v3b.fal.media/files/b/0aa8ec04/oxXiABpo5cqKu60_8uFvD_S12KPTlp.png)
