### PR TITLE
fix(desktop): route named local profile picks on This device and skip runtime resolve for remote-only profiles

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -12368,6 +12368,17 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     }
   }
 
+  // Guard BEFORE the slot wait, update gate and runtime resolve: a profile
+  // that only exists on a remote backend (remote-primary desktop asked for a
+  // forced-local child) rejects here without occupying a pool slot or paying
+  // the ~250 ms runtime resolve per profile (a remote-primary desktop probes
+  // every remote-only name at boot). Logging "Starting" first left an orphaned
+  // line with no READY and no exit — the exact undiagnosable burst signature
+  // in remote-gateway user bundles (Aug 2026, Dash's report).
+  assertLocalProfileCanStart(profile, profileDeletionGate, key =>
+    directoryExists(path.join(HERMES_HOME, 'profiles', key))
+  )
+
   // Bound the slot wait BELOW the renderer's backend-boot budget (45s): once
   // the renderer has given up on this spawn, a ticket still queued for the
   // pool-idle window (10 min) would hold the pool key hostage and every
@@ -12426,14 +12437,6 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   const webDist = resolveWebDist()
   const readyFile = backend.readyFile ? makeDashboardReadyFile() : null
 
-  // Guard BEFORE the "Starting" line: a profile that only exists on a remote
-  // backend (remote-primary desktop asked for a forced-local child) rejects
-  // here, and logging "Starting" first left an orphaned line with no READY
-  // and no exit — the exact undiagnosable burst signature in remote-gateway
-  // user bundles (Aug 2026, Dash's report).
-  assertLocalProfileCanStart(profile, profileDeletionGate, key =>
-    directoryExists(path.join(HERMES_HOME, 'profiles', key))
-  )
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const parentStartMarker = await desktopParentStartMarker()

--- a/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
+++ b/apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx
@@ -23,6 +23,7 @@ import {
   newSessionInProfile,
   selectProfile
 } from '@/store/profile'
+import { $profileRemoteOverrides } from '@/store/profile-remote-override'
 import {
   $activeSessionId,
   $connection,
@@ -396,6 +397,7 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     $newChatProfile.set(null)
     $newChatRoute.set(null)
     $newChatConnectionId.set(null)
+    $profileRemoteOverrides.set({})
     _resetSessionOwnerHintsForTests({ storage: true })
   })
 
@@ -507,16 +509,17 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect($newChatConnectionId.get()).toBe(SOURCE_ID)
   })
 
-  it('keeps the legacy profile door when boot published `local` on the active primary gateway', async () => {
-    // The published identity survives the reload, but a pick on the explicit
-    // local source is still a legacy profile pick (per-profile remote
-    // overrides resolve through getConnection), so the draft's owner is the
+  it('keeps the legacy profile door when boot published `local` and the picked profile has a remote override', async () => {
+    // The published identity survives the reload, but a pick of a profile
+    // WITH a per-profile remote override is still a legacy profile pick (the
+    // override resolves through getConnection), so the draft's owner is the
     // v1 profile socket, never the registry entry local::omar.
     const primary = makePrimary()
 
     setPrimaryGateway(primary as never, 'default')
     setConnection({ connectionId: 'local', mode: 'local', profile: 'default' } as never)
     expect(activeGatewayConnectionId()).toBe('local')
+    $profileRemoteOverrides.set({ omar: { host: 'vps.example', url: 'https://vps.example' } })
 
     selectProfile('omar')
 
@@ -706,6 +709,10 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     ownerPort = V1_PORT
     mintedRuntimeId = LEGACY_RUNTIME_ID
     mintedStoredId = LEGACY_STORED_ID
+    // This is the #94166 guard: only a profile WITH a remote override keeps
+    // the legacy profile-only door on the explicit `local` source. Without
+    // an override the pick would dial the registry entry conn:local::omar.
+    $profileRemoteOverrides.set({ omar: { host: 'vps.example', url: 'https://vps.example' } })
     selectProfile('omar')
     expect($newChatProfile.get()).toBe('omar')
     expect($newChatRoute.get()).toBeNull()
@@ -776,5 +783,84 @@ describe('profile rail: a fresh Omar chat keeps its exact registry owner across 
     expect($sessions.get().find(session => sessionMatchesStoredId(session, LEGACY_STORED_ID))).toMatchObject({
       profile: 'omar'
     })
+  })
+
+  it('a named pick without a remote override on the explicit `local` source keeps the registry owner: create and both turns ride the ONE conn:local::omar socket', async () => {
+    const primary = makePrimary()
+    setPrimaryGateway(primary as never, 'default')
+
+    // Active registry source: `local` (This device), on its default profile.
+    await ensureGatewayAgent('local', 'default')
+    expect(activeGatewayConnectionId()).toBe('local')
+
+    // No remote override for omar: the pick dials the registry entry
+    // conn:local::omar, never the v1 profile door (#94166 only applies to
+    // profiles that carry an override).
+    selectProfile('omar')
+    expect($newChatProfile.get()).toBe('omar')
+    expect($newChatRoute.get()).toBeNull()
+    await waitFor(() => expect(activeGatewayProfileKey()).toBe('omar'))
+    expect(activeGatewayConnectionId()).toBe('local')
+    expect($newChatConnectionId.get()).toBe('local')
+
+    const omarSocket = sockets.find(socket => socket.connectUrl?.includes(`:${OMAR_PORT}`))
+    expect(
+      omarSocket,
+      `no socket dialed port ${OMAR_PORT}; dialed: ${sockets.map(s => s.connectUrl).join(', ')}`
+    ).toBeDefined()
+    expect(activeGateway()).toBe(omarSocket as never)
+    expect(sockets.some(socket => socket.connectUrl?.includes(`:${V1_PORT}`))).toBe(false)
+
+    const desktop = window.hermesDesktop!
+    expect(desktop.getConnection).not.toHaveBeenCalledWith('omar')
+    expect(desktop.getConnectionFor).toHaveBeenCalledWith({ connectionId: 'local', profile: 'omar' })
+
+    // Ambient dispatcher: session traffic must ride the routed socket, never it.
+    const ambientRequest = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create' || sessionScoped(params)) {
+        throw new Error(`session traffic must not use ambient dispatcher: ${method}`)
+      }
+
+      return (activeGateway() as unknown as MockGateway).request(method, params)
+    })
+
+    let handle: HarnessHandle | null = null
+    render(<Harness ambientRequest={ambientRequest as never} onReady={h => (handle = h)} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    await expect(handle!.submitText('first prompt')).resolves.toBe(true)
+    await waitFor(() => expect($activeSessionId.get()).toBe(RUNTIME_ID))
+    await settleTurn(handle!)
+    await expect(handle!.submitText('second prompt')).resolves.toBe(true)
+
+    // The registry entry conn:local::omar minted AND owns the runtime.
+    expect(runtimeOwner).toBe(omarSocket)
+    expect(calls(omarSocket!).filter(method => method === 'session.create')).toHaveLength(1)
+    expect(
+      omarSocket!.request.mock.calls
+        .filter(call => call[0] === 'prompt.submit')
+        .map(call => (call[1] as { text: string }).text)
+    ).toEqual(['first prompt', 'second prompt'])
+
+    // Owner hint + tagged optimistic row for the stored id — the exact state
+    // that keeps the tile's owner ladder populated.
+    expect(getSessionOwnerHint(STORED_ID)).toEqual({ connectionId: 'local', profile: 'omar' })
+    expect($sessions.get().find(session => sessionMatchesStoredId(session, STORED_ID))).toMatchObject({
+      connection_id: 'local',
+      profile: 'omar'
+    })
+
+    // Nothing session-scoped reached the primary or any other socket; no REST probe.
+    expect(calls(primary).filter(method => method === 'session.create' || method === 'prompt.submit')).toEqual([])
+
+    for (const socket of sockets) {
+      if (socket !== omarSocket) {
+        expect(
+          socket.request.mock.calls.filter(call => sessionScoped(call[1]) || call[0] === 'session.create')
+        ).toEqual([])
+      }
+    }
+
+    expect(vi.mocked(getSession)).not.toHaveBeenCalled()
   })
 })

--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -31,7 +31,10 @@ vi.mock('@/hermes', () => ({
 vi.mock('@/lib/query-client', () => ({ invalidateProfileScopedQueries: vi.fn() }))
 vi.mock('@/store/starmap', () => ({ resetStarmapGraph }))
 
-const { $activeGatewayProfile, newSessionInProfile, selectProfile } = await import('./profile')
+import { $profileRemoteOverrides } from '@/store/profile-remote-override'
+
+const { $activeGatewayProfile, newSessionInProfile, resolveNewChatOwnerRoute, selectProfile } =
+  await import('./profile')
 
 beforeEach(() => {
   ensureGatewayForProfile.mockClear()
@@ -40,6 +43,7 @@ beforeEach(() => {
   activeGatewayConnectionId.mockReturnValue(null)
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
+  $profileRemoteOverrides.set({})
   // resolveConnectionForAgent is best-effort; without a bridge it resolves
   // null and the previous descriptor stays, which is fine here.
   ;(globalThis as { window?: unknown }).window = {}
@@ -64,13 +68,24 @@ describe('selectProfile', () => {
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
   })
 
-  it('keeps the legacy profile-only path when the explicit local source is live', async () => {
+  it('keeps the legacy profile-only path when the explicit local source is live and the profile has a remote override', async () => {
     activeGatewayConnectionId.mockReturnValue('local')
+    $profileRemoteOverrides.set({ 'override-profile': { host: 'vps.example', url: 'https://vps.example' } })
 
     selectProfile('override-profile')
 
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+  })
+
+  it('activates the registry route for a named pick without a remote override on the explicit local source', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+    $profileRemoteOverrides.set({})
+
+    selectProfile('omar')
+
+    await vi.waitFor(() => expect(ensureGatewayForAgent).toHaveBeenCalledWith('local', 'omar'))
+    expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 
   it('keeps Default on the explicit local source instead of the window primary', async () => {
@@ -93,13 +108,23 @@ describe('newSessionInProfile', () => {
     expect(ensureGatewayForProfile).not.toHaveBeenCalled()
   })
 
-  it('keeps the legacy profile-only path for a new chat on the explicit local source', async () => {
+  it('keeps the legacy profile-only path for a new chat on the explicit local source when the profile has a remote override', async () => {
     activeGatewayConnectionId.mockReturnValue('local')
+    $profileRemoteOverrides.set({ 'override-profile': { host: 'vps.example', url: 'https://vps.example' } })
 
     newSessionInProfile('override-profile')
 
     await vi.waitFor(() => expect(ensureGatewayForProfile).toHaveBeenCalledWith('override-profile'))
     expect(ensureGatewayForAgent).not.toHaveBeenCalled()
+  })
+
+  it('resolves the registry owner route for a new chat on the explicit local source when the profile has no remote override', () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+    $profileRemoteOverrides.set({})
+
+    newSessionInProfile('omar')
+
+    expect(resolveNewChatOwnerRoute()).toEqual({ connectionId: 'local', profile: 'omar' })
   })
 
   it('opens a Default new chat on the explicit local source, not the window primary', async () => {

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -26,7 +26,7 @@ import {
 } from '@/store/gateway'
 import { notifyError } from '@/store/notifications'
 import { $poolLimits } from '@/store/pool-limits'
-import { notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
+import { $profileRemoteOverrides, notifyRemoteOverrideAuthFailure } from '@/store/profile-remote-override'
 import { clearComposerSelectionOwner, setComposerSelectionOwner, setConnection } from '@/store/session'
 import type { SessionOwnerRoute } from '@/store/session-request-router'
 import { resetStarmapGraph } from '@/store/starmap'
@@ -270,8 +270,8 @@ export const $newChatRoute = atom<AgentProfileRoute | null>(null)
 // string "omar", and every follow-up RPC dialed requestGatewayForProfile
 // ("omar") — a DIFFERENT socket than the one that created the session —
 // and 4001'd "session not found" (#94071). null = the intent dials the legacy
-// profile-only path (a v1 primary with no registry identity, or a named
-// profile pick on the explicit `local` source — see profilePickConnectionId).
+// profile-only path (a v1 primary with no registry identity, or a pick on the
+// `local` source of a profile with a remote override — see profilePickConnectionId).
 export const $newChatConnectionId = atom<null | string>(null)
 
 /** Capture the registry source a new-chat profile intent lands on — by
@@ -284,14 +284,10 @@ export function captureNewChatSource(connectionId: null | string = activeGateway
 /**
  * The registry source a PROFILE PICK dials, mirroring activateOnCurrentSource:
  * a live remote registry source keeps its connection id. Named picks on the
- * explicit `local` source (and the window primary) take the legacy
- * profile-only path (null) so the main process can resolve a per-profile
- * remote override before falling back to a local backend (#94166).
- *
- * Default on that same `local` source is different: it is also the window
- * primary's profile key. The legacy door would activate the remote primary on
- * a VPS-primary desktop, and Bots would show the VPS as Current Gateway.
- * Keep Default on `local` so This-device home stays on This device.
+ * explicit `local` source stay on This-device `local` unless the profile has a
+ * remote override — then they take the legacy profile-only path (null) so the
+ * main process can resolve that override before falling back to a local
+ * backend (#94166). Default on `local` likewise stays on This device.
  */
 function profilePickConnectionId(profile?: string): null | string {
   const connectionId = activeGatewayConnectionId()
@@ -303,7 +299,7 @@ function profilePickConnectionId(profile?: string): null | string {
   if (connectionId === LOCAL_CONNECTION_ID) {
     const key = normalizeProfileKey(profile ?? $newChatProfile.get())
 
-    return key === 'default' ? LOCAL_CONNECTION_ID : null
+    return $profileRemoteOverrides.get()[key] ? null : LOCAL_CONNECTION_ID
   }
 
   return null
@@ -859,11 +855,9 @@ async function isLocalDesktopProfile(target: string): Promise<boolean> {
 
 // Route a profile pick at the source the user is LOOKING at. $profiles is the
 // active gateway's list, so a pick made while a remote registry source is live
-// names one of THAT source's profiles and must keep its connection id. Named
-// picks on the primary and explicit "local" source stay on the legacy
-// profile-only path so the main process can resolve a per-profile remote
-// override before falling back to a local backend. Default on `local` stays
-// on that source — see profilePickConnectionId.
+// names one of THAT source's profiles and must keep its connection id. Picks
+// on the primary, and picks of a profile with a remote override, stay on the
+// legacy profile-only path — see profilePickConnectionId.
 function activateOnCurrentSource(target: string): Promise<void> {
   const connectionId = profilePickConnectionId(target)
 


### PR DESCRIPTION
## What does this PR do?

Two fixes for desktops whose registry primary is a **remote** connection while
the user works on **This device** (`local`). Both stem from the same
constellation and were found together; each is a one-line logic change.

**1. New chats for a named local profile failed to open.**
Picking a non-default profile on the explicit `local` source and starting a
chat produced *"Session owner could not be resolved for <id> (session.resume):
no owner route, hint, connection-tagged row or profile probe named the backend…"*.
`profilePickConnectionId()` sent every named pick on `local` down the legacy
profile-only door (`null`), so the draft was created unrouted: no owner hint,
no connection-tagged optimistic row. The backend persists a fresh session lazily
(first prompt), so the next sessions refresh dropped the optimistic row, leaving
the owner ladder empty and the fail-closed guard firing. The legacy door exists
for one reason — letting the main process resolve a per-profile remote override
(#94166). Take it only when the picked profile actually carries an override
(`$profileRemoteOverrides`); every other named pick on `local` now yields the
`local` registry route, so the existing routed-create path records the owner
hint and stamps the row. Default on `local` stays on This device (#97038).

**2. Startup paid ~250 ms per remote-only profile.**
With a remote primary, the renderer probes that host's profile names against
This device at boot — one forced-local dial per remote-only profile. In
`spawnPoolBackend` the cheap local-directory guard (`assertLocalProfileCanStart`)
ran *after* the pool-slot wait, `waitForUpdateClearance`,
`ensureRuntime(resolveHermesBackend(...))` and the cwd/web-dist/ready-file
resolves, so every doomed dial paid the full runtime resolve first. With 15
remote-only profiles that was ~4 s of serial work and a burst of
`(forced-local) failed to start: Profile "X" no longer exists` lines on every
launch. The guard is moved (unchanged) to right after the remote-override check;
override profiles still return their remote descriptor before it, and it still
precedes the "Starting" log line it was originally placed for.

Known edge (fix 1): if the override cache has not refreshed yet, or the override
is per-profile SSH (which the renderer cache does not model), the pick routes
`local`; the main process still delegates to the override backend
(`resolveRegistryLocalRoute`), only the row's connection tag reads `local`.

## Related Issue

No existing issue found for either symptom (searched open issues/PRs for
"session owner could not be resolved" and "forced-local … no longer exists").
Related: #94166, #97038.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/profile.ts` — `profilePickConnectionId`: named pick on `local` → `LOCAL_CONNECTION_ID` unless the profile has a remote override; doc comments updated
- `apps/desktop/src/store/profile-select-source.test.ts`, `apps/desktop/src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx` — 3 regression tests (routed create, owner route, owner hint / tagged row); the 4 existing legacy-door tests now carry an override fixture and serve as the #94166 guard
- `apps/desktop/electron/main.ts` — `spawnPoolBackend`: `assertLocalProfileCanStart` moved before the slot wait / update gate / runtime resolve (pure move, comment updated)

## How to Test

1. Register a remote connection as primary (`~/.config/Hermes/connections.json`
   `primary` = the remote), keep `lastUsed: local`, and have ≥1 non-default local
   profile without a remote override.
2. **Fix 1** — on `main`: switch to This device, pick the local profile, start a
   chat → error card immediately. With this PR: chat opens; the session row is
   tagged `connection_id: local`.
3. **Fix 2** — on `main`: `~/.hermes/logs/desktop.log` shows one
   `(forced-local) failed to start: Profile "X" no longer exists` per remote-only
   profile, ~250 ms apart, after each launch. With this PR: the lines arrive
   within ~20 ms total (measured: 15 profiles, 19 ms) and startup no longer stalls.
4. `cd apps/desktop && npx vitest run src/store/profile-select-source.test.ts src/app/session/hooks/profile-rail-fresh-chat-owner.test.tsx`
   — 3 tests fail on `main`, 21/21 pass here. Full desktop suite: 9275 passed;
   `npx tsc -p . --noEmit` and eslint clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature
- [x] I've run the desktop suite (`cd apps/desktop && npx vitest run`, `npx tsc -p . --noEmit`, `npx eslint`) — no Python changes
- [x] I've added tests for my changes (fix 1). Fix 2 is a pure reorder inside `spawnPoolBackend` covered by the existing electron suite; a behavioural test would require extracting the spawn prologue, which is out of scope for a two-line move
- [x] I've tested on my platform: Arch Linux (packaged Electron build)

### Documentation & Housekeeping

- [x] Documentation — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (`path.join`-based directory check unchanged; only its position moved)
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

Before (desktop.log, one launch):
```
07:20:29.976 Hermes backend for profile "ariadne" (forced-local) failed to start: Profile "ariadne" no longer exists. 07:20:30.230 Hermes backend for profile "aster" (forced-local) failed to start: ... … (15 lines, ~250 ms apart)
```
After: 
same 15 lines within 19 ms; with fix 1 active and tabs re-created, the probe no longer fires at all (0 lines).