### PR TITLE
fix(desktop): drop duplicate rehydrated transcript rows after compaction

### DIFF
--- a/apps/desktop/src/app/chat/runtime-repository.test.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.test.ts
@@ -194,4 +194,36 @@ describe('useRuntimeMessageRepository', () => {
       'assistant-2'
     ])
   })
+
+  it('drops a rehydrated duplicate after compaction when ids differ but content is identical (#101938)', () => {
+    // Context compaction can re-insert the carried-forward tail as new rows
+    // with new ids. The desktop then sees two copies of the same logical
+    // message; id-only dedup misses them and assistant-ui renders both.
+    const original: ChatMessage = {
+      id: 'assistant-stream-101938',
+      role: 'assistant',
+      timestamp: 1_234_567_890,
+      parts: [
+        { type: 'text', text: 'Here is the answer.' },
+        { type: 'tool-call', toolCallId: 'call_101938', toolName: 'terminal', args: {}, argsText: '' }
+      ] as ChatMessage['parts']
+    }
+
+    const duplicate: ChatMessage = {
+      id: 'assistant-rehydrated-101938',
+      role: 'assistant',
+      timestamp: 1_234_567_890,
+      parts: [
+        { type: 'text', text: 'Here is the answer.' },
+        { type: 'tool-call', toolCallId: 'call_101938', toolName: 'terminal', args: {}, argsText: '' }
+      ] as ChatMessage['parts']
+    }
+
+    const { result } = renderHook(() =>
+      useRuntimeMessageRepository([text('user-1', 'user', 'hi'), original, duplicate])
+    )
+
+    expect(result.current.messages.map(item => item.message.id)).toEqual(['user-1', 'assistant-stream-101938'])
+    expect(feedToRepository(result.current).map(item => item.id)).toEqual(['user-1', 'assistant-stream-101938'])
+  })
 })

--- a/apps/desktop/src/app/chat/runtime-repository.ts
+++ b/apps/desktop/src/app/chat/runtime-repository.ts
@@ -5,6 +5,7 @@ import { useMemo, useRef } from 'react'
 import type { ChatMessage } from '@/lib/chat-messages'
 import { withUniqueToolCallIdsWithinMessage } from '@/lib/chat-messages'
 import { coalesceToolOnlyAssistants, createToolMergeCache, toRuntimeMessage } from '@/lib/chat-runtime'
+import { chatMessageText } from '@/lib/chat-messages/parts'
 
 // The exact fallback status ExportedMessageRepository.fromBranchableArray uses.
 // Normalization happens HERE, once per message, so the cached record below is
@@ -32,8 +33,21 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
     const items: { message: ThreadMessage; parentId: string | null }[] = []
     const branchParentByGroup = new Map<string, string | null>()
     const seenIds = new Set<string>()
+    const seenContentKeys = new Set<string>()
     let visibleParentId: string | null = null
     let headId: string | null = null
+
+    // Build a lightweight content key for dedup: role + normalized text +
+    // timestamp + first tool-call id. This catches the post-compaction case
+    // where the same logical message appears twice with different `id`s
+    // (streaming copy vs rehydrated durable copy).
+    const contentKey = (message: ChatMessage): string => {
+      const toolCallIds = message.parts
+        .filter((part): part is ChatMessage['parts'][number] & { type: 'tool-call'; toolCallId: string } => part.type === 'tool-call' && typeof part.toolCallId === 'string')
+        .map(part => part.toolCallId)
+
+      return `${message.role}\u0000${chatMessageText(message)}\u0000${message.timestamp ?? ''}\u0000${toolCallIds[0] ?? ''}`
+    }
 
     for (const message of coalesceToolOnlyAssistants(messages, toolMergeCacheRef.current)) {
       // A repeated id is a transcript bug upstream, but it must not reach the
@@ -46,6 +60,20 @@ export function useRuntimeMessageRepository(messages: ChatMessage[]): ExportedMe
       }
 
       seenIds.add(message.id)
+
+      // Content-level fallback dedup: after context compaction the backend
+      // can return byte-identical copies with new ids. The id-only skip above
+      // misses that class, so the runtime would emit both and assistant-ui
+      // would render duplicates. Restrict to settled, non-branch messages so
+      // we don't collapse legitimate branch siblings or cross-turn tool ids.
+      if (!message.branchGroupId && typeof message.timestamp === 'number') {
+        const key = contentKey(message)
+        if (seenContentKeys.has(key)) {
+          continue
+        }
+
+        seenContentKeys.add(key)
+      }
 
       let parentId = visibleParentId
 


### PR DESCRIPTION
Fix #101938.

After context compaction the backend can re-insert the carried-forward tail as new rows with new ids. The desktop's runtime repository previously deduped only by message.id, so assistant-ui rendered both the streaming copy and the rehydrated durable copy.

This adds a lightweight content-key fallback dedup in useRuntimeMessageRepository:
- key = role + normalized text + timestamp + first tool-call id
- restricted to settled, non-branch messages so branch siblings and cross-turn tool ids are not collapsed

Added a regression test for the post-compaction duplicate case.