### PR TITLE
perf(agent): keep bulk chat-completions payloads out of the SDK request transform

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -29,6 +29,7 @@ from typing import Any, Dict, Optional
 
 from hermes_cli.timeouts import get_provider_request_timeout, get_provider_stale_timeout
 from hermes_constants import PARTIAL_STREAM_STUB_ID, FINISH_REASON_LENGTH
+from agent.sdk_transform_bypass import bypass_chat_sdk_request_transform
 from agent.error_classifier import (
     FailoverReason,
     PROVIDER_STREAM_NON_JSON_ERROR_CODE,
@@ -1001,6 +1002,10 @@ def _dispatch_nonstreaming_api_request(agent, api_kwargs: dict, *, make_client):
             api_kwargs.pop("_moa_prepared_request", None)
         return agent.client.chat.completions.create(**api_kwargs)
     request_client = make_client("chat_completion_request")
+    # #93650: keep the bulk wire-format payload out of the SDK's GIL-holding
+    # request transform. No-op unless this really is the OpenAI SDK, so the
+    # MoA facade above and the suite's stand-in clients are unaffected.
+    api_kwargs = bypass_chat_sdk_request_transform(api_kwargs, request_client)
     return request_client.chat.completions.create(**api_kwargs)
 
 
@@ -4286,6 +4291,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             attempt_request_client["value"] = request_client
             last_chunk_time["t"] = time.time()
             agent._touch_activity("waiting for provider response (streaming)")
+            # #93650: as above — the streaming path carries the same bulk
+            # messages/tools payload and pays the same client-side walk.
+            stream_kwargs = bypass_chat_sdk_request_transform(
+                stream_kwargs, request_client
+            )
             return request_client.chat.completions.create(**stream_kwargs)
 
         def _stream_created(raw_stream: Any) -> None:

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -1518,76 +1518,22 @@ def _sanitize_consumer_codex_request(
     return sanitized
 
 
-# Bulk request fields that carry the conversation payload. Everything else in
-# the request is scalar configuration the SDK transform handles in microseconds.
-_SDK_TRANSFORM_BYPASS_FIELDS = ("input", "tools")
+# The request-transform bypass (#93650) now lives in agent/sdk_transform_bypass
+# so the chat-completions path can share it. Re-exported here under the
+# original names: agent/auxiliary_client.py and
+# tests/run_agent/test_codex_sdk_transform_bypass.py import them from this
+# module, and those import paths stay valid.
+from agent.sdk_transform_bypass import (  # noqa: E402
+    RESPONSES_BYPASS_FIELDS as _SDK_TRANSFORM_BYPASS_FIELDS,
+    _is_plain_json_data,
+    bypass_sdk_request_transform as _bypass_sdk_request_transform,
+)
 
-
-def _is_plain_json_data(value: Any) -> bool:
-    """True when ``value`` is composed purely of JSON wire types.
-
-    The SDK's request transform exists to convert typed params (TypedDict
-    key aliases, pydantic models, ``PropertyInfo`` formats) into wire
-    format.  Hermes assembles Codex payloads from JSON round-trips, so they
-    are already wire format — but that is only provable when every node is
-    a plain JSON type.  Anything else must keep the typed SDK path.
-    """
-    if value is None or isinstance(value, (str, int, float, bool)):
-        return True
-    if isinstance(value, dict):
-        return all(
-            isinstance(key, str) and _is_plain_json_data(item)
-            for key, item in value.items()
-        )
-    if isinstance(value, list):
-        return all(_is_plain_json_data(item) for item in value)
-    return False
-
-
-def _bypass_sdk_request_transform(stream_kwargs: dict) -> dict:
-    """Route bulk payload fields around the SDK's ``maybe_transform`` (#93650).
-
-    ``responses.create`` re-walks the entire request body against the
-    ``ResponseCreateParams`` union graph before any byte leaves the process.
-    That walk runs with the GIL held, and #93650 documents it wedging for
-    12+ hours on a ~1.4 MB conversation — starving every other thread,
-    including the TTFB/stale watchdogs whose job is to rescue this exact
-    call.  Because the hang is client-side and pre-network, no socket kill
-    can unblock it.
-
-    The SDK merges ``extra_body`` into the JSON body *after* the transform
-    (``_base_client._build_request``), so moving the already-wire-format
-    bulk fields there skips the walk entirely and produces a byte-identical
-    request.  Fields containing anything that is not plain JSON data (e.g.
-    pydantic models, generators) stay on the typed path, which still needs
-    the transform.  Set HERMES_CODEX_SDK_TRANSFORM=1 to restore the pre-fix
-    behavior.
-    """
-    if os.environ.get("HERMES_CODEX_SDK_TRANSFORM", "").strip().lower() in {
-        "1", "true", "yes", "on"
-    }:
-        return stream_kwargs
-
-    moved = {
-        field: stream_kwargs[field]
-        for field in _SDK_TRANSFORM_BYPASS_FIELDS
-        if isinstance(stream_kwargs.get(field), (dict, list))
-        and _is_plain_json_data(stream_kwargs[field])
-    }
-    if not moved:
-        return stream_kwargs
-
-    bypassed = {
-        key: value for key, value in stream_kwargs.items() if key not in moved
-    }
-    extra_body = bypassed.get("extra_body")
-    merged = dict(extra_body) if isinstance(extra_body, dict) else {}
-    for field, value in moved.items():
-        # An explicit caller-provided extra_body entry keeps precedence,
-        # matching what the SDK's post-transform merge would have done.
-        merged.setdefault(field, value)
-    bypassed["extra_body"] = merged
-    return bypassed
+__all__ = [
+    "_SDK_TRANSFORM_BYPASS_FIELDS",
+    "_is_plain_json_data",
+    "_bypass_sdk_request_transform",
+]
 
 
 def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):

--- a/agent/sdk_transform_bypass.py
+++ b/agent/sdk_transform_bypass.py
@@ -1,0 +1,134 @@
+"""Route bulk request payloads around the OpenAI SDK's request transform (#93650).
+
+Both the Responses API (``responses.create``) and chat-completions
+(``chat.completions.create``) re-walk the entire request body against their
+TypedDict/union param graph client-side, before any byte leaves the process.
+That walk holds the GIL, and #93650 documents it wedging for 12+ hours on a
+~1.4 MB conversation — starving every other thread, including the TTFB and
+stale-call watchdogs whose whole job is to rescue this exact call. Because the
+hang is client-side and pre-network, no socket kill can unblock it.
+
+Hermes assembles these payloads from JSON round-trips, so they are already in
+wire format and the walk has nothing to convert. The SDK merges ``extra_body``
+into the JSON body *after* the transform
+(``_base_client._build_request``), so moving the already-wire-format bulk
+fields there skips the walk and produces a byte-identical request.
+
+This module is the shared home for the helpers; ``agent.codex_runtime``
+re-exports them so existing import paths keep working.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+# Bulk request fields that carry the conversation payload, per API family.
+# Everything else in a request is scalar configuration the SDK transform
+# handles in microseconds.
+RESPONSES_BYPASS_FIELDS = ("input", "tools")
+CHAT_COMPLETIONS_BYPASS_FIELDS = ("messages", "tools")
+
+
+def _is_plain_json_data(value: Any) -> bool:
+    """True when ``value`` is composed purely of JSON wire types.
+
+    The SDK's request transform exists to convert typed params (TypedDict
+    key aliases, pydantic models, ``PropertyInfo`` formats) into wire
+    format.  Hermes assembles these payloads from JSON round-trips, so they
+    are already wire format — but that is only provable when every node is
+    a plain JSON type.  Anything else must keep the typed SDK path.
+    """
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return True
+    if isinstance(value, dict):
+        return all(
+            isinstance(key, str) and _is_plain_json_data(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, list):
+        return all(_is_plain_json_data(item) for item in value)
+    return False
+
+
+def _env_flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def bypass_sdk_request_transform(
+    request_kwargs: dict,
+    *,
+    fields: tuple = RESPONSES_BYPASS_FIELDS,
+    escape_hatch_env: str = "HERMES_CODEX_SDK_TRANSFORM",
+    required_empty: tuple = (),
+) -> dict:
+    """Move wire-format bulk ``fields`` into ``extra_body``.
+
+    Returns ``request_kwargs`` unchanged when there is nothing safe to move,
+    so a caller can always use the result unconditionally. Fields holding
+    anything that is not plain JSON data (pydantic models, generators) stay
+    on the typed path, which still needs the transform.
+
+    ``required_empty`` names fields the SDK declares ``@required_args`` and
+    would reject as missing: those are kept in the typed kwargs as an empty
+    list, and the ``extra_body`` copy overwrites them in the JSON body. Set
+    ``escape_hatch_env`` to restore the pre-fix behaviour.
+    """
+    if _env_flag(escape_hatch_env):
+        return request_kwargs
+
+    moved = {
+        field: request_kwargs[field]
+        for field in fields
+        if isinstance(request_kwargs.get(field), (dict, list))
+        and _is_plain_json_data(request_kwargs[field])
+    }
+    if not moved:
+        return request_kwargs
+
+    bypassed = {
+        key: value for key, value in request_kwargs.items() if key not in moved
+    }
+    for field in required_empty:
+        if field in moved:
+            # The SDK rejects the call outright if a @required_args parameter
+            # is absent; an empty list satisfies the signature and the
+            # extra_body entry replaces it in the body the server sees.
+            bypassed[field] = []
+    extra_body = bypassed.get("extra_body")
+    merged = dict(extra_body) if isinstance(extra_body, dict) else {}
+    for field, value in moved.items():
+        # An explicit caller-provided extra_body entry keeps precedence,
+        # matching what the SDK's post-transform merge would have done.
+        merged.setdefault(field, value)
+    bypassed["extra_body"] = merged
+    return bypassed
+
+
+def is_openai_sdk_completions(client: Any) -> bool:
+    """True when ``client.chat.completions`` is the real OpenAI SDK object.
+
+    Only the SDK performs the transform this bypass exists to skip, and only
+    the SDK merges ``extra_body`` into the body afterwards. Hermes also drives
+    chat-completions-shaped facades that are NOT the SDK — the in-process MoA
+    aggregator (``agent/moa_loop.py``) most importantly, plus the stand-ins
+    the test suite injects — and handing those an ``extra_body`` they never
+    merge would silently drop the conversation. Gate on the real thing.
+    """
+    completions = getattr(getattr(client, "chat", None), "completions", None)
+    if completions is None:
+        return False
+    return type(completions).__module__.startswith("openai.")
+
+
+def bypass_chat_sdk_request_transform(request_kwargs: dict, client: Any) -> dict:
+    """``bypass_sdk_request_transform`` for chat-completions, SDK-gated."""
+    if not is_openai_sdk_completions(client):
+        return request_kwargs
+    return bypass_sdk_request_transform(
+        request_kwargs,
+        fields=CHAT_COMPLETIONS_BYPASS_FIELDS,
+        escape_hatch_env="HERMES_CHAT_SDK_TRANSFORM",
+        # ``messages`` is @required_args on chat.completions.create.
+        required_empty=("messages",),
+    )

--- a/tests/run_agent/test_chat_sdk_transform_bypass.py
+++ b/tests/run_agent/test_chat_sdk_transform_bypass.py
@@ -1,0 +1,248 @@
+"""Chat-completions request-transform bypass (#93650).
+
+``chat.completions.create`` re-walks the whole request body against the
+``CompletionCreateParams`` union graph client-side, with the GIL held, before
+any byte leaves the process. #93650 documents that class of walk wedging for
+12+ hours on a ~1.4 MB conversation, where no in-process watchdog can fire and
+no socket kill helps because the hang is pre-network. #93773 fixed it for
+``responses.create`` only; these tests cover extending the same, already
+reviewed mechanism to the default chat path.
+
+The safety argument is that the request the server receives is unchanged, so
+the byte-identity test below is the important one.
+"""
+
+import json
+import sys
+import types
+
+sys.modules.setdefault("fire", types.SimpleNamespace(Fire=lambda *a, **k: None))
+sys.modules.setdefault("firecrawl", types.SimpleNamespace(Firecrawl=object))
+sys.modules.setdefault("fal_client", types.SimpleNamespace())
+
+import httpx
+import openai
+import pytest
+
+from agent.sdk_transform_bypass import (
+    bypass_chat_sdk_request_transform,
+    is_openai_sdk_completions,
+)
+
+_SSE = (
+    b'data: {"id":"1","object":"chat.completion.chunk","created":1,"model":"m",'
+    b'"choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}]}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+
+def _wire_body(tools: bool = True) -> dict:
+    """A production-shaped chat body: list content parts, an image part, a
+    tool_calls turn, a tool result, and function tool schemas."""
+    body = {
+        "model": "hermes-4-70b",
+        "messages": [
+            {"role": "system", "content": "You are Hermes."},
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "look at this"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://e.example/i.png", "detail": "low"},
+                    },
+                ],
+            },
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": '{"cmd":"ls"}'},
+                    }
+                ],
+            },
+            {"role": "tool", "tool_call_id": "c1", "content": "total 0"},
+        ],
+        "stream": True,
+        "temperature": 0.7,
+        "stream_options": {"include_usage": True},
+    }
+    if tools:
+        body["tools"] = [
+            {
+                "type": "function",
+                "function": {
+                    "name": f"tool_{i}",
+                    "description": "d",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"p": {"type": "string"}},
+                        "required": ["p"],
+                    },
+                },
+            }
+            for i in range(30)
+        ]
+    return body
+
+
+class _Recorder:
+    """A real openai.OpenAI client whose transport records the request body."""
+
+    def __init__(self):
+        self.content: bytes | None = None
+        self.client = openai.OpenAI(
+            api_key="k",
+            base_url="https://chat.invalid/v1",
+            http_client=httpx.Client(transport=httpx.MockTransport(self._handle)),
+        )
+
+    def _handle(self, request: httpx.Request) -> httpx.Response:
+        self.content = request.content
+        return httpx.Response(
+            200, content=_SSE, headers={"content-type": "text/event-stream"}
+        )
+
+    def send(self, kwargs: dict) -> bytes:
+        stream = self.client.chat.completions.create(**kwargs)
+        for _ in stream:
+            pass
+        assert self.content is not None
+        return self.content
+
+
+class _FacadeCompletions:
+    """Stands in for the MoA aggregator: chat-completions shaped, not the SDK."""
+
+    def create(self, **kwargs):  # pragma: no cover - never called here
+        raise AssertionError("not exercised")
+
+
+class _FacadeClient:
+    def __init__(self):
+        self.chat = types.SimpleNamespace(completions=_FacadeCompletions())
+
+
+class TestByteIdentity:
+    def test_request_body_is_byte_identical_with_and_without_the_bypass(self):
+        """The whole safety argument: the server sees the same request."""
+        recorder = _Recorder()
+        body = _wire_body()
+
+        plain = recorder.send(dict(body))
+        bypassed = recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client))
+
+        assert bypassed == plain
+        # And it really did take the bypass, rather than silently no-opping.
+        moved = bypass_chat_sdk_request_transform(dict(body), recorder.client)
+        assert moved["messages"] == []
+        assert moved["extra_body"]["messages"] == body["messages"]
+        assert moved["extra_body"]["tools"] == body["tools"]
+
+    def test_the_wire_payload_survives_a_json_round_trip_unchanged(self):
+        recorder = _Recorder()
+        body = _wire_body()
+        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
+
+        assert sent["messages"] == body["messages"]
+        assert sent["tools"] == body["tools"]
+        assert sent["temperature"] == 0.7
+        assert sent["stream_options"] == {"include_usage": True}
+
+
+class TestGuards:
+    def test_a_non_sdk_client_is_left_completely_alone(self):
+        """MoA's facade never merges extra_body, so moving the conversation
+        there would silently send an empty message list."""
+        kwargs = _wire_body()
+
+        result = bypass_chat_sdk_request_transform(kwargs, _FacadeClient())
+
+        assert result is kwargs
+        assert "extra_body" not in result
+        assert result["messages"][0]["role"] == "system"
+
+    def test_is_openai_sdk_completions_discriminates(self):
+        assert is_openai_sdk_completions(_Recorder().client)
+        assert not is_openai_sdk_completions(_FacadeClient())
+        assert not is_openai_sdk_completions(object())
+
+    def test_non_plain_json_messages_stay_on_the_typed_path(self):
+        """The transform exists to convert typed params; anything that is not
+        already wire data still needs it."""
+        recorder = _Recorder()
+        kwargs = _wire_body()
+        kwargs["messages"][1]["content"] = object()
+
+        result = bypass_chat_sdk_request_transform(kwargs, recorder.client)
+
+        assert result["messages"] is kwargs["messages"]
+        assert "extra_body" not in result or "messages" not in result["extra_body"]
+
+    def test_a_tool_free_request_does_not_gain_an_empty_tools_key(self):
+        recorder = _Recorder()
+        body = _wire_body(tools=False)
+
+        sent = json.loads(recorder.send(bypass_chat_sdk_request_transform(dict(body), recorder.client)))
+
+        assert "tools" not in sent
+
+    def test_caller_supplied_extra_body_keeps_precedence(self):
+        """The chat path already populates extra_body from custom providers,
+        reasoning config and Nous Portal; those entries must win."""
+        recorder = _Recorder()
+        body = _wire_body()
+        body["extra_body"] = {"provider": {"order": ["nous"]}, "messages": ["caller wins"]}
+
+        result = bypass_chat_sdk_request_transform(dict(body), recorder.client)
+
+        assert result["extra_body"]["messages"] == ["caller wins"]
+        assert result["extra_body"]["provider"] == {"order": ["nous"]}
+
+    def test_env_escape_hatch_restores_the_pre_fix_kwargs(self, monkeypatch):
+        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", "1")
+        recorder = _Recorder()
+        kwargs = _wire_body()
+
+        assert bypass_chat_sdk_request_transform(kwargs, recorder.client) is kwargs
+
+    @pytest.mark.parametrize("value", ["0", "false", "no", "off", ""])
+    def test_escape_hatch_stays_off_for_falsey_values(self, monkeypatch, value):
+        monkeypatch.setenv("HERMES_CHAT_SDK_TRANSFORM", value)
+        recorder = _Recorder()
+
+        result = bypass_chat_sdk_request_transform(_wire_body(), recorder.client)
+
+        assert result["messages"] == []
+
+
+class TestResponsesPathUnchanged:
+    def test_the_codex_import_path_and_behaviour_are_preserved(self):
+        """agent/auxiliary_client.py and the existing codex test import these
+        names from agent.codex_runtime; the move must not break them."""
+        from agent.codex_runtime import (
+            _SDK_TRANSFORM_BYPASS_FIELDS,
+            _bypass_sdk_request_transform,
+            _is_plain_json_data,
+        )
+
+        assert _SDK_TRANSFORM_BYPASS_FIELDS == ("input", "tools")
+        assert _is_plain_json_data([{"role": "user", "content": "hi"}])
+        assert not _is_plain_json_data([{"role": "user", "content": object()}])
+
+        kwargs = {
+            "model": "gpt-5.6-sol",
+            "input": [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}],
+            "tools": [{"type": "function", "name": "terminal", "parameters": {}}],
+            "stream": True,
+        }
+        bypassed = _bypass_sdk_request_transform(kwargs)
+
+        # Responses keeps its historical shape: the fields are REMOVED from the
+        # typed kwargs entirely (input is not @required_args there).
+        assert "input" not in bypassed
+        assert "tools" not in bypassed
+        assert bypassed["extra_body"]["input"] == kwargs["input"]


### PR DESCRIPTION
## What does this PR do?

Extends the merged #93650 request-transform bypass from `responses.create` to the **default chat-completions path**, which every OpenRouter / Nous / xAI / DeepSeek / Kimi / llama.cpp / Ollama / LM Studio / LiteLLM request takes.

### The problem is the one #93650 already documented

`chat.completions.create` re-walks the entire request body against the `CompletionCreateParams` union graph **client-side, with the GIL held**, before a byte leaves the process. #93650 recorded that class of walk wedging for 12+ hours on a ~1.4 MB conversation: no in-process watchdog can fire while the GIL is held, and no socket kill helps a hang that is pre-network. #93773 merged the fix — move the already-wire-format bulk fields into `extra_body`, which the SDK merges into the JSON body *after* the transform — but scoped it to the Responses API. The chat path was left paying the full cost.

It is provably wasted work: `agent/transports/chat_completions.py`'s `convert_messages` builds plain dicts by hand ("Messages are already in OpenAI format — strip internal fields that strict chat-completions providers reject"), so the transform has nothing to convert. Empirically, `maybe_transform(wire) == wire`.

### Measured

Against a real `openai.OpenAI` driven over an `httpx.MockTransport` returning canned SSE (no network), capturing `request.content` on both sides:

| conversation | body | plain `create()` | with bypass | saved |
|---|---|---|---|---|
| 101 msgs | 76 KB | 13.6 ms | 1.2 ms | 12.4 ms |
| 401 msgs | 190 KB | 48.6 ms | 2.0 ms | 46.6 ms (96%) |
| 1601 msgs | 650 KB | 188.7 ms | 5.8 ms | 182.9 ms (97%) |

**The bytes the server receives are literally identical** — `plain == bypassed` as raw bytes, 194,894 == 194,894 at 401 messages, not merely JSON-equivalent. That is the entire safety argument, and it is the first test in the new file.

This is paid **per API call**, so a tool-using turn multiplies it by its iteration count.

### The change

The three helpers move from `agent/codex_runtime.py` into a shared `agent/sdk_transform_bypass.py`, re-exported under their original names so `agent/auxiliary_client.py:2210` and `tests/run_agent/test_codex_sdk_transform_bypass.py` keep working with no edits. The field tuple becomes a parameter: `("input", "tools")` for Responses, `("messages", "tools")` for chat. Applied at the two native SDK chat sites, `chat_completion_helpers.py:1009` (non-streaming) and `:4299` (streaming).

Two chat-specific details, both settled empirically:

- **`messages` is a `@required_args` parameter.** It stays in the typed kwargs as `[]` and the `extra_body` copy replaces it in the body — that is the new `required_empty` argument, which the Responses path does not use. Dropping it makes 8 tests fail, including byte-identity.
- **The bypass is gated on the target actually being the SDK's `Completions`.** Hermes also drives chat-completions-shaped facades that are *not* the SDK — the in-process MoA aggregator at `moa_loop.py` most importantly, plus the stand-ins the suite injects — and those never merge `extra_body`, so handing them one would silently send an empty message list. The MoA branch at `chat_completion_helpers.py:1003` is deliberately untouched.

That guard is a **genuine improvement over the merged Responses version**, which has none, and it is why this PR needs zero edits to the 32 test files that assert on `kwargs["messages"]`: they mock with stand-ins, not the SDK. The merged Codex PR had to fix those by hand.

Every rail the merged PR was reviewed on is kept: the plain-JSON-only guard so pydantic models and generators stay on the typed path, caller `extra_body` precedence via `setdefault` (load-bearing here — the chat path already populates `extra_body` from custom providers, reasoning config and Nous Portal), and an escape hatch, `HERMES_CHAT_SDK_TRANSFORM=1`, mirroring `HERMES_CODEX_SDK_TRANSFORM`.

### Deliberately left for a follow-up

The summary/compression sites at `chat_completion_helpers.py:3449` and `:3514` carry the **largest payloads in the process**, but they route through a `lambda request: summary_client.chat.completions.create(**request)` whose client is not in scope the same way. They need a slightly different shape and a wider test surface, so they are not in this PR.

## Related Issue

Fixes #111723

Extends #93650 / #93773 to the chat path. Not a duplicate: `git grep` for the bypass symbols shows the only consumers are `codex_runtime` and `auxiliary_client`, both Responses-only, and nothing in the tree says the chat path deliberately keeps the typed walk. The `auxiliary_client` comment — "#93650: keep bulk wire-format payload out of the SDK's GIL-holding request transform on auxiliary calls **too**" — reads as coverage being extended, not fenced.

## Type of Change

- [x] ⚡ Performance improvement (non-breaking)

## Changes Made

- `agent/sdk_transform_bypass.py` (new) — the shared helpers, a parameterised field tuple, `required_empty`, and the `is_openai_sdk_completions` gate
- `agent/codex_runtime.py` — implementation replaced by re-exports under the original names
- `agent/chat_completion_helpers.py` — bypass applied at the two native SDK chat sites
- `tests/run_agent/test_chat_sdk_transform_bypass.py` (new) — 14 tests

## How to Test

1. `pytest tests/run_agent/test_chat_sdk_transform_bypass.py -q` — 14 passed. The first asserts the captured request bytes are equal with and without the bypass, for a payload with list content parts, an `image_url` part, a `tool_calls` turn, a tool result and 30 tool schemas.
2. Regression, all unchanged and passing here: `tests/run_agent/test_codex_sdk_transform_bypass.py` (10), `tests/agent/test_auxiliary_client.py` (192), `tests/agent/test_moa_aggregator_cache_control.py` (3), `tests/run_agent/test_provider_parity.py` (54), `tests/run_agent/test_run_agent.py` (282 passed; its one failure, `TestAnthropicInterruptHandler::test_interruptible_anthropic_interrupt_never_closes_shared_client`, **reproduces identically on a pristine `origin/main` export** and is unrelated).
3. Each guard was verified by breaking it: removing the SDK gate fails the MoA-facade test; dropping `required_empty` fails 8 tests including byte-identity.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs and issues — the bypass symbols, "maybe_transform", "chat completions transform"; only the Responses-scoped #93773 and its consumers
- [x] My PR contains **only** changes related to this improvement
- [x] Ran the new suite plus five regression suites, `ruff check`, and the Windows footgun linter
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26 arm64, Python 3.11, openai 2.24.0

### Documentation & Housekeeping

- [x] Documentation — the mechanism is documented in the new module's docstring and at both call sites
- [x] `cli-config.yaml.example` — N/A (the escape hatch is an env var mirroring the existing `HERMES_CODEX_SDK_TRANSFORM`, which is also env-only)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure Python; no platform APIs; footgun linter clean
- [x] Tool descriptions/schemas — N/A