### PR TITLE
fix(cli): report the .env files the loader actually reads

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -19,7 +19,7 @@ from hermes_cli.config import (
     is_nix_install_method,
     recommended_update_command_for_method,
 )
-from hermes_cli.env_loader import load_hermes_dotenv
+from hermes_cli.env_loader import load_hermes_dotenv, resolve_env_sources
 from hermes_constants import display_hermes_home
 from hermes_constants import agent_browser_runnable
 
@@ -1478,9 +1478,13 @@ def run_doctor(args):
     _section("Configuration Files")
     # Managed scope (administrator-pinned config/env), when present.
     managed_scope_check()
-    # Check ~/.hermes/.env (primary location for user config)
+    # Check ~/.hermes/.env (primary location for user config).  The candidates
+    # come from the loader's own resolver rather than a second hand-rolled
+    # fallback, so doctor, `hermes status` and load_hermes_dotenv() cannot
+    # disagree about which files count (#102023).
     env_path = HERMES_HOME / '.env'
-    if env_path.exists():
+    env_sources = resolve_env_sources(hermes_home=HERMES_HOME, project_env=PROJECT_ROOT / '.env')
+    if env_path in env_sources:
         check_ok(f"{_DHH}/.env file exists")
         
         # Prefer UTF-8 (.env is written as UTF-8 elsewhere). Fall back to
@@ -1496,9 +1500,8 @@ def run_doctor(args):
             check_warn(f"No API key found in {_DHH}/.env")
             issues.append("Run 'hermes setup' to configure API keys")
     else:
-        # Also check project root as fallback
-        fallback_env = PROJECT_ROOT / '.env'
-        if fallback_env.exists():
+        # Any remaining candidate is the project-root fallback.
+        if env_sources:
             check_ok(".env file exists (in project directory)")
         else:
             check_fail(f"{_DHH}/.env file missing")

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -471,6 +471,50 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         pass  # best-effort — don't block gateway startup
 
 
+def resolve_env_sources(
+    *,
+    hermes_home: str | os.PathLike | None = None,
+    project_env: str | os.PathLike | None = None,
+) -> list[Path]:
+    """Return the ``.env`` files ``load_hermes_dotenv`` reads, in load order.
+
+    Pure resolution: nothing is parsed and ``os.environ`` is left untouched.
+
+    This is the single source of truth for *which* files count.  The reporting
+    commands (``hermes status``, ``hermes doctor``) call it instead of
+    re-deriving the answer from ``get_env_path()`` or a hand-rolled project-root
+    fallback, so their output cannot drift from what the loader actually reads
+    (#102023).
+
+    ``.op.env`` is deliberately excluded: it bootstraps the 1Password service
+    token rather than carrying user configuration, and ``load_hermes_dotenv``
+    likewise keeps it out of its return value.
+
+    ``hermes_home`` defaults to the same bare ``HERMES_HOME`` lookup
+    ``load_hermes_dotenv`` performs.  Callers reporting to a user should pass
+    ``get_hermes_home()`` instead, so the profile override and the
+    platform-native default are honored.
+    """
+    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+
+    sources: list[Path] = []
+    seen: set[Path] = set()
+    for candidate in (home_path / ".env", Path(project_env) if project_env else None):
+        if candidate is None or not candidate.exists():
+            continue
+        # A checkout used as its own HERMES_HOME points both candidates at one
+        # file; list (and therefore load) it once.
+        try:
+            key = candidate.resolve()
+        except OSError:  # pragma: no cover - unusual filesystems
+            key = candidate
+        if key in seen:
+            continue
+        seen.add(key)
+        sources.append(candidate)
+    return sources
+
+
 def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
@@ -524,15 +568,15 @@ def load_hermes_dotenv(
 
     loaded: list[Path] = []
     user_env = home_path / ".env"
-    project_env_path = Path(project_env) if project_env else None
+    # Resolve once, through the same helper the reporting commands call, so
+    # `hermes status` / `hermes doctor` describe exactly this set (#102023).
+    sources = resolve_env_sources(hermes_home=home_path, project_env=project_env)
 
     # Normalize safe formatting and remove invalid NUL bytes before parsing.
-    if user_env.exists():
-        _sanitize_env_file_if_needed(user_env)
-    if project_env_path and project_env_path.exists():
-        _sanitize_env_file_if_needed(project_env_path)
+    for source in sources:
+        _sanitize_env_file_if_needed(source)
 
-    if user_env.exists():
+    if user_env in sources:
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
         # Mirror reload_env() known-key cleanup so inherited Hermes keys
@@ -553,9 +597,12 @@ def load_hermes_dotenv(
     if op_env.exists() and not os.environ.get("OP_SERVICE_ACCOUNT_TOKEN"):
         _load_dotenv_with_fallback(op_env, override=False)
 
-    if project_env_path and project_env_path.exists():
-        _load_dotenv_with_fallback(project_env_path, override=not loaded)
-        loaded.append(project_env_path)
+    # `override=not loaded` keeps the documented precedence: the project .env
+    # only fills gaps when the user .env was loaded, but overrides stale
+    # shell-exported values when it is the sole source.
+    for project_source in (p for p in sources if p != user_env):
+        _load_dotenv_with_fallback(project_source, override=not loaded)
+        loaded.append(project_source)
 
     # External secret sources are skipped in two updater situations:
     # 1. ``load_external_secrets=False`` — the caller is an ``update``

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -15,7 +15,8 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
-from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
+from hermes_cli.config import get_env_value, get_hermes_home, load_config
+from hermes_cli.env_loader import resolve_env_sources
 from hermes_cli.models import provider_label
 from hermes_cli.nous_account import (
     format_nous_portal_entitlement_message,
@@ -151,8 +152,28 @@ def show_status(args):
     print(f"  Project:      {PROJECT_ROOT}")
     print(f"  Python:       {sys.version.split()[0]}")
 
-    env_path = get_env_path()
-    print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
+    # Report the files load_hermes_dotenv() actually reads — including the
+    # project-root .env that setup-hermes.sh creates — instead of assuming
+    # ~/.hermes/.env is the only candidate.  Reusing the loader's own
+    # resolution is what keeps this line and `hermes doctor` in agreement
+    # (#102023).
+    # Pass the home explicitly: get_hermes_home() honors the profile override
+    # and the platform-native default (%LOCALAPPDATA%\hermes on Windows), which
+    # a bare HERMES_HOME lookup would miss.  doctor resolves it the same way, so
+    # the two commands stay aligned on every platform.
+    project_env_path = PROJECT_ROOT / ".env"
+    env_sources = resolve_env_sources(
+        hermes_home=get_hermes_home(),
+        project_env=project_env_path,
+    )
+    if not env_sources:
+        env_state = "not found"
+    elif env_sources == [project_env_path]:
+        # Same wording doctor uses for this case, so the two cannot disagree.
+        env_state = "exists (in project directory)"
+    else:
+        env_state = "exists"
+    print(f"  .env file:    {check_mark(bool(env_sources))} {env_state}")
 
     try:
         config = load_config()

--- a/tests/hermes_cli/test_env_source_reporting.py
+++ b/tests/hermes_cli/test_env_source_reporting.py
@@ -1,0 +1,140 @@
+"""Regression coverage for #102023.
+
+``hermes status`` used to print ``.env file: ✗ not found`` for the very
+checkout whose project-root ``.env`` it had just read credentials from, while
+``hermes doctor`` reported the same file as present.  Both commands re-derived
+the path themselves instead of asking the loader, so the two answers drifted.
+
+These tests pin the shared resolver, the invariant that keeps it aligned with
+``load_hermes_dotenv``, and the status line that consumes it.
+"""
+
+import os
+from types import SimpleNamespace
+
+from hermes_cli.env_loader import load_hermes_dotenv, resolve_env_sources
+
+
+def _write_env(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def test_resolve_env_sources_empty_when_nothing_exists(tmp_path):
+    home = tmp_path / "hermes"
+    home.mkdir()
+
+    assert resolve_env_sources(hermes_home=home, project_env=tmp_path / "repo" / ".env") == []
+
+
+def test_resolve_env_sources_finds_user_env(tmp_path):
+    home = tmp_path / "hermes"
+    user_env = _write_env(home / ".env", "USER_ONLY=1\n")
+
+    assert resolve_env_sources(hermes_home=home, project_env=tmp_path / "repo" / ".env") == [user_env]
+
+
+def test_resolve_env_sources_finds_project_env(tmp_path):
+    """The #102023 case: only the project-root .env that setup-hermes.sh creates."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    project_env = _write_env(tmp_path / "repo" / ".env", "PROJECT_ONLY=1\n")
+
+    assert resolve_env_sources(hermes_home=home, project_env=project_env) == [project_env]
+
+
+def test_resolve_env_sources_orders_user_before_project(tmp_path):
+    home = tmp_path / "hermes"
+    user_env = _write_env(home / ".env", "BOTH=user\n")
+    project_env = _write_env(tmp_path / "repo" / ".env", "BOTH=project\n")
+
+    assert resolve_env_sources(hermes_home=home, project_env=project_env) == [user_env, project_env]
+
+
+def test_resolve_env_sources_dedupes_when_home_is_the_checkout(tmp_path):
+    """A checkout used as its own HERMES_HOME must not list one file twice."""
+    home = tmp_path / "repo"
+    env_file = _write_env(home / ".env", "SHARED=1\n")
+
+    assert resolve_env_sources(hermes_home=home, project_env=env_file) == [env_file]
+
+
+def test_loader_return_matches_resolver(tmp_path, monkeypatch):
+    """The anti-drift invariant: what the loader reports loading is what the
+    resolver advertises.  Reporting commands read the resolver, so any future
+    change to loading order has to move both together or fail here."""
+    home = tmp_path / "hermes"
+    _write_env(home / ".env", "DRIFT_USER=user\n")
+    project_env = _write_env(tmp_path / "repo" / ".env", "DRIFT_PROJECT=project\n")
+    monkeypatch.delenv("DRIFT_USER", raising=False)
+    monkeypatch.delenv("DRIFT_PROJECT", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert loaded == resolve_env_sources(hermes_home=home, project_env=project_env)
+
+
+def test_project_env_still_loads_as_fallback(tmp_path, monkeypatch):
+    """Behavior preserved: a lone project .env is loaded, not merely reported."""
+    home = tmp_path / "hermes"
+    home.mkdir()
+    project_env = _write_env(tmp_path / "repo" / ".env", "FALLBACK_ONLY_KEY=from-project\n")
+    monkeypatch.delenv("FALLBACK_ONLY_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert loaded == [project_env]
+    assert os.environ["FALLBACK_ONLY_KEY"] == "from-project"
+
+
+def test_user_env_still_wins_over_project_env(tmp_path, monkeypatch):
+    """Precedence preserved: the project .env only fills gaps when a user .env exists."""
+    home = tmp_path / "hermes"
+    _write_env(home / ".env", "PRECEDENCE_KEY=from-user\n")
+    project_env = _write_env(
+        tmp_path / "repo" / ".env",
+        "PRECEDENCE_KEY=from-project\nPROJECT_GAP_KEY=gap-filled\n",
+    )
+    monkeypatch.delenv("PRECEDENCE_KEY", raising=False)
+    monkeypatch.delenv("PROJECT_GAP_KEY", raising=False)
+
+    load_hermes_dotenv(hermes_home=home, project_env=project_env)
+
+    assert os.environ["PRECEDENCE_KEY"] == "from-user"
+    assert os.environ["PROJECT_GAP_KEY"] == "gap-filled"
+
+
+def test_status_reports_project_env_instead_of_not_found(tmp_path, monkeypatch, capsys):
+    """#102023: status claimed 'not found' for a project .env it was reading."""
+    from hermes_cli import status as status_mod
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    repo = tmp_path / "repo"
+    _write_env(repo / ".env", "STATUS_PROJECT_KEY=1\n")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(status_mod, "PROJECT_ROOT", repo)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert ".env file:" in output
+    assert "exists (in project directory)" in output
+    assert "not found" not in output.split("Model:")[0]
+
+
+def test_status_reports_not_found_when_no_env_exists(tmp_path, monkeypatch, capsys):
+    from hermes_cli import status as status_mod
+
+    home = tmp_path / "hermes"
+    home.mkdir()
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(status_mod, "PROJECT_ROOT", repo)
+
+    status_mod.show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "not found" in output.split("Model:")[0]


### PR DESCRIPTION
## What does this PR do?

`hermes status` printed `.env file: ✗ not found` for a checkout whose project-root `.env` it had just read credentials from, while `hermes doctor` reported that same file as present.

The cause is not the status line itself — it is that **nothing owns the question of which `.env` files count**. `load_hermes_dotenv()` already computes the answer and returns it (`env_loader.py`, `return loaded`), but every caller discards that value, so each reporting command re-derives it independently and the derivations drift:

| Consumer | How it decided | Result |
|---|---|---|
| `status.py` | `get_env_path()` only | Missed the project-root `.env` — the reported bug |
| `doctor.py` | `HERMES_HOME/.env`, then a hand-rolled `PROJECT_ROOT` fallback | Correct, by duplicating loader logic inline |

This extracts that resolution into `resolve_env_sources()` and has the loader **and** both reporting commands share it, so the answer is decided in exactly one place. Patching only `status.py` would have produced a third copy of the same logic and left the next loader change free to diverge again.

## Related Issue

Fixes #102023

Context: #14517 and #31144 are the two user-facing symptom reports of this same divergence.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py` — new `resolve_env_sources()`: pure path resolution, no parsing, `os.environ` untouched. `load_hermes_dotenv()` now drives its sanitize/load/return off that list. **Load order, the `override=not loaded` precedence, and the return value are unchanged.**
- `hermes_cli/status.py` — report from the resolver, reusing doctor's existing wording so the two commands cannot word the same state differently. Passes `get_hermes_home()` explicitly so the profile override and the platform-native default (`%LOCALAPPDATA%\hermes` on Windows) are honored — a bare `HERMES_HOME` lookup would have made the two disagree on Windows.
- `hermes_cli/doctor.py` — drop the duplicated `PROJECT_ROOT` fallback and read the same list. **Output strings unchanged.**
- `tests/hermes_cli/test_env_source_reporting.py` — 10 regression tests.

Deliberately **not** in scope:

- `.op.env` stays out of the resolver: it bootstraps the 1Password service token rather than carrying user config, and the loader already keeps it out of its return value.
- `hermes config show`'s `Secrets:` line still prints `get_env_path()`. That is the **write** target (where `config set`/`unset` and `hermes setup` write), which is correct as-is; the loader-vs-`config show` mismatch is #31144, and #31245 is already changing loader resolution there. Kept out to avoid competing with that PR.

## How to Test

Reproduces on the plain flow documented in CONTRIBUTING.md — no `HERMES_HOME` override needed:

```bash
git clone https://github.com/NousResearch/hermes-agent && cd hermes-agent
./setup-hermes.sh          # creates ./.env from .env.example; skip the wizard
hermes status              # before: ".env file:  ✗ not found"
hermes doctor              # before: "✓ .env file exists (in project directory)"
```

Before, `status` contradicted itself on one screen — denying the file while displaying the key it had read from it:

```
  .env file:    ✗ not found        ← claims the file does not exist...
  Provider:     OpenRouter         ← ...but switched provider because of it
  OpenRouter    ✓ sk-o...ONLY      ← ...and is displaying the key read from it
```

After, verified against the live CLI across the full matrix:

| `~/.hermes/.env` | project `.env` | `hermes status` | `hermes doctor` |
|---|---|---|---|
| ✗ | ✓ | `✓ exists (in project directory)` | `✓ .env file exists (in project directory)` |
| ✓ | ✓ | `✓ exists` | `✓ ~/.hermes/.env file exists` |
| ✓ | ✗ | `✓ exists` | `✓ ~/.hermes/.env file exists` |
| ✗ | ✗ | `✗ not found` | `✗ ~/.hermes/.env file missing` |

Automated:

```bash
pytest tests/hermes_cli/test_env_source_reporting.py -q     # 10 passed
```

The regression test was confirmed to **fail** without the `status.py` change and pass with it, so it genuinely pins the bug rather than the fix.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run in full.** Ran the affected suites instead: `test_env_source_reporting`, `test_env_loader`, `test_env_load_cache`, `test_env_sanitize_on_load`, `test_dump_env_visibility`, `test_env_loader_applied_homes`, `test_env_loader_op_bootstrap`, `test_env_loader_secret_sources`, `test_cli_status_command`, `test_status*` → **95 passed**, plus `tests/hermes_cli/ -k "status or doctor"` → 358 passed, 4 skipped. `ruff check` clean on all changed files. One failure in that last run, `test_doctor.py::TestHonchoDoctorConfigDetection::test_reports_configured_when_enabled_with_api_key`, was verified to **reproduce identically on pristine `main` with these changes stashed** — a pre-existing ordering-dependent failure (it passes in isolation), left alone rather than widening this PR.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (container), Python 3.11.15, Hermes v0.21.0 (2026.8.31)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on the new helper; no user-facing docs describe this line
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — this is why `status` passes `get_hermes_home()` rather than letting the resolver fall back to a bare `HERMES_HOME` lookup, which would have diverged from `doctor` on Windows
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ hermes status          # after
  .env file:    ✓ exists (in project directory)

$ hermes doctor          # after
  ✓ .env file exists (in project directory)
```

