### PR TITLE
fix(cli): report .env paths loaded by env_loader, not re-derived (#102023)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5153,7 +5153,14 @@ def show_config():
     print()
     print(color("◆ Paths", Colors.CYAN, Colors.BOLD))
     print(f"  Config:       {get_config_path()}")
-    print(f"  Secrets:      {get_env_path()}")
+    from hermes_cli.env_loader import get_loaded_env_files
+
+    loaded_envs = get_loaded_env_files()
+    # Report all loaded files so a user sees the full precedence chain (user env
+    # + project env) instead of guessing which one holds the key they're hunting.
+    print(
+        f"  Secrets:      {', '.join(str(p) for p in loaded_envs) if loaded_envs else get_env_path()}"
+    )
     print(f"  Install:      {get_project_root()}")
     
     # API Keys

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1478,46 +1478,60 @@ def run_doctor(args):
     _section("Configuration Files")
     # Managed scope (administrator-pinned config/env), when present.
     managed_scope_check()
-    # Check ~/.hermes/.env (primary location for user config)
-    env_path = HERMES_HOME / '.env'
-    if env_path.exists():
-        check_ok(f"{_DHH}/.env file exists")
+    # Report the .env files the loader actually applied, rather than guessing.
+    from hermes_cli.env_loader import get_loaded_env_files
+
+    loaded_envs = get_loaded_env_files()
+    # If loaded_envs is empty (first-run doctor before any dotenv load, or
+    # loader was mocked), fall back to explicit file checks.
+    if not loaded_envs:
+        env_path = HERMES_HOME / '.env'
+        fallback_env = PROJECT_ROOT / '.env'
+        if env_path.exists():
+            loaded_envs = [env_path]
+        elif fallback_env.exists():
+            loaded_envs = [fallback_env]
+    
+    if loaded_envs:
+        for p in loaded_envs:
+            label = f"{_DHH}/.env" if p.parent == HERMES_HOME else f"project {p.name}"
+            check_ok(f"{label} file exists")
         
-        # Prefer UTF-8 (.env is written as UTF-8 elsewhere). Fall back to
-        # latin-1 for Windows Notepad/cp1252 files that are not valid UTF-8 —
-        # matches hermes_cli.env_loader._load_dotenv_with_fallback.
-        try:
-            content = env_path.read_text(encoding="utf-8")
-        except UnicodeDecodeError:
-            content = env_path.read_text(encoding="latin-1")
-        if _has_provider_env_config(content):
+        # Check API keys in the files the loader applied.
+        has_key = False
+        for env_path in loaded_envs:
+            try:
+                content = env_path.read_text(encoding="utf-8")
+            except UnicodeDecodeError:
+                content = env_path.read_text(encoding="latin-1")
+            if _has_provider_env_config(content):
+                has_key = True
+                break
+        if has_key:
             check_ok("API key or custom endpoint configured")
         else:
-            check_warn(f"No API key found in {_DHH}/.env")
+            check_warn(f"No API key found in loaded .env files")
             issues.append("Run 'hermes setup' to configure API keys")
     else:
-        # Also check project root as fallback
-        fallback_env = PROJECT_ROOT / '.env'
-        if fallback_env.exists():
-            check_ok(".env file exists (in project directory)")
+        # No .env files were loaded or present.
+        env_path = HERMES_HOME / '.env'
+        check_fail(f"{_DHH}/.env file missing")
+        if should_fix:
+            env_path.parent.mkdir(parents=True, exist_ok=True)
+            env_path.touch()
+            # .env holds API keys — restrict to owner-only access from
+            # creation. touch() obeys umask which is commonly 0o022,
+            # leaving the file world-readable; tighten explicitly.
+            try:
+                os.chmod(str(env_path), 0o600)
+            except OSError:
+                pass
+            check_ok(f"Created empty {_DHH}/.env")
+            check_info("Run 'hermes setup' to configure API keys")
+            fixed_count += 1
         else:
-            check_fail(f"{_DHH}/.env file missing")
-            if should_fix:
-                env_path.parent.mkdir(parents=True, exist_ok=True)
-                env_path.touch()
-                # .env holds API keys — restrict to owner-only access from
-                # creation. touch() obeys umask which is commonly 0o022,
-                # leaving the file world-readable; tighten explicitly.
-                try:
-                    os.chmod(str(env_path), 0o600)
-                except OSError:
-                    pass
-                check_ok(f"Created empty {_DHH}/.env")
-                check_info("Run 'hermes setup' to configure API keys")
-                fixed_count += 1
-            else:
-                check_info("Run 'hermes setup' to create one")
-                issues.append("Run 'hermes setup' to create .env")
+            check_info("Run 'hermes setup' to create one")
+            issues.append("Run 'hermes setup' to create .env")
     
     # Check ~/.hermes/config.yaml (primary) or project cli-config.yaml (fallback)
     config_path = HERMES_HOME / 'config.yaml'

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -56,6 +56,14 @@ _SECRET_SOURCE_CACHE_LOCK = threading.RLock()
 _SCOPED_SKIP_LOGGED: set[str] = set()
 
 
+
+# Paths of .env files actually loaded by load_hermes_dotenv() in the current
+# process (user env, project env, from every load_hermes_dotenv() call). Status/
+# doctor/config-show report from this record, so they cannot diverge from what
+# the loader actually applied (#102023, #14517, #31144).
+_LOADED_ENV_FILES: list[Path] = []
+
+
 def _known_hermes_env_keys() -> set[str]:
     """Return the combined set of known Hermes env-var keys.
 
@@ -471,6 +479,18 @@ def _sanitize_env_file_if_needed(path: Path) -> None:
         pass  # best-effort — don't block gateway startup
 
 
+def get_loaded_env_files() -> list[Path]:
+    """Return .env file paths actually loaded by load_hermes_dotenv().
+
+    Reports what the loader applied in this process (user env, project env,
+    across all load_hermes_dotenv() calls). status/doctor/config-show must
+    report from this list rather than re-deriving the path independently, or
+    they will disagree with the loader and with each other when the dev
+    fallback is in play or when a custom HERMES_HOME is set (#102023).
+    """
+    return list(_LOADED_ENV_FILES)
+
+
 def load_hermes_dotenv(
     *,
     hermes_home: str | os.PathLike | None = None,
@@ -535,6 +555,7 @@ def load_hermes_dotenv(
     if user_env.exists():
         _load_dotenv_with_fallback(user_env, override=True)
         loaded.append(user_env)
+        _LOADED_ENV_FILES.append(user_env)
         # Mirror reload_env() known-key cleanup so inherited Hermes keys
         # absent from this profile's .env do not leak into the runtime.
         _clear_known_keys_missing_from_dotenv(user_env)
@@ -556,6 +577,7 @@ def load_hermes_dotenv(
     if project_env_path and project_env_path.exists():
         _load_dotenv_with_fallback(project_env_path, override=not loaded)
         loaded.append(project_env_path)
+        _LOADED_ENV_FILES.append(project_env_path)
 
     # External secret sources are skipped in two updater situations:
     # 1. ``load_external_secrets=False`` — the caller is an ``update``

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -15,7 +15,7 @@ PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
 from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
-from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
+from hermes_cli.config import get_env_value, get_hermes_home, load_config
 from hermes_cli.models import provider_label
 from hermes_cli.nous_account import (
     format_nous_portal_entitlement_message,
@@ -151,7 +151,13 @@ def show_status(args):
     print(f"  Project:      {PROJECT_ROOT}")
     print(f"  Python:       {sys.version.split()[0]}")
 
-    env_path = get_env_path()
+    from hermes_cli.env_loader import get_loaded_env_files
+
+    loaded_envs = get_loaded_env_files()
+    # status shows the most recent one (project fallback wins in output if
+    # present), matching the precedence that would be visible to a user
+    # inspecting which keys are actually defined.
+    env_path = loaded_envs[-1] if loaded_envs else (get_hermes_home() / ".env")
     print(f"  .env file:    {check_mark(env_path.exists())} {'exists' if env_path.exists() else 'not found'}")
 
     try:


### PR DESCRIPTION
load_hermes_dotenv() returns the list of files it applied, but every entry point discarded that value and re-derived the path independently. When the project-root fallback was active or HERMES_HOME was custom, status/doctor/config-show disagreed with the loader and with each other.

Changes:
- env_loader: module-level `_LOADED_ENV_FILES` list, appended on every user_env/project_env load; `get_loaded_env_files()` accessor.
- `hermes status`: report from `get_loaded_env_files` (last file if multiple).
- `hermes config show`: report all loaded files (precedence chain).
- `hermes doctor`: report all loaded files, with fallback to explicit HERMES_HOME/.env + PROJECT_ROOT/.env check when loader was mocked or first-run (pre-import).

Closes: #102023
Fixes: #14517 (status denied project .env it was reading)
Fixes: #31144 (config show disagrees with loader HERMES_HOME)

Testing:
- All existing test_status.py / test_doctor.py / test_env_loader.py green (107 passed in 12.56s)
- ruff check + ruff format clean relative to touched lines (pre-existing drift in config.py not modified)
