### PR TITLE
test: isolate macOS suite from host state and platform assumptions

### DIFF
--- a/tests/agent/test_codex_aux_timeout_fd_ownership.py
+++ b/tests/agent/test_codex_aux_timeout_fd_ownership.py
@@ -22,7 +22,7 @@ import pytest
 from agent.auxiliary_client import _CodexCompletionsAdapter
 
 
-def _adapter_with_recording_client(stream):
+def _adapter_with_recording_client(stream, *, shutdown_seen=None):
     """Build an adapter whose client records (action, thread) events.
 
     The nested ``_client._transport._pool._connections`` shape is what
@@ -33,6 +33,8 @@ def _adapter_with_recording_client(stream):
     class _Sock:
         def shutdown(self, how):
             events.append(("shutdown", threading.get_ident()))
+            if shutdown_seen is not None:
+                shutdown_seen.set()
 
         def close(self):
             events.append(("sock.close", threading.get_ident()))
@@ -71,13 +73,25 @@ class TestCodexAuxiliaryTimeoutFdOwnership:
         shutdown(); the real close() must land on the owning thread in the
         adapter's ``finally``."""
 
-        def _stalled():
-            deadline = time.monotonic() + 30.0
-            while time.monotonic() < deadline:
-                time.sleep(0.02)
-                yield SimpleNamespace(type="response.in_progress")
+        shutdown_seen = threading.Event()
+        timers = []
+        timer_type = threading.Timer
 
-        adapter, events = _adapter_with_recording_client(_stalled())
+        def _record_timer(*args, **kwargs):
+            timer = timer_type(*args, **kwargs)
+            timers.append(timer)
+            return timer
+
+        def _stalled():
+            # Model a blocked socket read. Emitting keepalives here lets the
+            # owner detect the deadline first and legitimately cancel the
+            # timer, so it does not exercise stranger-thread FD ownership.
+            assert shutdown_seen.wait(10), "watchdog did not shut down the socket"
+            yield SimpleNamespace(type="response.in_progress")
+
+        adapter, events = _adapter_with_recording_client(
+            _stalled(), shutdown_seen=shutdown_seen
+        )
         owner_tid = threading.get_ident()
 
         def _consume(stream, *, model, on_event):
@@ -87,7 +101,8 @@ class TestCodexAuxiliaryTimeoutFdOwnership:
             return SimpleNamespace(output=[], usage=None)
 
         with (
-            patch("agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 0.3),
+            patch("agent.auxiliary_client._AUX_STREAM_NO_PROGRESS_TIMEOUT_SECONDS", 2.0),
+            patch("agent.auxiliary_client.threading.Timer", _record_timer),
             patch("agent.auxiliary_client._evict_cached_client_instance"),
             patch("agent.codex_runtime._consume_codex_event_stream", _consume),
             pytest.raises(TimeoutError),
@@ -97,8 +112,10 @@ class TestCodexAuxiliaryTimeoutFdOwnership:
                 timeout=300,
             )
 
-        # Give the daemon Timer thread a beat to finish its callback.
-        time.sleep(0.2)
+        # Observe all callback actions before asserting thread ownership.
+        for timer in timers:
+            timer.join(timeout=10)
+            assert not timer.is_alive(), "watchdog callback did not finish"
         actions = [a for a, _ in events]
         # Stranger thread (Timer) only shut the sockets down.
         shutdown_tids = {tid for a, tid in events if a == "shutdown"}

--- a/tests/computer_use/test_cua_no_overlay.py
+++ b/tests/computer_use/test_cua_no_overlay.py
@@ -244,9 +244,21 @@ class TestEmbeddedDaemonOverlayFlag:
             cua_backend.subprocess, "Popen", return_value=process,
         ) as popen, patch.object(
             cua_backend.subprocess, "run", return_value=status,
-        ), patch.object(cua_backend.threading, "Thread"):
+        ), patch.object(
+            cua_backend, "_resolve_cua_driver_app_path", return_value="/Applications/CuaDriver.app",
+        ), patch.object(
+            cua_backend, "_validate_cua_driver_app_signature",
+        ) as validate_signature, patch.object(cua_backend.threading, "Thread"):
             daemon.start()
 
         command = popen.call_args.args[0]
-        assert command[:2] == ["/usr/bin/cua-driver", "serve"]
+        if cua_backend.sys.platform == "darwin":
+            assert command[:7] == [
+                "/usr/bin/open", "-n", "-g", "-a",
+                "/Applications/CuaDriver.app", "--args", "serve",
+            ]
+            validate_signature.assert_called_once_with("/Applications/CuaDriver.app")
+        else:
+            assert command[:2] == ["/usr/bin/cua-driver", "serve"]
+            validate_signature.assert_not_called()
         assert "--no-overlay" in command

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1752,3 +1752,15 @@ def _moa_caches_isolated():
     yield
     moa._preset_cache.clear()
     moa._runtime_cache.clear()
+
+
+@pytest.fixture
+def short_tmp_path():
+    """Private temporary directory for Unix sockets and near-PATH_MAX fixtures.
+
+    pytest's descriptive paths can exceed sockaddr_un.sun_path on macOS.
+    Avoid both those names and macOS's long per-user TMPDIR prefix.
+    """
+    base = "/tmp" if os.name == "posix" else tempfile.gettempdir()
+    with tempfile.TemporaryDirectory(prefix="ht-", dir=base) as directory:
+        yield Path(directory)

--- a/tests/gateway/test_buzz_adapter.py
+++ b/tests/gateway/test_buzz_adapter.py
@@ -3060,8 +3060,8 @@ class TestInboundMediaAuthorizationGate:
         assert result.raw_response is None
 
     @pytest.mark.asyncio
-    async def test_live_media_redacts_long_path_before_bounding(self, tmp_path):
-        parent = tmp_path
+    async def test_live_media_redacts_long_path_before_bounding(self, short_tmp_path):
+        parent = short_tmp_path
         private_parts = []
         for index in range(6):
             part = f"private-{index}-" + ("x" * 150)
@@ -3070,6 +3070,7 @@ class TestInboundMediaAuthorizationGate:
             parent.mkdir()
         media = parent / "handoff.txt"
         media.write_text("safe handoff", encoding="utf-8")
+        assert len(str(media)) > 900  # Redaction must happen before truncation.
         adapter = _make_adapter()
         adapter._run_cli = AsyncMock(
             return_value=(

--- a/tests/gateway/test_readiness.py
+++ b/tests/gateway/test_readiness.py
@@ -3,12 +3,23 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+from collections import namedtuple
 from pathlib import Path
+
+import pytest
 
 from gateway.readiness import collect_runtime_readiness
 
 
-def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monkeypatch):
+@pytest.mark.parametrize("used, expected_status", [(50, "ok"), (95, "degraded")])
+def test_collect_runtime_readiness_reports_disk_health(
+    tmp_path, monkeypatch, used, expected_status
+):
+    usage = namedtuple("usage", "total used free")
+    monkeypatch.setattr(
+        "gateway.readiness.shutil.disk_usage",
+        lambda _path: usage(100, used, 100 - used),
+    )
     home = tmp_path / ".hermes"
     home.mkdir()
     (home / "config.yaml").write_text(
@@ -29,14 +40,14 @@ def test_collect_runtime_readiness_reports_healthy_local_runtime(tmp_path, monke
         active_api_runs=2,
     )
 
-    assert result["status"] == "ok"
+    assert result["status"] == expected_status
     assert result["checks"]["state_db"]["status"] == "ok"
     assert result["checks"]["session_store"]["status"] == "ok"
     assert result["checks"]["config"]["status"] == "ok"
     assert result["checks"]["model"]["status"] == "ok"
     assert result["checks"]["gateway"]["status"] == "ok"
     assert result["checks"]["background_queues"]["active_api_runs"] == 2
-    assert result["checks"]["disk"]["status"] in {"ok", "degraded"}
+    assert result["checks"]["disk"]["status"] == expected_status
 
 
 def test_collect_runtime_readiness_degrades_on_invalid_config_and_stopped_gateway(

--- a/tests/gateway/test_scale_to_zero.py
+++ b/tests/gateway/test_scale_to_zero.py
@@ -150,9 +150,9 @@ def _fake_flaps(tmp_path, status_line, capture):
     return sock_path, t
 
 
-def test_suspend_self_posts_suspend_for_this_machine(tmp_path):
+def test_suspend_self_posts_suspend_for_this_machine(short_tmp_path):
     captured: list[bytes] = []
-    sock_path, t = _fake_flaps(tmp_path, "200 OK", captured)
+    sock_path, t = _fake_flaps(short_tmp_path, "200 OK", captured)
     assert suspend_self(_FLY_ENV, socket_path=sock_path) is True
     t.join(timeout=5)
     request = captured[0].decode()
@@ -164,9 +164,9 @@ def test_suspend_self_posts_suspend_for_this_machine(tmp_path):
     assert "Host: flaps\r\n" in request
 
 
-def test_suspend_self_non_2xx_is_false_not_raise(tmp_path):
+def test_suspend_self_non_2xx_is_false_not_raise(short_tmp_path):
     captured: list[bytes] = []
-    sock_path, t = _fake_flaps(tmp_path, "412 Precondition Failed", captured)
+    sock_path, t = _fake_flaps(short_tmp_path, "412 Precondition Failed", captured)
     assert suspend_self(_FLY_ENV, socket_path=sock_path) is False
     t.join(timeout=5)
 

--- a/tests/gateway/test_systemd_notify.py
+++ b/tests/gateway/test_systemd_notify.py
@@ -8,9 +8,7 @@ import socket
 import pytest
 
 
-@pytest.mark.skipif(
-    not hasattr(socket, "AF_UNIX"), reason="Unix datagram sockets are unavailable"
-)
+@pytest.mark.linux_only
 def test_notify_supports_systemd_abstract_socket(monkeypatch):
     name = "\0hermes-test-notify"
     receiver = socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM)
@@ -25,6 +23,29 @@ def test_notify_supports_systemd_abstract_socket(monkeypatch):
         assert receiver.recv(4096) == b"WATCHDOG=1"
     finally:
         receiver.close()
+
+
+@pytest.mark.macos_only
+def test_notify_supports_filesystem_socket_on_macos(monkeypatch, short_tmp_path):
+    _assert_filesystem_notification(monkeypatch, short_tmp_path)
+
+
+@pytest.mark.linux_only
+def test_notify_supports_filesystem_socket_on_linux(monkeypatch, short_tmp_path):
+    _assert_filesystem_notification(monkeypatch, short_tmp_path)
+
+
+def _assert_filesystem_notification(monkeypatch, short_tmp_path):
+    path = str(short_tmp_path / "notify.sock")
+    with socket.socket(socket.AF_UNIX, socket.SOCK_DGRAM) as receiver:
+        receiver.bind(path)
+        receiver.settimeout(1.0)
+        monkeypatch.setenv("NOTIFY_SOCKET", path)
+
+        from gateway.systemd_notify import notify
+
+        assert notify("WATCHDOG=1") is True
+        assert receiver.recv(4096) == b"WATCHDOG=1"
 
 
 def test_notify_uses_nonblocking_datagram_send(monkeypatch):

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -960,7 +960,7 @@ def test_seed_from_singletons_respects_hermes_pkce_suppression(tmp_path, monkeyp
     }))
 
     # Stub the readers so only hermes_pkce is "available"; claude_code returns None
-    import agent.anthropic_adapter as aa
+    import agent.anthropic_credentials as aa
     monkeypatch.setattr(aa, "read_hermes_oauth_credentials", lambda: {
         "accessToken": "tok", "refreshToken": "r", "expiresAt": 9999999999000,
     })

--- a/tests/hermes_cli/test_session_recovery_lost_and_found.py
+++ b/tests/hermes_cli/test_session_recovery_lost_and_found.py
@@ -220,6 +220,7 @@ def test_unreadable_schema_without_cli_names_the_sqlite3_requirement(
     import hermes_cli.session_lost_and_found as laf
 
     monkeypatch.setattr(laf, "find_sqlite3_cli", lambda: None)
+    monkeypatch.setattr(laf, "find_sqlite3_cli_refusal", lambda: {})
     with pytest.raises(SessionRecoverySourceError) as excinfo:
         recover_session_database(
             source,

--- a/tests/hermes_cli/test_update_launchd_fleet_restart.py
+++ b/tests/hermes_cli/test_update_launchd_fleet_restart.py
@@ -205,6 +205,7 @@ class TestGetServicePidsScoping:
             "launchd_gateway_labels_for_install",
             lambda: ["ai.hermes.gateway", "ai.hermes.gateway-a", "ai.hermes.gateway-b"],
         )
+        monkeypatch.setattr(gw.subprocess, "run", lambda *_a, **_kw: _completed())
         located = {
             "ai.hermes.gateway": (f"gui/{UID}", 100),
             "ai.hermes.gateway-a": (f"gui/{UID}", 200),
@@ -642,12 +643,15 @@ class TestWaitForLaunchdServicePid:
 
 
 class TestIncompleteWarningMentionsLaunchctl:
+    @pytest.mark.macos_only
     def test_launchd_labels_get_launchctl_hint(self, capsys):
         _warn_incomplete_gateway_fleet_restart(["ai.hermes.gateway-merit-ops"])
         out = capsys.readouterr().out
         assert "Update incomplete" in out
-        assert "launchctl kickstart -k" in out
+        assert "launchctl bootstrap" in out
+        assert "~/Library/LaunchAgents/<label>.plist" in out
 
+    @pytest.mark.linux_only
     def test_systemd_units_keep_systemctl_hint(self, capsys):
         _warn_incomplete_gateway_fleet_restart(["hermes-gateway-coder"])
         out = capsys.readouterr().out

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -14,6 +14,7 @@ from hermes_cli import runtime_provider as rp
 def _no_live_builtin_provider_probes(monkeypatch):
     """Keep picker tests offline: builtin-provider catalog fetches hit the network."""
     monkeypatch.setattr("hermes_cli.models.fetch_api_models", lambda *_a, **_kw: None)
+    monkeypatch.setattr("hermes_cli.models.fetch_ollama_local_models", lambda *_a, **_kw: None)
     monkeypatch.setattr(
         "hermes_cli.models.cached_provider_model_ids", lambda *_a, **_kw: []
     )

--- a/tests/scripts/test_contributor_map.py
+++ b/tests/scripts/test_contributor_map.py
@@ -157,7 +157,8 @@ def test_add_contributor_refuses_a_case_collision(tmp_path, monkeypatch):
     monkeypatch.setattr(mod, "EMAILS_DIR", d)
 
     assert mod.add_contributor("agent@example-host.local", "otherperson") == 1
-    assert not (d / "agent@example-host.local").exists()
+    assert [p.name for p in d.iterdir()] == ["agent@Example-Host.local"]
+    assert (d / "agent@Example-Host.local").read_text(encoding="utf-8") == "someone\n"
 
 
 def test_add_contributor_refuses_case_collision_even_for_same_login(emails_dir, capsys):

--- a/tests/test_guest_durability_barriers.py
+++ b/tests/test_guest_durability_barriers.py
@@ -8,6 +8,7 @@ the guest entry point applies it directly.
 """
 
 import sqlite3
+import sys
 
 import pytest
 
@@ -40,14 +41,17 @@ def test_guest_barriers_apply_configured_synchronous(monkeypatch, tmp_path):
         conn.close()
 
 
-def test_guest_barriers_leave_synchronous_alone_when_unset(monkeypatch, tmp_path):
+def test_guest_barriers_preserve_platform_durability_when_unset(monkeypatch, tmp_path):
     _config(monkeypatch, {})
     conn = sqlite3.connect(tmp_path / "state.db")
     try:
         conn.execute("PRAGMA journal_mode=DELETE")
         conn.execute("PRAGMA synchronous=1")
         apply_durability_barriers(conn)
-        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1
+        # Unset configuration must not undo the macOS FULL durability floor.
+        expected = 2 if sys.platform == "darwin" else 1
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == expected
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
     finally:
         conn.close()
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -896,45 +896,51 @@ class TestFTS5Search:
         ]
         assert all("context" in row and row["context"] for row in default)
 
-    def test_search_projection_skips_context_enrichment_queries(self, db):
+    def test_search_projection_skips_context_enrichment_queries(self, db, monkeypatch):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="before")
         db.append_message("s1", role="assistant", content="projectionneedle")
         db.append_message("s1", role="user", content="after")
 
         statements = []
-        read_conn = db._get_read_conn() or db._conn
-        traced_connections = [db._conn]
-        if read_conn is not db._conn:
-            traced_connections.append(read_conn)
-        for conn in traced_connections:
-            conn.set_trace_callback(statements.append)
+        from contextlib import contextmanager
+
+        original_read_ctx = db._read_ctx
+
+        @contextmanager
+        def traced_read_ctx():
+            # Each read can acquire a fresh connection; trace the connection
+            # actually executing the search, not a separately acquired handle.
+            with original_read_ctx() as conn:
+                conn.set_trace_callback(statements.append)
+                try:
+                    yield conn
+                finally:
+                    conn.set_trace_callback(None)
+
+        monkeypatch.setattr(db, "_read_ctx", traced_read_ctx)
 
         def context_query_count():
             normalized = (" ".join(sql.upper().split()) for sql in statements)
             return sum("WITH TARGET AS (" in sql for sql in normalized)
 
-        try:
-            projected = db.search_messages(
-                "projectionneedle", fields=("session_id", "snippet")
-            )
-            assert len(projected) == 1
-            assert context_query_count() == 0
+        projected = db.search_messages(
+            "projectionneedle", fields=("session_id", "snippet")
+        )
+        assert len(projected) == 1
+        assert context_query_count() == 0
 
-            full = db.search_messages(
-                "projectionneedle", fields=("session_id", "context")
-            )
-            assert len(full) == 1
-            assert full[0]["context"]
-            assert context_query_count() == 1
+        full = db.search_messages(
+            "projectionneedle", fields=("session_id", "context")
+        )
+        assert len(full) == 1
+        assert full[0]["context"]
+        assert context_query_count() == 1
 
-            default = db.search_messages("projectionneedle")
-            assert len(default) == 1
-            assert default[0]["context"]
-            assert context_query_count() == 2
-        finally:
-            for conn in traced_connections:
-                conn.set_trace_callback(None)
+        default = db.search_messages("projectionneedle")
+        assert len(default) == 1
+        assert default[0]["context"]
+        assert context_query_count() == 2
 
     def test_sanitize_fts5_query_strips_dangerous_chars(self):
         """Unit test for _sanitize_fts5_query static method."""

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -16271,6 +16271,7 @@ def test_model_options_preserves_canonical_custom_row_after_agent_init(monkeypat
             custom_providers=[],
         ),
     )
+    monkeypatch.setattr("hermes_cli.inventory._anthropic_oauth_credentials_present", lambda: False)
     canonical = Mock(return_value="custom:local-ollama")
     monkeypatch.setattr(
         "hermes_cli.runtime_provider.canonical_custom_identity",

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -100,9 +100,12 @@ class TestDetectDangerousRm:
 
 
     def test_nonrecursive_verification_artifact_cleanup_is_not_dangerous(self):
-        with mock_patch("tempfile.gettempdir", return_value="/tmp"):
+        from pathlib import Path
+
+        temp_dir = Path("/tmp").resolve()
+        with mock_patch("tempfile.gettempdir", return_value=str(temp_dir)):
             for prefix in ("hermes-verify-", "hermes-ad-hoc-"):
-                assert detect_dangerous_command(f"rm -f /tmp/{prefix}example.py") == (
+                assert detect_dangerous_command(f"rm -f {temp_dir}/{prefix}example.py") == (
                     False,
                     None,
                     None,

--- a/tests/tools/test_code_kernel.py
+++ b/tests/tools/test_code_kernel.py
@@ -377,11 +377,13 @@ class TestKernelOwnershipAndLifecycle(unittest.TestCase):
                 t.join()
         self.assertEqual([r["status"] for r in results], ["success"] * 6)
         self.assertEqual(len(_KERNELS), 1)
-        live = subprocess.run(
-            ["pgrep", "-fc", "-P", str(os.getpid()), "hermes_kernel_runner"],
-            capture_output=True, text=True,
-        ).stdout.strip()
-        self.assertEqual(live, "1")
+        import psutil
+
+        live = [
+            child for child in psutil.Process().children()
+            if "hermes_kernel_runner" in " ".join(child.cmdline())
+        ]
+        self.assertEqual(len(live), 1)
 
 
 class TestPerCellRpcAuthority(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -387,7 +387,7 @@ class TestDelegateTask(unittest.TestCase):
         from pathlib import Path
 
         with tempfile.TemporaryDirectory() as tmp:
-            profile_db_path = Path(tmp) / "profile-work" / "state.db"
+            profile_db_path = Path(tmp).resolve() / "profile-work" / "state.db"
             profile_db_path.parent.mkdir(parents=True)
             parent = _make_mock_parent(depth=0)
             parent_db = SessionDB(db_path=profile_db_path)

--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -4,6 +4,7 @@ import os
 import shlex
 import shutil
 import subprocess
+import sys
 import time
 
 import pytest
@@ -39,14 +40,37 @@ def test_real_read_tool_binaries_confirm_option_ownership(
         ("rg", ["--hostname-bin=-payload-marker", "needle", "{input}"], None, False),
         ("sort", ["--buffer-size=1K", "--compress-program", "-payload-marker"], "{bulk}", False),
         ("ag", ["--pager=-payload-marker", "needle", "{input}"], None, True),
-        ("man", ["--pager", "-payload-marker", "ls"], None, True),
-        ("man", ["-P", "-payload-marker", "ls"], None, True),
     ],
 )
 def test_real_binaries_execute_leading_dash_program_payload(
     tmp_path, tool, args, stdin, needs_tty
 ):
     """A PATH marker proves these binaries do not reparse '-program' as an option."""
+    if tool == "sort":
+        # This is GNU sort's external-compressor protocol. macOS ships a BSD
+        # sort with similar flags but a different spill/compression pipeline.
+        tool = shutil.which("gsort") or shutil.which("sort")
+        if tool is None:
+            pytest.skip("GNU sort is not installed")
+        version = subprocess.run(
+            [tool, "--version"], capture_output=True, text=True,
+            encoding="utf-8", errors="replace", timeout=5
+        )
+        if "GNU coreutils" not in version.stdout:
+            pytest.skip("GNU sort is not installed")
+    _assert_program_payload(tmp_path, tool, args, stdin, needs_tty)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize("pager_option", ["--pager", "-P"])
+def test_man_db_executes_leading_dash_pager(tmp_path, pager_option):
+    # man-db's long options and util-linux script syntax are Linux-specific.
+    _assert_program_payload(
+        tmp_path, "man", [pager_option, "-payload-marker", "ls"], None, True
+    )
+
+
+def _assert_program_payload(tmp_path, tool, args, stdin, needs_tty):
     if shutil.which(tool) is None or (needs_tty and shutil.which("script") is None):
         pytest.skip(f"{tool} or script is not installed")
 
@@ -70,7 +94,10 @@ def test_real_binaries_execute_leading_dash_program_payload(
     }
     argv = [tool, *resolved_args]
     if needs_tty:
-        argv = ["script", "-qec", shlex.join(argv), "/dev/null"]
+        if sys.platform == "darwin":
+            argv = ["script", "-q", "/dev/null", *argv]
+        else:
+            argv = ["script", "-qec", shlex.join(argv), "/dev/null"]
 
     subprocess.run(argv, input=input_text, text=True, capture_output=True, env=env, timeout=20)
 

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -5,6 +5,7 @@ handling without requiring a running terminal environment.
 """
 
 import json
+from pathlib import Path
 import logging
 from unittest.mock import MagicMock, patch
 
@@ -54,7 +55,9 @@ class TestWriteFileHandler:
         from tools.file_tools import write_file_tool
         result = json.loads(write_file_tool("/tmp/out.txt", "hello world!\n"))
         assert result["status"] == "ok"
-        mock_ops.write_file.assert_called_once_with("/tmp/out.txt", "hello world!\n")
+        mock_ops.write_file.assert_called_once_with(
+            str(Path("/tmp/out.txt").resolve()), "hello world!\n"
+        )
 
     @patch("tools.file_tools._get_file_ops")
     def test_permission_error_returns_error_json_without_error_log(self, mock_get, caplog):
@@ -145,7 +148,9 @@ class TestPatchHandler:
             old_string="foo", new_string="bar"
         ))
         assert result["status"] == "ok"
-        mock_ops.patch_replace.assert_called_once_with("/tmp/f.py", "foo", "bar", False)
+        mock_ops.patch_replace.assert_called_once_with(
+            str(Path("/tmp/f.py").resolve()), "foo", "bar", False
+        )
 
 
     @patch("tools.file_tools._get_file_ops")

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -1912,6 +1912,7 @@ class TestSystemdCgroupIsolation:
 
         return fake_popen, captured
 
+    @pytest.mark.linux_only
     def test_wraps_in_systemd_scope_when_supervisor_and_available(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2129,6 +2130,7 @@ class TestSystemdCgroupIsolation:
 
         assert session.systemd_unit == ""
 
+    @pytest.mark.linux_only
     def test_systemd_post_spawn_failure_never_kills_gateway_process_group(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2163,6 +2165,7 @@ class TestSystemdCgroupIsolation:
         assert stop_unit.call_args.args[0].endswith(".scope")
         killpg.assert_not_called()
 
+    @pytest.mark.linux_only
     def test_pty_spawn_is_wrapped_in_systemd_scope(self, registry, monkeypatch, _gateway_identity):
         """Interactive executors receive the same sibling-cgroup isolation."""
         from ptyprocess import PtyProcess
@@ -2194,6 +2197,7 @@ class TestSystemdCgroupIsolation:
         assert argv[-3:] == ["/bin/bash", "-lic", "set +m; codex"]
         assert session.systemd_unit == f"hermes-worker-{session.id}.scope"
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_reaps_scope_before_distinct_pipe_fallback(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2249,6 +2253,7 @@ class TestSystemdCgroupIsolation:
             f"hermes-worker-{session.id}-pipe-fallback.scope"
         )
 
+    @pytest.mark.linux_only
     def test_pty_spawn_failure_does_not_fallback_when_scope_reap_fails(
         self, registry, monkeypatch, _gateway_identity
     ):
@@ -2343,6 +2348,7 @@ class TestSystemdCgroupIsolation:
         assert session.id in registry._finished
         assert session.id not in registry._running
 
+    @pytest.mark.linux_only
     def test_systemd_run_user_scope_available_caches_after_probe(
         self, registry, monkeypatch
     ):
@@ -2367,6 +2373,7 @@ class TestSystemdCgroupIsolation:
         assert second is True
         assert len(probe_calls) == 1, "probe must run only once (cached)"
 
+    @pytest.mark.linux_only
     def test_systemd_scope_first_probe_is_serialized(self, monkeypatch):
         """Concurrent first-use callers must wait for one definitive probe.
 
@@ -2414,6 +2421,7 @@ class TestSystemdCgroupIsolation:
         assert results == [True, True]
         assert len(probe_calls) == 1
 
+    @pytest.mark.linux_only
     def test_failed_systemd_probe_retries_after_cache_ttl(self, monkeypatch):
         import tools.process_registry as pr
 

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -382,8 +382,8 @@ class TestTranscribeLocalExtended:
         # WhisperModel should be created only once
         assert mock_whisper_cls.call_count == 1
 
-    def test_config_device_and_compute_type_passed_to_whisper(self, tmp_path):
-        """User-configured device and compute_type should be forwarded to WhisperModel.
+    def test_config_device_and_compute_type_passed_to_loader(self, tmp_path):
+        """Forward user configuration to the platform-aware Whisper loader.
 
         Regression test for #8319: these values were hardcoded to "auto".
         """
@@ -398,7 +398,7 @@ class TestTranscribeLocalExtended:
 
         mock_model = MagicMock()
         mock_model.transcribe.return_value = ([mock_segment], mock_info)
-        mock_whisper_cls = MagicMock(return_value=mock_model)
+        mock_loader = MagicMock(return_value=mock_model)
 
         fake_config = {
             "local": {
@@ -408,7 +408,7 @@ class TestTranscribeLocalExtended:
         }
 
         with patch("tools.transcription_tools._HAS_FASTER_WHISPER", True), \
-             patch("faster_whisper.WhisperModel", mock_whisper_cls), \
+             patch("tools.transcription_tools._load_local_whisper_model", mock_loader), \
              patch("tools.transcription_tools._local_model", None), \
              patch("tools.transcription_tools._local_model_name", None), \
              patch("tools.transcription_tools._load_stt_config", return_value=fake_config):
@@ -416,7 +416,7 @@ class TestTranscribeLocalExtended:
             result = _transcribe_local(str(audio), "base")
 
         assert result["success"] is True
-        mock_whisper_cls.assert_called_once_with("base", device="cpu", compute_type="float32")
+        mock_loader.assert_called_once_with("base", device="cpu", compute_type="float32")
 
 
     def test_cuda_out_of_memory_does_not_trigger_cpu_fallback(self, tmp_path):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -121,10 +121,10 @@ def fake_clock(monkeypatch):
 # ============================================================================
 
 class TestPulseSocketReachable:
-    def test_stale_socket_file_not_reachable(self, monkeypatch, tmp_path):
+    def test_stale_socket_file_not_reachable(self, monkeypatch, short_tmp_path):
         """A socket file with no listener should not count as reachable."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = short_tmp_path / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         # Create + bind, then close so the path is a stale socket file.
         s = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
@@ -132,14 +132,14 @@ class TestPulseSocketReachable:
         s.close()
         monkeypatch.delenv("PULSE_SERVER", raising=False)
         monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-        monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+        monkeypatch.setenv("XDG_RUNTIME_DIR", str(short_tmp_path))
         from tools.voice_mode import _pulse_socket_reachable
         assert _pulse_socket_reachable() is False
 
-    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, tmp_path):
+    def test_listening_socket_reachable_via_xdg_runtime(self, monkeypatch, short_tmp_path):
         """A live PulseAudio-style socket under XDG_RUNTIME_DIR is reachable (#35622)."""
         import socket as _socket
-        sock_path = tmp_path / "pulse" / "native"
+        sock_path = short_tmp_path / "pulse" / "native"
         sock_path.parent.mkdir(parents=True)
         server = _socket.socket(_socket.AF_UNIX, _socket.SOCK_STREAM)
         server.bind(str(sock_path))
@@ -147,7 +147,7 @@ class TestPulseSocketReachable:
         try:
             monkeypatch.delenv("PULSE_SERVER", raising=False)
             monkeypatch.delenv("PULSE_RUNTIME_PATH", raising=False)
-            monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+            monkeypatch.setenv("XDG_RUNTIME_DIR", str(short_tmp_path))
             from tools.voice_mode import _pulse_socket_reachable
             assert _pulse_socket_reachable() is True
         finally:
@@ -1391,6 +1391,7 @@ class TestWSL2PowerShellFallback:
             return next(it)
         return _side_effect
 
+    @pytest.mark.linux_only
     def test_powershell_pipeline_preserves_real_exit_status(self, sample_wav):
         """Regression (review of #63768): the shell pipeline must preserve
         the (ffmpeg && powershell) exit status past the unconditional
@@ -1440,7 +1441,8 @@ class TestWSL2PowerShellFallback:
             "Shell pipeline must preserve the real exit status past cleanup: " + sh_script
         )
 
-    def test_wsl2_unique_temp_filename(self, monkeypatch, tmp_path, sample_wav):
+    @pytest.mark.linux_only
+    def test_wsl2_unique_temp_filename(self, sample_wav):
         """Two concurrent calls must use different temp WAV filenames."""
         from unittest.mock import patch, MagicMock
         from tools import voice_mode as vm
@@ -1459,13 +1461,8 @@ class TestWSL2PowerShellFallback:
                 return f"C:\\Temp\\{wsl_path.split('/')[-1]}\n".encode()
             return b""
 
-        def _fake_open(path, *args, **kwargs):
-            if str(path) == "/proc/version":
-                import io
-                return io.StringIO("Linux Microsoft WSL2")
-            return open(path, *args, **kwargs)
-
-        with patch("builtins.open", side_effect=_fake_open), \
+        with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
+             patch("tools.voice_mode._import_audio", side_effect=ImportError), \
              patch("shutil.which", side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay") else None), \
              patch("subprocess.check_output", side_effect=_capture_check_output), \
              patch("subprocess.Popen", return_value=MagicMock(returncode=0, wait=lambda **k: 0)), \

--- a/tests/tools/test_wake_word.py
+++ b/tests/tools/test_wake_word.py
@@ -220,6 +220,7 @@ def test_openwakeword_ensures_base_models_for_custom_path(monkeypatch):
     # so a fresh install crashed at load time on a missing melspectrogram.onnx.
     # The base feature models must be ensured for a custom path too.
     calls = _install_fake_openwakeword(monkeypatch)
+    monkeypatch.setattr(ww, "ensure_tflite_runtime", lambda: True)
     eng = ww._OpenWakeWordEngine(
         {"provider": "openwakeword", "openwakeword": {"model": "/models/hey_hermes.onnx"}}
     )


### PR DESCRIPTION
[gpt-5.6-sol] RESPONDING ON BEHALF OF PRAGGY

## What does this PR do?

Make the Python test suite reproducible on a configured macOS workstation without changing production behavior. The full standard run exposed 39 failures that also reproduced on untouched upstream; a later run exposed one additional reproducible watchdog-test race.

The fixtures had assumed Linux utilities and socket limits, uncanonicalized paths, or an empty host configuration. Some also patched old discovery boundaries, allowing local credentials/services to affect their results.

## Changes

- Keep real socket and file-redaction coverage with a short, private temporary-directory fixture. The redaction test still requires a path longer than the output limit.
- Isolate credential, Ollama, launchd, SQLite-refusal and native-runtime probes; provide deterministic healthy/degraded disk readings.
- Match current native contracts: macOS app launch, database durability, canonical paths, and launchd bootstrap guidance. Trace the actual fresh SQLite read connections and count real child kernel processes with psutil.
- Use the verified GNU sort implementation for its compressor protocol and native terminal-wrapper syntax. Mark 14 Linux-specific cases with the existing Linux marker instead of faking the host or removing their assertions. Add real filesystem-datagram tests for both macOS and Linux CI lanes.
- Make the watchdog ownership fixture block until socket shutdown, then join the real timer before asserting thread ownership. The separate owner-deadline case remains covered.

This is a test-only companion to the validation work on #102002; it does not add the Discord feature or change installed/runtime behavior.

## Validation

`scripts/run_tests.sh -j 8 --file-retries 0`: **44,766 passed, 0 failed, 466 skipped**, all 3,686 test files completed in 805.7 seconds. Exit code 0; no retries.

The 466 skips include 14 former macOS failures now correctly assigned to Linux, plus the Linux counterpart of the new filesystem-socket test. Existing optional-dependency and other-OS skips remain explicit.

Environment: macOS ARM64, Python 3.11, dependencies from the locked CI extra set. The canonical runner is `scripts/run_tests.sh`, as required by AGENTS.md.

The standard suite excludes e2e/integration/docker. OS-gated and optional-dependency skips are not counted as passes. Linux and Windows runtime execution is not claimed from the macOS run.

Ruff and whitespace checks pass. Comparing the changed test files with upstream shows no new Windows-footgun findings; the broad scan of those existing files retains its 81 pre-existing findings.

## Checklist

- [x] Read the contribution guide and searched for related existing PRs.
- [x] Test-only scope; production source, configuration defaults and dependencies are unchanged.
- [x] Existing behavior assertions retained or corrected against current contracts; additional healthy/degraded disk and filesystem-socket coverage included.
- [x] Final full standard suite completed successfully on macOS with retries disabled.
- [x] Cross-platform behavior considered; native-host markers used instead of faking the OS.
- [x] Configuration/tool/schema documentation: N/A; no behavior or configuration keys changed.
- [x] Test comments explain the changed fixtures and platform requirements.
