### PR TITLE
fix(windows): hide nvidia-smi consoles on hardware polls

### DIFF
--- a/contributors/emails/monerostar@users.noreply.github.com
+++ b/contributors/emails/monerostar@users.noreply.github.com
@@ -1,0 +1,2 @@
+monerostar
+# PR #102047 CI: map login-only GitHub noreply

--- a/hermes_cli/local_runtime/bootstrap.py
+++ b/hermes_cli/local_runtime/bootstrap.py
@@ -15,6 +15,7 @@ import subprocess
 import time
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime.binaries import runtimes_root
 from hermes_cli.local_runtime.gguf import SPLIT_PART_RE, model_id_from_stem
 
@@ -35,7 +36,8 @@ def _detect_gpu_vendor() -> str | None:
     with suppress(OSError, subprocess.TimeoutExpired):
         out = subprocess.run(
             [smi, "--query-gpu=name", "--format=csv,noheader"],
-            capture_output=True, text=True, timeout=10)
+            capture_output=True, text=True, timeout=10,
+            creationflags=windows_hide_flags())
         if out.returncode == 0 and out.stdout.strip():
             return "nvidia " + out.stdout.strip().splitlines()[0]
     return None

--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -18,6 +18,7 @@ import sys
 import time
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime.estimator import HardwareBudget
 
 logger = logging.getLogger(__name__)
@@ -145,7 +146,8 @@ def _nvidia_vram() -> tuple[int, int] | None:
         out = subprocess.run(
             [exe, "--query-gpu=memory.total,memory.free",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=10)
+            capture_output=True, text=True, timeout=10,
+            creationflags=windows_hide_flags())
         if out.returncode != 0 or not out.stdout.strip():
             return None
         total_mib, free_mib = (int(x) for x in out.stdout.strip().splitlines()[0].split(","))

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -30,6 +30,7 @@ from pydantic import BaseModel
 from starlette.concurrency import run_in_threadpool
 
 from hermes_cli import config as config_mod, web_deps
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime import (
     binaries, bootstrap, catalog, context_policy, estimator, growth, hardware, hf_browse,
     load_progress, presets, supervisor,
@@ -493,7 +494,8 @@ def _nvidia_smi_facts() -> dict:
     if not smi_exe:
         return {}
     smi = subprocess.run([smi_exe, "--query-gpu=name,utilization.gpu,memory.used", "--format=csv,noheader,nounits"],
-                         capture_output=True, text=True, timeout=5)
+                         capture_output=True, text=True, timeout=5,
+                         creationflags=windows_hide_flags())
     if smi.returncode != 0 or not smi.stdout.strip():
         return {}
     name, util, used_mib = (x.strip() for x in smi.stdout.strip().splitlines()[0].split(","))

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -428,3 +428,88 @@ def test_suppress_platform_ver_console_stubs_syscmd_ver(monkeypatch):
     # Idempotent + never raises on repeat calls.
     _subprocess_compat.suppress_platform_ver_console()
     assert platform._syscmd_ver() == ("", "", "")
+
+
+# ── #101895 nvidia-smi statusbar / hardware probes ──────────────────────────
+#
+# The desktop GPU statusbar polls /api/local-models/hardware every 5s. That
+# endpoint shells out to Console-subsystem nvidia-smi twice per request
+# (VRAM budget in hardware._nvidia_vram, then name/util in the router).
+# A windowless parent (Electron backend / pythonw) therefore flashes two
+# consoles on every poll. Hide-only (creationflags); capture_output must
+# stay intact. bootstrap._detect_gpu_vendor is the same nvidia-smi spawn
+# at runtime-select time.
+
+
+def test_nvidia_vram_probe_hides_console_window(monkeypatch):
+    from hermes_cli.local_runtime import hardware as hw
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="8192, 4096\n")
+
+    monkeypatch.setattr(hw, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(hw, "_nvidia_smi_path", lambda: r"C:\Windows\System32\nvidia-smi.exe")
+    monkeypatch.setattr(hw.subprocess, "run", fake_run)
+
+    result = hw._nvidia_vram()
+
+    assert result == (8192 << 20, 4096 << 20)
+    spawns = _spawns(captured, "--query-gpu=memory.total,memory.free")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+    assert spawns[0][1]["capture_output"] is True
+
+
+def test_local_models_hardware_smi_hides_console_window(monkeypatch):
+    from hermes_cli.local_runtime import hardware as hw
+    from hermes_cli.web_routers import local_models
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="NVIDIA GeForce RTX 4060 Ti, 12, 2048\n")
+
+    monkeypatch.setattr(
+        hw, "probe_budget",
+        lambda: SimpleNamespace(
+            uma=False, total_device_bytes=8 << 30, usable_vram_bytes=6 << 30,
+        ),
+    )
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: (16 << 30, 8 << 30))
+    monkeypatch.setattr(hw, "_nvidia_smi_path", lambda: r"C:\Windows\System32\nvidia-smi.exe")
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    out = local_models.local_models_hardware()
+
+    assert out["gpu_name"] == "NVIDIA GeForce RTX 4060 Ti"
+    assert out["gpu_util_percent"] == 12
+    assert out["vram_used_bytes"] == 2048 << 20
+    spawns = _spawns(captured, "--query-gpu=name,utilization.gpu,memory.used")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+    assert spawns[0][1]["capture_output"] is True
+
+
+def test_detect_gpu_vendor_hides_console_window(monkeypatch):
+    from hermes_cli.local_runtime import bootstrap
+    from hermes_cli.local_runtime import hardware as hw
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="NVIDIA GeForce RTX 4060 Ti\n")
+
+    monkeypatch.setattr(bootstrap, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(hw, "_nvidia_smi_path", lambda: r"C:\Windows\System32\nvidia-smi.exe")
+    monkeypatch.setattr(bootstrap.subprocess, "run", fake_run)
+
+    assert bootstrap._detect_gpu_vendor() == "nvidia NVIDIA GeForce RTX 4060 Ti"
+    spawns = _spawns(captured, "--query-gpu=name")
+    assert len(spawns) == 1, captured
+    assert spawns[0][1]["creationflags"] == _CREATE_NO_WINDOW
+    assert spawns[0][1]["capture_output"] is True

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -464,6 +464,7 @@ def test_nvidia_vram_probe_hides_console_window(monkeypatch):
 
 
 def test_local_models_hardware_smi_hides_console_window(monkeypatch):
+    from hermes_cli import _subprocess_compat
     from hermes_cli.local_runtime import hardware as hw
     from hermes_cli.web_routers import local_models
 
@@ -481,6 +482,9 @@ def test_local_models_hardware_smi_hides_console_window(monkeypatch):
     )
     monkeypatch.setattr(hw, "_ram_bytes", lambda: (16 << 30, 8 << 30))
     monkeypatch.setattr(hw, "_nvidia_smi_path", lambda: r"C:\Windows\System32\nvidia-smi.exe")
+    # Router imports windows_hide_flags inside the handler; stub the source
+    # module so Linux CI does not assert against the POSIX helper's 0.
+    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
     monkeypatch.setattr(subprocess, "run", fake_run)
 
     out = local_models.local_models_hardware()

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -464,7 +464,6 @@ def test_nvidia_vram_probe_hides_console_window(monkeypatch):
 
 
 def test_local_models_hardware_smi_hides_console_window(monkeypatch):
-    from hermes_cli import _subprocess_compat
     from hermes_cli.local_runtime import hardware as hw
     from hermes_cli.web_routers import local_models
 
@@ -482,10 +481,10 @@ def test_local_models_hardware_smi_hides_console_window(monkeypatch):
     )
     monkeypatch.setattr(hw, "_ram_bytes", lambda: (16 << 30, 8 << 30))
     monkeypatch.setattr(hw, "_nvidia_smi_path", lambda: r"C:\Windows\System32\nvidia-smi.exe")
-    # Router imports windows_hide_flags inside the handler; stub the source
-    # module so Linux CI does not assert against the POSIX helper's 0.
-    monkeypatch.setattr(_subprocess_compat, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
-    monkeypatch.setattr(subprocess, "run", fake_run)
+    # Module-top import binds the helper on local_models; stub that name so
+    # Linux CI does not assert against the POSIX helper's 0.
+    monkeypatch.setattr(local_models, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(local_models.subprocess, "run", fake_run)
 
     out = local_models.local_models_hardware()
 


### PR DESCRIPTION
## Summary

The desktop GPU statusbar polls `/api/local-models/hardware` every 5s. That endpoint shells out to Console-subsystem `nvidia-smi` twice per request, both via `subprocess.run` with no `creationflags`:

1. `hermes_cli/local_runtime/hardware.py` — `_nvidia_vram()`
2. `hermes_cli/web_routers/local_models.py` — `local_models_hardware()`

A windowless parent (Electron backend / pythonw) therefore flashes **two** consoles on every poll. Same missing flag on `bootstrap._detect_gpu_vendor()` (one-shot at runtime select).

Thread the existing `windows_hide_flags()` helper (CREATE_NO_WINDOW on Windows, 0 on POSIX) through all three sites. Capture/timeout behavior is unchanged.

Fixes #101895

## Native Win11 evidence

Host: Windows 11 (NT 10.0.26200), Python 3.11.15, RTX 4060 Ti.

- `nvidia-smi.exe` PE subsystem **3** (CUI / console) at `C:\Windows\System32\nvidia-smi.exe`
- After the patch, live probes still return data with `windows_hide_flags() == 0x8000000`:
  - `_nvidia_vram()` → `(8585740288, 2780823552)`
  - `_detect_gpu_vendor()` → `nvidia NVIDIA GeForce RTX 4060 Ti`
- New wiring tests + existing file: **13 passed** (`tests/test_windows_subprocess_no_window_flags.py`)
- `tests/hermes_cli/test_unified_pool_quirk.py`: **17 passed**

## Test plan

- [x] `test_nvidia_vram_probe_hides_console_window`
- [x] `test_local_models_hardware_smi_hides_console_window`
- [x] `test_detect_gpu_vendor_hides_console_window`
- [x] Live `_nvidia_vram` / `_detect_gpu_vendor` on native Win11 NVIDIA