### PR TITLE
feat(privacy): anonymize document PII before model requests

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -259,6 +259,26 @@ async def preprocess_context_references_async(
     allowed_root_path = (
         Path(allowed_root).expanduser().resolve() if allowed_root is not None else cwd_path
     )
+    model_message = message
+    # The desktop intentionally retains @file chips in authored text. For an
+    # anonymized document that would still reveal the original path to tools,
+    # so replace only document-reference spans in the model-facing copy.
+    from agent.document_anonymizer import document_anonymization_enabled, is_document_path
+
+    if document_anonymization_enabled():
+        for ref in reversed(refs):
+            if ref.kind != "file":
+                continue
+            try:
+                ref_path = _resolve_path(cwd_path, ref.target, allowed_root=allowed_root_path)
+            except Exception:
+                continue
+            if is_document_path(ref_path):
+                model_message = (
+                    model_message[: ref.start]
+                    + "[анонимизированный документ]"
+                    + model_message[ref.end :]
+                )
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
@@ -294,7 +314,7 @@ async def preprocess_context_references_async(
             f"@ context injection refused: {injected_tokens} tokens exceeds the 50% hard limit ({hard_limit})."
         )
         return ContextReferenceResult(
-            message=message,
+            message=model_message,
             original_message=message,
             references=refs,
             warnings=warnings,
@@ -313,7 +333,7 @@ async def preprocess_context_references_async(
     # inline chip, so stripping them left a sentence with a hole in it ("review
     # and ship") and made the desktop re-derive the refs from the attached block
     # to show them as a detached list above the prose.
-    final = message
+    final = model_message
     if warnings:
         final = f"{final}\n\n--- Context Warnings ---\n" + "\n".join(f"- {warning}" for warning in warnings)
     if blocks:
@@ -382,6 +402,28 @@ def _expand_file_reference(
         return f"{ref.raw}: file not found", None
     if not path.is_file():
         return f"{ref.raw}: path is not a file", None
+    # Desktop/TUI file attachments enter the agent through @file references.
+    # Anonymize document formats here, before either their extracted text or
+    # original filesystem path can become model-visible.  Source-code files
+    # are intentionally excluded, and ordinary typed messages never pass this
+    # branch.
+    from agent.document_anonymizer import (
+        document_anonymization_enabled,
+        is_document_path,
+        sanitized_document_text,
+    )
+
+    if document_anonymization_enabled() and is_document_path(path):
+        try:
+            text = sanitized_document_text(path)
+        except Exception as exc:
+            return (
+                f"{ref.raw}: document withheld because local anonymization failed "
+                f"({type(exc).__name__})",
+                None,
+            )
+        label = f"anonymized document ({path.suffix.lower() or 'file'})"
+        return None, f"📄 {label} ({estimate_tokens_rough(text)} tokens)\n{text}"
     if _is_binary_file(path):
         # A binary file can't be inlined as text, but it IS on disk (the agent's
         # tools run where this resolves — the local cwd, or the staged copy in a

--- a/agent/document_anonymizer.py
+++ b/agent/document_anonymizer.py
@@ -1,0 +1,276 @@
+"""Local, document-scoped anonymization before document content reaches an LLM.
+
+This module deliberately does *not* expose a generic outbound-message redactor:
+ordinary chat text must remain byte-for-byte unchanged.  Callers opt in only
+for uploaded/attached document bytes or explicitly marked document-context
+blocks.  Extraction and replacement happen locally and fail closed.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+DOCUMENT_EXTENSIONS = frozenset(
+    {
+        ".txt", ".md", ".markdown", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml", ".log",
+        ".pdf", ".doc", ".docx", ".docm", ".rtf", ".odt", ".ods", ".odp",
+        ".xls", ".xlsx", ".xlsm", ".ppt", ".pptx", ".epub",
+    }
+)
+_TEXT_EXTENSIONS = frozenset({".txt", ".md", ".markdown", ".csv", ".tsv", ".json", ".xml", ".yaml", ".yml", ".log"})
+_SOURCE_EXTENSIONS = frozenset(
+    {".py", ".pyi", ".js", ".jsx", ".ts", ".tsx", ".java", ".c", ".h", ".cpp", ".hpp", ".rs", ".go", ".css", ".scss", ".sql", ".sh", ".ps1"}
+)
+_FALSE_VALUES = frozenset({"0", "false", "no", "off", "disabled"})
+
+# Currency is mandatory unless the number contains a grouped thousands
+# separator.  This avoids turning dates, clause numbers and IDs into sums.
+_MONEY_RE = re.compile(
+    r"(?<![\w])(?:"
+    r"(?:[$€£₽]\s*)?\d{1,3}(?:[ \u00a0\u202f.,]\d{3})+(?:[.,]\d{1,2})?"
+    r"|(?:[$€£₽]\s*)?\d+(?:[.,]\d{1,2})?\s*(?:руб(?:л(?:ей|я|ь)?)?\.?|р\.|₽|RUB|USD|EUR|доллар(?:ов|а)?|евро)"
+    r")(?:\s*(?:руб(?:л(?:ей|я|ь)?)?\.?|р\.|₽|RUB|USD|EUR|доллар(?:ов|а)?|евро))?",
+    re.IGNORECASE,
+)
+_EMAIL_RE = re.compile(r"(?<![\w.+-])[\w.+-]+@[\w.-]+\.[A-Za-zА-Яа-яЁё]{2,}(?![\w-])")
+_PHONE_RE = re.compile(r"(?<!\d)(?:\+7|8)[\s(.-]*\d{3}[\s).-]*\d{3}[\s.-]*\d{2}[\s.-]*\d{2}(?!\d)")
+_PASSPORT_RE = re.compile(r"(?i)(?:паспорт\s*(?:серия\s*)?)?\b\d{2}\s?\d{2}\s?\d{6}\b")
+_SNILS_RE = re.compile(r"(?i)(?:СНИЛС\s*[:№]?\s*)?\b\d{3}[- ]?\d{3}[- ]?\d{3}[ -]?\d{2}\b")
+_INN_RE = re.compile(r"(?i)(?:ИНН\s*[:№]?\s*)\d{10,12}\b")
+_ACCOUNT_RE = re.compile(r"(?i)(?:(?:р/?с|расч[её]тный сч[её]т|сч[её]т)\s*[:№]?\s*)\d{20}\b")
+# Privacy-biased Russian full-name heuristic. Requiring three title-cased words
+# avoids ordinary prose while covering nominative and common inflected forms.
+_RU_FULL_NAME_RE = re.compile(r"(?<![\w-])(?:[А-ЯЁ][а-яё]+(?:-[А-ЯЁ][а-яё]+)?\s+){2}[А-ЯЁ][а-яё]+(?:-[А-ЯЁ][а-яё]+)?(?![\w-])")
+_RU_INITIAL_NAME_RE = re.compile(r"(?<![\w-])(?:[А-ЯЁ]\.[ ]?){1,2}[А-ЯЁ][а-яё]+(?:-[А-ЯЁ][а-яё]+)?(?![\w-])")
+_LATIN_FULL_NAME_RE = re.compile(
+    r"(?<![\w-])[A-Z][a-z]+(?:-[A-Z][a-z]+)?(?:\s+[A-Z][a-z]+(?:-[A-Z][a-z]+)?){1,3}(?![\w-])"
+)
+_LABELED_NAME_RE = re.compile(
+    r"(?i)(?P<label>\b(?:ФИО|получатель|заказчик|исполнитель|сотрудник)\s*[:№-]?\s*)"
+    r"(?P<name>[А-ЯЁ][а-яё]+(?:\s+[А-ЯЁ][а-яё]+){1,2})"
+)
+_LABELED_PII_RE = re.compile(
+    r"(?im)(?P<label>\b(?:дата рождения|адрес(?: регистрации| проживания)?|место рождения)\s*[:№-]?\s*)"
+    r"(?P<value>[^\n;]{3,200})"
+)
+_OPENWEBUI_SOURCE_RE = re.compile(r"(?is)(<source\b[^>]*>)(.*?)(</source>)")
+
+
+@dataclass
+class _Tokens:
+    people: dict[str, str] = field(default_factory=dict)
+    sums: dict[str, str] = field(default_factory=dict)
+
+    def person(self, value: str) -> str:
+        key = " ".join(value.casefold().split())
+        return self.people.setdefault(key, f"person{len(self.people) + 1}")
+
+    def amount(self, value: str) -> str:
+        key = re.sub(r"\s+", " ", value.casefold()).strip().rstrip(".")
+        return self.sums.setdefault(key, f"SUM{len(self.sums) + 1}")
+
+
+def document_anonymization_enabled() -> bool:
+    """Resolve the feature flag; env override is useful for tests/workers."""
+    env = os.getenv("HERMES_DOCUMENT_ANONYMIZATION")
+    if env is not None:
+        return env.strip().casefold() not in _FALSE_VALUES
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        privacy = (load_config_readonly().get("privacy") or {})
+        return bool(privacy.get("anonymize_documents", False))
+    except Exception:
+        return False
+
+
+def is_document_path(path: str | Path) -> bool:
+    return Path(path).suffix.casefold() in DOCUMENT_EXTENSIONS
+
+
+def anonymize_document_text(text: str) -> str:
+    """Replace detected personal data and monetary amounts deterministically."""
+    tokens = _Tokens()
+
+    def person(match: re.Match[str]) -> str:
+        return tokens.person(match.group(0))
+
+    def labeled(match: re.Match[str]) -> str:
+        return f"{match.group('label')}{tokens.person(match.group('name'))}"
+
+    def labeled_pii(match: re.Match[str]) -> str:
+        return f"{match.group('label')}{tokens.person(match.group('value'))}"
+
+    result = _EMAIL_RE.sub(person, text)
+    result = _PHONE_RE.sub(person, result)
+    result = _SNILS_RE.sub(person, result)
+    result = _INN_RE.sub(person, result)
+    result = _ACCOUNT_RE.sub(person, result)
+    result = _PASSPORT_RE.sub(person, result)
+    result = _LABELED_PII_RE.sub(labeled_pii, result)
+    result = _LABELED_NAME_RE.sub(labeled, result)
+    result = _RU_INITIAL_NAME_RE.sub(person, result)
+    result = _RU_FULL_NAME_RE.sub(person, result)
+    result = _LATIN_FULL_NAME_RE.sub(person, result)
+    def amount(match: re.Match[str]) -> str:
+        numeric = re.search(r"\d[\d \u00a0\u202f.,]*", match.group(0))
+        key = numeric.group(0).rstrip(".,") if numeric else match.group(0)
+        return tokens.amount(key)
+
+    result = _MONEY_RE.sub(amount, result)
+    return result
+
+
+def anonymize_document_blocks(text: str) -> str:
+    """Anonymize known attached-document blocks, never ordinary message text."""
+    marker = "--- Attached Context ---"
+    if marker not in text:
+        return text
+    prefix, suffix = text.split(marker, 1)
+    return prefix + marker + anonymize_document_text(suffix)
+
+
+def anonymize_openwebui_source_blocks(text: str) -> str:
+    """Redact OpenWebUI RAG document bodies while preserving user prose."""
+    if not document_anonymization_enabled() or "<source" not in text.casefold():
+        return text
+    return _OPENWEBUI_SOURCE_RE.sub(
+        lambda match: '<source anonymized="true">'
+        + anonymize_document_text(match.group(2))
+        + match.group(3),
+        text,
+    )
+
+
+def anonymize_openwebui_content(content: Any) -> Any:
+    """Apply source-block redaction to OpenAI text content shapes."""
+    if isinstance(content, str):
+        return anonymize_openwebui_source_blocks(content)
+    if isinstance(content, list):
+        return [
+            {
+                **part,
+                "text": anonymize_openwebui_source_blocks(str(part.get("text") or "")),
+            }
+            if isinstance(part, dict)
+            and str(part.get("type") or "").casefold() in {"text", "input_text", "output_text"}
+            else part
+            for part in content
+        ]
+    return content
+
+
+def extract_document_text_local(path: str | Path) -> str:
+    """Extract locally. No network fallback is permitted."""
+    path = Path(path)
+    if path.suffix.casefold() in _TEXT_EXTENSIONS:
+        raw = path.read_bytes()
+        if len(raw) > 25 * 1024 * 1024:
+            raise ValueError("document exceeds the 25 MiB anonymization limit")
+        for encoding in ("utf-8-sig", "utf-16", "cp1251"):
+            try:
+                return raw.decode(encoding)
+            except UnicodeDecodeError:
+                continue
+        raise ValueError("text document encoding is not supported")
+    from tools.read_extract import extract_document_text
+
+    extracted = extract_document_text(str(path))
+    if "EXTRACTION COVERAGE WARNING" in extracted:
+        raise ValueError("document has pages without an extractable text layer")
+    if not extracted.strip():
+        raise ValueError("document contains no extractable text")
+    return extracted
+
+
+def sanitized_document_text(path: str | Path) -> str:
+    return anonymize_document_text(extract_document_text_local(path))
+
+
+def sanitized_document_bytes(data: bytes, filename: str) -> str:
+    """Extract and anonymize an uploaded document without persisting raw bytes."""
+    if len(data) > 25 * 1024 * 1024:
+        raise ValueError("document exceeds the 25 MiB anonymization limit")
+    suffix = Path(filename).suffix.casefold()
+    if suffix not in DOCUMENT_EXTENSIONS:
+        raise ValueError("unsupported document type")
+    if suffix in _TEXT_EXTENSIONS:
+        for encoding in ("utf-8-sig", "utf-16", "cp1251"):
+            try:
+                return anonymize_document_text(data.decode(encoding))
+            except UnicodeDecodeError:
+                continue
+        raise ValueError("text document encoding is not supported")
+    from tools.read_extract import extract_document_bytes
+
+    extracted = extract_document_bytes(data, filename)
+    if "EXTRACTION COVERAGE WARNING" in extracted or not extracted.strip():
+        raise ValueError("document does not have a complete extractable text layer")
+    return anonymize_document_text(extracted)
+
+
+def _is_document_attachment(path: str, mime: str, message_type: Any) -> bool:
+    if is_document_path(path):
+        return True
+    if Path(path).suffix.casefold() in _SOURCE_EXTENSIONS:
+        return False
+    mime = (mime or "").casefold()
+    if mime.startswith(("text/", "application/pdf")):
+        return True
+    value = str(getattr(message_type, "value", message_type) or "").casefold()
+    return value.endswith("document") or value == "file"
+
+
+def sanitize_document_event(message_text: str, event: Any) -> str:
+    """Replace attached documents with anonymous text and hide original paths.
+
+    Non-document media is preserved. Any extraction/anonymization failure is
+    fail-closed: the original path/content is removed from the model-visible
+    event and a neutral warning is added instead.
+    """
+    if not document_anonymization_enabled():
+        return message_text
+
+    paths = list(getattr(event, "media_urls", None) or [])
+    mimes = list(getattr(event, "media_types", None) or [])
+    kept_paths: list[str] = []
+    kept_mimes: list[str] = []
+    blocks: list[str] = []
+    result = message_text
+    saw_document = False
+
+    for index, path in enumerate(paths):
+        mime = str(mimes[index] if index < len(mimes) else "")
+        if not _is_document_attachment(str(path), mime, getattr(event, "message_type", None)):
+            kept_paths.append(path)
+            kept_mimes.append(mime)
+            continue
+        saw_document = True
+        try:
+            raw = extract_document_text_local(path)
+            clean = anonymize_document_text(raw)
+            if raw and raw in result:
+                # Adapters may prefix an exact copy of textual document bytes.
+                # Replace only those bytes, preserving the authored caption.
+                result = result.replace(raw, clean)
+            elif raw and ("\ufeff" + raw) in result:
+                result = result.replace("\ufeff" + raw, clean)
+            else:
+                blocks.append(f"[Анонимизированное содержимое документа {index + 1}]\n{clean}")
+        except Exception as exc:
+            blocks.append(
+                "[Документ не передан модели: локальная анонимизация не выполнена "
+                f"({type(exc).__name__}).]"
+            )
+
+    if not saw_document:
+        return message_text
+
+    event.media_urls = kept_paths
+    if hasattr(event, "media_types"):
+        event.media_types = kept_mimes
+    return "\n\n".join(part for part in [result, *blocks] if part).strip()

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -41,6 +41,7 @@ Requires:
 """
 
 import asyncio
+import base64
 import concurrent.futures
 import errno
 import hashlib
@@ -681,6 +682,39 @@ _IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
 _FILE_PART_TYPES = frozenset({"file", "input_file"})
 
 
+def _anonymize_inline_document_part(part: Dict[str, Any]) -> Dict[str, str]:
+    """Turn an OpenAI file/input_file part into local anonymized text."""
+    from agent.document_anonymizer import (
+        document_anonymization_enabled,
+        sanitized_document_bytes,
+    )
+
+    if not document_anonymization_enabled():
+        raise ValueError(
+            "unsupported_content_type:Document inputs require privacy.anonymize_documents=true."
+        )
+    payload = part.get("file") if isinstance(part.get("file"), dict) else part
+    filename = str(payload.get("filename") or payload.get("name") or "").strip()
+    file_data = payload.get("file_data") or payload.get("data")
+    if not filename or not isinstance(file_data, str):
+        raise ValueError(
+            "invalid_content_part:Document parts require filename and inline file_data. "
+            "Remote file_id/file_url inputs are not accepted."
+        )
+    encoded = file_data.split(",", 1)[1] if file_data.lower().startswith("data:") and "," in file_data else file_data
+    try:
+        raw = base64.b64decode(encoded, validate=True)
+    except Exception as exc:
+        raise ValueError("invalid_content_part:Document file_data is not valid base64.") from exc
+    try:
+        clean = sanitized_document_bytes(raw, filename)
+    except Exception as exc:
+        raise ValueError(
+            f"document_anonymization_failed:Document was withheld because local anonymization failed ({type(exc).__name__})."
+        ) from exc
+    return {"type": "text", "text": f"[Анонимизированное содержимое документа]\n{clean}"}
+
+
 def _normalize_multimodal_content(content: Any) -> Any:
     """Validate and normalize multimodal content for the API server.
 
@@ -775,10 +809,10 @@ def _normalize_multimodal_content(content: Any) -> Any:
             continue
 
         if part_type in _FILE_PART_TYPES:
-            raise ValueError(
-                "unsupported_content_type:Inline image inputs are supported, "
-                "but uploaded files and document inputs are not supported on this endpoint."
-            )
+            document_part = _anonymize_inline_document_part(part)
+            normalized_parts.append(document_part)
+            text_accum_len += len(document_part["text"])
+            continue
 
         # Unknown part type — reject explicitly so clients get a clear error
         # instead of a silently dropped turn.
@@ -809,7 +843,7 @@ def _content_has_visible_payload(content: Any) -> bool:
                 ptype = str(part.get("type") or "").strip().lower()
                 if ptype in _TEXT_PART_TYPES and str(part.get("text") or "").strip():
                     return True
-                if ptype in _IMAGE_PART_TYPES:
+                if ptype in _IMAGE_PART_TYPES or ptype in _FILE_PART_TYPES:
                     return True
     return False
 
@@ -5190,9 +5224,26 @@ class APIServerAdapter(BasePlatformAdapter):
         system_prompt = None
         conversation_messages: List[Dict[str, str]] = []
 
+        from agent.document_anonymizer import anonymize_openwebui_source_blocks
+
         for idx, msg in enumerate(messages):
             role = msg.get("role", "")
             raw_content = msg.get("content", "")
+            # OpenWebUI's file/RAG middleware wraps extracted document bytes in
+            # <source ...>...</source>. Redact only those bodies; ordinary text
+            # messages, including surrounding user prose, remain unchanged.
+            if isinstance(raw_content, str):
+                raw_content = anonymize_openwebui_source_blocks(raw_content)
+            elif isinstance(raw_content, list):
+                raw_content = [
+                    {
+                        **part,
+                        "text": anonymize_openwebui_source_blocks(str(part.get("text") or "")),
+                    }
+                    if isinstance(part, dict) and str(part.get("type") or "").lower() in _TEXT_PART_TYPES
+                    else part
+                    for part in raw_content
+                ]
             if role == "system":
                 # System messages don't support images (Anthropic rejects, OpenAI
                 # text-model systems don't render them).  Flatten to text.
@@ -6369,7 +6420,9 @@ class APIServerAdapter(BasePlatformAdapter):
         if raw_input is None:
             return web.json_response(_openai_error("Missing 'input' field"), status=400)
 
-        instructions = body.get("instructions")
+        from agent.document_anonymizer import anonymize_openwebui_content
+
+        instructions = anonymize_openwebui_content(body.get("instructions"))
         previous_response_id = body.get("previous_response_id")
         conversation = body.get("conversation")
         store = _coerce_request_bool(body.get("store"), default=True)
@@ -6386,15 +6439,17 @@ class APIServerAdapter(BasePlatformAdapter):
         # Normalize input to message list
         input_messages: List[Dict[str, Any]] = []
         if isinstance(raw_input, str):
-            input_messages = [{"role": "user", "content": raw_input}]
+            input_messages = [{"role": "user", "content": anonymize_openwebui_content(raw_input)}]
         elif isinstance(raw_input, list):
             for idx, item in enumerate(raw_input):
                 if isinstance(item, str):
-                    input_messages.append({"role": "user", "content": item})
+                    input_messages.append({"role": "user", "content": anonymize_openwebui_content(item)})
                 elif isinstance(item, dict):
                     role = item.get("role", "user")
                     try:
-                        content = _normalize_multimodal_content(item.get("content", ""))
+                        content = _normalize_multimodal_content(
+                            anonymize_openwebui_content(item.get("content", ""))
+                        )
                     except ValueError as exc:
                         return _multimodal_validation_error(exc, param=f"input[{idx}].content")
                     input_messages.append({"role": role, "content": content})
@@ -6420,7 +6475,9 @@ class APIServerAdapter(BasePlatformAdapter):
                         status=400,
                     )
                 try:
-                    entry_content = _normalize_multimodal_content(entry["content"])
+                    entry_content = _normalize_multimodal_content(
+                        anonymize_openwebui_content(entry["content"])
+                    )
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"conversation_history[{i}].content")
                 conversation_history.append({"role": str(entry["role"]), "content": entry_content})

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -20529,6 +20529,14 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _pending_stt_prepared
             else event.text
         ) or ""
+
+        # All messaging adapters converge here. Replace attached documents with
+        # locally extracted anonymous text before vision/document notes or the
+        # provider request can expose their bytes/path. Standalone text events
+        # are deliberately untouched by the document-scoped sanitizer.
+        from agent.document_anonymizer import sanitize_document_event
+
+        message_text = sanitize_document_event(message_text, event)
         _group_sessions_per_user = getattr(self.config, "group_sessions_per_user", True)
         _thread_sessions_per_user = getattr(self.config, "thread_sessions_per_user", False)
         # Prefer the already resolved session key from the caller so this write

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1866,7 +1866,10 @@ DEFAULT_CONFIG = {
 
     # Privacy settings
     "privacy": {
-        "redact_pii": False,  # When True, hash user IDs and strip phone numbers from LLM context
+        "redact_pii": False,  # Hash transport IDs / strip phone numbers from gateway context
+        # Local, document-scoped personN/SUMN replacement. Ordinary chat text
+        # is never passed through this filter. Unsupported documents fail closed.
+        "anonymize_documents": False,
     },
 
     # Text-to-speech configuration

--- a/tests/agent/test_document_anonymizer.py
+++ b/tests/agent/test_document_anonymizer.py
@@ -1,0 +1,186 @@
+import base64
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+def test_document_text_replaces_people_money_and_identifiers_deterministically():
+    from agent.document_anonymizer import anonymize_document_text
+
+    source = (
+        "Договор с Ивановым Иваном Ивановичем. Иванов Иван Иванович получает "
+        "1 250 000 рублей. Телефон +7 999 123-45-67, e-mail ivanov@example.ru. "
+        "Паспорт 45 01 123456. Повторная сумма: 1 250 000 руб."
+    )
+    result = anonymize_document_text(source)
+
+    assert "Иванов" not in result
+    assert "ivanov@example.ru" not in result
+    assert "+7 999 123-45-67" not in result
+    assert "45 01 123456" not in result
+    assert "1 250 000" not in result
+    assert "person1" in result
+    assert result.count("SUM1") == 2
+
+
+def test_plain_message_is_never_anonymized_by_document_block_filter():
+    from agent.document_anonymizer import anonymize_document_blocks
+
+    text = "Позвони Иванову Ивану Ивановичу и проверь 10 000 рублей"
+    assert anonymize_document_blocks(text) == text
+
+
+def test_latin_full_name_birth_date_and_address_are_removed():
+    from agent.document_anonymizer import anonymize_document_text
+
+    text = (
+        "John Michael Smith; дата рождения: 01.02.1980; "
+        "адрес регистрации: г. Москва, ул. Тверская, д. 1\n"
+    )
+    result = anonymize_document_text(text)
+    assert "John Michael Smith" not in result
+    assert "01.02.1980" not in result
+    assert "Тверская" not in result
+
+
+def test_only_attached_context_block_is_anonymized():
+    from agent.document_anonymizer import anonymize_document_blocks
+
+    text = (
+        "Обычный вопрос Иванову Ивану Ивановичу на 10 000 рублей\n\n"
+        "--- Attached Context ---\n\n"
+        "Договор Петрова Петра Петровича на 25 000 рублей"
+    )
+    result = anonymize_document_blocks(text)
+    assert "Иванову Ивану Ивановичу" in result
+    assert "10 000 рублей" in result
+    assert "Петрова Петра Петровича" not in result
+    assert "25 000" not in result
+
+
+def test_openwebui_source_tags_are_anonymized_without_touching_user_query(monkeypatch):
+    from agent.document_anonymizer import anonymize_openwebui_source_blocks
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    text = (
+        "Вопрос Иванову Ивану Ивановичу на 10 000 рублей\n"
+        '<source id="1" name="contract.pdf">Петров Петр Петрович, 25 000 рублей</source>'
+    )
+    result = anonymize_openwebui_source_blocks(text)
+    assert "Иванову Ивану Ивановичу" in result
+    assert "10 000 рублей" in result
+    assert "Петров Петр Петрович" not in result
+    assert "25 000" not in result
+    assert '<source anonymized="true">' in result
+
+
+def test_text_file_reference_is_anonymized_but_python_source_is_not(tmp_path, monkeypatch):
+    from agent.context_references import ContextReference, _expand_file_reference
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    payload = "Сотрудник Петров Петр Петрович, выплата 99 000 руб."
+    doc = tmp_path / "contract.txt"
+    code = tmp_path / "contract.py"
+    doc.write_text(payload, encoding="utf-8")
+    code.write_text(payload, encoding="utf-8")
+
+    ref_doc = ContextReference(raw=f"@file:{doc.name}", kind="file", target=doc.name, start=0, end=1)
+    ref_code = ContextReference(raw=f"@file:{code.name}", kind="file", target=code.name, start=0, end=1)
+    _, doc_block = _expand_file_reference(ref_doc, tmp_path)
+    _, code_block = _expand_file_reference(ref_code, tmp_path)
+
+    assert "Петров Петр Петрович" not in doc_block
+    assert "99 000" not in doc_block
+    assert "Петров Петр Петрович" in code_block
+    assert "99 000" in code_block
+
+
+def test_gateway_document_event_is_sanitized_and_original_path_removed(tmp_path, monkeypatch):
+    from agent.document_anonymizer import sanitize_document_event
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    doc = tmp_path / "contract.txt"
+    payload = "Сидоров Сидор Сидорович — 50 000 руб."
+    caption = "Сообщение Иванову Ивану Ивановичу на 88 000 рублей"
+    doc.write_text(payload, encoding="utf-8")
+    event = SimpleNamespace(
+        media_urls=[str(doc)],
+        media_types=["text/plain"],
+        message_type="document",
+    )
+
+    text = sanitize_document_event(
+        f"[Content of contract.txt]:\n{payload}\n\n{caption}", event
+    )
+    assert caption in text
+    assert "Сидоров Сидор Сидорович" not in text
+    assert "50 000" not in text
+    assert "person1" in text
+    assert "SUM1" in text
+    assert event.media_urls == []
+    assert event.media_types == []
+
+
+def test_gateway_anonymization_fails_closed(tmp_path, monkeypatch):
+    from agent.document_anonymizer import sanitize_document_event
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    bad = tmp_path / "scan.pdf"
+    bad.write_bytes(b"not a pdf")
+    event = SimpleNamespace(
+        media_urls=[str(bad)], media_types=["application/pdf"], message_type="document"
+    )
+
+    text = sanitize_document_event("Изучи", event)
+    assert "не передан модели" in text
+    assert str(bad) not in text
+    assert event.media_urls == []
+
+
+def test_context_preprocessor_hides_original_document_reference(tmp_path, monkeypatch):
+    from agent.context_references import preprocess_context_references
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    doc = tmp_path / "Иванов Иван Иванович contract.txt"
+    doc.write_text("Иванов Иван Иванович — 12 000 рублей", encoding="utf-8")
+    authored = f'Проверь @file:"{doc.name}" пожалуйста'
+    result = preprocess_context_references(authored, cwd=tmp_path, context_length=8192)
+
+    assert doc.name not in result.message
+    assert "[анонимизированный документ]" in result.message
+    assert "Иванов Иван Иванович" not in result.message
+    assert "12 000" not in result.message
+    assert result.original_message == authored
+
+
+def test_openai_inline_file_part_becomes_anonymized_text(monkeypatch):
+    from gateway.platforms.api_server import _normalize_multimodal_content
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "1")
+    raw = "Иванов Иван Иванович получает 123 000 рублей".encode()
+    result = _normalize_multimodal_content([
+        {"type": "text", "text": "Сообщение Петрову Петру Петровичу на 7 000 рублей"},
+        {
+            "type": "file",
+            "file": {
+                "filename": "contract.txt",
+                "file_data": "data:text/plain;base64," + base64.b64encode(raw).decode(),
+            },
+        },
+    ])
+
+    assert "Сообщение Петрову Петру Петровичу на 7 000 рублей" in result
+    assert "Иванов Иван Иванович" not in result
+    assert "123 000" not in result
+    assert "person1" in result and "SUM1" in result
+
+
+def test_openai_inline_file_part_is_rejected_when_feature_disabled(monkeypatch):
+    from gateway.platforms.api_server import _normalize_multimodal_content
+
+    monkeypatch.setenv("HERMES_DOCUMENT_ANONYMIZATION", "0")
+    with pytest.raises(ValueError, match="anonymize_documents=true"):
+        _normalize_multimodal_content([
+            {"type": "input_file", "filename": "contract.txt", "file_data": "WA=="}
+        ])

--- a/tui_gateway/methods_prompt.py
+++ b/tui_gateway/methods_prompt.py
@@ -6,6 +6,7 @@ are rebound onto server.py's globals at install time — see method_ctx.py.
 
 from .method_ctx import HandlerRegistry
 
+import hashlib
 import types
 
 _registry = HandlerRegistry()
@@ -1241,6 +1242,15 @@ def _(rid, params: dict) -> dict:
     if err:
         return err
 
+    from agent.document_anonymizer import document_anonymization_enabled
+
+    if document_anonymization_enabled():
+        return _err(
+            rid,
+            4019,
+            "PDF vision rendering is disabled while document anonymization is enabled; attach the PDF as a file instead",
+        )
+
     if shutil.which("pdftoppm") is None:
         return _err(rid, 5028, "pdftoppm not installed (poppler-utils package required)")
 
@@ -1378,6 +1388,23 @@ def _(rid, params: dict) -> dict:
         stored_path, uploaded = _stage_session_file_attachment(
             session, raw_path=raw, data_url=data_url, name=name
         )
+        from agent.document_anonymizer import (
+            document_anonymization_enabled,
+            is_document_path,
+            sanitized_document_text,
+        )
+
+        if document_anonymization_enabled() and is_document_path(stored_path):
+            clean = sanitized_document_text(stored_path)
+            digest = hashlib.sha256(clean.encode("utf-8")).hexdigest()[:16]
+            sanitized_path = Path(stored_path).with_name(f"anonymized_{digest}.txt")
+            sanitized_path.write_text(clean, encoding="utf-8")
+            if uploaded and Path(stored_path) != sanitized_path:
+                try:
+                    Path(stored_path).unlink()
+                except OSError:
+                    pass
+            stored_path = sanitized_path
         ref_path = _attachment_ref_path(session, stored_path)
         return _ok(
             rid,

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -2119,7 +2119,18 @@ Signal is listed as a valid platform key because the setting can be saved per pl
 
 ```yaml
 privacy:
-  redact_pii: false  # Strip PII from LLM context (gateway only)
+  redact_pii: false
+  anonymize_documents: false
+```
+
+`redact_pii` hashes gateway transport identifiers and removes phone-like identifiers from session context. It does not anonymize document content.
+
+Set `anonymize_documents: true` to extract supported document attachments locally and replace detected personal data with stable `personN` tokens and monetary values with `SUMN` before document text enters the model request. This applies to gateway document attachments, Desktop/TUI `@file:` document references, OpenAI-compatible inline `file`/`input_file` parts, and OpenWebUI `<source>...</source>` document blocks. Ordinary chat messages and source-code files are not rewritten. Extraction is fail-closed: corrupt, encrypted, unsupported, or incompletely extracted documents are withheld rather than sent unchanged. PDF vision rendering is disabled in this mode because raster pages cannot be safely text-redacted.
+
+Enable it with:
+
+```bash
+hermes config set privacy.anonymize_documents true
 ```
 
 When `redact_pii` is `true`, the gateway redacts personally identifiable information from the system prompt before sending it to the LLM on supported platforms:


### PR DESCRIPTION
## Summary

- add local, document-scoped anonymization before document content reaches an LLM
- replace detected personal data with stable `personN` tokens and monetary values with `SUMN`
- cover gateway attachments, Desktop/TUI `@file:` staging, OpenAI-compatible `file`/`input_file` parts, and OpenWebUI `<source>` blocks
- preserve ordinary chat messages and source-code files
- fail closed for corrupt, encrypted, unsupported, scanned, or incompletely extracted documents
- disable PDF vision rendering while document anonymization is enabled

## Configuration

```yaml
privacy:
  anonymize_documents: true
```

The option defaults to `false` for backward compatibility.

## Safety properties

- extraction and replacement are local
- raw inline API document bytes are not persisted
- original uploaded Desktop/TUI copies are deleted after sanitized staging where Hermes owns the upload
- original document paths and filenames are removed from model-facing context
- remote `file_id` and `file_url` inputs are rejected
- ordinary user text surrounding a document remains unchanged

## Verification

Tested on top of current `NousResearch/hermes-agent@05f548f35dd3242bf2ff74743e9112acde251f77`:

- `151 passed` — anonymizer, gateway document handling, Telegram document handling, and API server tests
- `8 passed` — Desktop/TUI `file.attach` and `pdf.attach` tests
- `git diff --check` passed
- local extraction verified for TXT, DOCX, XLSX, and text-layer PDF
- live `/v1/chat/completions` check confirmed ordinary user text was preserved while document names and amounts became `person1` / `SUM1`

## Limitations

This is deliberately privacy-biased heuristic redaction, not a legal guarantee of de-identification. Scanned PDFs without a complete text layer are withheld rather than sent to a vision model.
