### PR TITLE
fix(compression): use codex_responses_compact_threshold for local compressor when native disabled (#101867)

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2323,6 +2323,7 @@ def init_agent(
                 compression_threshold_tokens = None
         except (TypeError, ValueError):
             compression_threshold_tokens = None
+
     compression_checkpoint_required = is_truthy_value(
         _compression_cfg.get("checkpoint_required"), default=False
     )
@@ -2402,6 +2403,16 @@ def init_agent(
                 _native_threshold_raw,
             )
             codex_responses_compact_threshold = None
+    # Fallback: when native compaction is disabled but
+    # codex_responses_compact_threshold is configured, use it as the
+    # local compressor's absolute token cap so the user's intent is
+    # respected regardless of the compaction path.
+    if (
+        compression_threshold_tokens is None
+        and not codex_responses_native_compaction
+    ):
+        if codex_responses_compact_threshold is not None:
+            compression_threshold_tokens = codex_responses_compact_threshold
     # Opt-in idle compaction: compact a session up front when it resumes after
     # this many seconds of inactivity (0 = disabled). Time-based, so it
     # complements the size-based threshold above. Consumed by build_turn_context().


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where `codex_responses_compact_threshold` config was only respected for **native** (server-side) compaction, but ignored when `codex_responses_native: false` (local compression path).

## Root cause

The `codex_responses_compact_threshold` config was only used in `native_compaction.py` for server-side compaction. When users disabled native compaction (`codex_responses_native: false`) but set a custom threshold, the local `ContextCompressor` never saw it — it only used `compression.threshold_tokens` for an absolute token cap.

## The fix

In `agent_init.py`, when native compaction is disabled but `codex_responses_compact_threshold` is configured, fall back to using that value as the local compressor's `threshold_tokens_cap`. This preserves the user's intent regardless of which compaction path is active.

## Testing

- All existing native compaction tests pass (74 tests)
- All context compressor tests pass (152 tests)
- Verified the fallback logic only applies when:
  1. No explicit `compression.threshold_tokens` is set
  2. Native compaction is disabled (`codex_responses_native: false`)
  3. `codex_responses_compact_threshold` is configured

## Related Issue

Fixes #101867