### PR TITLE
fix: [Bug]: CLI takes 684 s when launched from a Windows service (LocalSystem) — 0.4 s in a user session, 0 CPU, no network (#77566)

### DIFF
--- a/hermes_cli/sessions_cmd.py
+++ b/hermes_cli/sessions_cmd.py
@@ -50,6 +50,19 @@ def _size_delta_label(saved_mb):
 def _confirm_prompt(prompt: str) -> bool:
     """Prompt for y/N confirmation, safe against non-TTY environments."""
     try:
+        if not sys.stdin.isatty():
+            # Windows service / piped-stdin contexts (#77566): stdin is an
+            # inherited pipe that never yields data or EOF, so input()
+            # below would block forever (0 CPU, no network, nothing on
+            # stderr) instead of failing. Fail fast and point at the
+            # non-interactive flags instead of hanging the caller.
+            print(
+                "Refusing to prompt for confirmation: stdin is not "
+                "interactive. Re-run with --yes to confirm or --dry-run "
+                "to preview.",
+                file=sys.stderr,
+            )
+            return False
         return input(prompt).strip().lower() in {"y", "yes"}
     except (EOFError, KeyboardInterrupt):
         return False

--- a/tests/hermes_cli/test_sessions_error_exit_codes.py
+++ b/tests/hermes_cli/test_sessions_error_exit_codes.py
@@ -47,3 +47,52 @@ def test_import_missing_file_returns_1(tmp_path, monkeypatch, capsys):
     rc = sc.cmd_sessions(_args("import", path=str(tmp_path / "nope.jsonl")))
     assert rc == 1
     assert "file not found" in capsys.readouterr().out.lower()
+
+
+class _NonTtyStdin:
+    def isatty(self):
+        return False
+
+
+class _TtyStdin:
+    def isatty(self):
+        return True
+
+
+def test_confirm_prompt_refuses_non_tty_without_blocking(monkeypatch, capsys):
+    """#77566: a service-inherited pipe never EOFs — input() would block forever."""
+    import builtins
+    import sys
+
+    monkeypatch.setattr(sys, "stdin", _NonTtyStdin())
+
+    def _must_not_block(_prompt=""):
+        raise AssertionError("input() must not be called on non-TTY stdin")
+
+    monkeypatch.setattr(builtins, "input", _must_not_block)
+    assert sc._confirm_prompt("Delete 3 session(s)? [y/N] ") is False
+    assert "--yes" in capsys.readouterr().err
+
+
+def test_confirm_prompt_still_prompts_on_tty(monkeypatch):
+    import builtins
+    import sys
+
+    monkeypatch.setattr(sys, "stdin", _TtyStdin())
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "y")
+    assert sc._confirm_prompt("Delete 3 session(s)? [y/N] ") is True
+    monkeypatch.setattr(builtins, "input", lambda _prompt="": "n")
+    assert sc._confirm_prompt("Delete 3 session(s)? [y/N] ") is False
+
+
+def test_confirm_prompt_eof_still_aborts_on_tty(monkeypatch):
+    import builtins
+    import sys
+
+    monkeypatch.setattr(sys, "stdin", _TtyStdin())
+
+    def _raise_eof(_prompt=""):
+        raise EOFError
+
+    monkeypatch.setattr(builtins, "input", _raise_eof)
+    assert sc._confirm_prompt("Delete 3 session(s)? [y/N] ") is False


### PR DESCRIPTION
## What Problem This Solves
Fixes #77566 — [Bug]: CLI takes 684 s when launched from a Windows service (LocalSystem) — 0.4 s in a user session, 0 CPU, no network. Ponytail minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Tests: relevant suite passed (see worktree 77566).

Closes #77566