### PR TITLE
fix(cli): hide nvidia-smi console flashes on the statusbar hardware poll

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -35,6 +35,7 @@ import sys
 import time
 from pathlib import Path
 
+from hermes_cli._subprocess_compat import windows_hide_flags
 from hermes_cli.local_runtime.estimator import HardwareBudget
 
 logger = logging.getLogger(__name__)
@@ -189,10 +190,14 @@ def _nvidia_vram() -> tuple[int, int] | None:
     if exe is None:
         return None
     try:
+        # nvidia-smi.exe is a console-subsystem binary; from the desktop's
+        # windowless pythonw backend (statusbar polls every ~5s) a bare
+        # spawn allocates a visible console per call (#101895).
         out = subprocess.run(
             [exe, "--query-gpu=memory.total,memory.free",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=10)
+            capture_output=True, text=True, timeout=10,
+            creationflags=windows_hide_flags())
         if out.returncode != 0 or not out.stdout.strip():
             return None
         total_mib, free_mib = (int(x) for x in out.stdout.strip().splitlines()[0].split(","))

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -459,13 +459,18 @@ def local_models_hardware():
     try:
         import subprocess
 
+        from hermes_cli._subprocess_compat import windows_hide_flags
         from hermes_cli.local_runtime.hardware import _nvidia_smi_path
 
         smi_exe = _nvidia_smi_path()
+        # Hide-only flag: this endpoint is polled by the statusbar every
+        # ~5s, and nvidia-smi.exe flashes a console window from the
+        # windowless desktop backend on each spawn (#101895).
         smi = subprocess.run(
             [smi_exe, "--query-gpu=name,utilization.gpu,memory.used",
              "--format=csv,noheader,nounits"],
-            capture_output=True, text=True, timeout=5) if smi_exe else None
+            capture_output=True, text=True, timeout=5,
+            creationflags=windows_hide_flags()) if smi_exe else None
         if smi and smi.returncode == 0 and smi.stdout.strip():
             name, util, used_mib = (x.strip() for x in smi.stdout.strip().splitlines()[0].split(","))
             out["gpu_name"] = name

--- a/tests/test_windows_subprocess_no_window_flags.py
+++ b/tests/test_windows_subprocess_no_window_flags.py
@@ -428,3 +428,75 @@ def test_suppress_platform_ver_console_stubs_syscmd_ver(monkeypatch):
     # Idempotent + never raises on repeat calls.
     _subprocess_compat.suppress_platform_ver_console()
     assert platform._syscmd_ver() == ("", "", "")
+
+
+
+
+# ── #101895 statusbar GPU probes (nvidia-smi) ───────────────────────────────
+#
+# The desktop's statusbar polls /api/local-models/hardware every ~5s; the
+# endpoint and the budget probe it consults each shell out to nvidia-smi
+# (a console-subsystem exe). From the windowless pythonw backend every
+# bare spawn allocated a visible console — two flashing windows per poll.
+# Both call sites are hide-only (creationflags); the synchronous
+# capture_output contract stays intact.
+
+
+def test_nvidia_vram_probe_hides_console_window(monkeypatch):
+    from hermes_cli.local_runtime import hardware
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="24576, 24576")
+
+    monkeypatch.setattr(hardware, "windows_hide_flags", lambda: _CREATE_NO_WINDOW)
+    monkeypatch.setattr(
+        hardware, "_nvidia_smi_path", lambda: "C:/Windows/System32/nvidia-smi.exe"
+    )
+    monkeypatch.setattr(hardware.subprocess, "run", fake_run)
+
+    assert hardware._nvidia_vram() == (24576 << 20, 24576 << 20)
+
+    assert len(captured) == 1, captured
+    cmd, kwargs = captured[0]
+    assert cmd[0] == "C:/Windows/System32/nvidia-smi.exe"
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW
+    assert kwargs["capture_output"] is True
+
+
+def test_local_models_hardware_hides_console_window(monkeypatch):
+    from hermes_cli.local_runtime import hardware
+    from hermes_cli.web_routers import local_models
+
+    captured = []
+
+    def fake_run(cmd, **kwargs):
+        captured.append((cmd, kwargs))
+        return _Completed(stdout="NVIDIA GeForce RTX 5090, 4, 512")
+
+    monkeypatch.setattr(
+        hardware, "_nvidia_smi_path", lambda: "C:/Windows/System32/nvidia-smi.exe"
+    )
+    monkeypatch.setattr(hardware.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        hardware,
+        "probe_budget",
+        lambda: SimpleNamespace(
+            uma=False, total_device_bytes=32 << 30, usable_vram_bytes=30 << 30
+        ),
+    )
+    monkeypatch.setattr(hardware, "_ram_bytes", lambda: (64 << 30, 32 << 30))
+    _patch_hide_flags(monkeypatch)
+
+    out = local_models.local_models_hardware()
+
+    assert out["gpu_name"] == "NVIDIA GeForce RTX 5090"
+    assert out["gpu_util_percent"] == 4
+    assert out["vram_used_bytes"] == 512 << 20
+    spawns = _spawns(captured, "--query-gpu=name,utilization.gpu,memory.used")
+    assert len(spawns) == 1, captured
+    cmd, kwargs = spawns[0]
+    assert cmd[0] == "C:/Windows/System32/nvidia-smi.exe"
+    assert kwargs["creationflags"] == _CREATE_NO_WINDOW


### PR DESCRIPTION
## What does this PR do?

On Windows, the desktop statusbar's GPU readout polls `/api/local-models/hardware` every ~5s. The endpoint and the budget probe it consults (`_nvidia_vram()`) each shell out to `nvidia-smi` via bare `subprocess.run`, so the windowless `pythonw` backend allocates a visible console per spawn — two flashing console windows every ~5 seconds for as long as the statusbar item is shown (#101895).

Both call sites now pass `creationflags=windows_hide_flags()` — the repo's existing hide-only helper in `hermes_cli/_subprocess_compat.py`, which is `CREATE_NO_WINDOW` on Windows and `0` on POSIX. No behavior change otherwise: stdout/stderr capture, timeouts, and error fallbacks are untouched.

## Related Issue

Fixes #101895

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` — `_nvidia_vram()`'s `subprocess.run` now passes `creationflags=windows_hide_flags()` (helper imported at module level).
- `hermes_cli/web_routers/local_models.py` — `local_models_hardware()`'s `nvidia-smi` spawn now passes the same flag (lazy import inside the endpoint, matching its existing lazy-import style).
- `tests/test_windows_subprocess_no_window_flags.py` — two regression tests pin the flag wiring at both call sites, following the file's existing `_patch_hide_flags` stub pattern.

## How to Test

1. `python -m pytest tests/test_windows_subprocess_no_window_flags.py -q`
   Observed result: **9 passed, 3 skipped** (the two new tests pass; the skips are the pre-existing `windows_only` tests).
2. `python -m pytest tests/hermes_cli/test_local_runtime_updates.py tests/hermes_cli/test_local_growth.py tests/hermes_cli/test_catalog_json.py tests/hermes_cli/test_hf_browse.py tests/hermes_cli/test_local_quickstart.py tests/hermes_cli/test_local_runtime_picker_row.py tests/hermes_cli/test_catalog_reachability.py tests/hermes_cli/test_boot_preset_staleness.py tests/hermes_cli/test_model_switch_custom_providers.py -q`
   Observed result: **114 passed, 1 skipped**.
3. `python -m ruff check` on the three changed files — all checks pass.
4. On Windows with an NVIDIA card: launch the desktop app with local models enabled and the statusbar visible — should pass with **zero console flashes** while the GPU readout updates. (The issue reporter already verified this exact two-call-site patch locally with a raw flag; this PR threads the repo's standard helper instead.)

Note: `tests/hermes_cli/test_cmd_update.py` shows 8 failures on this machine **on a clean `upstream/main` checkout as well** — pre-existing local environment failures, unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (no open PR references #101895; the open spawn-site audits #88945/#79827/#81039 cover different families — uv/git, cron, auto-update)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (call-site comments only)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (POSIX lanes get `creationflags=0`, a no-op)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
