### PR TITLE
fix(error_classifier): stop blind retry flood on local-inference mode…

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -421,6 +421,24 @@ _MODEL_NOT_FOUND_PATTERNS = [
     "no endpoints found that support tool use",
 ]
 
+# Local-inference-server model-load-failure patterns.  llama.cpp / llama-server,
+# LM Studio, and similar OpenAI-compatible backends report a server-side
+# model-load failure (weights missing/corrupt/too large for available memory)
+# as a plain HTTP 500 with no distinguishing status code of its own -- nothing
+# marks it as a 404-style "not found". Left unmatched, the generic 5xx rule
+# (see ``_classify_by_status``) treats it as a transient ``server_error`` and
+# blindly retries the identical request against the identical broken endpoint
+# state until the retry budget exhausts and the turn drops (#102044).
+# Deterministic, so route it like a missing model: don't retry, and let a
+# configured fallback model serve the turn instead.
+_MODEL_LOAD_FAILURE_PATTERNS = [
+    "failed to load",
+    "model load failed",
+    "error loading model",
+    "unable to load model",
+    "could not load model",
+]
+
 
 def _model_id_missing_known_prefix(model: str, provider: str) -> bool:
     """True when a bare model id is only known to the provider as ``vendor/id``.
@@ -1488,6 +1506,18 @@ def _classify_by_status(
                 retryable=True,
                 should_compress=True,
             )
+        # Local-inference-server model-load failure (weights missing/corrupt/
+        # too large for available memory) reported as a plain HTTP 500 — see
+        # _MODEL_LOAD_FAILURE_PATTERNS. Deterministic: every retry against the
+        # same server hits the same broken endpoint state, so route it like a
+        # missing model instead of the generic retryable server_error below
+        # (#102044).
+        if any(p in error_msg for p in _MODEL_LOAD_FAILURE_PATTERNS):
+            return result_fn(
+                FailoverReason.model_not_found,
+                retryable=False,
+                should_fallback=True,
+            )
         return result_fn(FailoverReason.server_error, retryable=True)
 
     if status_code in {503, 529}:
@@ -2036,6 +2066,19 @@ def _classify_by_message(
 
     # Model not found patterns
     if any(p in error_msg for p in _MODEL_NOT_FOUND_PATTERNS):
+        return result_fn(
+            FailoverReason.model_not_found,
+            retryable=False,
+            should_fallback=True,
+        )
+
+    # Local-inference-server model-load failure with no HTTP status attached —
+    # generic exception types (e.g. RuntimeError) raised by local shims that
+    # wrap a llama.cpp / LM Studio "failed to load" body lose the status code
+    # the same way the timeout/connection cases below do. Same deterministic
+    # reasoning as the 500/502 branch in _classify_by_status (#102044): don't
+    # retry, let a configured fallback model serve the turn.
+    if any(p in error_msg for p in _MODEL_LOAD_FAILURE_PATTERNS):
         return result_fn(
             FailoverReason.model_not_found,
             retryable=False,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -441,6 +441,66 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.server_error
 
+    # ── Local-inference-server model-load failure (#102044) ──
+
+    def test_500_model_load_failure_is_non_retryable_model_not_found(self):
+        """llama.cpp/LM Studio-style backends report a server-side model-load
+        failure (weights missing/corrupt/too large for available memory) as a
+        plain HTTP 500. The generic 5xx rule alone would retry the identical
+        request against the identical broken endpoint state until the retry
+        budget exhausts and the turn drops. Deterministic, so route it like a
+        missing model: don't retry, let a configured fallback model serve the
+        turn."""
+        e = MockAPIError(
+            "HTTP 500: model name=LFM2.5-2.6B-DSpark-Q8_0 failed to load",
+            status_code=500,
+        )
+        result = classify_api_error(e, provider="custom", model="LFM2.5-2.6B-DSpark-Q8_0")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_502_model_load_failure_is_non_retryable_model_not_found(self):
+        e = MockAPIError("model load failed: insufficient memory", status_code=502)
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    @pytest.mark.parametrize(
+        "phrase",
+        [
+            "error loading model",
+            "unable to load model",
+            "could not load model",
+        ],
+    )
+    def test_500_model_load_failure_phrase_variants(self, phrase):
+        e = MockAPIError(phrase, status_code=500)
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+
+    def test_500_generic_server_error_unaffected(self):
+        """A plain 500 with no model-load signal must keep the existing
+        retryable server_error classification — the new pattern check must
+        not widen beyond the reported phrases."""
+        e = MockAPIError("Internal Server Error", status_code=500)
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.server_error
+        assert result.retryable is True
+
+    def test_status_less_model_load_failure_from_local_shim(self):
+        """A local shim/custom provider that wraps the backend's error in a
+        generic exception loses the HTTP status code the same way transport
+        errors do — the message-pattern path must still catch it."""
+        e = RuntimeError("local shim: model load failed: out of memory")
+        result = classify_api_error(e, provider="custom")
+        assert result.reason == FailoverReason.model_not_found
+        assert result.retryable is False
+        assert result.should_fallback is True
+
     def test_503_overloaded(self):
         e = MockAPIError("Service Unavailable", status_code=503)
         result = classify_api_error(e)


### PR DESCRIPTION
…l-load failure

Local inference servers (llama.cpp llama-server, LM Studio, and similar OpenAI-compatible backends) report a server-side model-load failure (weights missing, corrupt GGUF, or too large for available memory) as a plain HTTP 500 with no distinguishing signal of its own -- nothing marks it as a 404-style "not found". _classify_by_status's 500/502 branch had no pattern check for this, so it fell through to the generic "5xx -> retryable server_error" rule and retried the identical request against the identical broken endpoint state until the retry budget exhausted and the turn dropped -- the exact retry-flood shape the same branch already guards against for request-validation errors.

Add _MODEL_LOAD_FAILURE_PATTERNS ("failed to load", "model load failed", "error loading model", "unable to load model", "could not load model") and consult it in two places: the 500/502 branch of _classify_by_status (the reported repro), and _classify_by_message (the status-less path local shims/custom providers fall into when they wrap the backend's error in a generic exception that loses the HTTP status). Both route to the existing FailoverReason.model_not_found with retryable=False, should_fallback=True -- the same, already-proven semantics _MODEL_NOT_FOUND_PATTERNS uses elsewhere in this file, so a configured fallback model can serve the turn instead of the turn being dropped. A plain 500 with no model-load signal is unaffected and keeps its existing retryable server_error classification.

Deliberately does not reuse or extend _MODEL_NOT_FOUND_PATTERNS itself, and does not touch the still-open, still-unmerged #62765 (LM Studio "model unloaded" -> non-retryable, no fallback, gated on #34076's loop-level should_fallback enforcement landing first). That PR handles a different endpoint-state case (an already-loaded model being unloaded/ejected at runtime) with different semantics (should_fallback=False, because silently swapping models there hides the real endpoint state); this fix is scoped to the reported case only (a model that never finished loading) and needs neither that PR's enum choice nor its loop-level gate, since should_fallback=True is already fully honored on current main.

Added tests/agent/test_error_classifier.py coverage: the exact reported 500 repro, a 502 variant, three additional phrase variants, a guard that a plain 500 with no model-load signal is unaffected, and the status-less local-shim path.

Fixes #102044

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

