### PR TITLE
fix(trajectory): redact turns before sending them to the summariser

### DIFF
--- a/tests/test_trajectory_summary_redaction.py
+++ b/tests/test_trajectory_summary_redaction.py
@@ -2,49 +2,100 @@
 
 ``_generate_summary`` sends the turns being compressed to OpenRouter. Those
 turns are raw tool output: an API key printed by a terminal command or read out
-of a file is still verbatim in the text. Both the sync and async paths built the
-prompt from ``content`` directly, so the secret left the machine.
+of a file is still verbatim in the text, and OpenRouter is a third party.
+
+These tests capture what the summariser actually puts on the wire — the
+``messages`` payload handed to the client — and assert the secret is not in it.
 """
 
-from __future__ import annotations
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
 
-import re
-from pathlib import Path
+import pytest
 
-SOURCE = Path(__file__).resolve().parents[1] / "trajectory_compressor.py"
+from trajectory_compressor import (
+    CompressionConfig,
+    TrajectoryCompressor,
+    TrajectoryMetrics,
+)
 
-
-def _prompt_bodies() -> list[str]:
-    """The f-string prompt in each _generate_summary variant."""
-    text = SOURCE.read_text(encoding="utf-8")
-    return re.findall(r"TURNS TO SUMMARIZE:\n\{(\w+)\}", text)
-
-
-def test_both_summary_paths_exist():
-    """Sync and async; a fix that misses one still leaks."""
-    assert len(_prompt_bodies()) == 2
+# Shaped like a real credential so the redactor treats it as one.
+SECRET = "sk-ant-api03-" + "V" * 40
+TURNS = f"$ cat .env\nANTHROPIC_API_KEY={SECRET}\nrequest succeeded\n"
 
 
-def test_no_prompt_interpolates_raw_turns():
-    assert "content" not in _prompt_bodies()
+def _compressor():
+    """A compressor with the network stubbed, built like the module's own tests."""
+    compressor = TrajectoryCompressor.__new__(TrajectoryCompressor)
+    compressor.config = CompressionConfig(
+        summarization_model="test-model",
+        temperature=0.3,
+        summary_target_tokens=100,
+        max_retries=1,
+    )
+    compressor.logger = MagicMock()
+    compressor._use_call_llm = False
+    compressor.client = MagicMock()
+    compressor.client.chat.completions.create.return_value = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: ok"))]
+    )
+    return compressor
 
 
-def test_every_prompt_interpolates_the_redacted_copy():
-    assert set(_prompt_bodies()) == {"safe_content"}
+def _sent_prompt(compressor) -> str:
+    kwargs = compressor.client.chat.completions.create.call_args.kwargs
+    return kwargs["messages"][0]["content"]
 
 
-def test_redaction_is_forced():
-    """force=True: the caller cannot know whether a trajectory is trusted."""
-    text = SOURCE.read_text(encoding="utf-8")
-    calls = re.findall(r"redact_sensitive_text\(content, ([^)]*)\)", text)
-    assert len(calls) == 2
-    assert all("force=True" in c for c in calls)
+def test_sync_summary_does_not_send_the_secret():
+    compressor = _compressor()
+    compressor._generate_summary(TURNS, TrajectoryMetrics())
+    assert SECRET not in _sent_prompt(compressor)
 
 
-def test_a_secret_in_the_turns_does_not_reach_the_prompt():
-    """End-to-end through the real redactor, not a mock."""
-    from agent.redact import redact_sensitive_text
+def test_async_summary_does_not_send_the_secret():
+    """The async path builds its own prompt; fixing only the sync one still leaks."""
+    compressor = _compressor()
+    create = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="[CONTEXT SUMMARY]: ok"))]
+        )
+    )
+    client = MagicMock()
+    client.chat.completions.create = create
+    compressor._get_async_client = MagicMock(return_value=client)
 
-    secret = "sk-ant-api03-" + "A" * 40
-    turns = f"$ cat .env\nANTHROPIC_API_KEY={secret}\n"
-    assert secret not in redact_sensitive_text(turns, force=True)
+    asyncio.run(compressor._generate_summary_async(TURNS, TrajectoryMetrics()))
+
+    assert SECRET not in create.call_args.kwargs["messages"][0]["content"]
+
+
+def test_the_surrounding_turn_text_still_reaches_the_model():
+    """Redaction must remove the credential, not gut the content being summarised."""
+    compressor = _compressor()
+    compressor._generate_summary(TURNS, TrajectoryMetrics())
+    prompt = _sent_prompt(compressor)
+    assert "request succeeded" in prompt
+    assert "ANTHROPIC_API_KEY" in prompt
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "sk-ant-api03-" + "V" * 40,
+        "ghp_" + "b" * 36,
+        "xoxb-123456789012-123456789012-" + "c" * 24,
+    ],
+)
+def test_common_credential_shapes_are_scrubbed(secret):
+    compressor = _compressor()
+    compressor._generate_summary(f"leaked: {secret}\n", TrajectoryMetrics())
+    assert secret not in _sent_prompt(compressor)
+
+
+def test_summary_is_still_returned_normally():
+    """The fix must not disturb the summariser's contract."""
+    compressor = _compressor()
+    result = compressor._generate_summary(TURNS, TrajectoryMetrics())
+    assert result.startswith("[CONTEXT SUMMARY]:")

--- a/tests/test_trajectory_summary_redaction.py
+++ b/tests/test_trajectory_summary_redaction.py
@@ -1,0 +1,50 @@
+"""The trajectory summariser must not ship raw secrets to a third party.
+
+``_generate_summary`` sends the turns being compressed to OpenRouter. Those
+turns are raw tool output: an API key printed by a terminal command or read out
+of a file is still verbatim in the text. Both the sync and async paths built the
+prompt from ``content`` directly, so the secret left the machine.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+SOURCE = Path(__file__).resolve().parents[1] / "trajectory_compressor.py"
+
+
+def _prompt_bodies() -> list[str]:
+    """The f-string prompt in each _generate_summary variant."""
+    text = SOURCE.read_text(encoding="utf-8")
+    return re.findall(r"TURNS TO SUMMARIZE:\n\{(\w+)\}", text)
+
+
+def test_both_summary_paths_exist():
+    """Sync and async; a fix that misses one still leaks."""
+    assert len(_prompt_bodies()) == 2
+
+
+def test_no_prompt_interpolates_raw_turns():
+    assert "content" not in _prompt_bodies()
+
+
+def test_every_prompt_interpolates_the_redacted_copy():
+    assert set(_prompt_bodies()) == {"safe_content"}
+
+
+def test_redaction_is_forced():
+    """force=True: the caller cannot know whether a trajectory is trusted."""
+    text = SOURCE.read_text(encoding="utf-8")
+    calls = re.findall(r"redact_sensitive_text\(content, ([^)]*)\)", text)
+    assert len(calls) == 2
+    assert all("force=True" in c for c in calls)
+
+
+def test_a_secret_in_the_turns_does_not_reach_the_prompt():
+    """End-to-end through the real redactor, not a mock."""
+    from agent.redact import redact_sensitive_text
+
+    secret = "sk-ant-api03-" + "A" * 40
+    turns = f"$ cat .env\nANTHROPIC_API_KEY={secret}\n"
+    assert secret not in redact_sensitive_text(turns, force=True)

--- a/trajectory_compressor.py
+++ b/trajectory_compressor.py
@@ -31,6 +31,7 @@ from rich.progress import Progress, SpinnerColumn, TextColumn, BarColumn, TaskPr
 from rich.console import Console
 from hermes_constants import OPENROUTER_BASE_URL, get_hermes_home
 from agent.retry_utils import jittered_backoff
+from agent.redact import redact_sensitive_text
 from hermes_cli.env_loader import load_hermes_dotenv
 
 # Load .env from HERMES_HOME first, then project root as a dev fallback.
@@ -455,7 +456,13 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
 
     def _generate_summary(self, content: str, metrics: TrajectoryMetrics) -> str:
         """Summarize ``content`` with retries; returns a fallback summary after the last failure."""
-        prompt = self._summary_prompt(content)
+        # The turns are raw tool output: API keys, tokens and credentials that
+        # appeared in a terminal result or a file read are still verbatim in
+        # here. The summariser is a THIRD-PARTY endpoint (OpenRouter), so this
+        # is the boundary where they must be scrubbed. force=True because the
+        # caller cannot know whether the trajectory is trusted.
+        safe_content = redact_sensitive_text(content, force=True)
+        prompt = self._summary_prompt(safe_content)
         for attempt in range(self.config.max_retries):
             try:
                 metrics.summarization_api_calls += 1
@@ -474,7 +481,13 @@ Write only the summary, starting with "[CONTEXT SUMMARY]:" prefix."""
 
     async def _generate_summary_async(self, content: str, metrics: TrajectoryMetrics) -> str:
         """Async twin of ``_generate_summary``."""
-        prompt = self._summary_prompt(content)
+        # The turns are raw tool output: API keys, tokens and credentials that
+        # appeared in a terminal result or a file read are still verbatim in
+        # here. The summariser is a THIRD-PARTY endpoint (OpenRouter), so this
+        # is the boundary where they must be scrubbed. force=True because the
+        # caller cannot know whether the trajectory is trusted.
+        safe_content = redact_sensitive_text(content, force=True)
+        prompt = self._summary_prompt(safe_content)
         for attempt in range(self.config.max_retries):
             try:
                 metrics.summarization_api_calls += 1


### PR DESCRIPTION
## What does this PR do?

`TrajectoryCompressor._generate_summary` interpolates the turns being compressed straight into the prompt it sends to OpenRouter. Those turns are raw tool output, so an API key printed by a terminal command or read out of a file is still verbatim in the text — and OpenRouter is a third party.

The path is real, not hypothetical: `compress_trajectory` → `_extract_turn_content_for_summary` → `_generate_summary` (`trajectory_compressor.py:912`) hands the extracted turn text to the summariser unchanged, and the prompt embeds it under `TURNS TO SUMMARIZE:`.

The project already has the primitive and already applies it on comparable boundaries — `plugins/platforms/telegram/adapter.py:37`, `gateway/run.py:878`, `agent/moa_loop.py:70` and others call `redact_sensitive_text(..., force=True)` before text leaves the process. This path simply never did.

## Approach

Both variants are fixed — the sync `_generate_summary` and the async `_generate_summary_async` build the same prompt, so patching only one still leaks. `force=True` because the caller cannot know whether a given trajectory is trusted. Note that this deliberately overrides the user's global `security.redact_secrets` preference — per the docstring, `force=True` is for "safety boundaries that must never return raw secrets regardless of the user's global logging redaction preference", and egress to a third-party summariser is one.

## Related Issue

No existing issue — found while auditing what leaves the process. Happy to open one if you prefer it tracked.

## Type of Change

- [x] 🔒 Security fix
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `trajectory_compressor.py` — both summary paths redact the turns before interpolating them into the prompt.
- `tests/test_trajectory_summary_redaction.py` — new.

## How to Test

```bash
scripts/run_tests.sh tests/test_trajectory_summary_redaction.py   # 7 passed
scripts/run_tests.sh tests/test_trajectory_compressor.py tests/test_trajectory_compressor_async.py   # 29 passed
```

The tests capture what the summariser actually puts on the wire: the client is stubbed, both `_generate_summary` and `_generate_summary_async` are called for real, and the assertion is that a credential present in the turns is absent from the `messages` payload — following the style of the module's existing tests in `tests/test_trajectory_compressor.py`.

They also pin what redaction must *not* do: the surrounding turn text and the `ANTHROPIC_API_KEY` key name still reach the model, so the summary keeps its meaning, and the summariser's return contract is unchanged.

Verified by mutation, including the partial-fix trap:

| reverted | failing tests |
| --- | --- |
| both interpolations | 5 of 7 |
| the sync path only | 4 of 7 |

So a fix that patches one path and leaves the other leaking cannot pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu, Python 3.11

> On the tests box: run via `scripts/run_tests.sh` (the CI-parity wrapper AGENTS.md mandates over bare `pytest`), on the affected files — not the entire suite. Green.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
