### PR TITLE
fix(telegram): rewire plugin handlers after a transient-init rebuild

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2843,7 +2843,11 @@ class TelegramAdapter(BasePlatformAdapter):
                     old_app = self._app
                     self._app = builder.build()
                     self._bot = self._app.bot
-                    self._register_handlers(self._app)  # keep core and observer handlers in lockstep
+                    # Reapply plugin, core, and observer handlers: the old Application — and every
+                    # handler wired to it — is discarded above. Plugin handlers go first, matching
+                    # normal startup, because PTB dispatches the first match per group.
+                    self._wire_plugin_handlers(self._app)
+                    self._register_handlers(self._app)
                     with contextlib.suppress(Exception):
                         await _shutdown_abandoned_app(old_app)
 

--- a/tests/gateway/test_platform_plugin_handlers.py
+++ b/tests/gateway/test_platform_plugin_handlers.py
@@ -16,7 +16,8 @@ from __future__ import annotations
 
 import sys
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -138,6 +139,8 @@ class TestTelegramAlias:
         assert mgr.get_platform_handler_factories("telegram") == [
             (factory, "test_plugin")
         ]
+        # Legacy accessor still works.
+        assert mgr.get_telegram_handler_factories() == [(factory, "test_plugin")]
 
     def test_alias_non_callable_raises(self):
         _, ctx = _make_ctx()
@@ -220,6 +223,52 @@ class TestAdapterPluginWiring:
         with patch("hermes_cli.plugins.get_plugin_manager", return_value=mgr):
             adapter._wire_plugin_handlers(None)
         assert seen == [None]
+
+    @pytest.mark.asyncio
+    async def test_transient_init_rebuild_rewires_plugin_handlers(self, monkeypatch):
+        adapter = TelegramAdapter(
+            PlatformConfig(enabled=True, token="test-token", extra={})
+        )
+        first_app = MagicMock()
+        first_app.bot = MagicMock()
+        first_app.initialize = AsyncMock(side_effect=OSError("transient"))
+        rebuilt_app = MagicMock()
+        rebuilt_app.bot = MagicMock()
+        rebuilt_app.initialize = AsyncMock(
+            side_effect=RuntimeError("stop after rebuild")
+        )
+
+        builder = MagicMock()
+        builder.token.return_value = builder
+        builder.request.return_value = builder
+        builder.get_updates_request.return_value = builder
+        builder.build.side_effect = [first_app, rebuilt_app]
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.Application",
+            SimpleNamespace(builder=MagicMock(return_value=builder)),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.HTTPXRequest", MagicMock
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.discover_fallback_ips",
+            AsyncMock(return_value=[]),
+        )
+        monkeypatch.setattr(
+            "plugins.platforms.telegram.adapter.asyncio.sleep", AsyncMock()
+        )
+        monkeypatch.setattr(
+            "gateway.status.acquire_scoped_lock",
+            lambda scope, identity, metadata=None: (True, None),
+        )
+        adapter._register_handlers = MagicMock()
+        adapter._wire_plugin_handlers = MagicMock()
+
+        assert await adapter.connect() is False
+        assert adapter._wire_plugin_handlers.call_args_list == [
+            ((first_app,), {}),
+            ((rebuilt_app,), {}),
+        ]
 
 
 # ===========================================================================


### PR DESCRIPTION
**Reopened 8 Sep**, rebased onto `main` (`b2aa855b6`).

I opened this on 3 Sep and closed it the same day as a duplicate of #96627, which proposes the same `_wire_plugin_handlers` call and predates it by a week.

Reopening because the bug is still live on `main` — the transient-init rebuild path calls only `_register_handlers`, so plugin handlers stay unregistered for the life of the process — while #96627 now conflicts with `main` and has had no activity since 27 Aug.

### Credit

The fix and the regression test are @roziscoding's work from #96627. His commit no longer cherry-picks cleanly (`main` extracted the retry ladder into `_initialize_app_with_retries`, so the hunk's context is gone), so this is reapplied by hand at the new location with `Co-authored-by:` preserved. **If you squash-merge, please keep that trailer** — it is the only thing carrying his authorship through a squash.

His test is used as authored: it drives the real `connect()` retry path rather than inspecting source, which is the better shape. My original AST-based test from the first version of this PR is dropped in its favour.

### What changed vs #96627

Only the insertion point, forced by the refactor — `plugins/platforms/telegram/adapter.py:2843` inside `_initialize_app_with_retries` instead of the old inline loop. The call ordering is his: plugin handlers before core, matching normal startup at `adapter.py:2948`, because PTB dispatches the first match per group and wiring core first would shadow every pattern-scoped plugin handler.

### Verification

`tests/gateway/test_platform_plugin_handlers.py::TestAdapterPluginWiring::test_transient_init_rebuild_rewires_plugin_handlers`

- with the fix: 17 passed
- with `adapter.py` reverted to `main`: 16 passed, **1 failed** (that test)

Happy to close this again in favour of #96627 if it gets rebased.