### PR TITLE
fix(cron): add spend-neutral provider reset backoff

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -3040,6 +3040,7 @@ def mark_job_run(
     status: Optional[str] = None,
     *,
     expected_fire_owner: Optional[str] = None,
+    provider_backoff: Optional[Dict[str, Any]] = None,
 ) -> bool:
     with _fire_job_lock(job_id) as acquired:
         if not acquired:
@@ -3051,6 +3052,7 @@ def mark_job_run(
             delivery_error,
             status=status,
             expected_fire_owner=expected_fire_owner,
+            provider_backoff=provider_backoff,
         )
 
 
@@ -3145,6 +3147,7 @@ def _mark_job_run_locked(
     *,
     status: Optional[str] = None,
     expected_fire_owner: Optional[str] = None,
+    provider_backoff: Optional[Dict[str, Any]] = None,
 ) -> bool:
     """
     Mark a job as having been run.
@@ -3202,6 +3205,14 @@ def _mark_job_run_locked(
                 else:
                     job["last_status"] = "ok"
                 job["last_error"] = error if not success else None
+                # Provider rate-limit deferrals are durable job state, separate
+                # from next_run_at: the scheduler can suppress unattended fires
+                # across restarts without hiding the failed execution or
+                # changing the user's cadence. A healthy run proves recovery.
+                if success:
+                    job.pop("provider_backoff", None)
+                elif provider_backoff is not None:
+                    job["provider_backoff"] = copy.deepcopy(provider_backoff)
                 # A healthy run means the configuration validates again — drop
                 # the preflight alert-dedup marker so a FUTURE config break
                 # re-alerts instead of being silently swallowed. Same contract
@@ -3607,6 +3618,7 @@ def claim_job_for_fire(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    allow_provider_backoff: bool = False,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     with _fire_job_lock(job_id) as acquired:
@@ -3616,6 +3628,7 @@ def claim_job_for_fire(
             job_id,
             claim_ttl_seconds=claim_ttl_seconds,
             force=force,
+            allow_provider_backoff=allow_provider_backoff,
             return_job=return_job,
         )
 
@@ -3625,6 +3638,7 @@ def _claim_job_for_fire_locked(
     *,
     claim_ttl_seconds: int = 300,
     force: bool = False,
+    allow_provider_backoff: bool = False,
     return_job: bool = False,
 ) -> Union[bool, Dict[str, Any]]:
     """Atomically claim a job for a single external 'fire' (multi-machine
@@ -3636,8 +3650,10 @@ def _claim_job_for_fire_locked(
 
     Under the file lock: reject if the job is missing/disabled/paused. An
     explicit manual fire may pass ``force=True`` to atomically enable and
-    resume the job as part of the claim; external scheduler callbacks must
-    leave it false so a stale callback cannot resurrect a paused job. If a
+    resume the job as part of the claim; ``allow_provider_backoff=True`` only
+    bypasses a temporary provider deferral and never bypasses pause/disable.
+    External scheduler callbacks must leave both false so a stale callback
+    cannot resurrect or prematurely execute a deferred job. If a
     fresh claim (younger than ``claim_ttl_seconds``) already exists, lose.
     Otherwise stamp a ``fire_claim`` and, for recurring jobs, advance
     ``next_run_at`` (mirrors ``advance_next_run``'s at-most-once bump so a stale
@@ -3664,6 +3680,14 @@ def _claim_job_for_fire_locked(
             if not force and not is_job_runnable(job):
                 return False
             now = _hermes_now()
+            from cron.rate_limit_backoff import provider_backoff_active
+
+            if (
+                not force
+                and not allow_provider_backoff
+                and provider_backoff_active(job, now=now)
+            ):
+                return False
             existing = job.get("fire_claim")
             if existing:
                 try:
@@ -3958,6 +3982,19 @@ def _get_due_jobs_locked() -> List[Dict[str, Any]]:
             if is_terminal_job(job) and not _is_recoverable_error_job(job):
                 continue
             if not job.get("enabled", True):
+                continue
+
+            # A provider-declared reset window suppresses unattended inference
+            # without pausing or rescheduling the job. The marker lives in
+            # jobs.json, so a gateway restart cannot forget it. Manual run-now
+            # intent remains an explicit operator override.
+            from cron.rate_limit_backoff import provider_backoff_active
+
+            manual_override = bool(
+                job.get("manual_run_at")
+                and job.get("manual_run_at") == job.get("next_run_at")
+            )
+            if not manual_override and provider_backoff_active(job, now=now):
                 continue
 
             # Contradiction self-heal: enabled=true with pause markers means the

--- a/cron/rate_limit_backoff.py
+++ b/cron/rate_limit_backoff.py
@@ -1,0 +1,156 @@
+"""Deterministic, durable backoff policy for provider rate-limit failures."""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from datetime import datetime, timedelta
+from email.utils import parsedate_to_datetime
+from typing import Any, Dict, Optional
+
+_RATE_LIMIT_RE = re.compile(r"\b429\b|rate[ -]?limit|usage limit", re.IGNORECASE)
+_RESET_AT_RE = re.compile(
+    r"(?:limit\s+will\s+reset|reset[_ -]?at|resets?)\s*(?:at|[:=])?\s*"
+    r"(?P<value>[^\n\r;}]+)",
+    re.IGNORECASE,
+)
+_RETRY_AFTER_RE = re.compile(
+    r"retry[- ]after\s*(?:[:=]|is)?\s*(?P<value>[^\n\r;}]+)",
+    re.IGNORECASE,
+)
+_EPOCH_RESET_RE = re.compile(
+    r"(?:x[- ]?rate[- ]?limit[- ]?reset|ratelimit[-_ ]reset)\s*[:=]\s*(?P<epoch>\d{10}(?:\.\d+)?)",
+    re.IGNORECASE,
+)
+
+_EXPLICIT_JITTER_SECONDS = 300
+_FALLBACK_JITTER_SECONDS = 60
+_FALLBACK_BASE_SECONDS = 15 * 60
+_FALLBACK_MAX_SECONDS = 6 * 60 * 60
+_MAX_DECLARED_DELAY_SECONDS = 31 * 24 * 60 * 60
+
+
+def _aware(value: datetime, now: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=now.tzinfo)
+    return value
+
+
+def _parse_datetime(value: str, now: datetime) -> Optional[datetime]:
+    text = value.strip().strip("'\"")
+    if text.endswith("Z"):
+        text = text[:-1] + "+00:00"
+    try:
+        return _aware(datetime.fromisoformat(text), now)
+    except ValueError:
+        pass
+    try:
+        return _aware(parsedate_to_datetime(text), now)
+    except (TypeError, ValueError, OverflowError):
+        pass
+    # Some providers render quota resets for humans rather than as ISO/RFC
+    # timestamps. Naive values inherit the provider error's local process zone,
+    # matching the ISO-without-offset behavior above.
+    normalized = re.sub(r"\s+at\s+", " ", text, flags=re.IGNORECASE)
+    for fmt in ("%B %d, %Y %I:%M %p", "%b %d, %Y %I:%M %p"):
+        try:
+            return _aware(datetime.strptime(normalized, fmt), now)
+        except ValueError:
+            continue
+    return None
+
+
+def _declared_reset(error: str, now: datetime) -> Optional[datetime]:
+    retry_after = _RETRY_AFTER_RE.search(error)
+    if retry_after:
+        value = retry_after.group("value").strip()
+        try:
+            candidate = now + timedelta(seconds=float(value))
+        except (TypeError, ValueError, OverflowError):
+            candidate = _parse_datetime(value, now)
+        if candidate is not None:
+            return candidate
+
+    epoch_reset = _EPOCH_RESET_RE.search(error)
+    if epoch_reset:
+        try:
+            candidate = datetime.fromtimestamp(
+                float(epoch_reset.group("epoch")), tz=now.tzinfo
+            )
+        except (TypeError, ValueError, OverflowError, OSError):
+            candidate = None
+        if candidate is not None:
+            return candidate
+
+    match = _RESET_AT_RE.search(error)
+    if match:
+        return _parse_datetime(match.group("value"), now)
+    return None
+
+
+def _jitter_seconds(job_id: str, key: str, ceiling: int) -> int:
+    digest = hashlib.sha256(f"{job_id}:{key}".encode("utf-8")).digest()
+    return int.from_bytes(digest[:4], "big") % ceiling + 1
+
+
+def plan_provider_backoff(
+    job: Dict[str, Any], error: Optional[str], *, now: datetime
+) -> Optional[Dict[str, Any]]:
+    """Plan a no-inference retry delay for a provider rate-limit failure."""
+    text = str(error or "")
+    if job.get("no_agent") or not _RATE_LIMIT_RE.search(text):
+        return None
+
+    job_id = str(job.get("id") or "unknown")
+    existing = job.get("provider_backoff")
+    attempt = 1
+    if isinstance(existing, dict):
+        try:
+            attempt = max(1, int(existing.get("attempt") or 0) + 1)
+        except (TypeError, ValueError):
+            attempt = 1
+
+    reset_at = _declared_reset(text, now)
+    max_reset = now + timedelta(seconds=_MAX_DECLARED_DELAY_SECONDS)
+    if reset_at is not None and now < reset_at <= max_reset:
+        key = reset_at.isoformat()
+        until = reset_at + timedelta(
+            seconds=_jitter_seconds(job_id, key, _EXPLICIT_JITTER_SECONDS)
+        )
+        return {
+            "until": until.isoformat(),
+            "reset_at": reset_at.isoformat(),
+            "detected_at": now.isoformat(),
+            "source": "provider_reset",
+            "attempt": attempt,
+        }
+
+    delay = min(
+        _FALLBACK_BASE_SECONDS * (2 ** min(attempt - 1, 16)),
+        _FALLBACK_MAX_SECONDS,
+    )
+    jitter = _jitter_seconds(job_id, str(attempt), _FALLBACK_JITTER_SECONDS)
+    return {
+        "until": (now + timedelta(seconds=delay + jitter)).isoformat(),
+        "reset_at": None,
+        "detected_at": now.isoformat(),
+        "source": "fallback",
+        "attempt": attempt,
+    }
+
+
+def provider_backoff_active(job: Dict[str, Any], *, now: datetime) -> bool:
+    """Return whether a persisted provider backoff still suppresses auto-fire."""
+    backoff = job.get("provider_backoff")
+    if not isinstance(backoff, dict):
+        return False
+    until = backoff.get("until")
+    if not isinstance(until, str):
+        return False
+    try:
+        parsed = _aware(datetime.fromisoformat(until), now)
+        delay = (parsed - now).total_seconds()
+    except (TypeError, ValueError):
+        return False
+    max_delay = _MAX_DECLARED_DELAY_SECONDS + _EXPLICIT_JITTER_SECONDS
+    return 0 < delay <= max_delay

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7808,7 +7808,22 @@ def _run_one_job_body(
             )
             return True
 
-        mark_kwargs = {"delivery_error": delivery_error}
+        mark_kwargs: dict[str, Any] = {"delivery_error": delivery_error}
+        if not success:
+            from cron.rate_limit_backoff import plan_provider_backoff
+
+            provider_backoff = plan_provider_backoff(
+                job, error, now=_hermes_now()
+            )
+            if provider_backoff is not None:
+                mark_kwargs["provider_backoff"] = provider_backoff
+                logger.warning(
+                    "Job '%s': provider rate limit suppresses unattended fires "
+                    "until %s (%s)",
+                    job["id"],
+                    provider_backoff["until"],
+                    provider_backoff["source"],
+                )
         if fire_owner is not None:
             mark_kwargs["expected_fire_owner"] = fire_owner
         if blocked_config:
@@ -8366,7 +8381,10 @@ def tick(
             # Acquire the durable claim only when this worker actually starts,
             # not while it may wait behind other work in an executor queue.
             # This prevents a queued lease from expiring before execution.
-            claimed = claim_job_for_fire(job["id"], return_job=True)
+            claim_kwargs: dict[str, Any] = {"return_job": True}
+            if job.get("manual_run_at"):
+                claim_kwargs["allow_provider_backoff"] = True
+            claimed = claim_job_for_fire(job["id"], **claim_kwargs)
             if not claimed:
                 finish_execution(
                     job["execution_id"],

--- a/cron/scheduler_provider.py
+++ b/cron/scheduler_provider.py
@@ -180,6 +180,7 @@ class CronScheduler(ABC):
         adapters: Any = None,
         loop: Any = None,
         force: bool = False,
+        allow_provider_backoff: bool = False,
     ) -> bool:
         """Run a single job NOW via the shared orchestrator. Called by the
         inbound fire webhook when an external scheduler signals a job is due.
@@ -193,12 +194,29 @@ class CronScheduler(ABC):
         the job itself failed. Returns False only if the claim was lost
         (another machine/retry won it) or the job no longer exists.
         """
-        claimed_job = self.claim_fire(job_id, force=force)
+        claim_kwargs = {"force": force}
+        if allow_provider_backoff:
+            if not _callable_supports_keyword(
+                self.claim_fire,
+                "allow_provider_backoff",
+            ):
+                raise TypeError(
+                    f"Cron provider '{self.name}' does not support "
+                    "provider-backoff override in claim_fire"
+                )
+            claim_kwargs["allow_provider_backoff"] = True
+        claimed_job = self.claim_fire(job_id, **claim_kwargs)
         if claimed_job is None:
             return False
         return self.fire_claimed(claimed_job, adapters=adapters, loop=loop)
 
-    def claim_fire(self, job_id: str, *, force: bool = False) -> dict | None:
+    def claim_fire(
+        self,
+        job_id: str,
+        *,
+        force: bool = False,
+        allow_provider_backoff: bool = False,
+    ) -> dict | None:
         """Durably claim one fire and create its audit attempt before dispatch.
 
         Webhook transports call this synchronously before acknowledging the
@@ -212,6 +230,8 @@ class CronScheduler(ABC):
         claim_kwargs = {"return_job": True}
         if force:
             claim_kwargs["force"] = True
+        if allow_provider_backoff:
+            claim_kwargs["allow_provider_backoff"] = True
         try:
             claimed_job = claim_job_for_fire(job_id, **claim_kwargs)
         except BaseException as exc:
@@ -263,21 +283,37 @@ class CronScheduler(ABC):
         return None
 
 
-def provider_supports_force_fire(provider: Any) -> bool:
-    """Return whether a provider can safely receive ``fire_due(force=...)``."""
+def _callable_supports_keyword(callback: Any, name: str) -> bool:
     try:
-        parameters = inspect.signature(provider.fire_due).parameters.values()
+        parameters = inspect.signature(callback).parameters.values()
     except (TypeError, ValueError):
         return False
     return any(
         parameter.kind is inspect.Parameter.VAR_KEYWORD
         or (
-            parameter.name == "force"
+            parameter.name == name
             and parameter.kind
             in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY)
         )
         for parameter in parameters
     )
+
+
+def provider_supports_force_fire(provider: Any) -> bool:
+    """Return whether a provider can safely receive ``fire_due(force=...)``."""
+    return _callable_supports_keyword(provider.fire_due, "force")
+
+
+def provider_supports_backoff_override(provider: Any) -> bool:
+    """Return whether a provider can safely bypass only provider backoff."""
+    if not _callable_supports_keyword(provider.fire_due, "allow_provider_backoff"):
+        return False
+    if type(provider).fire_due is CronScheduler.fire_due:
+        return _callable_supports_keyword(
+            provider.claim_fire,
+            "allow_provider_backoff",
+        )
+    return True
 
 
 def provider_supports_split_fire(provider: Any) -> bool:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -13470,13 +13470,12 @@ def _trigger_cron_job_sync(job_id: str, profile: Optional[str] = None):
     job = _call_cron_for_profile(selected, "resolve_job_ref", job_id)
     if not job:
         raise HTTPException(status_code=404, detail="Job not found")
-    # Do not expose the job as due before claiming it: the built-in ticker and
-    # external/manual fire paths share the same durable claim, so only one can
-    # execute this selected run even if they race across processes. Active jobs
-    # keep the legacy provider call shape; paused jobs need the explicit force
-    # flag to resume and claim atomically.
+    # Provider-backoff bypass follows the explicit manual intent rather than
+    # this pre-claim snapshot. The provider's atomic claim still enforces the
+    # current pause/disable state and duplicate-fire ownership.
     force = not job.get("enabled", True) or job.get("state") == "paused"
-    ran = _fire_cron_job_for_profile(selected, job["id"], force=force)
+    fire_kwargs = {"force": force, "allow_provider_backoff": True}
+    ran = _fire_cron_job_for_profile(selected, job["id"], **fire_kwargs)
     refreshed = _call_cron_for_profile(selected, "get_job", job["id"])
     if refreshed and refreshed.get("last_run_at") != job.get("last_run_at"):
         return refreshed
@@ -13519,6 +13518,7 @@ def _fire_cron_job_for_profile(
     job_id: str,
     *,
     force: bool = False,
+    allow_provider_backoff: bool = False,
 ) -> bool:
     """DEPRECATED for NAS webhook fires (superseded by gateway forwarding);
     retained for the dashboard trigger path — do not add new uses.
@@ -13537,6 +13537,7 @@ def _fire_cron_job_for_profile(
     _profile_name, home = _cron_profile_home(profile)
     from cron import jobs as cron_jobs
     from cron.scheduler_provider import (
+        provider_supports_backoff_override,
         provider_supports_force_fire,
         resolve_cron_scheduler,
     )
@@ -13549,6 +13550,7 @@ def _fire_cron_job_for_profile(
     try:
         with cron_jobs.use_cron_store(home):
             provider = resolve_cron_scheduler()
+            fire_kwargs = {}
             if force:
                 if not provider_supports_force_fire(provider):
                     raise HTTPException(
@@ -13558,10 +13560,30 @@ def _fire_cron_job_for_profile(
                             "does not support atomic forced firing of paused jobs"
                         ),
                     )
-                return bool(
-                    provider.fire_due(job_id, adapters=None, loop=None, force=True)
-                )
-            return bool(provider.fire_due(job_id, adapters=None, loop=None))
+                fire_kwargs["force"] = True
+            if allow_provider_backoff:
+                if provider_supports_backoff_override(provider):
+                    fire_kwargs["allow_provider_backoff"] = True
+                else:
+                    # Legacy providers retain their historical call shape
+                    # when no override is currently needed. They cannot
+                    # safely bypass an active backoff, so fail explicitly.
+                    from cron.rate_limit_backoff import provider_backoff_active
+
+                    current = cron_jobs.get_job(job_id)
+                    if current and provider_backoff_active(
+                        current, now=datetime.now(timezone.utc)
+                    ):
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"Cron provider '{getattr(provider, 'name', 'custom')}' "
+                                "does not support provider-backoff override"
+                            ),
+                        )
+            return bool(
+                provider.fire_due(job_id, adapters=None, loop=None, **fire_kwargs)
+            )
     finally:
         reset_hermes_home_override(token)
 

--- a/plugins/cron_providers/chronos/__init__.py
+++ b/plugins/cron_providers/chronos/__init__.py
@@ -138,15 +138,44 @@ class ChronosCronScheduler(CronScheduler):
 
     # -- arming -----------------------------------------------------------
 
-    def _arm_one_shot(self, job: Dict[str, Any]) -> None:
-        """Ask NAS to arm exactly one one-shot at the job's next_run_at.
+    @staticmethod
+    def _effective_fire_at(job: Dict[str, Any]) -> str:
+        """Return the remote fire time without changing the stored cadence."""
+        fire_at = str(job.get("next_run_at") or "")
+        if not fire_at:
+            return ""
+        if (
+            job.get("manual_run_at")
+            and job.get("manual_run_at") == job.get("next_run_at")
+        ):
+            return fire_at
 
-        The agent computes the time; NAS+its scheduler are the dumb executor.
-        Idempotent per (job_id, fire_at) via dedup_key, so re-arming the same
-        fire is a no-op NAS-side.
+        from datetime import datetime
+        from cron.jobs import _ensure_aware, _hermes_now
+        from cron.rate_limit_backoff import provider_backoff_active
+
+        now = _hermes_now()
+        if not provider_backoff_active(job, now=now):
+            return fire_at
+        until = str((job.get("provider_backoff") or {}).get("until") or "")
+        try:
+            if _ensure_aware(datetime.fromisoformat(until)) > _ensure_aware(
+                datetime.fromisoformat(fire_at)
+            ):
+                return until
+        except (TypeError, ValueError):
+            pass
+        return fire_at
+
+    def _arm_one_shot(self, job: Dict[str, Any]) -> None:
+        """Ask NAS to arm exactly one one-shot at the effective fire time.
+
+        The stored ``next_run_at`` remains the user's cadence. A durable model-
+        provider backoff only moves the external wake-up to its expiry, so a
+        consumed callback cannot strand the job while inference is suppressed.
         """
         job_id = job["id"]
-        fire_at = job.get("next_run_at")
+        fire_at = self._effective_fire_at(job)
         if not fire_at:
             return
         dedup_key = f"{job_id}:{fire_at}"
@@ -197,7 +226,7 @@ class ChronosCronScheduler(CronScheduler):
         from cron.jobs import load_jobs
 
         desired: Dict[str, str] = {
-            j["id"]: j["next_run_at"]
+            j["id"]: self._effective_fire_at(j)
             for j in load_jobs()
             if j.get("enabled") and j.get("next_run_at") and j.get("state") != "paused"
         }

--- a/tests/cron/test_provider_rate_limit_backoff.py
+++ b/tests/cron/test_provider_rate_limit_backoff.py
@@ -1,0 +1,335 @@
+"""Spend-neutral cron backoff for provider-declared reset windows."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def temp_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    return tmp_path
+
+
+def _rate_limit_error(reset: str) -> str:
+    return (
+        "RuntimeError: HTTP 429: Weekly/Monthly Limit Exhausted. "
+        f"Your limit will reset at {reset}"
+    )
+
+
+def test_declared_reset_is_deferred_until_reset_plus_deterministic_jitter():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 11, 24, tzinfo=timezone(timedelta(hours=7)))
+    error = _rate_limit_error("2026-09-04 10:03:01")
+
+    first = plan_provider_backoff({"id": "job-a"}, error, now=now)
+    second = plan_provider_backoff({"id": "job-a"}, error, now=now)
+
+    assert first == second
+    assert first is not None
+    reset_at = datetime.fromisoformat(first["reset_at"])
+    until = datetime.fromisoformat(first["until"])
+    assert reset_at == datetime(
+        2026, 9, 4, 10, 3, 1, tzinfo=timezone(timedelta(hours=7))
+    )
+    assert timedelta(seconds=1) <= until - reset_at <= timedelta(minutes=5)
+    assert first["source"] == "provider_reset"
+
+
+def test_repeated_rate_limits_without_reset_hint_back_off_exponentially():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    first = plan_provider_backoff({"id": "job-a"}, "HTTP 429", now=now)
+    second = plan_provider_backoff(
+        {"id": "job-a", "provider_backoff": first}, "rate limit reached", now=now
+    )
+
+    assert first is not None and second is not None
+    assert first["attempt"] == 1
+    assert second["attempt"] == 2
+    assert datetime.fromisoformat(second["until"]) > datetime.fromisoformat(first["until"])
+    assert second["source"] == "fallback"
+
+
+def test_invalid_reset_hint_uses_bounded_fallback():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    planned = plan_provider_backoff(
+        {"id": "job-a"}, _rate_limit_error("not-a-timestamp"), now=now
+    )
+
+    assert planned is not None
+    assert planned["source"] == "fallback"
+    assert now + timedelta(minutes=15) < datetime.fromisoformat(planned["until"])
+    assert datetime.fromisoformat(planned["until"]) <= now + timedelta(minutes=16)
+
+
+def test_retry_after_http_date_is_respected():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    reset = now + timedelta(hours=2)
+    error = f"HTTP 429; Retry-After: {format_datetime(reset, usegmt=True)}"
+
+    planned = plan_provider_backoff({"id": "job-a"}, error, now=now)
+
+    assert planned is not None
+    assert planned["source"] == "provider_reset"
+    assert datetime.fromisoformat(planned["reset_at"]) == reset
+
+
+def test_locale_reset_timestamp_is_respected():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    error = "HTTP 429; your limit will reset at September 4, 2026 10:03 AM"
+
+    planned = plan_provider_backoff({"id": "job-a"}, error, now=now)
+
+    assert planned is not None
+    assert planned["source"] == "provider_reset"
+    assert datetime.fromisoformat(planned["reset_at"]) == datetime(
+        2026, 9, 4, 10, 3, tzinfo=timezone.utc
+    )
+
+
+@pytest.mark.parametrize("spelling", ["reset_at=", "reset-at: "])
+def test_machine_reset_at_spellings_are_respected(spelling):
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    planned = plan_provider_backoff(
+        {"id": "job-a"}, f"HTTP 429; {spelling}2026-09-04T10:03:01Z", now=now
+    )
+
+    assert planned is not None
+    assert planned["source"] == "provider_reset"
+    assert planned["reset_at"] == "2026-09-04T10:03:01+00:00"
+
+
+def test_far_future_persisted_marker_fails_open():
+    from cron.rate_limit_backoff import provider_backoff_active
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    job = {"provider_backoff": {"until": (now + timedelta(days=365)).isoformat()}}
+
+    assert provider_backoff_active(job, now=now) is False
+
+
+def test_non_rate_limit_failure_does_not_create_backoff():
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    assert plan_provider_backoff({"id": "job-a"}, "HTTP 500 upstream error", now=now) is None
+    assert plan_provider_backoff(
+        {"id": "job-a", "no_agent": True}, "HTTP 429 from script output", now=now
+    ) is None
+
+
+def test_backoff_persists_across_reload_and_suppresses_due_run(temp_home, monkeypatch):
+    from cron.jobs import create_job, get_due_jobs, get_job, mark_job_run
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m", name="eng-completion")
+    error = _rate_limit_error("2026-09-04 10:03:01+00:00")
+    backoff = plan_provider_backoff(job, error, now=now)
+
+    assert mark_job_run(job["id"], False, error, provider_backoff=backoff)
+    persisted = get_job(job["id"])
+    assert persisted["last_status"] == "error"
+    assert persisted["last_error"] == error
+    assert persisted["provider_backoff"] == backoff
+
+    due_time = datetime.fromisoformat(persisted["next_run_at"]) + timedelta(seconds=1)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: due_time)
+    assert get_due_jobs() == []
+    assert get_job(job["id"])["provider_backoff"] == backoff
+
+
+def test_expired_backoff_resumes_automatically_and_success_clears_it(
+    temp_home, monkeypatch
+):
+    from cron.jobs import create_job, get_due_jobs, get_job, mark_job_run
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m", name="eng-completion")
+    error = "HTTP 429"
+    backoff = plan_provider_backoff(job, error, now=now)
+    assert mark_job_run(job["id"], False, error, provider_backoff=backoff)
+
+    after = datetime.fromisoformat(backoff["until"]) + timedelta(seconds=1)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: after)
+    due = get_due_jobs()
+    assert [item["id"] for item in due] == [job["id"]]
+    assert due[0]["provider_backoff"]["attempt"] == 1
+    persisted = get_job(job["id"])
+    assert persisted is not None
+    assert persisted["provider_backoff"] == backoff
+
+    repeated = plan_provider_backoff(due[0], error, now=after)
+    assert repeated is not None
+    assert repeated["attempt"] == 2
+
+    assert mark_job_run(job["id"], True)
+    recovered = get_job(job["id"])
+    assert recovered["enabled"] is True
+    assert recovered["state"] == "scheduled"
+    assert recovered["last_status"] == "ok"
+    assert recovered["failure_streak"] == 0
+
+
+def test_scheduler_records_backoff_without_hiding_failed_execution(monkeypatch):
+    import cron.scheduler as scheduler
+
+    now = datetime(2026, 9, 3, 11, 24, tzinfo=timezone(timedelta(hours=7)))
+    error = _rate_limit_error("2026-09-04 10:03:01")
+    job = {
+        "id": "job-a",
+        "name": "eng-completion",
+        "prompt": "work",
+        "deliver": "local",
+        "execution_id": "execution-a",
+    }
+    monkeypatch.setattr(scheduler, "_hermes_now", lambda: now)
+
+    with patch("cron.scheduler.claim_dispatch", return_value=True), patch(
+        "cron.scheduler.mark_execution_running"
+    ), patch("agent.secret_scope.set_secret_scope", return_value=None), patch(
+        "agent.secret_scope.build_profile_secret_scope", return_value=None
+    ), patch("agent.secret_scope.reset_secret_scope"), patch(
+        "cron.scheduler.run_job", return_value=(False, "full output", "", error)
+    ), patch(
+        "cron.scheduler.save_job_output", return_value="/tmp/out.md"
+    ), patch(
+        "cron.scheduler._deliver_result", return_value=None
+    ), patch(
+        "cron.scheduler._upsert_incident_for_failure", return_value=(False, "incident-a")
+    ), patch(
+        "cron.scheduler.mark_job_run", return_value=True
+    ) as mark_run, patch(
+        "cron.scheduler.finish_execution"
+    ) as finish:
+        assert scheduler.run_one_job(job) is True
+
+    assert mark_run.call_args.args[:3] == (job["id"], False, error)
+    backoff = mark_run.call_args.kwargs["provider_backoff"]
+    assert backoff["source"] == "provider_reset"
+    finish.assert_called_once_with(
+        "execution-a",
+        success=False,
+        error=error,
+        delivery_outcome="suppressed",
+    )
+
+
+def test_cron_tool_manual_run_bypasses_active_backoff(temp_home, monkeypatch):
+    from cron.jobs import create_job, get_job, mark_job_run
+    from cron.rate_limit_backoff import plan_provider_backoff
+    from tools import cronjob_tools
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m")
+    backoff = plan_provider_backoff(job, "HTTP 429", now=now)
+    assert mark_job_run(job["id"], False, "HTTP 429", provider_backoff=backoff)
+
+    persisted = get_job(job["id"])
+    assert persisted is not None
+    with patch.object(
+        cronjob_tools,
+        "_run_claimed_job",
+        return_value={"claimed": True, "success": True, "error": None},
+    ):
+        result = cronjob_tools._execute_job_now(persisted)
+
+    assert result["claimed"] is True
+    assert result["success"] is True
+
+
+def test_cron_tool_stale_snapshot_cannot_resume_concurrently_paused_job(
+    temp_home, monkeypatch
+):
+    from cron.jobs import create_job, get_job, mark_job_run, pause_job
+    from cron.rate_limit_backoff import plan_provider_backoff
+    from tools import cronjob_tools
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m")
+    backoff = plan_provider_backoff(job, "HTTP 429", now=now)
+    assert mark_job_run(job["id"], False, "HTTP 429", provider_backoff=backoff)
+    stale = get_job(job["id"])
+    assert stale is not None
+    assert pause_job(job["id"]) is not None
+
+    result = cronjob_tools._execute_job_now(stale)
+
+    assert result["claimed"] is False
+    persisted = get_job(job["id"])
+    assert persisted is not None
+    assert persisted["state"] == "paused"
+    assert persisted["enabled"] is False
+
+
+def test_triggered_run_bypasses_backoff_on_scheduler_claim(temp_home, monkeypatch):
+    from cron.jobs import (
+        advance_next_runs,
+        claim_job_for_fire,
+        create_job,
+        get_due_jobs,
+        mark_job_run,
+        trigger_job,
+    )
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m")
+    backoff = plan_provider_backoff(job, "HTTP 429", now=now)
+    assert mark_job_run(job["id"], False, "HTTP 429", provider_backoff=backoff)
+
+    triggered = trigger_job(job["id"])
+
+    assert triggered is not None
+    assert triggered["manual_run_at"] == triggered["next_run_at"]
+    due = get_due_jobs()
+    assert [item["id"] for item in due] == [job["id"]]
+    advance_next_runs([job["id"]])
+    assert claim_job_for_fire(
+        job["id"], allow_provider_backoff=True
+    ) is True
+
+
+def test_external_fire_claim_is_suppressed_until_backoff_expires(
+    temp_home, monkeypatch
+):
+    from cron.jobs import claim_job_for_fire, create_job, mark_job_run
+    from cron.rate_limit_backoff import plan_provider_backoff
+
+    now = datetime(2026, 9, 3, 4, tzinfo=timezone.utc)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+    job = create_job("work", "every 10m")
+    backoff = plan_provider_backoff(job, "HTTP 429", now=now)
+    assert mark_job_run(job["id"], False, "HTTP 429", provider_backoff=backoff)
+    assert claim_job_for_fire(job["id"]) is False
+    assert claim_job_for_fire(job["id"], force=True) is True
+    assert mark_job_run(job["id"], True)
+
+    # A normal unattended claim is allowed again after the reset window.
+    monkeypatch.setattr(
+        "cron.jobs._hermes_now",
+        lambda: datetime.fromisoformat(backoff["until"]) + timedelta(seconds=1),
+    )
+    assert claim_job_for_fire(job["id"]) is True

--- a/tests/cron/test_scheduler_provider.py
+++ b/tests/cron/test_scheduler_provider.py
@@ -422,6 +422,28 @@ def test_claim_fire_persists_attempt_before_fire_claimed(monkeypatch):
     assert events == ["ledger", "claim", ("run", "exec-1")]
 
 
+def test_fire_due_keeps_existing_claim_override_compatible():
+    from cron.scheduler_provider import (
+        InProcessCronScheduler,
+        provider_supports_backoff_override,
+    )
+
+    seen = []
+
+    class ExistingSplitProvider(InProcessCronScheduler):
+        def claim_fire(self, job_id, *, force=False):  # type: ignore[override]
+            seen.append((job_id, force))
+            return {"id": job_id, "execution_id": "exec-1"}
+
+        def fire_claimed(self, claimed_job, **kwargs):
+            return True
+
+    provider = ExistingSplitProvider()
+    assert provider.fire_due("j1") is True
+    assert seen == [("j1", False)]
+    assert provider_supports_backoff_override(provider) is False
+
+
 def test_fire_due_forwards_manual_force_to_store_claim(monkeypatch):
     import cron.jobs as jobs
     import cron.scheduler as sched

--- a/tests/hermes_cli/test_web_server_cron_profiles.py
+++ b/tests/hermes_cli/test_web_server_cron_profiles.py
@@ -38,6 +38,125 @@ def _drain_queue(q):
 
 
 
+def test_dashboard_trigger_bypasses_backoff_without_forcing_job_state(monkeypatch):
+    from datetime import datetime, timedelta, timezone
+
+    from hermes_cli import web_server
+
+    until = (datetime.now(timezone.utc) + timedelta(hours=1)).isoformat()
+    job = {
+        "id": "job-a",
+        "enabled": True,
+        "state": "scheduled",
+        "last_run_at": None,
+        "provider_backoff": {"until": until},
+    }
+    calls = []
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda _job_id: "default")
+    monkeypatch.setattr(web_server, "_call_cron_for_profile", lambda *_args: job)
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda profile, job_id, **kwargs: calls.append((profile, job_id, kwargs)) or True,
+    )
+
+    result = web_server._trigger_cron_job_sync("job-a")
+
+    assert result == job
+    assert calls == [
+        (
+            "default",
+            "job-a",
+            {"force": False, "allow_provider_backoff": True},
+        )
+    ]
+
+
+def test_dashboard_manual_intent_allows_backoff_added_during_claim(monkeypatch):
+    from hermes_cli import web_server
+
+    job = {
+        "id": "job-race",
+        "enabled": True,
+        "state": "scheduled",
+        "last_run_at": None,
+    }
+    calls = []
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda _job_id: "default")
+    monkeypatch.setattr(web_server, "_call_cron_for_profile", lambda *_args: job)
+    monkeypatch.setattr(
+        web_server,
+        "_fire_cron_job_for_profile",
+        lambda profile, job_id, **kwargs: calls.append((profile, job_id, kwargs)) or True,
+    )
+
+    assert web_server._trigger_cron_job_sync("job-race") == job
+    assert calls == [
+        (
+            "default",
+            "job-race",
+            {"force": False, "allow_provider_backoff": True},
+        )
+    ]
+
+
+def test_dashboard_backoff_snapshot_cannot_resume_concurrently_paused_job(
+    isolated_profiles,
+    monkeypatch,
+):
+    from datetime import datetime, timedelta, timezone
+
+    from cron import jobs as cron_jobs
+    from hermes_cli import web_server
+
+    default_home = isolated_profiles["default"]
+    now = datetime.now(timezone.utc)
+    with cron_jobs.use_cron_store(default_home):
+        job = cron_jobs.create_job("work", "every 10m")
+        backoff = {
+            "until": (now + timedelta(hours=1)).isoformat(),
+            "reason": "provider reset",
+        }
+        assert cron_jobs.mark_job_run(
+            job["id"],
+            False,
+            "HTTP 429",
+            provider_backoff=backoff,
+        )
+        stale = cron_jobs.get_job(job["id"])
+
+    def call_cron(_profile, operation, job_id):
+        assert job_id == job["id"]
+        if operation == "resolve_job_ref":
+            return stale
+        with cron_jobs.use_cron_store(default_home):
+            return cron_jobs.get_job(job_id)
+
+    def pause_then_claim(_profile, job_id, **kwargs):
+        with cron_jobs.use_cron_store(default_home):
+            assert cron_jobs.pause_job(job_id) is not None
+            claimed = cron_jobs.claim_job_for_fire(
+                job_id,
+                return_job=True,
+                **kwargs,
+            )
+            return isinstance(claimed, dict)
+
+    monkeypatch.setattr(web_server, "_find_cron_job_profile", lambda _job_id: "default")
+    monkeypatch.setattr(web_server, "_call_cron_for_profile", call_cron)
+    monkeypatch.setattr(web_server, "_fire_cron_job_for_profile", pause_then_claim)
+    monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+    with pytest.raises(HTTPException, match="already running or was claimed"):
+        web_server._trigger_cron_job_sync(job["id"])
+
+    with cron_jobs.use_cron_store(default_home):
+        persisted = cron_jobs.get_job(job["id"])
+    assert persisted is not None
+    assert persisted["enabled"] is False
+    assert persisted["state"] == "paused"
+
+
 def test_fire_cron_job_scopes_store_and_runtime_home_together(
     isolated_profiles,
     monkeypatch,

--- a/tests/plugins/test_chronos_cron.py
+++ b/tests/plugins/test_chronos_cron.py
@@ -9,6 +9,8 @@ All NAS calls are mocked — ZERO live network. These prove:
     (job gone) stops re-arming.
 """
 
+from datetime import datetime, timedelta, timezone
+
 import pytest
 
 
@@ -156,6 +158,48 @@ def test_fire_due_rearms_after_claimed_job_failure(chronos, monkeypatch):
 
     assert prov.fire_due("j1") is True
     assert [provision["job_id"] for provision in fake.provisions] == ["j1"]
+
+
+def test_failed_fire_rearms_at_provider_backoff_expiry(chronos, monkeypatch):
+    prov, fake = chronos
+    now = datetime.now(timezone.utc)
+    persisted = {
+        "id": "j1",
+        "enabled": True,
+        "state": "scheduled",
+        "next_run_at": (now + timedelta(minutes=5)).isoformat(),
+        "provider_backoff": {"until": (now + timedelta(hours=1)).isoformat()},
+    }
+    monkeypatch.setattr(
+        "cron.scheduler_provider.CronScheduler.fire_claimed",
+        lambda self, job, **kw: True,
+    )
+    monkeypatch.setattr("cron.jobs.get_job", lambda jid: persisted)
+
+    assert prov.fire_claimed({"id": "j1"}) is True
+    assert fake.provisions[0]["fire_at"] == persisted["provider_backoff"]["until"]
+
+
+def test_reconcile_after_restart_restores_backoff_expiry_fire(
+    temp_home,
+    chronos,
+    monkeypatch,
+):
+    prov, fake = chronos
+    now = datetime.now(timezone.utc)
+    job = {
+        "id": "j1",
+        "enabled": True,
+        "state": "scheduled",
+        "next_run_at": (now + timedelta(minutes=5)).isoformat(),
+        "provider_backoff": {"until": (now + timedelta(hours=1)).isoformat()},
+    }
+    monkeypatch.setattr("cron.jobs.load_jobs", lambda: [job])
+    monkeypatch.setattr("cron.jobs.get_job", lambda jid: job)
+
+    prov.reconcile()
+
+    assert fake.provisions[0]["fire_at"] == job["provider_backoff"]["until"]
 
 
 def test_fire_due_forwards_manual_force_to_claim(chronos, monkeypatch):

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -79,11 +79,55 @@ class TestBackgroundDispatch:
             assert res["claimed"] is True
             assert res["dispatched"] is True
             assert res["delegation_id"]
-            m_claim.assert_called_once_with("job-bg-01", return_job=True)
+            m_claim.assert_called_once_with(
+                "job-bg-01", return_job=True, allow_provider_backoff=True
+            )
             # The job actually starts on the daemon executor.
             assert run_started.wait(timeout=5.0), "job never started in background"
         finally:
             run_release.set()
+
+    def test_background_runner_reconciles_provider_after_completion(self):
+        """A detached failure may add provider backoff only after dispatch."""
+        captured = {}
+        order = []
+        job = _job("job-bg-backoff")
+        claimed = {**job, "fire_claim": {"by": "bg-owner"}}
+
+        def capture_dispatch(**kwargs):
+            captured["runner"] = kwargs["runner"]
+            return {"status": "dispatched", "delegation_id": "deleg-backoff"}
+
+        with _bound_session_key():
+            with patch(
+                "tools.cronjob_tools.claim_job_for_fire",
+                return_value=claimed,
+            ), patch(
+                "tools.async_delegation.dispatch_async_delegation",
+                side_effect=capture_dispatch,
+            ), patch(
+                "cron.scheduler.run_one_job",
+                side_effect=lambda *args, **kwargs: order.append("run") or True,
+            ), patch(
+                "tools.cronjob_tools.get_job",
+                return_value={
+                    "id": job["id"],
+                    "last_status": "error",
+                    "last_error": "HTTP 429",
+                    "provider_backoff": {"until": "2099-01-01T00:00:00+00:00"},
+                },
+            ), patch(
+                "tools.cronjob_tools._notify_provider_jobs_changed_safe",
+                side_effect=lambda: order.append("notify"),
+            ):
+                dispatched = _try_dispatch_background_run(job)
+                assert dispatched is not None
+                assert dispatched["dispatched"] is True
+                assert order == []
+                completion = captured["runner"]()
+
+        assert completion["status"] == "error"
+        assert order == ["run", "notify"]
 
     def test_completion_event_reaches_shared_queue(self):
         """The finished run pushes a type='async_delegation' event carrying
@@ -304,5 +348,7 @@ class TestCronjobRunToolIntegration:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-bg-13", return_job=True)
+        m_claim.assert_called_once_with(
+            "job-bg-13", return_job=True, allow_provider_backoff=True
+        )
         m_run.assert_called_once()

--- a/tests/tools/test_cronjob_run_immediate.py
+++ b/tests/tools/test_cronjob_run_immediate.py
@@ -39,8 +39,29 @@ class TestCronjobRunExecutesImmediately:
         assert out["success"] is True
         assert out["job"]["executed"] is True
         assert out["job"]["execution_success"] is True
-        m_claim.assert_called_once_with("job-run-1", return_job=True)
+        m_claim.assert_called_once_with(
+            "job-run-1", return_job=True, allow_provider_backoff=True
+        )
         m_run.assert_called_once_with(claimed, adapters=None, loop=None, extra_prompt=None)
+
+    def test_manual_run_allows_backoff_added_during_atomic_claim(self):
+        """Manual intent, not a stale snapshot, authorizes backoff bypass."""
+        job = dict(_JOB)
+        claimed = {**job, "fire_claim": {"by": "manual-owner"}}
+        with patch(
+            "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+        ) as m_claim, patch(
+            "cron.scheduler.run_one_job", return_value=True
+        ), patch(
+            "tools.cronjob_tools.get_job",
+            return_value={"last_status": "ok", "last_error": None},
+        ):
+            result = _execute_job_now(job)
+
+        assert result["success"] is True
+        m_claim.assert_called_once_with(
+            "job-run-1", return_job=True, allow_provider_backoff=True
+        )
 
     def test_run_reconciles_external_provider_after_claimed_execution(self):
         """A direct run must re-arm Chronos after it advances next_run_at.

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -967,7 +967,13 @@ def _execute_job_now(
     claimed_job = None
     try:
         # At-most-once claim: bail without running if a tick/other fire owns it.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        # Manual intent authorizes bypassing provider backoff. The locked claim
+        # still evaluates current pause/disable state and duplicate ownership.
+        claimed_job = claim_job_for_fire(
+            job_id,
+            return_job=True,
+            allow_provider_backoff=True,
+        )
         if not isinstance(claimed_job, dict):
             # claim_job_for_fire returns False for paused/disabled/missing
             # jobs too — don't mislabel those as "already being fired"
@@ -1319,7 +1325,13 @@ def _try_dispatch_background_run(
 
         # Same snapshot claim as _execute_job_now: carry the owner-bearing
         # record into the run so terminal writes stay fenced by this owner.
-        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        # Manual intent authorizes bypassing provider backoff. The locked claim
+        # still evaluates current pause/disable state and duplicate ownership.
+        claimed_job = claim_job_for_fire(
+            job_id,
+            return_job=True,
+            allow_provider_backoff=True,
+        )
         if not isinstance(claimed_job, dict):
             refreshed = get_job(job_id)
             if refreshed is None:
@@ -1380,6 +1392,9 @@ def _try_dispatch_background_run(
 
     def _runner() -> Dict[str, Any]:
         res = _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
+        # The detached run may persist provider_backoff after the initial
+        # dispatch reconciliation. Re-arm providers from the final job state.
+        _notify_provider_jobs_changed_safe()
         duration = round(time.time() - started_at, 2)
         refreshed = get_job(job_id) or {}
         lines = [


### PR DESCRIPTION
## Summary
- parse provider reset hints and persist deterministic bounded backoff after HTTP 429 failures
- suppress unattended fires until backoff expiry while preserving durable failure state and automatic resume
- keep explicit manual runs safe with a dedicated atomic backoff override, including dashboard, background, legacy-provider, and concurrent-pause paths
- make Chronos arm and reconcile one-shots at the effective backoff expiry

## Test plan
- `HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh tests/cron/test_provider_rate_limit_backoff.py tests/cron/test_scheduler_provider.py tests/plugins/test_chronos_cron.py tests/tools/test_cronjob_run_immediate.py tests/tools/test_cronjob_run_background.py tests/cron/test_ticker_stall_60703.py tests/hermes_cli/test_web_server_cron_profiles.py -q` (142 passed)
- `python -m compileall -q cron/jobs.py cron/rate_limit_backoff.py cron/scheduler.py cron/scheduler_provider.py hermes_cli/web_server.py plugins/cron_providers/chronos/__init__.py tools/cronjob_tools.py`
- `git diff --cached --check`

## Operational notes
- Live job `dabcf70cf427` (`eng-completion`) remains active on its unchanged `every 10m` schedule.
- Durable history confirms recovery after the task's original terminal 429 (`2336eaa607544e3ba33fae88e5b76def` failed, followed by `29282100a7c549b7b7464c73ad794f81` completed).
- Its latest provider reset is still in the future; the candidate parses the live error to a bounded reset time, while persistence/restart/automatic-resume behavior is covered deterministically in tests.
- No model, provider, reasoning, or X-job configuration was changed.

Do not merge from this task; review only.