### PR TITLE
fix(picker): always live-probe loopback endpoints so offline local models stay visible

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3826,10 +3826,32 @@ def list_authenticated_providers(
             # applying the probe gate to it re-pins the endpoint — see
             # ``_discovery_allowed`` in section 4 for the full rationale.
             _discovery_allowed = bool(api_url) and discover
+            # Local (loopback) endpoints are always probed live: the round
+            # trip is sub-millisecond and independent of internet access, so
+            # suppressing the probe merely to spare remote endpoints would
+            # wrongly hide local models (Ollama / LM Studio / llama.cpp
+            # servers) whenever the session's current provider is a remote
+            # one — and exactly when the user is offline and needs to switch
+            # to local models, the picker must show them in full. (See the
+            # offline-picker report: current provider = remote, ollama row
+            # collapsed to config `default_model` only.)
+            _is_loopback_endpoint = bool(api_url) and _norm_url(api_url).startswith(
+                (
+                    "http://localhost",
+                    "http://127.0.0.1",
+                    "http://[::1]",
+                    "https://localhost",
+                    "https://127.0.0.1",
+                    "https://[::1]",
+                )
+            )
             _probe_live = (
                 _discovery_allowed
                 and (bool(api_key) or not has_explicit_models)
-                and _can_probe_custom_provider(row_is_current=_ep_is_current)
+                and (
+                    _can_probe_custom_provider(row_is_current=_ep_is_current)
+                    or _is_loopback_endpoint
+                )
             )
             native_catalog_empty = False
             if _probe_live:


### PR DESCRIPTION
## Summary

**Bug**: When the session's current provider is a remote/cloud one (e.g. SiliconFlow, DeepSeek), the model picker shows only the configured `default_model` for local (loopback) endpoints such as Ollama — hiding the full list of locally available models. This is most visible **when offline**: users who need to switch to local models see a collapsed one-line list and cannot select e.g. `qwen3:8b` or `bge-m3` that exist locally but are not in config.

**Root cause**: In `list_authenticated_providers` (section 3, custom/user providers), the live-probe gate `_can_probe_custom_provider(row_is_current=...)` only permits probing **the current provider**. Non-current local endpoints are skipped, so with no cache they fall back to the config's singular `default_model` instead of probing `localhost:11434` for the real model list.

**Fix**: Loopback URLs (`http(s)://localhost|127.0.0.1|[::1]`) are always probe-eligible regardless of which provider is current. Probing a loopback endpoint is sub-millisecond and does not depend on internet access, so this cannot cause the offline blocking the original gate was designed to prevent.

## Verification

- Reproduced: GUI-equivalent context (`current_provider=siliconflow`, `refresh=False`) → Ollama row showed `models(1) = [deepseek-r1:14b]` (config `default_model` only)
- After fix: same context → `models(4) = [qwen2.5vl:7b, qwen3:8b, deepseek-r1:14b, bge-m3:latest]` (live probe of `localhost:11434`)
- 143 core tests pass (`test_provider_section3_grouping.py`, `test_model_switch_custom_providers.py`, `test_ollama_cloud_provider.py`, `test_aux_picker_inventory.py`, `test_list_picker_providers.py`, inventory/auth-gate/builtin/local-runtime/filter tests)
- 2 pre-existing failures in `test_user_providers_model_switch.py` are environment-dependent (a real local Ollama server answers native probe, bypassing the mocked generic `fetch_api_models`); they fail identically on `upstream/main` without this change.

## Scope

One file: `hermes_cli/model_switch.py` (+23/-1). No API/behavior change for remote endpoints — they keep the existing conservative probe gate.

Fixes #40554-adjacent regression class: singular `default_model` + remote current provider + local Ollama = collapsed picker when offline.
