### PR TITLE
fix(tui): list hang-indent and markdown-rendered thinking traces

### DIFF
--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -778,15 +778,18 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
       const fence = line.match(FENCE_RE)
 
       if (fence) {
+        const fenceStart = i
         const char = fence[1]![0] as '`' | '~'
         const len = fence[1]!.length
         const lang = fence[2]!.trim().toLowerCase()
         const block: string[] = []
+        let closed = false
 
         for (i++; i < lines.length; i++) {
           const close = lines[i]!.match(FENCE_CLOSE_RE)?.[1]
 
           if (close && close[0] === char && close.length >= len) {
+            closed = true
             break
           }
 
@@ -795,6 +798,23 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
 
         if (i < lines.length) {
           i++
+        }
+
+        // Unclosed fence at end of input (model drifted into prose without
+        // closing, or mid-stream snapshot): show the opener as a literal
+        // muted label and re-parse the body through the main loop so the
+        // prose structure after the drift point survives. MdInline would
+        // half-eat the backticks, so this is a plain Text.
+        if (!closed) {
+          start('code')
+          nodes.push(
+            <Box key={key} paddingLeft={2}>
+              <Text color={t.color.muted}>{`─ ${lang || 'code'} (unclosed)`}</Text>
+            </Box>
+          )
+          i = fenceStart + 1
+
+          continue
         }
 
         if (['md', 'markdown'].includes(lang)) {

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -1028,10 +1028,14 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
         const task = bullet[2]!.match(TASK_RE)
         const marker = task ? (task[1]!.toLowerCase() === 'x' ? '☑' : '☐') : '•'
 
+        // Marker in a fixed-width gutter so wrapped lines hang-indent under
+        // the item text instead of resetting to column 0 (Pi-style lists).
         nodes.push(
-          <Box key={key} paddingLeft={indentDepth(bullet[1]!) * 2}>
-            <Text wrap="wrap-trim">
+          <Box key={key} flexDirection="row" paddingLeft={indentDepth(bullet[1]!) * 2}>
+            <Box flexShrink={0}>
               <Text color={t.color.muted}>{marker} </Text>
+            </Box>
+            <Text wrap="wrap-trim">
               <MdInline color={t.color.text} t={t} text={task ? task[2]! : bullet[2]!} />
             </Text>
           </Box>
@@ -1045,10 +1049,13 @@ function MdImpl({ cols, compact, t, text }: MdProps) {
 
       if (numbered) {
         start('list')
+
         nodes.push(
-          <Box key={key} paddingLeft={indentDepth(numbered[1]!) * 2}>
-            <Text wrap="wrap-trim">
+          <Box key={key} flexDirection="row" paddingLeft={indentDepth(numbered[1]!) * 2}>
+            <Box flexShrink={0}>
               <Text color={t.color.muted}>{numbered[2]}. </Text>
+            </Box>
+            <Text wrap="wrap-trim">
               <MdInline color={t.color.text} t={t} text={numbered[3]!} />
             </Text>
           </Box>

--- a/ui-tui/src/components/thinking.tsx
+++ b/ui-tui/src/components/thinking.tsx
@@ -37,6 +37,22 @@ import type {
   ThinkingMode
 } from '../types.js'
 
+import { Md } from './markdown.js'
+
+// Thinking renders through the markdown renderer with a monochrome theme so
+// paragraph breaks, lists, and headings keep breathing room — same shape as
+// the assistant reply, tinted the thinking color (Pi renders its thinking
+// through its full Markdown component too).
+const thinkingTheme = (t: Theme): Theme => ({
+  ...t,
+  color: {
+    ...t.color,
+    accent: t.color.thinking,
+    text: t.color.thinking,
+    muted: t.color.thinking
+  }
+})
+
 const THINK: BrailleSpinnerName[] = ['helix', 'breathe', 'orbit', 'dna', 'waverows', 'snake', 'pulse']
 const TOOL: BrailleSpinnerName[] = ['cascade', 'scan', 'diagswipe', 'fillsweep', 'rain', 'columns', 'sparkle']
 
@@ -637,8 +653,6 @@ export const Thinking = memo(function Thinking({
     return mode === 'full' ? boundedLiveRenderText(raw) : raw
   }, [mode, reasoning])
 
-  const lines = useMemo(() => preview.split('\n').map(line => line.replace(/\t/g, '  ')), [preview])
-
   if (!preview && !active) {
     return null
   }
@@ -648,14 +662,14 @@ export const Thinking = memo(function Thinking({
       <Box flexDirection="column" flexGrow={1}>
         {preview ? (
           mode === 'full' ? (
-            lines.map((line, index) => (
-              <Text color={t.color.thinking} key={index} wrap="wrap-trim">
-                {line || ' '}
-                {index === lines.length - 1 ? (
+            <>
+              <Md cols={undefined} t={thinkingTheme(t)} text={preview} />
+              {active ? (
+                <Text color={t.color.thinking}>
                   <StreamCursor color={t.color.thinking} streaming={streaming} visible={active} />
-                ) : null}
-              </Text>
-            ))
+                </Text>
+              ) : null}
+            </>
           ) : (
             <Text color={t.color.thinking} wrap="truncate-end">
               {preview}

--- a/ui-tui/src/lib/text.ts
+++ b/ui-tui/src/lib/text.ts
@@ -112,8 +112,13 @@ const THINKING_STATUS_CHUNK_RE = new RegExp(`[^A-Za-z\n]+\\s*(?:${VERBS.join('|'
 export const cleanThinkingText = (reasoning: string) =>
   reasoning
     .split('\n')
-    .map(line => line.replace(THINKING_STATUS_CHUNK_RE, '').trim())
-    .filter(line => line && !THINKING_STATUS_RE.test(line.replace(/\.\.\.$/, '').trim()))
+    .map(raw => ({ wasBlank: raw.trim() === '', cleaned: raw.replace(THINKING_STATUS_CHUNK_RE, '').trim() }))
+    // Keep blank lines the model wrote (paragraph breaks); drop only lines
+    // that BECAME blank by stripping a status-ticker fragment, and pure
+    // status-verb lines. Squashing all blanks turned thinking into a wall.
+    .filter(({ wasBlank, cleaned }) => wasBlank || cleaned)
+    .filter(({ cleaned }) => !cleaned || !THINKING_STATUS_RE.test(cleaned.replace(/\.\.\.$/, '').trim()))
+    .map(({ cleaned }) => cleaned)
     .join('\n')
     .replace(/([^\n])(?=\*\*[^*\n][^\n]*?\*\*)/g, '$1\n\n')
     .replace(/\n{3,}/g, '\n\n')


### PR DESCRIPTION
## What does this PR do?

Improves readability of TUI assistant output and thinking traces by fixing three whitespace/structure problems, matching the readability of other terminal agents (verified side-by-side against Pi Coding Agent's renderer):

**1. Wrapped list items lose their structure (`markdown.tsx`)**

Bullet and numbered markers were rendered inline with the item text, so any item longer than one line wrapped its continuation back to column 0. Long lists collapsed into an undifferentiated wall of text. This puts the marker in a fixed-width gutter with the content beside it, so wrapped lines hang-indent under the item text — standard terminal-markdown behavior (marked-terminal, Pi, Glow all do this).

Before:
```
• item one with text that wraps
to column 0, flattening the list
• item two
```

After:
```
• item one with text that wraps
  under the marker
• item two
```

**2. Thinking traces render as a wall of text (`thinking.tsx`, `text.ts`)**

Two causes:

- `cleanThinkingText` dropped **every** blank line (`.filter(line => line && ...)`), destroying the paragraph breaks the model wrote — even when reasoning already contained them.
- Full-mode thinking rendered as raw `Text` lines: no paragraph gaps, no list structure, no indentation, regardless of what the reasoning contained.

Now blank lines the model wrote are preserved (only status-ticker fragments are still stripped), and full-mode thinking renders through the existing `Md` markdown renderer with a monochrome thinking-tinted theme — same layout engine as assistant replies, so paragraphs, headings, and lists get identical spacing. This is also how other agents render reasoning (Pi passes its thinking blocks through its full `Markdown` component).

**3. Unclosed code fences swallow the rest of the message (`markdown.tsx`)**

Model output sometimes drifts from a fenced block into prose without emitting the closing fence (observed in live reasoning streams). The old parser consumed everything after the opener as one giant code block — bold/list markers rendered as literal text inside "code", and all downstream paragraph structure vanished. Reproduced against a real captured reasoning stream.

Now an unclosed fence at end-of-input renders the opener as a muted `─ lang (unclosed)` label and re-parses the body through the main loop, so paragraph/list structure after the drift point survives. Closed fences are unchanged. During live streaming an in-flight fence shows the `(unclosed)` label only until its closer arrives, then re-renders as a proper block.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `ui-tui/src/components/markdown.tsx` — bullet/numbered markers in a fixed `flexShrink={0}` gutter; content `Text` beside it keeps `wrap="wrap-trim"`. Applies to nested lists and task lists (indent math unchanged). Plus: eof-close for unclosed fences (label + body re-parse).
- `ui-tui/src/lib/text.ts` — `cleanThinkingText` keeps blank lines that existed in the source; drops only lines that *became* blank via status-ticker stripping, plus pure status-verb lines. The `\n{3,} → \n\n` squash already caps runs.
- `ui-tui/src/components/thinking.tsx` — `Thinking` mode-`full` renders `<Md t={thinkingTheme(t)}>` (accent/text/muted all set to `t.color.thinking`, so the trace stays monochrome). Streaming cursor moved to its own trailing row so it never corrupts the markdown parse. Truncated mode unchanged.

## How Was This Tested?

- Targeted suites on latest `main` (fresh worktree, cherry-picked): `text.test.ts`, `reasoning.test.ts`, `markdown.test.ts`, `messages.test.ts` — **87/87 pass**.
- Rendered a realistic GLM-style reasoning sample through the component before/after; verified paragraph gaps, list gaps, and hang-indent against Pi's renderer output for the same markdown.
- Unclosed-fence fix verified against a real 39k-char captured reasoning stream containing a mid-stream unclosed ` ```swift ` fence — structure after the drift point survives; closed fences byte-identical.
- Full `ui-tui` vitest run: no new failures vs. baseline (the 21 failures in `subscriptionOverlay` / `appChromeBlockedTimers` / `ink-backpressure` reproduce on unmodified `main`).

## Screenshots / Demo

Thinking trace before (no paragraph or list structure survives) → after (gaps + hang-indent), as in section 2 above. Unclosed fence:

```
Stub scripts:
·
  ─ swift (unclosed)
·
let dir = FileManager.default.temporaryDirectory...
·
Loop test: candidates [bad, good] → pass...
```

(the `·` rows are blank terminal rows restored after the drift point)

## Checklist

- [x] Code follows the project's style guidelines
- [x] Self-review completed
- [x] New and existing unit tests pass locally with my changes
