### PR TITLE
fix(rsi): preserve audited interview evidence

### DIFF
--- a/scripts/rsi-audit.py
+++ b/scripts/rsi-audit.py
@@ -1,0 +1,664 @@
+#!/usr/bin/env python3
+"""Audit fleet chats and failed durable runs since the previous RSI tick.
+
+Writes ~/.hermes/rsi/audit/latest.json. Does not stamp last_tick.json
+(RSI stamps that after the tick).
+"""
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+HOME = Path.home()
+STORE = HOME / ".hermes" / "rsi"
+LAST = STORE / "last_tick.json"
+JOBS = HOME / ".hermes" / "cron" / "jobs.json"
+EXEC_DB = HOME / ".hermes" / "cron" / "executions.db"
+KANBAN = HOME / ".hermes" / "kanban.db"
+CONTRACT = STORE / "contract.yaml"
+
+DONE_RE = re.compile(r"\b(done|completed|all (?:set|good)|nothing to (?:do|report))\b", re.I)
+TASK_ID_RE = re.compile(r"\bt_[a-z0-9]+\b", re.I)
+CRON_SESSION_RE = re.compile(r"^cron_([^_]+)_")
+
+CRON_TO_PROFILE = {
+    "x-ops": "x",
+    "x-daily-drafts": "x",
+    "yuki-digest": "yuki",
+    "product-inbox": "product",
+    "gh-pr-scout": "reviewer",
+    "eng-completion": "product",
+    "rsi-loop": "rsi",
+}
+
+FAIL_END = {
+    "error",
+    "timeout",
+    "killed",
+    "max_turns",
+    "budget",
+    "exception",
+    "failed",
+    "cron_incomplete_no_output",
+    "orphaned_compression",
+    "session_persistence_failed",
+}
+FAIL_END_PREFIXES = (
+    "error_",
+    "max_iterations_reached",
+    "repeated_outer_errors",
+)
+NONTERMINAL_BOUNDARY_ENDS = {
+    "adopted_by_profile",
+    "branched",
+    "compression",
+    "resumed_other",
+    "session_reset",
+    "session_switch",
+    "superseded_by_repair",
+}
+FAIL_STATUSES = {
+    "blocked_config",
+    "error",
+    "failed",
+    "gave_up",
+    "interrupted",
+    "killed",
+    "spawn_failed",
+    "timeout",
+    "timed_out",
+}
+SUCCESS_STATUSES = {"completed", "done", "no_change", "ok", "skipped", "success"}
+NONTERMINAL_STATUSES = {"claimed", "pending", "queued", "running", "scheduled"}
+EXECUTION_STATUS_TOOLS = {"execute_code", "process", "terminal"}
+
+
+def load_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def fleet() -> list[str]:
+    names = (load_yaml(CONTRACT).get("fleet") or []) if CONTRACT.exists() else []
+    return [str(n) for n in names] or ["coder", "product", "qa", "reviewer", "yuki", "x"]
+
+
+def since_unix() -> float:
+    if LAST.exists():
+        try:
+            return float(json.loads(LAST.read_text(encoding="utf-8")).get("unix") or 0)
+        except Exception:
+            pass
+    if JOBS.exists():
+        try:
+            for job in json.loads(JOBS.read_text(encoding="utf-8")).get("jobs") or []:
+                if job.get("name") == "rsi-loop" and job.get("last_run_at"):
+                    return datetime.fromisoformat(str(job["last_run_at"])).timestamp()
+        except Exception:
+            pass
+    return (datetime.now(timezone.utc) - timedelta(hours=4)).timestamp()
+
+
+def db_path(profile: str) -> Path | None:
+    if profile == "default":
+        path = HOME / ".hermes" / "state.db"
+    else:
+        path = HOME / ".hermes" / "profiles" / profile / "state.db"
+    return path if path.exists() else None
+
+
+def _json_object(value: Any) -> dict | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except (json.JSONDecodeError, TypeError):
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _status_failure(value: Any) -> bool:
+    return str(value or "").strip().lower() in FAIL_STATUSES
+
+
+def _tool_error_reason(
+    tool_name: str,
+    content: str,
+    effect_disposition: Any = None,
+) -> str | None:
+    """Return a structural tool-error marker, never a lexical content match."""
+    if str(effect_disposition or "").lower() == "unknown":
+        return "effect_disposition=unknown"
+
+    payload = _json_object(content)
+    if payload is None:
+        # Hermes' exception wrapper is a stable transport envelope. Arbitrary
+        # non-JSON tool prose is data and must not be interpreted lexically.
+        if content.lstrip().startswith("Error executing tool "):
+            return "exception"
+        return None
+
+    if payload.get("success") is False or payload.get("ok") is False:
+        return "reported_failure"
+
+    if tool_name in EXECUTION_STATUS_TOOLS:
+        exit_code = payload.get("exit_code")
+        if isinstance(exit_code, int) and not isinstance(exit_code, bool) and exit_code != 0:
+            return f"exit_code={exit_code}"
+        if _status_failure(payload.get("status")):
+            return f"status={str(payload['status']).lower()}"
+        if _status_failure(payload.get("state")):
+            return f"state={str(payload['state']).lower()}"
+        if _status_failure(payload.get("outcome")):
+            return f"outcome={str(payload['outcome']).lower()}"
+
+    # ``tool_error()`` is Hermes' canonical generic failure envelope. A
+    # declared successful result wins over incidental error-shaped domain data.
+    if payload.get("success") is not True and payload.get("ok") is not True and payload.get("error"):
+        return "error"
+
+    return None
+
+
+def _tool_call_parts(raw: Any) -> tuple[str, dict]:
+    call = raw if isinstance(raw, dict) else {}
+    function = call.get("function") if isinstance(call.get("function"), dict) else {}
+    name = str(function.get("name") or call.get("name") or "")
+    arguments = function.get("arguments", call.get("arguments"))
+    parsed = _json_object(arguments) or (arguments if isinstance(arguments, dict) else {})
+    return name, parsed
+
+
+def _message_evidence(con: sqlite3.Connection, session_id: str, since: float) -> tuple[list[str], bool, list[str]]:
+    rows = con.execute(
+        """
+        SELECT role, content, tool_calls, tool_name, effect_disposition
+        FROM messages
+        WHERE session_id = ? AND timestamp >= ?
+          AND role IN ('assistant', 'tool', 'user')
+        ORDER BY id ASC
+        """,
+        (session_id, since),
+    ).fetchall()
+
+    hits: list[str] = []
+    task_ids: list[str] = []
+    has_final_response = False
+    for role, content, tool_calls, tool_name, effect_disposition in rows:
+        text = str(content or "")
+        if role == "user":
+            has_final_response = False
+            task_ids.extend(match.group(0).lower() for match in TASK_ID_RE.finditer(text))
+            continue
+        if role == "tool":
+            has_final_response = False
+            reason = _tool_error_reason(
+                str(tool_name or "unknown"),
+                text,
+                effect_disposition,
+            )
+            if reason:
+                hits.append(f"tool:{tool_name or 'unknown'}:{reason}")
+            payload = _json_object(text)
+            if (
+                str(tool_name or "") == "clarify"
+                and payload is not None
+                and payload.get("timed_out") is True
+            ):
+                hits.append("lifecycle:needs_input")
+            if (
+                str(tool_name or "") == "kanban_block"
+                and payload is not None
+                and str(payload.get("block_kind") or "").lower() == "needs_input"
+            ):
+                hits.append("lifecycle:needs_input")
+            continue
+
+        calls: list[Any] = []
+        if tool_calls:
+            try:
+                loaded = json.loads(tool_calls) if isinstance(tool_calls, str) else tool_calls
+                calls = loaded if isinstance(loaded, list) else []
+            except (json.JSONDecodeError, TypeError):
+                calls = []
+        if calls:
+            has_final_response = False
+        elif text.strip():
+            has_final_response = True
+        for call in calls:
+            name, arguments = _tool_call_parts(call)
+            if name == "kanban_block" and str(arguments.get("kind") or "").lower() == "needs_input":
+                hits.append("lifecycle:needs_input")
+
+    return list(dict.fromkeys(hits)), has_final_response, list(dict.fromkeys(task_ids))
+
+
+def _kanban_paths() -> list[Path]:
+    paths = [KANBAN]
+    boards = HOME / ".hermes" / "kanban" / "boards"
+    if boards.is_dir():
+        paths.extend(sorted(boards.glob("*/kanban.db")))
+    return list(dict.fromkeys(path for path in paths if path.exists()))
+
+
+def _kanban_evidence(
+    session_id: str,
+    task_ids: list[str],
+    started_at: float,
+) -> tuple[list[str], bool]:
+    for path in _kanban_paths():
+        try:
+            con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+            if task_ids:
+                placeholders = ",".join("?" for _ in task_ids)
+                tasks = con.execute(
+                    f"""SELECT id, status, current_run_id, block_kind
+                        FROM tasks WHERE id IN ({placeholders})""",
+                    tuple(task_ids),
+                ).fetchall()
+            else:
+                tasks = con.execute(
+                    """SELECT id, status, current_run_id, block_kind
+                       FROM tasks WHERE session_id = ?""",
+                    (session_id,),
+                ).fetchall()
+            candidates = []
+            for task in tasks:
+                runs = con.execute(
+                    """SELECT id, status, outcome, error, started_at, ended_at
+                       FROM task_runs WHERE task_id = ? ORDER BY id DESC""",
+                    (task[0],),
+                ).fetchall()
+                candidates.extend(
+                    (
+                        abs(float(run[4]) - float(started_at or 0)),
+                        task,
+                        run,
+                    )
+                    for run in runs
+                    if run[4] is not None
+                )
+            con.close()
+        except (sqlite3.Error, OSError):
+            continue
+
+        distance, task, run = min(
+            candidates,
+            default=(float("inf"), None, None),
+            key=lambda item: item[0],
+        )
+        if distance > 300:
+            run = None
+            task = tasks[0] if len(tasks) == 1 and not task_ids else None
+        if task is None:
+            continue
+
+        _, task_status, current_run_id, block_kind = task
+        hits: list[str] = []
+        status = str(task_status or "").lower()
+        kind = str(block_kind or "").lower()
+        run_is_current = bool(run and current_run_id == run[0])
+        if run_is_current and status == "blocked" and kind == "needs_input":
+            hits.append("lifecycle:needs_input")
+        elif run_is_current and _status_failure(status):
+            hits.append(f"kanban:status={status}")
+
+        durable_success = False
+        if run:
+            _, run_status, outcome, error, _, _ = run
+            run_status_l = str(run_status or "").lower()
+            outcome_l = str(outcome or "").lower()
+            if _status_failure(outcome_l):
+                hits.append(f"kanban:outcome={outcome_l}")
+            elif _status_failure(run_status_l):
+                hits.append(f"kanban:status={run_status_l}")
+            elif error:
+                hits.append("kanban:error")
+            durable_success = (
+                not hits
+                and (outcome_l in SUCCESS_STATUSES or run_status_l in SUCCESS_STATUSES)
+            )
+        return list(dict.fromkeys(hits)), durable_success
+    return [], False
+
+
+def _parse_iso_timestamp(value: Any) -> float | None:
+    try:
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00")).timestamp()
+    except (TypeError, ValueError):
+        return None
+
+
+def _cron_evidence(session_id: str, started_at: float) -> tuple[list[str], bool]:
+    match = CRON_SESSION_RE.match(session_id)
+    if not match or not EXEC_DB.exists():
+        return [], False
+    job_id = match.group(1)
+    try:
+        con = sqlite3.connect(f"file:{EXEC_DB}?mode=ro", uri=True)
+        rows = con.execute(
+            """SELECT status, error, started_at, finished_at
+               FROM executions WHERE job_id = ? ORDER BY started_at DESC LIMIT 20""",
+            (job_id,),
+        ).fetchall()
+        con.close()
+    except (sqlite3.Error, OSError):
+        return [], False
+
+    candidates = []
+    for row in rows:
+        row_started = _parse_iso_timestamp(row[2])
+        if row_started is not None:
+            candidates.append((abs(row_started - float(started_at or 0)), row))
+    if not candidates:
+        return [], False
+    distance, row = min(candidates, key=lambda item: item[0])
+    if distance > 300:
+        return [], False
+
+    status, error, _, finished_at = row
+    status_l = str(status or "").lower()
+    if _status_failure(status_l) or error:
+        return [f"cron:status={status_l or 'error'}"], False
+    return [], status_l in SUCCESS_STATUSES and bool(finished_at)
+
+
+def _end_reason_failed(end_reason: Any) -> bool:
+    reason = str(end_reason or "").lower()
+    return reason in FAIL_END or reason.startswith(FAIL_END_PREFIXES)
+
+
+def claimed_ok(con: sqlite3.Connection, session_id: str, since: float) -> bool:
+    rows = con.execute(
+        """
+        SELECT content FROM messages
+        WHERE session_id = ? AND timestamp >= ? AND role = 'assistant'
+        ORDER BY id DESC LIMIT 3
+        """,
+        (session_id, since),
+    ).fetchall()
+    return any(DONE_RE.search(row[0] or "") for row in rows)
+
+
+def scan_sessions(profile: str, since: float) -> list[dict]:
+    found: list[dict] = []
+    paths: list[tuple[str, Path]] = []
+    own = db_path(profile)
+    if own:
+        paths.append(("own", own))
+    default = db_path("default")
+    if default and default not in [path for _, path in paths]:
+        paths.append(("default", default))
+
+    for origin, path in paths:
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        if origin == "default":
+            rows = con.execute(
+                """
+                SELECT id, source, title, end_reason, last_activity_description,
+                       last_activity_at, started_at, ended_at
+                FROM sessions
+                WHERE last_activity_at >= ?
+                  AND (profile_name = ? OR (profile_name IS NULL AND source IN ('cron','kanban')))
+                ORDER BY last_activity_at DESC
+                """,
+                (since, profile),
+            ).fetchall()
+        else:
+            rows = con.execute(
+                """
+                SELECT id, source, title, end_reason, last_activity_description,
+                       last_activity_at, started_at, ended_at
+                FROM sessions
+                WHERE last_activity_at >= ?
+                ORDER BY last_activity_at DESC
+                """,
+                (since,),
+            ).fetchall()
+
+        for sid, source, title, end_reason, last_desc, last_at, started, ended_at in rows:
+            if origin == "default" and source == "cron":
+                title_l = (title or "").lower()
+                mapped = next(
+                    (
+                        owner
+                        for job, owner in CRON_TO_PROFILE.items()
+                        if job in title_l or job.replace("-", " ") in title_l
+                    ),
+                    None,
+                )
+                if mapped and mapped != profile:
+                    continue
+                if mapped is None and profile != "default":
+                    continue
+
+            fail_hits, has_final_response, task_ids = _message_evidence(con, sid, since)
+            title_task_ids = [match.group(0).lower() for match in TASK_ID_RE.finditer(title or "")]
+            task_ids = list(dict.fromkeys([*task_ids, *title_task_ids]))
+            durable_success = False
+            if source == "kanban":
+                durable_hits, durable_success = _kanban_evidence(
+                    sid,
+                    task_ids,
+                    float(started or 0),
+                )
+                fail_hits.extend(durable_hits)
+            elif source == "cron":
+                durable_hits, durable_success = _cron_evidence(sid, float(started or 0))
+                fail_hits.extend(durable_hits)
+
+            end_reason_l = str(end_reason or "").lower()
+            if _end_reason_failed(end_reason):
+                fail_hits.append(f"session:end_reason={end_reason_l}")
+            if (
+                ended_at is not None
+                and not has_final_response
+                and not durable_success
+                and end_reason_l not in NONTERMINAL_BOUNDARY_ENDS
+            ):
+                fail_hits.append("session:missing_final_response")
+
+            fail_hits = list(dict.fromkeys(fail_hits))
+            found.append(
+                {
+                    "id": sid,
+                    "source": source,
+                    "title": title or "",
+                    "end_reason": end_reason,
+                    "last_activity": (last_desc or "")[:120],
+                    "ts": int(last_at or started or 0),
+                    "failed": bool(fail_hits),
+                    "fail_hits": fail_hits,
+                    "claimed_ok": claimed_ok(con, sid, since),
+                    "db": origin,
+                }
+            )
+        con.close()
+    found.sort(key=lambda item: item.get("ts") or 0, reverse=True)
+    return found
+
+
+def cron_failures(since: float) -> list[dict]:
+    if not EXEC_DB.exists():
+        return []
+    con = sqlite3.connect(f"file:{EXEC_DB}?mode=ro", uri=True)
+    names = {}
+    if JOBS.exists():
+        try:
+            for job in json.loads(JOBS.read_text(encoding="utf-8")).get("jobs") or []:
+                names[job.get("id")] = job.get("name")
+        except Exception:
+            pass
+    since_iso = datetime.fromtimestamp(since, timezone.utc).isoformat()
+    rows = con.execute(
+        """
+        SELECT id, job_id, status, error, started_at, finished_at
+        FROM executions
+        WHERE (finished_at IS NOT NULL AND finished_at >= ?)
+           OR (started_at IS NOT NULL AND started_at >= ?)
+        ORDER BY finished_at DESC
+        """,
+        (since_iso, since_iso),
+    ).fetchall()
+    out = []
+    for execution_id, job_id, status, error, started, finished in rows:
+        status_l = (status or "").lower()
+        if status_l in NONTERMINAL_STATUSES and not error:
+            continue
+        if status_l in SUCCESS_STATUSES and not error:
+            continue
+        name = names.get(job_id) or job_id
+        out.append(
+            {
+                "execution_id": execution_id,
+                "job_id": job_id,
+                "name": name,
+                "profile": CRON_TO_PROFILE.get(str(name), "default"),
+                "status": status,
+                "error": (error or "")[:300],
+                "started_at": started,
+                "finished_at": finished,
+            }
+        )
+    con.close()
+    return out
+
+
+def kanban_failures(since: float) -> list[dict]:
+    out: list[dict] = []
+    since_i = int(since)
+    for path in _kanban_paths():
+        con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        runs = con.execute(
+            """
+            SELECT id, task_id, profile, status, outcome, substr(error,1,300),
+                   substr(summary,1,200), started_at, ended_at
+            FROM task_runs
+            WHERE COALESCE(ended_at, started_at, 0) >= ?
+            ORDER BY COALESCE(ended_at, started_at) DESC
+            """,
+            (since_i,),
+        ).fetchall()
+        for run_id, task_id, profile, status, outcome, error, summary, started, ended in runs:
+            outcome_l = (outcome or "").lower()
+            status_l = (status or "").lower()
+            failed = _status_failure(outcome_l) or _status_failure(status_l) or bool(error)
+            if not failed:
+                continue
+            row = con.execute("SELECT title FROM tasks WHERE id = ?", (task_id,)).fetchone()
+            out.append(
+                {
+                    "run_id": run_id,
+                    "task_id": task_id,
+                    "title": (row[0] if row else "") or "",
+                    "profile": profile,
+                    "status": status,
+                    "outcome": outcome,
+                    "error": error or "",
+                    "summary": summary or "",
+                    "started_at": started,
+                    "ended_at": ended,
+                    "board": str(path),
+                }
+            )
+        tasks = con.execute(
+            """
+            SELECT id, title, assignee, status, consecutive_failures,
+                   last_failure_error, block_kind
+            FROM tasks
+            WHERE consecutive_failures > 0 OR last_failure_error IS NOT NULL
+               OR (status = 'blocked' AND block_kind = 'needs_input')
+            """
+        ).fetchall()
+        for task_id, title, assignee, status, failures, error, block_kind in tasks:
+            if any(item.get("task_id") == task_id for item in out):
+                continue
+            outcome = "needs_input" if block_kind == "needs_input" else "consecutive_failures"
+            out.append(
+                {
+                    "run_id": None,
+                    "task_id": task_id,
+                    "title": title or "",
+                    "profile": assignee,
+                    "status": status,
+                    "outcome": outcome,
+                    "error": (error or "")[:300],
+                    "summary": f"consecutive_failures={failures or 0}",
+                    "started_at": None,
+                    "ended_at": None,
+                    "board": str(path),
+                }
+            )
+        con.close()
+    return out
+
+
+def stamp() -> None:
+    now = time.time()
+    LAST.write_text(
+        json.dumps(
+            {
+                "unix": int(now),
+                "iso": datetime.fromtimestamp(now, timezone.utc).isoformat(),
+            },
+            sort_keys=True,
+        ),
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    if len(sys.argv) > 1 and sys.argv[1] == "--stamp":
+        stamp()
+        print(LAST.read_text(encoding="utf-8"))
+        return
+    since = since_unix()
+    profiles = fleet()
+    cron_f = cron_failures(since)
+    kanban_f = kanban_failures(since)
+    by_profile = {}
+    for name in profiles:
+        sessions = scan_sessions(name, since)
+        by_profile[name] = {
+            "sessions": sessions,
+            "session_failures": [session for session in sessions if session.get("failed")],
+            "omission_risks": [
+                session
+                for session in sessions
+                if session.get("failed") and session.get("claimed_ok")
+            ],
+            "cron_failures": [failure for failure in cron_f if failure.get("profile") == name],
+            "kanban_failures": [failure for failure in kanban_f if failure.get("profile") == name],
+        }
+    payload = {
+        "since_unix": int(since),
+        "since_iso": datetime.fromtimestamp(since, timezone.utc).isoformat(),
+        "generated_unix": int(time.time()),
+        "profiles": by_profile,
+        "cron_failures": cron_f,
+        "kanban_failures": kanban_f,
+    }
+    outdir = STORE / "audit"
+    outdir.mkdir(parents=True, exist_ok=True)
+    text = json.dumps(payload, sort_keys=True)
+    (outdir / "latest.json").write_text(text, encoding="utf-8")
+    print(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rsi-audit.py
+++ b/scripts/rsi-audit.py
@@ -21,6 +21,7 @@ LAST = STORE / "last_tick.json"
 JOBS = HOME / ".hermes" / "cron" / "jobs.json"
 EXEC_DB = HOME / ".hermes" / "cron" / "executions.db"
 KANBAN = HOME / ".hermes" / "kanban.db"
+PROFILES_DIR = HOME / ".hermes" / "profiles"
 CONTRACT = STORE / "contract.yaml"
 
 DONE_RE = re.compile(r"\b(done|completed|all (?:set|good)|nothing to (?:do|report))\b", re.I)
@@ -92,8 +93,28 @@ def load_yaml(path: Path) -> dict:
 
 
 def fleet() -> list[str]:
-    names = (load_yaml(CONTRACT).get("fleet") or []) if CONTRACT.exists() else []
-    return [str(n) for n in names] or ["coder", "product", "qa", "reviewer", "yuki", "x"]
+    """Every installed profile, contract-listed or not.
+
+    The interview contract requires a structured audit slice for every
+    installed profile: a missing slice is a mandatory validation failure for
+    that profile. Installed = the default instance plus every directory under
+    ``~/.hermes/profiles/``; contract names without an install are skipped.
+    Contract-only ordering is preserved first, then any unlisted installs
+    alphabetically, so output stays deterministic.
+    """
+    installed = ["default"]
+    if PROFILES_DIR.is_dir():
+        installed.extend(
+            sorted(
+                entry.name
+                for entry in PROFILES_DIR.iterdir()
+                if entry.is_dir() and not entry.name.startswith(".")
+            )
+        )
+    contracted = [str(n) for n in (load_yaml(CONTRACT).get("fleet") or [])]
+    ordered = [n for n in contracted if n in installed]
+    ordered.extend(n for n in installed if n not in contracted)
+    return ordered or installed
 
 
 def since_unix() -> float:

--- a/scripts/rsi-audit.py
+++ b/scripts/rsi-audit.py
@@ -66,6 +66,7 @@ NONTERMINAL_BOUNDARY_ENDS = {
 }
 FAIL_STATUSES = {
     "blocked_config",
+    "crashed",
     "error",
     "failed",
     "gave_up",
@@ -277,6 +278,50 @@ def _kanban_paths() -> list[Path]:
     return list(dict.fromkeys(path for path in paths if path.exists()))
 
 
+def _kanban_profile(
+    session_id: str,
+    task_ids: list[str],
+    started_at: float,
+) -> str | None:
+    """Resolve a legacy default-database session to its durable task owner."""
+    for path in _kanban_paths():
+        try:
+            con = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+            if task_ids:
+                placeholders = ",".join("?" for _ in task_ids)
+                tasks = con.execute(
+                    f"SELECT id, assignee FROM tasks WHERE id IN ({placeholders})",
+                    tuple(task_ids),
+                ).fetchall()
+            else:
+                tasks = con.execute(
+                    "SELECT id, assignee FROM tasks WHERE session_id = ?",
+                    (session_id,),
+                ).fetchall()
+            candidates = []
+            for task_id, assignee in tasks:
+                runs = con.execute(
+                    "SELECT profile, started_at FROM task_runs WHERE task_id = ?",
+                    (task_id,),
+                ).fetchall()
+                candidates.extend(
+                    (
+                        abs(float(run_started) - float(started_at or 0)),
+                        str(run_profile or assignee or "") or None,
+                    )
+                    for run_profile, run_started in runs
+                    if run_started is not None
+                )
+            con.close()
+        except (sqlite3.Error, OSError):
+            continue
+        if candidates:
+            return min(candidates, key=lambda item: item[0])[1]
+        if len(tasks) == 1:
+            return str(tasks[0][1] or "") or None
+    return None
+
+
 def _kanban_evidence(
     session_id: str,
     task_ids: list[str],
@@ -365,27 +410,33 @@ def _parse_iso_timestamp(value: Any) -> float | None:
         return None
 
 
-def _cron_evidence(session_id: str, started_at: float) -> tuple[list[str], bool]:
+def _cron_evidence(
+    session_id: str,
+    started_at: float,
+    execution_dbs: list[Path],
+) -> tuple[list[str], bool]:
     match = CRON_SESSION_RE.match(session_id)
-    if not match or not EXEC_DB.exists():
+    if not match:
         return [], False
     job_id = match.group(1)
-    try:
-        con = sqlite3.connect(f"file:{EXEC_DB}?mode=ro", uri=True)
-        rows = con.execute(
-            """SELECT status, error, started_at, finished_at
-               FROM executions WHERE job_id = ? ORDER BY started_at DESC LIMIT 20""",
-            (job_id,),
-        ).fetchall()
-        con.close()
-    except (sqlite3.Error, OSError):
-        return [], False
-
     candidates = []
-    for row in rows:
-        row_started = _parse_iso_timestamp(row[2])
-        if row_started is not None:
-            candidates.append((abs(row_started - float(started_at or 0)), row))
+    for execution_db in dict.fromkeys(execution_dbs):
+        if not execution_db.exists():
+            continue
+        try:
+            con = sqlite3.connect(f"file:{execution_db}?mode=ro", uri=True)
+            rows = con.execute(
+                """SELECT status, error, started_at, finished_at
+                   FROM executions WHERE job_id = ? ORDER BY started_at DESC LIMIT 20""",
+                (job_id,),
+            ).fetchall()
+            con.close()
+        except (sqlite3.Error, OSError):
+            continue
+        for row in rows:
+            row_started = _parse_iso_timestamp(row[2])
+            if row_started is not None:
+                candidates.append((abs(row_started - float(started_at or 0)), row))
     if not candidates:
         return [], False
     distance, row = min(candidates, key=lambda item: item[0])
@@ -432,7 +483,7 @@ def scan_sessions(profile: str, since: float) -> list[dict]:
             rows = con.execute(
                 """
                 SELECT id, source, title, end_reason, last_activity_description,
-                       last_activity_at, started_at, ended_at
+                       last_activity_at, started_at, ended_at, profile_name
                 FROM sessions
                 WHERE last_activity_at >= ?
                   AND (profile_name = ? OR (profile_name IS NULL AND source IN ('cron','kanban')))
@@ -444,7 +495,7 @@ def scan_sessions(profile: str, since: float) -> list[dict]:
             rows = con.execute(
                 """
                 SELECT id, source, title, end_reason, last_activity_description,
-                       last_activity_at, started_at, ended_at
+                       last_activity_at, started_at, ended_at, profile_name
                 FROM sessions
                 WHERE last_activity_at >= ?
                 ORDER BY last_activity_at DESC
@@ -452,25 +503,38 @@ def scan_sessions(profile: str, since: float) -> list[dict]:
                 (since,),
             ).fetchall()
 
-        for sid, source, title, end_reason, last_desc, last_at, started, ended_at in rows:
-            if origin == "default" and source == "cron":
-                title_l = (title or "").lower()
-                mapped = next(
-                    (
-                        owner
-                        for job, owner in CRON_TO_PROFILE.items()
-                        if job in title_l or job.replace("-", " ") in title_l
-                    ),
-                    None,
-                )
-                if mapped and mapped != profile:
-                    continue
-                if mapped is None and profile != "default":
-                    continue
-
+        for (
+            sid,
+            source,
+            title,
+            end_reason,
+            last_desc,
+            last_at,
+            started,
+            ended_at,
+            row_profile,
+        ) in rows:
             fail_hits, has_final_response, task_ids = _message_evidence(con, sid, since)
             title_task_ids = [match.group(0).lower() for match in TASK_ID_RE.finditer(title or "")]
             task_ids = list(dict.fromkeys([*task_ids, *title_task_ids]))
+
+            if path == default and row_profile is None:
+                owner = "default"
+                if source == "cron":
+                    title_l = (title or "").lower()
+                    owner = next(
+                        (
+                            mapped_profile
+                            for job, mapped_profile in CRON_TO_PROFILE.items()
+                            if job in title_l or job.replace("-", " ") in title_l
+                        ),
+                        "default",
+                    )
+                elif source == "kanban":
+                    owner = _kanban_profile(sid, task_ids, float(started or 0)) or "default"
+                if owner != profile:
+                    continue
+
             durable_success = False
             if source == "kanban":
                 durable_hits, durable_success = _kanban_evidence(
@@ -480,7 +544,17 @@ def scan_sessions(profile: str, since: float) -> list[dict]:
                 )
                 fail_hits.extend(durable_hits)
             elif source == "cron":
-                durable_hits, durable_success = _cron_evidence(sid, float(started or 0))
+                execution_dbs = [EXEC_DB]
+                if profile != "default" and path != default:
+                    execution_dbs.insert(
+                        0,
+                        PROFILES_DIR / profile / "cron" / "executions.db",
+                    )
+                durable_hits, durable_success = _cron_evidence(
+                    sid,
+                    float(started or 0),
+                    execution_dbs,
+                )
                 fail_hits.extend(durable_hits)
 
             end_reason_l = str(end_reason or "").lower()
@@ -514,49 +588,76 @@ def scan_sessions(profile: str, since: float) -> list[dict]:
     return found
 
 
-def cron_failures(since: float) -> list[dict]:
-    if not EXEC_DB.exists():
-        return []
-    con = sqlite3.connect(f"file:{EXEC_DB}?mode=ro", uri=True)
-    names = {}
-    if JOBS.exists():
-        try:
-            for job in json.loads(JOBS.read_text(encoding="utf-8")).get("jobs") or []:
-                names[job.get("id")] = job.get("name")
-        except Exception:
-            pass
-    since_iso = datetime.fromtimestamp(since, timezone.utc).isoformat()
-    rows = con.execute(
-        """
-        SELECT id, job_id, status, error, started_at, finished_at
-        FROM executions
-        WHERE (finished_at IS NOT NULL AND finished_at >= ?)
-           OR (started_at IS NOT NULL AND started_at >= ?)
-        ORDER BY finished_at DESC
-        """,
-        (since_iso, since_iso),
-    ).fetchall()
-    out = []
-    for execution_id, job_id, status, error, started, finished in rows:
-        status_l = (status or "").lower()
-        if status_l in NONTERMINAL_STATUSES and not error:
-            continue
-        if status_l in SUCCESS_STATUSES and not error:
-            continue
-        name = names.get(job_id) or job_id
-        out.append(
-            {
-                "execution_id": execution_id,
-                "job_id": job_id,
-                "name": name,
-                "profile": CRON_TO_PROFILE.get(str(name), "default"),
-                "status": status,
-                "error": (error or "")[:300],
-                "started_at": started,
-                "finished_at": finished,
-            }
+def _cron_stores() -> list[tuple[str, Path, Path]]:
+    """Return every installed profile's isolated jobs and execution stores."""
+    stores = [("default", JOBS, EXEC_DB)]
+    if PROFILES_DIR.is_dir():
+        stores.extend(
+            (
+                entry.name,
+                entry / "cron" / "jobs.json",
+                entry / "cron" / "executions.db",
+            )
+            for entry in sorted(PROFILES_DIR.iterdir(), key=lambda path: path.name)
+            if entry.is_dir() and not entry.name.startswith(".")
         )
-    con.close()
+    return [store for store in stores if store[2].exists()]
+
+
+def cron_failures(since: float) -> list[dict]:
+    since_iso = datetime.fromtimestamp(since, timezone.utc).isoformat()
+    out = []
+    for store_profile, jobs_path, execution_db in _cron_stores():
+        names = {}
+        if jobs_path.exists():
+            try:
+                for job in json.loads(jobs_path.read_text(encoding="utf-8")).get("jobs") or []:
+                    names[job.get("id")] = job.get("name")
+            except Exception:
+                pass
+        try:
+            con = sqlite3.connect(f"file:{execution_db}?mode=ro", uri=True)
+            rows = con.execute(
+                """
+                SELECT id, job_id, status, error, started_at, finished_at
+                FROM executions
+                WHERE (finished_at IS NOT NULL AND finished_at >= ?)
+                   OR (started_at IS NOT NULL AND started_at >= ?)
+                ORDER BY finished_at DESC
+                """,
+                (since_iso, since_iso),
+            ).fetchall()
+            con.close()
+        except (sqlite3.Error, OSError):
+            continue
+        for execution_id, job_id, status, error, started, finished in rows:
+            status_l = (status or "").lower()
+            if status_l in NONTERMINAL_STATUSES and not error:
+                continue
+            if status_l in SUCCESS_STATUSES and not error:
+                continue
+            name = names.get(job_id) or job_id
+            profile = (
+                store_profile
+                if store_profile != "default"
+                else CRON_TO_PROFILE.get(str(name), "default")
+            )
+            out.append(
+                {
+                    "execution_id": execution_id,
+                    "job_id": job_id,
+                    "name": name,
+                    "profile": profile,
+                    "status": status,
+                    "error": (error or "")[:300],
+                    "started_at": started,
+                    "finished_at": finished,
+                }
+            )
+    out.sort(
+        key=lambda item: str(item.get("finished_at") or item.get("started_at") or ""),
+        reverse=True,
+    )
     return out
 
 

--- a/scripts/rsi-build-interview.py
+++ b/scripts/rsi-build-interview.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Build a per-profile RSI interview prompt (corrections + audit evidence)."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+STORE = Path.home() / ".hermes" / "rsi"
+BASE = STORE / "interview-prompt.txt"
+CORRECTIONS = STORE / "corrections.yaml"
+AUDIT = STORE / "audit" / "latest.json"
+OPEN = {"unverified", "regressed", "ineffective"}
+
+
+def load_yaml(path: Path) -> dict:
+    if not path.exists():
+        return {}
+    try:
+        import yaml  # type: ignore
+
+        data = yaml.safe_load(path.read_text()) or {}
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("usage: rsi-build-interview.py PROFILE", file=sys.stderr)
+        sys.exit(2)
+    profile = sys.argv[1].strip()
+    base = BASE.read_text() if BASE.exists() else ""
+    items = (load_yaml(CORRECTIONS).get("corrections") or [])
+    open_ones = [
+        c for c in items
+        if isinstance(c, dict)
+        and str(c.get("agent") or "") == profile
+        and str(c.get("status") or "unverified") in OPEN
+    ]
+    lines = [base.rstrip(), "", f"Your profile name is `{profile}`."]
+    if open_ones:
+        lines.append("OPEN CORRECTIONS to verify (do not invent ids):")
+        for c in open_ones:
+            lines.append(
+                f"- id={c.get('id')} status={c.get('status')} "
+                f"problem={c.get('problem')} fix={c.get('fix')}"
+            )
+    else:
+        lines.append("OPEN CORRECTIONS: none.")
+
+    audit = {}
+    if AUDIT.exists():
+        try:
+            audit = (json.loads(AUDIT.read_text()).get("profiles") or {}).get(profile) or {}
+        except Exception:
+            audit = {}
+    sessions = audit.get("sessions") or []
+    sess_fail = audit.get("session_failures") or []
+    cron_f = audit.get("cron_failures") or []
+    kan_f = audit.get("kanban_failures") or []
+    lines.append("")
+    lines.append("EVIDENCE RSI already read (since last tick). You must account for every failed item. Omitting it is a reporting failure.")
+    lines.append(f"chats_seen={len(sessions)} session_failures={len(sess_fail)} cron_failures={len(cron_f)} kanban_failures={len(kan_f)}")
+    for s in sess_fail:
+        lines.append(
+            f"- session id={s.get('id')} source={s.get('source')} "
+            f"end={s.get('end_reason')} title={s.get('title')} hits={s.get('fail_hits')}"
+        )
+    for c in cron_f:
+        lines.append(
+            f"- cron execution_id={c.get('execution_id')} name={c.get('name')} "
+            f"status={c.get('status')} error={c.get('error')}"
+        )
+    for k in kan_f:
+        lines.append(
+            f"- kanban task_id={k.get('task_id')} outcome={k.get('outcome')} error={k.get('error')}"
+        )
+    if not (sess_fail or cron_f or kan_f):
+        lines.append("- no failed runs in the audit window. Still report any you remember.")
+    print("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/rsi-build-interview.py
+++ b/scripts/rsi-build-interview.py
@@ -6,6 +6,9 @@ import json
 import sys
 from pathlib import Path
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rsi_interview import build_scaffold
+
 STORE = Path.home() / ".hermes" / "rsi"
 BASE = STORE / "interview-prompt.txt"
 CORRECTIONS = STORE / "corrections.yaml"
@@ -19,7 +22,7 @@ def load_yaml(path: Path) -> dict:
     try:
         import yaml  # type: ignore
 
-        data = yaml.safe_load(path.read_text()) or {}
+        data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
         return data if isinstance(data, dict) else {}
     except Exception:
         return {}
@@ -30,7 +33,7 @@ def main() -> None:
         print("usage: rsi-build-interview.py PROFILE", file=sys.stderr)
         sys.exit(2)
     profile = sys.argv[1].strip()
-    base = BASE.read_text() if BASE.exists() else ""
+    base = BASE.read_text(encoding="utf-8") if BASE.exists() else ""
     items = (load_yaml(CORRECTIONS).get("corrections") or [])
     open_ones = [
         c for c in items
@@ -52,7 +55,7 @@ def main() -> None:
     audit = {}
     if AUDIT.exists():
         try:
-            audit = (json.loads(AUDIT.read_text()).get("profiles") or {}).get(profile) or {}
+            audit = (json.loads(AUDIT.read_text(encoding="utf-8")).get("profiles") or {}).get(profile) or {}
         except Exception:
             audit = {}
     sessions = audit.get("sessions") or []
@@ -78,6 +81,16 @@ def main() -> None:
         )
     if not (sess_fail or cron_f or kan_f):
         lines.append("- no failed runs in the audit window. Still report any you remember.")
+    lines.extend(
+        [
+            "",
+            "REPORT_JSON_SCHEMA:",
+            '{"profile":"<name>","autonomous_failures":[{"id":"<exact audited id>","summary":"...","evidence":"...","suggested_fix":"..."}],"incomplete_tasks":[{"id":"<exact audited id>","title":"...","summary":"...","why_incomplete":"..."}],"incidents":[],"correction_feedback":[],"accounted_session_ids":[]}',
+            "",
+            "MANDATORY_REPORT_SCAFFOLD (runner-owned; enrich but do not alter IDs/categories):",
+            json.dumps(build_scaffold(profile, {"profiles": {profile: audit}}), sort_keys=True),
+        ]
+    )
     print("\n".join(lines))
 
 

--- a/scripts/rsi-merge-interview.py
+++ b/scripts/rsi-merge-interview.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Merge an RSI model response into the audit-owned report scaffold."""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rsi_interview import merge_interview
+
+
+STORE = Path.home() / ".hermes" / "rsi"
+AUDIT = STORE / "audit" / "latest.json"
+GRILL_PROMPT = STORE / "grill-prompt.txt"
+VALIDATOR = Path(__file__).with_name("rsi-validate-interview.py")
+
+
+def _load_validator():
+    spec = importlib.util.spec_from_file_location("rsi_validate_interview", VALIDATOR)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load validator: {VALIDATOR}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _read_json(path: Path) -> tuple[Any, str | None]:
+    try:
+        return json.loads(path.read_text(encoding="utf-8")), None
+    except (OSError, json.JSONDecodeError) as exc:
+        return None, f"interview unavailable or malformed: {exc}"
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile")
+    parser.add_argument("model_report", type=Path)
+    parser.add_argument("output", type=Path)
+    parser.add_argument("--audit", type=Path, default=AUDIT)
+    parser.add_argument("--grill-prompt", type=Path, default=GRILL_PROMPT)
+    parser.add_argument("--grill-output", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        audit = json.loads(args.audit.read_text(encoding="utf-8"))
+        if not isinstance(audit, dict):
+            raise ValueError("top level must be an object")
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        print(json.dumps({"valid": False, "profile": args.profile, "errors": [f"malformed audit JSON: {exc}"]}, sort_keys=True))
+        return 2
+
+    model_report, input_error = _read_json(args.model_report)
+    merged = merge_interview(args.profile, model_report, audit)
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(merged.report, sort_keys=True), encoding="utf-8")
+
+    validator = _load_validator()
+    result = validator.validate_interview(
+        args.profile,
+        merged.report,
+        audit,
+        merge_conflicts=merged.conflicts,
+    )
+    if input_error:
+        result["errors"].append(input_error)
+        result["valid"] = False
+    if not result["valid"] and args.grill_output is not None:
+        validator._write_grill(args.grill_output, args.grill_prompt, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rsi-validate-interview.py
+++ b/scripts/rsi-validate-interview.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Validate one RSI interview against structured audit evidence.
+
+The default operation is read-only. Invalid reports exit 1. When
+``--grill-output`` is supplied, an invalid report also produces a ready-to-run
+query file using the existing RSI grill prompt.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from pathlib import Path
+from typing import Any
+
+STORE = Path.home() / ".hermes" / "rsi"
+AUDIT = STORE / "audit" / "latest.json"
+GRILL_PROMPT = STORE / "grill-prompt.txt"
+REQUIRED_LIST_FIELDS = (
+    "autonomous_failures",
+    "incomplete_tasks",
+    "incidents",
+    "correction_feedback",
+    "accounted_session_ids",
+)
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _profile_evidence(profile: str, audit: dict[str, Any]) -> dict[str, Any]:
+    profiles = audit.get("profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    evidence = profiles.get(profile)
+    return evidence if isinstance(evidence, dict) else {}
+
+
+def required_ids(profile: str, audit: dict[str, Any]) -> dict[str, list[str]]:
+    """Return exact audited IDs grouped by the report field that must cite them.
+
+    Classification is based only on the audit's structured collections and
+    lifecycle markers. It deliberately does not inspect titles, summaries,
+    errors, or other free text.
+    """
+    evidence = _profile_evidence(profile, audit)
+    autonomous: list[str] = []
+    incomplete: list[str] = []
+
+    sessions = evidence.get("session_failures")
+    if isinstance(sessions, list):
+        for item in sessions:
+            if not isinstance(item, dict):
+                continue
+            session_id = str(item.get("id") or "").strip()
+            hits = item.get("fail_hits")
+            lifecycle_needs_input = (
+                isinstance(hits, list)
+                and "lifecycle:needs_input" in {str(hit) for hit in hits}
+            )
+            (incomplete if lifecycle_needs_input else autonomous).append(session_id)
+
+    cron_failures = evidence.get("cron_failures")
+    if isinstance(cron_failures, list):
+        for item in cron_failures:
+            if isinstance(item, dict):
+                autonomous.append(str(item.get("execution_id") or "").strip())
+
+    kanban_failures = evidence.get("kanban_failures")
+    if isinstance(kanban_failures, list):
+        for item in kanban_failures:
+            if isinstance(item, dict):
+                incomplete.append(str(item.get("task_id") or "").strip())
+
+    autonomous = _ordered_unique(autonomous)
+    incomplete = _ordered_unique(incomplete)
+    return {
+        "autonomous_failures": autonomous,
+        "incomplete_tasks": incomplete,
+        "all": _ordered_unique([*autonomous, *incomplete]),
+    }
+
+
+def _contains_standalone_id(value: Any, required_id: str) -> bool:
+    if isinstance(value, str):
+        pattern = rf"(?<![A-Za-z0-9_-]){re.escape(required_id)}(?![A-Za-z0-9_-])"
+        return re.search(pattern, value) is not None
+    if isinstance(value, list):
+        return any(_contains_standalone_id(item, required_id) for item in value)
+    if isinstance(value, dict):
+        return any(_contains_standalone_id(item, required_id) for item in value.values())
+    return False
+
+
+def _detail_record_matches(field: str, record: Any, required_id: str) -> bool:
+    if not isinstance(record, dict):
+        return False
+    if field == "incomplete_tasks":
+        return record.get("id") == required_id
+    # autonomous_failures records carry only summary/evidence/suggested_fix,
+    # so a standalone exact ID in any documented free-text field (including
+    # ``summary``) counts. The standalone boundary still rejects
+    # suffix/prefixed near-matches.
+    return (
+        record.get("id") == required_id
+        or record.get("execution_id") == required_id
+        or _contains_standalone_id(record.get("evidence"), required_id)
+        or _contains_standalone_id(record.get("summary"), required_id)
+    )
+
+
+def validate_interview(
+    profile: str,
+    report: Any,
+    audit: dict[str, Any],
+) -> dict[str, Any]:
+    required = required_ids(profile, audit)
+    errors: list[str] = []
+    profiles = audit.get("profiles")
+    if not isinstance(profiles, dict) or not isinstance(profiles.get(profile), dict):
+        errors.append("audit has no structured profile slice")
+    missing_accounted = list(required["all"])
+    missing_detail = {
+        "autonomous_failures": list(required["autonomous_failures"]),
+        "incomplete_tasks": list(required["incomplete_tasks"]),
+    }
+
+    if not isinstance(report, dict):
+        errors.append("interview JSON must be an object")
+    else:
+        if report.get("profile") != profile:
+            errors.append(f"profile must equal {profile!r}")
+
+        for field in REQUIRED_LIST_FIELDS:
+            if not isinstance(report.get(field), list):
+                errors.append(f"{field} must be a list")
+
+        accounted = report.get("accounted_session_ids")
+        if isinstance(accounted, list):
+            exact_accounted = {item for item in accounted if isinstance(item, str)}
+            missing_accounted = [item for item in required["all"] if item not in exact_accounted]
+
+        for field in ("autonomous_failures", "incomplete_tasks"):
+            records = report.get(field)
+            if isinstance(records, list):
+                missing_detail[field] = [
+                    item
+                    for item in required[field]
+                    if not any(
+                        _detail_record_matches(field, record, item)
+                        for record in records
+                    )
+                ]
+
+    if missing_accounted:
+        errors.append(
+            "accounted_session_ids missing exact audited IDs: "
+            + ", ".join(missing_accounted)
+        )
+    for field in ("autonomous_failures", "incomplete_tasks"):
+        if missing_detail[field]:
+            errors.append(
+                f"{field} missing literal audited IDs: "
+                + ", ".join(missing_detail[field])
+            )
+
+    return {
+        "valid": not errors,
+        "profile": profile,
+        "required_ids": required["all"],
+        "missing_accounted_ids": missing_accounted,
+        "missing_detail_ids": missing_detail,
+        "errors": errors,
+    }
+
+
+def _load_object(path: Path, label: str) -> dict[str, Any]:
+    try:
+        value = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"malformed {label} JSON: {exc}") from exc
+    if not isinstance(value, dict):
+        raise ValueError(f"malformed {label} JSON: top level must be an object")
+    return value
+
+
+def _write_grill(path: Path, base_path: Path, result: dict[str, Any]) -> None:
+    try:
+        base = base_path.read_text(encoding="utf-8").rstrip()
+    except OSError:
+        base = "RSI audited your chats since the last tick. Your interview did not match that evidence."
+    mismatch = json.dumps(
+        {
+            "profile": result["profile"],
+            "validation_errors": result["errors"],
+            "required_ids": result["required_ids"],
+        },
+        sort_keys=True,
+    )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(f"{base}\n\nDETERMINISTIC VALIDATION MISMATCHES:\n{mismatch}\n", encoding="utf-8")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("profile")
+    parser.add_argument("report", type=Path)
+    parser.add_argument("--audit", type=Path, default=AUDIT)
+    parser.add_argument("--grill-prompt", type=Path, default=GRILL_PROMPT)
+    parser.add_argument("--grill-output", type=Path)
+    args = parser.parse_args(argv)
+
+    try:
+        audit = _load_object(args.audit, "audit")
+    except ValueError as exc:
+        result = {
+            "valid": False,
+            "profile": args.profile,
+            "required_ids": [],
+            "missing_accounted_ids": [],
+            "missing_detail_ids": {
+                "autonomous_failures": [],
+                "incomplete_tasks": [],
+            },
+            "errors": [str(exc)],
+        }
+    else:
+        try:
+            report = _load_object(args.report, "interview")
+        except ValueError as exc:
+            required = required_ids(args.profile, audit)
+            result = {
+                "valid": False,
+                "profile": args.profile,
+                "required_ids": required["all"],
+                "missing_accounted_ids": required["all"],
+                "missing_detail_ids": {
+                    "autonomous_failures": required["autonomous_failures"],
+                    "incomplete_tasks": required["incomplete_tasks"],
+                },
+                "errors": [str(exc)],
+            }
+        else:
+            result = validate_interview(args.profile, report, audit)
+
+    if not result["valid"] and args.grill_output is not None:
+        _write_grill(args.grill_output, args.grill_prompt, result)
+    print(json.dumps(result, sort_keys=True))
+    return 0 if result["valid"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/rsi-validate-interview.py
+++ b/scripts/rsi-validate-interview.py
@@ -9,10 +9,12 @@ from __future__ import annotations
 
 import argparse
 import json
-import re
 import sys
 from pathlib import Path
 from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from rsi_interview import DETAIL_FIELDS, required_ids
 
 STORE = Path.home() / ".hermes" / "rsi"
 AUDIT = STORE / "audit" / "latest.json"
@@ -26,98 +28,21 @@ REQUIRED_LIST_FIELDS = (
 )
 
 
-def _ordered_unique(values: list[str]) -> list[str]:
-    return list(dict.fromkeys(value for value in values if value))
-
-
-def _profile_evidence(profile: str, audit: dict[str, Any]) -> dict[str, Any]:
-    profiles = audit.get("profiles")
-    if not isinstance(profiles, dict):
-        return {}
-    evidence = profiles.get(profile)
-    return evidence if isinstance(evidence, dict) else {}
-
-
-def required_ids(profile: str, audit: dict[str, Any]) -> dict[str, list[str]]:
-    """Return exact audited IDs grouped by the report field that must cite them.
-
-    Classification is based only on the audit's structured collections and
-    lifecycle markers. It deliberately does not inspect titles, summaries,
-    errors, or other free text.
-    """
-    evidence = _profile_evidence(profile, audit)
-    autonomous: list[str] = []
-    incomplete: list[str] = []
-
-    sessions = evidence.get("session_failures")
-    if isinstance(sessions, list):
-        for item in sessions:
-            if not isinstance(item, dict):
-                continue
-            session_id = str(item.get("id") or "").strip()
-            hits = item.get("fail_hits")
-            lifecycle_needs_input = (
-                isinstance(hits, list)
-                and "lifecycle:needs_input" in {str(hit) for hit in hits}
-            )
-            (incomplete if lifecycle_needs_input else autonomous).append(session_id)
-
-    cron_failures = evidence.get("cron_failures")
-    if isinstance(cron_failures, list):
-        for item in cron_failures:
-            if isinstance(item, dict):
-                autonomous.append(str(item.get("execution_id") or "").strip())
-
-    kanban_failures = evidence.get("kanban_failures")
-    if isinstance(kanban_failures, list):
-        for item in kanban_failures:
-            if isinstance(item, dict):
-                incomplete.append(str(item.get("task_id") or "").strip())
-
-    autonomous = _ordered_unique(autonomous)
-    incomplete = _ordered_unique(incomplete)
-    return {
-        "autonomous_failures": autonomous,
-        "incomplete_tasks": incomplete,
-        "all": _ordered_unique([*autonomous, *incomplete]),
-    }
-
-
-def _contains_standalone_id(value: Any, required_id: str) -> bool:
-    if isinstance(value, str):
-        pattern = rf"(?<![A-Za-z0-9_-]){re.escape(required_id)}(?![A-Za-z0-9_-])"
-        return re.search(pattern, value) is not None
-    if isinstance(value, list):
-        return any(_contains_standalone_id(item, required_id) for item in value)
-    if isinstance(value, dict):
-        return any(_contains_standalone_id(item, required_id) for item in value.values())
-    return False
-
-
 def _detail_record_matches(field: str, record: Any, required_id: str) -> bool:
-    if not isinstance(record, dict):
-        return False
-    if field == "incomplete_tasks":
-        return record.get("id") == required_id
-    # autonomous_failures records carry only summary/evidence/suggested_fix,
-    # so a standalone exact ID in any documented free-text field (including
-    # ``summary``) counts. The standalone boundary still rejects
-    # suffix/prefixed near-matches.
-    return (
-        record.get("id") == required_id
-        or record.get("execution_id") == required_id
-        or _contains_standalone_id(record.get("evidence"), required_id)
-        or _contains_standalone_id(record.get("summary"), required_id)
-    )
+    """The documented schema requires an exact ``id`` in both categories."""
+    return isinstance(record, dict) and record.get("id") == required_id
 
 
 def validate_interview(
     profile: str,
     report: Any,
     audit: dict[str, Any],
+    *,
+    merge_conflicts: list[str] | None = None,
 ) -> dict[str, Any]:
     required = required_ids(profile, audit)
     errors: list[str] = []
+    missing_qualitative: list[str] = []
     profiles = audit.get("profiles")
     if not isinstance(profiles, dict) or not isinstance(profiles.get(profile), dict):
         errors.append("audit has no structured profile slice")
@@ -153,6 +78,32 @@ def validate_interview(
                         for record in records
                     )
                 ]
+                seen_ids: set[str] = set()
+                for index, record in enumerate(records):
+                    if not isinstance(record, dict):
+                        errors.append(f"{field}[{index}] must be an object")
+                        continue
+                    item_id = record.get("id")
+                    if not isinstance(item_id, str) or not item_id.strip():
+                        errors.append(f"{field}[{index}].id must be a non-empty exact ID")
+                        continue
+                    if item_id in seen_ids:
+                        errors.append(f"{field} contains duplicate exact ID: {item_id}")
+                    seen_ids.add(item_id)
+                    missing_fields = [
+                        key
+                        for key in DETAIL_FIELDS[field]
+                        if not isinstance(record.get(key), str) or not record[key].strip()
+                    ]
+                    if missing_fields:
+                        missing_qualitative.append(item_id)
+                        errors.append(
+                            f"{field} id={item_id} missing qualitative fields: "
+                            + ", ".join(missing_fields)
+                        )
+
+    for conflict in merge_conflicts or []:
+        errors.append(f"scaffold merge contradiction: {conflict}")
 
     if missing_accounted:
         errors.append(
@@ -172,6 +123,7 @@ def validate_interview(
         "required_ids": required["all"],
         "missing_accounted_ids": missing_accounted,
         "missing_detail_ids": missing_detail,
+        "missing_qualitative_ids": list(dict.fromkeys(missing_qualitative)),
         "errors": errors,
     }
 

--- a/scripts/rsi_interview.py
+++ b/scripts/rsi_interview.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Evidence-derived scaffolding and merge rules for RSI interviews."""
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+
+REPORT_LIST_FIELDS = (
+    "autonomous_failures",
+    "incomplete_tasks",
+    "incidents",
+    "correction_feedback",
+    "accounted_session_ids",
+)
+DETAIL_FIELDS = {
+    "autonomous_failures": ("summary", "evidence", "suggested_fix"),
+    "incomplete_tasks": ("title", "summary", "why_incomplete"),
+}
+
+
+class MergeResult(NamedTuple):
+    report: dict[str, Any]
+    conflicts: list[str]
+    missing_qualitative_ids: list[str]
+
+
+def _ordered_unique(values: list[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _profile_evidence(profile: str, audit: dict[str, Any]) -> dict[str, Any]:
+    profiles = audit.get("profiles")
+    if not isinstance(profiles, dict):
+        return {}
+    evidence = profiles.get(profile)
+    return evidence if isinstance(evidence, dict) else {}
+
+
+def required_ids(profile: str, audit: dict[str, Any]) -> dict[str, list[str]]:
+    """Classify exact IDs using structured audit lifecycle fields only."""
+    evidence = _profile_evidence(profile, audit)
+    autonomous: list[str] = []
+    incomplete: list[str] = []
+
+    sessions = evidence.get("session_failures")
+    if isinstance(sessions, list):
+        for item in sessions:
+            if not isinstance(item, dict):
+                continue
+            session_id = str(item.get("id") or "").strip()
+            if not session_id:
+                continue
+            # Every structurally failed session is an autonomy failure. A
+            # needs-input lifecycle marker additionally makes the same run an
+            # incomplete task; the two categories are intentionally not
+            # mutually exclusive.
+            autonomous.append(session_id)
+            hits = item.get("fail_hits")
+            if isinstance(hits, list) and "lifecycle:needs_input" in {
+                str(hit) for hit in hits
+            }:
+                incomplete.append(session_id)
+
+    cron_failures = evidence.get("cron_failures")
+    if isinstance(cron_failures, list):
+        for item in cron_failures:
+            if isinstance(item, dict):
+                autonomous.append(str(item.get("execution_id") or "").strip())
+
+    kanban_failures = evidence.get("kanban_failures")
+    if isinstance(kanban_failures, list):
+        for item in kanban_failures:
+            if isinstance(item, dict):
+                incomplete.append(str(item.get("task_id") or "").strip())
+
+    autonomous = _ordered_unique(autonomous)
+    incomplete = _ordered_unique(incomplete)
+    return {
+        "autonomous_failures": autonomous,
+        "incomplete_tasks": incomplete,
+        "all": _ordered_unique([*autonomous, *incomplete]),
+    }
+
+
+def _items_by_id(items: Any, key: str) -> dict[str, dict[str, Any]]:
+    if not isinstance(items, list):
+        return {}
+    result: dict[str, dict[str, Any]] = {}
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        item_id = str(item.get(key) or "").strip()
+        if item_id and item_id not in result:
+            result[item_id] = item
+    return result
+
+
+def build_scaffold(profile: str, audit: dict[str, Any]) -> dict[str, Any]:
+    """Build the immutable ID/category skeleton for one profile report."""
+    required = required_ids(profile, audit)
+    evidence = _profile_evidence(profile, audit)
+    sessions = _items_by_id(evidence.get("session_failures"), "id")
+    cron = _items_by_id(evidence.get("cron_failures"), "execution_id")
+    kanban = _items_by_id(evidence.get("kanban_failures"), "task_id")
+
+    autonomous = []
+    for item_id in required["autonomous_failures"]:
+        source = sessions.get(item_id) or cron.get(item_id) or {}
+        source_name = str(source.get("source") or source.get("name") or "audited run")
+        autonomous.append(
+            {
+                "id": item_id,
+                "summary": "",
+                "evidence": "",
+                "suggested_fix": "",
+                "audit_source": source_name,
+            }
+        )
+
+    incomplete = []
+    for item_id in required["incomplete_tasks"]:
+        source = sessions.get(item_id) or kanban.get(item_id) or {}
+        incomplete.append(
+            {
+                "id": item_id,
+                "title": str(source.get("title") or ""),
+                "summary": "",
+                "why_incomplete": "",
+            }
+        )
+
+    return {
+        "profile": profile,
+        "autonomous_failures": autonomous,
+        "incomplete_tasks": incomplete,
+        "incidents": [],
+        "correction_feedback": [],
+        "accounted_session_ids": list(required["all"]),
+    }
+
+
+def _merge_record_values(
+    field: str,
+    item_id: str,
+    target: dict[str, Any],
+    incoming: dict[str, Any],
+    seen_values: dict[str, str],
+    conflicts: list[str],
+) -> None:
+    for key in DETAIL_FIELDS[field]:
+        value = incoming.get(key)
+        if not isinstance(value, str) or not value.strip():
+            continue
+        value = value.strip()
+        prior = seen_values.get(key)
+        if prior is not None and prior != value:
+            message = f"{field} id={item_id} has conflicting {key} values"
+            if message not in conflicts:
+                conflicts.append(message)
+            continue
+        seen_values[key] = value
+        target[key] = value
+
+
+def _merge_detail_field(
+    field: str,
+    scaffold_records: list[dict[str, Any]],
+    model_records: Any,
+    conflicts: list[str],
+    forbidden_ids: set[str],
+) -> list[dict[str, Any]]:
+    merged = [dict(item) for item in scaffold_records]
+    by_id = {item["id"]: item for item in merged}
+    seen: dict[str, dict[str, str]] = {item["id"]: {} for item in merged}
+
+    if not isinstance(model_records, list):
+        return merged
+    for record in model_records:
+        if not isinstance(record, dict):
+            continue
+        item_id = str(record.get("id") or "").strip()
+        if item_id in forbidden_ids:
+            # An audited ID belongs only to the categories selected by the
+            # structured lifecycle classifier. Model prose cannot reclassify it.
+            continue
+        if not item_id:
+            # Preserve malformed model output so validation can grill it; it
+            # cannot satisfy or alter any mandatory scaffold record.
+            merged.append(dict(record))
+            continue
+        if item_id not in by_id:
+            target = {"id": item_id}
+            merged.append(target)
+            by_id[item_id] = target
+            seen[item_id] = {}
+        _merge_record_values(
+            field,
+            item_id,
+            by_id[item_id],
+            record,
+            seen[item_id],
+            conflicts,
+        )
+    return merged
+
+
+def _nonempty(value: Any) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def merge_interview(
+    profile: str,
+    model_report: Any,
+    audit: dict[str, Any],
+) -> MergeResult:
+    """Merge model enrichment into an audit-owned immutable scaffold."""
+    scaffold = build_scaffold(profile, audit)
+    model = model_report if isinstance(model_report, dict) else {}
+    conflicts: list[str] = []
+    required = required_ids(profile, audit)
+
+    report = dict(scaffold)
+    for field in ("autonomous_failures", "incomplete_tasks"):
+        report[field] = _merge_detail_field(
+            field,
+            scaffold[field],
+            model.get(field),
+            conflicts,
+            set(required["all"]) - set(required[field]),
+        )
+
+    for field in ("incidents", "correction_feedback"):
+        values = model.get(field)
+        report[field] = list(values) if isinstance(values, list) else []
+
+    model_accounted = model.get("accounted_session_ids")
+    extras = [item for item in model_accounted if isinstance(item, str)] if isinstance(model_accounted, list) else []
+    report["accounted_session_ids"] = _ordered_unique(
+        [*scaffold["accounted_session_ids"], *extras]
+    )
+
+    missing: list[str] = []
+    for field in ("autonomous_failures", "incomplete_tasks"):
+        mandatory = set(required[field])
+        for record in report[field]:
+            if not isinstance(record, dict) or record.get("id") not in mandatory:
+                continue
+            if not all(_nonempty(record.get(key)) for key in DETAIL_FIELDS[field]):
+                missing.append(str(record["id"]))
+
+    return MergeResult(
+        report=report,
+        conflicts=conflicts,
+        missing_qualitative_ids=_ordered_unique(missing),
+    )

--- a/tests/scripts/test_rsi_audit.py
+++ b/tests/scripts/test_rsi_audit.py
@@ -576,3 +576,83 @@ def test_kanban_failure_scan_does_not_drop_older_failure_after_forty_runs(audit_
     failures = module.kanban_failures(since=90)
 
     assert [failure["run_id"] for failure in failures] == [1]
+
+
+def test_fleet_includes_default_and_every_installed_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = _load_module()
+    home = tmp_path / "home"
+    profiles = home / ".hermes" / "profiles"
+    for name in ("buggy", "coder", "jade", "jade-ops", "product", "qa",
+                 "research", "reviewer", "rsi", "x", "yuki", "yuki-ops"):
+        (profiles / name).mkdir(parents=True)
+    monkeypatch.setattr(module, "HOME", home)
+    monkeypatch.setattr(module, "PROFILES_DIR", profiles)
+    monkeypatch.setattr(module, "CONTRACT", tmp_path / "absent-contract.yaml")
+
+    roster = module.fleet()
+
+    # default + all 12 profile dirs = 13 installed; unlisted installs
+    # still get a slice even with no contract present.
+    assert len(roster) == 13
+    assert roster[0] == "default"
+    assert set(roster) >= {
+        "default", "buggy", "coder", "jade", "jade-ops", "product", "qa",
+        "research", "reviewer", "rsi", "x", "yuki", "yuki-ops",
+    }
+
+
+def test_fleet_contract_order_wins_but_covers_unlisted_installs(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = _load_module()
+    home = tmp_path / "home"
+    profiles = home / ".hermes" / "profiles"
+    for name in ("qa", "reviewer", "x", "yuki", "yuki-ops"):
+        (profiles / name).mkdir(parents=True)
+    contract = tmp_path / "contract.yaml"
+    contract.write_text("fleet: [coder, product, qa, reviewer, yuki, yuki-ops, x]\n")
+    monkeypatch.setattr(module, "HOME", home)
+    monkeypatch.setattr(module, "PROFILES_DIR", profiles)
+    monkeypatch.setattr(module, "CONTRACT", contract)
+
+    roster = module.fleet()
+
+    # Only contracted names that are actually installed come first, in
+    # contract order; installed-but-unlisted names (and default) still appear
+    # so no profile lacks a slice.
+    assert roster[:4] == ["qa", "reviewer", "yuki", "yuki-ops"]
+    assert roster[-1] == "default"
+    assert set(roster) == {"qa", "reviewer", "yuki", "yuki-ops", "x", "default"}
+
+
+def test_audit_emits_empty_slice_for_every_installed_profile(tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture):
+    module = _load_module()
+    home = tmp_path / "home"
+    state = home / ".hermes" / "profiles" / "qa" / "state.db"
+    state.parent.mkdir(parents=True)
+    _state_db(state)
+    store = tmp_path / "rsi"
+    store.mkdir()
+    contract = store / "contract.yaml"
+    contract.write_text("fleet: [qa]\n")
+    (store / "last_tick.json").write_text('{"unix": 50}', encoding="utf-8")
+    monkeypatch.setattr(module, "HOME", home)
+    monkeypatch.setattr(module, "KANBAN", home / ".hermes" / "kanban.db")
+    monkeypatch.setattr(module, "EXEC_DB", home / ".hermes" / "cron" / "executions.db")
+    monkeypatch.setattr(module, "PROFILES_DIR", home / ".hermes" / "profiles")
+    monkeypatch.setattr(module, "CONTRACT", contract)
+    monkeypatch.setattr(module, "STORE", store)
+    monkeypatch.setattr(module, "LAST", store / "last_tick.json")
+
+    module.main()
+    payload = json.loads(capsys.readouterr().out)
+
+    # Every installed profile (default + qa) gets an explicit slice, even the
+    # ones with nothing to report and no contracted name.
+    assert set(payload["profiles"]) == {"default", "qa"}
+    for slice_ in payload["profiles"].values():
+        assert isinstance(slice_, dict)
+        assert isinstance(slice_["sessions"], list)
+        assert isinstance(slice_["session_failures"], list)
+        assert isinstance(slice_["cron_failures"], list)
+        assert isinstance(slice_["kanban_failures"], list)
+    on_disk = json.loads((store / "audit" / "latest.json").read_text(encoding="utf-8"))
+    assert set(on_disk["profiles"]) == {"default", "qa"}

--- a/tests/scripts/test_rsi_audit.py
+++ b/tests/scripts/test_rsi_audit.py
@@ -1,0 +1,578 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "rsi-audit.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("rsi_audit", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _state_db(path: Path) -> None:
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT,
+            title TEXT,
+            end_reason TEXT,
+            last_activity_description TEXT,
+            last_activity_at REAL,
+            started_at REAL,
+            ended_at REAL,
+            profile_name TEXT
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT,
+            role TEXT,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            effect_disposition TEXT,
+            timestamp REAL
+        );
+        """
+    )
+    con.close()
+
+
+def _message(
+    db: Path,
+    session_id: str,
+    role: str,
+    content: str = "",
+    *,
+    tool_name: str | None = None,
+    tool_calls: list[dict] | None = None,
+    timestamp: float = 101.0,
+) -> None:
+    con = sqlite3.connect(db)
+    con.execute(
+        """INSERT INTO messages
+           (session_id, role, content, tool_calls, tool_name, timestamp)
+           VALUES (?, ?, ?, ?, ?, ?)""",
+        (session_id, role, content, json.dumps(tool_calls) if tool_calls else None, tool_name, timestamp),
+    )
+    con.commit()
+    con.close()
+
+
+def _session(
+    db: Path,
+    session_id: str,
+    *,
+    source: str = "cli",
+    title: str = "fixture",
+    end_reason: str | None = "cli_close",
+    ended_at: float | None = 110.0,
+) -> None:
+    con = sqlite3.connect(db)
+    con.execute(
+        """INSERT INTO sessions
+           (id, source, title, end_reason, last_activity_description,
+            last_activity_at, started_at, ended_at, profile_name)
+           VALUES (?, ?, ?, ?, '', 110, 100, ?, 'qa')""",
+        (session_id, source, title, end_reason, ended_at),
+    )
+    con.commit()
+    con.close()
+
+
+@pytest.fixture
+def audit_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    module = _load_module()
+    home = tmp_path / "home"
+    state = home / ".hermes" / "profiles" / "qa" / "state.db"
+    state.parent.mkdir(parents=True)
+    _state_db(state)
+    monkeypatch.setattr(module, "HOME", home)
+    monkeypatch.setattr(module, "KANBAN", home / ".hermes" / "kanban.db")
+    monkeypatch.setattr(module, "EXEC_DB", home / ".hermes" / "cron" / "executions.db")
+    return module, state, home
+
+
+def _only(module) -> dict:
+    rows = module.scan_sessions("qa", since=90)
+    assert len(rows) == 1
+    return rows[0]
+
+
+def test_user_failure_words_and_successful_tool_payload_are_not_failures(audit_env):
+    module, db, _ = audit_env
+    sid = "lexical-success"
+    _session(db, sid)
+    _message(db, sid, "user", "Explain why the previous command failed with error: timeout")
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"output": "0 failed, 12 passed", "exit_code": 0, "error": None}),
+        tool_name="terminal",
+    )
+    _message(db, sid, "assistant", '{"status":"completed","failed_checks":0}')
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert row["fail_hits"] == []
+
+
+def test_actual_tool_error_is_a_failure(audit_env):
+    module, db, _ = audit_env
+    sid = "tool-error"
+    _session(db, sid)
+    _message(db, sid, "user", "Run the check")
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"output": "", "exit_code": 1, "error": "command failed"}),
+        tool_name="terminal",
+    )
+    _message(db, sid, "assistant", "The command did not complete.")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "tool:terminal:exit_code=1" in row["fail_hits"]
+
+
+def test_failure_shaped_domain_payload_is_not_a_tool_error(audit_env):
+    module, db, _ = audit_env
+    sid = "domain-status"
+    _session(db, sid)
+    _message(db, sid, "user", "List failed jobs")
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"status": "failed", "failed": True, "items": ["historical-job"]}),
+        tool_name="search_files",
+    )
+    _message(db, sid, "assistant", "Found one historical failed job.")
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert row["fail_hits"] == []
+
+
+def test_tool_error_after_more_than_two_hundred_messages_is_detected(audit_env):
+    module, db, _ = audit_env
+    sid = "long-session"
+    _session(db, sid)
+    _message(db, sid, "user", "Run a long workflow")
+    for index in range(205):
+        _message(db, sid, "tool", json.dumps({"item": index}), tool_name="search_files")
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"output": "", "exit_code": 2, "error": "late failure"}),
+        tool_name="terminal",
+    )
+    _message(db, sid, "assistant", "The final command failed.")
+
+    row = _only(module)
+
+    assert "tool:terminal:exit_code=2" in row["fail_hits"]
+
+
+def test_ended_session_with_only_pre_tool_assistant_text_has_no_final_response(audit_env):
+    module, db, _ = audit_env
+    sid = "preamble-only"
+    _session(db, sid)
+    _message(db, sid, "user", "Inspect the files")
+    _message(db, sid, "assistant", "I am checking now.")
+    _message(db, sid, "tool", json.dumps({"items": []}), tool_name="search_files")
+
+    row = _only(module)
+
+    assert "session:missing_final_response" in row["fail_hits"]
+
+
+def test_new_user_turn_requires_a_new_terminal_assistant_response(audit_env):
+    module, db, _ = audit_env
+    sid = "unanswered-followup"
+    _session(db, sid)
+    _message(db, sid, "user", "First turn", timestamp=100)
+    _message(db, sid, "assistant", "First answer", timestamp=101)
+    _message(db, sid, "user", "Second turn", timestamp=102)
+
+    row = _only(module)
+
+    assert "session:missing_final_response" in row["fail_hits"]
+
+
+def test_scan_does_not_truncate_failures_after_thirty_sessions(audit_env):
+    module, db, _ = audit_env
+    for index in range(45):
+        sid = f"session-{index:02d}"
+        _session(db, sid)
+        _message(db, sid, "user", "Do the work")
+        if index != 44:
+            _message(db, sid, "assistant", "Done.")
+
+    rows = module.scan_sessions("qa", since=90)
+
+    assert len(rows) == 45
+    assert next(row for row in rows if row["id"] == "session-44")["failed"] is True
+
+
+def test_ended_session_without_terminal_assistant_response_is_a_failure(audit_env):
+    module, db, _ = audit_env
+    sid = "missing-final"
+    _session(db, sid)
+    _message(db, sid, "user", "Output JSON only")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "session:missing_final_response" in row["fail_hits"]
+
+
+def test_explicit_needs_input_block_event_is_a_failure(audit_env):
+    module, db, _ = audit_env
+    sid = "needs-input"
+    _session(db, sid, source="kanban")
+    _message(db, sid, "user", "Work kanban task t_fixture")
+    _message(
+        db,
+        sid,
+        "assistant",
+        tool_calls=[{
+            "id": "call-1",
+            "type": "function",
+            "function": {
+                "name": "kanban_block",
+                "arguments": json.dumps({"kind": "needs_input", "reason": "Choose a format"}),
+            },
+        }],
+    )
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"ok": True, "status": "blocked", "block_kind": "needs_input"}),
+        tool_name="kanban_block",
+    )
+    _message(db, sid, "assistant", "Blocked pending the required decision.")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "lifecycle:needs_input" in row["fail_hits"]
+
+
+def test_timed_out_clarification_is_a_needs_input_failure(audit_env):
+    module, db, _ = audit_env
+    sid = "clarify-timeout"
+    _session(db, sid)
+    _message(db, sid, "user", "Finish autonomously")
+    _message(
+        db,
+        sid,
+        "tool",
+        json.dumps({"responses": [], "timed_out": True}),
+        tool_name="clarify",
+    )
+    _message(db, sid, "assistant", "I could not continue without an answer.")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "lifecycle:needs_input" in row["fail_hits"]
+
+
+def test_compression_boundary_without_final_text_is_not_missing_response(audit_env):
+    module, db, _ = audit_env
+    sid = "compressed-parent"
+    _session(db, sid, end_reason="compression")
+    _message(db, sid, "user", "Continue the task")
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert row["fail_hits"] == []
+
+
+@pytest.mark.parametrize("end_reason", ["timeout", "exception", "cron_incomplete_no_output"])
+def test_crash_and_timeout_end_reasons_are_failures(audit_env, end_reason: str):
+    module, db, _ = audit_env
+    sid = f"ended-{end_reason}"
+    _session(db, sid, end_reason=end_reason)
+    _message(db, sid, "user", "Do the work")
+    _message(db, sid, "assistant", "Partial progress")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert f"session:end_reason={end_reason}" in row["fail_hits"]
+
+
+def _kanban_db(
+    path: Path,
+    *,
+    task_status: str,
+    run_status: str,
+    outcome: str,
+    error: str | None,
+    older_run: tuple[str, str, str | None] | None = None,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY,
+            status TEXT,
+            current_run_id INTEGER,
+            session_id TEXT,
+            block_kind TEXT
+        );
+        CREATE TABLE task_runs (
+            id INTEGER PRIMARY KEY,
+            task_id TEXT,
+            status TEXT,
+            outcome TEXT,
+            error TEXT,
+            started_at INTEGER,
+            ended_at INTEGER
+        );
+        """
+    )
+    con.execute(
+        "INSERT INTO tasks VALUES ('t_fixture', ?, 7, 'durable-kanban', NULL)",
+        (task_status,),
+    )
+    if older_run is not None:
+        con.execute(
+            "INSERT INTO task_runs VALUES (6, 't_fixture', ?, ?, ?, 100, 110)",
+            older_run,
+        )
+        run_started, run_ended = 200, 210
+    else:
+        run_started, run_ended = 100, 110
+    con.execute(
+        "INSERT INTO task_runs VALUES (7, 't_fixture', ?, ?, ?, ?, ?)",
+        (run_status, outcome, error, run_started, run_ended),
+    )
+    con.commit()
+    con.close()
+
+
+def test_failed_durable_kanban_lifecycle_overrides_plausible_final_text(audit_env):
+    module, db, home = audit_env
+    _session(db, "durable-kanban", source="kanban")
+    _message(db, "durable-kanban", "user", "Work kanban task t_fixture")
+    _message(db, "durable-kanban", "assistant", "Done. All checks passed.")
+    _kanban_db(
+        home / ".hermes" / "kanban.db",
+        task_status="ready",
+        run_status="completed",
+        outcome="failed",
+        error="worker crashed",
+    )
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "kanban:outcome=failed" in row["fail_hits"]
+
+
+def test_successful_durable_kanban_lifecycle_ignores_lexical_noise(audit_env):
+    module, db, home = audit_env
+    _session(db, "durable-kanban", source="kanban")
+    _message(db, "durable-kanban", "user", "Investigate failed jobs")
+    _message(
+        db,
+        "durable-kanban",
+        "tool",
+        json.dumps({"output": "found failed labels", "exit_code": 0, "error": None}),
+        tool_name="terminal",
+    )
+    _message(db, "durable-kanban", "assistant", "Done.")
+    _kanban_db(
+        home / ".hermes" / "kanban.db",
+        task_status="done",
+        run_status="completed",
+        outcome="success",
+        error=None,
+    )
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert row["fail_hits"] == []
+
+
+def test_kanban_retry_does_not_hide_failure_for_a_prior_session(audit_env):
+    module, db, home = audit_env
+    _session(db, "durable-kanban", source="kanban")
+    _message(db, "durable-kanban", "user", "Work kanban task t_fixture")
+    _message(db, "durable-kanban", "assistant", "Stopping this attempt.")
+    _kanban_db(
+        home / ".hermes" / "kanban.db",
+        task_status="done",
+        run_status="completed",
+        outcome="completed",
+        error=None,
+        older_run=("completed", "failed", "first attempt crashed"),
+    )
+
+    row = _only(module)
+
+    assert "kanban:outcome=failed" in row["fail_hits"]
+
+
+def test_multiple_task_ids_correlate_to_the_run_nearest_session_start(audit_env):
+    module, db, home = audit_env
+    _session(db, "durable-kanban", source="kanban")
+    _message(db, "durable-kanban", "user", "Work t_other while reporting t_fixture")
+    _message(db, "durable-kanban", "assistant", "Stopped.")
+    path = home / ".hermes" / "kanban.db"
+    _kanban_db(
+        path,
+        task_status="done",
+        run_status="completed",
+        outcome="failed",
+        error="matched failure",
+    )
+    con = sqlite3.connect(path)
+    con.execute("INSERT INTO tasks VALUES ('t_other', 'done', 8, NULL, NULL)")
+    con.execute(
+        "INSERT INTO task_runs VALUES (8, 't_other', 'completed', 'completed', NULL, 200, 210)"
+    )
+    con.commit()
+    con.close()
+
+    row = _only(module)
+
+    assert "kanban:outcome=failed" in row["fail_hits"]
+
+
+def _cron_db(
+    path: Path,
+    *,
+    status: str,
+    error: str | None,
+    finished_at: str | None = "1970-01-01T00:01:50+00:00",
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    con = sqlite3.connect(path)
+    con.execute(
+        """CREATE TABLE executions (
+               id TEXT, job_id TEXT, status TEXT, error TEXT,
+               started_at TEXT, finished_at TEXT
+           )"""
+    )
+    con.execute(
+        "INSERT INTO executions VALUES ('exec-1', 'job123', ?, ?, '1970-01-01T00:01:40+00:00', ?)",
+        (status, error, finished_at),
+    )
+    con.commit()
+    con.close()
+
+
+def test_failed_durable_cron_execution_is_a_failure(audit_env):
+    module, db, home = audit_env
+    sid = "cron_job123_19700101_000140"
+    _session(db, sid, source="cron", title="fixture-job", end_reason="cron_complete")
+    _message(db, sid, "user", "Run scheduled work")
+    _message(db, sid, "assistant", "Done.")
+    _cron_db(home / ".hermes" / "cron" / "executions.db", status="failed", error="process crashed")
+
+    row = _only(module)
+
+    assert row["failed"] is True
+    assert "cron:status=failed" in row["fail_hits"]
+
+
+def test_running_cron_execution_is_not_reported_as_failed(audit_env):
+    module, db, home = audit_env
+    sid = "cron_job123_19700101_000140"
+    _session(db, sid, source="cron", title="fixture-job", end_reason=None, ended_at=None)
+    _message(db, sid, "user", "Run scheduled work")
+    _cron_db(
+        home / ".hermes" / "cron" / "executions.db",
+        status="running",
+        error=None,
+        finished_at=None,
+    )
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert module.cron_failures(since=90) == []
+
+
+def test_cron_failure_scan_does_not_drop_older_failure_after_eighty_runs(audit_env):
+    module, _, home = audit_env
+    path = home / ".hermes" / "cron" / "executions.db"
+    _cron_db(path, status="failed", error="old failure")
+    con = sqlite3.connect(path)
+    for index in range(1, 85):
+        total_seconds = 40 + index
+        timestamp = f"1970-01-01T00:{total_seconds // 60:02d}:{total_seconds % 60:02d}+00:00"
+        con.execute(
+            "INSERT INTO executions VALUES (?, 'job123', 'completed', NULL, ?, ?)",
+            (f"exec-{index + 1}", timestamp, timestamp),
+        )
+    con.commit()
+    con.close()
+
+    failures = module.cron_failures(since=90)
+
+    assert [failure["execution_id"] for failure in failures] == ["exec-1"]
+
+
+def test_kanban_failure_scan_does_not_drop_older_failure_after_forty_runs(audit_env):
+    module, _, home = audit_env
+    path = home / ".hermes" / "kanban.db"
+    con = sqlite3.connect(path)
+    con.executescript(
+        """
+        CREATE TABLE tasks (
+            id TEXT PRIMARY KEY, title TEXT, assignee TEXT, status TEXT,
+            consecutive_failures INTEGER, last_failure_error TEXT,
+            block_kind TEXT
+        );
+        CREATE TABLE task_runs (
+            id INTEGER PRIMARY KEY, task_id TEXT, profile TEXT, status TEXT,
+            outcome TEXT, error TEXT, summary TEXT,
+            started_at INTEGER, ended_at INTEGER
+        );
+        """
+    )
+    for index in range(45):
+        task_id = f"t_{index:02d}"
+        con.execute(
+            "INSERT INTO tasks VALUES (?, ?, 'qa', 'done', 0, NULL, NULL)",
+            (task_id, f"task {index}"),
+        )
+        outcome = "failed" if index == 0 else "completed"
+        error = "old failure" if index == 0 else None
+        con.execute(
+            "INSERT INTO task_runs VALUES (?, ?, 'qa', 'done', ?, ?, '', ?, ?)",
+            (index + 1, task_id, outcome, error, 100 + index, 100 + index),
+        )
+    con.commit()
+    con.close()
+
+    failures = module.kanban_failures(since=90)
+
+    assert [failure["run_id"] for failure in failures] == [1]

--- a/tests/scripts/test_rsi_audit.py
+++ b/tests/scripts/test_rsi_audit.py
@@ -102,6 +102,7 @@ def audit_env(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr(module, "HOME", home)
     monkeypatch.setattr(module, "KANBAN", home / ".hermes" / "kanban.db")
     monkeypatch.setattr(module, "EXEC_DB", home / ".hermes" / "cron" / "executions.db")
+    monkeypatch.setattr(module, "PROFILES_DIR", home / ".hermes" / "profiles")
     return module, state, home
 
 
@@ -439,6 +440,39 @@ def test_kanban_retry_does_not_hide_failure_for_a_prior_session(audit_env):
     assert "kanban:outcome=failed" in row["fail_hits"]
 
 
+def test_legacy_default_kanban_session_belongs_only_to_task_profile(audit_env):
+    module, _, home = audit_env
+    default_db = home / ".hermes" / "state.db"
+    _state_db(default_db)
+    _session(default_db, "durable-kanban", source="kanban", title="task t_fixture")
+    con = sqlite3.connect(default_db)
+    con.execute("UPDATE sessions SET profile_name = NULL")
+    con.commit()
+    con.close()
+    _message(default_db, "durable-kanban", "user", "Work kanban task t_fixture")
+    _message(default_db, "durable-kanban", "assistant", "Done.")
+
+    board = home / ".hermes" / "kanban.db"
+    _kanban_db(
+        board,
+        task_status="done",
+        run_status="completed",
+        outcome="completed",
+        error=None,
+    )
+    con = sqlite3.connect(board)
+    con.execute("ALTER TABLE task_runs ADD COLUMN profile TEXT DEFAULT 'qa'")
+    con.execute("ALTER TABLE tasks ADD COLUMN assignee TEXT DEFAULT 'qa'")
+    con.commit()
+    con.close()
+
+    default_sessions = module.scan_sessions("default", since=90)
+    qa_sessions = module.scan_sessions("qa", since=90)
+
+    assert default_sessions == []
+    assert [session["id"] for session in qa_sessions] == ["durable-kanban"]
+
+
 def test_multiple_task_ids_correlate_to_the_run_nearest_session_start(audit_env):
     module, db, home = audit_env
     _session(db, "durable-kanban", source="kanban")
@@ -520,6 +554,23 @@ def test_running_cron_execution_is_not_reported_as_failed(audit_env):
     assert module.cron_failures(since=90) == []
 
 
+def test_profile_local_cron_success_is_durable_evidence(audit_env):
+    module, db, home = audit_env
+    sid = "cron_job123_19700101_000140"
+    _session(db, sid, source="cron", title="qa-local-job")
+    _message(db, sid, "user", "Run scheduled work")
+    _cron_db(
+        home / ".hermes" / "profiles" / "qa" / "cron" / "executions.db",
+        status="completed",
+        error=None,
+    )
+
+    row = _only(module)
+
+    assert row["failed"] is False
+    assert row["fail_hits"] == []
+
+
 def test_cron_failure_scan_does_not_drop_older_failure_after_eighty_runs(audit_env):
     module, _, home = audit_env
     path = home / ".hermes" / "cron" / "executions.db"
@@ -538,6 +589,62 @@ def test_cron_failure_scan_does_not_drop_older_failure_after_eighty_runs(audit_e
     failures = module.cron_failures(since=90)
 
     assert [failure["execution_id"] for failure in failures] == ["exec-1"]
+
+
+def test_cron_failure_scan_includes_profile_local_execution_ledgers(audit_env, monkeypatch):
+    module, _, home = audit_env
+    profiles = home / ".hermes" / "profiles"
+    profile_home = profiles / "qa"
+    _cron_db(
+        profile_home / "cron" / "executions.db",
+        status="failed",
+        error="profile-local failure",
+    )
+    (profile_home / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "job123", "name": "qa-local-job"}]}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(module, "PROFILES_DIR", profiles)
+
+    failures = module.cron_failures(since=90)
+
+    assert [(failure["name"], failure["profile"]) for failure in failures] == [
+        ("qa-local-job", "qa")
+    ]
+
+
+def test_cron_failure_scan_skips_uninitialized_profile_ledger(audit_env):
+    module, _, home = audit_env
+    path = home / ".hermes" / "profiles" / "qa" / "cron" / "executions.db"
+    path.parent.mkdir(parents=True)
+    sqlite3.connect(path).close()
+
+    assert module.cron_failures(since=90) == []
+
+
+def test_crashed_kanban_run_without_error_is_a_failure(audit_env):
+    module, _, home = audit_env
+    path = home / ".hermes" / "kanban.db"
+    _kanban_db(
+        path,
+        task_status="ready",
+        run_status="crashed",
+        outcome="crashed",
+        error=None,
+    )
+    con = sqlite3.connect(path)
+    con.execute("ALTER TABLE task_runs ADD COLUMN profile TEXT DEFAULT 'qa'")
+    con.execute("ALTER TABLE task_runs ADD COLUMN summary TEXT")
+    con.execute("ALTER TABLE tasks ADD COLUMN title TEXT DEFAULT 'fixture'")
+    con.execute("ALTER TABLE tasks ADD COLUMN assignee TEXT DEFAULT 'qa'")
+    con.execute("ALTER TABLE tasks ADD COLUMN consecutive_failures INTEGER DEFAULT 0")
+    con.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
+    con.commit()
+    con.close()
+
+    failures = module.kanban_failures(since=90)
+
+    assert [failure["run_id"] for failure in failures] == [7]
 
 
 def test_kanban_failure_scan_does_not_drop_older_failure_after_forty_runs(audit_env):

--- a/tests/scripts/test_rsi_interview_scaffold.py
+++ b/tests/scripts/test_rsi_interview_scaffold.py
@@ -1,0 +1,450 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+
+SCRIPT = Path(__file__).parents[2] / "scripts" / "rsi_interview.py"
+FULL_ROSTER = [
+    "default",
+    "buggy",
+    "coder",
+    "jade",
+    "jade-ops",
+    "product",
+    "qa",
+    "research",
+    "reviewer",
+    "rsi",
+    "x",
+    "yuki",
+    "yuki-ops",
+]
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("rsi_interview", SCRIPT)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def mod():
+    return _load_module()
+
+
+def _empty_report(profile: str) -> dict:
+    return {
+        "profile": profile,
+        "autonomous_failures": [],
+        "incomplete_tasks": [],
+        "incidents": [],
+        "correction_feedback": [],
+        "accounted_session_ids": [],
+    }
+
+
+def _audit(profile: str = "coder") -> dict:
+    return {
+        "profiles": {
+            profile: {
+                "sessions": [],
+                "session_failures": [
+                    {
+                        "id": "session-failed",
+                        "source": "kanban",
+                        "title": "failed run",
+                        "end_reason": "agent_close",
+                        "fail_hits": ["tool:terminal:exit_code=1"],
+                    },
+                    {
+                        "id": "session-needs-input",
+                        "source": "kanban",
+                        "title": "blocked run",
+                        "end_reason": "cli_close",
+                        "fail_hits": ["lifecycle:needs_input"],
+                    },
+                ],
+                "cron_failures": [
+                    {
+                        "execution_id": "cron-failed",
+                        "name": "eng-completion",
+                        "status": "failed",
+                        "error": "HTTP 429",
+                    }
+                ],
+                "kanban_failures": [
+                    {
+                        "task_id": "t_failed",
+                        "title": "failed task",
+                        "status": "blocked",
+                        "outcome": "needs_input",
+                    }
+                ],
+            }
+        }
+    }
+
+
+def _enrichment(profile: str = "coder") -> dict:
+    report = _empty_report(profile)
+    report["autonomous_failures"] = [
+        {
+            "id": item,
+            "summary": f"Summary for {item}",
+            "evidence": f"Evidence for {item}",
+            "suggested_fix": f"Fix for {item}",
+        }
+        for item in ("session-failed", "session-needs-input", "cron-failed")
+    ]
+    report["incomplete_tasks"] = [
+        {
+            "id": item,
+            "title": f"Title for {item}",
+            "summary": f"Summary for {item}",
+            "why_incomplete": f"Reason for {item}",
+        }
+        for item in ("session-needs-input", "t_failed")
+    ]
+    report["accounted_session_ids"] = [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+        "t_failed",
+    ]
+    return report
+
+
+def test_scaffold_mechanically_covers_coder_and_reviewer_recurrent_omissions(mod):
+    audit = {
+        "profiles": {
+            profile: {
+                "session_failures": [
+                    {
+                        "id": f"{profile}-failed-id",
+                        "fail_hits": ["tool:terminal:exit_code=1"],
+                    }
+                ],
+                "cron_failures": [],
+                "kanban_failures": [],
+            }
+            for profile in ("coder", "reviewer")
+        }
+    }
+
+    for profile in ("coder", "reviewer"):
+        scaffold = mod.build_scaffold(profile, audit)
+        expected = f"{profile}-failed-id"
+        assert [row["id"] for row in scaffold["autonomous_failures"]] == [expected]
+        assert scaffold["accounted_session_ids"] == [expected]
+
+
+def test_needs_input_session_is_required_in_both_categories(mod):
+    scaffold = mod.build_scaffold("coder", _audit())
+
+    assert [row["id"] for row in scaffold["autonomous_failures"]] == [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+    ]
+    assert [row["id"] for row in scaffold["incomplete_tasks"]] == [
+        "session-needs-input",
+        "t_failed",
+    ]
+
+
+@pytest.mark.parametrize(
+    "bad_record",
+    [
+        {
+            "id": "session-failed-typo",
+            "summary": "mistyped",
+            "evidence": "mistyped",
+            "suggested_fix": "retry",
+        },
+        {
+            "id": "grouped-failures",
+            "summary": "session-failed and session-needs-input",
+            "evidence": "two grouped failures",
+            "suggested_fix": "retry",
+        },
+    ],
+)
+def test_mistyped_or_grouped_model_records_cannot_replace_scaffold_rows(mod, bad_record):
+    model_report = _empty_report("coder")
+    model_report["autonomous_failures"] = [bad_record]
+
+    result = mod.merge_interview("coder", model_report, _audit())
+
+    assert [row["id"] for row in result.report["autonomous_failures"][:3]] == [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+    ]
+    assert "session-failed" in result.missing_qualitative_ids
+
+
+def test_audited_id_in_wrong_model_category_is_not_preserved_there(mod):
+    model_report = _enrichment()
+    model_report["incomplete_tasks"].append(
+        {
+            "id": "cron-failed",
+            "title": "misclassified cron",
+            "summary": "wrong category",
+            "why_incomplete": "wrong category",
+        }
+    )
+
+    result = mod.merge_interview("coder", model_report, _audit())
+
+    assert "cron-failed" not in {row["id"] for row in result.report["incomplete_tasks"]}
+    assert "cron-failed" in {row["id"] for row in result.report["autonomous_failures"]}
+
+
+def test_model_deleted_entries_are_restored_from_scaffold(mod):
+    model_report = _enrichment()
+    model_report["autonomous_failures"] = []
+    model_report["incomplete_tasks"] = []
+    model_report["accounted_session_ids"] = []
+
+    result = mod.merge_interview("coder", model_report, _audit())
+
+    assert {row["id"] for row in result.report["autonomous_failures"]} >= {
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+    }
+    assert {row["id"] for row in result.report["incomplete_tasks"]} >= {
+        "session-needs-input",
+        "t_failed",
+    }
+    assert result.report["accounted_session_ids"] == [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+        "t_failed",
+    ]
+
+
+def test_duplicate_ids_merge_once_when_enrichment_is_compatible(mod):
+    model_report = _enrichment()
+    model_report["autonomous_failures"] = [
+        {
+            "id": "session-failed",
+            "summary": "one summary",
+            "evidence": "one evidence",
+            "suggested_fix": "one fix",
+        },
+        {
+            "id": "session-failed",
+            "summary": "one summary",
+            "evidence": "one evidence",
+            "suggested_fix": "one fix",
+        },
+        *model_report["autonomous_failures"][1:],
+    ]
+
+    result = mod.merge_interview("coder", model_report, _audit())
+
+    assert [row["id"] for row in result.report["autonomous_failures"]].count("session-failed") == 1
+    assert result.conflicts == []
+
+
+def test_conflicting_duplicate_enrichment_is_reported_for_grill(mod):
+    model_report = _enrichment()
+    model_report["autonomous_failures"].insert(
+        1,
+        {
+            "id": "session-failed",
+            "summary": "contradictory summary",
+            "evidence": "Evidence for session-failed",
+            "suggested_fix": "Fix for session-failed",
+        },
+    )
+
+    result = mod.merge_interview("coder", model_report, _audit())
+
+    assert result.conflicts == ["autonomous_failures id=session-failed has conflicting summary values"]
+
+
+def test_valid_enrichment_preserves_model_qualitative_fields(mod):
+    result = mod.merge_interview("coder", _enrichment(), _audit())
+
+    assert result.conflicts == []
+    assert result.missing_qualitative_ids == []
+    row = next(row for row in result.report["autonomous_failures"] if row["id"] == "session-failed")
+    assert row["summary"] == "Summary for session-failed"
+    assert row["suggested_fix"] == "Fix for session-failed"
+
+
+def test_empty_audit_slice_leaves_clean_empty_report_unchanged(mod):
+    audit = {
+        "profiles": {
+            "qa": {
+                "sessions": [],
+                "session_failures": [],
+                "cron_failures": [],
+                "kanban_failures": [],
+            }
+        }
+    }
+
+    result = mod.merge_interview("qa", _empty_report("qa"), audit)
+
+    assert result.report == _empty_report("qa")
+    assert result.conflicts == []
+    assert result.missing_qualitative_ids == []
+
+
+@pytest.mark.parametrize("unavailable", [None, "HTTP 429: limit exhausted", {"error": "unavailable"}])
+def test_unavailable_interview_still_emits_complete_accounting_scaffold(mod, unavailable):
+    result = mod.merge_interview("coder", unavailable, _audit())
+
+    assert result.report["accounted_session_ids"] == [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+        "t_failed",
+    ]
+    assert set(result.missing_qualitative_ids) == {
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+        "t_failed",
+    }
+
+
+def test_builder_embeds_machine_readable_scaffold_before_interview(tmp_path, mod):
+    import json
+    import os
+    import subprocess
+
+    home = tmp_path / "home"
+    store = home / ".hermes" / "rsi"
+    (store / "audit").mkdir(parents=True)
+    (store / "interview-prompt.txt").write_text("BASE\n", encoding="utf-8")
+    (store / "audit" / "latest.json").write_text(json.dumps(_audit()), encoding="utf-8")
+    builder = Path(__file__).parents[2] / "scripts" / "rsi-build-interview.py"
+
+    run = subprocess.run(
+        ["python3", str(builder), "coder"],
+        text=True,
+        capture_output=True,
+        check=False,
+        env={**os.environ, "HOME": str(home)},
+    )
+
+    assert run.returncode == 0, run.stderr
+    assert '"autonomous_failures":[{"id":"<exact audited id>"' in run.stdout
+    marker = "MANDATORY_REPORT_SCAFFOLD (runner-owned; enrich but do not alter IDs/categories):\n"
+    assert marker in run.stdout
+    scaffold = json.loads(run.stdout.split(marker, 1)[1])
+    assert scaffold == mod.build_scaffold("coder", _audit())
+
+
+def test_merge_cli_writes_scaffolded_report_and_grills_only_missing_quality(tmp_path):
+    import json
+    import subprocess
+
+    runner = Path(__file__).parents[2] / "scripts" / "rsi-merge-interview.py"
+    audit_path = tmp_path / "audit.json"
+    raw_path = tmp_path / "raw.json"
+    output_path = tmp_path / "merged.json"
+    grill_path = tmp_path / "grill.txt"
+    grill_base = tmp_path / "grill-base.txt"
+    audit_path.write_text(json.dumps(_audit()), encoding="utf-8")
+    raw_path.write_text(json.dumps(_empty_report("coder")), encoding="utf-8")
+    grill_base.write_text("GRILL", encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            "python3",
+            str(runner),
+            "coder",
+            str(raw_path),
+            str(output_path),
+            "--audit",
+            str(audit_path),
+            "--grill-prompt",
+            str(grill_base),
+            "--grill-output",
+            str(grill_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert run.returncode == 1
+    merged = json.loads(output_path.read_text(encoding="utf-8"))
+    assert merged["accounted_session_ids"] == [
+        "session-failed",
+        "session-needs-input",
+        "cron-failed",
+        "t_failed",
+    ]
+    payload = json.loads(run.stdout)
+    assert not any("missing exact audited IDs" in error for error in payload["errors"])
+    assert any("missing qualitative fields" in error for error in payload["errors"])
+    assert grill_path.read_text(encoding="utf-8").startswith("GRILL")
+
+
+def test_merge_cli_accepts_valid_enrichment_without_grill(tmp_path):
+    import json
+    import subprocess
+
+    runner = Path(__file__).parents[2] / "scripts" / "rsi-merge-interview.py"
+    audit_path = tmp_path / "audit.json"
+    raw_path = tmp_path / "raw.json"
+    output_path = tmp_path / "merged.json"
+    grill_path = tmp_path / "grill.txt"
+    audit_path.write_text(json.dumps(_audit()), encoding="utf-8")
+    raw_path.write_text(json.dumps(_enrichment()), encoding="utf-8")
+
+    run = subprocess.run(
+        [
+            "python3",
+            str(runner),
+            "coder",
+            str(raw_path),
+            str(output_path),
+            "--audit",
+            str(audit_path),
+            "--grill-output",
+            str(grill_path),
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert run.returncode == 0, run.stdout + run.stderr
+    assert not grill_path.exists()
+    assert json.loads(run.stdout)["valid"] is True
+
+
+def test_thirteen_profile_fixture_matrix_is_complete_and_isolated(mod):
+    audit = {
+        "profiles": {
+            profile: {
+                "sessions": [],
+                "session_failures": [
+                    {"id": f"{profile}-session", "fail_hits": ["tool:terminal:exit_code=1"]}
+                ],
+                "cron_failures": [],
+                "kanban_failures": [],
+            }
+            for profile in FULL_ROSTER
+        }
+    }
+
+    for profile in FULL_ROSTER:
+        result = mod.merge_interview(profile, _empty_report(profile), audit)
+        assert result.report["accounted_session_ids"] == [f"{profile}-session"]
+        assert [row["id"] for row in result.report["autonomous_failures"]] == [
+            f"{profile}-session"
+        ]

--- a/tests/scripts/test_rsi_validate_interview.py
+++ b/tests/scripts/test_rsi_validate_interview.py
@@ -1,0 +1,384 @@
+#!/usr/bin/env python3
+"""Regression tests for deterministic RSI interview reconciliation."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "rsi-validate-interview.py"
+BUILDER = Path(__file__).resolve().parents[2] / "scripts" / "rsi-build-interview.py"
+# The full required installed roster: default + every installed profile dir.
+FULL_ROSTER = [
+    "default", "buggy", "coder", "jade", "jade-ops", "product", "qa",
+    "research", "reviewer", "rsi", "x", "yuki", "yuki-ops",
+]
+PRODUCT_IDS = [
+    "65333767b7964fc3986351e2a0ba2c02",
+    "d8f9a32809414530803297153c6ee3e4",
+    "50ca24c42feb4cfdb6a3deeabfc22a47",
+    "5359e5e602ba48cfb3b6604816122246",
+    "e157b0fb99a1440eb279be22f7ab5cac",
+    "0485af1762214200bf69c69bd1afcbab",
+]
+CODER_IDS = [
+    "20260902_180438_d8c6cd",
+    "20260902_175149_c1fce9",
+    "20260902_174221_00e278",
+    "20260902_173236_2f74c7",
+    "20260902_171518_7dc0f9",
+    "20260902_162325_d3131c",
+    "20260902_155533_7e6f23",
+    "20260902_151527_ccdc42",
+]
+
+
+def _audit() -> dict:
+    return {
+        "profiles": {
+            "product": {
+                "session_failures": [],
+                "cron_failures": [
+                    {
+                        "execution_id": execution_id,
+                        "name": "eng-completion",
+                        "status": "failed",
+                    }
+                    for execution_id in PRODUCT_IDS
+                ],
+                "kanban_failures": [],
+            },
+            "coder": {
+                "session_failures": [
+                    {
+                        "id": session_id,
+                        "failed": True,
+                        "claimed_ok": True,
+                        "fail_hits": ["lifecycle:needs_input"],
+                    }
+                    for session_id in CODER_IDS
+                ],
+                "cron_failures": [],
+                "kanban_failures": [],
+            },
+        }
+    }
+
+
+def _report(profile: str, ids: list[str], detail_field: str) -> dict:
+    report = {
+        "profile": profile,
+        "autonomous_failures": [],
+        "incomplete_tasks": [],
+        "incidents": [],
+        "correction_feedback": [],
+        "accounted_session_ids": list(ids),
+    }
+    report[detail_field] = [
+        ({"summary": f"failed execution {item}", "evidence": item, "suggested_fix": "retry"}
+         if detail_field == "autonomous_failures"
+         else {"id": item, "title": "audited task", "summary": item, "why_incomplete": "needs_input"})
+        for item in ids
+    ]
+    return report
+
+
+class InterviewValidationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        spec = importlib.util.spec_from_file_location("rsi_validate_interview", SCRIPT)
+        assert spec is not None and spec.loader is not None
+        cls.mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.mod)
+
+    def test_product_grouped_label_does_not_replace_six_execution_ids(self):
+        report = _report("product", [], "autonomous_failures")
+        report["autonomous_failures"] = [{
+            "summary": "eng-completion failed six times",
+            "evidence": "grouped under eng-completion",
+            "suggested_fix": "retry",
+        }]
+        report["accounted_session_ids"] = ["eng-completion"]
+
+        result = self.mod.validate_interview("product", report, _audit())
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_accounted_ids"], PRODUCT_IDS)
+        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], PRODUCT_IDS)
+
+    def test_coder_claimed_ok_does_not_exempt_eight_needs_input_ids(self):
+        report = _report("coder", [], "incomplete_tasks")
+
+        result = self.mod.validate_interview("coder", report, _audit())
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_accounted_ids"], CODER_IDS)
+        self.assertEqual(result["missing_detail_ids"]["incomplete_tasks"], CODER_IDS)
+
+    def test_incomplete_task_requires_exact_id_field(self):
+        required_id = CODER_IDS[0]
+        audit = _audit()
+        audit["profiles"]["coder"]["session_failures"] = [
+            audit["profiles"]["coder"]["session_failures"][0]
+        ]
+        report = _report("coder", [required_id], "incomplete_tasks")
+        report["incomplete_tasks"] = [{
+            "id": "wrong-id",
+            "title": "unrelated task",
+            "summary": required_id,
+            "why_incomplete": f"see {required_id}-extra",
+        }]
+
+        result = self.mod.validate_interview("coder", report, audit)
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_detail_ids"]["incomplete_tasks"], [required_id])
+
+    def test_autonomous_failure_rejects_prefixed_and_suffixed_ids(self):
+        """A near-match in every documented field still counts as missing."""
+        required_id = PRODUCT_IDS[0]
+        audit = _audit()
+        audit["profiles"]["product"]["cron_failures"] = [
+            audit["profiles"]["product"]["cron_failures"][0]
+        ]
+        for near_miss in (f"prefix-{required_id}", f"{required_id}-extra"):
+            with self.subTest(near_miss=near_miss):
+                report = _report("product", [required_id], "autonomous_failures")
+                report["autonomous_failures"] = [{
+                    "summary": f"eng-completion execution {near_miss} stopped",
+                    "evidence": near_miss,
+                    "suggested_fix": "retry",
+                }]
+
+                result = self.mod.validate_interview("product", report, audit)
+
+                self.assertFalse(result["valid"])
+                self.assertEqual(
+                    result["missing_detail_ids"]["autonomous_failures"],
+                    [required_id],
+                )
+
+    def test_autonomous_failure_near_match_in_one_field_does_not_undo_exact_id_in_another(self):
+        """A standalone exact ID in summary satisfies the record even when
+        evidence carries only a near-match; the citation exists."""
+        required_id = PRODUCT_IDS[0]
+        audit = _audit()
+        audit["profiles"]["product"]["cron_failures"] = [
+            audit["profiles"]["product"]["cron_failures"][0]
+        ]
+        report = _report("product", [required_id], "autonomous_failures")
+        report["autonomous_failures"] = [{
+            "summary": f"eng-completion execution {required_id} stopped",
+            "evidence": f"{required_id}-extra context",
+            "suggested_fix": "retry",
+        }]
+
+        result = self.mod.validate_interview("product", report, audit)
+
+        self.assertTrue(result["valid"], result["errors"])
+
+    def test_autonomous_failure_accepts_exact_id_in_summary_field(self):
+        """2026-09-03 tick: product/reviewer exact IDs in `summary` were rejected."""
+        required_id = PRODUCT_IDS[0]
+        audit = _audit()
+        audit["profiles"]["product"]["cron_failures"] = [
+            audit["profiles"]["product"]["cron_failures"][0]
+        ]
+        report = _report("product", [required_id], "autonomous_failures")
+        report["autonomous_failures"] = [{
+            "summary": f"eng-completion execution {required_id} stopped autonomously",
+            "evidence": "cron runner reported failure",
+            "suggested_fix": "retry",
+        }]
+
+        result = self.mod.validate_interview("product", report, audit)
+
+        self.assertTrue(result["valid"], result["errors"])
+        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], [])
+
+    def test_autonomous_failure_rejects_near_match_in_summary(self):
+        required_id = PRODUCT_IDS[0]
+        audit = _audit()
+        audit["profiles"]["product"]["cron_failures"] = [
+            audit["profiles"]["product"]["cron_failures"][0]
+        ]
+        report = _report("product", [required_id], "autonomous_failures")
+        report["autonomous_failures"] = [{
+            "summary": f"eng-completion execution {required_id}-extra stopped",
+            "evidence": "cron runner reported failure",
+            "suggested_fix": "retry",
+        }]
+
+        result = self.mod.validate_interview("product", report, audit)
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], [required_id])
+
+    def test_wrong_id_in_record_never_satisfies_required_id(self):
+        required_id = PRODUCT_IDS[0]
+        audit = _audit()
+        audit["profiles"]["product"]["cron_failures"] = [
+            audit["profiles"]["product"]["cron_failures"][0]
+        ]
+        report = _report("product", [required_id], "autonomous_failures")
+        report["autonomous_failures"] = [{
+            "summary": "some other execution entirely",
+            "evidence": "execution_id=different_run_001",
+            "suggested_fix": "retry",
+        }]
+
+        result = self.mod.validate_interview("product", report, audit)
+
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], [required_id])
+
+    def test_structured_lifecycle_marker_not_lexical_words_selects_incomplete_field(self):
+        session_id = "20260902_190251_66cec0"
+        audit = {
+            "profiles": {
+                "qa": {
+                    "session_failures": [{
+                        "id": session_id,
+                        "title": "user wrote failed and needs_input",
+                        "fail_hits": ["tool:terminal:exit_code=1"],
+                    }],
+                    "cron_failures": [],
+                    "kanban_failures": [],
+                }
+            }
+        }
+        report = _report("qa", [session_id], "autonomous_failures")
+
+        result = self.mod.validate_interview("qa", report, audit)
+
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["missing_detail_ids"]["incomplete_tasks"], [])
+
+    def test_valid_full_product_reconciliation(self):
+        result = self.mod.validate_interview(
+            "product",
+            _report("product", PRODUCT_IDS, "autonomous_failures"),
+            _audit(),
+        )
+        self.assertTrue(result["valid"])
+        self.assertEqual(result["required_ids"], PRODUCT_IDS)
+        self.assertEqual(result["errors"], [])
+
+    def test_valid_full_coder_reconciliation(self):
+        result = self.mod.validate_interview(
+            "coder",
+            _report("coder", CODER_IDS, "incomplete_tasks"),
+            _audit(),
+        )
+        self.assertTrue(result["valid"])
+
+    def test_missing_profile_audit_slice_cannot_be_accepted_clean(self):
+        result = self.mod.validate_interview(
+            "product",
+            _report("product", [], "autonomous_failures"),
+            {"profiles": {}},
+        )
+        self.assertFalse(result["valid"])
+        self.assertIn("audit has no structured profile slice", result["errors"])
+
+    def test_every_roster_profile_with_empty_slice_validates_clean_report(self):
+        """All-installed-profile contract: an empty slice must validate a
+        clean report for every one of the 13 installed profiles."""
+        audit = {
+            "profiles": {
+                name: {"sessions": [], "session_failures": [], "cron_failures": [], "kanban_failures": []}
+                for name in FULL_ROSTER
+            }
+        }
+        for name in FULL_ROSTER:
+            with self.subTest(profile=name):
+                result = self.mod.validate_interview(
+                    name, _report(name, [], "autonomous_failures"), audit
+                )
+                self.assertTrue(result["valid"], result["errors"])
+
+    def test_malformed_json_is_rejected_and_builds_grill_prompt(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            audit = root / "audit.json"
+            report = root / "report.json"
+            grill_base = root / "grill.txt"
+            grill_output = root / "generated-grill.txt"
+            audit.write_text(json.dumps(_audit()), encoding="utf-8")
+            report.write_text('{"profile":"product"', encoding="utf-8")
+            grill_base.write_text("GRILL BASE\n", encoding="utf-8")
+
+            run = subprocess.run(
+                [
+                    "python3", str(SCRIPT), "product", str(report),
+                    "--audit", str(audit),
+                    "--grill-prompt", str(grill_base),
+                    "--grill-output", str(grill_output),
+                ],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(run.returncode, 1)
+            payload = json.loads(run.stdout)
+            self.assertFalse(payload["valid"])
+            self.assertIn("malformed interview JSON", payload["errors"][0])
+            self.assertIn("GRILL BASE", grill_output.read_text(encoding="utf-8"))
+            self.assertIn("malformed interview JSON", grill_output.read_text(encoding="utf-8"))
+
+    def test_build_interview_includes_exact_structured_ids(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            store = home / ".hermes" / "rsi"
+            (store / "audit").mkdir(parents=True)
+            (store / "interview-prompt.txt").write_text("BASE\n", encoding="utf-8")
+            (store / "audit" / "latest.json").write_text(
+                json.dumps(_audit()), encoding="utf-8"
+            )
+            env = dict(os.environ, HOME=str(home))
+
+            run = subprocess.run(
+                ["python3", str(BUILDER), "product"],
+                text=True,
+                capture_output=True,
+                check=False,
+                env=env,
+            )
+
+            self.assertEqual(run.returncode, 0, run.stderr)
+            for execution_id in PRODUCT_IDS:
+                self.assertIn(execution_id, run.stdout)
+
+    def test_validation_is_read_only_without_grill_output(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            audit = root / "audit.json"
+            report = root / "report.json"
+            audit.write_text(json.dumps(_audit(), sort_keys=True), encoding="utf-8")
+            report.write_text(
+                json.dumps(_report("product", PRODUCT_IDS, "autonomous_failures"), sort_keys=True),
+                encoding="utf-8",
+            )
+            before = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in (audit, report)}
+
+            run = subprocess.run(
+                ["python3", str(SCRIPT), "product", str(report), "--audit", str(audit)],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(run.returncode, 0, run.stderr)
+            self.assertTrue(json.loads(run.stdout)["valid"])
+            after = {path: (path.read_bytes(), path.stat().st_mtime_ns) for path in (audit, report)}
+            self.assertEqual(before, after)
+            self.assertEqual(sorted(root.iterdir()), [audit, report])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/scripts/test_rsi_validate_interview.py
+++ b/tests/scripts/test_rsi_validate_interview.py
@@ -79,7 +79,7 @@ def _report(profile: str, ids: list[str], detail_field: str) -> dict:
         "accounted_session_ids": list(ids),
     }
     report[detail_field] = [
-        ({"summary": f"failed execution {item}", "evidence": item, "suggested_fix": "retry"}
+        ({"id": item, "summary": f"failed execution {item}", "evidence": item, "suggested_fix": "retry"}
          if detail_field == "autonomous_failures"
          else {"id": item, "title": "audited task", "summary": item, "why_incomplete": "needs_input"})
         for item in ids
@@ -162,9 +162,7 @@ class InterviewValidationTests(unittest.TestCase):
                     [required_id],
                 )
 
-    def test_autonomous_failure_near_match_in_one_field_does_not_undo_exact_id_in_another(self):
-        """A standalone exact ID in summary satisfies the record even when
-        evidence carries only a near-match; the citation exists."""
+    def test_exact_id_field_wins_even_when_evidence_has_a_near_match(self):
         required_id = PRODUCT_IDS[0]
         audit = _audit()
         audit["profiles"]["product"]["cron_failures"] = [
@@ -172,6 +170,7 @@ class InterviewValidationTests(unittest.TestCase):
         ]
         report = _report("product", [required_id], "autonomous_failures")
         report["autonomous_failures"] = [{
+            "id": required_id,
             "summary": f"eng-completion execution {required_id} stopped",
             "evidence": f"{required_id}-extra context",
             "suggested_fix": "retry",
@@ -181,8 +180,7 @@ class InterviewValidationTests(unittest.TestCase):
 
         self.assertTrue(result["valid"], result["errors"])
 
-    def test_autonomous_failure_accepts_exact_id_in_summary_field(self):
-        """2026-09-03 tick: product/reviewer exact IDs in `summary` were rejected."""
+    def test_summary_id_does_not_substitute_for_documented_exact_id_field(self):
         required_id = PRODUCT_IDS[0]
         audit = _audit()
         audit["profiles"]["product"]["cron_failures"] = [
@@ -197,8 +195,8 @@ class InterviewValidationTests(unittest.TestCase):
 
         result = self.mod.validate_interview("product", report, audit)
 
-        self.assertTrue(result["valid"], result["errors"])
-        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], [])
+        self.assertFalse(result["valid"])
+        self.assertEqual(result["missing_detail_ids"]["autonomous_failures"], [required_id])
 
     def test_autonomous_failure_rejects_near_match_in_summary(self):
         required_id = PRODUCT_IDS[0]
@@ -269,12 +267,14 @@ class InterviewValidationTests(unittest.TestCase):
         self.assertEqual(result["errors"], [])
 
     def test_valid_full_coder_reconciliation(self):
-        result = self.mod.validate_interview(
-            "coder",
-            _report("coder", CODER_IDS, "incomplete_tasks"),
-            _audit(),
-        )
-        self.assertTrue(result["valid"])
+        report = _report("coder", CODER_IDS, "incomplete_tasks")
+        report["autonomous_failures"] = _report(
+            "coder", CODER_IDS, "autonomous_failures"
+        )["autonomous_failures"]
+
+        result = self.mod.validate_interview("coder", report, _audit())
+
+        self.assertTrue(result["valid"], result["errors"])
 
     def test_missing_profile_audit_slice_cannot_be_accepted_clean(self):
         result = self.mod.validate_interview(


### PR DESCRIPTION
## Summary
- derive mandatory RSI interview entries from structured audit evidence for every installed profile
- merge model enrichment into runner-owned IDs/categories without allowing deletion, recategorization, or accounting omissions
- require exact detail IDs, emit follow-up grill diagnostics, and scan profile-local cron plus Kanban lifecycle evidence

## Verification
- `scripts/run_tests.sh tests/scripts/ -q` — 86 passed
- 13-profile live audit and fixture matrix verified
- all 13 representative `/tmp/rsi-interview-*.json` reports passed mandatory ID/category/accounting reconciliation after merge
- Ruff, Python byte compilation, `git diff --check`, and independent security/logic review passed

## Deployment
- deployed the five RSI scripts under `~/.hermes/scripts/` and verified SHA-256 equality and mode 755
- updated the default-profile RSI cron prompt to run the merge stage before validation

This PR is intentionally left unmerged for full review.