### PR TITLE
fix(webhook): deduplicate repeated WhatsApp messages

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -842,13 +842,25 @@ class WebhookAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[webhook] Skill loading failed: %s", e)
 
-        # Build a unique delivery ID
-        delivery_id = request.headers.get(
-            "X-GitHub-Delivery",
-            request.headers.get(
-                "svix-id",
-                request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
-            ),
+        # Build a unique delivery ID. WhatsApp's bridge can emit the same
+        # native message more than once with a different HTTP request ID; its
+        # stable messageId is therefore the only safe idempotency key for this
+        # route. Other providers retain their documented delivery headers.
+        whatsapp_message_id = (
+            payload.get("messageId")
+            if route_name == "whatsapp-inbound" and isinstance(payload, dict)
+            else None
+        )
+        delivery_id = (
+            f"whatsapp:{whatsapp_message_id}"
+            if isinstance(whatsapp_message_id, str) and whatsapp_message_id
+            else request.headers.get(
+                "X-GitHub-Delivery",
+                request.headers.get(
+                    "svix-id",
+                    request.headers.get("X-Request-ID", str(int(time.time() * 1000))),
+                ),
+            )
         )
 
         # ── Idempotency ─────────────────────────────────────────

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -538,6 +538,27 @@ class TestIdempotency:
             data = await resp2.json()
             assert data["status"] == "duplicate"
 
+    @pytest.mark.asyncio
+    async def test_duplicate_whatsapp_message_id_returns_200(self):
+        """WhatsApp retries with different HTTP IDs must run only once."""
+        routes = {"whatsapp-inbound": {"secret": _INSECURE_NO_AUTH, "prompt": "test"}}
+        adapter = _make_adapter(routes=routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        payload = {"messageId": "3EB0F00D", "content": "hello"}
+        async with TestClient(TestServer(app)) as cli:
+            resp1 = await cli.post(
+                "/webhooks/whatsapp-inbound", json=payload, headers={"X-Request-ID": "attempt-1"}
+            )
+            assert resp1.status == 202
+
+            resp2 = await cli.post(
+                "/webhooks/whatsapp-inbound", json=payload, headers={"X-Request-ID": "attempt-2"}
+            )
+            assert resp2.status == 200
+            assert (await resp2.json())["status"] == "duplicate"
+
 
 # ===================================================================
 # Rate limiting


### PR DESCRIPTION
## Problem

A duplicate inbound WhatsApp event was delivered twice to the `whatsapp-inbound` webhook route and processed twice, producing two relay replies to a single user message.

The existing idempotency key falls back to `X-GitHub-Delivery` → `svix-id` → `X-Request-ID` → a timestamp. The WhatsApp bridge can re-deliver the *same native message* under a **different HTTP request ID**, so every one of those fallbacks produces a fresh key and the duplicate sails through.

## Fix

For the configured `whatsapp-inbound` route only, prefer a non-empty JSON payload `messageId` as the idempotency key, namespaced as `whatsapp:<messageId>`. WhatsApp's native message ID is stable across re-deliveries, so repeats collapse onto one key.

Every other route — and any WhatsApp payload that arrives without a message ID — keeps the existing GitHub/Svix/`X-Request-ID` fallback behavior unchanged.

## Dependency

**This depends on the bridge preserving `messageId` for text messages** — verygoodplugins/whatsapp-mcp#220. Until the paired `whatsapp-mcp` bridge change lands, text-only webhook payloads carry no `messageId` and this route falls through to the existing header-based behavior — correct, just not yet deduplicating. Media and reaction payloads already include the ID.

## Test

`tests/gateway/test_webhook_adapter.py::TestIdempotency::test_duplicate_whatsapp_message_id_returns_200` posts the same WhatsApp payload twice with identical `messageId` but distinct `X-Request-ID` values; the first response is 202, the second 200 with status `duplicate`.

```
$ .venv/bin/pytest -q tests/gateway/test_webhook_adapter.py::TestIdempotency \
                     tests/gateway/test_webhook_integration.py
6 passed in 2.33s
```

## Scope

Two files, one hunk in `webhook.py` plus its regression test. No behavior change for any other route.
