### PR TITLE
fix(webhook): accept Standard Webhooks (webhook-*) signature headers

### DIFF
--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -617,14 +617,26 @@ class WebhookAdapter(BasePlatformAdapter):
     # --- Signature validation ---
 
     def _validate_signature(self, request: "web.Request", body: bytes, secret: str) -> bool:
-        """Validate webhook signature (GitHub, GitLab, Svix, Linear, generic HMAC-SHA256)."""
+        """Validate webhook signature (GitHub, GitLab, Svix, Standard Webhooks, Linear, generic HMAC-SHA256)."""
         headers = request.headers
 
         def _header(name: str) -> str:
             return headers.get(name, "") or headers.get(name.lower(), "") or headers.get(name.upper(), "")
 
-        # Svix / AgentMail: signed content is "{id}.{timestamp}.{raw_body}".
-        svix = [_header(name) for name in ("svix-id", "svix-timestamp", "svix-signature")]
+        # Svix / AgentMail, and the Standard Webhooks spec (webhook-id / webhook-timestamp /
+        # webhook-signature) it was adopted from: signed content is "{id}.{timestamp}.{raw_body}"
+        # for both -- Svix co-authored Standard Webhooks, so a sender using the standard's own
+        # header names validates the same way a Svix sender does. Without this fallback, every
+        # standard-conformant delivery was rejected 401 even with the correct secret configured,
+        # since no header was ever matched (#101837).
+        svix = [
+            _header(name) or _header(alt)
+            for name, alt in (
+                ("svix-id", "webhook-id"),
+                ("svix-timestamp", "webhook-timestamp"),
+                ("svix-signature", "webhook-signature"),
+            )
+        ]
         if any(svix):
             return _validate_svix_signature(body, secret, *svix)
         # Linear (any header case): hex HMAC of the body. GitHub: sha256=<hex>. GitLab: plain token.

--- a/tests/gateway/test_webhook_adapter.py
+++ b/tests/gateway/test_webhook_adapter.py
@@ -300,6 +300,65 @@ class TestValidateSignature:
         )
         assert adapter._validate_signature(req, body, secret) is True
 
+    def test_standard_webhooks_headers_with_whsec_secret_valid(self):
+        """#101837: a sender using the Standard Webhooks spec's own header
+        names (webhook-id / webhook-timestamp / webhook-signature) must
+        validate the same way a Svix sender does -- identical scheme,
+        Svix co-authored the standard."""
+        adapter = _make_adapter()
+        body = b'{"event_type":"invoice.paid"}'
+        secret = "whsec_" + base64.b64encode(b"0123456789abcdef").decode()
+        msg_id = "msg_std_1"
+        timestamp = str(int(time.time()))
+        sig = _svix_signature(body, secret, msg_id, timestamp)
+        req = _mock_request(headers={
+            "webhook-id": msg_id,
+            "webhook-timestamp": timestamp,
+            "webhook-signature": sig,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_standard_webhooks_headers_with_raw_secret_valid(self):
+        adapter = _make_adapter()
+        body = b'{"event_type":"invoice.paid"}'
+        secret = "raw-standard-webhooks-secret"
+        msg_id = "msg_std_2"
+        timestamp = str(int(time.time()))
+        sig = _svix_signature(body, secret, msg_id, timestamp)
+        req = _mock_request(headers={
+            "webhook-id": msg_id,
+            "webhook-timestamp": timestamp,
+            "webhook-signature": sig,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
+    def test_standard_webhooks_headers_wrong_secret_rejects(self):
+        adapter = _make_adapter()
+        body = b'{"event_type":"invoice.paid"}'
+        msg_id, timestamp = "msg_std_3", str(int(time.time()))
+        sig = _svix_signature(body, "attacker-controlled-secret", msg_id, timestamp)
+        req = _mock_request(headers={
+            "webhook-id": msg_id,
+            "webhook-timestamp": timestamp,
+            "webhook-signature": sig,
+        })
+        assert adapter._validate_signature(req, body, "real-secret") is False
+
+    def test_svix_headers_still_take_priority_and_are_unaffected(self):
+        """Regression guard: adding the webhook-* fallback must not change
+        behavior for an existing Svix sender when svix-* headers are present."""
+        adapter = _make_adapter()
+        body = b'{"event_type":"message.received"}'
+        secret = "svix-still-works"
+        msg_id, timestamp = "msg_svix_1", str(int(time.time()))
+        sig = _svix_signature(body, secret, msg_id, timestamp)
+        req = _mock_request(headers={
+            "svix-id": msg_id,
+            "svix-timestamp": timestamp,
+            "svix-signature": sig,
+        })
+        assert adapter._validate_signature(req, body, secret) is True
+
 
 # ===================================================================
 # Prompt rendering


### PR DESCRIPTION
The webhook adapter's _validate_signature() recognized Svix's svix-id / svix-timestamp / svix-signature headers, but not the Standard Webhooks spec's own webhook-id / webhook-timestamp / webhook-signature headers. Both specs use the identical scheme -- HMAC-SHA256 over "{id}.{timestamp}.{raw_body}", base64-encoded, "v1,<sig>" format, whsec_ base64 secrets -- because Svix co-authored Standard Webhooks. Every request signed per the standard's own header names was rejected 401 "Invalid signature" regardless of the configured secret, since the signature header was never even matched.

Extend the existing svix-id/svix-timestamp/svix-signature detection to also accept webhook-id/webhook-timestamp/webhook-signature and route both through the same, already-tested _validate_svix_signature() -- no new validation logic, just recognizing the standard's header names as an alias for the scheme already implemented.

Added tests/gateway/test_webhook_adapter.py coverage: Standard Webhooks headers with a whsec_ secret (the common real-world case) and with a raw shared secret, a wrong-secret rejection, and a regression guard that the existing svix-* path is unaffected.

Fixes #101837

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

