### PR TITLE
feat(observability): add local action receipts

### DIFF
--- a/agent/action_receipts.py
+++ b/agent/action_receipts.py
@@ -854,29 +854,42 @@ class ActionReceiptLedger:
         prune. If that entry is absent or mismatched, the broken link is still
         reported as a defect.
 
+        Both ``prune_boundary_prev_hash`` and the receipt rows are read within
+        the *same* ``_connect_readonly`` connection so they come from a single
+        WAL snapshot; there is no gap between a boundary read and a row read
+        that a concurrent writer could slip into.
+
         This does **not** prove originality. An actor who rewrites the entire
         file — or truncates the tail — can produce a chain that passes
         verification. The chain is a corruption/partial-tamper detector, not
         cryptographic proof of custody.
         """
         problems: list[str] = []
-        # Load the prune-boundary predecessor hash written by _apply_retention.
-        prune_boundary_prev: Optional[str] = None
-        if self.db_path.exists():
-            try:
-                conn = self._connect_readonly()
-                try:
-                    row = conn.execute(
-                        "SELECT value FROM meta WHERE key='prune_boundary_prev_hash'"
-                    ).fetchone()
-                    if row is not None:
-                        prune_boundary_prev = row[0] or None
-                finally:
-                    conn.close()
-            except Exception:
-                pass
+        if not self.db_path.exists():
+            return problems
 
-        rows = self.read_all()
+        # Both meta and receipt rows are fetched inside one BEGIN transaction
+        # on a single connection so they share the same WAL read-point — no
+        # concurrent writer can slip between the two SELECTs.
+        try:
+            conn = self._connect_readonly()
+            try:
+                conn.execute("BEGIN")
+                meta_row = conn.execute(
+                    "SELECT value FROM meta WHERE key='prune_boundary_prev_hash'"
+                ).fetchone()
+                prune_boundary_prev: Optional[str] = (
+                    meta_row[0] or None if meta_row is not None else None
+                )
+                raw_rows = conn.execute(
+                    "SELECT * FROM action_receipts ORDER BY id ASC"
+                ).fetchall()
+            finally:
+                conn.close()
+        except Exception:
+            return problems
+
+        rows = [dict(r) for r in raw_rows]
         previous: Optional[str] = None
         is_first = True
         for row in rows:

--- a/agent/action_receipts.py
+++ b/agent/action_receipts.py
@@ -24,8 +24,8 @@ credential-bearing keys.
 symlink substituted between validation and connection open. The descriptor
 also pins the inode across a concurrent pathname replacement. The database
 file and WAL/SHM sidecars are hardened to ``0o600`` on every writable open.
-First creation uses ``O_CREAT | O_EXCL`` with mode ``0o600``, eliminating the
-initial umask exposure window. Other platforms retain regular-file validation
+Writable creation passes mode ``0o600`` to ``os.open``, eliminating the initial
+umask exposure window. Other platforms retain regular-file validation
 and immediate owner-only permission hardening.
 
 **Retention / size policy**: ``max_size_mb`` is a deterministic bound on live

--- a/agent/action_receipts.py
+++ b/agent/action_receipts.py
@@ -1,0 +1,909 @@
+"""Append-only local action receipt ledger.
+
+One receipt per actually-executed tool call, written to a dedicated SQLite
+database. Update and delete triggers guard ordinary writes; configured retention
+temporarily removes the delete trigger to prune old rows. Rows are chained by a
+local SHA-256 hash so some bounded internal inconsistencies are detectable.
+
+**Security caveat**: the unkeyed local SHA-256 chain detects internal partial
+inconsistency but cannot prove originality against coordinated rewriting or
+tail truncation. Any actor with write access to the database file can rebuild
+a fully valid chain. The chain is a corruption detector, not a cryptographic
+proof of custody or tamper-evidence against a privileged local attacker.
+
+**Privacy design**: ``args_hash``, ``output_hash``, and body fingerprints are
+HMAC-SHA-256 values keyed by a per-process ephemeral secret that is never
+persisted or logged.  The chain still provides corruption detection (the same
+key is used consistently within a process lifetime) but the stored values cannot
+be used to confirm raw arguments or output content offline.  Cookie and
+Set-Cookie headers are redacted at arbitrary nesting depth alongside other
+credential-bearing keys.
+
+**DB hardening**: on POSIX, the database is opened through an owner-only
+``O_NOFOLLOW`` file descriptor so SQLite cannot follow a last-component
+symlink substituted between validation and connection open. The descriptor
+also pins the inode across a concurrent pathname replacement. The database
+file and WAL/SHM sidecars are hardened to ``0o600`` on every writable open.
+First creation uses ``O_CREAT | O_EXCL`` with mode ``0o600``, eliminating the
+initial umask exposure window. Other platforms retain regular-file validation
+and immediate owner-only permission hardening.
+
+**Retention / size policy**: ``max_size_mb`` is a deterministic bound on live
+data.  SQLite tracks deleted pages in its freelist; the live-data footprint is
+``(page_count - freelist_count) * page_size``, which shrinks within a
+transaction as rows are deleted (freed pages join the freelist immediately).
+``_apply_retention`` loops — deleting batches of oldest rows, preserving at
+least ``_SIZE_FLOOR_ROWS`` newest rows — until that metric is at or below
+``limit_bytes`` or no more deletable rows exist.  VACUUM is never called inside
+a transaction; the allocated *file* size does not shrink without an external
+VACUUM, but the live-data measure that governs pruning does converge within the
+same transaction.  If the table is already at the floor (``_SIZE_FLOOR_ROWS``
+rows or fewer) and still over the limit, no further deletion is attempted; this
+exceptional case (a single receipt larger than the entire configured budget) is
+documented and tested explicitly.
+
+The ledger is **default-off**. It is reachable only when the user opts in with
+
+.. code-block:: yaml
+
+    observability:
+      action_receipts:
+        enabled: true
+
+in ``config.yaml``. With the key absent or false — and on any config read
+error — :func:`is_enabled` returns ``False`` and nothing here opens a
+database, builds an envelope, or touches the filesystem.
+
+Optional retention / rotation settings (all default-off/unlimited):
+
+.. code-block:: yaml
+
+    observability:
+      action_receipts:
+        enabled: true
+        max_rows: 100000          # hard row cap; oldest rows pruned first
+        max_age_days: 90          # rows older than this are pruned on open
+        max_size_mb: 512          # deterministic bound on live-data pages; see retention note above
+
+The SQLite setup follows the same local-ledger conventions used elsewhere in
+Hermes: WAL mode, ``BEGIN IMMEDIATE``, a module lock, and a schema table.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import os
+import re
+import secrets
+import sqlite3
+import stat
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from agent.task_envelope import (
+    TaskEnvelope,
+    build_shadow_envelope,
+    canonical_hash,
+    canonical_json,
+    envelope_hash,
+)
+from hermes_constants import get_hermes_home
+
+
+RECEIPT_SCHEMA_VERSION = 1
+
+MAX_ARGS_SUMMARY_CHARS = 1000
+
+# Boring defaults for retention — unset means unlimited.
+_DEFAULT_MAX_ROWS: Optional[int] = None
+_DEFAULT_MAX_AGE_DAYS: Optional[int] = None
+_DEFAULT_MAX_SIZE_MB: Optional[int] = None
+
+_DB_LOCK = threading.Lock()
+_REDACTED = "[redacted]"
+_BODY_FIELD_KEYS = frozenset(
+    {
+        "content",
+        "code",
+        "file_content",
+        "information",
+        "message",
+        "new_string",
+        "old_string",
+        "patch",
+        "prompt",
+        "text",
+    }
+)
+
+# Per-process ephemeral HMAC key — generated once at import time, never stored.
+# Used for args_hash, output_hash, and body fingerprints so stored values cannot
+# be used to confirm raw content offline (no dictionary/preimage attack).
+_HMAC_KEY: bytes = secrets.token_bytes(32)
+
+
+#: Argument keys whose values are treated as secrets wherever they appear,
+#: at any nesting depth.
+_SECRET_KEY_RE = re.compile(
+    r"api[-_ ]?key|apikey|token|secret|password|passwd|pwd|auth|credential|"
+    r"bearer|session[-_ ]?id_secret|private[-_ ]?key|"
+    r"cookie|set[-_ ]?cookie",
+    re.IGNORECASE,
+)
+
+#: Values that look like credentials even under an innocuous key.
+_SECRET_VALUE_RE = re.compile(
+    r"(?:bearer\s+\S+)|"
+    r"(?:authorization\s*[:=]\s*(?:basic|bearer)?\s*\S+)|"
+    r"(?:--?(?:api[-_]?key|token|secret|password|passwd|pwd|auth|credential)(?:=|\s+)\S+)|"
+    r"(?:https?://[^\s/@:]+:[^\s/@]+@)|"
+    r"(?:\b(?:sk|pk|ghp|gho|ghu|ghs|xox[baprs])-[A-Za-z0-9_\-]{8,})|"
+    r"(?:-----BEGIN [A-Z ]*PRIVATE KEY-----)",
+    re.IGNORECASE,
+)
+
+
+def _load_config() -> Any:
+    """Read the user config, read-only.
+
+    Isolated behind a module-level function so tests inject a config dict
+    instead of touching the operator's real ``config.yaml``.
+    """
+    from hermes_cli.config import load_config_readonly
+
+    return load_config_readonly()
+
+
+def _receipts_section() -> dict[str, Any]:
+    """Return the ``observability.action_receipts`` config dict, or empty."""
+    try:
+        config = _load_config()
+        if not isinstance(config, dict):
+            return {}
+        section = config.get("observability")
+        if not isinstance(section, dict):
+            return {}
+        receipts = section.get("action_receipts")
+        if not isinstance(receipts, dict):
+            return {}
+        return receipts
+    except Exception:
+        return {}
+
+
+def is_enabled() -> bool:
+    """True only when ``observability.action_receipts.enabled`` is exactly true.
+
+    Any missing key, non-mapping section, or config read failure yields
+    ``False``: telemetry never fails open into being on.
+    """
+    try:
+        return _receipts_section().get("enabled") is True
+    except Exception:
+        return False
+
+
+def _retention_config() -> tuple[Optional[int], Optional[int], Optional[int]]:
+    """Return (max_rows, max_age_days, max_size_mb) from config, or defaults.
+
+    All three default to ``None`` (unlimited). Values <= 0 are treated as
+    unlimited so a typo of ``0`` is safe rather than destructive.
+    """
+    section = _receipts_section()
+
+    def _pos_int(key: str) -> Optional[int]:
+        val = section.get(key)
+        try:
+            n = int(val)
+            return n if n > 0 else None
+        except (TypeError, ValueError):
+            return None
+
+    return (
+        _pos_int("max_rows"),
+        _pos_int("max_age_days"),
+        _pos_int("max_size_mb"),
+    )
+
+
+def default_db_path() -> Path:
+    """The ledger's own database — never any existing Hermes store."""
+    return get_hermes_home() / "action_receipts.db"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _receipt_hmac(data: bytes) -> str:
+    """Return a per-process HMAC-SHA-256 hex digest.
+
+    The key ``_HMAC_KEY`` is ephemeral and never stored, so the digest cannot
+    be used offline to confirm raw content even if the DB is exfiltrated.
+    """
+    return hmac.new(_HMAC_KEY, data, hashlib.sha256).hexdigest()
+
+
+def _body_fingerprint(value: Any) -> dict[str, Any]:
+    """Represent quarantine-class bodies without retaining their contents.
+
+    Returns ``bytes`` (length) and ``hmac`` (per-process keyed digest).  The
+    HMAC cannot confirm raw content offline; it serves only as an internal
+    consistency token within one process lifetime.
+    """
+    if isinstance(value, str):
+        encoded = value.encode("utf-8")
+    elif value is None or isinstance(value, (bool, int, float)):
+        encoded = canonical_json(value).encode("utf-8")
+    else:
+        try:
+            encoded = canonical_json(value).encode("utf-8")
+        except Exception:
+            return {"type": type(value).__name__, "hmac": _receipt_hmac(b"")}
+    return {"bytes": len(encoded), "hmac": _receipt_hmac(encoded)}
+
+
+def _scrub_envelope_dict(env_dict: dict[str, Any]) -> dict[str, Any]:
+    """Return a copy of the envelope dict with input_hash replaced by an HMAC.
+
+    ``TaskEnvelope.input_hash`` is SHA-256(canonical_json(raw_args)), which is
+    a deterministic unkeyed digest that allows offline confirmation of guessed
+    argument content.  We replace it with an ephemeral HMAC before storing so
+    the persisted value carries no offline-confirmable information about the
+    original arguments.
+
+    ``planner_hash`` and ``policy_hash`` follow the same pattern if non-None;
+    we apply the same substitution for consistency.
+    """
+    out = dict(env_dict)
+    for key in ("input_hash", "planner_hash", "policy_hash"):
+        value = out.get(key)
+        if value is not None and isinstance(value, str):
+            out[key] = _receipt_hmac(value.encode("utf-8"))
+    return out
+
+
+def _redact(value: Any, *, depth: int = 0) -> Any:
+    """Recursively strip secret-shaped keys and values.
+
+    Redaction happens *before* anything is written, so a secret never reaches
+    the database in the first place.
+    """
+    if depth > 12:
+        return "[truncated]"
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for key, item in value.items():
+            if isinstance(key, str):
+                key_text = key
+            elif key is None:
+                key_text = "null"
+            elif isinstance(key, bool):
+                key_text = "true" if key else "false"
+            elif isinstance(key, (int, float)):
+                key_text = canonical_json(key)
+            else:
+                key_text = f"[unsupported-key:{type(key).__name__}]"
+            if _SECRET_KEY_RE.search(key_text):
+                out[key_text] = _REDACTED
+            elif key_text.lower() in _BODY_FIELD_KEYS:
+                out[key_text] = _body_fingerprint(item)
+            else:
+                out[key_text] = _redact(item, depth=depth + 1)
+        return out
+    if isinstance(value, (list, tuple)):
+        return [_redact(item, depth=depth + 1) for item in value]
+    if isinstance(value, str):
+        from agent.redact import redact_sensitive_text
+
+        redacted = redact_sensitive_text(
+            value,
+            force=True,
+            redact_url_credentials=True,
+        )
+        return _SECRET_VALUE_RE.sub(_REDACTED, redacted)
+    if value is None or isinstance(value, (bool, int, float)):
+        return value
+    return f"[unsupported:{type(value).__name__}]"
+
+
+def redacted_args_summary(args: Any) -> str:
+    """A bounded, secrets-stripped rendering of the call arguments."""
+    try:
+        summary = canonical_json(_redact(args if args is not None else {}))
+    except Exception:
+        summary = "[unserializable]"
+    if len(summary) > MAX_ARGS_SUMMARY_CHARS:
+        return summary[: MAX_ARGS_SUMMARY_CHARS - 3] + "..."
+    return summary
+
+
+def _output_text(output: Any) -> str:
+    if output is None:
+        return ""
+    if isinstance(output, str):
+        return output
+    if isinstance(output, (bool, int, float, dict, list, tuple)):
+        try:
+            return canonical_json(_redact(output))
+        except Exception:
+            pass
+    return f"[unsupported:{type(output).__name__}]"
+
+
+def _harden_db_permissions(path: Path) -> None:
+    """Set DB and any WAL/SHM sidecars to owner-read/write only (mode 0o600).
+
+    Rejects symlinks and non-regular files before chmod so a substitution
+    attack cannot redirect the chmod to another target. Failures are silently
+    swallowed because receipts are optional observability and must never alter
+    tool execution.
+    """
+    for suffix in ("", "-wal", "-shm"):
+        try:
+            target = path.parent / (path.name + suffix)
+            try:
+                st = os.lstat(target)
+            except OSError:
+                continue
+            if not stat.S_ISREG(st.st_mode):
+                continue
+            os.chmod(target, stat.S_IRUSR | stat.S_IWUSR, follow_symlinks=False)
+        except Exception:
+            pass
+
+
+def _assert_regular_file(path: Path) -> None:
+    """Raise ``PermissionError`` if *path* is a symlink or non-regular file."""
+    try:
+        st = os.lstat(path)
+    except FileNotFoundError:
+        return
+    if stat.S_ISLNK(st.st_mode):
+        raise PermissionError(f"action_receipts: DB path is a symlink: {path}")
+    if not stat.S_ISREG(st.st_mode):
+        raise PermissionError(f"action_receipts: DB path is not a regular file: {path}")
+
+
+def _open_db_file_0600(path: Path, *, readonly: bool = False) -> Optional[int]:
+    """Securely open *path* and return a pinned descriptor on POSIX.
+
+    ``O_NOFOLLOW`` closes the last-component symlink race between validation
+    and SQLite's own open. ``fstat`` verifies the object actually opened, and
+    ``fchmod`` hardens an existing permissive database before SQLite touches
+    it. The caller keeps the descriptor alive for the connection lifetime.
+
+    Windows has no portable descriptor path that SQLite can reopen, so it uses
+    the pre-open regular-file check and atomic creation path instead.
+    """
+    _assert_regular_file(path)
+    if os.name != "posix":
+        if readonly:
+            if not path.exists():
+                raise FileNotFoundError(path)
+            return None
+        try:
+            fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            os.close(fd)
+        except FileExistsError:
+            pass
+        return None
+
+    flags = os.O_RDONLY if readonly else os.O_RDWR | os.O_CREAT
+    flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+    fd = os.open(path, flags, 0o600)
+    try:
+        opened = os.fstat(fd)
+        if not stat.S_ISREG(opened.st_mode):
+            raise PermissionError(
+                f"action_receipts: DB path is not a regular file: {path}"
+            )
+        if not readonly:
+            os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+        return fd
+    except BaseException:
+        os.close(fd)
+        raise
+
+
+def _descriptor_path(fd: int) -> str:
+    """Return the platform descriptor path SQLite can reopen."""
+    proc_path = f"/proc/self/fd/{fd}"
+    return proc_path if os.path.exists(proc_path) else f"/dev/fd/{fd}"
+
+
+class _ReceiptConnection(sqlite3.Connection):
+    """SQLite connection that owns the descriptor used for its secure open."""
+
+    _action_receipts_fd: Optional[int] = None
+
+    def close(self) -> None:
+        fd = self._action_receipts_fd
+        self._action_receipts_fd = None
+        try:
+            super().close()
+        finally:
+            if fd is not None:
+                os.close(fd)
+
+
+
+
+class ActionReceiptLedger:
+    """Hash-chained ledger of executed actions.
+
+    Table triggers reject ordinary row updates and deletes. Configured retention
+    has the only built-in delete path: it temporarily removes the delete trigger
+    inside the append transaction and records the resulting chain boundary.
+
+    The local SHA-256 chain detects internal partial inconsistency (e.g. a
+    corrupted write) but cannot prove originality against coordinated
+    rewriting or tail truncation. See module docstring for the full caveat.
+    """
+
+    def __init__(self, db_path: Optional[Path | str] = None) -> None:
+        self.db_path = Path(db_path) if db_path is not None else default_db_path()
+
+    # ── connection / schema ────────────────────────────────────────────
+    def _connect(self) -> sqlite3.Connection:
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        fd = _open_db_file_0600(self.db_path)
+        sqlite_path: str | Path = _descriptor_path(fd) if fd is not None else self.db_path
+        try:
+            conn = sqlite3.connect(
+                sqlite_path,
+                isolation_level=None,
+                factory=_ReceiptConnection,
+            )
+        except BaseException:
+            if fd is not None:
+                os.close(fd)
+            raise
+        conn._action_receipts_fd = fd
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            self._ensure_schema(conn)
+            _harden_db_permissions(self.db_path)
+            return conn
+        except BaseException:
+            conn.close()
+            raise
+
+    def _connect_readonly(self) -> sqlite3.Connection:
+        fd = _open_db_file_0600(self.db_path, readonly=True)
+        sqlite_path: str | Path = _descriptor_path(fd) if fd is not None else self.db_path
+        try:
+            conn = sqlite3.connect(
+                sqlite_path,
+                isolation_level=None,
+                factory=_ReceiptConnection,
+            )
+        except BaseException:
+            if fd is not None:
+                os.close(fd)
+            raise
+        conn._action_receipts_fd = fd
+        try:
+            conn.execute("PRAGMA query_only=ON")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            return conn
+        except BaseException:
+            conn.close()
+            raise
+
+    @staticmethod
+    def _ensure_schema(conn: sqlite3.Connection) -> None:
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS meta (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """
+        )
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS action_receipts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                receipt_version INTEGER NOT NULL,
+                receipt_id TEXT NOT NULL UNIQUE,
+                created_at TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                action_id TEXT NOT NULL,
+                session_id TEXT,
+                task_id TEXT,
+                tool_call_id TEXT,
+                envelope_id TEXT,
+                actor_lane TEXT NOT NULL,
+                execution_surface TEXT NOT NULL,
+                tool_name TEXT NOT NULL,
+                exit_status TEXT NOT NULL,
+                duration_ms INTEGER NOT NULL,
+                cwd TEXT,
+                args_hash TEXT NOT NULL,
+                args_redacted_summary TEXT NOT NULL,
+                output_hash TEXT,
+                output_bytes INTEGER NOT NULL,
+                envelope_hash TEXT,
+                envelope_json TEXT,
+                prev_receipt_hash TEXT,
+                receipt_hash TEXT NOT NULL
+            )
+            """
+        )
+        # Append-only guards. RAISE(ABORT) surfaces to Python as
+        # sqlite3.IntegrityError, so a tamper attempt is loud, not silent.
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS action_receipts_no_update
+            BEFORE UPDATE ON action_receipts
+            BEGIN
+                SELECT RAISE(ABORT, 'action_receipts is append-only');
+            END
+            """
+        )
+        conn.execute(
+            """
+            CREATE TRIGGER IF NOT EXISTS action_receipts_no_delete
+            BEFORE DELETE ON action_receipts
+            BEGIN
+                SELECT RAISE(ABORT, 'action_receipts is append-only');
+            END
+            """
+        )
+        conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) VALUES ('schema_version', ?)",
+            (str(RECEIPT_SCHEMA_VERSION),),
+        )
+
+    # ── retention / rotation ───────────────────────────────────────────
+    def _apply_retention(self, conn: sqlite3.Connection) -> None:
+        """Prune the oldest rows to satisfy configured retention bounds.
+
+        Pruning is done inside the caller's BEGIN IMMEDIATE transaction via a
+        temporary trigger-bypass: the append-only triggers block DELETE so we
+        drop and recreate them around the prune, then restore them. This is
+        the single legitimate delete path in the module.
+
+        Bounds (from config):
+        - ``max_rows``: keep at most this many rows (newest first).
+        - ``max_age_days``: remove rows with ``created_at`` older than N days.
+        - ``max_size_mb``: deterministic live-data bound.  The live-data
+          footprint is ``(page_count - freelist_count) * page_size``; freed
+          pages join SQLite's freelist immediately within the transaction, so
+          this metric decreases with each DELETE batch without requiring a
+          VACUUM.  Pruning loops — deleting batches of oldest rows, preserving
+          at least ``_SIZE_FLOOR_ROWS`` newest rows — until the live-data
+          footprint is at or below ``limit_bytes`` or no more rows are
+          deletable.  If the floor is reached while still over-limit (a single
+          receipt larger than the entire budget) the loop stops; that
+          exceptional case is documented and tested.  VACUUM is never called
+          inside a transaction; the on-disk allocated-file size does not shrink
+          until an external VACUUM is run, but the live-data measure that
+          governs pruning converges deterministically within this transaction.
+
+        All three are best-effort. A failure here is swallowed.
+        """
+        max_rows, max_age_days, max_size_mb = _retention_config()
+        if max_rows is None and max_age_days is None and max_size_mb is None:
+            return
+
+        try:
+            # Temporarily disable the no-delete trigger for pruning.
+            conn.execute("DROP TRIGGER IF EXISTS action_receipts_no_delete")
+            try:
+                if max_age_days is not None:
+                    cutoff = (
+                        datetime.now(timezone.utc) - timedelta(days=max_age_days)
+                    ).isoformat()
+                    conn.execute(
+                        "DELETE FROM action_receipts WHERE created_at < ?", (cutoff,)
+                    )
+
+                if max_rows is not None:
+                    # Retention runs after the incoming receipt is inserted, so
+                    # pruning to max_rows yields the configured post-append bound.
+                    count = conn.execute(
+                        "SELECT COUNT(*) FROM action_receipts"
+                    ).fetchone()[0]
+                    excess = count - max_rows
+                    if excess > 0:
+                        conn.execute(
+                            "DELETE FROM action_receipts WHERE id IN "
+                            "(SELECT id FROM action_receipts ORDER BY id ASC LIMIT ?)",
+                            (excess,),
+                        )
+
+                if max_size_mb is not None:
+                    limit_bytes = max_size_mb * 1024 * 1024
+                    # _SIZE_FLOOR_ROWS: the minimum number of newest rows we
+                    # will never delete regardless of the size limit.  This
+                    # bounds the exceptional case where a single receipt
+                    # exceeds the entire configured budget.
+                    _SIZE_FLOOR_ROWS = 50
+                    # Loop until live-data fits or no more rows are deletable.
+                    # (page_count - freelist_count) * page_size measures only
+                    # the pages actually holding live data; freed pages join
+                    # the freelist immediately within this transaction, so the
+                    # metric decreases with each batch without requiring VACUUM.
+                    while True:
+                        live_row = conn.execute(
+                            "SELECT (page_count - freelist_count) * page_size"
+                            " FROM pragma_page_count(), pragma_freelist_count(),"
+                            " pragma_page_size()"
+                        ).fetchone()
+                        if live_row is None or live_row[0] <= limit_bytes:
+                            break
+                        total = conn.execute(
+                            "SELECT COUNT(*) FROM action_receipts"
+                        ).fetchone()[0]
+                        deletable = max(0, total - _SIZE_FLOOR_ROWS)
+                        if deletable == 0:
+                            # Floor reached with live-data still over limit:
+                            # the newest rows alone exceed the budget (single
+                            # oversized receipt).  Stop; cannot prune further.
+                            break
+                        # Delete at least 25 % of deletable rows per pass so
+                        # the loop converges in O(log n) iterations.
+                        batch = max(1, min(deletable, max(deletable // 4, 100)))
+                        conn.execute(
+                            "DELETE FROM action_receipts WHERE id IN "
+                            "(SELECT id FROM action_receipts ORDER BY id ASC LIMIT ?)",
+                            (batch,),
+                        )
+
+                # After all deletes, record the predecessor hash expected by the
+                # first surviving row. This lets verify_chain() distinguish the
+                # legitimate prune boundary from a broken chain link caused by
+                # corruption.  Written atomically inside the same transaction.
+                first = conn.execute(
+                    "SELECT prev_receipt_hash FROM action_receipts ORDER BY id ASC LIMIT 1"
+                ).fetchone()
+                if first is not None:
+                    boundary_hash = first["prev_receipt_hash"] if first["prev_receipt_hash"] else ""
+                    conn.execute(
+                        "INSERT OR REPLACE INTO meta(key, value) VALUES ('prune_boundary_prev_hash', ?)",
+                        (boundary_hash,),
+                    )
+                else:
+                    # Table is empty after pruning — clear any stale boundary.
+                    conn.execute(
+                        "DELETE FROM meta WHERE key='prune_boundary_prev_hash'"
+                    )
+            finally:
+                # Always restore the no-delete trigger.
+                conn.execute(
+                    """
+                    CREATE TRIGGER IF NOT EXISTS action_receipts_no_delete
+                    BEFORE DELETE ON action_receipts
+                    BEGIN
+                        SELECT RAISE(ABORT, 'action_receipts is append-only');
+                    END
+                    """
+                )
+        except Exception:
+            pass
+
+    # ── hashing ────────────────────────────────────────────────────────
+    @staticmethod
+    def _chain_payload(row: Any) -> dict[str, Any]:
+        """The exact field set covered by ``receipt_hash``."""
+        keys = (
+            "receipt_version",
+            "receipt_id",
+            "created_at",
+            "kind",
+            "action_id",
+            "session_id",
+            "task_id",
+            "tool_call_id",
+            "envelope_id",
+            "actor_lane",
+            "execution_surface",
+            "tool_name",
+            "exit_status",
+            "duration_ms",
+            "cwd",
+            "args_hash",
+            "args_redacted_summary",
+            "output_hash",
+            "output_bytes",
+            "envelope_hash",
+            "envelope_json",
+            "prev_receipt_hash",
+        )
+        return {key: row[key] for key in keys}
+
+    # ── write ──────────────────────────────────────────────────────────
+    def record_receipt(
+        self,
+        *,
+        tool_name: str,
+        args: Any = None,
+        output: Any = None,
+        exit_status: str = "ok",
+        duration_ms: int = 0,
+        session_id: Optional[str] = None,
+        task_id: Optional[str] = None,
+        tool_call_id: Optional[str] = None,
+        cwd: Optional[str] = None,
+        kind: str = "tool_exec",
+        envelope: Optional[TaskEnvelope] = None,
+        receipt_id: Optional[str] = None,
+        created_at: Optional[str] = None,
+    ) -> str:
+        """Append exactly one receipt and return its ``receipt_id``.
+
+        The tail read, hash computation, and insert all happen inside one
+        ``BEGIN IMMEDIATE`` transaction under a process-wide lock, so
+        concurrent callers extend a single chain instead of forking it.
+        """
+        if envelope is None:
+            envelope = build_shadow_envelope(
+                tool_name=tool_name,
+                args=args,
+                cwd=cwd,
+                session_id=session_id,
+                task_id=task_id,
+                tool_call_id=tool_call_id,
+            )
+
+        output_text = _output_text(output)
+        row: dict[str, Any] = {
+            "receipt_version": RECEIPT_SCHEMA_VERSION,
+            "receipt_id": receipt_id or f"r-{uuid.uuid4().hex}",
+            "created_at": created_at or _utc_now(),
+            "kind": kind,
+            "action_id": envelope.action_id,
+            "session_id": session_id,
+            "task_id": task_id,
+            "tool_call_id": tool_call_id,
+            "envelope_id": envelope.envelope_id,
+            "actor_lane": envelope.lane,
+            "execution_surface": envelope.execution_surface,
+            "tool_name": str(tool_name),
+            "exit_status": str(exit_status),
+            "duration_ms": int(duration_ms),
+            "cwd": cwd,
+            # args_hash is an HMAC of the canonical arguments; the key is
+            # ephemeral (_HMAC_KEY) so the stored value cannot be used offline
+            # to confirm specific inputs via dictionary or preimage attack.
+            "args_hash": _receipt_hmac(
+                canonical_json(args if args is not None else {}).encode("utf-8")
+            ),
+            "args_redacted_summary": redacted_args_summary(args),
+            # output_hash: same privacy property as args_hash.
+            "output_hash": (
+                _receipt_hmac(output_text.encode("utf-8"))
+                if output is not None
+                else None
+            ),
+            "output_bytes": len(output_text.encode("utf-8")),
+            # Scrub envelope before persisting: input_hash (SHA-256 of raw args)
+            # is replaced with an ephemeral HMAC so the stored JSON cannot be
+            # used offline to confirm argument content.
+            "envelope_hash": canonical_hash(
+                _scrub_envelope_dict(envelope.to_dict())
+            ),
+            "envelope_json": canonical_json(
+                _scrub_envelope_dict(envelope.to_dict())
+            ),
+        }
+
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                tail = conn.execute(
+                    "SELECT receipt_hash FROM action_receipts ORDER BY id DESC LIMIT 1"
+                ).fetchone()
+                row["prev_receipt_hash"] = tail["receipt_hash"] if tail else None
+                row["receipt_hash"] = canonical_hash(self._chain_payload(row))
+                columns = list(row.keys())
+                conn.execute(
+                    f"INSERT INTO action_receipts({', '.join(columns)}) "
+                    f"VALUES ({', '.join('?' for _ in columns)})",
+                    [row[c] for c in columns],
+                )
+                # Retain after insertion so every configured bound observes the
+                # incoming receipt and describes the committed ledger state.
+                self._apply_retention(conn)
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+        return str(row["receipt_id"])
+
+    # ── read ───────────────────────────────────────────────────────────
+    def read_all(self) -> list[dict[str, Any]]:
+        """Every receipt, oldest first. Read-only."""
+        if not self.db_path.exists():
+            return []
+        conn = self._connect_readonly()
+        try:
+            rows = conn.execute(
+                "SELECT * FROM action_receipts ORDER BY id ASC"
+            ).fetchall()
+        finally:
+            conn.close()
+        return [dict(row) for row in rows]
+
+    def verify_chain(self) -> list[str]:
+        """Return one message per chain defect; empty list means intact.
+
+        Detects internal partial inconsistency: a row whose stored hash does
+        not match a recomputation of its own fields, or whose prev_receipt_hash
+        does not match the previous row's receipt_hash.
+
+        When a legitimate prune has occurred, the first surviving row's
+        ``prev_receipt_hash`` will not match any stored row — but it WILL match
+        the ``prune_boundary_prev_hash`` entry written atomically during the
+        prune. If that entry is absent or mismatched, the broken link is still
+        reported as a defect.
+
+        This does **not** prove originality. An actor who rewrites the entire
+        file — or truncates the tail — can produce a chain that passes
+        verification. The chain is a corruption/partial-tamper detector, not
+        cryptographic proof of custody.
+        """
+        problems: list[str] = []
+        # Load the prune-boundary predecessor hash written by _apply_retention.
+        prune_boundary_prev: Optional[str] = None
+        if self.db_path.exists():
+            try:
+                conn = self._connect_readonly()
+                try:
+                    row = conn.execute(
+                        "SELECT value FROM meta WHERE key='prune_boundary_prev_hash'"
+                    ).fetchone()
+                    if row is not None:
+                        prune_boundary_prev = row[0] or None
+                finally:
+                    conn.close()
+            except Exception:
+                pass
+
+        rows = self.read_all()
+        previous: Optional[str] = None
+        is_first = True
+        for row in rows:
+            expected = canonical_hash(self._chain_payload(row))
+            if row["receipt_hash"] != expected:
+                problems.append(f"receipt {row['receipt_id']}: content hash mismatch")
+            if row["prev_receipt_hash"] != previous:
+                if is_first and prune_boundary_prev is not None:
+                    # First row after a prune: check against the recorded boundary.
+                    expected_prev = prune_boundary_prev if prune_boundary_prev else None
+                    if row["prev_receipt_hash"] != expected_prev:
+                        problems.append(
+                            f"receipt {row['receipt_id']}: broken chain link "
+                            f"(prune boundary mismatch)"
+                        )
+                else:
+                    problems.append(f"receipt {row['receipt_id']}: broken chain link")
+            previous = row["receipt_hash"]
+            is_first = False
+        return problems
+
+
+__all__ = [
+    "ActionReceiptLedger",
+    "MAX_ARGS_SUMMARY_CHARS",
+    "RECEIPT_SCHEMA_VERSION",
+    "default_db_path",
+    "is_enabled",
+    "redacted_args_summary",
+]

--- a/agent/task_envelope.py
+++ b/agent/task_envelope.py
@@ -1,0 +1,264 @@
+"""Shadow task envelope — the versioned unit of work for a tool execution.
+
+Phase 0 of the quad-rework contract is *observational*: the envelope records
+what the tool seam can actually observe (which tool, which args, which cwd,
+which session/task) and marks every safety field it cannot know as ``None``.
+It never invents a permissive default — an unknown network policy is recorded
+as unknown, not as "none".
+
+:func:`validate_envelope` reports the resulting gaps. In this phase the verdict
+is *recorded*, never enforced; enforcement is a later, separately gated phase.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import json
+import uuid
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+
+ENVELOPE_SCHEMA_VERSION = 1
+
+_MAX_OBJECTIVE_CHARS = 2000
+
+#: Safety fields an envelope must carry before it may ever gate execution.
+#: A shadow envelope legitimately lacks most of them; :func:`validate_envelope`
+#: names the gaps so the incompleteness is evidence rather than a silent
+#: assumption.
+MANDATORY_SAFETY_FIELDS: tuple[str, ...] = (
+    "idempotency_key",
+    "roots",
+    "permissions_read",
+    "permissions_write",
+    "permissions_spawn",
+    "network_policy",
+    "exec_policy",
+    "destructive_policy",
+    "budget_usd_max",
+    "budget_tokens_max",
+    "budget_wall_clock_s_max",
+    "deadline_utc",
+    "lease_holder",
+    "fence",
+)
+
+
+@dataclass(frozen=True)
+class TaskEnvelope:
+    """One sealed description of one execution surface's unit of work."""
+
+    envelope_version: int
+    envelope_id: str
+    action_id: str
+    session_id: Optional[str]
+    task_id: Optional[str]
+    tool_call_id: Optional[str]
+    objective: str
+    tool_name: str
+    execution_surface: str
+    lane: str
+
+    cwd: Optional[str]
+    roots: Optional[tuple[str, ...]]
+    permissions_read: Optional[tuple[str, ...]]
+    permissions_write: Optional[tuple[str, ...]]
+    permissions_spawn: Optional[tuple[str, ...]]
+    network_policy: Optional[str]
+    exec_policy: Optional[str]
+    destructive_policy: Optional[str]
+
+    budget_usd_max: Optional[float]
+    budget_tokens_max: Optional[int]
+    budget_wall_clock_s_max: Optional[float]
+    deadline_utc: Optional[str]
+
+    retry_max_attempts: Optional[int]
+    retry_eligible: Optional[bool]
+    cancellation_mode: Optional[str]
+    cancellation_grace_s: Optional[float]
+
+    evidence_required_receipt_kinds: Optional[tuple[str, ...]]
+    evidence_min_receipts: Optional[int]
+    verifier_required: Optional[bool]
+    verifier_lane_must_differ: Optional[bool]
+    verifier_clean_workspace_required: Optional[bool]
+
+    planner_hash: Optional[str]
+    policy_hash: Optional[str]
+    input_hash: str
+
+    attempt_id: Optional[str]
+    lease_holder: Optional[str]
+    lease_granted_utc: Optional[str]
+    lease_ttl_s: Optional[float]
+    fence: Optional[int]
+
+    idempotency_key: Optional[str]
+    created_at: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable mapping (tuples become lists)."""
+        payload = asdict(self)
+        return {
+            key: (list(value) if isinstance(value, tuple) else value)
+            for key, value in payload.items()
+        }
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _json_safe(payload: Any, *, depth: int = 0) -> Any:
+    """Normalize to JSON values without invoking arbitrary representations."""
+    if depth > 12:
+        return "[truncated]"
+    if payload is None or isinstance(payload, (str, bool, int)):
+        return payload
+    if isinstance(payload, float):
+        return payload if math.isfinite(payload) else f"[nonfinite:{payload.hex()}]"
+    if isinstance(payload, dict):
+        normalized: dict[str, Any] = {}
+        for key, value in payload.items():
+            if isinstance(key, str):
+                key_text = key
+            elif key is None:
+                key_text = "null"
+            elif isinstance(key, bool):
+                key_text = "true" if key else "false"
+            elif isinstance(key, int):
+                key_text = str(key)
+            elif isinstance(key, float):
+                key_text = str(key) if math.isfinite(key) else f"[nonfinite-key:{key.hex()}]"
+            else:
+                key_text = f"[unsupported-key:{type(key).__name__}]"
+            normalized[key_text] = _json_safe(value, depth=depth + 1)
+        return normalized
+    if isinstance(payload, (list, tuple)):
+        return [_json_safe(value, depth=depth + 1) for value in payload]
+    return f"[unsupported:{type(payload).__name__}]"
+
+
+def canonical_json(payload: Any) -> str:
+    """Canonical JSON without calling user-defined ``str`` or ``repr``."""
+    return json.dumps(
+        _json_safe(payload),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _sha256(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def canonical_hash(payload: Any) -> str:
+    """SHA-256 over the canonical JSON encoding of ``payload``."""
+    return _sha256(canonical_json(payload))
+
+
+def envelope_hash(env: TaskEnvelope) -> str:
+    """SHA-256 over the envelope's canonical JSON bytes."""
+    return canonical_hash(env.to_dict())
+
+
+def build_shadow_envelope(
+    *,
+    tool_name: str,
+    args: Any = None,
+    cwd: Optional[str] = None,
+    session_id: Optional[str] = None,
+    task_id: Optional[str] = None,
+    tool_call_id: Optional[str] = None,
+    objective: Optional[str] = None,
+    envelope_id: Optional[str] = None,
+    action_id: Optional[str] = None,
+    created_at: Optional[str] = None,
+) -> TaskEnvelope:
+    """Build an envelope from what the seam can observe.
+
+    Every field this function cannot honestly determine is left ``None``.
+    That is the point: shadow mode records incompleteness so the gap shows up
+    in :func:`validate_envelope` output instead of being papered over with a
+    permissive default.
+    """
+    goal = objective if objective is not None else f"execute tool {tool_name}"
+
+    return TaskEnvelope(
+        envelope_version=ENVELOPE_SCHEMA_VERSION,
+        envelope_id=envelope_id or f"e-{uuid.uuid4().hex}",
+        action_id=action_id or f"a-{uuid.uuid4().hex}",
+        session_id=session_id,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        objective=str(goal)[:_MAX_OBJECTIVE_CHARS],
+        tool_name=str(tool_name),
+        execution_surface="local_tool",
+        lane="hermes",
+        cwd=cwd,
+        # ── Unknown in shadow mode: recorded as unknown, never guessed ──
+        roots=None,
+        permissions_read=None,
+        permissions_write=None,
+        permissions_spawn=None,
+        network_policy=None,
+        exec_policy=None,
+        destructive_policy=None,
+        budget_usd_max=None,
+        budget_tokens_max=None,
+        budget_wall_clock_s_max=None,
+        deadline_utc=None,
+        retry_max_attempts=None,
+        retry_eligible=None,
+        cancellation_mode=None,
+        cancellation_grace_s=None,
+        evidence_required_receipt_kinds=None,
+        evidence_min_receipts=None,
+        verifier_required=None,
+        verifier_lane_must_differ=None,
+        verifier_clean_workspace_required=None,
+        planner_hash=None,
+        policy_hash=None,
+        input_hash=canonical_hash(args if args is not None else {}),
+        attempt_id=None,
+        lease_holder=None,
+        lease_granted_utc=None,
+        lease_ttl_s=None,
+        fence=None,
+        idempotency_key=None,
+        created_at=created_at or _utc_now(),
+    )
+
+
+def validate_envelope(env: TaskEnvelope) -> list[str]:
+    """Report absent mandatory safety fields. Never raises, never blocks.
+
+    An unknown ``envelope_version`` is reported too — a consumer that would
+    enforce this envelope must fail closed on it, but this function only names
+    the problem.
+    """
+    missing: list[str] = []
+    if getattr(env, "envelope_version", None) != ENVELOPE_SCHEMA_VERSION:
+        missing.append("envelope_version")
+    for field in MANDATORY_SAFETY_FIELDS:
+        if getattr(env, field, None) is None:
+            missing.append(field)
+    return missing
+
+
+__all__ = [
+    "ENVELOPE_SCHEMA_VERSION",
+    "MANDATORY_SAFETY_FIELDS",
+    "TaskEnvelope",
+    "build_shadow_envelope",
+    "canonical_hash",
+    "canonical_json",
+    "envelope_hash",
+    "validate_envelope",
+]

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -13,6 +13,7 @@ extracted functions reach back through the ``run_agent`` module via
 from __future__ import annotations
 
 import concurrent.futures
+import copy
 import json
 from pathlib import Path
 import logging
@@ -371,6 +372,67 @@ def _emit_cancelled_terminal_post_tool_call(
     return result
 
 
+
+def _maybe_record_action_receipt(
+    agent,
+    *,
+    function_name: str,
+    function_args: Any,
+    result: Any,
+    effective_task_id: str,
+    tool_call_id: str,
+    duration_s: float,
+    exit_status: str,
+) -> None:
+    """Record one shadow action receipt for a tool call that actually ran.
+
+    Default-off observability, gated on ``observability.action_receipts.enabled``.
+    When that setting is absent or false this returns after a single boolean
+    check — no envelope is built and no database is opened or created.
+
+    Every failure here is swallowed. This is telemetry: it must never change
+    what a tool did, what the model sees, or the order it sees it in. Callers
+    are responsible for invoking it only for calls that actually started —
+    malformed, preflight-blocked, and skipped-before-start calls never reach it.
+    """
+    try:
+        from agent.action_receipts import ActionReceiptLedger, is_enabled
+
+        if not is_enabled():
+            return
+
+        from agent.task_envelope import build_shadow_envelope
+
+        try:
+            cwd = getattr(get_active_env(effective_task_id), "cwd", None)
+        except Exception:
+            cwd = None
+
+        session_id = getattr(agent, "session_id", "") or None
+        envelope = build_shadow_envelope(
+            tool_name=function_name,
+            args=function_args,
+            cwd=str(cwd) if cwd else None,
+            session_id=session_id,
+            task_id=effective_task_id or None,
+            tool_call_id=tool_call_id or None,
+        )
+        receipt_cwd = getattr(envelope, "cwd", None)
+        ActionReceiptLedger().record_receipt(
+            tool_name=function_name,
+            args=function_args,
+            output=result,
+            exit_status=exit_status,
+            duration_ms=int(duration_s * 1000),
+            session_id=session_id,
+            task_id=effective_task_id or None,
+            tool_call_id=tool_call_id or None,
+            cwd=receipt_cwd,
+            envelope=envelope,
+        )
+    except Exception as exc:
+        logger.warning("action receipt write failed for %s: %s", function_name, exc)
+
 def _tool_search_scoped_names(agent) -> frozenset:
     """Return the deferrable tool names the session may invoke via tool_call.
 
@@ -428,6 +490,68 @@ class _ManagedToolResult:
     middleware_trace: list[dict[str, Any]]
     blocked: bool
     dispatched: bool
+
+
+class _ToolExecutionState:
+    """Atomically decide whether a call started before it was abandoned."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._started = False
+        self._abandoned = False
+        self._function_args: dict[str, Any] | None = None
+        self._middleware_trace: list[dict[str, Any]] = []
+
+    def try_start(
+        self,
+        function_args: dict[str, Any],
+        middleware_trace: list[dict[str, Any]],
+    ) -> bool:
+        """Mark the real callback boundary unless the executor abandoned it."""
+        with self._lock:
+            if self._abandoned or self._started:
+                return False
+            self._function_args = copy.deepcopy(function_args)
+            self._middleware_trace = copy.deepcopy(middleware_trace)
+            self._started = True
+            return True
+
+    def abandon(self) -> bool:
+        """Prevent a future start and return whether execution already began."""
+        with self._lock:
+            self._abandoned = True
+            return self._started
+
+    def has_started(self) -> bool:
+        with self._lock:
+            return self._started
+
+    def started_metadata(
+        self,
+    ) -> tuple[bool, dict[str, Any] | None, list[dict[str, Any]]]:
+        """Return callback-boundary metadata captured atomically at dispatch."""
+        with self._lock:
+            args = (
+                copy.deepcopy(self._function_args)
+                if self._function_args is not None
+                else None
+            )
+            return self._started, args, copy.deepcopy(self._middleware_trace)
+
+class _StartedToolError(Exception):
+    """A regular exception raised after crossing the real callback boundary."""
+
+    def __init__(
+        self,
+        cause: Exception,
+        *,
+        function_args: dict[str, Any],
+        middleware_trace: list[dict[str, Any]],
+    ) -> None:
+        super().__init__(str(cause))
+        self.cause = cause
+        self.function_args = copy.deepcopy(function_args)
+        self.middleware_trace = copy.deepcopy(middleware_trace)
 
 
 class _ToolTimeoutResult(str):
@@ -591,6 +715,7 @@ def _run_agent_tool_execution_middleware(
     display_index: int | None = None,
     middleware_trace: list[dict[str, Any]] | None = None,
     begin_execution=None,
+    execution_state: _ToolExecutionState | None = None,
     authorization_gate: _ConcurrentToolAuthorizationGate | None = None,
 ) -> _ManagedToolResult:
     """Run Relay rewrites before Hermes policy and dispatch exactly once."""
@@ -605,17 +730,18 @@ def _run_agent_tool_execution_middleware(
         "args": function_args,
         "middleware_trace": trace,
         "blocked": False,
+        "callback_invoked": False,
         "dispatched": False,
     }
     dispatch_lock = threading.Lock()
 
     def _authorized_dispatch(final_args: dict[str, Any]) -> Any:
         with dispatch_lock:
-            if state["dispatched"]:
+            if state["callback_invoked"]:
                 raise RuntimeError(
                     "Hermes tool execution callback invoked more than once"
                 )
-            state["dispatched"] = True
+            state["callback_invoked"] = True
             state["blocked"] = False
             state["args"] = final_args
 
@@ -712,6 +838,17 @@ def _run_agent_tool_execution_middleware(
             agent._iters_since_skill = 0
 
         _advance_start_order(_begin)
+        # This is the execution boundary: authorization and preflight completed,
+        # and the real tool callback is about to run.  Executor submission,
+        # worker startup, middleware entry, and gate residence do not count.
+        # ``try_start`` makes timeout/interrupt abandonment atomic with callback
+        # entry so a late worker cannot execute after its synthetic result.
+        if execution_state is not None and not execution_state.try_start(
+            final_args,
+            list(state["middleware_trace"]),
+        ):
+            raise _BatchAbandoned(function_name)
+        state["dispatched"] = True
 
         # Keep the gateway turn-inactivity watchdog from abandoning a turn
         # whose tool call runs silently for longer than the inactivity
@@ -730,6 +867,12 @@ def _run_agent_tool_execution_middleware(
         _hb_thread.start()
         try:
             return execute(final_args)
+        except Exception as exc:
+            raise _StartedToolError(
+                exc,
+                function_args=final_args,
+                middleware_trace=list(state["middleware_trace"]),
+            ) from exc
         finally:
             _hb_stop.set()
             _hb_thread.join(timeout=2.0)
@@ -828,6 +971,7 @@ def _run_sequential_tool_execution_middleware(
     scope_block: str | None = None,
     display_index: int | None = None,
     middleware_trace: list[dict[str, Any]] | None = None,
+    execution_state: _ToolExecutionState | None = None,
 ) -> _ManagedToolResult:
     """Run one sequential call with the concurrent executor's deadline.
 
@@ -837,6 +981,7 @@ def _run_sequential_tool_execution_middleware(
     return ``tool_timeout`` while the prompt and worker stay active.
     """
     timeout_s = _resolve_sequential_tool_timeout()
+    call_state = execution_state or _ToolExecutionState()
     kwargs = {
         "function_name": function_name,
         "function_args": function_args,
@@ -846,6 +991,7 @@ def _run_sequential_tool_execution_middleware(
         "scope_block": scope_block,
         "display_index": display_index,
         "middleware_trace": middleware_trace,
+        "execution_state": call_state,
     }
     if function_name in _NEVER_PARALLEL_TOOLS:
         return _run_agent_tool_execution_middleware(agent, **kwargs)
@@ -927,6 +1073,18 @@ def _run_sequential_tool_execution_middleware(
                 return future.result()
             timed_out = True  # reuse the abandon-shutdown path in finally
             future.cancel()
+            dispatched = call_state.abandon()
+            _started, started_args, started_trace = call_state.started_metadata()
+            accounting_args = (
+                started_args
+                if dispatched and started_args is not None
+                else function_args
+            )
+            accounting_trace = (
+                started_trace
+                if dispatched
+                else list(middleware_trace or [])
+            )
             interrupt_reason = (
                 getattr(agent, "_tool_interrupt_reason", None)
                 or "interrupt requested"
@@ -939,11 +1097,10 @@ def _run_sequential_tool_execution_middleware(
                 "sequential tool %s abandoned due to %s (%.1fs elapsed)",
                 function_name, interrupt_reason, time.monotonic() - started,
             )
-            trace = middleware_trace if middleware_trace is not None else []
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=function_name,
-                function_args=function_args,
+                function_args=accounting_args,
                 result=message,
                 effective_task_id=effective_task_id,
                 tool_call_id=tool_call_id,
@@ -951,14 +1108,14 @@ def _run_sequential_tool_execution_middleware(
                 status="cancelled",
                 error_type="tool_interrupted",
                 error_message=f"Tool execution cancelled: {interrupt_reason}",
-                middleware_trace=list(trace),
+                middleware_trace=accounting_trace,
             )
             return _ManagedToolResult(
                 result=_ToolCancelledResult(message),
-                args=function_args,
-                middleware_trace=trace,
+                args=accounting_args,
+                middleware_trace=accounting_trace,
                 blocked=False,
-                dispatched=True,
+                dispatched=dispatched,
             )
 
         # Only reachable when a deadline exists (interrupted returns above).
@@ -971,16 +1128,27 @@ def _run_sequential_tool_execution_middleware(
             "sequential tool %s timed out after %.1fs", function_name, timeout_s
         )
         future.cancel()
+        dispatched = call_state.abandon()
+        _started, started_args, started_trace = call_state.started_metadata()
+        accounting_args = (
+            started_args
+            if dispatched and started_args is not None
+            else function_args
+        )
+        accounting_trace = (
+            started_trace
+            if dispatched
+            else list(middleware_trace or [])
+        )
         for tid in worker_tid:
             try:
                 _ra()._set_interrupt(True, tid)
             except Exception:
                 pass
-        trace = middleware_trace if middleware_trace is not None else []
         _emit_terminal_post_tool_call(
             agent,
             function_name=function_name,
-            function_args=function_args,
+            function_args=accounting_args,
             result=message,
             effective_task_id=effective_task_id,
             tool_call_id=tool_call_id,
@@ -988,14 +1156,14 @@ def _run_sequential_tool_execution_middleware(
             status="timeout",
             error_type="tool_timeout",
             error_message=message,
-            middleware_trace=list(trace),
+            middleware_trace=accounting_trace,
         )
         return _ManagedToolResult(
             result=_ToolTimeoutResult(message),
-            args=function_args,
-            middleware_trace=trace,
+            args=accounting_args,
+            middleware_trace=accounting_trace,
             blocked=False,
-            dispatched=True,
+            dispatched=dispatched,
         )
     finally:
         # Never join a wedged worker. DaemonThreadPoolExecutor also keeps it out
@@ -1223,13 +1391,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     if not agent.quiet_mode and getattr(agent, "tool_progress_mode", "all") != "off":
         print(f"  ⚡ Concurrent: {num_tools} tool calls — {tool_names_str}")
 
-    # ── Concurrent execution ─────────────────────────────────────────
-    # Each slot holds (function_name, function_args, function_result, duration, error_flag, blocked_flag, middleware_trace)
+    # Each slot holds (function_name, function_args, function_result, duration,
+    # error_flag, blocked_flag, dispatched_flag, middleware_trace).
     results = [None] * num_tools
+    execution_states = [_ToolExecutionState() for _ in range(num_tools)]
     for i, (tc, name, args, middleware_trace, block_result, _scope_block) in enumerate(parsed_calls):
         if block_result is not None:
-            results[i] = (name, args, block_result, 0.0, True, True, middleware_trace)
-
+            results[i] = (
+                name, args, block_result, 0.0, True, True, False, middleware_trace
+            )
     start_condition = threading.Condition()
     next_start_order = 0
     # Set once the batch is abandoned (deadline or interrupt) so a worker parked
@@ -1318,6 +1488,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         middleware_trace,
         scope_block,
         start_order,
+        execution_state,
     ):
         """Worker function executed in a thread."""
         # Register this worker tid so the agent can fan out an interrupt
@@ -1355,6 +1526,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         tool_call_id = _pairing_tool_call_id(tool_call)
         blocked = False
         dispatched = False
+        execution_raised = False
         start_advanced = False
 
         def _advance_start(callback=None) -> None:
@@ -1401,6 +1573,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     display_index=index + 1,
                     middleware_trace=middleware_trace,
                     begin_execution=_advance_start,
+                    execution_state=execution_state,
                     authorization_gate=authorization_gate,
                 )
                 result = managed.result
@@ -1420,19 +1593,31 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 return
             except KeyboardInterrupt:
+                dispatched, started_args, started_trace = (
+                    execution_state.started_metadata()
+                )
+                if dispatched:
+                    if started_args is not None:
+                        function_args = started_args
+                    middleware_trace = started_trace
                 try:
                     agent.interrupt("keyboard interrupt")
                 except Exception:
                     pass
-                result = _emit_cancelled_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=tool_call_id,
-                    start_time=start,
-                    middleware_trace=list(middleware_trace),
+                cancelled_result = (
+                    _emit_cancelled_terminal_post_tool_call(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        start_time=start,
+                        middleware_trace=list(middleware_trace),
+                    )
+                    if dispatched
+                    else _cancelled_tool_result()
                 )
+                result = _ToolCancelledResult(cancelled_result)
                 duration = time.time() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
                 results[index] = (
@@ -1442,14 +1627,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     duration,
                     True,
                     False,
+                    dispatched,
                     middleware_trace,
                 )
                 return
             except Exception as tool_error:
-                result = f"Error executing tool '{function_name}': {tool_error}"
-                logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+                execution_raised = True
+                dispatched = execution_state.has_started()
+                if isinstance(tool_error, _StartedToolError):
+                    cause = tool_error.cause
+                    function_args = tool_error.function_args
+                    middleware_trace = tool_error.middleware_trace
+                else:
+                    cause = tool_error
+                result = f"Error executing tool '{function_name}': {cause}"
+                logger.error("_invoke_tool raised for %s: %s", function_name, cause, exc_info=True)
             duration = time.time() - start
-            if not blocked and not dispatched:
+            if not blocked and (execution_raised or not dispatched):
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=function_name,
@@ -1472,6 +1666,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 duration,
                 is_error,
                 blocked,
+                dispatched,
                 middleware_trace,
             )
         finally:
@@ -1541,6 +1736,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             parsed_calls[i][3],
                             scope_block,
                             submit_index,
+                            execution_states[i],
                         )
                     except RuntimeError as submit_error:
                         if not _is_interpreter_shutdown_submit_error(submit_error):
@@ -1570,6 +1766,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                                     result,
                                     0.0,
                                     True,
+                                    False,
                                     False,
                                     middleware_trace,
                                 )
@@ -1613,6 +1810,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                         >= deadline + authorization_gate.excluded_seconds()
                     ):
                         abandon_executor = True
+                        for f in not_done:
+                            index = future_to_index.get(f)
+                            if index is not None:
+                                execution_states[index].abandon()
                         timed_out_indices = {
                             future_to_index[f]
                             for f in not_done
@@ -1651,6 +1852,10 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     # that haven't started yet so we don't block on them.
                     if agent._interrupt_requested:
                         abandon_executor = True
+                        for f in not_done:
+                            index = future_to_index.get(f)
+                            if index is not None:
+                                execution_states[index].abandon()
                         if not _interrupt_logged:
                             _interrupt_logged = True
                             agent._vprint(
@@ -1720,10 +1925,23 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
             suffix = f"{timeout_s:.1f}s" if timeout_s is not None else "the configured timeout"
             function_result = f"Error executing tool '{name}': timed out after {suffix}"
             effect_disposition = "unknown"
+            dispatched, started_args, started_trace = (
+                execution_states[i].started_metadata()
+            )
+            accounting_args = (
+                started_args
+                if dispatched and started_args is not None
+                else args
+            )
+            accounting_trace = (
+                started_trace
+                if dispatched
+                else list(middleware_trace)
+            )
             _emit_terminal_post_tool_call(
                 agent,
                 function_name=name,
-                function_args=args,
+                function_args=accounting_args,
                 result=function_result,
                 effective_task_id=effective_task_id,
                 tool_call_id=tool_call_id,
@@ -1731,42 +1949,84 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 status="timeout",
                 error_type="tool_timeout",
                 error_message=function_result,
-                middleware_trace=list(middleware_trace),
+                middleware_trace=accounting_trace,
             )
             tool_duration = float(timeout_s or 0.0)
+            if dispatched:
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name=name,
+                    function_args=accounting_args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                    duration_s=tool_duration,
+                    exit_status="timeout",
+                )
         elif r is None:
-            # Tool was cancelled (interrupt) or thread didn't return
+            # Tool was cancelled (interrupt) or thread didn't return. Receipt
+            # eligibility comes from the callback-start state, never the
+            # future's submitted/running state.
+            dispatched, started_args, started_trace = (
+                execution_states[i].started_metadata()
+            )
+            accounting_args = (
+                started_args
+                if dispatched and started_args is not None
+                else args
+            )
+            accounting_trace = (
+                started_trace
+                if dispatched
+                else list(middleware_trace)
+            )
             if agent._interrupt_requested:
-                function_result = f"[Tool execution cancelled — {name} was skipped due to user interrupt]"
+                action = "was cancelled" if dispatched else "was skipped"
+                function_result = _ToolCancelledResult(
+                    f"[Tool execution cancelled — {name} {action} due to user interrupt]"
+                )
+                exit_status = "cancelled"
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
-                    function_args=args,
+                    function_args=accounting_args,
                     result=function_result,
                     effective_task_id=effective_task_id,
                     tool_call_id=tool_call_id,
                     status="cancelled",
                     error_type="keyboard_interrupt",
                     error_message="Tool execution cancelled by user interrupt",
-                    middleware_trace=list(middleware_trace),
+                    middleware_trace=accounting_trace,
                 )
             else:
                 function_result = f"Error executing tool '{name}': thread did not return a result"
+                exit_status = "error"
                 _emit_terminal_post_tool_call(
                     agent,
                     function_name=name,
-                    function_args=args,
+                    function_args=accounting_args,
                     result=function_result,
                     effective_task_id=effective_task_id,
                     tool_call_id=tool_call_id,
                     status="error",
                     error_type="thread_missing_result",
                     error_message=function_result,
-                    middleware_trace=list(middleware_trace),
+                    middleware_trace=accounting_trace,
                 )
             tool_duration = 0.0
+            if dispatched:
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name=name,
+                    function_args=accounting_args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                    duration_s=tool_duration,
+                    exit_status=exit_status,
+                )
         else:
-            function_name, function_args, function_result, tool_duration, is_error, blocked, middleware_trace = r
+            function_name, function_args, function_result, tool_duration, is_error, blocked, dispatched, middleware_trace = r
             name = function_name
             args = function_args
             progress_function_name = function_name
@@ -1783,6 +2043,8 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     error_message="Tool arguments must be a valid JSON object",
                     middleware_trace=list(middleware_trace),
                 )
+            _receipt_cancelled = isinstance(function_result, _ToolCancelledResult)
+            _receipt_timed_out = isinstance(function_result, _ToolTimeoutResult)
             if blocked:
                 effect_disposition = "none"
 
@@ -1810,6 +2072,24 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     )
                 except Exception as _ver_err:
                     logging.debug("file-mutation verifier record failed: %s", _ver_err)
+
+            if dispatched and not blocked:
+                if _receipt_cancelled:
+                    receipt_exit_status = "cancelled"
+                elif _receipt_timed_out:
+                    receipt_exit_status = "timeout"
+                else:
+                    receipt_exit_status = "error" if is_error else "ok"
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name=function_name,
+                    function_args=function_args,
+                    result=function_result,
+                    effective_task_id=effective_task_id,
+                    tool_call_id=tool_call_id,
+                    duration_s=tool_duration,
+                    exit_status=receipt_exit_status,
+                )
 
             if agent.verbose_logging:
                 logging.debug("Tool %s completed in %.2fs", function_name, tool_duration)
@@ -1966,8 +2246,65 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
 
     # Keep every runtime-tool branch on one bounded execution funnel without
     # duplicating timeout policy across the branch-specific callbacks below.
-    def _run_agent_tool_execution_middleware(agent, **kwargs):
-        return _run_sequential_tool_execution_middleware(agent, **kwargs)
+    def _run_agent_tool_execution_middleware(agent, *, error_result=None, **kwargs):
+        call_state = _ToolExecutionState()
+        started_at = time.time()
+        try:
+            return _run_sequential_tool_execution_middleware(
+                agent,
+                execution_state=call_state,
+                **kwargs,
+            )
+        except KeyboardInterrupt as interrupt:
+            started, effective_args, effective_trace = call_state.started_metadata()
+            setattr(interrupt, "_hermes_tool_execution_started", started)
+            if started:
+                args_for_receipt = (
+                    effective_args
+                    if effective_args is not None
+                    else kwargs["function_args"]
+                )
+                result = _emit_cancelled_terminal_post_tool_call(
+                    agent,
+                    function_name=kwargs["function_name"],
+                    function_args=args_for_receipt,
+                    effective_task_id=kwargs["effective_task_id"],
+                    tool_call_id=kwargs["tool_call_id"],
+                    start_time=started_at,
+                    middleware_trace=effective_trace,
+                )
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name=kwargs["function_name"],
+                    function_args=args_for_receipt,
+                    result=result,
+                    effective_task_id=kwargs["effective_task_id"],
+                    tool_call_id=kwargs["tool_call_id"],
+                    duration_s=time.time() - started_at,
+                    exit_status="cancelled",
+                )
+                setattr(interrupt, "_hermes_tool_execution_terminalized", True)
+            raise
+        except _StartedToolError as tool_error:
+            function_name = kwargs["function_name"]
+            logger.error(
+                "tool callback raised for %s: %s",
+                function_name,
+                tool_error.cause,
+                exc_info=True,
+            )
+            result = (
+                error_result(tool_error.cause)
+                if error_result is not None
+                else f"Error executing tool '{function_name}': {tool_error.cause}"
+            )
+            return _ManagedToolResult(
+                result=result,
+                args=tool_error.function_args,
+                middleware_trace=tool_error.middleware_trace,
+                blocked=False,
+                dispatched=True,
+            )
 
     for i, tool_call in enumerate(assistant_message.tool_calls, 1):
         tool_call_id = _pairing_tool_call_id(tool_call)
@@ -2460,6 +2797,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     execute=_execute,
                     scope_block=_ts_scope_block,
                     display_index=i,
+                    error_result=lambda cause: json.dumps({"error": f"Context engine tool '{function_name}' failed: {cause}"}),
                 ))
                 _ce_result = function_result
             except Exception as tool_error:
@@ -2496,6 +2834,7 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     execute=_execute,
                     scope_block=_ts_scope_block,
                     display_index=i,
+                    error_result=lambda cause: json.dumps({"error": f"Memory tool '{function_name}' failed: {cause}"}),
                 ))
                 _mem_result = function_result
             except Exception as tool_error:
@@ -2565,24 +2904,41 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                     )
                 )
                 _spinner_result = function_result
-            except KeyboardInterrupt:
-                function_result = _emit_cancelled_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=tool_call_id,
-                    start_time=tool_start_time,
-                    middleware_trace=list(middleware_trace),
-                )
+            except KeyboardInterrupt as interrupt:
+                function_result = _cancelled_tool_result()
+                if not getattr(
+                    interrupt,
+                    "_hermes_tool_execution_terminalized",
+                    False,
+                ) and getattr(
+                    interrupt,
+                    "_hermes_tool_execution_started",
+                    False,
+                ):
+                    function_result = _emit_cancelled_terminal_post_tool_call(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        start_time=tool_start_time,
+                        middleware_trace=list(middleware_trace),
+                    )
+                    _maybe_record_action_receipt(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=function_result,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        duration_s=time.time() - tool_start_time,
+                        exit_status="cancelled",
+                    )
                 _spinner_result = function_result
                 try:
                     agent.interrupt("keyboard interrupt")
                 except Exception:
                     pass
-                # Emit a tool result for THIS call and every remaining call in
-                # the batch before re-raising, so the assistant tool-call turn
-                # is never left without matching tool results (alternation).
                 _append_cancelled_tool_results(
                     messages,
                     assistant_message.tool_calls[i - 1:],
@@ -2646,22 +3002,40 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                         middleware_trace=middleware_trace,
                     )
                 )
-            except KeyboardInterrupt:
-                _emit_cancelled_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=tool_call_id,
-                    start_time=tool_start_time,
-                    middleware_trace=list(middleware_trace),
-                )
+            except KeyboardInterrupt as interrupt:
+                function_result = _cancelled_tool_result()
+                if not getattr(
+                    interrupt,
+                    "_hermes_tool_execution_terminalized",
+                    False,
+                ) and getattr(
+                    interrupt,
+                    "_hermes_tool_execution_started",
+                    False,
+                ):
+                    function_result = _emit_cancelled_terminal_post_tool_call(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        start_time=tool_start_time,
+                        middleware_trace=list(middleware_trace),
+                    )
+                    _maybe_record_action_receipt(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=function_result,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        duration_s=time.time() - tool_start_time,
+                        exit_status="cancelled",
+                    )
                 try:
                     agent.interrupt("keyboard interrupt")
                 except Exception:
                     pass
-                # Emit a tool result for THIS call and every remaining call in
-                # the batch before re-raising (see interactive branch above).
                 _append_cancelled_tool_results(
                     messages,
                     assistant_message.tool_calls[i - 1:],
@@ -2710,6 +3084,23 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 tool_call_id=tool_call_id,
                 duration_ms=int(tool_duration * 1000),
                 middleware_trace=list(middleware_trace),
+            )
+        if _execution_dispatched and not _execution_blocked:
+            if isinstance(function_result, _ToolCancelledResult):
+                receipt_exit_status = "cancelled"
+            elif isinstance(function_result, _ToolTimeoutResult):
+                receipt_exit_status = "timeout"
+            else:
+                receipt_exit_status = "error" if _is_error_result else "ok"
+            _maybe_record_action_receipt(
+                agent,
+                function_name=function_name,
+                function_args=function_args,
+                result=function_result,
+                effective_task_id=effective_task_id,
+                tool_call_id=tool_call_id,
+                duration_s=tool_duration,
+                exit_status=receipt_exit_status,
             )
         if not _execution_blocked:
             function_result = agent._append_guardrail_observation(

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1526,7 +1526,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         tool_call_id = _pairing_tool_call_id(tool_call)
         blocked = False
         dispatched = False
-        execution_raised = False
         start_advanced = False
 
         def _advance_start(callback=None) -> None:
@@ -1550,17 +1549,24 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
         try:
             try:
                 def _execute(next_args: dict[str, Any]) -> Any:
-                    return agent._invoke_tool(
-                        function_name,
-                        next_args,
-                        effective_task_id,
-                        tool_call_id,
-                        messages=messages,
-                        pre_tool_block_checked=True,
-                        skip_tool_request_middleware=True,
-                        skip_tool_execution_middleware=True,
-                        tool_request_middleware_trace=list(middleware_trace),
-                    )
+                    from model_tools import suppress_post_tool_call_hook
+
+                    # The batch executor owns the sole terminal event. Keeping
+                    # inner dispatch observationally silent also prevents a
+                    # non-cooperative worker from reporting late success after
+                    # timeout/cancellation has already terminalized the call.
+                    with suppress_post_tool_call_hook():
+                        return agent._invoke_tool(
+                            function_name,
+                            next_args,
+                            effective_task_id,
+                            tool_call_id,
+                            messages=messages,
+                            pre_tool_block_checked=True,
+                            skip_tool_request_middleware=True,
+                            skip_tool_execution_middleware=True,
+                            tool_request_middleware_trace=list(middleware_trace),
+                        )
 
                 managed = _run_agent_tool_execution_middleware(
                     agent,
@@ -1604,20 +1610,7 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     agent.interrupt("keyboard interrupt")
                 except Exception:
                     pass
-                cancelled_result = (
-                    _emit_cancelled_terminal_post_tool_call(
-                        agent,
-                        function_name=function_name,
-                        function_args=function_args,
-                        effective_task_id=effective_task_id,
-                        tool_call_id=tool_call_id,
-                        start_time=start,
-                        middleware_trace=list(middleware_trace),
-                    )
-                    if dispatched
-                    else _cancelled_tool_result()
-                )
-                result = _ToolCancelledResult(cancelled_result)
+                result = _ToolCancelledResult(_cancelled_tool_result())
                 duration = time.time() - start
                 logger.info("tool %s cancelled (%.2fs)", function_name, duration)
                 results[index] = (
@@ -1632,7 +1625,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 )
                 return
             except Exception as tool_error:
-                execution_raised = True
                 dispatched = execution_state.has_started()
                 if isinstance(tool_error, _StartedToolError):
                     cause = tool_error.cause
@@ -1643,17 +1635,6 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                 result = f"Error executing tool '{function_name}': {cause}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, cause, exc_info=True)
             duration = time.time() - start
-            if not blocked and (execution_raised or not dispatched):
-                _emit_terminal_post_tool_call(
-                    agent,
-                    function_name=function_name,
-                    function_args=function_args,
-                    result=result,
-                    effective_task_id=effective_task_id,
-                    tool_call_id=tool_call_id,
-                    duration_ms=int(duration * 1000),
-                    middleware_trace=list(middleware_trace),
-                )
             is_error, _ = _detect_tool_failure(function_name, result)
             if is_error:
                 logger.info("tool %s failed (%.2fs): %s", function_name, duration, result[:200])
@@ -2041,8 +2022,35 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                     status="error",
                     error_type="invalid_tool_arguments",
                     error_message="Tool arguments must be a valid JSON object",
+                    duration_ms=int(tool_duration * 1000),
                     middleware_trace=list(middleware_trace),
                 )
+            elif not blocked:
+                if isinstance(function_result, _ToolCancelledResult):
+                    _emit_terminal_post_tool_call(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=function_result,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        duration_ms=int(tool_duration * 1000),
+                        status="cancelled",
+                        error_type="keyboard_interrupt",
+                        error_message="Tool execution cancelled by user interrupt",
+                        middleware_trace=list(middleware_trace),
+                    )
+                else:
+                    _emit_terminal_post_tool_call(
+                        agent,
+                        function_name=function_name,
+                        function_args=function_args,
+                        result=function_result,
+                        effective_task_id=effective_task_id,
+                        tool_call_id=tool_call_id,
+                        duration_ms=int(tool_duration * 1000),
+                        middleware_trace=list(middleware_trace),
+                    )
             _receipt_cancelled = isinstance(function_result, _ToolCancelledResult)
             _receipt_timed_out = isinstance(function_result, _ToolTimeoutResult)
             if blocked:

--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -200,7 +200,7 @@ _IMPORT_SKIP_NAMES = {
 }
 
 # zipfile.open() drops Unix mode bits on extract; restore tightens these to 0600.
-_SECRET_FILE_NAMES = {".env", "auth.json", "state.db"}
+_SECRET_FILE_NAMES = {".env", "auth.json", "state.db", "action_receipts.db"}
 
 # Reserved archive subtree for provider state that lives OUTSIDE HERMES_HOME
 # (e.g. ~/.honcho, ~/.hindsight). The active memory provider declares these via
@@ -810,7 +810,9 @@ def _safe_restore_db(src: Path, dst: Path) -> bool:
 
     By writing pages through the backup API the file inode is preserved,
     the WAL journal is updated correctly, and all connections (old and
-    new) converge on the restored data.
+    new) converge on the restored data. Secret database names are tightened
+    to ``0600`` together with any live WAL/SHM sidecars before success is
+    reported.
 
     Falls back to the unlink+move approach on failure ONLY when no other
     process or in-process connection holds the file: replacing the inode
@@ -831,10 +833,19 @@ def _safe_restore_db(src: Path, dst: Path) -> bool:
         finally:
             src_conn.close()
         dst_conn.close()
-        # Restore original file permissions from the snapshot
+        # Restore the snapshot mode, except for known secret databases whose
+        # privacy contract also covers SQLite's live sidecars.
         try:
-            mode = src.stat().st_mode
-            dst.chmod(mode)
+            mode = 0o600 if dst.name in _SECRET_FILE_NAMES else stat.S_IMODE(src.stat().st_mode)
+            for candidate in (
+                dst,
+                dst.with_name(dst.name + "-wal"),
+                dst.with_name(dst.name + "-shm"),
+            ):
+                try:
+                    candidate.chmod(mode, follow_symlinks=False)
+                except FileNotFoundError:
+                    pass
         except Exception:
             pass
         return True
@@ -891,6 +902,8 @@ def _safe_restore_db(src: Path, dst: Path) -> bool:
                 for _sidecar_suffix in ("-wal", "-shm", "-journal"):
                     dst.with_name(dst.name + _sidecar_suffix).unlink(missing_ok=True)
                 shutil.move(str(tmp), str(dst))
+                if dst.name in _SECRET_FILE_NAMES:
+                    dst.chmod(0o600, follow_symlinks=False)
             return True
         except LiveConnectionError as exc2:
             logger.error(
@@ -1236,7 +1249,14 @@ def _extract_member_atomically(
     # the same shape as ``atomic_yaml_write``'s ``create_mode`` fallback.
     mode = _preserve_file_mode(target)
     owner = _preserve_file_owner(target)
-    if mode is None:
+    secret_file = target.name in _SECRET_FILE_NAMES
+    if secret_file:
+        # Secret-bearing files must land as 0600, not transit through an
+        # archive/default or previously permissive target mode before a later
+        # chmod. The temp inode has this mode before archive bytes are written,
+        # and atomic_replace publishes the already-private inode.
+        mode = 0o600
+    elif mode is None:
         mode = new_file_mode
     else:
         # Deliberately NOT a faithful mode copy: setuid/setgid are dropped.
@@ -1244,9 +1264,9 @@ def _extract_member_atomically(
         # bits, and the content replacing this file comes from the archive.
         # Carrying the elevated bits across would let archive-controlled bytes
         # take over an existing setuid/setgid file, so ``hermes import`` would
-        # hand whoever produced the zip the identity that file runs as.  Nothing
+        # hand whoever produced the zip the identity that file runs as. Nothing
         # constrains that to Hermes' own state either: the ``_external/`` branch
-        # of ``run_import`` publishes members anywhere under ``$HOME``.  The
+        # of ``run_import`` publishes members anywhere under ``$HOME``. The
         # sticky bit is kept — it is inert on a regular file.
         mode &= ~(stat.S_ISUID | stat.S_ISGID)
 

--- a/tests/agent/test_action_receipts.py
+++ b/tests/agent/test_action_receipts.py
@@ -1266,3 +1266,137 @@ class TestMaxSizeMbRetention:
         assert ledger.verify_chain() == [], (
             "Chain must be valid even when floor exception prevents pruning."
         )
+
+
+# ── verify_chain single-snapshot regression ─────────────────────────────────────
+
+class TestVerifyChainSingleSnapshot:
+    """verify_chain must read prune_boundary_prev_hash and receipt rows inside
+    one _connect_readonly connection *and* one BEGIN transaction so both
+    SELECTs share the same WAL read-point.
+
+    Two deterministic behavioral checks (no timing sleeps, no source reading,
+    no implementation-shape assertions beyond the public observable contract):
+
+    1. connection-count seam — _connect_readonly is called exactly once per
+       verify_chain invocation on a populated, pruned ledger.
+
+    2. between-SELECT mutation seam — a side-effect injected via execute()
+       wrapping fires right after the meta SELECT completes (i.e. after BEGIN
+       has pinned the WAL snapshot) and corrupts prune_boundary_prev_hash.
+       Because both SELECTs share the same BEGIN snapshot the mutation is
+       invisible to the receipts SELECT, so verify_chain still returns [].
+       The test asserts that outcome deterministically, with no timing
+       dependencies.
+    """
+
+    def _pruned_ledger(self, tmp_path, monkeypatch):
+        """Return (ledger, db_path) with a pruned boundary row in meta."""
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        # max_rows=2 so the third record prunes, writing prune_boundary_prev_hash.
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_rows=2))
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        for i in range(3):
+            ledger.record_receipt(tool_name=f"tool{i}", args={"i": i})
+        return ledger, db
+
+    def test_verify_chain_opens_one_connection(self, tmp_path, monkeypatch):
+        """_connect_readonly is called exactly once per verify_chain call."""
+        import agent.action_receipts as ar
+
+        ledger, _ = self._pruned_ledger(tmp_path, monkeypatch)
+
+        call_count = [0]
+        _real_connect_readonly = ar.ActionReceiptLedger._connect_readonly
+
+        def _counting_connect_readonly(self_inner):
+            call_count[0] += 1
+            return _real_connect_readonly(self_inner)
+
+        monkeypatch.setattr(
+            ar.ActionReceiptLedger, "_connect_readonly", _counting_connect_readonly
+        )
+
+        result = ledger.verify_chain()
+
+        assert result == [], f"verify_chain reported defects: {result}"
+        assert call_count[0] == 1, (
+            f"verify_chain opened {call_count[0]} read-only connections; "
+            "expected exactly 1 (single-snapshot contract)"
+        )
+
+    def test_verify_chain_unaffected_by_between_select_mutation(
+        self, tmp_path, monkeypatch
+    ):
+        """A boundary mutation committed between the meta SELECT and the receipts
+        SELECT must be invisible — the BEGIN transaction has already pinned the
+        WAL read-point before the meta SELECT ran, so the receipts SELECT sees
+        the same snapshot.
+
+        The injection seam wraps conn.execute() on the single connection returned
+        by _connect_readonly.  The first prune_boundary_prev_hash SELECT returns
+        the correct value; then the mutation fires via a separate writer that
+        corrupts the boundary; then the receipts SELECT proceeds.  Under a proper
+        BEGIN snapshot the mutation is outside the read horizon and verify_chain
+        returns no defects.
+        """
+        import sqlite3
+        import agent.action_receipts as ar
+
+        ledger, db = self._pruned_ledger(tmp_path, monkeypatch)
+
+        # Confirm the baseline chain is intact before instrumentation.
+        assert ledger.verify_chain() == []
+
+        _real_connect_readonly = ar.ActionReceiptLedger._connect_readonly
+
+        def _instrumenting_connect_readonly(self_inner):
+            conn = _real_connect_readonly(self_inner)
+            # Wrap execute() so we can inject a mutation between specific SELECTs.
+            mutation_fired = [False]
+            original_execute = conn.execute
+
+            def _execute_with_injection(sql, *args, **kwargs):
+                result = original_execute(sql, *args, **kwargs)
+                # After the meta row has been fetched, commit a corruption via
+                # a *separate* writer connection.  This fires after BEGIN has
+                # pinned our snapshot, so the receipts SELECT that follows
+                # should remain unaffected.
+                if (
+                    not mutation_fired[0]
+                    and "prune_boundary_prev_hash" in sql
+                    and sql.strip().upper().startswith("SELECT")
+                ):
+                    mutation_fired[0] = True
+                    try:
+                        writer = sqlite3.connect(str(db))
+                        writer.execute(
+                            "UPDATE meta SET value='deadbeef_injected' "
+                            "WHERE key='prune_boundary_prev_hash'"
+                        )
+                        writer.commit()
+                        writer.close()
+                    except Exception:
+                        pass
+                return result
+
+            conn.execute = _execute_with_injection
+            return conn
+
+        monkeypatch.setattr(
+            ar.ActionReceiptLedger, "_connect_readonly", _instrumenting_connect_readonly
+        )
+
+        result = ledger.verify_chain()
+
+        # The BEGIN snapshot pins both SELECTs to the same WAL point.  The
+        # mutation was committed after BEGIN but is outside the read horizon,
+        # so verify_chain sees the original correct boundary and returns no
+        # defects.
+        assert result == [], (
+            "verify_chain reported defects after a between-SELECT boundary "
+            "mutation; this indicates the receipts SELECT saw a different "
+            "snapshot than the meta SELECT"
+        )

--- a/tests/agent/test_action_receipts.py
+++ b/tests/agent/test_action_receipts.py
@@ -1,0 +1,1268 @@
+"""Tests for agent/action_receipts.py, agent/task_envelope.py, and the
+_maybe_record_action_receipt tool-executor boundary.
+
+All behavioral contracts are tested here per task spec:
+  - default-off gate (is_enabled)
+  - owner-only DB permissions (0o600)
+  - retention bounds (max_rows, max_age_days, max_size_mb)
+  - hash-chain verification (detects corruption, does NOT prove originality)
+  - redaction of secrets in args
+  - BEGIN IMMEDIATE / _DB_LOCK concurrency
+  - tool-executor import boundary (_maybe_record_action_receipt importable
+    and does not write when disabled)
+  - task_envelope: build_shadow_envelope, validate_envelope, canonical_hash
+"""
+
+from __future__ import annotations
+
+import hashlib
+import importlib
+import json
+import os
+import stat
+import threading
+import time
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ── helpers ────────────────────────────────────────────────────────────────────
+
+def _cfg(enabled: bool = True, **extra) -> dict:
+    """Build a minimal config dict for injection."""
+    receipts: dict[str, Any] = {"enabled": enabled}
+    receipts.update(extra)
+    return {"observability": {"action_receipts": receipts}}
+
+
+def _make_ledger(tmp_path: Path, monkeypatch, cfg: dict | None = None):
+    """Return an ActionReceiptLedger pointed at tmp_path, with config injected."""
+    import agent.action_receipts as ar
+
+    db = tmp_path / "receipts.db"
+    monkeypatch.setattr(ar, "_load_config", lambda: cfg if cfg is not None else _cfg())
+    return ar.ActionReceiptLedger(db_path=db), db
+
+
+# ── default-off ────────────────────────────────────────────────────────────────
+
+class TestIsEnabled:
+    def test_absent_key_is_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        assert ar.is_enabled() is False
+
+    def test_enabled_false_is_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(enabled=False))
+        assert ar.is_enabled() is False
+
+    def test_enabled_string_true_is_false(self, monkeypatch):
+        """Must be exactly the boolean True, not a truthy string."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(enabled="true"))
+        assert ar.is_enabled() is False
+
+    def test_enabled_true_is_true(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(enabled=True))
+        assert ar.is_enabled() is True
+
+    def test_config_exception_returns_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: (_ for _ in ()).throw(RuntimeError("oops")))
+        assert ar.is_enabled() is False
+
+    def test_non_dict_config_is_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: None)
+        assert ar.is_enabled() is False
+
+    def test_observability_non_dict_is_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {"observability": "yes"})
+        assert ar.is_enabled() is False
+
+    def test_action_receipts_non_dict_is_false(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {"observability": {"action_receipts": True}})
+        assert ar.is_enabled() is False
+
+
+# ── owner-only DB permissions ───────────────────────────────────────────────────
+
+class TestOwnerOnlyPermissions:
+    def test_db_created_with_0o600(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={})
+        mode = stat.S_IMODE(db.stat().st_mode)
+        assert mode == 0o600, f"Expected 0o600, got {oct(mode)}"
+
+    def test_db_not_world_readable(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={})
+        mode = db.stat().st_mode
+        assert not (mode & stat.S_IROTH), "DB must not be world-readable"
+        assert not (mode & stat.S_IRGRP), "DB must not be group-readable"
+
+    def test_wal_sidecars_hardened_to_0o600(self, tmp_path, monkeypatch):
+        """The hardening pass covers SQLite's WAL and SHM sidecars."""
+        import agent.action_receipts as ar
+
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        conn = ledger._connect()
+        try:
+            sidecars = [db.parent / f"{db.name}{suffix}" for suffix in ("-wal", "-shm")]
+            assert all(path.exists() for path in sidecars)
+            for path in sidecars:
+                path.chmod(0o666)
+
+            ar._harden_db_permissions(db)
+
+            for path in sidecars:
+                mode = stat.S_IMODE(path.stat().st_mode)
+                assert mode == 0o600, f"{path.name} expected 0o600, got {oct(mode)}"
+        finally:
+            conn.close()
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX descriptor opens only")
+    def test_connection_pins_validated_inode_across_path_substitution(
+        self, tmp_path, monkeypatch
+    ):
+        """SQLite must use the inode securely opened before a path swap."""
+        import agent.action_receipts as ar
+
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        original_open = ar._descriptor_path
+
+        def _swap_path(fd):
+            db.rename(tmp_path / "validated.db")
+            db.write_bytes(b"attacker replacement")
+            return original_open(fd)
+
+        monkeypatch.setattr(ar, "_descriptor_path", _swap_path)
+        conn = ledger._connect()
+        try:
+            database_path = conn.execute("PRAGMA database_list").fetchone()[2]
+            assert Path(database_path).name == "validated.db"
+        finally:
+            conn.close()
+        assert db.read_bytes() == b"attacker replacement"
+
+    def test_readonly_open_rejects_symlink(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+
+        real = tmp_path / "real.db"
+        real.write_bytes(b"")
+        link = tmp_path / "receipts.db"
+        link.symlink_to(real)
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        with pytest.raises(PermissionError, match="symlink"):
+            ar.ActionReceiptLedger(link)._connect_readonly()
+
+    def test_uri_significant_filename_opens_as_literal_path(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+
+        db = tmp_path / "receipts?mode=ro#literal.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db)
+        ledger.record_receipt(tool_name="echo", args={})
+        assert db.is_file()
+        assert len(ledger.read_all()) == 1
+
+# ── basic append / read ─────────────────────────────────────────────────────────
+
+class TestBasicAppend:
+    def test_record_returns_receipt_id(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        rid = ledger.record_receipt(tool_name="bash", args={"cmd": "ls"})
+        assert rid.startswith("r-") or len(rid) > 4
+
+    def test_read_all_returns_one_row(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args={})
+        rows = ledger.read_all()
+        assert len(rows) == 1
+        assert rows[0]["tool_name"] == "bash"
+
+    def test_read_all_empty_when_no_db(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        db = tmp_path / "nonexistent.db"
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        assert ledger.read_all() == []
+
+    def test_multiple_receipts_ordered_asc(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        for name in ("first", "second", "third"):
+            ledger.record_receipt(tool_name=name, args={})
+        rows = ledger.read_all()
+        assert [r["tool_name"] for r in rows] == ["first", "second", "third"]
+
+    def test_no_update_trigger_raises(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        import sqlite3
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args={})
+        conn = sqlite3.connect(db)
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute("UPDATE action_receipts SET tool_name='hacked'")
+        conn.close()
+
+    def test_no_delete_trigger_raises(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        import sqlite3
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args={})
+        conn = sqlite3.connect(db)
+        with pytest.raises(sqlite3.IntegrityError, match="append-only"):
+            conn.execute("DELETE FROM action_receipts")
+        conn.close()
+
+
+# ── hash-chain verification ─────────────────────────────────────────────────────
+
+class TestHashChain:
+    def test_intact_chain_returns_empty(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        for i in range(3):
+            ledger.record_receipt(tool_name=f"tool{i}", args={"i": i})
+        assert ledger.verify_chain() == []
+
+    def test_corrupted_hash_detected(self, tmp_path, monkeypatch):
+        """Modifying a stored hash field produces a chain defect.
+
+        The SHA-256 chain detects internal partial inconsistency.
+        It does NOT prove originality: an actor who rewrites the
+        entire file can rebuild a passing chain.
+        """
+        import agent.action_receipts as ar
+        import sqlite3
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args={})
+        ledger.record_receipt(tool_name="python", args={})
+
+        # Directly corrupt the receipt_hash of row 1 (bypass triggers via
+        # the connection-level override used in _apply_retention).
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TRIGGER IF EXISTS action_receipts_no_update")
+        conn.execute("UPDATE action_receipts SET receipt_hash='deadbeef' WHERE id=1")
+        conn.commit()
+        conn.close()
+
+        problems = ledger.verify_chain()
+        assert len(problems) >= 1
+        assert any("hash mismatch" in p or "chain link" in p for p in problems)
+
+    def test_prev_hash_linkage(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="a", args={})
+        ledger.record_receipt(tool_name="b", args={})
+        rows = ledger.read_all()
+        assert rows[0]["prev_receipt_hash"] is None
+        assert rows[1]["prev_receipt_hash"] == rows[0]["receipt_hash"]
+
+    def test_tail_truncation_is_not_detected(self, tmp_path, monkeypatch):
+        """A locally valid shorter chain has no cryptographic tail anchor."""
+        import sqlite3
+        import agent.action_receipts as ar
+
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        for i in range(5):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+
+        conn = sqlite3.connect(db)
+        conn.execute("DROP TRIGGER IF EXISTS action_receipts_no_delete")
+        conn.execute("DELETE FROM action_receipts WHERE id > 3")
+        conn.commit()
+        conn.close()
+
+        assert len(ledger.read_all()) == 3
+        assert ledger.verify_chain() == []
+
+
+# ── redaction ───────────────────────────────────────────────────────────────────
+
+class TestRedaction:
+    def test_api_key_redacted_in_summary(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        summary = ar.redacted_args_summary({"api_key": "sk-secretvalue"})
+        assert "sk-secretvalue" not in summary
+        assert "[redacted]" in summary
+
+    def test_password_key_redacted(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        summary = ar.redacted_args_summary({"password": "hunter2"})
+        assert "hunter2" not in summary
+        assert "[redacted]" in summary
+
+    def test_body_field_fingerprinted(self, tmp_path, monkeypatch):
+        """Body-class keys (content, code, etc.) are fingerprinted, not stored.
+
+        The fingerprint uses an ephemeral HMAC (not raw SHA-256) so the stored
+        value cannot be used offline to confirm the original content.
+        """
+        import agent.action_receipts as ar
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        summary = ar.redacted_args_summary({"content": "secret text here"})
+        parsed = json.loads(summary)
+        # The value is a fingerprint dict, not the original string.
+        assert isinstance(parsed["content"], dict)
+        assert "hmac" in parsed["content"], "fingerprint must use HMAC, not raw sha256"
+        assert "sha256" not in parsed["content"], "raw sha256 must not appear in fingerprint"
+        assert "bytes" in parsed["content"]
+        assert "secret text here" not in summary
+
+    def test_innocent_key_not_redacted(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        summary = ar.redacted_args_summary({"path": "/tmp/foo"})
+        assert "/tmp/foo" in summary
+
+    def test_args_hash_is_hmac_not_canonical_hash(self, tmp_path, monkeypatch):
+        """args_hash must be an ephemeral HMAC, not the deterministic canonical_hash.
+
+        The raw canonical_hash (unkeyed SHA-256) would allow an offline attacker
+        to confirm guessed inputs.  The stored HMAC uses a per-process ephemeral
+        key so the stored value is opaque to offline analysis.
+        """
+        import agent.action_receipts as ar
+        from agent.task_envelope import canonical_hash
+        args = {"api_key": "sk-abc", "cmd": "ls"}
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args=args)
+        rows = ledger.read_all()
+        stored = rows[0]["args_hash"]
+        # Must be a 64-char hex string (HMAC-SHA-256 digest).
+        assert len(stored) == 64
+        assert all(c in "0123456789abcdef" for c in stored)
+        # Must not equal the deterministic canonical_hash (raw SHA-256).
+        assert stored != canonical_hash(args), (
+            "args_hash must be an HMAC, not the unkeyed canonical_hash"
+        )
+
+    def test_redaction_stored_not_plaintext(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(
+            "agent.redact.redact_sensitive_text",
+            lambda text, **kw: text,
+        )
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="bash", args={"api_key": "sk-secret"})
+        rows = ledger.read_all()
+        assert "sk-secret" not in rows[0]["args_redacted_summary"]
+    def test_structured_output_secret_values_never_enter_database(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.action_receipts as ar
+
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(
+            tool_name="echo",
+            args={},
+            output={"result": {"api_key": "OUTPUT-SECRET", "ok": True}},
+        )
+        assert b"OUTPUT-SECRET" not in db.read_bytes()
+
+    def test_unsupported_output_object_string_is_never_invoked(
+        self, tmp_path, monkeypatch
+    ):
+        import agent.action_receipts as ar
+
+        class SecretObject:
+            def __str__(self):
+                raise AssertionError("receipt serialization must not call __str__")
+
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={}, output=SecretObject())
+        stored = ledger.read_all()[0]
+        assert stored["output_hash"] == ar._receipt_hmac(b"[unsupported:SecretObject]")
+
+
+
+# ── retention / rotation ────────────────────────────────────────────────────────
+
+class TestRetention:
+    def test_max_rows_prunes_oldest(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        cfg = _cfg(max_rows=3)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        for i in range(5):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+        rows = ledger.read_all()
+        assert len(rows) <= 3
+        # The newest rows survive.
+        names = [r["tool_name"] for r in rows]
+        assert "t4" in names
+
+    def test_max_age_days_prunes_old_rows(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        cfg = _cfg(max_age_days=30)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        old_ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat()
+        # Write one old receipt directly (bypass auto-timestamp).
+        ledger.record_receipt(tool_name="old", args={}, created_at=old_ts)
+        # Write one fresh receipt — this triggers pruning.
+        ledger.record_receipt(tool_name="fresh", args={})
+        rows = ledger.read_all()
+        names = [r["tool_name"] for r in rows]
+        assert "fresh" in names
+        assert "old" not in names
+
+    def test_zero_max_rows_treated_as_unlimited(self, tmp_path, monkeypatch):
+        """max_rows=0 is a safe no-op; treated as unlimited."""
+        import agent.action_receipts as ar
+        cfg = _cfg(max_rows=0)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        for i in range(5):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+        assert len(ledger.read_all()) == 5
+
+    def test_negative_max_rows_treated_as_unlimited(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        cfg = _cfg(max_rows=-1)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        for i in range(4):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+        assert len(ledger.read_all()) == 4
+
+    def test_no_retention_config_keeps_all(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        for i in range(10):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+        assert len(ledger.read_all()) == 10
+
+    def test_pruned_chain_verifies_cleanly(self, tmp_path, monkeypatch):
+        """A legitimately pruned chain must verify with no defects.
+
+        The prune-boundary metadata written atomically during _apply_retention
+        tells verify_chain the expected predecessor hash for the first surviving
+        row, so no broken-link defect is reported.
+        """
+        import agent.action_receipts as ar
+        cfg = _cfg(max_rows=3)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "r.db")
+        for i in range(6):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+        # verify_chain must report no defects: the prune boundary is legitimate.
+        assert ledger.verify_chain() == []
+
+    def test_forged_boundary_metadata_detected(self, tmp_path, monkeypatch):
+        """A mismatched prune_boundary_prev_hash must be reported as a defect.
+
+        If the boundary metadata is forged or corrupted the first surviving row's
+        prev_receipt_hash will not match it, and verify_chain must report an error.
+        """
+        import sqlite3
+        import agent.action_receipts as ar
+        cfg = _cfg(max_rows=3)
+        monkeypatch.setattr(ar, "_load_config", lambda: cfg)
+        db = tmp_path / "r.db"
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        for i in range(6):
+            ledger.record_receipt(tool_name=f"t{i}", args={})
+
+        # Corrupt the prune_boundary_prev_hash so it no longer matches the
+        # first surviving row's prev_receipt_hash.
+        conn = sqlite3.connect(db)
+        conn.execute(
+            "INSERT OR REPLACE INTO meta(key, value) "
+            "VALUES ('prune_boundary_prev_hash', 'forged_hash_value')"
+        )
+        conn.commit()
+        conn.close()
+
+        problems = ledger.verify_chain()
+        # A defect must be reported for the prune boundary mismatch.
+        assert any("chain link" in p for p in problems), (
+            f"Expected a chain-link defect for forged boundary; got: {problems}"
+        )
+        # Content hashes of surviving rows must still be intact.
+        hash_mismatches = [p for p in problems if "hash mismatch" in p]
+        assert hash_mismatches == [], f"Unexpected content hash errors: {hash_mismatches}"
+
+# ── concurrency ─────────────────────────────────────────────────────────────────
+
+class TestConcurrency:
+    def test_concurrent_writes_produce_valid_chain(self, tmp_path, monkeypatch):
+        """Multiple threads writing concurrently must produce a linear chain."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "c.db")
+        errors: list[Exception] = []
+
+        def _write(n: int) -> None:
+            try:
+                ledger.record_receipt(tool_name=f"tool_{n}", args={"n": n})
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_write, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Thread errors: {errors}"
+        rows = ledger.read_all()
+        assert len(rows) == 10
+        assert ledger.verify_chain() == []
+
+    def test_begin_immediate_serializes_writes(self, tmp_path, monkeypatch):
+        """Two simultaneous writers must not produce a forked chain."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=tmp_path / "ci.db")
+        barrier = threading.Barrier(2)
+        results: list[str] = []
+
+        def _write(name: str) -> None:
+            barrier.wait()
+            results.append(ledger.record_receipt(tool_name=name, args={}))
+
+        t1 = threading.Thread(target=_write, args=("alpha",))
+        t2 = threading.Thread(target=_write, args=("beta",))
+        t1.start(); t2.start()
+        t1.join(); t2.join()
+
+        # Both writes succeed with unique IDs.
+        assert len(set(results)) == 2
+        # Chain is linear (no fork).
+        assert ledger.verify_chain() == []
+
+
+# ── task_envelope behavior ──────────────────────────────────────────────────────
+
+class TestTaskEnvelope:
+    def test_build_shadow_envelope_minimal(self):
+        from agent.task_envelope import build_shadow_envelope, ENVELOPE_SCHEMA_VERSION
+        env = build_shadow_envelope(tool_name="bash", args={"cmd": "ls"})
+        assert env.tool_name == "bash"
+        assert env.envelope_version == ENVELOPE_SCHEMA_VERSION
+        assert env.execution_surface == "local_tool"
+        assert env.lane == "hermes"
+
+    def test_shadow_envelope_safety_fields_none(self):
+        """Shadow mode leaves all safety fields None — records incompleteness."""
+        from agent.task_envelope import build_shadow_envelope, MANDATORY_SAFETY_FIELDS
+        env = build_shadow_envelope(tool_name="bash")
+        for field in MANDATORY_SAFETY_FIELDS:
+            assert getattr(env, field) is None, f"Expected {field} to be None"
+
+    def test_validate_envelope_reports_missing(self):
+        from agent.task_envelope import build_shadow_envelope, validate_envelope, MANDATORY_SAFETY_FIELDS
+        env = build_shadow_envelope(tool_name="bash")
+        missing = validate_envelope(env)
+        for field in MANDATORY_SAFETY_FIELDS:
+            assert field in missing
+
+    def test_validate_envelope_never_raises(self):
+        from agent.task_envelope import validate_envelope, TaskEnvelope
+        # Pass a partial object — validate_envelope must not raise.
+        class _Broken:
+            envelope_version = 999
+        result = validate_envelope(_Broken())  # type: ignore[arg-type]
+        assert isinstance(result, list)
+
+    def test_canonical_hash_deterministic(self):
+        from agent.task_envelope import canonical_hash
+        payload = {"b": 2, "a": 1}
+        h1 = canonical_hash(payload)
+        h2 = canonical_hash(payload)
+        assert h1 == h2
+
+    def test_canonical_hash_key_order_independent(self):
+        from agent.task_envelope import canonical_hash
+        assert canonical_hash({"a": 1, "b": 2}) == canonical_hash({"b": 2, "a": 1})
+
+    def test_envelope_hash_changes_with_tool_name(self):
+        from agent.task_envelope import build_shadow_envelope, envelope_hash
+        e1 = build_shadow_envelope(tool_name="bash")
+        e2 = build_shadow_envelope(tool_name="python")
+        assert envelope_hash(e1) != envelope_hash(e2)
+
+    def test_to_dict_tuples_become_lists(self):
+        from agent.task_envelope import build_shadow_envelope
+        env = build_shadow_envelope(tool_name="bash")
+        d = env.to_dict()
+        for v in d.values():
+            assert not isinstance(v, tuple), "to_dict must not return tuples"
+
+    def test_objective_truncated_to_2000(self):
+        from agent.task_envelope import build_shadow_envelope
+        long_obj = "x" * 3000
+        env = build_shadow_envelope(tool_name="bash", objective=long_obj)
+        assert len(env.objective) == 2000
+
+    def test_input_hash_covers_args(self):
+        from agent.task_envelope import build_shadow_envelope, canonical_hash
+        args = {"cmd": "ls", "cwd": "/tmp"}
+        env = build_shadow_envelope(tool_name="bash", args=args)
+        assert env.input_hash == canonical_hash(args)
+
+    def test_input_hash_empty_args(self):
+        from agent.task_envelope import build_shadow_envelope, canonical_hash
+        env = build_shadow_envelope(tool_name="bash")
+        assert env.input_hash == canonical_hash({})
+
+    def test_input_hash_normalizes_nonfinite_numbers(self):
+        from agent.task_envelope import build_shadow_envelope, canonical_hash
+
+        args = {"nan": float("nan"), "inf": float("inf"), "neg": float("-inf")}
+        env = build_shadow_envelope(tool_name="bash", args=args)
+        assert env.input_hash == canonical_hash(args)
+        assert len(env.input_hash) == 64
+
+
+# ── tool-executor import boundary ───────────────────────────────────────────────
+
+class TestToolExecutorBoundary:
+    def test_maybe_record_action_receipt_importable(self):
+        """_maybe_record_action_receipt must be importable from tool_executor."""
+        from agent.tool_executor import _maybe_record_action_receipt
+        assert callable(_maybe_record_action_receipt)
+
+    def test_execution_state_starts_callback_at_most_once(self):
+        from agent.tool_executor import _ToolExecutionState
+
+        state = _ToolExecutionState()
+        args = {"nested": {"q": "rewritten"}}
+        trace = [{"source": "test-middleware"}]
+        assert state.try_start(args, trace) is True
+        args["nested"]["q"] = "mutated"
+        trace[0]["source"] = "mutated"
+        assert state.try_start({}, []) is False
+        assert state.started_metadata() == (
+            True,
+            {"nested": {"q": "rewritten"}},
+            [{"source": "test-middleware"}],
+        )
+        assert state.abandon() is True
+
+    def test_no_write_when_disabled(self, tmp_path, monkeypatch):
+        """When is_enabled() is False, no DB file must be created or written."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(enabled=False))
+        # Point the default DB path into tmp_path so we can verify it is absent.
+        db = tmp_path / "receipts_disabled.db"
+        monkeypatch.setattr(ar, "default_db_path", lambda: db)
+        from agent.tool_executor import _maybe_record_action_receipt
+
+        agent_mock = MagicMock()
+        agent_mock.session_id = "s1"
+
+        with patch("agent.tool_executor.get_active_env", return_value=None):
+            _maybe_record_action_receipt(
+                agent_mock,
+                function_name="bash",
+                function_args={"cmd": "ls"},
+                result="output",
+                effective_task_id="task1",
+                tool_call_id="tc1",
+                duration_s=0.1,
+                exit_status="ok",
+            )
+
+        # The ledger must have returned immediately without touching the filesystem.
+        assert not db.exists(), (
+            "DB must not be created when action_receipts is disabled; "
+            f"found: {db}"
+        )
+
+    def test_no_exception_propagated_on_write_error(self, tmp_path, monkeypatch):
+        """Receipt write failures must be swallowed, never raised to caller."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(enabled=True))
+        from agent.tool_executor import _maybe_record_action_receipt
+
+        agent = MagicMock()
+        agent.session_id = "s1"
+
+        # Patch ActionReceiptLedger.record_receipt to raise.
+        with patch.object(ar.ActionReceiptLedger, "record_receipt", side_effect=RuntimeError("disk full")):
+            with patch("agent.tool_executor.get_active_env", return_value=None):
+                # Must not raise.
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name="bash",
+                    function_args={},
+                    result="",
+                    effective_task_id="task1",
+                    tool_call_id="tc1",
+                    duration_s=0.0,
+                    exit_status="ok",
+                )
+
+    def test_write_when_enabled(self, tmp_path, monkeypatch):
+        """When enabled, _maybe_record_action_receipt writes one receipt."""
+        import agent.action_receipts as ar
+        db = tmp_path / "receipts.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        from agent.tool_executor import _maybe_record_action_receipt
+
+        agent = MagicMock()
+        agent.session_id = "s-test"
+
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        with patch.object(ar, "ActionReceiptLedger", return_value=ledger):
+            with patch("agent.tool_executor.get_active_env", return_value=None):
+                _maybe_record_action_receipt(
+                    agent,
+                    function_name="pytest_tool",
+                    function_args={"x": 1},
+                    result="done",
+                    effective_task_id="t1",
+                    tool_call_id="tc-abc",
+                    duration_s=0.05,
+                    exit_status="ok",
+                )
+
+        rows = ledger.read_all()
+        assert len(rows) == 1
+        assert rows[0]["tool_name"] == "pytest_tool"
+        assert rows[0]["exit_status"] == "ok"
+        assert rows[0]["session_id"] == "s-test"
+
+    def test_concurrent_dispatch_records_one_receipt_each(self, tmp_path, monkeypatch):
+        """_maybe_record_action_receipt from N concurrent callers writes N receipts.
+
+        Each concurrent call is independent; the ledger's _DB_LOCK serializes
+        writes so the chain is linear and verify_chain reports no defects.
+        """
+        import agent.action_receipts as ar
+        db = tmp_path / "concurrent_receipts.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        from agent.tool_executor import _maybe_record_action_receipt
+
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        errors: list[Exception] = []
+
+        def _call(i: int) -> None:
+            try:
+                mock_agent = MagicMock()
+                mock_agent.session_id = f"s-{i}"
+                with patch("agent.tool_executor.get_active_env", return_value=None):
+                    _maybe_record_action_receipt(
+                        mock_agent,
+                        function_name=f"tool_{i}",
+                        function_args={"i": i},
+                        result=f"out_{i}",
+                        effective_task_id="t1",
+                        tool_call_id=f"tc-{i}",
+                        duration_s=0.01 * i,
+                        exit_status="ok",
+                    )
+            except Exception as exc:
+                errors.append(exc)
+
+        # Patch ActionReceiptLedger once (thread-safely) before threads start,
+        # not per-thread; concurrent patch.object in threads races on module state.
+        monkeypatch.setattr(ar, "ActionReceiptLedger", lambda **kw: ledger)
+        threads = [threading.Thread(target=_call, args=(i,)) for i in range(8)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"Concurrent receipt errors: {errors}"
+        rows = ledger.read_all()
+        assert len(rows) == 8
+        assert ledger.verify_chain() == []
+
+
+    def test_unsupported_object_string_is_never_persisted(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+
+        class SecretObject:
+            def __str__(self):
+                return "SECRET-via-str"
+
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={"value": SecretObject()})
+        assert b"SECRET-via-str" not in db.read_bytes()
+        assert "[unsupported:SecretObject]" in ledger.read_all()[0]["args_redacted_summary"]
+
+
+# ── cookie / set-cookie redaction at arbitrary nesting ──────────────────────────
+
+class TestCookieRedaction:
+    """Cookie and Set-Cookie values must be redacted at any nesting depth."""
+
+    def _summary(self, args: Any) -> Any:
+        import agent.action_receipts as ar
+        import json
+        from unittest.mock import patch
+        with patch("agent.redact.redact_sensitive_text", lambda text, **kw: text):
+            return json.loads(ar.redacted_args_summary(args))
+
+    def test_top_level_cookie_redacted(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"cookie": "session=abc123; auth=xyz"})
+        assert result["cookie"] == "[redacted]"
+
+    def test_top_level_set_cookie_redacted(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"set-cookie": "id=secret; Path=/"})
+        assert result["set-cookie"] == "[redacted]"
+
+    def test_nested_cookie_redacted_depth_1(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"headers": {"cookie": "tok=abc"}})
+        assert result["headers"]["cookie"] == "[redacted]"
+
+    def test_nested_cookie_redacted_depth_2(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"req": {"headers": {"set-cookie": "s=x"}}})
+        assert result["req"]["headers"]["set-cookie"] == "[redacted]"
+
+    def test_cookie_inside_list_redacted(self, monkeypatch):
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"items": [{"Cookie": "user=jack"}]})
+        assert result["items"][0]["Cookie"] == "[redacted]"
+
+    def test_innocent_cookie_string_value_not_double_redacted(self, monkeypatch):
+        """The word 'cookie' inside an innocent value should not be redacted."""
+        import agent.action_receipts as ar
+        monkeypatch.setattr(ar, "_load_config", lambda: {})
+        result = self._summary({"description": "fortune cookie recipe"})
+        assert "fortune cookie recipe" in result["description"]
+
+
+# ── non-confirmable sensitive hashes ────────────────────────────────────────────
+
+class TestNonConfirmableHashes:
+    """args_hash, output_hash, and body fingerprints must use HMAC, not raw SHA-256.
+
+    Raw SHA-256 would allow an observer to confirm whether a stored hash matches
+    a guessed input (dictionary / preimage attack).  HMAC-SHA-256 with an
+    ephemeral key that is never persisted prevents this.
+    """
+
+    def test_body_fingerprint_contains_hmac_not_sha256(self):
+        import agent.action_receipts as ar
+        fp = ar._body_fingerprint("sensitive content")
+        assert "hmac" in fp, "body fingerprint must use 'hmac' key, not 'sha256'"
+        assert "sha256" not in fp, "raw sha256 must not appear in body fingerprint"
+        assert "bytes" in fp
+
+    def test_body_fingerprint_hmac_is_hex_string(self):
+        import agent.action_receipts as ar
+        fp = ar._body_fingerprint("content")
+        assert isinstance(fp["hmac"], str)
+        # HMAC-SHA-256 hex digest is always 64 chars.
+        assert len(fp["hmac"]) == 64
+
+    def test_args_hash_is_hmac_not_raw_sha256(self, tmp_path, monkeypatch):
+        """args_hash stored in DB must not match the raw SHA-256 of the canonical args.
+
+        If it did, an offline attacker could confirm input guesses by hashing
+        candidates and comparing to the stored value.
+        """
+        import agent.action_receipts as ar
+        import hashlib
+        from agent.task_envelope import canonical_json
+
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        args = {"cmd": "ls /tmp"}
+        ledger.record_receipt(tool_name="bash", args=args)
+        rows = ledger.read_all()
+
+        raw_sha256 = hashlib.sha256(
+            canonical_json(args).encode("utf-8")
+        ).hexdigest()
+        stored = rows[0]["args_hash"]
+        assert stored != raw_sha256, (
+            "args_hash must not equal the raw SHA-256 of the args "
+            "(that would allow offline confirmation of inputs)"
+        )
+        # It should still be a 64-char hex string (HMAC-SHA-256).
+        assert len(stored) == 64
+        assert all(c in "0123456789abcdef" for c in stored)
+
+    def test_output_hash_is_hmac_not_raw_sha256(self, tmp_path, monkeypatch):
+        """output_hash stored in DB must not match the raw SHA-256 of the output."""
+        import agent.action_receipts as ar
+        import hashlib
+
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        output = "command output here"
+        ledger.record_receipt(tool_name="bash", args={}, output=output)
+        rows = ledger.read_all()
+
+        raw_sha256 = hashlib.sha256(output.encode("utf-8")).hexdigest()
+        stored = rows[0]["output_hash"]
+        assert stored != raw_sha256, (
+            "output_hash must not equal the raw SHA-256 of the output text"
+        )
+        assert len(stored) == 64
+
+    def test_args_hash_consistent_within_process(self, tmp_path, monkeypatch):
+        """Same args produce the same HMAC within one process (ephemeral key is stable).
+
+        Tests the _receipt_hmac function directly to avoid any module-level attribute
+        leakage from concurrent tests that use patch.object on ar.ActionReceiptLedger.
+        The invariant is: _HMAC_KEY is generated once at module import and never changes;
+        identical inputs always produce identical HMAC-SHA-256 outputs.
+        """
+        import agent.action_receipts as ar
+        from agent.task_envelope import canonical_json
+        args = {"x": 42}
+        encoded = canonical_json(args).encode("utf-8")
+        h1 = ar._receipt_hmac(encoded)
+        h2 = ar._receipt_hmac(encoded)
+        assert h1 == h2, "Same data must produce the same HMAC (key is stable per process)"
+        # Also verify two DB writes produce the same args_hash.
+        # Use ActionReceiptLedger directly (imported name, not ar.ActionReceiptLedger)
+        # to be immune to concurrent-test patch.object leaks on the module attribute.
+        from agent.action_receipts import ActionReceiptLedger
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        db = tmp_path / "consistency.db"
+        ledger = ActionReceiptLedger(db_path=db)
+        ledger.record_receipt(tool_name="t1", args=args, receipt_id="r-first")
+        ledger.record_receipt(tool_name="t2", args=args, receipt_id="r-second")
+        rows = ledger.read_all()
+        assert rows[0]["args_hash"] == rows[1]["args_hash"], (
+            "Same args within one process must produce the same HMAC"
+        )
+        # The stored hash must match what _receipt_hmac computes directly.
+        assert rows[0]["args_hash"] == h1, (
+            "Stored args_hash must equal _receipt_hmac of canonical_json(args)"
+        )
+
+    def test_nonfinite_args_still_produce_receipt(self, tmp_path, monkeypatch):
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        args = {"nan": float("nan"), "inf": float("inf")}
+
+        ledger.record_receipt(tool_name="bash", args=args, output="ok")
+
+        rows = ledger.read_all()
+        assert len(rows) == 1
+        assert len(rows[0]["args_hash"]) == 64
+
+    def test_envelope_json_input_hash_is_hmac_not_canonical_hash(self, tmp_path, monkeypatch):
+        """envelope_json must not persist the raw canonical_hash(args) as input_hash.
+
+        TaskEnvelope.input_hash is SHA-256(canonical_json(args)); if persisted
+        verbatim it allows offline confirmation of argument content.  action_receipts
+        must replace it with an ephemeral HMAC before storing.
+        """
+        import json
+        import hashlib
+        import agent.action_receipts as ar
+        from agent.task_envelope import canonical_json as te_canonical_json
+
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        args = {"cmd": "ls /sensitive"}
+        ledger.record_receipt(tool_name="bash", args=args)
+        rows = ledger.read_all()
+        env = json.loads(rows[0]["envelope_json"])
+
+        raw_sha256 = hashlib.sha256(
+            te_canonical_json(args).encode("utf-8")
+        ).hexdigest()
+        stored_input_hash = env.get("input_hash")
+        assert stored_input_hash is not None
+        assert stored_input_hash != raw_sha256, (
+            "envelope_json.input_hash must not equal the raw SHA-256 of args "
+            "(offline confirmation attack vector)"
+        )
+        # The replacement value must still be a 64-char hex string.
+        assert len(stored_input_hash) == 64
+        assert all(c in "0123456789abcdef" for c in stored_input_hash)
+
+    def test_envelope_hash_does_not_expose_raw_input_hash(self, tmp_path, monkeypatch):
+        """envelope_hash must be computed over the scrubbed dict, not the raw envelope."""
+        import hashlib
+        import agent.action_receipts as ar
+        from agent.task_envelope import canonical_hash, canonical_json as te_canonical_json, build_shadow_envelope
+
+        ledger, _ = _make_ledger(tmp_path, monkeypatch)
+        args = {"x": 1}
+        ledger.record_receipt(tool_name="bash", args=args)
+        rows = ledger.read_all()
+        stored_eh = rows[0]["envelope_hash"]
+
+        # The raw envelope's SHA-256 (with unscrubbed input_hash) must not match.
+        env = build_shadow_envelope(tool_name="bash", args=args)
+        raw_env_hash = canonical_hash(env.to_dict())
+        assert stored_eh != raw_env_hash, (
+            "envelope_hash must be computed from the scrubbed dict, "
+            "not the original envelope containing raw input_hash"
+        )
+
+
+# ── symlink / non-regular file rejection ────────────────────────────────────────
+
+class TestDBFileHardening:
+    """DB and sidecars must be regular files; symlinks must be rejected."""
+
+    def test_db_created_as_regular_file(self, tmp_path, monkeypatch):
+        import agent.action_receipts as ar
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={})
+        st = os.lstat(db)
+        assert stat.S_ISREG(st.st_mode), "DB must be a regular file"
+        assert not stat.S_ISLNK(st.st_mode), "DB must not be a symlink"
+
+    def test_db_created_with_0600_no_umask_window(self, tmp_path, monkeypatch):
+        """DB must be created at 0o600 without a permissive umask window."""
+        import agent.action_receipts as ar
+        ledger, db = _make_ledger(tmp_path, monkeypatch)
+        ledger.record_receipt(tool_name="echo", args={})
+        mode = stat.S_IMODE(os.lstat(db).st_mode)
+        assert mode == 0o600, f"DB mode must be 0o600, got {oct(mode)}"
+
+    def test_symlink_db_raises_permission_error(self, tmp_path, monkeypatch):
+        """Opening a DB path that is a symlink must raise PermissionError."""
+        import agent.action_receipts as ar
+        db = tmp_path / "receipts.db"
+        target = tmp_path / "real.db"
+        target.write_bytes(b"")
+        db.symlink_to(target)
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        with pytest.raises(PermissionError, match="symlink"):
+            ledger._connect()
+
+    def test_assert_regular_file_passes_on_missing(self, tmp_path):
+        """_assert_regular_file must not raise when the path does not exist yet."""
+        import agent.action_receipts as ar
+        ar._assert_regular_file(tmp_path / "nonexistent.db")  # must not raise
+
+    def test_assert_regular_file_raises_on_symlink(self, tmp_path):
+        import agent.action_receipts as ar
+        link = tmp_path / "link.db"
+        real = tmp_path / "real.db"
+        real.write_bytes(b"")
+        link.symlink_to(real)
+        with pytest.raises(PermissionError, match="symlink"):
+            ar._assert_regular_file(link)
+
+    def test_harden_skips_symlink_sidecar(self, tmp_path):
+        """_harden_db_permissions must not follow a symlink sidecar."""
+        import agent.action_receipts as ar
+        db = tmp_path / "receipts.db"
+        db.write_bytes(b"")
+        # Create a symlink where the -wal sidecar would be.
+        other = tmp_path / "other_file"
+        other.write_bytes(b"")
+        other.chmod(0o644)
+        wal = tmp_path / "receipts.db-wal"
+        wal.symlink_to(other)
+        # Must not raise and must not chmod the symlink target.
+        ar._harden_db_permissions(db)
+        # The symlink target retains its original mode (was not chmoded).
+        assert stat.S_IMODE(other.stat().st_mode) == 0o644
+
+
+# ── max_size_mb deterministic bound ─────────────────────────────────────────────
+
+
+def _live_data_bytes(db_path) -> int:
+    """Return (page_count - freelist_count) * page_size for *db_path*.
+
+    This is the same metric _apply_retention uses: pages holding live data
+    (not yet reclaimed by VACUUM).  Matches the documented bound.
+    """
+    import sqlite3
+    conn = sqlite3.connect(str(db_path), isolation_level=None)
+    try:
+        r = conn.execute(
+            "SELECT (page_count - freelist_count) * page_size"
+            " FROM pragma_page_count(), pragma_freelist_count(), pragma_page_size()"
+        ).fetchone()
+        return r[0] if r else 0
+    finally:
+        conn.close()
+
+
+class TestMaxSizeMbRetention:
+    """max_size_mb yields a deterministic bound on live-data pages after pruning.
+
+    The bound is measured as (page_count - freelist_count) * page_size, which
+    tracks live-data usage and converges within a single transaction without
+    requiring VACUUM.  A floor of _SIZE_FLOOR_ROWS (50) newest rows is always
+    preserved; if those rows alone exceed the limit the pruning stops.
+    """
+
+    def test_converges_to_bound_from_far_above(self, tmp_path, monkeypatch):
+        """A ledger far above max_size_mb must converge to its bound after
+        record_receipt returns; the live-data size must not exceed the limit
+        while any deletable rows exist.
+        """
+        import sqlite3
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        # Pre-populate far above the limit without size enforcement active.
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        payload = "x" * 4000  # ~4 KB per row
+        for i in range(500):
+            ledger.record_receipt(tool_name=f"t{i}", args={"p": payload})
+
+        # Now enable a 1 MB limit and trigger pruning via one more insert.
+        limit_mb = 1
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=limit_mb))
+        ledger.record_receipt(tool_name="trigger", args={})
+
+        live = _live_data_bytes(db)
+        limit_bytes = limit_mb * 1024 * 1024
+        # After pruning, live-data footprint must be at or below the limit.
+        # The only exception is when only the floor rows remain and those still
+        # exceed the limit — but with 4 KB rows and a 1 MB limit, > 50 rows
+        # exist so no floor exception applies here.
+        assert live <= limit_bytes, (
+            f"Live-data footprint {live} exceeds configured bound {limit_bytes} "
+            f"after record_receipt; deterministic pruning must converge."
+        )
+
+    def test_chain_valid_after_deterministic_pruning(self, tmp_path, monkeypatch):
+        """verify_chain must return no defects after max_size_mb convergence."""
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        payload = "x" * 4000
+        for i in range(500):
+            ledger.record_receipt(tool_name=f"t{i}", args={"p": payload})
+
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=1))
+        ledger.record_receipt(tool_name="trigger", args={})
+
+        assert ledger.verify_chain() == [], (
+            "Chain must verify cleanly after max_size_mb deterministic pruning."
+        )
+
+    def test_newest_rows_survive_pruning(self, tmp_path, monkeypatch):
+        """The _SIZE_FLOOR_ROWS (50) most-recent rows must survive pruning."""
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        payload = "x" * 4000
+        for i in range(200):
+            ledger.record_receipt(tool_name=f"t{i}", args={"p": payload})
+
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=1))
+        ledger.record_receipt(tool_name="newest", args={})
+
+        names = {r["tool_name"] for r in ledger.read_all()}
+        assert "newest" in names, (
+            "Most-recent row must survive max_size_mb pruning."
+        )
+
+    def test_floor_case_no_deletion_when_at_floor(self, tmp_path, monkeypatch):
+        """When total rows <= _SIZE_FLOOR_ROWS, no row may be deleted even if
+        the live-data footprint exceeds max_size_mb.  This is the documented
+        exceptional case: the newest rows alone exceed the budget.
+        """
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        payload = "x" * 4000
+        # Write exactly 10 rows (well below the 50-row floor).
+        for i in range(10):
+            ledger.record_receipt(tool_name=f"t{i}", args={"p": payload})
+
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=1))
+        ledger.record_receipt(tool_name="floor_trigger", args={})
+
+        rows = ledger.read_all()
+        # All rows must survive because total <= _SIZE_FLOOR_ROWS.
+        assert len(rows) == 11, (
+            f"Expected 11 rows (floor protection); got {len(rows)}."
+        )
+        assert ledger.verify_chain() == []
+
+    def test_repeated_record_receipt_stays_bounded(self, tmp_path, monkeypatch):
+        """After initial convergence, every subsequent record_receipt call must
+        keep live-data at or below the limit — not re-inflate it.
+        """
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        limit_mb = 1
+        payload = "x" * 4000
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        for i in range(500):
+            ledger.record_receipt(tool_name=f"seed{i}", args={"p": payload})
+
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=limit_mb))
+        limit_bytes = limit_mb * 1024 * 1024
+        # After the first convergence trigger, every committed ledger state
+        # remains within the bound because pruning observes the incoming row.
+        for j in range(10):
+            ledger.record_receipt(tool_name=f"steady{j}", args={})
+            live = _live_data_bytes(db)
+            assert live <= limit_bytes, (
+                f"Iteration {j}: live-data {live} exceeded bound {limit_bytes} "
+                "after steady-state record_receipt."
+            )
+
+    def test_oversize_floor_case_chain_still_valid(self, tmp_path, monkeypatch):
+        """Even when the floor exception applies (all rows at floor, still over
+        limit), verify_chain must return no defects.
+        """
+        import agent.action_receipts as ar
+
+        db = tmp_path / "r.db"
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg())
+        ledger = ar.ActionReceiptLedger(db_path=db)
+        payload = "x" * 4000
+        for i in range(10):
+            ledger.record_receipt(tool_name=f"t{i}", args={"p": payload})
+
+        monkeypatch.setattr(ar, "_load_config", lambda: _cfg(max_size_mb=1))
+        ledger.record_receipt(tool_name="trigger", args={})
+
+        assert ledger.verify_chain() == [], (
+            "Chain must be valid even when floor exception prevents pruning."
+        )

--- a/tests/hermes_cli/test_backup.py
+++ b/tests/hermes_cli/test_backup.py
@@ -1223,6 +1223,7 @@ class TestSafeCopyDb:
         assert not dst.exists()
 
 
+    @pytest.mark.live_system_guard_bypass
     def test_locked_source_fails_fast_not_hang(self, tmp_path):
         import subprocess
         import sys

--- a/tests/hermes_cli/test_backup_path_errors.py
+++ b/tests/hermes_cli/test_backup_path_errors.py
@@ -1,10 +1,14 @@
-"""Regression test: `hermes backup -o <bad path>` errors cleanly (round-3 SUB-01).
+"""Regression tests: `hermes backup -o <bad path>` errors cleanly (round-3 SUB-01)
+and action_receipts.db is restored at mode 0600 on POSIX.
 
-Before, an unwritable/nonexistent-parent output path raised a raw
-PermissionError traceback from the unguarded is_dir()/mkdir() calls. It must
+Before the bad-path fix, an unwritable/nonexistent-parent output path raised a
+raw PermissionError traceback from the unguarded is_dir()/mkdir() calls. It must
 print a one-line error and exit 1 instead.
 """
 
+import os
+import stat
+import zipfile
 from argparse import Namespace
 from pathlib import Path
 
@@ -36,3 +40,84 @@ def test_backup_unwritable_parent_errors_cleanly(tmp_path, monkeypatch, capsys):
     out = capsys.readouterr().out
     assert "cannot write backup" in out.lower()
     assert "Traceback" not in out
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_import_restores_action_receipts_db_with_0600(tmp_path, monkeypatch):
+    """action_receipts.db must land at 0600 without a public transition.
+
+    The extraction helper creates and fills the temporary inode at the final
+    secret mode before atomic publication. This test spies on that helper's
+    atomic-replace boundary, so a regression to post-publication chmod is
+    observable even when the end state still happens to be 0600.
+    """
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    # Stub out gateway service helpers so the post-import step does not touch
+    # the host's systemd/launchd (mirrors the autouse fixture in test_backup.py).
+    import hermes_cli.gateway as gateway_mod
+    monkeypatch.setattr(gateway_mod, "ensure_gateway_service", lambda **kw: False)
+    monkeypatch.setattr(gateway_mod, "_is_service_running", lambda: False)
+    import hermes_cli.backup as backup_mod
+
+    published_modes = []
+    original_replace = backup_mod.atomic_replace
+    def _capture_replace(tmp, target):
+        if target.name == "action_receipts.db":
+            published_modes.append(stat.S_IMODE(Path(tmp).stat().st_mode))
+        return original_replace(tmp, target)
+
+    monkeypatch.setattr(backup_mod, "atomic_replace", _capture_replace)
+
+    # Build a minimal valid backup zip that contains action_receipts.db.
+    # _validate_backup_zip accepts any zip that has at least one of the
+    # canonical marker files; state.db satisfies that requirement.
+    zip_path = tmp_path / "backup.zip"
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("state.db", b"SQLite format 3\x00")
+        zf.writestr("action_receipts.db", b"SQLite format 3\x00")
+
+    backup_mod.run_import(Namespace(zipfile=str(zip_path), force=True))
+
+    restored = hermes_home / "action_receipts.db"
+    assert restored.exists(), "action_receipts.db was not restored"
+    mode = restored.stat().st_mode & 0o777
+    assert mode == 0o600, (
+        f"action_receipts.db restored with mode {oct(mode)}, expected 0o600"
+    )
+    assert published_modes == [0o600]
+
+
+@pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+def test_safe_restore_hardens_action_receipt_db_and_live_sidecars(tmp_path):
+    import sqlite3
+    import hermes_cli.backup as backup_mod
+
+    src = tmp_path / "snapshot.db"
+    with sqlite3.connect(src) as conn:
+        conn.execute("CREATE TABLE marker(value TEXT)")
+        conn.execute("INSERT INTO marker VALUES ('restored')")
+
+    dst = tmp_path / "action_receipts.db"
+    live = sqlite3.connect(dst)
+    try:
+        live.execute("PRAGMA journal_mode=WAL")
+        live.execute("CREATE TABLE old(value TEXT)")
+        live.commit()
+        sidecars = [
+            dst.with_name(dst.name + "-wal"),
+            dst.with_name(dst.name + "-shm"),
+        ]
+        assert all(path.exists() for path in sidecars)
+        for path in (dst, *sidecars):
+            path.chmod(0o644)
+
+        assert backup_mod._safe_restore_db(src, dst) is True
+        assert live.execute("SELECT value FROM marker").fetchone() == ("restored",)
+        for path in (dst, *sidecars):
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        live.close()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2201,6 +2201,87 @@ class TestConcurrentToolExecution:
         assert post_calls[0]["middleware_trace"] == trace
         assert post_calls[0]["status"] == "timeout"
 
+    def test_concurrent_timeout_suppresses_late_success_hook(self, agent, monkeypatch):
+        import hermes_cli.lifecycle as lifecycle
+        import model_tools
+
+        callback_started = threading.Event()
+        release = threading.Event()
+        callback_returned = threading.Event()
+        hook_calls = []
+
+        def _dispatch(_name, _args, **_kwargs):
+            callback_started.set()
+            release.wait()
+            callback_returned.set()
+            return "late result"
+
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments='{"q":"slow"}',
+            call_id="c1",
+        )
+        monkeypatch.setattr(
+            "agent.tool_executor._resolve_concurrent_tool_timeout", lambda: 1.0
+        )
+        monkeypatch.setattr(lifecycle, "has_hook", lambda name: True)
+        monkeypatch.setattr(
+            lifecycle,
+            "invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        try:
+            with patch.object(model_tools.registry, "dispatch", side_effect=_dispatch):
+                agent._execute_tool_calls_concurrent(
+                    _mock_assistant_msg(content="", tool_calls=[tc]), [], "task-1"
+                )
+                assert callback_started.is_set()
+                release.set()
+                assert callback_returned.wait(timeout=1)
+        finally:
+            release.set()
+
+        post_calls = [
+            kwargs for name, kwargs in hook_calls if name == "post_tool_call"
+        ]
+        assert len(post_calls) == 1
+        assert post_calls[0]["tool_call_id"] == "c1"
+        assert post_calls[0]["status"] == "timeout"
+
+    def test_concurrent_blocked_call_emits_one_terminal_hook(self, agent, monkeypatch):
+        hook_calls = []
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments='{"q":"blocked"}',
+            call_id="c1",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.plugins._dispatch_pre_tool_call_hooks",
+            lambda *_args, **_kwargs: ("Blocked by policy", None),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with patch(
+            "run_agent.handle_function_call",
+            side_effect=AssertionError("blocked tool must not dispatch"),
+        ):
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=[tc]), [], "task-1"
+            )
+
+        post_calls = [
+            kwargs for name, kwargs in hook_calls if name == "post_tool_call"
+        ]
+        assert len(post_calls) == 1
+        assert post_calls[0]["tool_call_id"] == "c1"
+        assert post_calls[0]["status"] == "blocked"
+        assert post_calls[0]["error_type"] == "plugin_block"
+
     def test_concurrent_timeout_before_dispatch_prevents_late_callback(self, agent, monkeypatch):
         preflight_started = threading.Event()
         release = threading.Event()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2135,6 +2135,416 @@ class TestConcurrentToolExecution:
         assert messages[0]["tool_call_id"] == "c1"
         assert messages[1]["tool_call_id"] == "c2"
         assert all("Python interpreter is shutting down" in m["content"] for m in messages)
+        # An unsubmitted call never crossed the real callback boundary.
+        # The eight-field collector contract must preserve that fact.
+
+    def test_concurrent_timeout_after_dispatch_records_effective_metadata(
+        self, agent, monkeypatch
+    ):
+        from hermes_cli.middleware import RequestMiddlewareResult
+
+        callback_started = threading.Event()
+        release = threading.Event()
+        receipts = []
+        hook_calls = []
+        effective_args = {}
+        trace = [{"source": "test-middleware"}]
+
+        def _dispatch(_name, args, *_positional, **_kwargs):
+            assert args == effective_args
+            callback_started.set()
+            release.wait()
+            return "late result"
+
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"slow"}', call_id="c1")
+        messages = []
+        monkeypatch.setattr(
+            "agent.tool_executor._resolve_concurrent_tool_timeout", lambda: 1.0
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: RequestMiddlewareResult(
+                payload=effective_args,
+                original_payload=args,
+                changed=True,
+                trace=trace,
+            ),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        try:
+            with (
+                patch("run_agent.handle_function_call", side_effect=_dispatch),
+                patch(
+                    "agent.tool_executor._maybe_record_action_receipt",
+                    side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+                ),
+            ):
+                agent._execute_tool_calls_concurrent(
+                    _mock_assistant_msg(content="", tool_calls=[tc]), messages, "task-1"
+                )
+        finally:
+            release.set()
+
+        assert callback_started.is_set()
+        assert "timed out after 1.0s" in messages[0]["content"]
+        assert len(receipts) == 1
+        assert receipts[0]["tool_call_id"] == "c1"
+        assert receipts[0]["exit_status"] == "timeout"
+        assert receipts[0]["function_args"] == effective_args
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["args"] == effective_args
+        assert post_calls[0]["middleware_trace"] == trace
+        assert post_calls[0]["status"] == "timeout"
+
+    def test_concurrent_timeout_before_dispatch_prevents_late_callback(self, agent, monkeypatch):
+        preflight_started = threading.Event()
+        release = threading.Event()
+        callback_calls = []
+        receipts = []
+
+        def _preflight(*_args, **_kwargs):
+            preflight_started.set()
+            release.wait()
+            return SimpleNamespace(allows_execution=True)
+
+        agent._tool_guardrails.before_call = _preflight
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"slow"}', call_id="c1")
+        monkeypatch.setattr(
+            "agent.tool_executor._resolve_concurrent_tool_timeout", lambda: 1.0
+        )
+        try:
+            with (
+                patch(
+                    "run_agent.handle_function_call",
+                    side_effect=lambda *_args, **_kwargs: callback_calls.append("called"),
+                ),
+                patch(
+                    "agent.tool_executor._maybe_record_action_receipt",
+                    side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+                ),
+            ):
+                agent._execute_tool_calls_concurrent(
+                    _mock_assistant_msg(content="", tool_calls=[tc]), [], "task-1"
+                )
+        finally:
+            release.set()
+
+        assert preflight_started.is_set()
+        time.sleep(0.1)
+        assert callback_calls == []
+        assert receipts == []
+
+    def test_concurrent_keyboard_interrupt_records_effective_metadata(
+        self, agent, monkeypatch
+    ):
+        from hermes_cli.middleware import RequestMiddlewareResult
+
+        receipts = []
+        hook_calls = []
+        effective_args = {}
+        trace = [{"source": "test-middleware"}]
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"stop"}', call_id="c1")
+        messages = []
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: RequestMiddlewareResult(
+                payload=effective_args,
+                original_payload=args,
+                changed=True,
+                trace=trace,
+            ),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        def _dispatch(_name, args, *_positional, **_kwargs):
+            assert args == effective_args
+            raise KeyboardInterrupt
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=[tc]), messages, "task-1"
+            )
+
+        assert "cancelled" in messages[0]["content"].lower()
+        assert len(receipts) == 1
+        assert receipts[0]["tool_call_id"] == "c1"
+        assert receipts[0]["exit_status"] == "cancelled"
+        assert receipts[0]["function_args"] == effective_args
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["args"] == effective_args
+        assert post_calls[0]["middleware_trace"] == trace
+        assert post_calls[0]["status"] == "cancelled"
+    def test_concurrent_started_exception_records_effective_metadata(
+        self, agent, monkeypatch
+    ):
+        from hermes_cli.middleware import RequestMiddlewareResult
+
+        receipts = []
+        hook_calls = []
+        effective_args = {}
+        trace = [{"source": "test-middleware"}]
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"fail"}', call_id="c1")
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: RequestMiddlewareResult(
+                payload=effective_args,
+                original_payload=args,
+                changed=True,
+                trace=trace,
+            ),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        def _dispatch(_name, args, *_positional, **_kwargs):
+            assert args == effective_args
+            raise RuntimeError("boom")
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+        ):
+            agent._execute_tool_calls_concurrent(
+                _mock_assistant_msg(content="", tool_calls=[tc]), [], "task-1"
+            )
+
+        assert len(receipts) == 1
+        assert receipts[0]["tool_call_id"] == "c1"
+        assert receipts[0]["exit_status"] == "error"
+        assert receipts[0]["function_args"] == effective_args
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["tool_call_id"] == "c1"
+        assert post_calls[0]["args"] == effective_args
+        assert post_calls[0]["middleware_trace"] == trace
+        assert post_calls[0]["status"] == "error"
+
+    def test_sequential_started_exception_records_error_receipt(self, agent):
+        receipts = []
+        tc = _mock_tool_call(name="web_search", arguments='{"q":"fail"}', call_id="c1")
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=RuntimeError("boom")),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+        ):
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]), [], "task-1"
+            )
+
+        assert len(receipts) == 1
+        assert receipts[0]["tool_call_id"] == "c1"
+        assert receipts[0]["exit_status"] == "error"
+
+    def test_sequential_inline_started_exception_terminalizes_once(
+        self, agent, monkeypatch
+    ):
+        receipts = []
+        hook_calls = []
+        tc = _mock_tool_call(
+            name="todo_list",
+            arguments='{"todos":[]}',
+            call_id="c1",
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with (
+            patch("tools.todo_tool.todo_tool", side_effect=RuntimeError("boom")),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+        ):
+            messages = []
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]),
+                messages,
+                "task-1",
+            )
+
+        assert "boom" in messages[0]["content"]
+        assert len(receipts) == 1
+        assert receipts[0]["exit_status"] == "error"
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["status"] == "error"
+    @pytest.mark.parametrize(
+        ("tool_name", "error_prefix"),
+        (
+            ("context_lookup", "Context engine tool 'context_lookup' failed: boom"),
+            ("memory_lookup", "Memory tool 'memory_lookup' failed: boom"),
+        ),
+    )
+    def test_sequential_specialized_started_exception_preserves_error_contract(
+        self,
+        agent,
+        monkeypatch,
+        tool_name,
+        error_prefix,
+    ):
+        receipts = []
+        hook_calls = []
+        tool_call = _mock_tool_call(name=tool_name, arguments="{}", call_id="c1")
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+        if tool_name == "context_lookup":
+            agent._context_engine_tool_names = {tool_name}
+            agent.context_compressor.handle_tool_call = MagicMock(
+                side_effect=RuntimeError("boom")
+            )
+        else:
+            agent._context_engine_tool_names = set()
+            agent._memory_manager = SimpleNamespace(
+                has_tool=lambda name: name == tool_name,
+                handle_tool_call=MagicMock(side_effect=RuntimeError("boom")),
+            )
+
+        with patch(
+            "agent.tool_executor._maybe_record_action_receipt",
+            side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+        ):
+            messages = []
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tool_call]),
+                messages,
+                "task-1",
+            )
+
+        assert json.loads(messages[0]["content"])["error"] == error_prefix
+        assert len(receipts) == 1
+        assert receipts[0]["exit_status"] == "error"
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert json.loads(post_calls[0]["result"])["error"] == error_prefix
+
+    @pytest.mark.parametrize("quiet_mode", [True, False])
+    def test_sequential_preflight_keyboard_interrupt_has_no_execution_receipt(
+        self, agent, monkeypatch, quiet_mode
+    ):
+        receipts = []
+        hook_calls = []
+        agent.quiet_mode = quiet_mode
+        agent._tool_guardrails.before_call = MagicMock(side_effect=KeyboardInterrupt)
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments='{"q":"stop"}',
+            call_id="c1",
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        with (
+            patch("run_agent.handle_function_call") as callback,
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]),
+                [],
+                "task-1",
+            )
+
+        callback.assert_not_called()
+        assert receipts == []
+        assert [
+            kwargs for name, kwargs in hook_calls if name == "post_tool_call"
+        ] == []
+
+    @pytest.mark.parametrize("quiet_mode", [True, False])
+    def test_sequential_started_interrupt_uses_effective_middleware_metadata(
+        self, agent, monkeypatch, quiet_mode
+    ):
+        from hermes_cli.middleware import RequestMiddlewareResult
+
+        receipts = []
+        hook_calls = []
+        trace = [{"source": "test-middleware"}]
+        effective_args = {}
+        agent.quiet_mode = quiet_mode
+        tc = _mock_tool_call(
+            name="web_search",
+            arguments='{"q":"original"}',
+            call_id="c1",
+        )
+        monkeypatch.setattr(
+            "hermes_cli.middleware.apply_tool_request_middleware",
+            lambda _name, args, **_kwargs: RequestMiddlewareResult(
+                payload=effective_args,
+                original_payload=args,
+                changed=True,
+                trace=trace,
+            ),
+        )
+        monkeypatch.setattr("hermes_cli.lifecycle.has_hook", lambda name: True)
+        monkeypatch.setattr(
+            "hermes_cli.lifecycle.invoke_hook",
+            lambda hook_name, **kwargs: hook_calls.append((hook_name, kwargs)) or [],
+        )
+
+        def interrupting_callback(_name, args, *_positional, **_kwargs):
+            assert args == effective_args
+            raise KeyboardInterrupt
+
+        with (
+            patch("run_agent.handle_function_call", side_effect=interrupting_callback),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+            pytest.raises(KeyboardInterrupt),
+        ):
+            agent._execute_tool_calls_sequential(
+                _mock_assistant_msg(content="", tool_calls=[tc]),
+                [],
+                "task-1",
+            )
+
+        assert len(receipts) == 1
+        assert receipts[0]["function_args"] == effective_args
+        assert receipts[0]["exit_status"] == "cancelled"
+        post_calls = [kwargs for name, kwargs in hook_calls if name == "post_tool_call"]
+        assert len(post_calls) == 1
+        assert post_calls[0]["args"] == effective_args
+        assert post_calls[0]["middleware_trace"] == trace
+        assert post_calls[0]["status"] == "cancelled"
+
 
 
 

--- a/tests/run_agent/test_sequential_tool_timeout.py
+++ b/tests/run_agent/test_sequential_tool_timeout.py
@@ -166,6 +166,108 @@ def test_sequential_tool_timeout_emits_result_and_continues(tmp_path, monkeypatc
     agent._flush_messages_to_session_db.assert_called()
 
 
+def test_sequential_timeout_after_dispatch_records_effective_metadata(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.middleware import RequestMiddlewareResult
+
+    agent = _make_agent(tmp_path)
+    callback_started = threading.Event()
+    release = threading.Event()
+    receipts: list[dict] = []
+    terminal_events: list[dict] = []
+    effective_args: dict = {}
+    trace = [{"source": "test-middleware"}]
+
+    def _dispatch(_name, args, *_positional, **_kwargs):
+        assert args == effective_args
+        callback_started.set()
+        release.wait()
+        return "late result"
+
+    monkeypatch.setattr(
+        "hermes_cli.middleware.apply_tool_request_middleware",
+        lambda _name, args, **_kwargs: RequestMiddlewareResult(
+            payload=effective_args,
+            original_payload=args,
+            changed=True,
+            trace=trace,
+        ),
+    )
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "1.0")
+    try:
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+            patch(
+                "agent.tool_executor._emit_terminal_post_tool_call",
+                side_effect=lambda *_args, **kwargs: terminal_events.append(kwargs),
+            ),
+        ):
+            execute_tool_calls_sequential(
+                agent,
+                SimpleNamespace(tool_calls=[_tool_call("hung")]),
+                [],
+                "task",
+            )
+    finally:
+        release.set()
+
+    assert callback_started.is_set()
+    assert len(receipts) == 1
+    assert receipts[0]["tool_call_id"] == "hung"
+    assert receipts[0]["exit_status"] == "timeout"
+    assert receipts[0]["function_args"] == effective_args
+    assert len(terminal_events) == 1
+    assert terminal_events[0]["function_args"] == effective_args
+    assert terminal_events[0]["middleware_trace"] == trace
+    assert terminal_events[0]["status"] == "timeout"
+
+
+def test_sequential_timeout_before_dispatch_prevents_late_callback(tmp_path, monkeypatch):
+    agent = _make_agent(tmp_path)
+    preflight_started = threading.Event()
+    release = threading.Event()
+    callback_calls: list[str] = []
+    receipts: list[dict] = []
+
+    def _preflight(*_args, **_kwargs):
+        preflight_started.set()
+        release.wait()
+        return SimpleNamespace(allows_execution=True)
+
+    def _dispatch(*_args, **_kwargs):
+        callback_calls.append("called")
+        return "must not run"
+
+    agent._tool_guardrails.before_call = _preflight
+    monkeypatch.setenv("HERMES_CONCURRENT_TOOL_TIMEOUT_S", "1.0")
+    try:
+        with (
+            patch("run_agent.handle_function_call", side_effect=_dispatch),
+            patch(
+                "agent.tool_executor._maybe_record_action_receipt",
+                side_effect=lambda *_args, **kwargs: receipts.append(kwargs),
+            ),
+        ):
+            execute_tool_calls_sequential(
+                agent,
+                SimpleNamespace(tool_calls=[_tool_call("preflight")]),
+                [],
+                "task",
+            )
+    finally:
+        release.set()
+
+    assert preflight_started.is_set()
+    time.sleep(0.1)
+    assert callback_calls == []
+    assert receipts == []
+
+
 def test_sequential_tool_timeout_suppresses_late_terminal_event(tmp_path, monkeypatch):
     import hermes_cli.lifecycle as lifecycle
     import model_tools


### PR DESCRIPTION
## What does this PR do?

Adds default-off local action receipts backed by SQLite. The ledger records dispatched tool lifecycle state, binds receipts to task envelopes, keeps one terminal event per dispatched call, and preserves post-middleware effective metadata for sequential and concurrent execution paths.

This is local observability, not external attestation. The unkeyed SHA-256 chain detects bounded internal corruption but does not prove originality, custody, tail completeness, or resistance to coordinated rewrite.

## Related Issue

No linked issue. This is a focused extraction from previously audited work.

## Type of Change

- [x] New feature
- [x] Security fix

## Changes Made

- add an opt-in local receipt ledger in `agent/action_receipts.py`
- bind receipt records to task-envelope metadata
- record post-request-middleware effective arguments and middleware trace
- guarantee exactly one terminal lifecycle event per dispatched call
- emit zero receipts for pre-dispatch blocks
- keep concurrent terminal-hook ownership in the outer collector, suppressing late-worker terminal duplicates
- harden SQLite main/WAL/SHM/import files to mode `0600`
- use descriptor-backed genuine read-only SQLite access for verification/readers
- include receipt state in backup and restore behavior

## Current revision

- Head: `ad4a1c77eee45f9f84fb560c822d97d000db1075`
- Rebase target / merge-base: `561b053f794a1781868bb032029d589c67708119`

## How to Test

On this exact revision:

```bash
HERMES_PYTHON=/home/jack/.venvs/gepa/bin/python \
scripts/run_tests.sh \
  tests/agent/test_action_receipts.py \
  tests/hermes_cli/test_backup.py \
  tests/hermes_cli/test_backup_path_errors.py \
  tests/run_agent/test_run_agent.py \
  tests/run_agent/test_sequential_tool_timeout.py
```

Result: **471 passed, 0 failed**.

Additional checks:

```bash
python -m ruff check agent/action_receipts.py
python -m py_compile agent/action_receipts.py
git diff --check
```

All passed.

## Independent review

Submitted-head correctness review found no blocker. The final head makes chain metadata and receipt rows share one explicit read-only WAL snapshot, with deterministic connection-count and between-query mutation regressions.

Earlier exact-head review found receipt accounting, concurrency handling, SQLite hardening, retention, and backup/restore behavior sound. Focused validation of the final snapshot correction passed 18 selected hash-chain and retention tests.

## Scope limits

- Disabled by default; no external telemetry.
- The local unkeyed SHA-256 chain is not proof of originality, custody, tail completeness, or coordinated-rewrite resistance.
- Stored content fingerprints use an ephemeral HMAC key; they are local correlation aids, not durable external attestations.

The final revision is authored and committed as `Jack Field <3956838+jdot-dev@users.noreply.github.com>`.

## Provenance

Receipt-only extraction originally cut from `NousResearch/hermes-agent@48c0c3a873bc5adaf20c632b5b7630a4fac000b4`, then rebased onto pinned publication base `561b053f794a1781868bb032029d589c67708119`.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit messages
- [x] Searched existing upstream PRs by this author
- [x] Focused logical change only
- [x] Added behavior and regression tests
- [x] Tested on Linux
- [x] Considered cross-platform and SQLite sidecar impact
- [x] Documentation/docstrings updated where relevant
- [x] No new dependency or core model tool
