### PR TITLE
fix(auth): preserve auth store ownership

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1481,6 +1481,18 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
     # secure_parent_dir refuses to chmod /, top-level dirs, or the
     # hermes-agent install tree (#25821, #93050).
     secure_parent_dir(auth_file)
+    # An atomic replace carries the temp file's ownership. Capture the
+    # existing auth.json owner, or the target HERMES_HOME directory's owner
+    # on first creation, so a privileged writer cannot strand a 0o600 store
+    # behind its own uid/gid.
+    desired_owner: Optional[Tuple[int, int]] = None
+    if os.name == "posix":
+        try:
+            owner_source = auth_file.stat()
+        except FileNotFoundError:
+            owner_source = auth_file.parent.stat()
+        desired_owner = (owner_source.st_uid, owner_source.st_gid)
+
     auth_store["version"] = AUTH_STORE_VERSION
     auth_store["updated_at"] = datetime.now(timezone.utc).isoformat()
     payload = json.dumps(auth_store, indent=2) + "\n"
@@ -1496,6 +1508,21 @@ def _save_auth_store(auth_store: Dict[str, Any], target_path: Optional[Path] = N
             stat.S_IRUSR | stat.S_IWUSR,
         )
         with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            if desired_owner is not None and hasattr(os, "fchown"):
+                temp_stat = os.fstat(handle.fileno())
+                if (temp_stat.st_uid, temp_stat.st_gid) != desired_owner:
+                    # Preserve the target owner when the writer has permission.
+                    # An unprivileged writer may be able to replace a stale,
+                    # foreign-owned store without being allowed to chown the
+                    # temp file; keep that recovery path working.
+                    try:
+                        os.fchown(handle.fileno(), *desired_owner)
+                    except OSError:
+                        pass
+            if hasattr(os, "fchmod"):
+                # fchown may clear permission bits on some platforms. Reassert
+                # the credential-store mode before the file becomes visible.
+                os.fchmod(handle.fileno(), stat.S_IRUSR | stat.S_IWUSR)
             handle.write(payload)
             handle.flush()
             os.fsync(handle.fileno())

--- a/tests/hermes_cli/test_auth_toctou_file_modes.py
+++ b/tests/hermes_cli/test_auth_toctou_file_modes.py
@@ -45,6 +45,8 @@ def test_save_auth_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch):
     try:
         from hermes_cli import auth as auth_mod
 
+        parent_owner = (tmp_path.stat().st_uid, tmp_path.stat().st_gid)
+
         auth_store = {
             "version": auth_mod.AUTH_STORE_VERSION,
             "providers": {"openai-codex": {"tokens": {"access_token": "secret-x"}}},
@@ -63,10 +65,150 @@ def test_save_auth_store_writes_0o600_with_0o700_parent(tmp_path, monkeypatch):
     assert parent_mode == 0o700, (
         f"auth.json parent dir mode 0o{parent_mode:o} != 0o700 — siblings can traverse"
     )
+    auth_stat = auth_path.stat()
+    assert (auth_stat.st_uid, auth_stat.st_gid) == parent_owner, (
+        "a new auth.json must inherit its HERMES_HOME directory's owner"
+    )
 
     # Content survived the rewrite
     data = json.loads(auth_path.read_text())
     assert data["providers"]["openai-codex"]["tokens"]["access_token"] == "secret-x"
+
+
+@pytest.mark.parametrize(
+    ("existing", "expected_owner"),
+    [
+        (True, (1101, 1102)),
+        (False, (2201, 2202)),
+    ],
+    ids=("existing-auth-file", "new-auth-file"),
+)
+def test_save_auth_store_sets_owner_before_atomic_replace(
+    tmp_path, monkeypatch, existing, expected_owner
+):
+    """A mismatched writer must assign the target owner on the temp fd.
+
+    Fake stat values exercise the privileged-writer branch without requiring
+    root or changing real filesystem ownership.
+    """
+    from hermes_cli import auth as auth_mod
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    auth_path = hermes_home / "auth.json"
+    if existing:
+        auth_path.write_text(
+            json.dumps(
+                {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+            )
+        )
+
+    real_stat = os.stat
+    real_fstat = os.fstat
+
+    class _StatWithOwner:
+        def __init__(self, wrapped, uid, gid):
+            self._wrapped = wrapped
+            self.st_uid = uid
+            self.st_gid = gid
+
+        def __getattr__(self, name):
+            return getattr(self._wrapped, name)
+
+    def fake_stat(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        candidate = os.fspath(path)
+        if existing and candidate == os.fspath(auth_path):
+            return _StatWithOwner(result, 1101, 1102)
+        if candidate == os.fspath(hermes_home):
+            return _StatWithOwner(result, 2201, 2202)
+        return result
+
+    def fake_fstat(fd):
+        return _StatWithOwner(real_fstat(fd), 9901, 9902)
+
+    fchown_calls = []
+    replace_observations = []
+    real_replace = auth_mod.atomic_replace
+
+    def fake_fchown(fd, uid, gid):
+        fchown_calls.append((uid, gid))
+        # Some POSIX systems clear permission bits after ownership changes.
+        # Make the replace-time assertion depend on the production fchmod.
+        os.fchmod(fd, 0o640)
+
+    def spying_replace(tmp, target):
+        replace_observations.append(
+            (list(fchown_calls), stat.S_IMODE(real_stat(tmp).st_mode))
+        )
+        return real_replace(tmp, target)
+
+    monkeypatch.setattr(auth_mod.os, "stat", fake_stat)
+    monkeypatch.setattr(auth_mod.os, "fstat", fake_fstat)
+    monkeypatch.setattr(auth_mod.os, "fchown", fake_fchown)
+    monkeypatch.setattr(auth_mod, "atomic_replace", spying_replace)
+
+    auth_mod._save_auth_store(
+        {"version": auth_mod.AUTH_STORE_VERSION, "providers": {}}
+    )
+
+    assert fchown_calls == [expected_owner]
+    assert replace_observations == [([expected_owner], 0o600)], (
+        "ownership and mode must be applied to the temp file before replace"
+    )
+    assert stat.S_IMODE(real_stat(auth_path).st_mode) == 0o600
+
+
+def test_save_auth_store_recovers_when_owner_cannot_be_preserved(
+    tmp_path, monkeypatch
+):
+    """A foreign-owned store remains replaceable by its directory owner."""
+    from hermes_cli import auth as auth_mod
+
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    auth_path = hermes_home / "auth.json"
+    auth_path.write_text(
+        json.dumps({"version": auth_mod.AUTH_STORE_VERSION, "providers": {}})
+    )
+
+    real_stat = os.stat
+
+    class _StatWithOwner:
+        def __init__(self, wrapped):
+            self._wrapped = wrapped
+            self.st_uid = wrapped.st_uid + 1
+            self.st_gid = wrapped.st_gid + 1
+
+        def __getattr__(self, name):
+            return getattr(self._wrapped, name)
+
+    def fake_stat(path, *args, **kwargs):
+        result = real_stat(path, *args, **kwargs)
+        if os.fspath(path) == os.fspath(auth_path):
+            return _StatWithOwner(result)
+        return result
+
+    def reject_fchown(_fd, _uid, _gid):
+        raise PermissionError("operation not permitted")
+
+    monkeypatch.setattr(auth_mod.os, "stat", fake_stat)
+    monkeypatch.setattr(auth_mod.os, "fchown", reject_fchown)
+
+    saved = auth_mod._save_auth_store(
+        {
+            "version": auth_mod.AUTH_STORE_VERSION,
+            "providers": {"openai-codex": {"tokens": {"access_token": "new"}}},
+        }
+    )
+
+    assert saved == auth_path
+    assert json.loads(auth_path.read_text())["providers"]["openai-codex"]["tokens"][
+        "access_token"
+    ] == "new"
+    assert stat.S_IMODE(real_stat(auth_path).st_mode) == 0o600
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Scope

- preserve existing `auth.json` uid/gid across atomic replacement on POSIX
- use the owning Hermes home directory for first creation
- establish mode `0600` on the temporary file before replacement
- apply `fchown` to the temporary descriptor before `atomic_replace`
- keep foreign-owner recovery best-effort when the writer lacks `chown` permission

## Current revision

- Head: `e6019e57ad59ec63919ebcfa249464bd2b8b38c2`
- Rebase target / merge-base: `561b053f794a1781868bb032029d589c67708119`

## Verification

On this exact revision:

- `HERMES_PYTHON=/home/jack/.venvs/gepa/bin/python scripts/run_tests.sh tests/hermes_cli/test_auth_toctou_file_modes.py -q`
- **7 passed, 0 failed**
- exact-revision independent review: **PASS**, no findings

The rebased patch is byte-identical to the previously reviewed extraction.

The final revision is patch-equivalent to the independently reviewed revision; only commit author/committer metadata changed to `Jack Field <3956838+jdot-dev@users.noreply.github.com>`.

## Provenance and limits

Clean ownership-only extraction originally cut from `NousResearch/hermes-agent@48c0c3a873bc5adaf20c632b5b7630a4fac000b4`, then rebased onto pinned publication base `561b053f794a1781868bb032029d589c67708119`. This preserves ownership where permitted; restoration of a foreign owner remains best effort. No claim is made for non-POSIX ownership semantics.