### PR TITLE
test(service): isolate s6 scandir state

### DIFF
--- a/hermes_cli/service_manager.py
+++ b/hermes_cli/service_manager.py
@@ -332,6 +332,25 @@ def get_service_manager() -> ServiceManager:
 # tmpfs and is the directory s6-svscan watches. Writes here trigger
 # automatic supervision on the next rescan.
 S6_DYNAMIC_SCANDIR = Path("/run/service")
+
+
+def _default_s6_scandir() -> Path:
+    """Return the production scandir, or an explicitly isolated test one.
+
+    The hermetic pytest fixture sets ``HERMES_TEST_S6_SCANDIR`` to prevent
+    container-aware tests from registering, stopping, or restarting live s6
+    services when the suite itself runs inside a production container. Normal
+    runtime processes do not set this internal test-only variable and continue
+    to use ``/run/service``.
+    """
+    import os
+
+    isolated = os.environ.get("HERMES_TEST_S6_SCANDIR")
+    if isolated:
+        return Path(isolated)
+    return S6_DYNAMIC_SCANDIR
+
+
 S6_SERVICE_PREFIX = "gateway-"
 
 
@@ -608,8 +627,8 @@ class S6ServiceManager:
 
     kind: ServiceManagerKind = "s6"
 
-    def __init__(self, scandir: Path = S6_DYNAMIC_SCANDIR) -> None:
-        self.scandir = scandir
+    def __init__(self, scandir: Path | None = None) -> None:
+        self.scandir = Path(scandir) if scandir is not None else _default_s6_scandir()
 
     # -- internal helpers --------------------------------------------------
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -514,6 +514,15 @@ def _hermetic_environment(tmp_path, monkeypatch):
         monkeypatch.setattr(
             hermes_state_mod, "DEFAULT_DB_PATH", fake_hermes_home / "state.db"
         )
+    # 3c. s6's live scandir is outside HERMES_HOME. When the suite itself runs
+    #     inside a supervised production container, container-aware tests would
+    #     otherwise register/stop/restart real gateways under /run/service.
+    #     Point default S6ServiceManager instances at this per-test directory;
+    #     explicit scandir arguments used by unit/integration tests still win.
+    fake_s6_scandir = tmp_path / "s6-scandir"
+    fake_s6_scandir.mkdir()
+    monkeypatch.setenv("HERMES_TEST_S6_SCANDIR", str(fake_s6_scandir))
+
 
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
@@ -1005,6 +1014,7 @@ def _ensure_current_event_loop(request):
 
 _LIVE_SYSTEM_GUARD_BYPASS_MARK = "live_system_guard_bypass"
 _REQUIRES_WAL_MARK = "requires_wal"
+_TEST_S6_SCANDIR: "Path | None" = None
 
 
 def _wal_is_usable() -> bool:
@@ -1149,7 +1159,14 @@ _OS_MARKS = {
 
 
 def pytest_configure(config):  # noqa: D401 — pytest hook
-    """Register markers used by hermetic conftest."""
+    """Register markers and isolate live s6 before collection starts."""
+    global _TEST_S6_SCANDIR
+
+    # Collection-time imports must never inherit the live /run/service tree.
+    if _TEST_S6_SCANDIR is None:
+        _TEST_S6_SCANDIR = Path(tempfile.mkdtemp(prefix="hermes-pytest-s6-"))
+    os.environ["HERMES_TEST_S6_SCANDIR"] = str(_TEST_S6_SCANDIR)
+
     config.addinivalue_line(
         "markers",
         f"{_LIVE_SYSTEM_GUARD_BYPASS_MARK}: bypass the live-system guard "
@@ -1199,6 +1216,16 @@ def pytest_configure(config):  # noqa: D401 — pytest hook
     # suite runs natively there (POSIX keeps the more reliable signal method).
     if sys.platform == "win32" and getattr(config.option, "timeout_method", None) == "signal":
         config.option.timeout_method = "thread"
+
+
+def pytest_unconfigure(config):  # noqa: D401 — pytest hook
+    """Remove the process-wide temporary s6 scandir."""
+    global _TEST_S6_SCANDIR
+
+    if _TEST_S6_SCANDIR is not None:
+        shutil.rmtree(_TEST_S6_SCANDIR, ignore_errors=True)
+        _TEST_S6_SCANDIR = None
+    os.environ.pop("HERMES_TEST_S6_SCANDIR", None)
 
 
 _symlink_supported_cache = None

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -7,6 +7,8 @@ implementation in this same file once that phase ships.
 """
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from hermes_cli.service_manager import (
@@ -20,6 +22,11 @@ from hermes_cli.service_manager import (
     get_service_manager,
     validate_profile_name,
 )
+
+
+# Captured at module import time so the regression test proves isolation is
+# active during pytest collection, before autouse fixtures begin setup.
+_COLLECTION_SCANDIR = S6ServiceManager().scandir
 
 
 # ---------------------------------------------------------------------------
@@ -179,6 +186,38 @@ def fake_subprocess_run(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setattr("subprocess.run", _fake)
     return calls
 
+
+def test_s6_manager_kind_and_supports_registration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("HERMES_TEST_S6_SCANDIR", raising=False)
+    mgr = S6ServiceManager()
+    assert mgr.kind == "s6"
+    assert mgr.supports_runtime_registration() is True
+    assert mgr.scandir == Path("/run/service")
+
+
+def test_s6_default_scandir_isolated_during_pytest(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A test process must never inherit the live s6 ``/run/service`` tree.
+
+    Regression: running the full suite inside the production container let
+    container-aware gateway tests register and restart live services, which
+    interrupted the active operator session and leaked test profile slots.
+    """
+    pytest_scandir = tmp_path / "pytest-s6-scandir"
+    # Collection and fixture setup run before PYTEST_CURRENT_TEST is set; the
+    # isolation must already apply during those phases.
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setenv("HERMES_TEST_S6_SCANDIR", str(pytest_scandir))
+
+    mgr = S6ServiceManager()
+
+    assert _COLLECTION_SCANDIR != Path("/run/service")
+    assert mgr.scandir == pytest_scandir
+    assert mgr.scandir != Path("/run/service")
 
 # ---------------------------------------------------------------------------
 # _seed_supervise_skeleton — unit tests

--- a/tests/hermes_cli/test_service_manager.py
+++ b/tests/hermes_cli/test_service_manager.py
@@ -206,11 +206,14 @@ def test_s6_default_scandir_isolated_during_pytest(
     Regression: running the full suite inside the production container let
     container-aware gateway tests register and restart live services, which
     interrupted the active operator session and leaked test profile slots.
+
+    The invariant: ``pytest_configure`` installs ``HERMES_TEST_S6_SCANDIR``
+    before collection begins, so ``S6ServiceManager()`` is already isolated
+    at module-import time (see ``_COLLECTION_SCANDIR`` above). Within a test,
+    ``HERMES_TEST_S6_SCANDIR`` is what controls which scandir is used; setting
+    it here exercises the explicit-override path.
     """
     pytest_scandir = tmp_path / "pytest-s6-scandir"
-    # Collection and fixture setup run before PYTEST_CURRENT_TEST is set; the
-    # isolation must already apply during those phases.
-    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setenv("HERMES_TEST_S6_SCANDIR", str(pytest_scandir))
 
     mgr = S6ServiceManager()


### PR DESCRIPTION
## Scope

- redirect default s6 scandir access to a per-test temporary directory during collection and test execution
- preserve the production default at `/run/service`
- cover runtime-default and pytest-isolation behavior

## Current revision

- Head: `b52bbd570967dc0c6230a2ff58a64ddf00d74d8c`
- Rebase target / merge-base: `561b053f794a1781868bb032029d589c67708119`

## Verification

On this exact revision:

- `HERMES_PYTHON=/home/jack/.venvs/gepa/bin/python scripts/run_tests.sh tests/hermes_cli/test_service_manager.py -q`
- **11 passed, 0 failed**
- exact-revision independent review: **PASS**, no findings

Both production constructors retain `/run/service`; the final amendment removes inert test cleanup and documents the actual test-only `HERMES_TEST_S6_SCANDIR` invariant.

The final revision retains the reviewed runtime behavior and is authored and committed as `Jack Field <3956838+jdot-dev@users.noreply.github.com>`.

## Provenance and limits

Clean extraction originally cut from `NousResearch/hermes-agent@48c0c3a873bc5adaf20c632b5b7630a4fac000b4`, then rebased onto pinned publication base `561b053f794a1781868bb032029d589c67708119`. This is test-isolation hardening only; it does not change the production s6 service directory or claim broad-suite or live Docker validation.