### PR TITLE
feat(authority): add durable authority primitives

### DIFF
--- a/agent/phase2_authority.py
+++ b/agent/phase2_authority.py
@@ -1,0 +1,47 @@
+"""Durable Hermes-owned authority for sealed Phase 2 graph nodes.
+
+Stable public facade.  The implementation lives in bounded modules:
+
+- ``agent.phase2_sqlite``   — descriptor-pinned SQLite opening/hardening
+- ``agent.phase2_errors``   — typed authority exceptions
+- ``agent.phase2_envelope`` — envelope v2 validation, canonical values,
+  context-scoped binding
+- ``agent.phase2_budget``   — budget reservation/reconciliation mixin
+- ``agent.phase2_ledger``   — append-only plan/event ledger and lease/fence
+  lifecycle (concrete ``Phase2AuthorityStore``)
+
+Import from this module; downstream code must not depend on the split.
+"""
+
+from __future__ import annotations
+
+from agent.phase2_envelope import (
+    bind_sealed_envelope,
+    current_authoritative_fence,
+    current_sealed_envelope,
+    validate_sealed_envelope,
+)
+from agent.phase2_errors import (
+    AuthorityError,
+    AuthorityMigrationRequired,
+    MalformedEnvelopeFence,
+    ResultRejection,
+)
+from agent.phase2_ledger import Phase2AuthorityStore, default_db_path
+from agent.phase2_sqlite import (  # noqa: F401  (shared-store private surface)
+    _check_phase2_db_files,
+    _open_phase2_sqlite,
+)
+
+__all__ = [
+    "AuthorityError",
+    "AuthorityMigrationRequired",
+    "MalformedEnvelopeFence",
+    "Phase2AuthorityStore",
+    "ResultRejection",
+    "bind_sealed_envelope",
+    "current_authoritative_fence",
+    "current_sealed_envelope",
+    "default_db_path",
+    "validate_sealed_envelope",
+]

--- a/agent/phase2_budget.py
+++ b/agent/phase2_budget.py
@@ -1,0 +1,325 @@
+"""Budget reservation and reconciliation mixin for the Phase 2 authority store.
+
+Cumulative, fence-scoped reservations with exact integer token ceilings and
+exact ``Decimal`` USD accounting.  Mixed into ``Phase2AuthorityStore``; never
+instantiated alone.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from typing import Any, Mapping
+
+from agent.phase2_envelope import (
+    _budget_decimal,
+    _normalized_reservation_metadata,
+    _tokens_max_integer,
+    _utc,
+)
+from agent.phase2_errors import AuthorityError
+from agent.phase2_sqlite import _DB_LOCK
+
+
+class Phase2BudgetMixin:
+    """Budget methods; the concrete store supplies connection and gate hooks."""
+
+    @staticmethod
+    def _budget_state(
+        conn: sqlite3.Connection,
+        graph_id: str,
+        node_id: str,
+        fence: int | None = None,
+    ) -> dict[str, Any]:
+        query = """SELECT kind, event_id, payload_json FROM authority_events
+                   WHERE graph_id = ? AND node_id = ?
+                     AND kind IN ('BUDGET_RESERVED', 'BUDGET_RECONCILED')"""
+        params: tuple[Any, ...] = (graph_id, node_id)
+        if fence is not None:
+            query += " AND fence = ?"
+            params += (fence,)
+        rows = conn.execute(query + " ORDER BY id", params).fetchall()
+        reservations: dict[str, dict[str, Any]] = {}
+        reconciled: set[str] = set()
+        charged_tokens = 0
+        charged_usd = Decimal(0)
+        cost_unknown = False
+        for row in rows:
+            payload = json.loads(row["payload_json"])
+            if row["kind"] == "BUDGET_RESERVED":
+                reservations[row["event_id"]] = payload
+            else:
+                reservation_id = payload["reservation_id"]
+                reconciled.add(reservation_id)
+                charged_tokens += int(payload["actual_tokens"])
+                if payload["actual_usd"] is None:
+                    cost_unknown = True
+                else:
+                    charged_usd += _budget_decimal(payload["actual_usd"], "actual_usd")
+        reserved_tokens = sum(
+            int(payload["tokens"])
+            for event_id, payload in reservations.items()
+            if event_id not in reconciled
+        )
+        reserved_usd = sum(
+            (
+                _budget_decimal(payload["usd"], "usd")
+                for event_id, payload in reservations.items()
+                if event_id not in reconciled
+            ),
+            Decimal(0),
+        )
+        return {
+            "reserved_tokens": reserved_tokens,
+            "reserved_usd": reserved_usd,
+            "charged_tokens": charged_tokens,
+            "charged_usd": charged_usd,
+            "cost_unknown": cost_unknown,
+        }
+
+    def reserve_budget_allocations(
+        self,
+        envelope: Mapping[str, Any],
+        allocations: list[Mapping[str, Any]],
+        *,
+        now: datetime | None = None,
+    ) -> list[str]:
+        """Atomically reserve a bounded parent allocation for every child."""
+
+        if not allocations:
+            raise AuthorityError("budget allocations must be non-empty")
+        normalized: list[dict[str, Any]] = []
+        for allocation in allocations:
+            tokens = allocation.get("tokens")
+            if isinstance(tokens, bool) or not isinstance(tokens, int) or tokens < 0:
+                raise AuthorityError("tokens must be a non-negative integer")
+            usd = allocation.get("usd")
+            _budget_decimal(usd, "usd")
+            normalized.append({
+                "tokens": tokens,
+                "usd": usd,
+                "metadata": _normalized_reservation_metadata(
+                    allocation.get("metadata"), "budget allocation metadata"
+                ),
+            })
+        current = _utc(now)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                graph_id, node_id, fence, latest_envelope = self._load_live_authority(
+                    conn, envelope, current, action="reserve budget"
+                )
+                state = self._budget_state(conn, graph_id, node_id)
+                if state["cost_unknown"]:
+                    raise AuthorityError("budget cost is unknown")
+                limits = latest_envelope["budgets"]
+                tokens_total = sum(item["tokens"] for item in normalized)
+                usd_total = sum(
+                    (_budget_decimal(item["usd"], "usd") for item in normalized),
+                    Decimal(0),
+                )
+                tokens_max = _tokens_max_integer(
+                    limits.get("tokens_max"), "sealed budgets.tokens_max"
+                )
+                usd_max = _budget_decimal(
+                    limits.get("usd_max"), "sealed budgets.usd_max"
+                )
+                if (
+                    state["charged_tokens"] + state["reserved_tokens"] + tokens_total
+                    > tokens_max
+                ):
+                    raise AuthorityError("token budget reservation exceeds node budget")
+                if state["charged_usd"] + state["reserved_usd"] + usd_total > usd_max:
+                    raise AuthorityError("USD budget reservation exceeds node budget")
+                reservation_ids: list[str] = []
+                for item in normalized:
+                    reservation_id = f"res-{uuid.uuid4().hex}"
+                    payload: dict[str, Any] = {
+                        "tokens": item["tokens"],
+                        "usd": item["usd"],
+                    }
+                    if item["metadata"] is not None:
+                        payload["metadata"] = item["metadata"]
+                    self._append_event(
+                        conn,
+                        kind="BUDGET_RESERVED",
+                        graph_id=graph_id,
+                        node_id=node_id,
+                        attempt_id=str(latest_envelope["attempt_id"]),
+                        fence=fence,
+                        payload=payload,
+                        now=current,
+                        event_id=reservation_id,
+                    )
+                    reservation_ids.append(reservation_id)
+                conn.execute("COMMIT")
+                return reservation_ids
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def reserve_budget(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        tokens: int,
+        usd: float,
+        metadata: Mapping[str, Any] | None = None,
+        now: datetime | None = None,
+    ) -> str:
+        """Reserve spend against the node budget under exact live authority."""
+
+        if isinstance(tokens, bool) or not isinstance(tokens, int) or tokens < 0:
+            raise AuthorityError("tokens must be a non-negative integer")
+        usd_value = usd
+        _budget_decimal(usd_value, "usd")
+        metadata_payload = _normalized_reservation_metadata(metadata)
+        current = _utc(now)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                graph_id, node_id, fence, latest_envelope = self._load_live_authority(
+                    conn, envelope, current, action="reserve budget"
+                )
+                state = self._budget_state(conn, graph_id, node_id)
+                if state["cost_unknown"]:
+                    raise AuthorityError("budget cost is unknown")
+                limits = latest_envelope["budgets"]
+                tokens_max = _tokens_max_integer(
+                    limits.get("tokens_max"), "sealed budgets.tokens_max"
+                )
+                usd_max = _budget_decimal(
+                    limits.get("usd_max"), "sealed budgets.usd_max"
+                )
+                if (
+                    state["charged_tokens"] + state["reserved_tokens"] + tokens
+                    > tokens_max
+                ):
+                    raise AuthorityError("token budget reservation exceeds node budget")
+                if (
+                    state["charged_usd"]
+                    + state["reserved_usd"]
+                    + _budget_decimal(usd_value, "usd")
+                    > usd_max
+                ):
+                    raise AuthorityError("USD budget reservation exceeds node budget")
+                reservation_id = f"res-{uuid.uuid4().hex}"
+                self._append_event(
+                    conn,
+                    kind="BUDGET_RESERVED",
+                    graph_id=graph_id,
+                    node_id=node_id,
+                    attempt_id=str(latest_envelope["attempt_id"]),
+                    fence=fence,
+                    payload={
+                        "tokens": tokens,
+                        "usd": usd_value,
+                        **(
+                            {"metadata": metadata_payload}
+                            if metadata_payload is not None
+                            else {}
+                        ),
+                    },
+                    now=current,
+                    event_id=reservation_id,
+                )
+                conn.execute("COMMIT")
+                return reservation_id
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def reconcile_budget(
+        self,
+        reservation_id: str,
+        *,
+        actual_tokens: int,
+        actual_usd: float | None,
+        now: datetime | None = None,
+    ) -> None:
+        if (
+            isinstance(actual_tokens, bool)
+            or not isinstance(actual_tokens, int)
+            or actual_tokens < 0
+        ):
+            raise AuthorityError("actual_tokens must be a non-negative integer")
+        if actual_usd is not None:
+            _budget_decimal(actual_usd, "actual_usd")
+        current = _utc(now)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                reservation = conn.execute(
+                    "SELECT * FROM authority_events WHERE event_id = ? AND kind = 'BUDGET_RESERVED'",
+                    (reservation_id,),
+                ).fetchone()
+                if reservation is None:
+                    raise AuthorityError("unknown budget reservation")
+                duplicate = conn.execute(
+                    """SELECT payload_json FROM authority_events
+                       WHERE kind = 'BUDGET_RECONCILED'
+                         AND json_extract(payload_json, '$.reservation_id') = ?""",
+                    (reservation_id,),
+                ).fetchone()
+                if duplicate:
+                    prior = json.loads(duplicate["payload_json"])
+                    if (
+                        int(prior.get("actual_tokens", -1)) == actual_tokens
+                        and prior.get("actual_usd") == actual_usd
+                    ):
+                        conn.execute("COMMIT")
+                        return
+                    raise AuthorityError("budget reservation already reconciled")
+                self._append_event(
+                    conn,
+                    kind="BUDGET_RECONCILED",
+                    graph_id=reservation["graph_id"],
+                    node_id=reservation["node_id"],
+                    attempt_id=reservation["attempt_id"],
+                    fence=reservation["fence"],
+                    payload={
+                        "reservation_id": reservation_id,
+                        "actual_tokens": actual_tokens,
+                        "actual_usd": actual_usd,
+                    },
+                    now=current,
+                )
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def budget_usage(
+        self, graph_id: str, node_id: str, *, fence: int
+    ) -> dict[str, Any]:
+        conn = self._connect()
+        try:
+            state = self._budget_state(conn, graph_id, node_id, fence)
+            return {
+                **state,
+                "reserved_usd": float(state["reserved_usd"]),
+                "charged_usd": float(state["charged_usd"]),
+            }
+        finally:
+            conn.close()

--- a/agent/phase2_envelope.py
+++ b/agent/phase2_envelope.py
@@ -1,0 +1,551 @@
+"""Sealed task-envelope v2 validation, canonical values, and context binding.
+
+Self-contained: no dependency on phase2_enforcement, the durable store, or any
+runtime/session wiring.  The store imports from here; never the reverse.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+import re
+from pathlib import Path
+from contextlib import contextmanager
+from contextvars import ContextVar
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from types import MappingProxyType
+from typing import Any, Iterator, Mapping
+
+from agent.phase2_errors import AuthorityError
+from agent.phase2_sqlite import _SQLITE_INT_MAX, _SQLITE_INT_MIN
+
+_HASH_KEYS = ("idempotency_key", "input_hash")
+_ALLOWED_SURFACES = {
+    "direct_model",
+    "combo",
+    "acp_worker",
+    "a2a",
+    "cloud",
+    "local_tool",
+}
+_SHA256_RE_LEN = 64
+# Bounded audit metadata for a rejected caller's malformed fence claim.
+_FENCE_REPR_MAX = 64
+# Bounded per-invariant sample size in a migration diagnostic.
+_MIGRATION_SAMPLE_MAX = 5
+
+
+def _freeze_envelope_value(value: Any) -> Any:
+    """Return an immutable snapshot of JSON-compatible envelope data."""
+
+    if isinstance(value, Mapping):
+        frozen: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise AuthorityError("sealed envelope object keys must be strings")
+            frozen[key] = _freeze_envelope_value(item)
+        return MappingProxyType(frozen)
+    if isinstance(value, (list, tuple)):
+        return tuple(_freeze_envelope_value(item) for item in value)
+    if value is None or isinstance(value, (str, bool, int)):
+        return value
+    if isinstance(value, float):
+        if math.isfinite(value):
+            return value
+        raise AuthorityError("sealed envelope numbers must be finite")
+    raise AuthorityError(
+        f"sealed envelope contains unsupported value type: {type(value).__name__}"
+    )
+
+
+# ── Envelope validation constants ─────────────────────────────────────────────
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_REQUIRED_FIELDS = (
+    "graph_id",
+    "node_id",
+    "attempt_id",
+    "idempotency_key",
+    "objective",
+    "execution_surface",
+    "lane",
+    "roots",
+    "permissions",
+    "network_policy",
+    "exec_policy",
+    "destructive_policy",
+    "budgets",
+    "deadline_utc",
+    "retry_policy",
+    "cancellation",
+    "evidence_policy",
+    "verifier_policy",
+    "planner_hash",
+    "policy_hash",
+    "input_hash",
+    "lease",
+    "fence",
+)
+_ALLOWED_LANES = {"hermes", "fable", "claude_opus", "omx_codex", "omp", "orca"}
+_ALLOWED_NETWORK = {"none", "loopback_only", "allowlist"}
+_ALLOWED_EXEC = {"none", "sandboxed", "host"}
+_ALLOWED_DESTRUCTIVE = {"forbid", "require_confirmation", "allow_within_roots"}
+_STATELESS_SURFACES = {"direct_model", "combo"}
+
+# ── Context-var envelope binding ──────────────────────────────────────────────
+_CURRENT_ENVELOPE: ContextVar[Mapping[str, Any] | None] = ContextVar(
+    "phase2_current_sealed_envelope", default=None
+)
+_CURRENT_FENCE: ContextVar[int | None] = ContextVar(
+    "phase2_current_fence", default=None
+)
+
+
+# ── Canonical value helpers ───────────────────────────────────────────────────
+
+
+def _json_tree(value: Any) -> Any:
+    """Copy mappings/sequences into a strict JSON-compatible value tree."""
+
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key, item in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings")
+            normalized[key] = _json_tree(item)
+        return normalized
+    if isinstance(value, (list, tuple)):
+        return [_json_tree(item) for item in value]
+    if value is None or isinstance(value, (str, bool, int, float)):
+        return value
+    raise TypeError(f"value of type {type(value).__name__} is not JSON serializable")
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        _json_tree(value),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _sealed_json(value: Any) -> str:
+    """Canonical JSON for an immutable sealed row, refusing non-finite numbers.
+
+    ``json.dumps`` emits the non-standard tokens ``Infinity``/``NaN`` by
+    default. ``sealed_plans`` and ``sealed_nodes`` are immutable and undeletable
+    by trigger, and a graph_id can only ever be sealed once, so a single
+    ``usd_max: inf`` would permanently wedge that graph behind a plan whose JSON
+    no strict reader can parse and whose ceiling can never be breached
+    (contract §9 requires budget breach to fail closed; ``tokens_max: inf``
+    additionally aborts accounting at ``int(inf)`` with an untyped
+    ``OverflowError``). Refusing at seal time keeps the defect out of the
+    immutable table instead of leaving a permanently ungrantable graph behind.
+    """
+
+    try:
+        return _canonical_json(value)
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise AuthorityError("sealed plan must contain finite JSON values") from exc
+
+
+def _canonical_hash(value: Any) -> str:
+    return hashlib.sha256(_canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def _utc(value: datetime | None = None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        raise AuthorityError("authority timestamps must be timezone-aware")
+    return current.astimezone(timezone.utc)
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat()
+
+
+def _parse_time(value: Any) -> datetime:
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except (TypeError, ValueError) as exc:
+        raise AuthorityError("invalid authority timestamp") from exc
+    if parsed.tzinfo is None:
+        raise AuthorityError("authority timestamp must be timezone-aware")
+    return parsed.astimezone(timezone.utc)
+
+
+def _nonnegative_number(value: Any, field: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise AuthorityError(f"{field} must be a non-negative number")
+    # Convert once under a typed boundary. Arbitrarily large JSON integers are
+    # valid Python values but cannot participate in finite budget arithmetic.
+    try:
+        normalized = float(value)
+    except OverflowError as exc:
+        raise AuthorityError(f"{field} must be a finite number") from exc
+    if not math.isfinite(normalized):
+        raise AuthorityError(f"{field} must be a finite number")
+    return normalized
+
+
+def _expiry_from_ttl(granted_at: datetime, ttl_s: Any) -> datetime:
+    """Add a finite TTL under the authority store's typed error contract."""
+
+    ttl = _nonnegative_number(ttl_s, "ttl_s")
+    try:
+        return granted_at + timedelta(seconds=ttl)
+    except OverflowError as exc:
+        raise AuthorityError("ttl_s exceeds the representable timestamp range") from exc
+
+
+def _budget_decimal(value: Any, field: str) -> Decimal:
+    """Return the exact decimal represented by one validated JSON number."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        raise AuthorityError(f"{field} must be a non-negative number")
+    if isinstance(value, int):
+        return Decimal(value)
+    if not math.isfinite(value):
+        raise AuthorityError(f"{field} must be a finite number")
+    try:
+        return Decimal(str(value))
+    except InvalidOperation as exc:  # pragma: no cover - value is finite
+        raise AuthorityError(f"{field} must be a finite number") from exc
+
+
+def _tokens_max_integer(value: Any, field: str) -> int:
+    """Return an exact non-negative signed-64-bit tokens_max integer.
+
+    Token accounting is exact integer arithmetic. Accepting a float here would
+    silently round values above 2**53, while accepting an integer beyond the
+    SQLite range would make persistence fail later with an untyped driver
+    ``OverflowError``. Enforce the durable representation at every boundary.
+    """
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or not 0 <= value <= _SQLITE_INT_MAX
+    ):
+        raise AuthorityError(f"{field} must be a non-negative signed 64-bit integer")
+    return value
+
+
+def _normalized_reservation_metadata(
+    value: Any, field: str = "budget reservation metadata"
+) -> dict[str, Any] | None:
+    """Canonicalize optional reservation metadata, or fail closed typed."""
+
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise AuthorityError(f"{field} must be an object")
+    try:
+        normalized = json.loads(_canonical_json(value))
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise AuthorityError(f"{field} is not canonically serializable") from exc
+    return normalized or None
+
+
+def _bounded_repr(value: Any) -> str:
+    """Render an untrusted value as bounded, JSON-safe audit text."""
+
+    try:
+        text = repr(value)
+    except Exception:  # pragma: no cover - defensive: hostile __repr__
+        return f"<unrepresentable {type(value).__name__}>"
+    if len(text) > _FENCE_REPR_MAX:
+        text = text[: _FENCE_REPR_MAX - 3] + "..."
+    return text
+
+
+def _bindable_fence(value: int) -> bool:
+    """True if a non-``bool`` ``int`` fits the signed 64-bit ``fence`` column."""
+
+    return _SQLITE_INT_MIN <= value <= _SQLITE_INT_MAX
+
+
+def _normalize_claimed_fence(value: Any) -> tuple[int | None, dict[str, Any]]:
+    """Normalize a caller-supplied fence to a column- and hash-stable value.
+
+    Returns ``(fence, audit)``. ``fence`` is both bound to the INTEGER ``fence``
+    column and folded into the event hash, so it must be exactly the type *and*
+    value SQLite hands back on read: a non-``bool`` ``int`` inside the signed
+    64-bit range, or ``None``. Every other value is malformed and normalizes to
+    ``None``.
+    """
+
+    if value is None:
+        return None, {"claimed_fence": None, "claimed_fence_malformed": False}
+    if isinstance(value, int) and not isinstance(value, bool):
+        if _bindable_fence(value):
+            return value, {"claimed_fence": value, "claimed_fence_malformed": False}
+        reason = "out_of_range"
+    else:
+        reason = "not_an_integer"
+    return None, {
+        "claimed_fence": None,
+        "claimed_fence_malformed": True,
+        "claimed_fence_reason": reason,
+        "claimed_fence_type": type(value).__name__,
+        "claimed_fence_repr": _bounded_repr(value),
+    }
+
+
+def _canonical_identity(value: Any) -> str | None:
+    """Canonical JSON of an untrusted envelope, or ``None`` if unrepresentable."""
+
+    try:
+        return _canonical_json(dict(value))
+    except (TypeError, ValueError, RecursionError):
+        return None
+
+
+def _valid_sha256(value: Any, field: str) -> str:
+    """Return a validated lowercase SHA-256 hex digest or fail closed."""
+
+    if not isinstance(value, str) or len(value) != _SHA256_RE_LEN:
+        raise AuthorityError(f"{field} must be a SHA-256 hex digest")
+    try:
+        int(value, 16)
+    except (TypeError, ValueError) as exc:
+        raise AuthorityError(f"{field} must be a SHA-256 hex digest") from exc
+    if value.lower() != value:
+        raise AuthorityError(f"{field} must be a SHA-256 hex digest")
+    return value
+
+
+# ── Envelope validation (self-contained, no enforcement dependency) ────────────
+
+
+def _env_aware_datetime(value: Any) -> datetime | None:
+    try:
+        parsed = datetime.fromisoformat(str(value or "").replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo is not None else None
+
+
+def _env_nonnegative_number(value: Any) -> bool:
+    """True for a finite, non-negative, non-``bool`` number."""
+
+    if isinstance(value, bool) or not isinstance(value, (int, float)) or value < 0:
+        return False
+    try:
+        return math.isfinite(value)
+    except OverflowError:
+        return False
+
+
+def _env_nonempty_strings(value: Any, *, allow_empty: bool = True) -> bool:
+    return (
+        isinstance(value, list)
+        and (allow_empty or bool(value))
+        and all(isinstance(item, str) and bool(item.strip()) for item in value)
+    )
+
+
+def validate_sealed_envelope(envelope: Mapping[str, Any]) -> list[str]:
+    """Return a sorted list of field-level errors in a sealed task envelope v2.
+
+    An empty list means the envelope is structurally valid. The store calls this
+    before persisting any grant; callers may call it independently for pre-flight
+    checks. No I/O is performed.
+    """
+
+    errors = [field for field in _REQUIRED_FIELDS if envelope.get(field) is None]
+    if envelope.get("envelope_version") != 2:
+        errors.append("envelope_version")
+    for field in ("graph_id", "node_id", "attempt_id", "objective"):
+        if (
+            not isinstance(envelope.get(field), str)
+            or not envelope.get(field, "").strip()
+        ):
+            errors.append(field)
+    if len(str(envelope.get("objective") or "")) > 2000:
+        errors.append("objective")
+    if envelope.get("execution_surface") not in _ALLOWED_SURFACES:
+        errors.append("execution_surface")
+    if envelope.get("lane") not in _ALLOWED_LANES:
+        errors.append("lane")
+    if not _env_nonempty_strings(envelope.get("roots"), allow_empty=False):
+        errors.append("roots")
+    elif any(not Path(root).expanduser().is_absolute() for root in envelope["roots"]):
+        errors.append("roots")
+
+    permissions = envelope.get("permissions")
+    if not isinstance(permissions, Mapping):
+        errors.append("permissions")
+        permissions = {}
+    for field in ("read", "write", "spawn"):
+        values = permissions.get(field)
+        if not _env_nonempty_strings(values):
+            errors.append(f"permissions.{field}")
+        elif field in {"read", "write"} and any(
+            not Path(value).expanduser().is_absolute() for value in (values or [])
+        ):
+            errors.append(f"permissions.{field}")
+
+    network_policy = envelope.get("network_policy")
+    if network_policy not in _ALLOWED_NETWORK:
+        errors.append("network_policy")
+    if network_policy == "allowlist" and not _env_nonempty_strings(
+        envelope.get("network_allowlist"), allow_empty=False
+    ):
+        errors.append("network_allowlist")
+    if envelope.get("exec_policy") not in _ALLOWED_EXEC:
+        errors.append("exec_policy")
+    if envelope.get("destructive_policy") not in _ALLOWED_DESTRUCTIVE:
+        errors.append("destructive_policy")
+
+    budgets = envelope.get("budgets")
+    if not isinstance(budgets, Mapping):
+        errors.append("budgets")
+        budgets = {}
+    for field in ("usd_max", "wall_clock_s_max"):
+        if not _env_nonnegative_number(budgets.get(field)):
+            errors.append(f"budgets.{field}")
+    tokens_max = budgets.get("tokens_max")
+    if (
+        isinstance(tokens_max, bool)
+        or not isinstance(tokens_max, int)
+        or not 0 <= tokens_max <= _SQLITE_INT_MAX
+    ):
+        errors.append("budgets.tokens_max")
+    if _env_aware_datetime(envelope.get("deadline_utc")) is None:
+        errors.append("deadline_utc")
+
+    retry = envelope.get("retry_policy")
+    if not isinstance(retry, Mapping):
+        errors.append("retry_policy")
+        retry = {}
+    max_attempts = retry.get("max_attempts")
+    retry_eligible = retry.get("retry_eligible")
+    valid_max_attempts = (
+        isinstance(max_attempts, int)
+        and not isinstance(max_attempts, bool)
+        and max_attempts >= 1
+    )
+    if not valid_max_attempts:
+        errors.append("retry_policy.max_attempts")
+    if not isinstance(retry_eligible, bool):
+        errors.append("retry_policy.retry_eligible")
+    if not isinstance(retry.get("backoff_s"), list) or not all(
+        _env_nonnegative_number(item) for item in retry.get("backoff_s", [])
+    ):
+        errors.append("retry_policy.backoff_s")
+    writes = permissions.get("write") if isinstance(permissions, Mapping) else []
+    if writes and (max_attempts != 1 or retry_eligible is not False):
+        errors.append("retry_policy.mutation")
+    if (
+        valid_max_attempts
+        and max_attempts > 1
+        and envelope.get("execution_surface") not in _STATELESS_SURFACES
+    ):
+        errors.append("retry_policy.execution_surface")
+
+    cancellation = envelope.get("cancellation")
+    if not isinstance(cancellation, Mapping):
+        errors.append("cancellation")
+        cancellation = {}
+    if cancellation.get("mode") != "cooperative":
+        errors.append("cancellation.mode")
+    if not _env_nonnegative_number(cancellation.get("grace_s")):
+        errors.append("cancellation.grace_s")
+
+    evidence = envelope.get("evidence_policy")
+    if not isinstance(evidence, Mapping):
+        errors.append("evidence_policy")
+        evidence = {}
+    if not _env_nonempty_strings(
+        evidence.get("required_receipt_kinds"), allow_empty=False
+    ):
+        errors.append("evidence_policy.required_receipt_kinds")
+    min_receipts = evidence.get("min_receipts")
+    if (
+        not isinstance(min_receipts, int)
+        or isinstance(min_receipts, bool)
+        or min_receipts < 1
+    ):
+        errors.append("evidence_policy.min_receipts")
+
+    verifier = envelope.get("verifier_policy")
+    if not isinstance(verifier, Mapping):
+        errors.append("verifier_policy")
+        verifier = {}
+    for field in ("required", "verifier_lane_must_differ", "clean_workspace_required"):
+        if not isinstance(verifier.get(field), bool):
+            errors.append(f"verifier_policy.{field}")
+    if writes and not all(
+        verifier.get(field) is True
+        for field in (
+            "required",
+            "verifier_lane_must_differ",
+            "clean_workspace_required",
+        )
+    ):
+        errors.append("verifier_policy.mutation")
+
+    for field in ("idempotency_key", "planner_hash", "policy_hash", "input_hash"):
+        if not _HASH_RE.fullmatch(str(envelope.get(field) or "")):
+            errors.append(field)
+
+    lease = envelope.get("lease")
+    if not isinstance(lease, Mapping):
+        errors.append("lease")
+        lease = {}
+    if not isinstance(lease.get("holder"), str) or not lease.get("holder", "").strip():
+        errors.append("lease.holder")
+    granted = _env_aware_datetime(lease.get("granted_utc"))
+    if granted is None:
+        errors.append("lease.granted_utc")
+    if not _env_nonnegative_number(lease.get("ttl_s")) or lease.get("ttl_s") == 0:
+        errors.append("lease.ttl_s")
+    if not isinstance(lease.get("renewable"), bool):
+        errors.append("lease.renewable")
+    fence = envelope.get("fence")
+    if (
+        not isinstance(fence, int)
+        or isinstance(fence, bool)
+        or fence < 1
+        or not _bindable_fence(fence)
+    ):
+        errors.append("fence")
+    return sorted(set(errors))
+
+
+# ── Context-scoped envelope binding ───────────────────────────────────────────
+
+
+@contextmanager
+def bind_sealed_envelope(
+    envelope: Mapping[str, Any], *, current_fence: int | None = None
+) -> Iterator[None]:
+    """Bind a defensive immutable copy to the current execution context.
+
+    The bound envelope and fence are scoped to the calling async task or thread
+    via ``ContextVar``; they reset unconditionally on exit, even on exception.
+    """
+
+    frozen = _freeze_envelope_value(envelope)
+    envelope_token = _CURRENT_ENVELOPE.set(frozen)
+    fence_token = _CURRENT_FENCE.set(current_fence)
+    try:
+        yield
+    finally:
+        _CURRENT_FENCE.reset(fence_token)
+        _CURRENT_ENVELOPE.reset(envelope_token)
+
+
+def current_sealed_envelope() -> Mapping[str, Any] | None:
+    """Return the envelope bound to the current execution context, or ``None``."""
+
+    return _CURRENT_ENVELOPE.get()
+
+
+def current_authoritative_fence() -> int | None:
+    """Return the fence bound by the Hermes control plane for this context."""
+
+    return _CURRENT_FENCE.get()

--- a/agent/phase2_errors.py
+++ b/agent/phase2_errors.py
@@ -1,0 +1,90 @@
+"""Typed exceptions for the Phase 2 durable authority contract."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+
+class AuthorityError(RuntimeError):
+    """A requested authority transition is invalid or unavailable."""
+
+
+class AuthorityMigrationRequired(AuthorityError):
+    """A durable store predates an integrity invariant its data now violates.
+
+    Raised instead of creating a unique index that existing authoritative rows
+    would violate. Authoritative events are never deleted or rewritten to make
+    an index fit, so the store stays readable for inspection
+    (:meth:`Phase2AuthorityStore.migration_report`,
+    :meth:`Phase2AuthorityStore.read_events`) while every authority-serving path
+    fails closed with this typed, actionable error.
+    """
+
+    def __init__(self, violations: list[dict[str, Any]], db_path: Path | str) -> None:
+        self.violations = tuple(violations)
+        self.db_path = str(db_path)
+        summary = "; ".join(
+            "{invariant}: {groups} violating group(s), sample {sample} ({remediation})".format(
+                invariant=violation["invariant"],
+                groups=violation["violating_groups"],
+                sample=[
+                    f"{item['key']} x{item['events']}" for item in violation["sample"]
+                ],
+                remediation=violation["remediation"],
+            )
+            for violation in self.violations
+        )
+        super().__init__(
+            f"authority store {self.db_path} requires explicit migration before use: "
+            f"{summary}. Authoritative events are never auto-deleted or rewritten; "
+            "inspect with Phase2AuthorityStore(db_path).migration_report() and "
+            "read_events(graph_id), then quarantine this database and re-seal, or "
+            "resolve the listed rows out of band."
+        )
+
+
+class ResultRejection(AuthorityError):
+    """A completion was rejected; exactly one RESULT_REJECTED event was appended.
+
+    The rejection is recorded durably in the same decision transaction, so this
+    exception carries the bounded machine-readable ``reason`` and the
+    ``result_hash`` that was refused.
+    """
+
+    def __init__(self, reason: str, *, result_hash: str | None = None) -> None:
+        super().__init__(f"result rejected: {reason}")
+        self.reason = reason
+        self.result_hash = result_hash
+
+
+class MalformedEnvelopeFence(ResultRejection):
+    """A completion presented a fence that is not a durably bindable integer.
+
+    Contract v2 requires ``fence`` to be a positive ``int``. A caller-supplied
+    ``"1"``, ``1.0``, ``True``, ``[1]``, or ``{}`` is not a fence: it can neither
+    be compared against the authoritative fence nor bound to the INTEGER column
+    without SQLite type affinity silently rewriting it into a value that no
+    longer matches the integrity hash computed over it. An ``int`` outside the
+    signed 64-bit range (``claimed_fence_reason == "out_of_range"``) is equally
+    unusable — SQLite cannot bind it at all. Such a completion is rejected
+    fail-closed, and the claim survives only as bounded audit metadata on the
+    ``RESULT_REJECTED`` event (whose ``fence`` column is ``NULL``).
+
+    Subclasses :class:`ResultRejection` so existing fail-closed handlers keep
+    working unchanged.
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        result_hash: str | None = None,
+        claimed_fence_reason: str | None = None,
+        claimed_fence_type: str | None = None,
+        claimed_fence_repr: str | None = None,
+    ) -> None:
+        super().__init__(reason, result_hash=result_hash)
+        self.claimed_fence_reason = claimed_fence_reason
+        self.claimed_fence_type = claimed_fence_type
+        self.claimed_fence_repr = claimed_fence_repr

--- a/agent/phase2_idempotency.py
+++ b/agent/phase2_idempotency.py
@@ -1,0 +1,255 @@
+"""Atomic persistent claims for Phase 2 mutating logical operations.
+
+A mutating tool call is keyed by the idempotency key from the sealed task
+envelope. The first writer atomically claims it; every subsequent attempt
+with the same key loses without side effects. Raw arguments are never stored.
+The persisted deterministic SHA-256 hash still permits offline confirmation
+of guessed arguments; it is an audit identity, not a confidentiality boundary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+import sqlite3
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Mapping
+
+from agent.phase2_sqlite import _check_phase2_db_files, _open_phase2_sqlite
+from hermes_constants import get_hermes_home
+
+_DB_LOCK = threading.Lock()
+_HASH_RE = re.compile(r"^[0-9a-f]{64}$")
+_SQLITE_INT_MAX = 2**63 - 1
+
+
+class MutationClaimError(ValueError):
+    """The caller supplied an invalid mutation claim."""
+
+
+def _required_identity(envelope: Mapping[str, Any], field: str) -> str:
+    value = envelope.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise MutationClaimError(f"{field} must be a non-empty string")
+    return value
+
+
+def _claim_fence(envelope: Mapping[str, Any]) -> int:
+    value = envelope.get("fence")
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not 1 <= value <= _SQLITE_INT_MAX
+    ):
+        raise MutationClaimError("fence must be a positive signed 64-bit integer")
+    return value
+
+
+def default_db_path() -> Path:
+    return get_hermes_home() / "phase2_idempotency.db"
+
+
+def _canonical_hash(value: Mapping[str, Any]) -> str:
+    if not isinstance(value, Mapping):
+        raise MutationClaimError("args must be a mapping")
+
+    def json_tree(item: Any) -> Any:
+        if isinstance(item, Mapping):
+            normalized: dict[str, Any] = {}
+            for key, child in item.items():
+                if not isinstance(key, str):
+                    raise TypeError("JSON object keys must be strings")
+                normalized[key] = json_tree(child)
+            return normalized
+        if isinstance(item, (list, tuple)):
+            return [json_tree(child) for child in item]
+        if item is None or isinstance(item, (str, bool, int, float)):
+            return item
+        raise TypeError(f"value of type {type(item).__name__} is not JSON serializable")
+
+    try:
+        encoded = json.dumps(
+            json_tree(value),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+            allow_nan=False,
+        ).encode("utf-8")
+    except (TypeError, ValueError, RecursionError) as exc:
+        raise MutationClaimError("args must be canonically JSON serializable") from exc
+    return hashlib.sha256(encoded).hexdigest()
+
+
+class MutationClaimStore:
+    """Own the durable first-writer claim for a mutating idempotency key."""
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = Path(db_path) if db_path is not None else default_db_path()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = _open_phase2_sqlite(self.db_path)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS mutation_claims (
+                    idempotency_key TEXT PRIMARY KEY,
+                    graph_id TEXT NOT NULL,
+                    node_id TEXT NOT NULL,
+                    attempt_id TEXT NOT NULL,
+                    fence INTEGER NOT NULL,
+                    tool_name TEXT NOT NULL,
+                    args_hash TEXT NOT NULL,
+                    claimed_utc TEXT NOT NULL
+                )
+                """
+            )
+            conn.execute(
+                """
+                CREATE TRIGGER IF NOT EXISTS mutation_claims_no_update
+                BEFORE UPDATE ON mutation_claims
+                BEGIN
+                    SELECT RAISE(ABORT, 'mutation_claims is append-only');
+                END
+                """
+            )
+            conn.execute(
+                """
+                CREATE TRIGGER IF NOT EXISTS mutation_claims_no_delete
+                BEFORE DELETE ON mutation_claims
+                BEGIN
+                    SELECT RAISE(ABORT, 'mutation_claims is append-only');
+                END
+                """
+            )
+            _check_phase2_db_files(self.db_path, harden=True)
+            return conn
+        except BaseException:
+            conn.close()
+            raise
+
+    def try_claim(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        tool_name: str,
+        args: Mapping[str, Any],
+    ) -> bool:
+        """Atomically claim one logical mutating operation.
+
+        Returns ``True`` if this caller is the first writer.  Returns ``False``
+        only when the same idempotency key was already claimed *for the same
+        logical effect* (same graph_id, node_id, attempt_id, fence, tool_name,
+        and args_hash) — a safe at-least-once redelivery.  Raises
+        ``MutationClaimError`` if the key was already claimed for a *different*
+        logical effect; callers MUST treat this as a hard error and must not
+        proceed.  The deterministic args hash omits raw payloads but permits
+        offline confirmation of guessed inputs.
+        """
+
+        if not isinstance(envelope, Mapping):
+            raise MutationClaimError("envelope must be a mapping")
+        idempotency_key = _required_identity(envelope, "idempotency_key")
+        if not _HASH_RE.fullmatch(idempotency_key):
+            raise MutationClaimError(
+                "idempotency_key must be a lowercase SHA-256 digest"
+            )
+        if not isinstance(tool_name, str) or not tool_name.strip():
+            raise MutationClaimError("tool_name must be a non-empty string")
+        row = (
+            idempotency_key,
+            _required_identity(envelope, "graph_id"),
+            _required_identity(envelope, "node_id"),
+            _required_identity(envelope, "attempt_id"),
+            _claim_fence(envelope),
+            tool_name,
+            _canonical_hash(args),
+            datetime.now(timezone.utc).isoformat(),
+        )
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                inserted = conn.execute(
+                    """
+                    INSERT INTO mutation_claims(
+                        idempotency_key, graph_id, node_id, attempt_id, fence,
+                        tool_name, args_hash, claimed_utc
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                    ON CONFLICT(idempotency_key) DO NOTHING
+                    """,
+                    row,
+                ).rowcount
+                if inserted == 1:
+                    conn.execute("COMMIT")
+                    return True
+                # Key already claimed.  Read the prior record to determine
+                # whether this is a safe same-effect replay (False) or an
+                # idempotency-key collision with a different effect (error).
+                prior = conn.execute(
+                    """
+                    SELECT graph_id, node_id, attempt_id, fence,
+                           tool_name, args_hash
+                    FROM mutation_claims
+                    WHERE idempotency_key = ?
+                    """,
+                    (idempotency_key,),
+                ).fetchone()
+                conn.execute("COMMIT")
+                # Identity: every field that distinguishes one logical effect
+                # from another.  graph_id/node_id/attempt_id anchor the
+                # provenance; fence captures the exact execution epoch;
+                # tool_name and args_hash capture the operation itself.
+                if prior is None:
+                    raise MutationClaimError(
+                        f"idempotency_key collision: key {idempotency_key!r} "
+                        "conflicted without a readable prior claim"
+                    )
+                if (
+                    prior["graph_id"] == row[1]
+                    and prior["node_id"] == row[2]
+                    and prior["attempt_id"] == row[3]
+                    and prior["fence"] == row[4]
+                    and prior["tool_name"] == row[5]
+                    and prior["args_hash"] == row[6]
+                ):
+                    return False
+                raise MutationClaimError(
+                    f"idempotency_key collision: key {idempotency_key!r} was "
+                    "already claimed for a different logical effect"
+                )
+            except MutationClaimError:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def read_all(self) -> list[dict[str, Any]]:
+        if not self.db_path.exists():
+            return []
+        conn = _open_phase2_sqlite(self.db_path, readonly=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            return [
+                dict(row)
+                for row in conn.execute("SELECT * FROM mutation_claims ORDER BY rowid")
+            ]
+        finally:
+            conn.close()
+
+
+__all__ = ["MutationClaimError", "MutationClaimStore", "default_db_path"]

--- a/agent/phase2_ledger.py
+++ b/agent/phase2_ledger.py
@@ -1,0 +1,1386 @@
+"""Durable plan/event ledger, lease/fence lifecycle, and integrity backstops.
+
+The store is deliberately append-only at the lifecycle layer.  Plans and node
+specifications are immutable after sealing; lease/fence and budget state are
+derived from hash-chained events written under ``BEGIN IMMEDIATE``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Iterator, Mapping, NamedTuple
+
+from hermes_constants import get_hermes_home
+
+from agent.phase2_budget import Phase2BudgetMixin
+from agent.phase2_envelope import (
+    _ALLOWED_SURFACES,
+    _HASH_KEYS,
+    _MIGRATION_SAMPLE_MAX,
+    _bindable_fence,
+    _canonical_hash,
+    _canonical_identity,
+    _canonical_json,
+    _expiry_from_ttl,
+    _nonnegative_number,
+    _iso,
+    _json_tree,
+    _normalize_claimed_fence,
+    _parse_time,
+    _sealed_json,
+    _utc,
+    _valid_sha256,
+    bind_sealed_envelope,
+    validate_sealed_envelope,
+)
+from agent.phase2_errors import (
+    AuthorityError,
+    AuthorityMigrationRequired,
+    MalformedEnvelopeFence,
+    ResultRejection,
+)
+from agent.phase2_sqlite import (
+    _DB_LOCK,
+    _check_phase2_db_files,
+    _open_phase2_sqlite,
+)
+
+_ACCEPTED_KINDS = ("RESULT_ACCEPTED", "NODE_COMPLETED")
+
+
+class _IntegrityIndex(NamedTuple):
+    """A partial unique index that backstops one authority invariant.
+
+    ``scan_sql`` groups the rows the index would collapse, using exactly the
+    index's own NULL semantics (a unique index treats every NULL as distinct,
+    so rows with a NULL indexed column can never conflict and are excluded).
+    Running the scan before ``CREATE UNIQUE INDEX`` turns a raw
+    ``sqlite3.IntegrityError`` on a legacy database into a typed, actionable
+    migration decision.
+    """
+
+    name: str
+    create_sql: str
+    invariant: str
+    scan_sql: str
+    remediation: str
+
+
+_INTEGRITY_INDEXES: tuple[_IntegrityIndex, ...] = (
+    _IntegrityIndex(
+        name="one_accepted_result_per_node",
+        create_sql=(
+            "CREATE UNIQUE INDEX one_accepted_result_per_node "
+            "ON authority_events(graph_id, node_id) WHERE kind = 'RESULT_ACCEPTED'"
+        ),
+        invariant="duplicate_accepted_result",
+        scan_sql=(
+            "SELECT graph_id || '/' || node_id AS violation_key, COUNT(*) AS events "
+            "FROM authority_events "
+            "WHERE kind = 'RESULT_ACCEPTED' AND node_id IS NOT NULL "
+            "GROUP BY graph_id, node_id HAVING COUNT(*) > 1 "
+            "ORDER BY graph_id, node_id"
+        ),
+        remediation=(
+            "more than one RESULT_ACCEPTED exists for a node; exactly one result "
+            "may be authoritative, so the correct acceptance must be chosen by an "
+            "operator before this store can serve authority"
+        ),
+    ),
+    _IntegrityIndex(
+        name="one_terminal_result_per_node",
+        create_sql=(
+            "CREATE UNIQUE INDEX one_terminal_result_per_node "
+            "ON authority_events(graph_id, node_id) "
+            "WHERE kind IN ('RESULT_ACCEPTED', 'NODE_COMPLETED')"
+        ),
+        invariant="duplicate_terminal_result",
+        scan_sql=(
+            "SELECT graph_id || '/' || node_id AS violation_key, COUNT(*) AS events "
+            "FROM authority_events "
+            "WHERE kind IN ('RESULT_ACCEPTED', 'NODE_COMPLETED') AND node_id IS NOT NULL "
+            "GROUP BY graph_id, node_id HAVING COUNT(*) > 1 "
+            "ORDER BY graph_id, node_id"
+        ),
+        remediation=(
+            "a node carries more than one terminal completion row (legacy stores "
+            "permitted regrant after completion, so a node could be completed once "
+            "per fence); the authoritative terminal event must be chosen by an "
+            "operator before this store can serve authority"
+        ),
+    ),
+    _IntegrityIndex(
+        name="one_grant_per_attempt",
+        create_sql=(
+            "CREATE UNIQUE INDEX one_grant_per_attempt "
+            "ON authority_events(attempt_id) WHERE kind = 'LEASE_GRANTED'"
+        ),
+        invariant="duplicate_grant_attempt_id",
+        scan_sql=(
+            "SELECT attempt_id AS violation_key, COUNT(*) AS events "
+            "FROM authority_events "
+            "WHERE kind = 'LEASE_GRANTED' AND attempt_id IS NOT NULL "
+            "GROUP BY attempt_id HAVING COUNT(*) > 1 "
+            "ORDER BY attempt_id"
+        ),
+        remediation=(
+            "an attempt_id was granted more than once (legacy stores did not bind "
+            "attempt_id globally, so the same id could be granted on another node "
+            "or graph); attempt identity cannot be reconstructed automatically and "
+            "must be resolved by an operator"
+        ),
+    ),
+)
+
+
+class _Reject(Exception):
+    """Internal control-flow signal: one typed rejection must be recorded."""
+
+    def __init__(self, reason: str, *, fence_hint: int | None = None) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.fence_hint = fence_hint
+
+
+def default_db_path() -> Path:
+    return get_hermes_home() / "phase2_authority.db"
+
+
+# ── Durable authority store ────────────────────────────────────────────────────
+
+
+class Phase2AuthorityStore(Phase2BudgetMixin):
+    """Seal plans and issue node-scoped fences, leases, and budget reservations."""
+
+    def __init__(self, db_path: Path | str | None = None) -> None:
+        self.db_path = Path(db_path) if db_path is not None else default_db_path()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = _open_phase2_sqlite(self.db_path, timeout=5.0)
+        try:
+            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute("PRAGMA busy_timeout=5000")
+            conn.row_factory = sqlite3.Row
+            self._ensure_schema(conn)
+            _check_phase2_db_files(self.db_path, harden=True)
+            return conn
+        except BaseException:
+            conn.close()
+            raise
+
+    def _ensure_schema(self, conn: sqlite3.Connection) -> None:
+        self._ensure_base_schema(conn)
+        self._ensure_integrity_indexes(conn, self.db_path)
+
+    @staticmethod
+    def _ensure_base_schema(conn: sqlite3.Connection) -> None:
+        """Create the tables and append-only triggers."""
+
+        conn.executescript(
+            """
+            CREATE TABLE IF NOT EXISTS sealed_plans (
+                graph_id TEXT PRIMARY KEY,
+                contract_version INTEGER NOT NULL,
+                planner_hash TEXT NOT NULL,
+                policy_hash TEXT NOT NULL,
+                plan_json TEXT NOT NULL,
+                sealed_utc TEXT NOT NULL
+            );
+            CREATE TABLE IF NOT EXISTS sealed_nodes (
+                graph_id TEXT NOT NULL,
+                node_id TEXT NOT NULL,
+                node_json TEXT NOT NULL,
+                PRIMARY KEY(graph_id, node_id),
+                FOREIGN KEY(graph_id) REFERENCES sealed_plans(graph_id)
+            );
+            CREATE TABLE IF NOT EXISTS authority_events (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                event_id TEXT NOT NULL UNIQUE,
+                ts_utc TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                graph_id TEXT NOT NULL,
+                node_id TEXT,
+                attempt_id TEXT,
+                fence INTEGER,
+                payload_json TEXT NOT NULL,
+                prev_event_hash TEXT,
+                event_hash TEXT NOT NULL UNIQUE
+            );
+            CREATE TRIGGER IF NOT EXISTS sealed_plans_no_update
+            BEFORE UPDATE ON sealed_plans BEGIN
+                SELECT RAISE(ABORT, 'sealed_plans is immutable');
+            END;
+            CREATE TRIGGER IF NOT EXISTS sealed_plans_no_delete
+            BEFORE DELETE ON sealed_plans BEGIN
+                SELECT RAISE(ABORT, 'sealed_plans is immutable');
+            END;
+            CREATE TRIGGER IF NOT EXISTS sealed_nodes_no_update
+            BEFORE UPDATE ON sealed_nodes BEGIN
+                SELECT RAISE(ABORT, 'sealed_nodes is immutable');
+            END;
+            CREATE TRIGGER IF NOT EXISTS sealed_nodes_no_delete
+            BEFORE DELETE ON sealed_nodes BEGIN
+                SELECT RAISE(ABORT, 'sealed_nodes is immutable');
+            END;
+            CREATE TRIGGER IF NOT EXISTS authority_events_no_update
+            BEFORE UPDATE ON authority_events BEGIN
+                SELECT RAISE(ABORT, 'authority_events is append-only');
+            END;
+            CREATE TRIGGER IF NOT EXISTS authority_events_no_delete
+            BEFORE DELETE ON authority_events BEGIN
+                SELECT RAISE(ABORT, 'authority_events is append-only');
+            END;
+            """
+        )
+
+    @staticmethod
+    def _normalize_schema_sql(value: str | None) -> str:
+        return " ".join(str(value or "").casefold().split())
+
+    @classmethod
+    def _missing_integrity_indexes(
+        cls, conn: sqlite3.Connection
+    ) -> list[_IntegrityIndex]:
+        present = {
+            row[0]: cls._normalize_schema_sql(row[1])
+            for row in conn.execute(
+                "SELECT name, sql FROM sqlite_master WHERE type = 'index'"
+            ).fetchall()
+        }
+        return [
+            index
+            for index in _INTEGRITY_INDEXES
+            if present.get(index.name) != cls._normalize_schema_sql(index.create_sql)
+        ]
+
+    @staticmethod
+    def _scan_integrity_violations(
+        conn: sqlite3.Connection, indexes: list[_IntegrityIndex]
+    ) -> list[dict[str, Any]]:
+        """Report, deterministically, which rows would violate each index."""
+
+        violations: list[dict[str, Any]] = []
+        for index in indexes:
+            groups = conn.execute(
+                f"SELECT COUNT(*) FROM ({index.scan_sql})"  # noqa: S608
+            ).fetchone()[0]
+            if not groups:
+                continue
+            sample = conn.execute(
+                f"{index.scan_sql} LIMIT ?",  # noqa: S608
+                (_MIGRATION_SAMPLE_MAX,),
+            ).fetchall()
+            violations.append({
+                "invariant": index.invariant,
+                "index": index.name,
+                "violating_groups": int(groups),
+                "sample": [{"key": row[0], "events": int(row[1])} for row in sample],
+                "remediation": index.remediation,
+            })
+        return violations
+
+    @classmethod
+    def _ensure_integrity_indexes(
+        cls, conn: sqlite3.Connection, db_path: Path | str
+    ) -> None:
+        """Create the backstop unique indexes, or fail closed with a typed error."""
+
+        if not cls._missing_integrity_indexes(conn):
+            return
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            missing = cls._missing_integrity_indexes(conn)
+            violations = (
+                cls._scan_integrity_violations(conn, missing) if missing else []
+            )
+            if violations:
+                conn.execute("ROLLBACK")
+                raise AuthorityMigrationRequired(violations, db_path)
+            for index in missing:
+                conn.execute(f'DROP INDEX IF EXISTS "{index.name}"')
+                conn.execute(index.create_sql)
+            conn.execute("COMMIT")
+        except AuthorityMigrationRequired:
+            raise
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+
+    @staticmethod
+    def _append_event(
+        conn: sqlite3.Connection,
+        *,
+        kind: str,
+        graph_id: str,
+        node_id: str | None,
+        attempt_id: str | None,
+        fence: int | None,
+        payload: Mapping[str, Any],
+        now: datetime,
+        event_id: str | None = None,
+    ) -> str:
+        if not isinstance(graph_id, str):
+            raise AuthorityError("event graph_id must be a string")
+        if node_id is not None and not isinstance(node_id, str):
+            raise AuthorityError("event node_id must be a string or null")
+        if attempt_id is not None and not isinstance(attempt_id, str):
+            raise AuthorityError("event attempt_id must be a string or null")
+        if fence is not None:
+            if isinstance(fence, bool) or not isinstance(fence, int):
+                raise AuthorityError("event fence must be an integer or null")
+            if not _bindable_fence(fence):
+                raise AuthorityError("event fence must be a signed 64-bit integer")
+        try:
+            payload_json = _canonical_json(payload)
+        except (TypeError, ValueError) as exc:
+            raise AuthorityError(
+                "event payload is not canonically serializable"
+            ) from exc
+
+        event_id = event_id or f"ev-{uuid.uuid4().hex}"
+        previous = conn.execute(
+            "SELECT event_hash FROM authority_events ORDER BY id DESC LIMIT 1"
+        ).fetchone()
+        prev_hash = previous["event_hash"] if previous else None
+        row = {
+            "event_id": event_id,
+            "ts_utc": _iso(now),
+            "kind": kind,
+            "graph_id": graph_id,
+            "node_id": node_id,
+            "attempt_id": attempt_id,
+            "fence": fence,
+            "payload": json.loads(payload_json),
+            "prev_event_hash": prev_hash,
+        }
+        event_hash = _canonical_hash(row)
+        conn.execute(
+            """INSERT INTO authority_events(
+                   event_id, ts_utc, kind, graph_id, node_id, attempt_id, fence,
+                   payload_json, prev_event_hash, event_hash
+               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                event_id,
+                row["ts_utc"],
+                kind,
+                graph_id,
+                node_id,
+                attempt_id,
+                fence,
+                payload_json,
+                prev_hash,
+                event_hash,
+            ),
+        )
+        return event_id
+
+    @staticmethod
+    def _validate_plan(
+        plan: Mapping[str, Any], policy_hash: str
+    ) -> tuple[str, list[dict[str, Any]]]:
+        if plan.get("contract_version") != 2:
+            raise AuthorityError("contract_version must be 2")
+        graph_id = plan.get("graph_id")
+        if not isinstance(graph_id, str) or not graph_id.strip():
+            raise AuthorityError("graph_id is required")
+        _valid_sha256(policy_hash, "policy_hash")
+        nodes = plan.get("nodes")
+        if not isinstance(nodes, list) or not nodes:
+            raise AuthorityError("plan nodes must be a non-empty list")
+        normalized: list[dict[str, Any]] = []
+        seen: set[str] = set()
+        seen_ikeys: set[str] = set()
+        for raw in nodes:
+            if not isinstance(raw, Mapping):
+                raise AuthorityError("each plan node must be an object")
+            node = json.loads(_sealed_json(raw))
+            reserved = {
+                "envelope_version",
+                "graph_id",
+                "attempt_id",
+                "planner_hash",
+                "policy_hash",
+                "lease",
+                "fence",
+            }.intersection(node)
+            if reserved:
+                raise AuthorityError(
+                    "plan node contains authority-owned fields: "
+                    + ", ".join(sorted(reserved))
+                )
+            node_id = node.get("node_id")
+            if not isinstance(node_id, str) or not node_id.strip():
+                raise AuthorityError("node_id is required")
+            if node_id in seen:
+                raise AuthorityError(f"duplicate node_id: {node_id}")
+            seen.add(node_id)
+            ikey = node.get("idempotency_key")
+            if isinstance(ikey, str) and ikey in seen_ikeys:
+                raise AuthorityError(f"duplicate idempotency_key across nodes: {ikey}")
+            if isinstance(ikey, str):
+                seen_ikeys.add(ikey)
+            surface = node.get("execution_surface")
+            if surface not in _ALLOWED_SURFACES:
+                raise AuthorityError(f"invalid execution_surface for {node_id}")
+            for key in _HASH_KEYS:
+                _valid_sha256(node.get(key), f"{key} for {node_id}")
+            candidate_envelope = {
+                "envelope_version": 2,
+                "graph_id": graph_id,
+                **node,
+                "attempt_id": "seal-validation",
+                "planner_hash": "0" * 64,
+                "policy_hash": policy_hash,
+                "lease": {
+                    "holder": "seal-validation",
+                    "granted_utc": "1970-01-01T00:00:00+00:00",
+                    "ttl_s": 1,
+                    "renewable": True,
+                },
+                "fence": 1,
+            }
+            errors = validate_sealed_envelope(candidate_envelope)
+            if errors:
+                raise AuthorityError(
+                    f"invalid sealed plan node {node_id}: " + ", ".join(errors)
+                )
+            normalized.append(node)
+        return graph_id, normalized
+
+    def seal_plan(
+        self,
+        plan: Mapping[str, Any],
+        *,
+        policy_hash: str,
+        now: datetime | None = None,
+    ) -> str:
+        """Persist an immutable plan and its nodes, returning the planner hash."""
+
+        graph_id, nodes = self._validate_plan(plan, policy_hash)
+        sealed_at = _utc(now)
+        canonical_plan = json.loads(_sealed_json(plan))
+        planner_hash = _canonical_hash(canonical_plan)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                if conn.execute(
+                    "SELECT 1 FROM sealed_plans WHERE graph_id = ?", (graph_id,)
+                ).fetchone():
+                    raise AuthorityError(f"graph {graph_id} is already sealed")
+                conn.execute(
+                    """INSERT INTO sealed_plans(
+                           graph_id, contract_version, planner_hash, policy_hash,
+                           plan_json, sealed_utc
+                       ) VALUES (?, 2, ?, ?, ?, ?)""",
+                    (
+                        graph_id,
+                        planner_hash,
+                        policy_hash,
+                        _sealed_json(canonical_plan),
+                        _iso(sealed_at),
+                    ),
+                )
+                conn.executemany(
+                    "INSERT INTO sealed_nodes(graph_id, node_id, node_json) VALUES (?, ?, ?)",
+                    [(graph_id, node["node_id"], _sealed_json(node)) for node in nodes],
+                )
+                self._append_event(
+                    conn,
+                    kind="PLAN_SEALED",
+                    graph_id=graph_id,
+                    node_id=None,
+                    attempt_id=None,
+                    fence=None,
+                    payload={"planner_hash": planner_hash, "policy_hash": policy_hash},
+                    now=sealed_at,
+                )
+                conn.execute("COMMIT")
+                return planner_hash
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    @staticmethod
+    def _load_plan_node(
+        conn: sqlite3.Connection, graph_id: str, node_id: str
+    ) -> tuple[sqlite3.Row, dict[str, Any]]:
+        plan = conn.execute(
+            "SELECT * FROM sealed_plans WHERE graph_id = ?", (graph_id,)
+        ).fetchone()
+        row = conn.execute(
+            "SELECT node_json FROM sealed_nodes WHERE graph_id = ? AND node_id = ?",
+            (graph_id, node_id),
+        ).fetchone()
+        if plan is None or row is None:
+            raise AuthorityError("unknown sealed graph node")
+        return plan, json.loads(row["node_json"])
+
+    @staticmethod
+    def _latest_grant(
+        conn: sqlite3.Connection, graph_id: str, node_id: str
+    ) -> sqlite3.Row | None:
+        return conn.execute(
+            """SELECT * FROM authority_events
+               WHERE graph_id = ? AND node_id = ? AND kind = 'LEASE_GRANTED'
+               ORDER BY id DESC LIMIT 1""",
+            (graph_id, node_id),
+        ).fetchone()
+
+    @classmethod
+    def _node_authority(
+        cls, conn: sqlite3.Connection, graph_id: str, node_id: str
+    ) -> dict[str, Any] | None:
+        """Fold the current fence's lifecycle events into one authority view."""
+
+        grant = cls._latest_grant(conn, graph_id, node_id)
+        if grant is None:
+            return None
+        fence = int(grant["fence"])
+        envelope = json.loads(grant["payload_json"])["envelope"]
+        rows = conn.execute(
+            """SELECT kind, payload_json FROM authority_events
+               WHERE graph_id = ? AND node_id = ? AND fence = ?
+                 AND kind IN ('LEASE_RENEWED', 'LEASE_REVOKED',
+                              'RESULT_ACCEPTED', 'NODE_COMPLETED')
+               ORDER BY id""",
+            (graph_id, node_id, fence),
+        ).fetchall()
+        revoked = False
+        completed = False
+        accepted_result_hash: str | None = None
+        new_expires_utc: str | None = None
+        for row in rows:
+            payload = json.loads(row["payload_json"])
+            if row["kind"] == "LEASE_RENEWED":
+                new_expires_utc = payload["new_expires_utc"]
+            elif row["kind"] == "LEASE_REVOKED":
+                revoked = True
+            elif row["kind"] in _ACCEPTED_KINDS:
+                completed = True
+                accepted_result_hash = payload.get("result_hash")
+        base_expiry = cls._lease_expiry(envelope)
+        effective_expiry = (
+            _parse_time(new_expires_utc) if new_expires_utc is not None else base_expiry
+        )
+        return {
+            "fence": fence,
+            "envelope": envelope,
+            "granted_expires": base_expiry,
+            "effective_expires": effective_expiry,
+            "revoked": revoked,
+            "completed": completed,
+            "accepted_result_hash": accepted_result_hash,
+        }
+
+    @staticmethod
+    def _lease_expiry(envelope: Mapping[str, Any]) -> datetime:
+        lease = envelope["lease"]
+        return _expiry_from_ttl(
+            _parse_time(lease["granted_utc"]),
+            lease["ttl_s"],
+        )
+
+    @staticmethod
+    def _terminal_completed(
+        conn: sqlite3.Connection, graph_id: str, node_id: str
+    ) -> bool:
+        """True if the node has any terminal acceptance across ALL fences."""
+
+        return (
+            conn.execute(
+                """SELECT 1 FROM authority_events
+                   WHERE graph_id = ? AND node_id = ?
+                     AND kind IN ('RESULT_ACCEPTED', 'NODE_COMPLETED')
+                   LIMIT 1""",
+                (graph_id, node_id),
+            ).fetchone()
+            is not None
+        )
+
+    @staticmethod
+    def _attempt_seen(conn: sqlite3.Connection, attempt_id: str) -> bool:
+        """True if the attempt_id was ever granted anywhere in this authority store."""
+
+        return (
+            conn.execute(
+                """SELECT 1 FROM authority_events
+                   WHERE kind = 'LEASE_GRANTED' AND attempt_id = ?
+                   LIMIT 1""",
+                (attempt_id,),
+            ).fetchone()
+            is not None
+        )
+
+    def grant_node(
+        self,
+        graph_id: str,
+        node_id: str,
+        *,
+        holder: str,
+        ttl_s: float,
+        attempt_id: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Atomically grant the next monotonic fence and return its sealed envelope.
+
+        A node closed by terminal completion can never be regranted. Attempt IDs
+        are single-use across the whole graph/node history and are never reused,
+        including after revocation or natural expiry.
+        """
+
+        granted_at = _utc(now)
+        if not isinstance(holder, str) or not holder.strip():
+            raise AuthorityError("lease holder is required")
+        if not isinstance(attempt_id, str) or not attempt_id.strip():
+            raise AuthorityError("attempt_id is required")
+        ttl = _nonnegative_number(ttl_s, "ttl_s")
+        if ttl == 0:
+            raise AuthorityError("ttl_s must be greater than zero")
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                plan, node = self._load_plan_node(conn, graph_id, node_id)
+                deadline = _parse_time(node["deadline_utc"])
+                expires = _expiry_from_ttl(granted_at, ttl)
+                if granted_at >= deadline:
+                    raise AuthorityError("expired deadline cannot grant")
+                if expires >= deadline:
+                    raise AuthorityError(
+                        "grant expiry must be strictly before the node deadline"
+                    )
+                if self._terminal_completed(conn, graph_id, node_id):
+                    raise AuthorityError("node is terminal and cannot be regranted")
+                if self._attempt_seen(conn, attempt_id):
+                    raise AuthorityError(f"attempt_id {attempt_id} was already used")
+                authority = self._node_authority(conn, graph_id, node_id)
+                if authority is not None:
+                    if not authority["revoked"] and not authority["completed"]:
+                        if granted_at < authority["effective_expires"]:
+                            raise AuthorityError("node already has an active lease")
+                    fence = authority["fence"] + 1
+                else:
+                    fence = 1
+                envelope = {
+                    "envelope_version": 2,
+                    "graph_id": graph_id,
+                    **node,
+                    "attempt_id": attempt_id,
+                    "planner_hash": plan["planner_hash"],
+                    "policy_hash": plan["policy_hash"],
+                    "lease": {
+                        "holder": holder,
+                        "granted_utc": _iso(granted_at),
+                        "ttl_s": ttl,
+                        "renewable": True,
+                    },
+                    "fence": fence,
+                }
+                errors = validate_sealed_envelope(envelope)
+                if errors:
+                    raise AuthorityError(
+                        "invalid sealed node envelope: " + ", ".join(errors)
+                    )
+                self._append_event(
+                    conn,
+                    kind="LEASE_GRANTED",
+                    graph_id=graph_id,
+                    node_id=node_id,
+                    attempt_id=attempt_id,
+                    fence=fence,
+                    payload={"envelope": envelope},
+                    now=granted_at,
+                )
+                conn.execute("COMMIT")
+                return envelope
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def _authority_gate(
+        self,
+        conn: sqlite3.Connection,
+        envelope: Mapping[str, Any],
+        *,
+        action: str,
+    ) -> tuple[str, str, dict[str, Any]]:
+        """Shared exact-authority gate binding holder and canonical envelope identity."""
+
+        graph_id = str(envelope.get("graph_id"))
+        node_id = str(envelope.get("node_id"))
+        authority = self._node_authority(conn, graph_id, node_id)
+        if authority is None or envelope.get("fence") != authority["fence"]:
+            raise AuthorityError(f"stale fence cannot {action}")
+        authoritative = authority["envelope"]
+        if authoritative.get("attempt_id") != envelope.get("attempt_id"):
+            raise AuthorityError(f"stale attempt cannot {action}")
+        env_lease = envelope.get("lease")
+        if not isinstance(env_lease, Mapping) or env_lease.get(
+            "holder"
+        ) != authoritative["lease"].get("holder"):
+            raise AuthorityError(f"lease holder cannot {action}")
+        if _canonical_identity(envelope) != _canonical_json(authoritative):
+            raise AuthorityError(f"non-authoritative envelope cannot {action}")
+        return graph_id, node_id, authority
+
+    def _load_live_authority(
+        self,
+        conn: sqlite3.Connection,
+        envelope: Mapping[str, Any],
+        current: datetime,
+        *,
+        action: str,
+    ) -> tuple[str, str, int, dict[str, Any]]:
+        """Return the authoritative envelope for a lifecycle transition or fail."""
+
+        graph_id, node_id, authority = self._authority_gate(
+            conn, envelope, action=action
+        )
+        if authority["completed"]:
+            raise AuthorityError("node already completed")
+        if authority["revoked"]:
+            raise AuthorityError(f"revoked lease cannot {action}")
+        if current >= authority["effective_expires"]:
+            raise AuthorityError(f"expired lease cannot {action}")
+        if current >= _parse_time(authority["envelope"]["deadline_utc"]):
+            raise AuthorityError(f"expired deadline cannot {action}")
+        return graph_id, node_id, authority["fence"], authority["envelope"]
+
+    def renew_node(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        ttl_s: float,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Atomically extend the active lease via external bounded metadata.
+
+        The sealed ``LEASE_GRANTED`` envelope is immutable forever. ``ttl_s`` is a
+        duration measured from the renewal moment, and the new effective expiry
+        must not reach or exceed the node deadline. Renewal must occur strictly
+        before the current effective expiry. It never revives an expired, revoked,
+        or terminal lease.
+        """
+
+        renewed_at = _utc(now)
+        ttl = _nonnegative_number(ttl_s, "ttl_s")
+        if ttl == 0:
+            raise AuthorityError("ttl_s must be greater than zero")
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                graph_id, node_id, authority = self._authority_gate(
+                    conn, envelope, action="renew"
+                )
+                if authority["completed"]:
+                    raise AuthorityError("node already completed")
+                if authority["revoked"]:
+                    raise AuthorityError("revoked lease cannot renew")
+                authoritative = authority["envelope"]
+                deadline = _parse_time(authoritative["deadline_utc"])
+                new_expires = _expiry_from_ttl(renewed_at, ttl)
+                if new_expires <= authority["effective_expires"]:
+                    raise AuthorityError(
+                        "renewal must extend the effective lease expiry"
+                    )
+                if new_expires >= deadline:
+                    raise AuthorityError(
+                        "renewal effective expiry must not exceed the node deadline"
+                    )
+                if renewed_at >= authority["effective_expires"]:
+                    raise AuthorityError("expired lease cannot renew")
+                if renewed_at >= deadline:
+                    raise AuthorityError("expired deadline cannot renew")
+                fence = authority["fence"]
+                self._append_event(
+                    conn,
+                    kind="LEASE_RENEWED",
+                    graph_id=graph_id,
+                    node_id=node_id,
+                    attempt_id=str(envelope["attempt_id"]),
+                    fence=fence,
+                    payload={
+                        "holder": authoritative["lease"]["holder"],
+                        "prior_expires_utc": _iso(authority["effective_expires"]),
+                        "new_expires_utc": _iso(new_expires),
+                    },
+                    now=renewed_at,
+                )
+                conn.execute("COMMIT")
+                return {
+                    "graph_id": graph_id,
+                    "node_id": node_id,
+                    "attempt_id": str(envelope["attempt_id"]),
+                    "fence": fence,
+                    "holder": authoritative["lease"]["holder"],
+                    "envelope": authoritative,
+                    "prior_expires_utc": _iso(authority["effective_expires"]),
+                    "new_expires_utc": _iso(new_expires),
+                    "effective_expires_utc": _iso(new_expires),
+                }
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def revoke_node(
+        self, envelope: Mapping[str, Any], *, now: datetime | None = None
+    ) -> dict[str, Any]:
+        """Cancel the current lease so the node can be immediately regranted.
+
+        Uses the shared exact authority gate: the supplied envelope must be the
+        byte-identical authoritative sealed envelope. After revocation the old
+        envelope validates ``lease_revoked``/``stale_fence`` and can never
+        authorize execution.
+        """
+
+        revoked_at = _utc(now)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                graph_id, node_id, authority = self._authority_gate(
+                    conn, envelope, action="revoke"
+                )
+                if authority["completed"]:
+                    raise AuthorityError("node already completed")
+                if authority["revoked"]:
+                    raise AuthorityError("lease already revoked")
+                authoritative = authority["envelope"]
+                self._append_event(
+                    conn,
+                    kind="LEASE_REVOKED",
+                    graph_id=graph_id,
+                    node_id=node_id,
+                    attempt_id=str(authoritative["attempt_id"]),
+                    fence=authority["fence"],
+                    payload={"holder": authoritative["lease"]["holder"]},
+                    now=revoked_at,
+                )
+                conn.execute("COMMIT")
+                return {
+                    "graph_id": graph_id,
+                    "node_id": node_id,
+                    "attempt_id": str(authoritative["attempt_id"]),
+                    "fence": authority["fence"],
+                }
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def complete_node(
+        self,
+        envelope: Mapping[str, Any],
+        *,
+        result_hash: str,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Accept the current unexpired holder/attempt/fence exactly once.
+
+        Result acceptance requires the caller's ``result_hash`` (a SHA-256 over
+        the canonical result; raw results are never stored). A redelivery of the
+        SAME accepted ``result_hash`` is an idempotent lookup. A stale, expired,
+        revoked, superseded, conflicting-duplicate, or forged completion appends
+        exactly one typed ``RESULT_REJECTED`` event, then raises
+        ``ResultRejection``. A completion whose ``fence`` is not a bindable
+        integer raises ``MalformedEnvelopeFence``.
+        """
+
+        result_hash = _valid_sha256(result_hash, "result_hash")
+        completed_at = _utc(now)
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    record = self._accept_result(
+                        conn, envelope, result_hash, completed_at
+                    )
+                except _Reject as reject:
+                    fence_audit = self._append_rejection(
+                        conn,
+                        envelope,
+                        reject.reason,
+                        result_hash,
+                        completed_at,
+                        fence_hint=reject.fence_hint,
+                    )
+                    conn.execute("COMMIT")
+                    if fence_audit["claimed_fence_malformed"]:
+                        raise MalformedEnvelopeFence(
+                            reject.reason,
+                            result_hash=result_hash,
+                            claimed_fence_reason=fence_audit["claimed_fence_reason"],
+                            claimed_fence_type=fence_audit["claimed_fence_type"],
+                            claimed_fence_repr=fence_audit["claimed_fence_repr"],
+                        ) from None
+                    raise ResultRejection(
+                        reject.reason, result_hash=result_hash
+                    ) from None
+                conn.execute("COMMIT")
+                return record
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+
+    def _accept_result(
+        self,
+        conn: sqlite3.Connection,
+        envelope: Mapping[str, Any],
+        result_hash: str,
+        current: datetime,
+    ) -> dict[str, Any]:
+        """Fold the acceptance decision; append RESULT_ACCEPTED or raise _Reject."""
+
+        graph_id = str(envelope.get("graph_id"))
+        node_id = str(envelope.get("node_id"))
+        self._load_plan_node(conn, graph_id, node_id)  # unknown node -> AuthorityError
+        authority = self._node_authority(conn, graph_id, node_id)
+
+        def reject(reason: str, *, fence_hint: int | None = None) -> None:
+            raise _Reject(reason, fence_hint=fence_hint)
+
+        if authority is None:
+            reject("no_grant")
+        assert authority is not None
+        _, fence_audit = _normalize_claimed_fence(envelope.get("fence"))
+        if fence_audit["claimed_fence_malformed"]:
+            reject("malformed_fence", fence_hint=authority["fence"])
+        if envelope.get("fence") != authority["fence"]:
+            reject("stale_fence", fence_hint=authority["fence"])
+        authoritative = authority["envelope"]
+        if authoritative.get("attempt_id") != envelope.get("attempt_id"):
+            reject("stale_attempt", fence_hint=authority["fence"])
+        env_lease = envelope.get("lease")
+        if not isinstance(env_lease, Mapping) or env_lease.get(
+            "holder"
+        ) != authoritative["lease"].get("holder"):
+            reject("holder_mismatch", fence_hint=authority["fence"])
+        if _canonical_identity(envelope) != _canonical_json(authoritative):
+            reject("envelope_not_authoritative", fence_hint=authority["fence"])
+        if authority["completed"]:
+            if authority["accepted_result_hash"] == result_hash:
+                return {
+                    "graph_id": graph_id,
+                    "node_id": node_id,
+                    "attempt_id": str(authoritative["attempt_id"]),
+                    "fence": authority["fence"],
+                    "holder": authoritative["lease"]["holder"],
+                    "result_hash": result_hash,
+                    "idempotent": True,
+                }
+            reject("node_completed", fence_hint=authority["fence"])
+        if authority["revoked"]:
+            reject("lease_revoked", fence_hint=authority["fence"])
+        if current >= authority["effective_expires"]:
+            reject("lease_expired", fence_hint=authority["fence"])
+        if current >= _parse_time(authoritative["deadline_utc"]):
+            reject("deadline_expired", fence_hint=authority["fence"])
+
+        self._append_event(
+            conn,
+            kind="RESULT_ACCEPTED",
+            graph_id=graph_id,
+            node_id=node_id,
+            attempt_id=str(authoritative["attempt_id"]),
+            fence=authority["fence"],
+            payload={
+                "holder": authoritative["lease"]["holder"],
+                "result_hash": result_hash,
+            },
+            now=current,
+        )
+        return {
+            "graph_id": graph_id,
+            "node_id": node_id,
+            "attempt_id": str(authoritative["attempt_id"]),
+            "fence": authority["fence"],
+            "holder": authoritative["lease"]["holder"],
+            "result_hash": result_hash,
+        }
+
+    def _append_rejection(
+        self,
+        conn: sqlite3.Connection,
+        envelope: Mapping[str, Any],
+        reason: str,
+        result_hash: str | None,
+        now: datetime,
+        *,
+        fence_hint: int | None = None,
+    ) -> dict[str, Any]:
+        """Append one typed RESULT_REJECTED audit event in the decision transaction."""
+
+        claimed_fence, fence_audit = _normalize_claimed_fence(envelope.get("fence"))
+        self._append_event(
+            conn,
+            kind="RESULT_REJECTED",
+            graph_id=str(envelope.get("graph_id")),
+            node_id=str(envelope.get("node_id")),
+            attempt_id=str(envelope.get("attempt_id"))
+            if envelope.get("attempt_id")
+            else None,
+            fence=claimed_fence,
+            payload={
+                "reason": reason,
+                "result_hash": result_hash,
+                "current_fence": fence_hint,
+                **fence_audit,
+            },
+            now=now,
+        )
+        return fence_audit
+
+    def current_fence(self, graph_id: str, node_id: str) -> int | None:
+        conn = self._connect()
+        try:
+            row = self._latest_grant(conn, graph_id, node_id)
+            return int(row["fence"]) if row is not None else None
+        finally:
+            conn.close()
+
+    def current_authority(self, graph_id: str, node_id: str) -> dict[str, Any] | None:
+        """Return the folded current authority view for a node, or ``None``."""
+
+        conn = self._connect()
+        try:
+            authority = self._node_authority(conn, graph_id, node_id)
+            if authority is None:
+                return None
+            return {
+                "fence": authority["fence"],
+                "envelope": authority["envelope"],
+                "granted_expires_utc": _iso(authority["granted_expires"]),
+                "effective_expires_utc": _iso(authority["effective_expires"]),
+                "revoked": authority["revoked"],
+                "completed": authority["completed"],
+                "accepted_result_hash": authority["accepted_result_hash"],
+            }
+        finally:
+            conn.close()
+
+    @staticmethod
+    def _validate_current_snapshot(
+        conn: sqlite3.Connection,
+        envelope: Mapping[str, Any],
+        current: datetime,
+    ) -> tuple[list[str], int | None]:
+        """Validate and return the matching fence from one SQLite snapshot."""
+
+        errors = list(validate_sealed_envelope(envelope))
+        try:
+            plan, _ = Phase2AuthorityStore._load_plan_node(
+                conn, str(envelope.get("graph_id")), str(envelope.get("node_id"))
+            )
+        except AuthorityError:
+            return sorted(set(errors + ["unknown_graph_node"])), None
+        authority = Phase2AuthorityStore._node_authority(
+            conn, str(envelope.get("graph_id")), str(envelope.get("node_id"))
+        )
+        if authority is None or envelope.get("fence") != authority["fence"]:
+            errors.append("stale_fence")
+        if authority is not None:
+            try:
+                authoritative = authority["envelope"]
+                if _canonical_identity(envelope) != _canonical_json(authoritative):
+                    errors.append("envelope_not_authoritative")
+            except (KeyError, TypeError, ValueError, RecursionError):
+                errors.append("authoritative_envelope_invalid")
+            if authority["revoked"]:
+                errors.append("lease_revoked")
+            if authority["completed"]:
+                errors.append("node_terminal")
+            if current >= authority["effective_expires"]:
+                errors.append("lease_expired")
+            if current >= _parse_time(authority["envelope"]["deadline_utc"]):
+                errors.append("deadline_expired")
+        else:
+            lease = envelope.get("lease")
+            try:
+                if not isinstance(lease, Mapping):
+                    raise AuthorityError("lease must be an object")
+                granted = _parse_time(lease.get("granted_utc"))
+                expires = _expiry_from_ttl(granted, lease.get("ttl_s"))
+                if current >= expires:
+                    errors.append("lease_expired")
+                if current >= _parse_time(envelope.get("deadline_utc")):
+                    errors.append("deadline_expired")
+            except (AuthorityError, TypeError, ValueError):
+                errors.append("lease_or_deadline_invalid")
+        if envelope.get("planner_hash") != plan["planner_hash"]:
+            errors.append("planner_hash")
+        if envelope.get("policy_hash") != plan["policy_hash"]:
+            errors.append("policy_hash")
+        fence = int(authority["fence"]) if authority is not None else None
+        return sorted(set(errors)), fence
+
+    def validate_current(
+        self, envelope: Mapping[str, Any], *, now: datetime | None = None
+    ) -> list[str]:
+        current = _utc(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            errors, _ = self._validate_current_snapshot(conn, envelope, current)
+            conn.execute("COMMIT")
+            return errors
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+
+    @contextmanager
+    def bind_current(
+        self, envelope: Mapping[str, Any], *, now: datetime | None = None
+    ) -> Iterator[None]:
+        """Bind authority valid at one atomic durable snapshot.
+
+        The envelope and fence are read and validated in the same SQLite read
+        transaction. Later revocation still requires consumers to recheck before
+        each effect; this context only attests to authority at bind time.
+        """
+
+        try:
+            snapshot = _json_tree(envelope)
+        except (TypeError, ValueError, RecursionError) as exc:
+            raise AuthorityError("envelope must be JSON serializable") from exc
+        current = _utc(now)
+        conn = self._connect()
+        try:
+            conn.execute("BEGIN")
+            errors, fence = self._validate_current_snapshot(conn, snapshot, current)
+            conn.execute("COMMIT")
+        except Exception:
+            try:
+                conn.execute("ROLLBACK")
+            except Exception:
+                pass
+            raise
+        finally:
+            conn.close()
+        if errors:
+            raise AuthorityError("invalid current node authority: " + ", ".join(errors))
+        if fence is None:
+            raise AuthorityError("missing authoritative current fence")
+        with bind_sealed_envelope(snapshot, current_fence=fence):
+            yield
+
+    def recover(self, *, now: datetime | None = None) -> dict[str, int]:
+        """Verify the durable chain and poison expired, unreconciled reservations.
+
+        Verifies every lifecycle event's hash chain, folds lifecycle state, and
+        reconciles orphaned reservations with ``actual_usd=None`` once their
+        owning lease is dead. Any malformed payload or hash-chain tamper fails
+        closed.
+        """
+
+        current = _utc(now)
+        reconciled_count = 0
+        with _DB_LOCK:
+            conn = self._connect()
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                rows = conn.execute(
+                    "SELECT * FROM authority_events ORDER BY id"
+                ).fetchall()
+                previous_hash: str | None = None
+                reservations: dict[str, sqlite3.Row] = {}
+                reconciled: set[str] = set()
+                grants: dict[tuple[str, str, int], dict[str, Any]] = {}
+                renewals: dict[tuple[str, str, int], dict[str, Any]] = {}
+                dead_leases: set[tuple[str, str, int]] = set()
+                for row in rows:
+                    try:
+                        payload = json.loads(row["payload_json"])
+                    except (TypeError, ValueError) as exc:
+                        raise AuthorityError(
+                            "authority event hash chain is invalid"
+                        ) from exc
+                    expected = _canonical_hash({
+                        "event_id": row["event_id"],
+                        "ts_utc": row["ts_utc"],
+                        "kind": row["kind"],
+                        "graph_id": row["graph_id"],
+                        "node_id": row["node_id"],
+                        "attempt_id": row["attempt_id"],
+                        "fence": row["fence"],
+                        "payload": payload,
+                        "prev_event_hash": row["prev_event_hash"],
+                    })
+                    if (
+                        row["prev_event_hash"] != previous_hash
+                        or row["event_hash"] != expected
+                    ):
+                        raise AuthorityError("authority event hash chain is invalid")
+                    previous_hash = row["event_hash"]
+                    if row["fence"] is None:
+                        continue
+                    key = (row["graph_id"], row["node_id"], int(row["fence"]))
+                    if row["kind"] == "LEASE_GRANTED":
+                        grants[key] = payload
+                    elif row["kind"] == "LEASE_RENEWED":
+                        renewals[key] = payload
+                    elif row["kind"] in ("LEASE_REVOKED",) + _ACCEPTED_KINDS:
+                        dead_leases.add(key)
+                    elif row["kind"] == "BUDGET_RESERVED":
+                        reservations[row["event_id"]] = row
+                    elif row["kind"] == "BUDGET_RECONCILED":
+                        reconciled.add(str(payload.get("reservation_id")))
+
+                for reservation_id, reservation in reservations.items():
+                    if reservation_id in reconciled:
+                        continue
+                    key = (
+                        reservation["graph_id"],
+                        reservation["node_id"],
+                        int(reservation["fence"]),
+                    )
+                    grant = grants.get(key)
+                    if grant is None:
+                        raise AuthorityError(
+                            "orphaned reservation has no authoritative lease"
+                        )
+                    if key not in dead_leases:
+                        try:
+                            envelope = grant["envelope"]
+                            lease = envelope["lease"]
+                            base_expires = _expiry_from_ttl(
+                                _parse_time(lease["granted_utc"]),
+                                lease["ttl_s"],
+                            )
+                            renewal = renewals.get(key)
+                            expires = (
+                                _parse_time(renewal["new_expires_utc"])
+                                if renewal is not None
+                                else base_expires
+                            )
+                        except (KeyError, TypeError, ValueError, AuthorityError) as exc:
+                            raise AuthorityError(
+                                "orphaned reservation lease is invalid"
+                            ) from exc
+                        if current < expires:
+                            continue
+                    self._append_event(
+                        conn,
+                        kind="BUDGET_RECONCILED",
+                        graph_id=reservation["graph_id"],
+                        node_id=reservation["node_id"],
+                        attempt_id=reservation["attempt_id"],
+                        fence=reservation["fence"],
+                        payload={
+                            "reservation_id": reservation_id,
+                            "actual_tokens": 0,
+                            "actual_usd": None,
+                            "recovery": "expired_lease_unknown_spend",
+                        },
+                        now=current,
+                    )
+                    reconciled_count += 1
+                conn.execute("COMMIT")
+            except Exception:
+                try:
+                    conn.execute("ROLLBACK")
+                except Exception:
+                    pass
+                raise
+            finally:
+                conn.close()
+        return {"orphaned_reservations_reconciled": reconciled_count}
+
+    def migration_report(self) -> dict[str, Any]:
+        """Read-only compatibility diagnostic; never writes, creates, or deletes."""
+
+        report: dict[str, Any] = {
+            "db_path": str(self.db_path),
+            "exists": self.db_path.exists(),
+            "compatible": True,
+            "missing_indexes": [],
+            "violations": [],
+        }
+        if not self.db_path.exists():
+            return report
+        conn = _open_phase2_sqlite(self.db_path, readonly=True)
+        try:
+            table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'authority_events'"
+            ).fetchone()
+            missing = self._missing_integrity_indexes(conn)
+            report["missing_indexes"] = [index.name for index in missing]
+            if table is None:
+                return report
+            violations = self._scan_integrity_violations(conn, missing)
+            report["violations"] = violations
+            report["compatible"] = not violations
+            return report
+        finally:
+            conn.close()
+
+    def get_planner_hash(self, graph_id: str) -> str | None:
+        conn = self._connect()
+        try:
+            row = conn.execute(
+                "SELECT planner_hash FROM sealed_plans WHERE graph_id = ?", (graph_id,)
+            ).fetchone()
+            return row["planner_hash"] if row else None
+        finally:
+            conn.close()
+
+    def read_events(self, graph_id: str) -> list[dict[str, Any]]:
+        if not self.db_path.exists():
+            return []
+        conn = _open_phase2_sqlite(self.db_path, readonly=True)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT * FROM authority_events WHERE graph_id = ? ORDER BY id",
+                (graph_id,),
+            )
+            result = []
+            for row in rows:
+                record = dict(row)
+                try:
+                    record["payload"] = json.loads(record["payload_json"])
+                except (TypeError, ValueError, KeyError):
+                    record["payload"] = None
+                result.append(record)
+            return result
+        finally:
+            conn.close()

--- a/agent/phase2_sqlite.py
+++ b/agent/phase2_sqlite.py
@@ -1,0 +1,115 @@
+"""Descriptor-pinned SQLite opening and file hardening for Phase 2 stores.
+
+Every durable Phase 2 database (authority ledger, mutation claims) opens
+through this module so the no-symlink, no-permissive-create, owner-only-mode
+guarantees are enforced at exactly one boundary.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import stat
+import threading
+from pathlib import Path
+
+# Serializes writers within this process; SQLite's own locking covers others.
+_DB_LOCK = threading.Lock()
+
+# SQLite binds an INTEGER column as a signed 64-bit value. A Python int outside
+# this range cannot be bound at all: the INSERT aborts with an untyped
+# ``OverflowError`` raised from the driver, before any audit row exists.
+_SQLITE_INT_MIN = -(2**63)
+_SQLITE_INT_MAX = 2**63 - 1
+
+
+class _Phase2Connection(sqlite3.Connection):
+    """SQLite connection that owns its descriptor-backed database handle."""
+
+    _phase2_fd: int | None = None
+
+    def close(self) -> None:
+        fd = self._phase2_fd
+        self._phase2_fd = None
+        try:
+            super().close()
+        finally:
+            if fd is not None:
+                os.close(fd)
+
+
+def _phase2_descriptor_path(fd: int) -> str:
+    for candidate in (f"/proc/self/fd/{fd}", f"/dev/fd/{fd}"):
+        if os.path.exists(candidate):
+            return candidate
+    raise OSError("this POSIX host exposes neither /proc/self/fd nor /dev/fd")
+
+
+def _check_phase2_db_files(path: Path, *, harden: bool) -> None:
+    """Reject substituted SQLite files and optionally enforce mode ``0600``."""
+
+    for suffix in ("", "-wal", "-shm"):
+        target = path.parent / (path.name + suffix)
+        try:
+            opened = os.lstat(target)
+        except FileNotFoundError:
+            continue
+        if not stat.S_ISREG(opened.st_mode):
+            raise PermissionError(
+                f"Phase 2 database path is not a regular file: {target}"
+            )
+        if harden and os.name == "posix":
+            os.chmod(target, stat.S_IRUSR | stat.S_IWUSR, follow_symlinks=False)
+
+
+def _open_phase2_sqlite(
+    path: Path, *, readonly: bool = False, timeout: float = 5.0
+) -> sqlite3.Connection:
+    """Open a Phase 2 database without a permissive-create or symlink window."""
+
+    path = path.expanduser().absolute()
+    if not readonly:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    _check_phase2_db_files(path, harden=not readonly)
+    fd: int | None = None
+    sqlite_path = path
+    if os.name == "posix":
+        flags = os.O_RDONLY if readonly else os.O_RDWR | os.O_CREAT
+        flags |= getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0)
+        fd = os.open(path, flags, 0o600)
+        try:
+            opened = os.fstat(fd)
+            if not stat.S_ISREG(opened.st_mode):
+                raise PermissionError(
+                    f"Phase 2 database path is not a regular file: {path}"
+                )
+            if not readonly:
+                os.fchmod(fd, stat.S_IRUSR | stat.S_IWUSR)
+            sqlite_path = Path(_phase2_descriptor_path(fd))
+        except BaseException:
+            os.close(fd)
+            raise
+    elif not readonly:
+        try:
+            created_fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            os.close(created_fd)
+        except FileExistsError:
+            pass
+    mode = "ro" if readonly else "rw"
+    sqlite_uri = f"{sqlite_path.as_uri()}?mode={mode}"
+    try:
+        conn = sqlite3.connect(
+            sqlite_uri,
+            uri=True,
+            isolation_level=None,
+            timeout=timeout,
+            factory=_Phase2Connection,
+        )
+    except BaseException:
+        if fd is not None:
+            os.close(fd)
+        raise
+    conn._phase2_fd = fd
+    if readonly:
+        conn.execute("PRAGMA query_only=ON")
+    return conn

--- a/tests/agent/test_phase2_authority.py
+++ b/tests/agent/test_phase2_authority.py
@@ -1,0 +1,1329 @@
+"""Durable authority store: seal, grant, lifecycle, budget, and chain contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import stat
+import sys
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent.phase2_authority import (
+    AuthorityError,
+    AuthorityMigrationRequired,
+    MalformedEnvelopeFence,
+    Phase2AuthorityStore,
+    ResultRejection,
+    bind_sealed_envelope,
+    current_authoritative_fence,
+    current_sealed_envelope,
+    validate_sealed_envelope,
+)
+
+
+def _node(node_id: str, surface: str = "local_tool") -> dict:
+    return {
+        "node_id": node_id,
+        "objective": f"execute {node_id}",
+        "idempotency_key": hashlib.sha256(node_id.encode()).hexdigest(),
+        "execution_surface": surface,
+        "lane": "hermes",
+        "roots": ["/tmp"],
+        "permissions": {"read": ["/tmp"], "write": [], "spawn": []},
+        "network_policy": "none",
+        "exec_policy": "none",
+        "destructive_policy": "forbid",
+        "budgets": {"usd_max": 1.0, "tokens_max": 1000, "wall_clock_s_max": 60},
+        "deadline_utc": "2030-01-01T00:00:00+00:00",
+        "retry_policy": {"max_attempts": 1, "retry_eligible": False, "backoff_s": [0]},
+        "cancellation": {"mode": "cooperative", "grace_s": 30},
+        "evidence_policy": {"required_receipt_kinds": ["tool_exec"], "min_receipts": 1},
+        "verifier_policy": {
+            "required": False,
+            "verifier_lane_must_differ": False,
+            "clean_workspace_required": False,
+        },
+        "input_hash": "c" * 64,
+    }
+
+
+def _plan(*nodes: dict) -> dict:
+    return {
+        "contract_version": 2,
+        "graph_id": "g-authority",
+        "nodes": list(nodes or (_node("n-tool"),)),
+    }
+
+
+def _overdeep_json_value() -> list:
+    value: list = []
+    for _ in range(sys.getrecursionlimit() + 100):
+        value = [value]
+    return value
+
+
+# ── Seal and grant ────────────────────────────────────────────────────────────
+
+
+def test_seal_and_grant_produces_full_nested_v2_envelope(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    planner_hash = store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:session-1",
+        ttl_s=300,
+        attempt_id="at-1",
+        now=datetime(2026, 7, 30, tzinfo=timezone.utc),
+    )
+
+    assert len(planner_hash) == 64
+    assert envelope["envelope_version"] == 2
+    assert envelope["graph_id"] == "g-authority"
+    assert envelope["node_id"] == "n-tool"
+    assert envelope["execution_surface"] == "local_tool"
+    assert envelope["planner_hash"] == planner_hash
+    assert envelope["policy_hash"] == "d" * 64
+    assert envelope["permissions"]["read"] == ["/tmp"]
+    assert envelope["lease"]["holder"] == "hermes:session-1"
+    assert envelope["fence"] == 1
+    assert validate_sealed_envelope(envelope) == []
+
+
+def test_grant_rejects_unrepresentable_finite_ttl_with_typed_error(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+
+    with pytest.raises(AuthorityError, match="representable timestamp range"):
+        store.grant_node(
+            "g-authority",
+            "n-tool",
+            holder="hermes:session-1",
+            ttl_s=1e300,
+            attempt_id="at-1",
+            now=datetime(2026, 7, 30, tzinfo=timezone.utc),
+        )
+
+    assert [event["kind"] for event in store.read_events("g-authority")] == [
+        "PLAN_SEALED"
+    ]
+
+
+def test_model_and_tool_work_are_distinct_nodes_and_envelopes(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(
+        _plan(_node("n-model", "direct_model"), _node("n-tool", "local_tool")),
+        policy_hash="d" * 64,
+    )
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    model = store.grant_node(
+        "g-authority",
+        "n-model",
+        holder="hermes:model",
+        ttl_s=60,
+        attempt_id="at-model",
+        now=now,
+    )
+    tool = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:tool",
+        ttl_s=60,
+        attempt_id="at-tool",
+        now=now,
+    )
+
+    assert model["node_id"] != tool["node_id"]
+    assert model["execution_surface"] == "direct_model"
+    assert tool["execution_surface"] == "local_tool"
+
+
+def test_invalid_or_duplicate_plan_nodes_fail_before_persistence(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    duplicate = _plan(_node("n-tool"), _node("n-tool"))
+    with pytest.raises(AuthorityError, match="duplicate node_id"):
+        store.seal_plan(duplicate, policy_hash="d" * 64)
+    bad_surface = _plan(_node("n-bad", "local_tool_alias"))
+    with pytest.raises(AuthorityError, match="execution_surface"):
+        store.seal_plan(bad_surface, policy_hash="d" * 64)
+    assert store.read_events("g-authority") == []
+
+
+def test_sealed_plan_rejects_non_finite_numbers(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    inf_node = _node("n-inf")
+    inf_node["budgets"] = {
+        "usd_max": float("inf"),
+        "tokens_max": 1000,
+        "wall_clock_s_max": 60,
+    }
+    with pytest.raises(AuthorityError, match="finite"):
+        store.seal_plan(_plan(inf_node), policy_hash="d" * 64)
+
+
+def test_sealed_plan_rejects_non_string_object_keys(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    node = _node("n-invalid-key")
+    node["permissions"][1] = []
+
+    with pytest.raises(AuthorityError, match="JSON"):
+        store.seal_plan(_plan(node), policy_hash="d" * 64)
+
+
+def test_sealed_plan_rejects_invalid_hashes_and_authority_owned_fields(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    invalid_hash = _node("n-invalid-hash")
+    invalid_hash["input_hash"] = "not-a-digest"
+    with pytest.raises(AuthorityError, match="input_hash"):
+        store.seal_plan(_plan(invalid_hash), policy_hash="d" * 64)
+
+    injected = _node("n-injected")
+    injected["graph_id"] = "g-attacker"
+    with pytest.raises(AuthorityError, match="authority-owned fields"):
+        store.seal_plan(_plan(injected), policy_hash="d" * 64)
+
+    incomplete = _node("n-incomplete")
+    incomplete["lane"] = "untrusted-lane"
+    with pytest.raises(AuthorityError, match="lane"):
+        store.seal_plan(_plan(incomplete), policy_hash="d" * 64)
+
+    oversized = _node("n-oversized")
+    oversized["budgets"]["tokens_max"] = 10**1000
+    with pytest.raises(AuthorityError, match="budgets.tokens_max"):
+        store.seal_plan(_plan(oversized), policy_hash="d" * 64)
+
+    with pytest.raises(AuthorityError, match="policy_hash"):
+        store.seal_plan(_plan(_node("n-tool")), policy_hash="D" * 64)
+    assert store.read_events("g-authority") == []
+
+
+def test_validate_current_reports_non_object_lease_without_raising(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    malformed = {
+        "graph_id": "g-authority",
+        "node_id": "n-tool",
+        "lease": "not-an-object",
+    }
+
+    errors = store.validate_current(malformed)
+
+    assert "lease" in errors
+    assert "lease_or_deadline_invalid" in errors
+
+
+def test_validate_current_reports_unrepresentable_finite_ttl(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    malformed = {
+        "graph_id": "g-authority",
+        "node_id": "n-tool",
+        "deadline_utc": "2030-01-01T00:00:00+00:00",
+        "lease": {
+            "granted_utc": "2026-07-30T00:00:00+00:00",
+            "ttl_s": 1e300,
+        },
+    }
+
+    errors = store.validate_current(
+        malformed, now=datetime(2026, 7, 30, tzinfo=timezone.utc)
+    )
+
+    assert "lease_or_deadline_invalid" in errors
+
+
+def test_authority_database_files_are_owner_only(tmp_path):
+    db = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(db)
+    conn = store._connect()
+    try:
+        sidecars = [tmp_path / f"{db.name}{suffix}" for suffix in ("", "-wal", "-shm")]
+        assert all(path.exists() for path in sidecars)
+        for path in sidecars:
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        conn.close()
+
+
+def test_authority_readers_do_not_require_write_access(tmp_path):
+    db = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(db)
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    db.chmod(0o400)
+
+    assert store.migration_report()["compatible"] is True
+    assert store.read_events("g-authority")[0]["kind"] == "PLAN_SEALED"
+
+
+def test_authority_database_rejects_last_component_symlink(tmp_path):
+    real = tmp_path / "real.db"
+    real.write_bytes(b"")
+    link = tmp_path / "authority.db"
+    link.symlink_to(real)
+    with pytest.raises(PermissionError, match="not a regular file"):
+        Phase2AuthorityStore(link)._connect()
+
+
+def test_grant_must_fit_strictly_before_node_deadline(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    node = _node("n-tool")
+    node["deadline_utc"] = "2026-07-30T00:01:00+00:00"
+    store.seal_plan(_plan(node), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+
+    with pytest.raises(AuthorityError, match="strictly before"):
+        store.grant_node(
+            "g-authority",
+            "n-tool",
+            holder="hermes:one",
+            ttl_s=60,
+            attempt_id="at-1",
+            now=now,
+        )
+    with pytest.raises(AuthorityError, match="expired deadline"):
+        store.grant_node(
+            "g-authority",
+            "n-tool",
+            holder="hermes:one",
+            ttl_s=1,
+            attempt_id="at-1",
+            now=now + timedelta(seconds=60),
+        )
+
+
+def test_sealed_plan_is_immutable_and_reseal_is_rejected(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    plan = _plan(_node("n-tool"))
+    first = store.seal_plan(plan, policy_hash="d" * 64)
+    with pytest.raises(AuthorityError, match="already sealed"):
+        store.seal_plan(plan, policy_hash="d" * 64)
+    reopened = Phase2AuthorityStore(tmp_path / "authority.db")
+    assert reopened.get_planner_hash("g-authority") == first
+
+
+# ── Lease lifecycle ───────────────────────────────────────────────────────────
+
+
+def test_active_lease_blocks_regrant_and_expired_regrant_increments_fence(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    first = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=30,
+        attempt_id="at-1",
+        now=now,
+    )
+    with pytest.raises(AuthorityError, match="active lease"):
+        store.grant_node(
+            "g-authority",
+            "n-tool",
+            holder="hermes:two",
+            ttl_s=30,
+            attempt_id="at-2",
+            now=now,
+        )
+
+    second = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=30,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=31),
+    )
+    assert first["fence"] == 1
+    assert second["fence"] == 2
+    assert store.current_fence("g-authority", "n-tool") == 2
+    assert "stale_fence" in store.validate_current(
+        first, now=now + timedelta(seconds=31)
+    )
+    assert store.validate_current(second, now=now + timedelta(seconds=31)) == []
+
+
+def test_attempt_id_is_globally_unique_across_nodes(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-a"), _node("n-b")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    store.grant_node(
+        "g-authority", "n-a", holder="h", ttl_s=60, attempt_id="uniq-1", now=now
+    )
+    with pytest.raises(AuthorityError, match="already used"):
+        store.grant_node(
+            "g-authority", "n-b", holder="h", ttl_s=60, attempt_id="uniq-1", now=now
+        )
+
+
+def test_revoke_allows_immediate_regrant_at_next_fence(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    store.revoke_node(envelope, now=now)
+    second = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now,
+    )
+    assert second["fence"] == 2
+    # After revocation and regrant at fence 2, the fence-1 envelope is stale;
+    # validate_current returns stale_fence (the authority has moved to fence 2).
+    errors = store.validate_current(envelope, now=now)
+    assert "stale_fence" in errors
+
+
+def test_renewal_extends_effective_expiry_and_envelope_stays_immutable(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=30,
+        attempt_id="at-1",
+        now=now,
+    )
+    result = store.renew_node(envelope, ttl_s=120, now=now + timedelta(seconds=20))
+    # Envelope is still the original sealed envelope, not a rewritten copy.
+    assert result["envelope"] is not envelope
+    assert result["envelope"]["fence"] == 1
+    assert result["envelope"]["lease"]["ttl_s"] == 30.0
+    # Effective expiry was extended.
+    assert "lease_expired" not in store.validate_current(
+        envelope, now=now + timedelta(seconds=50)
+    )
+
+
+def test_renewal_rejects_unrepresentable_finite_ttl_with_typed_error(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=30,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with pytest.raises(AuthorityError, match="representable timestamp range"):
+        store.renew_node(envelope, ttl_s=1e300, now=now + timedelta(seconds=20))
+
+    assert [event["kind"] for event in store.read_events("g-authority")] == [
+        "PLAN_SEALED",
+        "LEASE_GRANTED",
+    ]
+
+
+def test_terminal_node_cannot_be_regranted(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    result_hash = "e" * 64
+    store.complete_node(envelope, result_hash=result_hash, now=now)
+    with pytest.raises(AuthorityError, match="terminal"):
+        store.grant_node(
+            "g-authority",
+            "n-tool",
+            holder="hermes:two",
+            ttl_s=60,
+            attempt_id="at-2",
+            now=now,
+        )
+    assert store.validate_current(envelope, now=now) != []
+
+
+# ── Fence binding ─────────────────────────────────────────────────────────────
+
+
+def test_bind_current_node_sources_authoritative_fence_from_durable_store(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with store.bind_current(envelope, now=now):
+        assert (
+            dict(current_sealed_envelope() or {})["attempt_id"]
+            == envelope["attempt_id"]
+        )
+        assert current_sealed_envelope()["permissions"]["read"] == ("/tmp",)
+        assert current_authoritative_fence() == 1
+
+    assert current_sealed_envelope() is None
+    assert current_authoritative_fence() is None
+
+
+def test_bind_current_never_pairs_stale_envelope_with_newer_fence(tmp_path):
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+
+    class InterleavingStore(Phase2AuthorityStore):
+        interleaved = False
+
+        def _validate_current_snapshot(self, conn, candidate, current):
+            result = super()._validate_current_snapshot(conn, candidate, current)
+            if not self.interleaved:
+                self.interleaved = True
+                writer = Phase2AuthorityStore(self.db_path)
+                writer.revoke_node(candidate, now=current + timedelta(seconds=1))
+                writer.grant_node(
+                    "g-authority",
+                    "n-tool",
+                    holder="hermes:two",
+                    ttl_s=60,
+                    attempt_id="at-2",
+                    now=current + timedelta(seconds=2),
+                )
+            return result
+
+    store = InterleavingStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with store.bind_current(envelope, now=now):
+        assert current_sealed_envelope()["attempt_id"] == "at-1"
+        assert current_authoritative_fence() == 1
+        assert store.current_fence("g-authority", "n-tool") == 2
+
+    assert current_sealed_envelope() is None
+    assert current_authoritative_fence() is None
+
+
+def test_bind_current_publishes_the_exact_validated_envelope_snapshot(tmp_path):
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+
+    class MutatingStore(Phase2AuthorityStore):
+        def _validate_current_snapshot(self, conn, candidate, current):
+            result = super()._validate_current_snapshot(conn, candidate, current)
+            envelope["attempt_id"] = "mutated-after-validation"
+            envelope["permissions"]["read"].append("/stolen")
+            return result
+
+    store = MutatingStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with store.bind_current(envelope, now=now):
+        assert current_sealed_envelope()["attempt_id"] == "at-1"
+        assert current_sealed_envelope()["permissions"]["read"] == ("/tmp",)
+        assert current_authoritative_fence() == 1
+
+
+def test_bind_current_rejects_stale_envelope_before_context_is_published(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    stale = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=1,
+        attempt_id="at-1",
+        now=now,
+    )
+    store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=2),
+    )
+
+    with pytest.raises(AuthorityError, match="stale_fence"):
+        with store.bind_current(stale, now=now + timedelta(seconds=2)):
+            raise AssertionError("stale authority must not publish a context")
+
+    assert current_sealed_envelope() is None
+
+
+# ── Concurrency ───────────────────────────────────────────────────────────────
+
+
+def test_concurrent_grant_has_exactly_one_winner(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    barrier = threading.Barrier(8)
+    winners: list[dict] = []
+    failures: list[str] = []
+    lock = threading.Lock()
+
+    def worker(index: int) -> None:
+        barrier.wait()
+        try:
+            envelope = store.grant_node(
+                "g-authority",
+                "n-tool",
+                holder=f"hermes:{index}",
+                ttl_s=60,
+                attempt_id=f"at-{index}",
+                now=now,
+            )
+            with lock:
+                winners.append(envelope)
+        except AuthorityError as exc:
+            with lock:
+                failures.append(str(exc))
+
+    threads = [threading.Thread(target=worker, args=(index,)) for index in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(winners) == 1
+    assert len(failures) == 7
+    assert winners[0]["fence"] == 1
+
+
+# ── Exactly-once result acceptance ───────────────────────────────────────────
+
+
+def test_complete_node_accepts_exactly_once_and_idempotent_redelivery_is_safe(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    result_hash = "f" * 64
+
+    first = store.complete_node(envelope, result_hash=result_hash, now=now)
+    assert first["result_hash"] == result_hash
+    assert first.get("idempotent") is None
+
+    # Same result_hash is idempotent — no new event, no exception.
+    second = store.complete_node(envelope, result_hash=result_hash, now=now)
+    assert second["idempotent"] is True
+
+    # Different result_hash is rejected.
+    with pytest.raises(ResultRejection, match="node_completed"):
+        store.complete_node(envelope, result_hash="a" * 64, now=now)
+
+
+def test_stale_fence_completion_appends_rejection_event(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    stale = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=1,
+        attempt_id="at-1",
+        now=now,
+    )
+    store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=2),
+    )
+    with pytest.raises(ResultRejection, match="stale_fence"):
+        store.complete_node(stale, result_hash="b" * 64, now=now + timedelta(seconds=2))
+    events = store.read_events("g-authority")
+    kinds = [e["kind"] for e in events]
+    assert "RESULT_REJECTED" in kinds
+
+
+def test_malformed_fence_raises_typed_exception_and_records_null_fence(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    bad_envelope = dict(envelope)
+    bad_envelope["fence"] = "not-an-int"
+    with pytest.raises(MalformedEnvelopeFence) as exc_info:
+        store.complete_node(bad_envelope, result_hash="c" * 64, now=now)
+    assert exc_info.value.claimed_fence_reason == "not_an_integer"
+    # Rejection event must have NULL fence in the column.
+    events = store.read_events("g-authority")
+    rejected = [e for e in events if e["kind"] == "RESULT_REJECTED"]
+    assert len(rejected) == 1
+    assert rejected[0]["fence"] is None
+
+
+def test_out_of_range_fence_is_malformed(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    bad_envelope = dict(envelope)
+    bad_envelope["fence"] = 2**63  # one beyond signed 64-bit max
+    with pytest.raises(MalformedEnvelopeFence) as exc_info:
+        store.complete_node(bad_envelope, result_hash="d" * 64, now=now)
+    assert exc_info.value.claimed_fence_reason == "out_of_range"
+
+
+def test_hostile_fence_repr_cannot_abort_rejection_audit(tmp_path):
+    class HostileFence:
+        def __repr__(self):
+            raise RuntimeError("repr must not escape")
+
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    bad_envelope = dict(envelope)
+    bad_envelope["fence"] = HostileFence()
+
+    with pytest.raises(MalformedEnvelopeFence) as exc_info:
+        store.complete_node(bad_envelope, result_hash="e" * 64, now=now)
+
+    assert exc_info.value.claimed_fence_repr == "<unrepresentable HostileFence>"
+    rejected = [
+        event
+        for event in store.read_events("g-authority")
+        if event["kind"] == "RESULT_REJECTED"
+    ]
+    assert rejected[-1]["fence"] is None
+    assert (
+        rejected[-1]["payload"]["claimed_fence_repr"]
+        == "<unrepresentable HostileFence>"
+    )
+
+
+def test_hostile_recursive_envelope_is_typed_rejection_and_audited(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    hostile = dict(envelope)
+    hostile["untrusted_extension"] = _overdeep_json_value()
+
+    assert "envelope_not_authoritative" in store.validate_current(hostile, now=now)
+    with pytest.raises(ResultRejection, match="envelope_not_authoritative"):
+        store.complete_node(hostile, result_hash="f" * 64, now=now)
+
+    rejected = [
+        event
+        for event in store.read_events("g-authority")
+        if event["kind"] == "RESULT_REJECTED"
+    ]
+    assert len(rejected) == 1
+    assert rejected[0]["payload"]["reason"] == "envelope_not_authoritative"
+
+
+def test_bind_current_converts_serialization_failures_to_authority_error(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    for hostile_value in (object(), _overdeep_json_value()):
+        hostile = dict(envelope)
+        hostile["untrusted_extension"] = hostile_value
+        with pytest.raises(AuthorityError, match="envelope must be JSON serializable"):
+            with store.bind_current(hostile, now=now):
+                pass
+
+
+# ── Budget reservation and reconciliation ────────────────────────────────────
+
+
+def test_budget_reservation_reconciliation_is_durable_and_fail_closed(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    reservation = store.reserve_budget(envelope, tokens=600, usd=0.6, now=now)
+    with pytest.raises(AuthorityError, match="budget"):
+        store.reserve_budget(envelope, tokens=500, usd=0.5, now=now)
+    store.reconcile_budget(reservation, actual_tokens=400, actual_usd=0.4, now=now)
+
+    reopened = Phase2AuthorityStore(tmp_path / "authority.db")
+    usage = reopened.budget_usage("g-authority", "n-tool", fence=1)
+    assert usage == {
+        "reserved_tokens": 0,
+        "reserved_usd": 0.0,
+        "charged_tokens": 400,
+        "charged_usd": 0.4,
+        "cost_unknown": False,
+    }
+    # Budget is now free for another reservation.
+    reopened.reserve_budget(envelope, tokens=500, usd=0.5, now=now)
+
+
+def test_unknown_reconciled_cost_poisons_future_reservations(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    reservation = store.reserve_budget(envelope, tokens=100, usd=0.1, now=now)
+    store.reconcile_budget(reservation, actual_tokens=80, actual_usd=None, now=now)
+
+    assert store.budget_usage("g-authority", "n-tool", fence=1)["cost_unknown"] is True
+    with pytest.raises(AuthorityError, match="unknown"):
+        store.reserve_budget(envelope, tokens=1, usd=0.01, now=now)
+
+
+def test_node_budget_is_cumulative_across_regranted_fences(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    first = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    reservation = store.reserve_budget(first, tokens=600, usd=0.6, now=now)
+    store.reconcile_budget(reservation, actual_tokens=600, actual_usd=0.6, now=now)
+    store.revoke_node(first, now=now + timedelta(seconds=1))
+    second = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=2),
+    )
+
+    with pytest.raises(AuthorityError, match="node budget"):
+        store.reserve_budget(
+            second,
+            tokens=401,
+            usd=0.4,
+            now=now + timedelta(seconds=2),
+        )
+    store.reserve_budget(
+        second,
+        tokens=400,
+        usd=0.4,
+        now=now + timedelta(seconds=2),
+    )
+    assert store.budget_usage("g-authority", "n-tool", fence=1) == {
+        "reserved_tokens": 0,
+        "reserved_usd": 0.0,
+        "charged_tokens": 600,
+        "charged_usd": 0.6,
+        "cost_unknown": False,
+    }
+    assert store.budget_usage("g-authority", "n-tool", fence=2) == {
+        "reserved_tokens": 400,
+        "reserved_usd": 0.4,
+        "charged_tokens": 0,
+        "charged_usd": 0.0,
+        "cost_unknown": False,
+    }
+
+
+def test_unknown_cost_poison_survives_regrant(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    first = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    reservation = store.reserve_budget(first, tokens=100, usd=0.1, now=now)
+    store.reconcile_budget(reservation, actual_tokens=80, actual_usd=None, now=now)
+    store.revoke_node(first, now=now + timedelta(seconds=1))
+    second = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=2),
+    )
+
+    with pytest.raises(AuthorityError, match="unknown"):
+        store.reserve_budget(
+            second,
+            tokens=1,
+            usd=0.01,
+            now=now + timedelta(seconds=2),
+        )
+
+
+def test_outstanding_budget_survives_expiry_regrant_and_bounds_allocations(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    first = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=1,
+        attempt_id="at-1",
+        now=now,
+    )
+    store.reserve_budget(first, tokens=600, usd=0.6, now=now)
+    second = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:two",
+        ttl_s=60,
+        attempt_id="at-2",
+        now=now + timedelta(seconds=2),
+    )
+
+    with pytest.raises(AuthorityError, match="node budget"):
+        store.reserve_budget_allocations(
+            second,
+            [{"tokens": 401, "usd": 0.4}],
+            now=now + timedelta(seconds=2),
+        )
+    reservation_ids = store.reserve_budget_allocations(
+        second,
+        [{"tokens": 400, "usd": 0.4}],
+        now=now + timedelta(seconds=2),
+    )
+    assert len(reservation_ids) == 1
+
+
+def test_budget_decimal_boundary_is_exact(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    node = _node("n-tool")
+    node["budgets"]["usd_max"] = 0.3
+    store.seal_plan(_plan(node), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    store.reserve_budget(envelope, tokens=0, usd=0.1, now=now)
+    store.reserve_budget(envelope, tokens=0, usd=0.2, now=now)
+    with pytest.raises(AuthorityError, match="USD budget"):
+        store.reserve_budget(envelope, tokens=0, usd=1e-13, now=now)
+
+
+# ── Hash-chain integrity and recovery ─────────────────────────────────────────
+
+
+def test_budget_decimal_preserves_large_integer_boundary(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    node = _node("n-tool")
+    node["budgets"]["usd_max"] = 2**53 + 1
+    store.seal_plan(_plan(node), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    store.reserve_budget(envelope, tokens=0, usd=2**53, now=now)
+    store.reserve_budget(envelope, tokens=0, usd=1, now=now)
+    with pytest.raises(AuthorityError, match="USD budget"):
+        store.reserve_budget(envelope, tokens=0, usd=1, now=now)
+
+
+def test_authority_startup_rejects_tampered_event_chain(tmp_path):
+    path = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(path)
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP TRIGGER authority_events_no_update")
+        conn.execute("UPDATE authority_events SET payload_json = '{}' WHERE id = 1")
+
+    with pytest.raises(AuthorityError, match="hash chain"):
+        Phase2AuthorityStore(path).recover()
+
+
+def test_recovery_reconciles_orphaned_budget_reservation_exactly_once(tmp_path):
+    path = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(path)
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=1,
+        attempt_id="at-1",
+        now=now,
+    )
+    reservation = store.reserve_budget(envelope, tokens=100, usd=0.1, now=now)
+
+    recovered = Phase2AuthorityStore(path)
+    result = recovered.recover(now=now + timedelta(seconds=2))
+    assert result["orphaned_reservations_reconciled"] == 1
+    assert recovered.budget_usage("g-authority", "n-tool", fence=1) == {
+        "reserved_tokens": 0,
+        "reserved_usd": 0.0,
+        "charged_tokens": 0,
+        "charged_usd": 0.0,
+        "cost_unknown": True,
+    }
+    assert (
+        recovered.recover(now=now + timedelta(seconds=3))[
+            "orphaned_reservations_reconciled"
+        ]
+        == 0
+    )
+    with pytest.raises(AuthorityError, match="already reconciled"):
+        recovered.reconcile_budget(reservation, actual_tokens=1, actual_usd=0.01)
+
+
+# ── Migration guard ───────────────────────────────────────────────────────────
+
+
+def test_migration_report_is_read_only_and_describes_violations(tmp_path):
+    path = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(path)
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+    store.complete_node(
+        store.current_authority("g-authority", "n-tool")["envelope"],
+        result_hash="a" * 64,
+        now=now,
+    )
+
+    # A fresh store on the same db must see all indexes and be compatible.
+    report = Phase2AuthorityStore(path).migration_report()
+    assert report["compatible"] is True
+    assert report["missing_indexes"] == []
+
+
+def test_schema_replaces_same_name_non_unique_integrity_index(tmp_path):
+    path = tmp_path / "authority.db"
+    store = Phase2AuthorityStore(path)
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    with sqlite3.connect(path) as conn:
+        conn.execute("DROP INDEX one_grant_per_attempt")
+        conn.execute(
+            "CREATE INDEX one_grant_per_attempt ON authority_events(attempt_id)"
+        )
+
+    Phase2AuthorityStore(path).current_fence("g-authority", "n-tool")
+    with sqlite3.connect(path) as conn:
+        sql = conn.execute(
+            "SELECT sql FROM sqlite_master WHERE type = 'index' AND name = ?",
+            ("one_grant_per_attempt",),
+        ).fetchone()[0]
+    assert "CREATE UNIQUE INDEX" in sql.upper()
+    assert "WHERE kind = 'LEASE_GRANTED'" in sql
+
+
+# ── Token ceiling exactness (above 2**53 round-trip safety) ──────────────────
+
+
+def _sealed_high_token_node(node_id: str, tokens_max: int) -> dict:
+    node = _node(node_id)
+    node["budgets"]["tokens_max"] = tokens_max
+    return node
+
+
+def _grant(store, tokens_max: int):
+    """Seal a fresh graph with the given tokens_max and grant the single node."""
+    node = _sealed_high_token_node("n-tool", tokens_max)
+    plan = {
+        "contract_version": 2,
+        "graph_id": f"g-tok-{tokens_max}",
+        "nodes": [node],
+    }
+    store.seal_plan(plan, policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    return store.grant_node(
+        f"g-tok-{tokens_max}",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id=f"at-{tokens_max}",
+        now=now,
+    ), now
+
+
+def test_reserve_budget_enforces_exact_integer_ceiling_round_up(tmp_path):
+    """tokens_max just above a float boundary must not round down silently.
+
+    float(9007199254740993) == float(9007199254740992) due to IEEE-754 rounding.
+    The ceiling stored in the plan is 9007199254740993; if it were coerced
+    through float the enforcement would use 9007199254740992 and grant one extra
+    token.  The exact-integer path must refuse the over-budget request.
+    """
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    # 2**53 + 1: one above the largest integer exactly representable as float64
+    tokens_max = 2**53 + 1
+    envelope, now = _grant(store, tokens_max)
+
+    # Reserving exactly tokens_max should succeed.
+    store.reserve_budget(envelope, tokens=tokens_max, usd=0.0, now=now)
+    # Any further reservation must be refused — no phantom headroom.
+    with pytest.raises(AuthorityError, match="token budget"):
+        store.reserve_budget(envelope, tokens=1, usd=0.0, now=now)
+
+
+def test_reserve_budget_enforces_exact_integer_ceiling_round_down(tmp_path):
+    """tokens_max just below a float boundary must not round up silently.
+
+    A float-coerced ceiling could be *larger* than the true integer value,
+    granting excess headroom.  With tokens_max = 2**53 - 1 the float is exact,
+    but with 2**53 + 3 float(2**53 + 3) == float(2**53 + 4) — the ceiling
+    would appear one token larger than intended.
+    """
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    # 2**53 + 3 rounds up to 2**53 + 4 as float64; exact int must be enforced.
+    tokens_max = 2**53 + 3
+    envelope, now = _grant(store, tokens_max)
+
+    store.reserve_budget(envelope, tokens=tokens_max, usd=0.0, now=now)
+    with pytest.raises(AuthorityError, match="token budget"):
+        store.reserve_budget(envelope, tokens=1, usd=0.0, now=now)
+
+
+def test_reserve_budget_allocations_enforces_exact_integer_ceiling(tmp_path):
+    """reserve_budget_allocations must also enforce tokens_max exactly."""
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    tokens_max = 2**53 + 1
+    envelope, now = _grant(store, tokens_max)
+
+    store.reserve_budget_allocations(
+        envelope,
+        [{"tokens": tokens_max, "usd": 0.0}],
+        now=now,
+    )
+    with pytest.raises(AuthorityError, match="token budget"):
+        store.reserve_budget_allocations(
+            envelope,
+            [{"tokens": 1, "usd": 0.0}],
+            now=now,
+        )
+
+
+@pytest.mark.parametrize("tokens_max", [1.5, True])
+def test_tokens_max_non_integer_is_rejected_by_envelope_validation(tokens_max):
+    envelope = {
+        "envelope_version": 2,
+        "graph_id": "g-tok-invalid",
+        **_sealed_high_token_node("n-tool", tokens_max),
+        "attempt_id": "at-invalid",
+        "planner_hash": "0" * 64,
+        "policy_hash": "d" * 64,
+        "lease": {
+            "holder": "hermes:one",
+            "granted_utc": "2026-07-30T00:00:00+00:00",
+            "ttl_s": 60,
+            "renewable": True,
+        },
+        "fence": 1,
+    }
+
+    assert "budgets.tokens_max" in validate_sealed_envelope(envelope)
+
+
+@pytest.mark.parametrize("tokens_max", [1.5, True])
+def test_tokens_max_non_integer_is_rejected_before_plan_is_sealed(tmp_path, tokens_max):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    node = _node("n-tool")
+    node["budgets"]["tokens_max"] = tokens_max
+    plan = {
+        "contract_version": 2,
+        "graph_id": "g-tok-invalid",
+        "nodes": [node],
+    }
+
+    with pytest.raises(AuthorityError, match="budgets.tokens_max"):
+        store.seal_plan(plan, policy_hash="d" * 64)
+    assert store.read_events("g-tok-invalid") == []
+
+
+def test_reservation_metadata_recursion_is_rejected_typed(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with pytest.raises(AuthorityError, match="not canonically serializable"):
+        store.reserve_budget(
+            envelope,
+            tokens=1,
+            usd=0.0,
+            metadata={"hostile": _overdeep_json_value()},
+            now=now,
+        )
+
+
+def test_allocation_metadata_recursion_is_rejected_typed(tmp_path):
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    store.seal_plan(_plan(_node("n-tool")), policy_hash="d" * 64)
+    now = datetime(2026, 7, 30, tzinfo=timezone.utc)
+    envelope = store.grant_node(
+        "g-authority",
+        "n-tool",
+        holder="hermes:one",
+        ttl_s=60,
+        attempt_id="at-1",
+        now=now,
+    )
+
+    with pytest.raises(AuthorityError, match="not canonically serializable"):
+        store.reserve_budget_allocations(
+            envelope,
+            [
+                {
+                    "tokens": 1,
+                    "usd": 0.0,
+                    "metadata": {"hostile": _overdeep_json_value()},
+                }
+            ],
+            now=now,
+        )
+
+
+# ── seal_plan duplicate idempotency_key ───────────────────────────────────────
+
+
+def test_seal_plan_rejects_duplicate_idempotency_key_across_nodes(tmp_path):
+    """Two nodes sharing an idempotency_key create cross-node ambiguity and must
+    be refused at seal time, before any durable state is written."""
+    store = Phase2AuthorityStore(tmp_path / "authority.db")
+    shared_key = "a" * 64
+    node_a = _node("n-a")
+    node_a["idempotency_key"] = shared_key
+    node_b = _node("n-b")
+    node_b["idempotency_key"] = shared_key
+    plan = {
+        "contract_version": 2,
+        "graph_id": "g-dup-ikey",
+        "nodes": [node_a, node_b],
+    }
+
+    with pytest.raises(AuthorityError, match="duplicate idempotency_key"):
+        store.seal_plan(plan, policy_hash="d" * 64)
+    # No events must have been written.
+    assert store.read_events("g-dup-ikey") == []

--- a/tests/agent/test_phase2_envelope_binding.py
+++ b/tests/agent/test_phase2_envelope_binding.py
@@ -1,0 +1,225 @@
+"""Node-scoped binding contracts for sealed Phase 2 task envelopes.
+
+Tests ``validate_sealed_envelope``, ``bind_sealed_envelope``,
+``current_sealed_envelope``, and ``current_authoritative_fence`` as exported
+from phase2_authority. No dependency on phase2_enforcement or any runtime
+session wiring.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from agent.phase2_authority import (
+    AuthorityError,
+    bind_sealed_envelope,
+    current_authoritative_fence,
+    current_sealed_envelope,
+    validate_sealed_envelope,
+)
+
+
+def _envelope(
+    *,
+    node_id: str = "n-bound-node",
+    surface: str = "local_tool",
+    fence: int = 1,
+) -> dict:
+    now = datetime.now(timezone.utc)
+    return {
+        "envelope_version": 2,
+        "graph_id": "g-bound-graph",
+        "node_id": node_id,
+        "attempt_id": f"at-{node_id}",
+        "idempotency_key": "d" * 64,
+        "objective": "bind one sealed graph node to one execution surface",
+        "execution_surface": surface,
+        "lane": "hermes",
+        "roots": ["/tmp"],
+        "permissions": {"read": ["/tmp"], "write": [], "spawn": []},
+        "network_policy": "none",
+        "exec_policy": "none",
+        "destructive_policy": "forbid",
+        "budgets": {"usd_max": 1.0, "tokens_max": 1000, "wall_clock_s_max": 60},
+        "deadline_utc": (now + timedelta(minutes=5)).isoformat(),
+        "retry_policy": {"max_attempts": 1, "retry_eligible": False, "backoff_s": [0]},
+        "cancellation": {"mode": "cooperative", "grace_s": 30},
+        "evidence_policy": {"required_receipt_kinds": ["tool_exec"], "min_receipts": 1},
+        "verifier_policy": {
+            "required": False,
+            "verifier_lane_must_differ": False,
+            "clean_workspace_required": False,
+        },
+        "planner_hash": "a" * 64,
+        "policy_hash": "b" * 64,
+        "input_hash": "c" * 64,
+        "lease": {
+            "holder": "hermes",
+            "granted_utc": now.isoformat(),
+            "ttl_s": 300,
+            "renewable": True,
+        },
+        "fence": fence,
+    }
+
+
+# ── validate_sealed_envelope ──────────────────────────────────────────────────
+
+
+def test_valid_envelope_passes_validation():
+    assert validate_sealed_envelope(_envelope()) == []
+
+
+def test_missing_required_field_is_reported():
+    bad = _envelope()
+    del bad["graph_id"]
+    errors = validate_sealed_envelope(bad)
+    assert "graph_id" in errors
+
+
+def test_wrong_envelope_version_is_reported():
+    bad = _envelope()
+    bad["envelope_version"] = 1
+    assert "envelope_version" in validate_sealed_envelope(bad)
+
+
+def test_invalid_execution_surface_is_reported():
+    bad = _envelope()
+    bad["execution_surface"] = "unknown_surface"
+    assert "execution_surface" in validate_sealed_envelope(bad)
+
+
+def test_non_finite_budget_is_reported():
+    bad = _envelope()
+    bad["budgets"] = {
+        "usd_max": float("inf"),
+        "tokens_max": 1000,
+        "wall_clock_s_max": 60,
+    }
+    assert "budgets.usd_max" in validate_sealed_envelope(bad)
+
+
+def test_sha256_fields_must_be_lowercase_64_hex_chars():
+    bad = _envelope()
+    bad["idempotency_key"] = "UPPERCASE" + "a" * 55
+    assert "idempotency_key" in validate_sealed_envelope(bad)
+    bad2 = _envelope()
+    bad2["planner_hash"] = "short"
+    assert "planner_hash" in validate_sealed_envelope(bad2)
+
+
+def test_fence_must_be_positive_integer():
+    bad = _envelope()
+    bad["fence"] = 0
+    assert "fence" in validate_sealed_envelope(bad)
+    bad2 = _envelope()
+    bad2["fence"] = True  # bool subclasses int but is not a valid fence
+    assert "fence" in validate_sealed_envelope(bad2)
+    bad3 = _envelope()
+    bad3["fence"] = "1"
+    assert "fence" in validate_sealed_envelope(bad3)
+    bad4 = _envelope()
+    bad4["fence"] = 2**63
+    assert "fence" in validate_sealed_envelope(bad4)
+
+
+def test_malformed_retry_attempt_count_is_reported_without_raising():
+    bad = _envelope()
+    bad["retry_policy"]["max_attempts"] = "two"
+
+    assert "retry_policy.max_attempts" in validate_sealed_envelope(bad)
+
+
+def test_model_and_tool_envelopes_are_independently_valid():
+    model = _envelope(node_id="n-model", surface="direct_model")
+    tool = _envelope(node_id="n-tool", surface="local_tool")
+    assert validate_sealed_envelope(model) == []
+    assert validate_sealed_envelope(tool) == []
+    assert model["node_id"] != tool["node_id"]
+    assert model["execution_surface"] == "direct_model"
+    assert tool["execution_surface"] == "local_tool"
+
+
+# ── bind_sealed_envelope ──────────────────────────────────────────────────────
+
+
+def test_binding_is_node_scoped_and_resets_after_success():
+    with bind_sealed_envelope(_envelope(), current_fence=1):
+        current = current_sealed_envelope()
+        assert current is not None
+        assert current["graph_id"] == "g-bound-graph"
+        assert current["node_id"] == "n-bound-node"
+        assert current["execution_surface"] == "local_tool"
+        assert current_authoritative_fence() == 1
+
+    assert current_sealed_envelope() is None
+    assert current_authoritative_fence() is None
+
+
+def test_binding_resets_after_exception():
+    try:
+        with bind_sealed_envelope(_envelope(), current_fence=1):
+            raise RuntimeError("boom")
+    except RuntimeError:
+        pass
+
+    assert current_sealed_envelope() is None
+    assert current_authoritative_fence() is None
+
+
+def test_bound_envelope_is_immutable_proxy():
+    env = _envelope()
+    with bind_sealed_envelope(env, current_fence=1):
+        bound = current_sealed_envelope()
+        with pytest.raises((TypeError, AttributeError)):
+            bound["fence"] = 999  # type: ignore[index]
+
+
+def test_bound_envelope_is_recursively_immutable_and_detached():
+    env = _envelope()
+    with bind_sealed_envelope(env, current_fence=1):
+        bound = current_sealed_envelope()
+        assert bound is not None
+        env["permissions"]["read"].append("/outside")
+        env["budgets"]["tokens_max"] = 0
+        assert bound["permissions"]["read"] == ("/tmp",)
+        assert bound["budgets"]["tokens_max"] == 1000
+        with pytest.raises(TypeError):
+            bound["permissions"]["read"] += ("/outside",)  # type: ignore[index]
+        with pytest.raises(TypeError):
+            bound["budgets"]["tokens_max"] = 0  # type: ignore[index]
+        with pytest.raises(TypeError):
+            bound["retry_policy"]["backoff_s"] += (1,)  # type: ignore[index]
+        with pytest.raises(AttributeError):
+            bound["roots"].append("/outside")  # type: ignore[union-attr]
+
+
+def test_binding_rejects_non_json_mutable_values():
+    env = _envelope()
+    env["permissions"]["read"] = {"/tmp"}
+
+    with pytest.raises(AuthorityError, match="unsupported value type"):
+        with bind_sealed_envelope(env, current_fence=1):
+            pass
+
+
+def test_binding_without_fence_publishes_none():
+    with bind_sealed_envelope(_envelope()):
+        assert current_authoritative_fence() is None
+        assert current_sealed_envelope() is not None
+
+
+def test_nested_binding_is_scoped_to_innermost_context():
+    outer = _envelope(node_id="n-outer", fence=1)
+    inner = _envelope(node_id="n-inner", fence=2)
+    with bind_sealed_envelope(outer, current_fence=1):
+        assert current_sealed_envelope()["node_id"] == "n-outer"
+        assert current_authoritative_fence() == 1
+        with bind_sealed_envelope(inner, current_fence=2):
+            assert current_sealed_envelope()["node_id"] == "n-inner"
+            assert current_authoritative_fence() == 2
+        assert current_sealed_envelope()["node_id"] == "n-outer"
+        assert current_authoritative_fence() == 1
+    assert current_sealed_envelope() is None

--- a/tests/agent/test_phase2_idempotency.py
+++ b/tests/agent/test_phase2_idempotency.py
@@ -1,0 +1,339 @@
+"""Atomic idempotency claims for Phase 2 mutating tool calls."""
+
+from __future__ import annotations
+
+import sqlite3
+import stat
+import threading
+import pytest
+
+from agent.phase2_idempotency import MutationClaimError, MutationClaimStore
+
+
+def test_first_mutation_claim_wins_and_duplicate_is_denied(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "d" * 64,
+        "fence": 1,
+    }
+
+    assert (
+        store.try_claim(envelope, tool_name="write_file", args={"path": "one"}) is True
+    )
+    assert (
+        store.try_claim(envelope, tool_name="write_file", args={"path": "one"}) is False
+    )
+
+
+def test_mutation_claim_is_atomic_under_concurrency(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "e" * 64,
+        "fence": 4,
+    }
+    barrier = threading.Barrier(8)
+    outcomes: list[bool] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        barrier.wait()
+        outcome = store.try_claim(envelope, tool_name="patch", args={"path": "one"})
+        with lock:
+            outcomes.append(outcome)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert outcomes.count(True) == 1
+    assert outcomes.count(False) == 7
+
+
+def test_claim_persists_canonical_identity_without_raw_arguments(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-secret",
+        "idempotency_key": "f" * 64,
+        "fence": 2,
+    }
+    store.try_claim(
+        envelope,
+        tool_name="write_file",
+        args={"path": "/tmp/out", "content": "do-not-store-this"},
+    )
+
+    claims = store.read_all()
+    assert claims[0]["graph_id"] == "g-1"
+    assert claims[0]["node_id"] == "n-1"
+    assert claims[0]["attempt_id"] == "a-secret"
+    assert claims[0]["tool_name"] == "write_file"
+    assert claims[0]["fence"] == 2
+    assert len(claims[0]["args_hash"]) == 64
+    assert "do-not-store-this" not in repr(claims)
+
+
+def test_distinct_idempotency_keys_are_independent(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    base = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "fence": 1,
+    }
+    env_a = {**base, "idempotency_key": "a" * 64}
+    env_b = {**base, "idempotency_key": "b" * 64}
+
+    assert store.try_claim(env_a, tool_name="write_file", args={}) is True
+    assert store.try_claim(env_b, tool_name="write_file", args={}) is True
+    assert store.try_claim(env_a, tool_name="write_file", args={}) is False
+    assert store.try_claim(env_b, tool_name="write_file", args={}) is False
+    assert len(store.read_all()) == 2
+
+
+def test_claim_store_is_append_only_and_rejects_updates(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "c" * 64,
+        "fence": 1,
+    }
+    store.try_claim(envelope, tool_name="delete_file", args={"path": "/tmp/x"})
+
+    with sqlite3.connect(tmp_path / "phase2.db") as conn:
+        with pytest.raises(sqlite3.DatabaseError, match="append-only"):
+            conn.execute(
+                "UPDATE mutation_claims SET tool_name = 'tampered' WHERE idempotency_key = ?",
+                ("c" * 64,),
+            )
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("graph_id", "", "graph_id"),
+        ("node_id", None, "node_id"),
+        ("attempt_id", 7, "attempt_id"),
+        ("idempotency_key", "short", "idempotency_key"),
+        ("fence", True, "fence"),
+        ("fence", "1", "fence"),
+        ("fence", 2**63, "fence"),
+    ],
+)
+def test_invalid_claim_envelope_is_rejected_typed(tmp_path, field, value, message):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "a" * 64,
+        "fence": 1,
+    }
+    envelope[field] = value
+
+    with pytest.raises(MutationClaimError, match=message):
+        store.try_claim(envelope, tool_name="write_file", args={})
+    assert not (tmp_path / "phase2.db").exists()
+
+
+def test_invalid_tool_and_args_are_rejected_typed(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "a" * 64,
+        "fence": 1,
+    }
+    with pytest.raises(MutationClaimError, match="tool_name"):
+        store.try_claim(envelope, tool_name="", args={})
+    with pytest.raises(MutationClaimError, match="args must be a mapping"):
+        store.try_claim(envelope, tool_name="write_file", args=[])  # type: ignore[arg-type]
+    with pytest.raises(MutationClaimError, match="canonically JSON serializable"):
+        store.try_claim(envelope, tool_name="write_file", args={"bad": object()})
+    with pytest.raises(MutationClaimError, match="canonically JSON serializable"):
+        store.try_claim(envelope, tool_name="write_file", args={"bad": float("nan")})
+    with pytest.raises(MutationClaimError, match="canonically JSON serializable"):
+        store.try_claim(envelope, tool_name="write_file", args={1: "ambiguous"})
+
+
+def test_non_key_integrity_error_is_not_misclassified_as_duplicate(tmp_path):
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "a" * 64,
+        "fence": 1,
+    }
+    conn = store._connect()
+    try:
+        conn.execute(
+            """
+            CREATE TRIGGER mutation_claims_reject_tool
+            BEFORE INSERT ON mutation_claims
+            WHEN NEW.tool_name = 'reject'
+            BEGIN
+                SELECT RAISE(ABORT, 'tool rejected');
+            END
+            """
+        )
+    finally:
+        conn.close()
+
+    with pytest.raises(sqlite3.DatabaseError, match="tool rejected"):
+        store.try_claim(envelope, tool_name="reject", args={})
+
+
+def test_claim_database_files_are_owner_only(tmp_path):
+    db = tmp_path / "phase2.db"
+    store = MutationClaimStore(db)
+    conn = store._connect()
+    try:
+        sidecars = [tmp_path / f"{db.name}{suffix}" for suffix in ("", "-wal", "-shm")]
+        assert all(path.exists() for path in sidecars)
+        for path in sidecars:
+            assert stat.S_IMODE(path.stat().st_mode) == 0o600
+    finally:
+        conn.close()
+
+
+def test_claim_reader_does_not_require_write_access(tmp_path):
+    db = tmp_path / "phase2.db"
+    store = MutationClaimStore(db)
+    envelope = {
+        "graph_id": "g-1",
+        "node_id": "n-1",
+        "attempt_id": "a-1",
+        "idempotency_key": "a" * 64,
+        "fence": 1,
+    }
+    store.try_claim(envelope, tool_name="write_file", args={})
+    db.chmod(0o400)
+
+    assert store.read_all()[0]["idempotency_key"] == "a" * 64
+
+
+def test_claim_database_rejects_last_component_symlink(tmp_path):
+    real = tmp_path / "real.db"
+    real.write_bytes(b"")
+    link = tmp_path / "phase2.db"
+    link.symlink_to(real)
+    with pytest.raises(PermissionError, match="not a regular file"):
+        MutationClaimStore(link)._connect()
+
+
+# ── Typed collision vs same-effect replay ────────────────────────────────────
+
+
+_BASE_ENVELOPE = {
+    "graph_id": "g-col",
+    "node_id": "n-col",
+    "attempt_id": "a-col",
+    "idempotency_key": "9" * 64,
+    "fence": 7,
+}
+
+
+def test_same_intent_replay_returns_false(tmp_path):
+    """Exact same envelope + tool_name + args is a safe replay: must return False."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    assert store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"}) is True
+    assert store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"}) is False
+    # Multiple replays are all False; the store remains consistent.
+    assert store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"}) is False
+
+
+@pytest.mark.parametrize(
+    ("field", "new_value"),
+    [
+        ("graph_id", "g-other"),
+        ("node_id", "n-other"),
+        ("attempt_id", "a-other"),
+        ("fence", 8),
+    ],
+)
+def test_changed_envelope_field_raises_collision_error(tmp_path, field, new_value):
+    """Changing any identity field on the envelope must raise MutationClaimError."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={})
+
+    collision_env = {**_BASE_ENVELOPE, field: new_value}
+    with pytest.raises(MutationClaimError, match="collision"):
+        store.try_claim(collision_env, tool_name="write_file", args={})
+
+
+def test_changed_tool_name_raises_collision_error(tmp_path):
+    """Changing tool_name for the same idempotency_key must raise MutationClaimError."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={})
+
+    with pytest.raises(MutationClaimError, match="collision"):
+        store.try_claim(_BASE_ENVELOPE, tool_name="delete_file", args={})
+
+
+def test_changed_args_raises_collision_error(tmp_path):
+    """Changing args for the same idempotency_key must raise MutationClaimError."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"path": "one"})
+
+    with pytest.raises(MutationClaimError, match="collision"):
+        store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"path": "two"})
+
+
+def test_collision_does_not_corrupt_store(tmp_path):
+    """A MutationClaimError collision must not prevent future reads or correct claims."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"})
+
+    with pytest.raises(MutationClaimError, match="collision"):
+        store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "changed"})
+
+    # The store is still readable.
+    claims = store.read_all()
+    assert len(claims) == 1
+    assert claims[0]["idempotency_key"] == "9" * 64
+    # A new key can still be claimed.
+    new_env = {**_BASE_ENVELOPE, "idempotency_key": "8" * 64}
+    assert store.try_claim(new_env, tool_name="write_file", args={"k": "v"}) is True
+
+
+def test_conflict_without_readable_prior_is_not_a_safe_replay(tmp_path, monkeypatch):
+    """A conflicted insert without an inspectable row must fail closed."""
+    store = MutationClaimStore(tmp_path / "phase2.db")
+    store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"})
+    real_connect = store._connect
+
+    class MissingPriorConnection:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, parameters=()):
+            result = self._conn.execute(sql, parameters)
+            if "FROM mutation_claims" in sql and sql.lstrip().startswith("SELECT"):
+                class MissingPriorCursor:
+                    @staticmethod
+                    def fetchone():
+                        return None
+
+                return MissingPriorCursor()
+            return result
+
+        def close(self):
+            self._conn.close()
+
+    monkeypatch.setattr(store, "_connect", lambda: MissingPriorConnection(real_connect()))
+
+    with pytest.raises(MutationClaimError, match="without a readable prior claim"):
+        store.try_claim(_BASE_ENVELOPE, tool_name="write_file", args={"k": "v"})


### PR DESCRIPTION
Part of #95028 (authority umbrella architecture). This PR owns the durable authority/idempotency **persistence primitives** vertical; it intentionally leaves runtime enforcement gates, dispatch/settlement wiring, and gateway/API integration to later shards. Policy identity (`policy_hash`) is stored opaquely here and defers to the canonical policy ABI being settled in #95101 — this PR must be reconciled against that ABI before any runtime consumer treats its stored policy identity as authoritative. Complementary adjacent shards: #102082 (local action receipts/observability plane) and #102086 (delegation routes, which must consume this authority contract rather than growing a second envelope path).

## Scope

- add append-only durable plan, lease/fence, and exact-budget authority primitives
- add atomic idempotency reservation/completion primitives
- bind a defensively detached envelope and its authoritative fence from one SQLite read snapshot
- enforce sealed node budgets cumulatively across every lease fence, including outstanding reservations and unknown-cost poison, while preserving fence-scoped diagnostic reporting
- use descriptor-backed SQLite opening, genuine read-only readers, and owner-only database sidecars
- reject hostile overdeep envelope completion with a durable `RESULT_REJECTED` event and normalize binding serialization failures to `AuthorityError`
- reject finite TTL values beyond the representable timestamp range through the typed `AuthorityError` contract

## Module layout

Per review, the implementation is split into bounded modules behind a stable facade (every product file below the 2K ceiling):

- `agent/phase2_sqlite.py` — descriptor-pinned SQLite opening/hardening (no-symlink, no-permissive-create, owner-only mode, URI `mode=ro` readers)
- `agent/phase2_errors.py` — typed authority exceptions
- `agent/phase2_envelope.py` — sealed task-envelope v2 validation, canonical values, context-scoped binding
- `agent/phase2_budget.py` — cumulative fence-scoped budget reservation/reconciliation; exact `Decimal` USD accounting and exact signed-64 integer token ceilings
- `agent/phase2_ledger.py` — append-only plan/event ledger, hash-chained lifecycle events, lease/fence transitions, integrity-index backstops, fail-closed migration diagnostics, concrete `Phase2AuthorityStore`
- `agent/phase2_authority.py` — stable public import surface (unchanged `__all__`)
- `agent/phase2_idempotency.py` — `MutationClaimStore` with typed logical-effect collision semantics

## Current revision

- Head: `3ea18779db` (single commit atop live `main`)
- Rebase target / merge-base: `63279301bcbdc185c1b07b98a9312eb0c862f26d`

## Verification

On this exact revision:

- `HERMES_PYTHON=... scripts/run_tests.sh tests/agent/test_phase2_authority.py tests/agent/test_phase2_envelope_binding.py tests/agent/test_phase2_idempotency.py -q`
- **95 passed, 0 failed**
- Ruff format + check: **passed**

Review-driven hardening included at this head:

- **Exact integer token ceilings**: `tokens_max` is validated as a non-`bool` integer in `[0, 2**63 - 1]` at every validation and persistence boundary; no `float` round-trip. Regressions above `2**53` cover both rounding directions on both `reserve_budget()` and `reserve_budget_allocations()`.
- **Typed idempotency collision semantics**: `try_claim()` returns `False` only for an exact same-intent replay (same `graph_id`, `node_id`, `attempt_id`, `fence`, `tool_name`, `args_hash`); any divergence raises `MutationClaimError`; a conflict without an inspectable prior row fails closed. `seal_plan()` rejects duplicate idempotency keys across nodes.

Cross-fence regressions cover reconciled spend, unknown-cost poison, outstanding reservations across expiry/regrant, exact use of remaining cumulative budget, and explicit fence-scoped reporting. Effective budget tolerance is zero.

These are producer-side receipts; the hosted CI/Docker/Nix matrix on this exact head requires maintainer workflow approval (fork PR) and is not claimed.

## Explicit non-scope

No runtime enforcement gate, conversation/model-call integration, gateway/API idempotency wiring, readiness scripts, synthetic production sessions, or A2A integration. Current production receipts are v1 while these primitives validate nested v2 authority envelopes; this PR is not operational deployment evidence. Deterministic SHA-256 argument hashes permit offline confirmation of guessed inputs and are not a confidentiality guarantee.

The final revision is authored and committed as `Jack Field <3956838+jdot-dev@users.noreply.github.com>`.

## Provenance

Primitive-only extraction originally cut from `NousResearch/hermes-agent@48c0c3a873bc5adaf20c632b5b7630a4fac000b4` (extraction baseline only — the implementation commits are authored fresh on this branch), independently reviewed, then rebased onto live `main@63279301bcbdc185c1b07b98a9312eb0c862f26d`.
