### PR TITLE
feat(delegation): add operator-controlled routes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -333,6 +333,11 @@ _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
 # the merged-config cache validity check.
 _LOAD_CONFIG_CACHE: Dict[str, tuple] = {}
 _RAW_CONFIG_CACHE: Dict[str, tuple] = {}
+
+
+def _canonical_config_path_key(path: Path) -> str:
+    """Return the cache identity shared by config readers and writers."""
+    return str(path.resolve(strict=False))
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -4061,7 +4066,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         path_key = (
             user_signature[0]
             if user_signature is not None
-            else str(config_path.resolve(strict=False))
+            else _canonical_config_path_key(config_path)
         )
 
         # Fold the exact managed-config snapshot into the merged-cache key.
@@ -4306,6 +4311,7 @@ def save_config(
 
         ensure_hermes_home()
         config_path = get_config_path()
+        path_key = _canonical_config_path_key(config_path)
         require_readable_config_before_write(config_path)
         # Compute explicit user paths BEFORE any normalisation --------
         # _normalize_max_turns_config may inject agent.max_turns from
@@ -4330,7 +4336,7 @@ def save_config(
             normalized = _preserve_env_ref_templates(
                 normalized,
                 raw_existing,
-                _LAST_EXPANDED_CONFIG_BY_PATH.get(str(config_path)),
+                _LAST_EXPANDED_CONFIG_BY_PATH.get(path_key),
             )
 
         # Strip schema-default values so the user's custom settings are not
@@ -4373,8 +4379,8 @@ def save_config(
             extra_content="".join(parts) if parts else None,
         )
         _secure_file(config_path)
-        _RAW_CONFIG_CACHE.pop(str(config_path), None)
-        _LAST_EXPANDED_CONFIG_BY_PATH[str(config_path)] = copy.deepcopy(current_normalized)
+        _RAW_CONFIG_CACHE.pop(path_key, None)
+        _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(current_normalized)
 
 
 def _parse_env_value(raw_value: str) -> str:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -327,23 +327,12 @@ def validate_env_var_name_for_write(key: str) -> None:
     _reject_denylisted_env_var(key)
 
 _LAST_EXPANDED_CONFIG_BY_PATH: Dict[str, Any] = {}
-# (path, mtime_ns, size) -> cached expanded config dict.
-# load_config() returns a deepcopy of the cached value when the file
-# hasn't changed since the last load, skipping yaml.safe_load +
-# _deep_merge + _normalize_* + _expand_env_vars (~13 ms/call).
-# save_config() + migrate_config() write via atomic_yaml_write which
-# produces a fresh inode, so stat() sees a new mtime_ns and the next
-# load repopulates automatically — no explicit invalidation hook.
-# Cached tuple is (user_mtime_ns, user_size, managed_mtime_ns, managed_size,
-# merged_value, env_ref_snapshot) — the managed-file signature is folded in so
-# editing the managed-scope config.yaml invalidates the cache (see
-# managed_scope), and the env snapshot invalidates it when a referenced ${VAR}
-# changes value (late .env load, in-process rotation — #58514).
-_LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str, Optional[str]]]] = {}
-# (path, mtime_ns, size) -> cached raw yaml dict. Same pattern as
-# _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
-# the user's on-disk values without defaults merged in.
-_RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# Content-aware config cache identities are
+# (resolved_path, mtime_ns, size, SHA-256 digest). The digest catches
+# metadata-preserving rewrites; referenced environment values remain part of
+# the merged-config cache validity check.
+_LOAD_CONFIG_CACHE: Dict[str, tuple] = {}
+_RAW_CONFIG_CACHE: Dict[str, tuple] = {}
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -813,7 +802,7 @@ def get_container_exec_info() -> Optional[dict]:
 
 # Re-export from hermes_constants — canonical definition lives there.
 from hermes_constants import get_hermes_home, get_process_hermes_home  # noqa: F811,E402
-from utils import atomic_replace, fast_safe_load
+from utils import atomic_replace, fast_safe_load, read_file_with_signature
 
 def get_config_path() -> Path:
     """Get the main config file path."""
@@ -3638,40 +3627,26 @@ def resolve_ephemeral_system_prompt_from_config(cfg: Optional[Dict[str, Any]]) -
 
 
 def read_raw_config() -> Dict[str, Any]:
-    """Read ~/.hermes/config.yaml as-is, without merging defaults or migrating.
-
-    Returns the raw YAML dict, or ``{}`` if the file doesn't exist or can't
-    be parsed.  Use this for lightweight config reads where you just need a
-    single value and don't want the overhead of ``load_config()``'s deep-merge
-    + migration pipeline.
-
-    Cached on the config file's (mtime_ns, size) — same strategy as
-    ``load_config()``. Returns a deepcopy on every call since some callers
-    mutate the result before passing to ``save_config()``.
-    """
+    """Read config.yaml as-is, returning a defensive copy."""
     with _CONFIG_LOCK:
-        try:
-            config_path = get_config_path()
-            st = config_path.stat()
-            cache_key = (st.st_mtime_ns, st.st_size)
-        except (FileNotFoundError, OSError):
+        config_path = get_config_path()
+        snapshot = read_file_with_signature(config_path)
+        if snapshot is None:
             return {}
-
-        path_key = str(config_path)
+        content, signature = snapshot
+        path_key = signature[0]
         cached = _RAW_CONFIG_CACHE.get(path_key)
-        if cached is not None and cached[:2] == cache_key:
-            return copy.deepcopy(cached[2])
+        if cached is not None and cached[0] == signature:
+            return copy.deepcopy(cached[1])
 
         try:
-            with open(config_path, encoding="utf-8") as f:
-                data = fast_safe_load(f) or {}
+            data = fast_safe_load(content) or {}
         except Exception as e:
             _warn_config_parse_failure(config_path, e)
             return {}
-
         if not isinstance(data, dict):
             data = {}
-        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], copy.deepcopy(data))
+        _RAW_CONFIG_CACHE[path_key] = (signature, copy.deepcopy(data))
         return data
 
 
@@ -3725,47 +3700,31 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
 
 
 def read_raw_config_readonly() -> Dict[str, Any]:
-    """Fast-path variant of ``read_raw_config()`` for callers that ONLY READ.
+    """Read raw config without copying the content-aware cached value.
 
-    Returns the cached raw-config dict directly, skipping the per-call
-    ``copy.deepcopy`` that ``read_raw_config()`` performs (needed there
-    because some callers mutate the result before ``save_config``).
-
-    **Mutating the returned dict corrupts the in-process cache for every
-    subsequent caller.** Only use on read-only paths — e.g. per-turn policy
-    checks like the shared-metrics gate, which runs 2-3x per agent turn and
-    was paying a full config deepcopy each time.
-
-    Same (mtime_ns, size) freshness key as ``read_raw_config()`` — an edited
-    config.yaml is picked up on the next call.
+    Mutating the returned dict corrupts the in-process cache. Only use this
+    variant on paths that treat the result as immutable.
     """
     with _CONFIG_LOCK:
-        try:
-            config_path = get_config_path()
-            st = config_path.stat()
-            cache_key = (st.st_mtime_ns, st.st_size)
-        except (FileNotFoundError, OSError):
+        config_path = get_config_path()
+        snapshot = read_file_with_signature(config_path)
+        if snapshot is None:
             return {}
-
-        path_key = str(config_path)
+        content, signature = snapshot
+        path_key = signature[0]
         cached = _RAW_CONFIG_CACHE.get(path_key)
-        if cached is not None and cached[:2] == cache_key:
-            return cached[2]
+        if cached is not None and cached[0] == signature:
+            return cached[1]
 
         try:
-            with open(config_path, encoding="utf-8") as f:
-                data = fast_safe_load(f) or {}
+            data = fast_safe_load(content) or {}
         except Exception as e:
             _warn_config_parse_failure(config_path, e)
             return {}
-
         if not isinstance(data, dict):
             data = {}
-        # Store and return THE SAME object (identity invariant): the first
-        # caller must see the exact dict later cache hits return, so a test
-        # asserting ``ro1 is ro2`` holds from the very first call.
         cached_copy = copy.deepcopy(data)
-        _RAW_CONFIG_CACHE[path_key] = (cache_key[0], cache_key[1], cached_copy)
+        _RAW_CONFIG_CACHE[path_key] = (signature, cached_copy)
         return cached_copy
 
 
@@ -4097,58 +4056,38 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
     with _CONFIG_LOCK:
         ensure_hermes_home()
         config_path = get_config_path()
-        path_key = str(config_path)
+        user_snapshot = read_file_with_signature(config_path)
+        user_signature = user_snapshot[1] if user_snapshot is not None else None
+        path_key = (
+            user_signature[0]
+            if user_signature is not None
+            else str(config_path.resolve(strict=False))
+        )
 
-        try:
-            st = config_path.stat()
-            user_sig: Optional[Tuple[int, int]] = (st.st_mtime_ns, st.st_size)
-        except FileNotFoundError:
-            user_sig = None
-
-        # Managed scope: fold the managed config file's (mtime, size) into the
-        # cache signature so editing /etc/hermes/config.yaml invalidates the
-        # cached merged result. (0, 0) means "no managed config file".
+        # Fold the exact managed-config snapshot into the merged-cache key.
         from hermes_cli import managed_scope
 
-        managed_dir = managed_scope.get_managed_dir()
-        managed_cfg_path = (managed_dir / "config.yaml") if managed_dir else None
-        try:
-            mst = managed_cfg_path.stat() if managed_cfg_path else None
-            managed_sig = (mst.st_mtime_ns, mst.st_size) if mst else (0, 0)
-        except OSError:
-            managed_sig = (0, 0)
-
-        # Combined cache signature: user file + managed file. None only when the
-        # user config is absent AND no managed file exists (nothing to cache on).
-        if user_sig is not None:
-            cache_sig: Optional[Tuple[int, int, int, int]] = (
-                user_sig[0],
-                user_sig[1],
-                managed_sig[0],
-                managed_sig[1],
-            )
-        elif managed_sig != (0, 0):
-            cache_sig = (0, 0, managed_sig[0], managed_sig[1])
-        else:
-            cache_sig = None
+        managed_config, managed_signature = (
+            managed_scope.load_managed_config_snapshot()
+        )
+        cacheable = user_signature is not None or managed_signature is not None
 
         cached = _LOAD_CONFIG_CACHE.get(path_key)
-        if cached is not None and cache_sig is not None and cached[:4] == cache_sig:
-            # File signatures match, but the cached expansion is only valid if
-            # every ${VAR} it was expanded against still has the same value.
-            # Without this, a load_config() that ran before load_hermes_dotenv()
-            # pins unexpanded literals (e.g. auxiliary.<task>.api_key) for the
-            # life of the process (#58514).
-            env_snapshot = cached[5] if len(cached) > 5 else {}
+        if (
+            cached is not None
+            and cacheable
+            and cached[0] == user_signature
+            and cached[1] == managed_signature
+        ):
+            env_snapshot = cached[3]
             if all(_env_ref_lookup(k) == v for k, v in env_snapshot.items()):
-                return copy.deepcopy(cached[4]) if want_deepcopy else cached[4]
+                return copy.deepcopy(cached[2]) if want_deepcopy else cached[2]
 
         config = copy.deepcopy(DEFAULT_CONFIG)
 
-        if user_sig is not None:
+        if user_snapshot is not None:
             try:
-                with open(config_path, encoding="utf-8") as f:
-                    user_config = fast_safe_load(f) or {}
+                user_config = fast_safe_load(user_snapshot[0]) or {}
 
                 if "max_turns" in user_config:
                     agent_user_config = dict(user_config.get("agent") or {})
@@ -4186,16 +4125,12 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     lkg_copy: Dict[str, Any] = _cast(
                         Dict[str, Any], _expand_env_vars(copy.deepcopy(lkg))
                     )
-                    if cache_sig is not None:
-                        # Cache under the corrupt file's signature (empty env
-                        # snapshot: always valid) so repeated loads don't
-                        # re-parse the broken file; fixing the file changes the
-                        # signature and triggers a normal reload.
-                        _empty_env: Dict[str, Optional[str]] = {}
+                    if cacheable:
                         _LOAD_CONFIG_CACHE[path_key] = (
-                            cache_sig[0], cache_sig[1],
-                            cache_sig[2], cache_sig[3],
-                            lkg_copy, _empty_env,
+                            user_signature,
+                            managed_signature,
+                            lkg_copy,
+                            {},
                         )
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
@@ -4206,7 +4141,10 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
         # against the process environment, never against user-config-defined refs.
         # This deliberately inverts the usual env-over-config precedence for the
         # keys the managed layer pins — see docs/design/managed-scope.md §4.1.
-        managed_config = managed_scope.load_managed_config()
+        # ``managed_config`` was parsed from the same byte snapshot that
+        # produced ``managed_signature`` above. Never read it again here: a
+        # rewrite between fingerprint and parse could otherwise cache one
+        # version's policy under another version's identity.
         if managed_config:
             # Normalize the managed overlay through the same canonicalization as
             # the user config BEFORE merging (parity with
@@ -4222,20 +4160,17 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
             managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
-        if cache_sig is not None:
-            # Cache stores a separate deepcopy so subsequent ``load_config()``
-            # (deepcopy=True) callers can mutate freely without affecting the
-            # cached value, and ``load_config_readonly()`` (deepcopy=False)
-            # callers all see the same stable cached object. The cached tuple is
-            # (user_mtime, user_size, managed_mtime, managed_size, value,
-            # env_ref_snapshot). The snapshot records the environment values
-            # this expansion was made against so later loads can detect env
-            # drift (late .env load, in-process rotation) — see cache hit above.
+        if cacheable:
             cached_copy = copy.deepcopy(expanded)
             env_snapshot = _env_ref_snapshot(normalized)
             if managed_config:
                 _env_ref_snapshot(managed_config, env_snapshot)
-            _LOAD_CONFIG_CACHE[path_key] = (*cache_sig, cached_copy, env_snapshot)
+            _LOAD_CONFIG_CACHE[path_key] = (
+                user_signature,
+                managed_signature,
+                cached_copy,
+                env_snapshot,
+            )
             # On the readonly path return the same cached object subsequent
             # calls will see — keeps "two readonly calls return the same
             # object" invariant that callers may rely on for identity checks.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -337,7 +337,10 @@ _RAW_CONFIG_CACHE: Dict[str, tuple] = {}
 
 def _canonical_config_path_key(path: Path) -> str:
     """Return the cache identity shared by config readers and writers."""
-    return str(path.resolve(strict=False))
+    try:
+        return str(path.resolve(strict=False))
+    except (OSError, RuntimeError):
+        return str(path.absolute())
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2165,6 +2165,21 @@ DEFAULT_CONFIG = {
         # extras" without silently stripping MCP tools the parent already has.
         # Set to false for strict intersection.
         "inherit_mcp_toolsets": True,
+        # Operator-owned default toolset ceiling for every child agent.
+        # None (default) preserves parent inheritance so every child gets
+        # whatever tools the parent has enabled. A list narrows every child
+        # to that intersection with the parent's toolsets — the configured
+        # list cannot grant access the parent does not have. An empty list
+        # gives children no enabled toolsets. MCP toolsets are subject to
+        # the same ceiling; inherit_mcp_toolsets does NOT override this.
+        "default_toolsets": None,
+        # Named operator delegation routes: pre-approved (provider, model,
+        # base_url, api_key, api_mode) bundles the model can select by name.
+        # Route names must match ^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$. Only the
+        # allowlisted fields above are honoured; everything else is ignored.
+        # Use ${ENV_VAR} for secrets. Only configured route names appear in
+        # the tool schema; unknown names fail before credential resolution.
+        "routes": {},
         "max_iterations": 250,  # per-subagent iteration cap (each subagent gets its own budget,
                                # independent of the parent's max_iterations)
         # Subagent summaries return to the parent's context verbatim. A batch

--- a/hermes_cli/managed_scope.py
+++ b/hermes_cli/managed_scope.py
@@ -25,6 +25,7 @@ from pathlib import Path
 from typing import Dict, Optional
 
 import yaml
+from utils import read_file_with_signature
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ logger = logging.getLogger(__name__)
 _DEFAULT_MANAGED_DIR = Path("/etc/hermes")
 
 _CACHE_LOCK = threading.Lock()
-# path_key -> (mtime_ns, size, parsed)
+# path_key -> (content_signature, parsed)
 _CONFIG_CACHE: Dict[str, tuple] = {}
 _ENV_CACHE: Dict[str, tuple] = {}
 
@@ -78,27 +79,25 @@ def invalidate_managed_cache() -> None:
         _ENV_CACHE.clear()
 
 
-def _cached_read(path: Path, cache: Dict[str, tuple], parse):
-    """Shared (mtime_ns, size)-keyed read. Returns a deepcopy of the parsed value.
+def _cached_read_with_signature(path: Path, cache: Dict[str, tuple], parse):
+    """Read and cache one managed file by path and exact content.
 
-    Returns ``None`` when the file is absent or fails to parse (fail-open). A
-    parse failure is logged LOUDLY — the admin needs to know their policy isn't
-    being applied — but never raises, so a malformed managed file can't brick
-    startup.
+    Returns ``(parsed, signature)``. Parsing and hashing use the same bytes,
+    so equal-(mtime,size) rewrites cannot retain stale policy. The signature
+    remains available when parsing fails, allowing callers to cache their
+    fail-open result only for that exact malformed snapshot.
     """
-    try:
-        st = path.stat()
-    except OSError:
-        return None  # absent
-    key = (st.st_mtime_ns, st.st_size)
-    path_key = str(path)
+    snapshot = read_file_with_signature(path)
+    if snapshot is None:
+        return None, None
+    content, signature = snapshot
+    path_key = signature[0]
     with _CACHE_LOCK:
         hit = cache.get(path_key)
-        if hit is not None and hit[:2] == key:
-            return copy.deepcopy(hit[2])
+        if hit is not None and hit[0] == signature:
+            return copy.deepcopy(hit[1]), signature
     try:
-        with open(path, encoding="utf-8") as f:
-            parsed = parse(f)
+        parsed = parse(content)
     except Exception as exc:  # noqa: BLE001 — fail-open, but LOUD
         logger.warning(
             "managed scope: failed to parse %s: %s — IGNORING this managed file. "
@@ -106,23 +105,33 @@ def _cached_read(path: Path, cache: Dict[str, tuple], parse):
             path,
             exc,
         )
-        return None
+        return None, signature
     with _CACHE_LOCK:
-        cache[path_key] = (key[0], key[1], copy.deepcopy(parsed))
+        cache[path_key] = (signature, copy.deepcopy(parsed))
+    return parsed, signature
+
+
+def _cached_read(path: Path, cache: Dict[str, tuple], parse):
+    parsed, _signature = _cached_read_with_signature(path, cache, parse)
     return parsed
+
+
+def load_managed_config_snapshot() -> "tuple[dict, tuple | None]":
+    """Return managed config and the signature of the bytes it was parsed from."""
+    managed_dir = get_managed_dir()
+    if managed_dir is None:
+        return {}, None
+    parsed, signature = _cached_read_with_signature(
+        managed_dir / "config.yaml",
+        _CONFIG_CACHE,
+        lambda data: yaml.safe_load(data) or {},
+    )
+    return (parsed if isinstance(parsed, dict) else {}), signature
 
 
 def load_managed_config() -> dict:
     """Parsed managed config.yaml, or {} when absent/malformed (fail-open)."""
-    managed_dir = get_managed_dir()
-    if managed_dir is None:
-        return {}
-    parsed = _cached_read(
-        managed_dir / "config.yaml",
-        _CONFIG_CACHE,
-        lambda f: yaml.safe_load(f) or {},
-    )
-    return parsed if isinstance(parsed, dict) else {}
+    return load_managed_config_snapshot()[0]
 
 
 def load_managed_env() -> Dict[str, str]:
@@ -177,10 +186,10 @@ def apply_managed_overlay(config: dict) -> dict:
         return config
 
 
-def _parse_env(f) -> Dict[str, str]:
+def _parse_env(data: bytes) -> Dict[str, str]:
     out: Dict[str, str] = {}
-    for line in f:
-        line = line.strip()
+    for raw_line in data.splitlines():
+        line = raw_line.decode("utf-8").strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
         key, _, value = line.partition("=")

--- a/model_tools.py
+++ b/model_tools.py
@@ -438,6 +438,9 @@ def get_tool_definitions(
                 # A continuously changing config cannot safely populate a cache.
                 # The cached entry still matches the latest complete `before`
                 # snapshot, so prefer it to crashing or returning a torn schema.
+                _last_resolved_tool_names = [
+                    t["function"]["name"] for t in cached
+                ]
                 return list(cached)
 
             result = _compute_tool_definitions(

--- a/model_tools.py
+++ b/model_tools.py
@@ -39,6 +39,7 @@ from tools.registry import (
     tool_error,
 )
 from toolsets import resolve_toolset, validate_toolset
+from utils import file_content_signature
 
 logger = logging.getLogger(__name__)
 
@@ -320,6 +321,51 @@ def _clear_tool_defs_cache() -> None:
         _tool_defs_cache.clear()
 
 
+def _tool_defs_config_fingerprints() -> tuple[Any, Any]:
+    """Return content identities for config files that affect tool schemas."""
+    try:
+        from hermes_cli.config import get_config_path
+
+        cfg_fp = file_content_signature(get_config_path())
+    except ImportError:
+        cfg_fp = None
+    try:
+        from hermes_cli import managed_scope as _managed_scope
+
+        managed_dir = _managed_scope.get_managed_dir()
+        managed_fp = (
+            file_content_signature(managed_dir / "config.yaml")
+            if managed_dir is not None
+            else None
+        )
+    except Exception:
+        managed_fp = None
+    return cfg_fp, managed_fp
+
+
+def _tool_defs_cache_key(
+    enabled_toolsets: Optional[List[str]],
+    disabled_toolsets: Optional[List[str]],
+    skip_tool_search_assembly: bool,
+    profile_scope: Any,
+    config_fingerprints: tuple[Any, Any],
+) -> tuple:
+    cfg_fp, managed_fp = config_fingerprints
+    return (
+        registry.current_scope_key(),
+        frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
+        frozenset(disabled_toolsets) if disabled_toolsets else None,
+        registry._generation,
+        cfg_fp,
+        managed_fp,
+        bool(os.environ.get("HERMES_KANBAN_TASK")),
+        bool(skip_tool_search_assembly),
+        _is_delegated_child_context(),
+        _is_dispatcher_owned_worker(),
+        profile_scope,
+    )
+
+
 def get_tool_definitions(
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
@@ -344,64 +390,74 @@ def get_tool_definitions(
     Returns:
         Filtered list of OpenAI-format tool definitions.
     """
-    # Fast path: memoized result when the caller doesn't need stdout prints.
-    # The cache key captures every argument-level input; the registry
-    # generation captures registry mutations (MCP refresh, plugin load).
-    # check_fn results are TTL-cached one level down, inside
-    # registry.get_definitions. The config-mtime fingerprint below captures
-    # user-visible config edits that affect dynamic schemas (execute_code
-    # mode, discord action allowlist, etc.) without needing an explicit
-    # invalidate hook on every config-writer.
-    cache_key = None
-    if quiet_mode:
-        try:
-            from hermes_cli.config import get_config_path
-            cfg_path = get_config_path()
-            cfg_stat = cfg_path.stat()
-            cfg_fp = (cfg_stat.st_mtime_ns, cfg_stat.st_size)
-        except (FileNotFoundError, OSError, ImportError):
-            cfg_fp = None
-        profile_scope = check_fn_cache_scope()
-        if profile_scope != CHECK_FN_CACHE_BYPASS:
-            cache_key = (
-                registry.current_scope_key(),
-                frozenset(enabled_toolsets) if enabled_toolsets is not None else None,
-                frozenset(disabled_toolsets) if disabled_toolsets else None,
-                registry._generation,
-                cfg_fp,
-                bool(os.environ.get("HERMES_KANBAN_TASK")),
-                bool(skip_tool_search_assembly),
-                _is_delegated_child_context(),
-                _is_dispatcher_owned_worker(),
-                profile_scope,
-            )
-        with _tool_defs_cache_lock:
-            cached = _tool_defs_cache.get(cache_key) if cache_key is not None else None
-        if cached is not None:
-            # Update _last_resolved_tool_names so downstream callers see
-            # consistent state even on a cache hit.
-            global _last_resolved_tool_names
-            _last_resolved_tool_names = [t["function"]["name"] for t in cached]
-            # Return a shallow copy of the list but share the dict references —
-            # schemas are treated as read-only by all known callers.
-            return list(cached)
+    if not quiet_mode:
+        return _compute_tool_definitions(
+            enabled_toolsets,
+            disabled_toolsets,
+            quiet_mode,
+            skip_tool_search_assembly=skip_tool_search_assembly,
+        )
 
-    result = _compute_tool_definitions(enabled_toolsets, disabled_toolsets, quiet_mode,
-                                       skip_tool_search_assembly=skip_tool_search_assembly)
-    if quiet_mode and cache_key is not None:
+    # Dynamic tool schemas read config during computation. Bind any cached
+    # result to fingerprints observed both before and after that computation;
+    # otherwise a concurrent rewrite can cache schema B under snapshot A's key.
+    profile_scope = check_fn_cache_scope()
+    cache_enabled = profile_scope != CHECK_FN_CACHE_BYPASS
+    from hermes_cli.config import _CONFIG_LOCK
+
+    for attempt in range(2):
+        # Serialize fingerprinting and dynamic config parsing with config
+        # writers. Atomic external replacements can still occur, so retain
+        # the post-compute identity check and retry below.
+        with _CONFIG_LOCK:
+            before = _tool_defs_config_fingerprints()
+            cache_key = (
+                _tool_defs_cache_key(
+                    enabled_toolsets,
+                    disabled_toolsets,
+                    skip_tool_search_assembly,
+                    profile_scope,
+                    before,
+                )
+                if cache_enabled
+                else None
+            )
+            with _tool_defs_cache_lock:
+                cached = (
+                    _tool_defs_cache.get(cache_key) if cache_key is not None else None
+                )
+            if cached is not None:
+                if _tool_defs_config_fingerprints() == before:
+                    global _last_resolved_tool_names
+                    _last_resolved_tool_names = [
+                        t["function"]["name"] for t in cached
+                    ]
+                    return list(cached)
+                if attempt == 0:
+                    continue
+                # A continuously changing config cannot safely populate a cache.
+                # The cached entry still matches the latest complete `before`
+                # snapshot, so prefer it to crashing or returning a torn schema.
+                return list(cached)
+
+            result = _compute_tool_definitions(
+                enabled_toolsets,
+                disabled_toolsets,
+                quiet_mode,
+                skip_tool_search_assembly=skip_tool_search_assembly,
+            )
+            after = _tool_defs_config_fingerprints()
+            if before != after:
+                if attempt == 0:
+                    continue
+                # A continuously changing config cannot safely populate a cache.
+                return list(result)
+        if cache_key is None:
+            return list(result)
+
         # Cache the freshly-computed list, but hand callers a shallow copy so
-        # downstream mutations (e.g. run_agent appending memory/LCM tool
-        # schemas to self.tools) don't poison the cache. Without this, a
-        # long-lived Gateway process accumulates duplicate tool names across
-        # agent inits and providers that enforce unique tool names
-        # (DeepSeek, Xiaomi MiMo, Moonshot Kimi) reject the request with
-        # HTTP 400. Mirrors the cache-hit path above. (issue #17335)
-        # Bound the cache with LRU eviction so a long-lived Gateway process
-        # doesn't accumulate entries unboundedly across the many distinct
-        # toolset/config fingerprints it sees over its lifetime (#19251).
+        # downstream mutations cannot poison later agent initialization.
         with _tool_defs_cache_lock:
-            # Another thread may have populated this exact key while this
-            # thread computed. Reuse it and serialize capacity eviction.
             cached = _tool_defs_cache.get(cache_key)
             if cached is None:
                 if len(_tool_defs_cache) >= _TOOL_DEFS_CACHE_MAX:
@@ -409,9 +465,8 @@ def get_tool_definitions(
                 _tool_defs_cache[cache_key] = result
                 cached = result
         return list(cached)
-    if quiet_mode:
-        return list(result)
-    return result
+
+    raise AssertionError("unreachable")
 
 
 def _compute_tool_definitions(

--- a/run_agent.py
+++ b/run_agent.py
@@ -9156,6 +9156,7 @@ class AIAgent:
             goal=function_args.get("goal"),
             context=function_args.get("context"),
             tasks=_strip_model_hidden_task_fields(function_args.get("tasks")),
+            route=function_args.get("route"),
             max_iterations=function_args.get("max_iterations"),
             role=function_args.get("role"),
             background=(not _is_subagent),

--- a/tests/hermes_cli/test_canonical_config_path_key.py
+++ b/tests/hermes_cli/test_canonical_config_path_key.py
@@ -1,0 +1,47 @@
+"""Focused tests for _canonical_config_path_key symlink-loop fallback."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.config import _canonical_config_path_key
+
+
+def test_canonical_config_path_key_returns_string_for_normal_path(tmp_path):
+    """Normal path resolves without error and returns a non-empty string."""
+    p = tmp_path / "config.yaml"
+    key = _canonical_config_path_key(p)
+    assert isinstance(key, str)
+    assert key  # non-empty
+
+
+def test_canonical_config_path_key_falls_back_on_oserror(monkeypatch):
+    """OSError during resolve → absolute path string, no crash."""
+    p = Path("/some/nonexistent/path/config.yaml")
+
+    def _raising_resolve(*_args, **_kwargs):
+        raise OSError("No such file or directory")
+
+    monkeypatch.setattr(Path, "resolve", _raising_resolve)
+
+    key = _canonical_config_path_key(p)
+    assert isinstance(key, str)
+    assert "config.yaml" in key, "fallback key should contain the filename"
+
+
+def test_canonical_config_path_key_falls_back_on_runtime_error(monkeypatch):
+    """RuntimeError (symlink loop) during resolve → absolute path, no crash."""
+    p = Path("/symlink/loop/config.yaml")
+
+    def _raising_resolve(*_args, **_kwargs):
+        raise RuntimeError("Symlink loop detected")
+
+    monkeypatch.setattr(Path, "resolve", _raising_resolve)
+
+    key = _canonical_config_path_key(p)
+    assert isinstance(key, str)
+    assert "config.yaml" in key, (
+        "_canonical_config_path_key must return an absolute fallback "
+        "identity on RuntimeError, not propagate the exception"
+    )

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -228,6 +228,38 @@ class TestLoadConfigParseFailure:
             err = capsys.readouterr().err
             assert "previously loaded config" in err
 
+    def test_saved_config_is_last_known_good_through_symlinked_home(
+        self, tmp_path, capsys
+    ):
+        """Writer and loader must address last-known-good state by one path."""
+        import time
+
+        real_home = tmp_path / "real-home"
+        real_home.mkdir()
+        linked_home = tmp_path / "linked-home"
+        try:
+            linked_home.symlink_to(real_home, target_is_directory=True)
+        except (OSError, NotImplementedError) as exc:
+            pytest.skip(f"symlinks unavailable in test environment: {exc}")
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(linked_home)}):
+            save_config(
+                {
+                    "model": {"default": "test/saved-model"},
+                    "approvals": {"deny": ["curl*evil.com*"]},
+                }
+            )
+            time.sleep(0.05)
+            (real_home / "config.yaml").write_text(
+                "approvals:\n  deny: [unclosed\n", encoding="utf-8"
+            )
+
+            after = load_config()
+
+        assert after["model"]["default"] == "test/saved-model"
+        assert after["approvals"]["deny"] == ["curl*evil.com*"]
+        assert "previously loaded config" in capsys.readouterr().err
+
 
 
 

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -1,4 +1,6 @@
 """Tests for ${ENV_VAR} substitution in config.yaml values."""
+import os
+
 
 import pytest
 from hermes_cli.config import _expand_env_vars, load_config
@@ -88,6 +90,27 @@ class TestLoadConfigCacheEnvStaleness:
 
         assert first is second
         assert first["providers"]["mistral"]["api_key"] == "key-stable"
+
+    def test_same_metadata_rewrite_invalidates_merged_cache(
+        self, tmp_path, monkeypatch
+    ):
+        config_file = tmp_path / "config.yaml"
+        before = "delegation:\n  routes:\n    alpha: {}\n"
+        after = "delegation:\n  routes:\n    bravo: {}\n"
+        assert len(before) == len(after)
+        config_file.write_text(before, encoding="utf-8")
+        original = config_file.stat()
+        monkeypatch.setitem(load_config.__globals__, "get_config_path", lambda: config_file)
+
+        assert set(load_config()["delegation"]["routes"]) == {"alpha"}
+        config_file.write_text(after, encoding="utf-8")
+        os.utime(config_file, ns=(original.st_atime_ns, original.st_mtime_ns))
+        rewritten = config_file.stat()
+        assert (rewritten.st_mtime_ns, rewritten.st_size) == (
+            original.st_mtime_ns,
+            original.st_size,
+        )
+        assert set(load_config()["delegation"]["routes"]) == {"bravo"}
 
 
 class TestLoadCliConfigExpansion:

--- a/tests/hermes_cli/test_config_env_refs.py
+++ b/tests/hermes_cli/test_config_env_refs.py
@@ -1,4 +1,5 @@
 import textwrap
+import pytest
 
 from hermes_cli.config import load_config, save_config
 
@@ -33,6 +34,40 @@ def test_save_config_preserves_unresolved_env_refs(monkeypatch, tmp_path):
     save_config(config)
 
     assert "api_key: ${MISSING_SECRET}" in _read_config(tmp_path)
+
+
+def test_save_config_preserves_env_ref_through_symlinked_home_after_rotation(
+    monkeypatch, tmp_path
+):
+    real_home = tmp_path / "real-home"
+    real_home.mkdir()
+    linked_home = tmp_path / "linked-home"
+    try:
+        linked_home.symlink_to(real_home, target_is_directory=True)
+    except (OSError, NotImplementedError) as exc:
+        pytest.skip(f"symlinks unavailable in test environment: {exc}")
+    monkeypatch.setenv("HERMES_HOME", str(linked_home))
+    monkeypatch.setenv("ROTATING_SECRET", "sk-old-secret")
+    _write_config(
+        linked_home,
+        """\
+        custom_providers:
+          - name: rotating
+            api_key: ${ROTATING_SECRET}
+            model: claude-opus-4-6
+        model:
+          default: claude-opus-4-6
+        """,
+    )
+
+    config = load_config()
+    monkeypatch.setenv("ROTATING_SECRET", "sk-new-secret")
+    config["display"]["compact"] = True
+    save_config(config)
+
+    saved = _read_config(linked_home)
+    assert "api_key: ${ROTATING_SECRET}" in saved
+    assert "sk-old-secret" not in saved
 
 
 def test_save_config_allows_intentional_secret_value_change(monkeypatch, tmp_path):

--- a/tests/hermes_cli/test_managed_scope.py
+++ b/tests/hermes_cli/test_managed_scope.py
@@ -1,5 +1,7 @@
 """Unit tests for hermes_cli.managed_scope (resolver + loaders + key helpers)."""
 import textwrap
+import os
+
 
 import pytest
 
@@ -45,6 +47,29 @@ def test_load_managed_env_and_is_env_managed(tmp_path, monkeypatch):
     }
     assert managed_scope.is_env_managed("OPENAI_API_BASE") is True
     assert managed_scope.is_env_managed("OTHER") is False
+
+def test_same_metadata_rewrite_invalidates_managed_cache(tmp_path, monkeypatch):
+    from hermes_cli import managed_scope
+
+    managed = _write_managed(
+        tmp_path,
+        monkeypatch,
+        config="delegation:\n  routes:\n    alpha: {}\n",
+    )
+    path = managed / "config.yaml"
+    original = path.stat()
+    assert set(managed_scope.load_managed_config()["delegation"]["routes"]) == {"alpha"}
+
+    replacement = "delegation:\n  routes:\n    bravo: {}\n"
+    assert len(replacement.encode()) == original.st_size
+    path.write_text(replacement, encoding="utf-8")
+    os.utime(path, ns=(original.st_atime_ns, original.st_mtime_ns))
+    rewritten = path.stat()
+    assert (rewritten.st_mtime_ns, rewritten.st_size) == (
+        original.st_mtime_ns,
+        original.st_size,
+    )
+    assert set(managed_scope.load_managed_config()["delegation"]["routes"]) == {"bravo"}
 
 
 

--- a/tests/hermes_cli/test_managed_scope_config.py
+++ b/tests/hermes_cli/test_managed_scope_config.py
@@ -1,4 +1,5 @@
 """Config integration tests — managed scope wins over user config at the leaf."""
+import os
 import textwrap
 
 import pytest
@@ -101,3 +102,46 @@ def test_managed_bare_string_model_flattens_to_default_on_load(homes):
     _write(managed / "config.yaml", "model: managed/bare\n")
     cfg = load_config()
     assert cfg_get(cfg, "model", "default") == "managed/bare"
+
+
+def test_load_config_uses_one_managed_snapshot(homes, monkeypatch):
+    """A mid-load rewrite cannot pair one snapshot's policy with another's ID."""
+    from hermes_cli import managed_scope
+    from hermes_cli.config import cfg_get, load_config
+
+    home, managed = homes
+    _write(home / "config.yaml", "model:\n  default: user/model\n")
+    original_body = "model:\n  default: managed/alpha\n"
+    rewritten_body = "model:\n  default: managed/bravo\n"
+    assert len(original_body.encode()) == len(rewritten_body.encode())
+    path = managed / "config.yaml"
+    _write(path, original_body)
+    original_stat = path.stat()
+    real_snapshot = managed_scope.load_managed_config_snapshot
+    call_count = 0
+
+    def snapshot_then_rewrite():
+        nonlocal call_count
+        parsed, signature = real_snapshot()
+        call_count += 1
+        if call_count == 1:
+            path.write_text(rewritten_body, encoding="utf-8")
+            os.utime(
+                path,
+                ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns),
+            )
+        return parsed, signature
+
+    monkeypatch.setattr(
+        managed_scope,
+        "load_managed_config_snapshot",
+        snapshot_then_rewrite,
+    )
+
+    first = load_config()
+    assert cfg_get(first, "model", "default") == "managed/alpha"
+    assert call_count == 1
+
+    second = load_config()
+    assert cfg_get(second, "model", "default") == "managed/bravo"
+    assert call_count == 2

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 from concurrent.futures import ThreadPoolExecutor
 from threading import Barrier
+import os
+
 
 import pytest
 
@@ -85,13 +87,23 @@ class TestQuietModeCacheIsolation:
         assert len(model_tools._tool_defs_cache) == 0
 
     def test_concurrent_capacity_misses_evict_atomically(self, monkeypatch):
-        """Two profile/toolset misses at capacity cannot race on eviction."""
+        """The cache lock keeps concurrent capacity misses bounded."""
         barrier = Barrier(2)
+
+        class UnlockedConfig:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
 
         def compute(*args, **kwargs):
             barrier.wait(timeout=2)
             return []
 
+        # Isolate the cache's concurrency contract from config's RLock, which
+        # intentionally serializes normal schema builds around config parsing.
+        monkeypatch.setattr("hermes_cli.config._CONFIG_LOCK", UnlockedConfig())
         monkeypatch.setattr(model_tools, "_compute_tool_definitions", compute)
         for index in range(model_tools._TOOL_DEFS_CACHE_MAX):
             model_tools._tool_defs_cache[("old", index)] = []
@@ -108,3 +120,146 @@ class TestQuietModeCacheIsolation:
             assert [future.result(timeout=2) for future in futures] == [[], []]
 
         assert len(model_tools._tool_defs_cache) == model_tools._TOOL_DEFS_CACHE_MAX
+
+    def test_same_metadata_rewrite_invalidates_dynamic_schema(
+        self, tmp_path, monkeypatch
+    ):
+        config_path = tmp_path / "config.yaml"
+        before = "delegation:\n  routes:\n    alpha: {}\n"
+        after = "delegation:\n  routes:\n    bravo: {}\n"
+        assert len(before) == len(after)
+        config_path.write_text(before, encoding="utf-8")
+        original = config_path.stat()
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_config_path", lambda: config_path
+        )
+        monkeypatch.setattr(
+            model_tools, "check_fn_cache_scope", lambda: "cache-rewrite-test"
+        )
+
+        first = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation"], quiet_mode=True
+        )
+        first_delegate = next(
+            item["function"] for item in first if item["function"]["name"] == "delegate_task"
+        )
+        assert first_delegate["parameters"]["properties"]["route"]["enum"] == ["alpha"]
+
+        config_path.write_text(after, encoding="utf-8")
+        os.utime(config_path, ns=(original.st_atime_ns, original.st_mtime_ns))
+        rewritten = config_path.stat()
+        assert rewritten.st_size == original.st_size
+        assert rewritten.st_mtime_ns == original.st_mtime_ns
+
+        second = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation"], quiet_mode=True
+        )
+        second_delegate = next(
+            item["function"] for item in second if item["function"]["name"] == "delegate_task"
+        )
+        assert second_delegate["parameters"]["properties"]["route"]["enum"] == ["bravo"]
+
+    def test_config_rewrite_during_schema_build_never_poisons_old_key(
+        self, tmp_path, monkeypatch
+    ):
+        """Schema parsed after a rewrite must not be cached under the prior digest."""
+        config_path = tmp_path / "config.yaml"
+        alpha = "delegation:\n  routes:\n    alpha: {}\n"
+        bravo = "delegation:\n  routes:\n    bravo: {}\n"
+        assert len(alpha) == len(bravo)
+        config_path.write_text(alpha, encoding="utf-8")
+        original = config_path.stat()
+
+        monkeypatch.setattr(
+            "hermes_cli.config.get_config_path",
+            lambda: config_path,
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "check_fn_cache_scope",
+            lambda: "cache-interleaving-test",
+        )
+        real_compute = model_tools._compute_tool_definitions
+        compute_count = 0
+
+        def rewrite_during_first_compute(*args, **kwargs):
+            nonlocal compute_count
+            compute_count += 1
+            if compute_count == 1:
+                config_path.write_text(bravo, encoding="utf-8")
+                os.utime(
+                    config_path,
+                    ns=(original.st_atime_ns, original.st_mtime_ns),
+                )
+            return real_compute(*args, **kwargs)
+
+        monkeypatch.setattr(
+            model_tools,
+            "_compute_tool_definitions",
+            rewrite_during_first_compute,
+        )
+
+        first = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation"], quiet_mode=True
+        )
+        first_delegate = next(
+            item["function"]
+            for item in first
+            if item["function"]["name"] == "delegate_task"
+        )
+        assert first_delegate["parameters"]["properties"]["route"]["enum"] == [
+            "bravo"
+        ]
+        assert compute_count == 2
+
+        config_path.write_text(alpha, encoding="utf-8")
+        os.utime(
+            config_path,
+            ns=(original.st_atime_ns, original.st_mtime_ns),
+        )
+        restored = model_tools.get_tool_definitions(
+            enabled_toolsets=["delegation"], quiet_mode=True
+        )
+        restored_delegate = next(
+            item["function"]
+            for item in restored
+            if item["function"]["name"] == "delegate_task"
+        )
+        assert restored_delegate["parameters"]["properties"]["route"]["enum"] == [
+            "alpha"
+        ]
+        assert compute_count == 3
+
+    def test_repeated_cache_hit_fingerprint_changes_return_last_complete_snapshot(
+        self, monkeypatch
+    ):
+        snapshots = iter(("A", "B", "A", "B"))
+        cached = [{"function": {"name": "cached_tool"}}]
+
+        monkeypatch.setattr(
+            model_tools,
+            "_tool_defs_config_fingerprints",
+            lambda: next(snapshots),
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "check_fn_cache_scope",
+            lambda: "cache-oscillation-test",
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "_tool_defs_cache_key",
+            lambda *_args: "cache-key",
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "_compute_tool_definitions",
+            lambda *_args, **_kwargs: pytest.fail("cached snapshots must not recompute"),
+        )
+        model_tools._tool_defs_cache["cache-key"] = cached
+
+        result = model_tools.get_tool_definitions(quiet_mode=True)
+
+        assert result == cached
+        assert result is not cached

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -263,3 +263,58 @@ class TestQuietModeCacheIsolation:
 
         assert result == cached
         assert result is not cached
+
+    def test_oscillation_fallback_refreshes_last_resolved_tool_names(
+        self, monkeypatch
+    ):
+        """Continuously-changing-config fallback must keep _last_resolved_tool_names
+        aligned with the cached definitions it returns, not leave them stale.
+
+        The oscillation-fallback branch (attempt==1, cache hit, fingerprint still
+        changing) is reached by pre-seeding the cache under the known key and
+        arranging the fingerprint mock to always return a different value after
+        the initial binding — mirroring the existing
+        ``test_repeated_cache_hit_fingerprint_changes_return_last_complete_snapshot``
+        scenario but adding the _last_resolved_tool_names assertion.
+        """
+        # Each ``with _CONFIG_LOCK`` block calls _tool_defs_config_fingerprints()
+        # once for `before`.  The second call (after `if cached is not None:`)
+        # checks whether the config changed while we held the result.
+        # With the cache pre-populated, the sequence is:
+        #   attempt 0: before=A  [hit]  check=B  → mismatch → attempt==0 → continue
+        #   attempt 1: before=A  [hit]  check=B  → mismatch → attempt==1 → fallback
+        snapshots = iter(("fp-A", "fp-B", "fp-A", "fp-B"))
+        cached = [{"function": {"name": "expected_tool"}}]
+
+        monkeypatch.setattr(
+            model_tools,
+            "_tool_defs_config_fingerprints",
+            lambda: next(snapshots),
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "check_fn_cache_scope",
+            lambda: "oscillation-names-test",
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "_tool_defs_cache_key",
+            lambda *_args: "osc-names-key",
+        )
+        monkeypatch.setattr(
+            model_tools,
+            "_compute_tool_definitions",
+            lambda *_args, **_kwargs: pytest.fail("pre-seeded cache must not recompute"),
+        )
+        model_tools._tool_defs_cache["osc-names-key"] = cached
+        # Force a stale value so we can verify it gets overwritten.
+        model_tools._last_resolved_tool_names = ["stale_tool"]
+
+        result = model_tools.get_tool_definitions(quiet_mode=True)
+
+        assert result == cached
+        assert result is not cached
+        assert model_tools._last_resolved_tool_names == ["expected_tool"], (
+            "oscillation fallback must refresh _last_resolved_tool_names "
+            "to match the returned cached definitions"
+        )

--- a/tests/test_utils_read_file_signature.py
+++ b/tests/test_utils_read_file_signature.py
@@ -1,0 +1,45 @@
+"""Focused tests for read_file_with_signature symlink-loop fallback."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from utils import read_file_with_signature
+
+
+def test_read_file_with_signature_returns_none_on_oserror(tmp_path, monkeypatch):
+    """OSError from Path.resolve (missing file, permission) → None, not crash."""
+    p = tmp_path / "absent.txt"
+    result = read_file_with_signature(p)
+    assert result is None
+
+
+def test_read_file_with_signature_returns_none_on_runtime_error(tmp_path, monkeypatch):
+    """RuntimeError from Path.resolve (symlink loop) → None, not crash."""
+    p = tmp_path / "loop.txt"
+
+    def _raising_resolve(*_args, **_kwargs):
+        raise RuntimeError("Symlink loop detected")
+
+    monkeypatch.setattr(Path, "resolve", _raising_resolve)
+
+    result = read_file_with_signature(p)
+    assert result is None, (
+        "read_file_with_signature must return None on a symlink-loop "
+        "RuntimeError, not propagate the exception"
+    )
+
+
+def test_read_file_with_signature_still_works_for_normal_files(tmp_path):
+    """Sanity: a readable regular file returns (bytes, signature)."""
+    p = tmp_path / "normal.txt"
+    p.write_bytes(b"hello world")
+    result = read_file_with_signature(p)
+    assert result is not None
+    data, sig = result
+    assert data == b"hello world"
+    resolved, mtime_ns, size, digest = sig
+    assert isinstance(resolved, str)
+    assert size == len(b"hello world")
+    assert len(digest) == 64  # SHA-256 hex

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -15,6 +15,7 @@ import threading
 import time
 import types
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -30,7 +31,12 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _configured_delegation_routes,
+    _resolve_delegation_route_config,
+    _normalize_endpoint_authority,
+    _check_credential_authority,
 )
+from hermes_cli.config_defaults import DEFAULT_CONFIG
 from hermes_state import SessionDB
 
 
@@ -1655,6 +1661,45 @@ class TestDispatchDelegateTask(unittest.TestCase):
         self.assertNotIn("acp_command", captured["tasks"][0])
         self.assertNotIn("acp_args", captured["tasks"][0])
 
+    def test_top_level_route_forwarded(self):
+        """The live model dispatch path must preserve the selected route."""
+        import run_agent
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            run_agent.AIAgent._dispatch_delegate_task(
+                parent,
+                {"tasks": [{"goal": "test"}], "route": "hosted"},
+            )
+
+        self.assertEqual(captured["route"], "hosted")
+
+    def test_registry_fallback_forwards_top_level_route(self):
+        """The registry fallback must match the live model dispatch path."""
+        from tools.registry import registry
+
+        captured = {}
+
+        def fake_delegate_task(**kwargs):
+            captured.update(kwargs)
+            return "{}"
+
+        parent = _make_mock_parent(depth=0)
+        with patch("tools.delegate_tool.delegate_task", fake_delegate_task):
+            registry.dispatch(
+                "delegate_task",
+                {"tasks": [{"goal": "test"}], "route": "local"},
+                parent_agent=parent,
+            )
+
+        self.assertEqual(captured["route"], "local")
+
 class TestDelegateEventEnum(unittest.TestCase):
     """Tests for DelegateEvent enum and back-compat aliases."""
 
@@ -2231,6 +2276,626 @@ class TestFallbackModelInheritance(unittest.TestCase):
                 with self.assertRaises(ValueError) as ctx:
                     _resolve_delegation_credentials(cfg, parent)
         self.assertIn("missing-acp-binary", str(ctx.exception))
+
+
+
+class TestDelegationDefaultToolsets(unittest.TestCase):
+    def _build(self, config, parent_enabled, *, role="leaf"):
+        parent = _make_mock_parent()
+        parent.enabled_toolsets = parent_enabled
+        with (
+            patch("tools.delegate_tool._load_config", return_value=config),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test",
+                context=None,
+                toolsets=None,
+                model="test-model",
+                max_iterations=5,
+                parent_agent=parent,
+                task_count=1,
+                role=role,
+            )
+        return MockAgent.call_args.kwargs
+
+    def test_absent_config_preserves_parent_inheritance(self):
+        kwargs = self._build({}, ["terminal", "file", "web"])
+        self.assertEqual(kwargs["enabled_toolsets"], ["terminal", "file", "web"])
+
+    def test_operator_route_and_toolset_defaults_are_registered(self):
+        delegation = DEFAULT_CONFIG["delegation"]
+        self.assertIsNone(delegation["default_toolsets"])
+        self.assertEqual(delegation["routes"], {})
+        self.assertIs(delegation["inherit_mcp_toolsets"], True)
+
+    def test_configured_list_narrows_parent_capabilities(self):
+        kwargs = self._build(
+            {"default_toolsets": ["file"]},
+            ["terminal", "file", "web"],
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], ["file"])
+
+    def test_configured_list_is_a_ceiling_over_inherited_mcp_toolsets(self):
+        kwargs = self._build(
+            {"default_toolsets": ["file"], "inherit_mcp_toolsets": True},
+            ["terminal", "file", "mcp-qdrant"],
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], ["file"])
+
+    def test_configured_empty_list_enables_no_child_toolsets(self):
+        kwargs = self._build(
+            {"default_toolsets": []},
+            ["terminal", "file", "web", "mcp-qdrant"],
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], [])
+
+    def test_orchestrator_without_ceiling_retains_delegation(self):
+        kwargs = self._build(
+            {"max_spawn_depth": 2, "orchestrator_enabled": True},
+            ["terminal", "file"],
+            role="orchestrator",
+        )
+        self.assertIn("delegation", kwargs["enabled_toolsets"])
+        self.assertNotIn("delegation", kwargs["disabled_toolsets"])
+
+    def test_orchestrator_empty_ceiling_blocks_delegation(self):
+        kwargs = self._build(
+            {
+                "default_toolsets": [],
+                "max_spawn_depth": 2,
+                "orchestrator_enabled": True,
+            },
+            ["terminal", "file", "delegation"],
+            role="orchestrator",
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], [])
+        self.assertIn("delegation", kwargs["disabled_toolsets"])
+
+    def test_orchestrator_ceiling_can_include_delegation(self):
+        kwargs = self._build(
+            {
+                "default_toolsets": ["file", "delegation"],
+                "max_spawn_depth": 2,
+                "orchestrator_enabled": True,
+            },
+            ["terminal", "file", "delegation"],
+            role="orchestrator",
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], ["file", "delegation"])
+        self.assertNotIn("delegation", kwargs["disabled_toolsets"])
+
+    def test_configured_list_cannot_grant_unknown_or_blocked_toolsets(self):
+        kwargs = self._build(
+            {"default_toolsets": ["file", "not-a-toolset", "delegation", "memory"]},
+            ["terminal", "file", "web"],
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], ["file"])
+        self.assertIn("delegation", kwargs["disabled_toolsets"])
+        self.assertIn("memory", kwargs["disabled_toolsets"])
+
+    def test_invalid_config_type_preserves_parent_inheritance(self):
+        kwargs = self._build(
+            {"default_toolsets": "file"},
+            ["terminal", "file", "web"],
+        )
+        self.assertEqual(kwargs["enabled_toolsets"], ["terminal", "file", "web"])
+
+
+class TestDelegationRouteSchema(unittest.TestCase):
+    def test_routes_are_absent_when_operator_configures_none(self):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            props = _build_dynamic_schema_overrides()["parameters"]["properties"]
+        self.assertNotIn("route", props)
+        self.assertNotIn("route", props["tasks"]["items"]["properties"])
+
+    def test_routes_expose_only_operator_configured_names(self):
+        from tools.delegate_tool import _build_dynamic_schema_overrides
+
+        cfg = {
+            "routes": {
+                "local": {"model": "local-model"},
+                "hosted-fast": {"model": "hosted-model", "provider": "custom"},
+                "bad route": {"model": "must-not-appear"},
+                "not-a-map": "bad",
+            }
+        }
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            props = _build_dynamic_schema_overrides()["parameters"]["properties"]
+        self.assertEqual(props["route"]["enum"], ["hosted-fast", "local"])
+        self.assertEqual(
+            props["tasks"]["items"]["properties"]["route"]["enum"],
+            ["hosted-fast", "local"],
+        )
+        self.assertNotIn("provider", props)
+        self.assertNotIn("model", props)
+        self.assertNotIn("base_url", props)
+        self.assertNotIn("api_key", props)
+        self.assertNotIn("api_mode", props)
+
+        # Dynamic schema assembly must not mutate the import-time schema or
+        # leak route names into sessions/configurations that do not define them.
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            absent_props = _build_dynamic_schema_overrides()["parameters"]["properties"]
+        self.assertNotIn("route", absent_props)
+        self.assertNotIn(
+            "route", absent_props["tasks"]["items"]["properties"]
+        )
+
+
+class TestConfiguredDelegationRoutes(unittest.TestCase):
+    def test_empty_routes_config(self):
+        self.assertEqual(_configured_delegation_routes({}), {})
+
+    def test_non_dict_routes_ignored(self):
+        self.assertEqual(_configured_delegation_routes({"routes": "bad"}), {})
+
+    def test_allowlisted_fields_only(self):
+        routes = _configured_delegation_routes({
+            "routes": {
+                "myroute": {
+                    "model": "m",
+                    "provider": "p",
+                    "base_url": "http://x/v1",
+                    "api_key": "k",
+                    "api_mode": "chat_completions",
+                    "request_overrides": {"foo": 1},  # not allowlisted
+                    "max_iterations": 99,  # not allowlisted
+                }
+            }
+        })
+        self.assertEqual(set(routes["myroute"]), {"model", "provider", "base_url", "api_key", "api_mode"})
+
+    def test_invalid_names_skipped(self):
+        routes = _configured_delegation_routes({
+            "routes": {
+                "valid-route": {"model": "m"},
+                "bad route": {"model": "m"},  # space not allowed
+                "": {"model": "m"},           # empty not allowed
+                "!bad": {"model": "m"},       # special char
+            }
+        })
+        self.assertEqual(list(routes), ["valid-route"])
+
+    def test_non_dict_entry_skipped(self):
+        routes = _configured_delegation_routes({
+            "routes": {
+                "ok": {"model": "m"},
+                "bad": "not-a-dict",
+            }
+        })
+        self.assertIn("ok", routes)
+        self.assertNotIn("bad", routes)
+
+
+class TestDelegationRoutes(unittest.TestCase):
+    @staticmethod
+    def _creds_for(cfg, _parent):
+        return {
+            "model": cfg.get("model"),
+            "provider": cfg.get("provider"),
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+            "request_overrides": None,
+            "max_output_tokens": None,
+            "command": None,
+            "args": [],
+        }
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_routes_each_child_through_named_operator_preset(
+        self, mock_creds, mock_cfg
+    ):
+        cfg = {
+            "model": "default-model",
+            "provider": "default-provider",
+            "max_iterations": 17,
+            "default_toolsets": ["file"],
+            "routes": {
+                "local": {"model": "local-model", "provider": "local-provider"},
+                "hosted": {"model": "hosted-model", "provider": "hosted-provider"},
+            },
+        }
+        mock_cfg.return_value = cfg
+        mock_creds.side_effect = self._creds_for
+        parent = _make_mock_parent()
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            children = [MagicMock(), MagicMock()]
+            for child in children:
+                child.run_conversation.return_value = {
+                    "final_response": "done",
+                    "completed": True,
+                    "api_calls": 1,
+                }
+            MockAgent.side_effect = children
+            delegate_task(
+                tasks=[
+                    {"goal": "local work", "route": "local"},
+                    {"goal": "hosted work", "route": "hosted"},
+                ],
+                parent_agent=parent,
+            )
+
+        kwargs = [call.kwargs for call in MockAgent.call_args_list]
+        self.assertEqual([item["model"] for item in kwargs], ["local-model", "hosted-model"])
+        self.assertEqual(
+            [item["provider"] for item in kwargs],
+            ["local-provider", "hosted-provider"],
+        )
+        resolved_cfgs = [call.args[0] for call in mock_creds.call_args_list]
+        self.assertNotIn("routes", resolved_cfgs[0])
+        self.assertEqual(resolved_cfgs[0]["model"], "local-model")
+        self.assertEqual(resolved_cfgs[1]["model"], "hosted-model")
+        self.assertEqual(resolved_cfgs[0]["max_iterations"], 17)
+        self.assertEqual(resolved_cfgs[0]["default_toolsets"], ["file"])
+
+    def test_top_level_route_is_batch_fallback_only(self):
+        cfg = {
+            "routes": {
+                "local": {"model": "local-model", "provider": "local-provider"},
+                "hosted": {"model": "hosted-model", "provider": "hosted-provider"},
+            }
+        }
+        parent = _make_mock_parent()
+        with (
+            patch("tools.delegate_tool._load_config", return_value=cfg),
+            patch(
+                "tools.delegate_tool._resolve_delegation_credentials",
+                side_effect=self._creds_for,
+            ),
+            patch("run_agent.AIAgent") as MockAgent,
+        ):
+            children = [MagicMock(), MagicMock()]
+            for child in children:
+                child.run_conversation.return_value = {
+                    "final_response": "done", "completed": True, "api_calls": 1
+                }
+            MockAgent.side_effect = children
+            delegate_task(
+                tasks=[
+                    {"goal": "inherits fallback"},
+                    {"goal": "explicit local", "route": "local"},
+                ],
+                route="hosted",
+                parent_agent=parent,
+            )
+        kwargs = [call.kwargs for call in MockAgent.call_args_list]
+        self.assertEqual(
+            [item["model"] for item in kwargs],
+            ["hosted-model", "local-model"],
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_unknown_route_fails_closed_before_credential_resolution(
+        self, mock_creds, mock_cfg
+    ):
+        mock_cfg.return_value = {
+            "routes": {"local": {"model": "local-model"}}
+        }
+        result = json.loads(
+            delegate_task(
+                goal="work",
+                route="attacker/provider-model",
+                parent_agent=_make_mock_parent(),
+            )
+        )
+        self.assertIn("Unknown delegation route", result["error"])
+        self.assertIn("local", result["error"])
+        mock_creds.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_later_unknown_route_fails_before_any_credential_resolution(
+        self, mock_creds, mock_cfg
+    ):
+        mock_cfg.return_value = {
+            "routes": {"local": {"model": "local-model"}}
+        }
+        result = json.loads(
+            delegate_task(
+                tasks=[
+                    {"goal": "valid first", "route": "local"},
+                    {"goal": "invalid second", "route": "attacker/provider-model"},
+                ],
+                parent_agent=_make_mock_parent(),
+            )
+        )
+        self.assertIn("Unknown delegation route", result["error"])
+        mock_creds.assert_not_called()
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_absent_route_preserves_legacy_top_level_config(
+        self, mock_creds, mock_cfg
+    ):
+        cfg = {"model": "legacy-model", "provider": "legacy-provider"}
+        mock_cfg.return_value = cfg
+        mock_creds.side_effect = self._creds_for
+        parent = _make_mock_parent()
+        with patch("run_agent.AIAgent") as MockAgent:
+            child = MagicMock()
+            child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = child
+            delegate_task(goal="legacy work", parent_agent=parent)
+        self.assertEqual(MockAgent.call_args.kwargs["model"], "legacy-model")
+        self.assertEqual(MockAgent.call_args.kwargs["provider"], "legacy-provider")
+        self.assertEqual(mock_creds.call_count, 1)
+        self.assertIs(mock_creds.call_args.args[0], cfg)
+
+    def test_resolve_delegation_route_config_overlays_route_fields(self):
+        cfg = {
+            "model": "base-model",
+            "provider": "base-provider",
+            "max_iterations": 100,
+            "routes": {
+                "fast": {"model": "fast-model", "provider": "fast-provider"},
+            },
+        }
+        effective = _resolve_delegation_route_config(cfg, "fast")
+        self.assertEqual(effective["model"], "fast-model")
+        self.assertEqual(effective["provider"], "fast-provider")
+        self.assertEqual(effective["max_iterations"], 100)
+        self.assertNotIn("routes", effective)
+
+    def test_named_route_does_not_reuse_legacy_key_for_changed_authority(self):
+        """A top-level legacy key is not explicit authority for a named route."""
+        cfg = {
+            "base_url": "https://legacy.example/v1",
+            "api_key": "LEGACY",
+            "routes": {
+                "isolated": {"base_url": "https://route.example/v1"},
+            },
+        }
+        parent = _make_mock_parent()
+        parent.base_url = "https://legacy.example/v1"
+        parent.api_key = "LEGACY"
+
+        effective = _resolve_delegation_route_config(cfg, "isolated")
+        self.assertNotIn("api_key", effective)
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_credentials(effective, parent)
+
+        self.assertIn("authority mismatch", str(ctx.exception))
+
+    def test_resolve_delegation_route_config_unknown_route_raises(self):
+        cfg = {"routes": {"local": {"model": "m"}}}
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_route_config(cfg, "nonexistent")
+        self.assertIn("Unknown delegation route", str(ctx.exception))
+        self.assertIn("local", str(ctx.exception))
+
+    def test_resolve_delegation_route_config_none_route_returns_cfg_unchanged(self):
+        cfg = {"model": "m", "routes": {"r": {"model": "r-model"}}}
+        self.assertIs(_resolve_delegation_route_config(cfg, None), cfg)
+        self.assertIs(_resolve_delegation_route_config(cfg, ""), cfg)
+        self.assertIs(_resolve_delegation_route_config(cfg, "  "), cfg)
+
+
+class TestCredentialAuthority(unittest.TestCase):
+    """Tests for endpoint credential authority enforcement."""
+
+    def test_normalize_endpoint_authority_basic(self):
+        self.assertEqual(
+            _normalize_endpoint_authority("https://api.example.com/v1"),
+            ("https", "api.example.com", 443),
+        )
+
+    def test_normalize_endpoint_authority_strips_path(self):
+        self.assertEqual(
+            _normalize_endpoint_authority("http://localhost:1234/v1/chat"),
+            ("http", "localhost", 1234),
+        )
+
+    def test_normalize_endpoint_authority_default_port_is_explicit(self):
+        self.assertEqual(
+            _normalize_endpoint_authority("https://api.example.com:443/v1"),
+            ("https", "api.example.com", 443),
+        )
+        self.assertEqual(
+            _normalize_endpoint_authority("http://api.example.com:80/v1"),
+            ("http", "api.example.com", 80),
+        )
+
+    def test_normalize_endpoint_authority_non_default_port_kept(self):
+        self.assertEqual(
+            _normalize_endpoint_authority("https://api.example.com:8443/v1"),
+            ("https", "api.example.com", 8443),
+        )
+
+    def test_bracketed_ipv6_authorities_preserve_port_boundary(self):
+        self.assertNotEqual(
+            _normalize_endpoint_authority("https://[2001:db8::1]:8443/v1"),
+            _normalize_endpoint_authority("https://[2001:db8::1:8443]/v1"),
+        )
+
+    def test_normalize_endpoint_authority_none_returns_none(self):
+        self.assertIsNone(_normalize_endpoint_authority(None))
+        self.assertIsNone(_normalize_endpoint_authority(""))
+
+    def test_same_authority_no_explicit_key_passes(self):
+        """Same scheme/host/port: parent key inheritance is safe."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        err = _check_credential_authority(
+            parent,
+            configured_base_url="https://openrouter.ai/api/v1",
+            configured_api_key=None,
+        )
+        self.assertIsNone(err)
+
+    def test_different_authority_no_explicit_key_fails(self):
+        """Changed endpoint without api_key must be rejected."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        err = _check_credential_authority(
+            parent,
+            configured_base_url="https://evil.example.com/v1",
+            configured_api_key=None,
+        )
+        self.assertIsNotNone(err)
+        self.assertIn("authority mismatch", err)
+
+    def test_different_authority_with_explicit_key_passes(self):
+        """Explicit key provided: authority restriction does not apply."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        err = _check_credential_authority(
+            parent,
+            configured_base_url="https://evil.example.com/v1",
+            configured_api_key="sk-explicit-key",
+        )
+        self.assertIsNone(err)
+
+    def test_no_base_url_skips_check(self):
+        """No configured_base_url: authority check is bypassed."""
+        parent = _make_mock_parent()
+        err = _check_credential_authority(parent, configured_base_url=None, configured_api_key=None)
+        self.assertIsNone(err)
+
+    def test_resolve_credentials_raises_on_authority_mismatch(self):
+        """_resolve_delegation_credentials raises ValueError for mismatched endpoint without key."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        cfg = {"base_url": "https://different-host.com/v1"}
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_credentials(cfg, parent)
+        self.assertIn("authority mismatch", str(ctx.exception))
+
+    def test_resolve_credentials_same_authority_inherits_key(self):
+        """Same authority without api_key resolves without error (inherits parent key)."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        cfg = {"base_url": "https://openrouter.ai/api/v1"}
+        with patch("hermes_cli.runtime_provider._detect_api_mode_for_url", return_value=None):
+            result = _resolve_delegation_credentials(cfg, parent)
+        self.assertIsNone(result["api_key"])  # inherited from parent
+
+    def test_live_parent_snapshot_drives_authority_and_child_credentials(self):
+        """Validation and construction must ignore stale credential attributes."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://stale.example/v1"
+        parent.api_key = "STALE"
+        parent._client_kwargs = {
+            "base_url": "https://live.example/v1",
+            "api_key": "LIVE",
+        }
+        cfg = {"base_url": "https://live.example/v1"}
+
+        with patch(
+            "hermes_cli.runtime_provider._detect_api_mode_for_url",
+            return_value=None,
+        ):
+            resolved = _resolve_delegation_credentials(cfg, parent)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Use the live parent route",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                override_provider=resolved["provider"],
+                override_base_url=resolved["base_url"],
+                override_api_key=resolved["api_key"],
+                override_api_mode=resolved["api_mode"],
+            )
+
+        self.assertEqual(MockAgent.call_args.kwargs["base_url"], "https://live.example/v1")
+        self.assertEqual(MockAgent.call_args.kwargs["api_key"], "LIVE")
+
+    def test_stale_surface_endpoint_cannot_receive_live_parent_key(self):
+        """A stale matching surface URL cannot bypass the live authority check."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://stale.example/v1"
+        parent.api_key = "STALE"
+        parent._client_kwargs = {
+            "base_url": "https://live.example/v1",
+            "api_key": "LIVE",
+        }
+
+        err = _check_credential_authority(
+            parent,
+            configured_base_url="https://stale.example/v1",
+            configured_api_key=None,
+        )
+
+        self.assertIsNotNone(err)
+        self.assertIn("authority mismatch", err)
+
+    def test_resolve_credentials_different_authority_with_key_succeeds(self):
+        """Changed endpoint with explicit api_key must succeed."""
+        parent = _make_mock_parent()
+        parent.base_url = "https://openrouter.ai/api/v1"
+        cfg = {"base_url": "https://other.provider.com/v1", "api_key": "explicit-key"}
+        with patch("hermes_cli.runtime_provider._detect_api_mode_for_url", return_value=None):
+            result = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(result["api_key"], "explicit-key")
+
+
+class TestRouteSchemaCache(unittest.TestCase):
+    """Cache invalidation for managed-overlay and same-(mtime_ns,size) rewrites."""
+
+    def test_managed_content_signature_included_in_tool_defs_cache_key(self):
+        """A managed-config identity change invalidates the schema cache."""
+        import model_tools
+
+        model_tools._tool_defs_cache.clear()
+        signatures = [
+            ("/managed-a/config.yaml", 1000, 100, "a" * 64),
+            ("/managed-b/config.yaml", 1000, 100, "b" * 64),
+        ]
+        with (
+            patch("model_tools._tool_defs_config_fingerprints") as fingerprints,
+            patch("model_tools.check_fn_cache_scope", return_value="test-scope"),
+            patch("model_tools._compute_tool_definitions", return_value=[]) as compute,
+        ):
+            fingerprints.side_effect = [
+                (None, signatures[0]),
+                (None, signatures[0]),
+                (None, signatures[1]),
+                (None, signatures[1]),
+            ]
+            model_tools.get_tool_definitions(quiet_mode=True)
+            model_tools.get_tool_definitions(quiet_mode=True)
+
+        self.assertEqual(compute.call_count, 2)
+
+    def test_route_schema_does_not_mutate_import_time_schema(self):
+        """_build_dynamic_schema_overrides must not modify DELEGATE_TASK_SCHEMA."""
+        from tools.delegate_tool import _build_dynamic_schema_overrides, DELEGATE_TASK_SCHEMA
+        import copy as _copy
+
+        original = _copy.deepcopy(DELEGATE_TASK_SCHEMA)
+        cfg = {
+            "routes": {
+                "fast": {"model": "fast-model", "provider": "custom"},
+            }
+        }
+        with patch("tools.delegate_tool._load_config", return_value=cfg):
+            _build_dynamic_schema_overrides()
+
+        # Static schema must be unchanged
+        self.assertEqual(DELEGATE_TASK_SCHEMA, original)
+
+        # Subsequent call without routes must not see leftovers
+        with patch("tools.delegate_tool._load_config", return_value={}):
+            props = _build_dynamic_schema_overrides()["parameters"]["properties"]
+        self.assertNotIn("route", props)
+        self.assertNotIn("route", props["tasks"]["items"]["properties"])
 
 
 if __name__ == "__main__":

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -17,6 +17,7 @@ The parent's context only sees the delegation call and the summary result,
 never the child's intermediate tool calls or reasoning.
 """
 
+import copy
 import enum
 import contextvars
 import json
@@ -41,9 +42,14 @@ from agent.interrupt_compat import request_hard_interrupt
 # not natively known (named custom providers, third-party aggregators, etc.).
 # Must match hermes_cli.runtime_provider.RUNTIME_PROVIDER_TYPE_CUSTOM.
 _RUNTIME_PROVIDER_CUSTOM = "custom"
+
+_DELEGATION_ROUTE_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
+_DELEGATION_ROUTE_FIELDS = frozenset(
+    {"model", "provider", "base_url", "api_key", "api_mode"}
+)
 from tools import file_state
 from tools.terminal_tool import set_approval_callback as _set_subagent_approval_cb
-from utils import base_url_hostname, is_truthy_value
+from utils import base_url_hostname, base_url_origin, is_truthy_value
 
 
 # Tools that children must never have access to
@@ -1742,6 +1748,14 @@ def _inherit_parent_base_url(parent_agent, fallback_base_url: Optional[str]) -> 
     return fallback_base_url or None
 
 
+def _inherit_parent_api_key(parent_agent) -> Optional[str]:
+    """Return the API key from the parent's live client snapshot when present."""
+    client_kwargs = getattr(parent_agent, "_client_kwargs", None)
+    if isinstance(client_kwargs, dict) and "api_key" in client_kwargs:
+        return client_kwargs.get("api_key")
+    return getattr(parent_agent, "api_key", None)
+
+
 def _build_child_agent(
     task_index: int,
     goal: str,
@@ -1819,13 +1833,33 @@ def _build_child_agent(
     else:
         parent_toolsets = set(DEFAULT_TOOLSETS)
 
-    if toolsets:
+    # Operator-owned defaults can narrow every child without exposing toolset
+    # selection to the model. Absent or malformed config preserves the legacy
+    # parent-inheritance behavior. A configured empty list intentionally gives
+    # leaf children no enabled toolsets.
+    configured_default_toolsets = delegation_cfg.get("default_toolsets")
+    if toolsets is None and isinstance(configured_default_toolsets, list):
+        using_configured_default_toolsets = True
+        requested_toolsets: Optional[List[str]] = [
+            item.strip()
+            for item in configured_default_toolsets
+            if isinstance(item, str) and item.strip()
+        ]
+    else:
+        using_configured_default_toolsets = False
+        requested_toolsets = toolsets
+
+    if requested_toolsets is not None:
         # Intersect with parent — subagent must not gain tools the parent lacks.
         # Expand composite toolsets (e.g. hermes-cli) so that individual
         # toolset names (e.g. web, terminal) are recognised during intersection.
         expanded_parent = _expand_parent_toolsets(parent_toolsets)
-        child_toolsets = [t for t in toolsets if t in expanded_parent]
-        if _get_inherit_mcp_toolsets():
+        child_toolsets = [t for t in requested_toolsets if t in expanded_parent]
+        # An operator-owned default is a hard ceiling over every toolset,
+        # including MCP. Preserve legacy MCP inheritance only for explicit
+        # per-child narrowing; otherwise an omitted MCP name would silently
+        # widen the configured ceiling.
+        if not using_configured_default_toolsets and _get_inherit_mcp_toolsets():
             child_toolsets = _preserve_parent_mcp_toolsets(
                 child_toolsets, parent_toolsets
             )
@@ -1842,14 +1876,21 @@ def _build_child_agent(
     # carry useful tools too. Pass exact one-tool deny toolsets through to the
     # child so model_tools subtracts the blocked names AFTER composite
     # expansion, and the restriction survives later registry/MCP refreshes.
+    orchestrator_delegation_allowed = effective_role == "orchestrator" and (
+        not using_configured_default_toolsets
+        or (
+            "delegation" in (requested_toolsets or [])
+            and "delegation" in _expand_parent_toolsets(parent_toolsets)
+        )
+    )
     raw_parent_disabled = getattr(parent_agent, "disabled_toolsets", None)
     if isinstance(raw_parent_disabled, (list, tuple, set)):
         inherited_disabled = [str(name) for name in raw_parent_disabled]
     else:
         inherited_disabled = []
-    if effective_role == "orchestrator":
-        # Role grants delegate_task explicitly, matching the unconditional
-        # delegation toolset re-add below.
+    if orchestrator_delegation_allowed:
+        # The orchestrator role grants delegate_task unless an operator-owned
+        # default_toolsets ceiling omits it.
         inherited_disabled = [
             name for name in inherited_disabled if name != "delegation"
         ]
@@ -1858,12 +1899,12 @@ def _build_child_agent(
             inherited_disabled + _blocked_toolsets_for_role(effective_role) + ["kanban"]
         )
     )
+    if not orchestrator_delegation_allowed:
+        child_disabled_toolsets = list(
+            dict.fromkeys(child_disabled_toolsets + ["delegation"])
+        )
 
-    # Orchestrators retain the 'delegation' toolset that _strip_blocked_tools
-    # removed.  The re-add is unconditional on parent-toolset membership because
-    # orchestrator capability is granted by role, not inherited — see the
-    # test_intersection_preserves_delegation_bound test for the design rationale.
-    if effective_role == "orchestrator" and "delegation" not in child_toolsets:
+    if orchestrator_delegation_allowed and "delegation" not in child_toolsets:
         child_toolsets.append("delegation")
 
     workspace_hint = _resolve_workspace_hint(parent_agent)
@@ -1875,10 +1916,9 @@ def _build_child_agent(
         max_spawn_depth=max_spawn,
         child_depth=child_depth,
     )
-    # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
-    parent_api_key = getattr(parent_agent, "api_key", None)
-    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
-        parent_api_key = parent_agent._client_kwargs.get("api_key")
+    # Inherit credentials from the live client-construction snapshot. Surface
+    # attributes can remain stale after an in-process endpoint/key rotation.
+    parent_api_key = _inherit_parent_api_key(parent_agent)
 
     # Resolve the child's effective model early so it can ride on every event.
     effective_model_for_cb = model or getattr(parent_agent, "model", None)
@@ -3926,6 +3966,7 @@ def delegate_task(
     tasks: Optional[List[Dict[str, Any]]] = None,
     max_iterations: Optional[int] = None,
     role: Optional[str] = None,
+    route: Optional[str] = None,
     background: Optional[bool] = None,
     output_schema: Optional[Dict[str, Any]] = None,
     action: Optional[str] = None,
@@ -3939,8 +3980,8 @@ def delegate_task(
     already-running ones.
 
     Spawn modes (action='spawn' or omitted):
-      - Single: provide goal (+ optional context and role)
-      - Batch:  provide tasks array [{goal, context, role}, ...]
+      - Single: provide goal (+ optional context, role, and configured route)
+      - Batch:  provide tasks array [{goal, context, role, route}, ...]
 
     Control modes (synchronous, never backgrounded):
       - action='list'  -> live children of this conversation's spawn tree
@@ -3952,6 +3993,8 @@ def delegate_task(
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+    In batch mode, routes are selected per task; the top-level route is only
+    used as a fallback when a task omits its own route.
 
     Returns JSON with results array, one entry per task.
     """
@@ -4021,25 +4064,9 @@ def delegate_task(
         )
     effective_max_iter = default_max_iter
 
-    # Resolve delegation credentials (provider:model pair).
-    # When delegation.provider is configured, this resolves the full credential
-    # bundle (base_url, api_key, api_mode) via the same runtime provider system
-    # used by CLI/gateway startup.  When unconfigured, returns None values so
-    # children inherit from the parent.
-    #
-    # ``credentials_cfg`` (internal callers only — never model-facing) is a
-    # per-call override shaped like the delegation config section
-    # ({provider, model, base_url, api_key, api_mode}); the /review engine
-    # uses it to route its reviewer subagent onto ``auxiliary.review``
-    # without touching the global delegation pin.
-    try:
-        creds = _resolve_delegation_credentials(
-            credentials_cfg if credentials_cfg else cfg, parent_agent
-        )
-    except ValueError as exc:
-        return tool_error(str(exc))
-
-    # Normalize to task list
+    # Normalize to task list first, then resolve per-task routes and credentials.
+    # Route validation runs across all tasks before any credential lookup so a
+    # later invalid route does not trigger provider resolution for earlier valid tasks.
     max_children = _get_max_concurrent_children()
     recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
     if tasks_error:
@@ -4065,7 +4092,12 @@ def delegate_task(
             )
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
-        single_task: Dict[str, Any] = {"goal": goal, "context": context, "role": top_role}
+        single_task: Dict[str, Any] = {
+            "goal": goal,
+            "context": context,
+            "role": top_role,
+            "route": route,
+        }
         if output_schema is not None:
             single_task["output_schema"] = output_schema
         task_list = [single_task]
@@ -4115,6 +4147,32 @@ def delegate_task(
             return tool_error(f"Task {i} output_schema invalid: {schema_err}")
         task_schemas.append(coerced_schema)
 
+    # Validate every route before resolving any credentials. This keeps a later
+    # invalid batch item from triggering provider lookup, credential loading, or
+    # any other route-specific side effect for an earlier valid item.
+    base_credentials_cfg = credentials_cfg if credentials_cfg else cfg
+    effective_routes: List[Optional[str]] = [
+        task.get("route") or route for task in task_list
+    ]
+    try:
+        route_cfgs = [
+            _resolve_delegation_route_config(base_credentials_cfg, effective_route)
+            for effective_route in effective_routes
+        ]
+    except ValueError as exc:
+        return tool_error(str(exc))
+
+    # Resolve each child's provider:model bundle independently only after the
+    # whole batch's operator-owned route names have passed validation.
+    task_creds: List[Dict[str, Any]] = []
+    try:
+        for route_cfg in route_cfgs:
+            task_creds.append(
+                _resolve_delegation_credentials(route_cfg, parent_agent)
+            )
+    except ValueError as exc:
+        return tool_error(str(exc))
+
     overall_start = time.monotonic()
     results = []
 
@@ -4133,8 +4191,21 @@ def delegate_task(
         wrap_progress_callback,
     )
 
+    manifest_identities = [
+        (
+            item.get("model") or getattr(parent_agent, "model", None),
+            item.get("provider") or getattr(parent_agent, "provider", None),
+        )
+        for item in task_creds
+    ]
+    manifest_model, manifest_provider = manifest_identities[0]
+    if len(set(manifest_identities)) != 1:
+        manifest_model = manifest_provider = "mixed"
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
-        task_list, context, model=creds.get("model"), provider=creds.get("provider")
+        task_list,
+        context,
+        model=manifest_model,
+        provider=manifest_provider,
     )
     # Announce the batch tag once so the later ``[tag n/N]`` completion lines
     # (and any nested batch's lines interleaving with them) are attributable.
@@ -4177,6 +4248,7 @@ def delegate_task(
     # subagent-lifecycle API).
     children = []
     for i, t in enumerate(task_list):
+        creds = task_creds[i]
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
@@ -4816,6 +4888,112 @@ def _merge_request_overrides(runtime_overrides, explicit_overrides):
     return merged or None
 
 
+
+def _normalize_endpoint_authority(
+    url: Optional[str],
+) -> Optional[tuple[str, str, int]]:
+    """Return normalized ``(scheme, host, port)`` authority for *url*.
+
+    Reuse the shared origin parser so default ports, trailing dots, bare hosts,
+    and IPv6 literals have one unambiguous representation. A formatted string
+    can collapse an IPv6 host and port into the same text as a different IPv6
+    host, which is unsafe for credential-boundary comparisons.
+    """
+    if not url:
+        return None
+    origin = base_url_origin(str(url))
+    return origin if origin[1] else None
+
+
+def _check_credential_authority(
+    parent_agent,
+    configured_base_url: Optional[str],
+    configured_api_key: Optional[str],
+) -> Optional[str]:
+    """Validate API-key inheritance for a direct-endpoint delegation.
+
+    Rules:
+    - Same normalized scheme/host/port as the parent's active endpoint →
+      inheriting the parent's raw API key is safe; return None (no error).
+    - Different authority → the route MUST supply its own api_key (either
+      an explicit ``delegation.api_key`` or an env-var ref); if none is
+      present, returns an error string so the caller can fail closed.
+    - No configured_base_url → not a direct-endpoint delegation; skip.
+
+    This enforces that a route endpoint change cannot silently forward an
+    unrelated top-level key to a third-party endpoint.
+    """
+    if not configured_base_url:
+        return None  # not a direct-endpoint delegation
+    if configured_api_key:
+        return None  # explicit key provided; authority does not matter
+
+    parent_url = _inherit_parent_base_url(
+        parent_agent, getattr(parent_agent, "base_url", None)
+    )
+    child_auth = _normalize_endpoint_authority(configured_base_url)
+    parent_auth = _normalize_endpoint_authority(parent_url)
+
+    if child_auth and parent_auth and child_auth == parent_auth:
+        return None  # same authority → key inheritance is safe
+
+    # Different authority and no explicit key: fail closed.
+    return (
+        f"Delegation route endpoint '{configured_base_url}' differs from the "
+        f"parent endpoint (authority mismatch: {child_auth!r} vs {parent_auth!r}). "
+        "Provide an explicit 'api_key' for this route (use ${ENV_VAR} for secrets) "
+        "or ensure the route uses the same scheme/host/port as the parent."
+    )
+
+
+def _configured_delegation_routes(cfg: dict) -> Dict[str, Dict[str, Any]]:
+    """Return valid operator-owned route presets from delegation.routes."""
+    raw_routes = cfg.get("routes")
+    if not isinstance(raw_routes, dict):
+        return {}
+    routes: Dict[str, Dict[str, Any]] = {}
+    for raw_name, raw_route in raw_routes.items():
+        if not isinstance(raw_name, str) or not _DELEGATION_ROUTE_NAME_RE.fullmatch(raw_name):
+            continue
+        if not isinstance(raw_route, dict):
+            continue
+        routes[raw_name] = {
+            key: value
+            for key, value in raw_route.items()
+            if key in _DELEGATION_ROUTE_FIELDS
+        }
+    return routes
+
+
+def _resolve_delegation_route_config(
+    cfg: dict, route_name: Optional[str]
+) -> dict:
+    """Resolve a named route as an isolated operator-owned route bundle.
+
+    Non-routing delegation settings (budgets, toolset ceilings, concurrency)
+    carry into the selected route. Routing and credential fields do not: a
+    named route must explicitly bind its own endpoint key rather than silently
+    inheriting a top-level key configured for another authority.
+    """
+    if route_name is None or not str(route_name).strip():
+        return cfg
+    route_name = str(route_name).strip()
+    routes = _configured_delegation_routes(cfg)
+    if route_name not in routes:
+        available = ", ".join(sorted(routes)) or "none"
+        raise ValueError(
+            f"Unknown delegation route '{route_name}'. "
+            f"Configured routes: {available}."
+        )
+    effective = {
+        key: copy.deepcopy(value)
+        for key, value in cfg.items()
+        if key != "routes" and key not in _DELEGATION_ROUTE_FIELDS
+    }
+    effective.update(copy.deepcopy(routes[route_name]))
+    return effective
+
+
 def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     """Resolve credentials for subagent delegation.
 
@@ -4891,6 +5069,14 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         # (e.g. MINIMAX_API_KEY, DASHSCOPE_API_KEY) work without requiring
         # callers to duplicate the key under delegation.api_key.
         api_key = configured_api_key  # None → inherited from parent in _build_child_agent
+
+        # Endpoint credential authority check: inheriting the parent's raw key
+        # is only safe when the route targets the same scheme/host/port.
+        # A changed endpoint must supply its own key or fail closed — the
+        # parent's key must not be forwarded to an unrelated third-party host.
+        _auth_err = _check_credential_authority(parent_agent, configured_base_url, configured_api_key)
+        if _auth_err:
+            raise ValueError(_auth_err)
 
         # Use the shared URL-based api_mode detector (same path the main agent's
         # runtime resolver uses) so Anthropic-compatible direct endpoints with a
@@ -5205,12 +5391,40 @@ def _build_dynamic_schema_overrides() -> dict:
     overrides_params["properties"] = {
         k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
     }
+    overrides_params["properties"]["tasks"] = copy.deepcopy(
+        DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]
+    )
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
+
+    route_names = sorted(_configured_delegation_routes(_load_config()))
+    if route_names:
+        route_schema = {
+            "type": "string",
+            "enum": route_names,
+            "description": (
+                "Select an operator-configured delegation route. Only the "
+                "listed route names are accepted; provider/model endpoints "
+                "remain controlled by config.yaml."
+            ),
+        }
+        overrides_params["properties"]["route"] = dict(route_schema)
+        overrides_params["properties"]["route"]["description"] = (
+            "Route for single-task mode. " + route_schema["description"]
+        )
+        overrides_params["properties"]["tasks"]["items"]["properties"][
+            "route"
+        ] = dict(route_schema)
+        overrides_params["properties"]["tasks"]["items"]["properties"][
+            "route"
+        ]["description"] = (
+            "Per-task route override. " + route_schema["description"]
+        )
 
     return {
         "description": _build_top_level_description(),
         "parameters": overrides_params,
     }
+
 
 
 DELEGATE_TASK_SCHEMA = {
@@ -5371,6 +5585,7 @@ registry.register(
         goal=args.get("goal"),
         context=args.get("context"),
         tasks=_strip_model_hidden_task_fields(args.get("tasks")),
+        route=args.get("route"),
         max_iterations=args.get("max_iterations"),
         role=args.get("role"),
         background=_model_background_value(args, kw.get("parent_agent")),

--- a/utils.py
+++ b/utils.py
@@ -20,6 +20,34 @@ logger = logging.getLogger(__name__)
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
 
 
+def read_file_with_signature(
+    path: Union[Path, str],
+) -> "tuple[bytes, tuple[str, int, int, str]] | None":
+    """Read a file once and return its bytes with a content-aware identity."""
+    import hashlib
+
+    candidate = Path(path)
+    try:
+        resolved = str(candidate.resolve(strict=False))
+        with candidate.open("rb") as handle:
+            data = handle.read()
+            stat_result = os.fstat(handle.fileno())
+    except OSError:
+        return None
+    return data, (
+        resolved,
+        stat_result.st_mtime_ns,
+        stat_result.st_size,
+        hashlib.sha256(data).hexdigest(),
+    )
+
+
+def file_content_signature(path: Union[Path, str]) -> "tuple[str, int, int, str] | None":
+    """Return a path- and content-sensitive identity for a regular file."""
+    snapshot = read_file_with_signature(path)
+    return snapshot[1] if snapshot is not None else None
+
+
 def is_truthy_value(value: Any, default: bool = False) -> bool:
     """Coerce bool-ish values using the project's shared truthy string set."""
     if value is None:

--- a/utils.py
+++ b/utils.py
@@ -32,7 +32,7 @@ def read_file_with_signature(
         with candidate.open("rb") as handle:
             data = handle.read()
             stat_result = os.fstat(handle.fileno())
-    except OSError:
+    except (OSError, RuntimeError):
         return None
     return data, (
         resolved,

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -190,7 +190,23 @@ delegation:
 
 Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then `delegation.provider` (full credential bundle resolved via the runtime provider system), and when neither is set children inherit the parent's provider and credentials; `delegation.model` applies in all cases, and when it is empty children inherit the parent's model. Setting `delegation.provider` alongside `delegation.base_url` keeps the explicit endpoint but carries that provider's request overrides and max output tokens into the child. An explicit `delegation.request_overrides` dict is honored on every branch and merges over those runtime-derived values (see [Configuration](#configuration) below).
 
-Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
+The raw provider/model/endpoint fields remain operator-owned: `delegate_task` does not accept them. For a small set of approved alternatives, configure named `delegation.routes` presets and let the model select only a route name, globally or per task. A per-task route overrides the top-level route fallback; tasks without either use the legacy top-level delegation settings.
+
+```yaml
+delegation:
+  routes:
+    local:
+      model: "qwen2.5-coder"
+      base_url: "http://localhost:1234/v1"
+      api_key: ${LOCAL_ROUTER_API_KEY}
+    hosted-fast:
+      model: "google/gemini-flash-2.0"
+      provider: "openrouter"
+```
+
+Only valid configured names appear in the tool schema. Unknown names fail before credential resolution, and route entries may override only `model`, `provider`, `base_url`, `api_key`, and `api_mode`. Keep route secrets in environment variables and reference them with `${VAR_NAME}`; do not commit literal API keys.
+
+**Credential authority:** a route that changes the endpoint (`base_url`) must supply its own `api_key`; the parent's key is forwarded only when the scheme, host, and port are identical. A route with a different authority and no explicit key is rejected before any child is spawned.
 
 ## The `/review` Command
 
@@ -227,7 +243,7 @@ Credentials resolve exactly like a `delegation.provider` pin (full runtime-provi
 
 ## Inherited Tool Access
 
-`delegate_task` does not accept a model-facing `toolsets` parameter. Each subagent inherits the parent's enabled toolsets so the model cannot grant a child capabilities that the parent does not have. Configure the parent's tools before starting the conversation if delegated work needs additional capabilities.
+`delegate_task` does not accept a model-facing `toolsets` parameter. By default, each subagent inherits the parent's enabled toolsets. Operators can narrow all children with `delegation.default_toolsets`; the configured list is intersected with the parent's capabilities, so it cannot grant new access. The list is a hard ceiling over every child toolset, including inherited MCP toolsets. Omit the key to preserve inheritance, or use `[]` to give children no enabled toolsets.
 
 Certain tools are blocked for subagents even when the parent has them:
 - `delegate_task` — blocked for leaf subagents (the default). Retained for `role="orchestrator"` children, bounded by `max_spawn_depth` — see [Depth Limit and Nested Orchestration](#depth-limit-and-nested-orchestration) below.


### PR DESCRIPTION
## What does this PR do?

Adds operator-controlled delegation routes while preserving the existing direct-endpoint path. Named routes can select child provider/model/base URL, bound credentials, and child toolset ceilings. The extraction also hardens config/route/tool-schema cache identity so a long-lived process observes file changes without leaking state across route or path aliases.

Credential forwarding is authority-bound: raw parent credentials are retained only when normalized `(scheme, host, port)` authority is unchanged. Changed authorities require endpoint-bound credentials. Authorities are compared structurally, including IPv6 hosts.

## Related Issue

No linked issue. This is a focused extraction from previously audited work.

## Type of Change

- [x] Bug fix
- [x] New feature
- [x] Security fix

## Changes Made

- add named delegation routes and route validation in `tools/delegate_tool.py`
- add parent/operator ceilings for child toolsets
- add route-aware, content-aware cache identities for config and resolved tool schemas
- canonicalize config reader/writer cache keys across relative, absolute, and symlinked paths
- preserve `${ENV_REF}` templates when config is loaded and saved through a symlinked Hermes home
- compare credential endpoint authorities as normalized tuples rather than serialized URLs
- document route configuration and add focused regression coverage

## Current revision

- Head: `d87011e411241e3447953b7c61ce8315497a2875`
- Rebase target / merge-base: `561b053f794a1781868bb032029d589c67708119`

## How to Test

On this exact revision:

```bash
HERMES_PYTHON=/home/jack/.venvs/gepa/bin/python \
scripts/run_tests.sh \
  tests/hermes_cli/test_config.py \
  tests/hermes_cli/test_config_env_refs.py \
  tests/hermes_cli/test_config_env_expansion.py \
  tests/hermes_cli/test_managed_scope.py \
  tests/hermes_cli/test_managed_scope_config.py \
  tests/test_get_tool_definitions_cache_isolation.py \
  tests/tools/test_delegate.py
```

Result: **276 passed, 0 failed, 4 skipped**. The skipped cases are existing `windows_only` tests on Linux.

Additional checks:

```bash
python -m ruff check hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_env_refs.py
python -m py_compile hermes_cli/config.py tests/hermes_cli/test_config.py tests/hermes_cli/test_config_env_refs.py
git diff --check
```

All passed.

## Scope limits
- Named routes extend rather than replace pre-existing direct-endpoint behavior.
- No raw parent credential crosses a changed normalized scheme/host/port without endpoint-bound credentials.
- No live remote-provider validation is claimed.
- Symlink regressions skip when the host or test account cannot create symlinks.

## Independent review

Submitted-head correctness and architecture reviews found no blocker. The final head also refreshes returned-definition metadata on the oscillation-cache fallback and treats symlink-loop `RuntimeError` as an unreadable route/config path.

The final revision is authored and committed as `Jack Field <3956838+jdot-dev@users.noreply.github.com>`.

## Provenance

Clean extraction originally cut from `NousResearch/hermes-agent@48c0c3a873bc5adaf20c632b5b7630a4fac000b4`, then rebased onto pinned publication base `561b053f794a1781868bb032029d589c67708119`.

## Checklist

- [x] Read the contributing guide
- [x] Conventional commit messages
- [x] Searched existing upstream PRs by this author
- [x] Focused logical change only
- [x] Added behavior and regression tests
- [x] Tested on Linux
- [x] Considered Windows/macOS impact; symlink-dependent tests skip where unsupported
- [x] Updated relevant user documentation
- [x] No new dependency or core model tool
