### PR TITLE
fix(discord): honor channel-scoped profile_routes in gateway_platform_event fire-sites

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1714,6 +1714,7 @@ class DiscordAdapter(BasePlatformAdapter):
         user_name: Optional[str],
         thread_id: Optional[str],
         guild_id: Optional[str],
+        parent_chat_id: Optional[str] = None,
         message_id: Optional[str] = None,
     ):
         """Build the internal SessionSource the gateway authorizes against.
@@ -1721,6 +1722,10 @@ class DiscordAdapter(BasePlatformAdapter):
         Raises ``ValueError`` when the actor or chat identity is missing so the
         post-auth boundary fails closed instead of authorizing an incomplete
         source (mirrors the Telegram reaction extractor).
+
+        ``parent_chat_id`` feeds profile_routes matching in build_source,
+        exactly as the message and slash-command paths pass it — without it a
+        channel-scoped route never matches a thread-keyed event (#69178).
         """
         if not user_id or not chat_id:
             raise ValueError(
@@ -1733,6 +1738,7 @@ class DiscordAdapter(BasePlatformAdapter):
             user_name=user_name,
             thread_id=thread_id,
             guild_id=guild_id,
+            parent_chat_id=parent_chat_id,
             message_id=message_id,
         )
 
@@ -1795,12 +1801,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     ),
                 },
             }
+            parent_chat_id = self._get_parent_channel_id(
+                getattr(message, "channel", None)
+            )
             source = self._source_for_platform_event(
                 chat_id=str(chat_id),
                 user_id=str(getattr(author, "id", "") or "") or None,
                 user_name=getattr(author, "display_name", None),
                 thread_id=thread_id,
                 guild_id=str(getattr(guild, "id", "")) if guild else None,
+                parent_chat_id=parent_chat_id,
                 message_id=str(message_id),
             )
         except Exception:
@@ -1840,12 +1850,16 @@ class DiscordAdapter(BasePlatformAdapter):
                     "author_id": str(getattr(author, "id", "") or "")[:128] or None,
                 },
             }
+            parent_chat_id = self._get_parent_channel_id(
+                getattr(message, "channel", None)
+            )
             source = self._source_for_platform_event(
                 chat_id=str(chat_id),
                 user_id=str(getattr(author, "id", "") or "") or None,
                 user_name=getattr(author, "display_name", None),
                 thread_id=thread_id,
                 guild_id=str(getattr(guild, "id", "")) if guild else None,
+                parent_chat_id=parent_chat_id,
                 message_id=str(message_id),
             )
         except Exception:
@@ -1883,6 +1897,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 user_name=None,
                 thread_id=str(thread_id),
                 guild_id=str(getattr(guild, "id", "")) if guild else None,
+                parent_chat_id=str(parent_id) if parent_id is not None else None,
             )
         except Exception:
             logger.debug(
@@ -1929,6 +1944,7 @@ class DiscordAdapter(BasePlatformAdapter):
                 user_name=None,
                 thread_id=str(thread_id),
                 guild_id=str(getattr(guild, "id", "")) if guild else None,
+                parent_chat_id=str(parent_id) if parent_id is not None else None,
             )
         except Exception:
             logger.debug(

--- a/tests/gateway/test_discord_platform_events.py
+++ b/tests/gateway/test_discord_platform_events.py
@@ -86,10 +86,11 @@ def _adapter() -> DiscordAdapter:
     return a
 
 
-def _channel(chan_id=555, thread=False):
+def _channel(chan_id=555, thread=False, parent_id=None):
     if thread:
         chan = _DiscordThread()
         chan.id = chan_id
+        chan.parent_id = parent_id
         return chan
     return SimpleNamespace(id=chan_id)
 
@@ -386,3 +387,91 @@ class TestRunnerBoundaryIntegration:
         assert args == ("gateway_platform_event",)
         assert kwargs["platform"] == "discord"
         assert kwargs["event_type"] == "message_edited"
+
+
+class TestProfileRouting:
+    """A channel-scoped profile_routes entry (no explicit guild_id) must
+    resolve for thread-keyed gateway_platform_event fire-sites exactly as it
+    does for messages and slash commands: the route's chat_id matches the
+    THREAD's parent channel id via parent_chat_id, not the thread id itself
+    (#69178, #91633 follow-up — the fire-sites built their source with no
+    parent_chat_id at all)."""
+
+    @staticmethod
+    def _routed_adapter(parent_channel_id="200"):
+        from gateway import run as gateway_run
+        from gateway.config import GatewayConfig
+        from gateway.profile_routing import ProfileRoute
+
+        a = _adapter()
+        runner = object.__new__(gateway_run.GatewayRunner)
+        runner.config = GatewayConfig(
+            multiplex_profiles=True,
+            profile_routes=[
+                ProfileRoute(
+                    name="work", profile="work", platform="discord",
+                    chat_id=parent_channel_id,
+                )
+            ],
+        )
+        import pytest as _pytest
+        monkeypatch = _pytest.MonkeyPatch()
+        monkeypatch.setattr(gateway_run, "_multiplex_profile_homes", lambda _cfg: [("work", None)])
+        a.gateway_runner = runner
+        return a, monkeypatch
+
+    def test_message_edit_in_thread_routes_by_parent_channel(self):
+        a, monkeypatch = self._routed_adapter(parent_channel_id="200")
+        try:
+            seen = _capture(a)
+            after = _message(chan=_channel(chan_id=888, thread=True, parent_id=200))
+
+            asyncio.run(a._on_platform_message_edit(None, after))
+
+            _event, source = seen[0]
+            assert source.parent_chat_id == "200"
+            assert source.profile == "work"
+        finally:
+            monkeypatch.undo()
+
+    def test_message_delete_in_thread_routes_by_parent_channel(self):
+        a, monkeypatch = self._routed_adapter(parent_channel_id="200")
+        try:
+            seen = _capture(a)
+            msg = _message(chan=_channel(chan_id=888, thread=True, parent_id=200))
+
+            asyncio.run(a._on_platform_message_delete(msg))
+
+            _event, source = seen[0]
+            assert source.parent_chat_id == "200"
+            assert source.profile == "work"
+        finally:
+            monkeypatch.undo()
+
+    def test_thread_create_routes_by_parent_channel(self):
+        a, monkeypatch = self._routed_adapter(parent_channel_id="555")
+        try:
+            seen = _capture(a)
+
+            asyncio.run(a._on_platform_thread_create(_thread_obj(parent_id=555)))
+
+            _event, source = seen[0]
+            assert source.parent_chat_id == "555"
+            assert source.profile == "work"
+        finally:
+            monkeypatch.undo()
+
+    def test_thread_renamed_routes_by_parent_channel(self):
+        a, monkeypatch = self._routed_adapter(parent_channel_id="555")
+        try:
+            seen = _capture(a)
+            before = _thread_obj(name="old name", parent_id=555)
+            after = _thread_obj(name="new name", parent_id=555)
+
+            asyncio.run(a._on_platform_thread_update(before, after))
+
+            _event, source = seen[0]
+            assert source.parent_chat_id == "555"
+            assert source.profile == "work"
+        finally:
+            monkeypatch.undo()


### PR DESCRIPTION
## Summary

Today's `0437fe66f7` fixed `_build_slash_event`/`_dispatch_thread_session` to pass `guild_id`/`parent_chat_id` into `build_source(...)`, because route matching in `gateway/profile_routing.py`'s `ProfileRoute.matches()` needs `parent_chat_id` to match a channel-scoped `profile_routes` entry (no explicit `guild_id`) against a Discord *thread* event — a thread's channel id differs from its parent channel's id, and a route configured with the parent channel id only matches via `parent_chat_id`.

The same gap remained in the four Discord `gateway_platform_event` fire-sites: `message_edited`, `message_deleted`, `thread_created`, and `thread_renamed`. `_source_for_platform_event` built its `SessionSource` with no `parent_chat_id` at all, so a channel-scoped `profile_routes` entry silently fails to match these events and they route to the default profile instead of the intended one.

## Fix

- Added a `parent_chat_id` parameter to `_source_for_platform_event`, threaded straight into `build_source(...)`.
- `_on_platform_message_edit` / `_on_platform_message_delete`: compute `parent_chat_id` via the existing `_get_parent_channel_id(channel)` helper (same helper the already-fixed slash-command path uses), since these two functions had no parent-id computation at all.
- `_on_platform_thread_create` / `_on_platform_thread_update`: pass through the `parent_id` these functions **already compute** for the event payload dict (`payload["parent_chat_id"]`) — no new lookup needed, just reuse.

## Reachability / severity

Narrow: only affects installs that (a) configure a **channel-scoped** `profile_routes` entry (no explicit `guild_id`) under `gateway.multiplex_profiles`, **and** (b) have a plugin subscribed to `gateway_platform_event` for one of these four Discord event types. When both conditions hold, the affected events are misrouted to the default profile's session/config instead of the routed one.

## Tests

Added `TestProfileRouting` to `tests/gateway/test_discord_platform_events.py` — one test per event type (`message_edited`, `message_deleted`, `thread_created`, `thread_renamed`), each asserting a channel-scoped route (matching the *parent* channel, not the thread) resolves `source.profile` correctly. The existing tests in this file only asserted the event payload dict, never routing.

```
tests/gateway/test_discord_platform_events.py .....................  [21 passed, 4 new]
tests/gateway/test_discord_slash_commands.py ..................      [14 passed, unaffected]
```

**Mutation-verify:** reverted the `adapter.py` fix (kept the new tests) — all 4 new `TestProfileRouting` tests failed with `assert None == "<parent_id>"` (i.e. `source.parent_chat_id` stayed `None` and `source.profile` never resolved to the routed profile). Restored the fix — all 21 tests pass again.

## Competitor check

Searched `_source_for_platform_event`, `discord parent_chat_id`, `discord thread_created profile`, `gateway_platform_event profile_routes`, `discord message_edited routing` — no open/closed PR touches these four fire-sites or `_source_for_platform_event`. One superficially similar result, #38248 ("bind thread sessions to parent channel"), is a stale PR reworking `_build_slash_event`/`_dispatch_thread_session` (the functions today's `0437fe66f7` already fixed on `main`) — it never touches `_on_platform_message_edit`/`_on_platform_message_delete`/`_on_platform_thread_create`/`_on_platform_thread_update`/`_source_for_platform_event`, so it does not overlap this PR's scope.

## Checklist

- [x] Read the current file and confirmed the gap empirically (not from assumption)
- [x] Reused existing helpers (`_get_parent_channel_id`, the already-computed `parent_id`) rather than introducing new lookups
- [x] Regression tests added, mutation-verified (fail without fix, pass with fix)
- [x] Fresh competitor search immediately before push — clean