### PR TITLE
fix(copilot-acp): stop completion.model impersonating a model that never ran

### DIFF
--- a/agent/copilot_acp_client.py
+++ b/agent/copilot_acp_client.py
@@ -438,7 +438,7 @@ class CopilotACPClient:
             _numeric = [float(v) for v in _candidates if isinstance(v, (int, float))]
             _effective_timeout = max(_numeric) if _numeric else _DEFAULT_TIMEOUT_SECONDS
 
-        response_text, reasoning_text = self._run_prompt(
+        response_text, reasoning_text, model_applied = self._run_prompt(
             prompt_text,
             timeout_seconds=_effective_timeout,
             model=model,
@@ -461,10 +461,17 @@ class CopilotACPClient:
         )
         finish_reason = "tool_calls" if tool_calls else "stop"
         choice = SimpleNamespace(message=assistant_message, finish_reason=finish_reason)
+        # Only claim the requested model when it was actually applied to the
+        # session. When Copilot doesn't offer it (unknown/policy-disabled id)
+        # or the session/set_config_option|set_model RPC failed, _run_prompt
+        # silently continues with the session's default model — reporting
+        # the requested id here would falsely attribute cost/audit records
+        # to a model that never ran. Fall back to the generic marker instead,
+        # matching the "no model requested" case below.
         completion = SimpleNamespace(
             choices=[choice],
             usage=usage,
-            model=model or "copilot-acp",
+            model=(model or "copilot-acp") if model_applied else "copilot-acp",
         )
         if stream:
             return _completion_to_stream_chunks(completion)
@@ -476,7 +483,19 @@ class CopilotACPClient:
         *,
         timeout_seconds: float,
         model: str | None = None,
-    ) -> tuple[str, str]:
+    ) -> tuple[str, str, bool]:
+        """Run one ACP prompt turn.
+
+        Returns ``(response_text, reasoning_text, model_applied)``.
+        ``model_applied`` is False when a specific ``model`` was requested
+        but the session ended up running its own default instead (the
+        requested id wasn't offered, or the selection RPC raised) — the
+        caller must not report the requested id as authoritative in that
+        case. It is True whenever no specific substitution risk exists
+        (no model requested, or the requested id is the generic
+        ``copilot-acp`` marker) as well as when selection genuinely
+        succeeded.
+        """
         # Fast-fail when the CLI doesn't support the ACP args we'd pass.
         # Without this guard, a CLI like Claude Code v2.x exits with
         # ``error: unknown option '--acp'`` immediately, then the parent
@@ -655,6 +674,10 @@ class CopilotACPClient:
             # select option and session/set_config_option updates it. Copilot
             # still exposes the older models/session/set_model extension too,
             # so retain that only as compatibility fallback for older agents.
+            # ``model_applied`` records whether the requested id genuinely
+            # ended up selected, so the caller can avoid reporting an id the
+            # session never actually ran (see the return statements below).
+            model_applied = True
             if requested_model and requested_model != "copilot-acp":
                 try:
                     selection = _model_selection_request(session, requested_model)
@@ -662,12 +685,14 @@ class CopilotACPClient:
                         method, params = selection
                         _request(method, params)
                     else:
+                        model_applied = False
                         logger.warning(
                             "Copilot ACP does not offer model %r; using the "
                             "session default.",
                             requested_model,
                         )
                 except Exception as exc:
+                    model_applied = False
                     logger.warning(
                         "Copilot ACP model selection for %r failed; continuing "
                         "with the session default: %s",
@@ -691,7 +716,7 @@ class CopilotACPClient:
                 text_parts=text_parts,
                 reasoning_parts=reasoning_parts,
             )
-            return "".join(text_parts), "".join(reasoning_parts)
+            return "".join(text_parts), "".join(reasoning_parts), model_applied
         finally:
             self.close()
 

--- a/tests/agent/test_copilot_acp_client.py
+++ b/tests/agent/test_copilot_acp_client.py
@@ -32,7 +32,7 @@ class CopilotACPClientSafetyTests(unittest.TestCase):
             "</tool_call>"
         )
 
-        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "")):
+        with patch.object(self.client, "_run_prompt", return_value=(tool_response, "", True)):
             stream = self.client._create_chat_completion(
                 model="copilot-acp",
                 messages=[{"role": "user", "content": "read README.md"}],
@@ -414,10 +414,52 @@ def test_run_prompt_receives_picker_model():
 
     def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
         seen["model"] = model
-        return "ok", ""
+        return "ok", "", True
 
     with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
         client._create_chat_completion(
             model="gpt-5.6-terra", messages=[{"role": "user", "content": "hi"}]
         )
     assert seen["model"] == "gpt-5.6-terra"
+
+
+def test_completion_model_reflects_fallback_when_selection_not_applied():
+    # Regression: when Copilot doesn't offer the requested model (unknown or
+    # policy-disabled id) or the session/set_config_option|set_model RPC
+    # fails, _run_prompt silently continues with the session's own default
+    # model. completion.model must not then claim the requested id was
+    # actually used — downstream cost/audit attribution (agent/aux_accounting.py,
+    # agent/plugin_llm.py) trusts this field as authoritative.
+    client = CopilotACPClient(acp_cwd="/tmp")
+
+    def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
+        # Mirrors what the real _run_prompt does on a rejected/failed
+        # selection: it logs a warning and returns the text produced by
+        # whatever model the session actually ran, with model_applied=False.
+        return "response from the session's actual default model", "", False
+
+    with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
+        completion = client._create_chat_completion(
+            model="claude-fable-5-DEFINITELY-NOT-SERVED",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert completion.model == "copilot-acp"
+    assert completion.model != "claude-fable-5-DEFINITELY-NOT-SERVED"
+
+
+def test_completion_model_reflects_requested_model_when_applied():
+    # Companion to the fallback regression above: when selection genuinely
+    # succeeds, completion.model must still report the requested id.
+    client = CopilotACPClient(acp_cwd="/tmp")
+
+    def fake_run_prompt(prompt_text, *, timeout_seconds, model=None):
+        return "response from the requested model", "", True
+
+    with patch.object(CopilotACPClient, "_run_prompt", side_effect=fake_run_prompt):
+        completion = client._create_chat_completion(
+            model="gpt-5.6-terra",
+            messages=[{"role": "user", "content": "hi"}],
+        )
+
+    assert completion.model == "gpt-5.6-terra"


### PR DESCRIPTION
## Problem

`CopilotACPClient._create_chat_completion()` sets `completion.model` to the originally requested model id unconditionally:

```python
completion = SimpleNamespace(
    choices=[choice],
    usage=usage,
    model=model or "copilot-acp",
)
```

But the actual model application happens in `_run_prompt()`, which can silently fall back to the Copilot session's own default model in two cases:

1. `_model_selection_request()` returns `None` — the requested id isn't in the session's advertised/enabled model list (unknown id, or `_meta.copilotEnablement == "disabled"`).
2. The `session/set_config_option` / `session/set_model` RPC raises.

In both cases `_run_prompt()` only logs a warning and continues with the session default — it never signals the fallback back to the caller. So `completion.model` ends up claiming the requested model was used even when it wasn't.

This matters because downstream code reads `response.model`/`completion.model` as authoritative for cost/audit attribution:
- `agent/aux_accounting.py::record_aux_usage()` — "The model is read from `response.model` (accurate even after the aux client's provider-fallback chains)"
- `agent/plugin_llm.py`
- `agent/conversation_loop.py`'s error-path provider attribution

A silently-substituted model gets attributed to the wrong id in cost/audit records.

## Relationship to the prior "impersonation" fix

`a94b68ad4` ("stop substituted models impersonating the requested one") fixed a *different* vector: the model impersonating itself in the prompt text sent *to* the model (it removed a `"Hermes requested model hint: <id>"` line, since a substituted backend would otherwise parrot the requested name back as its own identity). That fix did not touch this structured-metadata vector — `completion.model` was, and until this PR remained, set unconditionally regardless of whether selection actually succeeded.

## Fix

Thread a `model_applied: bool` signal out of `_run_prompt()`:
- `True` when there's no substitution risk (no model requested, or the generic `"copilot-acp"` marker), or when selection genuinely succeeded.
- `False` when the requested model wasn't offered, or the selection RPC raised.

`_create_chat_completion()` now uses it:

```python
model=(model or "copilot-acp") if model_applied else "copilot-acp",
```

falling back to the existing generic `"copilot-acp"` marker (rather than inventing a new identifier) when the requested model wasn't actually applied — consistent with the "no model requested" case already handled by this expression, and with this file's existing degrade-with-warning error-handling style (no new exception type, no change to `_create_chat_completion`'s external contract).

## Tests

Added to `tests/agent/test_copilot_acp_client.py`:
- `test_completion_model_reflects_fallback_when_selection_not_applied` — simulates the fallback (`model_applied=False`) and asserts `completion.model` is the generic marker, not the unapplied requested id.
- `test_completion_model_reflects_requested_model_when_applied` — companion positive case, asserts the requested id is still reported when selection genuinely succeeds.

Updated two pre-existing tests whose mocks of `_run_prompt` returned a 2-tuple to return the new 3-tuple shape (`test_stream_true_preserves_tool_call_deltas`, `test_run_prompt_receives_picker_model`).

**Mutation-verify:** reverted the `agent/copilot_acp_client.py` fix (test file changes kept) — both new tests failed (`ValueError: too many values to unpack`, since the old code can't handle the new 3-tuple mock contract). Restored the fix — both passed. Full file: `20 passed`. Sibling `tests/agent/test_acp_openai_bridge.py`: `14 passed`.

## Scope note

This only addresses the structured `completion.model` metadata field. The prompt-text vector was already closed by `a94b68ad4`.

## Competitor check

Searched `gh pr list --search` (state=all) for `"copilot-acp completion.model"`, `"copilot-acp impersonat"`, `"copilot_acp_client model"`, `"copilot acp accounting"`, `"copilot_acp_client"`, `"model_applied copilot"` — no open or closed PR addresses `completion.model` accuracy on model-selection fallback. The closest hits (`#97735` adds an unrelated ACP provider for a different file `agent/acp_subprocess_client.py`; `#59911` is a test-isolation fix for an unrelated ambient-env leak) are unrelated.