### PR TITLE
fix(config): migrate bell_on_clarify/bell_on_approval to bell_on_prompt

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -4108,7 +4108,7 @@ DEFAULT_CONFIG = {
     },
 
     # Config schema version - bump this when adding new required fields
-    "_config_version": 40,
+    "_config_version": 41,
 }
 
 # Optional environment variables that enhance functionality

--- a/hermes_cli/config_migrations.py
+++ b/hermes_cli/config_migrations.py
@@ -885,6 +885,43 @@ def _migrate_to_40(results: Dict[str, Any], quiet: bool) -> None:
             print("  ✓ Model catalog now refreshes every 20 minutes (model_catalog.ttl_minutes)")
 
 
+def _migrate_to_41(results: Dict[str, Any], quiet: bool) -> None:
+    # ── Version 40 → 41: collapse display.bell_on_clarify/bell_on_approval
+    # into display.bell_on_prompt ──
+    # The two single-purpose bell flags were replaced by one key covering
+    # every blocking prompt modal (clarify, approval, sudo password, secret
+    # capture). A user who had EITHER old flag on wanted a bell on some
+    # blocking prompt, so either true migrates to bell_on_prompt: true (the
+    # broadened scope — now also sudo/secret prompts — is the intended
+    # collapse, not a regression). Both old keys are always dropped so they
+    # don't sit orphaned in the file; bell_on_prompt is only written when the
+    # migrated value is true (false already matches the schema default, so
+    # persisting it would only bloat a lean config).
+    _c = _cfg()
+    read_raw_config = _c.read_raw_config
+    _persist_migration = _c._persist_migration
+
+    config = read_raw_config()
+    display = config.get("display")
+    if not isinstance(display, dict):
+        return
+    had_clarify = "bell_on_clarify" in display
+    had_approval = "bell_on_approval" in display
+    if not had_clarify and not had_approval:
+        return
+
+    was_clarify_on = bool(display.pop("bell_on_clarify", False))
+    was_approval_on = bool(display.pop("bell_on_approval", False))
+    was_on = was_clarify_on or was_approval_on
+    if was_on:
+        display["bell_on_prompt"] = True
+    config["display"] = display
+    _persist_migration(config)
+    results["config_added"].append(f"display.bell_on_clarify/bell_on_approval → bell_on_prompt={was_on}")
+    if not quiet:
+        print(f"  ✓ Merged bell_on_clarify/bell_on_approval → display.bell_on_prompt={was_on}")
+
+
 #: Registry of (target_version, migration_fn), strictly ascending. The driver
 #: applies every entry whose target version is greater than the on-disk
 #: observe earlier steps' writes via read_raw_config() (filesystem state).
@@ -913,6 +950,7 @@ MIGRATIONS: Tuple[Tuple[int, Callable[[Dict[str, Any], bool], None]], ...] = (
     (38, _migrate_to_38),
     (39, _migrate_to_39),
     (40, _migrate_to_40),
+    (41, _migrate_to_41),
 )
 
 

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -1394,6 +1394,55 @@ class TestWriteApprovalMigration:
             assert loaded["skills"]["write_approval"] is False
 
 
+class TestBellOnPromptMigration:
+    """Version 40→41 collapses display.bell_on_clarify/bell_on_approval into
+    display.bell_on_prompt (bool).
+
+    Either legacy flag being on means the user wanted a bell on some blocking
+    prompt, so either true migrates to bell_on_prompt: true. Both old keys are
+    always removed. bell_on_prompt is only persisted when true (false matches
+    the schema default and is left implicit).
+    """
+
+    def _write(self, tmp_path, body: str):
+        (tmp_path / "config.yaml").write_text(body)
+
+    def test_either_flag_true_migrates_to_bell_on_prompt_true(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            self._write(tmp_path,
+                        "_config_version: 40\ndisplay:\n  bell_on_clarify: true\n"
+                        "  bell_on_approval: true\n")
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            assert raw["display"]["bell_on_prompt"] is True
+            assert "bell_on_clarify" not in raw["display"]
+            assert "bell_on_approval" not in raw["display"]
+
+    def test_only_approval_true_migrates_to_bell_on_prompt_true(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            self._write(tmp_path,
+                        "_config_version: 40\ndisplay:\n  bell_on_clarify: false\n"
+                        "  bell_on_approval: true\n")
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            assert raw["display"]["bell_on_prompt"] is True
+            assert "bell_on_clarify" not in raw["display"]
+            assert "bell_on_approval" not in raw["display"]
+
+    def test_both_false_drops_keys_without_materializing_default(self, tmp_path):
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            self._write(tmp_path,
+                        "_config_version: 40\ndisplay:\n  bell_on_clarify: false\n"
+                        "  bell_on_approval: false\n")
+            migrate_config(interactive=False, quiet=True)
+            raw = yaml.safe_load((tmp_path / "config.yaml").read_text())
+            loaded = load_config()
+            assert "bell_on_clarify" not in raw.get("display", {})
+            assert "bell_on_approval" not in raw.get("display", {})
+            assert "bell_on_prompt" not in raw.get("display", {})
+            assert loaded["display"]["bell_on_prompt"] is False
+
+
 class TestMigrationWriteInvariant:
     """Architectural guard: every migration write routes through the single
     _persist_migration() chokepoint, which strips schema defaults so a lean


### PR DESCRIPTION
## Problem

#101284 (merge commit `552159d222`) collapsed the two legacy bell flags `display.bell_on_clarify` and `display.bell_on_approval` into a single `display.bell_on_prompt`, but did not add a config migration step.

Without one, a user who had `bell_on_clarify: true` and/or `bell_on_approval: true` set in their `config.yaml`:
- silently loses that behavior — `bell_on_prompt` resolves to the schema default (`false`), so the bell stops ringing, with no warning
- keeps the orphaned legacy keys sitting in their config file forever (they're no longer read by any code path)

Confirmed empirically: writing a `_config_version: 40` config with both legacy flags `true` and running it through `migrate_config()` leaves both stale keys in place and `bell_on_prompt` resolves to `false`.

## Fix

Added `_migrate_to_41` to `hermes_cli/config_migrations.py`, following the exact pattern of `_migrate_to_29` (the `memory/skills.write_mode` → `write_approval` rename referenced in the migration module's own docstring):

- If either `display.bell_on_clarify` or `display.bell_on_approval` was `true`, sets `display.bell_on_prompt = true`. Either legacy flag being on means the user wanted a bell on *some* blocking prompt; per the commit that introduced `bell_on_prompt`, the new flag's scope is broader (now also covers sudo-password and secret-capture prompts in addition to clarify/approval) — collapsing to `true` on either legacy flag is the intended migration, not an over-broadening.
- Both legacy keys are always removed (dropped even when both are `false`, so they don't linger).
- `bell_on_prompt` is only persisted when the migrated value is `true`, matching the lean-config invariant every other step in the ladder follows (a `false` value already matches the schema default).
- Registered in `MIGRATIONS` and bumped `_config_version` 40 → 41, matching how every other step in the table is wired up.

## Tests

Added `TestBellOnPromptMigration` to `tests/hermes_cli/test_config.py`, following `TestWriteApprovalMigration`'s exact convention:
- `test_either_flag_true_migrates_to_bell_on_prompt_true`
- `test_only_approval_true_migrates_to_bell_on_prompt_true`
- `test_both_false_drops_keys_without_materializing_default`

**Mutation-verify:** reverted just the fix (`hermes_cli/config_defaults.py` + `hermes_cli/config_migrations.py`) via a patch file, confirmed all three new tests fail without it, re-applied the patch, confirmed all three pass.

**Full suite:** `tests/hermes_cli/test_config.py` — 117 passed, 4 skipped, no regressions.

## Checklist
- [x] Empirically confirmed the gap before writing the fix
- [x] Followed the established migration pattern (`_migrate_to_29`)
- [x] New regression tests added and mutation-verified
- [x] Full `test_config.py` suite passes with no regressions
- [x] Fresh competitor search immediately before opening this PR (`bell_on_prompt migration`, `bell_on_clarify migration`, `bell config migrate`, `bell_on_prompt`, `config_migrations.py bell`, `collapse bell`, `_config_version 41`, `migrate_to_41`) — no open or merged PR adds a migration step for this rename