### PR TITLE
fix(state): guard vacuum()/optimize_fts()/_try_wal_checkpoint() against quarantined SessionDB handles

### DIFF
--- a/hermes_cli/console_engine.py
+++ b/hermes_cli/console_engine.py
@@ -1522,11 +1522,20 @@ def _sessions_optimize(_engine: HermesConsoleEngine, args: list[str]) -> str:
     _expect_no_args(args, "sessions optimize")
 
     def _run() -> None:
-        from hermes_state import SessionDB
+        from hermes_state import SessionDB, StateDbCorruptError
 
         db = SessionDB()
         try:
-            count = db.vacuum()
+            try:
+                count = db.vacuum()
+            except StateDbCorruptError as exc:
+                # Not a RuntimeError (subclasses sqlite3.DatabaseError), so
+                # _capture_output would not catch it and it would escape
+                # execute() and kill the REPL / websocket session — convert
+                # to the console error type like the sibling RuntimeError
+                # quarantine errors (StateDbReplacedError,
+                # DeletedWalGenerationError) already get from _capture_output.
+                raise ConsoleCommandError(str(exc)) from exc
             print(f"Optimized {count} FTS index(es).")
         finally:
             db.close()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -6960,8 +6960,11 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         databases (65K+ pages) due to the exclusive-lock I/O pressure
         from checkpointing thousands of frames at once (issue #45383).
         """
-        if self._db_corrupt:
-            return  # quarantined: never checkpoint over a damaged image
+        if self._db_corrupt or self._db_replaced or self._db_wal_generation_lost:
+            # Quarantined (structural corruption), or the file/WAL generation
+            # under this path is no longer the one this handle opened: never
+            # checkpoint over a damaged or foreign image.
+            return
         try:
             with self._lock:
                 result = self._conn.execute(
@@ -16840,6 +16843,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         Returns the number of FTS indexes that were optimized (0 if the
         merge step failed or no FTS tables exist).
         """
+        # A quarantined/replaced/split-generation handle must never run a
+        # full-file rewrite: VACUUM would read every page of a structurally
+        # damaged or foreign image and commit the result back to disk,
+        # turning a contained, diagnosable corruption into an amplified,
+        # unrecoverable one. Same guard _execute_write uses on every write.
+        self._raise_if_db_corrupt()
+        self._raise_if_db_replaced()
         # Merge FTS5 segments before VACUUM so the freed pages are returned
         # to the OS in the same pass. optimize_fts() manages its own lock.
         optimized = 0

--- a/hermes_state_search.py
+++ b/hermes_state_search.py
@@ -2347,6 +2347,13 @@ class SessionSearchMixin:
 
         Returns the number of FTS indexes that were optimized.
         """
+        # Same quarantine guard as every canonical write path
+        # (_execute_write): a quarantined/replaced/split-generation handle
+        # must never issue FTS5 'optimize', which rewrites index segments
+        # in place and would compound structural damage instead of leaving
+        # it diagnosable.
+        self._raise_if_db_corrupt()
+        self._raise_if_db_replaced()
         optimized = 0
         with self._lock:
             for tbl in self._FTS_TABLES:

--- a/tests/hermes_state/test_state_db_corrupt_quarantine.py
+++ b/tests/hermes_state/test_state_db_corrupt_quarantine.py
@@ -13,7 +13,12 @@ import sqlite3
 
 import pytest
 
-from hermes_state import SessionDB, StateDbCorruptError
+from hermes_state import (
+    DeletedWalGenerationError,
+    SessionDB,
+    StateDbCorruptError,
+    StateDbReplacedError,
+)
 
 
 class _MalformedConn:
@@ -234,3 +239,88 @@ class TestSharedRegistry:
         registry.close_all()
         assert not any("wal_checkpoint" in sql for sql in recorder.recorded)
         assert holder_a._conn is None
+
+
+_QUARANTINE_FLAGS = [
+    ("_db_corrupt", StateDbCorruptError),
+    ("_db_replaced", StateDbReplacedError),
+    ("_db_wal_generation_lost", DeletedWalGenerationError),
+]
+
+
+def _force_flag(db, flag_name):
+    setattr(db, flag_name, True)
+    if flag_name == "_db_corrupt":
+        db._db_corrupt_reason = "forced for test"
+
+
+def _clear_flag(db, flag_name):
+    setattr(db, flag_name, False)
+    if flag_name == "_db_corrupt":
+        db._db_corrupt_reason = ""
+
+
+class TestVacuumAndMaintenanceRespectQuarantine:
+    """vacuum()/optimize_fts()/_try_wal_checkpoint() must check the same
+    quarantine flags _execute_write does before touching the connection.
+
+    Without this, `hermes sessions vacuum`/`optimize` and the default-on
+    ``maybe_auto_prune_and_vacuum`` auto-maintenance could run VACUUM /
+    FTS5 'optimize' / an explicit WAL checkpoint directly over a
+    structurally damaged, replaced, or split-WAL-generation file — turning
+    a contained, diagnosable corruption into an amplified, unrecoverable
+    one (the exact class of damage the quarantine exists to prevent).
+    """
+
+    @pytest.mark.parametrize("flag_name,expected_exc", _QUARANTINE_FLAGS)
+    def test_vacuum_refuses_when_quarantined(self, tmp_path, flag_name, expected_exc):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            db.append_message("s1", role="user", content="hello world")
+            recorder = _RecordingConn(real_conn)
+            db._conn = recorder
+            _force_flag(db, flag_name)
+            with pytest.raises(expected_exc):
+                db.vacuum()
+            assert recorder.recorded == []
+        finally:
+            _clear_flag(db, flag_name)
+            db._conn = real_conn
+            db.close()
+
+    @pytest.mark.parametrize("flag_name,expected_exc", _QUARANTINE_FLAGS)
+    def test_optimize_fts_refuses_when_quarantined(self, tmp_path, flag_name, expected_exc):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            db.append_message("s1", role="user", content="hello world")
+            recorder = _RecordingConn(real_conn)
+            db._conn = recorder
+            _force_flag(db, flag_name)
+            with pytest.raises(expected_exc):
+                db.optimize_fts()
+            assert recorder.recorded == []
+        finally:
+            _clear_flag(db, flag_name)
+            db._conn = real_conn
+            db.close()
+
+    @pytest.mark.parametrize("flag_name,_expected_exc", _QUARANTINE_FLAGS)
+    def test_try_wal_checkpoint_no_ops_when_quarantined(self, tmp_path, flag_name, _expected_exc):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        real_conn = db._conn
+        try:
+            db.create_session(session_id="s1", source="cli", model="test")
+            recorder = _RecordingConn(real_conn)
+            db._conn = recorder
+            _force_flag(db, flag_name)
+            # Documented contract: "Best-effort ... Never raises."
+            db._try_wal_checkpoint()
+            assert recorder.recorded == []
+        finally:
+            _clear_flag(db, flag_name)
+            db._conn = real_conn
+            db.close()


### PR DESCRIPTION
## Bug

`hermes_state.py`'s corruption-quarantine mechanism sets one of three sticky flags on a `SessionDB` handle — `_db_corrupt`, `_db_replaced`, `_db_wal_generation_lost` — after detecting structural corruption, an out-of-band file replace, or a split WAL generation. Every canonical write path checks these before touching `self._conn`:

- `_execute_write()` calls `self._raise_if_db_corrupt()` + `self._raise_if_db_replaced()` (the latter also covers `_db_wal_generation_lost`) at the top of its retry loop.
- `_reopen_after_close_locked()` refuses to reopen a quarantined/replaced/split-generation handle.
- `_enter_fts_fail_open()` checks all three before its own recovery write.

But `SessionDB.vacuum()` and the `optimize_fts()` it calls (in `hermes_state_search.py`) ran `PRAGMA wal_checkpoint`, `INSERT INTO fts(fts) VALUES('optimize')`, and `VACUUM` directly against `self._conn` with **zero** checks of these flags. `_try_wal_checkpoint()` (in `hermes_state.py`) checked only `self._db_corrupt`, missing the two flags added later in the file's evolution.

This matters specifically because VACUUM/optimize are the class of operation the quarantine exists to guard against: VACUUM reads and rewrites every page of the database and commits the result back to disk. Running it over a file already known to be structurally damaged, replaced, or WAL-split turns a contained, diagnosable corruption into an amplified, unrecoverable one — exactly the failure mode `_halt_db_corrupt()`'s own log message warns about ("no further writes, no automatic reopen, no explicit WAL checkpoint").

Reachable from:
- `hermes sessions vacuum` (`hermes_cli/console_engine.py`) and `hermes sessions optimize` (`hermes_cli/sessions_cmd.py`), both of which call `db.vacuum()` directly.
- `maybe_auto_prune_and_vacuum()`, the default-on startup auto-maintenance path, which calls `self.vacuum()` with no guard of its own.

### Empirical confirmation

A throwaway script forced each of the three flags to `True` on a real `SessionDB` and wrapped the connection to record every executed statement. Before the fix, `vacuum()` and `optimize_fts()` ran all their destructive SQL regardless of which flag was set; `_try_wal_checkpoint()` correctly no-opped for `_db_corrupt` but ran `PRAGMA wal_checkpoint(PASSIVE)` anyway for `_db_replaced` and `_db_wal_generation_lost`.

## Fix

- `vacuum()` and `optimize_fts()`: added `self._raise_if_db_corrupt(); self._raise_if_db_replaced()` at the top — the exact pair `_execute_write()` uses, reusing the existing flags/exception types (`StateDbCorruptError`, `StateDbReplacedError`, `DeletedWalGenerationError`) rather than inventing a new contract. `optimize_fts()` is guarded directly (not just via `vacuum()`'s guard) since it's a public method — `vacuum()` is its only current production caller, but `vacuum()` also wraps the `optimize_fts()` call in a bare `except Exception: log and continue`, so guarding only inside `vacuum()` before the call would not have been sufficient to actually stop the subsequent VACUUM.
- `_try_wal_checkpoint()`: added the two missing flag checks (`self._db_replaced`, `self._db_wal_generation_lost`) alongside the existing `self._db_corrupt` check. Kept its documented "Best-effort... Never raises" contract — silent early return, not a raise.
- `hermes_cli/console_engine.py`'s `sessions optimize` handler: `StateDbCorruptError` subclasses `sqlite3.DatabaseError`, not `RuntimeError` (unlike `StateDbReplacedError`/`DeletedWalGenerationError`), so it would have escaped `_capture_output`'s catch (`SystemExit` / `ConsoleCommandError` / `RuntimeError` only) and crashed the console REPL/websocket session instead of surfacing a clean error message. Converted to `ConsoleCommandError` at the call site, matching the established local try/except pattern already used elsewhere in that file (e.g. `_cron_pause`). `hermes_cli/sessions_cmd.py`'s `sessions optimize` action already wraps `db.vacuum()` in a broad `except Exception`, so it needed no change.

## Tests

Added `TestVacuumAndMaintenanceRespectQuarantine` to `tests/hermes_state/test_state_db_corrupt_quarantine.py`, parametrized over all three flags, for all three functions (9 new cases), reusing the file's existing `_RecordingConn`/`_MalformedConn` fixture style rather than inventing a new mocking approach.

**Mutation-verify:** saved the production-file diff, reverted `hermes_state.py`/`hermes_state_search.py`/`hermes_cli/console_engine.py` to `HEAD`, re-ran the new tests — 8 of the 9 new parametrized cases failed with the connection recorder showing the destructive SQL actually ran (the 9th, `_try_wal_checkpoint` under `_db_corrupt`, correctly still passed since that single check pre-existed — confirming the fixture genuinely isolates the new behavior rather than trivially passing). Re-applied the fix: clean `17 passed, 1 skipped`.

Full runs, no regressions:
- `tests/state/ tests/hermes_state/ tests/test_hermes_state.py tests/gateway/test_session_db_corrupt_fallback.py tests/test_state_db_notadb_fail_closed.py` → 688 passed, 9 skipped
- `tests/hermes_cli/test_console_engine.py tests/hermes_cli/test_sessions_size_delta_label.py` → 16 passed

## Scope note

Did not add a guard inside `maybe_auto_prune_and_vacuum()` itself — it has no guard of its own today, but its `self.vacuum()` call is already wrapped in `try/except Exception: logger.warning(...)`, so once `vacuum()` raises on quarantine, this caller already degrades gracefully (logs and returns an `"error"` key) with no further change needed.