### PR TITLE
fix(desktop): do not steal focus from main window when pet overlay becomes focusable (#102039)

### DIFF
--- a/apps/desktop/electron/pet-overlay-ipc.test.ts
+++ b/apps/desktop/electron/pet-overlay-ipc.test.ts
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import type { BrowserWindow } from 'electron'
+import { describe, it, vi } from 'vitest'
+
+const onHandlers = new Map<string, (...args: unknown[]) => unknown>()
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    on: (channel: string, fn: (...args: unknown[]) => unknown) => {
+      onHandlers.set(channel, fn)
+    }
+  }
+}))
+
+const { registerPetOverlayIpc } = await import('./pet-overlay-ipc')
+
+describe('pet-overlay-ipc', () => {
+  it('does not steal focus from main window when pet overlay becomes focusable (#102039)', () => {
+    let petFocused = false
+    let petFocusable = false
+
+    const mockPetOverlayWindow = {
+      focus: () => {
+        petFocused = true
+      },
+      isDestroyed: () => false,
+      setFocusable: (val: boolean) => {
+        petFocusable = val
+      }
+    } as unknown as BrowserWindow
+
+    let mainFocused = true
+    const mockMainWindow = {
+      isDestroyed: () => false,
+      isFocused: () => mainFocused
+    } as unknown as BrowserWindow
+
+    registerPetOverlayIpc({
+      closePetOverlay: vi.fn(),
+      getMainWindow: () => mockMainWindow,
+      getPetOverlayWindow: () => mockPetOverlayWindow,
+      openPetOverlay: vi.fn()
+    })
+
+    const setFocusableHandler = onHandlers.get('hermes:pet-overlay:set-focusable')
+    assert.ok(setFocusableHandler, 'handler registered for hermes:pet-overlay:set-focusable')
+
+    // 1. When main window is focused, pet overlay should become focusable but NOT steal focus
+    setFocusableHandler({}, true)
+    assert.equal(petFocusable, true)
+    assert.equal(petFocused, false, 'must not steal focus when main window is focused')
+
+    // 2. When main window is not focused, pet overlay should focus
+    mainFocused = false
+    setFocusableHandler({}, true)
+    assert.equal(petFocused, true, 'should focus pet overlay when main window is not focused')
+
+    // 3. When focusable is false, focus should not be called
+    petFocused = false
+    setFocusableHandler({}, false)
+    assert.equal(petFocusable, false)
+    assert.equal(petFocused, false)
+  })
+})

--- a/apps/desktop/electron/pet-overlay-ipc.ts
+++ b/apps/desktop/electron/pet-overlay-ipc.ts
@@ -102,7 +102,11 @@ export function registerPetOverlayIpc({
     petOverlayWindow.setFocusable(Boolean(focusable))
 
     if (focusable) {
-      petOverlayWindow.focus()
+      const mainWindow = getMainWindow()
+
+      if (!mainWindow || mainWindow.isDestroyed() || !mainWindow.isFocused()) {
+        petOverlayWindow.focus()
+      }
     }
   })
   // Main renderer → overlay: forward the latest pet state for the overlay to render.


### PR DESCRIPTION
## Problem

When the desktop pet overlay (mascot window) changes its focusability via the `hermes:pet-overlay:set-focusable` IPC channel, the main process unconditionally called `petOverlayWindow.focus()`.

If the user is actively typing in the main chat composer, this unconditionally steals OS keyboard focus away from the main window, causing the cursor to disappear and interrupting the user's typing flow (#102039).

## Solution

1. In `apps/desktop/electron/pet-overlay-ipc.ts`, check whether `mainWindow` is currently focused before calling `petOverlayWindow.focus()`:
   ```ts
   if (focusable) {
     const mainWindow = getMainWindow()

     if (!mainWindow || mainWindow.isDestroyed() || !mainWindow.isFocused()) {
       petOverlayWindow.focus()
     }
   }
   ```
2. Added unit tests in `apps/desktop/electron/pet-overlay-ipc.test.ts` verifying:
   - When `mainWindow.isFocused() === true`, `petOverlayWindow.setFocusable(true)` is set but `petOverlayWindow.focus()` is NOT called.
   - When `mainWindow.isFocused() === false` or `mainWindow` is absent/destroyed, `petOverlayWindow.focus()` is called.
   - When `focusable` is `false`, focus is not called.

## Verification

- Ran `vitest run electron/pet-overlay-ipc.test.ts --project electron`: 1/1 test passed.
- Verified Electron main bundling succeeds (`dist/electron-main.mjs`).

Closes #102039
