### PR TITLE
fix(gateway): scope Nous auth keepalive and model-catalog refresh to every multiplex profile

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2707,6 +2707,34 @@ def load_gateway_config_for_runner() -> "GatewayConfig":
         return cfg
 
 
+async def _refresh_model_catalogs_for_all_profiles(config: object) -> None:
+    """Refresh the on-disk model-catalog cache for every profile this gateway serves.
+
+    ``refresh_catalogs`` resolves its cache path (and the provider-credential
+    lookups it makes along the way) via ``get_hermes_home()``, so an unscoped
+    call only ever refreshes the launch/default profile's cache. Under
+    multiplex, run it once per served profile inside that profile's
+    ``_profile_runtime_scope`` -- mirrors ``_discover_gateway_mcp_tools``.
+    Single-profile gateways keep the one unscoped call.
+    """
+    from hermes_cli.model_catalog import refresh_catalogs
+
+    if not getattr(config, "multiplex_profiles", False):
+        try:
+            await asyncio.to_thread(refresh_catalogs)
+        except Exception as exc:
+            logger.debug("Model catalog refresh failed: %s", exc)
+        return
+    for profile_name, profile_home in _multiplex_profile_homes(config):
+        try:
+            async with _async_profile_runtime_scope(Path(profile_home)):
+                await asyncio.to_thread(refresh_catalogs)
+        except Exception as exc:
+            logger.debug(
+                "Model catalog refresh failed for profile '%s': %s", profile_name, exc,
+            )
+
+
 async def _discover_gateway_mcp_tools(config: object) -> None:
     """Run startup MCP discovery for every profile this gateway serves.
 
@@ -15885,16 +15913,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         cached. This loop calls ``model_catalog.refresh_catalogs()`` (manifest
         + OpenRouter live filter + Nous Portal recommendations) off-thread on
         the configured cadence (``model_catalog.ttl_minutes``, default 20) so
-        the on-disk caches every surface reads are never older than one window.
+        the on-disk caches every surface reads are never older than one
+        window -- for every profile a multiplex gateway serves, not just the
+        default one (``_refresh_model_catalogs_for_all_profiles``).
         """
-        from hermes_cli.model_catalog import refresh_catalogs, refresh_interval_seconds
+        from hermes_cli.model_catalog import refresh_interval_seconds
 
         await asyncio.sleep(30)  # let startup settle
         while self._running:
-            try:
-                await asyncio.to_thread(refresh_catalogs)
-            except Exception as exc:
-                logger.debug("Model catalog refresh failed: %s", exc)
+            await _refresh_model_catalogs_for_all_profiles(self.config)
             try:
                 interval = refresh_interval_seconds()
             except Exception:

--- a/hermes_cli/nous_auth_keepalive.py
+++ b/hermes_cli/nous_auth_keepalive.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import os
 import threading
+from pathlib import Path
 from typing import Optional
 
 from hermes_cli.auth import (
@@ -237,6 +238,100 @@ def refresh_nous_auth_keepalive_once(
         return False
 
 
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return "default"
+
+
+def _keepalive_profile_homes() -> list[tuple[str, Optional[Path]]]:
+    """Every profile this process should proactively tick Nous auth for.
+
+    A raw ``threading.Thread`` (which is what runs ``_keepalive_loop``) does
+    not inherit the spawning thread's contextvars, so without this the loop
+    only ever resolves ``get_hermes_home()`` as whatever it was at process
+    start -- the default profile. Under ``gateway.multiplex_profiles``, a
+    secondary profile can hold its own independent Nous OAuth login that
+    equally needs proactive ticking, or its credential silently expires into
+    reactive 401s exactly like the bug this module exists to fix (just
+    scoped to one profile instead of none).
+
+    Returns ``(name, None)`` for the single-profile/non-multiplex case so the
+    tick runs unscoped exactly as before -- behavior-preserving, and avoids
+    pulling in ``gateway.run`` for the common case. Under multiplex, returns
+    ``(name, home)`` for the default profile plus every named profile under
+    ``profiles/`` (mirrors ``gateway.run._multiplex_profile_homes``).
+
+    Config is read fresh on every pass rather than threaded from the caller:
+    ``start_nous_auth_keepalive`` is called from two places (gateway boot,
+    dashboard/web-server boot) with different config objects in scope, and
+    this loop already re-reads ``nous.keepalive_interval_seconds`` live each
+    pass for the same reason. The read is a YAML parse gated by the tick
+    interval (floored at 60s), not a hot path.
+    """
+    try:
+        from gateway.config import load_gateway_config
+        from gateway.run import _multiplex_profile_homes
+
+        config = load_gateway_config()
+        if not getattr(config, "multiplex_profiles", False):
+            return [(_active_profile_name(), None)]
+        homes = _multiplex_profile_homes(config)
+        if not homes:
+            return [(_active_profile_name(), None)]
+        return list(homes)
+    except Exception:
+        logger.debug(
+            "Nous auth keepalive: could not resolve multiplex profile set; "
+            "falling back to the active profile",
+            exc_info=True,
+        )
+        return [(_active_profile_name(), None)]
+
+
+def _keepalive_tick_one_profile(
+    profile_name: str,
+    profile_home: Optional[Path],
+    *,
+    interval_seconds: int,
+    min_key_ttl_seconds: int,
+    timeout_seconds: Optional[float],
+) -> int:
+    """Refresh one profile's Nous auth and return its next tick spacing.
+
+    ``profile_home is None`` runs unscoped (the legacy single-profile path).
+    Otherwise enters that profile's ``_profile_runtime_scope`` for the
+    observe-then-refresh so ``get_provider_auth_state`` / the credential pool
+    / ``resolve_nous_runtime_credentials`` all resolve THAT profile's home
+    and ``.env`` instead of whatever profile happened to be active when the
+    keepalive thread was spawned.
+    """
+
+    def _observe_and_refresh() -> int:
+        # Re-read each pass: the lifetime can change when the account, plan,
+        # or server-side policy does, and a keepalive that caches it would go
+        # stale in exactly the case it exists to cover.
+        tick = _tick_seconds(interval_seconds, _observed_lifetime_seconds())
+        horizon = _refresh_horizon_seconds(tick, min_key_ttl_seconds)
+        refresh_nous_auth_keepalive_once(
+            min_key_ttl_seconds=horizon,
+            min_access_ttl_seconds=horizon,
+            timeout_seconds=timeout_seconds,
+        )
+        return tick
+
+    if profile_home is None:
+        return _observe_and_refresh()
+
+    from gateway.run import _profile_runtime_scope
+
+    with _profile_runtime_scope(Path(profile_home)):
+        return _observe_and_refresh()
+
+
 def _keepalive_loop(
     stop_event: threading.Event,
     *,
@@ -249,17 +344,28 @@ def _keepalive_loop(
         return
 
     while not stop_event.is_set():
-        # Re-read each pass: the lifetime can change when the account, plan, or
-        # server-side policy does, and a keepalive that caches it would go stale
-        # in exactly the case it exists to cover.
-        tick = _tick_seconds(interval_seconds, _observed_lifetime_seconds())
-        horizon = _refresh_horizon_seconds(tick, min_key_ttl_seconds)
-        refresh_nous_auth_keepalive_once(
-            min_key_ttl_seconds=horizon,
-            min_access_ttl_seconds=horizon,
-            timeout_seconds=timeout_seconds,
-        )
-        stop_event.wait(tick)
+        next_tick = interval_seconds
+        for profile_name, profile_home in _keepalive_profile_homes():
+            try:
+                tick = _keepalive_tick_one_profile(
+                    profile_name,
+                    profile_home,
+                    interval_seconds=interval_seconds,
+                    min_key_ttl_seconds=min_key_ttl_seconds,
+                    timeout_seconds=timeout_seconds,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Nous auth keepalive tick failed for profile '%s': %s",
+                    profile_name, exc,
+                )
+                continue
+            # The overall loop cadence must be safe for whichever profile
+            # needs the tightest tick; a slower cadence derived from another
+            # profile's longer-lived credential would step over this one's
+            # refresh window entirely (see the module docstring).
+            next_tick = min(next_tick, tick)
+        stop_event.wait(next_tick)
 
 
 def start_nous_auth_keepalive(

--- a/tests/gateway/test_model_catalog_refresh_watcher_multiplex.py
+++ b/tests/gateway/test_model_catalog_refresh_watcher_multiplex.py
@@ -1,0 +1,108 @@
+"""Model-catalog refresh watcher must refresh EVERY multiplex profile's cache.
+
+Regression guard: ``_model_catalog_refresh_watcher`` called
+``model_catalog.refresh_catalogs()`` once per tick via ``asyncio.to_thread``
+without ever entering a profile's ``_profile_runtime_scope``.
+``refresh_catalogs()`` resolves its on-disk cache path via
+``get_hermes_home()``, so the loop only ever refreshed the DEFAULT profile's
+catalog cache. Secondary multiplex profiles never got the proactive refresh
+the whole feature exists to provide -- they kept the pre-fix behavior of
+refreshing only on a cold ``/model`` open.
+
+Mirrors ``tests/gateway/test_multiplex_mcp_discovery.py`` for
+``_discover_gateway_mcp_tools``, the reference template this fix follows.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig
+from hermes_constants import get_hermes_home
+
+
+@pytest.mark.asyncio
+async def test_single_profile_gateway_refreshes_once_unscoped(monkeypatch):
+    """No multiplexing -> exactly the legacy single unscoped call."""
+    import gateway.run as gateway_run
+
+    seen: list[tuple[Path, str]] = []
+
+    def fake_refresh() -> bool:
+        seen.append((get_hermes_home(), threading.current_thread().name))
+        return True
+
+    monkeypatch.setattr("hermes_cli.model_catalog.refresh_catalogs", fake_refresh)
+
+    await gateway_run._refresh_model_catalogs_for_all_profiles(
+        GatewayConfig(multiplex_profiles=False)
+    )
+
+    assert len(seen) == 1
+    # Off the event-loop thread, exactly like the pre-fix behavior.
+    assert seen[0][1] != threading.current_thread().name
+
+
+@pytest.mark.asyncio
+async def test_multiplex_gateway_refreshes_every_profile_under_its_own_home(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    import gateway.run as gateway_run
+
+    homes = [("default", tmp_path / "default"), ("worker", tmp_path / "worker")]
+    for _name, home in homes:
+        home.mkdir()
+    seen: list[tuple[Path, str]] = []
+
+    def fake_refresh() -> bool:
+        seen.append((get_hermes_home(), threading.current_thread().name))
+        return True
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: homes,
+    )
+    monkeypatch.setattr("hermes_cli.model_catalog.refresh_catalogs", fake_refresh)
+
+    await gateway_run._refresh_model_catalogs_for_all_profiles(
+        GatewayConfig(multiplex_profiles=True)
+    )
+
+    # Ran once per profile, under that profile's own home, off the loop thread.
+    assert [home for home, _ in seen] == [home for _, home in homes]
+    assert all(thread != threading.current_thread().name for _, thread in seen)
+
+
+@pytest.mark.asyncio
+async def test_one_profile_refresh_failure_does_not_skip_the_rest(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A broken/unreachable catalog fetch for one profile must not starve siblings."""
+    import gateway.run as gateway_run
+
+    homes = [("default", tmp_path / "default"), ("worker", tmp_path / "worker")]
+    for _name, home in homes:
+        home.mkdir()
+    seen: list[Path] = []
+
+    def flaky_refresh() -> bool:
+        home = get_hermes_home()
+        if home == tmp_path / "default":
+            raise RuntimeError("network unreachable")
+        seen.append(home)
+        return True
+
+    monkeypatch.setattr(
+        "hermes_cli.profiles.profiles_to_serve",
+        lambda multiplex, profile_allowlist=None: homes,
+    )
+    monkeypatch.setattr("hermes_cli.model_catalog.refresh_catalogs", flaky_refresh)
+
+    await gateway_run._refresh_model_catalogs_for_all_profiles(
+        GatewayConfig(multiplex_profiles=True)
+    )
+
+    assert seen == [tmp_path / "worker"]

--- a/tests/hermes_cli/test_nous_auth_keepalive.py
+++ b/tests/hermes_cli/test_nous_auth_keepalive.py
@@ -1,4 +1,8 @@
+import threading
+from pathlib import Path
+
 from hermes_cli import nous_auth_keepalive as keepalive
+from hermes_constants import get_hermes_home
 
 # Both lifetimes have been observed on real installs.
 OBSERVED_LIFETIMES_SECONDS = (3594, 899)
@@ -122,3 +126,159 @@ def test_keepalive_falls_back_to_singleton_state(monkeypatch):
 
     assert keepalive.refresh_nous_auth_keepalive_once(timeout_seconds=15.0) is True
     assert calls == [{"timeout_seconds": 15.0}]
+
+
+# ---------------------------------------------------------------------------
+# Multiplex profile scoping (#-, raw threading.Thread does not inherit the
+# spawning thread's contextvars, so an unscoped keepalive loop only ever
+# resolves get_hermes_home() as the default profile).
+# ---------------------------------------------------------------------------
+
+
+def test_profile_homes_single_profile_gateway_is_unscoped(monkeypatch):
+    """No multiplexing -> legacy shape: one entry, home=None (run unscoped)."""
+
+    class _Config:
+        multiplex_profiles = False
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: _Config())
+    monkeypatch.setattr(keepalive, "_active_profile_name", lambda: "default")
+
+    assert keepalive._keepalive_profile_homes() == [("default", None)]
+
+
+def test_profile_homes_multiplex_returns_every_profile_home(monkeypatch):
+    """Multiplexed -> every profile gateway.run._multiplex_profile_homes yields."""
+
+    class _Config:
+        multiplex_profiles = True
+        multiplex_profile_allowlist = None
+
+    homes = [("default", Path("/h")), ("worker", Path("/h/profiles/worker"))]
+    monkeypatch.setattr("gateway.config.load_gateway_config", lambda: _Config())
+    monkeypatch.setattr("gateway.run._multiplex_profile_homes", lambda _cfg: homes)
+
+    assert keepalive._keepalive_profile_homes() == homes
+
+
+def test_profile_homes_degrades_to_active_profile_when_resolution_raises(monkeypatch):
+    """A broken config/profile resolver must not disable the keepalive entirely."""
+
+    def _boom():
+        raise RuntimeError("config.yaml unreadable")
+
+    monkeypatch.setattr("gateway.config.load_gateway_config", _boom)
+    monkeypatch.setattr(keepalive, "_active_profile_name", lambda: "default")
+
+    assert keepalive._keepalive_profile_homes() == [("default", None)]
+
+
+def test_tick_one_profile_enters_that_profiles_runtime_scope(
+    tmp_path, monkeypatch
+):
+    """The whole point of the fix: the refresh call sees THAT profile's home.
+
+    Asserting on the observed ``get_hermes_home()`` (not just the call count)
+    keeps this mutation-survivable -- dropping the ``with
+    _profile_runtime_scope(...)`` still calls ``refresh_nous_auth_keepalive_once``
+    once, but it would see the process-default home instead of the profile's.
+    """
+    profile_home = tmp_path / "profiles" / "worker"
+    profile_home.mkdir(parents=True)
+    seen = []
+
+    def _fake_refresh(**_kwargs):
+        seen.append(get_hermes_home())
+        return True
+
+    monkeypatch.setattr(keepalive, "refresh_nous_auth_keepalive_once", _fake_refresh)
+    monkeypatch.setattr(keepalive, "_observed_lifetime_seconds", lambda: None)
+
+    tick = keepalive._keepalive_tick_one_profile(
+        "worker",
+        profile_home,
+        interval_seconds=900,
+        min_key_ttl_seconds=60,
+        timeout_seconds=None,
+    )
+
+    assert seen == [profile_home]
+    assert tick == 900
+    # Scope must not leak past the call.
+    assert get_hermes_home() != profile_home
+
+
+def test_tick_one_profile_none_home_runs_unscoped(monkeypatch):
+    """``profile_home=None`` is the legacy single-profile path: no scope entered."""
+    ambient_home = get_hermes_home()
+    seen = []
+
+    def _fake_refresh(**_kwargs):
+        seen.append(get_hermes_home())
+        return True
+
+    monkeypatch.setattr(keepalive, "refresh_nous_auth_keepalive_once", _fake_refresh)
+    monkeypatch.setattr(keepalive, "_observed_lifetime_seconds", lambda: None)
+
+    keepalive._keepalive_tick_one_profile(
+        "default",
+        None,
+        interval_seconds=900,
+        min_key_ttl_seconds=60,
+        timeout_seconds=None,
+    )
+
+    assert seen == [ambient_home]
+
+
+class _StopAfterFirstPass:
+    """Fake ``threading.Event``: lets ``_keepalive_loop`` run exactly one pass."""
+
+    def __init__(self):
+        self._set = False
+
+    def wait(self, _timeout=None):
+        self._set = True
+        return self._set
+
+    def is_set(self):
+        return self._set
+
+
+def test_keepalive_loop_ticks_every_multiplex_profile_home_per_pass(
+    tmp_path, monkeypatch
+):
+    """End-to-end: one loop pass must refresh every configured profile's own home.
+
+    This is the regression this whole fix exists for: before it, the loop
+    called ``refresh_nous_auth_keepalive_once`` exactly once per pass, always
+    under whatever home was ambient at thread-spawn time (the default
+    profile) -- a secondary profile's independent Nous OAuth login was never
+    proactively refreshed.
+    """
+    homes = [
+        ("default", tmp_path / "default"),
+        ("worker", tmp_path / "worker"),
+    ]
+    for _name, home in homes:
+        home.mkdir()
+
+    seen = []
+
+    def _fake_refresh(**_kwargs):
+        seen.append((get_hermes_home(), threading.current_thread().name))
+        return True
+
+    monkeypatch.setattr(keepalive, "_keepalive_profile_homes", lambda: homes)
+    monkeypatch.setattr(keepalive, "refresh_nous_auth_keepalive_once", _fake_refresh)
+    monkeypatch.setattr(keepalive, "_observed_lifetime_seconds", lambda: None)
+
+    keepalive._keepalive_loop(
+        _StopAfterFirstPass(),
+        interval_seconds=900,
+        initial_delay_seconds=0,
+        min_key_ttl_seconds=60,
+        timeout_seconds=None,
+    )
+
+    assert [home for home, _thread in seen] == [home for _name, home in homes]


### PR DESCRIPTION
## Summary

Two background jobs resolve `get_hermes_home()` internally but never enter a per-profile scope, so under `gateway.multiplex_profiles` they only ever act on the default profile. Same root cause, two different loops — one PR.

- **`hermes_cli/nous_auth_keepalive.py`**: `start_nous_auth_keepalive()` spawns a raw `threading.Thread`. Unlike `asyncio.to_thread`, a raw `threading.Thread` does **not** inherit the spawning thread's contextvars (verified empirically — see test plan). `_keepalive_loop` calls `get_provider_auth_state("nous")` / the credential pool / `resolve_nous_runtime_credentials()`, all of which resolve `get_hermes_home()`. Under multiplex, a secondary profile's independent Nous OAuth login is never proactively refreshed — it silently expires into reactive 401s, the exact failure mode this whole module exists to prevent (#101464), just scoped to one profile instead of none.

  Fix: each pass now resolves every profile this process serves (mirrors `gateway.run._multiplex_profile_homes`) and enters that profile's `_profile_runtime_scope` for its own observe-then-refresh. The loop's cadence (`stop_event.wait(...)`) is driven by whichever profile's credential needs the tightest tick, so the existing tick/horizon invariant (a credential must survive until the next check) still holds for every profile, not just the default one.

- **`gateway/run.py`'s `_model_catalog_refresh_watcher`** (new today, #101319): calls `model_catalog.refresh_catalogs()` via `asyncio.to_thread` once per 20-minute tick, never re-entering `_profile_runtime_scope` per profile. `refresh_catalogs()` resolves its on-disk cache path via `get_hermes_home()`, so secondary multiplex profiles' catalog caches never get this proactive refresh — they're stuck on the pre-#101319 behavior (refresh only on a cold `/model` open), which is exactly the gap the whole feature was built to close, just not extended to secondary profiles.

  Fix: added `_refresh_model_catalogs_for_all_profiles()`, which mirrors the existing `_discover_gateway_mcp_tools()` per-profile scoping pattern already established in this file (single unscoped call when `multiplex_profiles` is off, one `async with _async_profile_runtime_scope(...)` per served profile otherwise).

## Test plan

- Empirically confirmed (throwaway scripts) that a raw `threading.Thread` does **not** inherit contextvars, while `asyncio.to_thread` does — the premise both fixes rely on.
- `tests/hermes_cli/test_nous_auth_keepalive.py`: added tests for `_keepalive_profile_homes` (single-profile legacy shape, multiplex profile list, degrade-on-error), `_keepalive_tick_one_profile` (proves the refresh call observes the *scoped* profile's `get_hermes_home()`, and that the scope doesn't leak past the call), and an end-to-end `_keepalive_loop` test proving one pass touches every configured profile's own home.
- `tests/gateway/test_model_catalog_refresh_watcher_multiplex.py` (new): mirrors `tests/gateway/test_multiplex_mcp_discovery.py`'s pattern for `_discover_gateway_mcp_tools`. Proves `_refresh_model_catalogs_for_all_profiles` refreshes once, unscoped, for a single-profile gateway; refreshes every profile under its own home for a multiplex gateway; and that one profile's refresh failure doesn't starve its siblings.
- Mutation-verify for both fixes: reverted each file via patch (not `git stash` — this worktree shares a `.git` with sibling worktrees), confirmed the new tests fail without the fix (`AttributeError` on the now-missing helpers), reapplied, confirmed pass.
- `tests/hermes_cli/test_nous_auth_keepalive.py`, `tests/gateway/test_model_catalog_refresh_watcher_multiplex.py`, `tests/gateway/test_multiplex_mcp_discovery.py`, `tests/gateway/test_handoff_watcher_multiprofile.py`, and `tests/hermes_cli/test_model_catalog.py` all pass together with no regressions.
- [x] Confirmed no open competitor PR touches `hermes_cli/nous_auth_keepalive.py` or `_model_catalog_refresh_watcher`/`_discover_gateway_mcp_tools`-style multiplex scoping in `gateway/run.py` for these two specific call sites (checked right before push).