### PR TITLE
fix(desktop): resolve session color picker across all pinnable slices

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.test.tsx
@@ -1,10 +1,23 @@
 import { cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react'
 import { atom } from 'nanostores'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest'
 
-import { SessionActionsMenu, SessionContextMenu } from './session-actions-menu'
+import { DropdownMenu, DropdownMenuContent, DropdownMenuSub, DropdownMenuSubTrigger } from '@/components/ui/dropdown-menu'
+import { setSessionColorOverride } from '@/store/session-color'
+import { loadedRowFor } from '@/store/session-pin-sync'
+
+import { SessionActionsMenu, SessionColorSwatches, SessionContextMenu } from './session-actions-menu'
 
 afterEach(cleanup)
+
+// Radix calls these on open; jsdom doesn't implement them. Only the
+// Appearance-submenu test below (which force-opens a DropdownMenuSub) needs
+// them, but stubbing globally is harmless for the rest of the suite.
+beforeAll(() => {
+  Element.prototype.scrollIntoView = vi.fn()
+  Element.prototype.hasPointerCapture = vi.fn(() => false)
+  Element.prototype.releasePointerCapture = vi.fn()
+})
 
 // Exercises the real SessionActionsMenu end-to-end (no DropdownMenu mock) so
 // a broken asChild composition on the kebab trigger fails here — the menu
@@ -71,7 +84,7 @@ vi.mock('@/i18n', () => ({
   })
 }))
 vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
-vi.mock('@/lib/profile-color', () => ({ PROFILE_SWATCHES: [] }))
+vi.mock('@/lib/profile-color', () => ({ PROFILE_SWATCHES: ['#3b82f6'] }))
 vi.mock('@/lib/session-export', () => ({ exportSession: vi.fn() }))
 vi.mock('@/store/gateway', () => ({ activeGateway: vi.fn(() => null) }))
 vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
@@ -91,12 +104,22 @@ vi.mock('@/store/session', () => ({
   $unreadFinishedSessionIds: atom<string[]>([]),
   markSessionRead: vi.fn(),
   sessionMatchesStoredId: vi.fn(() => false),
-  sessionPinId: vi.fn((s: { id: string }) => s.id),
+  // Real fallback semantics (see session.ts's sessionPinId): a lineage-rotated
+  // row's durable pin id is its ORIGINAL root, not its current live id.
+  sessionPinId: vi.fn((s: { _lineage_root_id?: null | string; id: string }) => s._lineage_root_id ?? s.id),
   setSessions: vi.fn()
 }))
 vi.mock('@/store/session-color', () => ({
   $sessionColorOverrides: atom<Record<string, string>>({}),
   setSessionColorOverride: vi.fn()
+}))
+// The cross-slice pin resolver (recents + cron + messaging, active-gateway
+// tie-break) — session-pin-sync.test.ts already covers its own resolution
+// logic in depth. Here it's a plain stub SessionColorSwatches calls into, so
+// this suite only has to prove it's consulted (and its result used) instead
+// of the component re-deriving a $sessions-only lookup.
+vi.mock('@/store/session-pin-sync', () => ({
+  loadedRowFor: vi.fn(() => undefined)
 }))
 vi.mock('@/store/session-states', () => ({
   $sessionTiles: atom<unknown[]>([]),
@@ -286,5 +309,57 @@ describe('SessionActionsMenu', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }))
     expect(await screen.findByText('Session deleted')).toBeTruthy()
     expect(onDelete).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('SessionColorSwatches', () => {
+  // A pinned row from a NON-$sessions slice (cron/messaging) whose live id has
+  // rotated away from its original lineage root — the realistic case for any
+  // session that has been through auto-compression. The reader
+  // (session-color.ts's resolveSessionColor) always keys on sessionPinId,
+  // i.e. the lineage root — so the picker must write under that same key, not
+  // the raw live id it was passed, or the color silently never renders.
+  const cronRow = { _lineage_root_id: 'root-1', id: 'live-2', profile: 'default', title: 'Nightly build' }
+
+  // Force-opens the DropdownMenuSub so the swatches mount without needing to
+  // drive Radix's real hover/keyboard sub-menu interaction — same technique
+  // as apps/desktop/src/app/shell/model-edit-submenu.test.tsx.
+  function renderSwatches(sessionId: string) {
+    return render(
+      <DropdownMenu open>
+        <DropdownMenuContent>
+          <DropdownMenuSub open>
+            <DropdownMenuSubTrigger>Appearance</DropdownMenuSubTrigger>
+            <SessionColorSwatches sessionId={sessionId} />
+          </DropdownMenuSub>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  }
+
+  it('writes the color override under the lineage-root id for a pinned cron/messaging row not in $sessions', async () => {
+    // $sessions itself never has this row (it lives in $cronSessions /
+    // $messagingSessions) — loadedRowFor is the cross-slice resolver that
+    // finds it regardless.
+    vi.mocked(loadedRowFor).mockReturnValue(cronRow as never)
+
+    renderSwatches('live-2')
+
+    const swatch = await screen.findByRole('button', { name: '#3b82f6' })
+    fireEvent.click(swatch)
+
+    expect(setSessionColorOverride).toHaveBeenCalledWith('root-1', '#3b82f6')
+    expect(setSessionColorOverride).not.toHaveBeenCalledWith('live-2', expect.anything())
+  })
+
+  it('falls back to the raw sessionId when no slice has the row', async () => {
+    vi.mocked(loadedRowFor).mockReturnValue(undefined)
+
+    renderSwatches('unresolvable-id')
+
+    const swatch = await screen.findByRole('button', { name: '#3b82f6' })
+    fireEvent.click(swatch)
+
+    expect(setSessionColorOverride).toHaveBeenCalledWith('unresolvable-id', '#3b82f6')
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx
@@ -35,6 +35,8 @@ import { $projectTree, moveSessionToProject, projectIdForCwd, projectRootCwd } f
 import {
   $activeSessionId,
   $connection,
+  $cronSessions,
+  $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
   $unreadFinishedSessionIds,
@@ -44,6 +46,7 @@ import {
   setSessions
 } from '@/store/session'
 import { $sessionColorOverrides, setSessionColorOverride } from '@/store/session-color'
+import { loadedRowFor } from '@/store/session-pin-sync'
 import { $sessionTiles, closeAllOpenSessionTiles } from '@/store/session-states'
 import { ackStoredSessionId } from '@/store/session-unread'
 import { canOpenSessionInTerminal, canOpenSessionWindow, openSessionInTerminal } from '@/store/windows'
@@ -126,10 +129,23 @@ interface SessionActions {
 // component so only an OPEN submenu subscribes to the stores (not every row's
 // menu). Reads/writes the override keyed by the DURABLE id so a color survives
 // compression; clearing falls back to the inherited project color.
-function SessionColorSwatches({ sessionId }: { sessionId: string }) {
+//
+// This menu renders for pinned rows from ANY of the three pinnable slices
+// (recents, cron runs, messaging), not just $sessions — a cron/messaging row
+// looked up only in $sessions would never be found, silently falling back to
+// the raw (possibly stale, pre-lineage-rotation) sessionId prop and writing
+// the override under a key session-color.ts's reader never looks up. Reuse
+// session-pin-sync's cross-slice `loadedRowFor`, the same resolver the pin
+// mirror itself uses, instead of re-deriving a $sessions-only lookup here.
+export function SessionColorSwatches({ sessionId }: { sessionId: string }) {
   const { t } = useI18n()
   const overrides = useStore($sessionColorOverrides)
-  const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
+  // Subscribed only so this component re-renders when any slice changes —
+  // loadedRowFor re-reads the stores' current values itself.
+  useStore($sessions)
+  useStore($cronSessions)
+  useStore($messagingSessions)
+  const session = loadedRowFor(sessionId)
   const durableId = session ? sessionPinId(session) : sessionId
 
   return (
@@ -149,6 +165,13 @@ function SessionColorSwatches({ sessionId }: { sessionId: string }) {
 // project's root — the fix for a chat created in the wrong folder. The current
 // owner and folderless projects (the Home bucket) are excluded: there is
 // nothing to move into.
+//
+// Scope note: this lookup is $sessions-only too, but unlike SessionColorSwatches
+// that's not treated as a cross-slice gap here — the project tree ($projectTree)
+// is built from $sessions/$projects alone, cron and messaging rows are never
+// grouped into it (grep confirms neither slice feeds projects/model.ts), so
+// "move to project" has no user-visible effect for those row types either way.
+// Left unchanged; flagging it instead of guessing.
 function MoveToProjectItems({ kit, sessionId, profile }: { kit: MenuKit; sessionId: string; profile?: string }) {
   const { t } = useI18n()
   const p = t.sidebar.projects

--- a/apps/desktop/src/store/session-pin-sync.ts
+++ b/apps/desktop/src/store/session-pin-sync.ts
@@ -83,8 +83,13 @@ function loadedSessionRows(): SessionInfo[] {
  * `rowsByPinId`: when two profiles share the id, the write must target the
  * row the pull adopted — the active gateway's — or an unpin PATCHes the other
  * profile and the next page re-adopts the pin.
+ *
+ * Exported so any other surface that needs to resolve a row by its pin id (or
+ * its live id — `sessionMatchesStoredId` accepts either) across all three
+ * pinnable slices reuses this instead of re-deriving its own `$sessions`-only
+ * lookup, which would miss cron/messaging rows entirely.
  */
-function loadedRowFor(pinId: string): SessionInfo | undefined {
+export function loadedRowFor(pinId: string): SessionInfo | undefined {
   const rows = loadedSessionRows().filter(row => sessionMatchesStoredId(row, pinId))
   const gateway = normalizeProfileKey($activeGatewayProfile.get())
 


### PR DESCRIPTION
## Problem

`SessionColorSwatches` (the Appearance submenu in the sidebar row context menu, `apps/desktop/src/app/chat/sidebar/session-actions-menu.tsx`) resolved its target session by looking it up **only in `$sessions`**:

```ts
const session = useStore($sessions).find(s => sessionMatchesStoredId(s, sessionId))
const durableId = session ? sessionPinId(session) : sessionId
```

This menu renders generically for any pinned sidebar row, regardless of which of the three pinnable slices it came from (`$sessions`, `$cronSessions`, `$messagingSessions` — see `apps/desktop/src/app/chat/sidebar/index.tsx`'s `pinnedSessions`, which merges all three). A pinned cron-run or messaging row is never present in `$sessions`, so the lookup always misses and `durableId` falls back to the raw `sessionId` prop — the row's **current, live** id.

Meanwhile the read side (`session-color.ts`'s `resolveSessionColor`) always keys purely on `sessionPinId(session)`, which prefers `_lineage_root_id` over the live `id` so a color survives auto-compression's session-id rotation:

```ts
export const sessionPinId = (session) => session._lineage_root_id ?? session.id
```

So for a pinned cron/messaging session whose `_lineage_root_id` differs from its current `id` (the realistic case for any session that has been through auto-compression — a generic `SessionInfo` field, applicable to all three slices), picking a color writes the override under the wrong key (`session.id`) while the reader looks it up under the correct key (`_lineage_root_id`). The picked color silently never renders for that row.

## Fix

Same-day PR #101208 established `loadedRowFor()` in `session-pin-sync.ts` — a cross-slice resolver (checks `$sessions` + `$cronSessions` + `$messagingSessions`, tie-broken by active gateway profile) — for exactly this "pin id might belong to any of the three slices" problem, but only wired it into the pin-sync mechanism itself. `SessionColorSwatches` was left on its old `$sessions`-only lookup.

This PR exports `loadedRowFor()` and reuses it in `SessionColorSwatches` instead of re-deriving a `$sessions`-only lookup:

```ts
const session = loadedRowFor(sessionId)
const durableId = session ? sessionPinId(session) : sessionId
```

(plus subscribing to all three slice atoms so the component still re-renders when any of them change — `loadedRowFor` itself reads plain snapshots).

### `MoveToProjectItems` — scope note

This same file has a second, identical-looking `useStore($sessions).find(...)` lookup in `MoveToProjectItems` (the "Move to project" submenu). I checked whether this is an analogous bug and concluded it is not worth touching here: the project tree (`$projectTree`) is built from `$sessions`/`$projects` alone, and cron/messaging rows are never grouped into it (grep confirms neither slice feeds `projects/model.ts`). "Move to project" has no user-visible effect for those row types regardless of which slice the lookup checks, so widening this lookup wouldn't fix anything currently reachable. Left unchanged and flagged here rather than guessed at.

## Tests

Extended `session-actions-menu.test.tsx`:
- `SessionColorSwatches` writes the color override under the lineage-root id for a pinned cron/messaging row not present in `$sessions` (mocks `loadedRowFor` to return such a row, then asserts `setSessionColorOverride` is called with the lineage-root id, not the live id).
- Falls back to the raw `sessionId` when no slice resolves the row at all (unchanged existing behavior).

Also fixed the test file's `sessionPinId` mock, which previously always returned `s.id` regardless of `_lineage_root_id` — a mock that couldn't have caught this class of bug even with a correct test, since it never modeled the lineage-root fallback.

**Mutation-verify:** reverted just the `SessionColorSwatches` lookup back to the pre-fix `$sessions`-only version (patch-file method, not stash — this worktree shares a `.git` with several concurrent agents), reran the suite — the new lineage-root test failed exactly as expected (asserted `'root-1'`, got `'live-2'`), the fallback test still passed. Restored the fix; diff verified byte-identical to before the mutation. Full file suite: 8/8 passing. Also ran `session-pin-sync.test.ts` and `session-color.test.ts` (41/41 total) — no regressions.

**Typecheck:** `npx tsc -p tsconfig.electron.json --noEmit` and `npx tsc -p tsconfig.json --noEmit` both clean. `eslint` on the three changed files clean.

## Competitor check

Fresh searches right before push (`"color swatch"`, `"durableId session color"`, `"session color pinned cron"`, `"SessionColorSwatches"`, `"session-actions-menu"`, `"MoveToProjectItems"`) turned up nothing overlapping — the closest hits are the original color-override feature PR (#67681, merged) and the same-day pin-sync saga PR (#101208, merged, confirmed via `gh pr diff` to never touch `session-actions-menu.tsx`).