### PR TITLE
fix(cli): tell Linux users to install a C++ toolchain when desktop deps fail

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7640,6 +7640,33 @@ def _electron_pkg_staged_missing_dist(project_root: Path) -> bool:
     )
 
 
+def _linux_native_build_toolchain_hint() -> Optional[str]:
+    """Missing C++ toolchain hint for native module builds on Linux (#102081).
+
+    node-pty ships prebuilds for Windows and macOS only, so on Linux its
+    install script always falls back to a local node-gyp build, which needs
+    ``make`` and a C++ compiler on PATH. When either is missing the install
+    dies deep inside a long npm log whose only actionable line is
+    ``make: g++: No such file or directory``, and the generic "run npm ci
+    manually" advice cannot help — the manual run fails the same way.
+    """
+    if sys.platform != "linux":
+        return None
+    missing = [tool for tool in ("make", "g++") if shutil.which(tool) is None]
+    if not missing:
+        return None
+    listed = ", ".join(missing)
+    return (
+        "  ⚠ Native modules such as node-pty ship no Linux prebuilds and must\n"
+        f"    be compiled locally, but these are missing from PATH: {listed}.\n"
+        "    Install a C++ toolchain (or your distro's equivalent), e.g.:\n"
+        "      Debian/Ubuntu:  sudo apt install -y build-essential\n"
+        "      Fedora:         sudo dnf install -y gcc-c++ make\n"
+        "      Arch:           sudo pacman -S --needed base-devel\n"
+        "    then run this command again."
+    )
+
+
 def _redownload_electron_dist(
     project_root: Path,
     env: dict,
@@ -8643,6 +8670,9 @@ def cmd_gui(args: argparse.Namespace):
                 if not _electron_pkg_staged_missing_dist(PROJECT_ROOT):
                     print("✗ Desktop dependency install failed")
                     print(f"  Run manually:  cd {PROJECT_ROOT} && npm ci")
+                    toolchain_hint = _linux_native_build_toolchain_hint()
+                    if toolchain_hint:
+                        print(toolchain_hint)
                     sys.exit(install_result.returncode or 1)
                 repaired = _try_redownload_electron_dist(PROJECT_ROOT, env)
                 if repaired:

--- a/tests/hermes_cli/test_desktop_native_toolchain_hint.py
+++ b/tests/hermes_cli/test_desktop_native_toolchain_hint.py
@@ -1,0 +1,44 @@
+"""Regression tests for the Linux native toolchain hint (#102081).
+
+``hermes desktop`` installs the workspace's Node dependencies, and on Linux
+node-pty has no prebuilds — its install script always compiles locally and
+needs ``make`` plus a C++ compiler on PATH. When the compiler is missing the
+npm install fails with a wall of log text and the generic "run npm ci
+manually" advice cannot help, so the CLI must call out the missing toolchain
+explicitly.
+"""
+
+import hermes_cli.main as main_mod
+
+
+def test_hint_none_off_linux(monkeypatch):
+    monkeypatch.setattr(main_mod.sys, "platform", "darwin")
+    monkeypatch.setattr(main_mod.shutil, "which", lambda tool: None)
+    assert main_mod._linux_native_build_toolchain_hint() is None
+
+
+def test_hint_when_whole_toolchain_missing(monkeypatch):
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+    monkeypatch.setattr(main_mod.shutil, "which", lambda tool: None)
+    hint = main_mod._linux_native_build_toolchain_hint()
+    assert hint is not None
+    assert "missing from PATH: make, g++" in hint
+    assert "build-essential" in hint
+
+
+def test_hint_lists_only_the_missing_tools(monkeypatch):
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+
+    def fake_which(tool: str):
+        return "/usr/bin/make" if tool == "make" else None
+
+    monkeypatch.setattr(main_mod.shutil, "which", fake_which)
+    hint = main_mod._linux_native_build_toolchain_hint()
+    assert hint is not None
+    assert "missing from PATH: g++" in hint
+
+
+def test_hint_none_when_toolchain_present(monkeypatch):
+    monkeypatch.setattr(main_mod.sys, "platform", "linux")
+    monkeypatch.setattr(main_mod.shutil, "which", lambda tool: f"/usr/bin/{tool}")
+    assert main_mod._linux_native_build_toolchain_hint() is None


### PR DESCRIPTION
## What does this PR do?

When `hermes desktop` fails to install workspace Node dependencies on a Linux host without a C++ toolchain, the only advice printed is `Run manually: cd <root> && npm ci` — which fails the exact same way, because the root cause is environmental, not a broken install tree.

The root cause: `node-pty` ships prebuilds for Windows and macOS only (its npm tarball contains `prebuilds/darwin-*` and `prebuilds/win32-*`, no `linux-x64`), so on Linux its install script always falls back to a local `node-gyp` rebuild. That rebuild needs `make` and `g++` on PATH; without them the install dies deep inside a long npm log whose only actionable line is `make: g++: No such file or directory` (exit 127) — exactly what the reporter of #102081 hit.

This PR adds a small hint helper: after the install failure (same exit code, same behavior otherwise), on Linux we check `shutil.which` for `make`/`g++` and, when either is missing, print a distro-specific install command (`build-essential` / `gcc-c++ make` / `base-devel`) so the user knows what to do instead of re-running a doomed `npm ci`.

## Related Issue

Fixes #102081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/main.py`: added `_linux_native_build_toolchain_hint()` — returns `None` off Linux or when `make`/`g++` are both on PATH; otherwise returns a multi-line hint naming the missing tools and distro install commands.
- `hermes_cli/main.py`: in `cmd_gui`'s desktop dependency install failure branch, print the hint (when applicable) before `sys.exit`, right after the existing `npm ci` advice.
- `tests/hermes_cli/test_desktop_native_toolchain_hint.py`: new regression tests (off-Linux → `None`; full toolchain missing → lists `make, g++` + `build-essential`; only `g++` missing → lists just `g++`; toolchain present → `None`).

## How to Test

1. `python -m pytest tests/hermes_cli/test_desktop_native_toolchain_hint.py -v` — all 4 tests pass (Observed result: 4 passed in 0.57s).
2. On macOS: `python -c "import hermes_cli.main as m; print(m._linux_native_build_toolchain_hint())"` prints `None` (helper is a no-op off Linux).
3. On a Linux host without `g++` (the #102081 environment): `hermes desktop` still fails with the same exit code, but now additionally prints:
   ```
     ⚠ Native modules such as node-pty ship no Linux prebuilds and must
       be compiled locally, but these are missing from PATH: make, g++.
       Install a C++ toolchain (or your distro's equivalent), e.g.:
         Debian/Ubuntu:  sudo apt install -y build-essential
         Fedora:         sudo dnf install -y gcc-c++ make
         Arch:           sudo pacman -S --needed base-devel
       then run this command again.
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/hermes_cli/test_desktop_native_toolchain_hint.py -q` and all tests pass (full suite is covered by CI; the change is a purely additive print path with no existing tests touching the modified branch)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64); Linux path verified via the mocked-platform unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A (helper carries an explanatory docstring)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — helper returns `None` on non-Linux platforms; Windows/macOS users have prebuilds and are unaffected
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — not a skill.

## Screenshots / Logs

See "How to Test" step 3 for the exact hint output on the affected Linux environment.
