### PR TITLE
fix(feishu): deliver files when topic routing rejects them

### DIFF
--- a/plugins/platforms/feishu/adapter.py
+++ b/plugins/platforms/feishu/adapter.py
@@ -4901,11 +4901,14 @@ class FeishuAdapter(BasePlatformAdapter):
                     reply_to=reply_to,
                     metadata=metadata,
                 )
-                # Audio messages may fail with 99992402 when using thread_id routing.
-                # Try replying to the last message in the thread, then fall back to chat_id.
+                # Uploaded attachments may fail with 99992402 when using
+                # thread_id routing. Try replying to the last message in the
+                # thread, then fall back to chat_id so a valid upload is not
+                # silently lost. This covers voice, document, and video
+                # attachments without changing their normal success path.
                 if (not self._response_succeeded(message_response)
                         and getattr(message_response, "code", None) == 99992402
-                        and resolved_message_type == "audio"
+                        and resolved_message_type in {"audio", "file", "media"}
                         and (metadata or {}).get("thread_id")):
                     # Try reply API with thread_id as reply anchor
                     thread_msg_id = (metadata or {}).get("reply_to_message_id")
@@ -4914,7 +4917,10 @@ class FeishuAdapter(BasePlatformAdapter):
                             (metadata or {}).get("thread_id")
                         )
                     if thread_msg_id:
-                        logger.info("[Feishu] Audio: retrying via reply API in thread")
+                        logger.info(
+                            "[Feishu] Attachment (%s): retrying via reply API in thread",
+                            resolved_message_type,
+                        )
                         message_response = await self._feishu_send_with_retry(
                             chat_id=chat_id,
                             msg_type=resolved_message_type,
@@ -4923,7 +4929,10 @@ class FeishuAdapter(BasePlatformAdapter):
                             metadata=metadata,
                         )
                     if not self._response_succeeded(message_response):
-                        logger.warning("[Feishu] Audio send failed in thread, retrying with chat_id")
+                        logger.warning(
+                            "[Feishu] Attachment (%s) send failed in thread, retrying with chat_id",
+                            resolved_message_type,
+                        )
                         message_response = await self._feishu_send_with_retry(
                             chat_id=chat_id,
                             msg_type=resolved_message_type,

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -1246,6 +1246,77 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(result.success)
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_document_thread_validation_failure_falls_back_to_chat(self):
+        from gateway.config import PlatformConfig
+        from plugins.platforms.feishu.adapter import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {"replies": [], "creates": []}
+
+        class _FileAPI:
+            def create(self, request):
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_123"),
+                )
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["replies"].append(request)
+                return SimpleNamespace(
+                    success=lambda: False,
+                    code=99992402,
+                    msg="field validation failed",
+                )
+
+            def create(self, request):
+                captured["creates"].append(request)
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_file_fallback"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".xlsx", delete=False) as tmp:
+            tmp.write(b"xlsx fixture")
+            file_path = tmp.name
+
+        try:
+            with patch("plugins.platforms.feishu.adapter.asyncio.to_thread", side_effect=_direct):
+                result = asyncio.run(
+                    adapter.send_document(
+                        chat_id="oc_chat",
+                        file_path=file_path,
+                        metadata={
+                            "thread_id": "omt-thread",
+                            "reply_to_message_id": "om_parent",
+                        },
+                    )
+                )
+        finally:
+            os.unlink(file_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(len(captured["replies"]), 2)
+        self.assertTrue(captured["replies"][0].request_body.reply_in_thread)
+        self.assertEqual(len(captured["creates"]), 1)
+        fallback = captured["creates"][0]
+        self.assertEqual(fallback.receive_id_type, "chat_id")
+        self.assertEqual(fallback.request_body.receive_id, "oc_chat")
+        self.assertEqual(fallback.request_body.msg_type, "file")
+
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_uses_post_for_every_chunk_of_multi_chunk_markdown(self):
@@ -2520,5 +2591,4 @@ class TestChatLockEviction(unittest.TestCase):
 
         adapter = self._make_adapter()
         self.assertIsInstance(adapter._chat_locks, _collections.OrderedDict)
-
 


### PR DESCRIPTION
## Summary

- extend the existing Feishu topic fallback from audio to document and video attachments
- preserve the normal successful topic reply path
- fall back to the parent chat only after Feishu rejects an uploaded attachment with `99992402 field validation failed`
- add regression coverage for an `.xlsx` document sent from a topic

## Reproduction

A Feishu topic response containing two valid `MEDIA:` paths to `.xlsx` files reached the attachment delivery loop. Both workbooks existed and were valid ZIP/XLSX files, but Feishu rejected both attachment messages with code `99992402`. The current adapter already handles this failure for `audio`; `file` and `media` skip the fallback and are silently absent apart from the generic delivery warning.

## Compatibility boundary

The change is confined to the Feishu plugin and its test. It does not change MEDIA parsing, path allowlists, generic gateway behavior, other platforms, or the success path for topic attachments.

## Testing

Tests will be run after PR creation and results appended here.