### PR TITLE
fix(reasoning): GLM-5.3 on Nous/OpenRouter no longer 400s when thinking is disabled

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1969,14 +1969,24 @@ def _consume_ephemeral_reasoning_off(agent) -> bool:
 
 
 def _reasoning_config_for_wire(agent):
-    """``agent.reasoning_config`` with the one-shot reasoning-off override applied."""
+    """``agent.reasoning_config`` with the one-shot reasoning-off override applied.
+
+    Once the route has answered a disable with "reasoning is mandatory"
+    (``agent._reasoning_disable_rejected``), every disable — configured or
+    the one-shot continuation override — is dropped for the rest of the
+    session: the request goes out without a reasoning config and the route
+    applies its own default.
+    """
+    cfg = agent.reasoning_config
     if _consume_ephemeral_reasoning_off(agent):
-        return {
-            **(agent.reasoning_config or {}),
-            "enabled": False,
-            "effort": "none",
-        }
-    return agent.reasoning_config
+        cfg = {**(cfg or {}), "enabled": False, "effort": "none"}
+    if (
+        getattr(agent, "_reasoning_disable_rejected", False)
+        and isinstance(cfg, dict)
+        and (cfg.get("enabled") is False or cfg.get("effort") == "none")
+    ):
+        return None
+    return cfg
 
 
 def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = None) -> dict:

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -1978,14 +1978,20 @@ def _reasoning_config_for_wire(agent):
     applies its own default.
     """
     cfg = agent.reasoning_config
-    if _consume_ephemeral_reasoning_off(agent):
+    ephemeral_off = _consume_ephemeral_reasoning_off(agent)
+    if getattr(agent, "_reasoning_disable_rejected", False):
+        # The route rejects disables. Resend exactly what the session has
+        # been sending — the user's own config — so the retry lands on the
+        # same provider cache key as every prior request. Only a config that
+        # is itself a disable is dropped (omitted → route default), and that
+        # session has never sent anything else, so nothing warm is lost.
+        if isinstance(cfg, dict) and (
+            cfg.get("enabled") is False or cfg.get("effort") == "none"
+        ):
+            return None
+        return cfg
+    if ephemeral_off:
         cfg = {**(cfg or {}), "enabled": False, "effort": "none"}
-    if (
-        getattr(agent, "_reasoning_disable_rejected", False)
-        and isinstance(cfg, dict)
-        and (cfg.get("enabled") is False or cfg.get("effort") == "none")
-    ):
-        return None
     return cfg
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5648,6 +5648,37 @@ def run_conversation(
                     )
                     continue
 
+                # ── Reasoning-mandatory route rejected a disable ──────
+                # The route (Nous Portal / OpenRouter, e.g. GLM-5.3) answers
+                # ``reasoning: {enabled: false}`` with HTTP 400.  The catalog
+                # guard in the provider profile normally swallows the
+                # disable, but a process that warmed its capability cache
+                # before the route flipped to mandatory keeps sending it.
+                # One-shot: never send a disable again this session (the
+                # wire builder omits it → upstream default thinking), queue
+                # a catalog refresh so the guard is right next time, retry.
+                if (
+                    classified.reason == FailoverReason.reasoning_mandatory
+                    and not _retry.reasoning_mandatory_retry_attempted
+                ):
+                    _retry.reasoning_mandatory_retry_attempted = True
+                    agent._reasoning_disable_rejected = True
+                    try:
+                        from hermes_cli.models import refresh_reasoning_caps_async
+                        refresh_reasoning_caps_async(agent.provider)
+                    except Exception:
+                        pass
+                    agent._vprint(
+                        f"{agent.log_prefix}⚠️  {agent.model} requires reasoning — "
+                        f"thinking stays on for this session, retrying...",
+                        force=True,
+                    )
+                    logger.warning(
+                        "%sReasoning-mandatory recovery: dropping reasoning disable for %s",
+                        agent.log_prefix, agent.model,
+                    )
+                    continue
+
                 # ── Native compaction rejection recovery ──────────────
                 # Provider explicitly rejected the ``context_management``
                 # field (structured 400 naming the param). One-shot: turn

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -68,6 +68,7 @@ class FailoverReason(enum.Enum):
     format_error = "format_error"        # 400 bad request — abort or strip + retry
     invalid_encrypted_content = "invalid_encrypted_content"  # Responses replay blob rejected — strip replay state and retry
     multimodal_tool_content_unsupported = "multimodal_tool_content_unsupported"  # Provider rejected list-type content in tool messages (e.g. Xiaomi MiMo) — downgrade to text and retry
+    reasoning_mandatory = "reasoning_mandatory"  # Route rejects reasoning: {enabled: false} — send the disable no more this session and retry
 
     # Provider-specific
     thinking_signature = "thinking_signature"  # Anthropic thinking block sig invalid
@@ -503,6 +504,10 @@ _REQUEST_VALIDATION_PATTERNS = [
     "unknown_parameter",
     "unsupported_parameter",
 ]
+
+# A reasoning-mandatory route answering ``reasoning: {enabled: false}``
+# (Nous Portal + OpenRouter wording; ``error_msg`` is lowercased upstream).
+_REASONING_MANDATORY_PATTERN = "reasoning is mandatory"
 
 # Request parameters that Hermes sends on SOME routes only, paired with the
 # providers/hosts where sending them is deliberate.
@@ -1663,6 +1668,20 @@ def _classify_400(
         return result_fn(
             FailoverReason.invalid_encrypted_content,
             retryable=True,
+            should_fallback=False,
+        )
+
+    # Reasoning-mandatory route rejecting a disable (Nous Portal / OpenRouter
+    # for GLM-5.3 etc.: "Reasoning is mandatory for this endpoint and cannot
+    # be disabled").  Deterministic for the request shape, but the only bad
+    # field is ``reasoning: {enabled: false}`` — the conversation_loop drops
+    # the disable and retries once.  Must precede the request-validation
+    # branch, which would abort the turn as a format_error.
+    if _REASONING_MANDATORY_PATTERN in error_msg:
+        return result_fn(
+            FailoverReason.reasoning_mandatory,
+            retryable=True,
+            should_compress=False,
             should_fallback=False,
         )
 

--- a/agent/turn_retry_state.py
+++ b/agent/turn_retry_state.py
@@ -61,6 +61,7 @@ class TurnRetryState:
     native_compaction_reject_retry_attempted: bool = False
     image_shrink_retry_attempted: bool = False
     multimodal_tool_content_retry_attempted: bool = False
+    reasoning_mandatory_retry_attempted: bool = False
     oauth_1m_beta_retry_attempted: bool = False
     llama_cpp_grammar_retry_attempted: bool = False
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -2126,6 +2126,25 @@ def warm_nous_reasoning_caps_async() -> None:
     _warm_reasoning_caps_async(_refresh_nous_reasoning_caps)
 
 
+def refresh_reasoning_caps_async(provider: Optional[str]) -> None:
+    """Force a background re-fetch of *provider*'s reasoning-capability catalog.
+
+    The in-memory cache is otherwise held for the process lifetime, so a
+    route that flips to reasoning-mandatory mid-process (GLM-5.3-flash, Sep
+    2026) keeps being sent disables it now rejects. Called from the
+    conversation loop's reasoning_mandatory recovery so the profile guard is
+    right again on the next request; no-op for providers without a catalog.
+    """
+    refresh = {
+        "nous": _refresh_nous_reasoning_caps,
+        "nous-portal": _refresh_nous_reasoning_caps,
+        "nousresearch": _refresh_nous_reasoning_caps,
+        "openrouter": _refresh_openrouter_reasoning_caps,
+    }.get(str(provider or "").strip().lower())
+    if refresh is not None:
+        _warm_reasoning_caps_async(refresh)
+
+
 # Canonical low→high ordering used for nearest-level clamping. Kept as an
 # alias of the single source of truth in ``agent.reasoning_effort``.
 from agent.reasoning_effort import EFFORT_LADDER as _REASONING_EFFORT_ORDER

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -50,8 +50,11 @@ class OpenRouterProfile(ProviderProfile):
     """OpenRouter aggregator — provider preferences, reasoning config passthrough."""
 
     @staticmethod
-    def _clamp_reasoning_to_catalog(cfg: dict[str, Any], model: str | None) -> dict[str, Any]:
+    def _clamp_reasoning_to_catalog(cfg: dict[str, Any], model: str | None) -> dict[str, Any] | None:
         """Clamp ``cfg["effort"]`` to the model's catalog-advertised levels.
+
+        Returns None when the config is a disable and the catalog marks the
+        route reasoning-mandatory (the caller omits the field).
 
         OpenRouter's /v1/models entries publish ``reasoning.supported_efforts``
         per model (ported from PrimeIntellect-ai/prime-agent#1258). Sending an
@@ -61,7 +64,8 @@ class OpenRouterProfile(ProviderProfile):
         or no supported_efforts list is published (None = all levels accepted).
         """
         effort = cfg.get("effort")
-        if not effort or cfg.get("enabled") is False:
+        disabled = cfg.get("enabled") is False or effort == "none"
+        if not effort and not disabled:
             return cfg
         try:
             from hermes_cli.models import (
@@ -71,6 +75,11 @@ class OpenRouterProfile(ProviderProfile):
             caps = openrouter_model_reasoning_capabilities(model)
             if not caps or not caps.get("supports_reasoning"):
                 return cfg
+            # A reasoning-mandatory route 400s on a disable ("Reasoning is
+            # mandatory for this endpoint and cannot be disabled") — omit
+            # the field and let the model think, same as the Nous profile.
+            if disabled:
+                return None if caps.get("mandatory") else cfg
             clamped = clamp_reasoning_effort_to_supported(
                 effort, caps.get("supported_efforts")
             )
@@ -215,9 +224,11 @@ class OpenRouterProfile(ProviderProfile):
                 if cfg.get("enabled", True) is not False and effort and effort != "none":
                     top_level["verbosity"] = effort
             elif reasoning_config is not None:
-                extra_body["reasoning"] = self._clamp_reasoning_to_catalog(
+                clamped = self._clamp_reasoning_to_catalog(
                     dict(reasoning_config), model
                 )
+                if clamped is not None:
+                    extra_body["reasoning"] = clamped
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -65,6 +65,7 @@ class TestFailoverReason:
             "model_not_found", "format_error",
             "invalid_encrypted_content",
             "multimodal_tool_content_unsupported",
+            "reasoning_mandatory",
             "provider_policy_blocked",
             "content_policy_blocked",
             "thinking_signature", "long_context_tier",
@@ -689,6 +690,21 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.invalid_encrypted_content
         assert result.retryable is True
         assert result.should_fallback is False
+
+    # ── Reasoning-mandatory route rejecting a disable ──
+
+    def test_reasoning_mandatory_400_is_retryable_not_format_error(self):
+        e = MockAPIError(
+            "Error code: 400 - This request is not valid. Check the model name "
+            "and other parameters. Additional info: Reasoning is mandatory for "
+            "this endpoint and cannot be disabled.",
+            status_code=400,
+        )
+        result = classify_api_error(e, provider="nous", model="z-ai/glm-5.3-flash")
+        assert result.reason == FailoverReason.reasoning_mandatory
+        assert result.retryable is True
+        assert result.should_fallback is False
+        assert result.should_compress is False
 
     # ── Provider-specific: llama.cpp grammar-parse ──
 

--- a/tests/agent/test_turn_retry_state.py
+++ b/tests/agent/test_turn_retry_state.py
@@ -26,6 +26,7 @@ EXPECTED_FIELDS = {
     "native_compaction_reject_retry_attempted",
     "image_shrink_retry_attempted",
     "multimodal_tool_content_retry_attempted",
+    "reasoning_mandatory_retry_attempted",
     "oauth_1m_beta_retry_attempted",
     "llama_cpp_grammar_retry_attempted",
     "primary_recovery_attempted",

--- a/tests/hermes_cli/test_openrouter_reasoning_metadata.py
+++ b/tests/hermes_cli/test_openrouter_reasoning_metadata.py
@@ -266,3 +266,29 @@ class TestOpenRouterProfileClamp:
         )
         # Unknown capability → passthrough unchanged (no silent downgrade).
         assert extra_body["reasoning"]["effort"] == "ultra"
+
+    def test_disable_omitted_for_mandatory_route_kept_otherwise(self, monkeypatch):
+        """A reasoning-mandatory route 400s on ``{enabled: false}`` — omit it;
+        a route that can disable still gets the user's disable verbatim."""
+        import hermes_cli.models as models_mod
+        from providers import get_provider_profile
+
+        monkeypatch.setattr(models_mod, "_openrouter_reasoning_caps_failed_at", None)
+        monkeypatch.setattr(models_mod, "_openrouter_reasoning_caps_cache", {
+            "z-ai/glm-5.3-flash": {
+                "supports_reasoning": True,
+                "supported_efforts": ["max", "high", "low"],
+                "mandatory": True,
+            },
+            "z-ai/glm-5.1": {"supports_reasoning": True, "supported_efforts": None, "mandatory": False},
+        })
+        profile = get_provider_profile("openrouter")
+        for disable in ({"enabled": False}, {"enabled": True, "effort": "none"}):
+            extra_body, _top = profile.build_api_kwargs_extras(
+                reasoning_config=disable, supports_reasoning=True, model="z-ai/glm-5.3-flash",
+            )
+            assert "reasoning" not in extra_body, disable
+        extra_body, _top = profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False}, supports_reasoning=True, model="z-ai/glm-5.1",
+        )
+        assert extra_body["reasoning"] == {"enabled": False}

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -68,21 +68,21 @@ class TestReasoningOffOneShotOverride:
         cfg = _reasoning_config_for_wire(agent)
         assert cfg == {"enabled": False, "effort": "none"}
 
-    def test_rejected_disable_drops_every_disable_but_keeps_enabled(self):
-        """After a 'reasoning is mandatory' 400, no disable reaches the wire —
-        neither the configured one nor the one-shot continuation override —
-        while an enabled config still passes through."""
+    def test_rejected_disable_resends_users_config_verbatim(self):
+        """After a 'reasoning is mandatory' 400 the retry must land on the
+        SAME provider cache key as every prior request: the ephemeral
+        continuation override is discarded and the user's own config goes
+        out unchanged. A config that is itself a disable is omitted."""
         from agent.chat_completion_helpers import _reasoning_config_for_wire
 
-        agent = _AgentStandIn({"enabled": False})
+        agent = _AgentStandIn({"enabled": True, "effort": "high"})
         agent._reasoning_disable_rejected = True
-        assert _reasoning_config_for_wire(agent) is None
         agent._ephemeral_reasoning_off = True
-        assert _reasoning_config_for_wire(agent) is None
+        assert _reasoning_config_for_wire(agent) == {"enabled": True, "effort": "high"}
         assert agent._ephemeral_reasoning_off is False
 
-        agent.reasoning_config = {"enabled": True, "effort": "high"}
-        assert _reasoning_config_for_wire(agent) == {"enabled": True, "effort": "high"}
+        agent.reasoning_config = {"enabled": False}
+        assert _reasoning_config_for_wire(agent) is None
 
 
 @pytest.fixture()

--- a/tests/run_agent/test_length_continuation_thinking_exhaustion.py
+++ b/tests/run_agent/test_length_continuation_thinking_exhaustion.py
@@ -68,6 +68,22 @@ class TestReasoningOffOneShotOverride:
         cfg = _reasoning_config_for_wire(agent)
         assert cfg == {"enabled": False, "effort": "none"}
 
+    def test_rejected_disable_drops_every_disable_but_keeps_enabled(self):
+        """After a 'reasoning is mandatory' 400, no disable reaches the wire —
+        neither the configured one nor the one-shot continuation override —
+        while an enabled config still passes through."""
+        from agent.chat_completion_helpers import _reasoning_config_for_wire
+
+        agent = _AgentStandIn({"enabled": False})
+        agent._reasoning_disable_rejected = True
+        assert _reasoning_config_for_wire(agent) is None
+        agent._ephemeral_reasoning_off = True
+        assert _reasoning_config_for_wire(agent) is None
+        assert agent._ephemeral_reasoning_off is False
+
+        agent.reasoning_config = {"enabled": True, "effort": "high"}
+        assert _reasoning_config_for_wire(agent) == {"enabled": True, "effort": "high"}
+
 
 @pytest.fixture()
 def loop_agent():


### PR DESCRIPTION
## Summary
GLM-5.3 on the Nous Portal / OpenRouter no longer aborts the turn with `HTTP 400: Reasoning is mandatory for this endpoint and cannot be disabled` when Hermes sends a reasoning disable.

Root cause: Hermes emits `reasoning: {enabled: false}` for `/reasoning none`, `agent.reasoning_effort: none`, and the one-shot thinking-exhaustion continuation override (which GLM-5.3-flash triggers on its own). The Nous profile's catalog guard only swallows the disable when its per-process capability cache already says `mandatory: true`; a long-running gateway that warmed the cache before the route flipped kept sending it, and the 400 was classified `format_error` (non-retryable) → turn aborted. Community report: Discord, Sep 3 2026 ("glm seems totally busted").

## Changes
- `agent/error_classifier.py`: new `FailoverReason.reasoning_mandatory` (retryable, no fallback, no compression), matched before the request-validation branch.
- `agent/conversation_loop.py`: one-shot recovery — set `agent._reasoning_disable_rejected`, queue a catalog refresh for the provider, retry.
- `agent/chat_completion_helpers.py`: once the route has rejected a disable, `_reasoning_config_for_wire` discards the one-shot continuation disable and resends the user's own config verbatim — the retry lands on the same provider cache key as every prior request. A config that is itself a disable is omitted (that session never sent anything else).
- `hermes_cli/models.py`: `refresh_reasoning_caps_async(provider)` forces a background re-fetch of the Nous/OpenRouter catalog (the in-memory cache was otherwise held for the process lifetime).
- `plugins/model-providers/openrouter/__init__.py`: omit a disable when the catalog marks the route mandatory (parity with the Nous profile).
- Tests: 3 invariant tests + 2 enumeration contract updates.

## Validation
**Live repro:** `z-ai/glm-5.3-flash` on the Portal, real `AIAgent.run_conversation`, catalog cache poisoned to `mandatory: false` (the stale-gateway state).

| | Before (origin/main) | After |
|---|---|---|
| Wire (config disable) | `{enabled: false}` → 400 | 400 → retry without `reasoning` → 200 |
| Wire (ephemeral disable, user effort=high) | `{enabled: false}` → 400 | 400 → retry with `{enabled: true, effort: high}` → 200 |
| Turn | `completed: False`, "Non-retryable client error" | `completed: True`, `final_response: pong` |
| Warm/correct cache | n/a | no retry, completes directly |

Raw Portal probe: `{enabled:false}`, `{effort:none}`, `{enabled:true, effort:none}` all 400; `minimal/low/medium/high` and omitting the field all 200.

Prompt cache: the retry resends the exact reasoning config the session has been using, so the provider cache key is unchanged; system prompt and messages are byte-identical.

Targeted tests: `tests/agent/test_error_classifier.py`, `tests/agent/test_turn_retry_state.py`, `tests/run_agent/test_length_continuation_thinking_exhaustion.py`, `tests/hermes_cli/test_openrouter_reasoning_metadata.py`, `tests/plugins/model_providers/test_nous_profile.py`, `tests/agent/transports/test_chat_completions.py` — 235 passed.

## Infographic

![Reasoning is mandatory — before/after, stale cache, routes](https://v3b.fal.media/files/b/0aa8eea4/OeBNvtsQ_i0FQS5EMqSXq_kmMKvCZs.png)
