### PR TITLE
fix: fail open when worker threads are exhausted

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -47,6 +47,7 @@ from agent.message_sanitization import (
 from agent.reasoning_summaries import separate_glued_reasoning_blocks
 from agent.stream_single_writer import claim_stream_writer, stream_writer_is_current
 from tools.terminal_tool import is_persistent_env
+from tools.thread_exhaustion import is_thread_start_exhaustion
 from utils import base_url_host_matches, base_url_hostname, env_float, env_int
 
 logger = logging.getLogger(__name__)
@@ -1294,6 +1295,7 @@ def direct_api_call(agent, api_kwargs: dict):
         name="direct-api-activity-hb",
         daemon=True,
     )
+    activity_hb_started = False
     # Resolve the budget BEFORE starting the heartbeat: the resolver may
     # raise (fail-closed contract), and a raise after start() would leak the
     # heartbeat thread — ticking last_activity_ts forever and masking real
@@ -1308,7 +1310,13 @@ def direct_api_call(agent, api_kwargs: dict):
     if hard_timeout is not None and "timeout" not in api_kwargs:
         api_kwargs = dict(api_kwargs)
         api_kwargs["timeout"] = hard_timeout
-    activity_hb.start()
+    try:
+        activity_hb.start()
+        activity_hb_started = True
+    except Exception as exc:
+        if not is_thread_start_exhaustion(exc):
+            raise
+        logger.warning("direct API activity heartbeat unavailable: %s", exc)
 
     def _on_stale() -> None:
         # Runs on the timer thread. It only aborts the in-flight sockets —
@@ -1377,7 +1385,8 @@ def direct_api_call(agent, api_kwargs: dict):
         with request_client_lock:
             request_state["done"] = True
         activity_hb_stop.set()
-        activity_hb.join(timeout=2.0)
+        if activity_hb_started:
+            activity_hb.join(timeout=2.0)
         if getattr(agent, "_active_request_abort", None) is _abort_active_request:
             agent._active_request_abort = None
         with request_client_lock:
@@ -1708,9 +1717,16 @@ def interruptible_api_call(agent, api_kwargs: dict):
     agent._touch_activity("waiting for non-streaming API response")
 
     t = threading.Thread(target=_context_thread_target(_call), daemon=True)
-    t.start()
+    try:
+        t.start()
+    except Exception as exc:
+        if not is_thread_start_exhaustion(exc):
+            raise
+        logger.warning("API interrupt worker unavailable; running inline: %s", exc)
+        t = None
+        _call()
     _poll_count = 0
-    while t.is_alive():
+    while t is not None and t.is_alive():
         t.join(timeout=0.3)
         _poll_count += 1
 
@@ -5533,7 +5549,14 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         t = None
     else:
         t = threading.Thread(target=_context_thread_target(_run_call), daemon=True)
-        t.start()
+        try:
+            t.start()
+        except Exception as exc:
+            if not is_thread_start_exhaustion(exc):
+                raise
+            logger.warning("stream interrupt worker unavailable; running inline: %s", exc)
+            t = None
+            _run_call()
 
     def _call_alive() -> bool:
         return not _call_done.is_set()

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -16,6 +16,8 @@ import logging
 from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
+from tools.thread_exhaustion import is_thread_start_exhaustion
+
 logger = logging.getLogger(__name__)
 
 # Synthetic error code used when the OpenAI SDK rejects a provider's SSE
@@ -1230,10 +1232,10 @@ def classify_api_error(
         )
 
     # ── 8. Local thread exhaustion ───────────────────────────────────
-    if "can't start new thread" in error_msg or (
-        "resource temporarily unavailable" in error_msg
-        and error_type in {"OSError", "RuntimeError"}
-    ):
+    # Delegate to the shared spawn-boundary predicate (also used by the
+    # fail-open paths in tool_executor.py / chat_completion_helpers.py) so
+    # classification can't drift from detection and stays errno-aware.
+    if is_thread_start_exhaustion(error):
         return _result(FailoverReason.thread_exhaustion, retryable=False)
 
     # ── 9. Transport / timeout heuristics ───────────────────────────

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -47,6 +47,7 @@ class FailoverReason(enum.Enum):
 
     # Transport
     timeout = "timeout"                  # Connection/read timeout — rebuild client + retry
+    thread_exhaustion = "thread_exhaustion"  # Local worker creation failed
     # TLS certificate verification failure — deterministic for the host
     # (TLS-inspecting proxy, missing/expired CA bundle, self-signed cert).
     # Retrying reproduces the identical handshake failure, so fail fast
@@ -1228,8 +1229,14 @@ def classify_api_error(
             should_fallback=True,
         )
 
-    # ── 8. Transport / timeout heuristics ───────────────────────────
+    # ── 8. Local thread exhaustion ───────────────────────────────────
+    if "can't start new thread" in error_msg or (
+        "resource temporarily unavailable" in error_msg
+        and error_type in {"OSError", "RuntimeError"}
+    ):
+        return _result(FailoverReason.thread_exhaustion, retryable=False)
 
+    # ── 9. Transport / timeout heuristics ───────────────────────────
     if error_type in _TRANSPORT_ERROR_TYPES or isinstance(error, (TimeoutError, ConnectionError, OSError)):
         return _result(FailoverReason.timeout, retryable=True)
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -879,6 +879,7 @@ def _run_sequential_tool_execution_middleware(
     except Exception as exc:
         if not is_thread_start_exhaustion(exc):
             raise
+        executor.shutdown(wait=False)
         logger.warning(
             "sequential tool worker unavailable; running %s inline: %s",
             function_name,

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -46,6 +46,7 @@ from tools.terminal_tool import (
     get_active_env,
 )
 from tools.thread_context import propagate_context_to_thread
+from tools.thread_exhaustion import is_thread_start_exhaustion
 from tools.tool_result_storage import (
     maybe_persist_tool_result,
     enforce_turn_budget,
@@ -873,7 +874,17 @@ def _run_sequential_tool_execution_middleware(
                 pass
 
     executor = DaemonThreadPoolExecutor(max_workers=1)
-    future = executor.submit(propagate_context_to_thread(_run))
+    try:
+        future = executor.submit(propagate_context_to_thread(_run))
+    except Exception as exc:
+        if not is_thread_start_exhaustion(exc):
+            raise
+        logger.warning(
+            "sequential tool worker unavailable; running %s inline: %s",
+            function_name,
+            exc,
+        )
+        return _run()
     # ``timeout_s`` disabled (None) still runs on the worker: the wait loop
     # below is what makes a non-cooperative tool interruptible at all, so
     # "no deadline" must not mean "no interrupt checks" (#86xxx class fix —
@@ -1543,6 +1554,37 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
                             submit_index,
                         )
                     except RuntimeError as submit_error:
+                        if is_thread_start_exhaustion(submit_error):
+                            if submit_index == 0:
+                                logger.warning(
+                                    "concurrent tool workers unavailable; falling back to sequential"
+                                )
+                                execute_tool_calls_sequential(
+                                    agent,
+                                    assistant_message,
+                                    messages,
+                                    effective_task_id,
+                                    api_call_count,
+                                    finalize=finalize,
+                                )
+                                return
+                            logger.warning(
+                                "thread exhaustion after %d concurrent tool(s); "
+                                "leaving unsubmitted calls as errors",
+                                submit_index,
+                            )
+                            for skipped_i, _tc, skipped_name, skipped_args, _scope_block in runnable_calls[submit_index:]:
+                                if results[skipped_i] is None:
+                                    results[skipped_i] = (
+                                        skipped_name,
+                                        skipped_args,
+                                        f"Error executing tool '{skipped_name}': no worker thread available",
+                                        0.0,
+                                        True,
+                                        False,
+                                        parsed_calls[skipped_i][3],
+                                    )
+                            break
                         if not _is_interpreter_shutdown_submit_error(submit_error):
                             raise
                         skipped_calls = runnable_calls[submit_index:]

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -86,6 +86,25 @@ class TestClassifyThreadExhaustion:
         result = classify_api_error(RuntimeError("boom"))
         assert result.reason is FailoverReason.unknown
 
+    def test_uses_shared_predicate_not_local_message_heuristic(self):
+        """Regression: classification must defer to is_thread_start_exhaustion().
+
+        A local message-only heuristic (checking for "resource temporarily
+        unavailable" against error_type in {OSError, RuntimeError} without
+        the errno check the shared predicate applies) would misclassify any
+        OSError whose strerror-style text happens to read "resource
+        temporarily unavailable" as thread_exhaustion, regardless of errno.
+        The shared predicate requires errno to be EAGAIN/EWOULDBLOCK, so an
+        EMFILE/ENFILE-style fd exhaustion must fall through to a different
+        classification instead.
+        """
+        import errno as errno_module
+
+        unrelated = OSError("Resource temporarily unavailable")
+        unrelated.errno = errno_module.ENFILE
+        result = classify_api_error(unrelated)
+        assert result.reason is not FailoverReason.thread_exhaustion
+
 
 # ── Test: ClassifiedError ──────────────────────────────────────────────
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -58,7 +58,7 @@ class TestFailoverReason:
         expected = {
             "auth", "auth_permanent", "billing", "rate_limit",
             "upstream_rate_limit",
-            "overloaded", "server_error", "timeout",
+            "overloaded", "server_error", "timeout", "thread_exhaustion",
             "ssl_cert_verification",
             "context_overflow", "payload_too_large", "image_too_large",
             "image_corrupt",
@@ -74,6 +74,17 @@ class TestFailoverReason:
         }
         actual = {r.value for r in FailoverReason}
         assert expected == actual
+
+
+class TestClassifyThreadExhaustion:
+    def test_thread_start_failure_is_not_unknown_retry(self):
+        result = classify_api_error(RuntimeError("can't start new thread"))
+        assert result.reason is FailoverReason.thread_exhaustion
+        assert result.retryable is False
+
+    def test_generic_runtime_error_remains_unknown(self):
+        result = classify_api_error(RuntimeError("boom"))
+        assert result.reason is FailoverReason.unknown
 
 
 # ── Test: ClassifiedError ──────────────────────────────────────────────

--- a/tests/agent/test_sequential_tool_thread_exhaustion.py
+++ b/tests/agent/test_sequential_tool_thread_exhaustion.py
@@ -1,0 +1,78 @@
+"""Sequential tool worker must shut down its executor before failing open.
+
+Regression test for the t_5c83b6fe PR-102111 review finding: when the
+sequential tool worker's ``DaemonThreadPoolExecutor.submit()`` raises a
+thread-start-exhaustion error, ``_run_sequential_tool_execution_middleware``
+fell back to running the tool inline without ever calling
+``executor.shutdown()`` on the executor it had just created — leaking
+executor-internal resources (queue, work-item registration) even though no
+worker thread was ever started.
+"""
+
+import threading
+
+import pytest
+
+import agent.tool_executor as tool_executor
+from agent.tool_executor import (
+    _ManagedToolResult,
+    _run_sequential_tool_execution_middleware,
+)
+from tools.daemon_pool import DaemonThreadPoolExecutor
+
+
+class _FakeAgent:
+    def __init__(self):
+        self._tool_worker_threads = set()
+        self._tool_worker_threads_lock = threading.Lock()
+        self._interrupt_requested = False
+
+
+@pytest.fixture()
+def fake_agent():
+    return _FakeAgent()
+
+
+class _ExhaustedExecutor(DaemonThreadPoolExecutor):
+    """Fails every submit() like a process out of OS threads, tracking shutdown()."""
+
+    shutdown_calls: list = []
+
+    def submit(self, fn, /, *args, **kwargs):
+        raise RuntimeError("can't start new thread")
+
+    def shutdown(self, *args, **kwargs):
+        _ExhaustedExecutor.shutdown_calls.append((args, kwargs))
+        return super().shutdown(*args, **kwargs)
+
+
+def test_thread_exhaustion_shuts_down_executor_before_inline_fallback(
+    monkeypatch, fake_agent
+):
+    _ExhaustedExecutor.shutdown_calls = []
+    monkeypatch.setattr(
+        "tools.daemon_pool.DaemonThreadPoolExecutor", _ExhaustedExecutor
+    )
+    monkeypatch.setattr(
+        tool_executor,
+        "_run_agent_tool_execution_middleware",
+        lambda agent_arg, **kwargs: _ManagedToolResult(
+            result="inline result", args={}, middleware_trace=[],
+            blocked=False, dispatched=True,
+        ),
+    )
+
+    managed = _run_sequential_tool_execution_middleware(
+        fake_agent,
+        function_name="image_generate",
+        function_args={"prompt": "x"},
+        effective_task_id="t",
+        tool_call_id="call_1",
+        execute=lambda a: "unused",
+    )
+
+    assert managed.result == "inline result"
+    assert _ExhaustedExecutor.shutdown_calls, (
+        "executor.shutdown() was never called after the thread-exhausted "
+        "submit() fell back to running the tool inline"
+    )

--- a/tests/tools/test_thread_exhaustion.py
+++ b/tests/tools/test_thread_exhaustion.py
@@ -1,0 +1,21 @@
+import errno
+
+from tools.thread_exhaustion import is_thread_start_exhaustion
+
+
+def test_runtime_thread_start_message_matches():
+    assert is_thread_start_exhaustion(RuntimeError("can't start new thread"))
+
+
+def test_resource_unavailable_os_error_matches():
+    assert is_thread_start_exhaustion(
+        OSError(errno.EAGAIN, "Resource temporarily unavailable")
+    )
+
+
+def test_unrelated_errors_do_not_match():
+    assert not is_thread_start_exhaustion(RuntimeError("boom"))
+    assert not is_thread_start_exhaustion(OSError(errno.EAGAIN, "database busy"))
+    assert not is_thread_start_exhaustion(
+        RuntimeError("cannot schedule new futures after interpreter shutdown")
+    )

--- a/tools/thread_exhaustion.py
+++ b/tools/thread_exhaustion.py
@@ -1,0 +1,21 @@
+"""Detection for OS thread/resource exhaustion at spawn boundaries."""
+
+from __future__ import annotations
+
+import errno
+
+
+def is_thread_start_exhaustion(exc: BaseException) -> bool:
+    """Return True only for failures indicating no OS thread is available."""
+    message = str(exc).lower()
+    if isinstance(exc, RuntimeError):
+        return "can't start new thread" in message
+    if isinstance(exc, OSError) and getattr(exc, "errno", None) in {
+        errno.EAGAIN,
+        errno.EWOULDBLOCK,
+    }:
+        return (
+            "can't start new thread" in message
+            or "resource temporarily unavailable" in message
+        )
+    return False


### PR DESCRIPTION
## Summary
- Detect OS thread/resource exhaustion with a narrow shared predicate.
- Run chat-completion workers inline when interrupt-thread creation fails.
- Fall back from concurrent tool batches to sequential execution and guard sequential submit.
- Classify thread exhaustion separately from unknown runtime errors.

## Test plan
- `python3 -m py_compile tools/thread_exhaustion.py agent/chat_completion_helpers.py agent/tool_executor.py agent/error_classifier.py`
- `python3 -m pytest tests/tools/test_thread_exhaustion.py tests/agent/test_error_classifier.py tests/run_agent/test_tool_batch_segmentation.py tests/run_agent/test_concurrent_interrupt.py tests/cron/test_cron_direct_api_call_62151.py tests/run_agent/test_interpreter_shutdown_turn_exit.py -q`
- Result: 174 passed, 1 skipped

Rollback: revert commit `185ff5ec8d` (or the eventual merge commit).
