### PR TITLE
fix(env): resolve the loader's default home through hermes_constants

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -491,7 +491,17 @@ def load_hermes_dotenv(
       profile's private secret snapshot without mutating the shared process
       environment; unscoped startup loads retain the normal behavior above.
     """
-    home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
+    # Resolve the launch-scope home through hermes_constants rather than a bare
+    # ``HERMES_HOME`` lookup.  The bare lookup hard-coded ``~/.hermes`` as its
+    # fallback, so on Windows with ``HERMES_HOME`` unset this read
+    # ``~/.hermes/.env`` while every other caller — ``hermes status``,
+    # ``hermes doctor``, ``get_env_path()`` — resolved the platform-native
+    # ``%LOCALAPPDATA%\hermes``, and the startup load in ``hermes_cli/main.py``
+    # (which passes no ``hermes_home=``) silently used a different file than the
+    # one those commands reported.
+    from hermes_constants import get_process_hermes_home
+
+    home_path = Path(hermes_home) if hermes_home else get_process_hermes_home()
 
     # A multiplex gateway hosts every profile in one process.  While a routed
     # profile-home override is active, copying that profile's .env into

--- a/tests/hermes_cli/test_env_loader_default_home.py
+++ b/tests/hermes_cli/test_env_loader_default_home.py
@@ -1,0 +1,87 @@
+"""The dotenv loader must resolve its default home the way everyone else does.
+
+``load_hermes_dotenv`` fell back to a bare
+``os.getenv("HERMES_HOME", Path.home() / ".hermes")``, which hard-codes the
+POSIX layout.  ``get_hermes_home()`` / ``get_env_path()`` — and therefore
+``hermes status`` and ``hermes doctor`` — resolve the platform-native default
+instead (``%LOCALAPPDATA%\\hermes`` on Windows).
+
+``hermes_cli/main.py`` runs the startup load without passing ``hermes_home=``,
+and ``HERMES_HOME`` is only exported into the environment when a profile is
+actually resolved.  So on Windows, with no profile and no ``HERMES_HOME``, the
+process loaded one ``.env`` while both reporting commands described another.
+
+These tests pin the delegation rather than the Windows path, so they assert the
+same invariant on every platform: with ``HERMES_HOME`` unset, the loader reads
+whatever ``hermes_constants`` calls the platform default.
+"""
+
+import os
+
+import hermes_constants
+from hermes_cli.env_loader import load_hermes_dotenv
+
+
+def _write_env(path, body):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+    return path
+
+
+def _pin_platform_default(monkeypatch, home):
+    """Make the platform-native default resolve to ``home`` on any OS."""
+    monkeypatch.setattr(
+        hermes_constants, "_get_platform_default_hermes_home", lambda: home
+    )
+
+
+def test_loader_follows_platform_default_home(tmp_path, monkeypatch):
+    """The regression: the startup load must read the file status/doctor report."""
+    home = tmp_path / "platform-home"
+    _write_env(home / ".env", "PLATFORM_DEFAULT_KEY=from-platform-home\n")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    _pin_platform_default(monkeypatch, home)
+    monkeypatch.delenv("PLATFORM_DEFAULT_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(load_external_secrets=False)
+
+    assert loaded == [home / ".env"]
+    assert os.environ["PLATFORM_DEFAULT_KEY"] == "from-platform-home"
+
+
+def test_hermes_home_env_var_still_wins_over_platform_default(tmp_path, monkeypatch):
+    """Behavior preserved: an explicit HERMES_HOME still beats the default."""
+    platform_home = tmp_path / "platform-home"
+    _write_env(platform_home / ".env", "WRONG_HOME_KEY=from-platform-home\n")
+    env_home = tmp_path / "env-home"
+    _write_env(env_home / ".env", "RIGHT_HOME_KEY=from-env-home\n")
+    _pin_platform_default(monkeypatch, platform_home)
+    monkeypatch.setenv("HERMES_HOME", str(env_home))
+    monkeypatch.delenv("WRONG_HOME_KEY", raising=False)
+    monkeypatch.delenv("RIGHT_HOME_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(load_external_secrets=False)
+
+    assert loaded == [env_home / ".env"]
+    assert os.environ["RIGHT_HOME_KEY"] == "from-env-home"
+    assert "WRONG_HOME_KEY" not in os.environ
+
+
+def test_explicit_hermes_home_argument_still_wins(tmp_path, monkeypatch):
+    """Behavior preserved: the keyword argument beats env var and default."""
+    platform_home = tmp_path / "platform-home"
+    _write_env(platform_home / ".env", "WRONG_HOME_KEY=from-platform-home\n")
+    explicit_home = tmp_path / "explicit-home"
+    _write_env(explicit_home / ".env", "EXPLICIT_KEY=from-explicit-home\n")
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    _pin_platform_default(monkeypatch, platform_home)
+    monkeypatch.delenv("WRONG_HOME_KEY", raising=False)
+    monkeypatch.delenv("EXPLICIT_KEY", raising=False)
+
+    loaded = load_hermes_dotenv(
+        hermes_home=explicit_home, load_external_secrets=False
+    )
+
+    assert loaded == [explicit_home / ".env"]
+    assert os.environ["EXPLICIT_KEY"] == "from-explicit-home"
+    assert "WRONG_HOME_KEY" not in os.environ


### PR DESCRIPTION
## What does this PR do?

`load_hermes_dotenv()` resolves its default Hermes home with a bare lookup that hard-codes the POSIX layout:

```python
home_path = Path(hermes_home or os.getenv("HERMES_HOME", Path.home() / ".hermes"))
```

Every other caller resolves the home through `hermes_constants`, whose platform-native default is `%LOCALAPPDATA%\hermes` on Windows (`_get_platform_default_hermes_home`).

`hermes_cli/main.py` runs the startup load **without** passing `hermes_home=`, and `HERMES_HOME` is only exported into the environment when a profile is actually resolved (inside `if profile_name is not None`). So on Windows, with no profile and no `HERMES_HOME` set:

| | file used |
|---|---|
| startup load (`hermes_cli/main.py`) | `~/.hermes/.env` |
| `hermes status` (via `get_hermes_home()`) | `%LOCALAPPDATA%\hermes\.env` |
| `hermes doctor` (via `get_hermes_home()`) | `%LOCALAPPDATA%\hermes\.env` |

The two reporting commands agree with each other and disagree with the file the process actually read. Practical effect: credentials written where `hermes setup` and `hermes doctor` point the user are silently not loaded, and the diagnostics then report that same file as present — pointing the user away from the problem.

Not reproducible on Linux/macOS, where both expressions evaluate to `~/.hermes`.

**Why this approach:** `get_process_hermes_home()` resolves `HERMES_HOME` → platform-native default, deliberately ignoring the context-local profile override. That preserves today's launch-scope semantics exactly — the override case is already handled by the multiplex branch a few lines below in the same function — so the only behavior change is the Windows fallback.

Fixing the default rather than passing `hermes_home=` at the `main.py` call site also covers `cron/scheduler.py`, `hermes_cli/plugins.py`, `tools/mcp_tool.py`, `hermes_cli/mcp_config.py` and the other callers that omit the argument.

## Related Issue

No existing issue — found while investigating why `hermes status` and `hermes doctor` disagreed about `.env` on a script-based install. Happy to file one if you'd prefer the tracking.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py` — `load_hermes_dotenv()` resolves its default home via `hermes_constants.get_process_hermes_home()` instead of `os.getenv("HERMES_HOME", Path.home() / ".hermes")`. Lazy import, matching the existing `get_hermes_home_override` import style in this module (it loads very early in startup).
- `tests/hermes_cli/test_env_loader_default_home.py` — new. Pins the delegation rather than the Windows path, so the same invariant is asserted on every platform, plus the two precedence cases that must not change (`HERMES_HOME` env var, explicit `hermes_home=` argument).

## How to Test

1. `pytest tests/hermes_cli/test_env_loader_default_home.py -q` → 3 passed.
2. Revert only `hermes_cli/env_loader.py` and re-run → `test_loader_follows_platform_default_home` fails (`1 failed, 2 passed`), confirming the test catches the regression rather than merely describing the new code.
3. Windows, `HERMES_HOME` unset: put a provider key in `%LOCALAPPDATA%\hermes\.env` and run `hermes status`. Before: the key is missing from the process environment while status reports that file as present. After: the file status reports is the file that was loaded.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (one commit)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not done, flagging honestly**: the container this was developed in lacks native deps (`_cffi_backend`, `httpx`, `aiohttp`), so the full suite is not runnable there. The targeted tests above were run and pass. Worth a full CI run before merge.
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (container). **The Windows path itself was not executed** — the tests pin the delegation to `hermes_constants` rather than the `%LOCALAPPDATA%` value, so they assert the fix on any platform, but a real Windows run would be worth having before merge.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstring/comment at the call site) — no README/`docs/` impact
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — this change *is* the cross-platform fix; POSIX behavior is unchanged (`get_process_hermes_home()` returns `~/.hermes` there)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

