### PR TITLE
fix(desktop): compensate preview input coords for fractional guest DPR (#91130)

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-input.test.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-input.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { type PreviewInputEvent, scalePreviewInputForDpr } from './preview-input'
+
+describe('scalePreviewInputForDpr', () => {
+  // Issue #91130: on displays where the guest's devicePixelRatio is ≠ 1,
+  // Chromium divides sendInputEvent coordinates by that scale before
+  // dispatching into the page, so a CSS-space click lands at point/DPR. The
+  // funnel multiplies by DPR to cancel the division. DPR 1 is the no-op
+  // identity — the common 1x case must never change.
+
+  it('is the identity at DPR 1', () => {
+    const event: PreviewInputEvent = { type: 'mouseMove', x: 100, y: 100 }
+
+    expect(scalePreviewInputForDpr(event, 1)).toBe(event)
+  })
+
+  it('scales mouse moves by a fractional DPR', () => {
+    const event: PreviewInputEvent = { type: 'mouseMove', x: 100, y: 100 }
+
+    expect(scalePreviewInputForDpr(event, 1.5)).toEqual({ type: 'mouseMove', x: 150, y: 150 })
+  })
+
+  it('scales mouse moves by integer DPR too', () => {
+    const event: PreviewInputEvent = { type: 'mouseMove', x: 100, y: 100 }
+
+    expect(scalePreviewInputForDpr(event, 2)).toEqual({ type: 'mouseMove', x: 200, y: 200 })
+    expect(scalePreviewInputForDpr(event, 3)).toEqual({ type: 'mouseMove', x: 300, y: 300 })
+  })
+
+  it('rounds scaled coordinates to whole pixels', () => {
+    const event: PreviewInputEvent = { type: 'mouseMove', x: 101, y: 99 }
+
+    expect(scalePreviewInputForDpr(event, 1.25)).toEqual({ type: 'mouseMove', x: 126, y: 124 })
+  })
+
+  it('scales click coordinates and preserves button/clickCount', () => {
+    const event: PreviewInputEvent = { button: 'left', clickCount: 1, type: 'mouseDown', x: 200, y: 150 }
+
+    expect(scalePreviewInputForDpr(event, 1.5)).toEqual({
+      button: 'left',
+      clickCount: 1,
+      type: 'mouseDown',
+      x: 300,
+      y: 225
+    })
+  })
+
+  it('scales wheel position but keeps the wheel deltas untouched', () => {
+    const event: PreviewInputEvent = { deltaX: 0, deltaY: -120, type: 'mouseWheel', x: 400, y: 300 }
+
+    expect(scalePreviewInputForDpr(event, 1.25)).toEqual({
+      deltaX: 0,
+      deltaY: -120,
+      type: 'mouseWheel',
+      x: 500,
+      y: 375
+    })
+  })
+
+  it('never touches keyboard events (they carry no coordinates)', () => {
+    const down: PreviewInputEvent = { keyCode: 'Enter', type: 'keyDown' }
+    const char: PreviewInputEvent = { keyCode: 'a', modifiers: ['shift'], type: 'char' }
+
+    expect(scalePreviewInputForDpr(down, 1.5)).toBe(down)
+    expect(scalePreviewInputForDpr(char, 2)).toBe(char)
+  })
+})

--- a/apps/desktop/src/app/chat/right-rail/preview-input.ts
+++ b/apps/desktop/src/app/chat/right-rail/preview-input.ts
@@ -27,6 +27,29 @@ export type PreviewInputEvent =
   | { keyCode: string; modifiers?: string[]; type: 'char' | 'keyDown' | 'keyUp' }
   | { type: 'mouseMove'; x: number; y: number }
 
+/**
+ * Convert a pointer event's CSS-pixel coordinates into the physical widget
+ * space Chromium's input router expects for a scaled guest.
+ *
+ * On displays where the guest's `devicePixelRatio` is ≠ 1 (fractional scaling
+ * on Wayland/Windows, or any webview frame Chromium composites at a scale
+ * ≠ 1), `webview.sendInputEvent` coordinates are DIVIDED by that scale factor
+ * before the event is dispatched into the page, so a click aimed at a
+ * CSS-space point lands at `point / DPR` — short by `1 − 1/DPR`. Multiplying
+ * by the guest's DPR before sending cancels the division and puts the click
+ * exactly where the act engine measured it (issue #91130).
+ *
+ * Identity at DPR 1, and keyboard events (which carry no x/y) pass through
+ * untouched.
+ */
+export function scalePreviewInputForDpr(event: PreviewInputEvent, dpr: number): PreviewInputEvent {
+  if (dpr === 1 || !('x' in event)) {
+    return event
+  }
+
+  return { ...event, x: Math.round(event.x * dpr), y: Math.round(event.y * dpr) }
+}
+
 export interface PreviewInputHandle {
   /** Give the guest keyboard focus, so key events reach its active element. */
   focus: () => void

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.test.tsx
@@ -2,9 +2,12 @@ import { act, cleanup, fireEvent, render, waitFor } from '@testing-library/react
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { onComposerAttachImagesRequest } from '@/app/chat/composer/focus'
+import { $rightRailActiveTabId, type RightRailTabId } from '@/store/layout'
+import { $previewTabs } from '@/store/preview'
 import { $connection, $selectedStoredSessionId } from '@/store/session'
 
 import { forgetPreviewConsole, previewConsoleState } from './preview-console-store'
+import { activePreviewInput } from './preview-input'
 import { PreviewPane } from './preview-pane'
 
 // The consent dialog has its own test file and needs a QueryClientProvider;
@@ -43,6 +46,8 @@ describe('PreviewPane console state', () => {
     cleanup()
     $connection.set(null)
     $selectedStoredSessionId.set(null)
+    $previewTabs.set([])
+    $rightRailActiveTabId.set(null)
     vi.unstubAllGlobals()
   })
 
@@ -639,5 +644,106 @@ describe('PreviewPane console state', () => {
       path: `/api/fs/read-data-url?path=${encodeURIComponent(filePath)}`,
       profile: 'macmini'
     })
+  })
+})
+
+describe('PreviewPane input funnel DPR compensation', () => {
+  // Issue #91130: Chromium divides sendInputEvent coordinates by the guest's
+  // devicePixelRatio when it is ≠ 1, so clicks on fractional-DPR displays land
+  // short. The pane caches the guest DPR on navigation and the funnel
+  // multiplies pointer coordinates by it before sending. DPR 1 stays a no-op.
+
+  const urlTarget = {
+    kind: 'url' as const,
+    label: 'Preview',
+    source: 'http://localhost:5174',
+    url: 'http://localhost:5174'
+  }
+
+  const renderWebPreview = async (dpr: number) => {
+    const tabId: RightRailTabId = `url:${urlTarget.url}`
+
+    $previewTabs.set([{ id: tabId, target: urlTarget }])
+    $rightRailActiveTabId.set(tabId)
+
+    let rendered!: ReturnType<typeof render>
+    await act(async () => {
+      rendered = render(<PreviewPane tabId={tabId} target={urlTarget} />)
+    })
+
+    const webview = rendered.container.querySelector('webview') as HTMLElement & {
+      executeJavaScript?: (code: string) => Promise<unknown>
+      sendInputEvent?: (event: unknown) => void
+    }
+
+    const sendInputEvent = vi.fn()
+    const executeJavaScript = vi.fn(async () => dpr)
+
+    Object.assign(webview, { executeJavaScript, sendInputEvent })
+
+    // did-navigate is what makes the pane re-read the guest DPR (both the
+    // initial load and every later navigation go through it).
+    act(() => {
+      webview.dispatchEvent(Object.assign(new Event('did-navigate'), { url: urlTarget.url }))
+    })
+
+    // The refreshGuestDpr promise resolves on a microtask.
+    await act(async () => {
+      await Promise.resolve()
+    })
+
+    return { sendInputEvent, tabId }
+  }
+
+  it('multiplies click coordinates by a fractional guest DPR', async () => {
+    const { sendInputEvent, tabId } = await renderWebPreview(1.5)
+
+    await act(async () => {
+      activePreviewInput()?.send({ button: 'left', clickCount: 1, type: 'mouseDown', x: 100, y: 100 })
+    })
+
+    expect(sendInputEvent).toHaveBeenCalledWith({
+      button: 'left',
+      clickCount: 1,
+      type: 'mouseDown',
+      x: 150,
+      y: 150
+    })
+  })
+
+  it('multiplies wheel position but keeps wheel deltas', async () => {
+    const { sendInputEvent } = await renderWebPreview(1.25)
+
+    await act(async () => {
+      activePreviewInput()?.send({ deltaX: 0, deltaY: -120, type: 'mouseWheel', x: 400, y: 300 })
+    })
+
+    expect(sendInputEvent).toHaveBeenCalledWith({
+      deltaX: 0,
+      deltaY: -120,
+      type: 'mouseWheel',
+      x: 500,
+      y: 375
+    })
+  })
+
+  it('leaves coordinates untouched at DPR 1', async () => {
+    const { sendInputEvent } = await renderWebPreview(1)
+
+    await act(async () => {
+      activePreviewInput()?.send({ type: 'mouseMove', x: 200, y: 150 })
+    })
+
+    expect(sendInputEvent).toHaveBeenCalledWith({ type: 'mouseMove', x: 200, y: 150 })
+  })
+
+  it('does not scale keyboard events', async () => {
+    const { sendInputEvent } = await renderWebPreview(2)
+
+    await act(async () => {
+      activePreviewInput()?.send({ keyCode: 'a', type: 'keyDown' })
+    })
+
+    expect(sendInputEvent).toHaveBeenCalledWith({ keyCode: 'a', type: 'keyDown' })
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -65,7 +65,7 @@ import {
 import { type ConsoleEntry } from './preview-console-state'
 import { previewConsoleState } from './preview-console-store'
 import { LocalFilePreview, PreviewEmptyState } from './preview-file'
-import { type PreviewInputEvent, registerPreviewInput } from './preview-input'
+import { type PreviewInputEvent, registerPreviewInput, scalePreviewInputForDpr } from './preview-input'
 import { PREVIEW_BROWSER_ATTR, registerPreviewNav } from './preview-nav'
 import { registerPreviewPageReader } from './preview-reader'
 import { registerPreviewScriptRunner } from './preview-script-runner'
@@ -253,6 +253,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
   const consoleBodyRef = useRef<HTMLDivElement | null>(null)
   const consoleShouldStickRef = useRef(true)
   const hostRef = useRef<HTMLDivElement | null>(null)
+  // The guest page's `devicePixelRatio`, cached per page load. Chromium's
+  // input router divides `sendInputEvent` coordinates by this scale factor on
+  // displays where it is ≠ 1, so the input funnel multiplies by it before
+  // sending (see scalePreviewInputForDpr). Default 1 = the multiply is a no-op
+  // on standard displays; refreshed on navigation, when the value can change
+  // (monitor move, scale change).
+  const guestDprRef = useRef(1)
   const lastReloadRequestRef = useRef(reloadRequest)
   const lastRestartEventRef = useRef('')
   const previewContentRef = useRef<HTMLDivElement | null>(null)
@@ -810,7 +817,13 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
           throw new Error('preview webview cannot take input events')
         }
 
-        webview.sendInputEvent(event)
+        // The guest's CSS-pixel coordinates (measured by the act engine via
+        // getBoundingClientRect) must be converted into the physical widget
+        // space Chromium's input router expects for a scaled guest — it divides
+        // sendInputEvent coordinates by the guest's devicePixelRatio when that
+        // is ≠ 1, which would otherwise land every click short on fractional-
+        // DPR displays. No-op at DPR 1 and for keyboard events.
+        webview.sendInputEvent(scalePreviewInputForDpr(event, guestDprRef.current))
       }
     })
   }, [isRemoteHtml, isWebPreview, tabId])
@@ -1072,6 +1085,30 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       noteBrowserPage(tabId, guestPage(webview, target.url))
     }
 
+    // Cache the guest page's devicePixelRatio for the input funnel. Chromium
+    // divides sendInputEvent coordinates by this scale, so the funnel must
+    // know it exactly; the value can change across navigations (monitor move,
+    // scale change), so re-read it whenever the page changes. A failed read
+    // keeps the previous value — worst case the funnel behaves as before this
+    // fix (DPR 1 default = no-op).
+    const refreshGuestDpr = () => {
+      if (typeof webview.executeJavaScript !== 'function') {
+        return
+      }
+
+      void webview
+        .executeJavaScript('window.devicePixelRatio || 1')
+        .then(value => {
+          if (typeof value === 'number' && Number.isFinite(value) && value > 0) {
+            guestDprRef.current = value
+          }
+        })
+        .catch(() => {
+          // Keep the last known DPR; a transient read failure must not break
+          // the input funnel.
+        })
+    }
+
     const onNavigate = (event: Event) => {
       const detail = event as Event & { url?: string }
 
@@ -1087,6 +1124,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       // so it is the only thing that knows what its history holds. Wired to
       // `did-navigate-in-page` too, or SPA route changes never update it.
       syncHistory()
+      refreshGuestDpr()
     }
 
     const onFail = (event: Event) => {

--- a/tests/hermes_cli/test_psutil_android.py
+++ b/tests/hermes_cli/test_psutil_android.py
@@ -1,0 +1,27 @@
+"""Tests for hermes_cli/psutil_android.py — pure helpers."""
+
+import pytest
+
+
+def test_psutil_android_install_error_is_runtime_error():
+    from hermes_cli.psutil_android import PsutilAndroidInstallError
+    with pytest.raises(PsutilAndroidInstallError):
+        raise PsutilAndroidInstallError("test")
+
+
+def test_marker_and_replacement_are_non_empty():
+    from hermes_cli.psutil_android import MARKER, REPLACEMENT
+    assert "linux" in MARKER
+    assert "android" in REPLACEMENT
+
+
+def test_normalize_member_parts_strips_prefix():
+    from hermes_cli.psutil_android import _normalize_member_parts
+    parts = _normalize_member_parts("psutil-7.2.2/psutil/__init__.py")
+    assert parts[0] != "psutil-7.2.2" or len(parts) > 1
+
+
+def test_psutil_url_points_to_tar_gz():
+    from hermes_cli.psutil_android import PSUTIL_URL
+    assert PSUTIL_URL.endswith(".tar.gz")
+    assert "psutil" in PSUTIL_URL.lower()


### PR DESCRIPTION
## What does this PR do?

Fixes #91130: drive_preview clicks land ~20% short on fractional-DPR displays (Wayland fractional scaling, 125%/150% Windows) because Chromium divides webview.sendInputEvent coordinates by the guest's devicePixelRatio before dispatching into the page.

## The fix

- **preview-input.ts**: Add scalePreviewInputForDpr function that multiplies pointer event coordinates by the guest DPR (identity at DPR 1, keyboard events untouched, wheel deltas preserved)
- **preview-pane.tsx**: Cache the guest page's window.devicePixelRatio per page load (refreshed on did-navigate / did-navigate-in-page), scale pointer coords in the sendInputEvent funnel
- **Tests**: Pure-function unit tests (DPR 1/1.25/1.5/2/3, rounding, wheel, keyboard) + PreviewPane funnel tests (fractional multiply, wheel position, DPR-1 no-op, keyboard passthrough)

## Verification

Verified end-to-end in Electron 40.10.2 with a scaled webview frame:
- Without compensation: RECEIVED = SENT / DPR (clicks miss target)
- With compensation: WANT == RECEIVED at DPR 1, 1.25, 1.5, 2, 3

This is a rebased/clean version of the approved PR #91154 (approved by Shotflame with E2E verification).