### PR TITLE
fix(dashboard): don't latch the restart action on a foreground gateway child

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -4696,6 +4696,40 @@ def _terminate_desktop_managed_gateway() -> None:
         pass
 
 
+def _gateway_restart_child_hosts_the_gateway(proc: subprocess.Popen) -> bool:
+    """True when a live ``gateway restart`` child has *become* the gateway.
+
+    On a host with no service manager the restart's manual fallback runs
+    ``run_gateway()`` in that same process, so the child never exits: its argv
+    stays ``gateway restart`` while it owns the runtime and the PID record
+    (``gateway.status.looks_like_gateway_runtime_command_line`` exists for
+    exactly this shape — #51325/#51468).  To the action layer that is
+    indistinguishable from a restart still in flight, and the difference
+    matters: a child that never exits pins
+    ``/api/actions/gateway-restart/status`` at ``running`` forever and makes
+    :func:`_spawn_gateway_restart` coalesce every later request onto a restart
+    that already finished, so the dashboard's restart button turns into a
+    permanent no-op.
+
+    Owning the PID record is the observable that separates the two: by the time
+    it names this PID, the fallback has stopped the old gateway and started the
+    new one in-process.
+    """
+    try:
+        if proc.poll() is not None:
+            return False
+
+        # Module-level probe reference on purpose: it keeps this file's
+        # established `monkeypatch.setattr(web_server, "get_running_pid", ...)`
+        # seam working.  Profile-scoped by construction too — get_running_pid()
+        # reads this profile's record, so a restart hosting some *other*
+        # profile's gateway never matches and keeps the in-flight semantics.
+        return get_running_pid(cleanup_stale=False) == proc.pid
+    except Exception:
+        # Best effort — on any doubt keep treating the child as in-flight.
+        return False
+
+
 def _record_completed_action(name: str, message: str, exit_code: int = 1) -> None:
     """Record a non-spawned action result and write it to the action log."""
     log_file_name = _ACTION_LOG_FILES[name]
@@ -4974,6 +5008,14 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
     within ``GATEWAY_RESTART_COOLDOWN_SECONDS`` of the last spawn for the
     same profile are coalesced onto that spawn as well.
 
+    Reusing the live child is also *too much* on a host with no service
+    manager: there the restart's manual fallback hosts the new gateway in that
+    same process, so the child never exits and the reuse latches forever —
+    every later restart request rides a restart that already finished, which is
+    what makes the dashboard's restart button a permanent no-op. Such a child
+    is excluded by :func:`_gateway_restart_child_hosts_the_gateway`; the
+    cooldown above remains the guard against repeat-request storms.
+
     Before spawning, sweep for orphaned gateway processes whose parent has
     exited (e.g. desktop-app restarts leaving a reparented gateway child
     under launchd/PPID=1).  Without this the orphan keeps its platform
@@ -4993,7 +5035,11 @@ def _spawn_gateway_restart(profile: Optional[str] = None) -> Tuple[subprocess.Po
 
     subcommand = _gateway_subcommand(profile, "restart")
     existing = _ACTION_PROCS.get("gateway-restart")
-    if existing is not None and existing.poll() is None:
+    if (
+        existing is not None
+        and existing.poll() is None
+        and not _gateway_restart_child_hosts_the_gateway(existing)
+    ):
         existing_command = _ACTION_COMMANDS.get("gateway-restart")
         if existing_command is None or existing_command == tuple(subcommand):
             return existing, True
@@ -5964,6 +6010,18 @@ async def get_action_status(name: str, lines: int = 200):
             _ACTION_PROCS.pop(name, None)
             _ACTION_COMMANDS.pop(name, None)
             _ACTION_IDS.pop(name, None)
+        elif name == "gateway-restart" and _gateway_restart_child_hosts_the_gateway(
+            proc
+        ):
+            # No-supervisor manual fallback: this child completed the restart by
+            # *becoming* the gateway, so it will never exit.  Report the action
+            # as finished — otherwise clients poll a ``running`` that never
+            # clears and the restart control stays disabled for the life of the
+            # gateway.  The handle intentionally stays in ``_ACTION_PROCS``:
+            # ``_terminate_desktop_managed_gateway()`` needs it to stop the
+            # gateway its Desktop backend owns.
+            running = False
+            exit_code = 0
 
     response = {
         "name": name,

--- a/tests/hermes_cli/test_spawn_gateway_restart_foreground_child.py
+++ b/tests/hermes_cli/test_spawn_gateway_restart_foreground_child.py
@@ -1,0 +1,300 @@
+"""The dashboard restart action must not latch on a foreground restart child.
+
+On a host with no service manager, ``hermes gateway restart`` falls through to
+its manual fallback and runs ``run_gateway()`` in that same process: the child
+*becomes* the gateway and never exits — the shape that
+``gateway.status.looks_like_gateway_runtime_command_line`` exists for
+(#51325/#51468).  The action layer used to read that as "a restart is still in
+flight", which pinned ``/api/actions/gateway-restart/status`` at ``running``
+for the life of the gateway and coalesced every later restart request onto that
+child, turning the dashboard's restart button into a permanent no-op.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def reset_restart_cooldown():
+    """Keep the module-level cooldown state out of neighbouring tests."""
+    import hermes_cli.web_server as web_server
+
+    web_server._LAST_GATEWAY_RESTART = None
+    yield
+    web_server._LAST_GATEWAY_RESTART = None
+
+
+def _live_proc(pid: int) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = None
+    proc.pid = pid
+    return proc
+
+
+def _exited_proc(pid: int) -> MagicMock:
+    proc = MagicMock(spec=subprocess.Popen)
+    proc.poll.return_value = 0
+    proc.pid = pid
+    return proc
+
+
+class TestHostsTheGatewayDetection:
+    """Owning the gateway PID record is what distinguishes the two states."""
+
+    def test_child_owning_the_pid_record_is_the_gateway(self):
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        with patch("hermes_cli.web_server.get_running_pid", return_value=4242):
+            assert _gateway_restart_child_hosts_the_gateway(_live_proc(4242)) is True
+
+    def test_child_that_does_not_own_it_is_still_in_flight(self):
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        with patch("hermes_cli.web_server.get_running_pid", return_value=99):
+            assert _gateway_restart_child_hosts_the_gateway(_live_proc(4242)) is False
+
+    def test_exited_child_is_never_the_gateway(self):
+        """A finished restart is handled by the pre-existing exit-code path."""
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        with patch("hermes_cli.web_server.get_running_pid", return_value=4242):
+            assert _gateway_restart_child_hosts_the_gateway(_exited_proc(4242)) is False
+
+    def test_probe_failure_keeps_in_flight_semantics(self):
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        with patch(
+            "hermes_cli.web_server.get_running_pid", side_effect=OSError("no record")
+        ):
+            assert _gateway_restart_child_hosts_the_gateway(_live_proc(4242)) is False
+
+
+class TestDetectionAgainstARealPidRecord:
+    """The same detection, with the real ``gateway.status`` code and real I/O.
+
+    The whole fix rests on one claim about existing code: a process whose argv
+    is ``gateway restart`` and which owns the PID record reads back as the
+    running gateway.  That is what ``looks_like_gateway_runtime_command_line``
+    exists for, and why the strict ``looks_like_gateway_command_line`` is left
+    alone (#51325/#51468).  Mocking ``get_running_pid`` cannot check the claim,
+    so check it here.
+    """
+
+    RESTART_CMDLINE = "/usr/local/bin/python /usr/local/bin/hermes gateway restart"
+
+    def test_the_runtime_matcher_accepts_a_restart_command_line(self):
+        """No mocks at all — this pair of verdicts is the whole premise."""
+        from gateway.status import (
+            looks_like_gateway_command_line,
+            looks_like_gateway_runtime_command_line,
+        )
+
+        assert looks_like_gateway_runtime_command_line(self.RESTART_CMDLINE) is True
+        # Still not a *management*-command match: #51468 kept this one strict.
+        assert looks_like_gateway_command_line(self.RESTART_CMDLINE) is False
+
+    @pytest.fixture
+    def gateway_identity_files(self):
+        from gateway import status
+
+        yield status
+        status.release_gateway_runtime_lock()
+        status._get_pid_path().unlink(missing_ok=True)
+
+    def test_a_restart_process_owning_the_record_reads_back_as_the_gateway(
+        self, gateway_identity_files, monkeypatch
+    ):
+        """End-to-end through the real record, under the suite's temp HERMES_HOME.
+
+        ``acquire_gateway_runtime_lock()`` + ``write_pid_file()`` is verbatim what
+        ``run_gateway()`` does at startup, so the record on disk is the one a
+        no-supervisor ``gateway restart`` leaves behind.  Everything downstream is
+        real: lock probe, record parse, liveness, ``start_time`` match, profile
+        scoping.
+
+        The single substitution is ``_read_process_cmdline``:
+        ``_record_matches_live_gateway_pid`` prefers the *live OS* command line
+        over the recorded argv, and a pytest process cannot present
+        ``gateway restart`` as its own argv.  The string it returns is the same
+        one asserted un-mocked above.
+        """
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        status = gateway_identity_files
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "restart"])
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: self.RESTART_CMDLINE if pid == os.getpid() else None,
+        )
+        assert status.acquire_gateway_runtime_lock() is True
+        status.write_pid_file()
+
+        assert status.get_running_pid(cleanup_stale=False) == os.getpid()
+        assert _gateway_restart_child_hosts_the_gateway(_live_proc(os.getpid())) is True
+
+    def test_a_non_gateway_process_owning_the_record_is_not_the_gateway(
+        self, gateway_identity_files, monkeypatch
+    ):
+        """PID reuse guard: same record, but the live process is not a gateway."""
+        from hermes_cli.web_server import _gateway_restart_child_hosts_the_gateway
+
+        status = gateway_identity_files
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "restart"])
+        monkeypatch.setattr(
+            status, "_read_process_cmdline", lambda pid: "/usr/bin/s6-log /var/log/x"
+        )
+        assert status.acquire_gateway_runtime_lock() is True
+        status.write_pid_file()
+
+        hosting = _gateway_restart_child_hosts_the_gateway(_live_proc(os.getpid()))
+        assert hosting is False
+
+
+class TestSpawnGatewayRestart:
+    """A child that already became the gateway must not block a new restart."""
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    def test_a_hosting_child_does_not_coalesce_the_next_request(
+        self, mock_spawn, mock_subcmd
+    ):
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        hosting = _live_proc(4242)
+        fresh = _live_proc(4243)
+        mock_spawn.return_value = fresh
+
+        with patch(
+            "hermes_cli.web_server._ACTION_PROCS", {"gateway-restart": hosting}
+        ), patch(
+            "hermes_cli.web_server._ACTION_COMMANDS",
+            {"gateway-restart": ("gateway", "restart")},
+        ), patch(
+            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+        ), patch(
+            "hermes_cli.web_server.get_running_pid", return_value=4242
+        ):
+            proc, reused = _spawn_gateway_restart()
+
+        assert reused is False, (
+            "the restart it was handed is already done — the child IS the gateway"
+        )
+        assert proc is fresh
+        mock_spawn.assert_called_once()
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    def test_a_genuinely_in_flight_child_is_still_reused(self, mock_spawn, mock_subcmd):
+        """#89034's guard stays: a restart mid-handoff is not restarted again."""
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        in_flight = _live_proc(4242)
+
+        with patch(
+            "hermes_cli.web_server._ACTION_PROCS", {"gateway-restart": in_flight}
+        ), patch(
+            "hermes_cli.web_server._ACTION_COMMANDS",
+            {"gateway-restart": ("gateway", "restart")},
+        ), patch(
+            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+        ), patch(
+            "hermes_cli.web_server.get_running_pid", return_value=None
+        ):
+            proc, reused = _spawn_gateway_restart()
+
+        assert proc is in_flight
+        assert reused is True
+        mock_spawn.assert_not_called()
+
+    @patch(
+        "hermes_cli.web_server._gateway_subcommand",
+        return_value=["gateway", "restart"],
+    )
+    @patch("hermes_cli.web_server._spawn_hermes_action")
+    def test_the_cooldown_still_absorbs_a_repeat_burst(self, mock_spawn, mock_subcmd):
+        """Releasing the latch must not reopen the #89034 restart storm."""
+        import hermes_cli.web_server as web_server
+        from hermes_cli.web_server import _spawn_gateway_restart
+
+        hosting = _live_proc(4242)
+        mock_spawn.return_value = hosting
+
+        with patch(
+            "hermes_cli.web_server._ACTION_PROCS", {}
+        ), patch(
+            "hermes_cli.web_server._ACTION_COMMANDS", {}
+        ), patch(
+            "hermes_cli.gateway._reap_unsupervised_gateway_orphans"
+        ), patch(
+            "hermes_cli.web_server.get_running_pid", return_value=4242
+        ), patch(
+            "hermes_cli.web_server.time.monotonic", side_effect=[100.0, 103.5]
+        ):
+            _spawn_gateway_restart()
+            web_server._ACTION_PROCS["gateway-restart"] = hosting
+            web_server._ACTION_COMMANDS["gateway-restart"] = ("gateway", "restart")
+            _, reused = _spawn_gateway_restart()
+
+        assert mock_spawn.call_count == 1
+        assert reused is True
+
+
+class TestActionStatus:
+    """The status endpoint must not report a completed restart as running."""
+
+    def test_a_hosting_child_is_reported_as_finished(self, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        hosting = _live_proc(4242)
+
+        with patch.object(web_server, "_ACTION_LOG_DIR", tmp_path), patch.object(
+            web_server, "_ACTION_PROCS", {"gateway-restart": hosting}
+        ), patch("hermes_cli.web_server.get_running_pid", return_value=4242):
+            result = asyncio.run(web_server.get_action_status("gateway-restart"))
+            # The handle must survive: _terminate_desktop_managed_gateway()
+            # stops the Desktop-owned gateway through it.
+            assert web_server._ACTION_PROCS["gateway-restart"] is hosting
+
+        assert result["running"] is False
+        assert result["exit_code"] == 0
+        assert result["pid"] == 4242
+
+    def test_a_genuinely_in_flight_child_is_still_reported_running(self, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        in_flight = _live_proc(4242)
+
+        with patch.object(web_server, "_ACTION_LOG_DIR", tmp_path), patch.object(
+            web_server, "_ACTION_PROCS", {"gateway-restart": in_flight}
+        ), patch("hermes_cli.web_server.get_running_pid", return_value=None):
+            result = asyncio.run(web_server.get_action_status("gateway-restart"))
+
+        assert result["running"] is True
+        assert result["exit_code"] is None
+
+    def test_other_actions_are_untouched(self, tmp_path):
+        """The reconciliation is scoped to ``gateway-restart``."""
+        import hermes_cli.web_server as web_server
+
+        live = _live_proc(4242)
+
+        with patch.object(web_server, "_ACTION_LOG_DIR", tmp_path), patch.object(
+            web_server, "_ACTION_PROCS", {"dump": live}
+        ), patch("hermes_cli.web_server.get_running_pid", return_value=4242):
+            result = asyncio.run(web_server.get_action_status("dump"))
+
+        assert result["running"] is True
+        assert result["exit_code"] is None


### PR DESCRIPTION
## Summary
On a host with no service manager, the dashboard's "Restart gateway" control works exactly once and then becomes a silent no-op for the life of that gateway: `/api/actions/gateway-restart/status` stays `running` forever, and every later request is coalesced onto a restart that already finished. Nothing is logged, and the CLI restart itself succeeded — so the failure looks like the button doing nothing.

Root cause: `hermes gateway restart`'s manual fallback ends in `run_gateway(verbose=0)` **in that same process**, so the child never exits — it *becomes* the gateway (the shape `looks_like_gateway_runtime_command_line` exists for, #51325/#51468). The action layer reads liveness purely from `proc.poll()`, so `get_action_status` reports `running` forever, and `_spawn_gateway_restart`'s in-flight reuse hands that same child to every subsequent caller. Both are correct for a supervised restart, where the child execs the service manager and exits; neither has a way to tell "still in flight" from "finished by becoming the gateway".

Owning the gateway PID record is the observable that separates them: by the time the record names the child's PID, the fallback has already stopped the old gateway and started the new one in-process.

## Changes
- `hermes_cli/web_server.py`: new `_gateway_restart_child_hosts_the_gateway(proc)` — live child whose PID equals `get_running_pid(cleanup_stale=False)`. Fails closed (any exception → keep treating the child as in-flight). Uses the module-level `get_running_pid` reference so this file's established `monkeypatch.setattr(web_server, ...)` probe seam keeps working, and is profile-scoped by construction: `get_running_pid()` reads *this* profile's record, so a restart hosting another profile's gateway keeps in-flight semantics.
- `_spawn_gateway_restart`: in-flight reuse now excludes such a child, so the next restart request actually spawns. The `GATEWAY_RESTART_COOLDOWN_SECONDS` window (#89034/#90275) is untouched and remains the guard against repeat-request storms.
- `get_action_status`: a hosting child is reported `running: false, exit_code: 0`. Attached as an `elif` to the existing `exit_code is not None` branch so it only runs while the child is alive — no `proc.wait()` on a process that never exits. **The handle deliberately stays in `_ACTION_PROCS`**: `_terminate_desktop_managed_gateway()` needs it to stop the gateway its Desktop backend owns, and popping it would reintroduce the orphan class of #51325.
- Supervised hosts are unaffected: there the child execs the service manager and exits, never owning the record.

## Validation
`scripts/run_tests.sh`, macOS 26.3.2 (arm64), Python 3.11.15.

| | Before (origin/main) | After |
|---|---|---|
| No-supervisor restart child, 2nd request | coalesced onto the finished restart, `reused=True` | new child spawned |
| No-supervisor restart child, status poll | `running: true` forever, `exit_code: null` | `running: false, exit_code: 0` |
| Handle needed by `_terminate_desktop_managed_gateway()` | present | still present (asserted) |
| Genuinely in-flight child (record not yet theirs / probe fails) | reused, `running` | unchanged — reused, `running` |
| Repeat-request burst inside the cooldown | absorbed | unchanged — absorbed |
| Non-gateway actions (`dump`) | unaffected | unaffected (asserted) |
| 6 files touching the changed paths (`test_spawn_gateway_restart_*`, `test_dashboard_admin_endpoints`, `test_gateway_job_teardown_live`, `tests/gateway/test_status`) | | 138 passed, 0 failed, 6 skipped |
| `ruff check .` (the blocking rules) / `ty` on the changed files | | clean / 0 new diagnostics (19 pre-existing on `web_server.py`, none inside the changed hunks) |

**The premise is asserted against real code, not mocks.** `TestDetectionAgainstARealPidRecord` first checks the load-bearing pair with no mocking at all — `looks_like_gateway_runtime_command_line()` accepts a `gateway restart` command line while the strict `looks_like_gateway_command_line()` still rejects it — then drives the record path end-to-end under a temp `HERMES_HOME`: `acquire_gateway_runtime_lock()` + `write_pid_file()` (verbatim what `run_gateway()` does at startup), then real record parse, liveness, `start_time` match and profile scoping through `get_running_pid()`. The one substitution is `_read_process_cmdline`, because `_record_matches_live_gateway_pid` prefers the *live OS* command line and a pytest process cannot present `gateway restart` as its own argv; the string it returns is the one asserted un-mocked above. A PID-reuse case (record present, live process is `s6-log`) is covered too.

**Mutation-checked** — each guard was reverted in turn and the suite re-run:

| Reverted | Tests that fail |
|---|---|
| the reuse exclusion in `_spawn_gateway_restart` | 1 (`test_a_hosting_child_does_not_coalesce_the_next_request`) |
| the `elif` in `get_action_status` | 1 (`test_a_hosting_child_is_reported_as_finished`) |
| PID-record ownership in the helper (accept every live child) | 5, all guarding the *don't over-trigger* direction |

**Not verified:** I have no supervisor-less host to drive the live restart on, so the button-level reproduction below is derived from the code path, not observed. Steps for anyone who has one:

1. Install Hermes on a host with no service manager (WSL2 without systemd, or a container) and start the gateway.
2. Open the dashboard, click "Restart gateway" — it works.
3. Poll `GET /api/actions/gateway-restart/status`: `running` stays `true` indefinitely.
4. Click "Restart gateway" again, after the 10s cooldown: the request is coalesced onto the finished restart and nothing happens, for the life of the gateway.

## Related
- **#51325 → #51468** established the contract this builds on. That fix deliberately *accommodated* the foreground-restart shape rather than changing it: `looks_like_gateway_command_line()` stayed strict (`run` only) and the broader `looks_like_gateway_runtime_command_line()` was added for validating Hermes-owned runtime records and no-supervisor cleanup scans. This PR extends the same accommodation to the action layer — which is why it does not make the CLI fallback detach instead, as that would re-open the orphaned-untracked-gateway hazard #51468 closed.
- **#89034 / #90275** (restart coalescing) is not re-opened. #89034 chose a fixed window over health-gating because "a gateway that never comes back would leave the restart action permanently inert, which is a worse failure than the flood it prevents." The no-supervisor latch *is* that permanently-inert state, reached whenever the restart succeeds. The cooldown window is untouched; only the separate in-flight-reuse branch is narrowed.
- **#66595** (dashboard restart action) — same control, unrelated cause.
- Duplicate search per CONTRIBUTING, nothing found: `gh search issues` and `gh search prs` (open and closed) over `gateway restart` + `dashboard` / `action` / `latch` / `no-supervisor` / `foreground`, plus `_spawn_gateway_restart` and `gateway-restart status running`.
- `Fixes #` — none; filing this as the report.
