### PR TITLE
fix: route Kimi Code /coding fallbacks onto Anthropic Messages

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2683,6 +2683,8 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         #
         # An explicit ``api_mode`` on the fallback entry always wins — including
         # an explicit "chat_completions" — and suppresses all re-detection below.
+        from hermes_cli.runtime_provider import _detect_api_mode_for_url
+
         fb_api_mode_explicit = bool(str(fb.get("api_mode") or "").strip())
         fb_api_mode = "chat_completions"
         if fb_api_mode_explicit:
@@ -2699,6 +2701,12 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 _orig_url.endswith("/anthropic")
                 or base_url_hostname(fb_base_url_hint) == "api.anthropic.com"
             ):
+                fb_api_mode = "anthropic_messages"
+            elif _detect_api_mode_for_url(fb_base_url_hint) == "anthropic_messages":
+                # Kimi Code ``api.kimi.com/coding`` (and other host-mandated
+                # Anthropic-Messages wires) when the fallback entry carries
+                # an explicit base_url. Same class as api.anthropic.com
+                # (#32243, #49247).
                 fb_api_mode = "anthropic_messages"
         
         # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
@@ -2756,6 +2764,15 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
                 # pre-resolve hint check above never sees it. Match the host
                 # the same way determine_api_mode() and _detect_api_mode_for_url()
                 # do on the primary path. (#32243, #49247)
+                fb_api_mode = "anthropic_messages"
+            elif _detect_api_mode_for_url(fb_base_url) == "anthropic_messages":
+                # Kimi Code ``api.kimi.com/coding`` (and other host-mandated
+                # Anthropic-Messages wires already classified on the primary
+                # path) must not stay on chat_completions — that POSTs
+                # /v1/chat/completions against a Messages-only route and 404s.
+                # Typical fallback entries name provider kimi-coding-cn
+                # without a base_url, so the pre-resolve hint pass misses
+                # them. Same class as api.anthropic.com (#32243, #49247).
                 fb_api_mode = "anthropic_messages"
             elif _fb_is_azure:
                 # Azure OpenAI serves gpt-5.x on /chat/completions — does NOT

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -270,6 +270,61 @@ class TestFallbackChainAdvancement:
         assert rebuilt["base_url"] == portal
         assert agent._anthropic_client is not None
 
+    def test_kimi_coding_fallback_uses_the_messages_wire(self):
+        """Kimi Code /coding fallbacks must not stay on chat_completions.
+
+        ``resolve_provider_client`` still returns an OpenAI client; without
+        re-deriving api_mode from the /coding host, activation POSTs
+        /v1/chat/completions at api.kimi.com/coding and 404s.
+        """
+        coding = "https://api.kimi.com/coding"
+        fbs = [
+            {
+                "provider": "kimi-coding-cn",
+                "model": "k3",
+            }
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        rebuilt = {"count": 0}
+
+        def _fake_build(api_key, base_url, timeout=None, **kwargs):
+            rebuilt["count"] += 1
+            rebuilt["api_key"] = api_key
+            rebuilt["base_url"] = base_url
+            return MagicMock(name="anthropic-client")
+
+        with (
+            patch(
+                "agent.chat_completion_helpers._fallback_entry_unavailable_without_network",
+                return_value=None,
+            ),
+            patch(
+                "agent.auxiliary_client.resolve_provider_client",
+                return_value=(
+                    _mock_client(base_url=coding, api_key="sk-kimi-test"),
+                    "k3",
+                ),
+            ),
+            patch(
+                "hermes_cli.model_normalize.normalize_model_for_provider",
+                side_effect=lambda m, p: m,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                side_effect=_fake_build,
+            ),
+        ):
+            assert agent._try_activate_fallback() is True
+
+        assert agent.api_mode == "anthropic_messages"
+        assert agent.provider == "kimi-coding-cn"
+        assert agent.model == "k3"
+        assert agent.client is None
+        assert rebuilt["count"] == 1
+        assert rebuilt["api_key"] == "sk-kimi-test"
+        assert rebuilt["base_url"] == coding
+        assert agent._anthropic_client is not None
+
     def test_nous_non_anthropic_fallback_stays_on_chat_completions(self):
         portal = "https://inference-api.nousresearch.com/v1"
         fbs = [{"provider": "nous", "model": "hermes-4-405b"}]


### PR DESCRIPTION
## Summary

When the primary model times out, Hermes walks `fallback_providers`. Kimi Code's `https://api.kimi.com/coding` host speaks **Anthropic Messages** (`/v1/messages`), the same way `api.anthropic.com` does.

`try_activate_fallback` still defaulted that hop to `chat_completions`, so the retry POSTed `/v1/chat/completions` against a Messages-only route and got **HTTP 404**. Primary-path resolution already classifies this host via `_detect_api_mode_for_url`; fallback did not reuse it.

## Change

Reuse `_detect_api_mode_for_url` on both:

1. the pre-resolve `base_url` hint (when the fallback entry carries one)
2. the resolved client `base_url` (typical `kimi-coding-cn` / `k3` entries have no hint)

Same bug class as `api.anthropic.com` (#32243, #49247). Explicit `api_mode` on the fallback entry still wins.

## Test plan

- [x] Neighbor-tree pytest (main checkout venv + `PYTHONPATH` = this worktree):
  `tests/run_agent/test_provider_fallback.py` — 30 passed, including
  `test_kimi_coding_fallback_uses_the_messages_wire`
- [ ] CI on this PR

## Notes

- Neighbor-tree interpreter: `%LOCALAPPDATA%/hermes/hermes-agent/venv/Scripts/python.exe`
- No Desktop / asar change. Python-only.
