### PR TITLE
fix(tools): preserve MCP tool schemas in the schema-cache write-through

### DIFF
--- a/tests/tools/test_mcp_schema_cache.py
+++ b/tests/tools/test_mcp_schema_cache.py
@@ -110,3 +110,85 @@ class TestWriteSkip:
         # Changed payload → rewrite.
         msc.write_cache_entry("srv", "fp2", tools=tools, utility_tools=[])
         assert len(saves) == 2
+
+
+class TestWriteThroughPreservesSchema:
+    """Regression: the write-through path must persist real tool parameters.
+
+    ``mcp`` 2.0 renamed ``Tool.inputSchema`` to ``input_schema``, keeping the
+    camelCase spelling only as a *serialization* alias — pydantic aliases do
+    not apply to attribute access, so ``getattr(tool, "inputSchema")`` returns
+    None on 2.x instead of raising. The cache-write path used exactly that
+    bare read, so every entry landed on disk with ``"inputSchema": {}``. A
+    server later registered from that cache (``lazy: true``) was advertised to
+    the model with every parameter stripped, which makes required-argument
+    tools such as zhihu's ``zhida`` (``query`` + ``model`` both required)
+    uncallable.
+
+    These tests drive the live ``_register_server_tools`` write-through with a
+    genuine SDK ``Tool`` so the field-rename is actually exercised — the mock
+    fixtures elsewhere build ``SimpleNamespace`` objects and cannot catch it.
+    """
+
+    _SCHEMA = {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "model": {"type": "string"},
+        },
+        "required": ["query", "model"],
+    }
+
+    def _cache_write_through(self, tmp_path, monkeypatch):
+        import json
+        from unittest.mock import MagicMock, patch
+
+        from mcp.types import Tool
+
+        import tools.mcp_tool as mt
+
+        monkeypatch.setattr(msc, "_cache_path", lambda: tmp_path / "cache.json")
+        server = mt.MCPServerTask("probe_srv")
+        server._tools = [
+            Tool(name="zhida", description="知乎直答", inputSchema=self._SCHEMA)
+        ]
+        server.session = MagicMock()
+        from tools.registry import ToolRegistry
+
+        with patch("tools.registry.registry", ToolRegistry()):
+            registered = mt._register_server_tools("probe_srv", server, {})
+        assert registered, "tool was not registered; write-through never fired"
+        entry = json.loads((tmp_path / "cache.json").read_text(encoding="utf-8"))["probe_srv"]
+        return entry["tools"][0]["inputSchema"]
+
+    def test_cached_schema_keeps_properties(self, tmp_path, monkeypatch):
+        cached = self._cache_write_through(tmp_path, monkeypatch)
+        assert set(cached.get("properties", {})) == {"query", "model"}, (
+            "write-through persisted an empty schema — the SDK field rename "
+            "was read with a bare camelCase getattr"
+        )
+
+    def test_cached_schema_keeps_required(self, tmp_path, monkeypatch):
+        cached = self._cache_write_through(tmp_path, monkeypatch)
+        assert cached.get("required") == ["query", "model"]
+
+    def test_cache_round_trip_reaches_agent_schema(self, tmp_path, monkeypatch):
+        """The whole point of the cache: a lazy server re-advertises params."""
+        from unittest.mock import patch
+
+        import tools.mcp_tool as mt
+        from tools.registry import ToolRegistry
+
+        cached = self._cache_write_through(tmp_path, monkeypatch)
+        entry = {
+            "fingerprint": "fp",
+            "tools": [{"name": "zhida", "description": "d", "inputSchema": cached}],
+            "utility_tools": [],
+        }
+        lazy_reg = ToolRegistry()
+        with patch("tools.registry.registry", lazy_reg):
+            names = mt._register_from_cache_sync("probe_srv", {}, entry)
+        assert names, "lazy registration produced no tools"
+        schema = lazy_reg.get_schema("mcp__probe_srv__zhida")
+        assert schema is not None, "lazy path did not register the tool"
+        assert set(schema["parameters"].get("properties", {})) == {"query", "model"}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -7930,7 +7930,14 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             for mcp_tool in server._tools:
                 if not _should_register(mcp_tool.name):
                     continue
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                # mcp 2.0 renamed every Tool model field to snake_case and
+                # left camelCase as a *serialization* alias only, which pydantic
+                # does not apply to attribute access: a bare camelCase getattr
+                # returns None on 2.x instead of raising. That silently wrote an
+                # empty ``inputSchema`` into the schema cache on every write-
+                # through, so a ``lazy: true`` server registered from cache with
+                # every parameter stripped. ``mcp_field`` reads both spellings.
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
                 tools_payload.append({
                     "name": mcp_tool.name,
                     "description": mcp_tool.description or "",


### PR DESCRIPTION
## What

One-line fix in `tools/mcp_tool.py`: the MCP schema-cache **write-through** read each tool's parameter schema with a bare camelCase `getattr`, which returns `None` on `mcp` 2.x. Result: every entry in `cache/mcp_schema_cache.json` was persisted with `"inputSchema": {}`.

## Why it matters

The damage surfaces on the **lazy registration** path (`mcp_servers.<name>.lazy: true`), which registers tools from the cached manifest *without* connecting. The model is then advertised a tool with every parameter stripped, so required-argument tools become uncallable — the agent cannot even see that the argument exists.

Observed locally against all four Zhihu MCP servers: cached schemas were empty for `zhida`, `zhihu_search`, `global_search` and `hot_list`, while live `tools/list` returns full schemas (`zhida` requires both `query` and `model`).

## Root cause

`mcp` 2.0 renamed every `Tool` model field to snake_case and kept the camelCase spelling only as a *serialization* alias. Pydantic aliases do not apply to attribute access, so `getattr(tool, "inputSchema")` silently yields the default instead of raising — exactly the failure mode documented in this module's own `mcp_field()` docstring ("tool schemas read as empty"). Five other field reads in `mcp_tool.py` already go through `mcp_field()` and survived the rename; the cache-write path was the one straggler.

## Fix

```diff
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
```

`mcp_field()` checks both spellings, so the cache round-trips correctly on either SDK generation. The on-disk JSON key stays `inputSchema`, so existing cache files and the read path are unaffected.

## How to test

Three regression tests in `tests/tools/test_mcp_schema_cache.py` drive the **live** `_register_server_tools` write-through and then feed the resulting manifest through `_register_from_cache_sync`, asserting the model-visible schema still carries `query` + `model`.

They use a genuine `mcp.types.Tool` rather than the `SimpleNamespace` fixtures used elsewhere in the suite — those construct a camelCase attribute, so they cannot catch a field rename at all (which is presumably how this slipped through).

Verified red → green:
- With the fix reverted: all 3 new tests fail (`cached props = []`, `required = None`), reproducing the on-disk symptom exactly.
- With the fix applied: 42 passed across `test_mcp_schema_cache.py`, `test_mcp_schema_cache_ttl.py`, `test_mcp_dynamic_discovery.py`, `test_mcp_lazy_start.py`.
- End-to-end on a live gateway: after restart, all four cached entries hold their real schemas (`zhida` → 3 params / required `[query, model]`; `global_search` → 4 params).

Lint gates:
- `ruff check` — passes.
- `scripts/check-windows-footguns.py` — passes (it caught a bare `read_text()` in my first draft, now `encoding="utf-8"`).
- No `ruff format` run: `origin/main` is not format-clean for either of these two files, so a reformat would bury a one-line fix in unrelated churn.

## Impact / risk

Behaviour change is limited to what gets written to (and read back from) a local cache file; no wire-format, no registry, no call path changes. Servers that are *not* lazy-configured are unaffected today because they always register from a live connection — which is why this has been silent so far.

## Tested on

- Linux (Ubuntu 24.04), Python 3.11.16, `mcp` 2.0.0 (the affected generation).
- The camelCase branch of `mcp_field()` keeps this correct on `mcp` 1.x, but I could not exercise a 1.x install locally.

## Notes

- Not a security issue, but worth flagging: any user who enables `lazy: true` on a server with required tool parameters will hit uncallable tools until this lands.
- No related issue found (searched `inputSchema`, schema cache, `mcp 2.0` rename).
