### PR TITLE
fix(auth): preserve basic refresh window

### DIFF
--- a/plugins/dashboard_auth/basic/__init__.py
+++ b/plugins/dashboard_auth/basic/__init__.py
@@ -88,6 +88,11 @@ logger = logging.getLogger(__name__)
 # logged in.
 _DEFAULT_TTL_SECONDS = 12 * 60 * 60  # 12h
 _REFRESH_TTL_SECONDS = 30 * 24 * 60 * 60  # 30d
+# Permit small clock differences when deciding whether an access token was
+# minted under a longer, superseded TTL. Tokens substantially longer than the
+# provider's current policy are sent through the normal refresh path so a TTL
+# reduction takes effect without forcing a login.
+_ACCESS_TTL_CLOCK_SKEW_SECONDS = 60
 
 # scrypt parameters (RFC 7914 / stdlib hashlib.scrypt). n must be a power
 # of two; these are the widely-recommended interactive-login parameters
@@ -222,7 +227,21 @@ class BasicAuthProvider(DashboardAuthProvider):
         self._username = username
         self._password_hash = password_hash
         self._secret = secret
-        self._ttl = max(60, int(ttl_seconds))
+        requested_ttl = max(60, int(ttl_seconds))
+        if requested_ttl >= _REFRESH_TTL_SECONDS:
+            # Refresh is attempted only after access verification fails. If the
+            # two tokens expire together there is no interval in which the RT
+            # can rotate the session, so "automatic refresh" deterministically
+            # becomes a forced login at the shared boundary.
+            logger.warning(
+                "dashboard-auth-basic: access-token TTL (%ss) must be shorter "
+                "than the refresh-token TTL (%ss); using the safe default (%ss)",
+                requested_ttl,
+                _REFRESH_TTL_SECONDS,
+                _DEFAULT_TTL_SECONDS,
+            )
+            requested_ttl = _DEFAULT_TTL_SECONDS
+        self._ttl = requested_ttl
 
     # ---- OAuth methods: not used (pure-password provider) ------------------
 
@@ -261,11 +280,18 @@ class BasicAuthProvider(DashboardAuthProvider):
     # ---- session lifecycle -------------------------------------------------
 
     def verify_session(self, *, access_token: str) -> Optional[Session]:
+        now = int(time.time())
         payload = _unsign(access_token, self._secret)
         if (
             payload is None
             or payload.get("kind") != "access"
-            or payload.get("exp", 0) <= int(time.time())
+            or payload.get("exp", 0) <= now
+            # A config correction from an overlong access TTL to a safe value
+            # must also repair sessions minted before the restart. Treat those
+            # still-valid tokens as refresh-due; middleware then rotates the
+            # matching RT and writes the shorter-lived pair back to the client.
+            or payload.get("exp", 0)
+            > now + self._ttl + _ACCESS_TTL_CLOCK_SKEW_SECONDS
         ):
             return None
         return self._session_from_payload(access_token, "", payload)

--- a/tests/plugins/dashboard_auth/test_basic_provider.py
+++ b/tests/plugins/dashboard_auth/test_basic_provider.py
@@ -118,6 +118,51 @@ class TestProvider:
         assert r.user_id == "admin"
         assert p.verify_session(access_token=r.access_token) is not None
 
+    def test_access_ttl_cannot_consume_the_refresh_window(self, basic, monkeypatch):
+        now = 1_000_000
+        monkeypatch.setattr(basic.time, "time", lambda: now)
+        p = self._make(basic, ttl_seconds=basic._REFRESH_TTL_SECONDS)
+
+        session = p.complete_password_login(
+            username="admin", password="hunter2"
+        )
+
+        assert session.expires_at == now + basic._DEFAULT_TTL_SECONDS
+        monkeypatch.setattr(
+            basic.time,
+            "time",
+            lambda: now + basic._DEFAULT_TTL_SECONDS,
+        )
+        assert p.verify_session(access_token=session.access_token) is None
+        assert p.refresh_session(refresh_token=session.refresh_token).user_id == "admin"
+
+    def test_shorter_config_rotates_an_existing_overlong_session(
+        self, basic, monkeypatch
+    ):
+        now = 2_000_000
+        secret = secrets.token_bytes(32)
+        password_hash = basic.hash_password("hunter2")
+        monkeypatch.setattr(basic.time, "time", lambda: now)
+        old = basic.BasicAuthProvider(
+            username="admin",
+            password_hash=password_hash,
+            secret=secret,
+            ttl_seconds=7 * 24 * 60 * 60,
+        )
+        session = old.complete_password_login(
+            username="admin", password="hunter2"
+        )
+        current = basic.BasicAuthProvider(
+            username="admin",
+            password_hash=password_hash,
+            secret=secret,
+            ttl_seconds=basic._DEFAULT_TTL_SECONDS,
+        )
+
+        assert current.verify_session(access_token=session.access_token) is None
+        rotated = current.refresh_session(refresh_token=session.refresh_token)
+        assert rotated.expires_at == now + basic._DEFAULT_TTL_SECONDS
+
 
     def test_cross_secret_token_does_not_verify(self, basic):
         p1 = self._make(basic)


### PR DESCRIPTION
## Summary

- keep the Basic dashboard auth access-token TTL strictly shorter than the fixed 30-day refresh-token TTL
- fall back to the safe 12-hour access TTL when configuration would make the access and refresh tokens expire together
- treat still-valid access tokens minted under an older, longer TTL as refresh-due so middleware rotates them onto the corrected policy

## Root cause and reproduction

`BasicAuthProvider` accepted any configured access TTL, including values equal to or longer than `_REFRESH_TTL_SECONDS`. Dashboard auth middleware attempts refresh only after access verification fails. With both tokens expiring at the same boundary, the first refresh opportunity arrives only after the refresh token is already expired, so automatic refresh deterministically becomes a forced login.

Applying only the two regression tests to upstream `main` reproduced the bug:

- `test_access_ttl_cannot_consume_the_refresh_window`
- `test_shorter_config_rotates_an_existing_overlong_session`
- result: 19 passed, 2 failed

## Fix

- clamp configured access TTLs greater than or equal to the refresh TTL back to the 12-hour safe default and emit a warning
- during access verification, reject tokens whose remaining lifetime substantially exceeds the current access policy (with 60 seconds of clock-skew allowance), allowing the existing middleware refresh path to rotate sessions minted before the configuration correction

## Tests

- `scripts/run_tests.sh tests/plugins/dashboard_auth/test_basic_provider.py -q` — 21 passed
- dashboard auth suite (16 files) via `scripts/run_tests.sh` — 204 passed
- `ruff check plugins/dashboard_auth/basic/__init__.py tests/plugins/dashboard_auth/test_basic_provider.py` — passed
- `python -m py_compile plugins/dashboard_auth/basic/__init__.py tests/plugins/dashboard_auth/test_basic_provider.py` — passed
- `git diff --cached --check` — passed

This clean one-commit PR supersedes #102121, which contained unrelated commits/files and conflicted with current `main`.
