### PR TITLE
fix(compression): reset skill_view dedup on codex app-server compaction (#101518)

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -4062,6 +4062,16 @@ def _compress_context_via_codex_app_server(
     except Exception:
         pass
 
+    # Same as the primary compression path: a post-compaction re-view must
+    # return the full skill content again, not the "unchanged" dedup stub
+    # (#101518) — the earlier skill_view result was compacted away.
+    try:
+        from tools.skills_tool import reset_skill_view_dedup
+
+        reset_skill_view_dedup(task_id)
+    except Exception:
+        pass
+
     logger.info(
         "codex app-server compaction done: session=%s thread=%s turn=%s",
         getattr(agent, "session_id", None) or "none",


### PR DESCRIPTION
Fixes #101518

## Problem
After context compression via the codex app-server path, `skill_view` re-requests return the "unchanged" dedup stub with no content. The stub's own message says "Re-issued after context compression, this returns the full content again", but `content_returned` is false — the earlier skill_view result was compacted away, so there is nothing to refer to. Weaker models loop indefinitely on the empty response (issue reports 21 identical calls, zero user-facing output).

## Root cause
The primary compression path resets both dedup caches (`agent/conversation_compression.py` ~L3891-3898: `reset_file_dedup` and `reset_skill_view_dedup`). The codex app-server compaction path (~L4061) resets only `reset_file_dedup` — the `reset_skill_view_dedup` call was missed when the skill dedup was wired in.

## Fix
Add the same `reset_skill_view_dedup(task_id)` call to the codex app-server compaction path, mirroring the primary path. Failure/interruption paths intentionally do not reset.

## Verification
- Syntax check passes.
- Existing compression test suites run clean (the 3 failures in `test_auxiliary_compression_timeout_floor` are pre-existing on main, verified by running the same tests on an unmodified checkout).
