### PR TITLE
fix(photon): unwrap spectrum 12.x threaded replies instead of dropping them (#100663)

### DIFF
--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -1289,6 +1289,21 @@ class PhotonAdapter(BasePlatformAdapter):
                 [],
             )
 
+        # spectrum 12.x threaded replies: {type: "reply", content: <Content>,
+        # target: <Message>}. Unwrap to the inner content so the human's
+        # actual words reach the agent; keep a light pointer to the quoted
+        # message for reply context (#100663).
+        reply_target_id = None
+        reply_target_text = None
+        if content.get("type") == "reply":
+            inner = content.get("content")
+            if isinstance(inner, dict) and inner.get("type"):
+                target = content.get("target")
+                if isinstance(target, dict):
+                    reply_target_id = target.get("messageId") or target.get("id")
+                    reply_target_text = target.get("text")
+                content = inner
+
         ctype = content.get("type")
         if ctype == "reaction":
             # Route only tapbacks on messages WE sent — those are implicitly
@@ -1479,6 +1494,8 @@ class PhotonAdapter(BasePlatformAdapter):
             timestamp=timestamp,
             media_urls=media_urls,
             media_types=media_types,
+            reply_to_message_id=reply_target_id,
+            reply_to_text=reply_target_text,
         )
         await self.handle_message(message_event)
 


### PR DESCRIPTION
Fixes #100663

## Problem
spectrum-ts 12.x delivers an iMessage threaded reply as `{type: "reply", content: <Content>, target: <Message>}`. The photon adapter's content ladder has no `reply` branch, so the unknown-type fallback fires and the agent receives the literal `[Photon content type not handled: reply]` — the human's actual words are dropped. Every deployment taking the v2026.8.31 sidecar hits this the first time a user swipe-replies.

## Fix
Before the ctype ladder, unwrap `type == "reply"` envelopes whose inner `content` is a dict: use the inner content for all existing processing (reaction gates, U+FFFC placeholder handling, attachment decoding, mention gating all operate on the real payload), and carry `reply_to_message_id` / `reply_to_text` from the `target` onto the MessageEvent — the same contract the reaction path already uses (`base.py` declares both fields). Malformed envelopes (inner content not a dict) fall through to the existing unknown-type fallback instead of raising.

## Verification
- Syntax check passes.
- Existing photon adapter tests: 4 passed (main baseline: 4 passed).
