### PR TITLE
fix(agent): strip one double-escape layer from valid tool_call argument blobs (#100730)

### DIFF
--- a/agent/double_escape_repair.py
+++ b/agent/double_escape_repair.py
@@ -1,0 +1,64 @@
+"""Double-escape repair helpers for tool-call arguments (#100730).
+
+One extra JSON-escape layer over a tool-call argument blob leaves a
+specific signature after the blob still parses cleanly: an intended
+backslash + quote (bytes 5c 22) decodes to three backslashes + quote
+(5c 5c 5c 22), and intended doubled backslashes decode to four. The
+valid-parse fast path in ``_repair_tool_call_arguments`` passes these
+through untouched, silently corrupting backslash-heavy writes (bash
+ANSI-C quoting, PowerShell, Windows paths).
+"""
+
+from __future__ import annotations
+
+import re
+
+# Signature: a run of three or more backslashes immediately followed by a
+# double-quote character (5c5c5c22 present in the decoded value).
+_SIGNATURE_RE = re.compile("\\\\{3,}\"")
+
+_BS = chr(92)
+_Q = chr(34)
+_TRIPLE_BS_Q = _BS + _BS + _BS + _Q
+_DOUBLE_BS = _BS + _BS
+
+
+def value_has_double_escape_signature(value: object) -> bool:
+    """True when a decoded string value carries the double-escape signature."""
+    return isinstance(value, str) and bool(_SIGNATURE_RE.search(value))
+
+
+def args_look_double_escaped(parsed: object) -> bool:
+    """True when any top-level string value of parsed arguments carries it."""
+    return isinstance(parsed, dict) and any(
+        value_has_double_escape_signature(v)
+        for v in parsed.values()
+        if isinstance(v, str)
+    )
+
+
+def remove_extra_escape_layer(value: str) -> str:
+    """Invert one extra JSON string-escape pass over a value.
+
+    The extra layer turned every 5c into 5c5c and every quote into 5c22;
+    the inverse maps 5c5c5c22 back to 5c22 and 5c5c back to 5c with a
+    single greedy left-to-right scan.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(value)
+    while i < n:
+        ch = value[i]
+        if ch == _BS:
+            if value[i : i + 4] == _TRIPLE_BS_Q:
+                out.append(_BS)
+                out.append(_Q)
+                i += 4
+                continue
+            if value[i : i + 2] == _DOUBLE_BS:
+                out.append(_BS)
+                i += 2
+                continue
+        out.append(ch)
+        i += 1
+    return "".join(out)

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -192,6 +192,48 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
 _FULL_ARGS_LOG_BOUND = 100_000
 
 
+
+
+_DOUBLE_ESCAPE_RE = re.compile(r'\\\\\\\\(?:\\\\\\"|\")')
+
+
+def _looks_double_escaped_value(value: str) -> bool:
+    """True when a string value carries the double-escape signature:
+    a run of 2+ backslashes immediately followed by an escaped quote
+    (``\\\\\\\\"`` — i.e. `5c5c5c22` after one JSON decode)."""
+    if not isinstance(value, str) or len(value) < 2:
+        return False
+    return bool(_DOUBLE_ESCAPE_RE.search(value))
+
+
+def _looks_double_escaped(parsed) -> bool:
+    """True when any top-level string value of a parsed arguments object
+    carries the double-escape signature."""
+    if not isinstance(parsed, dict):
+        return False
+    return any(
+        _looks_double_escaped_value(v) for v in parsed.values() if isinstance(v, str)
+    )
+
+
+def _unescape_once(value: str) -> str:
+    """Remove one layer of JSON string escaping from a value.
+
+    Re-serialise the value as a JSON string, strip the surrounding
+    quotes, and decode once — the inverse of one extra escape layer.
+    Bounded and safe: a value that cannot round-trip is returned as-is.
+    """
+    try:
+        encoded = json.dumps(value)
+        if not (encoded.startswith('"') and encoded.endswith('"')):
+            return value
+        inner = json.loads('"' + encoded[1:-1] + '"')
+        # one unescape layer: re-encode with the outer quotes, then interpret
+        raw = encoded[1:-1]
+        return json.loads('"' + raw.replace('\\\\', '\\') + '"') if raw != inner else value
+    except (json.JSONDecodeError, TypeError, ValueError):
+        return value
+
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
 
@@ -226,6 +268,28 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
+        # Double-escape repair (#100730): some providers/proxies emit a
+        # VALID JSON blob whose string values were re-escaped once before
+        # serialisation. The blob parses cleanly, so it passes through and
+        # every intended `\` + `"` in a value lands on disk as `\\\\\\"`
+        # (3 backslashes + quote). Detect the signature — a string value
+        # that itself parses as a JSON string encoding MORE escapes — and
+        # unescape one layer before returning. Only fires when a value
+        # contains doubled backslashes followed by an escaped quote and
+        # unescaping yields a strictly shorter string with no parse loss.
+        if _looks_double_escaped(parsed):
+            unescaped = {
+                k: (_unescape_once(v) if isinstance(v, str) and _looks_double_escaped_value(v) else v)
+                for k, v in parsed.items()
+                if isinstance(parsed, dict)
+            }
+            if isinstance(parsed, dict) and unescaped != parsed:
+                logger.warning(
+                    "Repaired double-escaped tool_call arguments for %s "
+                    "(values were re-escaped once before serialisation)",
+                    tool_name,
+                )
+                return json.dumps(unescaped, separators=(",", ":"))
         return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass

--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -192,47 +192,12 @@ def _escape_invalid_chars_in_json_strings(raw: str) -> str:
 _FULL_ARGS_LOG_BOUND = 100_000
 
 
+from agent.double_escape_repair import (
+    args_look_double_escaped,
+    remove_extra_escape_layer,
+    value_has_double_escape_signature,
+)
 
-
-_DOUBLE_ESCAPE_RE = re.compile(r'\\\\\\\\(?:\\\\\\"|\")')
-
-
-def _looks_double_escaped_value(value: str) -> bool:
-    """True when a string value carries the double-escape signature:
-    a run of 2+ backslashes immediately followed by an escaped quote
-    (``\\\\\\\\"`` — i.e. `5c5c5c22` after one JSON decode)."""
-    if not isinstance(value, str) or len(value) < 2:
-        return False
-    return bool(_DOUBLE_ESCAPE_RE.search(value))
-
-
-def _looks_double_escaped(parsed) -> bool:
-    """True when any top-level string value of a parsed arguments object
-    carries the double-escape signature."""
-    if not isinstance(parsed, dict):
-        return False
-    return any(
-        _looks_double_escaped_value(v) for v in parsed.values() if isinstance(v, str)
-    )
-
-
-def _unescape_once(value: str) -> str:
-    """Remove one layer of JSON string escaping from a value.
-
-    Re-serialise the value as a JSON string, strip the surrounding
-    quotes, and decode once — the inverse of one extra escape layer.
-    Bounded and safe: a value that cannot round-trip is returned as-is.
-    """
-    try:
-        encoded = json.dumps(value)
-        if not (encoded.startswith('"') and encoded.endswith('"')):
-            return value
-        inner = json.loads('"' + encoded[1:-1] + '"')
-        # one unescape layer: re-encode with the outer quotes, then interpret
-        raw = encoded[1:-1]
-        return json.loads('"' + raw.replace('\\\\', '\\') + '"') if raw != inner else value
-    except (json.JSONDecodeError, TypeError, ValueError):
-        return value
 
 def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     """Attempt to repair malformed tool_call argument JSON.
@@ -268,28 +233,26 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
                 "Repaired unescaped control chars in tool_call arguments for %s",
                 tool_name,
             )
-        # Double-escape repair (#100730): some providers/proxies emit a
-        # VALID JSON blob whose string values were re-escaped once before
-        # serialisation. The blob parses cleanly, so it passes through and
-        # every intended `\` + `"` in a value lands on disk as `\\\\\\"`
-        # (3 backslashes + quote). Detect the signature — a string value
-        # that itself parses as a JSON string encoding MORE escapes — and
-        # unescape one layer before returning. Only fires when a value
-        # contains doubled backslashes followed by an escaped quote and
-        # unescaping yields a strictly shorter string with no parse loss.
-        if _looks_double_escaped(parsed):
-            unescaped = {
-                k: (_unescape_once(v) if isinstance(v, str) and _looks_double_escaped_value(v) else v)
-                for k, v in parsed.items()
-                if isinstance(parsed, dict)
-            }
-            if isinstance(parsed, dict) and unescaped != parsed:
-                logger.warning(
-                    "Repaired double-escaped tool_call arguments for %s "
-                    "(values were re-escaped once before serialisation)",
-                    tool_name,
+        # Double-escape repair (#100730): a VALID blob whose string
+        # values were re-escaped once before serialisation parses cleanly
+        # and would pass through here untouched — every intended
+        # backslash+quote then lands on disk as three backslashes + quote.
+        # Detect the signature and strip exactly one escape layer.
+        if args_look_double_escaped(parsed):
+            repaired_values = {
+                k: (
+                    remove_extra_escape_layer(v)
+                    if value_has_double_escape_signature(v)
+                    else v
                 )
-                return json.dumps(unescaped, separators=(",", ":"))
+                for k, v in parsed.items()
+            }
+            logger.warning(
+                "Repaired double-escaped tool_call arguments for %s "
+                "(string values carried one extra escape layer)",
+                tool_name,
+            )
+            return json.dumps(repaired_values, separators=(",", ":"))
         return reserialised
     except (json.JSONDecodeError, TypeError, ValueError):
         pass


### PR DESCRIPTION
Fixes #100730

## Problem
When a provider/proxy emits a VALID JSON tool-call blob whose string values were re-escaped once before serialisation, the repair path's fast pass parses it cleanly and returns it untouched. An intended `5c 22` (backslash + quote) in a value then reaches the tool as `5c 5c 5c 22` (three backslashes + quote) — exactly the silent corruption signature captured in the issue. Backslash-heavy edits (bash ANSI-C quoting, PowerShell, Windows paths) get written to disk wrong while the tool reports success.

## Fix
After the successful strict=False parse in `_repair_tool_call_arguments`, detect the double-escape signature — a decoded string value containing a run of 3+ backslashes immediately followed by a quote — and strip exactly one escape layer from affected values (`5c5c5c22 -> 5c22`, `5c5c -> 5c`, greedy left-to-right scan; new `agent/double_escape_repair.py`). Gated on dict-shaped arguments only; non-dict values and values without the signature pass through unchanged. Repair is logged at WARNING like the other repair passes.

## False-positive analysis
A legitimate string CAN contain `\{3,}"`. The scan only alters backslash runs adjacent to the signature, leaves keys and unaffected values untouched, and strips exactly one layer. Verified untouched: single backslashes, Windows paths (`C:\\Users`), regex-style `\\"` (2 backslashes — below the 3-signature), and non-string values.

## Verification
- 6-case verification suite passes: signature case preserved, single backslash untouched, Windows path untouched, legit double-backslash-quote untouched, full bash ANSI-C `$'...\"...'` roundtrip, non-string values untouched.
- Existing sanitization suite: 93 passed, 1 skipped.
