### PR TITLE
fix(packaging): include hermes_state_holders module

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -572,6 +572,7 @@ py-modules = [
   "hermes_bootstrap",
   "hermes_constants",
   "hermes_state",
+  "hermes_state_holders",
   "hermes_state_common",
   "hermes_state_portability",
   "hermes_state_schema",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -46,6 +46,16 @@ def test_packaging_declared_as_core_dependency():
     )
 
 
+def test_hermes_state_holders_is_declared_as_top_level_module():
+    """The installed module contract must include hermes_state_holders."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    modules = data["tool"]["setuptools"]["py-modules"]
+    assert "hermes_state_holders" in modules, (
+        "hermes_state.py imports hermes_state_holders; it must be included "
+        "in setuptools py-modules for isolated installs"
+    )
+
+
 def test_faster_whisper_is_not_a_base_dependency():
     data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
     deps = data["project"]["dependencies"]


### PR DESCRIPTION
## What does this PR do?

Adds `hermes_state_holders` to setuptools' top-level `py-modules` list. `hermes_state.py` imports this module, but isolated candidate installations currently omit it and fail with:

```text
ModuleNotFoundError: No module named 'hermes_state_holders'
```

Declaring the existing module in package metadata fixes the installed-module contract without adding a compatibility shim or changing runtime behavior.

## Related Issue

N/A — reproduced directly during an isolated updater candidate validation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add `hermes_state_holders` to `[tool.setuptools].py-modules` in `pyproject.toml`.
- Add a focused packaging metadata regression test in `tests/test_packaging_metadata.py`.

## How to Test

1. Run `tests/test_packaging_metadata.py` with pytest.
2. Confirm `hermes_state_holders` is present in `tool.setuptools.py-modules`.
3. Confirm an isolated Hermes candidate can resolve `import hermes_state_holders` when installed from this metadata.

Focused result on Windows 11:

```text
10 passed in 4.46s
```

The repository intentionally blocks ordinary non-Nix wheel builds, so a blocked wheel attempt is not presented as passing evidence.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and historical issues/PRs for duplicates.
- [x] My PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` and all tests pass. (Focused packaging boundary was run instead.)
- [x] I've added a regression test for the bug.
- [x] I've tested on Windows 11.

### Documentation & Housekeeping

- [x] Documentation update: N/A; this corrects package metadata for an existing module.
- [x] `cli-config.yaml.example`: N/A.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no workflow or architecture change.
- [x] Cross-platform impact considered; the metadata declaration is platform-neutral.
- [x] Tool descriptions/schemas: N/A.