### PR TITLE
fix(plugins): skip foreign-harness manifest dirs to avoid warning spam (fixes #101962)

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -80,6 +80,22 @@ from hermes_cli.relay_plugin_cutover import (
 )
 
 
+# Well-known foreign-harness manifest directories that ship inside
+# multi-harness repos like obra/superpowers. Each contains a plugin.json
+# for another harness (Claude Code, Codex, Cursor, Devin, Kimi) and would
+# otherwise spam "unsupported schema" warnings on every discovery cycle.
+# Hermes' own portable manifest lives at .hermes-plugin/. See #101962.
+_FOREIGN_HARNESS_MANIFEST_DIRS = frozenset(
+    {
+        ".claude-plugin",
+        ".codex-plugin",
+        ".cursor-plugin",
+        ".devin-plugin",
+        ".kimi-plugin",
+    }
+)
+
+
 def get_bundled_plugins_dir() -> Path:
     """Locate the bundled ``plugins/`` directory.
 
@@ -4706,6 +4722,11 @@ class PluginManager:
 
         for child in sorted(path.iterdir()):
             if not child.is_dir():
+                continue
+            # Skip foreign-harness manifest dirs (obra/superpowers layout)
+            # that would otherwise spam "unsupported schema" warnings (#101962).
+            if child.name in _FOREIGN_HARNESS_MANIFEST_DIRS:
+                logger.debug("Skipping foreign harness manifest dir %s", child)
                 continue
             if depth == 0 and skip_names and child.name in skip_names:
                 continue


### PR DESCRIPTION
## What does this PR do?

Every plugin-discovery cycle logged 5 warnings for `~/.hermes/plugins/superpowers/.claude-plugin/plugin.json` (and `.codex-plugin`, `.cursor-plugin`, `.devin-plugin`, `.kimi-plugin`) — the multi-harness manifests shipped by `obra/superpowers` 6.3.0. Each contains a `plugin.json` for another harness (Claude Code, Codex, Cursor, …) with no `"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"`, so `hermes_cli/agent_plugins.py:110` (`_validate_manifest`) raises `AgentPluginError: unsupported or missing Agent Plugins schema` and `hermes_cli/plugins.py:4751` logs `WARNING Failed to parse …`. Functionality was unaffected (Hermes manifest at `.hermes-plugin/plugin.yaml` is parsed correctly), but it produced ~1,500 warnings/day in `errors.log` on Windows, drowning real signals.

This PR skips those well-known foreign-harness directories during discovery, so they never reach the portable-manifest parser:

- Add `_FOREIGN_HARNESS_MANIFEST_DIRS = frozenset({".claude-plugin",".codex-plugin",".cursor-plugin",".devin-plugin",".kimi-plugin"})` with comment referencing #101962.
- In `PluginManager._scan_directory_level` (`hermes_cli/plugins.py:4707`), before `plugin.yaml`/`plugin.json` checks, `if child.name in _FOREIGN_HARNESS_MANIFEST_DIRS: logger.debug("Skipping foreign harness manifest dir %s", child); continue`.

No deletion from upstream `superpowers` repo; other-harness manifests remain there, Hermes simply ignores them.

## Related Issue

Fixes #101962

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/plugins.py:80` — define `_FOREIGN_HARNESS_MANIFEST_DIRS` (5 entries) with comment.
- `hermes_cli/plugins.py:4707` — insert early `continue` for those names (logs at `DEBUG`, not `WARNING`), before manifest checks.

## How to Test

1. **Repro before fix:** Install `superpowers` 6.3.0 under `~/.hermes/plugins/superpowers/` (or copy its `.claude-plugin` etc. dirs). Run `hermes plugins list` or `hermes doctor` — before: `errors.log` shows 5× `WARNING Failed to parse …/.claude-plugin/plugin.json: unsupported or missing Agent Plugins schema` per cycle; after: no `WARNING`, only `DEBUG Skipping foreign harness manifest dir` when `--log-level DEBUG`.
2. `hermes plugins list` still shows `superpowers` portable and its Hermes skills (via `.hermes-plugin/plugin.yaml`) — functionality unchanged.
3. CI: `Python tests / Run tests` and `Python lints / ruff + ty diff` pass; `hermes_cli/test_plugins` (if any) still passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (CI: `Python tests / Run tests` pass)
- [x] I've added tests for my changes (N/A — log-filter only; existing discovery tests cover `plugin.yaml`/`plugin.json` paths)
- [x] I've tested on my platform: Windows 11, Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python `Path.name` check, no OS calls)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Before: `errors.log` shows `WARNING hermes_cli.plugins: Failed to parse …/.codex-plugin/plugin.json: unsupported…` 5× per discovery (every process). After: no `WARNING`; `DEBUG` line `Skipping foreign harness manifest dir …` appears only with debug logging.
