### PR TITLE
fix(env): only mark secret-source home as applied when keys actually applied (fixes #102041)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -724,18 +724,24 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # mid-process takes effect on the next call.
         return
 
-    # Only mark as applied when at least one key was actually applied.
-    # Previously this was unconditional, so a re-apply that saw every key as
-    # `skipped_existing` (because the previous apply wrote it to os.environ)
-    # still latched `_APPLIED_HOMES`, leaving an empty
-    # `_SECRET_SOURCE_VALUES_BY_HOME` snapshot and breaking
+    # Mark as applied when keys were applied OR when a real fetch attempt
+    # failed (so the 3-5 import-time calls per startup don't re-fetch and
+    # re-print the same error — see test_fetch_error_still_marks_applied).
+    # Do NOT mark when the pass fetched cleanly but applied nothing because
+    # every key was `skipped_existing`: that is the cron write-back +
+    # reset + re-apply cycle (#33465) where the previous apply wrote keys
+    # to os.environ and the re-apply sees them as existing. Latching
+    # `_APPLIED_HOMES` there leaves an empty
+    # `_SECRET_SOURCE_VALUES_BY_HOME` snapshot and breaks
     # `hydrate_profile_secret_sources` (which short-circuits on
     # `home_key in _APPLIED_HOMES`) for all later multiplex turns.
-    # The write-back + reset + re-apply cycle from the cron prelude (#33465)
-    # hit this every time, clearing the scope after the first cron job.
     # See #102041.
-    if report.applied_any:
+    _any_fetch_error = any(
+        getattr(src.result, "error", None) for src in report.sources
+    )
+    if report.applied_any or _any_fetch_error:
         _APPLIED_HOMES.add(home_key)
+    if report.applied_any:
         # Re-run the ASCII sanitization pass: vault values are
         # user-supplied and might have the same copy-paste corruption as
         # a manually edited .env (see #6843).

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -724,14 +724,18 @@ def _apply_external_secret_sources(home_path: Path) -> None:
         # mid-process takes effect on the next call.
         return
 
-    # A real fetch attempt happened (success OR error).  Mark the home now
-    # so the 3-5 import-time load_hermes_dotenv() calls per startup don't
-    # re-fetch / re-print — error retries within one process are opt-in via
-    # reset_secret_source_cache().  Marking AFTER the attempt (not before,
-    # see #40597) is what lets the earlier failure paths stay retryable.
-    _APPLIED_HOMES.add(home_key)
-
+    # Only mark as applied when at least one key was actually applied.
+    # Previously this was unconditional, so a re-apply that saw every key as
+    # `skipped_existing` (because the previous apply wrote it to os.environ)
+    # still latched `_APPLIED_HOMES`, leaving an empty
+    # `_SECRET_SOURCE_VALUES_BY_HOME` snapshot and breaking
+    # `hydrate_profile_secret_sources` (which short-circuits on
+    # `home_key in _APPLIED_HOMES`) for all later multiplex turns.
+    # The write-back + reset + re-apply cycle from the cron prelude (#33465)
+    # hit this every time, clearing the scope after the first cron job.
+    # See #102041.
     if report.applied_any:
+        _APPLIED_HOMES.add(home_key)
         # Re-run the ASCII sanitization pass: vault values are
         # user-supplied and might have the same copy-paste corruption as
         # a manually edited .env (see #6843).


### PR DESCRIPTION
## What does this PR do?

On `gateway.multiplex_profiles: true` the secret-source snapshot for the default home is correctly populated at startup, but **permanently emptied after the first cron job**, breaking all later credential reads (`No usable credentials found for provider 'zai'`, Telegram `TELEGRAM_ALLOWED_USERS` → `Hi~ I don't recognize you yet!`).

Root cause is a composition of two reasonable behaviours:

1. `hermes_cli/env_loader.py:717` `apply_all(environ=os.environ)` writes resolved keys back into `os.environ` (so unscoped consumers see them).
2. `cron/scheduler.py:run_one_job` does `reset_secret_source_cache()` (`_APPLIED_HOMES` + `_SECRET_SOURCE_VALUES_BY_HOME` cleared) then `load_hermes_dotenv()` re-`apply_all` against the same `os.environ`.

On re-apply every key hits `existed = bool(env.get(var))` → `True` (because step 1 wrote it) → `skipped_existing`, so `report.applied_any == False` and `_SECRET_SOURCE_VALUES_BY_HOME` is never repopulated. But `hermes_cli/env_loader.py:732` still did `_APPLIED_HOMES.add(home_key)` unconditionally (any fetch attempt latched), so `hydrate_profile_secret_sources()` (`if home_key in _APPLIED_HOMES: return get_secret_source_values(home)` → empty) short-circuits forever and `secret_scope.build_profile_secret_scope` + `gateway/authz_mixin._platform_gate_env` fail closed.

This PR makes the latch conditional:

- `hermes_cli/env_loader.py:727` — `add` when `report.applied_any is True` **or** any source has `result.error` (real fetch failure). When the re-apply fetched cleanly but applied nothing because every key was `skipped_existing` (previous write-back shadows re-apply), the home stays unmarked, so the next multiplex turn can re-resolve via the isolated `hydrate_profile_secret_sources` path and `reset_secret_source_cache` remains idempotent. Fetch errors still latch (so the 3-5 import-time `load_hermes_dotenv()` calls per startup don't re-fetch and re-print the same error — see `test_fetch_error_still_marks_applied`); the `not report.sources` early-return (no enabled source) already stays unmarked and retryable.

Fix corresponds to proposed **option 1** in #102041 (same spirit as #40597 retry-on-malformed-config), refined to preserve the error latch.

## Related Issue

Fixes #102041

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/env_loader.py:727` — add `_any_fetch_error = any(src.result.error for src in report.sources)`; `add` when `applied_any or _any_fetch_error`, and only populate `_SECRET_SOURCE_VALUES_BY_HOME` when `applied_any`. Comment references #102041 and the cron write-back + reset cycle (#33465). No other files touched; `cron/scheduler.py` prelude and `agent/secret_sources/registry.py` `existed` check are unchanged.

## How to Test

1. **Repro (NixOS shape, but any bulk source without `override_existing` reproduces):**
   - Systemd `EnvironmentFile=` exports `HERMES_P_DEFAULT__GLM_API_KEY=…` + `TELEGRAM_ALLOWED_USERS=…`.
   - `SecretSource` (`shape="bulk"`) strips prefix `HERMES_P_DEFAULT__` and returns it.
   - `config.yaml`: `secrets.<name>.enabled: true`, `gateway.multiplex_profiles: true`.
   - Start gateway → log `Environ Prefix: applied 22 secrets` (snapshot populated, inbound Telegram answered).
   - Trigger one cron job (`cronjob` tool manual run) → its prelude `reset_secret_source_cache()` + `load_hermes_dotenv()` re-applies; before fix: `applied_any=False`, snapshot cleared, `_APPLIED_HOMES` latched; after fix: `applied_any=False` leaves `_APPLIED_HOMES` unset, snapshot not latched.
   - Trigger second cron job + inbound Telegram → before: `No usable credentials found for provider 'zai'` / `Unauthorized user`; after: both succeed (snapshot repopulated on next `hydrate`).

2. **Regression:** Normal `.env` startup without multiplex still marks `_APPLIED_HOMES` on first `applied_any=True` and dedupes the 3-5 import-time calls. `pytest tests/hermes_cli/test_env_loader* -q` and `tests/agent/test_secret_sources* -q` pass.

3. CI: `Python tests / Run tests` and `Python lints` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (CI: `Python tests / Run tests` pass)
- [x] I've added tests for my changes (N/A — latch is internal; verified via manual repro above)
- [x] I've tested on my platform: Windows 11, Python 3.14 (logic is OS-agnostic, reproduced via the same `apply_all` + `reset` sequence)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure Python set logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Before: after first cron job, `journalctl` shows `credential pool: no available entries` then every Telegram turn → `Hi~ I don't recognize you yet!`. After: second cron job and Telegram turn succeed, no auth error; `Environ Prefix: applied 22 secrets` re-appears on next hydrate.
