### PR TITLE
Fix/session store profile seam

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -168,6 +168,24 @@ _READ_OPEN_RETRY_SECONDS = 60.0
 _READ_ONLY_IOERR_RETRY_ATTEMPTS, _READ_ONLY_IOERR_RETRY_BACKOFF_S = 3, 0.05
 
 
+def default_root_db_path() -> Path:
+    """The DEFAULT profile's ``state.db``, pinned to the platform default root.
+
+    ``get_default_hermes_root()`` reads ``HERMES_HOME`` / the native home
+    directly (``hermes_constants.py:183``) rather than the context-local
+    ``_HERMES_HOME_OVERRIDE`` ContextVar, so this resolves to the SAME
+    ``<root>/state.db`` regardless of any residual per-turn home override
+    active on a reused executor. Default build/persist sites bind THIS explicit
+    handle instead of the lazy no-path :func:`_default_db_path`, so a DEFAULT
+    session's store can no longer follow an ambient foreign home. Written once
+    and reused at every default build site (never duplicate the expression);
+    import-safe (stdlib + ``hermes_constants`` only).
+    """
+    from hermes_constants import get_default_hermes_root
+
+    return get_default_hermes_root() / "state.db"
+
+
 def _default_db_path() -> Path:
     """Default state DB path at CALL time: a re-pointed ``DEFAULT_DB_PATH`` wins, else
     ``get_hermes_home()`` is resolved fresh (a runtime HERMES_HOME redirect works regardless of import)."""

--- a/run_agent.py
+++ b/run_agent.py
@@ -291,7 +291,26 @@ class AIAgent(
         try:
             from hermes_state_registry import acquire
 
-            self._session_db = acquire()
+            # Bind the EXPLICIT default-root store handle here, at the earliest
+            # open site -- NOT the lazy no-path default (acquire() -> _default_db_path()),
+            # which resolves against the context-local HERMES_HOME at first open. On
+            # a reused compute-host executor a residual foreign home override
+            # would otherwise bind this DEFAULT session's store (cached on the
+            # agent below) to another profile's state.db while its label stays
+            # 'default'. Pinning the default root makes store and label one
+            # fact. Named-profile agents receive their handle via session_db=
+            # at construction, so self._session_db is already set and we never
+            # reach here for them.
+            try:
+                from hermes_state import default_root_db_path
+
+                default_db_path = default_root_db_path()
+            except Exception:
+                # No resolvable default root (hermes_state stubbed in tests) -> plain
+                # acquire(), the pre-#102146 behavior. Keeps recall usable instead of
+                # aborting to None just because the root path couldn't be derived.
+                default_db_path = None
+            self._session_db = acquire(default_db_path)
             self._owns_session_db = True  # we opened it, so close() must release it
             return self._session_db
         except Exception:
@@ -323,8 +342,25 @@ class AIAgent(
             # Persist the profile name explicitly, including "default": profile-keyed consumers treat NULL
             # as unowned.
             try:
-                from hermes_cli.profiles import get_active_profile_name
-                profile_for_session = get_active_profile_name()
+                # Derive the label from the BOUND store handle first, not the
+                # ambient process. _own_profile_name() reads the store's db_path,
+                # so for an in-tree store the label and the store are ONE fact
+                # and cannot diverge: a DEFAULT session bound to <root>/state.db
+                # stamps 'default'; a named-profile store stamps its own owner.
+                # This is the label side of the #99222/#102146 fix — the old
+                # get_active_profile_name() resolved independently of the store
+                # handle (at a possibly-clean instant while the store had
+                # followed a residual foreign home).
+                #
+                # An OUT-OF-TREE store (explicit db_path in tests, degraded
+                # JSONL fallback) has no derivable owner and returns None; fall
+                # back to the ambient profile so a gateway-routed session still
+                # records its routing identity (the degraded-db lazy create is
+                # the ONLY durable write of that identity — see #102146 CI).
+                profile_for_session = getattr(self._session_db, "_own_profile_name", lambda: None)()
+                if not profile_for_session:
+                    from hermes_cli.profiles import get_active_profile_name
+                    profile_for_session = get_active_profile_name()
             except Exception:
                 # Persist the profile name EXPLICITLY, including "default". NULL used to stand in for the
                 # default profile, but the #94724 legacy-owner backfill already stamps literal "default"

--- a/tests/gateway/test_session_store_profile_scope.py
+++ b/tests/gateway/test_session_store_profile_scope.py
@@ -1,0 +1,180 @@
+"""A DEFAULT session must persist to default's state.db, labelled default.
+
+Fifth "profile seam" fix. The store path and the profile label used to be
+resolved by two independent code paths at different instants: the store was
+opened LAZILY against the context-local ``HERMES_HOME`` at first DB open, while
+``profile_name`` was stamped separately from ``get_active_profile_name()``. On
+the reused compute-host executor a residual foreign ``HERMES_HOME`` override
+active at the store-open instant bound a DEFAULT session's rows to another
+profile's ``state.db`` while the label stayed ``default`` -- a cross-profile
+data-isolation break.
+
+These tests assert the PHYSICAL db file that holds the row (design finding R4)
+under a residual foreign home, not merely ``store._own_profile_name() == label``
+at a build site (which passes on HEAD). ``HERMES_HOME`` is set via env
+(monkeypatch.setenv), NOT only the ``_HERMES_HOME_OVERRIDE`` ContextVar, so
+``get_default_hermes_root()`` (which reads ``os.environ``) resolves the temp
+default-root INSIDE the tree and ``_own_profile_name`` yields ``default``, not
+None (design finding R5).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import hermes_constants as hc
+import hermes_state
+from hermes_state import SessionDB
+from hermes_state_registry import close_all
+from run_agent import AIAgent
+
+
+def _profile_of(db_path, session_id):
+    if not Path(db_path).exists():
+        return "__MISSING_FILE__"
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT profile_name FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        return ("__NO_ROW__" if row is None else row[0])
+    finally:
+        conn.close()
+
+
+def _has_row(db_path, session_id) -> bool:
+    if not Path(db_path).exists():
+        return False
+    conn = sqlite3.connect(db_path)
+    try:
+        row = conn.execute(
+            "SELECT 1 FROM sessions WHERE id = ?", (session_id,)
+        ).fetchone()
+        return row is not None
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def roots(tmp_path, monkeypatch):
+    """Temp default-root with a tommy profile subtree, wired via env.
+
+    HERMES_HOME is set via env so ``get_default_hermes_root()`` (reads
+    os.environ) resolves the temp default-root in-tree. DEFAULT_DB_PATH is
+    restored to its import-time snapshot so the lazy no-path
+    ``get_shared_session_db()`` open resolves through ``get_hermes_home()``
+    (the context-local override) the way production does -- otherwise the
+    escape hatch would pin every lookup to one fixed path and mask the
+    divergence.
+    """
+    root = tmp_path / "hermes"
+    root.mkdir(parents=True)
+    (root / "profiles" / "tommy").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.setattr(
+        hermes_state, "DEFAULT_DB_PATH", hermes_state._IMPORT_DEFAULT_DB_PATH
+    )
+    yield SimpleNamespace(
+        root=root,
+        default_db=(root / "state.db"),
+        tommy_home=(root / "profiles" / "tommy"),
+        tommy_db=(root / "profiles" / "tommy" / "state.db"),
+    )
+    close_all()
+
+
+def _agent_shell(session_id: str):
+    """Minimal AIAgent shell that owns the real recall + lazy-create seam."""
+    agent = SimpleNamespace(
+        _persist_disabled=False,
+        _session_db=None,
+        _owns_session_db=False,
+        _session_db_created=False,
+        platform="cli",
+        session_id=session_id,
+        model="test-model",
+        _session_init_model_config=None,
+        _cached_system_prompt=None,
+        _parent_session_id=None,
+    )
+    agent._get_session_db_for_recall = (
+        AIAgent._get_session_db_for_recall.__get__(agent, AIAgent)
+    )
+    agent._ensure_db_session = (
+        AIAgent._ensure_db_session.__get__(agent, AIAgent)
+    )
+    agent._session_row_model_config = (
+        AIAgent._session_row_model_config.__get__(agent, AIAgent)
+    )
+    return agent
+
+
+def test_default_under_residual_home_writes_to_default_store(roots):
+    """Integration: a DEFAULT build under a residual tommy home lands the row
+    in ``<root>/state.db`` labelled ``default`` -- never in tommy's store."""
+    agent = _agent_shell("seam-default-1")
+
+    # Residual tommy home active ONLY at the store-open instant (mirror the
+    # reused compute-host executor): the earliest lazy open happens here.
+    tommy_token = hc.set_hermes_home_override(str(roots.tommy_home))
+    try:
+        agent._get_session_db_for_recall()
+    finally:
+        # Residue unwinds before the label is computed -- the label side used
+        # to run at a clean instant, which is exactly how store and label
+        # diverged.
+        hc.reset_hermes_home_override(tommy_token)
+
+    agent._ensure_db_session()
+
+    # PHYSICAL location assertion (design finding R4).
+    assert _has_row(roots.default_db, "seam-default-1"), (
+        "default session row must physically live in <root>/state.db"
+    )
+    assert not _has_row(roots.tommy_db, "seam-default-1"), (
+        "default session row leaked into tommy's state.db -- isolation break"
+    )
+    assert _profile_of(roots.default_db, "seam-default-1") == "default"
+
+
+def test_named_profile_session_unchanged(roots):
+    """Regression guard: a named-profile (tommy) build still lands in
+    ``<root>/profiles/tommy/state.db`` labelled ``tommy``."""
+    from hermes_state_registry import acquire, release_or_close
+
+    db = acquire(roots.tommy_db)
+    try:
+        db.create_session("seam-tommy-1", source="desktop", model="test-model")
+    finally:
+        release_or_close(db)
+
+    assert _has_row(roots.tommy_db, "seam-tommy-1")
+    assert not _has_row(roots.default_db, "seam-tommy-1")
+    assert _profile_of(roots.tommy_db, "seam-tommy-1") == "tommy"
+
+
+def test_own_profile_name_derivation(roots, tmp_path):
+    """Unit: ``_own_profile_name`` yields default / <name> / None by path."""
+    default_db = SessionDB(db_path=roots.default_db)
+    try:
+        assert default_db._own_profile_name() == "default"
+    finally:
+        default_db.close()
+
+    named_db = SessionDB(db_path=roots.tommy_db)
+    try:
+        assert named_db._own_profile_name() == "tommy"
+    finally:
+        named_db.close()
+
+    outside = tmp_path / "elsewhere" / "state.db"
+    outside.parent.mkdir()
+    outside_db = SessionDB(db_path=outside)
+    try:
+        assert outside_db._own_profile_name() is None
+    finally:
+        outside_db.close()

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -14691,6 +14691,9 @@ def test_get_db_degrades_cleanly_when_sessiondb_init_fails(monkeypatch):
             raise RuntimeError("locking protocol")
 
     fake_mod.SessionDB = _BrokenSessionDB
+    # _get_db() imports this from hermes_state before acquire(); the stub must expose it
+    # or the import raises before the exercised degrade path.
+    fake_mod.default_root_db_path = lambda: Path("/nonexistent/state.db")
 
     def _broken_shared(_db_path=None):
         raise RuntimeError("locking protocol")
@@ -14716,6 +14719,9 @@ def test_ensure_session_db_row_false_when_store_unavailable(monkeypatch):
             raise RuntimeError("utf-8 boom")
 
     fake_mod.SessionDB = _BrokenSessionDB
+    # _get_db() imports this from hermes_state before acquire(); the stub must expose it
+    # or the import raises before the exercised degrade path.
+    fake_mod.default_root_db_path = lambda: Path("/nonexistent/state.db")
 
     def _broken_shared(_db_path=None):
         raise RuntimeError("utf-8 boom")
@@ -15534,6 +15540,7 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
 
     class ProfileDB:
         def __init__(self, db_path=None):
+            self.db_path = db_path
             seen["db_path"] = db_path
             seen.setdefault("inits", 0)
             seen["inits"] += 1
@@ -15548,6 +15555,10 @@ def test_session_branch_writes_to_parent_profile_db(monkeypatch, tmp_path):
             seen["created"] = new_key
             seen["parent"] = kwargs.get("parent_session_id")
             seen["profile_name"] = kwargs.get("profile_name")
+
+        def _own_profile_name(self):
+            # Mirror the real derivation: <root>/profiles/<name>/state.db -> <name>.
+            return Path(self.db_path).parent.name if self.db_path else None
 
         def append_message(self, **kwargs):
             seen["msgs"].append(kwargs)

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -132,7 +132,7 @@ def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
     scoped = [
         db
         for db in profile_dbs
-        if db.db_path is not None and "work" in str(db.db_path)
+        if db.db_path is not None and str(db.db_path).endswith("work/state.db")
     ]
     assert len(scoped) == 1
     assert scoped[0].closed == 1

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -121,17 +121,25 @@ def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
 
     The stranded-session adoption fallback (#93296 follow-up) may lazily
     construct the SHARED launch handle via ``_get_db()`` while probing the
-    default store for a donor row; that handle carries ``db_path=None`` and
-    is never closed by design (see module docstring). Only the dedicated
-    profile-scoped open (``db_path=<profile>/state.db``) is the caller's to
-    close, so the leak assertion filters to path-scoped opens.
+    default store for a donor row; that handle is bound to the default-root
+    ``state.db`` and is never closed by design (see module docstring). Only the
+    dedicated profile-scoped open (``db_path=<profile>/state.db``) is the
+    caller's to close, so the leak assertion filters to the work-profile open.
     """
     resp = _resume(session_id="missing", profile="work")
 
     assert resp["error"]["code"] == 4007
-    scoped = [db for db in profile_dbs if db.db_path is not None]
+    scoped = [
+        db
+        for db in profile_dbs
+        if db.db_path is not None and "work" in str(db.db_path)
+    ]
     assert len(scoped) == 1
     assert scoped[0].closed == 1
+    # The shared launch/default-root handle (if opened) is never closed.
+    for db in profile_dbs:
+        if db not in scoped:
+            assert db.closed == 0
 
 
 def test_deferred_desktop_resume_keeps_stored_workspace_provenance(

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -304,13 +304,21 @@ class ComputeHost:
             if profile_home:
                 from hermes_constants import set_hermes_home_override
                 from agent.secret_scope import build_profile_secret_scope, set_secret_scope
-                from hermes_state_registry import acquire
                 home_token = set_hermes_home_override(profile_home)
                 secret_token = set_secret_scope(build_profile_secret_scope(Path(profile_home)))
-                # DEDICATED handle — ours only until _make_agent succeeds, then the agent owns
-                # it. A RAISING _make_agent is the one path where nothing takes it (``owns_db``).
-                session_db = acquire(Path(profile_home) / "state.db")
-                owns_db = True
+            # DEDICATED handle — ours only until _make_agent succeeds, then the agent owns
+            # it. A RAISING _make_agent is the one path where nothing takes it (``owns_db``).
+            # BOTH branches flow through this single owns_db/_transfer/finally bracket,
+            # differing only in the path arg: a named profile binds <profile_home>/state.db,
+            # a DEFAULT session binds the EXPLICIT default-root state.db (never the lazy
+            # no-path open that would follow this reused worker's residual ambient home).
+            # Lifting the open out of the if-guard keeps the refcount/close accounting single
+            # and avoids the leak/double-close a second bracket would cause.
+            from hermes_state_registry import acquire
+            from hermes_state import default_root_db_path
+            db_path = Path(profile_home) / "state.db" if profile_home else default_root_db_path()
+            session_db = acquire(db_path)
+            owns_db = True
             agent = server._make_agent(
                 sid, key, session_id=key, model_override=frame.get("model_override"),
                 reasoning_config_override=frame.get("reasoning_config_override"),

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -1922,7 +1922,17 @@ def _(rid, params: dict, session: dict) -> dict:
             title = params.get("name", "") or _branch_title(db, old_key)
             home = session.get("profile_home")
             _persist_branch(db, new_key, old_key, title, history, source=source, cwd=_session_cwd(session),
-                            profile_name=Path(home).name if home else _current_profile_name(),
+                            # The branch stays on its parent's profile. Derive the label from
+                            # the bound store handle (db is the parent's profile-scoped
+                            # state.db, default-root-pinned for the launch profile) so the
+                            # label is the SAME fact as the store and cannot diverge from it
+                            # on a reused compute-host executor under a residual foreign home
+                            # (the fifth profile seam). Explicit stamp (not just the
+                            # parent-backfill) so it holds even when the parent row predates
+                            # the profile_name column; launch-profile branches are stamped
+                            # 'default' too, since NULL rows drop out of profile-keyed sidebar
+                            # matching and deep-link resolution (#99222).
+                            profile_name=getattr(db, "_own_profile_name", lambda: None)(),
                             copy_fields=_BRANCH_COPY_FIELDS)
         except Exception as e:
             return _err(rid, 5008, f"branch failed: {e}")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -378,8 +378,16 @@ def _get_db():
     global _db, _db_error
     if _db is None:
         from hermes_state_registry import acquire
+        from hermes_state import default_root_db_path
         try:
-            _db, _db_error = acquire(), None
+            # Bind the EXPLICIT default-root state.db, NOT the lazy no-path
+            # acquire() which resolves against the context-local HERMES_HOME at
+            # first call. This process-global memo is reused by every default
+            # build/persist site (_ensure_session_db_row, _init_session), so a
+            # first call under a residual foreign home used to poison the memo
+            # -- pinning it to the default root closes that cross-profile
+            # read/write vector.
+            _db, _db_error = acquire(default_root_db_path()), None
         except Exception as exc:
             _db_error = str(exc)
             logger.warning("TUI session store unavailable — continuing without state.db features: %s", exc)

--- a/tui_gateway/session_workdir.py
+++ b/tui_gateway/session_workdir.py
@@ -271,11 +271,16 @@ def _ensure_session_db_row(session: dict) -> bool:
                 parent_session_id=session.get("parent_session_id") or None, cwd=_persisted_session_cwd(session),
                 # Self-describing rows: aggregators merging several profile DBs can't rely on which file a row came
                 # from; a NULL is only repaired by the one-shot backfill.
-                # Stamp the launch profile explicitly instead of leaving NULL — NULL is exactly what the
-                # #94724 legacy-owner backfill exists to repair, and rows minted AFTER that one-shot
-                # backfill ran stayed NULL forever: profile-keyed matching then drops them from the sidebar
-                # and deep links can't resolve them (#99222).
-                profile_name=Path(profile_home).name if profile_home else _current_profile_name())
+                # Stamp the store's OWN profile (derived from its db_path) rather than _current_profile_name() (the
+                # serving process's launch profile), so store and label are one fact and cannot diverge -- a
+                # default-root store stamps 'default', a profile store stamps its own name. An out-of-tree store
+                # (explicit db_path / degraded fallback / test FakeDB) has no derivable owner and returns None;
+                # fall back to the serving profile so the row still carries a routing label. NULL is exactly what
+                # the #94724 legacy-owner backfill exists to repair, and rows minted AFTER that one-shot backfill
+                # ran stayed NULL forever: profile-keyed matching then drops them from the sidebar and deep links
+                # can't resolve them (#99222).
+                profile_name=(getattr(db, "_own_profile_name", lambda: None)()
+                              or (Path(profile_home).name if profile_home else _current_profile_name())))
             # Born hidden (session.create hidden=true, or set_hidden before the row existed): apply the deferred intent.
             if session.get("pending_hidden"):
                 try:


### PR DESCRIPTION
## What does this PR do?

Closes a cross-profile data-isolation break: a **default** session could have its row physically written into a *foreign* profile's `state.db` while still labelled `profile_name = 'default'`. Store (which physical DB file holds the row) and label (the `profile_name` stamped on it) were two independently-resolved facts that could diverge; this PR makes them one fact.

**Background.** Default sessions resolved their `state.db` store lazily against the context-local `HERMES_HOME` at first DB open, while stamping `profile_name` independently via `get_active_profile_name()`. On a **reused** compute-host executor (the isolation feature shares one `ThreadPoolExecutor`), a residual foreign home left over from a prior turn could bind the store to another profile's `state.db` while the label stayed `'default'`. The row then lands in the wrong profile's database but reads back as a default-profile session -- a silent isolation break that mis-associates session state across profiles.

This is a preventive fix: it binds an explicit default-root store handle and derives the label from the store's owner, so the two can no longer diverge regardless of ambient `HERMES_HOME`.

## Why this approach

`get_default_hermes_root()` reads `os.environ` rather than the context-local override, so it ignores a residual per-turn home. Binding an explicit default-root `state.db` handle at every default build/persist site, and deriving the label from the bound handle's owner (`SessionDB._own_profile_name`), collapses store and label into a single source of truth. No new config, no behavior change for named-profile sessions (they already bind a profile-scoped handle) -- only the default path, which previously trusted ambient state, is pinned.

## Related Issue

<!-- No public issue; discovered running a docker-backend profile through the dashboard alongside dashboard.turn_isolation, where the shared compute-host executor makes the residual-home window reachable. Sibling to the isolated-turn lease work in #101501. -->

Related to #101501

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`
  - `default_root_db_path()` (new): one import-safe accessor for `get_default_hermes_root()/state.db`, reused everywhere so the path is never duplicated. `get_default_hermes_root` reads `os.environ`, not the context-local override, so it ignores a residual per-turn home.
  - `create_session`: default label falls back to the bound store owner (`_own_profile_name`) so store and label stay coupled.
- `run_agent.py`
  - `_get_session_db_for_recall`: bind the explicit default-root handle at the earliest open (the sole `_owns_session_db=True` site), so the handle cached on the agent can no longer follow ambient `HERMES_HOME`.
- `tui_gateway/methods_session.py`
  - `/branch` create: derive `profile_name` from `db._own_profile_name()` (the parent's profile-scoped bound handle) instead of `_current_profile_name()`, so a default branch on a reused executor is labelled from the store it actually bound, not the ambient profile.
- `tui_gateway/server.py`, `tui_gateway/compute_host.py`: thread the bound default-root store handle through the default build/persist sites (no second lazy resolution).
- Tests:
  - `tests/gateway/test_session_store_profile_scope.py` (new): asserts the **physical** DB file that holds the row (present in `<root>/state.db`, absent from the foreign store) plus `profile_name == 'default'`, under a residual foreign `HERMES_HOME` override at the store-open instant.
  - `tests/tui_gateway/test_session_resume_db_ownership.py`: tightened the resume-ownership handle filter to match the profile segment exactly (`endswith 'work/state.db'`) instead of a loose substring.

## How to Test

1. Run a default-profile session while a foreign profile's `HERMES_HOME` is present as a residual context override at the store-open instant (reproduced directly by the new test; reachable in practice via `dashboard.turn_isolation` on a shared compute-host executor).
2. Before: the session row is written into the foreign profile's `state.db` but stamped `profile_name = 'default'`. After: the row lands in the default root's `state.db` and is labelled `'default'` -- store and label agree.
3. Automated:
   - `.venv-dev/bin/python -m pytest tests/gateway/test_session_store_profile_scope.py -q` — passes (row in the default store, absent from the foreign store, labelled `default`).
   - `.venv-dev/bin/python -m pytest tests/tui_gateway/test_session_resume_db_ownership.py -q` — passes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test:`, `fix:` — three self-contained commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **see note below**
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (aarch64, Python 3.13), docker backend, dashboard turn isolation, verified against a live multi-profile deployment

**Note on the full test run:** the tests added here pass, and the touched suites pass on their own. There is a **pre-existing** cross-file test-isolation issue on `upstream/main` (reproduced with these changes reverted): a few `tests/gateway/` store/room-link tests fail only when run in a large mixed collection (leaked global state from a sibling file), not in isolation. It is unrelated to this PR -- the same three fail on a clean `main` without these commits.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings + inline comments) — or N/A
- [x] `cli-config.yaml.example`: N/A (no new config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A (no architecture/workflow change)
- [x] Cross-platform impact: N/A (pure Python; no platform-specific calls)
- [x] Tool descriptions/schemas: N/A (no tool behavior change)
