### PR TITLE
fix(gateway): serialize hosted-rooms first-open of shared state.db

### DIFF
--- a/gateway/hosted_rooms.py
+++ b/gateway/hosted_rooms.py
@@ -14,13 +14,17 @@ from __future__ import annotations
 
 import hashlib
 import json
+import logging
 import re
 import sqlite3
+import sys
 import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Iterator, Mapping, NoReturn
 
+
+logger = logging.getLogger(__name__)
 
 PROTOCOL_VERSION = 2
 MAX_ROOM_ID_CHARS = 128
@@ -47,6 +51,12 @@ MAX_GATEWAY_EVENT_BYTES = 16 * 1024 * 1024
 CONTROL_EVENT_COUNT_RESERVE = 64
 CONTROL_EVENT_BYTE_RESERVE = 1024 * 1024
 _JOURNAL_MODE_LOCK_RETRIES = 8
+# Bounded so a wedged holder degrades to the pre-fix unserialized open instead
+# of hanging the hosted-room worker; a real first open is milliseconds.
+_SHARED_DB_OPEN_LOCK_TIMEOUT_SECONDS = 20.0
+_SHARED_DB_OPEN_LOCK_POLL_SECONDS = 0.02
+_FIRST_OPEN_CORRUPTION_RETRIES = 3
+_FIRST_OPEN_CORRUPTION_BACKOFF_SECONDS = 0.05
 
 _IDENTIFIER_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:-]*$")
 _EVENT_KIND_RE = re.compile(r"^[a-z][a-z0-9_.-]*$")
@@ -1111,11 +1121,148 @@ def remote_run_receipt(
     return dict(row) if row is not None else None
 
 
-def _connect(db_path: Path | str) -> sqlite3.Connection:
-    from hermes_state import apply_wal_with_fallback
+def _shared_db_open_lock_path(db_path: Path) -> Path:
+    """Return the dedicated first-open lock file for *db_path*."""
 
+    return db_path.with_name(db_path.name + ".hosted-rooms.lock")
+
+
+@contextmanager
+def _shared_db_open_lock(db_path: Path) -> Iterator[bool]:
+    """Serialize first-open of the shared room store across processes.
+
+    Every profile gateway opens the same install-root ``state.db``. On a
+    simultaneous fleet restart their first opens overlapped inside the
+    journal-mode pragma and left a file whose header was no longer a SQLite
+    database (#102120); ``BEGIN IMMEDIATE`` only covers the schema migration
+    that runs *after* journal mode is applied. This advisory lock covers the
+    whole open, and unlike the auto-maintenance lock it blocks rather than
+    skips: a newcomer must wait and then open a healthy file.
+
+    Yields True when this process holds the lock. A timed-out or unopenable
+    lock still yields (False) and the caller proceeds: never opening the room
+    store is a worse outcome than opening it unserialized, which is exactly
+    the pre-fix behavior.
+    """
+
+    from hermes_state_common import (
+        _acquire_db_flock,
+        _clear_lock_holder_record,
+        is_advisory_lock_contention,
+    )
+
+    lock_path = _shared_db_open_lock_path(db_path)
+    try:
+        lock_path.parent.mkdir(parents=True, exist_ok=True)
+        handle = lock_path.open("a+b")
+    except OSError as exc:
+        logger.warning(
+            "Could not open hosted-rooms open lock %s (%s) — opening %s "
+            "without cross-process serialization.",
+            lock_path, exc, db_path,
+        )
+        yield False
+        return
+
+    acquired: bool | None = False
+    try:
+        if sys.platform == "win32":
+            deadline = time.monotonic() + _SHARED_DB_OPEN_LOCK_TIMEOUT_SECONDS
+            while True:
+                try:
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                    acquired = True
+                    break
+                except (BlockingIOError, OSError) as exc:
+                    if not is_advisory_lock_contention(exc):
+                        logger.warning(
+                            "Could not acquire hosted-rooms open lock %s (%s).",
+                            lock_path, exc,
+                        )
+                        acquired = None
+                        break
+                    if time.monotonic() >= deadline:
+                        break
+                    time.sleep(_SHARED_DB_OPEN_LOCK_POLL_SECONDS)
+        else:
+            acquired, handle = _acquire_db_flock(
+                str(lock_path),
+                handle,
+                _SHARED_DB_OPEN_LOCK_TIMEOUT_SECONDS,
+                _SHARED_DB_OPEN_LOCK_POLL_SECONDS,
+                "hosted-rooms open lock",
+            )
+        if acquired is None:
+            # Non-contention failure already logged with its errno.
+            acquired = False
+        elif not acquired:
+            logger.warning(
+                "hosted-rooms open lock %s held elsewhere for more than %.0fs "
+                "— opening %s unserialized rather than failing the worker.",
+                lock_path, _SHARED_DB_OPEN_LOCK_TIMEOUT_SECONDS, db_path,
+            )
+        yield acquired
+    finally:
+        try:
+            if acquired:
+                if sys.platform == "win32":
+                    import msvcrt
+
+                    handle.seek(0)
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    _clear_lock_holder_record(handle)
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+        except OSError:  # pragma: no cover - best effort release
+            pass
+        finally:
+            handle.close()
+
+
+def _is_transient_first_open_corruption(
+    path: Path, exc: sqlite3.DatabaseError
+) -> bool:
+    """True when a first open read a header another opener was still writing."""
+
+    if "file is not a database" not in str(exc).lower():
+        return False
+    try:
+        size = path.stat().st_size
+    except OSError:
+        return False
+    # A zero-length file is a brand-new database, never a scrambled header.
+    return size > 0
+
+
+def _connect(db_path: Path | str) -> sqlite3.Connection:
     path = Path(db_path)
     path.parent.mkdir(parents=True, exist_ok=True)
+    with _shared_db_open_lock(path):
+        for attempt in range(1, _FIRST_OPEN_CORRUPTION_RETRIES):
+            try:
+                return _connect_locked(path)
+            except sqlite3.DatabaseError as exc:
+                if not _is_transient_first_open_corruption(path, exc):
+                    raise
+                logger.warning(
+                    "Hosted-rooms db %s read as a non-database on open "
+                    "attempt %d (%s) — retrying under the open lock.",
+                    path, attempt, exc,
+                )
+                time.sleep(_FIRST_OPEN_CORRUPTION_BACKOFF_SECONDS * attempt)
+        return _connect_locked(path)
+
+
+def _connect_locked(path: Path) -> sqlite3.Connection:
+    """Open and migrate the room store; callers hold the shared open lock."""
+
+    from hermes_state import apply_wal_with_fallback
+
     conn = sqlite3.connect(path, timeout=10)
     conn.row_factory = sqlite3.Row
     try:

--- a/tests/gateway/test_hosted_rooms_shared_db_lock.py
+++ b/tests/gateway/test_hosted_rooms_shared_db_lock.py
@@ -1,0 +1,166 @@
+"""Cross-process first-open serialization for the shared hosted-rooms db.
+
+Every profile gateway opens the same install-root ``state.db`` through
+``hosted_rooms._connect``. On a simultaneous fleet restart those first opens
+overlapped inside the journal-mode pragma and left a file whose header was no
+longer a SQLite database (#102120). The invariant under test: concurrent first
+opens of one hosted-rooms db can never leave a non-database behind.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+import hermes_state
+from gateway import hosted_rooms
+
+
+SQLITE_MAGIC = b"SQLite format 3\x00"
+
+
+def _assert_healthy_database(db_path: Path) -> None:
+    assert db_path.is_file()
+    header = db_path.read_bytes()[: len(SQLITE_MAGIC)]
+    assert header == SQLITE_MAGIC, f"shared db lost its SQLite header: {header!r}"
+    conn = sqlite3.connect(db_path)
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    finally:
+        conn.close()
+
+
+def test_concurrent_first_open_cannot_leave_a_non_database(tmp_path, monkeypatch):
+    """Two racing first opens must both succeed against a healthy file.
+
+    ``apply_wal_with_fallback`` is replaced by a deterministic stand-in for the
+    unserialized failure: if two callers are ever inside journal-mode setup at
+    the same moment, it scrambles the on-disk header and every later open of
+    that file raises the observed ``file is not a database``. Under the lock the
+    two callers cannot overlap, so the stand-in never fires.
+    """
+
+    db_path = tmp_path / "state.db"
+    real_apply = hermes_state.apply_wal_with_fallback
+    overlap_gate = threading.Barrier(2)
+    poisoned = threading.Event()
+
+    def racing_apply(conn: sqlite3.Connection, **kwargs: object) -> str:
+        if poisoned.is_set():
+            raise sqlite3.DatabaseError("file is not a database")
+        mode = real_apply(conn, **kwargs)  # type: ignore[arg-type]
+        try:
+            overlap_gate.wait(timeout=0.5)
+        except threading.BrokenBarrierError:
+            return mode
+        # Two openers were inside journal-mode setup simultaneously.
+        poisoned.set()
+        with db_path.open("r+b") as handle:
+            handle.write(b"\x00" * len(SQLITE_MAGIC))
+        raise sqlite3.DatabaseError("file is not a database")
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", racing_apply)
+
+    failures: list[BaseException] = []
+
+    def open_and_prune() -> None:
+        try:
+            hosted_rooms.prune_disbanded_rooms(db_path)
+        except BaseException as exc:  # noqa: BLE001 - reported as a failure
+            failures.append(exc)
+
+    threads = [threading.Thread(target=open_and_prune) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=30)
+        assert not thread.is_alive()
+
+    assert not failures, f"concurrent first open failed: {failures!r}"
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", real_apply)
+    _assert_healthy_database(db_path)
+
+
+def test_second_opener_waits_for_the_lock_instead_of_skipping(tmp_path, monkeypatch):
+    """A busy lock defers the newcomer; it must not skip the open."""
+
+    monkeypatch.setattr(hosted_rooms, "_SHARED_DB_OPEN_LOCK_TIMEOUT_SECONDS", 5.0)
+    db_path = tmp_path / "state.db"
+    hold_seconds = 0.3
+    holder_ready = threading.Event()
+
+    def hold_lock() -> None:
+        with hosted_rooms._shared_db_open_lock(db_path) as acquired:
+            assert acquired
+            holder_ready.set()
+            time.sleep(hold_seconds)
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    try:
+        assert holder_ready.wait(timeout=5)
+        started = time.monotonic()
+        conn = hosted_rooms._connect(db_path)
+        waited = time.monotonic() - started
+    finally:
+        holder.join(timeout=10)
+    try:
+        assert conn.execute("SELECT 1 FROM hosted_rooms LIMIT 1").fetchall() == []
+    finally:
+        conn.close()
+    assert waited >= hold_seconds / 2, "second opener did not wait for the holder"
+    _assert_healthy_database(db_path)
+
+
+def test_lock_file_lives_next_to_the_shared_db(tmp_path):
+    """The hosted-rooms lock must not collide with repair/FTS lock files."""
+
+    db_path = tmp_path / "state.db"
+    with hosted_rooms._shared_db_open_lock(db_path) as acquired:
+        assert acquired
+        lock_path = db_path.with_name("state.db.hosted-rooms.lock")
+        assert lock_path.is_file()
+
+
+def test_first_open_retries_transient_not_a_database(tmp_path, monkeypatch):
+    """A transient scrambled read on first open is retried, not surfaced."""
+
+    db_path = tmp_path / "state.db"
+    real_apply = hermes_state.apply_wal_with_fallback
+    calls: list[int] = []
+
+    def flaky_apply(conn: sqlite3.Connection, **kwargs: object) -> str:
+        calls.append(1)
+        mode = real_apply(conn, **kwargs)  # type: ignore[arg-type]
+        if len(calls) == 1:
+            raise sqlite3.DatabaseError("file is not a database")
+        return mode
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", flaky_apply)
+    conn = hosted_rooms._connect(db_path)
+    conn.close()
+    assert len(calls) == 2
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", real_apply)
+    _assert_healthy_database(db_path)
+
+
+def test_persistent_not_a_database_still_raises(tmp_path, monkeypatch):
+    """Retries are bounded: a genuinely corrupt file still fails loudly."""
+
+    db_path = tmp_path / "state.db"
+    real_apply = hermes_state.apply_wal_with_fallback
+    calls: list[int] = []
+
+    def broken_apply(conn: sqlite3.Connection, **kwargs: object) -> str:
+        calls.append(1)
+        real_apply(conn, **kwargs)  # type: ignore[arg-type]
+        raise sqlite3.DatabaseError("file is not a database")
+
+    monkeypatch.setattr(hermes_state, "apply_wal_with_fallback", broken_apply)
+    with pytest.raises(sqlite3.DatabaseError):
+        hosted_rooms._connect(db_path)
+    assert len(calls) == hosted_rooms._FIRST_OPEN_CORRUPTION_RETRIES


### PR DESCRIPTION
## Summary

Every profile gateway starts the hosted-rooms worker against the **install-root** `state.db`, not the per-profile file. On a simultaneous multi-profile restart (`hermes update` fires the fleet back-to-back) those first opens overlapped inside `PRAGMA journal_mode` and left a file whose header was no longer a SQLite database (`sqlite3.DatabaseError: file is not a database`). `BEGIN IMMEDIATE` only covers the schema migration that runs *after* journal mode is applied.

This PR serializes `_connect` with a blocking advisory lock (`state.db.hosted-rooms.lock`, distinct from FTS / repair / auto-maintenance locks) and retries a transient `file is not a database` under that lock. A timed-out lock still opens (pre-fix behavior) rather than failing the worker.

## Test plan

```bash
scripts/run_tests.sh tests/gateway/test_hosted_rooms_shared_db_lock.py tests/gateway/test_hosted_room_gateway_lifecycle.py
```

- Two racing first opens cannot scramble the SQLite header (deterministic overlap stand-in; sabotage of the lock fails the invariant).
- A held lock makes the second opener wait instead of skipping.
- Transient `file is not a database` retries; a persistently corrupt file still raises.

## Platforms

Linux (fcntl flock; this box). Windows uses the existing msvcrt non-blocking lock loop. No new `HERMES_*` env vars. No updater rewrite.

Fixes #102120
