### PR TITLE
feat(gateway): allow configured media producer tools

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -948,6 +948,13 @@ max_concurrent_sessions: null
 # explicitly want one shared "room brain" per group/channel.
 group_sessions_per_user: true
 
+# Custom or MCP tools that intentionally return deliverable MEDIA:<path>
+# artifacts. The gateway may append these current-turn artifacts when the model
+# omits them from its final reply. Keep this list explicit: ordinary tool output
+# may contain MEDIA examples that must not be sent as local files.
+# auto_append_media_tools:
+#   - mcp__charts__render_chart
+
 # =============================================================================
 # Session Storage Retention (state.db)
 # =============================================================================

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -956,6 +956,10 @@ class GatewayConfig:
     
     # Delivery settings
     always_log_local: bool = True  # Always save cron outputs to local files
+    # Additional custom/MCP tools whose current-turn MEDIA:<path> results may
+    # be appended to the gateway reply when the model omits them. Built-in
+    # media producers remain enabled independently in gateway.run.
+    auto_append_media_tools: List[str] = field(default_factory=list)
     # Drop outbound "silence narration" messages (e.g. *(silent)*, 🔇, a bare
     # ".") pre-send. These are model hallucinations emitted when a persona has
     # nothing actionable to say; in bot-to-bot channels they mirror back and
@@ -1036,6 +1040,16 @@ class GatewayConfig:
     profile_routes: list = field(default_factory=list)
 
     def __post_init__(self) -> None:
+        if not isinstance(self.auto_append_media_tools, (list, tuple, set)):
+            self.auto_append_media_tools = []
+        else:
+            self.auto_append_media_tools = list(
+                dict.fromkeys(
+                    value.strip()
+                    for value in self.auto_append_media_tools
+                    if isinstance(value, str) and value.strip()
+                )
+            )
         self.multiplex_profile_allowlist = _normalize_multiplex_profile_allowlist(
             self.multiplex_profile_allowlist
         )
@@ -1146,6 +1160,7 @@ class GatewayConfig:
             "sessions_dir": str(self.sessions_dir),
             "write_sessions_json": self.write_sessions_json,
             "always_log_local": self.always_log_local,
+            "auto_append_media_tools": self.auto_append_media_tools,
             "filter_silence_narration": self.filter_silence_narration,
             "stt_enabled": self.stt_enabled,
             "stt_echo_transcripts": self.stt_echo_transcripts,
@@ -1329,6 +1344,7 @@ class GatewayConfig:
             sessions_dir=sessions_dir,
             write_sessions_json=_coerce_bool(data.get("write_sessions_json"), True),
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
+            auto_append_media_tools=data.get("auto_append_media_tools") or [],
             filter_silence_narration=_coerce_bool(
                 data.get("filter_silence_narration"), True
             ),
@@ -1478,6 +1494,13 @@ def load_gateway_config() -> GatewayConfig:
                 gw_data["thread_sessions_per_user"] = yaml_cfg["thread_sessions_per_user"]
             elif isinstance(gateway_section, dict) and "thread_sessions_per_user" in gateway_section:
                 gw_data["thread_sessions_per_user"] = gateway_section["thread_sessions_per_user"]
+
+            if "auto_append_media_tools" in yaml_cfg:
+                gw_data["auto_append_media_tools"] = yaml_cfg["auto_append_media_tools"]
+            elif isinstance(gateway_section, dict) and "auto_append_media_tools" in gateway_section:
+                gw_data["auto_append_media_tools"] = gateway_section[
+                    "auto_append_media_tools"
+                ]
 
             # Multiplexing flag: accept both the top-level key and the nested
             # gateway.multiplex_profiles form (written by

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2105,6 +2105,7 @@ def _collect_auto_append_media_tags(
     messages: List[Dict[str, Any]],
     history_offset: int = 0,
     history_media_paths: Optional[set] = None,
+    additional_producer_tools: Optional[set] = None,
 ) -> tuple[List[str], bool]:
     """Collect real media tags from current-turn producer-tool results only.
 
@@ -2125,6 +2126,9 @@ def _collect_auto_append_media_tags(
     of #160. The producer-tool allowlist still applies on the fallback path.
     """
     history_media_paths = history_media_paths or set()
+    producer_tools = _AUTO_APPEND_MEDIA_TOOL_NAMES | (
+        additional_producer_tools or set()
+    )
     # Only trust the slice boundary when the message list still contains the
     # full history prefix. Otherwise scan everything (compression-safe fallback).
     if history_offset and len(messages) >= history_offset:
@@ -2140,7 +2144,7 @@ def _collect_auto_append_media_tags(
         if msg.get("role") not in ("tool", "function"):
             continue
         call_id = str(msg.get("tool_call_id") or msg.get("call_id") or "")
-        if tool_name_by_call_id.get(call_id) not in _AUTO_APPEND_MEDIA_TOOL_NAMES:
+        if tool_name_by_call_id.get(call_id) not in producer_tools:
             continue
         content = str(msg.get("content") or "")
         tool_name = tool_name_by_call_id.get(call_id)
@@ -7373,6 +7377,9 @@ class TurnRunner:
                 result.get("messages", []),
                 history_offset=len(agent_history),
                 history_media_paths=_history_media_paths,
+                additional_producer_tools=set(
+                    getattr(self._runner.config, "auto_append_media_tools", [])
+                ),
             )
 
             if media_tags:

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -644,6 +644,26 @@ class TestLoadGatewayConfig:
 
         assert config.always_log_local is False
 
+    def test_auto_append_media_tools_from_nested_gateway_section(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "gateway:\n"
+            "  auto_append_media_tools:\n"
+            "    - mcp__charts__render_chart\n"
+            "    - '  mcp__charts__render_chart  '\n"
+            "    - ''\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        config = load_gateway_config()
+
+        assert config.auto_append_media_tools == ["mcp__charts__render_chart"]
+
 
     def test_unauthorized_dm_behavior_from_nested_gateway_section(self, tmp_path, monkeypatch):
         hermes_home = tmp_path / ".hermes"

--- a/tests/gateway/test_media_extraction.py
+++ b/tests/gateway/test_media_extraction.py
@@ -326,6 +326,35 @@ caption
         assert tags == []
         assert voice is False
 
+    def test_gateway_auto_append_accepts_configured_custom_media_tool(self):
+        """An explicitly trusted custom producer is eligible for auto-append."""
+        from gateway.run import _collect_auto_append_media_tags
+
+        messages = [
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_chart",
+                        "function": {"name": "mcp__charts__render_chart"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_chart",
+                "content": '{"media_tag":"MEDIA:/tmp/chart.png"}',
+            },
+        ]
+
+        tags, voice = _collect_auto_append_media_tags(
+            messages,
+            additional_producer_tools={"mcp__charts__render_chart"},
+        )
+
+        assert tags == ["MEDIA:/tmp/chart.png"]
+        assert voice is False
+
 
     def test_collect_history_media_paths_includes_image_generate_json(self):
         """Regression for #46627: the history media-path collector must pick up


### PR DESCRIPTION
## Summary

- Add an explicit gateway `auto_append_media_tools` allowlist for custom/MCP tools that intentionally produce deliverable `MEDIA:` paths.
- Union configured tools with the existing built-in TTS/image producer allowlist.
- Keep current-turn isolation, history deduplication, path-extension validation, and existing defaults unchanged.
- Document the opt-in configuration and cover nested gateway config plus custom-tool extraction.

## Problem

A custom chart or image tool can successfully create a local artifact and return a valid `MEDIA:/absolute/path.png` tag, but the model may omit that tag from its final response. The gateway currently auto-appends media only for three hard-coded built-in producer names, so custom MCP producer output is silently lost unless the model repeats it.

Scanning every tool result would be unsafe because documentation, logs, and search results can contain example `MEDIA:` paths. This change therefore remains fail-closed: operators must explicitly name trusted producer tools.

## Compatibility and security

- Default configuration produces identical behavior.
- No downstream or private tool names are hard-coded.
- Only current-turn results from explicitly configured tools become eligible.
- Existing media path validation and prior-turn deduplication remain in force.

## Validation

- `uv run --extra dev --extra messaging pytest -q tests/gateway/test_media_extraction.py tests/gateway/test_config.py` — 80 passed.
- `uv run ruff check gateway/config.py gateway/run.py tests/gateway/test_config.py tests/gateway/test_media_extraction.py` — passed.
- `git diff --check` — passed.
