### PR TITLE
feat(skills): honor `skills.compact_categories` in every posture (names-only, never hidden)

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -432,6 +432,26 @@ def _profile_name_for_home(home: Path) -> str:
         return "default"
 
 
+def _configured_compact_skill_categories() -> frozenset:
+    """Top-level skill categories the user asked to keep names-only, from
+    ``skills.compact_categories`` in config. Never hides a skill: the index
+    still lists every name and ``skill_view``/``skills_list`` reach all of
+    them. Fails open to an empty set on any config problem."""
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        raw = ((load_config_readonly() or {}).get("skills") or {}).get("compact_categories")
+    except Exception:
+        return frozenset()
+    if isinstance(raw, str):
+        raw = [raw]
+    if not isinstance(raw, (list, tuple, set, frozenset)):
+        return frozenset()
+    return frozenset(
+        str(c).strip().split("/", 1)[0] for c in raw if str(c).strip()
+    )
+
+
 def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) -> Dict[str, str]:
     """Assemble the system prompt as three ordered cache tiers.
 
@@ -638,6 +658,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
             )
         except Exception:
             _compact_cats = frozenset()
+        # ``skills.compact_categories`` in config demotes those categories to
+        # names-only in EVERY posture (same never-hidden semantics as focus
+        # mode): the user's explicit list is unioned with the posture's.
+        _compact_cats = _compact_cats | _configured_compact_skill_categories()
         skills_prompt = _r.build_skills_system_prompt(
             available_tools=agent.valid_tool_names,
             available_toolsets=avail_toolsets,

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1076,6 +1076,15 @@ skills:
   #   - ~/.agents/skills
   #   - /home/shared/team-skills
 
+  # Keep the always-on skill index small: these top-level categories are
+  # listed names-only in the system prompt (descriptions dropped). Skills are
+  # never hidden — skill_view / skills_list still reach every one of them.
+  # Unioned with the coding "focus" posture's own demotions.
+  # compact_categories:
+  #   - devops
+  #   - creative
+  #   - productivity
+
 # =============================================================================
 # Agent Behavior
 # =============================================================================

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -763,3 +763,37 @@ class TestConversationStartedTwoLine:
         assert "Conversation started:" not in vol
         assert "as of the last context rebuild" not in vol
 
+
+
+class TestConfiguredCompactSkillCategories:
+    """``skills.compact_categories`` in config demotes categories to names-only
+    in every posture, unioned with whatever the coding posture demotes."""
+
+    def _compact_kwarg(self, cfg, posture=frozenset()):
+        agent = _make_agent(valid_tool_names=["skills_list"])
+        with (
+            patch("run_agent.load_soul_md", return_value=""),
+            patch("run_agent.build_environment_hints", return_value=""),
+            patch("run_agent.build_context_files_prompt", return_value=""),
+            patch("run_agent.get_toolset_for_tool", return_value=None),
+            patch("hermes_cli.config.load_config_readonly", return_value=cfg),
+            patch("agent.coding_context.coding_compact_skill_categories", return_value=posture),
+            patch("run_agent.build_skills_system_prompt", return_value="") as bs,
+        ):
+            build_system_prompt(agent)
+        return bs.call_args.kwargs.get("compact_categories")
+
+    def test_config_list_is_applied_in_general_posture(self):
+        got = self._compact_kwarg({"skills": {"compact_categories": ["devops", "creative"]}})
+        assert got == frozenset({"devops", "creative"})
+
+    def test_config_unions_with_posture_and_normalises_nested(self):
+        got = self._compact_kwarg(
+            {"skills": {"compact_categories": ["social-media/twitter", " mlops "]}},
+            posture=frozenset({"creative"}),
+        )
+        assert got == frozenset({"social-media", "mlops", "creative"})
+
+    def test_missing_or_malformed_config_changes_nothing(self):
+        assert self._compact_kwarg({}) is None
+        assert self._compact_kwarg({"skills": {"compact_categories": 42}}) is None

--- a/website/docs/user-guide/features/skills.md
+++ b/website/docs/user-guide/features/skills.md
@@ -158,6 +158,26 @@ Level 2: skill_view(name, path)  → Specific reference file       (varies)
 
 The agent only loads the full skill content when it actually needs it.
 
+### Keeping the skill index small (`compact_categories`)
+
+Every skill's one-line description ships in the system prompt. With a few
+hundred skills that index can outweigh the rest of the prompt. List the
+top-level categories you want **names-only** in the index:
+
+```yaml
+skills:
+  compact_categories:
+    - devops
+    - creative
+    - productivity
+```
+
+Demoted categories are never hidden: every skill name stays in the index and
+`skill_view` / `skills_list` still reach all of them; only the descriptions are
+dropped from the always-on prompt. Nested categories (`social-media/twitter`)
+are demoted with their parent. Applies in every posture; the coding `focus`
+mode's own demotions are added on top.
+
 ## SKILL.md Format
 
 ```markdown


### PR DESCRIPTION
## What does this PR do?

The skill index ships every skill's one-line description in the system prompt on every turn. With a few hundred skills it can outweigh the rest of the prompt — measured on a real profile with `hermes prompt-size`: **305 skills → 29 KB of a 59 KB system prompt**. Focus mode already demotes non-coding categories to names-only (#44342), but a user outside the coding posture has no knob at all: a `skills.compact_categories` list in config is silently ignored.

This PR reads `skills.compact_categories` from config and unions it with the coding posture's demotions before `build_skills_system_prompt`. Semantics are exactly focus mode's: every name stays in the index, `skill_view`/`skills_list` reach everything, nested categories (`social-media/twitter`) follow their parent, malformed config fails open to "no change". No behavior change for anyone who hasn't set the key.

Measured effect on the same profile with all categories listed: skills index 29,017 B → ~7.6 KB (names-only), system prompt ≈ 59 KB → ≈ 34 KB, every skill still loadable.

## Related Issue

No existing issue; happy to open one if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/system_prompt.py`: new `_configured_compact_skill_categories()` (reads `skills.compact_categories` via `load_config_readonly`, top-level segment, fails open), unioned with `coding_compact_skill_categories()` before the skills index is built.
- `tests/agent/test_system_prompt.py`: `TestConfiguredCompactSkillCategories` — applied in general posture; union with posture + nested normalisation; missing/malformed config is a no-op.
- `website/docs/user-guide/features/skills.md`: "Keeping the skill index small" section.
- `cli-config.yaml.example`: documented the key under `skills:`.

## How to Test

1. Add to config: `skills: { compact_categories: [devops, creative] }` (or any top-level categories you have).
2. `hermes prompt-size --platform cli --json` — `skills_index.bytes` drops; the index still lists every skill name in those categories.
3. `skill_view <any demoted skill>` still returns it in full.
4. `pytest tests/agent/test_system_prompt.py tests/agent/test_coding_context.py tests/agent/test_prompt_builder.py -q` → 154 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — full suite running; the three affected modules pass 154/154
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux 7.0), Python venv, real 305-skill profile

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — pure config read, no platform code
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)
