### PR TITLE
fix(api_server): report served runtime and cache tokens on /v1/runs completion (#102101)

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -875,14 +875,32 @@ async def _handle_runs(
                                     reset_room_execution_policy(room_policy_token)
                                 except Exception:
                                     pass
+                    # Prefer the turn record: ``run_conversation()``'s result
+                    # dict (agent/turn_finalizer.py) snapshots the served
+                    # runtime and cache tokens at turn end. After a
+                    # fallback_providers switch the agent keeps the fallback
+                    # runtime until the next turn restores the primary, so
+                    # this is the served pair, not the requested one —
+                    # pollers of GET /v1/runs/{id} need it for cost
+                    # attribution because the ``model`` field on the run
+                    # record only echoes the request (#102101).
+                    _turn = r if isinstance(r, dict) else {}
                     u = {
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        "cache_read_tokens": _turn.get("cache_read_tokens", 0) or 0,
+                        "cache_write_tokens": _turn.get("cache_write_tokens", 0) or 0,
                     }
-                    return r, u
+                    served_runtime = {
+                        "provider": str(_turn.get("provider") or ""),
+                        "model": str(_turn.get("model") or ""),
+                    }
+                    return r, u, served_runtime
 
-            result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+            result, usage, served_runtime = await asyncio.get_running_loop().run_in_executor(
+                None, _run_sync
+            )
             if (
                 run_id in self._stopping_run_ids
                 and isinstance(result, dict)
@@ -927,6 +945,7 @@ async def _handle_runs(
                     "timestamp": time.time(),
                     "output": final_response,
                     "usage": usage,
+                    "runtime": served_runtime,
                 }
                 if pending_steer:
                     completed_event["pending_steer"] = pending_steer
@@ -936,6 +955,7 @@ async def _handle_runs(
                     "completed",
                     output=final_response,
                     usage=usage,
+                    runtime=served_runtime,
                     last_event="run.completed",
                     **({"pending_steer": pending_steer} if pending_steer else {}),
                 )

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -354,6 +354,100 @@ class TestRunStatus:
                 assert mock_agent.run_conversation.call_args.kwargs["task_id"] == "space-session"
                 assert status["session_id"] == "space-session"
 
+    @pytest.mark.asyncio
+    async def test_status_completed_run_reports_served_runtime_not_requested(self, adapter):
+        """After a fallback switch the run record must carry the runtime that
+        actually served the turn, not just the requested model (#102101).
+
+        The top-level ``model`` field echoes the request; ``runtime`` must
+        hold the served provider/model pair still present on the agent when
+        ``run_conversation()`` returns (the primary runtime is only restored
+        at the start of the NEXT turn by ``restore_primary_runtime``).
+        """
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "done",
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-luna",
+                    "cache_read_tokens": 84,
+                    "cache_write_tokens": 11,
+                }
+                mock_agent.session_prompt_tokens = 100
+                mock_agent.session_completion_tokens = 5
+                mock_agent.session_total_tokens = 105
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "model": "deepseek-v4-pro"},
+                )
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    assert status_resp.status == 200
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "completed"
+                assert status["output"] == "done"
+                # Top-level model still echoes the request...
+                assert status["model"] == "deepseek-v4-pro"
+                # ...but the served pair is disclosed for cost attribution.
+                assert status["runtime"] == {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-luna",
+                }
+                # Cache tokens ride along so cache reads are not billed as
+                # full-price input.
+                assert status["usage"]["input_tokens"] == 100
+                assert status["usage"]["output_tokens"] == 5
+                assert status["usage"]["total_tokens"] == 105
+                assert status["usage"]["cache_read_tokens"] == 84
+                assert status["usage"]["cache_write_tokens"] == 11
+
+    @pytest.mark.asyncio
+    async def test_status_completed_run_defaults_when_agent_lacks_runtime_attrs(self, adapter):
+        """An agent without the runtime/token attributes must still yield a
+        well-formed usage dict and runtime pair (no crash, no null leak)."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock(spec=[])
+                mock_agent.run_conversation = MagicMock(
+                    return_value={"final_response": "bare"}
+                )
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post("/v1/runs", json={"input": "hello"})
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                for _ in range(40):
+                    status_resp = await cli.get(f"/v1/runs/{run_id}")
+                    assert status_resp.status == 200
+                    status = await status_resp.json()
+                    if status["status"] == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+                assert status["status"] == "completed"
+                assert status["output"] == "bare"
+                assert status["usage"] == {
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "cache_read_tokens": 0,
+                    "cache_write_tokens": 0,
+                }
+                assert status["runtime"] == {"provider": "", "model": ""}
+
 
 # ---------------------------------------------------------------------------
 # GET /v1/runs/{run_id}/events — SSE event stream
@@ -388,6 +482,58 @@ class TestRunEvents:
                 # Should contain run.completed
                 assert "run.completed" in body
                 assert "Hello!" in body
+
+    @pytest.mark.asyncio
+    async def test_completed_event_carries_served_runtime_and_cache_tokens(self, adapter):
+        """The run.completed SSE event must disclose the served runtime and
+        cache tokens so streaming clients get the same cost-attribution data
+        as status pollers (#102101)."""
+        import json as _json
+
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {
+                    "final_response": "served",
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-luna",
+                    "cache_read_tokens": 650000,
+                    "cache_write_tokens": 42,
+                }
+                mock_agent.session_prompt_tokens = 774050
+                mock_agent.session_completion_tokens = 6286
+                mock_agent.session_total_tokens = 780336
+                mock_create.return_value = mock_agent
+
+                resp = await cli.post(
+                    "/v1/runs",
+                    json={"input": "hello", "model": "deepseek-v4-pro"},
+                )
+                data = await resp.json()
+                run_id = data["run_id"]
+
+                events_resp = await cli.get(f"/v1/runs/{run_id}/events")
+                assert events_resp.status == 200
+                body = await events_resp.text()
+
+                completed = None
+                for frame in body.split("\n"):
+                    if frame.startswith("data: "):
+                        try:
+                            payload = _json.loads(frame[len("data: "):])
+                        except ValueError:
+                            continue
+                        if payload.get("event") == "run.completed":
+                            completed = payload
+                            break
+                assert completed is not None, "run.completed event missing from stream"
+                assert completed["runtime"] == {
+                    "provider": "openai-codex",
+                    "model": "gpt-5.6-luna",
+                }
+                assert completed["usage"]["cache_read_tokens"] == 650000
+                assert completed["usage"]["cache_write_tokens"] == 42
 
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## What

`GET /v1/runs/{id}` and the `run.completed` SSE event only echoed the **requested** model and three token counters. After a `fallback_providers` switch (e.g. `deepseek-v4-pro` → `gpt-5.6-luna` on a 429) the run record still said the requested model and `usage` had no cache figures — a supervisor polling `/v1/runs` for cost attribution booked the whole run to the wrong provider at the wrong price, with cache reads billed as full-price input.

## Fix

- `usage` gains `cache_read_tokens` / `cache_write_tokens`
- completed status + `run.completed` event gain `runtime: {provider, model}` — the **served** pair

Both are sourced from the turn record (`run_conversation()` result dict, populated unconditionally by `agent/turn_finalizer.py` — the canonical served-runtime snapshot). After a fallback switch the agent still holds the fallback runtime when `run_conversation()` returns (the primary is restored only at the start of the *next* turn by `restore_primary_runtime`), so this discloses the runtime that actually served the turn. The top-level `model` field keeps echoing the request, unchanged. Failed/cancelled paths untouched.

## Verification

- 3 new production-path regression tests in `tests/gateway/test_api_server_runs.py`: completed status carries served runtime + cache tokens; bare agent (no runtime attrs) yields well-formed zeros (no crash/null leak); `run.completed` SSE event carries the same
- RED on pristine upstream/main (`KeyError: 'runtime'`, missing cache fields) → GREEN with fix
- Rebased onto current `main` (`63279301`) and re-verified: focused file 62/62, nearby api_server suites 139/139
- `git rev-list --left-right --count main...HEAD` → `0 1` (one focused commit)

Fixes #102101

Competitor check: no open PR for this issue. #90126 (fallback disclosure) touches CLI/session surfaces only — complementary, no file overlap.

Auto-published by Moonsong via Path B automated pipeline.