### PR TITLE
fix(gateway): report served fallback runtime and cache tokens on /v1/runs

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -879,10 +879,24 @@ async def _handle_runs(
                         "input_tokens": getattr(agent, "session_prompt_tokens", 0) or 0,
                         "output_tokens": getattr(agent, "session_completion_tokens", 0) or 0,
                         "total_tokens": getattr(agent, "session_total_tokens", 0) or 0,
+                        "cache_read_tokens": getattr(agent, "session_cache_read_tokens", 0) or 0,
                     }
-                    return r, u
+                    # The provider/model that actually served this turn. After a
+                    # fallback_providers switch the agent keeps the fallback
+                    # runtime until the next turn starts (turn_context restores
+                    # the primary), so this is the served pair, not the
+                    # requested one. Pollers of GET /v1/runs/{id} need it for
+                    # cost attribution: the ``model`` field on the run record
+                    # only echoes the request.
+                    served = {
+                        "provider": str(getattr(agent, "provider", "") or ""),
+                        "model": str(getattr(agent, "model", "") or ""),
+                    }
+                    return r, u, served
 
-            result, usage = await asyncio.get_running_loop().run_in_executor(None, _run_sync)
+            result, usage, served_runtime = await asyncio.get_running_loop().run_in_executor(
+                None, _run_sync
+            )
             if (
                 run_id in self._stopping_run_ids
                 and isinstance(result, dict)
@@ -927,6 +941,7 @@ async def _handle_runs(
                     "timestamp": time.time(),
                     "output": final_response,
                     "usage": usage,
+                    "runtime": served_runtime,
                 }
                 if pending_steer:
                     completed_event["pending_steer"] = pending_steer
@@ -936,6 +951,7 @@ async def _handle_runs(
                     "completed",
                     output=final_response,
                     usage=usage,
+                    runtime=served_runtime,
                     last_event="run.completed",
                     **({"pending_steer": pending_steer} if pending_steer else {}),
                 )

--- a/tests/gateway/test_api_server_runs.py
+++ b/tests/gateway/test_api_server_runs.py
@@ -227,6 +227,9 @@ class TestStartRun:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.provider = ""
+                mock_agent.model = ""
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -334,6 +337,9 @@ class TestRunStatus:
                 mock_agent.session_prompt_tokens = 0
                 mock_agent.session_completion_tokens = 0
                 mock_agent.session_total_tokens = 0
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.provider = ""
+                mock_agent.model = ""
                 mock_create.return_value = mock_agent
 
                 resp = await cli.post(
@@ -372,6 +378,9 @@ class TestRunEvents:
                 mock_agent.session_prompt_tokens = 10
                 mock_agent.session_completion_tokens = 5
                 mock_agent.session_total_tokens = 15
+                mock_agent.session_cache_read_tokens = 0
+                mock_agent.provider = ""
+                mock_agent.model = ""
                 mock_create.return_value = mock_agent
 
                 # Start run
@@ -615,6 +624,40 @@ class TestSteerRun:
 
         assert adapter._run_statuses[run_id]["status"] == "completed"
         assert adapter._run_statuses[run_id]["pending_steer"] == "tighten the ending"
+
+    @pytest.mark.asyncio
+    async def test_completed_run_reports_served_runtime_and_cache_tokens(self, adapter):
+        """After a fallback_providers switch the run record must carry the
+        runtime that actually served the turn (provider/model) plus
+        cache-read tokens — not just the requested model and full-price
+        token counts (#102101)."""
+        app = _create_runs_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_create_agent") as mock_create:
+                mock_agent = MagicMock()
+                mock_agent.run_conversation.return_value = {"final_response": "done"}
+                mock_agent.session_prompt_tokens = 774050
+                mock_agent.session_completion_tokens = 6286
+                mock_agent.session_total_tokens = 780336
+                mock_agent.session_cache_read_tokens = 650000
+                mock_agent.provider = "openai-codex"
+                mock_agent.model = "gpt-5.6-luna"
+                mock_create.return_value = mock_agent
+
+                start_resp = await cli.post("/v1/runs", json={"input": "hello"})
+                run_id = (await start_resp.json())["run_id"]
+
+                for _ in range(40):
+                    status = adapter._run_statuses.get(run_id, {})
+                    if status.get("status") == "completed":
+                        break
+                    await asyncio.sleep(0.05)
+
+        completed = adapter._run_statuses[run_id]
+        assert completed["status"] == "completed"
+        assert completed["usage"]["cache_read_tokens"] == 650000
+        assert completed["usage"]["total_tokens"] == 780336
+        assert completed["runtime"] == {"provider": "openai-codex", "model": "gpt-5.6-luna"}
 
     @pytest.mark.asyncio
     async def test_steer_requires_auth(self, auth_adapter):
@@ -1392,6 +1435,9 @@ class TestRunIdempotency:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
+                agent.provider = ""
+                agent.model = ""
                 create.return_value = agent
                 started = await cli.post(
                     "/v1/runs",
@@ -2101,6 +2147,9 @@ class TestHostedRoomRuns:
                 agent.session_prompt_tokens = agent.session_completion_tokens = (
                     agent.session_total_tokens
                 ) = 0
+                agent.session_cache_read_tokens = 0
+                agent.provider = ""
+                agent.model = ""
                 create.return_value = agent
                 started = await cli.post(
                     "/v1/runs",


### PR DESCRIPTION
Fixes #102101.

## What
- `usage` on the run record (GET /v1/runs/{id} and the `run.completed` event) now includes `cache_read_tokens`, read from `agent.session_cache_read_tokens` — cache reads were previously counted as full-price input.
- The completed run status/event now carry `runtime: {provider, model}` — the pair that actually served the turn. After a `fallback_providers` switch the agent still holds the fallback runtime when `run_conversation()` returns (the primary is restored at the start of the next turn via `turn_context`), so this is the served pair, not the requested echo.
- Verified on current main that `_run_sync` (api_server_runs.py) has a single return path and `_set_run_status` accepts arbitrary fields, so the 3-tuple change is fully local to the run lifecycle.

## Tests
- `uv run python -m pytest tests/gateway/test_api_server_runs.py -q` → 60 passed (includes new `test_completed_run_reports_served_runtime_and_cache_tokens`)
- `uv run python -m pytest tests/gateway/test_api_server_runs_extraction.py tests/gateway/test_api_server_run_idempotency.py tests/gateway/test_api_server_active_work_drain.py -q` → 35 passed
- `uv run python -m pytest tests/gateway/test_api_server.py -q` → 110 passed
- Existing MagicMock-based tests needed `session_cache_read_tokens`/`provider`/`model` set on the mock agents (same pattern as the existing `session_*_tokens` attrs) — otherwise the new usage field serializes a MagicMock and breaks JSON responses.

## Notes
- No live fallback repro run (would need a rate-limited primary + paid fallback key); the served-pair timing is documented in code with the turn_context restore reference.
- Windows 11 host; aiohttp gateway tests run green locally.