### PR TITLE
fix(setup): start Codex OAuth for the image-gen Codex-auth picker row

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2411,6 +2411,44 @@ def _run_post_setup(post_setup_key: str):
         else:
             _print_info("    xAI will remain inactive until credentials are configured.")
 
+    elif post_setup_key == "openai_codex":
+        # Credential bootstrap for picker entries that talk to
+        # ChatGPT/Codex OAuth (image gen today). Mirrors the xai_grok
+        # pattern: the picker rows declare empty env_vars, so the full
+        # auth UX is driven here instead of an env-var prompt.
+        try:
+            from hermes_cli.auth import get_codex_auth_status
+            logged_in = bool(get_codex_auth_status().get("logged_in"))
+        except Exception:
+            logged_in = False
+
+        if logged_in:
+            _print_success(
+                "    Image generation will use your OpenAI Codex (ChatGPT) OAuth credentials"
+            )
+            return
+
+        _print_info("    OpenAI (Codex auth) needs credentials. Starting login...")
+        try:
+            import argparse
+
+            from hermes_cli.auth import PROVIDER_REGISTRY, _login_openai_codex
+
+            # Same call shape as _model_flow_openai_codex: the login helper
+            # ignores the args namespace, and SystemExit covers a cancelled
+            # device-code flow. Login must never abort the picker write that
+            # follows — the selection stays valid and re-runs later via
+            # `hermes auth add openai-codex`.
+            _login_openai_codex(argparse.Namespace(), PROVIDER_REGISTRY["openai-codex"])
+        except SystemExit:
+            _print_warning(
+                "    Login cancelled — run later: hermes auth add openai-codex"
+            )
+        except Exception as exc:
+            _print_warning(
+                f"    Login failed: {exc} — run later: hermes auth add openai-codex"
+            )
+
 
 def valid_post_setup_keys() -> Set[str]:
     """Return the set of post-setup keys declared by any visible provider.

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -557,8 +557,13 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             "badge": "free",
             "tag": "gpt-image-2 via ChatGPT/Codex OAuth — no API key required; supports text and image inputs",
             "env_vars": [],
+            # Empty env_vars means the picker writes the selection without
+            # prompting for credentials — declare the shared Codex OAuth
+            # bootstrap so setup actually starts the device-code login
+            # instead of leaving the backend unauthenticated (#102144).
+            "post_setup": "openai_codex",
             "post_setup_hint": (
-                "Sign in with `hermes auth codex` (or `hermes setup` → Codex) "
+                "Sign in with `hermes auth add openai-codex` (or `hermes setup` → Codex) "
                 "if you haven't already. No API key needed."
             ),
         }
@@ -594,7 +599,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             return error_response(
                 error=(
                     "No Codex/ChatGPT OAuth credentials available. Run "
-                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
+                    "`hermes auth add openai-codex` (or `hermes setup` → Codex) to sign in."
                 ),
                 error_type="auth_required",
                 provider="openai-codex",
@@ -619,7 +624,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             return error_response(
                 error=(
                     "No Codex/ChatGPT OAuth credentials available. Run "
-                    "`hermes auth codex` (or `hermes setup` → Codex) to sign in."
+                    "`hermes auth add openai-codex` (or `hermes setup` → Codex) to sign in."
                 ),
                 error_type="auth_required",
                 provider="openai-codex",

--- a/tests/hermes_cli/test_image_gen_picker.py
+++ b/tests/hermes_cli/test_image_gen_picker.py
@@ -170,3 +170,61 @@ class TestConfigWriting:
         assert tools_config._is_provider_active(openai_row, config) is True
         assert tools_config._is_provider_active(nous_row, config) is False
 
+
+class TestCodexPostSetupHook:
+    """The openai-codex image-gen row declares empty env_vars, so setup only
+    starts the OAuth flow when the schema's ``post_setup`` survives the
+    schema→row translation (#102144)."""
+
+    def test_post_setup_propagated_when_declared(self, monkeypatch):
+        from hermes_cli import tools_config
+
+        image_gen_registry.register_provider(_FakeProvider("codexish", schema={
+            "name": "Codexish",
+            "badge": "free",
+            "tag": "",
+            "env_vars": [],
+            "post_setup": "openai_codex",
+        }))
+
+        rows = tools_config._plugin_image_gen_providers()
+        match = next(r for r in rows if r.get("image_gen_plugin_name") == "codexish")
+        assert match["post_setup"] == "openai_codex"
+
+    def test_logged_in_skips_login(self, monkeypatch):
+        from hermes_cli import auth, tools_config
+
+        monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {"logged_in": True})
+        login_calls = []
+        monkeypatch.setattr(
+            auth, "_login_openai_codex", lambda *a, **kw: login_calls.append(a)
+        )
+
+        tools_config._run_post_setup("openai_codex")
+        assert login_calls == []
+
+    def test_not_logged_in_starts_login(self, monkeypatch):
+        from hermes_cli import auth, tools_config
+
+        monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {"logged_in": False})
+        login_calls = []
+        monkeypatch.setattr(
+            auth, "_login_openai_codex", lambda *a, **kw: login_calls.append(a)
+        )
+
+        tools_config._run_post_setup("openai_codex")
+        assert len(login_calls) == 1
+
+    def test_login_failure_does_not_raise(self, monkeypatch):
+        from hermes_cli import auth, tools_config
+
+        monkeypatch.setattr(auth, "get_codex_auth_status", lambda: {"logged_in": False})
+
+        def _boom(*a, **kw):
+            raise RuntimeError("network down")
+
+        monkeypatch.setattr(auth, "_login_openai_codex", _boom)
+        # Fail-soft: a failed login must not abort the picker write that
+        # follows the post-setup hook.
+        tools_config._run_post_setup("openai_codex")
+

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -68,6 +68,20 @@ class TestMetadata:
         assert schema["env_vars"] == []
         assert schema["badge"] == "free"
 
+    def test_setup_schema_declares_codex_oauth_post_setup(self, provider):
+        # Empty env_vars means the picker writes the selection without any
+        # credential prompt — the schema must declare the shared Codex OAuth
+        # bootstrap so `hermes setup` starts the login flow (#102144).
+        schema = provider.get_setup_schema()
+        assert schema["post_setup"] == "openai_codex"
+
+    def test_setup_hint_names_valid_auth_command(self, provider):
+        # `hermes auth codex` is not a real command; the valid spelling is
+        # `hermes auth add openai-codex` (#102144).
+        hint = provider.get_setup_schema().get("post_setup_hint", "")
+        assert "hermes auth add openai-codex" in hint
+        assert "hermes auth codex" not in hint
+
 
 # ── Availability ────────────────────────────────────────────────────────────
 
@@ -100,6 +114,9 @@ class TestGenerate:
         result = provider.generate("a cat")
         assert result["success"] is False
         assert result["error_type"] == "auth_required"
+        # The recovery command in the error must be one that actually exists.
+        assert "hermes auth add openai-codex" in result["error"]
+        assert "hermes auth codex" not in result["error"]
 
 
     def test_generate_uses_codex_stream_path(self, provider, monkeypatch, tmp_path):


### PR DESCRIPTION
## What does this PR do?

Selecting **Image Generation → OpenAI (Codex auth)** in `hermes setup` saved the provider/model but never started the OAuth flow, leaving the backend unauthenticated. The provider schema declared `env_vars: []` with only a `post_setup_hint` — a field nothing consumes — so `_configure_provider()` wrote the selection and finished with no credential step. The schema hint and the `generate()` auth_required error also pointed at `hermes auth codex`, which is not a real command.

This mirrors the existing `xai_grok` bootstrap pattern: the schema now declares `post_setup: "openai_codex"`, and `_run_post_setup("openai_codex")` drives the existing `get_codex_auth_status()` / `_login_openai_codex()` flow — skipping the login when already authenticated, and failing soft with the correct `hermes auth add openai-codex` fallback so a cancelled/failed login never aborts the picker write that follows the hook. The stale command spelling is fixed in both the schema hint and the `generate()` error message.

## Related Issue

Fixes #102144

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `plugins/image_gen/openai-codex/__init__.py`: `get_setup_schema()` now declares `post_setup: "openai_codex"`; `post_setup_hint` and both `generate()` auth_required messages use the valid `hermes auth add openai-codex` spelling.
- `hermes_cli/tools_config.py`: new `openai_codex` branch in `_run_post_setup()` — checks `get_codex_auth_status()` first and only calls `_login_openai_codex()` when not logged in; login errors/`SystemExit` are swallowed with a warning.
- `tests/plugins/image_gen/test_openai_codex_provider.py`: pin the schema `post_setup` declaration, the valid hint command, and the valid recovery command in the auth error.
- `tests/hermes_cli/test_image_gen_picker.py`: `post_setup` survives the schema→row translation, and the hook skips/starts login/fails soft per auth status.

## How to Test

1. `python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py tests/hermes_cli/test_image_gen_picker.py tests/hermes_cli/test_tools_config.py tests/hermes_cli/test_post_setup_gating.py -q` — Observed result: 41 + 63 passed (6 skipped), 0 failures.
2. Fresh `HERMES_HOME` without Codex credentials, run `hermes setup`, pick **Image Generation → OpenAI (Codex auth)** — Observed result: the Codex device-code login now starts instead of silently completing setup; `hermes auth status openai-codex` should report logged in after completing it.
3. With Codex credentials already present, repeat the selection — Observed result: setup prints that existing Codex credentials will be used and does not re-prompt.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Not applicable — CLI auth flow change, covered by the unit tests listed above.