### PR TITLE
fix(config): warn when a bare ${VAR} config ref is unresolved

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3073,7 +3073,13 @@ def _env_expand_match(m: re.Match) -> str:
         return raw
     # Legacy ``${VAR}`` — bare name.
     val = _env_ref_lookup(inner)
-    return val if val is not None else raw
+    if val is None:
+        logger.warning(
+            "Config ref %r: %s is not set (check ~/.hermes/.env); "
+            "keeping the literal placeholder", raw, inner,
+        )
+        return raw
+    return val
 
 
 def _env_ref_var_name(ref: str) -> Optional[str]:

--- a/tests/hermes_cli/test_config_env_expansion.py
+++ b/tests/hermes_cli/test_config_env_expansion.py
@@ -1,5 +1,7 @@
 """Tests for ${ENV_VAR} substitution in config.yaml values."""
 
+import logging
+
 import pytest
 from hermes_cli.config import _expand_env_vars, load_config
 
@@ -150,3 +152,31 @@ class TestExpansionUnderProfileScope:
             ss.set_multiplex_active(was_active)
         # Unscoped (default profile / single-profile CLI): legacy environ read.
         assert _expand_env_vars("${MATRIX_ACCESS_TOKEN}") == "default-token"
+
+
+class TestUnresolvedBareRefWarns:
+    """A bare ``${VAR}`` ref whose variable is unset must log the same
+    warning as the ``${env:VAR}`` shape (hermes_cli/config.py
+    ``_env_expand_match``).  Silently keeping the literal placeholder sends
+    a string like ``${SOME_KEY}`` to the API as a bearer token and surfaces
+    only as an opaque 401; the ``env:`` prefix already warned, the legacy
+    bare form did not."""
+
+    def test_missing_bare_var_keeps_literal_and_warns(self, caplog):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.delenv("HERMES_MISSING_BARE_REF_KEY", raising=False)
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                result = _expand_env_vars("${HERMES_MISSING_BARE_REF_KEY}")
+        assert result == "${HERMES_MISSING_BARE_REF_KEY}"
+        assert any(
+            "HERMES_MISSING_BARE_REF_KEY is not set" in r.getMessage()
+            for r in caplog.records
+        )
+
+    def test_resolved_bare_var_does_not_warn(self, caplog):
+        with pytest.MonkeyPatch().context() as mp:
+            mp.setenv("HERMES_PRESENT_BARE_REF_KEY", "sk-present")
+            with caplog.at_level(logging.WARNING, logger="hermes_cli.config"):
+                result = _expand_env_vars("${HERMES_PRESENT_BARE_REF_KEY}")
+        assert result == "sk-present"
+        assert not caplog.records


### PR DESCRIPTION
## What                                                                  
   A bare `${VAR}` config ref (e.g. `model.api_key: "${SOME_KEY}"`, the     
 shape                                                                      
   `hermes model` / setup writes) whose variable is unset in                
 `~/.hermes/.env`                                                           
   was kept verbatim with no log line — the `${env:VAR}` form warns, the    
 bare                                                                       
   form was silent. The literal `${SOME_KEY}` string is then sent to the    
 API                                                                        
   as a bearer token, surfacing only as an opaque 401.                      
                                                                            
   `_env_expand_match()` now logs the same warning for the legacy bare      
 form:                                                                      
   "Config ref '${SOME_KEY}': SOME_KEY is not set (check ~/.hermes/.env);   
   keeping the literal placeholder". Behavior otherwise unchanged — the     
   placeholder is still returned so existing caller-side detection keeps    
   working.                                                                 
                                                                            
   ## How to test                                                           
   1. config.yaml with `api_key: "${MISSING_KEY}"`, no such var in .env     
   2. `hermes --version` → warning on stderr (was: silent)                  
   3. Unit test: `TestUnresolvedBareRefWarns` (red without the fix)         
                                                                            
   ## Platform                                                              
   Tested on macOS; pure config-path change, no platform-specific code.

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test files: test_config_env_expansion / test_config_env_refs / test_config_env_ref_parity / test_mcp_config / test_model_set_secret_copy (all passed)
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS
