### PR TITLE
feat(mcp): expose OAuth flow v1 gateway contract

### DIFF
--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import math
 from typing import Any, Dict, List, Literal, Optional
+from urllib.parse import urlsplit
 
-from pydantic import BaseModel, SecretStr, field_validator
+from pydantic import BaseModel, ConfigDict, Field, SecretStr, field_validator
 
 
 # --- from web_server.py (originally lines 1273-1372) ---
@@ -48,6 +49,73 @@ class MemoryProviderConfigUpdate(BaseModel):
 
 class MemoryProviderSetupRequest(BaseModel):
     values: Dict[str, Any] = {}
+
+
+class MCPRemoteOAuthTarget(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+    profile: str = Field(min_length=1, max_length=255)
+    server: str = Field(min_length=1, max_length=255)
+
+    @field_validator("profile", "server")
+    @classmethod
+    def validate_target_identifier(cls, value: str) -> str:
+        if value != value.strip() or any(
+            ord(char) < 32 or ord(char) == 127 for char in value
+        ):
+            raise ValueError("target identifier is invalid")
+        return value
+
+
+class MCPRemoteOAuthStart(MCPRemoteOAuthTarget):
+    callback_url: Optional[str] = None
+
+    @field_validator("callback_url")
+    @classmethod
+    def validate_callback_url(cls, value: Optional[str]) -> Optional[str]:
+        if value is None:
+            return None
+        if not value or len(value) > 2048 or any(
+            ord(char) < 32 or ord(char) == 127 for char in value
+        ):
+            raise ValueError("callback_url is invalid")
+        parsed = urlsplit(value)
+        loopback = parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+        if (
+            not parsed.hostname
+            or parsed.username is not None
+            or parsed.password is not None
+            or parsed.query
+            or parsed.fragment
+            or parsed.scheme not in ({"http", "https"} if loopback else {"https"})
+        ):
+            raise ValueError("callback_url must be HTTPS or a loopback HTTP URL")
+        return value
+
+
+class MCPRemoteOAuthFlow(MCPRemoteOAuthTarget):
+    flow_id: str = Field(min_length=1, max_length=255)
+
+    @field_validator("flow_id")
+    @classmethod
+    def validate_flow_identifier(cls, value: str) -> str:
+        if value != value.strip() or any(
+            ord(char) < 32 or ord(char) == 127 for char in value
+        ):
+            raise ValueError("flow identifier is invalid")
+        return value
+
+
+class MCPRemoteOAuthRelay(MCPRemoteOAuthFlow):
+    code: str = Field(min_length=1, max_length=4096)
+    state: str = Field(min_length=1, max_length=2048)
+
+    @field_validator("code", "state")
+    @classmethod
+    def validate_relay_material(cls, value: str) -> str:
+        if any(ord(char) < 32 or ord(char) == 127 for char in value):
+            raise ValueError("OAuth relay material is invalid")
+        return value
 
 
 class CustomEndpointUpdate(BaseModel):
@@ -763,4 +831,3 @@ class _PluginProvidersPutBody(BaseModel):
 
 class _PluginVisibilityBody(BaseModel):
     hidden: bool
-

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -22,6 +22,9 @@ from hermes_cli.web_deps import late, LateState
 from hermes_cli.web_models import (
     MCPCatalogInstall,
     MCPEnabledToggle,
+    MCPRemoteOAuthFlow,
+    MCPRemoteOAuthRelay,
+    MCPRemoteOAuthStart,
     MCPServerCreate,
     MCPServersReplace,
 )
@@ -56,6 +59,155 @@ _MAX_PENDING_MCP_OAUTH_FLOWS = LateState("_MAX_PENDING_MCP_OAUTH_FLOWS")
 # Config read-modify-write serialization for off-loop handlers (defined in
 # web_server.py; LateState supports ``with``-blocks, so this is the live lock).
 _CONFIG_MUTATION_LOCK = LateState("_CONFIG_MUTATION_LOCK")
+
+
+@router.get("/api/capabilities")
+async def mission_control_mcp_oauth_capability(
+    request: Request,
+    profile: str,
+    server: str,
+):
+    """Advertise the bounded MCP OAuth contract for one configured target."""
+    from hermes_cli.mcp_config import _get_mcp_servers
+
+    _require_token(request)
+
+    def _read():
+        with _config_profile_scope(profile):
+            return _get_mcp_servers()
+
+    servers = await asyncio.to_thread(_read)
+    cfg = servers.get(server)
+    if not isinstance(cfg, dict) or not cfg.get("url") or cfg.get("auth") != "oauth":
+        raise HTTPException(status_code=404, detail="OAuth MCP target not found")
+    return {
+        "capabilities": {
+            "mcp_oauth_flow_v1": {"callback_mode": "relay"},
+        }
+    }
+
+
+@router.post("/api/mcp/oauth/start")
+async def mission_control_start_mcp_oauth(
+    body: MCPRemoteOAuthStart,
+    request: Request,
+):
+    """Start the existing Hermes OAuth engine for a Mission Control target."""
+    from hermes_cli.mcp_config import _get_mcp_servers
+    from hermes_constants import get_hermes_home
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    _require_token(request)
+    _gc_mcp_oauth_flows()
+
+    def _read():
+        with _config_profile_scope(body.profile):
+            return _get_mcp_servers(), str(
+                get_hermes_home().expanduser().resolve(strict=False)
+            )
+
+    servers, flow_home = await asyncio.to_thread(_read)
+    cfg = servers.get(body.server)
+    if not isinstance(cfg, dict) or not cfg.get("url") or cfg.get("auth") != "oauth":
+        raise HTTPException(status_code=404, detail="OAuth MCP target not found")
+
+    flow_id = secrets.token_urlsafe(24)
+    flow = DashboardOAuthFlow(
+        flow_id=flow_id,
+        server_name=body.server,
+        profile=body.profile,
+        hermes_home=flow_home,
+        redirect_uri=body.callback_url,
+        reconnect_live=False,
+    )
+    with _mcp_oauth_flows_lock:
+        pending = sum(not existing.worker_done for existing in _mcp_oauth_flows.values())
+        if pending >= _MAX_PENDING_MCP_OAUTH_FLOWS:
+            raise HTTPException(
+                status_code=429,
+                detail="Too many MCP OAuth flows are already in progress",
+            )
+        if any(
+            existing.server_name == body.server
+            and existing.hermes_home == flow_home
+            and not existing.worker_done
+            for existing in _mcp_oauth_flows.values()
+        ):
+            raise HTTPException(
+                status_code=409,
+                detail=f"MCP OAuth for '{body.server}' is already in progress",
+            )
+        _mcp_oauth_flows[flow_id] = flow
+
+    threading.Thread(
+        target=_run_dashboard_mcp_oauth,
+        args=(flow, dict(cfg)),
+        daemon=True,
+        name=f"mcp-oauth-{body.server}",
+    ).start()
+    try:
+        authorization_url = await flow.wait_for_authorization_url(timeout=30)
+    except Exception as exc:
+        flow.mark_error(str(exc))
+        raise HTTPException(status_code=502, detail="MCP OAuth could not start") from exc
+    return {"flow_id": flow_id, "authorization_url": authorization_url}
+
+
+def _mission_control_flow(flow_id: str, profile: str, server: str):
+    flow = _mcp_oauth_flows.get(flow_id)
+    if (
+        flow is None
+        or flow.profile != profile
+        or flow.server_name != server
+    ):
+        raise HTTPException(status_code=404, detail="OAuth flow not found or expired")
+    return flow
+
+
+@router.get("/api/mcp/oauth/status")
+async def mission_control_mcp_oauth_status(
+    request: Request,
+    profile: str,
+    server: str,
+    flow_id: str,
+):
+    _require_token(request)
+    _gc_mcp_oauth_flows()
+    flow = _mission_control_flow(flow_id, profile, server)
+    status = {
+        "approved": "succeeded",
+        "error": "failed",
+    }.get(flow.snapshot()["status"], "pending")
+    return {"status": status}
+
+
+@router.post("/api/mcp/oauth/relay")
+async def mission_control_relay_mcp_oauth(
+    body: MCPRemoteOAuthRelay,
+    request: Request,
+):
+    _require_token(request)
+    _gc_mcp_oauth_flows()
+    flow = _mission_control_flow(body.flow_id, body.profile, body.server)
+    try:
+        flow.deliver_callback(code=body.code, state=body.state, error=None)
+    except ValueError as exc:
+        if "already received" in str(exc):
+            raise HTTPException(status_code=409, detail="OAuth callback already used") from exc
+        raise HTTPException(status_code=404, detail="OAuth flow not found or expired") from exc
+    return {"status": "pending"}
+
+
+@router.post("/api/mcp/oauth/cancel")
+async def mission_control_cancel_mcp_oauth(
+    body: MCPRemoteOAuthFlow,
+    request: Request,
+):
+    _require_token(request)
+    _gc_mcp_oauth_flows()
+    flow = _mission_control_flow(body.flow_id, body.profile, body.server)
+    flow.mark_error("Cancelled by Mission Control")
+    return {"ok": True}
 
 
 @router.get("/api/mcp/servers")

--- a/tests/hermes_cli/test_mcp_dashboard_oauth.py
+++ b/tests/hermes_cli/test_mcp_dashboard_oauth.py
@@ -55,6 +55,227 @@ def test_hosted_auth_start_returns_public_authorization_url(monkeypatch):
     assert flow.redirect_uri == "https://agent.example/api/mcp/oauth/callback/reports"
 
 
+def test_mission_control_oauth_capability_is_profile_and_server_scoped(tmp_path, monkeypatch):
+    from hermes_cli import web_server
+
+    profile_home = tmp_path / "profiles" / "phaseboauth"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda _name: profile_home)
+    client = _client()
+    with patch(
+        "hermes_cli.mcp_config._get_mcp_servers",
+        return_value={"linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"}},
+    ):
+        response = client.get(
+            "/api/capabilities?profile=phaseboauth&server=linear"
+        )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "capabilities": {
+            "mcp_oauth_flow_v1": {"callback_mode": "relay"},
+        }
+    }
+
+
+def test_mission_control_starts_relay_flow_for_exact_target(tmp_path, monkeypatch):
+    import asyncio
+
+    from hermes_cli import web_server
+
+    profile_home = tmp_path / "profiles" / "phaseboauth"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda _name: profile_home)
+
+    def fake_worker(flow, cfg):
+        asyncio.run(
+            flow.publish_authorization_url(
+                "https://linear.app/oauth/authorize?state=expected-state"
+            )
+        )
+
+    monkeypatch.setattr(web_server, "_run_dashboard_mcp_oauth", fake_worker)
+    with patch(
+        "hermes_cli.mcp_config._get_mcp_servers",
+        return_value={"linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"}},
+    ):
+        response = _client().post(
+            "/api/mcp/oauth/start",
+            json={
+                "profile": "phaseboauth",
+                "server": "linear",
+                "callback_url": "https://mc.example/api/mcp/oauth/callback",
+            },
+        )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body == {
+        "flow_id": body["flow_id"],
+        "authorization_url": "https://linear.app/oauth/authorize?state=expected-state",
+    }
+    flow = web_server._mcp_oauth_flows[body["flow_id"]]
+    assert flow.profile == "phaseboauth"
+    assert flow.server_name == "linear"
+    assert flow.redirect_uri == "https://mc.example/api/mcp/oauth/callback"
+
+
+def test_mission_control_status_is_bound_to_exact_profile_and_server():
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-scoped",
+        server_name="linear",
+        profile="phaseboauth",
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://mc.example/api/mcp/oauth/callback",
+    )
+    flow.status = "approved"
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+
+    client = _client()
+    accepted = client.get(
+        "/api/mcp/oauth/status?profile=phaseboauth&server=linear&flow_id=flow-scoped"
+    )
+    rejected = client.get(
+        "/api/mcp/oauth/status?profile=other&server=linear&flow_id=flow-scoped"
+    )
+
+    assert accepted.status_code == 200
+    assert accepted.json() == {"status": "succeeded"}
+    assert rejected.status_code == 404
+
+
+def test_mission_control_relay_consumes_callback_once():
+    import asyncio
+
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-relay",
+        server_name="linear",
+        profile="phaseboauth",
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://mc.example/api/mcp/oauth/callback",
+    )
+    asyncio.run(
+        flow.publish_authorization_url(
+            "https://linear.app/oauth/authorize?state=expected-state"
+        )
+    )
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+    payload = {
+        "profile": "phaseboauth",
+        "server": "linear",
+        "flow_id": "flow-relay",
+        "code": "provider-code",
+        "state": "expected-state",
+    }
+
+    first = _client().post("/api/mcp/oauth/relay", json=payload)
+    replay = _client().post("/api/mcp/oauth/relay", json=payload)
+
+    assert first.status_code == 200
+    assert first.json() == {"status": "pending"}
+    assert flow._callback == ("provider-code", "expected-state")
+    assert replay.status_code == 409
+    assert "provider-code" not in first.text
+    assert "expected-state" not in first.text
+
+
+def test_mission_control_cancel_is_bound_to_exact_target():
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-cancel",
+        server_name="linear",
+        profile="phaseboauth",
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://mc.example/api/mcp/oauth/callback",
+    )
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+    client = _client()
+
+    rejected = client.post(
+        "/api/mcp/oauth/cancel",
+        json={"profile": "other", "server": "linear", "flow_id": "flow-cancel"},
+    )
+    accepted = client.post(
+        "/api/mcp/oauth/cancel",
+        json={
+            "profile": "phaseboauth",
+            "server": "linear",
+            "flow_id": "flow-cancel",
+        },
+    )
+
+    assert rejected.status_code == 404
+    assert accepted.status_code == 200
+    assert accepted.json() == {"ok": True}
+    assert flow.status == "error"
+
+
+def test_mission_control_rejects_unsafe_oauth_callback_url(tmp_path, monkeypatch):
+    from hermes_cli import web_server
+
+    profile_home = tmp_path / "profiles" / "phaseboauth"
+    profile_home.mkdir(parents=True)
+    monkeypatch.setattr(web_server, "_resolve_profile_dir", lambda _name: profile_home)
+    with patch(
+        "hermes_cli.mcp_config._get_mcp_servers",
+        return_value={"linear": {"url": "https://mcp.linear.app/mcp", "auth": "oauth"}},
+    ):
+        response = _client().post(
+            "/api/mcp/oauth/start",
+            json={
+                "profile": "phaseboauth",
+                "server": "linear",
+                "callback_url": "javascript:alert(1)",
+            },
+        )
+
+    assert response.status_code == 422
+    assert not web_server._mcp_oauth_flows
+
+
+def test_mission_control_rejects_oversized_relay_material():
+    import asyncio
+
+    from hermes_cli import web_server
+    from tools.mcp_dashboard_oauth import DashboardOAuthFlow
+
+    flow = DashboardOAuthFlow(
+        flow_id="flow-bounded",
+        server_name="linear",
+        profile="phaseboauth",
+        hermes_home="/tmp/hermes-test",
+        redirect_uri="https://mc.example/api/mcp/oauth/callback",
+    )
+    asyncio.run(
+        flow.publish_authorization_url(
+            "https://linear.app/oauth/authorize?state=expected-state"
+        )
+    )
+    web_server._mcp_oauth_flows[flow.flow_id] = flow
+
+    response = _client().post(
+        "/api/mcp/oauth/relay",
+        json={
+            "profile": "phaseboauth",
+            "server": "linear",
+            "flow_id": "flow-bounded",
+            "code": "x" * 4097,
+            "state": "expected-state",
+        },
+    )
+
+    assert response.status_code == 422
+    assert flow._callback is None
+
+
 def test_hosted_callback_bypasses_gated_cookie_auth(monkeypatch):
     import asyncio
 


### PR DESCRIPTION
## Summary
- expose authenticated, profile/server-scoped MCP OAuth capability discovery
- add bounded start/status/cancel/relay routes backed by the existing Hermes OAuth engine
- keep callback material and authorization responses bounded and fail closed

## Test plan
- [x] pytest -q tests/hermes_cli/test_mcp_dashboard_oauth.py tests/tools/test_mcp_dashboard_oauth.py (15 passed)
- [x] git diff --check

Kanban task: t_d757f5df
Mission Control: https://mc.solobot.cloud