### PR TITLE
fix(docker): don't classify a Docker host as a container

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1672,15 +1672,20 @@ def is_container() -> bool:
                 return True
     except OSError:
         pass
-    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. A container's
+    # root mount may still expose the runtime in mountinfo. Inspect only the
+    # entry mounted at "/": a Docker host also lists every container's overlay
+    # under /var/lib/docker/rootfs/... and scanning the whole table therefore
+    # misclassifies the host itself as a container.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                fields = line.split()
+                if len(fields) > 4 and fields[4] == "/" and any(
+                    marker in line for marker in ("kubepods", "containerd", "crio")
+                ):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -361,6 +361,52 @@ class TestIsContainer:
         monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
         assert is_container() is True
 
+    def test_ignores_containerd_mounts_below_host_root(self, monkeypatch):
+        """A Docker host's child overlay mounts do not make the host a container."""
+        import builtins
+        import io
+
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/init.scope\n")
+            if path == "/proc/self/mountinfo":
+                return io.StringIO(
+                    "24 1 0:22 / / rw - ext4 /dev/root rw\n"
+                    "90 24 0:81 / /var/lib/docker/rootfs/overlayfs/abc rw "
+                    "- overlay containerd-overlay rw\n"
+                )
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        assert is_container() is False
+
+    def test_detects_containerd_root_mount(self, monkeypatch):
+        """A runtime marker on the process root mount remains a positive signal."""
+        import builtins
+        import io
+
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/\n")
+            if path == "/proc/self/mountinfo":
+                return io.StringIO(
+                    "24 1 0:81 / / rw - overlay containerd-overlay rw\n"
+                )
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "open", fake_open)
+        assert is_container() is True
+
 
 
     def test_caches_result(self, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

`is_container()` returns `True` on ordinary Linux hosts that run Docker or containerd.

The cgroup-v2 fallback added for #44721 scans the whole of `/proc/self/mountinfo` for
`kubepods` / `containerd` / `crio`. On a Docker **host**, that file also lists every
running container's overlay mount under `/var/lib/docker/rootfs/...`, so the markers are
present even though the calling process is not in a container. On the machine this was
found on, a normal systemd host running ~30 compose stacks, 72 mountinfo lines match and
`is_container()` returns `True`.

This narrows the mountinfo fallback to the entry whose **mount point is `/`** — the
calling process's own root — rather than any entry anywhere in the table. A container's
root mount still carries the runtime marker, so genuine containerd/CRI-O detection is
preserved; a host's *child* overlay mounts no longer misclassify the host.

**This does not regress #44721.** Kubernetes pods are detected earlier and
unconditionally, by the `KUBERNETES_SERVICE_HOST` check, which this PR does not touch.
The mountinfo scan is only reached for a cgroup-v2 container with no `/.dockerenv`, no
`/run/.containerenv`, no `KUBERNETES_SERVICE_HOST` and no `/proc/1/cgroup` marker — and
that case is still caught, via its root mount, and is pinned by a test.

Why it matters beyond the dashboard symptom in #48594: `is_container()` also drives
`get_subprocess_home()` under `terminal.home_mode: auto`, which returns
`{HERMES_HOME}/home` for containers and the real `$HOME` otherwise. A misdetected host
therefore hands every spawned sub-agent a synthetic `$HOME`, silently cutting them off
from the user's real `~/.claude`, `~/.config` and `~/.npm`. That failure is invisible —
nothing errors, the sub-agent just starts with an empty profile.

## Related Issue

Fixes #48594

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_constants.py` — `is_container()`: iterate `/proc/self/mountinfo` line by line and
  require `fields[4] == "/"` (the mount point) before matching runtime markers, instead of
  substring-matching the entire file. Comment updated to say why.
- `tests/test_hermes_constants.py` — two tests:
  - `test_ignores_containerd_mounts_below_host_root` — a host whose mountinfo has a normal
    ext4 root plus a `/var/lib/docker/rootfs/overlayfs/...` containerd overlay → `False`.
  - `test_detects_containerd_root_mount` — a containerd marker on the `/` mount → `True`.

## How to Test

1. On a systemd host with Docker running and at least one container up:
   `python -c "import hermes_constants as h; print(h.is_container())"`
   → `True` before this change, `False` after.
2. Confirm the host really is a host: `/proc/1/comm` is `systemd`, `/.dockerenv` and
   `/run/.containerenv` absent, `KUBERNETES_SERVICE_HOST` unset, `findmnt /` a normal
   block device.
3. `pytest tests/test_hermes_constants.py -q` — both new tests pin the two directions.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass — `tests/test_hermes_constants.py` and
      `tests/tools/test_local_env_blocklist.py`: 153 passed, 8 skipped
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 13 (trixie), Python 3.11.16

### Documentation & Housekeeping

- [x] Docstring updated to describe the narrowed fallback — otherwise N/A
- [x] No config keys added — N/A
- [x] No architecture/workflow change — N/A
- [x] Cross-platform: `/proc/self/mountinfo` is Linux-only and was already guarded by
      `try/except OSError`; behaviour on macOS and Windows is unchanged (the read fails
      and falls through exactly as before)
- [x] No tool behaviour change — N/A
