### PR TITLE
feat(cli): add task-ownership controller (hermes task ...)

### DIFF
--- a/docs/task-ownership-controller.md
+++ b/docs/task-ownership-controller.md
@@ -1,0 +1,133 @@
+# Task-Ownership Controller
+
+Operator reference for `hermes task` — durable local state for tasks an
+agent or operator owns end to end, with completion gated on recorded
+verification evidence. Edge-layer feature (CLI + skill + optional cron
+wiring); no new core model tool, no gateway/agent-loop changes.
+
+## Files
+
+- `hermes_cli/task_ownership_db.py` — storage engine: SQLite schema, state
+  machine, CRUD, receipts, outcomes, verification, aging.
+- `hermes_cli/task_ownership.py` — `hermes task` argparse subcommands
+  (`register_cli`, wired in `hermes_cli/main.py`).
+- `hermes_cli/config_defaults.py` — `task_ownership:` config section.
+- `skills/productivity/task-ownership-controller/SKILL.md` — agent-facing
+  usage skill.
+- `tests/hermes_cli/test_task_ownership_db.py`,
+  `tests/hermes_cli/test_task_ownership_cli.py` — test suite.
+
+## Storage
+
+SQLite DB at `<HERMES_HOME>/task_ownership.db` (profile-scoped via
+`get_hermes_home()`; a fresh install creates it lazily on first `hermes
+task` invocation, or explicitly via `hermes task init`). Four tables:
+`tasks`, `task_events` (full audit trail of every state transition),
+`task_outcomes` (worker attempt log), `task_receipts` (idempotent external
+receipts, `UNIQUE(task_id, receipt_id)`).
+
+## State machine
+
+`NEW, WORKING, WAITING_FOR_USER, RETRYING, VERIFYING, DONE, BLOCKED,
+STALE, CANCELLED`. Terminal: `DONE`, `CANCELLED`. Reachability is
+enforced by a transition table in `task_ownership_db.TRANSITIONS`;
+`set_state()` raises `InvalidTransitionError` outside it.
+
+**No-false-completion invariant:** `mark_done()` is the *only* function
+that can set `state=DONE`, and it refuses unless:
+
+1. `verification_evidence` is on the task row (via `hermes task verify`,
+   or inline `hermes task done --evidence ...`), and
+2. for tasks created with `--approval-required`, `approved_by` is set
+   (via `hermes task approve`), and
+3. the task is currently in `VERIFYING`.
+
+`record_outcome()` (worker attempt logging) cannot set `DONE` under any
+result value — a worker self-reporting "success" is not sufficient to
+complete a task.
+
+## Bounded retries and fallback
+
+`hermes task outcome <id> --result failure --retry [--fallback "..."]`
+increments `retry_count`. While `retry_count <= max_retries` (set at
+`create` time, default 3, configurable via
+`task_ownership.default_max_retries`) it moves the task to `RETRYING`.
+Once exceeded, it auto-transitions to `BLOCKED`, records the blocker
+reason, and persists `--fallback` if given.
+
+## Idempotent receipts
+
+`hermes task receipt <id> --receipt-id <external-key> [--source ...]
+[--payload ...]`. Same `(task_id, receipt_id)` recorded twice is a no-op
+— the second call returns the original row with `duplicate: true` and
+does not insert a second row. Safe for at-least-once external callers to
+retry.
+
+## Aging (24h / 72h) without notification spam
+
+`hermes task age-check` scans every non-terminal task's
+`state_changed_at`. Each tier fires **once per distinct
+`state_changed_at` value** (tracked via `aged_24h_marker` /
+`aged_72h_marker` columns) — a task that has been silent for a week
+doesn't get reflagged on every run, only once per aging window. The 72h
+tier also auto-transitions the task to `STALE` (state change resets the
+anchor). Thresholds are configurable:
+`task_ownership.aging_warn_hours` (default 24),
+`task_ownership.aging_stale_hours` (default 72).
+
+## Feature flag — default OFF / shadow mode
+
+`task_ownership.enabled` in `config.yaml`, default `false`. Only
+`age-check` is gated:
+
+- **Disabled (default):** `age-check` is a strict no-op — no stdout, no DB
+  mutation. `--dry-run` still works (pure read, prints a preview,
+  regardless of the flag) so you can inspect what *would* happen before
+  opting in.
+- **Enabled:** `age-check` mutates markers/state and prints newly-crossed
+  tasks (or JSON via `--json`).
+
+Every other command (`create`, `update`, `outcome`, `receipt`, `verify`,
+`done`, `approve`, `block`, `cancel`, `events`, `status`, `list`, `show`)
+works regardless of the flag — those are explicit operator/worker
+actions, not passive automation, so gating them would just get in the
+way of the "real reversible system" the flag is meant to protect.
+
+### Enable / disable / rollback
+
+```bash
+hermes task enable      # sets task_ownership.enabled: true
+hermes task disable     # sets task_ownership.enabled: false
+```
+
+Disabling is a clean, complete rollback of the *automation surface*:
+`age-check` goes immediately inert (no code path runs once the flag read
+returns `false`), while all durable task state (the SQLite DB) is left
+exactly as-is — nothing is deleted, nothing needs a migration to reverse.
+To remove the feature entirely (e.g. in a test/throwaway profile), delete
+`<HERMES_HOME>/task_ownership.db`; no other Hermes state references it.
+
+## Optional cron wiring
+
+Not a native hook — documented, standard `--no-agent` cron script (see
+AGENTS.md § Cron):
+
+```bash
+cat > ~/.hermes/scripts/task_age_check.sh <<'SH'
+#!/usr/bin/env bash
+hermes task age-check
+SH
+chmod +x ~/.hermes/scripts/task_age_check.sh
+hermes task enable
+hermes cron add --no-agent --script task_age_check.sh --name task-aging "every 1h"
+```
+
+`--no-agent` delivers the script's stdout verbatim and skips the LLM
+entirely; empty stdout is silent, matching `age-check`'s
+already-deduplicated output.
+
+## Command reference
+
+See the Quick Reference table in
+`skills/productivity/task-ownership-controller/SKILL.md`, or `hermes task
+--help` / `hermes task <verb> --help`.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2439,6 +2439,30 @@ DEFAULT_CONFIG = {
     # (apiKey, workspace, peerName, sessions, enabled) comes from the global config.
     "honcho": {},
 
+    # Task-ownership controller (`hermes task ...`) — durable local task state
+    # with verification-gated completion. See docs/task-ownership-controller.md.
+    "task_ownership": {
+        # Master switch. OFF by default (shadow mode): explicit `hermes task`
+        # commands (create/update/outcome/receipt/verify/done/...) always work
+        # regardless of this flag — they're deliberate operator/worker actions.
+        # Only `hermes task age-check` (the one command meant to run unattended,
+        # e.g. from cron) is gated: with this off, age-check is a strict no-op
+        # (no output, no state mutation), so wiring the cron job ahead of
+        # opting in can never spam notifications or silently rot task state.
+        # `hermes task enable` / `hermes task disable` flip this cleanly.
+        "enabled": False,
+        # Hours of no activity (no state change) before a task is flagged at
+        # the soft "warn" tier by `hermes task age-check`. No state change,
+        # just a one-time flag per aging window (no repeat spam on later runs).
+        "aging_warn_hours": 24,
+        # Hours of no activity before a task auto-transitions to STALE and is
+        # flagged at the "stale" tier. Fires once per aging window, same as above.
+        "aging_stale_hours": 72,
+        # Default `max_retries` for `hermes task create` when --max-retries is
+        # not passed explicitly.
+        "default_max_retries": 3,
+    },
+
     # IANA timezone (e.g. "Asia/Kolkata", "America/New_York").
     # Empty string means use server-local time.
     "timezone": "",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12680,7 +12680,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "project", "proxy",
         "prompt-size",
         "resume",
-        "send", "sessions", "setup",
+        "send", "sessions", "setup", "task",
         "skin", "skills", "slack", "status", "sync", "tools", "uninstall", "update",
         "webhook", "whatsapp", "whatsapp-cloud", "worktree", "chat", "secrets", "security",
         "browser",
@@ -14180,6 +14180,29 @@ def main():
         _register_curator_cli(curator_parser)
     except Exception as _exc:
         logging.getLogger(__name__).debug("curator CLI wiring failed: %s", _exc)
+
+    # =========================================================================
+    # task command — task-ownership controller (durable local task state)
+    # =========================================================================
+    task_parser = subparsers.add_parser(
+        "task",
+        help="Task-ownership controller — durable local task state with verified completion",
+        description=(
+            "Tracks tasks an agent or operator owns end to end: state, next "
+            "action, blockers/decisions, bounded retries with fallback "
+            "recording, idempotent external receipts, and aging. A task "
+            "can only be marked DONE with verification evidence on file. "
+            "Feature-flagged off by default (task_ownership.enabled); "
+            "explicit commands always work, only the unattended `age-check` "
+            "is gated."
+        ),
+    )
+    try:
+        from hermes_cli.task_ownership import register_cli as _register_task_cli
+
+        _register_task_cli(task_parser)
+    except Exception as _exc:
+        logging.getLogger(__name__).debug("task CLI wiring failed: %s", _exc)
 
     # =========================================================================
     # pets command — petdex animated mascots (CLI / TUI / desktop display)

--- a/hermes_cli/task_ownership.py
+++ b/hermes_cli/task_ownership.py
@@ -1,0 +1,539 @@
+"""``hermes task`` subcommand — the task-ownership controller.
+
+Durable local tracking for tasks an agent or operator owns end to end:
+state, next action, blockers/decisions, bounded retries with fallback
+recording, idempotent external receipts, and verification evidence gating
+completion. See ``hermes_cli/task_ownership_db.py`` for the storage engine
+and state machine, and ``docs/task-ownership-controller.md`` for the
+operator guide.
+
+This module intentionally has no side effects at import time — main.py
+wires the argparse subparsers on demand (same convention as curator.py).
+
+Feature flag: ``task_ownership.enabled`` in config.yaml, default False.
+Explicit CRUD commands (create/update/outcome/receipt/verify/done/...)
+always work — they are deliberate operator/worker actions, not passive
+automation. Only ``hermes task age-check`` (the one command that runs
+unattended, e.g. from cron) is gated: with the flag off it is a strict
+no-op (shadow mode) — it prints nothing and mutates nothing — so wiring
+the cron job ahead of opting in can never spam or silently rot state.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from typing import Any, Dict, List, Optional
+
+from hermes_cli import task_ownership_db as tdb
+
+
+def _is_enabled() -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+    except Exception:
+        return False
+    return bool(cfg.get("task_ownership", {}).get("enabled", False))
+
+
+def _aging_hours() -> tuple:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config().get("task_ownership", {})
+    except Exception:
+        cfg = {}
+    return (
+        int(cfg.get("aging_warn_hours", 24) or 24),
+        int(cfg.get("aging_stale_hours", 72) or 72),
+    )
+
+
+def _default_max_retries() -> int:
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config().get("task_ownership", {})
+    except Exception:
+        cfg = {}
+    return int(cfg.get("default_max_retries", 3) or 3)
+
+
+def _print_task(task: Dict[str, Any], *, as_json: bool = False) -> None:
+    if as_json:
+        print(json.dumps(task, indent=2, sort_keys=True))
+        return
+    print(f"{task['id']}  [{task['state']}]  {task['title']}")
+    if task.get("owner"):
+        print(f"  owner: {task['owner']}")
+    if task.get("next_action"):
+        print(f"  next_action: {task['next_action']}")
+    if task.get("blocker"):
+        print(f"  blocker: {task['blocker']}")
+    if task.get("decision"):
+        print(f"  decision: {task['decision']}")
+    if task.get("fallback"):
+        print(f"  fallback: {task['fallback']}")
+    print(f"  retries: {task['retry_count']}/{task['max_retries']}")
+    if task.get("approval_required"):
+        approved = f"by {task['approved_by']} at {task['approved_at']}" if task.get(
+            "approved_by"
+        ) else "PENDING"
+        print(f"  approval: {approved}")
+    if task.get("verification_evidence"):
+        print(f"  verified: {task['verification_evidence']} (at {task['verified_at']})")
+    print(f"  created_at: {task['created_at']}  updated_at: {task['updated_at']}")
+
+
+def _cmd_init(args) -> int:
+    path = tdb.init_db()
+    print(f"task-ownership db ready at {path}")
+    return 0
+
+
+def _cmd_create(args) -> int:
+    conn = tdb.connect()
+    task = tdb.create_task(
+        conn,
+        title=args.title,
+        next_action=args.next_action,
+        owner=args.owner,
+        max_retries=args.max_retries if args.max_retries is not None else _default_max_retries(),
+        approval_required=args.approval_required,
+    )
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_list(args) -> int:
+    conn = tdb.connect()
+    tasks = tdb.list_tasks(conn, state=args.state, include_terminal=args.all)
+    if args.json:
+        print(json.dumps(tasks, indent=2, sort_keys=True))
+        return 0
+    if not tasks:
+        print("no tasks")
+        return 0
+    for task in tasks:
+        print(f"{task['id']}  [{task['state']:<16}]  {task['title']}")
+    return 0
+
+
+def _cmd_show(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.get_task(conn, args.task_id)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_update(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.update_task(
+            conn,
+            args.task_id,
+            next_action=args.next_action,
+            blocker=args.blocker,
+            decision=args.decision,
+            owner=args.owner,
+            fallback=args.fallback,
+            max_retries=args.max_retries,
+            state=args.state,
+        )
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except tdb.InvalidTransitionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_outcome(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.record_outcome(
+            conn,
+            args.task_id,
+            result=args.result,
+            detail=args.detail,
+            retry=args.retry,
+            fallback=args.fallback,
+        )
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_receipt(args) -> int:
+    conn = tdb.connect()
+    try:
+        receipt = tdb.record_receipt(
+            conn,
+            args.task_id,
+            receipt_id=args.receipt_id,
+            source=args.source,
+            payload=args.payload,
+        )
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps(receipt, indent=2, sort_keys=True))
+    elif receipt["duplicate"]:
+        print(f"receipt {args.receipt_id} already recorded for {args.task_id} — no-op")
+    else:
+        print(f"receipt {args.receipt_id} recorded for {args.task_id}")
+    return 0
+
+
+def _cmd_verify(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.record_verification(conn, args.task_id, args.evidence)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except (ValueError, tdb.InvalidTransitionError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_done(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.mark_done(conn, args.task_id, evidence=args.evidence)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except (
+        tdb.VerificationRequiredError,
+        tdb.ApprovalRequiredError,
+        tdb.InvalidTransitionError,
+    ) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_approve(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.approve_task(conn, args.task_id, args.by)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_block(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.block_task(conn, args.task_id, args.reason)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except tdb.InvalidTransitionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_cancel(args) -> int:
+    conn = tdb.connect()
+    try:
+        task = tdb.cancel_task(conn, args.task_id, args.reason)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    except tdb.InvalidTransitionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    _print_task(task, as_json=args.json)
+    return 0
+
+
+def _cmd_events(args) -> int:
+    conn = tdb.connect()
+    try:
+        tdb.get_task(conn, args.task_id)
+    except tdb.TaskNotFoundError:
+        print(f"no such task: {args.task_id}", file=sys.stderr)
+        return 1
+    events = tdb.list_events(conn, args.task_id)
+    if args.json:
+        print(json.dumps(events, indent=2, sort_keys=True))
+        return 0
+    for ev in events:
+        arrow = f"{ev['from_state']} -> {ev['to_state']}" if ev["to_state"] else ""
+        detail = f"  ({ev['detail']})" if ev["detail"] else ""
+        print(f"{ev['created_at']}  {ev['event']:<22} {arrow}{detail}")
+    return 0
+
+
+def _cmd_age_check(args) -> int:
+    enabled = _is_enabled()
+    warn_hours, stale_hours = _aging_hours()
+    conn = tdb.connect()
+
+    if not enabled and not args.dry_run:
+        # Shadow mode: strictly inert. No stdout (so a cron --no-agent job
+        # wired ahead of opt-in stays silent), no mutation.
+        if args.verbose:
+            preview = tdb.age_check(
+                conn,
+                enabled=False,
+                dry_run=True,
+                warn_hours=warn_hours,
+                stale_hours=stale_hours,
+            )
+            print(
+                f"task_ownership disabled (shadow mode) — {len(preview)} task(s) would "
+                "age; run `hermes task enable` to activate",
+                file=sys.stderr,
+            )
+        return 0
+
+    flagged = tdb.age_check(
+        conn,
+        enabled=enabled,
+        dry_run=args.dry_run,
+        warn_hours=warn_hours,
+        stale_hours=stale_hours,
+    )
+    if args.json:
+        print(json.dumps(flagged, indent=2, sort_keys=True))
+        return 0
+    if not flagged:
+        return 0
+    prefix = "[DRY RUN] " if args.dry_run else ""
+    for item in flagged:
+        print(
+            f"{prefix}{item['tier']:<4} {item['task_id']}  {item['age_hours']}h  "
+            f"[{item['state']}]  {item['title']}"
+        )
+    return 0
+
+
+def _cmd_enable(args) -> int:
+    from hermes_cli.config import set_config_value
+
+    set_config_value("task_ownership.enabled", "true")
+    print("task-ownership controller: enabled")
+    return 0
+
+
+def _cmd_disable(args) -> int:
+    from hermes_cli.config import set_config_value
+
+    set_config_value("task_ownership.enabled", "false")
+    print("task-ownership controller: disabled (age-check is now a strict no-op)")
+    return 0
+
+
+def _cmd_status(args) -> int:
+    conn = tdb.connect()
+    tasks = tdb.list_tasks(conn, include_terminal=True)
+    counts: Dict[str, int] = {}
+    for task in tasks:
+        counts[task["state"]] = counts.get(task["state"], 0) + 1
+    enabled = _is_enabled()
+    warn_hours, stale_hours = _aging_hours()
+    if args.json:
+        print(
+            json.dumps(
+                {
+                    "enabled": enabled,
+                    "aging_warn_hours": warn_hours,
+                    "aging_stale_hours": stale_hours,
+                    "total_tasks": len(tasks),
+                    "by_state": counts,
+                    "db_path": str(tdb.db_path()),
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+        return 0
+    print(f"task-ownership controller: {'enabled' if enabled else 'disabled (shadow mode)'}")
+    print(f"aging thresholds: warn={warn_hours}h stale={stale_hours}h")
+    print(f"db: {tdb.db_path()}")
+    print(f"total tasks: {len(tasks)}")
+    for state in tdb.STATES:
+        if counts.get(state):
+            print(f"  {state:<18} {counts[state]}")
+    return 0
+
+
+def register_cli(parent: argparse.ArgumentParser) -> None:
+    """Attach `task` subcommands to *parent*.
+
+    main.py calls this with the ArgumentParser returned by
+    ``subparsers.add_parser("task", ...)``.
+    """
+    parent.set_defaults(func=_cmd_status)
+    subs = parent.add_subparsers(dest="task_command")
+
+    def _add_json(p):
+        p.add_argument("--json", action="store_true", help="Emit JSON instead of a table")
+
+    p_init = subs.add_parser("init", help="Create task_ownership.db if missing (idempotent)")
+    p_init.set_defaults(func=_cmd_init)
+
+    p_status = subs.add_parser("status", help="Show feature-flag state and task counts")
+    _add_json(p_status)
+    p_status.set_defaults(func=_cmd_status)
+
+    p_create = subs.add_parser("create", help="Create a new task (state=NEW)")
+    p_create.add_argument("title", help="Task title / description")
+    p_create.add_argument("--next-action", dest="next_action", help="What to do next")
+    p_create.add_argument("--owner", help="Who/what owns this task")
+    p_create.add_argument(
+        "--max-retries", dest="max_retries", type=int, default=None,
+        help="Bounded retry limit before auto-BLOCKED (default from config, 3)",
+    )
+    p_create.add_argument(
+        "--approval-required", dest="approval_required", action="store_true",
+        help="Require `hermes task approve` before this task can be marked DONE",
+    )
+    _add_json(p_create)
+    p_create.set_defaults(func=_cmd_create)
+
+    p_list = subs.add_parser("list", help="List tasks")
+    p_list.add_argument("--state", choices=sorted(tdb.STATES), help="Filter by exact state")
+    p_list.add_argument(
+        "--all", action="store_true",
+        help="Include DONE/CANCELLED tasks (excluded by default when --state is not given)",
+    )
+    _add_json(p_list)
+    p_list.set_defaults(func=_cmd_list)
+
+    p_show = subs.add_parser("show", help="Show one task")
+    p_show.add_argument("task_id")
+    _add_json(p_show)
+    p_show.set_defaults(func=_cmd_show)
+
+    p_update = subs.add_parser("update", help="Update task fields and/or explicit state")
+    p_update.add_argument("task_id")
+    p_update.add_argument("--next-action", dest="next_action")
+    p_update.add_argument("--blocker", dest="blocker")
+    p_update.add_argument("--decision", dest="decision")
+    p_update.add_argument("--owner", dest="owner")
+    p_update.add_argument("--fallback", dest="fallback")
+    p_update.add_argument("--max-retries", dest="max_retries", type=int)
+    p_update.add_argument(
+        "--state", dest="state", choices=sorted(tdb.STATES),
+        help="Explicit state transition, validated against the state machine",
+    )
+    _add_json(p_update)
+    p_update.set_defaults(func=_cmd_update)
+
+    p_outcome = subs.add_parser("outcome", help="Record a worker attempt outcome")
+    p_outcome.add_argument("task_id")
+    p_outcome.add_argument("--result", required=True, choices=("success", "failure", "partial"))
+    p_outcome.add_argument("--detail", help="Free-text detail about the attempt")
+    p_outcome.add_argument(
+        "--retry", action="store_true",
+        help="On failure, bump retry_count and move to RETRYING (or BLOCKED once max-retries is exceeded)",
+    )
+    p_outcome.add_argument(
+        "--fallback", help="Fallback plan to record if the retry limit is exceeded by this outcome",
+    )
+    _add_json(p_outcome)
+    p_outcome.set_defaults(func=_cmd_outcome)
+
+    p_receipt = subs.add_parser(
+        "receipt", help="Record an idempotent external receipt (safe to retry)"
+    )
+    p_receipt.add_argument("task_id")
+    p_receipt.add_argument("--receipt-id", dest="receipt_id", required=True, help="External idempotency key")
+    p_receipt.add_argument("--source", help="Where the receipt came from (e.g. stripe, email)")
+    p_receipt.add_argument("--payload", help="Free-text/JSON payload to store alongside the receipt")
+    _add_json(p_receipt)
+    p_receipt.set_defaults(func=_cmd_receipt)
+
+    p_verify = subs.add_parser("verify", help="Record verification evidence (moves to VERIFYING)")
+    p_verify.add_argument("task_id")
+    p_verify.add_argument("--evidence", required=True, help="Concrete evidence the task's outcome was checked")
+    _add_json(p_verify)
+    p_verify.set_defaults(func=_cmd_verify)
+
+    p_done = subs.add_parser(
+        "done", help="Mark a task DONE — refuses without verification evidence on file"
+    )
+    p_done.add_argument("task_id")
+    p_done.add_argument(
+        "--evidence", help="Verification evidence, if not already recorded via `task verify`"
+    )
+    _add_json(p_done)
+    p_done.set_defaults(func=_cmd_done)
+
+    p_approve = subs.add_parser("approve", help="Record approval for an approval-required task")
+    p_approve.add_argument("task_id")
+    p_approve.add_argument("--by", required=True, help="Who approved it")
+    _add_json(p_approve)
+    p_approve.set_defaults(func=_cmd_approve)
+
+    p_block = subs.add_parser("block", help="Move a task to BLOCKED with a reason")
+    p_block.add_argument("task_id")
+    p_block.add_argument("--reason", required=True)
+    _add_json(p_block)
+    p_block.set_defaults(func=_cmd_block)
+
+    p_cancel = subs.add_parser("cancel", help="Move a task to CANCELLED")
+    p_cancel.add_argument("task_id")
+    p_cancel.add_argument("--reason")
+    _add_json(p_cancel)
+    p_cancel.set_defaults(func=_cmd_cancel)
+
+    p_events = subs.add_parser("events", help="Show the audit trail for a task")
+    p_events.add_argument("task_id")
+    _add_json(p_events)
+    p_events.set_defaults(func=_cmd_events)
+
+    p_age = subs.add_parser(
+        "age-check",
+        help="Evaluate 24h/72h aging thresholds (no-op unless enabled, unless --dry-run)",
+    )
+    p_age.add_argument(
+        "--dry-run", action="store_true",
+        help="Preview aging regardless of the feature flag; never mutates state",
+    )
+    p_age.add_argument(
+        "--verbose", action="store_true",
+        help="When disabled and not --dry-run, print a shadow-mode summary to stderr",
+    )
+    _add_json(p_age)
+    p_age.set_defaults(func=_cmd_age_check)
+
+    p_enable = subs.add_parser("enable", help="Turn on the task-ownership controller")
+    p_enable.set_defaults(func=_cmd_enable)
+
+    p_disable = subs.add_parser(
+        "disable", help="Turn off the task-ownership controller (clean rollback: age-check goes inert)"
+    )
+    p_disable.set_defaults(func=_cmd_disable)

--- a/hermes_cli/task_ownership_db.py
+++ b/hermes_cli/task_ownership_db.py
@@ -1,0 +1,692 @@
+"""SQLite-backed store for the task-ownership controller.
+
+Durable local state for tasks an agent (or a human operator) owns end to
+end: what state a task is in, what the next action is, why it's blocked,
+how many times it's been retried, and — the load-bearing invariant — proof
+that a task was actually verified before it is marked DONE.
+
+DB lives at ``<HERMES_HOME>/task_ownership.db``. Single-profile, single-file,
+no multi-worker coordination needed (unlike ``kanban_db.py``, which this
+module borrows its WAL/connect/init_db shape from) — one profile's tasks are
+private to that profile.
+
+State machine
+-------------
+NEW -> WORKING -> {WAITING_FOR_USER, RETRYING, VERIFYING, BLOCKED, STALE, CANCELLED}
+VERIFYING -> DONE   (ONLY reachable state for DONE — see mark_done())
+Terminal states: DONE, CANCELLED (no transitions out).
+
+No-false-completion invariant
+------------------------------
+``mark_done()`` refuses to set state=DONE unless ``verification_evidence``
+is present on the task (recorded via ``record_verification()``, or passed
+directly to ``mark_done()`` which records it first) AND, for tasks created
+with ``approval_required=True``, an approval is on file. There is no code
+path that reaches DONE without both checks passing.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+SCHEMA_SQL = """
+CREATE TABLE IF NOT EXISTS tasks (
+    id TEXT PRIMARY KEY,
+    title TEXT NOT NULL,
+    state TEXT NOT NULL,
+    next_action TEXT,
+    blocker TEXT,
+    decision TEXT,
+    owner TEXT,
+    retry_count INTEGER NOT NULL DEFAULT 0,
+    max_retries INTEGER NOT NULL DEFAULT 3,
+    fallback TEXT,
+    approval_required INTEGER NOT NULL DEFAULT 0,
+    approved_by TEXT,
+    approved_at TEXT,
+    verification_evidence TEXT,
+    verified_at TEXT,
+    last_outcome TEXT,
+    last_outcome_detail TEXT,
+    last_outcome_at TEXT,
+    aged_24h_marker TEXT,
+    aged_72h_marker TEXT,
+    created_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    state_changed_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
+
+CREATE TABLE IF NOT EXISTS task_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    event TEXT NOT NULL,
+    from_state TEXT,
+    to_state TEXT,
+    detail TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_events_task ON task_events(task_id);
+
+CREATE TABLE IF NOT EXISTS task_outcomes (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    attempt INTEGER NOT NULL,
+    result TEXT NOT NULL,
+    detail TEXT,
+    created_at TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_outcomes_task ON task_outcomes(task_id);
+
+CREATE TABLE IF NOT EXISTS task_receipts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id TEXT NOT NULL,
+    receipt_id TEXT NOT NULL,
+    source TEXT,
+    payload TEXT,
+    created_at TEXT NOT NULL,
+    UNIQUE(task_id, receipt_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_task_receipts_task ON task_receipts(task_id);
+"""
+
+STATES = frozenset(
+    {
+        "NEW",
+        "WORKING",
+        "WAITING_FOR_USER",
+        "RETRYING",
+        "VERIFYING",
+        "DONE",
+        "BLOCKED",
+        "STALE",
+        "CANCELLED",
+    }
+)
+
+TERMINAL_STATES = frozenset({"DONE", "CANCELLED"})
+
+# Reachability graph. This encodes which transitions are structurally
+# sane; it does NOT encode the extra evidence/approval preconditions that
+# gate entry into DONE specifically — those live in mark_done().
+TRANSITIONS: Dict[str, frozenset] = {
+    "NEW": frozenset({"WORKING", "BLOCKED", "CANCELLED"}),
+    "WORKING": frozenset(
+        {"WAITING_FOR_USER", "RETRYING", "VERIFYING", "BLOCKED", "STALE", "CANCELLED"}
+    ),
+    "WAITING_FOR_USER": frozenset({"WORKING", "BLOCKED", "STALE", "CANCELLED"}),
+    "RETRYING": frozenset({"WORKING", "BLOCKED", "STALE", "CANCELLED"}),
+    "VERIFYING": frozenset({"DONE", "WORKING", "BLOCKED", "CANCELLED"}),
+    "BLOCKED": frozenset({"WORKING", "STALE", "CANCELLED"}),
+    "STALE": frozenset({"WORKING", "BLOCKED", "CANCELLED"}),
+    "DONE": frozenset(),
+    "CANCELLED": frozenset(),
+}
+
+
+class TaskOwnershipError(Exception):
+    """Base class for task-ownership state errors."""
+
+
+class InvalidTransitionError(TaskOwnershipError):
+    pass
+
+
+class VerificationRequiredError(TaskOwnershipError):
+    pass
+
+
+class ApprovalRequiredError(TaskOwnershipError):
+    pass
+
+
+class TaskNotFoundError(TaskOwnershipError):
+    pass
+
+
+class DuplicateReceiptError(TaskOwnershipError):
+    """Raised only by callers that opt into strict (non-idempotent) mode."""
+
+
+_INIT_LOCK = threading.Lock()
+_INITIALIZED_PATHS: set = set()
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _now_iso() -> str:
+    return _now().isoformat()
+
+
+def _parse_iso(value: str) -> datetime:
+    dt = datetime.fromisoformat(value)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def db_path(db_path: Optional[Path] = None) -> Path:
+    if db_path is not None:
+        return db_path
+    return get_hermes_home() / "task_ownership.db"
+
+
+def _sqlite_connect(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(str(path), timeout=30.0)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def connect(path: Optional[Path] = None) -> sqlite3.Connection:
+    """Open (and initialize if needed) the task-ownership DB."""
+    resolved_path = db_path(path)
+    resolved_path.parent.mkdir(parents=True, exist_ok=True)
+    key = str(resolved_path.resolve())
+
+    conn = _sqlite_connect(resolved_path)
+    conn.execute("PRAGMA foreign_keys=OFF")
+    with _INIT_LOCK:
+        if key not in _INITIALIZED_PATHS:
+            from hermes_state import apply_wal_with_fallback
+
+            apply_wal_with_fallback(conn, db_label="task_ownership.db")
+            conn.executescript(SCHEMA_SQL)
+            conn.commit()
+            _INITIALIZED_PATHS.add(key)
+    return conn
+
+
+def connect_closing(path: Optional[Path] = None):
+    return contextlib.closing(connect(path))
+
+
+def init_db(path: Optional[Path] = None) -> Path:
+    """Create the schema if missing; return the resolved path.
+
+    Unlike :func:`connect`'s cached first-open init, this always clears the
+    cache entry first so a test harness or a caller that suspects schema
+    drift can force a re-check.
+    """
+    resolved_path = db_path(path)
+    key = str(resolved_path.resolve())
+    with _INIT_LOCK:
+        _INITIALIZED_PATHS.discard(key)
+    with connect_closing(resolved_path):
+        pass
+    return resolved_path
+
+
+def _row_to_dict(row: sqlite3.Row) -> Dict[str, Any]:
+    return dict(row)
+
+
+def _log_event(
+    conn: sqlite3.Connection,
+    task_id: str,
+    event: str,
+    *,
+    from_state: Optional[str] = None,
+    to_state: Optional[str] = None,
+    detail: Optional[str] = None,
+) -> None:
+    conn.execute(
+        "INSERT INTO task_events (task_id, event, from_state, to_state, detail, created_at) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        (task_id, event, from_state, to_state, detail, _now_iso()),
+    )
+
+
+def create_task(
+    conn: sqlite3.Connection,
+    *,
+    title: str,
+    next_action: Optional[str] = None,
+    owner: Optional[str] = None,
+    max_retries: int = 3,
+    approval_required: bool = False,
+) -> Dict[str, Any]:
+    if not title or not title.strip():
+        raise ValueError("title is required")
+    task_id = "t_" + uuid.uuid4().hex[:12]
+    now = _now_iso()
+    conn.execute(
+        "INSERT INTO tasks (id, title, state, next_action, owner, max_retries, "
+        "approval_required, created_at, updated_at, state_changed_at) "
+        "VALUES (?, ?, 'NEW', ?, ?, ?, ?, ?, ?, ?)",
+        (
+            task_id,
+            title.strip(),
+            next_action,
+            owner,
+            max_retries,
+            1 if approval_required else 0,
+            now,
+            now,
+            now,
+        ),
+    )
+    _log_event(conn, task_id, "created", to_state="NEW", detail=title.strip())
+    conn.commit()
+    return get_task(conn, task_id)
+
+
+def get_task(conn: sqlite3.Connection, task_id: str) -> Dict[str, Any]:
+    row = conn.execute("SELECT * FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if row is None:
+        raise TaskNotFoundError(task_id)
+    return _row_to_dict(row)
+
+
+def list_tasks(
+    conn: sqlite3.Connection,
+    *,
+    state: Optional[str] = None,
+    include_terminal: bool = True,
+) -> List[Dict[str, Any]]:
+    query = "SELECT * FROM tasks"
+    clauses = []
+    params: List[Any] = []
+    if state:
+        clauses.append("state = ?")
+        params.append(state)
+    elif not include_terminal:
+        clauses.append("state NOT IN ('DONE', 'CANCELLED')")
+    if clauses:
+        query += " WHERE " + " AND ".join(clauses)
+    query += " ORDER BY created_at ASC"
+    rows = conn.execute(query, params).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+def _touch(conn: sqlite3.Connection, task_id: str) -> None:
+    conn.execute("UPDATE tasks SET updated_at = ? WHERE id = ?", (_now_iso(), task_id))
+
+
+def set_state(
+    conn: sqlite3.Connection,
+    task_id: str,
+    to_state: str,
+    *,
+    detail: Optional[str] = None,
+    event: str = "state_change",
+) -> Dict[str, Any]:
+    if to_state not in STATES:
+        raise ValueError(f"unknown state: {to_state}")
+    task = get_task(conn, task_id)
+    from_state = task["state"]
+    if to_state == from_state:
+        return task
+    allowed = TRANSITIONS.get(from_state, frozenset())
+    if to_state not in allowed:
+        raise InvalidTransitionError(f"{from_state} -> {to_state} is not a valid transition")
+    now = _now_iso()
+    conn.execute(
+        "UPDATE tasks SET state = ?, updated_at = ?, state_changed_at = ? WHERE id = ?",
+        (to_state, now, now, task_id),
+    )
+    _log_event(conn, task_id, event, from_state=from_state, to_state=to_state, detail=detail)
+    conn.commit()
+    return get_task(conn, task_id)
+
+
+def update_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    next_action: Optional[str] = None,
+    blocker: Optional[str] = None,
+    decision: Optional[str] = None,
+    owner: Optional[str] = None,
+    fallback: Optional[str] = None,
+    max_retries: Optional[int] = None,
+    state: Optional[str] = None,
+) -> Dict[str, Any]:
+    get_task(conn, task_id)  # 404s cleanly if missing
+    fields = {
+        "next_action": next_action,
+        "blocker": blocker,
+        "decision": decision,
+        "owner": owner,
+        "fallback": fallback,
+        "max_retries": max_retries,
+    }
+    sets = [(k, v) for k, v in fields.items() if v is not None]
+    if sets:
+        assignments = ", ".join(f"{k} = ?" for k, _ in sets)
+        params = [v for _, v in sets] + [_now_iso(), task_id]
+        conn.execute(
+            f"UPDATE tasks SET {assignments}, updated_at = ? WHERE id = ?", params
+        )
+        _log_event(conn, task_id, "updated", detail=json.dumps({k: v for k, v in sets}))
+        conn.commit()
+    if state is not None:
+        return set_state(conn, task_id, state, event="manual_update")
+    return get_task(conn, task_id)
+
+
+def record_outcome(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    result: str,
+    detail: Optional[str] = None,
+    retry: bool = False,
+    fallback: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Record a worker's attempt outcome. Never sets state to DONE.
+
+    Completion only ever happens through :func:`record_verification` +
+    :func:`mark_done` — outcome recording is deliberately incapable of
+    completing a task, so a worker reporting "success" cannot by itself
+    produce a false DONE.
+    """
+    if result not in {"success", "failure", "partial"}:
+        raise ValueError("result must be one of: success, failure, partial")
+    task = get_task(conn, task_id)
+    attempt = task["retry_count"] + 1
+    now = _now_iso()
+    conn.execute(
+        "INSERT INTO task_outcomes (task_id, attempt, result, detail, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (task_id, attempt, result, detail, now),
+    )
+    conn.execute(
+        "UPDATE tasks SET last_outcome = ?, last_outcome_detail = ?, last_outcome_at = ?, "
+        "updated_at = ? WHERE id = ?",
+        (result, detail, now, now, task_id),
+    )
+    conn.commit()
+
+    if result != "failure" or not retry:
+        return get_task(conn, task_id)
+
+    # Bounded retry bookkeeping.
+    new_retry_count = task["retry_count"] + 1
+    conn.execute(
+        "UPDATE tasks SET retry_count = ?, updated_at = ? WHERE id = ?",
+        (new_retry_count, _now_iso(), task_id),
+    )
+    if fallback:
+        conn.execute(
+            "UPDATE tasks SET fallback = ?, updated_at = ? WHERE id = ?",
+            (fallback, _now_iso(), task_id),
+        )
+    conn.commit()
+    task = get_task(conn, task_id)
+
+    if new_retry_count > task["max_retries"]:
+        _log_event(
+            conn,
+            task_id,
+            "retry_limit_exceeded",
+            detail=f"{new_retry_count}/{task['max_retries']}"
+            + (f"; fallback={fallback}" if fallback else ""),
+        )
+        conn.commit()
+        blocker_msg = f"retry limit exceeded ({new_retry_count}/{task['max_retries']})"
+        conn.execute(
+            "UPDATE tasks SET blocker = ?, updated_at = ? WHERE id = ?",
+            (blocker_msg, _now_iso(), task_id),
+        )
+        conn.commit()
+        return set_state(conn, task_id, "BLOCKED", event="retry_exhausted", detail=blocker_msg)
+
+    if task["state"] in TRANSITIONS and "RETRYING" in TRANSITIONS[task["state"]]:
+        return set_state(
+            conn,
+            task_id,
+            "RETRYING",
+            event="retry_scheduled",
+            detail=f"attempt {new_retry_count}/{task['max_retries']}",
+        )
+    return task
+
+
+def record_receipt(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    receipt_id: str,
+    source: Optional[str] = None,
+    payload: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Idempotently record an external receipt.
+
+    Recording the same ``receipt_id`` for the same task twice is a no-op —
+    the second call returns the original row untouched with
+    ``duplicate=True``, so callers integrating a flaky/at-least-once
+    external system can safely retry without double-booking side effects.
+    """
+    get_task(conn, task_id)  # 404s cleanly if missing
+    if not receipt_id or not receipt_id.strip():
+        raise ValueError("receipt_id is required")
+    receipt_id = receipt_id.strip()
+    existing = conn.execute(
+        "SELECT * FROM task_receipts WHERE task_id = ? AND receipt_id = ?",
+        (task_id, receipt_id),
+    ).fetchone()
+    if existing is not None:
+        result = _row_to_dict(existing)
+        result["duplicate"] = True
+        return result
+    now = _now_iso()
+    conn.execute(
+        "INSERT INTO task_receipts (task_id, receipt_id, source, payload, created_at) "
+        "VALUES (?, ?, ?, ?, ?)",
+        (task_id, receipt_id, source, payload, now),
+    )
+    _log_event(conn, task_id, "receipt_recorded", detail=f"{receipt_id} ({source or 'unknown'})")
+    conn.commit()
+    row = conn.execute(
+        "SELECT * FROM task_receipts WHERE task_id = ? AND receipt_id = ?",
+        (task_id, receipt_id),
+    ).fetchone()
+    result = _row_to_dict(row)
+    result["duplicate"] = False
+    return result
+
+
+def list_receipts(conn: sqlite3.Connection, task_id: str) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT * FROM task_receipts WHERE task_id = ? ORDER BY created_at ASC", (task_id,)
+    ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+def record_verification(
+    conn: sqlite3.Connection, task_id: str, evidence: str
+) -> Dict[str, Any]:
+    if not evidence or not evidence.strip():
+        raise ValueError("evidence is required")
+    task = get_task(conn, task_id)
+    now = _now_iso()
+    conn.execute(
+        "UPDATE tasks SET verification_evidence = ?, verified_at = ?, updated_at = ? "
+        "WHERE id = ?",
+        (evidence.strip(), now, now, task_id),
+    )
+    conn.commit()
+    if task["state"] != "VERIFYING":
+        task = set_state(
+            conn, task_id, "VERIFYING", event="verification_recorded", detail=evidence.strip()
+        )
+    else:
+        _log_event(conn, task_id, "verification_recorded", detail=evidence.strip())
+        conn.commit()
+        task = get_task(conn, task_id)
+    return task
+
+
+def approve_task(conn: sqlite3.Connection, task_id: str, approved_by: str) -> Dict[str, Any]:
+    if not approved_by or not approved_by.strip():
+        raise ValueError("approved_by is required")
+    get_task(conn, task_id)
+    now = _now_iso()
+    conn.execute(
+        "UPDATE tasks SET approved_by = ?, approved_at = ?, updated_at = ? WHERE id = ?",
+        (approved_by.strip(), now, now, task_id),
+    )
+    _log_event(conn, task_id, "approved", detail=approved_by.strip())
+    conn.commit()
+    return get_task(conn, task_id)
+
+
+def mark_done(
+    conn: sqlite3.Connection, task_id: str, *, evidence: Optional[str] = None
+) -> Dict[str, Any]:
+    """Transition a task to DONE. Refuses without verification evidence.
+
+    This is the ONLY function in the module that can set state=DONE. It:
+
+    1. Records ``evidence`` via :func:`record_verification` if supplied
+       (moving the task into VERIFYING if it isn't already there).
+    2. Requires a non-empty ``verification_evidence`` to already be on the
+       task row — raises :class:`VerificationRequiredError` otherwise.
+    3. For tasks created with ``approval_required=True``, requires
+       ``approved_by`` to be set — raises :class:`ApprovalRequiredError`
+       otherwise.
+    4. Only then transitions VERIFYING -> DONE.
+    """
+    task = get_task(conn, task_id)
+    if evidence:
+        task = record_verification(conn, task_id, evidence)
+    if not task.get("verification_evidence"):
+        raise VerificationRequiredError(
+            f"task {task_id} cannot be marked DONE without verification evidence "
+            "— run `hermes task verify <id> --evidence ...` first"
+        )
+    if task["approval_required"] and not task.get("approved_by"):
+        raise ApprovalRequiredError(
+            f"task {task_id} requires approval before DONE "
+            "— run `hermes task approve <id> --by ...` first"
+        )
+    if task["state"] != "VERIFYING":
+        raise InvalidTransitionError(
+            f"task {task_id} must be in VERIFYING state to be marked DONE (currently {task['state']})"
+        )
+    return set_state(
+        conn,
+        task_id,
+        "DONE",
+        event="completed",
+        detail=task["verification_evidence"],
+    )
+
+
+def block_task(conn: sqlite3.Connection, task_id: str, reason: str) -> Dict[str, Any]:
+    get_task(conn, task_id)
+    conn.execute(
+        "UPDATE tasks SET blocker = ?, updated_at = ? WHERE id = ?",
+        (reason, _now_iso(), task_id),
+    )
+    conn.commit()
+    return set_state(conn, task_id, "BLOCKED", event="blocked", detail=reason)
+
+
+def cancel_task(
+    conn: sqlite3.Connection, task_id: str, reason: Optional[str] = None
+) -> Dict[str, Any]:
+    return set_state(conn, task_id, "CANCELLED", event="cancelled", detail=reason)
+
+
+def list_events(conn: sqlite3.Connection, task_id: str) -> List[Dict[str, Any]]:
+    rows = conn.execute(
+        "SELECT * FROM task_events WHERE task_id = ? ORDER BY id ASC", (task_id,)
+    ).fetchall()
+    return [_row_to_dict(r) for r in rows]
+
+
+def age_check(
+    conn: sqlite3.Connection,
+    *,
+    enabled: bool,
+    dry_run: bool = False,
+    warn_hours: int = 24,
+    stale_hours: int = 72,
+    now: Optional[datetime] = None,
+) -> List[Dict[str, Any]]:
+    """Evaluate warn/stale aging thresholds for every non-terminal task.
+
+    Anti-spam: each tier only fires once per distinct ``state_changed_at``
+    value on the task (tracked via ``aged_24h_marker`` / ``aged_72h_marker``).
+    If the task's state changes (deliberately, or via the 72h auto-STALE
+    transition below), the anchor moves and the clock effectively resets —
+    a task doesn't get re-flagged every run.
+
+    Mutation (marker writes + the 72h auto-transition to STALE) only
+    happens when ``enabled`` is True and ``dry_run`` is False. Otherwise
+    this is a pure read — safe to call for a preview regardless of the
+    feature flag, and guaranteed inert (shadow mode) when the flag is off.
+    """
+    moment = now or _now()
+    warn_delta = timedelta(hours=warn_hours)
+    stale_delta = timedelta(hours=stale_hours)
+    flagged: List[Dict[str, Any]] = []
+
+    for task in list_tasks(conn, include_terminal=False):
+        anchor = task["state_changed_at"]
+        age = moment - _parse_iso(anchor)
+        age_hours = round(age.total_seconds() / 3600, 1)
+
+        if age >= stale_delta and task["aged_72h_marker"] != anchor:
+            flagged.append(
+                {
+                    "task_id": task["id"],
+                    "title": task["title"],
+                    "tier": "stale",
+                    "age_hours": age_hours,
+                    "state": task["state"],
+                }
+            )
+            if enabled and not dry_run:
+                set_state(
+                    conn,
+                    task["id"],
+                    "STALE",
+                    event="aging_stale",
+                    detail=f"no activity for {age_hours}h",
+                )
+                conn.execute(
+                    "UPDATE tasks SET aged_72h_marker = ? WHERE id = ?",
+                    (anchor, task["id"]),
+                )
+                conn.commit()
+        elif age >= warn_delta and task["aged_24h_marker"] != anchor:
+            flagged.append(
+                {
+                    "task_id": task["id"],
+                    "title": task["title"],
+                    "tier": "warn",
+                    "age_hours": age_hours,
+                    "state": task["state"],
+                }
+            )
+            if enabled and not dry_run:
+                conn.execute(
+                    "UPDATE tasks SET aged_24h_marker = ? WHERE id = ?",
+                    (anchor, task["id"]),
+                )
+                _log_event(
+                    conn,
+                    task["id"],
+                    "aging_warn",
+                    detail=f"no activity for {age_hours}h",
+                )
+                conn.commit()
+
+    return flagged

--- a/skills/productivity/task-ownership-controller/SKILL.md
+++ b/skills/productivity/task-ownership-controller/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: task-ownership-controller
+description: Track task state, retries, and evidence-gated completion.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [tasks, state-machine, verification, retries, cron]
+    category: productivity
+    related_skills: [weekly-review-planning]
+---
+
+# Task-Ownership Controller Skill
+
+Durable local tracking for a task you own end to end — not a TODO list, a
+state machine. It records what state a task is in, what the next action
+is, why it's blocked, how many times it's been retried, and — the
+load-bearing rule — it refuses to let you mark a task DONE without
+verification evidence on file. Backed by `hermes task`, a CLI over a local
+SQLite DB (`~/.hermes/task_ownership.db`). Off by default; explicit
+commands always work even while off (see Prerequisites).
+
+## When to Use
+
+- You're carrying a multi-step task across turns/sessions and need durable
+  state (next action, blockers, decisions) that survives context loss.
+- A task involves retries against a flaky dependency and you need a bounded
+  retry count with a recorded fallback once it's exhausted.
+- A task involves an external side effect (payment, email, API call) from
+  an at-least-once caller and you need to record receipts idempotently so
+  a retry doesn't double-book the effect.
+- You are tempted to declare a task "done" and want a hard stop that
+  forces you to record concrete verification evidence first.
+- Not for: ephemeral in-session todos with no cross-session durability need
+  — use the `todo` tool for those. Not for multi-agent/multi-worker
+  coordination across a shared board — use `kanban` for that.
+
+## Prerequisites
+
+None — ships with Hermes core, no extra install. The controller has a
+feature flag (`task_ownership.enabled` in `config.yaml`, default `false`)
+that gates only the unattended `hermes task age-check` command (e.g. run
+from cron): with the flag off, `age-check` is a strict no-op — no output,
+no state mutation. Every other command (`create`, `update`, `outcome`,
+`receipt`, `verify`, `done`, ...) works regardless of the flag, since
+those are explicit actions you're deliberately taking, not passive
+automation. Turn the flag on with `hermes task enable` once you also want
+unattended aging sweeps; `hermes task disable` cleanly turns it back off.
+
+## How to Run
+
+```bash
+hermes task create "Migrate customer export job" --next-action "write the batch script" --owner me
+# -> t_ab12cd34ef56  [NEW]  Migrate customer export job
+
+hermes task update t_ab12cd34ef56 --state WORKING
+hermes task outcome t_ab12cd34ef56 --result failure --detail "rate limited" --retry --fallback "page on-call"
+hermes task verify t_ab12cd34ef56 --evidence "output row count matches source (12,904 == 12,904)"
+hermes task done t_ab12cd34ef56
+hermes task show t_ab12cd34ef56 --json
+```
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Create a task | `hermes task create "<title>" [--next-action ...] [--owner ...] [--max-retries N] [--approval-required]` |
+| List tasks | `hermes task list [--state STATE] [--all] [--json]` |
+| Show one task | `hermes task show <id> [--json]` |
+| Update fields / explicit transition | `hermes task update <id> [--next-action ...] [--blocker ...] [--decision ...] [--owner ...] [--fallback ...] [--state STATE]` |
+| Record a worker attempt | `hermes task outcome <id> --result success\|failure\|partial [--detail ...] [--retry] [--fallback ...]` |
+| Record an idempotent external receipt | `hermes task receipt <id> --receipt-id <ext-id> [--source ...] [--payload ...]` |
+| Record verification evidence | `hermes task verify <id> --evidence "..."` |
+| Mark DONE (requires evidence on file) | `hermes task done <id> [--evidence "..."]` |
+| Record approval (approval-required tasks) | `hermes task approve <id> --by <name>` |
+| Block / cancel | `hermes task block <id> --reason "..."` / `hermes task cancel <id> [--reason ...]` |
+| Show a task's audit trail | `hermes task events <id> [--json]` |
+| Evaluate aging (24h warn / 72h stale) | `hermes task age-check [--dry-run] [--json]` |
+| Feature flag on/off | `hermes task enable` / `hermes task disable` |
+| Overview: flag state + counts by state | `hermes task status [--json]` |
+
+## Procedure
+
+1. **Create** the task with `hermes task create`. It starts in `NEW` with
+   a `next_action`.
+2. **Work it.** Move to `WORKING` via `hermes task update <id> --state
+   WORKING`. Update `next_action`/`blocker`/`decision` as you learn things
+   — these are the fields to re-read after a context reset instead of
+   re-deriving state from scratch.
+3. **Record every attempt** with `hermes task outcome`. On failure with
+   `--retry`, the controller bumps `retry_count` and moves to `RETRYING`;
+   once `retry_count` exceeds `max_retries` it auto-transitions to
+   `BLOCKED` and records whatever `--fallback` you gave on that call.
+   `outcome` can never set a task to `DONE` — that's by design.
+4. **Record receipts** for any external side effect via `hermes task
+   receipt --receipt-id <external-idempotency-key>`. Calling it twice with
+   the same `receipt_id` is a safe no-op (`duplicate: true` in the JSON) —
+   this is what makes it safe to retry the surrounding operation.
+5. **Verify before you claim done.** `hermes task verify --evidence "..."`
+   records concrete evidence (a diff, a row count match, a URL, an output
+   snippet — something checkable, not "looks right"). This moves the task
+   to `VERIFYING`.
+6. **Mark done.** `hermes task done` refuses unless verification evidence
+   is on file (recorded in step 5, or passed inline via `--evidence`) and,
+   for tasks created with `--approval-required`, unless `hermes task
+   approve` has been recorded. There is no other path to `DONE`.
+7. **(Optional) Wire aging into cron.** Once you've turned the flag on
+   with `hermes task enable`, schedule a periodic sweep:
+   ```bash
+   cat > ~/.hermes/scripts/task_age_check.sh <<'SH'
+   #!/usr/bin/env bash
+   hermes task age-check
+   SH
+   chmod +x ~/.hermes/scripts/task_age_check.sh
+   hermes cron add --no-agent --script task_age_check.sh --name task-aging "every 1h"
+   ```
+   `age-check` only prints when a task newly crosses the 24h/72h threshold
+   (each tier fires once per aging window, not every run) — empty stdout
+   is silent per the cron `--no-agent` contract, so this never spams.
+
+## Pitfalls
+
+- **Don't try to shortcut `done`.** There's no flag or force-mode to skip
+  verification evidence — that's the entire point of the invariant. If a
+  task genuinely can't be verified, record why in `--decision` and leave
+  it in `VERIFYING`/`WORKING` rather than inventing evidence.
+- **`outcome --result success` does not complete the task.** It logs the
+  attempt only. You still need `verify` + `done`.
+- **Aging only auto-progresses to `STALE`, never further** — the
+  controller doesn't auto-cancel or auto-retry a stale task. A human/agent
+  has to look at it and move it via `hermes task update --state WORKING`
+  (or `cancel`).
+- **`--max-retries` is set at creation** (or via `hermes task update
+  --max-retries`); raising it after the fact does not clear an existing
+  `BLOCKED` state — you still need `--state WORKING` to resume.
+
+## Verification
+
+- [ ] `hermes task show <id>` reflects the expected state, next action,
+      and (if applicable) verification evidence.
+- [ ] `hermes task events <id>` shows a `verification_recorded` event
+      before any `completed` event — DONE never appears without it.
+- [ ] `hermes task status` shows the feature flag state you expect before
+      relying on `age-check` output in automation.

--- a/tests/hermes_cli/test_task_ownership_cli.py
+++ b/tests/hermes_cli/test_task_ownership_cli.py
@@ -1,0 +1,282 @@
+"""CLI-level tests for ``hermes task``.
+
+HERMES_HOME is isolated per test by the autouse ``_hermetic_environment``
+fixture in tests/conftest.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hermes_cli import task_ownership as tcli
+from hermes_cli import task_ownership_db as tdb
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="hermes", add_help=False)
+    sub = parser.add_subparsers(dest="command")
+    task_parser = sub.add_parser("task", add_help=False)
+    tcli.register_cli(task_parser)
+    return parser
+
+
+def run(argv, capsys=None):
+    parser = _build_parser()
+    args = parser.parse_args(["task", *argv])
+    rc = args.func(args)
+    if capsys is not None:
+        # Drain output now so an unrelated later run_json() doesn't pick up
+        # this call's stdout along with its own.
+        capsys.readouterr()
+    return rc
+
+
+def run_json(capsys, argv):
+    rc = run(argv)
+    out = capsys.readouterr().out
+    return rc, json.loads(out)
+
+
+def _create(capsys, title="Sample task", extra=None) -> str:
+    argv = ["create", title, "--json"]
+    if extra:
+        argv += extra
+    rc, task = run_json(capsys, argv)
+    assert rc == 0
+    return task["id"]
+
+
+# ── happy path CRUD ──────────────────────────────────────────────────────
+
+
+def test_create_show_list(capsys):
+    task_id = _create(capsys)
+    rc, shown = run_json(capsys, ["show", task_id, "--json"])
+    assert rc == 0
+    assert shown["id"] == task_id
+    assert shown["state"] == "NEW"
+
+    rc, listed = run_json(capsys, ["list", "--json"])
+    assert rc == 0
+    assert any(t["id"] == task_id for t in listed)
+
+
+def test_show_missing_task_returns_error(capsys):
+    rc = run(["show", "t_nope"])
+    assert rc == 1
+    assert "no such task" in capsys.readouterr().err
+
+
+def test_update_next_action_and_explicit_state(capsys):
+    task_id = _create(capsys)
+    rc, task = run_json(
+        capsys,
+        ["update", task_id, "--next-action", "write tests", "--state", "WORKING", "--json"],
+    )
+    assert rc == 0
+    assert task["next_action"] == "write tests"
+    assert task["state"] == "WORKING"
+
+
+def test_update_invalid_transition_errors(capsys):
+    task_id = _create(capsys)
+    rc = run(["update", task_id, "--state", "DONE"])
+    assert rc == 1
+    assert "not a valid transition" in capsys.readouterr().err
+
+
+# ── no-false-completion invariant ───────────────────────────────────────
+
+
+def test_done_without_evidence_is_refused(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"])
+    rc = run(["done", task_id])
+    assert rc == 1
+    assert "verification evidence" in capsys.readouterr().err
+    _, task = run_json(capsys, ["show", task_id, "--json"])
+    assert task["state"] != "DONE"
+
+
+def test_verify_then_done_succeeds(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    rc = run(["verify", task_id, "--evidence", "output diff is empty"], capsys)
+    assert rc == 0
+    rc, task = run_json(capsys, ["done", task_id, "--json"])
+    assert rc == 0
+    assert task["state"] == "DONE"
+
+
+def test_approval_required_task_needs_approve_before_done(capsys):
+    task_id = _create(capsys, extra=["--approval-required"])
+    run(["update", task_id, "--state", "WORKING"])
+    run(["verify", task_id, "--evidence", "checked"])
+
+    rc = run(["done", task_id])
+    assert rc == 1
+    assert "approval" in capsys.readouterr().err.lower()
+
+    run(["approve", task_id, "--by", "operator"], capsys)
+    rc, task = run_json(capsys, ["done", task_id, "--json"])
+    assert rc == 0
+    assert task["state"] == "DONE"
+
+
+# ── duplicate receipts ───────────────────────────────────────────────────
+
+
+def test_duplicate_receipt_cli_is_reported_as_noop(capsys):
+    task_id = _create(capsys)
+    rc = run(["receipt", task_id, "--receipt-id", "ext-1", "--source", "stripe"])
+    assert rc == 0
+    assert "recorded" in capsys.readouterr().out
+
+    rc = run(["receipt", task_id, "--receipt-id", "ext-1", "--source", "stripe"])
+    assert rc == 0
+    assert "no-op" in capsys.readouterr().out
+
+
+# ── retries + fallback ───────────────────────────────────────────────────
+
+
+def test_outcome_retry_exhausts_and_records_fallback(capsys):
+    task_id = _create(capsys, extra=["--max-retries", "1"])
+    run(["update", task_id, "--state", "WORKING"], capsys)
+
+    rc, task = run_json(
+        capsys, ["outcome", task_id, "--result", "failure", "--retry", "--json"]
+    )
+    assert task["state"] == "RETRYING"
+
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    rc, task = run_json(
+        capsys,
+        [
+            "outcome", task_id, "--result", "failure", "--retry",
+            "--fallback", "notify on-call", "--json",
+        ],
+    )
+    assert rc == 0
+    assert task["state"] == "BLOCKED"
+    assert task["fallback"] == "notify on-call"
+
+
+def test_outcome_success_does_not_complete_task(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    rc, task = run_json(
+        capsys, ["outcome", task_id, "--result", "success", "--json"]
+    )
+    assert rc == 0
+    assert task["state"] != "DONE"
+
+
+# ── events / audit trail ─────────────────────────────────────────────────
+
+
+def test_events_trail_shows_verification_before_completion(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    run(["verify", task_id, "--evidence", "confirmed"], capsys)
+    run(["done", task_id], capsys)
+
+    rc, events = run_json(capsys, ["events", task_id, "--json"])
+    assert rc == 0
+    kinds = [e["event"] for e in events]
+    assert kinds.index("verification_recorded") < kinds.index("completed")
+
+
+# ── feature flag / shadow mode ───────────────────────────────────────────
+
+
+def test_status_reports_disabled_by_default(capsys):
+    rc, status = run_json(capsys, ["status", "--json"])
+    assert rc == 0
+    assert status["enabled"] is False
+
+
+def test_age_check_is_silent_and_inert_while_disabled(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+
+    conn = tdb.connect()
+    when = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    conn.execute(
+        "UPDATE tasks SET state_changed_at = ?, updated_at = ? WHERE id = ?",
+        (when, when, task_id),
+    )
+    conn.commit()
+
+    rc = run(["age-check"])
+    assert rc == 0
+    assert capsys.readouterr().out == ""  # no notification spam while off
+
+    _, task = run_json(capsys, ["show", task_id, "--json"])
+    assert task["state"] == "WORKING"  # untouched — shadow mode is inert
+
+
+def test_age_check_dry_run_works_regardless_of_flag(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"])
+    conn = tdb.connect()
+    when = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    conn.execute(
+        "UPDATE tasks SET state_changed_at = ?, updated_at = ? WHERE id = ?",
+        (when, when, task_id),
+    )
+    conn.commit()
+
+    rc = run(["age-check", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert task_id in out
+    assert "[DRY RUN]" in out
+
+    _, task = run_json(capsys, ["show", task_id, "--json"])
+    assert task["state"] == "WORKING"  # dry-run never mutates
+
+
+def test_enable_disable_flip_age_check_behavior(capsys):
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    conn = tdb.connect()
+    when = (datetime.now(timezone.utc) - timedelta(hours=100)).isoformat()
+    conn.execute(
+        "UPDATE tasks SET state_changed_at = ?, updated_at = ? WHERE id = ?",
+        (when, when, task_id),
+    )
+    conn.commit()
+
+    rc = run(["enable"], capsys)
+    assert rc == 0
+    _, status = run_json(capsys, ["status", "--json"])
+    assert status["enabled"] is True
+
+    rc = run(["age-check"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert task_id in out
+    _, task = run_json(capsys, ["show", task_id, "--json"])
+    assert task["state"] == "STALE"
+
+    # Clean rollback: disable makes age-check inert again immediately.
+    rc = run(["disable"], capsys)
+    assert rc == 0
+    _, status = run_json(capsys, ["status", "--json"])
+    assert status["enabled"] is False
+
+
+def test_disable_does_not_touch_existing_task_state(capsys):
+    """Rollback (disabling the flag) must never mutate/delete durable state."""
+    task_id = _create(capsys)
+    run(["update", task_id, "--state", "WORKING"], capsys)
+    run(["enable"], capsys)
+    run(["disable"], capsys)
+    _, task = run_json(capsys, ["show", task_id, "--json"])
+    assert task["id"] == task_id
+    assert task["state"] == "WORKING"

--- a/tests/hermes_cli/test_task_ownership_db.py
+++ b/tests/hermes_cli/test_task_ownership_db.py
@@ -1,0 +1,323 @@
+"""Storage-engine tests for the task-ownership controller.
+
+HERMES_HOME is isolated per test by the autouse ``_hermetic_environment``
+fixture in tests/conftest.py, so every test gets a fresh
+task_ownership.db with no extra setup.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hermes_cli import task_ownership_db as tdb
+
+
+@pytest.fixture
+def conn():
+    with tdb.connect_closing() as c:
+        yield c
+
+
+def _touch_state_changed_at(conn, task_id: str, hours_ago: float) -> None:
+    when = (datetime.now(timezone.utc) - timedelta(hours=hours_ago)).isoformat()
+    conn.execute(
+        "UPDATE tasks SET state_changed_at = ?, updated_at = ? WHERE id = ?",
+        (when, when, task_id),
+    )
+    conn.commit()
+
+
+# ── basic CRUD ───────────────────────────────────────────────────────────
+
+
+def test_create_task_starts_new(conn):
+    task = tdb.create_task(conn, title="Do the thing", next_action="start it")
+    assert task["state"] == "NEW"
+    assert task["next_action"] == "start it"
+    assert task["retry_count"] == 0
+    assert task["max_retries"] == 3
+
+    fetched = tdb.get_task(conn, task["id"])
+    assert fetched == task
+
+
+def test_get_missing_task_raises(conn):
+    with pytest.raises(tdb.TaskNotFoundError):
+        tdb.get_task(conn, "t_does_not_exist")
+
+
+def test_list_tasks_excludes_terminal_by_default(conn):
+    a = tdb.create_task(conn, title="A")
+    b = tdb.create_task(conn, title="B")
+    tdb.set_state(conn, b["id"], "WORKING")
+    tdb.set_state(conn, b["id"], "CANCELLED")
+
+    active = tdb.list_tasks(conn, include_terminal=False)
+    assert [t["id"] for t in active] == [a["id"]]
+
+    everything = tdb.list_tasks(conn, include_terminal=True)
+    assert {t["id"] for t in everything} == {a["id"], b["id"]}
+
+
+# ── state machine ────────────────────────────────────────────────────────
+
+
+def test_valid_transition_chain(conn):
+    task = tdb.create_task(conn, title="Chain")
+    task = tdb.set_state(conn, task["id"], "WORKING")
+    assert task["state"] == "WORKING"
+    task = tdb.set_state(conn, task["id"], "VERIFYING")
+    assert task["state"] == "VERIFYING"
+
+
+def test_invalid_transition_rejected(conn):
+    task = tdb.create_task(conn, title="Bad jump")
+    with pytest.raises(tdb.InvalidTransitionError):
+        tdb.set_state(conn, task["id"], "DONE")  # NEW -> DONE is not reachable
+    # State must be unchanged after the rejected attempt.
+    assert tdb.get_task(conn, task["id"])["state"] == "NEW"
+
+
+@pytest.mark.parametrize("terminal", ["DONE", "CANCELLED"])
+def test_terminal_states_have_no_outgoing_transitions(terminal):
+    assert tdb.TRANSITIONS[terminal] == frozenset()
+
+
+def test_same_state_transition_is_a_noop(conn):
+    task = tdb.create_task(conn, title="Idempotent")
+    before = tdb.get_task(conn, task["id"])
+    after = tdb.set_state(conn, task["id"], "NEW")
+    assert after["updated_at"] == before["updated_at"]
+
+
+# ── no-false-completion invariant ───────────────────────────────────────
+
+
+def test_mark_done_without_evidence_is_refused(conn):
+    task = tdb.create_task(conn, title="Needs proof")
+    tdb.set_state(conn, task["id"], "WORKING")
+    tdb.set_state(conn, task["id"], "VERIFYING")
+    with pytest.raises(tdb.VerificationRequiredError):
+        tdb.mark_done(conn, task["id"])
+    assert tdb.get_task(conn, task["id"])["state"] == "VERIFYING"
+
+
+def test_mark_done_requires_verifying_state_even_with_evidence_field_set(conn):
+    """Evidence alone isn't enough — the task must actually be in VERIFYING."""
+    task = tdb.create_task(conn, title="Sneaky")
+    # Directly poke evidence onto a NEW task without going through the
+    # normal record_verification() path (which would itself transition to
+    # VERIFYING) to prove mark_done() checks *state*, not just the field.
+    conn.execute(
+        "UPDATE tasks SET verification_evidence = 'looks fine' WHERE id = ?",
+        (task["id"],),
+    )
+    conn.commit()
+    with pytest.raises(tdb.InvalidTransitionError):
+        tdb.mark_done(conn, task["id"])
+
+
+def test_verify_then_done_succeeds(conn):
+    task = tdb.create_task(conn, title="Provable")
+    tdb.set_state(conn, task["id"], "WORKING")
+    tdb.record_verification(conn, task["id"], "row counts match: 100 == 100")
+    done = tdb.mark_done(conn, task["id"])
+    assert done["state"] == "DONE"
+    assert done["verification_evidence"] == "row counts match: 100 == 100"
+
+
+def test_done_with_inline_evidence_succeeds_without_prior_verify_call(conn):
+    task = tdb.create_task(conn, title="Inline proof")
+    tdb.set_state(conn, task["id"], "WORKING")
+    done = tdb.mark_done(conn, task["id"], evidence="checked output by hand")
+    assert done["state"] == "DONE"
+
+
+def test_outcome_success_never_completes_a_task(conn):
+    """A worker reporting success cannot, by itself, produce DONE."""
+    task = tdb.create_task(conn, title="Reported done")
+    tdb.set_state(conn, task["id"], "WORKING")
+    result = tdb.record_outcome(conn, task["id"], result="success", detail="looks done to me")
+    assert result["state"] == "WORKING"
+    assert result["state"] != "DONE"
+
+
+def test_events_log_records_verification_before_completion(conn):
+    task = tdb.create_task(conn, title="Audited")
+    tdb.set_state(conn, task["id"], "WORKING")
+    tdb.record_verification(conn, task["id"], "checked")
+    tdb.mark_done(conn, task["id"])
+    events = tdb.list_events(conn, task["id"])
+    kinds = [e["event"] for e in events]
+    assert "verification_recorded" in kinds
+    assert "completed" in kinds
+    assert kinds.index("verification_recorded") < kinds.index("completed")
+
+
+def test_approval_required_blocks_done_until_approved(conn):
+    task = tdb.create_task(conn, title="Needs sign-off", approval_required=True)
+    tdb.set_state(conn, task["id"], "WORKING")
+    tdb.record_verification(conn, task["id"], "evidence attached")
+    with pytest.raises(tdb.ApprovalRequiredError):
+        tdb.mark_done(conn, task["id"])
+
+    tdb.approve_task(conn, task["id"], "zalmen")
+    done = tdb.mark_done(conn, task["id"])
+    assert done["state"] == "DONE"
+    assert done["approved_by"] == "zalmen"
+
+
+# ── duplicate / idempotent receipts ─────────────────────────────────────
+
+
+def test_duplicate_receipt_is_idempotent_noop(conn):
+    task = tdb.create_task(conn, title="Payment task")
+    first = tdb.record_receipt(conn, task["id"], receipt_id="ext-123", source="stripe")
+    assert first["duplicate"] is False
+
+    second = tdb.record_receipt(conn, task["id"], receipt_id="ext-123", source="stripe")
+    assert second["duplicate"] is True
+    assert second["id"] == first["id"]
+
+    rows = tdb.list_receipts(conn, task["id"])
+    assert len(rows) == 1
+
+
+def test_different_receipt_ids_both_recorded(conn):
+    task = tdb.create_task(conn, title="Multi-receipt")
+    tdb.record_receipt(conn, task["id"], receipt_id="a")
+    tdb.record_receipt(conn, task["id"], receipt_id="b")
+    assert len(tdb.list_receipts(conn, task["id"])) == 2
+
+
+def test_receipt_requires_existing_task(conn):
+    with pytest.raises(tdb.TaskNotFoundError):
+        tdb.record_receipt(conn, "t_missing", receipt_id="x")
+
+
+# ── retries + fallback ──────────────────────────────────────────────────
+
+
+def test_retry_moves_to_retrying_until_limit(conn):
+    task = tdb.create_task(conn, title="Flaky", max_retries=2)
+    tdb.set_state(conn, task["id"], "WORKING")
+
+    r1 = tdb.record_outcome(conn, task["id"], result="failure", detail="timeout", retry=True)
+    assert r1["state"] == "RETRYING"
+    assert r1["retry_count"] == 1
+
+    tdb.set_state(conn, task["id"], "WORKING")
+    r2 = tdb.record_outcome(conn, task["id"], result="failure", detail="timeout again", retry=True)
+    assert r2["state"] == "RETRYING"
+    assert r2["retry_count"] == 2
+
+
+def test_retry_limit_exceeded_blocks_and_records_fallback(conn):
+    task = tdb.create_task(conn, title="Doomed", max_retries=1)
+    tdb.set_state(conn, task["id"], "WORKING")
+    tdb.record_outcome(conn, task["id"], result="failure", retry=True)
+    tdb.set_state(conn, task["id"], "WORKING")
+
+    result = tdb.record_outcome(
+        conn, task["id"], result="failure", retry=True, fallback="escalate to on-call"
+    )
+    assert result["state"] == "BLOCKED"
+    assert result["retry_count"] == 2
+    assert "retry limit exceeded" in result["blocker"]
+    assert result["fallback"] == "escalate to on-call"
+
+
+def test_outcome_without_retry_flag_does_not_change_state(conn):
+    task = tdb.create_task(conn, title="Just logging")
+    tdb.set_state(conn, task["id"], "WORKING")
+    result = tdb.record_outcome(conn, task["id"], result="failure", detail="noted")
+    assert result["state"] == "WORKING"
+    assert result["retry_count"] == 0
+
+
+def test_invalid_outcome_result_rejected(conn):
+    task = tdb.create_task(conn, title="Bad result")
+    with pytest.raises(ValueError):
+        tdb.record_outcome(conn, task["id"], result="maybe")
+
+
+# ── aging ────────────────────────────────────────────────────────────────
+
+
+def test_aging_warn_tier_flags_without_state_change(conn):
+    task = tdb.create_task(conn, title="Getting old")
+    _touch_state_changed_at(conn, task["id"], hours_ago=25)
+
+    flagged = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert len(flagged) == 1
+    assert flagged[0]["tier"] == "warn"
+    assert tdb.get_task(conn, task["id"])["state"] == "NEW"
+
+
+def test_aging_stale_tier_auto_transitions(conn):
+    task = tdb.create_task(conn, title="Really old")
+    tdb.set_state(conn, task["id"], "WORKING")
+    _touch_state_changed_at(conn, task["id"], hours_ago=73)
+
+    flagged = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert len(flagged) == 1
+    assert flagged[0]["tier"] == "stale"
+    assert tdb.get_task(conn, task["id"])["state"] == "STALE"
+
+
+def test_aging_does_not_repeat_within_same_window(conn):
+    """No notification spam: the same threshold crossing only fires once."""
+    task = tdb.create_task(conn, title="Silent")
+    _touch_state_changed_at(conn, task["id"], hours_ago=25)
+
+    first = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert len(first) == 1
+
+    second = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert second == []
+
+
+def test_aging_dry_run_never_mutates(conn):
+    task = tdb.create_task(conn, title="Preview only")
+    tdb.set_state(conn, task["id"], "WORKING")
+    _touch_state_changed_at(conn, task["id"], hours_ago=73)
+
+    flagged = tdb.age_check(conn, enabled=True, dry_run=True, warn_hours=24, stale_hours=72)
+    assert len(flagged) == 1
+    assert tdb.get_task(conn, task["id"])["state"] == "WORKING"
+
+    # A live run afterwards still fires — dry-run left no marker behind.
+    live = tdb.age_check(conn, enabled=True, dry_run=False, warn_hours=24, stale_hours=72)
+    assert len(live) == 1
+    assert tdb.get_task(conn, task["id"])["state"] == "STALE"
+
+
+def test_aging_disabled_flag_never_mutates_even_when_flagged(conn):
+    task = tdb.create_task(conn, title="Shadow")
+    tdb.set_state(conn, task["id"], "WORKING")
+    _touch_state_changed_at(conn, task["id"], hours_ago=73)
+
+    flagged = tdb.age_check(conn, enabled=False, warn_hours=24, stale_hours=72)
+    assert len(flagged) == 1  # still computed/returned for introspection
+    assert tdb.get_task(conn, task["id"])["state"] == "WORKING"  # but not applied
+
+
+def test_aging_resets_after_state_change(conn):
+    task = tdb.create_task(conn, title="Revived")
+    _touch_state_changed_at(conn, task["id"], hours_ago=25)
+    tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+
+    tdb.set_state(conn, task["id"], "WORKING")  # moves state_changed_at forward
+    flagged = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert flagged == []  # fresh anchor, not yet 24h old again
+
+
+def test_aging_ignores_terminal_tasks(conn):
+    task = tdb.create_task(conn, title="Finished")
+    tdb.set_state(conn, task["id"], "CANCELLED")
+    _touch_state_changed_at(conn, task["id"], hours_ago=200)
+
+    flagged = tdb.age_check(conn, enabled=True, warn_hours=24, stale_hours=72)
+    assert flagged == []


### PR DESCRIPTION
## Summary
- Adds durable local task ownership state: a bounded retry counter, idempotent external receipts, aging (warn/stale), and evidence-gated DONE transitions, backed by a local SQLite DB.
- Ships as a CLI command (`hermes task ...`) plus a bundled skill (`task-ownership-controller`).
- `task_ownership.enabled` config flag is off by default; only the unattended `age-check` command is gated by the flag.

## Test plan
- [x] `tests/hermes_cli/test_task_ownership_cli.py`
- [x] `tests/hermes_cli/test_task_ownership_db.py`