### PR TITLE
fix(desktop): pop-out Browser comment mode flushes to the primary window composer

### DIFF
--- a/apps/desktop/electron/annotate-flush.test.ts
+++ b/apps/desktop/electron/annotate-flush.test.ts
@@ -1,0 +1,45 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { ANNOTATE_FLUSH_MAX_ITEMS, isAnnotateFlushEnvelope } from './annotate-flush'
+
+function envelope(partial: Record<string, unknown> = {}) {
+  return {
+    id: 'flush-1',
+    items: [{ imageDataUrl: 'data:image/png;base64,AAAA', note: 'note', number: 1, prompt: 'Comment 1' }],
+    pageUrl: 'http://127.0.0.1:4173/',
+    ...partial
+  }
+}
+
+test('isAnnotateFlushEnvelope accepts a well-shaped envelope', () => {
+  assert.equal(isAnnotateFlushEnvelope(envelope()), true)
+})
+
+test('isAnnotateFlushEnvelope accepts pins without crops', () => {
+  assert.equal(isAnnotateFlushEnvelope(envelope({ items: [{ number: 2, prompt: 'Comment 2' }] })), true)
+})
+
+test('isAnnotateFlushEnvelope rejects non-objects and envelopes without items', () => {
+  for (const value of [null, undefined, 'flush', 42, [], { id: 'x' }, envelope({ items: [] })]) {
+    assert.equal(isAnnotateFlushEnvelope(value), false)
+  }
+})
+
+test('isAnnotateFlushEnvelope rejects malformed ids and items', () => {
+  assert.equal(isAnnotateFlushEnvelope(envelope({ id: '' })), false)
+  assert.equal(isAnnotateFlushEnvelope(envelope({ items: [{ number: '1', prompt: 'x' }] })), false)
+  assert.equal(isAnnotateFlushEnvelope(envelope({ items: [{ number: 1 }] })), false)
+  assert.equal(isAnnotateFlushEnvelope(envelope({ items: [{ number: 1, prompt: 'x', imageDataUrl: 7 }] })), false)
+  assert.equal(isAnnotateFlushEnvelope(envelope({ pageUrl: 42 })), false)
+})
+
+test('isAnnotateFlushEnvelope caps the pin count', () => {
+  const items = Array.from({ length: ANNOTATE_FLUSH_MAX_ITEMS + 1 }, (_, index) => ({
+    number: index + 1,
+    prompt: `Comment ${index + 1}`
+  }))
+
+  assert.equal(isAnnotateFlushEnvelope(envelope({ items })), false)
+})

--- a/apps/desktop/electron/annotate-flush.ts
+++ b/apps/desktop/electron/annotate-flush.ts
@@ -1,0 +1,92 @@
+/**
+ * Pop-out annotate-flush relay (main process side).
+ *
+ * The popped-out Browser lives in its own OS window/renderer with no composer,
+ * so it cannot flush comment pins locally. It packages its pin stack and posts
+ * the envelope here; the main process validates the shape and forwards it to
+ * the primary window, whose renderer attaches the crops + prompt to the real
+ * composer. Keeps the untrusted renderer payload small and well-shaped before
+ * it crosses the IPC boundary.
+ */
+
+export interface AnnotateFlushItem {
+  imageDataUrl?: string
+  note?: string
+  number?: number
+  prompt?: string
+}
+
+export interface AnnotateFlushEnvelope {
+  id?: string
+  items?: AnnotateFlushItem[]
+  pageUrl?: string
+}
+
+/** Hard ceiling on pins per flush — a human click, not a bulk import. */
+export const ANNOTATE_FLUSH_MAX_ITEMS = 100
+
+/** Hard ceiling on the encoded crops riding one flush (~base64 PNG bytes). */
+export const ANNOTATE_FLUSH_MAX_CHARS = 32 * 1024 * 1024
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function isFlushItem(value: unknown): value is AnnotateFlushItem {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  if (typeof value.number !== 'number' || !Number.isFinite(value.number)) {
+    return false
+  }
+
+  if (typeof value.prompt !== 'string') {
+    return false
+  }
+
+  if (value.imageDataUrl !== undefined && typeof value.imageDataUrl !== 'string') {
+    return false
+  }
+
+  if (value.note !== undefined && typeof value.note !== 'string') {
+    return false
+  }
+
+  return true
+}
+
+/** Shape + size gate for a renderer-posted flush envelope. */
+export function isAnnotateFlushEnvelope(value: unknown): value is AnnotateFlushEnvelope {
+  if (!isRecord(value)) {
+    return false
+  }
+
+  if (typeof value.id !== 'string' || value.id.length === 0 || value.id.length > 256) {
+    return false
+  }
+
+  if (!Array.isArray(value.items) || value.items.length === 0 || value.items.length > ANNOTATE_FLUSH_MAX_ITEMS) {
+    return false
+  }
+
+  if (value.pageUrl !== undefined && typeof value.pageUrl !== 'string') {
+    return false
+  }
+
+  let chars = 0
+
+  for (const item of value.items) {
+    if (!isFlushItem(item)) {
+      return false
+    }
+
+    chars += (item.imageDataUrl?.length ?? 0) + item.prompt.length + (item.note?.length ?? 0)
+
+    if (chars > ANNOTATE_FLUSH_MAX_CHARS) {
+      return false
+    }
+  }
+
+  return true
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -31,6 +31,7 @@ import {
 } from 'electron'
 
 import { classifyActiveRuntime } from './active-runtime-state'
+import { isAnnotateFlushEnvelope } from './annotate-flush'
 import { destroyKeepaliveAgents, downloadAgentFor, jsonAgentFor, withRetry } from './api-transport'
 import { appIconCandidates, resolveAppIcon } from './app-icon'
 import { stopBackendChild as stopBackendChildImpl, stopBackendTreesForUpdate } from './backend-child'
@@ -14841,6 +14842,31 @@ ipcMain.handle('hermes:window:openBrowser', async (_event, tabId) => {
   }
 
   createBrowserWindow(tabId.trim())
+
+  return { ok: true }
+})
+
+// Pop-out annotate flush: a popped-out Browser has no composer in its
+// renderer, so it posts its packaged comment pins here for the primary
+// window, whose receiver attaches them to the real composer. Fail closed —
+// the pop-out keeps its pins when there is nowhere to deliver them.
+ipcMain.handle('hermes:annotate:flush', async (_event, payload) => {
+  if (!isAnnotateFlushEnvelope(payload)) {
+    return { ok: false, error: 'invalid-payload' }
+  }
+
+  if (!mainWindow || mainWindow.isDestroyed()) {
+    return { ok: false, error: 'no-main-window' }
+  }
+
+  mainWindow.webContents.send('hermes:annotate:flushed', payload)
+
+  try {
+    mainWindow.focus()
+  } catch {
+    // Focusing is a courtesy so the user sees where the comments landed —
+    // delivery already happened above.
+  }
 
   return { ok: true }
 })

--- a/apps/desktop/electron/preload.ts
+++ b/apps/desktop/electron/preload.ts
@@ -42,6 +42,16 @@ contextBridge.exposeInMainWorld('hermesDesktop', {
 
     return () => ipcRenderer.removeListener('hermes:browser-popout:closed', listener)
   },
+  // Pop-out annotate flush: the popped-out Browser has no composer, so it
+  // posts its packaged comment pins here; main forwards them to the primary
+  // window, whose receiver attaches them to the real composer.
+  postAnnotateFlush: envelope => ipcRenderer.invoke('hermes:annotate:flush', envelope),
+  onAnnotateFlushed: callback => {
+    const listener = (_event, envelope) => callback(envelope)
+    ipcRenderer.on('hermes:annotate:flushed', listener)
+
+    return () => ipcRenderer.removeListener('hermes:annotate:flushed', listener)
+  },
   claimAmbientCue: key => ipcRenderer.invoke('hermes:ambient:claim', key),
   wakeIndicator: {
     getState: () => ipcRenderer.invoke('hermes:wake-indicator:get'),

--- a/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-pane.tsx
@@ -23,7 +23,8 @@ import {
   emptyAnnotateSession,
   emptyAnnotateStack,
   endAnnotateMode,
-  flushAnnotateStack
+  flushAnnotateStack,
+  postPopoutAnnotateFlush
 } from '@/lib/preview-annotate'
 import { reachablePreviewUrl } from '@/lib/preview-reach'
 import { rafCoalesce } from '@/lib/raf-coalesce'
@@ -517,6 +518,37 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
 
     const guest = annotateGuest()
 
+    // The popped-out Browser has no composer in its renderer — the
+    // same-window composer bus has no subscriber there, so hand the packaged
+    // stack to the primary window instead of flushing it into the void.
+    if (isBrowserWindow()) {
+      let delivered = false
+
+      try {
+        delivered = (await postPopoutAnnotateFlush(pins, currentUrl)).delivered
+      } catch (error) {
+        notifyError(error, copy.annotateFailed)
+
+        return
+      }
+
+      if (!delivered) {
+        notify({ kind: 'warning', title: copy.annotate, message: copy.annotateFlushUnavailable })
+
+        return
+      }
+
+      setAnnotate(session => ({ ...session, draft: null, stack: clearAnnotatePins(session.stack) }))
+      setDraftNote('')
+
+      if (guest) {
+        await hideAnnotateDraft(guest).catch(() => undefined)
+        await syncAnnotatePins(guest, []).catch(() => undefined)
+      }
+
+      return
+    }
+
     await flushAnnotateStack(
       pins,
       {
@@ -535,7 +567,7 @@ export function PreviewPane({ embedded = false, onRestartServer, reloadRequest =
       await hideAnnotateDraft(guest).catch(() => undefined)
       await syncAnnotatePins(guest, []).catch(() => undefined)
     }
-  }, [annotateGuest, currentUrl])
+  }, [annotateGuest, copy.annotate, copy.annotateFailed, copy.annotateFlushUnavailable, currentUrl])
 
   const startAnnotate = useCallback(async () => {
     const guest = annotateGuest()

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -45,6 +45,7 @@ import { translateNow } from '@/i18n'
 import { NEW_SESSION_TITLE, sessionTitle as storedSessionTitle } from '@/lib/chat-runtime'
 import { Download, FileText, LayoutDashboard, PanelBottom, PanelTop, Terminal, Upload, Zap } from '@/lib/icons'
 import { type KeybindContribution, KEYBINDS_AREA } from '@/lib/keybinds/actions'
+import { installAnnotateFlushReceiver } from '@/lib/preview-annotate'
 import { TRANSCRIPT_DIRECTIVE_AREA, type TranscriptDirectiveContribution } from '@/lib/transcript-directives'
 import { setYoloEnabled } from '@/lib/yolo-session'
 import { pruneComposerPopoutZones } from '@/store/composer-popout'
@@ -74,7 +75,7 @@ import { watchSessionPins } from '@/store/session-pin-sync'
 import { $botChatScopes } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
 import { $statusbarVisible } from '@/store/statusbar-prefs'
-import { isBrowserWindow, isHudWindow } from '@/store/windows'
+import { isAuxiliaryWindow, isBrowserWindow, isHudWindow } from '@/store/windows'
 
 import { BrowserPopoutShell } from '../chat/browser-popout-shell'
 import type { SessionDragPayload } from '../chat/composer/inline-refs'
@@ -463,6 +464,14 @@ if (!isBrowserWindow() && !isHudWindow()) {
   startUnrestoredTileTitleBackfill()
   watchRouteTiles()
   watchPreviewTiles()
+}
+
+// Pop-out annotate flushes land in the primary window's composer. Auxiliary
+// windows (secondary, HUD, and the pop-out itself) never install the receiver:
+// secondary windows own their own composers, and the pop-out has none —
+// installing it there would swallow its own flushes back into the void.
+if (!isAuxiliaryWindow()) {
+  installAnnotateFlushReceiver()
 }
 
 // Composer pop-out state is keyed by layout zone, so drop entries for zones the

--- a/apps/desktop/src/global.d.ts
+++ b/apps/desktop/src/global.d.ts
@@ -81,6 +81,20 @@ declare global {
       // `onBrowserPopoutClosed` so the caller can dock the tab again.
       openBrowserWindow: (tabId: string) => Promise<{ ok: boolean; error?: string }>
       onBrowserPopoutClosed: (callback: (tabId: string) => void) => () => void
+      // Pop-out annotate flush: post packaged comment pins for the primary
+      // window's composer (`hermes:annotate:flush`), and receive them there
+      // (`hermes:annotate:flushed`). Items carry the packed per-comment prompt
+      // plus the crop as a data URL; the receiver rebuilds `Comment_N.png`.
+      postAnnotateFlush: (envelope: {
+        id: string
+        items: { imageDataUrl?: string; note?: string; number: number; prompt: string }[]
+        pageUrl?: string
+      }) => Promise<{ error?: string; ok: boolean }>
+      onAnnotateFlushed: (callback: (envelope: {
+        id: string
+        items: { imageDataUrl?: string; note?: string; number: number; prompt: string }[]
+        pageUrl?: string
+      }) => void) => () => void
       // Claim a one-shot cross-window ambient cue (turn-end sound / spoken
       // reply). Resolves true for the first window to claim a key, false for
       // peers — so N open windows don't all fire the same cue.

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3274,6 +3274,7 @@ export const en: Translations = {
       annotateOn: 'Stop annotating',
       annotateNeedPage: 'Open a page in the in-app browser first.',
       annotateFailed: 'Could not start annotation mode',
+      annotateFlushUnavailable: 'Could not reach the main window — keep this window open with the app and try again.',
       commenting: 'Commenting',
       addComments: count => (count === 1 ? 'Add 1 comment' : `Add ${count} comments`),
       commentPlaceholder: 'Add a comment...',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2816,6 +2816,7 @@ export interface Translations {
       annotateOn: string
       annotateNeedPage: string
       annotateFailed: string
+      annotateFlushUnavailable: string
       commenting: string
       addComments: (count: number) => string
       commentPlaceholder: string

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3421,6 +3421,7 @@ export const zh: Translations = {
       annotateOn: '停止标注',
       annotateNeedPage: '请先在内置浏览器中打开页面。',
       annotateFailed: '无法开始标注',
+      annotateFlushUnavailable: '无法连接到主窗口——请保持应用主窗口打开，然后重试。',
       commenting: '标注中',
       addComments: count => (count === 1 ? '添加 1 条批注' : `添加 ${count} 条批注`),
       commentPlaceholder: '添加批注…',

--- a/apps/desktop/src/lib/preview-annotate/bridge.test.ts
+++ b/apps/desktop/src/lib/preview-annotate/bridge.test.ts
@@ -1,0 +1,145 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { type AnnotateFlushEnvelope, installAnnotateFlushReceiver, postPopoutAnnotateFlush } from './bridge'
+import type { AnnotatePin } from './stack'
+
+const png =
+  'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg=='
+
+function pin(partial: Partial<AnnotatePin> = {}): AnnotatePin {
+  return {
+    id: 'annotate-1',
+    imageDataUrl: png,
+    kind: 'element',
+    note: 'This button overflows on mobile.',
+    number: 1,
+    pageTitle: 'Pricing',
+    pageUrl: 'http://127.0.0.1:4173/',
+    rect: { height: 40, width: 120, x: 8, y: 8 },
+    ...partial
+  }
+}
+
+function setBridge(bridge: unknown) {
+  ;(window as unknown as { hermesDesktop?: unknown }).hermesDesktop = bridge as never
+}
+
+const tick = () => new Promise(resolve => setTimeout(resolve, 0))
+
+describe('postPopoutAnnotateFlush', () => {
+  beforeEach(() => {
+    setBridge(undefined)
+  })
+
+  it('reports undelivered when the shell predates the flush bridge', async () => {
+    await expect(postPopoutAnnotateFlush([pin()], 'http://127.0.0.1:4173/')).resolves.toEqual({
+      delivered: false
+    })
+  })
+
+  it('packages the pin stack into the posted envelope', async () => {
+    const postAnnotateFlush = vi.fn(async (envelope: AnnotateFlushEnvelope) => ({ ok: true }))
+    setBridge({ postAnnotateFlush })
+
+    const result = await postPopoutAnnotateFlush([pin()], 'http://127.0.0.1:4173/')
+
+    expect(result).toEqual({ delivered: true })
+    expect(postAnnotateFlush).toHaveBeenCalledTimes(1)
+    const envelope = postAnnotateFlush.mock.calls[0][0]
+    expect(typeof envelope.id).toBe('string')
+    expect(envelope.pageUrl).toBe('http://127.0.0.1:4173/')
+    expect(envelope.items).toHaveLength(1)
+    expect(envelope.items[0].number).toBe(1)
+    expect(envelope.items[0].imageDataUrl).toBe(png)
+  })
+
+  it('rejects when the main process refuses the envelope so the caller keeps its pins', async () => {
+    setBridge({ postAnnotateFlush: vi.fn(async () => ({ error: 'no-main-window', ok: false })) })
+
+    await expect(postPopoutAnnotateFlush([pin()])).resolves.toEqual({ delivered: false })
+  })
+})
+
+describe('installAnnotateFlushReceiver', () => {
+  beforeEach(() => {
+    setBridge(undefined)
+  })
+
+  it('is a no-op without the shell bridge', () => {
+    expect(() => installAnnotateFlushReceiver()()).not.toThrow()
+  })
+
+  it('attaches crops and inserts the prompt into the local composer bus', async () => {
+    const slot: { fire: ((envelope: unknown) => void) | null } = { fire: null }
+    setBridge({
+      onAnnotateFlushed: vi.fn((callback: (envelope: unknown) => void) => {
+        slot.fire = callback
+
+        return () => {
+          slot.fire = null
+        }
+      })
+    })
+
+    const seen: { detail: unknown; name: string }[] = []
+
+    const record = (name: string) => (event: Event) => {
+      seen.push({ detail: (event as CustomEvent).detail, name })
+    }
+
+    window.addEventListener('hermes:composer-attach-images', record('hermes:composer-attach-images'))
+    window.addEventListener('hermes:composer-insert', record('hermes:composer-insert'))
+
+    const unsubscribe = installAnnotateFlushReceiver()
+    slot.fire?.({
+      id: 'flush-1',
+      items: [
+        {
+          imageDataUrl: png,
+          note: 'This button overflows on mobile.',
+          number: 1,
+          prompt: 'Comment 1 prompt'
+        }
+      ],
+      pageUrl: 'http://127.0.0.1:4173/'
+    })
+    await tick()
+    await tick()
+
+    const attach = seen.find(event => event.name === 'hermes:composer-attach-images')
+    expect(attach).toBeDefined()
+    const blobs = (attach!.detail as { blobs: Blob[] }).blobs
+    expect(blobs).toHaveLength(1)
+    expect(blobs[0]).toBeInstanceOf(Blob)
+
+    const insert = seen.find(event => event.name === 'hermes:composer-insert')
+    expect(insert).toBeDefined()
+    expect((insert!.detail as { text: string }).text).toContain('http://127.0.0.1:4173/')
+
+    unsubscribe()
+  })
+
+  it('ignores malformed envelopes instead of touching the composer', async () => {
+    const slot: { fire: ((envelope: unknown) => void) | null } = { fire: null }
+    setBridge({
+      onAnnotateFlushed: vi.fn((callback: (envelope: unknown) => void) => {
+        slot.fire = callback
+
+        return () => undefined
+      })
+    })
+
+    const inserts: unknown[] = []
+    window.addEventListener('hermes:composer-insert', event => {
+      inserts.push((event as CustomEvent).detail)
+    })
+
+    installAnnotateFlushReceiver()
+    slot.fire?.({ id: 'flush-bad' })
+    slot.fire?.({ id: 'flush-empty', items: [] })
+    await tick()
+    await tick()
+
+    expect(inserts).toHaveLength(0)
+  })
+})

--- a/apps/desktop/src/lib/preview-annotate/bridge.ts
+++ b/apps/desktop/src/lib/preview-annotate/bridge.ts
@@ -1,0 +1,130 @@
+import { requestComposerAttachImages, requestComposerFocus, requestComposerInsert } from '@/app/chat/composer/focus'
+import { notifyError } from '@/store/notifications'
+
+import { annotateFlushPrompt, type ComposerReadyAnnotation, dataUrlToFile, packageAnnotateStack } from './pack'
+import type { AnnotatePin } from './stack'
+
+/**
+ * Cross-window annotate-flush relay (popped-out Browser → primary window).
+ *
+ * The pop-out (`?win=browser`) renders the preview pane with NO composer, so
+ * the same-window composer bus (`hermes:composer-*` CustomEvents) has no
+ * subscriber there and a flush would vanish. The pop-out instead packages its
+ * pin stack and hands the envelope to the main process, which forwards it to
+ * the primary window — the one renderer that runs this module's receiver and
+ * owns a composer.
+ */
+export interface AnnotateFlushEnvelope {
+  id: string
+  items: ComposerReadyAnnotation[]
+  pageUrl?: string
+}
+
+export interface AnnotateFlushPostResult {
+  delivered: boolean
+}
+
+function makeEnvelopeId(): string {
+  try {
+    return crypto.randomUUID()
+  } catch {
+    return `flush-${Date.now().toString(36)}-${Math.floor(Math.random() * 0xffffffff).toString(36)}`
+  }
+}
+
+type AnnotateFlushBridge = {
+  onAnnotateFlushed?: (callback: (envelope: AnnotateFlushEnvelope) => void) => () => void
+  postAnnotateFlush?: (envelope: AnnotateFlushEnvelope) => Promise<{ error?: string; ok: boolean }>
+}
+
+function bridge(): AnnotateFlushBridge | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const candidate = (window as unknown as { hermesDesktop?: AnnotateFlushBridge }).hermesDesktop
+
+  if (!candidate || typeof candidate.postAnnotateFlush !== 'function') {
+    return null
+  }
+
+  return candidate
+}
+
+/**
+ * Package `pins` and post them to the primary window's composer. Resolves
+ * `{ delivered: true }` only when the main process accepted the envelope;
+ * resolves `{ delivered: false }` when this renderer has no flush bridge
+ * (older shell) and rejects when the main process reports a failure (e.g.
+ * the primary window is gone) — the caller keeps its pins in both cases.
+ */
+export async function postPopoutAnnotateFlush(
+  pins: readonly AnnotatePin[],
+  pageUrl?: string
+): Promise<AnnotateFlushPostResult> {
+  const candidate = bridge()
+
+  if (!candidate?.postAnnotateFlush) {
+    return { delivered: false }
+  }
+
+  const envelope: AnnotateFlushEnvelope = {
+    id: makeEnvelopeId(),
+    items: packageAnnotateStack(pins),
+    pageUrl
+  }
+
+  const result = await candidate.postAnnotateFlush(envelope)
+
+  return { delivered: result?.ok === true }
+}
+
+function isEnvelope(value: unknown): value is AnnotateFlushEnvelope {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const envelope = value as { id?: unknown; items?: unknown }
+
+  return typeof envelope.id === 'string' && Array.isArray(envelope.items)
+}
+
+/**
+ * Subscribe the primary window to pop-out flushes. Incoming envelopes are
+ * attached to the local composer exactly like a docked-pane flush (numbered
+ * crops + packed prompt, never auto-sent). Install once per renderer, in
+ * composer-bearing windows only — the pop-out itself must never install this,
+ * or its own flush would loop back onto a composer that isn't there.
+ */
+export function installAnnotateFlushReceiver(): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined
+  }
+
+  const candidate = (window as unknown as { hermesDesktop?: AnnotateFlushBridge }).hermesDesktop
+
+  if (!candidate || typeof candidate.onAnnotateFlushed !== 'function') {
+    return () => undefined
+  }
+
+  return candidate.onAnnotateFlushed(envelope => {
+    try {
+      if (!isEnvelope(envelope) || envelope.items.length === 0) {
+        return
+      }
+
+      const files = envelope.items
+        .filter(item => typeof item.imageDataUrl === 'string' && item.imageDataUrl.length > 0)
+        .map(item => dataUrlToFile(item.imageDataUrl, `Comment_${item.number}.png`))
+
+      if (files.length > 0) {
+        requestComposerAttachImages(files)
+      }
+
+      requestComposerInsert(annotateFlushPrompt(envelope.items, envelope.pageUrl), { mode: 'block' })
+      requestComposerFocus()
+    } catch (error) {
+      notifyError(error, 'Could not attach browser comments')
+    }
+  })
+}

--- a/apps/desktop/src/lib/preview-annotate/index.ts
+++ b/apps/desktop/src/lib/preview-annotate/index.ts
@@ -1,3 +1,9 @@
+export {
+  type AnnotateFlushEnvelope,
+  type AnnotateFlushPostResult,
+  installAnnotateFlushReceiver,
+  postPopoutAnnotateFlush
+} from './bridge'
 export { type AnnotateFlushPorts, type AnnotateFlushResult, flushAnnotateStack } from './flush'
 export { type AnnotateGroup, annotateSplitDepth, groupAnnotations } from './group'
 export { compactIdentity, type CompactIdentity, type ElementSnapshot, formatIdentityLine } from './identity'


### PR DESCRIPTION
## Summary

Comment mode (shipped in #100083) silently drops its payload in a popped-out Browser window: the pop-out (`?win=browser` → `BrowserPopoutShell`) renders the preview pane with **no composer**, but `flushComments` delivered crops + prompt over the same-window composer bus (`hermes:composer-*` CustomEvents). With no subscriber, “Add N comments” cleared the pins and delivered nothing — pinning/cropping always worked (main-process `capturePreview` resolves the guest by webContents id globally).

This PR relays the packaged pin stack pop-out → main process → primary window, whose receiver attaches it to the real composer (numbered `Comment_N.png` crops + packed prompt, still never auto-sent).

## Changes

- `apps/desktop/src/lib/preview-annotate/bridge.ts` (new): `postPopoutAnnotateFlush` (packages the stack via existing `packageAnnotateStack`, posts the envelope over the preload bridge) + `installAnnotateFlushReceiver` (rebuilds `Comment_N.png` files, reuses `annotateFlushPrompt` + the composer bus; ignores malformed envelopes)
- `apps/desktop/src/lib/preview-annotate/bridge.test.ts` (new): post packaging/delivery-shape, receiver attach+insert on the composer bus, malformed-envelope no-op
- `apps/desktop/src/app/chat/right-rail/preview-pane.tsx`: `flushComments` takes the relay path when `isBrowserWindow()`; fail-closed (keeps pins + warns on delivery failure instead of clearing them into the void)
- `apps/desktop/src/app/contrib/controller.tsx`: installs the receiver once per renderer in the primary window only (`!isAuxiliaryWindow()`) — the pop-out never receives its own flush back
- `apps/desktop/electron/annotate-flush.ts` (new) + `.test.ts`: main-side envelope shape/size gate (100 pins / 32MB caps)
- `apps/desktop/electron/main.ts`: `hermes:annotate:flush` handler — validates, forwards to `mainWindow`, focuses it so the user sees where the comments landed
- `apps/desktop/electron/preload.ts` + `apps/desktop/src/global.d.ts`: `postAnnotateFlush` / `onAnnotateFlushed` bridge (same invoke/on pattern as `onBrowserPopoutClosed`)
- `apps/desktop/src/i18n/{en,zh,types}.ts`: `annotateFlushUnavailable` warning string

## Validation

| Check | Result |
|---|---|
| `npx vitest run` (annotate lib + pane + browser-bar + annotate-host/card + new electron test) | 126/126 passed (11 files); re-run after lint fixes: 111/111 (8 files) |
| `npx eslint` on all touched files | 0 errors, 0 warnings |
| `tsc -p . --noEmit`, `tsconfig.electron.json`, `tsconfig.e2e.json` | clean |
| Live pop-out E2E | not run (needs packaged app with two OS windows) — code paths follow the existing, proven `hermes:browser-popout:closed` relay pattern |

Follow-up to #100083.