### PR TITLE
fix(desktop): keep a generated .html file visible on the artifacts page

### DIFF
--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -35,7 +35,7 @@ const WINDOWS_PATH_RE = /(^|[\s("'`])([A-Za-z]:[\\/][^\s"'`<>]+(?:\.[a-z0-9]{1,8
 const IMAGE_EXT_RE = /\.(?:png|jpe?g|gif|webp|svg|bmp)(?:\?.*)?$/i
 
 const FILE_EXT_RE =
-  /\.(?:png|jpe?g|gif|webp|svg|bmp|pdf|txt|json|md|csv|zip|tar|gz|avi|flac|m4a|mkv|mp3|ogg|opus|wav|webm|mp4|mov)(?:\?.*)?$/i
+  /\.(?:png|jpe?g|gif|webp|svg|bmp|html|htm|pdf|txt|json|md|csv|zip|tar|gz|avi|flac|m4a|mkv|mp3|ogg|opus|wav|webm|mp4|mov)(?:\?.*)?$/i
 
 const MAX_UNIX_SECONDS = 10_000_000_000
 

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -120,6 +120,12 @@ describe('collectArtifactsForSession', () => {
         role: 'tool',
         timestamp: 1_781_774_005,
         tool_name: 'text_to_speech'
+      },
+      {
+        content: JSON.stringify({ files_modified: ['/tmp/generated/dashboard.html'], success: true }),
+        role: 'tool',
+        timestamp: 1_781_774_006,
+        tool_name: 'write_file'
       }
     ])
 
@@ -128,7 +134,8 @@ describe('collectArtifactsForSession', () => {
       '/tmp/generated/report.pdf',
       '/tmp/generated/notes.md',
       'https://cdn.example.com/generated/data.csv',
-      '/tmp/generated/voice.ogg'
+      '/tmp/generated/voice.ogg',
+      '/tmp/generated/dashboard.html'
     ])
   })
 


### PR DESCRIPTION
## What does this PR do?

A generated `.html` file never appears on the Artifacts page. `html` is not on `FILE_EXT_RE`'s allowlist, so the path is discarded during collection — it shows under **no** tab, not `file` and not `all`.

This is a regression with a date. Until 021950ac (`fix(desktop): stop artifact over-indexing`, 2026-08-15), `looksLikeArtifact` fell through to a last resort:

```ts
if (looksLikePathOrUrl(value) && (IMAGE_EXT_RE.test(value) || FILE_EXT_RE.test(value))) {
  return true
}

return value.startsWith('/') && value.includes('.')   // ← kept the HTML file
```

That commit collapsed it to the allowlist alone:

```ts
return looksLikePathOrUrl(value) && (IMAGE_EXT_RE.test(value) || FILE_EXT_RE.test(value))
```

and extended `FILE_EXT_RE` with seven media containers (`avi`, `flac`, `m4a`, `mkv`, `ogg`, `opus`, `webm`) — without adding `html`. Narrowing the fallback was right, and #45969 §4.4 documents why (~90% of 1515 indexed items were noise). Dropping HTML reads as collateral rather than intent: nothing in that commit, its message or its tests mentions HTML, and the renderer's own right rail already treats an HTML document as a first-class artifact (`lib/artifact-detect.ts` → `ArtifactKind = 'code' | 'html' | 'svg'`). The one page that lists artifacts by name should agree with it.

**Why `html` and `htm` only.** `.py`, `.ts`, `.js`, `.xml`, `.yaml`, `.sh` and friends are dropped by the same line and this PR leaves them dropped. Those paths appear constantly in ordinary prose about a codebase — exactly the noise 021950ac set out to remove. A generated HTML document is the opposite case: it is a deliverable, not a mention.

## Related Issue

No existing issue — I searched open and closed issues and PRs first. The closest are all different mechanisms in the same file:

- #92220 / #92255 — `terminal` output is never scanned, and bare filenames are rejected. **Complementary, not overlapping**: my case has an absolute path *and* an explicit `MEDIA:` tag, so it clears both of those hurdles and still fails on the extension check. Worth noting: the workaround #92220 documents (have the assistant re-emit the file as `MEDIA:/abs/path`) works for its `.png` but does **not** work for `.html` — the `MEDIA:` value is collected and then dropped anyway.
- #45969 §4.4 — the over-indexing/noise umbrella. This PR is scoped to stay inside its constraint.

No `Fixes #` line, since there is no issue to close.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/artifacts/artifact-utils.ts` — `html` and `htm` added to `FILE_EXT_RE`'s alternation (1 line).
- `apps/desktop/src/app/artifacts/index.test.ts` — one `write_file` message carrying `files_modified: ['/tmp/generated/dashboard.html']` added to the existing `keeps explicit generated artifacts from tool output` case, plus its expected value.

`IMAGE_EXT_RE` is deliberately untouched: HTML is a file, not an image, and `artifactKind()` should keep classifying it under the `file` tab.

## How to Test

**Reproduce** (measured on `v2026.8.31`, commit 29112be):

1. Ask the agent to create an HTML artifact — anything that ends in a `write_file` to a `.html` path.
2. The tool result is real and complete:
   ```json
   {"bytes_written": 6326, "verified": true,
    "resolved_path": "/data/workspace/artefato-teste.html",
    "files_modified": ["/data/workspace/artefato-teste.html"]}
   ```
   and the assistant announces it in the form this collector reads: `MEDIA:/data/workspace/artefato-teste.html`.
3. Open **Artifacts**. The file is absent under every tab, including `?tab=all`. The file itself is fine — 6,326 bytes on disk, and the in-chat `::preview` opens it.

**Why it happens** — the two regexes, run against that exact value:

```
value            : /data/workspace/artefato-teste.html
looksLikePathOrUrl: true
IMAGE_EXT_RE     : false
FILE_EXT_RE      : false
→ looksLikeArtifact: false        (dropped before it is ever a record)
```

**Proof the fix works** — `collectArtifactsForSession` run over that real transcript, before and after:

```
before (v2026.8.31): 0 artifact(s)
after  (this PR):    1 artifact(s)
   tab=file  artefato-teste.html  ->  /data/workspace/artefato-teste.html
```

**The added test is meaningful** — it fails without the one-line change and passes with it:

```
# with this PR
$ npx vitest run src/app/artifacts/index.test.ts
 Test Files  1 passed (1)
      Tests  14 passed (14)

# with only the regex reverted, test kept
$ npx vitest run src/app/artifacts/index.test.ts
 × keeps explicit generated artifacts from tool output
   AssertionError: expected [ …(5) ] to deeply equal [ …(6) ]
   -   "/tmp/generated/dashboard.html",
 Test Files  1 failed (1)
      Tests  1 failed | 13 passed (14)
```

**Blast radius**: `looksLikeArtifact` and `FILE_EXT_RE` are referenced only inside `artifact-utils.ts` — no other module or test reads either, so the change cannot reach a surface outside the Artifacts page.

**Full desktop suite** (`npx vitest run` in `apps/desktop`): **9,269 passed**, 6 skipped, 4 failed. The 4 failures are unrelated and pre-existing — `settings/billing`, `assistant-ui/tool/fallback-model` and `use-prompt-actions/utils`. I verified they fail identically with my change reverted, and at least one is plainly locale-dependent on my machine (pt-BR):

```
Expected: "Usage: 12 calls · 1,234,567 in / 89,012 out · 1,323,579 total"
Received: "Usage: 12 calls · 1.234.567 in / 89.012 out · 1.323.579 total"
```

**Platform tested**: Linux (Ubuntu, engine running in Docker, `v2026.8.31` / `29112be`).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — open and closed, plus issues; findings listed above
- [x] My PR contains **only** changes related to this fix (two files, one logical change)
- [x] Tests pass — with one honest note: this change touches **no Python**, so `pytest tests/ -q` exercises nothing here. I ran the suite that does cover it instead: `npx vitest run` in `apps/desktop` (9,269 passing; the 4 failures are pre-existing and unrelated, shown above).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu (Linux), engine `v2026.8.31` in Docker

### Documentation & Housekeeping

- [x] Documentation — N/A (no user-facing surface or docs describe the allowlist)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A (no architecture or workflow change)
- [x] Cross-platform impact considered — the change is a regex literal with no path or platform semantics. `.html` on Windows takes the same branch it already takes for `.pdf`; `WINDOWS_PATH_RE` and `isWindowsPath` are untouched.
- [x] Tool descriptions/schemas — N/A (no tool behavior change)
