### PR TITLE
feat(memory): conditional fields (when) for declared provider schemas

### DIFF
--- a/apps/desktop/src/app/settings/memory/field-control.tsx
+++ b/apps/desktop/src/app/settings/memory/field-control.tsx
@@ -11,6 +11,18 @@ import { CONTROL_TEXT } from '../constants'
 // Fade the placeholder well below set values so example text never reads as data.
 const FIELD_INPUT = `font-mono ${CONTROL_TEXT} placeholder:text-muted-foreground/45`
 
+// Whether `field` should render given the in-progress draft `values` (keyed
+// by field key, as edited — not yet-saved state is fine and intended: a mode
+// select's own onChange updates `values` before its autosave commit
+// resolves, so a dependent field appears/disappears the instant the user
+// picks a new mode, not after the network round-trip).
+export function isFieldVisible(field: MemoryProviderField, values: Record<string, string>): boolean {
+  if (!field.when) {
+    return true
+  }
+  return Object.entries(field.when).every(([depKey, expected]) => values[depKey] === expected)
+}
+
 // Field label with an optional info tooltip, shared by the panel and modal rows.
 export function FieldTitle({ field }: { field: MemoryProviderField }) {
   if (!field.info) {

--- a/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-modal.tsx
@@ -19,7 +19,7 @@ import type { MemoryProviderConfig, MemoryProviderField } from '@/types/hermes'
 
 import { ListRow } from '../primitives'
 
-import { FieldControl, FieldTitle } from './field-control'
+import { FieldControl, FieldTitle, isFieldVisible } from './field-control'
 
 // Secrets seed blank: values are write-only and blank keeps the stored one.
 function seedAll(config: MemoryProviderConfig): Record<string, string> {
@@ -118,7 +118,7 @@ export function ProviderConfigModal({
         </DialogHeader>
 
         <div className="min-w-0">
-          {groupFields(config.fields).map(([group, fields]) => (
+          {groupFields(config.fields.filter(field => isFieldVisible(field, values))).map(([group, fields]) => (
             <section className="mt-6 first:mt-2" key={group}>
               <h3 className="border-b border-(--ui-accent-secondary)/30 pb-1.5 font-mono text-[0.68rem] uppercase tracking-wide text-(--ui-accent-secondary)">
                 {group}

--- a/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-panel.test.tsx
@@ -207,3 +207,69 @@ describe('ProviderConfigPanel', () => {
     expect(container.querySelector('section')).toBeNull()
   })
 })
+
+describe('ProviderConfigPanel — conditional fields (when)', () => {
+  function modeGatedSchema(): MemoryProviderConfig {
+    return {
+      name: 'hindsight',
+      label: 'Hindsight',
+      docs_url: '',
+      fields: [
+        {
+          key: 'mode',
+          label: 'Mode',
+          kind: 'select',
+          value: 'cloud',
+          description: '',
+          placeholder: '',
+          is_set: true,
+          inline: true,
+          group: '',
+          options: [
+            { value: 'cloud', label: 'Cloud', description: '' },
+            { value: 'local_embedded', label: 'Local Embedded', description: '' }
+          ]
+        },
+        {
+          key: 'llm_model',
+          label: 'LLM model',
+          kind: 'text',
+          value: 'gpt-4o-mini',
+          description: '',
+          placeholder: '',
+          is_set: false,
+          inline: true,
+          group: '',
+          options: [],
+          when: { mode: 'local_embedded' }
+        }
+      ]
+    }
+  }
+
+  beforeEach(() => {
+    getMemoryProviderConfig.mockResolvedValue(modeGatedSchema())
+  })
+
+  it('hides a when-gated field until its dependency matches', async () => {
+    await renderPanel('hindsight')
+
+    await screen.findByText('Cloud')
+    expect(screen.queryByText('LLM model')).toBeNull()
+  })
+
+  it('reveals a when-gated field the instant its dependency is picked, before autosave resolves', async () => {
+    // Radix's Select portal doesn't drive real option clicks under jsdom
+    // (missing scrollIntoView), so this exercises the same live-draft path
+    // through the underlying visibility check directly rather than through a
+    // simulated dropdown interaction.
+    const { isFieldVisible } = await import('./field-control')
+    const schema = modeGatedSchema()
+    const llmModel = schema.fields.find(f => f.key === 'llm_model')!
+
+    expect(isFieldVisible(llmModel, { mode: 'cloud' })).toBe(false)
+    // The instant mode is drafted to local_embedded — no save round-trip
+    // required — the dependent field's own gate already matches.
+    expect(isFieldVisible(llmModel, { mode: 'local_embedded' })).toBe(true)
+  })
+})

--- a/apps/desktop/src/app/settings/memory/provider-config-panel.tsx
+++ b/apps/desktop/src/app/settings/memory/provider-config-panel.tsx
@@ -10,7 +10,7 @@ import type { MemoryProviderConfig, MemoryProviderField } from '@/types/hermes'
 
 import { ListRow, Pill } from '../primitives'
 
-import { FieldControl, FieldTitle } from './field-control'
+import { FieldControl, FieldTitle, isFieldVisible } from './field-control'
 import { ProviderConfigModal } from './provider-config-modal'
 
 // Inline fields only: the compact panel must never re-write modal-owned keys.
@@ -69,6 +69,17 @@ export function ProviderConfigPanel({ profile, provider }: { profile?: string; p
           )
         } else {
           setSaved(current => ({ ...current, [field.key]: value }))
+          // Keep config.fields' own value in sync too: the full-config modal
+          // reseeds its visibility gates from config.fields on open, so a
+          // committed change to a gating field (e.g. mode) must be reflected
+          // there immediately, not only in this panel's local draft state.
+          setConfig(
+            current =>
+              current && {
+                ...current,
+                fields: current.fields.map(f => (f.key === field.key ? { ...f, value } : f))
+              }
+          )
         }
       } catch (err) {
         notifyError(err, `Failed to save ${field.label}`)
@@ -99,8 +110,11 @@ export function ProviderConfigPanel({ profile, provider }: { profile?: string; p
     return <PageLoader className="min-h-24" label="Loading memory provider settings..." />
   }
 
-  const inlineFields = config.fields.filter(field => field.inline)
-  const secretFields = config.fields.filter(field => field.kind === 'secret')
+  // Visibility is judged against the live draft `values`, not `saved`: a mode
+  // switch must show/hide dependent fields the instant it's picked, before
+  // its autosave PUT resolves.
+  const inlineFields = config.fields.filter(field => field.inline && isFieldVisible(field, values))
+  const secretFields = config.fields.filter(field => field.kind === 'secret' && isFieldVisible(field, values))
   const hasFullConfig = config.fields.some(field => !field.inline)
 
   return (

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -161,6 +161,10 @@ export interface MemoryProviderField {
   options: MemoryProviderFieldOption[]
   placeholder: string
   value: string
+  // Visibility gate: {other_field_key: required_value}, ALL must match the
+  // current in-progress form values for this field to render. Absent/null
+  // means always visible. See ProviderField.when on the backend.
+  when?: null | Record<string, string>
 }
 
 export interface MemoryProviderConfig {

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6121,6 +6121,7 @@ def _provider_field_entry(field: ProviderField) -> Dict[str, Any]:
             {"value": opt.value, "label": opt.label, "description": opt.description}
             for opt in field.options
         ],
+        "when": {dep_key: expected for dep_key, expected in field.when} or None,
     }
 
 
@@ -6287,7 +6288,23 @@ def _declared_provider_payload(provider: ProviderConfigSchema) -> Dict[str, Any]
         def sources_for(field: ProviderField) -> tuple:
             return (data,)
 
+    # Read every field's resolved value first: a field gated by ``when`` may
+    # depend on a sibling declared later in the schema, so visibility can only
+    # be decided once every value is known.
+    resolved: Dict[str, Any] = {}
     for field in provider.fields:
+        if field.is_secret:
+            continue
+        native = _read_field(field, sources_for(field), env)
+        value = _serialize_field_value(field, native)
+        if field.kind == "select" and value not in field.allowed_values():
+            value = field.default
+        resolved[field.key] = value
+
+    for field in provider.fields:
+        if not field.is_visible(resolved):
+            continue
+
         entry = _provider_field_entry(field)
         sources = sources_for(field)
 
@@ -6302,9 +6319,7 @@ def _declared_provider_payload(provider: ProviderConfigSchema) -> Dict[str, Any]
             # Blank fields surface the resolved host Honcho will actually use.
             entry["placeholder"] = host
 
-        value = _serialize_field_value(field, native)
-        if field.kind == "select" and value not in field.allowed_values():
-            value = field.default
+        value = resolved[field.key]
         entry["value"] = value
         # Presence, not truthiness — a stored False/0 is still "set".
         entry["is_set"] = native is not None if is_honcho else bool(value)
@@ -6318,13 +6333,20 @@ def _apply_field_values(provider: ProviderConfigSchema, values: Dict[str, str], 
 
     Only keys present in ``values`` are touched, so a partial save never
     clobbers fields owned by another surface. ``_UNSET`` clears the key (and
-    its aliases) so it falls back to the host/default mapping.
+    its aliases) so it falls back to the host/default mapping. A field whose
+    ``when`` gate is not satisfied is skipped even if present: visibility is
+    judged against each field's own backend dict (via ``target_for``) layered
+    with the submitted batch, so a single-field autosave PUT (the inline panel
+    submits one key at a time) still sees the sibling ``mode`` value already
+    on disk instead of a same-request key that was never sent.
     """
 
     for field in provider.fields:
         if field.is_secret or field.key not in values:
             continue
         target = target_for(field)
+        if not field.is_visible({**target, **values}):
+            continue
         coerced = _coerce_field_value(field, values[field.key])
         if coerced is _UNSET:
             target.pop(field.key, None)

--- a/plugins/memory/config_schema.py
+++ b/plugins/memory/config_schema.py
@@ -64,6 +64,14 @@ class ProviderField:
     earlier CLI/env setup without re-introducing per-provider code. ``inline``
     marks the curated subset shown in the compact panel; the rest surface only
     in the full-config modal. ``group`` buckets fields within that modal.
+
+    ``when`` gates visibility on other fields in the same schema: a mapping of
+    ``{other_field_key: required_string_value}`` that must ALL match the
+    current (in-progress, not-yet-saved) values for this field to render, be
+    read back, or be persisted. A field with no ``when`` is always visible.
+    This lets a provider grow a mode-specific sub-surface (e.g. Hindsight's
+    ``local_embedded`` LLM settings) as pure declaration, matching the
+    conditional-field semantics the CLI setup wizard already uses.
     """
 
     key: str
@@ -82,6 +90,8 @@ class ProviderField:
     info: str = ""
     # Host-block placement: "host" (per-profile) or "root"; flat-json ignores it.
     scope: str = "host"
+    # Visibility gate; see the class docstring. Empty mapping = always visible.
+    when: tuple[tuple[str, str], ...] = ()
 
     @property
     def is_secret(self) -> bool:
@@ -89,6 +99,21 @@ class ProviderField:
 
     def allowed_values(self) -> set[str]:
         return {opt.value for opt in self.options}
+
+    def is_visible(self, values_by_key: dict) -> bool:
+        """Whether this field should render/persist given sibling ``values_by_key``.
+
+        Missing dependency values (a sibling not yet in the map) count as
+        not-matching rather than raising, so an incomplete draft simply hides
+        the dependent field instead of erroring. Values are compared as
+        strings so callers can pass either raw native values (bool/int from a
+        just-read config file) or the string form submitted over the API.
+        """
+        _MISSING = object()
+        return all(
+            str(values_by_key.get(dep_key, _MISSING)) == expected
+            for dep_key, expected in self.when
+        )
 
 
 @dataclass(frozen=True)

--- a/plugins/memory/hindsight/config_schema.py
+++ b/plugins/memory/hindsight/config_schema.py
@@ -1,12 +1,29 @@
 """Hindsight's declared config surface — rendered by the generic desktop panel."""
 
 from plugins.memory.config_schema import (
+    KIND_NUMBER,
     KIND_SECRET,
     KIND_SELECT,
     KIND_TEXT,
     ProviderConfigSchema,
     ProviderField,
     ProviderFieldOption,
+)
+
+# Keep in sync with ``_PROVIDER_DEFAULT_MODELS`` in ``hindsight/__init__.py``.
+# Duplicated rather than imported: this module may only import from
+# ``plugins.memory.config_schema`` (see that module's docstring) so the
+# desktop web server never pulls the agent runtime in through a schema file.
+_LLM_PROVIDERS = (
+    "openai",
+    "anthropic",
+    "gemini",
+    "groq",
+    "openrouter",
+    "minimax",
+    "ollama",
+    "lmstudio",
+    "openai_compatible",
 )
 
 CONFIG_SCHEMA = ProviderConfigSchema(
@@ -24,6 +41,11 @@ CONFIG_SCHEMA = ProviderConfigSchema(
                     "cloud",
                     "Cloud",
                     "Hindsight Cloud API (lightweight, just needs an API key)",
+                ),
+                ProviderFieldOption(
+                    "local_embedded",
+                    "Local Embedded",
+                    "Run Hindsight's own engine and database on this machine",
                 ),
                 ProviderFieldOption(
                     "local_external",
@@ -71,6 +93,58 @@ CONFIG_SCHEMA = ProviderConfigSchema(
                 ProviderFieldOption("high", "high"),
             ),
             inline=True,
+        ),
+        # ── local_embedded-only fields: Hindsight's own engine needs an LLM to
+        # run fact extraction/consolidation. Gated so cloud/local_external
+        # users — who point at someone else's already-configured instance —
+        # never see an LLM sub-form that doesn't apply to them.
+        ProviderField(
+            key="llm_provider",
+            label="LLM provider",
+            kind=KIND_SELECT,
+            default="openai",
+            group="Embedded engine",
+            description="Backend used by the local Hindsight engine for fact extraction.",
+            options=tuple(ProviderFieldOption(p, p) for p in _LLM_PROVIDERS),
+            when=(("mode", "local_embedded"),),
+        ),
+        ProviderField(
+            key="llm_base_url",
+            label="LLM endpoint URL",
+            kind=KIND_TEXT,
+            default="",
+            group="Embedded engine",
+            placeholder="e.g. http://127.0.0.1:8080/v1",
+            description="Required for the openai_compatible provider; ignored otherwise.",
+            when=(("mode", "local_embedded"), ("llm_provider", "openai_compatible")),
+        ),
+        ProviderField(
+            key="llm_api_key",
+            label="LLM API key",
+            kind=KIND_SECRET,
+            env_key="HINDSIGHT_LLM_API_KEY",
+            group="Embedded engine",
+            description="Optional for the openai_compatible provider; required otherwise.",
+            placeholder="Enter LLM API key",
+            when=(("mode", "local_embedded"),),
+        ),
+        ProviderField(
+            key="llm_model",
+            label="LLM model",
+            kind=KIND_TEXT,
+            default="gpt-4o-mini",
+            group="Embedded engine",
+            placeholder="e.g. gpt-4o-mini, claude-haiku-4-5",
+            when=(("mode", "local_embedded"),),
+        ),
+        ProviderField(
+            key="idle_timeout",
+            label="Idle timeout (seconds)",
+            kind=KIND_NUMBER,
+            default="300",
+            group="Embedded engine",
+            description="Auto-shutdown the embedded daemon after this many idle seconds. 0 disables it.",
+            when=(("mode", "local_embedded"),),
         ),
     ),
 )

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -985,6 +985,103 @@ class TestWebServerEndpoints:
         assert "secret-value" not in json.dumps(data)
 
 
+    def test_local_embedded_mode_exposes_and_persists_llm_fields(self):
+        """The generic conditional-field gate (``ProviderField.when``) lets
+        Hindsight's local_embedded LLM sub-form ship as pure declaration:
+        switching mode surfaces the sub-form, and its fields persist/read
+        back through the same declared-schema GET/PUT pair as everything
+        else — no bespoke Hindsight endpoint code."""
+        from hermes_constants import get_hermes_home
+        from hermes_cli.config import load_env
+
+        resp = self.client.put(
+            "/api/memory/providers/hindsight/config?surface=declared",
+            json={
+                "values": {
+                    "mode": "local_embedded",
+                    "llm_provider": "openai_compatible",
+                    "llm_base_url": "http://127.0.0.1:8317/v1",
+                    "llm_api_key": "hs-llm-key",
+                    "llm_model": "claude-sonnet-4-6",
+                    "idle_timeout": "0",
+                    "bank_id": "hermes",
+                    "recall_budget": "high",
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+        assert resp.json() == {"ok": True}
+        assert load_env()["HINDSIGHT_LLM_API_KEY"] == "hs-llm-key"
+
+        config_path = get_hermes_home() / "hindsight" / "config.json"
+        provider_config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert provider_config["mode"] == "local_embedded"
+        assert provider_config["llm_provider"] == "openai_compatible"
+        assert provider_config["llm_base_url"] == "http://127.0.0.1:8317/v1"
+        assert provider_config["llm_model"] == "claude-sonnet-4-6"
+        assert provider_config["idle_timeout"] == 0
+        assert "llm_api_key" not in provider_config  # secret, never in the flat file
+
+        # GET surfaces the llm_* fields now that mode == local_embedded, with
+        # the secret readable only as an is_set flag.
+        resp = self.client.get("/api/memory/providers/hindsight/config?surface=declared")
+        fields = self._provider_field_map(resp.json())
+        assert fields["llm_model"]["value"] == "claude-sonnet-4-6"
+        assert fields["llm_base_url"]["value"] == "http://127.0.0.1:8317/v1"
+        assert fields["llm_api_key"]["is_set"] is True
+        assert fields["llm_api_key"]["value"] == ""
+
+    def test_llm_fields_are_hidden_and_not_persisted_outside_local_embedded(self):
+        """A stray llm_* key submitted while mode is cloud/local_external must
+        not land in the provider config: those fields only exist once
+        local_embedded is selected."""
+        from hermes_constants import get_hermes_home
+
+        resp = self.client.put(
+            "/api/memory/providers/hindsight/config?surface=declared",
+            json={
+                "values": {
+                    "mode": "cloud",
+                    "api_url": "https://api.hindsight.vectorize.io",
+                    "llm_model": "should-not-be-saved",
+                }
+            },
+        )
+
+        assert resp.status_code == 200
+
+        config_path = get_hermes_home() / "hindsight" / "config.json"
+        provider_config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert provider_config["mode"] == "cloud"
+        assert "llm_model" not in provider_config
+
+        resp = self.client.get("/api/memory/providers/hindsight/config?surface=declared")
+        assert "llm_model" not in self._provider_field_map(resp.json())
+
+    def test_local_embedded_llm_fields_persist_via_single_field_autosave(self):
+        """The desktop inline panel autosaves one field per PUT. A later
+        single-key PUT for an llm_* field must still see mode=local_embedded
+        already on disk from an earlier request and persist normally."""
+        from hermes_constants import get_hermes_home
+
+        self.client.put(
+            "/api/memory/providers/hindsight/config?surface=declared",
+            json={"values": {"mode": "local_embedded"}},
+        )
+
+        resp = self.client.put(
+            "/api/memory/providers/hindsight/config?surface=declared",
+            json={"values": {"llm_model": "claude-haiku-4-5"}},
+        )
+        assert resp.status_code == 200
+
+        config_path = get_hermes_home() / "hindsight" / "config.json"
+        provider_config = json.loads(config_path.read_text(encoding="utf-8"))
+        assert provider_config["mode"] == "local_embedded"
+        assert provider_config["llm_model"] == "claude-haiku-4-5"
+
+
 
 
     # ── Memory provider config (Honcho host-block backend) ──────────────

--- a/tests/plugins/memory/test_hindsight_config_schema.py
+++ b/tests/plugins/memory/test_hindsight_config_schema.py
@@ -18,16 +18,35 @@ def test_hindsight_is_declared():
         "api_url",
         "bank_id",
         "recall_budget",
+        "llm_provider",
+        "llm_base_url",
+        "llm_api_key",
+        "llm_model",
+        "idle_timeout",
     }
 
 
-def test_fields_are_all_inline():
+def test_inline_fields_are_the_always_visible_curated_subset():
     provider = get_provider_config_schema("hindsight")
     assert provider is not None
 
-    # Hindsight is simple enough to render fully in the compact panel, so it
-    # never grows a Full config… modal.
-    assert all(field.inline for field in provider.fields)
+    # The always-on connection basics render in the compact panel...
+    assert {field.key for field in provider.fields if field.inline} == {
+        "mode",
+        "api_key",
+        "api_url",
+        "bank_id",
+        "recall_budget",
+    }
+    # ...while the local_embedded-only LLM sub-form is full-config-modal-only,
+    # since it only applies once that mode is selected.
+    assert {field.key for field in provider.fields if not field.inline} == {
+        "llm_provider",
+        "llm_base_url",
+        "llm_api_key",
+        "llm_model",
+        "idle_timeout",
+    }
 
 
 def test_mode_gating_is_expressed_as_select_options():
@@ -36,9 +55,33 @@ def test_mode_gating_is_expressed_as_select_options():
 
     mode = next(field for field in provider.fields if field.key == "mode")
     assert mode.kind == KIND_SELECT
-    assert mode.allowed_values() == {"cloud", "local_external"}
-    # local_embedded is intentionally unsupported on desktop.
-    assert "local_embedded" not in mode.allowed_values()
+    assert mode.allowed_values() == {"cloud", "local_embedded", "local_external"}
+
+
+def test_llm_fields_are_gated_behind_local_embedded_mode():
+    provider = get_provider_config_schema("hindsight")
+    assert provider is not None
+
+    llm_fields = {"llm_provider", "llm_api_key", "llm_model", "idle_timeout"}
+    for field in provider.fields:
+        if field.key in llm_fields:
+            assert field.is_visible({"mode": "local_embedded"}) is True
+            assert field.is_visible({"mode": "cloud"}) is False
+            assert field.is_visible({"mode": "local_external"}) is False
+
+    # llm_base_url carries an additional gate (see the dedicated test below),
+    # but still requires local_embedded as one of its conditions.
+    base_url = next(field for field in provider.fields if field.key == "llm_base_url")
+    assert base_url.is_visible({"mode": "cloud", "llm_provider": "openai_compatible"}) is False
+
+
+def test_llm_base_url_is_further_gated_to_openai_compatible():
+    provider = get_provider_config_schema("hindsight")
+    assert provider is not None
+
+    base_url = next(field for field in provider.fields if field.key == "llm_base_url")
+    assert base_url.is_visible({"mode": "local_embedded", "llm_provider": "openai_compatible"}) is True
+    assert base_url.is_visible({"mode": "local_embedded", "llm_provider": "openai"}) is False
 
 
 def test_api_key_is_a_secret_bound_to_env():
@@ -49,3 +92,13 @@ def test_api_key_is_a_secret_bound_to_env():
     assert api_key.kind == KIND_SECRET
     assert api_key.is_secret is True
     assert api_key.env_key == "HINDSIGHT_API_KEY"
+
+
+def test_llm_api_key_is_a_secret_bound_to_its_own_env_var():
+    provider = get_provider_config_schema("hindsight")
+    assert provider is not None
+
+    llm_api_key = next(field for field in provider.fields if field.key == "llm_api_key")
+    assert llm_api_key.kind == KIND_SECRET
+    assert llm_api_key.is_secret is True
+    assert llm_api_key.env_key == "HINDSIGHT_LLM_API_KEY"


### PR DESCRIPTION
## Summary

Adds a generic `ProviderField.when` visibility gate to the declared memory-provider config schema — `{other_field_key: required_value}`, ALL must match — so a provider can grow a mode-specific sub-form as pure declaration. No bespoke endpoint or component is needed per mode.

Concretely this lets Hindsight expose `local_embedded` as a third desktop `Mode` option (previously only `cloud`/`local_external` were declared — #37546 intentionally left it out because the LLM sub-form the mode needs didn't exist yet), plus its `llm_provider`/`llm_base_url`/`llm_api_key`/`llm_model`/`idle_timeout` fields, gated behind `mode=local_embedded` (and `llm_base_url` additionally behind `llm_provider=openai_compatible`).

## Backend

- `plugins/memory/config_schema.py`: `ProviderField.when` + `is_visible()`.
- `hermes_cli/web_server.py`:
  - `_declared_provider_payload` (GET) resolves every field's value first, then filters by `when` — a gated field may depend on a sibling declared later in the schema, so visibility can only be judged once every value is known.
  - `_apply_field_values` (PUT) checks visibility against `target_for`'s own backend dict merged with the submitted batch. This matters because the desktop inline panel autosaves one field per PUT — without the merge, a single-field PUT for e.g. `llm_model` would only see that one key and wrongly conclude `mode` doesn't match, hiding a legitimately-visible write.
- `plugins/memory/hindsight/config_schema.py`: the new `local_embedded` option + gated fields, per above.

## Frontend

- `types/hermes.ts`: `MemoryProviderField.when`.
- `field-control.tsx`: `isFieldVisible(field, values)`, judged against the live draft so a dependent field appears/disappears the instant its dependency is picked — not after the autosave round-trip resolves.
- `provider-config-panel.tsx` / `provider-config-modal.tsx`: filter fields through `isFieldVisible` before rendering. The panel also mirrors a committed non-secret value back into `config.fields` so the full-config modal's reseed-on-open sees the latest gating value.

## Test plan

- 7 schema tests (`test_hindsight_config_schema.py`) covering the new `local_embedded` option and every field's gate.
- 3 new `web_server` integration tests: GET/PUT round-trip through `surface=declared` for the full `local_embedded` field set, a stray `llm_model` key submitted outside `local_embedded` is neither persisted nor read back, and the single-field-autosave case (mode saved in one PUT, `llm_model` saved in a following PUT) still persists correctly.
- 2 new desktop panel tests: a `when`-gated field stays hidden until its dependency matches, and the underlying `isFieldVisible` gate flips the instant a draft value changes.
- 604 existing Python tests and 14 existing desktop tests pass unchanged. The only Python failures in the full run (`TestThemeBootstrapCSS::test_serve_index_injects_bootstrap_for_user_theme`, `test_mount_spa_dynamic_web_dist_recheck`) are pre-existing on `main` without this change (confirmed via `git stash`) and unrelated to memory providers.