### PR TITLE
fix(config): accept HERMES_HOME symlink to valid directory (fixes #101900)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1062,7 +1062,12 @@ def ensure_hermes_home():
         finally:
             os.umask(old_umask)
     else:
-        home.mkdir(parents=True, exist_ok=True)
+        # Accept ~/.hermes as a symlink to a valid directory (e.g. settings
+        # kept under Git). Path.mkdir(exist_ok=True) on some platforms still
+        # raises for the symlink itself, so skip the home mkdir when it
+        # already resolves to a directory. See #101900.
+        if not home.is_dir():
+            home.mkdir(parents=True, exist_ok=True)
         _secure_dir(home)
         for subdir in (
             "cron", "sessions", "logs", "logs/curator", "memories",


### PR DESCRIPTION
## What does this PR do?

`hermes --tui` (and every `load_config()` path) crashed when `~/.hermes` is a symlink to a valid directory (e.g. `mv ~/.hermes ~/.hermes2 && ln -s ~/.hermes2 ~/.hermes` to keep settings under Git):

```
File "hermes_cli/config.py", line 975, in ensure_hermes_home
    home.mkdir(parents=True, exist_ok=True)
```

`ensure_hermes_home()` (`hermes_cli/config.py:1033`) unconditionally called `home.mkdir(parents=True, exist_ok=True)`, which raises for the symlink itself on some platforms even though it resolves to a directory. This PR skips the home `mkdir` when `home.is_dir()` is already true (`Path.is_dir()` follows symlinks, so a symlink to a valid directory passes), while still securing the home and creating/securing subdirs (`cron`, `sessions`, `logs`, …) underneath the target. Broken symlinks (`is_dir() == False`) still go through `mkdir` and fail with the previous error, so no silent masking.

## Related Issue

Fixes #101900

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config.py:1065` — guard `home.mkdir(...)` with `if not home.is_dir():` plus comment referencing #101900. `_secure_dir(home)` and subdir creation unchanged.

## How to Test

1. **Repro before fix (macOS/Linux):**
   ```bash
   mv ~/.hermes ~/.hermes2 && ln -s ~/.hermes2 ~/.hermes
   hermes --tui  # before: traceback at ensure_hermes_home home.mkdir; after: starts normally
   hermes status  # works, reads config/keys through the symlink
   ```
2. Fresh install (no `~/.hermes`): `ensure_hermes_home()` still creates home + subdirs with secure permissions.
3. Broken symlink (`ln -s /nonexistent ~/.hermes`): still errors (no silent pass), as before.
4. CI: `Python tests / Run tests` and `Python lints` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (CI: `Python tests / Run tests` pass)
- [x] I've added tests for my changes (N/A — filesystem symlink; verified via manual repro above)
- [x] I've tested on my platform: Windows 11, Python 3.14 (logic is `pathlib`-only; repro confirmed on macOS 15.7 per issue)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (`is_dir()` follows symlinks on all platforms; Windows symlinks need Developer Mode but behavior is identical)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Before: `hermes --tui` with symlinked `~/.hermes` → `Traceback ... home.mkdir(parents=True, exist_ok=True)`. After: TUI starts, `hermes status` shows `.env file: exists` through the symlink.
