### PR TITLE
fix(agent): stop synchronized sessions from misidentifying the active host

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -21,6 +21,7 @@ import logging
 import os
 import random
 import re
+import socket
 import ssl
 import sys
 import time
@@ -1258,16 +1259,17 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
         each message and destroying the prefix cache for the whole session,
         which is far worse than the staleness this function guards against.
 
-        Anchor on the ``User home directory:`` line that immediately precedes
-        the working-directory line in that block, and take the FIRST such
-        occurrence, so only Hermes' own emitted block can satisfy the read.
+        Anchor on the ``User home directory:`` line in the middle of that
+        block, and take the FIRST such occurrence, so only Hermes' own emitted
+        block can satisfy the read. Runtime host fields precede the anchor;
+        the working-directory field follows it.
         """
         prefix = f"{label}:"
         lines = prompt.splitlines()
         for idx, line in enumerate(lines):
             if not line.startswith("User home directory:"):
                 continue
-            for candidate in lines[idx + 1: idx + 4]:
+            for candidate in lines[max(0, idx - 3): idx + 4]:
                 if candidate.startswith(prefix):
                     return candidate[len(prefix):].strip()
         return ""
@@ -1290,6 +1292,22 @@ def _stored_prompt_matches_runtime(agent, prompt: str) -> bool:
     stored_cwd = host_info_value("Current working directory")
     if stored_cwd:
         if stored_cwd != str(resolve_agent_cwd()):
+            return False
+
+    # Session databases can be synchronized between machines. A stored local
+    # prompt must never carry the other machine's runtime identity into this
+    # process merely because its profile name and cwd happen to match. Legacy
+    # local prompts have no hostname at all, so reject them once to upgrade the
+    # persisted snapshot. Remote/sandbox prompts intentionally omit the whole
+    # host-info block and remain reusable.
+    stored_host = host_info_value("Host")
+    stored_hostname = host_info_value("Machine hostname")
+    try:
+        current_hostname = socket.gethostname().strip()
+    except OSError:
+        current_hostname = ""
+    if stored_host and current_hostname:
+        if not stored_hostname or stored_hostname.casefold() != current_hostname.casefold():
             return False
 
     # Detect runtime-surface drift: the stored prompt records which platform it

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -8,6 +8,7 @@ import json
 import logging
 import os
 import queue
+import socket
 import sys
 import threading
 import contextvars
@@ -1406,8 +1407,8 @@ def build_environment_hints() -> str:
     """Return environment-specific guidance for the system prompt.
 
     Always emits a factual block describing the execution environment:
-    - For **local** terminal backends: the host OS, user home, current
-      working directory (plus a Windows-only note about hostname != user
+    - For **local** terminal backends: the host OS, live machine hostname,
+      user home, current working directory (plus a Windows-only note about hostname != user
       and a Windows-only note that `terminal` shells out to bash, not
       PowerShell).
     - For **remote / sandbox** terminal backends (docker, singularity,
@@ -1439,6 +1440,12 @@ def build_environment_hints() -> str:
         else:
             host_lines.append(f"Host: {platform.system()} ({platform.release()})")
 
+        try:
+            hostname = socket.gethostname().strip()
+        except OSError:
+            hostname = ""
+        if hostname:
+            host_lines.append(f"Machine hostname: {hostname}")
         host_lines.append(f"User home directory: {os.path.expanduser('~')}")
         try:
             host_lines.append(f"Current working directory: {resolve_agent_cwd()}")

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -763,6 +763,18 @@ class TestEnvironmentHints:
         assert "Terminal backend: docker" in result
         assert "inside" in result.lower()
 
+    def test_build_environment_hints_identifies_live_machine(self, monkeypatch):
+        """The prompt must identify the process host, not synchronized state."""
+        import agent.prompt_builder as _pb
+
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.setattr("socket.gethostname", lambda: "atlas")
+
+        result = _pb.build_environment_hints()
+
+        assert "Machine hostname: atlas" in result
+        assert result.index("Machine hostname: atlas") < result.index("User home directory:")
+
     def test_build_environment_hints_uses_terminal_cwd_over_launch_dir(self, monkeypatch, tmp_path):
         """THE BUG: gateway/cron set TERMINAL_CWD but the prompt emitted os.getcwd()
         (the daemon launch dir). Regression for #24882/#24969/#27383/#29265."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -390,7 +390,7 @@ class TestStoredPromptCwdDrift:
         return agent
 
     @staticmethod
-    def _host_block(cwd: str) -> str:
+    def _host_block(cwd: str, hostname: str = "atlas") -> str:
         """A stored prompt fragment shaped like the real host-info block.
 
         ``build_environment_hints`` always emits ``User home directory:``
@@ -401,9 +401,55 @@ class TestStoredPromptCwdDrift:
         """
         return (
             "Host: Linux (6.16.0)\n"
+            f"Machine hostname: {hostname}\n"
             "User home directory: /home/tester\n"
             f"Current working directory: {cwd}\n"
         )
+
+    def test_stored_prompt_stale_when_machine_hostname_differs(self):
+        """A session DB copied from another host must rebuild its prompt."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = self._host_block("/project/current", hostname="personal-pc")
+
+        with (
+            patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/current"),
+            patch("socket.gethostname", return_value="atlas"),
+        ):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False
+
+    def test_stored_prompt_fresh_when_machine_hostname_matches(self):
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = self._host_block("/project/current", hostname="atlas")
+
+        with (
+            patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/current"),
+            patch("socket.gethostname", return_value="atlas"),
+        ):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is True
+
+    def test_legacy_local_prompt_without_machine_hostname_is_rebuilt(self):
+        """One rebuild upgrades pre-runtime-identity prompt snapshots."""
+        from unittest.mock import patch
+        from agent.conversation_loop import _stored_prompt_matches_runtime
+
+        agent = self._make_agent()
+        stored_prompt = (
+            "Host: Linux (6.16.0)\n"
+            "User home directory: /home/tester\n"
+            "Current working directory: /project/current\n"
+        )
+
+        with (
+            patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/current"),
+            patch("socket.gethostname", return_value="atlas"),
+        ):
+            assert _stored_prompt_matches_runtime(agent, stored_prompt) is False
 
     def test_stored_prompt_stale_when_cwd_differs(self):
         """Different cwd should force a prompt rebuild."""

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -17,6 +17,7 @@ Bug scenario (pre-fix):
 """
 
 import os
+import socket
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -390,7 +391,7 @@ class TestStoredPromptCwdDrift:
         return agent
 
     @staticmethod
-    def _host_block(cwd: str, hostname: str = "atlas") -> str:
+    def _host_block(cwd: str, hostname: str | None = None) -> str:
         """A stored prompt fragment shaped like the real host-info block.
 
         ``build_environment_hints`` always emits ``User home directory:``
@@ -401,7 +402,7 @@ class TestStoredPromptCwdDrift:
         """
         return (
             "Host: Linux (6.16.0)\n"
-            f"Machine hostname: {hostname}\n"
+            f"Machine hostname: {hostname or socket.gethostname()}\n"
             "User home directory: /home/tester\n"
             f"Current working directory: {cwd}\n"
         )
@@ -425,7 +426,10 @@ class TestStoredPromptCwdDrift:
         from agent.conversation_loop import _stored_prompt_matches_runtime
 
         agent = self._make_agent()
-        stored_prompt = self._host_block("/project/current", hostname="atlas")
+        stored_prompt = (
+            self._host_block("/project/current", hostname="atlas")
+            + "\n# AGENTS.md\nMachine hostname: personal-pc\n"
+        )
 
         with (
             patch("agent.conversation_loop.resolve_agent_cwd", return_value="/project/current"),


### PR DESCRIPTION
## What does this PR do?

Hermes can restore a persisted system prompt copied from another machine and confidently report the wrong active host. This change places the live machine hostname in the local-runtime prompt and rejects copied or legacy local prompt snapshots when their hostname is missing or no longer matches.

### Symptom

A Telegram session served by Atlas can claim it is running on a synchronized personal PC because the prompt exposes only the operating system, home, cwd, and synchronized profile state, not the live machine identity.

### Impact

Users in synchronized multi-host setups can receive incorrect host attribution and direct debugging or operational instructions at the wrong machine.

### Bug Cause

**Trigger:** `agent/prompt_builder.py:build_environment_hints` and `agent/conversation_loop.py:_stored_prompt_matches_runtime`

**Causal chain:**
1. A local-runtime prompt is persisted in a session database and synchronized to another host.
2. The prompt omits the machine hostname, while restore validation checks model, provider, cwd, and platform only.
3. When those values match, the new host reuses the stale prompt and the model has no authoritative live host identity, so synchronized state can drive a wrong answer.

**Why it is wrong:** Profile and filesystem identity are not proof of which process currently serves the session.

**Working sibling / contrast:** Remote terminal backends intentionally describe the tool execution sandbox instead of the Hermes process host and continue to suppress local host information.

**Ruled out:** Platform routing is not the missing signal. The prompt already persists `Platform: telegram`; it does not identify whether that gateway process is on Atlas or the personal PC.

### Fix

Add the live `socket.gethostname()` value to local environment hints. During stored-prompt restoration, compare that anchored hostname with the current process host, reject cross-host snapshots, and rebuild legacy local snapshots once so they gain the new identity field. Keep the existing project-context anchoring so user prose cannot spoof the comparison.

## Related Issue

Closes #102170

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` - expose the live local machine hostname in the stable environment block.
- `agent/conversation_loop.py` - invalidate persisted local prompts when the machine identity is absent or stale.
- `tests/agent/test_prompt_builder.py` - verify local hostname emission.
- `tests/run_agent/test_compression_persistence.py` - cover copied-host, matching-host, and legacy prompt restoration.

## How to Test

1. Build a local environment hint with a known hostname and verify it identifies that host.
2. Restore a prompt saved with another hostname and verify Hermes rejects it; restore one from the same hostname and verify it remains cache-reusable.
3. Run:

```bash
scripts/run_tests.sh tests/run_agent/test_compression_persistence.py -k 'machine_hostname or legacy_local_prompt'
scripts/run_tests.sh tests/agent/test_prompt_builder.py -k identifies_live_machine
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant test files and all selected regression tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant docstrings - or N/A
- [x] `cli-config.yaml.example` is N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses Python's cross-platform `socket.gethostname()`
- [x] Tool descriptions and schemas are N/A because no tool behavior changed
