### PR TITLE
feat(bot-mode): support declarative CLI roster

### DIFF
--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -108,6 +108,62 @@ def test_never_injects_on_unmanaged_install(tmp_path):
     assert agent.tools == []
 
 
+def test_config_enabled_injects_message_agent_without_ui_meta(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    researcher = home / "profiles" / "researcher"
+    researcher.mkdir(parents=True)
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            agent:
+              bot_mode:
+                enabled: true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert [t["function"]["name"] for t in agent.tools] == [
+        bot_mode_dm.MESSAGE_AGENT_TOOL_NAME
+    ]
+
+
+def test_config_roster_rejects_unlisted_local_teammate(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher", "coder"))
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            agent:
+              bot_mode:
+                enabled: true
+                roster:
+                  - from: default
+                    to: [coder]
+            """
+        ),
+        encoding="utf-8",
+    )
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    denied = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="hi", agent=agent)
+    )
+    assert "error" in denied
+    assert denied["teammates"] == ["coder"]
+    assert calls == []
+
+    allowed = json.loads(
+        bot_mode_dm.message_agent_tool(target="coder", message="hi", agent=agent)
+    )
+    assert allowed["status"] == "sent"
+    assert len(calls) == 1
+
+
 def test_config_toggle_disables_injection(tmp_path):
     home = _managed_home(tmp_path)
     agent = _FakeAgent(home, title="Bot Chat")
@@ -189,7 +245,9 @@ def test_unregistered_peer_rejected(tmp_path):
     home = _managed_home(tmp_path, peers=("spark",))
     agent = _FakeAgent(home, title="Bot Chat")
     result = json.loads(
-        bot_mode_dm.message_agent_tool(target="homelab/coder", message="hi", agent=agent)
+        bot_mode_dm.message_agent_tool(
+            target="homelab/coder", message="hi", agent=agent
+        )
     )
     assert "error" in result
     assert result["peers"] == ["spark"]
@@ -203,7 +261,10 @@ def _capture_spawn(monkeypatch):
 
     def fake_terminal_tool(command, **kwargs):
         calls.append({"command": command, **kwargs})
-        return json.dumps({"output": "Background process started", "session_id": "proc_test1234"})
+        return json.dumps({
+            "output": "Background process started",
+            "session_id": "proc_test1234",
+        })
 
     import tools.terminal_tool as terminal_tool_module
 
@@ -265,7 +326,7 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     # attribution prefix applied server-side; body verbatim inside the file
     content = Path(dm_file).read_text(encoding="utf-8")
     assert content.startswith("Message from 🤖 hermes (@hermes): ")
-    assert '$(and this is not shell)' in content
+    assert "$(and this is not shell)" in content
 
 
 def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
@@ -303,13 +364,22 @@ def test_peer_delivery_command(tmp_path, monkeypatch):
     agent = _FakeAgent(home, title="Bot Chat")
 
     result = json.loads(
-        bot_mode_dm.message_agent_tool(target="spark/researcher", message="ping", agent=agent)
+        bot_mode_dm.message_agent_tool(
+            target="spark/researcher", message="ping", agent=agent
+        )
     )
     assert result["status"] == "sent"
     assert "spark" in result["to"]
     mode, _dm_file, transport_argv = _runner_parts(calls[0]["command"])
     assert mode == "stdin"
-    assert transport_argv == ["hermes", "-p", "default", "peer", "dm", "spark/researcher"]
+    assert transport_argv == [
+        "hermes",
+        "-p",
+        "default",
+        "peer",
+        "dm",
+        "spark/researcher",
+    ]
 
     # bare peer name targets the peer's main agent
     result2 = json.loads(
@@ -333,8 +403,10 @@ def test_named_profile_sender_prefix(tmp_path, monkeypatch):
     )
     assert result["status"] == "sent"
     _mode, dm_file, _transport_argv = _runner_parts(calls[0]["command"])
-    assert Path(dm_file).read_text(encoding="utf-8").startswith(
-        "Message from 🤖 coder (@coder): "
+    assert (
+        Path(dm_file)
+        .read_text(encoding="utf-8")
+        .startswith("Message from 🤖 coder (@coder): ")
     )
 
 
@@ -475,7 +547,9 @@ def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(
     assert not dm_file.exists()
 
 
-@pytest.mark.parametrize("args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]])
+@pytest.mark.parametrize(
+    "args", [[], ["--run-delivery"], ["--run-delivery", "bad", "x"]]
+)
 def test_delivery_main_rejects_invalid_cli(args):
     assert bot_mode_dm._delivery_main(args) == 2
 
@@ -495,17 +569,15 @@ def test_delivery_main_runs_valid_cli_and_unlinks(tmp_path, mode):
     )
     source_arg = "-" if mode == "stdin" else str(dm_file)
 
-    returncode = bot_mode_dm._delivery_main(
-        [
-            "--run-delivery",
-            mode,
-            str(dm_file),
-            sys.executable,
-            str(child),
-            source_arg,
-            str(observed),
-        ]
-    )
+    returncode = bot_mode_dm._delivery_main([
+        "--run-delivery",
+        mode,
+        str(dm_file),
+        sys.executable,
+        str(child),
+        source_arg,
+        str(observed),
+    ])
 
     assert returncode == 0
     assert observed.read_text(encoding="utf-8") == "secret"
@@ -521,9 +593,12 @@ def test_delivery_main_maps_launch_exception_to_one_and_unlinks(tmp_path, monkey
 
     monkeypatch.setattr(subprocess, "run", boom)
     assert (
-        bot_mode_dm._delivery_main(
-            ["--run-delivery", "query-file", str(dm_file), "missing-transport"]
-        )
+        bot_mode_dm._delivery_main([
+            "--run-delivery",
+            "query-file",
+            str(dm_file),
+            "missing-transport",
+        ])
         == 1
     )
     assert not dm_file.exists()
@@ -639,7 +714,9 @@ def test_successful_spawn_transfers_cleanup_to_runner(tmp_path, monkeypatch):
     )
 
     assert result["status"] == "sent"
-    assert dm_file.exists(), "the parent must not delete before the background runner reads"
+    assert dm_file.exists(), (
+        "the parent must not delete before the background runner reads"
+    )
 
 
 def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeypatch):
@@ -661,7 +738,9 @@ def test_write_dm_file_unlinks_partial_file_on_write_exception(tmp_path, monkeyp
             raise OSError("disk full")
 
     monkeypatch.setattr(bot_mode_dm.tempfile, "mkstemp", fixed_mkstemp)
-    monkeypatch.setattr(bot_mode_dm.os, "fdopen", lambda *args, **kwargs: BrokenWriter())
+    monkeypatch.setattr(
+        bot_mode_dm.os, "fdopen", lambda *args, **kwargs: BrokenWriter()
+    )
 
     with pytest.raises(OSError, match="disk full"):
         bot_mode_dm._write_dm_file("secret")
@@ -695,7 +774,8 @@ def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
     dm_dir = bot_mode_dm._dm_dir()
 
     if hasattr(os, "getuid"):
-        assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+        uid = os.getuid()  # windows-footgun: ok
+        assert dm_dir.name == f"{bot_mode_dm._DM_DIR_NAME}-{uid}"
     else:
         assert dm_dir.name == bot_mode_dm._DM_DIR_NAME
     assert dm_dir.stat().st_mode & 0o777 == 0o700
@@ -704,7 +784,11 @@ def test_dm_dir_is_private_and_uid_scoped_on_posix(tmp_path, monkeypatch):
 def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
     uid = os.getuid() if hasattr(os, "getuid") else None
-    dirname = f"{bot_mode_dm._DM_DIR_NAME}-{uid}" if uid is not None else bot_mode_dm._DM_DIR_NAME
+    dirname = (
+        f"{bot_mode_dm._DM_DIR_NAME}-{uid}"
+        if uid is not None
+        else bot_mode_dm._DM_DIR_NAME
+    )
     dm_dir = tmp_path / dirname
     dm_dir.mkdir(mode=0o500)
     dm_dir.chmod(0o500)
@@ -717,7 +801,8 @@ def test_dm_dir_repairs_restrictive_owner_mode(tmp_path, monkeypatch):
 def test_dm_dir_rejects_precreated_symlink(tmp_path, monkeypatch):
     target = tmp_path / "attacker-controlled"
     target.mkdir()
-    expected = tmp_path / f"{bot_mode_dm._DM_DIR_NAME}-{os.getuid()}"
+    uid = os.getuid()  # windows-footgun: ok
+    expected = tmp_path / f"{bot_mode_dm._DM_DIR_NAME}-{uid}"
     expected.symlink_to(target, target_is_directory=True)
     monkeypatch.setattr(bot_mode_dm.tempfile, "gettempdir", lambda: str(tmp_path))
 

--- a/tests/tools/test_bot_mode_probe.py
+++ b/tests/tools/test_bot_mode_probe.py
@@ -94,6 +94,52 @@ def test_roster_lines_carry_roles(tmp_path):
     assert "Deep research and literature review" in section
 
 
+def test_config_enabled_emits_without_desktop_ui_meta(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=False)
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            agent:
+              bot_mode:
+                enabled: true
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    assert bot_mode_probe.is_bot_mode_managed(home) is True
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert section.startswith("## Messaging other agents")
+    assert "`@researcher`" in section
+
+
+def test_config_roster_limits_local_teammates(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    _make_bot_profile(home, "researcher", managed=False)
+    _make_bot_profile(home, "coder", managed=False)
+    (home / "config.yaml").write_text(
+        textwrap.dedent(
+            """\
+            agent:
+              bot_mode:
+                enabled: true
+                roster:
+                  - from: default
+                    to: [coder]
+            """
+        ),
+        encoding="utf-8",
+    )
+
+    section = bot_mode_probe.get_bot_mode_protocol_section(home)
+    assert "`@coder`" in section
+    assert "`@researcher`" not in section
+    assert bot_mode_probe.allowed_local_profile_names(home) == ["coder"]
+
+
 def test_silent_when_soul_already_carries_protocol(tmp_path):
     """Legacy plugin-side append — never double the section."""
     home = tmp_path / ".hermes"
@@ -125,7 +171,9 @@ def test_never_raises_on_garbage(tmp_path, monkeypatch):
     (profiles / "profile.yaml").write_text("ui_meta: [unclosed", encoding="utf-8")
     assert isinstance(bot_mode_probe.get_bot_mode_protocol_section(home), str)
 
-    monkeypatch.setattr(bot_mode_probe, "_roster", lambda root: (_ for _ in ()).throw(OSError("boom")))
+    monkeypatch.setattr(
+        bot_mode_probe, "_roster", lambda root: (_ for _ in ()).throw(OSError("boom"))
+    )
     bot_mode_probe._reset_cache_for_tests()
     assert bot_mode_probe.get_bot_mode_protocol_section(home) == ""
 
@@ -137,7 +185,9 @@ def test_fingerprint_stable_when_nothing_changes(tmp_path):
     home = tmp_path / ".hermes"
     home.mkdir()
     _make_bot_profile(home, "researcher", managed=True)
-    assert bot_mode_probe.capability_fingerprint(home) == bot_mode_probe.capability_fingerprint(home)
+    assert bot_mode_probe.capability_fingerprint(
+        home
+    ) == bot_mode_probe.capability_fingerprint(home)
 
 
 def test_fingerprint_changes_on_each_capability_axis(tmp_path):
@@ -154,7 +204,9 @@ def test_fingerprint_changes_on_each_capability_axis(tmp_path):
     assert after_skill != base
 
     # toolset pin changed
-    (home / "config.yaml").write_text("tools:\n  enabled_toolsets: [web]\n", encoding="utf-8")
+    (home / "config.yaml").write_text(
+        "tools:\n  enabled_toolsets: [web]\n", encoding="utf-8"
+    )
     after_tools = bot_mode_probe.capability_fingerprint(home)
     assert after_tools != after_skill
 
@@ -208,13 +260,21 @@ def test_legacy_bot_chat_upgrade(tmp_path):
     assert bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(legacy, home)
 
     # a rebuilt prompt (stamped) never re-fires
-    upgraded = legacy + "\n\n" + bot_mode_probe.get_bot_mode_protocol_section(home) + "\n\n" + bot_mode_probe.epoch_line(home)
+    upgraded = (
+        legacy
+        + "\n\n"
+        + bot_mode_probe.get_bot_mode_protocol_section(home)
+        + "\n\n"
+        + bot_mode_probe.epoch_line(home)
+    )
     assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(upgraded, home)
 
     # SOUL already carries the legacy plugin-side append → probe silent →
     # no upgrade (rebuilding would loop: the new prompt would be unstamped too)
     bot_mode_probe._reset_cache_for_tests()
-    (home / "SOUL.md").write_text("# Me\n\n## Messaging other agents\nlegacy\n", encoding="utf-8")
+    (home / "SOUL.md").write_text(
+        "# Me\n\n## Messaging other agents\nlegacy\n", encoding="utf-8"
+    )
     assert not bot_mode_probe.stored_bot_chat_prompt_needs_upgrade(legacy, home)
 
     # prompt whose SOUL section rode into it → protocol heading present → no upgrade

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -68,7 +68,9 @@ MESSAGE_MAX_CHARS = 16000
 _DM_DIR_NAME = "hermes-dm"
 _DM_STALE_SECONDS = 24 * 60 * 60
 
-_PEER_TARGET_RE = re.compile(r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$")
+_PEER_TARGET_RE = re.compile(
+    r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$"
+)
 _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
 
 
@@ -227,10 +229,15 @@ def _resolve_local_name(target: str, roster: list[str]) -> Optional[str]:
 # ── the tool ─────────────────────────────────────────────────────────────────
 
 
-def _err(message: str, *, roster: list[str] | None = None, peers: list[str] | None = None) -> str:
+def _err(
+    message: str, *, roster: list[str] | None = None, peers: list[str] | None = None
+) -> str:
     from tools.bot_failure_reasons import classify_agent_error
 
-    payload: dict[str, Any] = {"error": message, "reason": classify_agent_error(message)}
+    payload: dict[str, Any] = {
+        "error": message,
+        "reason": classify_agent_error(message),
+    }
     if roster is not None:
         payload["teammates"] = roster
     if peers is not None:
@@ -273,7 +280,13 @@ def message_agent_tool(
     me = _self_profile_name(Path(home))
     roster = _local_roster(root)
     peers = _peers(root)
-    teammates = [_handle(n) for n in roster if n != me]
+    try:
+        from tools.bot_mode_probe import allowed_local_profile_names
+
+        allowed_local = allowed_local_profile_names(home)
+    except Exception:
+        allowed_local = [n for n in roster if n != me]
+    teammates = [_handle(n) for n in allowed_local]
 
     body = str(message or "").strip()
     if not body:
@@ -299,7 +312,9 @@ def message_agent_tool(
         peer_profile = peer_match.group(2) if peer_match else None
         if peer_name not in peers:
             return _err(
-                f"No registered peer named '{peer_name}'.", roster=teammates, peers=peers
+                f"No registered peer named '{peer_name}'.",
+                roster=teammates,
+                peers=peers,
             )
         dm_target = f"{peer_name}/{peer_profile}" if peer_profile else peer_name
         label = f"@{peer_profile or peer_name} on peer '{peer_name}'"
@@ -330,7 +345,11 @@ def message_agent_tool(
     # ── local teammate ──
     if not _LOCAL_TARGET_RE.match(raw_target) and "@" not in raw_target:
         return _err(f"Invalid target: {raw_target!r}.", roster=teammates, peers=peers)
-    resolved = _resolve_local_name(raw_target, roster) if _LOCAL_TARGET_RE.match(raw_target) else None
+    resolved = (
+        _resolve_local_name(raw_target, roster)
+        if _LOCAL_TARGET_RE.match(raw_target)
+        else None
+    )
     if resolved is None:
         # ── cross-connection teammate (Desktop relay) ──
         # Every gateway connected to the user's Desktop is reachable: the
@@ -345,6 +364,13 @@ def message_agent_tool(
             f"No teammate named '{raw_target}' on this install, on a connected "
             "machine, or on a registered peer. Pick a name from the roster "
             "(roles are listed in your system prompt).",
+            roster=teammates,
+            peers=peers,
+        )
+    if resolved is not None and resolved != me and resolved not in allowed_local:
+        return _err(
+            f"You are not allowed to message '{raw_target}' from this Bot Mode profile. "
+            "Pick a teammate from the configured roster.",
             roster=teammates,
             peers=peers,
         )
@@ -609,16 +635,22 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                     )
             # Re-emit the transport's streams: stdout is the reply text the
             # completion notification carries back to the sending agent.
-            if proc.returncode != 0 and "already has a live owner" in (proc.stderr or ""):
+            if proc.returncode != 0 and "already has a live owner" in (
+                proc.stderr or ""
+            ):
                 # #100523: the target's Bot Chat is held live by another
                 # surface (Desktop). The turn never ran, so tell the sender
                 # plainly instead of leaking a raw lease error + exit code.
-                who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
-                print(json.dumps({
-                    "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
-                             "surface right now, so your message was NOT delivered. Try again later.",
-                    "reason": "target_busy",
-                }))
+                who = (
+                    argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
+                )
+                print(
+                    json.dumps({
+                        "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
+                        "surface right now, so your message was NOT delivered. Try again later.",
+                        "reason": "target_busy",
+                    })
+                )
                 return 1
             if proc.stdout:
                 sys.stdout.write(proc.stdout)
@@ -713,20 +745,18 @@ def _spawn_delivery(
         # From this point the background runner owns the file and removes it
         # only after the local query-file or peer stdin consumer has finished.
         transferred = True
-        return json.dumps(
-            {
-                "status": "sent",
-                "to": label,
-                "detail": (
-                    f"Message dispatched to {label}. This is asynchronous — do NOT wait "
-                    "or poll. Finish your turn now; when the delivery completes, its "
-                    "notification carries the reply — relay it then, attributed to "
-                    "that agent."
-                ),
-                **({"process_id": proc_id} if proc_id else {}),
-                "sent_at": int(time.time()),
-            }
-        )
+        return json.dumps({
+            "status": "sent",
+            "to": label,
+            "detail": (
+                f"Message dispatched to {label}. This is asynchronous — do NOT wait "
+                "or poll. Finish your turn now; when the delivery completes, its "
+                "notification carries the reply — relay it then, attributed to "
+                "that agent."
+            ),
+            **({"process_id": proc_id} if proc_id else {}),
+            "sent_at": int(time.time()),
+        })
     except Exception as exc:
         logger.error("message_agent delivery spawn failed: %s", exc, exc_info=True)
         return _err(f"Delivery to {label} could not be started: {exc}")

--- a/tools/bot_mode_probe.py
+++ b/tools/bot_mode_probe.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import os
 import threading
 from pathlib import Path
+from typing import Any
 
 _PROTOCOL_HEADING = "## Messaging other agents"
 
@@ -57,6 +58,78 @@ def _profile_name(home: Path) -> str:
     return "default"
 
 
+def _bot_mode_config(root: Path) -> dict[str, Any]:
+    """CLI-native Bot Mode config from machine-root config.yaml. Never raises."""
+    try:
+        cfg_path = root / "config.yaml"
+        if not cfg_path.is_file():
+            return {}
+        raw = cfg_path.read_text(encoding="utf-8", errors="replace")
+        if "bot_mode" not in raw:
+            return {}
+        import yaml
+
+        data = yaml.safe_load(raw)
+        if not isinstance(data, dict):
+            return {}
+        agent_cfg = data.get("agent")
+        if not isinstance(agent_cfg, dict):
+            return {}
+        bot_cfg = agent_cfg.get("bot_mode")
+        return bot_cfg if isinstance(bot_cfg, dict) else {}
+    except Exception:
+        return {}
+
+
+def _declarative_bot_mode_enabled(root: Path) -> bool:
+    return _bot_mode_config(root).get("enabled") is True
+
+
+def _configured_targets(root: Path, me: str) -> set[str] | None:
+    """Allowed local profile names from agent.bot_mode.roster, or None for all."""
+    cfg = _bot_mode_config(root)
+    roster = cfg.get("roster")
+    if not isinstance(roster, list):
+        return None
+    targets: set[str] = set()
+    for row in roster:
+        if not isinstance(row, dict):
+            continue
+        source = str(row.get("from") or "").strip()
+        if source != me:
+            continue
+        raw_targets = row.get("to")
+        if isinstance(raw_targets, str):
+            raw_targets = [raw_targets]
+        if not isinstance(raw_targets, list):
+            continue
+        for target in raw_targets:
+            name = str(target or "").strip()
+            if name:
+                targets.add("default" if name == "hermes" else name)
+    return targets
+
+
+def allowed_local_profile_names(home: str | os.PathLike | None = None) -> list[str]:
+    """Local profile names this Bot Mode profile may message. Never raises."""
+    try:
+        if home:
+            resolved = Path(str(home))
+        else:
+            from hermes_constants import get_hermes_home
+
+            resolved = get_hermes_home()
+        root = _hermes_root(resolved)
+        me = _profile_name(resolved)
+        names = [name for name, _profile_dir in _roster(root) if name != me]
+        targets = _configured_targets(root, me)
+        if targets is not None:
+            names = [name for name in names if name in targets]
+        return names
+    except Exception:
+        return []
+
+
 def _is_bot_managed(profile_dir: Path) -> bool:
     """True when profile.yaml carries a ui_meta['hermes-bots'] block.
 
@@ -73,7 +146,9 @@ def _is_bot_managed(profile_dir: Path) -> bool:
 
         data = yaml.safe_load(raw)
         ui_meta = data.get("ui_meta") if isinstance(data, dict) else None
-        return isinstance(ui_meta, dict) and isinstance(ui_meta.get("hermes-bots"), dict)
+        return isinstance(ui_meta, dict) and isinstance(
+            ui_meta.get("hermes-bots"), dict
+        )
     except Exception:
         return False
 
@@ -102,10 +177,14 @@ def is_bot_mode_managed(home: str | os.PathLike | None = None) -> bool:
     """
     try:
         resolved = Path(
-            str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+            str(home)
+            if home
+            else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
         )
         root = _hermes_root(resolved)
-        return any(_is_bot_managed(d) for _n, d in _roster(root))
+        return _declarative_bot_mode_enabled(root) or any(
+            _is_bot_managed(d) for _n, d in _roster(root)
+        )
     except Exception:
         return False
 
@@ -113,7 +192,9 @@ def is_bot_mode_managed(home: str | os.PathLike | None = None) -> bool:
 def _soul_has_protocol(profile_dir: Path) -> bool:
     try:
         soul = profile_dir / "SOUL.md"
-        return soul.is_file() and _PROTOCOL_HEADING in soul.read_text(encoding="utf-8", errors="replace")
+        return soul.is_file() and _PROTOCOL_HEADING in soul.read_text(
+            encoding="utf-8", errors="replace"
+        )
     except Exception:
         return False
 
@@ -213,9 +294,7 @@ def _remote_paragraph(root: Path) -> str:
     for row, form in zip(roster, remote_target_forms(roster)):
         where = row["connection_label"] or row["connection_id"]
         role = " — ".join(p for p in (row["title"], row["description"]) if p)
-        lines.append(
-            f"- `@{form}` — on {where}" + (f" — {role}" if role else "")
-        )
+        lines.append(f"- `@{form}` — on {where}" + (f" — {role}" if role else ""))
     return (
         "\n\nTeammates on OTHER connected machines (reachable through the "
         "Desktop relay — message them with message_agent exactly like local "
@@ -244,7 +323,10 @@ def _build_section(home: Path) -> str:
     me = _profile_name(home)
 
     roster = _roster(root)
-    if not any(_is_bot_managed(d) for _n, d in roster):
+    if not (
+        _declarative_bot_mode_enabled(root)
+        or any(_is_bot_managed(d) for _n, d in roster)
+    ):
         return ""
 
     # An older plugin build may have appended the protocol to SOUL.md
@@ -254,7 +336,17 @@ def _build_section(home: Path) -> str:
         return ""
 
     handle = _handle(me)
-    roster_block = "\n".join(_roster_lines(root, me)) or "- (no teammates yet)"
+    allowed = _configured_targets(root, me)
+    roster_block = (
+        "\n".join(
+            line
+            for line, (name, _profile_dir) in zip(
+                _roster_lines(root, me), [(n, d) for n, d in _roster(root) if n != me]
+            )
+            if allowed is None or name in allowed
+        )
+        or "- (no teammates yet)"
+    )
 
     return (
         f"{_PROTOCOL_HEADING}\n"
@@ -267,7 +359,7 @@ def _build_section(home: Path) -> str:
         "that wakes you; relay it to the user then, attributed to that agent. "
         "COMPOSE every message yourself — say what YOU need from that agent; never "
         "forward the user's words verbatim, and never reveal private 1:1 chat "
-        "content. When the user says \"ask <name>\" or \"tell <name> ...\", that is "
+        'content. When the user says "ask <name>" or "tell <name> ...", that is '
         "a handoff: pick the right teammate from the roster below, message them "
         "with message_agent, and report back naming which agent replied. Message "
         "ONE clearly relevant teammate; don't fan out to several unless the user "
@@ -279,20 +371,24 @@ def _build_section(home: Path) -> str:
         "acknowledgements.\n"
         f"You are `@{handle}`. Your teammates (live roster; roles from their "
         "profiles):\n"
-        f"{roster_block}"
-        + _remote_paragraph(root)
-        + _peer_paragraph(root)
+        f"{roster_block}" + _remote_paragraph(root) + _peer_paragraph(root)
     )
 
 
-def get_bot_mode_protocol_section(home: str | os.PathLike | None = None, *, force_refresh: bool = False) -> str:
+def get_bot_mode_protocol_section(
+    home: str | os.PathLike | None = None, *, force_refresh: bool = False
+) -> str:
     """Cached probe entry point — one filesystem pass per (process, home).
 
     ``home`` should be the AGENT'S OWN resolved home (session-db derived),
     not the ambient HERMES_HOME — build threads can lose the ContextVar
     override and the env var would then name the wrong profile.
     """
-    resolved = str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    resolved = (
+        str(home)
+        if home
+        else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    )
     with _lock:
         if force_refresh or resolved not in _cached:
             try:
@@ -332,13 +428,20 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
     import hashlib
     import json
 
-    resolved = Path(str(home) if home else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes")))
+    resolved = Path(
+        str(home)
+        if home
+        else (os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    )
     surface: dict = {}
     try:
         # Canonical loader (managed overlay + env expansion + normalization),
         # scoped to the bot's home via the override the loaders already honor.
         from hermes_cli.config import load_config_readonly
-        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from hermes_constants import (
+            reset_hermes_home_override,
+            set_hermes_home_override,
+        )
 
         token = set_hermes_home_override(str(resolved))
         try:
@@ -349,15 +452,25 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
         tools_cfg = cfg.get("tools") if isinstance(cfg.get("tools"), dict) else {}
         skills_cfg = skills_cfg or {}
         tools_cfg = tools_cfg or {}
-        surface["disabled_skills"] = sorted(str(s).lower() for s in (skills_cfg.get("disabled") or []))
-        surface["enabled_toolsets"] = sorted(str(t) for t in (tools_cfg.get("enabled_toolsets") or []))
+        surface["disabled_skills"] = sorted(
+            str(s).lower() for s in (skills_cfg.get("disabled") or [])
+        )
+        surface["enabled_toolsets"] = sorted(
+            str(t) for t in (tools_cfg.get("enabled_toolsets") or [])
+        )
         mcp = cfg.get("mcp_servers")
-        surface["mcp"] = json.dumps(mcp, sort_keys=True, default=str) if isinstance(mcp, dict) else ""
+        surface["mcp"] = (
+            json.dumps(mcp, sort_keys=True, default=str)
+            if isinstance(mcp, dict)
+            else ""
+        )
     except Exception:
         pass
     try:
         soul = resolved / "SOUL.md"
-        surface["soul"] = hashlib.sha256(soul.read_bytes()).hexdigest() if soul.is_file() else ""
+        surface["soul"] = (
+            hashlib.sha256(soul.read_bytes()).hexdigest() if soul.is_file() else ""
+        )
     except Exception:
         surface["soul"] = ""
     try:
@@ -371,7 +484,12 @@ def capability_fingerprint(home: str | os.PathLike | None = None) -> str:
         surface["skills"] = []
     try:
         root = _hermes_root(resolved)
-        surface["roster"] = sorted(n for n, d in _roster(root) if _is_bot_managed(d))
+        surface["bot_mode_config"] = _bot_mode_config(root)
+        surface["roster"] = sorted(
+            n
+            for n, d in _roster(root)
+            if _declarative_bot_mode_enabled(root) or _is_bot_managed(d)
+        )
         # Roles are part of the messaging surface: renaming a bot or editing
         # a profile description must refresh eternal Bot Chat prompts so the
         # roster block teammates pick recipients from stays current.
@@ -415,7 +533,9 @@ def epoch_line(home: str | os.PathLike | None = None) -> str:
     return f"{_EPOCH_PREFIX}{capability_fingerprint(home)}"
 
 
-def stored_prompt_capability_stale(stored_prompt: str, home: str | os.PathLike | None = None) -> bool:
+def stored_prompt_capability_stale(
+    stored_prompt: str, home: str | os.PathLike | None = None
+) -> bool:
     """True when ``stored_prompt`` is a Bot Chat prompt whose embedded
     capability epoch no longer matches the current disk state.
 
@@ -437,7 +557,9 @@ def stored_prompt_capability_stale(stored_prompt: str, home: str | os.PathLike |
         return False
 
 
-def stored_bot_chat_prompt_needs_upgrade(stored_prompt: str, home: str | os.PathLike | None = None) -> bool:
+def stored_bot_chat_prompt_needs_upgrade(
+    stored_prompt: str, home: str | os.PathLike | None = None
+) -> bool:
     """True when a Bot Chat session's stored prompt PREDATES this feature.
 
     Legacy Bot Chats (created before bundling / this epoch mechanism)


### PR DESCRIPTION
## Summary

Adds a CLI-native Bot Mode declaration path so `agent.bot_mode.enabled: true` in `config.yaml` enables the Bot Chat protocol and `message_agent` tool without requiring Desktop-written `ui_meta["hermes-bots"]`. Optional `agent.bot_mode.roster` entries now constrain local profile DMs, while existing Desktop `ui_meta` behavior remains supported.

---

## Changes

- `tools/bot_mode_probe.py`: reads `agent.bot_mode` from root `config.yaml`, treats `enabled: true` as a managed Bot Mode install, filters local roster entries by optional `roster`, and includes config state in the Bot Chat capability fingerprint.
- `tools/bot_mode_dm.py`: applies the configured local roster to `message_agent` target validation and teammate error payloads.
- `tests/tools/test_bot_mode_probe.py`: adds regression coverage for config-only Bot Mode enablement and roster-limited prompt injection.
- `tests/tools/test_bot_mode_dm.py`: adds regression coverage for config-only tool injection and rejection of unlisted local teammates.

## How to Test

```bash
/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_bot_mode_probe.py tests/tools/test_bot_mode_dm.py -q
# ✅ 60 passed, 1 skipped

ruff check tools/bot_mode_probe.py tools/bot_mode_dm.py tests/tools/test_bot_mode_probe.py tests/tools/test_bot_mode_dm.py
# ✅ All checks passed

/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py tools/bot_mode_probe.py tools/bot_mode_dm.py tests/tools/test_bot_mode_probe.py tests/tools/test_bot_mode_dm.py
# ✅ No Windows footguns found
```

Full `scripts/run_tests.sh` was attempted on Termux and failed before exercising the suite because the parallel runner crashed with repeated `PermissionError(13, 'Permission denied')`; scoped regression tests passed.

## Checklist

- [x] Tests pass — 60/60 targeted, 1 skipped
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes added for new fallback paths
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

## Risk & Impact

Low. The existing Desktop-managed `ui_meta` path is preserved; config-based Bot Mode only activates when users explicitly set `agent.bot_mode.enabled: true`.

Type: New feature
Closes: #102155
