### PR TITLE
fix(updater): stop late autostash failures on sudo-owned installs

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -8020,6 +8020,73 @@ def _path_uid(path) -> Optional[int]:
         return None
 
 
+def _git_objects_foreign_owned_paths(project_root, limit: int = 5) -> list:
+    """Return foreign-owned directories in the Git object database.
+
+    A prior ``sudo hermes`` / ``sudo git`` invocation can leave one or more
+    loose-object fan-out directories owned by root. Git can still read the
+    checkout, so the damage stays hidden until fetch or autostash needs to
+    write an object whose hash lands in that directory (#102172).
+
+    Only the object root and its direct child directories are relevant write
+    boundaries, so this scan is bounded to at most 259 stat calls. POSIX-only;
+    root and platforms without ``geteuid`` have no ownership mismatch to gate.
+    Never raises.
+    """
+    try:
+        if not hasattr(os, "geteuid"):
+            return []
+        euid = os.geteuid()
+        if euid == 0:
+            return []
+
+        objects = Path(project_root) / ".git" / "objects"
+        foreign: list = []
+
+        owner = _path_uid(objects)
+        if owner is not None and owner != euid:
+            foreign.append((str(objects), owner))
+        if len(foreign) >= limit:
+            return foreign
+
+        try:
+            entries = os.scandir(objects)
+        except OSError:
+            return foreign
+        with entries:
+            for entry in entries:
+                try:
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:
+                    continue
+                owner = _path_uid(entry.path)
+                if owner is not None and owner != euid:
+                    foreign.append((str(entry.path), owner))
+                    if len(foreign) >= limit:
+                        break
+        return foreign
+    except Exception:
+        return []
+
+
+def _refuse_update_if_git_objects_foreign_owned(project_root) -> None:
+    """Stop before backup/stash when Git cannot safely write new objects."""
+    foreign = _git_objects_foreign_owned_paths(project_root)
+    if not foreign:
+        return
+    print("\n✗ Update stopped: this checkout's Git objects are owned by another user.")
+    print("  Fetching or stashing now would fail when Git writes a new object.")
+    print("  This usually happens after running hermes or git with sudo. Offending paths:")
+    for path, uid in foreign:
+        print(f"    - {path} (owner uid {uid})")
+    print("\n  Fix ownership, then re-run the update:")
+    print(f"    sudo chown -R $(id -un): {project_root}")
+    print("    hermes update")
+    print("\n  Nothing was modified; update stopped before creating a backup or stashing local changes.")
+    sys.exit(1)
+
+
 def _venv_foreign_owned_paths(venv_root, limit: int = 5) -> list:
     """Bounded scan for venv entries not owned by the current user (#83529).
 
@@ -8304,6 +8371,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         )
                     )
                     sys.exit(2)
+
+    # A foreign-owned .git/objects fan-out can stay latent until fetch or
+    # autostash happens to write a matching hash. Refuse before spending time
+    # on a backup, and before any Git mutation, with an exact recovery command.
+    _refuse_update_if_git_objects_foreign_owned(_m().PROJECT_ROOT)
 
     # Pre-update backup — runs before any git/file mutation so users can
     # always roll back to the exact state they had before this update.

--- a/tests/hermes_cli/test_update_repo_ownership_preflight.py
+++ b/tests/hermes_cli/test_update_repo_ownership_preflight.py
@@ -1,0 +1,144 @@
+"""Git object ownership preflight for ``hermes update`` (#102172).
+
+A checkout previously touched through ``sudo`` can contain root-owned fan-out
+folders under ``.git/objects``. A later update then fails while autostash or
+fetch tries to add an object. The preflight refuses before the backup and Git
+mutation phases and prints the exact ownership repair command.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli import update_cmd
+
+
+def _make_object_db(root: Path) -> Path:
+    objects = root / ".git" / "objects"
+    (objects / "1c").mkdir(parents=True)
+    (objects / "info").mkdir()
+    (objects / "pack").mkdir()
+    return objects
+
+
+def test_foreign_owned_object_fanout_is_detected(tmp_path, monkeypatch):
+    objects = _make_object_db(tmp_path)
+    fanout = str(objects / "1c")
+
+    monkeypatch.setattr(update_cmd.os, "geteuid", lambda: 12345, raising=False)
+    monkeypatch.setattr(
+        update_cmd,
+        "_path_uid",
+        lambda path: 0 if str(path) == fanout else 12345,
+    )
+
+    assert update_cmd._git_objects_foreign_owned_paths(tmp_path) == [(fanout, 0)]
+
+
+def test_repository_ownership_gate_refuses_with_repair_hint(
+    tmp_path, monkeypatch, capsys
+):
+    object_dir = str(tmp_path / ".git" / "objects" / "1c")
+    monkeypatch.setattr(
+        update_cmd,
+        "_git_objects_foreign_owned_paths",
+        lambda _root: [(object_dir, 0)],
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        update_cmd._refuse_update_if_git_objects_foreign_owned(tmp_path)
+
+    assert exc.value.code == 1
+    output = capsys.readouterr().out
+    assert object_dir in output
+    assert "owner uid 0" in output
+    assert f"sudo chown -R $(id -un): {tmp_path}" in output
+    assert "before creating a backup or stashing local changes" in output
+
+
+def test_repository_ownership_gate_is_noop_for_healthy_checkout(
+    tmp_path, monkeypatch, capsys
+):
+    monkeypatch.setattr(
+        update_cmd,
+        "_git_objects_foreign_owned_paths",
+        lambda _root: [],
+    )
+
+    update_cmd._refuse_update_if_git_objects_foreign_owned(tmp_path)
+
+    assert capsys.readouterr().out == ""
+
+
+def test_update_runs_repository_ownership_gate_before_backup(tmp_path, monkeypatch):
+    from hermes_cli import main as hermes_main
+
+    calls = []
+    monkeypatch.setattr(hermes_main, "PROJECT_ROOT", tmp_path)
+    monkeypatch.setattr(hermes_main, "_capture_active_lazy_features", lambda: set())
+    monkeypatch.setattr(hermes_main, "_capture_active_tool_dependencies", lambda: set())
+    monkeypatch.setattr(hermes_main, "_is_windows", lambda: False)
+    monkeypatch.setattr(
+        hermes_main,
+        "_run_pre_update_backup",
+        lambda _args: calls.append("backup"),
+    )
+    monkeypatch.setattr(update_cmd, "_read_project_version", lambda: "test")
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {})
+    monkeypatch.setattr("hermes_cli.update_receipt.begin_update_receipt", lambda: None)
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[]),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.record_plan_in_receipt", lambda _plan: None
+    )
+
+    def refuse(_root):
+        calls.append("preflight")
+        raise SystemExit(37)
+
+    monkeypatch.setattr(
+        update_cmd, "_refuse_update_if_git_objects_foreign_owned", refuse
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        update_cmd._cmd_update_impl(SimpleNamespace(), gateway_mode=False)
+
+    assert exc.value.code == 37
+    assert calls == ["preflight"]
+
+
+def test_object_scan_is_bounded_to_direct_entries(tmp_path, monkeypatch):
+    objects = _make_object_db(tmp_path)
+    loose_object = objects / "1c" / "deadbeef"
+    loose_object.write_text("object")
+
+    monkeypatch.setattr(update_cmd.os, "geteuid", lambda: 12345, raising=False)
+    monkeypatch.setattr(
+        update_cmd,
+        "_path_uid",
+        lambda path: 0 if Path(path) == loose_object else 12345,
+    )
+
+    assert update_cmd._git_objects_foreign_owned_paths(tmp_path) == []
+
+
+def test_object_scan_skips_root_and_platforms_without_geteuid(
+    tmp_path, monkeypatch
+):
+    real_os = update_cmd.os
+    _make_object_db(tmp_path)
+    monkeypatch.setattr(update_cmd, "_path_uid", lambda _path: 12345)
+    monkeypatch.setattr(update_cmd.os, "geteuid", lambda: 0, raising=False)
+    assert update_cmd._git_objects_foreign_owned_paths(tmp_path) == []
+
+    class _NoGeteuidOS:
+        def __getattr__(self, name):
+            if name == "geteuid":
+                raise AttributeError(name)
+            return getattr(real_os, name)
+
+    monkeypatch.setattr(update_cmd, "os", _NoGeteuidOS())
+    assert update_cmd._git_objects_foreign_owned_paths(tmp_path) == []


### PR DESCRIPTION
## What does this PR do?

Stops `hermes update --backup` from spending time on a backup and then failing inside autostash when `.git/objects` contains directories owned by another user. The updater now performs a bounded ownership preflight, refuses before backup or Git mutation, identifies the offending paths, and prints the exact ownership repair command.

### Symptom

On a checkout previously touched through `sudo`, `hermes update --backup` can successfully create a large backup and then abort with `insufficient permission for adding an object to repository database .git/objects` while saving local changes.

### Impact

Affected POSIX git installs cannot update as the normal user until repository ownership is repaired. The old path also wastes the full backup time before exposing the underlying ownership problem.

### Bug Cause

**Trigger:** `hermes_cli/update_cmd.py:2613` / `_stash_local_changes_if_needed` calls `git stash push --include-untracked` after the backup phase.

**Causal chain:**
1. A prior `sudo hermes` or `sudo git` invocation leaves a loose-object fan-out directory under `.git/objects` owned by root.
2. The checkout remains readable, so the updater reaches backup and autostash normally.
3. Autostash needs to create a Git object whose hash maps to the foreign-owned directory, Git cannot write it, no stash ref is created, and the update aborts late.

**Why it is wrong:** The updater already preflights foreign ownership in the venv before dependency mutation, but it did not preflight the Git object database before backup, fetch, or autostash.

**Working sibling / contrast:** The existing venv ownership gate detects the same `sudo` residue class before `uv` mutates the environment and provides a `sudo chown` recovery command.

**Ruled out:** This is not the existing undeletable-untracked-file case. That path creates a complete stash entry and safely continues; the reported object database error prevents a stash entry from being created at all.

### Fix

Add a POSIX-only, bounded scan of the Git object root and direct child directories. Run the ownership gate before pre-update backup and all Git mutation, while preserving no-op behavior for healthy checkouts, root, unsupported platforms, unreadable structures, and foreign-owned loose object files that do not block directory writes.

## Related Issue

Closes #102172

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/update_cmd.py` - preflight `.git/objects` ownership before backup, fetch, and autostash; print actionable recovery guidance.
- `tests/hermes_cli/test_update_repo_ownership_preflight.py` - cover fan-out detection, bounded scanning, refusal output, healthy/root/platform no-ops, and ordering before backup.

## How to Test

1. Create a temporary git checkout with a direct `.git/objects/<fanout>` directory reported as owned by another uid.
2. Run the ownership preflight and verify it exits before `_run_pre_update_backup`, names the path, and prints the repair command.
3. Run the automated regression tests:

```bash
scripts/run_tests.sh tests/hermes_cli/test_update_repo_ownership_preflight.py -q
scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py -k 'autostash_survives_undeletable_untracked_dir or update_keep_stash_parks_instead_of_restoring or update_without_keep_stash_still_restores' -q
```

Local result: 8 passed, 1 skipped. The skipped test requires POSIX permission semantics.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all selected tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11; POSIX ownership verification is delegated to review

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; user-facing recovery guidance is inline
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - the automated tests assert the refusal output and phase ordering.
