### PR TITLE
fix(gateway): ground status in live runtime identity

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4879,6 +4879,36 @@ def systemd_restart(system: bool = False):
     _wait_for_systemd_service_restart(system=system, previous_pid=pid)
 
 
+def _runtime_identity_lines(pid: int | None = None) -> list[str]:
+    """Return live, redacted identity fields for gateway diagnostics.
+
+    Profile files and logs can be synchronized or stale across hosts.  These
+    fields deliberately come from the current process and the current
+    profile-scoped service lookup, so status output has an explicit source of
+    truth for host attribution.
+    """
+    try:
+        host = socket.gethostname().strip() or "unknown"
+    except OSError:
+        host = "unknown"
+    try:
+        profile = _profile_suffix() or "default"
+    except Exception:
+        profile = "unknown"
+    try:
+        home = str(get_hermes_home().resolve())
+    except Exception:
+        home = "unknown"
+    lines = [
+        f"Host: {host}",
+        f"Profile: {profile}",
+        f"HERMES_HOME: {home}",
+    ]
+    if pid is not None and pid > 0:
+        lines.append(f"Gateway PID: {pid}")
+    return lines
+
+
 def systemd_status(deep: bool = False, system: bool = False, full: bool = False):
     system = _select_systemd_scope(system)
     unit_path = get_systemd_unit_path(system=system)
@@ -4904,28 +4934,37 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         )
         print()
 
-    status_cmd = ["status", get_service_name(), "--no-pager"]
-    if full:
-        status_cmd.append("-l")
+    # ``systemctl status`` includes journal lines in its output.  Keep that
+    # historical/log view behind --deep/--full so stale or cross-profile logs
+    # cannot be mistaken for live gateway state (#102170).
+    if deep or full:
+        status_cmd = ["status", get_service_name(), "--no-pager"]
+        if full:
+            status_cmd.append("-l")
+        _run_systemctl(
+            status_cmd,
+            system=system,
+            capture_output=False,
+            timeout=10,
+        )
 
-    _run_systemctl(
-        status_cmd,
-        system=system,
-        capture_output=False,
-        timeout=10,
-    )
+    unit_props = _read_systemd_unit_properties(system=system)
+    active_state = unit_props.get("ActiveState", "")
+    sub_state = unit_props.get("SubState", "")
+    exec_main_status = unit_props.get("ExecMainStatus", "")
+    result_code = unit_props.get("Result", "")
+    try:
+        main_pid = int(unit_props.get("MainPID", "0") or "0")
+    except (TypeError, ValueError):
+        main_pid = 0
 
-    result = _run_systemctl(
-        ["is-active", get_service_name()],
-        system=system,
-        capture_output=True,
-        text=True, encoding='utf-8', errors='replace',
-        timeout=10,
-    )
+    print("Gateway runtime identity:")
+    for line in _runtime_identity_lines(main_pid):
+        print(f"  {line}")
+    print(f"  Service: {get_service_name()}")
+    print(f"  Service state: {active_state or 'unknown'} ({sub_state or 'unknown'})")
 
-    status = result.stdout.strip()
-
-    if status == "active":
+    if active_state == "active":
         print(
             f"✓ {_service_scope_label(system).capitalize()} gateway service is running"
         )

--- a/tests/hermes_cli/test_gateway_status_live_identity.py
+++ b/tests/hermes_cli/test_gateway_status_live_identity.py
@@ -1,0 +1,66 @@
+"""Regression tests for live gateway identity reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import hermes_cli.gateway as gateway_cli
+
+
+def _patch_systemd_status(monkeypatch, tmp_path: Path, *, deep: bool):
+    calls = []
+    unit = tmp_path / "hermes-gateway.service"
+    unit.write_text("[Unit]\n", encoding="utf-8")
+
+    monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+    monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit)
+    monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
+    monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)
+    monkeypatch.setattr(gateway_cli, "systemd_unit_is_current", lambda system=False: True)
+    monkeypatch.setattr(gateway_cli, "get_service_name", lambda: "hermes-gateway")
+    monkeypatch.setattr(
+        gateway_cli,
+        "_read_systemd_unit_properties",
+        lambda system=False, properties=None: {
+            "ActiveState": "active",
+            "SubState": "running",
+            "MainPID": "4242",
+        },
+    )
+    monkeypatch.setattr(gateway_cli, "_profile_suffix", lambda: "atlas")
+    monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: tmp_path / "profiles" / "atlas")
+    monkeypatch.setattr(gateway_cli, "_runtime_health_lines", lambda: [])
+    monkeypatch.setattr(gateway_cli, "get_systemd_linger_status", lambda: (True, ""))
+    monkeypatch.setattr(
+        gateway_cli,
+        "_run_systemctl",
+        lambda args, **kwargs: calls.append(args),
+    )
+    monkeypatch.setattr(gateway_cli.subprocess, "run", lambda *args, **kwargs: calls.append(args[0]))
+    return calls
+
+
+def test_status_uses_structured_state_and_live_identity_without_logs(
+    monkeypatch, tmp_path, capsys
+):
+    calls = _patch_systemd_status(monkeypatch, tmp_path, deep=False)
+
+    gateway_cli.systemd_status(deep=False)
+
+    output = capsys.readouterr().out
+    assert "Gateway runtime identity:" in output
+    assert "Host:" in output
+    assert "Profile: atlas" in output
+    assert "Gateway PID: 4242" in output
+    assert "Service state: active (running)" in output
+    assert not any(command and command[0] == "status" for command in calls)
+
+
+def test_deep_status_keeps_explicit_log_view(monkeypatch, tmp_path, capsys):
+    calls = _patch_systemd_status(monkeypatch, tmp_path, deep=True)
+
+    gateway_cli.systemd_status(deep=True)
+
+    capsys.readouterr()
+    assert any(command[:2] == ["status", "hermes-gateway"] for command in calls)
+    assert any(command and command[0] == "journalctl" for command in calls)


### PR DESCRIPTION
## Summary

- Stop treating `systemctl status` journal output as the primary gateway status surface.
- Use structured systemd runtime properties for the normal status path.
- Expose explicit host, profile, `HERMES_HOME`, service, and gateway PID identity fields.
- Preserve detailed service/log inspection behind `--deep` or `--full`.
- Add regression coverage for live identity output and log isolation.

This addresses the multi-host/profile confusion described in #102170, where synchronized profiles and stale logs can cause the agent to attribute the active gateway to the wrong host.

## Test plan

- `./scripts/run_tests.sh tests/hermes_cli/test_gateway_status_live_identity.py tests/hermes_cli/test_gateway_multiplex_status.py tests/hermes_cli/test_gateway_service.py`
- Result: 107 passed, 1 macOS-only test skipped on Linux.
- `git diff --check`
- Verified against a live Atlas gateway: output reports `Host: atlas`, the active profile, and the current gateway PID without journal log dumping in normal mode.

Closes #102170
