### PR TITLE
feat(desktop): copy Markdown from file previews

### DIFF
--- a/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.test.tsx
@@ -1,7 +1,38 @@
-import { cleanup, render, screen } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { MarkdownPreview } from './preview-file'
+import { LocalFilePreview, MarkdownPreview } from './preview-file'
+
+const desktopWindow = window as unknown as { hermesDesktop?: Window['hermesDesktop'] }
+const initialHermesDesktop = desktopWindow.hermesDesktop
+
+function installFileBridge(text: string, truncated = false) {
+  const writeClipboard = vi.fn().mockResolvedValue(undefined)
+
+  desktopWindow.hermesDesktop = {
+    gitRoot: vi.fn().mockResolvedValue(null),
+    readFileText: vi.fn().mockResolvedValue({
+      byteSize: text.length,
+      language: 'markdown',
+      path: '/tmp/notes.md',
+      text,
+      truncated
+    }),
+    writeClipboard
+  } as unknown as Window['hermesDesktop']
+
+  return writeClipboard
+}
+
+const markdownTarget = {
+  kind: 'file' as const,
+  label: 'notes.md',
+  language: 'markdown',
+  path: '/tmp/notes.md',
+  previewKind: 'text' as const,
+  source: '/tmp/notes.md',
+  url: 'file:///tmp/notes.md'
+}
 
 // Behavior tests for the .md file preview renderer: input markdown goes
 // through normalizeFilePreviewMath -> Streamdown (+ KaTeX math plugin) and must
@@ -11,6 +42,13 @@ import { MarkdownPreview } from './preview-file'
 describe('MarkdownPreview', () => {
   afterEach(() => {
     cleanup()
+    vi.restoreAllMocks()
+
+    if (initialHermesDesktop) {
+      desktopWindow.hermesDesktop = initialHermesDesktop
+    } else {
+      delete desktopWindow.hermesDesktop
+    }
   })
 
   it('renders block and inline math through KaTeX', () => {
@@ -49,5 +87,32 @@ describe('MarkdownPreview', () => {
     expect(anchor?.getAttribute('href')).toBe('https://example.com/docs')
     expect(anchor?.getAttribute('target')).toBe('_blank')
     expect(anchor?.getAttribute('rel')).toBe('noopener noreferrer')
+  })
+
+  it('copies the complete raw Markdown from the preview toolbar', async () => {
+    const markdown = '# Heading\n\n**bold** and [link](https://example.com)\n'
+    const writeClipboard = installFileBridge(markdown)
+
+    render(<LocalFilePreview reloadKey={0} target={markdownTarget} />)
+    const copy = await screen.findByRole('button', { name: 'Copy' })
+    const edit = screen.getByRole('button', { name: 'Edit' })
+
+    expect(copy.textContent).toBe('')
+    expect(edit.textContent).toBe('')
+    fireEvent.click(copy)
+
+    await waitFor(() => expect(writeClipboard).toHaveBeenCalledWith(markdown))
+  })
+
+  it.each([
+    { text: '# Partial', truncated: true },
+    { text: '', truncated: false }
+  ])('does not offer a whole-file copy for truncated or empty Markdown', async ({ text, truncated }) => {
+    installFileBridge(text, truncated)
+
+    render(<LocalFilePreview reloadKey={0} target={markdownTarget} />)
+
+    await screen.findByText('SOURCE')
+    expect(screen.queryByRole('button', { name: 'Copy' })).toBeNull()
   })
 })

--- a/apps/desktop/src/app/chat/right-rail/preview-file.tsx
+++ b/apps/desktop/src/app/chat/right-rail/preview-file.tsx
@@ -19,6 +19,8 @@ import { FileDiffPanel } from '@/components/chat/diff-lines'
 import { chunkTextLines, useFixedRowWindow } from '@/components/chat/fixed-row-window'
 import { LazyShiki as ShikiHighlighter } from '@/components/chat/shiki-highlighter'
 import { PageLoader } from '@/components/page-loader'
+import { Button } from '@/components/ui/button'
+import { CopyButton } from '@/components/ui/copy-button'
 import { Tip } from '@/components/ui/tooltip'
 import { translateNow, useI18n } from '@/i18n'
 import {
@@ -1115,17 +1117,25 @@ export function LocalFilePreview({ reloadKey, target }: { reloadKey: number; tar
           modes={modes}
           onSelect={setUserMode}
           trailing={
-            canEdit ? (
-              <Tip label={`${t.preview.edit} (e)`}>
-                <button
-                  className="flex items-center gap-1 text-[0.625rem] font-bold text-muted-foreground underline-offset-4 transition-colors hover:text-foreground"
-                  onClick={beginEdit}
-                  type="button"
-                >
-                  <Pencil className="size-3" />
-                  {t.preview.edit}
-                </button>
-              </Tip>
+            isMarkdown || canEdit ? (
+              <>
+                {isMarkdown && !state.truncated && state.text.length > 0 && (
+                  <CopyButton appearance="icon" buttonSize="icon-xs" text={state.text} />
+                )}
+                {canEdit && (
+                  <Tip label={`${t.preview.edit} (e)`}>
+                    <Button
+                      aria-label={t.preview.edit}
+                      onClick={beginEdit}
+                      size="icon-xs"
+                      type="button"
+                      variant="ghost"
+                    >
+                      <Pencil />
+                    </Button>
+                  </Tip>
+                )}
+              </>
             ) : null
           }
         />


### PR DESCRIPTION
## Summary
- add an icon-only Copy action beside the Markdown preview mode controls
- copy the complete raw Markdown source rather than rendered text or diff output
- use matching icon-only styling for Edit while preserving its existing `e` shortcut
- hide whole-file Copy when the preview is empty or truncated

## Verification
- `npm run test:ui -- src/app/chat/right-rail/preview-file.test.tsx src/components/ui/copy-button.test.tsx` (8 passed)
- `npm run typecheck`
- changed-file ESLint
- `npm run build`
- `npm run builder -- --dir --publish never`
- full UI suite on the candidate worktree (718 files, 7,169 tests passed)
- packaged isolated macOS QA build, with Copy and Edit verified as aligned icon-only controls
- independent exact-patch review passed with no security or logic blockers

## Baseline-only test failure
- the Electron platform suite has one unrelated failure in `managed-ssh-update.test.ts`; the same failure reproduces on untouched `origin/main` at the PR base

## Manual QA
- opened a real Markdown file in the packaged isolated Desktop build
- verified the toolbar order is Preview, Source, Copy, Edit
- verified both actions are accessible icon buttons with tooltips
- verified Copy receives the unchanged raw Markdown source
