### PR TITLE
fix(cli): report real plugin platform configuration in hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -32,6 +32,27 @@ def check_mark(ok: bool) -> str:
         return color("✓", Colors.GREEN)
     return color("✗", Colors.RED)
 
+def _plugin_platform_configured(entry) -> bool:
+    """True when the user actually configured this plugin platform.
+
+    ``PlatformEntry.check_fn`` is a passive *dependency* probe ("are the
+    platform's deps importable right now"), not a configuration check —
+    every bundled platform ships its dependencies, so calling it here made
+    ``hermes status`` report A2A, Mattermost, WeCom, … as "configured" for
+    users who never opted into any of them (#102183). ``is_connected`` holds
+    the real verdict (env vars / config.yaml); probe it with a synthetic
+    enabled config the same way ``hermes setup``'s ``_platform_status``
+    does. Only fall back to ``check_fn`` when the platform registered no
+    ``is_connected`` hook, and never when the hook already said "no" — an
+    installed SDK must not override a missing token.
+    """
+    if entry.is_connected is not None:
+        from gateway.config import PlatformConfig
+
+        synthetic = PlatformConfig(enabled=True)
+        return bool(entry.is_connected(synthetic))
+    return bool(entry.check_fn())
+
 def redact_key(key: str) -> str:
     """Redact an API key for display.
 
@@ -547,7 +568,7 @@ def show_status(args):
             # of every remaining plugin platform (matches the other three
             # check_fn call sites).
             try:
-                configured = bool(entry.check_fn())
+                configured = _plugin_platform_configured(entry)
             except Exception:
                 configured = False
             status_str = "configured" if configured else "not configured"

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -249,3 +249,71 @@ def test_show_status_reports_gateway_session_last_activity(monkeypatch, capsys, 
     assert "Active:       2 session(s)" in output
     assert "Last activity:" in output
     assert "1m ago" in output
+
+
+# ── Plugin platform "configured" verdict (#102183) ─────────────────────────
+#
+# check_fn is a passive dependency probe that reads True for every bundled
+# plugin (their deps ship with Hermes); consulting it for the "configured"
+# label made `hermes status` claim platforms the user never opted into.
+
+
+def test_plugin_platform_configured_prefers_is_connected_over_dep_probe():
+    from hermes_cli.status import _plugin_platform_configured
+
+    entry = SimpleNamespace(
+        check_fn=lambda: True,
+        is_connected=lambda cfg: False,
+    )
+    assert _plugin_platform_configured(entry) is False
+
+
+def test_plugin_platform_configured_reports_true_when_is_connected_true():
+    from hermes_cli.status import _plugin_platform_configured
+
+    def _is_connected(cfg):
+        # Bundled hooks read env/auth state directly; the synthetic probe
+        # config only needs `enabled` so hooks that gate on it proceed.
+        assert cfg.enabled is True
+        return True
+
+    entry = SimpleNamespace(check_fn=lambda: True, is_connected=_is_connected)
+    assert _plugin_platform_configured(entry) is True
+
+
+def test_plugin_platform_configured_falls_back_to_check_fn_without_hook():
+    from hermes_cli.status import _plugin_platform_configured
+
+    entry = SimpleNamespace(check_fn=lambda: True, is_connected=None)
+    assert _plugin_platform_configured(entry) is True
+
+
+def test_show_status_plugin_platforms_label_follows_is_connected(monkeypatch, capsys, tmp_path):
+    """A bundled plugin platform whose deps are installed but that the user
+    never configured must print 'not configured (plugin)' — not the
+    dependency probe's True (#102183)."""
+    from gateway.platform_registry import platform_registry
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    def _boom(cfg):
+        raise RuntimeError("probe failed")
+
+    entries = [
+        SimpleNamespace(label="A2A", check_fn=lambda: True, is_connected=lambda cfg: False),
+        SimpleNamespace(label="IRC", check_fn=lambda: True, is_connected=None),
+        SimpleNamespace(label="Mattermost", check_fn=lambda: True, is_connected=_boom),
+    ]
+    monkeypatch.setattr(platform_registry, "plugin_entries", lambda: entries)
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    plugin_lines = {}
+    for ln in output.splitlines():
+        if "(plugin)" in ln:
+            plugin_lines[ln.split()[0]] = ln
+    assert "not configured (plugin)" in plugin_lines["A2A"]
+    assert "configured (plugin)" in plugin_lines["IRC"]
+    assert "not configured" not in plugin_lines["IRC"]
+    assert "not configured (plugin)" in plugin_lines["Mattermost"]


### PR DESCRIPTION
## What does this PR do?

`hermes status` labeled every bundled plugin platform as "✓ configured (plugin)" — A2A, Mattermost, WeCom, WhatsApp, iMessage via Photon, … — for users who never opted into any of them. The Messaging Platforms section consulted `PlatformEntry.check_fn`, but `check_fn` is a **passive dependency probe** ("are the platform's deps importable right now", per the registry docstring): bundled platforms ship their dependencies, so it reads True for every installed plugin.

This PR probes `entry.is_connected` with a synthetic enabled `PlatformConfig` instead — the exact verdict `hermes setup`'s `_platform_status` (hermes_cli/gateway.py) already uses, and the same chain `GatewayConfig._is_platform_connected` consults. It only falls back to `check_fn` when the platform registered no `is_connected` hook, and never when the hook already said "no": an installed SDK must not override a missing token.

## Related Issue

Fixes #102183

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/status.py`: added `_plugin_platform_configured(entry)` — prefers `is_connected(PlatformConfig(enabled=True))` over the dependency probe; the plugin-platform loop now uses it for the configured/not-configured label. Per-entry exception guard and output format unchanged.
- `tests/hermes_cli/test_status.py`: 3 unit tests for the verdict chain (is_connected wins over check_fn; True passes through; check_fn fallback without a hook) + 1 `show_status` regression test asserting the printed label follows `is_connected`, including the raising-probe guard.

## How to Test

1. On a machine with no messaging platform configured, run `hermes status` before this PR: the Messaging Platforms section shows A2A / Mattermost / WeCom / WhatsApp as "✓ configured (plugin)".
2. Apply this PR and re-run: those rows now show "✗ not configured (plugin)".
   - Observed result (this machine, no platforms configured): before — 6 plugin rows claimed configured (A2A, Home Assistant, Mattermost, iMessage via Photon, WeCom, WhatsApp); after — all report not configured, matching the env/YAML state.
3. Configure a real platform (e.g. `MATTERMOST_TOKEN` + `MATTERMOST_URL`) and re-run: Mattermost reports "✓ configured (plugin)" again, because its `is_connected` checks those credentials.
4. `pytest tests/hermes_cli/test_status.py tests/hermes_cli/test_gateway_platform_gating.py tests/hermes_cli/test_setup_hidden_env.py -q` — should pass (15 + 13 passed, 3 skipped here).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A