### PR TITLE
fix(bot-mode): preserve scoped group speaker identity

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.test.ts
@@ -4,7 +4,7 @@ import type * as groupChat from './group-chat'
 import type * as groupRounds from './group-rounds'
 import { createGroupGateway, deferTimers, drain, runTimersInline, scriptedStorage } from './group-test-utils'
 import type { GatewayOptions, ScriptedGateway } from './group-test-utils'
-import type { GroupChat, GroupMessage } from './types'
+import type { GroupChat, GroupMember, GroupMessage } from './types'
 
 // The room store: the atom every group surface reads, the durable projection
 // written to plugin storage, and the bounded mirror published to the gateway's
@@ -160,6 +160,51 @@ describe('speaker labels', () => {
     data.$lastRoster.set([{ display_name: 'HomelabBot', name: 'default', remoteSource: true }])
 
     expect(chat.groupSpeakerLabel('default')).toBe('Hermes')
+  })
+
+  it('uses the exact source-scoped Bot Meta v2 identity for a working label', async () => {
+    let release!: (reply: string) => void
+
+    const pending = new Promise<string>(resolve => {
+      release = resolve
+    })
+
+    const { chat, rounds } = await loadRoom({ turn: () => pending })
+    const data = await import('./data')
+
+    const local = {
+      connectionId: 'local',
+      connectionKind: 'local',
+      name: 'default',
+      route: { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' },
+      sourceScoped: true
+    } as GroupMember
+
+    const cloud = {
+      connectionId: 'cloud',
+      connectionKind: 'cloud',
+      name: 'default',
+      remoteSource: true,
+      route: { connectionId: 'cloud', mode: 'remote', profile: 'default', targetProfile: 'default' },
+      sourceScoped: true
+    } as GroupMember
+
+    data.$botMeta.set({ 'cloud::default': { title: 'Mira' }, 'local::default': { title: 'Atlas' } })
+    data.$lastRoster.set([local, cloud])
+
+    rounds.sendToGroupChat('Scoped', [local], 'identify yourself')
+    await drain(() => !chat.$groupChats.get().Scoped?.turn)
+
+    expect(chat.$groupChats.get().Scoped?.turn).toBe('local::default')
+    expect(chat.groupSpeakerLabel(chat.$groupChats.get().Scoped?.turn)).toBe('Atlas')
+
+    data.$botMeta.set({})
+
+    expect(chat.groupSpeakerLabel(chat.$groupChats.get().Scoped?.turn)).toBe('Hermes')
+    expect(chat.groupSpeakerLabel('default')).toBe('Hermes')
+
+    release('(pass)')
+    await drain(() => Boolean(chat.$groupChats.get().Scoped?.running))
   })
 })
 

--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -13,6 +13,8 @@ import { atom, host } from '@hermes/plugin-sdk'
 
 import { $botMeta, $lastRoster, botRosterKey } from './data'
 import { groupMemberReferencesConnection, markOrphanedGroupMemberDescriptor } from './hygiene'
+import { displayName } from './labels'
+import { botRosterMeta } from './routing'
 import { getPluginCtx } from './shared'
 import type {
   Attachment,
@@ -1240,6 +1242,12 @@ export function groupSpeakerLabel(name?: null | string) {
   // the ACTIVE gateway's roster row. Source-scoped remote speakers carry
   // their device suffix separately and keep their raw name here.
   const roster = $lastRoster.get()
+
+  const exactRow = Array.isArray(roster) ? roster.find(bot => botRosterKey(bot) === trimmed) : null
+
+  if (exactRow) {
+    return displayName(exactRow, botRosterMeta(exactRow, $botMeta.get()))
+  }
 
   const row = Array.isArray(roster)
     ? roster.find(bot => bot?.name === trimmed && !bot?.remoteSource && !bot?.sourceScoped)

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.test.ts
@@ -763,6 +763,34 @@ describe('stopGroupThread (#91868/#94569)', () => {
     expect(interrupts[0].params.session_id).toBe('live-alpha-sid')
   })
 
+  it('interrupts a source-scoped member by its exact working key', async () => {
+    const room = await loadRoom()
+
+    const member = {
+      connectionId: 'local',
+      name: 'default',
+      route: { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'default' },
+      sourceScoped: true
+    } as GroupMember
+
+    room.chat.$groupChats.set({
+      Room: {
+        epoch: 3,
+        log: [],
+        members: [member],
+        running: true,
+        sessions: { 'local::default': 'live-default-sid' },
+        turn: 'local::default',
+        watermarks: {}
+      }
+    } as unknown as Record<string, GroupChat>)
+
+    await room.rounds.stopGroupThread('Room', 't1', [member])
+
+    expect(room.gateway.rpcFor('session.interrupt')).toHaveLength(1)
+    expect(room.gateway.rpcFor('session.interrupt')[0].params.session_id).toBe('live-default-sid')
+  })
+
   it('stops a room with nobody on turn without any interrupt RPC', async () => {
     const room = await loadRoom()
     seedRoom(room, null)

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -472,7 +472,7 @@ export async function stopGroupThread(group: string, thread: null | string, memb
 
   // Interrupt the member actually mid-turn. room.turn is runtime-only and
   // names exactly one member (the loop is serial); a settled room has none.
-  const onTurn = turnName ? roster.find((member: GroupMember) => member?.name === turnName) : null
+  const onTurn = turnName ? roster.find((member: GroupMember) => groupMemberKey(member) === turnName) : null
   const sessionId = onTurn ? (room.sessions || {})[groupMemberKey(onTurn)] : null
 
   if (onTurn && sessionId) {
@@ -633,7 +633,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
         // room shows "Radar is thinking…" instead of a generic working line —
         // long model turns otherwise read as the room being stuck.
         updateGroupChat(group, (r: GroupChatRoom) => {
-          r.turn = member.name
+          r.turn = groupMemberKey(member)
 
           return r
         })
@@ -800,7 +800,7 @@ export async function runGroupChatRounds(group: string, members: GroupMember[], 
               })
 
               updateGroupChat(group, (r: GroupChatRoom) => {
-                r.turn = member.name
+                r.turn = groupMemberKey(member)
 
                 return r
               })


### PR DESCRIPTION
## Summary

- Preserve the existing source-qualified `groupMemberKey()` while a Bot Mode group member is working.
- Let the existing speaker-label ladder resolve Bot Meta v2 from the exact `connectionId::profile` key.
- Keep Stop/interrupt lookup on that same exact member key.
- Keep single-source members and the unrenamed `default` to `Hermes` fallback unchanged.

## Root cause

The room stored `member.name` in its runtime-only `turn` field. That discarded the connection owner before `groupSpeakerLabel()` ran, so a multi-connection primary Bot with metadata under `local::default` fell through to `Hermes`.

The room already uses `groupMemberKey()` for source-exact sessions, watermarks, holds, and attention state. Reusing it for the working marker fixes the label without adding state or changing persisted room data.

Fixes #102180.

## Verification

- Regression sabotage: restoring `member.name` failed the working-label test with expected `local::default`, received `default`.
- Fallback sabotage: removing the exact roster-row resolution rendered an untitled scoped primary as `local::default` instead of `Hermes`.
- Stop sabotage: restoring the bare-name lookup produced zero interrupt RPCs for an in-flight scoped member.
- Full bundled Bot Mode suite: 61 files, 574 tests passed.
- Focused lint: passed with zero warnings.
- Desktop TypeScript checks: passed.
- Production Desktop build: passed.
- `git diff --check`: passed.

## Risk

Low. `turn` is runtime-only; its display and Stop consumers now use the same existing source-qualified key. No persisted schema, gateway API, or model prompt changes.
