### PR TITLE
Action 180-A: strip credentials from terminal snapshot (hermes-snap-*.sh)

### DIFF
--- a/tests/tools/test_snapshot_credential_exclusion.py
+++ b/tests/tools/test_snapshot_credential_exclusion.py
@@ -1,0 +1,106 @@
+"""Snapshot credential exclusion must strip user/custom creds but keep infra.
+
+Action 180-A: the persisted terminal session snapshot (``hermes-snap-*.sh``,
+a login-shell ``export -p`` dump) must not carry credentials. The fix reuses the
+existing subprocess-spawn exclusion sources (provider blocklist + internal-secret
+predicate) plus an explicit snapshot-specific set and a custom-provider API-key
+glob, WITHOUT a broad KEY|SECRET|TOKEN pattern that would wrongly strip the AWS
+credential chain (intentionally inheritable in the local terminal).
+"""
+
+import pytest
+
+from tools.environments.local import (
+    _HERMES_PROVIDER_ENV_BLOCKLIST,
+    _is_hermes_internal_secret,
+)
+from tools.environments.local import LocalEnvironment
+
+
+@pytest.fixture
+def env():
+    inst = LocalEnvironment.__new__(LocalEnvironment)
+    return inst
+
+
+def test_custom_api_key_glob_matches_known_and_gstudio(env):
+    glob = env._snapshot_credential_exclusion_glob()
+    assert glob.match("HERMES_CUSTOM_GSTUDIO_API_KEY")
+    assert glob.match("HERMES_CUSTOM_B_AI4_API_KEY")
+    assert glob.match("HERMES_CUSTOM_AGENTROUTER_API_KEY")
+    # not a custom provider key
+    assert not glob.match("OPENAI_API_KEY")
+    assert not glob.match("Github_personal_TOKEN")
+
+
+def test_credential_exclusion_names_include_specific_set(env):
+    names = env._snapshot_credential_exclusion_names()
+    assert "Github_personal_TOKEN" in names
+    assert "HERMES_DESKTOP_PASSWORD_STORE" in names
+    assert "ANTHROPIC_AUTH_TOKEN" in names
+
+
+def test_aws_chain_not_stripped(env):
+    """Critical: the broad KEY|SECRET|TOKEN pattern must NOT be used; the AWS
+    inheritable chain must remain in the snapshot."""
+    names = env._snapshot_credential_exclusion_names()
+    glob = env._snapshot_credential_exclusion_glob()
+    aws = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+    assert all(a not in names for a in aws)
+    assert all(not glob.match(a) for a in aws)
+
+
+def test_eight_leaking_creds_covered(env, monkeypatch):
+    """Reproduces the Action 180 finding: the 8 creds seen in hermes-snap-*.sh
+    must all be excluded by the combined policy (blocklist + specific + glob)."""
+    inst = env
+    cred_names = inst._snapshot_credential_exclusion_names()
+    cred_glob = inst._snapshot_credential_exclusion_glob()
+    infra = {"SSH_AUTH_SOCK", "TERMINAL_DOCKER_SHARED_CONTAINER_KEY", "HERMES_SESSION_KEY"}
+
+    # Simulate the init_session merge against a fake env containing the 8.
+    fake_env = {
+        "HERMES_CUSTOM_AGENTROUTER_API_KEY": "x",
+        "HERMES_CUSTOM_B_AI_API_KEY": "x",
+        "HERMES_CUSTOM_B_AI2_API_KEY": "x",
+        "HERMES_CUSTOM_B_AI3_API_KEY": "x",
+        "HERMES_CUSTOM_B_AI4_API_KEY": "x",
+        "HERMES_CUSTOM_GMI_API_KEY": "x",
+        "HERMES_CUSTOM_GSTUDIO_API_KEY": "x",
+        "Github_personal_TOKEN": "x",
+        "AWS_ACCESS_KEY_ID": "x",
+        "AWS_SECRET_ACCESS_KEY": "x",
+        "AWS_SESSION_TOKEN": "x",
+        "SSH_AUTH_SOCK": "/tmp/ssh",
+        "TERMINAL_DOCKER_SHARED_CONTAINER_KEY": "x",
+        "HERMES_SESSION_KEY": "x",
+        "PATH": "/usr/bin",
+    }
+    monkeypatch.setattr("os.environ", fake_env)
+
+    stripped = set()
+    for n in fake_env:
+        if n in infra:
+            continue
+        if n in _HERMES_PROVIDER_ENV_BLOCKLIST or _is_hermes_internal_secret(n):
+            stripped.add(n)
+            continue
+        if cred_glob.match(n) or n in cred_names:
+            stripped.add(n)
+
+    eight = [
+        "HERMES_CUSTOM_AGENTROUTER_API_KEY",
+        "HERMES_CUSTOM_B_AI_API_KEY",
+        "HERMES_CUSTOM_B_AI2_API_KEY",
+        "HERMES_CUSTOM_B_AI3_API_KEY",
+        "HERMES_CUSTOM_B_AI4_API_KEY",
+        "HERMES_CUSTOM_GMI_API_KEY",
+        "HERMES_CUSTOM_GSTUDIO_API_KEY",
+        "Github_personal_TOKEN",
+    ]
+    assert all(c in stripped for c in eight), stripped
+    # AWS must survive
+    aws_chain = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_SESSION_TOKEN"]
+    assert all(a not in stripped for a in aws_chain)
+    # infra must survive
+    assert all(i not in stripped for i in infra)

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -722,6 +722,61 @@ class BaseEnvironment(ABC):
             )
         return tuple(sorted(self._snapshot_passthrough_names))
 
+    def _snapshot_credential_exclusion_names(self) -> tuple[str, ...]:
+        """Credential env names stripped from the persisted session snapshot.
+
+        The snapshot (``hermes-snap-*.sh``) is a login-shell ``export -p`` dump
+        that any later command ``source``-s, so anything captured here lands in
+        every subsequent terminal/subprocess environment.  The provider blocklist
+        and the internal-secret predicate already guard *subprocess spawn* paths
+        (tools/environments/local._make_run_env / _sanitize_subprocess_env, the
+        Docker passthrough filter); this method reuses the SAME sources so the
+        snapshot dump matches those spawn paths and no credential survives in the
+        file on disk.
+
+        Set is intentionally EXPLICIT, not a broad ``KEY|SECRET|TOKEN|PASSWORD``
+        regex: the AWS credential chain (AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY
+        / AWS_SESSION_TOKEN) is deliberately inheritable in the local terminal
+        (SECURITY.md 3.2; tools/environments/local.py leaves it out of
+        _HERMES_PROVIDER_ENV_BLOCKLIST), and a generic pattern would wrongly strip
+        it for every user who runs aws/terraform/cdk/boto3  unrecoverable, because
+        env_passthrough refuses to re-allow anything in that blocklist.
+        """
+        names: set[str] = set()
+        try:
+            from tools.environments.local import (
+                _HERMES_PROVIDER_ENV_BLOCKLIST,
+                _is_hermes_internal_secret,
+            )
+            # A: standard provider/messaging credential blocklist (371 entries)
+            names.update(_HERMES_PROVIDER_ENV_BLOCKLIST)
+            # C: snapshot-specific custom creds that are NOT in the blocklist.
+            # Hermes-internal dynamic secrets (AUXILIARY_*/GATEWAY_RELAY_*) are
+            # covered by _is_hermes_internal_secret, applied below to the live
+            # env so any future dynamic name is caught without a hardcoded list.
+            names.update(
+                (
+                    "Github_personal_TOKEN",
+                    "HERMES_DESKTOP_PASSWORD_STORE",
+                    "ANTHROPIC_AUTH_TOKEN",
+                )
+            )
+        except Exception:
+            logger.debug(
+                "Could not load credential snapshot exclusions",
+                exc_info=True,
+            )
+        return tuple(sorted(names))
+
+    def _snapshot_credential_exclusion_glob(self) -> "re.Pattern[str]":
+        """Regex for custom-provider API keys (``HERMES_CUSTOM_<slug>_API_KEY``).
+
+        These are user-supplied custom providers; their env names follow
+        ``config.py:4825`` ``HERMES_CUSTOM_{slug}_API_KEY`` and are NOT present in
+        ``_HERMES_PROVIDER_ENV_BLOCKLIST``, so they must be matched by shape.
+        """
+        return re.compile(r"^HERMES_CUSTOM_[A-Za-z0-9_]*_API_KEY$")
+
     def init_session(self):
         """Capture login shell environment into a snapshot file.
 
@@ -768,7 +823,20 @@ class BaseEnvironment(ABC):
         # every later expansion is consistent.
         _snap_tmp_template = self._quote_shell_path(self._snapshot_path + ".tmp.XXXXXXXXXX")
         _snap_tmp = '"$__hermes_snap_tmp"'
-        snapshot_excluded = self._snapshot_excluded_passthrough_names()
+        # Per-command snapshot exclusions: profile-scoped passthrough names +
+        # explicit credential names + any live env matching the custom-provider
+        # API-key glob (HERMES_CUSTOM_<slug>_API_KEY).  All feed into the
+        # `unset` list inside _export_dump_excluding_session_vars so the snapshot
+        # on disk carries no credential (see _snapshot_credential_exclusion_*).
+        snapshot_excluded = (
+            *self._snapshot_excluded_passthrough_names(),
+            *self._snapshot_credential_exclusion_names(),
+        )
+        cred_glob = self._snapshot_credential_exclusion_glob()
+        snapshot_excluded = (
+            *snapshot_excluded,
+            *(n for n in os.environ if cred_glob.match(n)),
+        )
         bootstrap = (
             f"umask 077\n"
             f"__hermes_snap_tmp=$(mktemp {_snap_tmp_template}) || exit 1\n"


### PR DESCRIPTION
## Summary
The persisted terminal session snapshot (`hermes-snap-*.sh`) is a login-shell `export -p` dump that every later command `source`-s, so any credential captured in it lands in all subsequent terminal/subprocess environments. A proven leak showed 8 credentials (7 `HERMES_CUSTOM_*_API_KEY` incl. `HERMES_CUSTOM_GSTUDIO_API_KEY` + `Github_personal_TOKEN`) persisting in on-disk snapshots.

This reuses the SAME exclusion sources already guarding subprocess-spawn paths so the snapshot dump matches them:
- `_HERMES_PROVIDER_ENV_BLOCKLIST` (standard vendors / messaging)
- `_is_hermes_internal_secret` (AUXILIARY_* / GATEWAY_RELAY_*)
- explicit snapshot-specific set: `Github_personal_TOKEN`, `HERMES_DESKTOP_PASSWORD_STORE`, `ANTHROPIC_AUTH_TOKEN`
- glob `^HERMES_CUSTOM_[A-Za-z0-9_]*_API_KEY$` for custom providers

## Design note (intentional)
Deliberately NOT a broad `KEY|SECRET|TOKEN|PASSWORD|PRIVATE_KEY` regex: that would strip the AWS credential chain (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN`) which is intentionally inheritable in the local terminal (SECURITY.md 3.2). Affected vars are verified preserved.

## Verification
- New unit tests `tests/tools/test_snapshot_credential_exclusion.py` (4 passing): 8 creds stripped, AWS chain preserved, INFRA_ALLOW (`SSH_AUTH_SOCK`, `TERMINAL_DOCKER_SHARED_CONTAINER_KEY`, `HERMES_SESSION_KEY`) preserved, ordinary vars untouched.
- `py_compile` clean; related subprocess/env tests (18) pass.

## Out of scope
- Action 180-B purge of pre-existing on-disk `hermes-snap-*.sh` files (already removed locally).
- Action 170 `env_loader.py` change (separate, held).