### PR TITLE
fix(state): quarantine invalid state db header

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -4698,6 +4698,44 @@ def _connect_tracked_db(path, tracking_path=None, **kwargs):
     )
 
 
+def has_invalid_sqlite_header_preopen(
+    path: Path, *, probe_bytes: int = 100, force: bool = False
+) -> bool:
+    """Detect a pre-existing state.db whose first page is not SQLite.
+
+    This is intentionally a pre-open byte probe: use it before creating a
+    SQLite connection so startup can preserve a clobbered page 0 instead of
+    letting sqlite3 create sidecars or report an opaque NOTADB error. A live
+    tracked connection makes the helper return False unless ``force=True``.
+    """
+    try:
+        if not path.is_file():
+            return False
+        size = path.stat().st_size
+    except OSError:
+        return False
+    if size < 0:
+        return False
+    try:
+        from hermes_cli.sqlite_safe_read import (
+            has_live_connection,
+            read_header_bytes_preopen,
+        )
+
+        if not force and has_live_connection(path):
+            return False
+        head = read_header_bytes_preopen(
+            path, length=max(16, probe_bytes), force=force
+        )
+    except Exception:
+        return False
+    if head is None:
+        return False
+    if len(head) == 0:
+        return True
+    return not head.startswith(b"SQLite format 3")
+
+
 def is_zeroed_state_db(
     path: Path, *, probe_bytes: int = 100, force: bool = False
 ) -> bool:
@@ -4803,54 +4841,52 @@ def quarantine_cross_process_lock(path: Path, timeout: float = 5.0):
             handle.close()
 
 
-def quarantine_zeroed_state_db(
+def quarantine_invalid_state_db(
     path: Path, *, already_locked: bool = False
 ) -> Optional[Path]:
-    """Move a zeroed state.db aside (preserve bytes) and return quarantine path.
+    """Move a pre-existing non-SQLite state.db aside and preserve sidecars.
 
-    Uses a cross-process lock (``#68805``) so two concurrent startups cannot
-    race: the first process moves the zeroed file and the second re-checks
-    under the lock, finding the file already gone (or a fresh DB in its place)
-    instead of clobbering the quarantine.
+    Uses a cross-process lock (``#68805``) so concurrent startups cannot race:
+    the first process moves the damaged file and the second re-checks under the
+    lock, finding the file already gone or a fresh valid DB in its place.
     """
+
     def _do_quarantine():
         if not path.exists():
             logger.info(
-                "quarantine_zeroed_state_db: %s already moved by another process",
+                "quarantine_invalid_state_db: %s already moved by another process",
                 path,
             )
             return None
-        if not is_zeroed_state_db(path):
+        if not has_invalid_sqlite_header_preopen(path):
             logger.info(
-                "quarantine_zeroed_state_db: %s is no longer zeroed (another "
+                "quarantine_invalid_state_db: %s is no longer invalid (another "
                 "process quarantined it and a fresh DB was created)",
                 path,
             )
             return None
 
+        zeroed = is_zeroed_state_db(path)
         try:
             ts = time.strftime("%Y%m%d-%H%M%S")
         except Exception:
             ts = "unknown"
-        dest = path.with_name(
-            f"{path.name}.zeroed-{ts}-{os.getpid()}.bak"
-        )
+        suffix = "zeroed" if zeroed else "notadb"
+        dest = path.with_name(f"{path.name}.{suffix}-{ts}-{os.getpid()}.bak")
         n = 0
         while dest.exists():
             n += 1
-            dest = path.with_name(
-                f"{path.name}.zeroed-{ts}-{os.getpid()}-{n}.bak"
-            )
+            dest = path.with_name(f"{path.name}.{suffix}-{ts}-{os.getpid()}-{n}.bak")
         try:
             path.rename(dest)
         except OSError as exc:
-            logger.error("Failed to quarantine zeroed %s: %s", path, exc)
+            logger.error("Failed to quarantine invalid %s: %s", path, exc)
             return None
-        for suffix in ("-wal", "-shm"):
-            side = Path(str(path) + suffix)
+        for side_suffix in ("-wal", "-shm"):
+            side = Path(str(path) + side_suffix)
             if side.exists():
                 try:
-                    side.rename(Path(str(dest) + suffix))
+                    side.rename(Path(str(dest) + side_suffix))
                 except OSError:
                     pass
         return dest
@@ -4862,7 +4898,7 @@ def quarantine_zeroed_state_db(
         if not acquired:
             logger.error(
                 "quarantine lock for %s not acquired within 5s — refusing to "
-                "quarantine without the cross-process lock. The zeroed file "
+                "quarantine without the cross-process lock. The invalid file "
                 "is left in place. If sessions fail to load, restore from "
                 "state-snapshots via `hermes snapshot list` / "
                 "`hermes snapshot restore <id>`.",
@@ -4871,6 +4907,14 @@ def quarantine_zeroed_state_db(
             return None
         return _do_quarantine()
 
+
+def quarantine_zeroed_state_db(
+    path: Path, *, already_locked: bool = False
+) -> Optional[Path]:
+    """Move a zeroed state.db aside (preserve bytes) and return quarantine path."""
+    if path.exists() and not is_zeroed_state_db(path):
+        return None
+    return quarantine_invalid_state_db(path, already_locked=already_locked)
 
 # ── Read-only health/stats probes (hermes doctor, dashboards) ──────────
 
@@ -5499,32 +5543,32 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             if not read_only:
                 preflight_db_writability(self.db_path, db_label="state.db")
 
-            # #68474 / #97568: Serialize startup across zero-byte check, quarantine,
-            # connect, and schema commit so concurrent openers don't race on an
-            # absent-path -> connect -> schema-commit window.
+            # #68474 / #97568 / #102198: Serialize startup across absent-path /
+            # invalid-header quarantine, connect, and schema commit so concurrent
+            # openers don't race on an absent-path -> connect -> schema-commit window.
             needs_startup_guard = (
                 not read_only
                 and (
                     not self.db_path.exists()
-                    or is_zeroed_state_db(self.db_path)
+                    or has_invalid_sqlite_header_preopen(self.db_path)
                 )
             )
 
-            def _handle_quarantine_if_zeroed(already_locked: bool = False):
+            def _handle_quarantine_if_invalid(already_locked: bool = False):
                 if (
                     self.db_path.exists()
-                    and is_zeroed_state_db(self.db_path)
+                    and has_invalid_sqlite_header_preopen(self.db_path)
                 ):
                     try:
                         zsize = self.db_path.stat().st_size
                     except OSError:
                         zsize = -1
-                    qpath = quarantine_zeroed_state_db(
+                    qpath = quarantine_invalid_state_db(
                         self.db_path, already_locked=already_locked
                     )
                     snaps = self.db_path.parent / "state-snapshots"
                     msg = (
-                        f"state.db looks ZEROED ({zsize} bytes, no SQLite header). "
+                        f"state.db has no SQLite header ({zsize} bytes). "
                         f"Preserved at {qpath or '(quarantine failed — file left in place)'}. "
                         f"Restore from {snaps} via `hermes snapshot list` / "
                         f"`hermes snapshot restore <id>` if available. "
@@ -5532,9 +5576,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     )
                     logger.error(msg)
                     _set_last_init_error(msg)
-                    # If quarantine failed, do not open the zeroed file (would fail
+                    # If quarantine failed, do not open the invalid file (would fail
                     # opaquely or risk further damage). Raise with the clear message.
-                    if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
+                    if (
+                        qpath is None
+                        and self.db_path.exists()
+                        and has_invalid_sqlite_header_preopen(self.db_path)
+                    ):
                         raise sqlite3.DatabaseError(msg)
 
             def _connect_and_init():
@@ -5609,10 +5657,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                                 "startup quarantine lock for %s not acquired within 5s; proceeding",
                                 self.db_path,
                             )
-                        _handle_quarantine_if_zeroed(already_locked=lock_acquired)
+                        _handle_quarantine_if_invalid(already_locked=lock_acquired)
                         _connect_and_init_with_lock_patience()
                 else:
-                    _handle_quarantine_if_zeroed(already_locked=False)
+                    _handle_quarantine_if_invalid(already_locked=False)
                     _connect_and_init_with_lock_patience()
 
             try:

--- a/tests/test_zeroed_state_db.py
+++ b/tests/test_zeroed_state_db.py
@@ -61,6 +61,41 @@ def test_sessiondb_opens_fresh_after_zeroed_quarantine(tmp_path, monkeypatch):
         sdb.close()
 
 
+def test_sessiondb_quarantines_page_zero_clobber_before_open(tmp_path, monkeypatch):
+    """#102198: preserve a non-SQLite page 0 instead of opening degraded."""
+    import sqlite3
+
+    import hermes_state as hs
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db = tmp_path / "state.db"
+    clobbered = (b"bg_032237_0e4ce7A" * 256)[:4096]
+    db.write_bytes(clobbered)
+    (tmp_path / "state.db-wal").write_bytes(b"wal evidence")
+    (tmp_path / "state.db-shm").write_bytes(b"shm evidence")
+
+    assert hs.has_invalid_sqlite_header_preopen(db) is True
+    assert hs.is_zeroed_state_db(db) is False
+
+    sdb = hs.SessionDB(db_path=db)
+    try:
+        backups = list(tmp_path.glob("state.db.notadb-*.bak"))
+        assert len(backups) == 1
+        assert backups[0].read_bytes() == clobbered
+        assert Path(str(backups[0]) + "-wal").read_bytes() == b"wal evidence"
+        assert Path(str(backups[0]) + "-shm").read_bytes() == b"shm evidence"
+        assert db.read_bytes().startswith(b"SQLite format 3\x00")
+        sdb.create_session(session_id="after-quarantine", source="test")
+    finally:
+        sdb.close()
+
+    conn = sqlite3.connect(str(db))
+    try:
+        assert conn.execute("PRAGMA integrity_check").fetchone()[0] == "ok"
+    finally:
+        conn.close()
+
+
 def test_is_zeroed_state_db_zero_byte_quarantine(tmp_path, monkeypatch):
     """#97568: a 0-byte file must be detected as zeroed and quarantined."""
     import hermes_state as hs
@@ -90,7 +125,6 @@ def test_is_zeroed_state_db_zero_byte_quarantine(tmp_path, monkeypatch):
         assert row_created is not None and row_created[0]
     finally:
         sdb.close()
-
 
 
 def test_concurrent_quarantine_no_clobber(tmp_path):
@@ -181,19 +215,23 @@ def test_quarantine_fails_closed_when_lock_held(tmp_path):
         try:
             if platform.system() == "Windows":
                 import msvcrt
+
                 handle.seek(0)
                 msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
             else:
                 import fcntl
+
                 fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
             lock_held.set()
             release_lock.wait(timeout=15)
             if platform.system() == "Windows":
                 import msvcrt
+
                 handle.seek(0)
                 msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
             else:
                 import fcntl
+
                 fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
         except OSError:
             lock_held.clear()
@@ -298,4 +336,3 @@ def test_live_connection_0_byte_not_quarantined_in_process(tmp_path, monkeypatch
         conn.commit()
     finally:
         conn.close()
-


### PR DESCRIPTION
## Summary

Startup only quarantined zeroed `state.db` files before opening SQLite, so a non-empty file with a clobbered page 0 and no SQLite header could still proceed into SQLite open/init paths and surface as `file is not a database` instead of preserving forensic bytes cleanly. This adds a pre-open invalid-header guard that quarantines non-SQLite `state.db` files (including WAL/SHM sidecars) under the existing cross-process startup lock, while keeping the older zeroed-file backup naming for 0-byte/NUL files.

---

## Changes

- `hermes_state.py`: Added `has_invalid_sqlite_header_preopen()` and `quarantine_invalid_state_db()`; wired startup quarantine to missing/invalid SQLite headers before connect/schema init.
- `tests/test_zeroed_state_db.py`: Added a regression for page-0 application-data clobber preserving the damaged DB plus sidecars and then creating a healthy fresh SQLite DB.

## How to Test

```bash
/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python -m pytest tests/test_zeroed_state_db.py tests/test_state_db_notadb_fail_closed.py -q
# ✅ 16 passed

ruff check hermes_state.py tests/test_zeroed_state_db.py
# ✅ All checks passed!

/data/data/com.termux/files/home/.hermes/hermes-agent/venv/bin/python scripts/check-windows-footguns.py hermes_state.py tests/test_zeroed_state_db.py
# ✅ No Windows footguns found
```

Full `scripts/run_tests.sh` was attempted on Termux and failed due runner-level `PermissionError(13, 'Permission denied')` crashes across unrelated test files before executing assertions.

## Checklist

- [x] Tests pass — 16/16 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

## Risk & Impact

Low. The new path only runs before opening a pre-existing writable `state.db` whose first bytes are not a SQLite header, preserving damaged bytes instead of mutating them through SQLite.

Type: Bug fix
Closes: #102198
