### PR TITLE
feat(oauth): centered, brandable OAuth callback page shared by every flow

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -87,6 +87,7 @@ from hermes_cli.config import (
     read_raw_config,
     require_readable_config_before_write,
 )
+from hermes_cli.oauth_callback_page import render_callback_page
 from hermes_constants import OPENROUTER_BASE_URL, secure_parent_dir
 from agent.credential_persistence import sanitize_borrowed_credential_payload
 from utils import atomic_replace, atomic_yaml_write, env_float, is_truthy_value
@@ -3786,9 +3787,16 @@ def _make_spotify_callback_handler(expected_path: str) -> tuple[type[BaseHTTPReq
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             if result["error"]:
-                body = "<html><body><h1>Spotify authorization failed.</h1>You can close this tab.</body></html>"
+                body = render_callback_page(
+                    "Spotify authorization failed",
+                    "You can close this tab and re-run setup.",
+                    status="error",
+                )
             else:
-                body = "<html><body><h1>Spotify authorization received.</h1>You can close this tab.</body></html>"
+                body = render_callback_page(
+                    "Spotify authorization received",
+                    "You can close this tab and return to Hermes.",
+                )
             self.wfile.write(body.encode("utf-8"))
 
         def log_message(self, format: str, *args: Any) -> None:  # noqa: A003

--- a/hermes_cli/oauth_callback_page.py
+++ b/hermes_cli/oauth_callback_page.py
@@ -1,0 +1,275 @@
+"""Shared markup for the browser-facing OAuth callback pages.
+
+Every OAuth flow in Hermes ends with the provider redirecting the user's
+browser at a page we serve — a loopback listener (``hermes mcp login``, the
+TUI/desktop gateway flows, Spotify, honcho) or the dashboard's callback route.
+Each of those sites grew its own one-line ``<h1>`` string, so the last thing a
+user sees after authorizing is unstyled Times New Roman in the top-left corner
+of a blank tab. This module is the single place that markup lives.
+
+Branding is user-supplied and deliberately lives OUTSIDE the repo so it
+survives ``hermes update``: drop an image at
+``$HERMES_HOME/branding/oauth-logo.png`` (``.svg``/``.jpg``/``.webp``/``.gif``
+also work) and it is inlined into the page as a ``data:`` URI. Add
+``oauth-logo-dark.*`` to swap in a different mark under
+``prefers-color-scheme: dark``. Inlining rather than linking is required, not
+cosmetic: the callback page must render with no network and no second request
+back to a listener that closes itself the moment the redirect lands.
+
+Callers pass plain text. Headings, messages, and provider-supplied error
+strings are HTML-escaped here, so a hostile ``?error=`` parameter cannot inject
+markup into the page.
+"""
+
+from __future__ import annotations
+
+import base64
+import html
+import logging
+from pathlib import Path
+from typing import Literal
+
+from hermes_constants import get_hermes_home
+
+logger = logging.getLogger(__name__)
+
+Status = Literal["success", "error", "pending"]
+
+# Extensions we will inline, in preference order: vector first, then the
+# lossless raster formats, then lossy. Keyed to the media type so the data URI
+# and the sniff share one table.
+_LOGO_MEDIA_TYPES: dict[str, str] = {
+    ".svg": "image/svg+xml",
+    ".png": "image/png",
+    ".webp": "image/webp",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+}
+
+# A logo is inlined into every callback page, so an accidentally-dropped
+# multi-megabyte asset would be pasted into the response in base64 (~4/3 size).
+# Skip anything implausible for a wordmark rather than serve a huge page.
+_MAX_LOGO_BYTES = 1024 * 1024
+
+_STATUS_GLYPHS: dict[Status, str] = {
+    "success": "&#10003;",  # check
+    "error": "&#10005;",  # cross
+    "pending": "&#8230;",  # ellipsis
+}
+
+_STYLES = """
+:root {
+  color-scheme: light dark;
+  --bg: #eef1f6;
+  --card: #ffffff;
+  --fg: #16233a;
+  --muted: #5a6b85;
+  --edge: rgba(22, 35, 58, 0.10);
+  --shadow: 0 1px 2px rgba(16, 24, 40, 0.05), 0 16px 40px -16px rgba(16, 24, 40, 0.22);
+  --success: #4f9d3f;
+  --success-bg: rgba(109, 190, 95, 0.16);
+  --error: #c0392b;
+  --error-bg: rgba(192, 57, 43, 0.12);
+  --pending: #3d6bb3;
+  --pending-bg: rgba(61, 107, 179, 0.12);
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --bg: #0b1120;
+    --card: #141d2f;
+    --fg: #e9eef7;
+    --muted: #9aabc4;
+    --edge: rgba(255, 255, 255, 0.09);
+    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3), 0 16px 40px -16px rgba(0, 0, 0, 0.6);
+    --success: #7ecd6c;
+    --success-bg: rgba(109, 190, 95, 0.18);
+    --error: #f0837a;
+    --error-bg: rgba(240, 131, 122, 0.14);
+    --pending: #8fb2e8;
+    --pending-bg: rgba(143, 178, 232, 0.14);
+  }
+}
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: var(--bg);
+  color: var(--fg);
+  font: 15px/1.55 -apple-system, BlinkMacSystemFont, "Segoe UI", Inter,
+        Roboto, Helvetica, Arial, sans-serif;
+  -webkit-font-smoothing: antialiased;
+}
+main {
+  width: 100%;
+  max-width: 25rem;
+  padding: 2.75rem 2rem 2.5rem;
+  border: 1px solid var(--edge);
+  border-radius: 16px;
+  background: var(--card);
+  box-shadow: var(--shadow);
+  text-align: center;
+}
+.logo {
+  display: block;
+  width: auto;
+  max-width: 11.5rem;
+  max-height: 4.25rem;
+  margin: 0 auto 2rem;
+}
+.logo-dark { display: none; }
+@media (prefers-color-scheme: dark) {
+  .has-dark-logo .logo-light { display: none; }
+  .has-dark-logo .logo-dark { display: block; }
+}
+.glyph {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  margin: 0 auto 1.125rem;
+  border-radius: 50%;
+  font-size: 1.25rem;
+  line-height: 1;
+}
+.glyph-success { color: var(--success); background: var(--success-bg); }
+.glyph-error { color: var(--error); background: var(--error-bg); }
+.glyph-pending { color: var(--pending); background: var(--pending-bg); }
+h1 {
+  margin: 0 0 0.5rem;
+  font-size: 1.1875rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+p { margin: 0; color: var(--muted); }
+"""
+
+
+def _logo_data_uri(path: Path) -> str | None:
+    """Read *path* and return it as a ``data:`` URI, or None if unusable.
+
+    Never raises: a missing, oversized, or unreadable branding file degrades to
+    a logo-less page rather than failing the OAuth callback the user is
+    currently waiting on.
+    """
+    media_type = _LOGO_MEDIA_TYPES.get(path.suffix.lower())
+    if media_type is None:
+        return None
+    try:
+        if path.stat().st_size > _MAX_LOGO_BYTES:
+            logger.warning(
+                "Skipping OAuth callback logo %s: larger than %d bytes",
+                path, _MAX_LOGO_BYTES,
+            )
+            return None
+        raw = path.read_bytes()
+    except OSError as exc:
+        logger.debug("Could not read OAuth callback logo %s: %s", path, exc)
+        return None
+    if not raw:
+        return None
+    return f"data:{media_type};base64,{base64.b64encode(raw).decode('ascii')}"
+
+
+def _find_logo(stem: str) -> str | None:
+    """Find ``$HERMES_HOME/branding/<stem>.<ext>`` and inline it."""
+    try:
+        branding_dir = get_hermes_home() / "branding"
+    except Exception as exc:  # pragma: no cover - get_hermes_home is defensive
+        logger.debug("Could not resolve branding directory: %s", exc)
+        return None
+    for extension in _LOGO_MEDIA_TYPES:
+        data_uri = _logo_data_uri(branding_dir / f"{stem}{extension}")
+        if data_uri:
+            return data_uri
+    return None
+
+
+def _logo_markup() -> tuple[str, str]:
+    """Return ``(body_class, logo_html)`` for the active branding, if any.
+
+    Resolved per call rather than cached: the pages render at most once per
+    OAuth flow, and a process-wide cache would pin one profile's branding for
+    every other profile the gateway serves.
+    """
+    light = _find_logo("oauth-logo")
+    if not light:
+        return "", ""
+    dark = _find_logo("oauth-logo-dark")
+    if not dark:
+        return "", f'<img class="logo logo-light" src="{light}" alt="">'
+    return (
+        ' class="has-dark-logo"',
+        f'<img class="logo logo-light" src="{light}" alt="">'
+        f'<img class="logo logo-dark" src="{dark}" alt="">',
+    )
+
+
+def render_callback_page(
+    heading: str,
+    message: str,
+    *,
+    status: Status = "success",
+    auto_close: bool = False,
+) -> str:
+    """Render a centered, branded OAuth callback page.
+
+    Args:
+        heading: Short outcome line, e.g. ``"Authorization received"``. Used as
+            the page title too. Escaped.
+        message: Supporting sentence telling the user what to do next. Escaped.
+        status: Picks the glyph and its accent color.
+        auto_close: Attempt ``window.close()`` shortly after paint. Only honor
+            this for tabs Hermes opened itself (``window.open``-created tabs are
+            the only ones browsers let script close).
+
+    Returns:
+        A complete, self-contained HTML document.
+    """
+    safe_heading = html.escape(heading)
+    safe_message = html.escape(message)
+    glyph = _STATUS_GLYPHS.get(status, _STATUS_GLYPHS["success"])
+    body_class, logo = _logo_markup()
+    closer = (
+        "<script>setTimeout(function(){window.close()},1200)</script>"
+        if auto_close
+        else ""
+    )
+    return (
+        "<!doctype html>\n"
+        '<html lang="en">\n'
+        "<head>\n"
+        '<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        f"<title>{safe_heading}</title>\n"
+        f"<style>{_STYLES}</style>\n"
+        "</head>\n"
+        f"<body{body_class}>\n"
+        "<main>\n"
+        f"{logo}\n"
+        f'<div class="glyph glyph-{status}" aria-hidden="true">{glyph}</div>\n'
+        f"<h1>{safe_heading}</h1>\n"
+        f"<p>{safe_message}</p>\n"
+        "</main>\n"
+        f"{closer}\n"
+        "</body>\n"
+        "</html>\n"
+    )
+
+
+def render_callback_page_bytes(
+    heading: str,
+    message: str,
+    *,
+    status: Status = "success",
+    auto_close: bool = False,
+) -> bytes:
+    """UTF-8 encoded :func:`render_callback_page`, for ``wfile.write``."""
+    return render_callback_page(
+        heading, message, status=status, auto_close=auto_close
+    ).encode("utf-8")

--- a/hermes_cli/web_routers/mcp.py
+++ b/hermes_cli/web_routers/mcp.py
@@ -18,6 +18,7 @@ from typing import Any, Dict, Optional  # noqa: F401
 from fastapi import APIRouter, HTTPException, Request  # noqa: F401
 from fastapi.responses import HTMLResponse  # noqa: F401
 
+from hermes_cli.oauth_callback_page import render_callback_page
 from hermes_cli.web_deps import late, LateState
 from hermes_cli.web_models import (
     MCPCatalogInstall,
@@ -358,20 +359,42 @@ async def mcp_oauth_callback(
         None,
     )
     if flow is None:
-        return HTMLResponse("<h1>OAuth flow expired</h1><p>Return to Hermes and try again.</p>", status_code=404)
+        return HTMLResponse(
+            render_callback_page(
+                "OAuth flow expired",
+                "Return to Hermes and try again.",
+                status="error",
+            ),
+            status_code=404,
+        )
     try:
         flow.deliver_callback(code=code, state=state, error=error)
     except ValueError as exc:
         reason = str(exc)
         status_code = 409 if "already received" in reason else 400
         return HTMLResponse(
-            "<h1>OAuth callback rejected</h1>"
-            "<p>The callback was invalid or already used.</p>",
+            render_callback_page(
+                "OAuth callback rejected",
+                "The callback was invalid or already used.",
+                status="error",
+            ),
             status_code=status_code,
         )
     if error:
-        return HTMLResponse("<h1>Authorization failed</h1><p>Return to Hermes for details.</p>", status_code=400)
-    return HTMLResponse("<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>")
+        return HTMLResponse(
+            render_callback_page(
+                "Authorization failed",
+                "Return to Hermes for details.",
+                status="error",
+            ),
+            status_code=400,
+        )
+    return HTMLResponse(
+        render_callback_page(
+            "Authorization received",
+            "You can close this tab and return to Hermes.",
+        )
+    )
 
 
 @router.put("/api/mcp/servers/{name}/enabled")

--- a/plugins/memory/honcho/oauth_flow.py
+++ b/plugins/memory/honcho/oauth_flow.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Callable
 from urllib.parse import parse_qs, urlencode, urlparse
 
+from hermes_cli.oauth_callback_page import render_callback_page_bytes
 from plugins.memory.honcho import oauth
 from plugins.memory.honcho.client import resolve_active_host, resolve_config_path
 
@@ -237,21 +238,19 @@ def complete_authorization(
     return cred
 
 
-_CALLBACK_HTML = (
-    b"<!doctype html><meta charset=utf-8>"
-    b"<title>Honcho connected</title>"
-    b"<body style='font:14px ui-monospace,monospace;background:#0b0e14;color:#c9d1d9;"
-    b"display:flex;align-items:center;justify-content:center;height:100vh;margin:0'>"
-    b"<div>Connected to Honcho. You can close this tab and return to Hermes.</div>"
-)
+def _callback_page() -> bytes:
+    return render_callback_page_bytes(
+        "Connected to Honcho",
+        "You can close this tab and return to Hermes.",
+    )
 
-_CALLBACK_ERROR_HTML = (
-    "<!doctype html><meta charset=utf-8>"
-    "<title>Honcho sign-in failed</title>"
-    "<body style='font:14px ui-monospace,monospace;background:#0b0e14;color:#c9d1d9;"
-    "display:flex;align-items:center;justify-content:center;height:100vh;margin:0'>"
-    "<div>Sign-in was not completed ({error}). You can close this tab and re-run setup.</div>"
-)
+
+def _callback_error_page(error: str) -> bytes:
+    return render_callback_page_bytes(
+        "Honcho sign-in failed",
+        f"Sign-in was not completed ({error}). You can close this tab and re-run setup.",
+        status="error",
+    )
 
 
 def _bind_loopback_server() -> tuple[HTTPServer, dict[str, str]]:
@@ -280,12 +279,9 @@ def _bind_loopback_server() -> tuple[HTTPServer, dict[str, str]]:
             self.send_header("Content-Type", "text/html; charset=utf-8")
             self.end_headers()
             if captured["error"]:
-                import html as _html
-
-                page = _CALLBACK_ERROR_HTML.format(error=_html.escape(captured["error"]))
-                self.wfile.write(page.encode("utf-8"))
+                self.wfile.write(_callback_error_page(captured["error"]))
             else:
-                self.wfile.write(_CALLBACK_HTML)
+                self.wfile.write(_callback_page())
 
         def log_message(self, *args):  # silence stdlib request logging
             return

--- a/tests/hermes_cli/test_oauth_callback_page.py
+++ b/tests/hermes_cli/test_oauth_callback_page.py
@@ -1,0 +1,176 @@
+"""Behavior tests for the shared OAuth callback page renderer.
+
+The page is the last thing a user sees after authorizing, served by loopback
+listeners that shut down the moment the redirect lands. That constrains it in
+ways worth pinning: it must be self-contained (no network fetch for the logo),
+it must escape provider-supplied text, and it must degrade to a logo-less page
+rather than raising when the branding directory is missing or unusable.
+"""
+
+import base64
+
+import pytest
+
+# The stylesheet always defines the .has-dark-logo rules; only the body tag
+# tells you whether a dark variant was actually found. Assert on the tag.
+_DARK_BODY = '<body class="has-dark-logo">'
+_PLAIN_BODY = "<body>"
+
+from hermes_cli.oauth_callback_page import (
+    _MAX_LOGO_BYTES,
+    render_callback_page,
+    render_callback_page_bytes,
+)
+
+# Smallest thing a browser will accept as a PNG; contents are irrelevant here.
+_PNG_BYTES = base64.b64decode(
+    b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH"
+    b"/q842iQAAAABJRU5ErkJggg=="
+)
+
+
+@pytest.fixture
+def branding_dir(tmp_path, monkeypatch):
+    """Point HERMES_HOME at a temp dir and return its (uncreated) branding dir."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home / "branding"
+
+
+def test_page_is_a_self_contained_document():
+    page = render_callback_page("Authorization received", "You can close this tab.")
+    assert page.startswith("<!doctype html>")
+    assert "Authorization received" in page
+    assert "You can close this tab." in page
+    # Self-contained: no external stylesheet, script, or image to fetch. The
+    # listener is gone by the time the browser would ask for one.
+    assert "<style>" in page
+    assert 'src="http' not in page
+    assert "<link" not in page
+
+
+def test_heading_doubles_as_the_tab_title():
+    page = render_callback_page("Authorization received", "Done.")
+    assert "<title>Authorization received</title>" in page
+
+
+@pytest.mark.parametrize("status", ["success", "error", "pending"])
+def test_status_selects_a_distinct_glyph_class(status):
+    page = render_callback_page("Heading", "Message", status=status)
+    assert f'class="glyph glyph-{status}"' in page
+
+
+def test_provider_supplied_text_is_escaped():
+    """A hostile ?error= value must not become markup.
+
+    tools/mcp_oauth.py used to interpolate the raw parameter into the page.
+    """
+    page = render_callback_page(
+        "<script>alert(1)</script>",
+        '<img src=x onerror="alert(2)">',
+        status="error",
+    )
+    assert "<script>alert(1)</script>" not in page
+    assert "<img src=x" not in page
+    assert "&lt;script&gt;alert(1)&lt;/script&gt;" in page
+
+
+def test_auto_close_is_opt_in():
+    assert "window.close()" not in render_callback_page("H", "M")
+    assert "window.close()" in render_callback_page("H", "M", auto_close=True)
+
+
+def test_bytes_helper_matches_the_string_helper():
+    assert render_callback_page_bytes("H", "M") == render_callback_page("H", "M").encode(
+        "utf-8"
+    )
+
+
+def test_no_logo_markup_when_branding_dir_is_absent(branding_dir):
+    assert not branding_dir.exists()
+    page = render_callback_page("Authorization received", "Done.")
+    assert "<img" not in page
+    assert _PLAIN_BODY in page
+
+
+def test_light_logo_is_inlined_as_a_data_uri(branding_dir):
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.png").write_bytes(_PNG_BYTES)
+
+    page = render_callback_page("Authorization received", "Done.")
+    expected = base64.b64encode(_PNG_BYTES).decode("ascii")
+    assert f'src="data:image/png;base64,{expected}"' in page
+    # With no dark variant supplied, the single logo serves both schemes.
+    assert _PLAIN_BODY in page
+    assert page.count("<img") == 1
+
+
+def test_dark_variant_adds_a_second_scheme_specific_logo(branding_dir):
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.png").write_bytes(_PNG_BYTES)
+    (branding_dir / "oauth-logo-dark.png").write_bytes(_PNG_BYTES)
+
+    page = render_callback_page("Authorization received", "Done.")
+    assert _DARK_BODY in page
+    assert 'class="logo logo-light"' in page
+    assert 'class="logo logo-dark"' in page
+
+
+def test_svg_branding_gets_the_right_media_type(branding_dir):
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.svg").write_bytes(b"<svg xmlns='http://www.w3.org/2000/svg'/>")
+
+    assert "data:image/svg+xml;base64," in render_callback_page("H", "M")
+
+
+def test_unsupported_extension_is_ignored(branding_dir):
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.bmp").write_bytes(b"BM not inlined")
+
+    assert "<img" not in render_callback_page("H", "M")
+
+
+def test_oversized_logo_is_skipped_rather_than_inlined(branding_dir):
+    """A stray large asset would be base64'd into every callback response."""
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.png").write_bytes(b"\x89PNG" + b"\0" * _MAX_LOGO_BYTES)
+
+    assert "<img" not in render_callback_page("H", "M")
+
+
+def test_empty_logo_file_is_skipped(branding_dir):
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.png").write_bytes(b"")
+
+    assert "<img" not in render_callback_page("H", "M")
+
+
+def test_unreadable_logo_does_not_break_the_callback(branding_dir, monkeypatch):
+    """The user is mid-OAuth; a bad branding file must not fail the redirect."""
+    branding_dir.mkdir()
+    logo = branding_dir / "oauth-logo.png"
+    logo.write_bytes(_PNG_BYTES)
+
+    real_read_bytes = type(logo).read_bytes
+
+    def exploding_read_bytes(self):
+        if self.name.startswith("oauth-logo"):
+            raise OSError("permission denied")
+        return real_read_bytes(self)
+
+    monkeypatch.setattr(type(logo), "read_bytes", exploding_read_bytes)
+
+    page = render_callback_page("Authorization received", "Done.")
+    assert "Authorization received" in page
+    assert "<img" not in page
+
+
+def test_branding_is_resolved_per_call_not_cached_process_wide(branding_dir):
+    """One gateway process serves many profiles; caching would pin the first."""
+    assert "<img" not in render_callback_page("H", "M")
+
+    branding_dir.mkdir()
+    (branding_dir / "oauth-logo.png").write_bytes(_PNG_BYTES)
+
+    assert "<img" in render_callback_page("H", "M")

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -60,6 +60,7 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from pathlib import Path
 from typing import Any
 from urllib.parse import parse_qs, urlparse
+from hermes_cli.oauth_callback_page import render_callback_page
 from hermes_constants import secure_parent_dir
 
 logger = logging.getLogger(__name__)
@@ -774,12 +775,13 @@ def _make_callback_handler() -> tuple[type, dict]:
             result["error"] = error
             result["iss"] = iss
 
-            body = (
-                "<html><body><h2>Authorization Successful</h2>"
-                "<p>You can close this tab and return to Hermes.</p></body></html>"
-            ) if code else (
-                "<html><body><h2>Authorization Failed</h2>"
-                f"<p>Error: {error or 'unknown'}</p></body></html>"
+            body = render_callback_page(
+                "Authorization received",
+                "You can close this tab and return to Hermes.",
+            ) if code else render_callback_page(
+                "Authorization failed",
+                f"The provider reported: {error or 'unknown error'}",
+                status="error",
             )
             self.send_response(200)
             self.send_header("Content-Type", "text/html; charset=utf-8")

--- a/tui_gateway/mcp_oauth_sessions.py
+++ b/tui_gateway/mcp_oauth_sessions.py
@@ -51,6 +51,8 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 from urllib.parse import parse_qs, urlparse
 
+from hermes_cli.oauth_callback_page import render_callback_page_bytes
+
 # Session registry: session_id -> record. A record wraps the shared
 # DashboardOAuthFlow bridge plus a bit of gateway bookkeeping.
 _sessions: Dict[str, Dict[str, Any]] = {}
@@ -132,12 +134,19 @@ def _start_loopback_listener(flow) -> "http.server.HTTPServer":
             code = (qs.get("code") or [None])[0]
             state = (qs.get("state") or [None])[0]
             error = (qs.get("error") or [None])[0]
-            body = b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
+            body = render_callback_page_bytes(
+                "Authorization received",
+                "You can close this tab and return to Hermes.",
+            )
             status = 200
             try:
                 flow.deliver_callback(code=code, state=state, error=error)
             except Exception:
-                body = b"<h1>OAuth callback rejected</h1><p>The callback was invalid or already used.</p>"
+                body = render_callback_page_bytes(
+                    "OAuth callback rejected",
+                    "The callback was invalid or already used.",
+                    status="error",
+                )
                 status = 400
             self.send_response(status)
             self.send_header("Content-Type", "text/html; charset=utf-8")

--- a/website/docs/user-guide/features/mcp.md
+++ b/website/docs/user-guide/features/mcp.md
@@ -310,6 +310,19 @@ Then run `hermes mcp login googledrive` — with the pre-registered client, Herm
 
 **Pitfall — config auto-reload race.** When you edit `~/.hermes/config.yaml` from inside a running Hermes session, the CLI auto-reloads MCP connections with a 30s timeout. That's not enough for an interactive OAuth flow. Add the entry, then run `hermes mcp login <server>` from a fresh terminal — it waits the full 5 minutes for you to complete auth.
 
+### Branding the callback page
+
+The page the provider redirects your browser to at the end of any OAuth flow — MCP, Spotify, honcho — is a centered card that follows your system light/dark preference. Drop an image at `$HERMES_HOME/branding/oauth-logo.png` and it appears above the confirmation message:
+
+```bash
+mkdir -p ~/.hermes/branding
+cp /path/to/your-logo.png ~/.hermes/branding/oauth-logo.png
+```
+
+`.svg`, `.jpg`, `.webp`, and `.gif` work too. Add `oauth-logo-dark.*` alongside it to swap in a second mark under `prefers-color-scheme: dark` — useful when your primary logo is dark ink that disappears on a dark background.
+
+The image is inlined into the page rather than linked, so keep it small (under 1 MB; anything larger is skipped). Because branding lives in `$HERMES_HOME` rather than the repo, it survives `hermes update` and is per-profile.
+
 ## mTLS / client certificates
 
 Remote HTTP MCP servers that require mutual TLS (client-certificate authentication) are supported via `client_cert` / `client_key`. Hermes passes the resolved certificate to the underlying HTTP client for the TLS handshake.


### PR DESCRIPTION
## What does this PR do?

The last thing a user sees after authorizing any OAuth flow is the page the provider redirects their browser to. Six call sites had each grown their own one-line `<h1>` string, so that page is unstyled Times New Roman in the top-left corner of an otherwise blank tab:

```python
b"<h1>Authorization received</h1><p>You can close this tab and return to Hermes.</p>"
```

This adds `hermes_cli/oauth_callback_page.py` as the single source for that markup — a centered card that follows the system light/dark preference — and routes every callback site through it.

It also makes the page **brandable without touching the repo**. An image at `$HERMES_HOME/branding/oauth-logo.*` is inlined above the confirmation message, with `oauth-logo-dark.*` swapped in under `prefers-color-scheme: dark`. Two deliberate choices there:

- **Branding lives in `$HERMES_HOME`, not the tree.** It survives `hermes update`, it's per-profile for free, and no vendor assets land in the repo.
- **The logo is inlined as a `data:` URI rather than linked.** This is a correctness requirement, not a size trade-off: the loopback listener closes itself the moment the redirect lands, so a second request for `/logo.png` would hit nothing. The page has to render with no network at all.

## Related Issue

No linked issue — this started as "why does the MCP login callback page look broken?" while setting up an OAuth MCP server.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix (see below)

## Changes Made

**New:**
- `hermes_cli/oauth_callback_page.py` — `render_callback_page()` / `render_callback_page_bytes()`. Takes plain text plus a `status` of `success` / `error` / `pending`; escapes everything it's given.
- `tests/hermes_cli/test_oauth_callback_page.py` — 17 tests.

**Routed through the shared renderer:**
- `tui_gateway/mcp_oauth_sessions.py` — the gateway/TUI/desktop loopback listener.
- `hermes_cli/web_routers/mcp.py` — the dashboard callback route (all four outcomes: received, failed, expired, rejected).
- `tools/mcp_oauth.py` — the `hermes mcp login` loopback listener.
- `hermes_cli/auth.py` — the Spotify PKCE callback.
- `plugins/memory/honcho/oauth_flow.py` — the honcho callback. Also drops a function-body `import html` now that escaping is centralized.

**Docs:**
- `website/docs/user-guide/features/mcp.md` — new "Branding the callback page" subsection.

### Incidental security fix

`tools/mcp_oauth.py` interpolated the provider's raw `?error=` query parameter straight into the response:

```python
f"<p>Error: {error or 'unknown'}</p></body></html>"
```

That's reflected XSS on the callback origin. It's a narrow hole — loopback, one-shot listener, needs a crafted redirect — but the origin briefly shares `127.0.0.1` with whatever else the user is running locally. The shared renderer escapes all caller-supplied text, so it's closed by construction rather than by remembering to escape at each site. `test_provider_supplied_text_is_escaped` pins it.

## How to Test

1. Point an MCP server at OAuth and log in: `hermes mcp login <server>`. The callback tab now shows a centered card instead of bare `<h1>` text.
2. Add branding and repeat:
   ```bash
   mkdir -p ~/.hermes/branding
   cp your-logo.png ~/.hermes/branding/oauth-logo.png
   ```
   The logo renders above the message. Add `oauth-logo-dark.png` and toggle your OS to dark mode to see the variant swap.
3. Error path — visit the listener with `?error=access_denied` while a flow is pending, or pass `?error=<img src=x onerror=alert(1)>` to confirm it renders as text rather than executing.
4. Degradation — delete `~/.hermes/branding`, or drop in an empty / oversized / `.bmp` file. Each yields a logo-less page; none fail the callback.

**Test runs** (via `scripts/run_tests.sh`, per AGENTS.md):

```
tests/hermes_cli/test_oauth_callback_page.py     17 passed
tests/tools/test_mcp_oauth.py                    58 passed
tests/tui_gateway/test_mcp_oauth_client_callback.py  19 passed
tests/honcho_plugin/test_oauth_flow.py           17 passed
tests/hermes_cli/test_mcp_dashboard_oauth.py      4 passed
tests/tools/test_mcp_dashboard_oauth.py           4 passed
```

I ran the touched areas rather than the full suite. For the `tests/hermes_cli/test_auth*.py` group, a handful of tests fail in my environment on missing optional deps (`openai`); I confirmed against a clean `main` worktree that the failure set is byte-identical before and after this change, so they're environmental rather than regressions.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [ ] I've run `pytest tests/ -q` and all tests pass — ran the affected files via `scripts/run_tests.sh` with a clean-`main` baseline comparison instead of the full suite; see above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (darwin 25.6.0), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` — N/A, no config keys added (branding is file-presence based, deliberately not a config key)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture or workflow change
- [x] Cross-platform impact considered — `pathlib` only, no POSIX-specific primitives; the branding lookup is a suffix match over a directory listing
- [x] Tool descriptions/schemas — N/A, no tool behavior changed

## Notes for reviewers

- **No new config key, by design.** Branding activates on file presence in `$HERMES_HOME/branding/`, matching how `~/.hermes/skins/*.yaml` works. Adding `display.oauth_logo` would mean a config key whose only legal values are paths to a file the user already had to place.
- **Branding is resolved per call, not cached.** One gateway process serves many profiles, so a module-level cache would pin the first profile's logo for every subsequent one. These pages render at most once per OAuth flow, so there's nothing to gain from caching. `test_branding_is_resolved_per_call_not_cached_process_wide` guards it.
- **The Electron desktop relay listener** (`apps/desktop/electron/mcp-oauth-callback-ipc.ts`) still has its own inline `DONE_HTML`. It's already centered and legible, and giving it parity means either duplicating the stylesheet in TypeScript or sharing a CSS asset across the Python/asar boundary. Left alone deliberately; happy to follow up if you have a preference on which way it should go.

## Screenshots / Logs

Rendered light mode, error state, and dark mode (branding shown is my own org's logo, dropped into `$HERMES_HOME/branding/` — nothing vendor-specific ships in the repo). I'll attach the images in a follow-up comment.
