### PR TITLE
fix(cli): in-place transform after streaming prints only the divergent suffix

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -578,7 +578,7 @@ class CLIAgentSetupMixin:
                 tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
-                stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                stream_delta_callback=self._resolve_stream_delta_callback(),
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
                 notice_callback=self._on_notice,
                 notice_clear_callback=self._on_notice_clear,
@@ -639,6 +639,42 @@ class CLIAgentSetupMixin:
             for line in partial_update_hint(e):
                 console.print(line)
             return False
+
+    def _transform_llm_output_hook_active(self) -> bool:
+        """True when a transform_llm_output hook is registered (#102203).
+
+        A mutating hook replaces the final response after streaming has
+        already printed tokens; any post-hoc suffix repair (banner /
+        divergent suffix) leaves garbled output on screen, since the CLI has
+        no way to revoke bytes already rendered. Skip token streaming for
+        those sessions and let run_conversation's final-response Panel
+        branch (cli.py ~17664) print the transformed text once.
+        """
+        try:
+            from cli import logger
+            from hermes_cli.plugins import has_hook
+
+            return has_hook("transform_llm_output")
+        except Exception:  # pragma: no cover - plugin manager may be unavailable
+            try:
+                from cli import logger
+                logger.debug("transform_llm_output hook check failed", exc_info=True)
+            except Exception:
+                pass
+            return False
+
+    def _resolve_stream_delta_callback(self):
+        """Decide the ``stream_delta_callback`` value for ``_init_agent``.
+
+        Extracted as a named method so tests can drive the same wiring
+        decision the production path executes, without duplicating the
+        expression: suppress token streaming whenever a mutating
+        ``transform_llm_output`` hook is registered (#102203)."""
+        if not self.streaming_enabled:
+            return None
+        if self._transform_llm_output_hook_active():
+            return None
+        return self._stream_delta
 
     def _resume_history_limit_error(self, tip_only: bool = False):
         """Return a safe-resume error without materializing transcript rows.

--- a/tests/cli/test_transform_stream_buffered_102203.py
+++ b/tests/cli/test_transform_stream_buffered_102203.py
@@ -1,0 +1,79 @@
+"""Regression tests for the #102203 buffered fix.
+
+When a transform_llm_output hook is registered, the CLI must NOT stream
+token-by-token — a mutating transform is applied AFTER streaming, so any
+post-hoc print (suffix or banner) lands after already-rendered bytes and
+garbles the terminal (see review of the ba0969505a approach on PR #102239).
+
+The fix gates ``stream_delta_callback`` via
+``CLIAgentSetupMixin._resolve_stream_delta_callback``, wired from
+``_init_agent``. Tests drive THAT method (not a copy of its expression), so
+a refactor that drops the hook gate breaks the suite.
+
+Pinned against origin/main 63279301bc: the tests must FAIL on main (the
+resolver method does not exist there).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+def _make_cli(*, streaming_enabled: bool) -> CLIAgentSetupMixin:
+    cli = CLIAgentSetupMixin()
+    cli.streaming_enabled = streaming_enabled
+    cli._stream_delta = lambda *_a, **_k: None
+    return cli
+
+
+class TestTransformHookGate:
+    """The predicate behind the gate."""
+
+    def test_gate_true_when_hook_registered(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", return_value=True):
+            assert cli._transform_llm_output_hook_active() is True
+
+    def test_gate_false_without_hook(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", return_value=False):
+            assert cli._transform_llm_output_hook_active() is False
+
+    def test_gate_fail_open_on_plugin_error(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", side_effect=RuntimeError("boom")):
+            assert cli._transform_llm_output_hook_active() is False
+
+
+class TestResolveStreamDeltaCallback:
+    """The actual wiring decision — invoked from _init_agent at line ~581."""
+
+    def test_hook_active_suppresses_streaming(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            assert cli._resolve_stream_delta_callback() is None
+
+    def test_no_hook_streams_normally(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            assert cli._resolve_stream_delta_callback() is cli._stream_delta
+
+    def test_streaming_disabled_still_none(self):
+        cli = _make_cli(streaming_enabled=False)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            assert cli._resolve_stream_delta_callback() is None
+
+    def test_hook_active_with_streaming_disabled_still_none(self):
+        cli = _make_cli(streaming_enabled=False)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            assert cli._resolve_stream_delta_callback() is None


### PR DESCRIPTION
Fixes #102203

## Summary

When a `transform_llm_output` plugin hook is registered, the CLI was streaming tokens to the terminal as the model generated them, then applying the transform and re-printing the (full or suffix of the) transformed response. Reviewer andrexibiza correctly identified on PR #102239 that this cannot work: once bytes hit the terminal, there's no way to revoke them — `_cprint` has no ANSI erase sequence, and `_OUTPUT_HISTORY` replay resurrects the corruption on Ctrl+L. The earlier iteration of this PR (suffix-only reprint via common prefix) was therefore incorrect by construction.

Observable result: stream prints `Hello, world`, transform returns `Hello， world`, terminal ends up with `Hello, world， world` — both versions visible, corruption durable across redraws.

## Fix

Suppress token streaming (pass `stream_delta_callback=None` to the AIAgent) whenever the `transform_llm_output` hook is registered. With no stream callbacks active, `already_streamed` stays False, the transform runs inside `turn_finalizer` against the buffered response, and the final-response Panel branch (`cli.py:17664+`) renders the transformed text exactly once.

- New helper `CLIAgentSetupMixin._transform_llm_output_hook_active()` calls `hermes_cli.plugins.has_hook("transform_llm_output")`. Fails open (returns False) so a broken plugin registry can't silently disable streaming.
- New helper `_resolve_stream_delta_callback()` is the wiring point the tests exercise — no duplicated expression between source and tests.

## How to Test

```
python -m pytest tests/cli/test_transform_stream_buffered_102203.py -v
```

Expected: 7 passed.

Sabotage check: against main (`63279301bc`), all 7 tests fail with `AttributeError: <class 'CLIAgentSetupMixin'> does not have the attribute '_transform_llm_output_hook_active'`.

Regression:

```
python -m pytest tests/cli/test_transform_stream_buffered_102203.py tests/cli/test_transformed_stream_output.py -q
# 10 passed
```

## What this does NOT cover

- The voice TTS path's `stream_callback` is separate from `stream_delta_callback` and unchanged — it only speaks the final (already transformed) text via `turn_finalizer`, and muting it would degrade voice latency without fixing anything.
- The `_post_stream_transform_output` helper stays: with the hook gate active, `already_streamed` is False on hook turns, so it never fires for transforms; without hooks it's still called on streamed turns where `result.get("response_transformed")` is falsy and returns "".
- A plugin that registers `transform_llm_output` *after* the agent is built (dynamic runtime registration, not the normal plugin-discovery flow) will not be gated until the next `_init_agent`. That path is not a supported flow today.
