### PR TITLE
fix(cron): continuity injects the previous response, not the whole run file

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -4759,6 +4759,30 @@ def _parse_wake_gate(script_output: str) -> bool:
     return gate.get("wakeAgent", True) is not False
 
 
+_CRON_RESPONSE_HEADING = "\n## Response\n"
+_CRON_ERROR_HEADING = "\n## Error\n"
+
+
+def _extract_cron_output_body(output_text: str) -> str:
+    """Return just the response (or error) body of a cron run's output file.
+
+    Run files are written ``## Prompt`` first, and the prompt they record is
+    the *augmented* one — including any context injected into that run. Feeding
+    a whole file back as context therefore nests each run inside the next, and
+    once the character cap bites it truncates away the very response the
+    injection exists to carry.
+
+    Slicing the trailing body out keeps continuity carrying content rather than
+    history, and it recovers correctly from files that already nested. Anything
+    not in the known format is returned unchanged.
+    """
+    for heading in (_CRON_RESPONSE_HEADING, _CRON_ERROR_HEADING):
+        idx = output_text.rfind(heading)
+        if idx != -1:
+            return output_text[idx + len(heading):].strip()
+    return output_text.strip()
+
+
 def _build_job_prompt(
     job: dict,
     prerun_script: Optional[tuple] = None,
@@ -4858,7 +4882,9 @@ def _build_job_prompt(
                 )
                 if not output_files:
                     continue  # silent skip — no output yet
-                latest_output = output_files[0].read_text(encoding="utf-8").strip()
+                latest_output = _extract_cron_output_body(
+                    output_files[0].read_text(encoding="utf-8")
+                )
                 # Truncate to 8K characters to avoid prompt bloat
                 _MAX_CONTEXT_CHARS = 8000
                 if len(latest_output) > _MAX_CONTEXT_CHARS:

--- a/tests/cron/test_cron_continuity_response_only.py
+++ b/tests/cron/test_cron_continuity_response_only.py
@@ -1,0 +1,168 @@
+"""Continuity must carry the previous *response*, not the whole run file.
+
+Regression tests for #101623: ``context_from`` injected the entire previous
+output file, which begins with the augmented ``## Prompt``. Each run therefore
+nested inside the next, and the 8,000-character cap truncated away the response
+the injection exists to carry.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    """Isolated cron environment with temp HERMES_HOME."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "cron").mkdir()
+    (hermes_home / "cron" / "output").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import cron.jobs as jobs_mod
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+
+    return hermes_home
+
+
+def _run_file(prompt: str, response: str, job_name: str = "nest") -> str:
+    """Render an output file the way the scheduler writes one."""
+    return (
+        f"# Cron Job: {job_name}\n\n"
+        "**Job ID:** abcdef123456\n"
+        "**Run Time:** 2026-09-02 10:00:00\n"
+        "**Schedule:** */5 * * * *\n\n"
+        "## Prompt\n\n"
+        f"{prompt}\n\n"
+        "## Response\n\n"
+        f"{response}\n"
+    )
+
+
+class TestExtractCronOutputBody:
+    def test_returns_response_section(self):
+        from cron.scheduler import _extract_cron_output_body
+
+        text = _run_file("Say one new fact.", "Otters hold hands.")
+        assert _extract_cron_output_body(text) == "Otters hold hands."
+
+    def test_ignores_prompt_section_entirely(self):
+        from cron.scheduler import _extract_cron_output_body
+
+        text = _run_file("SECRET_PROMPT_MARKER", "the answer")
+        assert "SECRET_PROMPT_MARKER" not in _extract_cron_output_body(text)
+
+    def test_recovers_response_from_an_already_nested_file(self):
+        """Files written before the fix embed prior runs in ## Prompt."""
+        from cron.scheduler import _extract_cron_output_body
+
+        inner = _run_file("original prompt", "FIRST RESPONSE")
+        nested_prompt = (
+            "## Your previous run's output\n"
+            f"```\n{inner}\n```\n\n"
+            "original prompt"
+        )
+        outer = _run_file(nested_prompt, "SECOND RESPONSE")
+
+        # The last ## Response is this run's own, not the embedded one.
+        assert _extract_cron_output_body(outer) == "SECOND RESPONSE"
+
+    def test_falls_back_to_error_section(self):
+        from cron.scheduler import _extract_cron_output_body
+
+        text = (
+            "# Cron Job: nest (FAILED)\n\n"
+            "## Prompt\n\nsome prompt\n\n"
+            "## Error\n\n```\nboom\n```\n"
+        )
+        assert "boom" in _extract_cron_output_body(text)
+        assert "some prompt" not in _extract_cron_output_body(text)
+
+    def test_unknown_format_returned_unchanged(self):
+        """Plain-text output files predate the sectioned format."""
+        from cron.scheduler import _extract_cron_output_body
+
+        assert _extract_cron_output_body("  just text  ") == "just text"
+
+    def test_empty_input(self):
+        from cron.scheduler import _extract_cron_output_body
+
+        assert _extract_cron_output_body("") == ""
+
+
+class TestContinuityInjection:
+    def test_self_context_injects_response_not_prompt(self, cron_env):
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="Say one new fact.", schedule="every 1h",
+                         context_from="self")
+        out = OUTPUT_DIR / job["id"]
+        out.mkdir(parents=True, exist_ok=True)
+        (out / "2026-09-02_10-00-00.md").write_text(
+            _run_file("Say one new fact.", "Otters hold hands."), encoding="utf-8"
+        )
+
+        result = _build_job_prompt(job)
+
+        assert "Otters hold hands." in result
+        assert "## Prompt" not in result
+        assert "**Job ID:**" not in result
+
+    def test_does_not_nest_across_three_runs(self, cron_env):
+        """The reported symptom: run 3 must still see run 2's response."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="Say one new fact.", schedule="every 1h",
+                         context_from="self")
+        out = OUTPUT_DIR / job["id"]
+        out.mkdir(parents=True, exist_ok=True)
+
+        # Run 1 — no prior context. A realistically sized report: the issue
+        # reports 10-11 KB run files, which is what pushes the next run's
+        # ## Response past the 8,000-character cap.
+        fact_one = "FACT ONE. " + ("detail line for the weekly report. " * 300)
+        (out / "2026-09-02_10-00-00.md").write_text(
+            _run_file("Say one new fact.", fact_one), encoding="utf-8"
+        )
+
+        # Run 2 — built from run 1, then recorded with its augmented prompt.
+        run2_prompt = _build_job_prompt(job)
+        assert "FACT ONE" in run2_prompt
+        assert len(run2_prompt) > 8000  # the next read would truncate mid-prompt
+        f2 = out / "2026-09-02_10-05-00.md"
+        f2.write_text(_run_file(run2_prompt, "FACT TWO"), encoding="utf-8")
+        import os, time
+        os.utime(f2, (time.time() + 10, time.time() + 10))
+
+        # Run 3 must carry FACT TWO — before the fix this was truncated away.
+        run3_prompt = _build_job_prompt(job)
+        assert "FACT TWO" in run3_prompt
+
+    def test_injected_context_stays_small(self, cron_env):
+        """Without the fix each run's file grows by the whole previous file."""
+        from cron.jobs import create_job, OUTPUT_DIR
+        from cron.scheduler import _build_job_prompt
+
+        job = create_job(prompt="p", schedule="every 1h", context_from="self")
+        out = OUTPUT_DIR / job["id"]
+        out.mkdir(parents=True, exist_ok=True)
+
+        bulky_prompt = "PRIOR CONTEXT " * 800  # ~11 KB of prompt history
+        (out / "2026-09-02_10-00-00.md").write_text(
+            _run_file(bulky_prompt, "short answer"), encoding="utf-8"
+        )
+
+        result = _build_job_prompt(job)
+
+        assert "short answer" in result
+        assert "PRIOR CONTEXT" not in result
+        assert "[... output truncated ...]" not in result


### PR DESCRIPTION
## What & why

`context_from` — including `--continuity`, which sets `context_from: ["self"]` — read the **entire** previous output file and prepended it as *"Your previous run's output"*. Run files are written `## Prompt` first, and the prompt they record is the *augmented* one, so every run nested inside the next. Once `_MAX_CONTEXT_CHARS = 8000` bit, the truncation window was all nested prompt text and the `## Response` section was cut off completely.

Net effect: a job with continuity enabled **never actually saw its own previous response**. It re-read its own prompt history, spent the whole character budget on it, and repeated work it had already reported.

Closes #101623.

## Fix

Slice the response body out of the previous run file *before* applying the cap. `_extract_cron_output_body()` takes the text after the last `## Response` heading, falls back to `## Error` for failed runs, and returns anything not in the known format unchanged — plain-text output files predate the sectioned format, and the existing `test_cron_context_from.py` fixtures write exactly those.

Taking the **last** `## Response` is what lets it recover from files that already nested: in such a file the last one is this run's real response, and the embedded older ones are skipped.

This also stops the growth at the source. The injected block now holds only the previous response, so the augmented prompt that gets recorded no longer carries a nested run file — files stop compounding without needing to change what the writer records.

`context_from` pointing at *another* job had the same shape (the issue notes this) and is fixed by the same change.

I went with the issue's suggested fix (1) rather than (2) — writing `job["prompt"]` into the output file instead of the augmented prompt. (1) alone resolves both reported symptoms, and it recovers the files already nested on disk, which (2) can't. (2) would also drop other legitimate prompt augmentation from the debug record. Happy to add it as a follow-up if maintainers want the `## Prompt` section to show only the declared prompt.

## How to test

```bash
hermes cron create "*/5 * * * *" "Say one new fact." --name nest --deliver local --continuity
# wait three runs
cat ~/.hermes/cron/output/<job-id>/<third-run>.md
```

Before: the third file's `## Prompt` holds `## Your previous run's output` → a fenced block containing the *second* file → whose own `## Prompt` holds the *first*, and the injected block ends in `[... output truncated ...]` before any `## Response` is reached.

After: the injected block contains only the previous run's response text.

## Tests

`tests/cron/test_cron_continuity_response_only.py` — 9 tests.

Verified **red → green**: all 9 fail on `main` without the change, all 9 pass with it.

```
# without the fix
9 failed in 1.33s
# with the fix
9 passed in 1.55s
```

The behavioural tests reproduce the reported symptom directly. `test_injected_context_stays_small` fails on `main` with the response truncated away:

```
AssertionError: assert 'short answer' in '[IMPORTANT: You are running as a scheduled cron job...
  ...PRIOR CONTEXT PRIOR CONTEXT PRI\n\n[... output truncated ...]\n```\n\np'
```

`test_does_not_nest_across_three_runs` simulates three runs with a realistically sized report (the issue reports 10–11 KB run files, which is what pushes the next run's `## Response` past the cap) and asserts run 3 still sees run 2's response.

Coverage also includes the `## Error` fallback, the unknown/plain-text passthrough, empty input, and recovery from an already-nested file.

**No regressions** in the three most closely related cron suites:

```
tests/cron/test_cron_context_from.py
tests/cron/test_notepad.py
tests/cron/test_cron_empty_payload.py     84 passed in 7.95s
```

A full `tests/cron/` run did **not** complete locally — my connection to the test box kept dropping — so I'm not claiming it green. What I can show instead is why the change is a no-op for every pre-existing fixture:

**No test in the repo writes `## Response` or `## Error` into a cron output file.** The existing `context_from` fixtures write plain text — `"Today's top story: AI is everywhere."`, `"Old output"`, `"Context data"` — so `_extract_cron_output_body()` takes its unchanged-passthrough branch and returns `text.strip()`, byte-identical to the previous `read_text(...).strip()`. The only other `Response` matches under `tests/cron/` are the `"Cronjob Response:"` delivery prefix in `test_scheduler.py`, which the `\n## Response\n` pattern does not match.

So the sectioned-format branch is reachable only by files the scheduler itself wrote, and the suite that exercises this path most directly — `test_cron_context_from.py` — is among the 84 passing above.

## Platforms

Linux (Debian 12, Python 3.11). The change is pure string slicing with no OS-dependent behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
