### PR TITLE
fix(desktop): stopTurn calls end() instead of handleTurn(forceTranscribe=true)

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts
@@ -613,10 +613,8 @@ export function useVoiceConversation({
   }, [consumePendingResponse, handle])
 
   const stopTurn = useCallback(() => {
-    if (statusRef.current === 'listening') {
-      void handleTurn(true)
-    }
-  }, [handleTurn])
+    void end()
+  }, [end])
 
   const toggleMute = useCallback(() => {
     setMuted(value => {


### PR DESCRIPTION
## Symptom

Pressing the voice Stop button while listening does not stop the conversation. The turn is force-transcribed and restarts instead of ending (reported on Windows: voice input cannot be exited, mic stays live).

## Root cause

`useVoiceConversation.stopTurn` called `handleTurn(true)` when listening. `forceTranscribe=true` forces transcription + `onSubmit`, i.e. the turn continues instead of stopping.

## Fix

Route `stopTurn` through the existing `end()` path, which cancels the mic recording, stops voice playback, clears turn/timeout/monitor state and resets status to `idle`:

`apps/desktop/src/app/chat/composer/hooks/use-voice-conversation.ts`

```ts
const stopTurn = useCallback(() => {
  void end()
}, [end])
```

## Follow-up (separate issue)

The full-duplex barge-in tests in `use-voice-conversation.test.tsx` assume the old behavior (`stopTurn` -> `handleTurn`) in the `enterThinking` helper and need updating. Left untouched here to keep this PR to the source fix only.