### PR TITLE
fix(desktop): warm cross-gateway Bot roster for mentions

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/data.roster.test.tsx
@@ -25,7 +25,7 @@ import { renderHook, waitFor } from '@testing-library/react'
 import type { ReactNode } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $lastRoster, useRoster } from './data'
+import { $lastRoster, serverInjectsProtocol, useRoster } from './data'
 import type { RosterRow } from './types'
 
 const { hostMock } = vi.hoisted(() => ({
@@ -81,7 +81,7 @@ async function mergedRoster(
   liveConnectionId: null | string = 'local'
 ): Promise<RowFixture[]> {
   hostMock.state.connectionId.get.mockReturnValue(liveConnectionId as string)
-  hostMock.request.mockResolvedValue(local)
+  hostMock.requestProfile.mockResolvedValue(local)
 
   if (union) {
     hostMock.agents.mockResolvedValue(union)
@@ -103,6 +103,16 @@ async function mergedRoster(
 }
 
 const identities = (rows: RowFixture[]) => rows.map(row => `${row.connectionId}:${row.name}`)
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(settle => {
+    resolve = settle
+  })
+
+  return { promise, resolve }
+}
 
 beforeEach(() => {
   vi.clearAllMocks()
@@ -581,7 +591,7 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     // Bots sidebar on a spinner with no error card. The 5s refetchInterval and
     // the gateway-open effect already recover drops.
     hostMock.state.connectionId.get.mockReturnValue('local')
-    hostMock.request.mockRejectedValue(new Error('state.db is locked'))
+    hostMock.requestProfile.mockRejectedValue(new Error('state.db is locked'))
 
     const client = new QueryClient({ defaultOptions: { queries: { retryDelay: 0 } } })
 
@@ -594,6 +604,107 @@ describe('a stalled profiles.list cannot pin the spinner forever', () => {
     await waitFor(() => expect(result.current.isError).toBe(true), { timeout: 5000 })
 
     expect(result.current.isLoading).toBe(false)
-    expect(hostMock.request.mock.calls.length).toBeGreaterThan(1)
+    expect(hostMock.requestProfile.mock.calls.length).toBeGreaterThan(1)
+  })
+})
+
+describe('roster request ownership', () => {
+  it('uses the older host request door while its captured owner is current', async () => {
+    const requestProfile = hostMock.requestProfile
+
+    try {
+      Object.assign(hostMock, { requestProfile: undefined })
+      hostMock.state.connectionId.get.mockReturnValue('local')
+      hostMock.request.mockResolvedValue({ profiles: [{ name: 'default' }] })
+      hostMock.agents.mockRejectedValue(new Error('older host'))
+
+      const client = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+      const roster = renderHook(() => useRoster(), {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        )
+      })
+
+      await waitFor(() => expect(roster.result.current.data?.profiles).toHaveLength(1))
+      expect(hostMock.request).toHaveBeenCalledWith('profiles.list', {})
+      roster.unmount()
+      client.clear()
+    } finally {
+      Object.assign(hostMock, { requestProfile })
+    }
+  })
+
+  it('fails closed when an older host switches owner during route discovery', async () => {
+    const requestProfile = hostMock.requestProfile
+    const profileRoutes = hostMock.profileRoutes
+
+    hostMock.state.connectionId.get.mockReturnValue('local')
+    Object.assign(hostMock, {
+      requestProfile: undefined,
+      profileRoutes: vi.fn(async () => {
+        hostMock.state.connectionId.get.mockReturnValue('other')
+        setTimeout(() => hostMock.state.connectionId.get.mockReturnValue('local'), 0)
+
+        return []
+      })
+    })
+
+    try {
+      const switchedClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+      const switched = renderHook(() => useRoster(), {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={switchedClient}>{children}</QueryClientProvider>
+        )
+      })
+
+      await waitFor(() => expect(switched.result.current.isError).toBe(true), { timeout: 5000 })
+      expect(hostMock.request).not.toHaveBeenCalled()
+      switched.unmount()
+      switchedClient.clear()
+    } finally {
+      Object.assign(hostMock, { profileRoutes, requestProfile })
+    }
+  })
+
+  it('publishes protocol support only from the latest current foreground request', async () => {
+    const a = deferred<{ bot_mode_protocol: boolean; profiles: RowFixture[] }>()
+    const b = deferred<{ bot_mode_protocol: boolean; profiles: RowFixture[] }>()
+
+    hostMock.state.connectionId.get.mockReturnValue('a')
+    hostMock.requestProfile.mockImplementation(route => (route.connectionId === 'a' ? a.promise : b.promise))
+    hostMock.agents.mockResolvedValue({ agents: [], sources: [] })
+
+    const firstClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const first = renderHook(() => useRoster(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={firstClient}>{children}</QueryClientProvider>
+      )
+    })
+
+    await waitFor(() => expect(hostMock.requestProfile).toHaveBeenCalledTimes(1))
+    hostMock.state.connectionId.get.mockReturnValue('b')
+
+    const secondClient = new QueryClient({ defaultOptions: { queries: { retry: false } } })
+
+    const second = renderHook(() => useRoster(), {
+      wrapper: ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={secondClient}>{children}</QueryClientProvider>
+      )
+    })
+
+    await waitFor(() => expect(hostMock.requestProfile).toHaveBeenCalledTimes(2))
+    b.resolve({ bot_mode_protocol: true, profiles: [{ name: 'from-b' }] })
+    await waitFor(() => expect(second.result.current.data).toBeTruthy())
+    expect(serverInjectsProtocol).toBe(true)
+
+    a.resolve({ bot_mode_protocol: false, profiles: [{ name: 'from-a' }] })
+    await waitFor(() => expect(first.result.current.data).toBeTruthy())
+    expect(serverInjectsProtocol).toBe(true)
+
+    first.unmount()
+    second.unmount()
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -636,77 +636,79 @@ export function useRoster() {
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
-    queryFn: async () => {
-      // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
-      // against each bot's last local meta write, and a fetch issued before
-      // a write can only carry pre-write ui_meta. (Issue time is the
-      // conservative bound — the server answered no earlier than this.)
-      const issuedAt = Date.now()
-
-      // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
-      // come from the ACTIVE gateway's profiles.list — the canonical Bot
-      // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
-      // so the roster never sends session pointers.
-      // Refresh the alias identity index alongside the roster: alias routes
-      // (Desktop profile → remote backend root) are what let a backend row
-      // keep its configured friendly identity after activation (#89131).
-      // Best-effort and feature-detected — a failed read keeps the last
-      // good index rather than dropping identities mid-session.
-      if (typeof host.profileRoutes === 'function') {
-        const epoch = beginAliasRouteIndex()
-
-        try {
-          indexAliasRoutes(await host.profileRoutes(), epoch)
-        } catch {
-          /* keep the previous alias index */
-        }
-      }
-
-      // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-      // resolves the active owner itself, no captured route needed here.
-      const activeBot = {
-        name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
-      }
-
-      const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
-      // Newer backends inject the teammate-messaging protocol into every
-      // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
-      // carry a second copy. Older gateways lack the flag: keep appending.
-      serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
-
-      // Multi-source desktops (hermes-agent #86875) also expose the union
-      // agent roster across every registered connection. Merge agents from
-      // OTHER sources in as additional rows. Feature-detected + best-effort:
-      // an older Desktop build (no host.agents) or a roster hiccup leaves
-      // the local list exactly as it was.
-      if (typeof host.agents === 'function') {
-        try {
-          const union = await host.agents()
-          const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
-          const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
-          const sources = Array.isArray(union?.sources) ? union.sources : []
-
-          return {
-            ...merged,
-            profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
-            sources,
-            fetchedAt: issuedAt
-          }
-        } catch {
-          /* older build or roster failure — single-source list stands */
-        }
-      }
-
-      return {
-        ...(local && typeof local === 'object' ? local : {}),
-        fetchedAt: issuedAt
-      }
-    },
+    queryFn: () => fetchRoster(activeConnectionId),
     refetchInterval: 5000,
     staleTime: 5000,
     retry: ROSTER_QUERY_RETRY,
     retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
   })
+}
+
+async function fetchRoster(activeConnectionId?: null | string): Promise<RosterSnapshot> {
+  // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
+  // against each bot's last local meta write, and a fetch issued before
+  // a write can only carry pre-write ui_meta. (Issue time is the
+  // conservative bound — the server answered no earlier than this.)
+  const issuedAt = Date.now()
+
+  // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
+  // come from the ACTIVE gateway's profiles.list — the canonical Bot
+  // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
+  // so the roster never sends session pointers.
+  // Refresh the alias identity index alongside the roster: alias routes
+  // (Desktop profile → remote backend root) are what let a backend row
+  // keep its configured friendly identity after activation (#89131).
+  // Best-effort and feature-detected — a failed read keeps the last
+  // good index rather than dropping identities mid-session.
+  if (typeof host.profileRoutes === 'function') {
+    const epoch = beginAliasRouteIndex()
+
+    try {
+      indexAliasRoutes(await host.profileRoutes(), epoch)
+    } catch {
+      /* keep the previous alias index */
+    }
+  }
+
+  // Owner routing is ambient in the SDK now (post-#92731): requestForBot
+  // resolves the active owner itself, no captured route needed here.
+  const activeBot = {
+    name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  }
+
+  const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+  // Newer backends inject the teammate-messaging protocol into every
+  // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
+  // carry a second copy. Older gateways lack the flag: keep appending.
+  serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+
+  // Multi-source desktops (hermes-agent #86875) also expose the union
+  // agent roster across every registered connection. Merge agents from
+  // OTHER sources in as additional rows. Feature-detected + best-effort:
+  // an older Desktop build (no host.agents) or a roster hiccup leaves
+  // the local list exactly as it was.
+  if (typeof host.agents === 'function') {
+    try {
+      const union = await host.agents()
+      const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
+      const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
+      const sources = Array.isArray(union?.sources) ? union.sources : []
+
+      return {
+        ...merged,
+        profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
+        sources,
+        fetchedAt: issuedAt
+      }
+    } catch {
+      /* older build or roster failure — single-source list stands */
+    }
+  }
+
+  return {
+    ...(local && typeof local === 'object' ? local : {}),
+    fetchedAt: issuedAt
+  }
 }
 
 /** Synchronous union-roster read for the composer surfaces (autocomplete
@@ -750,6 +752,35 @@ export function cachedUnionRoster(): RosterSnapshot | null {
   }
 
   return null
+}
+
+/** Cold cache (no Bots pane mounted yet): fetch once and seed the query cache
+ * so the completion popup answers on the next keystroke. */
+const warmingRosterFor = new Set<string>()
+
+export function warmUnionRoster() {
+  if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.setQueryData !== 'function') {
+    return
+  }
+
+  const connectionId = String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+
+  if (warmingRosterFor.has(connectionId)) {
+    return
+  }
+
+  warmingRosterFor.add(connectionId)
+
+  void fetchRoster(connectionId)
+    .then(roster => {
+      if (Array.isArray(roster?.profiles)) {
+        queryClient.setQueryData([...ROSTER_KEY, connectionId], roster)
+      }
+    })
+    .catch(() => undefined)
+    .finally(() => {
+      warmingRosterFor.delete(connectionId)
+    })
 }
 
 /** Merge the union agent roster (host.agents) over the active gateway's

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -598,6 +598,7 @@ export async function migrateBotMeta(storage: BotMetaStorage | undefined = getPl
  *  protocol into the system prompt itself (hermes-agent bot_mode_probe).
  *  Gates every SOUL.md protocol append below. */
 export let serverInjectsProtocol = false
+let foregroundRosterRequest: symbol | undefined
 
 /** A `profiles.list` answer as Bot Mode consumes it, plus the fields the
  *  multi-source merge and the roster query stamp on afterwards. Not in
@@ -636,7 +637,7 @@ export function useRoster() {
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
-    queryFn: () => fetchRoster(activeConnectionId),
+    queryFn: () => fetchRoster(activeConnectionId, { publishProtocol: true }),
     refetchInterval: 5000,
     staleTime: 5000,
     retry: ROSTER_QUERY_RETRY,
@@ -644,7 +645,24 @@ export function useRoster() {
   })
 }
 
-async function fetchRoster(activeConnectionId?: null | string): Promise<RosterSnapshot> {
+async function fetchRoster(
+  activeConnectionId?: null | string,
+  { publishProtocol = true }: { publishProtocol?: boolean } = {}
+): Promise<RosterSnapshot> {
+  const connectionId = String(activeConnectionId || host.activeConnectionId?.() || 'local')
+  const profile = String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  const requestOwner = publishProtocol ? Symbol(connectionId) : undefined
+
+  if (requestOwner) {
+    foregroundRosterRequest = requestOwner
+  }
+
+  const ownerIsCurrent = () =>
+    connectionId === String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local') &&
+    profile === (String(host.state.profile?.get?.() || 'default').trim() || 'default')
+
+  const requestMayPublish = () => requestOwner !== undefined && foregroundRosterRequest === requestOwner && ownerIsCurrent()
+
   // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
   // against each bot's last local meta write, and a fetch issued before
   // a write can only carry pre-write ui_meta. (Issue time is the
@@ -660,27 +678,59 @@ async function fetchRoster(activeConnectionId?: null | string): Promise<RosterSn
   // keep its configured friendly identity after activation (#89131).
   // Best-effort and feature-detected — a failed read keeps the last
   // good index rather than dropping identities mid-session.
+  let activeRoute: ProfileRoute | undefined
+
   if (typeof host.profileRoutes === 'function') {
-    const epoch = beginAliasRouteIndex()
+    const epoch = publishProtocol ? beginAliasRouteIndex() : undefined
 
     try {
-      indexAliasRoutes(await host.profileRoutes(), epoch)
+      const routes = await host.profileRoutes()
+
+      activeRoute = routes.find(
+        route => String(route.connectionId) === connectionId && String(route.profile) === profile
+      )
+
+      if (epoch !== undefined && requestMayPublish()) {
+        indexAliasRoutes(routes, epoch)
+      }
     } catch {
       /* keep the previous alias index */
     }
   }
 
-  // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-  // resolves the active owner itself, no captured route needed here.
-  const activeBot = {
-    name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  // Dispatch through the source captured before profileRoutes awaited. A
+  // connection switch must not retarget this request through ambient state.
+  const activeBot: RosterRow = {
+    connectionId,
+    name: profile,
+    route: activeRoute || {
+      connectionId,
+      mode: connectionId === 'local' ? 'local' : 'remote',
+      profile,
+      targetProfile: profile
+    },
+    sourceScoped: true
   }
 
-  const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+  // Older hosts only have the ambient request door. It is safe while the
+  // captured owner is still active; after a switch, fail closed instead of
+  // letting that ambient door silently retarget the request.
+  if (typeof host.requestProfile !== 'function' && !ownerIsCurrent()) {
+    throw new Error(`Cannot route profiles.list for ${connectionId}::${profile}`)
+  }
+
+  const local = await requestForBot<RosterSnapshot>(
+    typeof host.requestProfile === 'function' ? activeBot : { name: profile },
+    'profiles.list',
+    {}
+  )
+
   // Newer backends inject the teammate-messaging protocol into every
   // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
   // carry a second copy. Older gateways lack the flag: keep appending.
-  serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+  if (requestMayPublish()) {
+    serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+  }
 
   // Multi-source desktops (hermes-agent #86875) also expose the union
   // agent roster across every registered connection. Merge agents from
@@ -756,34 +806,54 @@ export function cachedUnionRoster(): RosterSnapshot | null {
 
 /** Cold cache (no Bots pane mounted yet): fetch once and seed the query cache
  * so the completion popup answers on the next keystroke. */
-const warmingRosterFor = new Set<string>()
+const warmingRosterFor = new Map<string, symbol>()
 
 export function warmUnionRoster() {
-  if (typeof queryClient === 'undefined' || !queryClient || typeof queryClient.setQueryData !== 'function') {
+  if (
+    typeof queryClient === 'undefined' ||
+    !queryClient ||
+    typeof queryClient.getQueryData !== 'function' ||
+    typeof queryClient.setQueryData !== 'function'
+  ) {
     return
   }
 
   const connectionId = String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+  const cacheKey = [...ROSTER_KEY, connectionId]
+  const cacheBefore = queryClient.getQueryData<RosterSnapshot>(cacheKey)
 
   if (warmingRosterFor.has(connectionId)) {
     return
   }
 
-  warmingRosterFor.add(connectionId)
+  const owner = Symbol(connectionId)
+
+  warmingRosterFor.set(connectionId, owner)
 
   // A hung fetch must not block warms for this connection forever.
-  const evict = setTimeout(() => warmingRosterFor.delete(connectionId), 15000)
+  const evict = setTimeout(() => {
+    if (warmingRosterFor.get(connectionId) === owner) {
+      warmingRosterFor.delete(connectionId)
+    }
+  }, 15000)
 
-  void fetchRoster(connectionId)
+  void fetchRoster(connectionId, { publishProtocol: false })
     .then(roster => {
-      if (Array.isArray(roster?.profiles)) {
-        queryClient.setQueryData([...ROSTER_KEY, connectionId], roster)
+      if (
+        warmingRosterFor.get(connectionId) === owner &&
+        queryClient.getQueryData<RosterSnapshot>(cacheKey) === cacheBefore &&
+        Array.isArray(roster?.profiles)
+      ) {
+        queryClient.setQueryData(cacheKey, roster)
       }
     })
     .catch(() => undefined)
     .finally(() => {
       clearTimeout(evict)
-      warmingRosterFor.delete(connectionId)
+
+      if (warmingRosterFor.get(connectionId) === owner) {
+        warmingRosterFor.delete(connectionId)
+      }
     })
 }
 

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -771,6 +771,9 @@ export function warmUnionRoster() {
 
   warmingRosterFor.add(connectionId)
 
+  // A hung fetch must not block warms for this connection forever.
+  const evict = setTimeout(() => warmingRosterFor.delete(connectionId), 15000)
+
   void fetchRoster(connectionId)
     .then(roster => {
       if (Array.isArray(roster?.profiles)) {
@@ -779,6 +782,7 @@ export function warmUnionRoster() {
     })
     .catch(() => undefined)
     .finally(() => {
+      clearTimeout(evict)
       warmingRosterFor.delete(connectionId)
     })
 }

--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -63,6 +63,7 @@ const { cache, hostMock, live } = vi.hoisted(() => {
   return {
     cache: new Map<string, { key: unknown[]; value: unknown }>(),
     hostMock: {
+      agents: vi.fn(async () => ({ agents: [], sources: [] })),
       notify: vi.fn(),
       request: vi.fn(async () => ({})),
       requestProfile: vi.fn(async () => ({})),
@@ -222,6 +223,35 @@ describe('@-mention completions', () => {
     const { provide } = await contributions({ profiles: [] })
 
     expect(provide('')).toEqual([])
+  })
+
+  it('warms a cold union roster for the next keystroke', async () => {
+    const { provide } = await contributions({ profiles: [] })
+    cache.clear()
+    hostMock.request.mockResolvedValue({ profiles: [{ name: 'default' }] })
+    hostMock.agents.mockResolvedValue({
+      agents: [
+        {
+          connectionId: 'local',
+          connectionKind: 'local',
+          connectionLabel: 'This device',
+          handle: 'default',
+          profile: 'default'
+        },
+        {
+          connectionId: 'cloud',
+          connectionKind: 'cloud',
+          connectionLabel: 'Cloud',
+          handle: 'writer',
+          profile: 'writer'
+        }
+      ],
+      primaryConnectionId: 'local',
+      sources: []
+    })
+
+    expect(provide('')).toEqual([])
+    await vi.waitFor(() => expect(provide('').map(item => item.insert)).toContain('@writer'))
   })
 
   it('never offers the bot whose chat you are already in', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.mentions.test.ts
@@ -19,7 +19,7 @@
  * composes no CLI handoff and delivers nothing itself.
  */
 
-import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
 
 interface MentionCompletionItem {
   display: string
@@ -58,17 +58,30 @@ const ROSTER = {
 }
 
 const { cache, hostMock, live } = vi.hoisted(() => {
-  const live = { focused: 'default', profile: 'default' }
+  const live = { connection: 'local', focused: 'default', profile: 'default' }
 
   return {
     cache: new Map<string, { key: unknown[]; value: unknown }>(),
     hostMock: {
-      agents: vi.fn(async () => ({ agents: [], sources: [] })),
+      agents: vi.fn(
+        async (): Promise<{
+          agents: Array<Record<string, unknown>>
+          primaryConnectionId?: string
+          sources: unknown[]
+        }> => ({ agents: [], sources: [] })
+      ),
       notify: vi.fn(),
+      profileRoutes: vi.fn(
+        async (): Promise<
+          Array<{ connectionId: string; mode: 'local' | 'remote'; profile: string; targetProfile: string }>
+        > => []
+      ),
       request: vi.fn(async () => ({})),
-      requestProfile: vi.fn(async () => ({})),
+      requestProfile: vi.fn(
+        async (_route: { connectionId: string; targetProfile?: string }): Promise<Record<string, unknown>> => ({})
+      ),
       state: {
-        connectionId: { get: () => 'local', listen: () => () => undefined },
+        connectionId: { get: () => live.connection, listen: () => () => undefined },
         focusedSessionProfile: { get: () => live.focused, listen: () => () => undefined },
         focusedStoredSessionId: { get: () => null, listen: () => () => undefined },
         gateway: { get: () => null, listen: () => () => undefined },
@@ -125,6 +138,16 @@ interface Fixture {
   profiles?: Array<Record<string, unknown>>
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>(settle => {
+    resolve = settle
+  })
+
+  return { promise, resolve }
+}
+
 /** Register the plugin and hand back its composer contributions. */
 async function contributions({
   cacheKeyConnection = 'local',
@@ -172,9 +195,15 @@ beforeAll(async () => {
 
 beforeEach(() => {
   vi.clearAllMocks()
+  hostMock.agents.mockResolvedValue({ agents: [], sources: [] })
+  hostMock.profileRoutes.mockResolvedValue([])
+  hostMock.requestProfile.mockResolvedValue({})
+  live.connection = 'local'
   live.focused = 'default'
   live.profile = 'default'
 })
+
+afterEach(() => vi.useRealTimers())
 
 describe('@-mention completions', () => {
   it('offers the remote @name-device handle from the suffixed cache entry', async () => {
@@ -219,16 +248,19 @@ describe('@-mention completions', () => {
     expect(inserts).not.toContain('@renametest')
   })
 
-  it('yields nothing, and never throws, on a cold roster cache', async () => {
+  it('does not warm an authoritative empty roster', async () => {
     const { provide } = await contributions({ profiles: [] })
 
     expect(provide('')).toEqual([])
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(hostMock.requestProfile).not.toHaveBeenCalled()
   })
 
   it('warms a cold union roster for the next keystroke', async () => {
     const { provide } = await contributions({ profiles: [] })
     cache.clear()
-    hostMock.request.mockResolvedValue({ profiles: [{ name: 'default' }] })
+    hostMock.requestProfile.mockResolvedValue({ profiles: [{ name: 'default' }] })
     hostMock.agents.mockResolvedValue({
       agents: [
         {
@@ -252,6 +284,115 @@ describe('@-mention completions', () => {
 
     expect(provide('')).toEqual([])
     await vi.waitFor(() => expect(provide('').map(item => item.insert)).toContain('@writer'))
+  })
+
+  it('keeps switched source warms on their captured routes', async () => {
+    const { provide } = await contributions({ profiles: [] })
+    const a = deferred<{ bot_mode_protocol: boolean; profiles: Array<{ name: string }> }>()
+    const b = deferred<{ bot_mode_protocol: boolean; profiles: Array<{ name: string }> }>()
+
+    cache.clear()
+    hostMock.profileRoutes.mockResolvedValue([
+      { connectionId: 'a', mode: 'remote', profile: 'default', targetProfile: 'root-a' },
+      { connectionId: 'b', mode: 'remote', profile: 'default', targetProfile: 'root-b' }
+    ])
+    hostMock.requestProfile.mockImplementation(route => (route.connectionId === 'a' ? a.promise : b.promise))
+
+    live.connection = 'a'
+    expect(provide('')).toEqual([])
+    live.connection = 'b'
+    expect(provide('')).toEqual([])
+    await vi.waitFor(() => expect(hostMock.requestProfile).toHaveBeenCalledTimes(2))
+
+    const data = await import('./data')
+    const protocolBefore = data.serverInjectsProtocol
+
+    b.resolve({ bot_mode_protocol: true, profiles: [{ name: 'from-b' }] })
+    await vi.waitFor(() => expect(cache.get(JSON.stringify(['hermes-bots', 'roster', 'b']))).toBeTruthy())
+    expect(data.serverInjectsProtocol).toBe(protocolBefore)
+    live.connection = 'a'
+    a.resolve({ bot_mode_protocol: false, profiles: [{ name: 'from-a' }] })
+    await vi.waitFor(() => expect(cache.get(JSON.stringify(['hermes-bots', 'roster', 'a']))).toBeTruthy())
+
+    expect(data.serverInjectsProtocol).toBe(protocolBefore)
+
+    expect(hostMock.requestProfile.mock.calls.map(([route]) => [route.connectionId, route.targetProfile])).toEqual([
+      ['a', 'root-a'],
+      ['b', 'root-b']
+    ])
+    expect((cache.get(JSON.stringify(['hermes-bots', 'roster', 'a']))?.value as { profiles: unknown[] }).profiles[0]).toMatchObject({
+      name: 'from-a'
+    })
+    expect((cache.get(JSON.stringify(['hermes-bots', 'roster', 'b']))?.value as { profiles: unknown[] }).profiles[0]).toMatchObject({
+      name: 'from-b'
+    })
+  })
+
+  it('lets a timed-out warm retry without stale publish or owner deletion', async () => {
+    const { provide } = await contributions({ profiles: [] })
+    const old = deferred<{ profiles: Array<{ name: string }> }>()
+    const current = deferred<{ profiles: Array<{ name: string }> }>()
+
+    cache.clear()
+    hostMock.requestProfile.mockReturnValueOnce(old.promise).mockReturnValueOnce(current.promise)
+    vi.useFakeTimers()
+
+    expect(provide('')).toEqual([])
+    await vi.advanceTimersByTimeAsync(15_000)
+    expect(provide('')).toEqual([])
+    await vi.advanceTimersByTimeAsync(0)
+    expect(hostMock.requestProfile).toHaveBeenCalledTimes(2)
+
+    old.resolve({ profiles: [{ name: 'stale' }] })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(cache.get(JSON.stringify(['hermes-bots', 'roster', 'local']))).toBeUndefined()
+
+    expect(provide('')).toEqual([])
+    await vi.advanceTimersByTimeAsync(0)
+    expect(hostMock.requestProfile).toHaveBeenCalledTimes(2)
+
+    current.resolve({ profiles: [{ name: 'current' }] })
+    await vi.advanceTimersByTimeAsync(0)
+    expect(
+      (cache.get(JSON.stringify(['hermes-bots', 'roster', 'local']))?.value as { profiles: unknown[] }).profiles[0]
+    ).toMatchObject({ name: 'current' })
+  })
+
+  it('does not let a delayed warm replace foreground cache or rebuild alias identity', async () => {
+    const { provide } = await contributions({ profiles: [] })
+    const warm = deferred<{ profiles: Array<{ name: string }> }>()
+    const routing = await import('./routing')
+    const cacheKey = JSON.stringify(['hermes-bots', 'roster', 'local'])
+
+    cache.clear()
+    routing.indexAliasRoutes([
+      { connectionId: 'seed', mode: 'remote', profile: 'keep', targetProfile: 'root' }
+    ])
+    hostMock.profileRoutes.mockResolvedValue([
+      { connectionId: 'local', mode: 'local', profile: 'default', targetProfile: 'root' }
+    ])
+    hostMock.requestProfile.mockReturnValue(warm.promise)
+
+    try {
+      expect(provide('')).toEqual([])
+      await vi.waitFor(() => expect(hostMock.requestProfile).toHaveBeenCalledTimes(1))
+
+      const authoritative = { fetchedAt: 999, profiles: [{ name: 'foreground' }] }
+      cache.set(cacheKey, {
+        key: ['hermes-bots', 'roster', 'local'],
+        value: authoritative
+      })
+      warm.resolve({ profiles: [{ name: 'background' }] })
+
+      await vi.waitFor(() => expect(hostMock.agents).toHaveBeenCalled())
+      await vi.waitFor(() => expect(cache.get(cacheKey)?.value).toBe(authoritative))
+      expect(routing.aliasIdentityFor({ connectionId: 'local', name: 'root', sourceScoped: true })).toBeNull()
+      expect(routing.aliasIdentityFor({ connectionId: 'seed', name: 'root', sourceScoped: true })).toMatchObject({
+        name: 'keep'
+      })
+    } finally {
+      routing.indexAliasRoutes([])
+    }
   })
 
   it('never offers the bot whose chat you are already in', async () => {

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -40,7 +40,8 @@ import {
   cachedUnionRoster,
   isActiveRosterBot,
   migrateBotMeta,
-  resolveRosterMentions
+  resolveRosterMentions,
+  warmUnionRoster
 } from './data'
 import {
   $groupChats,
@@ -129,6 +130,8 @@ export default {
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
+            warmUnionRoster()
+
             return []
           }
 

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -130,7 +130,9 @@ export default {
           const profiles = Array.isArray(roster?.profiles) ? roster.profiles : []
 
           if (!profiles.length) {
-            warmUnionRoster()
+            if (!roster) {
+              warmUnionRoster()
+            }
 
             return []
           }


### PR DESCRIPTION
## Summary

Ports the still-needed cold-cache portion of Guido Rosso's #94490 onto current TypeScript Bot Mode while preserving Guido's commit authorship.

- On a genuinely missing roster cache, the first `@` keystroke starts one background union-roster fetch; the next keystroke can offer Bots from every registered connection.
- Capture the connection, logical profile and exact alias route before asynchronous work, so a gateway switch cannot retarget or poison another source's cache.
- Keep background warming presentation-only: it cannot update the foreground `serverInjectsProtocol` capability.
- Use a per-connection ownership token and bounded 15-second eviction, so stale or timed-out requests cannot publish or delete a newer flight.
- Treat an authoritative empty roster as authoritative rather than refetching on every keystroke.
- Preserve the older host's ambient request fallback only while its captured connection/profile remains current; otherwise fail closed.

## Contributor preservation

The first two commits remain authored by Guido Rosso (`neurowave`) from #94490. Current `main` already carries richer union `profileMetadata` than the original PR, so that superseded plumbing is omitted. The unrelated local connection-label edit and substring ranking are also intentionally excluded.

## Verification

- Cold-cache success, authoritative-empty, A/B switching, alias `targetProfile`, protocol non-publication, timeout retry, stale completion and request-owner regressions: passed.
- Full bundled Bot Mode suite: 61 files, 579 tests passed.
- Focused ESLint: passed with zero warnings.
- Desktop TypeScript checks: passed.
- Production Desktop build: passed.
- Static security scan: no findings.
- `git diff --check`: passed.

## Risk

Narrow renderer-side cache warm only. It adds no model tool, prompt mutation, persisted schema or backend API. The first keystroke remains non-blocking and returns no speculative result.

Salvages the cold-cache portion of #94490.
