### PR TITLE
fix(agent): stop flagging successful JSON tool output as failure

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -1370,6 +1370,15 @@ def _detect_tool_failure(tool_name: str, result: str | None) -> tuple[bool, str]
         if err and (data.get("success") is False or "error" in data):
             return True, f" [{_trim_error(str(err))}]"
 
+    # Result parsed cleanly as structured JSON with no recognized error —
+    # treat as success. The serialized-text scan below exists for non-JSON
+    # tool output; running it over parsed JSON only yields false positives:
+    # success shapes routinely embed "error": null / "failed" tokens (e.g.
+    # web_extract's {"results": [{..., "error": null}]}, where per-result
+    # "error" keys are part of the SUCCESS shape).
+    if data is not None:
+        return False, ""
+
     # Generic heuristic for non-terminal tools
     # Multimodal tool results (dicts with _multimodal=True) are not strings —
     # treat them as successes since failures would be JSON-encoded strings.


### PR DESCRIPTION
## Problem

`_detect_tool_failure` (agent/display.py) misreports **successful** tool calls as failures whenever the tool returns structured JSON whose serialized text contains `"error"` / `"failed"` tokens.

Concrete symptom: `web_extract` returns `{"results": [{url, title, content, "error": ...}]}` — a per-result `"error"` key is part of its **success** shape (null on every healthy fetch). The function's generic text heuristic scans the serialized result for `'"error"'` and flags every successful multi-URL batch as `[error]`.

Repro on current main:

```python
from agent.display import _detect_tool_failure
import json
ok = {"results": [{"url": "https://a", "title": "t", "content": "c", "error": None}]}
_detect_tool_failure("web_extract", json.dumps(ok))  # -> (True, " [error]")  WRONG
```

## Root cause

The failure detector has two layers:
1. **Structured checks** — parse the result as JSON, look for an `error`/`message` key with a truthy value (`success is False` or an `error` key present).
2. **Text heuristic** — for everything else, scan the raw string for `"error"` / `"failed"` tokens.

Layer 2 was also being applied to results that *already parsed cleanly as JSON* in layer 1. Any JSON success shape that embeds an `"error"` key — null-valued, nested, or otherwise benign — trips it. That is a false-positive machine, not a detector: JSON-returning tools surface failures through structured fields, which layer 1 already handles.

## Fix

After the structured checks pass, if the result parsed as JSON (dict or list), treat it as a success and skip the text scan. The text heuristic now only runs on genuinely non-JSON tool output, where it was always intended to operate. Non-JSON failures (raw `Error: ...` text, etc.) are still caught exactly as before.

This fixes the whole bug class rather than the one observed site: any tool returning structured JSON with nested/benign `error` or `failed` tokens (web_extract today, others in the future) no longer gets misreported — while failures that do surface structured `error`/`message` fields or `success: false` are still detected by the existing checks above.

## Behavior after fix

```python
_detect_tool_failure("web_extract", json.dumps(ok))          # -> (False, "")   now correct
_detect_tool_failure("web_extract", json.dumps(
    {"results": [{"error": "boom", "title": "", "content": ""}]}))  # -> (True, ...)  still caught
_detect_tool_failure("terminal", 'Error: no such file')      # -> (True, ...)   unchanged
```
