### PR TITLE
fix(tools): serialize list/dict terminal scope values as JSON

### DIFF
--- a/tests/tools/test_terminal_scope_multiplex.py
+++ b/tests/tools/test_terminal_scope_multiplex.py
@@ -182,3 +182,38 @@ def test_tui_and_cron_boundaries_bind_and_reset(tmp_path):
     with install_and_reset_profile_terminal_scope(home):  # cron fire helper
         assert terminal_env("TERMINAL_ENV") == "local"
     assert get_terminal_scope() is None
+
+
+def test_config_yaml_lists_serialize_as_json_not_repr(tmp_path):
+    """#101465: list/dict terminal keys from config.yaml must be JSON text.
+
+    ``_apply()`` used ``str()`` (Python repr), so the ``json.loads()``
+    downstream in terminal_tool failed and docker-backend profiles served
+    through the multiplexed dashboard lost terminal execution entirely.
+    """
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(
+        tmp_path,
+        "dee",
+        "terminal:\n"
+        "  backend: docker\n"
+        "  docker_forward_env:\n"
+        "    - EMAIL_HOME_ADDRESS\n"
+        "  docker_env:\n"
+        "    FOO: bar\n",
+    )
+    scope = build_profile_terminal_scope(home)
+    assert scope["TERMINAL_DOCKER_FORWARD_ENV"] == json.dumps(["EMAIL_HOME_ADDRESS"])
+    assert json.loads(scope["TERMINAL_DOCKER_FORWARD_ENV"]) == ["EMAIL_HOME_ADDRESS"]
+    assert scope["TERMINAL_DOCKER_ENV"] == json.dumps({"FOO": "bar"})
+    assert json.loads(scope["TERMINAL_DOCKER_ENV"]) == {"FOO": "bar"}
+
+
+def test_dotenv_json_strings_pass_through_untouched(tmp_path):
+    """`.env` TERMINAL_* selections are already JSON strings — `str()` stays."""
+    from tools.terminal_scope import build_profile_terminal_scope
+
+    home = _profile(tmp_path, "eff", "", 'TERMINAL_DOCKER_VOLUMES=["/host:/data:rw"]\n')
+    scope = build_profile_terminal_scope(home)
+    assert scope["TERMINAL_DOCKER_VOLUMES"] == '["/host:/data:rw"]'

--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -27,6 +27,7 @@ Two contracts distinguish this from a plain override dict:
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
@@ -172,7 +173,13 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
 
         env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
         if env_var:
-            scope[env_var] = str(value)
+            # Mirror _terminal_env_value() (hermes_cli/config.py): list/dict
+            # values must be JSON text — downstream parses them with
+            # json.loads(), which chokes on str()'s Python repr (#101465).
+            if isinstance(value, (list, dict)):
+                scope[env_var] = json.dumps(value)
+            else:
+                scope[env_var] = str(value)
 
     # 1) Defined defaults — the total baseline.
     for cfg_key, value in defaults.items():


### PR DESCRIPTION
Hey, ran into #101465 while serving a docker-backend profile through the multiplexed dashboard — terminal tools just vanished on me with that `Invalid value for TERMINAL_DOCKER_FORWARD_ENV` error.

Turns out `build_profile_terminal_scope()` serializes list/dict values from `config.yaml` with `str()`, so downstream `json.loads()` chokes on the Python repr. Fix mirrors what `_terminal_env_value()` already does (`json.dumps()` for lists/dicts). Left the `.env` path alone since those values are already JSON strings.

Added a regression test for it. Also ran the neighboring terminal/scope suites — 48 passed — and the windows-footguns check came back clean. Tested on macOS, Python 3.11.

Fixes #101465
