### PR TITLE
fix(desktop): avoid warm Bot Chat overlay flash

### DIFF
--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -946,12 +946,6 @@ export const host = {
         throw new Error('Session open was superseded by a newer selection.')
       }
 
-      if (options.awaitHydration) {
-        // Keep the target-specific overlay visible through transcript hydration,
-        // not merely through the gateway/profile activation that precedes it.
-        $gatewaySwapTarget.set(targetProfile)
-      }
-
       // Only the HYDRATION half retries. Activation already failed its own
       // bounded wait above, and a wedged dial does not get better by dialling
       // again inside the same wake — that is the Retry surface's job.
@@ -994,6 +988,12 @@ export const host = {
             $selectedStoredSessionId.get() === storedSessionId &&
             Boolean($activeSessionId.get()) &&
             (!expectHistory || $messages.get().length > 0)
+
+          if (options.awaitHydration) {
+            // A warm Bot Chat is already painted. Covering it before a forced
+            // transcript refresh produces a full-pane flash on every reopen.
+            $gatewaySwapTarget.set(surfaceHealthy ? null : targetProfile)
+          }
 
           // surfaceHealthy trusts ANY non-empty cached transcript, so it
           // cannot distinguish a fresh transcript from a stale snapshot the

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -382,6 +382,25 @@ function beginHydrationBackgroundSync(profile: string): void {
   })
 }
 
+function sessionHydrationSurface(storedSessionId: string) {
+  const mainMatches = $selectedStoredSessionId.get() === storedSessionId
+  const storedTile = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)
+  const tileMatches = $focusedStoredSessionId.get() === storedSessionId || Boolean(storedTile)
+  const focusedTileMatches = $focusedStoredSessionId.get() === storedSessionId
+  const tileRuntimeId = focusedTileMatches ? $focusedRuntimeId.get() : (storedTile?.runtimeId ?? null)
+  const tileState = focusedTileMatches
+    ? $focusedSessionState.get()
+    : tileRuntimeId
+      ? $sessionStates.get()[tileRuntimeId]
+      : undefined
+
+  return {
+    historyPainted: mainMatches ? Boolean($messages.get().length) : tileMatches ? Boolean(tileState?.messages.length) : false,
+    runtimeReady: mainMatches ? Boolean($activeSessionId.get()) : tileMatches ? Boolean(tileRuntimeId) : false,
+    surfaceMatches: mainMatches || tileMatches
+  }
+}
+
 function waitForFocusedSessionHydration({
   expectHistory,
   generation,
@@ -434,25 +453,7 @@ function waitForFocusedSessionHydration({
       }
 
       const profileMatches = !requireActiveProfile || normalizeProfileKey($activeGatewayProfile.get()) === profile
-      const mainMatches = $selectedStoredSessionId.get() === storedSessionId
-      const storedTile = $sessionTiles.get().find(tile => tile.storedSessionId === storedSessionId)
-      const tileMatches = $focusedStoredSessionId.get() === storedSessionId || Boolean(storedTile)
-      const focusedTileMatches = $focusedStoredSessionId.get() === storedSessionId
-      const tileRuntimeId = focusedTileMatches ? $focusedRuntimeId.get() : (storedTile?.runtimeId ?? null)
-
-      const tileState = focusedTileMatches
-        ? $focusedSessionState.get()
-        : tileRuntimeId
-          ? $sessionStates.get()[tileRuntimeId]
-          : undefined
-
-      const runtimeReady = mainMatches ? Boolean($activeSessionId.get()) : tileMatches ? Boolean(tileRuntimeId) : false
-
-      const historyPainted = mainMatches
-        ? Boolean($messages.get().length)
-        : tileMatches
-          ? Boolean(tileState?.messages.length)
-          : false
+      const { historyPainted, runtimeReady, surfaceMatches } = sessionHydrationSurface(storedSessionId)
 
       // Paint-first hydration: for a history-bearing chat, the wake is DONE
       // the moment the persisted transcript is painted on the right session —
@@ -468,7 +469,7 @@ function waitForFocusedSessionHydration({
       // surface is real rather than a stuck loader.
       const hydrated = expectHistory ? historyPainted : runtimeReady
 
-      if ((mainMatches || tileMatches) && hydrated) {
+      if (surfaceMatches && hydrated) {
         if (profileMatches) {
           finish()
 
@@ -984,10 +985,8 @@ export const host = {
           // The route-resume effect only honors the request while the route
           // points at this session, and consumes it alongside any resume the
           // navigation itself triggers, so a redundant request is a no-op.
-          const surfaceHealthy =
-            $selectedStoredSessionId.get() === storedSessionId &&
-            Boolean($activeSessionId.get()) &&
-            (!expectHistory || $messages.get().length > 0)
+          const { historyPainted, runtimeReady, surfaceMatches } = sessionHydrationSurface(storedSessionId)
+          const surfaceHealthy = surfaceMatches && (expectHistory ? historyPainted : runtimeReady)
 
           if (options.awaitHydration) {
             // A warm Bot Chat is already painted. Covering it before a forced

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -889,9 +889,15 @@ describe('profile-aware plugin session opens', () => {
     // health check while painting STALE messages. The heuristic alone skips
     // the resume; the explicit-navigation caller must be able to force it.
     $activeGatewayProfile.set('hyoseob')
-    setMockAtom($selectedStoredSessionId, 'bot-chat')
-    setMockAtom($activeSessionId, 'runtime-stale-snapshot')
-    setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
+    const resumeTile = vi.fn(async () => 'runtime-stale-snapshot')
+    vi.mocked(sessionTileDelegate).mockReturnValue({ resumeTile } as never)
+    setMockAtom($sessionTiles, [{ runtimeId: 'runtime-stale-snapshot', storedSessionId: 'bot-chat' }] as never)
+    setMockAtom($focusedStoredSessionId, 'bot-chat')
+    setMockAtom($focusedRuntimeId, 'runtime-stale-snapshot')
+    setMockAtom($focusedSessionState, {
+      messages: [{ id: 'stale-history', parts: [], role: 'assistant' }],
+      storedSessionId: 'bot-chat'
+    } as never)
     const swapTargets: Array<null | string> = []
     const unsubscribe = $gatewaySwapTarget.subscribe(value => swapTargets.push(value))
 
@@ -904,7 +910,8 @@ describe('profile-aware plugin session opens', () => {
     })
 
     await Promise.resolve()
-    expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
+    expect(resumeTile).toHaveBeenCalledWith('bot-chat', { refreshTranscript: true })
+    expect(requestSessionResume).not.toHaveBeenCalled()
 
     await opening
     unsubscribe()

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -883,7 +883,7 @@ describe('profile-aware plugin session opens', () => {
     expect(requestSessionResume).not.toHaveBeenCalled()
   })
 
-  it('forces a resume on an explicit bot switch even when a cached transcript looks healthy (#93604)', async () => {
+  it('forces a resume on an explicit bot switch without flashing over a healthy cached transcript (#93604)', async () => {
     // Bot-switch shape from the field: the previous visit left a non-empty
     // snapshot in the session-states cache, so the surface passes every
     // health check while painting STALE messages. The heuristic alone skips
@@ -892,6 +892,8 @@ describe('profile-aware plugin session opens', () => {
     setMockAtom($selectedStoredSessionId, 'bot-chat')
     setMockAtom($activeSessionId, 'runtime-stale-snapshot')
     setMockAtom($messages, [{ id: 'stale-history', parts: [], role: 'assistant' }] as never)
+    const swapTargets: Array<null | string> = []
+    const unsubscribe = $gatewaySwapTarget.subscribe(value => swapTargets.push(value))
 
     const opening = host.openSession('bot-chat', {
       profile: 'hyoseob',
@@ -905,6 +907,8 @@ describe('profile-aware plugin session opens', () => {
     expect(requestSessionResume).toHaveBeenCalledWith('bot-chat', undefined)
 
     await opening
+    unsubscribe()
+    expect(swapTargets).not.toContain('hyoseob')
     expect($gatewaySwapTarget.get()).toBeNull()
   })
 


### PR DESCRIPTION
## Summary
- keep the blocking profile-swap overlay off when the target Bot Chat is already selected, runtime-bound, and painted
- retain the overlay for cold or unhealthy session hydration
- preserve forced transcript refresh behavior

## Scope / risk
- Desktop Bot Chat navigation only
- Risk: low
- Non-goal: gateway reconnect or transcript refresh semantics

## Verification
- `npm test -- --project ui src/sdk/profile-routing.test.ts`
- 1 file passed, 50 tests passed

## Release / rollback
- Release through the repository desktop release pipeline after merge
- Roll back to `63279301bcbdc185c1b07b98a9312eb0c862f26d` if warm navigation regresses

## Review
- Independent fresh-context review for `7e6c491ae103b3ef55d7f688e3db3e710c0189b2` is in progress.