### PR TITLE
fix(providers): resync auth registry after discovery completes (fixes #102123)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -574,52 +574,71 @@ PROVIDER_REGISTRY: Dict[str, ProviderConfig] = {
 # Auto-extend PROVIDER_REGISTRY with any api-key provider registered in
 # providers/ that is not already declared above.  New providers only need a
 # plugins/model-providers/<name>/ plugin — no edits to this file required.
-try:
-    from providers import list_providers as _list_providers_for_registry
-    for _pp in _list_providers_for_registry():
-        if _pp.name in PROVIDER_REGISTRY:
-            continue
-        if _pp.auth_type == "external_process":
-            # An external-process provider (an ACP CLI driven over stdio) has no
-            # API-key env vars to resolve — its credentials come from
-            # resolve_external_process_provider_credentials(), keyed on this
-            # auth_type. Registering it here is what lets a provider shipped
-            # outside this tree pass resolve_provider()'s known-provider gate;
-            # without it, `hermes -m <that provider>` dies with
-            # "Unknown provider" before any client is ever built.
+def sync_plugin_providers_to_registry() -> int:
+    """(Re-)sync discovered provider plugins into ``PROVIDER_REGISTRY``.
+
+    Idempotent: re-running adds only missing names and never overwrites
+    hand-declared entries. Called once at import time below, and again by
+    ``providers._discover_providers()`` after a full scan — an entry-point
+    plugin that imports this module mid-discovery would otherwise freeze a
+    partial snapshot with no refresh (see #102123).
+    """
+    added = 0
+    try:
+        from providers import list_providers as _list_providers_for_registry
+        for _pp in _list_providers_for_registry():
+            if _pp.name in PROVIDER_REGISTRY:
+                continue
+            if _pp.auth_type == "external_process":
+                # An external-process provider (an ACP CLI driven over stdio) has no
+                # API-key env vars to resolve — its credentials come from
+                # resolve_external_process_provider_credentials(), keyed on this
+                # auth_type. Registering it here is what lets a provider shipped
+                # outside this tree pass resolve_provider()'s known-provider gate;
+                # without it, `hermes -m <that provider>` dies with
+                # "Unknown provider" before any client is ever built.
+                PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
+                    id=_pp.name,
+                    name=_pp.display_name or _pp.name,
+                    auth_type="external_process",
+                    inference_base_url=_pp.base_url,
+                )
+                for _alias in _pp.aliases:
+                    if _alias not in PROVIDER_REGISTRY:
+                        PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
+                added += 1
+                continue
+            if _pp.auth_type != "api_key" or not _pp.env_vars:
+                continue
+            # Skip providers that need custom token resolution or are special-cased
+            # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
+            # openrouter/custom are aggregator/user-supplied and handled outside
+            # the registry — adding them here breaks runtime_provider resolution
+            # that relies on `openrouter not in PROVIDER_REGISTRY`).
+            if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
+                continue
+            _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
+            _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
             PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
                 id=_pp.name,
                 name=_pp.display_name or _pp.name,
-                auth_type="external_process",
+                auth_type="api_key",
                 inference_base_url=_pp.base_url,
+                api_key_env_vars=_api_key_vars or _pp.env_vars,
+                base_url_env_var=_base_url_var or "",
             )
+            # Also register aliases so resolve_provider() resolves them
             for _alias in _pp.aliases:
                 if _alias not in PROVIDER_REGISTRY:
                     PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
-            continue
-        if _pp.auth_type != "api_key" or not _pp.env_vars:
-            continue
-        # Skip providers that need custom token resolution or are special-cased
-        # in resolve_provider() (copilot/kimi/zai have bespoke token refresh;
-        # openrouter/custom are aggregator/user-supplied and handled outside
-        # the registry — adding them here breaks runtime_provider resolution
-        # that relies on `openrouter not in PROVIDER_REGISTRY`).
-        if _pp.name in {"copilot", "kimi-coding", "kimi-coding-cn", "zai", "openrouter", "custom"}:
-            continue
-        _api_key_vars = tuple(v for v in _pp.env_vars if not v.endswith("_BASE_URL") and not v.endswith("_URL"))
-        _base_url_var = next((v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")), None)
-        PROVIDER_REGISTRY[_pp.name] = ProviderConfig(
-            id=_pp.name,
-            name=_pp.display_name or _pp.name,
-            auth_type="api_key",
-            inference_base_url=_pp.base_url,
-            api_key_env_vars=_api_key_vars or _pp.env_vars,
-            base_url_env_var=_base_url_var or "",
-        )
-        # Also register aliases so resolve_provider() resolves them
-        for _alias in _pp.aliases:
-            if _alias not in PROVIDER_REGISTRY:
-                PROVIDER_REGISTRY[_alias] = PROVIDER_REGISTRY[_pp.name]
+            added += 1
+    except Exception:
+        pass
+    return added
+
+
+try:
+    sync_plugin_providers_to_registry()
 except Exception:
     pass
 

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -46,6 +46,11 @@ _REGISTRY: dict[str, ProviderProfile] = {}
 _ALIASES: dict[str, str] = {}
 _PROVIDER_LIST_CACHE: list[ProviderProfile] | None = None
 _discovered = False
+# True while _discover_providers() is running. An entry-point plugin that
+# transitively imports hermes_cli.auth mid-scan re-enters list_providers();
+# without this guard the re-entrant call would either recurse or observe a
+# premature `_discovered = True` and freeze a partial snapshot (see #102123).
+_discovering = False
 
 # Repo-root ``plugins/model-providers/`` — populated at discovery time.
 _BUNDLED_PLUGINS_DIR = (
@@ -322,6 +327,46 @@ def _requires_arguments(fn) -> bool:
 def _discover_providers() -> None:
     """Populate the registry by importing every provider plugin.
 
+    Re-entrancy safe: an entry-point plugin that transitively imports
+    ``hermes_cli.auth`` mid-scan re-enters ``list_providers()``; the
+    ``_discovering`` guard makes that a no-op instead of a recursion, and
+    ``_discovered`` is set only after the full scan so no caller can
+    observe a premature done flag (see #102123). Auth's provider registry
+    is re-synced at the end for importa-time snapshots taken mid-scan.
+    """
+    global _discovered, _discovering
+    if _discovered or _discovering:
+        return
+    _discovering = True
+    try:
+        _discover_providers_inner()
+    finally:
+        _discovering = False
+        _discovered = True
+        _resync_auth_registry()
+
+
+def _resync_auth_registry() -> None:
+    """Best-effort re-sync of ``hermes_cli.auth.PROVIDER_REGISTRY``.
+
+    ``hermes_cli.auth`` snapshots ``list_providers()`` at import time; when
+    that import lands mid-discovery the snapshot is partial and never
+    refreshed. If auth is already imported, re-run its idempotent sync so
+    late-discovered providers appear. Guarded by ``sys.modules`` so this
+    package never imports ``hermes_cli.auth`` itself (circular).
+    """
+    try:
+        auth_mod = sys.modules.get("hermes_cli.auth")
+        sync = getattr(auth_mod, "sync_plugin_providers_to_registry", None)
+        if callable(sync):
+            sync()
+    except Exception:
+        pass
+
+
+def _discover_providers_inner() -> None:
+    """Run every provider-plugin import step (see :func:`_discover_providers`).
+
     Order:
       1. Bundled plugins at ``<repo>/plugins/model-providers/<name>/``
       2. User plugins at ``$HERMES_HOME/plugins/model-providers/<name>/``
@@ -332,10 +377,6 @@ def _discover_providers() -> None:
     Each step imports its plugins, which call ``register_provider()`` at
     module-level. Later steps win on name collision.
     """
-    global _discovered
-    if _discovered:
-        return
-    _discovered = True
 
     # 0. Pip-installed plugins — entry points in the ``hermes_agent.plugins``
     #    group (the same group the general PluginManager uses). The manager


### PR DESCRIPTION
## What does this PR do?

Provider discovery can leave `hermes_cli.auth.PROVIDER_REGISTRY` incomplete: `_discover_providers()` in `providers/__init__.py` set the global `_discovered = True` at scan *start*, then ran entry-point plugin imports. An entry-point plugin that transitively imports `hermes_cli.auth` mid-scan triggers auth's import-time `list_providers()` snapshot, which returns only the subset registered so far. Later bundled/user plugins populate `providers._REGISTRY` but `auth.PROVIDER_REGISTRY` never re-syncs — so valid providers (e.g. anything alphabetically after the entry-point plugin) drop from `/api/model/options?explicit_only=1` and fail `is_provider_explicitly_configured()`.

This PR fixes the lifecycle:

- `providers/__init__.py` — add a `_discovering` in-progress guard (re-entrant `list_providers()` during a scan is a no-op instead of observing a premature done flag); set `_discovered = True` only after the full scan via a `_discover_providers()` wrapper around the renamed `_discover_providers_inner()`; at scan end, best-effort call `hermes_cli.auth.sync_plugin_providers_to_registry()` through `sys.modules` (no circular import — providers never imports auth).
- `hermes_cli/auth.py` — extract the import-time auto-extend block into idempotent `sync_plugin_providers_to_registry() -> int` (adds only missing names, never overwrites hand-declared entries or the `copilot/kimi/zai/openrouter/custom` skips); still called once at import, and now also after discovery completes.

## Related Issue

Fixes #102123

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `providers/__init__.py:48` — add `_discovering` flag with comment.
- `providers/__init__.py:322` — `_discover_providers()` wrapper (re-entrancy guard, done-flag at end, `_resync_auth_registry()` in `finally`); new `_resync_auth_registry()` helper (sys.modules-guarded, never raises); existing body moved to `_discover_providers_inner()` unchanged.
- `hermes_cli/auth.py:574` — extract `sync_plugin_providers_to_registry()` (same skips and alias handling), called at import as before.

## How to Test

1. **Repro:** install an entry-point provider plugin that imports `hermes_cli.auth` at module import; run a cold `hermes model options` / `/api/model/options?explicit_only=1`. Before: providers registered after the entry-point plugin are missing from `PROVIDER_REGISTRY`. After: present in both `_REGISTRY` and `PROVIDER_REGISTRY`.
2. Import-order: cold `python -c "import hermes_cli.auth"` still loads clean with no circular-import error.
3. CI: `tests/providers/test_entry_point_discovery.py`, `test_provider_profiles.py`, `tests/hermes_cli/test_api_key_providers.py`, plus full `Python tests / Run tests` and `Python lints` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (CI: `Python tests / Run tests` pass)
- [x] I've added tests for my changes (covered by existing provider discovery tests; verified via manual repro above)
- [x] I've tested on my platform: Windows 11, Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure import-order logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Not applicable — import-lifecycle fix. Before: late-discovered provider in `providers._REGISTRY` but missing from `auth.PROVIDER_REGISTRY`. After: present in both.
