### PR TITLE
fix(state): keep interrupted tool calls visible to the resumed model

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -275,6 +275,64 @@ def _strip_stale_tool_call_markers(messages: List[Dict[str, Any]]) -> List[Dict[
     return messages
 
 
+INTERRUPTED_TOOL_CALL_RESULT = (
+    "[No result recorded — the session was interrupted while this tool call "
+    "was in flight (process crash, kill, or timeout). Its side effects may have "
+    "been applied fully, partially, or not at all; verify the current state "
+    "before relying on it.]"
+)
+
+
+def _answer_interrupted_tool_calls(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Give the transcript's trailing unanswered tool calls an explicit result.
+
+    The agent loop persists an assistant ``tool_calls`` turn BEFORE the tools
+    run (conversation_loop: "if a destructive tool restarts or terminates
+    Hermes mid-turn, resume logic still sees the exact tool-call block").
+    When the process then dies mid-tool (crash, SIGKILL, watchdog timeout),
+    the durable transcript ends with that turn and no result rows — and
+    ``repair_message_sequence`` Pass 2 would prune the unanswered calls, so
+    the resumed model never learns a write was in flight (#99869).
+
+    Only the TRAILING run is touched: an unanswered call followed by later
+    turns is the compression-displacement shape Pass 2 exists for, not an
+    interruption. The synthetic results are marked durable so a later flush
+    does not write them as real rows; a repeat resume regenerates them.
+    """
+    from agent.context_compressor import _DB_PERSISTED_MARKER as _DB_PERSISTED_MARKER_KEY
+    from agent.message_sanitization import coalesce_tool_call_id
+
+    answered: set[str] = set()
+    idx = len(messages) - 1
+    while idx >= 0 and messages[idx].get("role") == "tool":
+        answered.add(str(messages[idx].get("tool_call_id") or ""))
+        idx -= 1
+    if idx < 0 or messages[idx].get("role") != "assistant":
+        return messages
+    synthetic = []
+    for tc in messages[idx].get("tool_calls") or []:
+        call_id = coalesce_tool_call_id(tc)
+        if not call_id or call_id in answered:
+            continue
+        fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
+        name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)) or ""
+        synthetic.append({
+            "role": "tool",
+            "content": INTERRUPTED_TOOL_CALL_RESULT,
+            "tool_call_id": call_id,
+            "tool_name": name,
+            _DB_PERSISTED_MARKER_KEY: True,
+        })
+    if synthetic:
+        logger.info(
+            "Answered %d interrupted tool call(s) while restoring session (#99869)",
+            len(synthetic),
+        )
+    return messages + synthetic
+
+
 def format_session_db_unavailable(prefix: str = "Session database not available") -> str:
     """User-facing message with the captured init cause (+ WAL-docs hint for NFS/SMB locking failures)."""
     cause = get_last_init_error()

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -312,9 +312,13 @@ def _answer_interrupted_tool_calls(
     if idx < 0 or messages[idx].get("role") != "assistant":
         return messages
     synthetic = []
+    skipped_idless = 0
     for tc in messages[idx].get("tool_calls") or []:
         call_id = coalesce_tool_call_id(tc)
-        if not call_id or call_id in answered:
+        if not call_id:
+            skipped_idless += 1
+            continue
+        if call_id in answered:
             continue
         fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
         name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)) or ""
@@ -329,6 +333,11 @@ def _answer_interrupted_tool_calls(
         logger.info(
             "Answered %d interrupted tool call(s) while restoring session (#99869)",
             len(synthetic),
+        )
+    if skipped_idless:
+        logger.debug(
+            "Skipped %d trailing tool call(s) with no pairing id while restoring session",
+            skipped_idless,
         )
     return messages + synthetic
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -320,13 +320,12 @@ def _answer_interrupted_tool_calls(
             continue
         if call_id in answered:
             continue
-        fn = tc.get("function") if isinstance(tc, dict) else getattr(tc, "function", None)
-        name = (fn.get("name") if isinstance(fn, dict) else getattr(fn, "name", None)) or ""
+        fn = tc.get("function") or {}
         synthetic.append({
             "role": "tool",
             "content": INTERRUPTED_TOOL_CALL_RESULT,
             "tool_call_id": call_id,
-            "tool_name": name,
+            "tool_name": fn.get("name", "") if isinstance(fn, dict) else "",
             _DB_PERSISTED_MARKER_KEY: True,
         })
     if synthetic:

--- a/hermes_state_messages.py
+++ b/hermes_state_messages.py
@@ -778,7 +778,11 @@ class SessionMessagesMixin:
         stamped ``_DB_PERSISTED_MARKER_KEY`` (born durable) so an identity-losing handoff never re-appends the
         transcript on flush. ``_row_id`` is opt-in (gateway reactions); reasoning restored on assistant rows
         only; ``api_content`` VERBATIM (no sanitize/strip) so replay keeps the provider prompt cache byte-stable."""
-        from hermes_state import _strip_background_review_harness, _strip_stale_tool_call_markers
+        from hermes_state import (
+            _answer_interrupted_tool_calls,
+            _strip_background_review_harness,
+            _strip_stale_tool_call_markers,
+        )
         messages = []
         exact_user_clones: Dict[Tuple[Any, str], Dict[str, Any]] = {}
         for row in rows:
@@ -827,6 +831,9 @@ class SessionMessagesMixin:
         # session_id) plus its curator reply, and bare tool-call marker content ("[memory]") persisted as an answer.
         messages = _strip_stale_tool_call_markers(_strip_background_review_harness(messages))
         if repair_alternation and messages:
+            # Must run BEFORE repair_message_sequence, whose Pass 2 would
+            # otherwise prune the interrupted calls (#99869).
+            messages = _answer_interrupted_tool_calls(messages)
             from agent.agent_runtime_helpers import repair_message_sequence
             repaired = repair_message_sequence(None, messages)
             if repaired:

--- a/tests/hermes_state/test_resume_interrupted_tool_calls.py
+++ b/tests/hermes_state/test_resume_interrupted_tool_calls.py
@@ -1,0 +1,106 @@
+"""A session killed mid-tool must tell the resumed model what was in flight (#99869).
+
+The agent loop persists the assistant ``tool_calls`` turn before the tools run,
+so a crash / SIGKILL / watchdog kill leaves the durable transcript ending with
+that turn and no result rows. On resume, ``repair_message_sequence`` Pass 2
+used to prune those unanswered calls — the model resumed with no trace that a
+``write_file`` had been in progress, and trusted stale on-disk state.
+
+``_answer_interrupted_tool_calls`` gives each trailing unanswered call an
+explicit synthetic result instead, and ONLY the trailing run: an unanswered
+call followed by later turns is the compression-displacement shape Pass 2
+exists for.
+"""
+
+import json
+
+import pytest
+
+from agent.context_compressor import _DB_PERSISTED_MARKER
+from hermes_state import INTERRUPTED_TOOL_CALL_RESULT, SessionDB
+
+
+@pytest.fixture
+def db(tmp_path):
+    return SessionDB(tmp_path / "state.db")
+
+
+def _call(call_id, name="write_file", **args):
+    return {
+        "id": call_id,
+        "type": "function",
+        "function": {"name": name, "arguments": json.dumps(args)},
+    }
+
+
+def _tool_results(messages):
+    return [m for m in messages if m["role"] == "tool"]
+
+
+def test_trailing_unanswered_call_gets_interrupted_result(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "cap the loop-state files")
+    db.append_message(
+        "s1", "assistant", "Applying cap.",
+        tool_calls=[_call("call_1", path="loop-state/ci-sweeper.md")],
+    )
+    # Process dies here: no tool result row, no end_session().
+
+    model, display = db.get_resume_conversations("s1")
+
+    assert model[-2]["role"] == "assistant"
+    assert model[-2]["tool_calls"][0]["function"]["name"] == "write_file"
+    stub = model[-1]
+    assert stub["role"] == "tool"
+    assert stub["tool_call_id"] == "call_1"
+    assert stub["tool_name"] == "write_file"
+    assert stub["content"] == INTERRUPTED_TOOL_CALL_RESULT
+    # Never re-flushed as a real row; a repeat resume regenerates it.
+    assert stub[_DB_PERSISTED_MARKER] is True
+    # Display projection keeps the historical shape.
+    assert _tool_results(display) == []
+
+
+def test_partially_answered_batch_only_stubs_the_missing_calls(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "cap both files")
+    db.append_message(
+        "s1", "assistant", None,
+        tool_calls=[_call("call_a", path="a.md"), _call("call_b", path="b.md")],
+    )
+    db.append_message("s1", "tool", "ok", tool_name="write_file", tool_call_id="call_a")
+    # Dies during call_b.
+
+    model, _ = db.get_resume_conversations("s1")
+
+    results = _tool_results(model)
+    assert [r["tool_call_id"] for r in results] == ["call_a", "call_b"]
+    assert results[0]["content"] == "ok"
+    assert results[1]["content"] == INTERRUPTED_TOOL_CALL_RESULT
+
+
+def test_mid_transcript_unanswered_call_is_still_pruned(db):
+    """Not trailing => compression-displacement shape, Pass 2 semantics unchanged."""
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "first")
+    db.append_message("s1", "assistant", "old", tool_calls=[_call("call_old")])
+    db.append_message("s1", "user", "second")
+    db.append_message("s1", "assistant", "done")
+
+    model, _ = db.get_resume_conversations("s1")
+
+    assert _tool_results(model) == []
+    assert not any(m.get("tool_calls") for m in model)
+
+
+def test_clean_transcript_is_untouched(db):
+    db.create_session("s1", source="cli")
+    db.append_message("s1", "user", "hi")
+    db.append_message("s1", "assistant", "x", tool_calls=[_call("call_1")])
+    db.append_message("s1", "tool", "ok", tool_name="write_file", tool_call_id="call_1")
+    db.append_message("s1", "assistant", "all done")
+    db.end_session("s1", "cli_close")
+
+    model, _ = db.get_resume_conversations("s1")
+
+    assert [r["content"] for r in _tool_results(model)] == ["ok"]


### PR DESCRIPTION
## What does this PR do?

When a session dies mid-tool (crash, SIGKILL, watchdog kill, closed terminal), the resumed model currently gets **no signal** that a tool call was in flight. This PR keeps that call visible and tells the model to verify its side effects.

**Root cause.** `agent/conversation_loop.py` (~L8106) deliberately persists the assistant `tool_calls` turn *before* the tools run — "if a destructive tool restarts or terminates Hermes mid-turn, resume logic still sees the exact tool-call block". But on resume, `hermes_state._rows_to_conversation` → `repair_message_sequence` Pass 2 **prunes** any `tool_calls` that have no result, and drops the turn if that leaves it empty. So the persisted evidence is erased at the exact moment it is needed. Reproduced on `main`:

```
# session died during write_file(loop-state/ci-sweeper.md)
model_history after resume:
  user:      "cap the loop-state files"
  assistant: "Applying cap."          <- tool_calls gone, no tool result
```

The model resumes believing nothing happened and trusts stale on-disk state — the failure shape in #99869.

**Fix.** One load-time pass, `_answer_interrupted_tool_calls`, added next to the existing `_strip_background_review_harness` / `_strip_stale_tool_call_markers` passes in `_rows_to_conversation`, running before the alternation repair. If the transcript's **trailing** run is an assistant `tool_calls` turn with unanswered calls, each gets an explicit synthetic tool result:

> [No result recorded — the session was interrupted while this tool call was in flight (process crash, kill, or timeout). Its side effects may have been applied fully, partially, or not at all; verify the current state before relying on it.]

- Only the trailing run is touched. A dangling call followed by later turns is the compression-displacement shape Pass 2 exists for; that behaviour is unchanged (covered by a test).
- Partially answered batches (`[A, B]`, `A` answered, died in `B`) only stub `B`.
- Synthetic rows carry `_DB_PERSISTED_MARKER` so no flush ever writes them; a repeat resume regenerates them deterministically. `display_history` is untouched (historical shape).
- Model projection only (`repair_alternation=True`), so every consumer of `get_resume_conversations` / `get_messages_as_conversation(repair_alternation=True)` gets it: CLI `--resume`, `-c`, `/resume`, TUI gateway, desktop — and the crash-restore offer in #96848 once it lands.

## Related Issue

Related to #99869 (proposal 2/3: the next session must know the prior one died mid-write).
Complements #96848 (detects the dead session and offers restore; this PR is what the restored model then sees) and #100220 (broader checkpoint/journal work; this closes the continuation-prompt gap independently, 1 file + 1 test).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_state.py`: `INTERRUPTED_TOOL_CALL_RESULT` + `_answer_interrupted_tool_calls()`; one call in `_rows_to_conversation` before `repair_message_sequence`.
- `tests/hermes_state/test_resume_interrupted_tool_calls.py`: trailing unanswered call stubbed; partially answered batch; mid-transcript dangling call still pruned; clean transcript untouched.

## How to Test

1. `pytest tests/hermes_state/test_resume_interrupted_tool_calls.py -q` → 4 passed (collection fails on `main` without the fix; the first test's assertion fails if the pass is removed).
2. Manual: start `hermes`, ask for a long `write_file`/`terminal` call, `kill -9` the process while the tool runs, then `hermes -c`. The first model turn now sees the interrupted call and its verify-first result instead of an empty assistant turn.
3. Neighbouring suites run locally (`tests/hermes_state`, `tests/test_hermes_state.py`, `tests/run_agent`, `tests/agent/test_pre_compress_checkpoint_contract.py`, `tests/agent/test_load_time_durability_stamp_92231.py`, `tests/test_session_db_read_path_split.py`, all tests referencing `repair_message_sequence` / `sanitize_api_messages` / `get_resume_conversations`): 1,412 passed. 9 failures are pre-existing on untouched `main` in this environment (Windows `os.replace`-on-open-handle inode tests, a cp949 subprocess decode, and `test_interruptible_anthropic_interrupt_never_closes_shared_client`) — unrelated to this change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (#96848 and #100220 are adjacent, not overlapping — see above)
- [x] My PR contains **only** changes related to this fix
- [x] I've run the relevant tests and they pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] Documentation — N/A (internal restore behaviour; user-visible only as a tool result the model sees)
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered — pure list transform, no I/O
- [x] Tool descriptions/schemas — N/A
