### PR TITLE
fix(agent): persist api_content sidecar on the normal CLI path

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1626,32 +1626,32 @@ def build_turn_context(
         )
         if _api_content is not None and _api_content != _turn_user_msg.get("content"):
             _turn_user_msg["api_content"] = _api_content
-            # In-place preflight compaction has ALREADY inserted this turn's
-            # user row (archive_and_compact runs before prefetch/pre_llm_call
-            # can compose the sidecar), and the crash persist below identity-
-            # skips every compacted dict (they are all in the rebound
-            # conversation_history) — so the stamp would never reach the DB.
-            # Backfill it onto the freshly-inserted row directly. Rotation
-            # mode needs nothing here: its compacted copies flush to the
-            # child session after this stamp.
-            if _preflight_compressed and bool(
-                getattr(agent, "_last_compaction_in_place", False)
-            ):
-                _db = getattr(agent, "_session_db", None)
-                if _db is not None:
-                    try:
-                        _db.set_latest_user_api_content(
-                            agent.session_id,
-                            _turn_user_msg.get("content"),
-                            _api_content,
-                        )
-                    except Exception:
-                        logger.warning(
-                            "in-place compaction api_content backfill failed "
-                            "for session=%s",
-                            agent.session_id or "none",
-                            exc_info=True,
-                        )
+            # The stamp must reach the DB even when the row already exists.
+            # Two paths land a sidecar-less user row before this point:
+            #  - In-place preflight compaction: archive_and_compact inserts
+            #    the row, and the crash persist identity-skips every
+            #    compacted dict.
+            #  - CLI close-persist / early flush: a signal handler or
+            #    cross-process flush reads the staged dict and writes the
+            #    row before this stamp runs (#102194). The marker-based
+            #    flush then skips it forever.
+            # set_latest_user_api_content is content-guarded: it no-ops
+            # when the newest row already has the exact sidecar or when
+            # the live content no longer matches (persist override).
+            _db = getattr(agent, "_session_db", None)
+            if _db is not None:
+                try:
+                    _db.set_latest_user_api_content(
+                        agent.session_id,
+                        _turn_user_msg.get("content"),
+                        _api_content,
+                    )
+                except Exception:
+                    logger.warning(
+                        "api_content backfill failed for session=%s",
+                        agent.session_id or "none",
+                        exc_info=True,
+                    )
 
     # Crash-resilience: persist the inbound user turn before the first LLM
     # call. Runs after preflight compression (which rewrites history anyway)

--- a/tests/agent/test_api_content_cli_backfill_102194.py
+++ b/tests/agent/test_api_content_cli_backfill_102194.py
@@ -1,0 +1,108 @@
+"""Repro for NousResearch/hermes-agent#102194.
+
+CLI path never persists the ``api_content`` sidecar: when the current-turn
+user row reaches the DB BEFORE ``build_turn_context`` stamps the sidecar
+(close-persist ``_persist_active_session_before_close`` on the staged
+``_pending_cli_user_message``, an early gateway/cross-process flush, or a
+retry of a failed turn-start persist), the prologue stamp only lands on the
+in-memory dict and the marker-based flush skips the already-written row.
+``set_latest_user_api_content`` is only invoked from the in-place-compaction
+branch, so on the normal flow the row keeps ``api_content = NULL`` and the
+next turn replays the clean content — the request prefix diverges exactly at
+the first decorated message and the provider prompt cache is missed on the
+first call of every turn.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from agent.turn_context import compose_user_api_content
+from hermes_state import SessionDB
+from tests.agent.test_api_content_sidecar import _FakeAgent, _build
+
+
+def _agent_with_preexisting_row(tmp_path, session_id: str, content: str):
+    """FakeAgent whose current-turn user row is ALREADY in the DB (without
+    sidecar) before the prologue runs — exactly what a close-persist on the
+    staged CLI dict produces. The in-turn persist no-ops for that row, the
+    same way the marker-based flush skips already-written messages."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(session_id, source="cli")
+    db.append_message(session_id, "user", content=content)
+
+    agent = _FakeAgent()
+    agent.session_id = session_id
+    agent._session_db = db
+    agent._session_db_created = True
+    # Marker-skip: the early persist sees the row as already durable and
+    # writes nothing.
+    agent._persist_session = lambda _messages, _history=None: None
+    agent._ensure_db_session = lambda: None
+    return agent, db
+
+
+class TestPreExistingUserRowBackfill:
+    def test_prologue_backfills_sidecar_onto_preexisting_row(self, tmp_path):
+        """Row inserted BEFORE the stamp (close-persist racing the staged CLI
+        dict) must still receive the sidecar once the prologue composes it.
+        Without the fix the row stays NULL and the next turn replays the
+        clean content, breaking the prompt-cache prefix."""
+        sid = "sess-102194"
+        agent, db = _agent_with_preexisting_row(tmp_path, sid, "hello")
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent)
+
+            msg = ctx.messages[ctx.current_turn_user_idx]
+            expected = compose_user_api_content("hello", "", "PLUGIN-CTX")
+            # The live dict always carries the stamp (in-memory turn works).
+            assert msg["api_content"] == expected
+
+            # The durable row must carry the same sidecar; otherwise the
+            # next turn rehydrates clean bytes and misses the cache.
+            rows = db.get_messages_as_conversation(sid)
+            assert len(rows) == 1
+            assert rows[0]["content"] == "hello"
+            assert rows[0].get("api_content") == expected
+        finally:
+            db.close()
+
+    def test_no_backfill_without_injections(self, tmp_path):
+        """No injection → no sidecar → the pre-existing clean row is left
+        exactly as-is (no spurious UPDATE)."""
+        sid = "sess-102194-b"
+        agent, db = _agent_with_preexisting_row(tmp_path, sid, "hello")
+        try:
+            with patch("hermes_cli.plugins.invoke_hook", return_value=[]):
+                ctx = _build(agent)
+            msg = ctx.messages[ctx.current_turn_user_idx]
+            assert "api_content" not in msg
+            rows = db.get_messages_as_conversation(sid)
+            assert "api_content" not in rows[0]
+        finally:
+            db.close()
+
+    def test_no_backfill_when_content_mismatch(self, tmp_path):
+        """If the newest user row no longer matches the live content (e.g. a
+        persist-override rewrote the durable value), the backfill must NOT
+        stamp the sidecar onto the wrong row."""
+        sid = "sess-102194-c"
+        agent, db = _agent_with_preexisting_row(tmp_path, sid, "clean override text")
+        try:
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent)
+            msg = ctx.messages[ctx.current_turn_user_idx]
+            # Live dict is stamped (live content "hello" ≠ durable row).
+            assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+            rows = db.get_messages_as_conversation(sid)
+            assert rows[0]["content"] == "clean override text"
+            assert "api_content" not in rows[0]
+        finally:
+            db.close()


### PR DESCRIPTION
Fixes #102194

## Summary

Every new user turn's first API call was missing the provider prompt cache. The `<memory-context>` / plugin context is composed by `agent/turn_context.py::compose_user_api_content` and stamped onto the live user dict as `msg["api_content"]` so the next turn replays the exact sent bytes. The stamp only reached the DB when the row was written *after* the stamp, or via `set_latest_user_api_content`, which was gated behind the **in-place preflight compaction** branch only.

When an early flush materialized the row *before* `build_turn_context` could stamp the sidecar (CLI close-persist reading the staged `_pending_cli_user_message`, a cross-process flush, or a retry of a failed turn-start persist), the marker-based flush then skipped the row forever and it kept `api_content = NULL`. The next turn rehydrated the clean content, the request prefix diverged from what the provider had cached, and `cache_read` collapsed to the offset of the first decorated message — exactly the "50688 cutoff on every turn boundary" symptom from the issue.

## Fix

Remove the `_preflight_compressed` / `_last_compaction_in_place` gate around the backfill call. After stamping `api_content` on the live dict, always invoke `set_latest_user_api_content`. The helper is content-guarded: it no-ops when the newest row already carries the exact sidecar (normal ordering) or when the live content no longer matches (persist override), so this costs nothing in the common path and closes the gap when an early flush raced the stamp.

## How to Test

```
python -m pytest tests/agent/test_api_content_cli_backfill_102194.py -v
```

Expected: 3 passed. On current main, `test_prologue_backfills_sidecar_onto_preexisting_row` fails with `AssertionError: assert None == 'hello\\n\\nPLUGIN-CTX'` — the row kept `api_content = NULL`, which is the cache-miss condition.

Also regressed cleanly:

```
python -m pytest tests/agent/test_api_content_sidecar.py tests/agent/test_turn_context.py -q
```

27 + 20 passed, 0 failures.

## Non-goals / Follow-up

This closes the ordering gap in the existing sidecar mechanism. It does **not** redesign the sidecar as the *typed, producer-bound, non-authoritative cache* that #102194 lists as Option 2; that remains follow-up work tracked separately and is orthogonal to the P0 cache miss fixed here.
