### PR TITLE
fix(dashboard): stop session opener from landing in delegate/branch transcripts (fixes #101742)

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12422,11 +12422,35 @@ async def cancel_oauth_session(
 
 
 
+def _is_non_continuation_child(session: dict | None) -> bool:
+    """True when a session row is a delegate/branch child, not a continuation.
+
+    Delegate subagent runs (``model_config._delegate_from``) and explicit
+    branches (``model_config._branched_from``) share the ``parent_session_id``
+    edge with /model-continuation children, but opening them in place of the
+    requested parent shows the wrong transcript (see #101742). Fail-open:
+    unparseable/missing config means continuation.
+    """
+    if not isinstance(session, dict):
+        return False
+    cfg = session.get("model_config")
+    if isinstance(cfg, str):
+        try:
+            cfg = json.loads(cfg) if cfg.strip() else {}
+        except Exception:
+            return False
+    if not isinstance(cfg, dict):
+        return False
+    return bool(cfg.get("_delegate_from") or cfg.get("_branched_from"))
+
+
 def _session_latest_descendant(session_id: str, db):
     """Resolve a session id to the newest child leaf session.
 
     /model may create child sessions. Dashboard refresh should continue the
-    newest child instead of reopening the old parent.
+    newest child instead of reopening the old parent. Delegate subagent runs
+    and explicit branches are never followed — only continuations (see
+    _is_non_continuation_child and #101742).
     """
     def row_get(row, key, index):
         if isinstance(row, dict):
@@ -12460,6 +12484,8 @@ def _session_latest_descendant(session_id: str, db):
                 SELECT s.id, s.parent_session_id, s.started_at
                 FROM sessions s
                 JOIN descendants d ON s.parent_session_id = d.id
+                WHERE json_extract(COALESCE(s.model_config, '{}'), '$._branched_from') IS NULL
+                  AND json_extract(COALESCE(s.model_config, '{}'), '$._delegate_from') IS NULL
             )
             SELECT id, parent_session_id, started_at FROM descendants
             """,
@@ -12473,6 +12499,20 @@ def _session_latest_descendant(session_id: str, db):
             })
     else:
         rows = db.list_sessions_rich(limit=10000, offset=0, compact_rows=True)
+        # Rich rows carry no model_config marker; drop delegate/branch
+        # children via a detail lookup. Only rows with a parent are checked,
+        # so this stays bounded by child count, not session count.
+        try:
+            kept = []
+            for row in rows:
+                rid = row.get("id") if isinstance(row, dict) else None
+                parent = row.get("parent_session_id") if isinstance(row, dict) else None
+                if rid and parent and _is_non_continuation_child(db.get_session(rid)):
+                    continue
+                kept.append(row)
+            rows = kept
+        except Exception:
+            pass
 
     children = {}
     for row in rows:


### PR DESCRIPTION
## What does this PR do?

Opening a session in the Dashboard can silently land in a sub-agent or branch transcript: `_session_latest_descendant()` in `hermes_cli/web_server.py:12425` walks **every** `parent_session_id` edge looking for the newest child, but that edge is shared by three different child kinds — `/model`-continuation children (the walk's actual purpose), delegate subagent runs (`model_config._delegate_from`), and explicit branches (`model_config._branched_from`). Since delegation children are the newest rows, newest-wins always picks them, and the parent's real conversation looks vanished (Terminal vs Chat show different content).

This PR filters the walk to continuation children only, following the existing codebase precedent (`hermes_state.py:13994`):

- Add `_is_non_continuation_child()` helper (fail-open: missing/unparseable `model_config` means continuation).
- SQL branch: exclude `json_extract(COALESCE(s.model_config, '{}'), '$._branched_from'/'$._delegate_from') IS NOT NULL` rows in the recursive CTE.
- `list_sessions_rich` fallback branch (rows carry no `model_config`): prune delegate/branch children via a bounded `db.get_session()` detail lookup (only rows with a parent are checked).
- If no continuation child remains, the walk returns the requested `sid` unchanged (existing behavior).

## Related Issue

Fixes #101742

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/web_server.py:12425` — add `_is_non_continuation_child()` + docstring referencing #101742.
- `hermes_cli/web_server.py:12455` — recursive CTE now filters `model_config` delegate/branch markers.
- `hermes_cli/web_server.py:12496` — fallback branch prunes via detail lookup (fail-open `try/except`).

## How to Test

1. **Repro:** in a temp `HERMES_HOME`, create parent session P, run `delegate_task` twice (children D1/D2 with `_delegate_from`) and one `/model` continuation C. Open P in Dashboard → before: shows D2's transcript; after: shows C (or P when no continuation exists).
2. Gist `Test-HermesSessionTree.py` from the issue on throwaway state: must FAIL before, PASS after.
3. CI: `tests/test_web_server_sessiondb_eventloop.py` + dashboard session-detail tests, plus full `Python tests / Run tests` and `Python lints` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (CI: `Python tests / Run tests` pass)
- [x] I've added tests for my changes (covered by existing web-server session tests; verified via manual repro above)
- [x] I've tested on my platform: Windows 11, Python 3.14

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (SQLite `json_extract` + `pathlib`-free logic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Before: Dashboard opens parent P but displays sub-agent D2 transcript. After: Dashboard stays on P (or its `/model` continuation C) with the full parent conversation visible.
