### PR TITLE
fix(cli, tui_gateway): support prefill_messages_file across Desktop and CLI (#60456)

### DIFF
--- a/tests/test_tui_gateway_prefill.py
+++ b/tests/test_tui_gateway_prefill.py
@@ -1,0 +1,119 @@
+"""Regression tests for Desktop/TUI prefill messages injection (tui_gateway.server).
+
+Desktop agents are built in ``_make_agent`` (never through ``CLIAgentSetupMixin``), so the
+CLI-side prefill resolution never runs for them. These tests pin the two properties that
+make the Desktop injection work:
+
+1. ``_load_prefill_messages`` resolves the file from env → top-level config → legacy
+   ``agent.*`` key, mirroring ``cli._load_prefill_messages``.
+2. ``_make_agent`` passes ``prefill_messages`` through to ``AIAgent``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tui_gateway import server
+
+
+# ── _load_prefill_messages resolution ──────────────────────────────────────
+
+def test_tui_load_prefill_messages_from_env(monkeypatch, tmp_path):
+    data = [{"role": "user", "content": "from env"}]
+    f = tmp_path / "env.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.setenv("HERMES_PREFILL_MESSAGES_FILE", str(f))
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {})
+    assert server._load_prefill_messages() == data
+
+
+def test_tui_load_prefill_messages_top_level(monkeypatch, tmp_path):
+    data = [{"role": "system", "content": "top"}]
+    f = tmp_path / "top.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {"prefill_messages_file": str(f)})
+    assert server._load_prefill_messages() == data
+
+
+def test_tui_load_prefill_messages_legacy_agent_key(monkeypatch, tmp_path):
+    data = [{"role": "user", "content": "legacy"}]
+    f = tmp_path / "legacy.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(
+        "tui_gateway.server._load_cfg", lambda: {"agent": {"prefill_messages_file": str(f)}})
+    assert server._load_prefill_messages() == data
+
+
+def test_tui_load_prefill_messages_env_wins_over_cfg(monkeypatch, tmp_path):
+    env_data = [{"role": "user", "content": "env"}]
+    cfg_data = [{"role": "user", "content": "cfg"}]
+    env_f = tmp_path / "env.json"
+    cfg_f = tmp_path / "cfg.json"
+    env_f.write_text(json.dumps(env_data), encoding="utf-8")
+    cfg_f.write_text(json.dumps(cfg_data), encoding="utf-8")
+    monkeypatch.setenv("HERMES_PREFILL_MESSAGES_FILE", str(env_f))
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {"prefill_messages_file": str(cfg_f)})
+    assert server._load_prefill_messages() == env_data
+
+
+def test_tui_load_prefill_messages_no_file_returns_empty(monkeypatch):
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {})
+    assert server._load_prefill_messages() == []
+
+
+def test_tui_load_prefill_messages_invalid_json_returns_empty(monkeypatch, tmp_path):
+    bad = tmp_path / "bad.json"
+    bad.write_text("not json", encoding="utf-8")
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {"prefill_messages_file": str(bad)})
+    assert server._load_prefill_messages() == []
+
+
+def test_tui_load_prefill_messages_missing_file_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr(
+        "tui_gateway.server._load_cfg",
+        lambda: {"prefill_messages_file": str(tmp_path / "nope.json")})
+    assert server._load_prefill_messages() == []
+
+
+# ── _make_agent injects prefill_messages into AIAgent ──────────────────────
+
+def test_tui_make_agent_injects_prefill(monkeypatch, tmp_path):
+    data = [{"role": "system", "content": "DR.TEST"}]
+    f = tmp_path / "prefill.json"
+    f.write_text(json.dumps(data), encoding="utf-8")
+    monkeypatch.delenv("HERMES_PREFILL_MESSAGES_FILE", raising=False)
+    monkeypatch.setattr("tui_gateway.server._load_cfg", lambda: {"prefill_messages_file": str(f)})
+
+    captured = {}
+    def mock_agent(**kwargs):
+        captured.update(kwargs)
+        mock = MagicMock()
+        mock.prefill_messages = kwargs.get("prefill_messages")
+        return mock
+
+    with patch("tui_gateway.server._startup_system_prompt", return_value=""):
+        with patch("tui_gateway.server._resolve_agent_model_runtime", return_value=("mock", {})):
+            with patch("tui_gateway.server._load_provider_routing", return_value={}):
+                with patch("tui_gateway.server._resolve_agent_platform", return_value="desktop"):
+                    with patch("tui_gateway.server._cfg_max_turns", return_value=500):
+                        with patch("tui_gateway.server._load_reasoning_config", return_value=None):
+                            with patch("tui_gateway.server._load_service_tier", return_value=None):
+                                with patch("tui_gateway.server._load_enabled_toolsets", return_value=[]):
+                                    with patch("tui_gateway.server._load_fallback_model", return_value=None):
+                                        with patch("tui_gateway.server._agent_cbs", return_value={}):
+                                            with patch("tui_gateway.server._context_cwd_is_launch_artifact", return_value=True):
+                                                with patch("tui_gateway.synthetic_turn.maybe_build_synthetic_agent", return_value=None):
+                                                    with patch("run_agent.AIAgent", side_effect=mock_agent) as _:
+                                                        agent = server._make_agent("test_sid", "test_key")
+    assert captured.get("prefill_messages") == data
+    assert agent.prefill_messages == data

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2257,6 +2257,41 @@ def _startup_system_prompt(cfg: dict, task_id: str) -> str:
     return system_prompt
 
 
+
+def _load_prefill_messages() -> list:
+    """Return configured ephemeral prefill messages for TUI-created agents.
+
+    Parity with HermesCLI (cli._load_prefill_messages): resolves the prefill
+    messages file from the HERMES_PREFILL_MESSAGES_FILE env var, the top-level
+    ``prefill_messages_file`` key, or the legacy ``agent.prefill_messages_file``
+    key. Desktop/TUI agents are built in ``_make_agent`` and never get the CLI's
+    ``CLIAgentSetupMixin`` loading, so this is the Desktop injection point.
+    """
+    file_path = os.getenv("HERMES_PREFILL_MESSAGES_FILE", "").strip()
+    if not file_path:
+        cfg = _load_cfg()
+        file_path = str(cfg.get("prefill_messages_file", "") or "").strip()
+        if not file_path:
+            agent_cfg = cfg.get("agent")
+            if isinstance(agent_cfg, dict):
+                file_path = str(agent_cfg.get("prefill_messages_file", "") or "").strip()
+    if not file_path:
+        return []
+    path = Path(file_path).expanduser()
+    if not path.is_absolute():
+        path = get_hermes_home() / path
+    if not path.exists():
+        return []
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        if isinstance(data, list):
+            return data
+    except Exception as e:
+        logger.warning("Failed to load prefill messages from %s: %s", path, e)
+    return []
+
+
 def _make_agent(
     sid: str, key: str, session_id: str | None = None, session_db=None,
     model_override: dict | str | None = None, provider_override: str | None = None,
@@ -2294,6 +2329,7 @@ def _make_agent(
         provider_sort=_pr.get("sort"), provider_require_parameters=_pr.get("require_parameters", False),
         provider_data_collection=_pr.get("data_collection"), platform=platform, session_id=session_id or key,
         session_db=session_db if session_db is not None else _get_db(), ephemeral_system_prompt=system_prompt or None,
+        prefill_messages=_load_prefill_messages() or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
         skip_context_files=ignore_rules, skip_memory=ignore_rules, fallback_model=_load_fallback_model(),


### PR DESCRIPTION
## What does this PR do?

Resolves #60456 by restoring `prefill_messages_file` support across **both** the Desktop App / TUI gateway server (`tui_gateway/server.py`) and the CLI entrypoints (`hermes_cli/cli_agent_setup_mixin.py`).

### Root Causes
1. **Desktop App (`Hermes.app`)**: The desktop app runs `hermes serve` which boots the WebSocket/RPC server in `tui_gateway/server.py`. In `_make_agent()` and `_background_agent_kwargs()`, `prefill_messages` was omitted entirely during `AIAgent` instantiation.
2. **CLI Entrypoints (`hermes -z` / `hermes chat`)**: `CLIAgentSetupMixin._init_agent()` passed `prefill_messages=self.prefill_messages`, but `self.prefill_messages` was never assigned anywhere in `hermes_cli/`.

### Solution
- **`tui_gateway/server.py`**: Added `_load_prefill_messages()` resolving from `HERMES_PREFILL_MESSAGES_FILE` env var, top-level `prefill_messages_file`, or legacy `agent.prefill_messages_file`. Passed `prefill_messages` to `AIAgent` in `_make_agent` and `_background_agent_kwargs`.
- **`hermes_cli/cli_agent_setup_mixin.py`**: In `_init_agent()`, lazily resolves and loads `self.prefill_messages` using `hermes_cli.config.load_config()` and CLI helpers if unset.
- **Tests**:
  - `tests/test_tui_gateway_prefill.py`: 7 tests covering config resolution, env precedence, missing/malformed file handling, and agent creation injection.
  - `tests/cli/test_prefill_config.py`: Added test verifying `CLIAgentSetupMixin._init_agent()` properly initializes `self.prefill_messages` and passes them to `AIAgent`.

## Related Issue

Fixes #60456

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py`: Added `_load_prefill_messages()` and passed to `AIAgent`.
- `hermes_cli/cli_agent_setup_mixin.py`: Added lazy resolution and loading of `prefill_messages` in `_init_agent()`.
- `tests/test_tui_gateway_prefill.py`: 7 new unit tests for gateway prefill loading.
- `tests/cli/test_prefill_config.py`: Added unit test for CLI mixin prefill initialization.

## How to Test

```bash
pytest tests/test_tui_gateway_prefill.py
pytest tests/cli/test_prefill_config.py
ruff check hermes_cli/cli_agent_setup_mixin.py tui_gateway/server.py tests/test_tui_gateway_prefill.py tests/cli/test_prefill_config.py
python scripts/check-windows-footguns.py --all
```
Verified on macOS Desktop (`Hermes.app`) and CLI (`hermes -z`).

## Checklist

### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x (Darwin arm64)

### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — verified with `check-windows-footguns.py`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A