### PR TITLE
fix: preserve callable custom credentials across derived clients (vision et al.)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6698,6 +6698,76 @@ def _effective_provider_for_client(client: Any, fallback: str) -> str:
 # below — never look up auth env vars ad-hoc.
 
 
+def _sync_client_credential(client) -> Any:
+    """The credential to hand to another client built from *client*.
+
+    The OpenAI SDK accepts either a string api_key or a callable token
+    provider (the ``key_cmd`` / Entra ID contract). When a callable was
+    passed, the SDK stores it in ``_api_key_provider`` and leaves the public
+    ``client.api_key`` attribute as the EMPTY STRING until the first request
+    refreshes it. Copying ``client.api_key`` to build a sibling client
+    therefore silently produces an unauthenticated client that 401s on every
+    request — the failure mode behind vision/aux calls against a key_cmd
+    provider (CLIProxy et al.).
+
+    Returns the token provider when one is installed, else the plain key.
+    """
+    provider = getattr(client, "_api_key_provider", None)
+    if provider is not None:
+        return provider
+    return getattr(client, "api_key", "")
+
+
+def _credential_for_client(credential: Any) -> Any:
+    """Normalize a static credential without consuming refreshable providers."""
+    if callable(credential) and not isinstance(credential, str):
+        return credential
+    return str(credential or "").strip()
+
+
+def _credential_as_text(credential: Any) -> str:
+    """Best-effort string form of a credential, for header-shaping decisions.
+
+    Callable providers are invoked (they are cached token sources); any
+    failure degrades to an empty string rather than breaking client
+    construction.
+    """
+    if callable(credential) and not isinstance(credential, str):
+        try:
+            value = credential()
+        except Exception:
+            return ""
+        if inspect.isawaitable(value):
+            # An async provider can't be resolved synchronously here; the
+            # header shaping that uses this is advisory only.
+            closer = getattr(value, "close", None)
+            if callable(closer):
+                closer()
+            return ""
+        return str(value or "")
+    return str(credential or "")
+
+
+def _as_async_credential(credential: Any) -> Any:
+    """Adapt a credential for ``AsyncOpenAI``.
+
+    ``AsyncOpenAI`` awaits its ``_api_key_provider``, so a synchronous
+    ``CommandTokenSource`` must be wrapped in a coroutine function. Plain
+    strings and already-async providers pass through unchanged.
+    """
+    if not callable(credential) or isinstance(credential, str):
+        return credential
+    if inspect.iscoroutinefunction(credential) or inspect.iscoroutinefunction(
+        getattr(credential, "__call__", None)
+    ):
+        return credential
+
+    async def _async_provider() -> str:
+        return str(credential() or "")
+
+    return _async_provider
+
+
 def _to_async_client(sync_client, model: str, is_vision: bool = False):
     """Convert a sync client to its async counterpart, preserving Codex routing.
 
@@ -6801,7 +6871,7 @@ def resolve_provider_client(
     async_mode: bool = False,
     raw_codex: bool = False,
     explicit_base_url: str = None,
-    explicit_api_key: str = None,
+    explicit_api_key: Any = None,
     api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
@@ -7111,7 +7181,7 @@ def resolve_provider_client(
             if api_mode == "anthropic_messages":
                 wrap_base = (explicit_base_url or "").strip().rstrip("/")
             custom_key = (
-                (explicit_api_key or "").strip()
+                _credential_for_client(explicit_api_key)
                 or _scoped_key_env("OPENAI_API_KEY")
                 or _read_main_api_key_if_same_host(custom_base)
                 or "no-key-required"  # local servers don't need auth
@@ -7130,7 +7200,7 @@ def resolve_provider_client(
             # OpenRouter or a wrong API-key provider — the main agent already
             # solved this, we just need to reuse its answer. (#45472)
             _main_base = str(main_runtime.get("base_url") or "").strip().rstrip("/")
-            _main_key = str(main_runtime.get("api_key") or "").strip()
+            _main_key = _credential_for_client(main_runtime.get("api_key"))
             if _main_base and _main_key:
                 custom_base = _main_base
                 custom_key = _main_key

--- a/tests/agent/test_command_token_source.py
+++ b/tests/agent/test_command_token_source.py
@@ -229,6 +229,110 @@ class TestCallableKeyGetsBearerAuth:
         assert seen.get("callable") is True
 
 
+class TestCallableKeySurvivesClientDerivation:
+    """A callable api_key must survive being copied to a derived client.
+
+    The OpenAI SDK stashes a callable api_key in ``_api_key_provider`` and
+    leaves the public ``client.api_key`` attribute as the EMPTY STRING until
+    the first request refreshes it. Every site that builds a sibling client
+    from a resolved one (``_to_async_client``, agent init, fallback swap) read
+    ``client.api_key`` — producing an unauthenticated client that 401s on
+    every request. That is the whole failure mode behind key_cmd providers
+    (CLIProxy et al.) working on the main turn but 401ing on vision.
+    """
+
+    def test_sync_client_credential_prefers_the_token_provider(self):
+        from agent.auxiliary_client import _sync_client_credential
+
+        class _FakeSDKClient:
+            api_key = ""  # what the SDK exposes for a callable credential
+
+            def __init__(self, provider):
+                self._api_key_provider = provider
+
+        provider = lambda: "minted-token"  # noqa: E731
+        assert _sync_client_credential(_FakeSDKClient(provider)) is provider
+
+    def test_sync_client_credential_passes_static_keys_through(self):
+        from agent.auxiliary_client import _sync_client_credential
+
+        class _FakeSDKClient:
+            api_key = "sk-static"
+            _api_key_provider = None
+
+        assert _sync_client_credential(_FakeSDKClient()) == "sk-static"
+
+    def test_async_credential_is_awaitable_for_a_sync_provider(self):
+        import asyncio
+
+        from agent.auxiliary_client import _as_async_credential
+
+        adapted = _as_async_credential(lambda: "minted-token")
+        assert asyncio.run(adapted()) == "minted-token"
+
+    def test_async_credential_passes_strings_through(self):
+        from agent.auxiliary_client import _as_async_credential
+
+        assert _as_async_credential("sk-static") == "sk-static"
+
+    def test_credential_as_text_resolves_a_callable(self):
+        from agent.auxiliary_client import _credential_as_text
+
+        assert _credential_as_text(lambda: "minted-token") == "minted-token"
+        assert _credential_as_text("sk-static") == "sk-static"
+
+    def test_explicit_custom_endpoint_preserves_callable_key(self, monkeypatch):
+        """Vision receives the main runtime's refreshable CLIProxy credential."""
+        import agent.auxiliary_client as ac
+
+        token_source = lambda: "minted-token"  # noqa: E731
+        seen = {}
+
+        def _spy(*, api_key, base_url, **kw):
+            seen["api_key"] = api_key
+            return SimpleNamespace(api_key=api_key, base_url=base_url)
+
+        monkeypatch.setattr(ac, "_create_openai_client", _spy)
+        client, model = ac.resolve_provider_client(
+            "custom",
+            model="claude-sonnet-5",
+            explicit_base_url="http://127.0.0.1:8317/v1",
+            explicit_api_key=token_source,
+            api_mode="chat_completions",
+            is_vision=True,
+        )
+
+        assert client is not None
+        assert model == "claude-sonnet-5"
+        assert seen["api_key"] is token_source
+
+    def test_main_runtime_preserves_callable_key(self, monkeypatch):
+        import agent.auxiliary_client as ac
+
+        token_source = lambda: "minted-token"  # noqa: E731
+        seen = {}
+
+        def _spy(*, api_key, base_url, **kw):
+            seen["api_key"] = api_key
+            return SimpleNamespace(api_key=api_key, base_url=base_url)
+
+        monkeypatch.setattr(ac, "_create_openai_client", _spy)
+        client, _ = ac.resolve_provider_client(
+            "custom",
+            model="claude-sonnet-5",
+            main_runtime={
+                "base_url": "http://127.0.0.1:8317/v1",
+                "api_key": token_source,
+                "model": "claude-sonnet-5",
+            },
+            api_mode="chat_completions",
+            is_vision=True,
+        )
+
+        assert client is not None
+        assert seen["api_key"] is token_source
+
+
 class TestAbsoluteExpiry:
     """Helpers that advertise a deadline instead of a lifetime.
 


### PR DESCRIPTION
## Problem

When a custom OpenAI-compatible provider (e.g. CLIProxy fronting Anthropic Claude) supplies a **callable** `api_key` (a refreshable token provider / `key_cmd` contract, e.g. `CommandTokenSource`), the main chat turn works fine, but any code path that *derives a sibling client* from the resolved one -- vision analysis, async conversion, fallback swap -- reads the plain `client.api_key` attribute instead of the underlying provider.

The OpenAI SDK stores a callable credential in `_api_key_provider` and leaves the public `client.api_key` attribute as an **empty string** until the first live request refreshes it. Copying `client.api_key` therefore either:
- produces an unauthenticated client (empty string), or
- crashes outright when downstream code calls `.strip()` on the raw `CommandTokenSource` object:

```
AttributeError: 'CommandTokenSource' object has no attribute 'strip'
```

This reproduces reliably on any custom/key_cmd provider (CLIProxy et al.) as soon as `vision_analyze` (or any other derived-client path) runs against a request whose main runtime uses a callable API key.

## Fix

- `_sync_client_credential(client)`: prefer `client._api_key_provider` over `client.api_key` when deriving a sibling client, falling back to the plain key for static-string credentials.
- `_credential_for_client(credential)`: normalize a *static* credential without invoking/consuming a callable one.
- `_credential_as_text(credential)`: best-effort string form for header-shaping decisions only; invokes callables defensively and degrades to `""` on any failure (including unresolved awaitables) rather than raising.
- `_as_async_credential(credential)`: wraps a synchronous token-provider callable in a coroutine function so `AsyncOpenAI` (which awaits `_api_key_provider`) can consume it; strings and already-async providers pass through unchanged.

## Tests

Added `TestCallableKeySurvivesClientDerivation` (6 new tests) in `tests/agent/test_command_token_source.py`:
- sync client credential prefers the token provider over the empty public attribute
- static string keys still pass through unchanged
- async credential adapts a sync provider into an awaitable
- async credential passes strings through unchanged
- `_credential_as_text` resolves a callable and a string
- end-to-end: `resolve_provider_client(..., is_vision=True)` preserves the exact callable identity for both an explicit custom endpoint and a `main_runtime` dict

All 6 new tests pass. Full `tests/agent/test_command_token_source.py` suite: 35 passed, 1 pre-existing failure unrelated to this change (`anthropic` package not installed in this environment -- import error at module load time, unrelated to credential handling).

## Verified live

Reproduced the original failure against a real CLIProxy + Claude Sonnet backend, applied the fix, and confirmed a real `vision_analyze` call against a real image succeeds end-to-end post-fix (previously failed with the `CommandTokenSource.strip` AttributeError on every attempt).