### PR TITLE
fix(desktop): re-anchor the session thread to the latest message on keep-alive reopen

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -11,6 +11,7 @@ import {
   resolveThreadScrollTarget,
   RUN_START_SNAP_THRESHOLD_PX,
   shouldClampTranscriptBudget,
+  shouldReAnchorOnPaneReveal,
   shouldRePinOnTranscriptReload,
   shouldSnapOnRunStart,
   subscribeToThreadForeground,
@@ -363,5 +364,20 @@ describe('shouldRePinOnTranscriptReload', () => {
 
   it('pins on a cold-load arrival (same session, never settled non-empty)', () => {
     expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: false })).toBe(true)
+  })
+})
+
+describe('shouldReAnchorOnPaneReveal', () => {
+  it('re-anchors when a keep-alive pane reopens after settling', () => {
+    expect(shouldReAnchorOnPaneReveal({ becameVisible: true, settled: true })).toBe(true)
+  })
+
+  it('stays out while the settle loop still owns a cold load', () => {
+    expect(shouldReAnchorOnPaneReveal({ becameVisible: true, settled: false })).toBe(false)
+  })
+
+  it('ignores renders that are not a hidden → visible edge', () => {
+    expect(shouldReAnchorOnPaneReveal({ becameVisible: false, settled: true })).toBe(false)
+    expect(shouldReAnchorOnPaneReveal({ becameVisible: false, settled: false })).toBe(false)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -154,6 +154,13 @@ export function shouldRePinOnTranscriptReload(opts: { sessionSwitched: boolean; 
   return opts.sessionSwitched || !opts.settledNonEmpty
 }
 
+// Hidden → visible reopen edge: a keep-alive tab coming back into focus must
+// land on the latest message, but only once its load has settled — a cold
+// load in progress is owned by the settle loop, which re-pins on its own.
+export function shouldReAnchorOnPaneReveal(opts: { becameVisible: boolean; settled: boolean }): boolean {
+  return opts.becameVisible && opts.settled
+}
+
 export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
   let frameId: number | null = null
   let framePending = false
@@ -601,6 +608,23 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
   useEffect(() => publishThreadAtBottom(isAtBottom, { paneVisible }), [isAtBottom, paneVisible])
   useEffect(() => () => resetPublishedThreadScroll({ paneVisible }), [paneVisible])
+
+  // Reopen edge (same class as the group-room fix for #89835): keep-alive tabs
+  // stay MOUNTED while hidden, so returning to one never remounts it and the
+  // mount/session-switch pin-to-bottom never reruns — the pane lands where it
+  // was parked, with fresh turns below the fold. Re-anchor to the latest
+  // message on the hidden → visible edge: opening a chat is an explicit
+  // "show me what's new now" gesture. A load still settling is owned by the
+  // settle loop, which pins on its own — never race it here.
+  const wasPaneVisibleRef = useRef(paneVisible)
+
+  useEffect(() => {
+    if (shouldReAnchorOnPaneReveal({ becameVisible: paneVisible && !wasPaneVisibleRef.current, settled: loadSettledRef.current })) {
+      void scrollToBottom('instant')
+    }
+
+    wasPaneVisibleRef.current = paneVisible
+  }, [paneVisible, scrollToBottom])
 
   // Floating jump button (outside this subtree) → return to the bottom.
   useEffect(() => onScrollToBottomRequest(() => void scrollToBottom(), sessionId), [scrollToBottom, sessionId])


### PR DESCRIPTION
Fixes #102248

## The bug
Keep-alive tabs stay MOUNTED while hidden, so returning to a chat that received messages while hidden never remounts it and never reruns the pin-to-bottom logic — the transcript lands where it was parked, fresh turns sit below the fold, and the user scrolls down manually every time.

The group-room surface already handles this exact reopen edge (#89835 follow-up in `group-chat-view.tsx` re-anchors on the hidden → visible transition); the session thread list never got the equivalent.

## The fix
Adds the hidden → visible re-anchor to `ThreadMessageList` (`src/components/assistant-ui/thread/list.tsx`):

- New predicate `shouldReAnchorOnPaneReveal` — fires only on a true hidden → visible edge, and only once the load has settled (`loadSettledRef`). A cold load in flight stays owned by the settle loop and is never raced.
- Component effect tracks `paneVisible` transitions with a ref and snaps to the bottom instantly on the reopen edge.

Opening a chat is an explicit "show me what's new now" gesture — re-anchoring matches intent, mirrors the group-room behavior, and cannot disturb a pane the user is actively reading (no edge fires while visible).

## Verification
- `npx vitest run` over the thread/chat scroll suites: **202 passed (32 files)**, incl. 3 new tests for the predicate
- `npx tsc -p tsconfig.json --noEmit`: clean
- Reproduced against the packaged app (v0.21.0 bd6cc48, Windows 11 ARM) and against main at 63279301b — the base file is byte-identical, patch applies cleanly