### PR TITLE
fix(desktop): close preview tabs by live browser URL

### DIFF
--- a/apps/desktop/src/app/session/hooks/preview-open.test.tsx
+++ b/apps/desktop/src/app/session/hooks/preview-open.test.tsx
@@ -3,7 +3,16 @@ import { useEffect } from 'react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { assistantTextPart, type ChatMessage } from '@/lib/chat-messages'
-import { $previewTabs, $previewTarget, closeRightRail, type PreviewTarget } from '@/store/preview'
+import {
+  $browserPages,
+  $previewTabs,
+  $previewTarget,
+  closeRightRail,
+  markBrowserTabPopped,
+  noteBrowserPage,
+  openPreview,
+  type PreviewTarget
+} from '@/store/preview'
 import { $activeSessionId, $currentCwd, $messages, $selectedStoredSessionId } from '@/store/session'
 import type { RpcEvent } from '@/types/hermes'
 
@@ -17,6 +26,10 @@ function assistantMessage(id: string, text: string): ChatMessage {
 
 function fileTarget(path: string): PreviewTarget {
   return { kind: 'file', label: path, path, previewKind: 'html', source: path, url: `file://${path}` }
+}
+
+function urlTarget(url: string): PreviewTarget {
+  return { kind: 'url', label: url, source: url, url }
 }
 
 let handleEvent: (event: RpcEvent) => void = () => undefined
@@ -61,6 +74,7 @@ describe('preview routing', () => {
     $activeSessionId.set(RUNTIME_SESSION_ID)
     $currentCwd.set('/work')
     $messages.set([])
+    $browserPages.set({})
     closeRightRail()
     window.localStorage.clear()
 
@@ -73,6 +87,7 @@ describe('preview routing', () => {
   afterEach(() => {
     cleanup()
     $messages.set([])
+    $browserPages.set({})
     closeRightRail()
     $activeSessionId.set(null)
     $selectedStoredSessionId.set(null)
@@ -231,6 +246,42 @@ describe('preview routing', () => {
 
       await waitFor(() => expect($previewTabs.get()).toHaveLength(1))
       expect($previewTarget.get()?.path).toBe('/tmp/keep.html')
+    })
+
+    it('closes a Browser tab by the page it navigated to', async () => {
+      render(<Harness />)
+      openPreview(urlTarget('https://example.com/start'), 'tool-result')
+      const tabId = $previewTabs.get()[0].id
+
+      noteBrowserPage(tabId, {
+        title: 'Dashboard',
+        url: 'https://example.com/dashboard'
+      })
+
+      await emitPreviewClose('https://example.com/dashboard')
+
+      expect($previewTabs.get()).toHaveLength(0)
+      expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+    })
+
+    it('does not remove a popped Browser tab through the persisted-url fallback', async () => {
+      render(<Harness />)
+      openPreview(urlTarget('https://example.com/start'), 'tool-result')
+      const tabId = $previewTabs.get()[0].id
+
+      noteBrowserPage(tabId, {
+        title: 'Dashboard',
+        url: 'https://example.com/dashboard'
+      })
+      markBrowserTabPopped(tabId, true)
+
+      try {
+        await emitPreviewClose('https://example.com/start')
+
+        expect($previewTabs.get().map(tab => tab.id)).toEqual([tabId])
+      } finally {
+        markBrowserTabPopped(tabId, false)
+      }
     })
 
     it('ignores a close from a session that is not the one on screen', async () => {

--- a/apps/desktop/src/app/session/hooks/use-preview-routing.ts
+++ b/apps/desktop/src/app/session/hooks/use-preview-routing.ts
@@ -6,7 +6,8 @@ import { reachablePreviewUrl } from '@/lib/preview-reach'
 import {
   $previewTabs,
   beginPreviewServerRestart,
-  closePreviewMatching,
+  closeBrowserPreviewMatchingLiveUrl,
+  closeDockedPreviewMatching,
   closeRightRail,
   completePreviewServerRestart,
   openPreview,
@@ -125,10 +126,6 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
           return
         }
 
-        if (closePreviewMatching(target)) {
-          return
-        }
-
         void normalizeOrLocalPreviewTarget(target, $currentCwd.get() || currentCwd || undefined).then(
           async resolved => {
             const candidates = [target]
@@ -141,7 +138,9 @@ export function usePreviewRouting({ baseHandleGatewayEvent, currentCwd, requestG
               }
             }
 
-            closePreviewMatching(...candidates)
+            if (!closeBrowserPreviewMatchingLiveUrl(...candidates)) {
+              closeDockedPreviewMatching(...candidates)
+            }
           }
         )
 

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -2,17 +2,20 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest'
 
 import { $rightRailActiveTabId, selectRightRailTab } from './layout'
 import {
+  $browserPages,
   $previewServerRestart,
   $previewServerRestartStatus,
   $previewTabs,
   $previewTarget,
   beginPreviewServerRestart,
+  closeBrowserPreviewMatchingLiveUrl,
   closePreviewForSource,
   closePreviewMatching,
   closeRightRail,
   closeRightRailTab,
   commitBrowserTabLocation,
   newBrowserTab,
+  noteBrowserPage,
   openPreview,
   previewTabId,
   type PreviewTarget,
@@ -33,12 +36,14 @@ function artifactTarget(id: string): PreviewTarget {
 
 describe('preview store', () => {
   beforeEach(() => {
+    $browserPages.set({})
     $previewServerRestart.set(null)
     closeRightRail()
     window.localStorage.clear()
   })
 
   afterEach(() => {
+    $browserPages.set({})
     $previewServerRestart.set(null)
     closeRightRail()
     window.localStorage.clear()
@@ -196,6 +201,36 @@ describe('preview store', () => {
 
     expect(closePreviewMatching('Demo')).toBe(true)
     expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('closes a Browser tab by its live navigated URL and removes it from persistence', () => {
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const tabId = $previewTabs.get()[0].id
+
+    noteBrowserPage(tabId, {
+      title: 'Dashboard',
+      url: 'https://example.com/dashboard'
+    })
+
+    expect(closeBrowserPreviewMatchingLiveUrl('https://example.com/dashboard')).toBe(true)
+    expect($previewTabs.get()).toHaveLength(0)
+    expect($browserPages.get()[tabId]).toBeUndefined()
+    expect(window.localStorage.getItem('hermes.desktop.previewTabs.v2')).toBe('[]')
+  })
+
+  it('prefers the tab currently showing a URL over one that navigated away from it', () => {
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const first = $previewTabs.get()[0].id
+    noteBrowserPage(first, { title: 'Elsewhere', url: 'https://elsewhere.example/' })
+
+    newBrowserTab()
+    openPreview(urlTarget('https://example.com'), 'tool-result')
+    const second = $previewTabs.get()[1].id
+    noteBrowserPage(second, { title: 'Example', url: 'https://example.com/' })
+
+    expect(closeBrowserPreviewMatchingLiveUrl('https://example.com')).toBe(true)
+    expect($previewTabs.get().map(tab => tab.id)).toEqual([first])
+    expect($browserPages.get()[first]?.url).toBe('https://elsewhere.example/')
   })
 
   it('does not wipe the rail on an empty or unknown close query', () => {

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -424,6 +424,7 @@ export function closeRightRailTab(tabId: string) {
 
   const next = current.filter(tab => tab.id !== tabId)
 
+  forgetBrowserPage(tabId)
   $previewTabs.set(next)
 
   if ($rightRailActiveTabId.get() === tabId) {
@@ -440,17 +441,69 @@ export function closePreviewForSource(source: string): boolean {
   return closePreviewMatching(source)
 }
 
-/** Close the first tab whose source, url, or label matches any candidate.
- *  Empty candidates are a no-op so a missed match cannot wipe the rail —
- *  closing the whole pane is `closeRightRail`. */
-export function closePreviewMatching(...candidates: string[]): boolean {
+/** Close the first docked Browser tab whose current page URL matches.
+ *  Browsers keep navigation state outside their persisted target so matching
+ *  only target.url misses redirects and in-page navigation. */
+export function closeBrowserPreviewMatchingLiveUrl(...candidates: string[]): boolean {
+  const queries = new Set(
+    candidates
+      .map(value => {
+        try {
+          const url = new URL(value.trim())
+
+          return url.protocol === 'http:' || url.protocol === 'https:' ? url.href : ''
+        } catch {
+          return ''
+        }
+      })
+      .filter(Boolean)
+  )
+
+  if (queries.size === 0) {
+    return false
+  }
+
+  const pages = $browserPages.get()
+  const popped = $poppedBrowserTabIds.get()
+  const tabs = $previewTabs.get()
+  const activeId = $rightRailActiveTabId.get()
+  const ordered = [...tabs.filter(tab => tab.id === activeId), ...tabs.filter(tab => tab.id !== activeId)]
+
+  const tab = ordered.find(item => {
+    if (item.target.kind !== 'url' || popped.has(item.id)) {
+      return false
+    }
+
+    const liveUrl = pages[item.id]?.url
+
+    if (!liveUrl) {
+      return false
+    }
+
+    try {
+      return queries.has(new URL(liveUrl).href)
+    } catch {
+      return false
+    }
+  })
+
+  if (!tab) {
+    return false
+  }
+
+  closeRightRailTab(tab.id)
+
+  return true
+}
+
+function closePreviewMatchingTabs(tabs: PreviewTab[], candidates: string[]): boolean {
   const queries = [...new Set(candidates.map(value => value.trim()).filter(Boolean))]
 
   if (queries.length === 0) {
     return false
   }
 
-  const tab = $previewTabs.get().find(item => {
+  const tab = tabs.find(item => {
     const fields = [item.target.source, item.target.url, item.target.label]
 
     return queries.some(query => fields.includes(query))
@@ -463,6 +516,22 @@ export function closePreviewMatching(...candidates: string[]): boolean {
   closeRightRailTab(tab.id)
 
   return true
+}
+
+/** Close the first tab whose source, url, or label matches any candidate.
+ *  Empty candidates are a no-op so a missed match cannot wipe the rail —
+ *  closing the whole pane is `closeRightRail`. */
+export function closePreviewMatching(...candidates: string[]): boolean {
+  return closePreviewMatchingTabs($previewTabs.get(), candidates)
+}
+
+/** Agent-driven close is scoped to the docked rail; an independent Browser
+ *  window owns popped tabs and must not lose its backing state here. */
+export function closeDockedPreviewMatching(...candidates: string[]): boolean {
+  const popped = $poppedBrowserTabIds.get()
+  const docked = $previewTabs.get().filter(tab => !popped.has(tab.id))
+
+  return closePreviewMatchingTabs(docked, candidates)
 }
 
 /** Artifact tabs can't outlive the registry they read from, so clearing it


### PR DESCRIPTION
## What does this PR do?

`preview.close` could report success without closing a Browser tab after the tab navigated or redirected away from its original URL. The current page URL lives in `$browserPages`, while the close path only matched the persisted source, URL, and label.

This PR makes agent-driven close operations wait for all normalized/reachable URL candidates, then match docked Browser tabs by their canonical current URL before falling back to persisted target fields. It preserves the existing source-matching behavior and does not remove popped-out Browser backing tabs.

## Related Issue

Fixes #102166

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests only
- [ ] Refactor

## Changes Made

- Add a dedicated live-URL matcher for docked Browser tabs.
- Canonicalize HTTP(S) URLs before comparison.
- Prefer the active Browser tab when multiple tabs show the same URL.
- Keep popped-out Browser windows outside the docked close path.
- Preserve existing source/URL/label matching as the fallback.
- Clear Browser live-page state when its backing tab closes.
- Add store and routing regression tests for navigation, persistence, multiple tabs, and popped-out tabs.

## How to Test

```bash
cd apps/desktop
npx vitest run --project ui src/store/preview.test.ts src/app/session/hooks/preview-open.test.tsx src/app/chat/preview-tile.test.ts
npm run typecheck
npx eslint --max-warnings=0 src/store/preview.ts src/store/preview.test.ts src/app/session/hooks/use-preview-routing.ts src/app/session/hooks/preview-open.test.tsx
```

Results:

- 49 tests passed
- TypeScript typecheck passed
- ESLint passed with zero warnings
- Prettier and `git diff --check` passed
- Manually verified in Hermes Desktop on macOS

## Checklist

### Code

- [x] Read the contributing guide
- [x] Commit follows Conventional Commits
- [x] Searched for existing PRs and issue claims
- [x] PR contains only changes related to this fix
- [ ] Ran the complete repository test suite
- [x] Added regression tests
- [x] Tested on macOS

### Documentation & Housekeeping

- [x] Documentation update: N/A, no user-facing configuration changed
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered
- [x] Tool descriptions/schemas update: N/A