### PR TITLE
fix(agent): backfill stamped api_content for pre-persisted CLI rows

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -1634,9 +1634,18 @@ def build_turn_context(
             # Backfill it onto the freshly-inserted row directly. Rotation
             # mode needs nothing here: its compacted copies flush to the
             # child session after this stamp.
-            if _preflight_compressed and bool(
-                getattr(agent, "_last_compaction_in_place", False)
-            ):
+            #
+            # The same loss happens WITHOUT compaction on the CLI path
+            # (#102194): the staged input may already have been written and
+            # marked _db_persisted by an earlier close flush, so the crash
+            # persist below skips it the same way. Backfill whenever the row
+            # is known-persisted. The content match inside
+            # set_latest_user_api_content is the guard: nothing is written
+            # unless the newest active user row is this message.
+            if (
+                _preflight_compressed
+                and bool(getattr(agent, "_last_compaction_in_place", False))
+            ) or bool(_turn_user_msg.get("_db_persisted")):
                 _db = getattr(agent, "_session_db", None)
                 if _db is not None:
                     try:
@@ -1647,8 +1656,7 @@ def build_turn_context(
                         )
                     except Exception:
                         logger.warning(
-                            "in-place compaction api_content backfill failed "
-                            "for session=%s",
+                            "api_content backfill failed for session=%s",
                             agent.session_id or "none",
                             exc_info=True,
                         )

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -13631,6 +13631,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         every compacted dict — without this backfill the stamped sidecar would
         never land in the DB and any reload would replay clean content,
         re-introducing the prompt-cache divergence the sidecar exists to close.
+        The same applies when a close flush persisted the staged CLI input
+        before the stamp (#102194): the message carries ``_db_persisted`` and
+        is skipped the same way.
 
         The ``content`` match is a defensive guard: if the newest active user
         row is not the message the caller stamped (racing rewrite, unexpected

--- a/tests/agent/test_api_content_sidecar.py
+++ b/tests/agent/test_api_content_sidecar.py
@@ -25,6 +25,7 @@ import tempfile
 import threading
 import types
 from http.server import BaseHTTPRequestHandler, HTTPServer
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -192,6 +193,8 @@ class _FakeAgent:
         # Captures the user message's api_content at persist time, proving
         # the stamp lands BEFORE the early persist writes the row.
         self.api_content_at_persist = "<unset>"
+        self._session_db: Any = None
+        self._pending_cli_user_message: Any = None
 
     def _ensure_db_session(self):
         pass
@@ -640,6 +643,86 @@ class TestPrologueMoaAndInPlaceBackfill:
         agent._session_db.set_latest_user_api_content.assert_called_once_with(
             "sess-1", "hello", "hello\n\nPLUGIN-CTX"
         )
+
+
+class TestPrePersistedRowBackfill:
+    """#102194: the CLI close flush may write+mark the staged input BEFORE
+    the prologue stamps the sidecar. The crash persist then identity-skips
+    the marked message and the stamp would never reach the DB — the prologue
+    must backfill it onto the existing row."""
+
+    def _open(self, tmp_path):
+        db = SessionDB(db_path=tmp_path / "state.db")
+        db.create_session("s1", source="cli")
+        return db
+
+    def test_marked_message_backfills_sidecar_into_db(self, tmp_path):
+        db = self._open(tmp_path)
+        try:
+            # Earlier close flush wrote the clean staged input.
+            db.append_message("s1", "user", content="hello")
+            agent = _FakeAgent()
+            agent.session_id = "s1"
+            agent._session_db = db
+            agent._pending_cli_user_message = {
+                "role": "user",
+                "content": "hello",
+                "_db_persisted": True,
+            }
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                ctx = _build(agent)
+            msg = ctx.messages[ctx.current_turn_user_idx]
+            assert msg["api_content"] == "hello\n\nPLUGIN-CTX"
+            # The pre-existing row — skipped by the crash persist — now
+            # carries the exact sent bytes for verbatim replay.
+            msgs = db.get_messages_as_conversation("s1")
+            assert msgs[-1]["api_content"] == "hello\n\nPLUGIN-CTX"
+        finally:
+            db.close()
+
+    def test_unmarked_message_skips_backfill(self):
+        """No pre-existing row: the crash persist below writes the stamped
+        row itself, so no backfill may fire (it could otherwise stamp an
+        older, identical row)."""
+        agent = _FakeAgent()
+        agent._session_db = MagicMock()
+        with patch(
+            "hermes_cli.plugins.invoke_hook",
+            return_value=[{"context": "PLUGIN-CTX"}],
+        ):
+            ctx = _build(agent)
+        assert (
+            ctx.messages[ctx.current_turn_user_idx]["api_content"]
+            == "hello\n\nPLUGIN-CTX"
+        )
+        agent._session_db.set_latest_user_api_content.assert_not_called()
+
+    def test_backfill_guard_leaves_mismatched_row_alone(self, tmp_path):
+        """The content match is the guard: when the newest row is not this
+        message, nothing is written."""
+        db = self._open(tmp_path)
+        try:
+            db.append_message("s1", "user", content="something-else")
+            agent = _FakeAgent()
+            agent.session_id = "s1"
+            agent._session_db = db
+            agent._pending_cli_user_message = {
+                "role": "user",
+                "content": "hello",
+                "_db_persisted": True,
+            }
+            with patch(
+                "hermes_cli.plugins.invoke_hook",
+                return_value=[{"context": "PLUGIN-CTX"}],
+            ):
+                _build(agent)
+            msgs = db.get_messages_as_conversation("s1")
+            assert "api_content" not in msgs[0]
+        finally:
+            db.close()
 
 
 class TestSetLatestUserApiContent:


### PR DESCRIPTION
Hey — verified #102194 independently on current main and the chain checks out, so I put together a fix.

The stamp lands on the live dict, but on the CLI path the row is already written and marked by an earlier close flush, so the crash persist skips it and the sidecar never reaches the DB. This extends the existing in-place-compaction backfill to any stamped message whose row is known-persisted — no schema change. The content match inside `set_latest_user_api_content` guards against touching the wrong row, and unmarked messages still skip the backfill (their row is written later with the sidecar by the crash persist itself).

Tests: added three regression tests (marked row gets the sidecar, unmarked rows skip the backfill, mismatched rows are left alone). Verified red on unfixed code, green after. Neighboring suites pass (api_content_sidecar: 30, turn_context/gateway-sidecar/preflight: 31), footguns check clean. Tested on macOS, Python 3.11.

Fixes #102194
