### PR TITLE
fix(web): decode keyless MCP responses as UTF-8 when no charset declared

### DIFF
--- a/plugins/web/keyless_mcp.py
+++ b/plugins/web/keyless_mcp.py
@@ -161,7 +161,19 @@ def mcp_call(url: str, tool: str, arguments: Dict[str, Any], timeout: int = _TIM
         raise KeylessMCPError(f"request failed: {exc}") from exc
     if response.status_code >= 400:
         raise KeylessMCPError(f"HTTP {response.status_code}: {response.text[:300]}")
-    return _parse_mcp_body(response.text)
+    # ``requests`` only decodes bodies with an explicit charset; a bare
+    # ``text/event-stream`` content-type falls back to ISO-8859-1 (RFC 2616
+    # default), which mangles UTF-8 CJK/emoji into lone control bytes.
+    # ``_parse_mcp_body`` then splits the SSE JSON on those bytes
+    # (``str.splitlines`` treats ``\x85`` as a line break) and dies with
+    # "Unrecognized MCP response shape" — but only for non-ASCII pages.
+    # Force UTF-8 whenever the endpoint declares no charset.
+    content_type = (response.headers.get("content-type") or "").lower()
+    if "charset" in content_type:
+        body = response.text
+    else:
+        body = response.content.decode("utf-8", errors="replace")
+    return _parse_mcp_body(body)
 
 
 # --- Parallel (search.parallel.ai) — JSON text payloads -----------------------

--- a/tests/tools/test_web_keyless_fallback.py
+++ b/tests/tools/test_web_keyless_fallback.py
@@ -552,3 +552,92 @@ class TestKeylessFailover:
         out = keyless_mcp.extract_with_failover("exa", ["https://a", "https://b"])
         assert out == partial
         assert not called
+
+
+# ---------------------------------------------------------------------------
+# mcp_call charset handling (SSE bodies without a charset declaration)
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Mimics requests.Response decoding semantics.
+
+    requests only honors an explicit charset; otherwise it falls back to
+    ISO-8859-1 for text/* types, so ``.text`` mangles UTF-8 multibyte
+    content while ``.content`` keeps the raw bytes.
+    """
+
+    def __init__(self, content: bytes, content_type: str, status: int = 200):
+        self.content = content
+        self.status_code = status
+        self.headers = {"content-type": content_type}
+
+    @property
+    def text(self) -> str:
+        if "charset" in self.headers["content-type"].lower():
+            return self.content.decode("utf-8")
+        return self.content.decode("iso-8859-1")
+
+
+def _sse_bytes(payload_text: str) -> bytes:
+    payload = {"result": {"content": [{"type": "text", "text": payload_text}]}}
+    # ensure_ascii=False: real endpoints (mcp.exa.ai) emit raw UTF-8 in the
+    # SSE data line; \u escapes would make the body pure ASCII and hide the
+    # ISO-8859-1 mangling this regression test exists to catch.
+    return (
+        "event: message\ndata: "
+        + json.dumps(payload, ensure_ascii=False)
+        + "\n\n"
+    ).encode("utf-8")
+
+
+class _TextOnlyResponse:
+    """Declares a charset; ``.text`` carries the decoded body directly.
+
+    ``.content`` is deliberately invalid UTF-8: if mcp_call wrongly reads
+    raw bytes on the declared-charset path, decoding raises and the test
+    fails.
+    """
+
+    def __init__(self, text: str, content_type: str = "text/event-stream; charset=utf-8"):
+        self.text = text
+        self.status_code = 200
+        self.headers = {"content-type": content_type}
+        self.content = b"\xff\xfe invalid utf-8 \x85"
+
+
+class TestMcpCallCharset:
+    def _call(self, monkeypatch, fake) -> str:
+        def fake_post(url, json=None, headers=None, timeout=None):
+            return fake
+
+        monkeypatch.setattr("requests.post", fake_post)
+        return keyless_mcp.mcp_call("https://example.test/mcp", "web_fetch", {})
+
+    def test_utf8_sse_without_charset_declaration(self, monkeypatch):
+        # Real shape from mcp.exa.ai: SSE, no charset, CJK + emoji payload.
+        cjk = "帮我安装 \U0001f6e1\ufe0f Agent"
+        fake = _FakeResponse(_sse_bytes(cjk), "text/event-stream")
+        assert self._call(monkeypatch, fake) == cjk
+
+    def test_declared_charset_uses_requests_text_path(self, monkeypatch):
+        payload_text = "declared charset path"
+        body = "event: message\ndata: " + json.dumps(
+            {"result": {"content": [{"type": "text", "text": payload_text}]}}
+        ) + "\n\n"
+        fake = _TextOnlyResponse(body)
+        assert self._call(monkeypatch, fake) == payload_text
+
+    def test_plain_json_without_charset(self, monkeypatch):
+        cjk = "雪球行情"  # Parallel-style direct JSON response
+        payload = {"result": {"content": [{"type": "text", "text": cjk}]}}
+        fake = _FakeResponse(
+            json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+            "application/json",
+        )
+        assert self._call(monkeypatch, fake) == cjk
+
+    def test_http_error_still_raises(self, monkeypatch):
+        fake = _FakeResponse(b"boom", "text/plain", status=503)
+        with pytest.raises(keyless_mcp.KeylessMCPError, match="HTTP 503"):
+            self._call(monkeypatch, fake)


### PR DESCRIPTION
## Summary

`mcp_call` breaks on any non-ASCII payload from the keyless MCP endpoints (`mcp.exa.ai`, `search.parallel.ai`): it fails with `KeylessMCPError: Unrecognized MCP response shape`, so `web_extract` falls over on every CJK/emoji page while pure-English pages work fine.

## Root cause

`requests` only honors an explicit charset in `Content-Type`; both public endpoints answer `text/event-stream` **without** one, so `response.text` is decoded as ISO-8859-1 (the RFC 2616 default). UTF-8 multibyte sequences become lone control bytes, and `_parse_mcp_body`'s `str.splitlines()` treats `\x85` (NEL) as a line break — splitting the SSE JSON mid-payload and failing to parse it.

Reproduced live against `mcp.exa.ai` fetching a Chinese-language page: raw curl gets a clean 200 SSE body, but `mcp_call` raises `Unrecognized MCP response shape`; after forcing UTF-8 decode the same body parses and the full 3,095-char payload is returned intact.

## Fix

In `mcp_call`, decode `response.content` as UTF-8 whenever the response declares no charset; keep `response.text` (requests' own decoding) when a charset is present. 12-line change in one function, no behavior change for charset-declaring endpoints.

## Tests

Adds `TestMcpCallCharset` to `tests/tools/test_web_keyless_fallback.py` with a fake response that mirrors requests' real decoding semantics:
- CJK + emoji SSE body without charset (the exact `mcp.exa.ai` shape) — fails without the fix, passes with it
- declared-charset passthrough (corrupt `.content` proves the text path is taken)
- direct-JSON body without charset (Parallel-style)
- HTTP-error path unchanged

RED verified: with the fix stashed, the two no-charset tests fail; with it applied, the full file passes (45 passed).

## Note on branch base

The branch is based on this fork's `main` snapshot; the fix applies byte-identically to current upstream `main` (the touched lines in `plugins/web/keyless_mcp.py` are unchanged between them). Happy to rebase if preferred.

Fixes #107439
