### PR TITLE
fix(desktop): stop hydration scroll settle restarts

### DIFF
--- a/apps/desktop/src/components/assistant-ui/thread/list.test.ts
+++ b/apps/desktop/src/components/assistant-ui/thread/list.test.ts
@@ -12,6 +12,7 @@ import {
   RUN_START_SNAP_THRESHOLD_PX,
   shouldClampTranscriptBudget,
   shouldRePinOnTranscriptReload,
+  shouldRunHydrationSettle,
   shouldSnapOnRunStart,
   subscribeToThreadForeground,
   transcriptBackfillFrameCount,
@@ -363,5 +364,23 @@ describe('shouldRePinOnTranscriptReload', () => {
 
   it('pins on a cold-load arrival (same session, never settled non-empty)', () => {
     expect(shouldRePinOnTranscriptReload({ sessionSwitched: false, settledNonEmpty: false })).toBe(true)
+  })
+})
+
+describe('shouldRunHydrationSettle', () => {
+  it('runs on initial non-empty hydration', () => {
+    expect(shouldRunHydrationSettle({ hasGroups: true, previousHasGroups: false, sessionSwitched: false })).toBe(true)
+  })
+
+  it('does not run for an unchanged empty placeholder render', () => {
+    expect(shouldRunHydrationSettle({ hasGroups: false, previousHasGroups: false, sessionSwitched: false })).toBe(false)
+  })
+
+  it('does not restart while the same non-empty transcript is only re-rendering', () => {
+    expect(shouldRunHydrationSettle({ hasGroups: true, previousHasGroups: true, sessionSwitched: false })).toBe(false)
+  })
+
+  it('always runs on a session switch, including an empty cold load', () => {
+    expect(shouldRunHydrationSettle({ hasGroups: false, previousHasGroups: true, sessionSwitched: true })).toBe(true)
   })
 })

--- a/apps/desktop/src/components/assistant-ui/thread/list.tsx
+++ b/apps/desktop/src/components/assistant-ui/thread/list.tsx
@@ -154,6 +154,14 @@ export function shouldRePinOnTranscriptReload(opts: { sessionSwitched: boolean; 
   return opts.sessionSwitched || !opts.settledNonEmpty
 }
 
+export function shouldRunHydrationSettle(opts: {
+  hasGroups: boolean
+  previousHasGroups: boolean
+  sessionSwitched: boolean
+}): boolean {
+  return opts.sessionSwitched || (!opts.previousHasGroups && opts.hasGroups)
+}
+
 export function subscribeToThreadForeground(shouldReanchor: () => boolean, onReanchor: () => void): () => void {
   let frameId: number | null = null
   let framePending = false
@@ -429,6 +437,11 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     targetScrollTop: resolveThreadScrollTarget
   })
 
+  const scrollToBottomRef = useRef(scrollToBottom)
+  const stopScrollRef = useRef(stopScroll)
+  scrollToBottomRef.current = scrollToBottom
+  stopScrollRef.current = stopScroll
+
   const { olderAvailable, expandWindow } = useTranscriptWindow()
 
   useEffect(() => {
@@ -493,6 +506,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
   // a cold-load arrival re-arms. Reset on switch so a mid-settle key change
   // cannot inherit the outgoing session's settled flag.
   const settledNonEmptyRef = useRef(false)
+  const settleHadGroupsRef = useRef(false)
 
   // Record where the view should land once a prepend has grown the content,
   // measured from the BOTTOM so the added height doesn't invalidate it. Only a
@@ -678,6 +692,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
 
     const sessionSwitched = settleKeyRef.current !== sessionKey
 
+    const shouldSettle = shouldRunHydrationSettle({
+      hasGroups,
+      previousHasGroups: settleHadGroupsRef.current,
+      sessionSwitched
+    })
+
+    settleHadGroupsRef.current = hasGroups
+
     if (sessionSwitched) {
       settledNonEmptyRef.current = false
     }
@@ -685,11 +707,14 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     // Same-session refresh (transcript briefly cleared and repopulated) must
     // keep the reader's position. Run before stopScroll / scrollTop reset so
     // a refresh neither yanks the view nor clears the settled flag.
-    if (!shouldRePinOnTranscriptReload({ sessionSwitched, settledNonEmpty: settledNonEmptyRef.current })) {
+    if (
+      !shouldSettle ||
+      !shouldRePinOnTranscriptReload({ sessionSwitched, settledNonEmpty: settledNonEmptyRef.current })
+    ) {
       return
     }
 
-    stopScroll()
+    stopScrollRef.current()
     el.scrollTop = el.scrollHeight
     loadSettledRef.current = false
 
@@ -722,7 +747,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
       // the old 90-frame ceiling was for slow async image loads. Cap at 15
       // frames to minimize the settle-loop racing markdown paint on every switch.
       if (stableFrames >= 2 || ++frame > 15) {
-        void scrollToBottom('instant')
+        void scrollToBottomRef.current('instant')
         settledNonEmptyRef.current = hasGroups
         loadSettledRef.current = true
 
@@ -735,7 +760,7 @@ const ThreadMessageListInner: FC<ThreadMessageListProps> = ({
     let rafId = requestAnimationFrame(settle)
 
     return () => cancelAnimationFrame(rafId)
-  }, [hasGroups, scrollRef, scrollToBottom, sessionKey, stopScroll])
+  }, [hasGroups, scrollRef, sessionKey])
 
   // Prepend an older page while preserving the on-screen position. The user is
   // scrolled up (reading history) so the stick-to-bottom lock is escaped and


### PR DESCRIPTION
## Summary

Long Web Dashboard session hydration could repeatedly restart the thread settle loop while the transcript was still laying out, causing the viewport to jump and fight itself during initial load. The fix narrows the hydration settle trigger to real session switches or the cold-load empty→non-empty transition, and reads the latest scroll callbacks through refs so callback identity churn cannot re-arm the settle effect mid-hydration.

---

## Changes

- `apps/desktop/src/components/assistant-ui/thread/list.tsx`: Added a hydration-settle predicate and callback refs; the layout settle effect now runs only on session switch or first transcript arrival instead of every scroll callback identity change.
- `apps/desktop/src/components/assistant-ui/thread/list.test.ts`: Added regression coverage proving unchanged non-empty transcript re-renders do not restart hydration settle while initial/cold loads and session switches still settle.

## How to Test

```bash
CHOKIDAR_USEPOLLING=1 WATCHPACK_POLLING=true node ../../node_modules/vitest/vitest.mjs run --project ui src/components/assistant-ui/thread/list.test.ts
# ✅ 39 passed

node ../../node_modules/prettier/bin/prettier.cjs --check src/components/assistant-ui/thread/list.tsx src/components/assistant-ui/thread/list.test.ts
# ✅ All matched files use Prettier code style!

NODE_OPTIONS=--max-old-space-size=3072 npm run typecheck
# ✅ passed

NODE_OPTIONS=--max-old-space-size=3072 npm run lint
# ✅ exit 0 (existing warnings only; none in changed files)
```

Sabotage check: temporarily changing `shouldRunHydrationSettle` to re-run on every non-empty render made the new regression fail as expected.

## Checklist

- [x] Tests pass — 39/39 targeted
- [x] Follows Conventional Commits
- [x] Changes scoped to this fix only
- [x] Cross-platform impact assessed (Linux / macOS / WSL2 / Windows / Termux)
- [x] profile-safe paths used — no hardcoded ~/.hermes
- [x] .env not used for non-credential settings (behavioral settings → config.yaml)

## Risk & Impact

Low. This only narrows when the existing hydration settle loop can re-arm; session switches and cold-load transcript arrival still pin to bottom.

Type: Bug fix
Closes: #102231
