### PR TITLE
fix(desktop): restore native composer spellcheck suggestions

### DIFF
--- a/apps/desktop/e2e/context-menu-editables.spec.ts
+++ b/apps/desktop/e2e/context-menu-editables.spec.ts
@@ -15,8 +15,17 @@
  * host-dependent.
  */
 
+import { type ElectronApplication } from '@playwright/test'
+
 import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
 import { expect, test } from './test'
+
+type NativeSpellcheckParams = {
+  dictionarySuggestions: string[]
+  isEditable: boolean
+  misspelledWord: string
+  spellcheckEnabled: boolean
+}
 
 let fixture: MockBackendFixture | null = null
 
@@ -28,6 +37,216 @@ test.beforeAll(async () => {
 test.afterAll(async () => {
   await fixture?.cleanup()
   fixture = null
+})
+
+async function installNativeContextMenuCapture(app: ElectronApplication) {
+  await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+
+    if (!window) {
+      throw new Error('No BrowserWindow available for native spellcheck test')
+    }
+
+    const captured: NativeSpellcheckParams[] = []
+
+    const listener = (
+      _event: unknown,
+      params: {
+        dictionarySuggestions: string[]
+        isEditable: boolean
+        misspelledWord: string
+        spellcheckEnabled: boolean
+      }
+    ) => {
+      captured.push({
+        dictionarySuggestions: params.dictionarySuggestions,
+        isEditable: params.isEditable,
+        misspelledWord: params.misspelledWord,
+        spellcheckEnabled: params.spellcheckEnabled
+      })
+    }
+
+    window.webContents.on('context-menu', listener)
+    ;(
+      window as unknown as {
+        __nativeSpellcheckTest?: { captured: NativeSpellcheckParams[]; listener: typeof listener }
+      }
+    ).__nativeSpellcheckTest = {
+      captured,
+      listener
+    }
+  })
+}
+
+async function readNativeContextMenuCapture(app: ElectronApplication) {
+  return (await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+
+    const testState = (
+      window as unknown as { __nativeSpellcheckTest?: { captured: NativeSpellcheckParams[] } }
+    ).__nativeSpellcheckTest
+
+    return testState?.captured ?? []
+  })) as NativeSpellcheckParams[]
+}
+
+async function removeNativeContextMenuCapture(app: ElectronApplication) {
+  await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+
+    if (!window) {
+      return
+    }
+
+    const testState = (
+      window as unknown as {
+        __nativeSpellcheckTest?: { listener: (...args: never[]) => void }
+      }
+    ).__nativeSpellcheckTest
+
+    if (!testState) {
+      return
+    }
+
+    window.webContents.removeListener('context-menu', testState.listener as never)
+    delete (window as unknown as { __nativeSpellcheckTest?: unknown }).__nativeSpellcheckTest
+  })
+}
+
+test('composer enables native spellcheck without autocorrect', async () => {
+  const composer = fixture!.page.locator('[data-slot="composer-rich-input"]').first()
+
+  await expect(composer).toHaveAttribute('spellcheck', 'true')
+  await expect(composer).toHaveAttribute('autocorrect', 'off')
+  await expect(composer).toHaveAttribute('autocapitalize', 'off')
+})
+
+function isEnglishAppLocale(locale: string) {
+  return /^en([_-]|$)/i.test(locale)
+}
+
+test('synthetic noneditable spellcheck emit does not send spellcheck IPC', async () => {
+  // Main-process gate only: webContents.emit is not a native right-click.
+  // Assert the channel was not sent (sync in installContextMenuBridge).
+  // A UI not.toBeVisible would false-pass before a late renderer attach.
+  // The native recieve → receive dictionary proof is macOS + English only;
+  // this test is the cross-platform contract Linux CI can actually run.
+  const { app } = fixture!
+
+  const sentSpellcheck = await app.evaluate(({ BrowserWindow }) => {
+    const window = BrowserWindow.getAllWindows()[0]
+
+    if (!window) {
+      throw new Error('No BrowserWindow available for synthetic spellcheck guard')
+    }
+
+    const sent: string[] = []
+    const originalSend = window.webContents.send
+
+    window.webContents.send = ((channel: string, ...args: unknown[]) => {
+      sent.push(channel)
+
+      return originalSend.call(window.webContents, channel, ...args)
+    }) as typeof window.webContents.send
+
+    try {
+      window.webContents.emit('context-menu', {}, {
+        dictionarySuggestions: ['receive'],
+        isEditable: false,
+        misspelledWord: 'recieve',
+        spellcheckEnabled: true,
+        x: 0,
+        y: 0
+      })
+
+      return sent.includes('hermes:context-menu-spellcheck')
+    } finally {
+      window.webContents.send = originalSend
+    }
+  })
+
+  expect(sentSpellcheck).toBe(false)
+})
+
+test('native right-click on recieve offers receive and replaces the word', async () => {
+  // Not Linux CI parity. Chromium's misspelledWord / dictionarySuggestions
+  // for recieve → receive is a macOS + English app-locale fact. Linux CI
+  // proves the cross-platform unit/type contracts and the IPC gate above.
+  const { app, page } = fixture!
+  const composer = page.locator('[data-slot="composer-rich-input"]').first()
+
+  test.skip(
+    process.platform !== 'darwin',
+    'Native recieve→receive dictionary proof is macOS-only; not Linux CI parity'
+  )
+
+  const appLocale = await app.evaluate(({ app: electronApp }) => electronApp.getLocale())
+
+  test.skip(
+    !isEnglishAppLocale(appLocale),
+    `Native recieve→receive dictionary proof needs an English app locale (got ${appLocale})`
+  )
+
+  let capturing = false
+
+  try {
+    await installNativeContextMenuCapture(app)
+    capturing = true
+
+    await composer.fill('')
+    await composer.click()
+    await composer.pressSequentially('recieve', { delay: 80 })
+    await expect(composer).toHaveText('recieve')
+
+    const wordPoint = await composer.evaluate(element => {
+      const walker = document.createTreeWalker(element, NodeFilter.SHOW_TEXT)
+      const text = walker.nextNode()
+
+      if (!text) {
+        throw new Error('Composer has no text node for native spellcheck test')
+      }
+
+      const range = document.createRange()
+      range.selectNodeContents(text)
+      const rect = range.getBoundingClientRect()
+
+      return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 }
+    })
+
+    await expect
+      .poll(
+        async () => {
+          await page.keyboard.press('Escape')
+          await page.mouse.click(wordPoint.x, wordPoint.y, { button: 'right' })
+          const captured = await readNativeContextMenuCapture(app)
+
+          return captured.some(
+            params =>
+              params.isEditable &&
+              params.misspelledWord === 'recieve' &&
+              params.dictionarySuggestions.includes('receive')
+          )
+        },
+        { timeout: 15_000 }
+      )
+      .toBe(true)
+
+    const menu = page.getByRole('menu')
+    await menu.waitFor({ state: 'visible', timeout: 10_000 })
+    await expect(menu.getByRole('menuitem', { name: 'receive' })).toBeVisible()
+    await menu.getByRole('menuitem', { name: 'receive' }).click()
+
+    await expect(composer).toHaveText('receive')
+  } finally {
+    try {
+      await page.keyboard.press('Escape')
+      await composer.fill('')
+    } finally {
+      if (capturing) {
+        await removeNativeContextMenuCapture(app)
+      }
+    }
+  }
 })
 
 test('select all from the composer context menu selects the draft, not the chat', async () => {

--- a/apps/desktop/src/app/chat/composer/composer-drag-region.tsx
+++ b/apps/desktop/src/app/chat/composer/composer-drag-region.tsx
@@ -1,0 +1,33 @@
+import { cn } from '@/lib/utils'
+
+const EDGE_CLASSES = {
+  bottom: 'inset-x-0 bottom-0 h-[5px]',
+  left: 'inset-y-0 left-0 w-[5px]',
+  right: 'inset-y-0 right-0 w-[5px]',
+  top: 'inset-x-0 top-0 h-[5px]'
+} as const
+
+/** Visual drag frame with pointer-active strips only on the exposed 5px ring. */
+export function ComposerDragRegion({ dragging }: { dragging: boolean }) {
+  return (
+    <div
+      aria-hidden
+      className="pointer-events-none absolute inset-0"
+      data-dragging={dragging ? '' : undefined}
+      data-slot="composer-drag-region"
+    >
+      {(Object.keys(EDGE_CLASSES) as Array<keyof typeof EDGE_CLASSES>).map(edge => (
+        <span
+          aria-hidden
+          className={cn(
+            'pointer-events-auto absolute cursor-grab',
+            EDGE_CLASSES[edge],
+            dragging && 'cursor-grabbing'
+          )}
+          data-drag-edge={edge}
+          key={edge}
+        />
+      ))}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.test.tsx
@@ -2,6 +2,8 @@ import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { useRef } from 'react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
+import { ComposerDragRegion } from '../composer-drag-region'
+
 import { useComposerPopoutGestures } from './use-popout-drag'
 
 function GestureHarness({ onPopOut }: { onPopOut: () => void }) {
@@ -17,8 +19,8 @@ function GestureHarness({ onPopOut }: { onPopOut: () => void }) {
   })
 
   return (
-    <form data-testid="composer" onPointerDown={onPointerDown} ref={composerRef}>
-      <div data-slot="composer-drag-region" data-testid="drag-region" />
+    <form data-slot="composer-root" data-testid="composer" onPointerDown={onPointerDown} ref={composerRef}>
+      <ComposerDragRegion dragging={false} />
       <div data-slot="composer-surface" data-testid="surface">
         <div contentEditable data-slot="composer-rich-input">
           <span data-testid="editable-text">select me</span>
@@ -59,8 +61,47 @@ describe('useComposerPopoutGestures', () => {
     const onPopOut = vi.fn()
     render(<GestureHarness onPopOut={onPopOut} />)
 
-    dragUp(screen.getByTestId('drag-region'))
+    dragUp(window.document.querySelector('[data-drag-edge]')!)
 
     expect(onPopOut).toHaveBeenCalledOnce()
+  })
+
+  it('peels from the exposed composer-root margin when the visual frame is pointer-transparent', () => {
+    const onPopOut = vi.fn()
+    render(<GestureHarness onPopOut={onPopOut} />)
+
+    dragUp(screen.getByTestId('composer'))
+
+    expect(onPopOut).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the drag affordance pointer-active only on the five-pixel ring', () => {
+    render(<GestureHarness onPopOut={vi.fn()} />)
+
+    const region = window.document.querySelector('[data-slot="composer-drag-region"]') as HTMLElement
+    const edges = region.querySelectorAll('[data-drag-edge]')
+
+    expect(region.classList.contains('pointer-events-none')).toBe(true)
+    expect(edges).toHaveLength(4)
+
+    for (const edge of edges) {
+      expect(edge.classList.contains('pointer-events-auto')).toBe(true)
+      expect(edge.classList.contains('cursor-grab')).toBe(true)
+    }
+  })
+
+  it('switches the exposed ring to a grabbing cursor without activating its frame', () => {
+    const { rerender } = render(<ComposerDragRegion dragging={false} />)
+
+    rerender(<ComposerDragRegion dragging />)
+
+    const region = window.document.querySelector('[data-slot="composer-drag-region"]') as HTMLElement
+
+    expect(region.hasAttribute('data-dragging')).toBe(true)
+    expect(region.classList.contains('pointer-events-none')).toBe(true)
+
+    for (const edge of region.querySelectorAll('[data-drag-edge]')) {
+      expect(edge.classList.contains('cursor-grabbing')).toBe(true)
+    }
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-popout-drag.ts
@@ -58,7 +58,18 @@ function gestureTargetOk(target: EventTarget | null) {
  *  the editor and composer surface bubble through the root too, but they belong
  *  to text selection and controls, never to the pop-out gesture. */
 function isDockDragPlatform(target: EventTarget | null) {
-  return target instanceof Element && Boolean(target.closest('[data-slot="composer-drag-region"]'))
+  if (!(target instanceof Element)) {
+    return false
+  }
+
+  if (target.closest('[data-slot="composer-drag-region"]')) {
+    return true
+  }
+
+  // The visual drag region is pointer-transparent so Chromium's native
+  // context-menu hit test reaches the editable surface. The root receives
+  // events from its exposed 5px padding instead.
+  return Boolean(target.closest('[data-slot="composer-root"]') && !target.closest('[data-slot="composer-surface"]'))
 }
 
 /** Floating composer's 5px outer frame — grab here to drag without long-press. */

--- a/apps/desktop/src/app/chat/composer/index.tsx
+++ b/apps/desktop/src/app/chat/composer/index.tsx
@@ -30,6 +30,7 @@ import { $autoSpeakReplies } from '@/store/voice-prefs'
 import { useTheme } from '@/themes'
 
 import { AttachmentList } from './attachments'
+import { ComposerDragRegion } from './composer-drag-region'
 import {
   acceptsTriggerCompletion,
   COMPOSER_FADE_BACKGROUND,
@@ -1095,7 +1096,7 @@ export function ChatBar({
         onPaste={handlePaste}
         ref={editorRef}
         role="textbox"
-        spellCheck={false}
+        spellCheck
         suppressContentEditableWarning
       />
       <ComposerDirectiveActions editorRef={editorRef} />
@@ -1243,6 +1244,18 @@ export function ChatBar({
             data-thread-scrolled-up={scrolledUp ? '' : undefined}
             data-tip-region=""
             data-tour={composerTourMarker}
+            onDoubleClick={
+              popoutAllowed
+                ? event => {
+                    if (
+                      event.target instanceof Element &&
+                      !event.target.closest('[data-slot="composer-surface"]')
+                    ) {
+                      handleComposerToggle()
+                    }
+                  }
+                : undefined
+            }
             onDragEnter={handleDragEnter}
             onDragLeave={handleDragLeave}
             onDragOver={handleDragOver}
@@ -1275,22 +1288,16 @@ export function ChatBar({
             {!poppedOut && (
               <div
                 className="pointer-events-none absolute inset-0 rounded-[inherit]"
+                data-slot="composer-fade-overlay"
                 style={{ background: COMPOSER_FADE_BACKGROUND }}
               />
             )}
-            {/* Drag region: covers the transparent grab margin around the surface.
-              The surface sits on top (z-4) so only the exposed ring receives this
-              element's hover/cursor — grab cursor + a diagonal hatch (/////)
-              appear when you hover the draggable margin, never over the input.
-              The hatch pattern + opacity ladder live in styles.css. */}
+            {/* Drag affordance: the visual frame covers the transparent grab
+              margin, but stays pointer-transparent so Chromium's native
+              context-menu hit test reaches the editable surface. The root
+              handles drag and double-click gestures from that margin. */}
             {popoutAllowed && (
-              <div
-                aria-hidden
-                className={cn('pointer-events-auto absolute inset-0', dragging ? 'cursor-grabbing' : 'cursor-grab')}
-                data-dragging={dragging ? '' : undefined}
-                data-slot="composer-drag-region"
-                onDoubleClick={handleComposerToggle}
-              />
+              <ComposerDragRegion dragging={dragging} />
             )}
             <div className="relative w-full rounded-[inherit]">
               {hudMode && busy && <span aria-hidden className="arc-border arc-composer" />}

--- a/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.test.tsx
@@ -13,6 +13,7 @@ import { AppContextMenu } from './app-context-menu'
 import {
   $contextMenu,
   augmentSpellcheck,
+  closeContextMenu,
   type GuestMenuHandle,
   type GuestMenuParams,
   openGuestContextMenu
@@ -186,6 +187,94 @@ describe('AppContextMenu', () => {
 
     expect(await screen.findByText('Add to dictionary')).toBeTruthy()
     expect(screen.getByText('the')).toBeTruthy()
+  })
+
+  it('keeps the mounted menu DOM when spellcheck facts arrive late', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<textarea></textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    const menu = await screen.findByRole('menu')
+
+    augmentSpellcheck({ misspelledWord: 'teh', suggestions: ['the'] })
+
+    expect(await screen.findByText('Add to dictionary')).toBeTruthy()
+    expect(screen.getByRole('menu')).toBe(menu)
+  })
+
+  it('limits late spellcheck suggestions to five and keeps Add to dictionary', async () => {
+    const contextMenuSpellcheck = vi.fn().mockResolvedValue(undefined)
+
+    installBridge({ contextMenuSpellcheck })
+    mountMenu()
+    const host = attach('<textarea></textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    augmentSpellcheck({
+      misspelledWord: 'teh',
+      suggestions: ['the', 'ten', 'tech', 'tee', 'tea', 'tenth']
+    })
+
+    expect(await screen.findByText('Add to dictionary')).toBeTruthy()
+
+    for (const suggestion of ['the', 'ten', 'tech', 'tee', 'tea']) {
+      expect(screen.getByText(suggestion)).toBeTruthy()
+    }
+
+    expect(screen.queryByText('tenth')).toBeNull()
+  })
+
+  it('replaces with the selected late spellcheck suggestion after the menu closes', async () => {
+    const contextMenuSpellcheck = vi.fn().mockResolvedValue(undefined)
+
+    installBridge({ contextMenuSpellcheck })
+    mountMenu()
+    const host = attach('<textarea></textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    augmentSpellcheck({ misspelledWord: 'teh', suggestions: ['the'] })
+    fireEvent.click(await screen.findByText('the'))
+
+    await waitFor(() => expect(contextMenuSpellcheck).toHaveBeenCalledWith({ kind: 'replace', word: 'the' }))
+  })
+
+  it('adds the original misspelled word to the dictionary after the menu closes', async () => {
+    const contextMenuSpellcheck = vi.fn().mockResolvedValue(undefined)
+
+    installBridge({ contextMenuSpellcheck })
+    mountMenu()
+    const host = attach('<textarea></textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    augmentSpellcheck({ misspelledWord: 'teh', suggestions: ['the'] })
+    fireEvent.click(await screen.findByText('Add to dictionary'))
+
+    await waitFor(() => expect(contextMenuSpellcheck).toHaveBeenCalledWith({ kind: 'add', word: 'teh' }))
+  })
+
+  it('ignores late spellcheck facts after the menu closes', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<textarea></textarea>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    closeContextMenu()
+    augmentSpellcheck({ misspelledWord: 'teh', suggestions: ['the'] })
+
+    expect(screen.queryByText('Add to dictionary')).toBeNull()
+  })
+
+  it('ignores late spellcheck facts after a noneditable menu replaces an editable one', async () => {
+    installBridge()
+    mountMenu()
+    const host = attach('<textarea></textarea><p>plain text</p>')
+
+    fireEvent.contextMenu(host.querySelector('textarea')!)
+    fireEvent.contextMenu(host.querySelector('p')!)
+    augmentSpellcheck({ misspelledWord: 'teh', suggestions: ['the'] })
+
+    expect(screen.queryByText('Add to dictionary')).toBeNull()
   })
 
   it('shows edit verbs without icons and with faded accelerators', async () => {

--- a/apps/desktop/src/app/context-menu/app-context-menu.tsx
+++ b/apps/desktop/src/app/context-menu/app-context-menu.tsx
@@ -1,6 +1,6 @@
 import { useStore } from '@nanostores/react'
 import type { ReactNode } from 'react'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
 
 import { terminalMenuHandleFor } from '@/app/right-sidebar/terminal/terminal-context-menu'
@@ -37,7 +37,7 @@ import {
   openDomContextMenu,
   openTerminalContextMenu
 } from './store'
-import { isWebUrl, resolveDomTarget } from './target'
+import { type ContextMenuDomTarget, isWebUrl, resolveDomTarget } from './target'
 
 /** Marks a surface that owns PLAIN right-clicks itself (the user-message
  *  reaction bubble). Owned targets inside it — links, images, editables,
@@ -616,6 +616,23 @@ export function AppContextMenu() {
   const { t } = useI18n()
   const navigate = useNavigate()
   const open = useStore($contextMenu)
+  const [domMenuTarget, setDomMenuTarget] = useState<ContextMenuDomTarget | null>(null)
+  const domTarget = open?.kind === 'dom' ? open.target : null
+
+  // Native Chromium context-menu facts are emitted after the DOM gesture. Keep
+  // the Radix menu out of the hit-test surface for one frame so that event can
+  // still resolve the original editable instead of this menu or its modal lock.
+  useEffect(() => {
+    if (!domTarget) {
+      setDomMenuTarget(null)
+
+      return undefined
+    }
+
+    const frame = requestAnimationFrame(() => setDomMenuTarget(domTarget))
+
+    return () => cancelAnimationFrame(frame)
+  }, [domTarget])
 
   useEffect(() => {
     // stopPropagation beats other renderer handlers; preventDefault is never
@@ -667,7 +684,7 @@ export function AppContextMenu() {
   // them on its own context-menu event); attach them to the open menu.
   useEffect(() => window.hermesDesktop?.onContextMenuSpellcheck?.(augmentSpellcheck), [])
 
-  if (!open) {
+  if (!open || (open.kind === 'dom' && domMenuTarget !== open.target)) {
     return null
   }
 

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1730,11 +1730,11 @@ body.guest-pointer-lock :is(webview, iframe) {
     filter 75ms ease-out;
 }
 
-/* Drag-region hatch — a diagonal ///// pattern (Photoshop-style) that fades into
-   the transparent grab margin on hover (and stays while dragging) to signal the
-   composer is draggable. Inherits the root radius so it clips to the corners. */
-[data-slot='composer-drag-region'] {
-  /* Hatch frame radius (tuned by hand). */
+/* Drag-ring hatch — only the four exposed 5px strips are pointer-active. The
+   full frame stays transparent to preserve native editor hit testing. Hovering
+   any edge lights the whole ring via :has(); the wrapper never takes hits. */
+[data-slot='composer-drag-region'] > [data-drag-edge] {
+  /* Hatch edge radius (tuned by hand). */
   border-radius: 0.4rem;
   opacity: 0;
   transition: opacity 150ms ease;
@@ -1747,12 +1747,12 @@ body.guest-pointer-lock :is(webview, iframe) {
   );
 }
 
-[data-slot='composer-drag-region']:hover,
-[data-slot='composer-drag-region'][data-dragging] {
+[data-slot='composer-drag-region']:has(> [data-drag-edge]:hover) > [data-drag-edge],
+[data-slot='composer-drag-region'][data-dragging] > [data-drag-edge] {
   opacity: 0.33;
 }
 
-[data-slot='composer-root'] > .pointer-events-none {
+[data-slot='composer-root'] > [data-slot='composer-fade-overlay'] {
   background: linear-gradient(
     to bottom,
     transparent,
@@ -3476,7 +3476,7 @@ button[data-slot='aui_msg-reactions'] svg {
 
 /* The dock's fade-to-surface gradient assumes a chat column behind it; over a
    transparent HUD it's a grey smear. */
-[data-hud-shell] [data-slot='composer-root'] > .pointer-events-none {
+[data-hud-shell] [data-slot='composer-root'] > [data-slot='composer-fade-overlay'] {
   display: none !important;
 }
 


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop already has native spellcheck plumbing: Electron reports `misspelledWord` and dictionary suggestions, and the renderer exposes them through the translated custom context menu. The visible chat composer opted out of spellcheck, while two UI layers prevented Chromium’s native context-menu hit test from reaching the editable surface.

This change:

- enables native spellcheck on the visible chat composer while keeping `autoCorrect="off"` and `autoCapitalize="off"`;
- makes the composer drag frame pointer-transparent except for its 5px grab ring, allowing Chromium to target the editor;
- delays mounting the custom context menu by one animation frame so native spellcheck facts can be collected from the originating editable target;
- preserves composer pop-out dragging and adds focused coverage for late spellcheck updates and hit-testing behavior.

This is deliberately narrower than the other open approaches:

- #48960 adds settings and a language preference. This PR adds no configuration and does not claim that a renderer `lang` value controls the macOS system spellchecker.
- #95876 implements a renderer-side dictionary for Linux and remote-display limitations. This PR stays on the native macOS/Electron path and does not vendor a word list.
- The behavior disabled in #44415 remains disabled: technical text is not silently autocorrected or autocapitalized. This restores underlines and explicit right-click replacement only.

## Related Issue

Addresses the native macOS path in #48375.

Related: #48960, #95876, #44415.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/chat/composer/index.tsx`: enable spellcheck on the visible editor; preserve autocorrect/autocapitalize opt-outs; isolate the fade overlay; retain drag/double-click behavior.
- `apps/desktop/src/app/chat/composer/composer-drag-region.tsx`: provide a pointer-transparent drag frame with four pointer-active 5px edges.
- `apps/desktop/src/app/chat/composer/hooks/use-popout-drag.ts`: accept peel gestures from the exposed composer-root padding while excluding the editor surface.
- `apps/desktop/src/app/context-menu/app-context-menu.tsx`: defer DOM-menu mounting one animation frame so Chromium can complete native context-menu targeting.
- `apps/desktop/src/styles.css`: scope fade styles explicitly and preserve the full-ring drag affordance without intercepting editor input.
- Focused unit and Electron E2E coverage for the contracts above.

## How to Test

1. Headless UI tests:
   ```bash
   cd apps/desktop
   npx vitest run --project ui \
     src/app/context-menu/app-context-menu.test.tsx \
     src/app/chat/composer/hooks/use-popout-drag.test.tsx
   ```
2. Typecheck and focused lint:
   ```bash
   npm run typecheck
   npx eslint \
     src/app/chat/composer/index.tsx \
     src/app/chat/composer/composer-drag-region.tsx \
     src/app/chat/composer/hooks/use-popout-drag.ts \
     src/app/chat/composer/hooks/use-popout-drag.test.tsx \
     src/app/context-menu/app-context-menu.tsx \
     src/app/context-menu/app-context-menu.test.tsx \
     e2e/context-menu-editables.spec.ts
   ```
3. macOS + English app locale native proof:
   ```bash
   npx playwright test e2e/context-menu-editables.spec.ts
   ```
   Type `recieve`, verify Chromium reports `receive`, choose the custom-menu suggestion, and verify the composer changes to `receive`. This test is skipped outside macOS or with a non-English app locale. Linux CI validates the cross-platform unit/type contracts, the composer attributes, and the main-process IPC guard; it is not native-dictionary parity.
4. Manual macOS check: confirm the underline and right-click replacement appear, while paths and slash commands are not silently rewritten.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched existing issues and PRs; this targets the native macOS hit-test path not covered by #48960 or #95876.
- [x] The PR contains only changes related to this fix.
- [ ] I've run `pytest tests/ -q` — not run; this is Desktop-only and the focused JS/TS suites are listed above.
- [x] I've added tests for the change.
- [x] Tested on macOS 26.6.2 arm64.

### Documentation & Housekeeping

- [x] Documentation update: N/A; no user-facing configuration or workflow changed.
- [x] `cli-config.yaml.example`: N/A; no config keys changed.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no architecture or workflow changed.
- [x] Cross-platform impact considered: native dictionary behavior is explicitly macOS+English-gated; Windows/Linux behavior is not claimed.
- [x] Tool descriptions/schemas: N/A; no tool behavior changed.

## Screenshots / Logs

Headless verification: 49 focused UI tests pass; renderer, Electron, and E2E TypeScript projects typecheck; focused ESLint has zero errors; production build succeeds; `git diff --check` passes.

macOS Electron verification: all 6 focused E2E tests pass, including native `recieve` detection, the `receive` suggestion, selection, and replacement in the composer.
