### PR TITLE
fix(browser): readable console/network, safe cdp(), own tab for every browser_exec session

### DIFF
--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -541,8 +541,15 @@ class TestOwnTabPreamble:
         # model code still present, after the preamble
         assert result["output"].index("_hermes_ensure_own_tab") < result["output"].index("print('payload')")
 
-    def test_unnamed_session_gets_no_preamble(self, tmp_path, monkeypatch):
+    def test_unnamed_session_on_shared_browser_gets_preamble(self, tmp_path, monkeypatch):
+        """The default daemon attaches to the first page — often the user's
+        own tab — so it needs its own tab just as much as a named one."""
         result = self._run(tmp_path, monkeypatch, session="")
+        assert result["success"] is True
+        assert "_hermes_ensure_own_tab" in result["output"]
+
+    def test_unnamed_provider_browser_skips_preamble(self, tmp_path, monkeypatch):
+        result = self._run(tmp_path, monkeypatch, session="", provider=True)
         assert result["success"] is True
         assert "_hermes_ensure_own_tab" not in result["output"]
 
@@ -616,9 +623,27 @@ class TestHelpersPreamble:
             buf.clear()
             return out
 
-        g = {"cdp": cdp, "drain_events": drain_events}
+        g = {
+            "cdp": cdp, "drain_events": drain_events,
+            "page_info": lambda: {"url": "u", "title": "\U0001F434 Real Title"},
+            "current_tab": lambda: {"targetId": "T1", "title": "\U0001F434 Real Title"},
+            "list_tabs": lambda: [{"targetId": "T1", "title": "\U0001F434 Real Title"}],
+        }
         exec(bu_cli._HELPERS_PREAMBLE, g)
         return g, calls
+
+    def test_horse_marker_hidden_from_titles(self, tmp_path, monkeypatch):
+        g, _ = self._exec(tmp_path, monkeypatch, [])
+        assert g["page_info"]()["title"] == "Real Title"
+        assert g["current_tab"]()["title"] == "Real Title"
+        assert g["list_tabs"]()[0]["title"] == "Real Title"
+
+    def test_any_drain_is_journaled(self, tmp_path, monkeypatch):
+        """wait_for_network_idle() drains the daemon buffer too; its reads
+        must land in the journal instead of vanishing."""
+        g, _ = self._exec(tmp_path, monkeypatch, self.EVENTS)
+        assert len(g["drain_events"]()) == 4  # raw consumer sees events...
+        assert len(g["console_logs"]()) == 2  # ...and so does the journal
 
     def test_cdp_positional_dict_becomes_params(self, tmp_path, monkeypatch):
         g, calls = self._exec(tmp_path, monkeypatch, [])
@@ -1378,3 +1403,4 @@ class TestLightpandaStatusLine:
         out = self._status(monkeypatch, used=False, reason="cloud provider Browserbase is selected")
         assert "NOT in use" in out
         assert "Browserbase" in out
+

--- a/tests/tools/test_browser_use_cli.py
+++ b/tests/tools/test_browser_use_cli.py
@@ -573,6 +573,75 @@ class TestOwnTabPreamble:
         # and composes with model code
         ast.parse(bu_cli._OWN_TAB_PREAMBLE + "print('x')")
 
+    def test_helpers_preamble_always_prepended(self, tmp_path, monkeypatch):
+        """console_logs()/network_log()/cdp guard ride along on every call,
+        named or not, and sit before the own-tab preamble and model code."""
+        for session in ("", "r7k2"):
+            result = self._run(tmp_path, monkeypatch, session=session)
+            out = result["output"]
+            assert out.index("def console_logs") < out.index("print('payload')")
+            if session:
+                assert out.index("def console_logs") < out.index("_hermes_ensure_own_tab")
+
+
+class TestHelpersPreamble:
+    """Exec the preamble against a stubbed harness: cdp() positional-dict
+    guard, and the console/network journal that survives across calls."""
+
+    EVENTS = [
+        {"method": "Runtime.consoleAPICalled", "params": {"type": "warning",
+         "args": [{"type": "string", "value": "HERMES-TEST-2"}], "timestamp": 1}},
+        {"method": "Runtime.exceptionThrown", "params": {"exceptionDetails": {
+         "exception": {"description": "Error: HERMES-TEST-3"}, "url": "u", "lineNumber": 3}}},
+        {"method": "Network.requestWillBeSent", "params": {"requestId": "r1",
+         "request": {"url": "https://x/get?probe=1", "method": "GET"}, "type": "Fetch"}},
+        {"method": "Network.responseReceived", "params": {"requestId": "r1",
+         "response": {"status": 200, "mimeType": "application/json"}}},
+    ]
+
+    def _exec(self, tmp_path, monkeypatch, events):
+        import ast
+
+        ast.parse(bu_cli._HELPERS_PREAMBLE + "print('x')")
+        monkeypatch.setenv("BH_AGENT_WORKSPACE", str(tmp_path))
+        calls = []
+        buf = list(events)
+
+        def cdp(method, session_id=None, **params):
+            calls.append((method, session_id, params))
+            return {}
+
+        def drain_events():
+            out = list(buf)
+            buf.clear()
+            return out
+
+        g = {"cdp": cdp, "drain_events": drain_events}
+        exec(bu_cli._HELPERS_PREAMBLE, g)
+        return g, calls
+
+    def test_cdp_positional_dict_becomes_params(self, tmp_path, monkeypatch):
+        g, calls = self._exec(tmp_path, monkeypatch, [])
+        g["cdp"]("Network.enable", {"maxTotalBufferSize": 1}, maxResourceBufferSize=2)
+        assert calls == [("Network.enable", None, {"maxTotalBufferSize": 1, "maxResourceBufferSize": 2})]
+        g["cdp"]("DOM.getDocument", "SESSION1", depth=-1)
+        assert calls[-1] == ("DOM.getDocument", "SESSION1", {"depth": -1})
+        with pytest.raises(TypeError):
+            g["cdp"]("X.y", 5)
+
+    def test_console_and_network_journal(self, tmp_path, monkeypatch):
+        g, _ = self._exec(tmp_path, monkeypatch, self.EVENTS)
+        logs = g["console_logs"](contains="HERMES-TEST")
+        assert [(c["level"], c["text"]) for c in logs] == [
+            ("warning", "HERMES-TEST-2"), ("error", "Error: HERMES-TEST-3")]
+        assert g["network_log"]() == [{"url": "https://x/get?probe=1", "method": "GET",
+                                       "status": 200, "mime": "application/json",
+                                       "type": "Fetch", "requestId": "r1"}]
+        # journal persists on disk across "calls" (daemon buffer already drained)
+        g2, _ = self._exec(tmp_path, monkeypatch, [])
+        assert len(g2["console_logs"]()) == 2
+        assert g2["console_logs"](clear=True) and g2["console_logs"]() == []
+
 
 class TestProviderPickerIntegration:
     """The `hermes tools` Browser Automation picker row (browser_backend
@@ -857,7 +926,8 @@ class TestBrowserExec:
         result = json.loads(bu_cli.browser_exec('print("hi")'))
         assert result["success"] is True
         assert result["exit_code"] == 0
-        assert 'got:print("hi")' in result["output"]
+        assert result["output"].startswith("got:")
+        assert result["output"].rstrip().endswith('print("hi")')  # model code last
         assert "session" not in result
 
     def test_session_sets_bu_name(self, tmp_path, monkeypatch):

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -30,15 +30,16 @@ _SESSION_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]{0,63}$")
 # subprocess launches — never exported to the CLI.
 _PRIVATE_BROWSER_SENTINEL = "_HERMES_BU_PRIVATE_BROWSER"
 
-# Preamble prepended to the model's code for named sessions on SHARED
-# browsers (local Chrome / CDP override). The harness daemon attaches to the
-# first existing page at startup, so two fresh named daemons can land on the
-# SAME tab; steering this daemon onto a tab it created keeps concurrent named
-# sessions from clobbering each other before their first new_tab(). Runs
-# once per daemon (marker file keyed by BU_NAME under the harness runtime
-# state), costs one IPC round-trip on later calls.
+# Preamble prepended to the model's code on SHARED browsers (local Chrome /
+# CDP override). The harness daemon attaches to the first CDP target at
+# startup — for the default daemon that is whatever tab happens to be first
+# (often the user's), and two fresh named daemons can land on the SAME tab.
+# Pin every daemon to a tab it created, remember that tab's targetId in a
+# marker file keyed by daemon pid, and re-pin when the pinned tab is gone
+# (closed tab → the daemon silently fell back to the first shared page).
+# Costs one IPC round-trip per call after the first.
 _OWN_TAB_PREAMBLE = """\
-# hermes: pin this named session to its own tab (once per daemon process)
+# hermes: pin this session to its own tab (once per daemon process)
 def _hermes_ensure_own_tab():
     import os as _os, tempfile as _tf
     _name = _os.environ.get("BU_NAME", "default")
@@ -62,18 +63,38 @@ def _hermes_ensure_own_tab():
     _marker = _os.path.join(
         _tf.gettempdir(), "hermes-bu-owntab-%s-%s-%s" % (_uid, _name, _dpid)
     )
-    if _os.path.exists(_marker):
-        return
+    try:
+        _pinned = open(_marker).read().strip()
+    except OSError:
+        _pinned = None
+    if _pinned is not None:
+        try:
+            _pages = [t for t in cdp("Target.getTargets")["targetInfos"] if t.get("type") == "page"]
+            _live = {t["targetId"] for t in _pages}
+        except Exception:
+            return
+        if _pinned in _live:
+            return
+        # Pinned tab is gone. If the agent is on a tab it attached itself
+        # (harness marks those with the horse emoji), adopt it; otherwise
+        # the daemon fell back to a shared page — move off it.
+        try:
+            _cur = current_tab()
+            if _cur["targetId"] in _live and str(_cur.get("title", "")).startswith("\U0001F434"):
+                open(_marker, "w").write(_cur["targetId"])
+                return
+        except Exception:
+            pass
     try:
         # Force a fresh target: new_tab() would REUSE a blank current tab,
-        # which is exactly the tab a sibling daemon may also hold.
+        # which is exactly the tab a sibling daemon (or the user) may hold.
         _tid = cdp("Target.createTarget", url="about:blank").get("targetId")
         if _tid:
             switch_tab(_tid)
     except Exception:
-        pass  # best-effort: worst case is pre-fix behavior
+        return  # best-effort: worst case is pre-fix behavior
     try:
-        open(_marker, "w").close()
+        open(_marker, "w").write(_tid or "")
     except OSError:
         pass
 _hermes_ensure_own_tab()
@@ -117,13 +138,7 @@ def _hermes_events_path():
     name = os.environ.get("BU_NAME", "default")
     return os.path.join(_tf.gettempdir(), "hermes-bu-events-%s-%s.jsonl" % (uid, name))
 
-def _hermes_flush_events():
-    # ponytail: daemon buffer is a 500-event deque shared by every reader;
-    # journal to disk so events survive across browser_exec calls.
-    try:
-        evs = drain_events()
-    except Exception:
-        return
+def _hermes_journal(evs):
     if not evs:
         return
     try:
@@ -132,6 +147,55 @@ def _hermes_flush_events():
                 f.write(json.dumps(e, default=str) + "\\n")
     except OSError:
         pass
+
+def _hermes_wrap_drain(_raw):
+    # ponytail: the daemon buffer is a 500-event deque and every reader
+    # (incl. the harness's own wait_for_network_idle) drains it destructively;
+    # journal on the way out so nothing is lost across browser_exec calls.
+    def drain_events():
+        evs = _raw()
+        _hermes_journal(evs)
+        return evs
+    drain_events.__doc__ = _raw.__doc__
+    drain_events.__hermes_journaled__ = True
+    return drain_events
+try:
+    import browser_harness.helpers as _hh
+    if not getattr(_hh.drain_events, "__hermes_journaled__", False):
+        _hh.drain_events = _hermes_wrap_drain(_hh.drain_events)
+    drain_events = _hh.drain_events
+    del _hh
+except Exception:
+    drain_events = _hermes_wrap_drain(drain_events)
+del _hermes_wrap_drain
+
+def _hermes_flush_events():
+    try:
+        drain_events()
+    except Exception:
+        pass
+
+def _hermes_untitle(obj):
+    # The harness prefixes attached tabs' titles with a horse emoji so the
+    # user can spot the agent's tab; hide it from what the model reads.
+    if isinstance(obj, dict) and isinstance(obj.get("title"), str) and obj["title"].startswith("\U0001F434"):
+        obj["title"] = obj["title"][1:].lstrip()
+    return obj
+
+def _hermes_wrap_untitle(_raw):
+    def wrapped(*a, **kw):
+        r = _raw(*a, **kw)
+        if isinstance(r, list):
+            for t in r:
+                _hermes_untitle(t)
+        return _hermes_untitle(r)
+    wrapped.__doc__ = _raw.__doc__
+    wrapped.__name__ = getattr(_raw, "__name__", "wrapped")
+    return wrapped
+page_info = _hermes_wrap_untitle(page_info)
+current_tab = _hermes_wrap_untitle(current_tab)
+list_tabs = _hermes_wrap_untitle(list_tabs)
+del _hermes_wrap_untitle
 
 def _hermes_read_events(clear=False):
     _hermes_flush_events()
@@ -778,11 +842,10 @@ def _resolve_backend_cdp(
             "the built-in browser tools for this provider."
         )
     env["BU_CDP_URL" if cdp.startswith(("http://", "https://")) else "BU_CDP_WS"] = cdp
-    # A provider browser keyed bu-named-<name> is exclusive to this session —
-    # the own-tab preamble is unnecessary there (it would just leak a blank
-    # tab into a browser nobody else touches).
-    if session_name:
-        env[_PRIVATE_BROWSER_SENTINEL] = "1"
+    # A provider browser (per-task, or keyed bu-named-<name>) is exclusive to
+    # this daemon — the own-tab preamble is unnecessary there (it would just
+    # leak a blank tab into a browser nobody else touches).
+    env[_PRIVATE_BROWSER_SENTINEL] = "1"
     return None
 
 
@@ -925,13 +988,13 @@ def browser_exec(
     if backend_err:
         return tool_error(backend_err)
 
-    # On a SHARED browser (local Chrome / CDP override) a fresh named daemon
-    # attaches to the first existing page — the same page a sibling daemon
-    # may hold. Pin each named session to a tab it created before running
-    # the model's code. Private per-name browsers (provider-keyed or BU
-    # cloud) skip this: no one to collide with, and the extra tab would leak.
+    # On a SHARED browser (local Chrome / CDP override) a fresh daemon
+    # attaches to the first existing page — the user's tab, or the same page
+    # a sibling daemon holds. Pin each session to a tab it created before
+    # running the model's code. Private browsers (provider-keyed, BU cloud,
+    # Lightpanda) skip this: no one to collide with, and the tab would leak.
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
-    if session and not private_browser:
+    if not private_browser:
         code = _OWN_TAB_PREAMBLE + code
     code = _HELPERS_PREAMBLE + code
 
@@ -1185,7 +1248,7 @@ BROWSER_EXEC_SCHEMA = {
             },
             "session": {
                 "type": "string",
-                "description": "Named isolated browser session — its own daemon and (on cloud backends) own browser, so concurrent tasks don't share tabs. Reuse the same name on every related call; omit for the shared default session.",
+                "description": "Named isolated browser session — its own daemon and (on cloud backends) own browser, so concurrent tasks don't share tabs. Once you use a name, pass the SAME name on every later call of that task: omitting it lands on a different browser/tab (the shared default session).",
             },
             "timeout_s": {
                 "type": "integer",

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -47,9 +47,17 @@ def _hermes_ensure_own_tab():
         # re-attaches to the first shared page) re-pins automatically,
         # while agent-driven tab switches mid-session are left alone.
         from browser_harness import _ipc as _bipc
-        _dpid = _bipc.pid_path(_name).read_text().strip() or "0"
+        _dpid = _bipc.pid_path(_name).read_text().strip()
     except Exception:
-        _dpid = "0"
+        _dpid = ""
+    if not _dpid:
+        try:
+            from browser_harness.helpers import _send as _bsend
+            _dpid = str(_bsend({"meta": "ping"}).get("pid") or "")
+        except Exception:
+            pass
+    if not _dpid:
+        return  # daemon unreachable: pinning would fail too
     _uid = _os.getuid() if hasattr(_os, "getuid") else 0
     _marker = _os.path.join(
         _tf.gettempdir(), "hermes-bu-owntab-%s-%s-%s" % (_uid, _name, _dpid)
@@ -70,6 +78,135 @@ def _hermes_ensure_own_tab():
         pass
 _hermes_ensure_own_tab()
 del _hermes_ensure_own_tab
+"""
+
+# Preamble prepended to EVERY browser_exec call. The harness exposes only a
+# destructive drain_events() for CDP events and never tells the model about
+# it, so console/network reading was impossible; and cdp()'s second
+# positional is session_id, which the model reliably fills with a params
+# dict. Everything here is Hermes-side (browser_harness is a third-party
+# package): stdlib pre-imports, a cdp() guard, and an event journal in the
+# workspace that console_logs()/network_log() read from.
+_HELPERS_PREAMBLE = """\
+# hermes: stdlib pre-imports + console/network journal + cdp() guard
+import re, json, csv, os, sys, time, datetime, collections
+from pathlib import Path
+
+def _hermes_wrap_cdp(_raw):
+    def cdp(method, session_id=None, **params):
+        if isinstance(session_id, dict):  # cdp('X.y', {...}) -> params
+            params = {**session_id, **params}
+            session_id = None
+        elif session_id is not None and not isinstance(session_id, str):
+            raise TypeError(
+                "cdp(method, session_id=None, **params): session_id must be a "
+                "CDP session id string; pass CDP params as keyword arguments"
+            )
+        return _raw(method, session_id, **params)
+    cdp.__doc__ = _raw.__doc__
+    return cdp
+cdp = _hermes_wrap_cdp(cdp)
+del _hermes_wrap_cdp
+
+def _hermes_events_path():
+    import tempfile as _tf
+    ws = os.environ.get("BH_AGENT_WORKSPACE")
+    if ws:
+        return os.path.join(ws, "browser_events.jsonl")
+    uid = os.getuid() if hasattr(os, "getuid") else 0
+    name = os.environ.get("BU_NAME", "default")
+    return os.path.join(_tf.gettempdir(), "hermes-bu-events-%s-%s.jsonl" % (uid, name))
+
+def _hermes_flush_events():
+    # ponytail: daemon buffer is a 500-event deque shared by every reader;
+    # journal to disk so events survive across browser_exec calls.
+    try:
+        evs = drain_events()
+    except Exception:
+        return
+    if not evs:
+        return
+    try:
+        with open(_hermes_events_path(), "a") as f:
+            for e in evs:
+                f.write(json.dumps(e, default=str) + "\\n")
+    except OSError:
+        pass
+
+def _hermes_read_events(clear=False):
+    _hermes_flush_events()
+    path = _hermes_events_path()
+    out = []
+    try:
+        with open(path) as f:
+            for line in f:
+                try:
+                    out.append(json.loads(line))
+                except ValueError:
+                    pass
+        if clear:
+            open(path, "w").close()
+    except OSError:
+        pass
+    return out
+
+def _hermes_remote_text(obj):
+    if not isinstance(obj, dict):
+        return str(obj)
+    if "value" in obj:
+        return obj["value"] if isinstance(obj["value"], str) else json.dumps(obj["value"])
+    return obj.get("description") or obj.get("unserializableValue") or obj.get("type", "")
+
+def console_logs(clear=False, contains=None):
+    \"\"\"Console messages + uncaught exceptions captured so far, oldest first.
+    Returns [{level, text, url, line, ts}]. clear=True empties the journal.\"\"\"
+    out = []
+    for e in _hermes_read_events(clear):
+        m, p = e.get("method"), e.get("params", {})
+        if m == "Runtime.consoleAPICalled":
+            frame = (p.get("stackTrace") or {}).get("callFrames") or [{}]
+            out.append({
+                "level": p.get("type", "log"),
+                "text": " ".join(_hermes_remote_text(a) for a in p.get("args", [])),
+                "url": frame[0].get("url", ""), "line": frame[0].get("lineNumber"),
+                "ts": p.get("timestamp"),
+            })
+        elif m == "Runtime.exceptionThrown":
+            d = p.get("exceptionDetails", {})
+            out.append({
+                "level": "error",
+                "text": _hermes_remote_text(d.get("exception")) or d.get("text", ""),
+                "url": d.get("url", ""), "line": d.get("lineNumber"),
+                "ts": p.get("timestamp"),
+            })
+    if contains:
+        out = [c for c in out if contains in c["text"]]
+    return out
+
+def network_log(clear=False, contains=None):
+    \"\"\"Requests captured so far, oldest first: [{url, method, status, mime, type, requestId}].
+    clear=True empties the journal.\"\"\"
+    reqs = collections.OrderedDict()
+    for e in _hermes_read_events(clear):
+        m, p = e.get("method"), e.get("params", {})
+        rid = p.get("requestId")
+        if m == "Network.requestWillBeSent":
+            r = p.get("request", {})
+            reqs[rid] = {"url": r.get("url"), "method": r.get("method"), "status": None,
+                         "mime": None, "type": p.get("type"), "requestId": rid}
+        elif m == "Network.responseReceived" and rid in reqs:
+            r = p.get("response", {})
+            reqs[rid].update(status=r.get("status"), mime=r.get("mimeType"))
+        elif m == "Network.loadingFailed" and rid in reqs:
+            reqs[rid]["error"] = p.get("errorText")
+    out = list(reqs.values())
+    if contains:
+        out = [r for r in out if contains in (r["url"] or "")]
+    return out
+
+import atexit as _hermes_atexit
+_hermes_atexit.register(_hermes_flush_events)
+del _hermes_atexit
 """
 
 _DEFAULT_TIMEOUT_S = 300
@@ -796,6 +933,7 @@ def browser_exec(
     private_browser = env.pop(_PRIVATE_BROWSER_SENTINEL, None)
     if session and not private_browser:
         code = _OWN_TAB_PREAMBLE + code
+    code = _HELPERS_PREAMBLE + code
 
     workspace = _workspace_dir(task_id)
     if workspace:
@@ -873,7 +1011,9 @@ def browser_exec(
 # The tool description is the CLI's skill, fetched from browser-use skill
 _HEADER_BASE = (
     "Drive a real web browser via the Browser Use CLI: `code` runs as full "
-    "Python (stdlib available) with pre-imported browser helpers; stdout "
+    "Python (re/json/csv/os/sys/time/datetime/collections/Path are "
+    "pre-imported; `import` any other stdlib module yourself) with "
+    "pre-imported browser helpers; stdout "
     "comes back in the result. Start `code` with a one-line comment "
     "describing the step for the user in plain language, max 60 chars "
     "(e.g. `# Searching Amazon for paper towels`) — the UI shows it as the "
@@ -973,7 +1113,17 @@ _HELPERS_DIGEST = (
     "a bare '() => {...}' returns the function itself, uncalled), "
     "fill_input(selector, text) types into inputs, click_at_xy(x, y) clicks "
     "viewport coordinates, capture_screenshot() saves and prints a "
-    "screenshot path, cdp('Domain.method', **kwargs) is raw CDP — "
+    "screenshot path. TABS: list_tabs() -> [{targetId,url,title}], "
+    "current_tab(), switch_tab(targetId) attaches to a tab, close_tab(targetId). "
+    "DEVTOOLS: console_logs(contains=None, clear=False) -> "
+    "[{level,text,url,line}] console messages and uncaught exceptions "
+    "captured since the last clear (Runtime is always enabled — no setup); "
+    "network_log(contains=None, clear=False) -> [{url,method,status,mime}] "
+    "requests captured so far (Network is always enabled); call wait(1) "
+    "after triggering activity before reading either. cdp(method, "
+    "session_id=None, **params) is raw CDP — params MUST be keyword args: "
+    "cdp('DOM.getDocument', depth=-1); the 2nd positional is a CDP "
+    "sessionId string (rarely needed; the attached tab is the default). "
     "cdp('Accessibility.getFullAXTree')['nodes'] lists every element's "
     "role/name/backendDOMNodeId (filter in Python before printing; it is "
     "thousands of nodes), then cdp('DOM.getBoxModel', backendNodeId=n) gives "

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -79,6 +79,22 @@ The mode is a **driver** that composes with your configured browser backend: it 
 
 **Concurrent sessions:** `browser_exec` accepts a `session=<name>` argument that isolates browser work per name on every backend. Each name gets its own harness daemon (its own IPC socket, log, and state), and on cloud backends its own browser — so parallel subagents or simultaneous chats no longer clobber a single shared connection. Omitting `session` uses the shared default daemon, which is fine for one-at-a-time browsing.
 
+**Tabs:** on a shared local Chrome (or a `/browser connect` endpoint) every `browser_exec` session pins itself to a tab it created, so the agent never navigates away the tab you were reading. If the agent closes its pinned tab, the next call pins a fresh one. Tab helpers: `list_tabs()`, `current_tab()`, `switch_tab(targetId)`, `close_tab(targetId)`.
+
+**DevTools access:** the console and network panes are readable from `browser_exec` without any setup — the harness keeps Runtime and Network enabled on the attached tab and Hermes journals their events to `browser_events.jsonl` in the workspace so they survive across calls:
+
+```python
+js("(() => { console.warn('hi'); fetch('/api/items'); })()")
+wait(1)
+console_logs(contains="hi")       # [{level, text, url, line, ts}] incl. uncaught exceptions
+network_log(contains="/api/")     # [{url, method, status, mime, type, requestId}]
+console_logs(clear=True)          # empty the journal
+```
+
+Raw CDP is `cdp("Domain.method", **params)` — params are keyword arguments (`cdp("DOM.getDocument", depth=-1)`); the second *positional* argument is a CDP session id string, which you rarely need since the attached tab is the default.
+
+**macOS "Allow remote debugging?" sheet:** Chrome shows this sheet for every new DevTools connection, so it appears each time a harness daemon starts (first browser call, `browser-use --reload`, daemon restart after Chrome restarts). Click Allow in Chrome; Hermes never clicks it for you. To avoid the sheet entirely, launch a Chrome with `--remote-debugging-port` and point Hermes at it with `BROWSER_CDP_URL` or `/browser connect`.
+
 To opt out and force the built-in browser tools, use `/browser use off`, or:
 
 ```yaml


### PR DESCRIPTION
## What does this PR do?

Makes `browser_exec` (Browser Use mode, the default) usable for DevTools-style work out of the box, and stops it from landing on the user's own tab.

### What we saw without this change

Asking Hermes to test the browser produced this sequence (local Chrome, Browser Use mode, default session):

- **Console/network reading was impossible.** The model was asked to read the JS console. It tried `cdp('Network.enable', {...})` and got Chromium's `Message may have string 'sessionId' property`. The `cdp()` helper's second *positional* parameter is `session_id`, while the tool digest documented it as `cdp('Domain.method', **kwargs)`, so the natural params-dict call sends a dict as the session id. Even with the right call shape there was no way to read events: the harness daemon buffers `Runtime.consoleAPICalled` / `Network.*` events but exposes only a destructive `drain_events()` that Hermes never told the model about, and the harness's own `wait_for_network_idle()` drains that buffer too.
- **"Pre-imported helpers" / "stdlib available" were half true.** Helpers reach the exec namespace through a star import, so only the stdlib modules `helpers.py` itself imports leak in. `re`, `datetime`, `collections` etc. raised `NameError` until the model wrote an explicit import, and the model concluded the helpers themselves were broken.
- **The agent drove whatever tab happened to be first.** A fresh default daemon attaches to the first CDP target, which is not tab-strip order and is often the user's active tab (#89143). If the agent's tab was closed, the daemon silently re-attached to the first page again. Named sessions had an own-tab preamble; unnamed sessions did not.
- **Titles came back as `🐴`.** The harness prefixes attached tabs' titles with a horse emoji (#85430); `page_info()` reported it as the page title.

A 7-step scripted probe (navigate, list/switch tabs, read console, read network, raw CDP, extract to workspace, close tab) scored **0/7** on baseline.

### What we see with this change

Same probe, same local model, headless Chrome that already had an `example.com` tab open: **7/7**. The agent started on its own blank tab and left `example.com` untouched; `console_logs()` returned all three test messages with the right levels (log / warning / uncaught error); `network_log()` returned the probe request with its 200; after the agent closed its own tab the next call re-pinned to a fresh tab instead of the user's; a request fired during `wait_for_network_idle()` still appeared in `network_log()`.

## Related Issue

Related: #89143 (agent hijacks the user's Chrome tab), #85430 (horse emoji in titles). Complements #91528 (own-tab preamble vs. native harness isolation for *named* sessions; this PR extends pinning to the *default* session, which the harness still does not isolate).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

All Hermes-side; `browser_harness` is a third-party package and is not modified.

`tools/browser_use_cli.py`
- New `_HELPERS_PREAMBLE`, prepended to every `browser_exec` call:
  - pre-imports `re, json, csv, os, sys, time, datetime, collections, Path`
  - wraps `cdp()` so a positional dict becomes params and a non-string session id raises a clear `TypeError`
  - patches `browser_harness.helpers.drain_events` so every drain (including the harness's own `wait_for_network_idle`) is journaled to `browser_events.jsonl` in the workspace, surviving across calls
  - adds `console_logs(contains=None, clear=False)` and `network_log(contains=None, clear=False)` reading from that journal
  - strips the horse marker from `page_info()`, `current_tab()`, `list_tabs()` titles
- `_OWN_TAB_PREAMBLE` now runs for every session on a shared browser (local Chrome / CDP override), stores the pinned targetId, and re-pins when that tab is gone. Unnamed provider browsers are marked private (per-task) so they skip it like named ones. The daemon-pid fallback of `"0"` is replaced by asking the daemon for its pid.
- `_HELPERS_DIGEST` names the tab helpers, the two DevTools helpers, and the real `cdp()` signature; header says to import other stdlib modules explicitly; `session` schema tells the model to keep passing the same name.

`tests/tools/test_browser_use_cli.py`
- Preamble exec'd against a stubbed harness: cdp guard, console/network parsing, journal persistence across calls, journaling through raw drains, title cleanup, preamble ordering for named/unnamed sessions, unnamed-provider skip.

`website/docs/user-guide/features/browser.md`
- New Tabs, DevTools access, and "Allow remote debugging?" sections. The Allow sheet is documented as the user's to click; nothing automates it.

## How to Test

1. Start a Chrome with a debug port and a "user" tab: `chrome --headless=new --remote-debugging-port=9333 --user-data-dir=/tmp/hx https://example.com`
2. `BROWSER_CDP_URL=http://127.0.0.1:9333 hermes -z '<prompt below>'`
3. Prompt: open `https://httpbin.org/html`, list tabs, open `https://example.com` in a second tab and switch back, run JS that does `console.log/console.warn` and throws in a `setTimeout`, read the console, `fetch('https://httpbin.org/get?probe=hermes')` and read the network log, `DOM.getDocument` via raw CDP, extract h1/p to a workspace JSON file, close the second tab, report PASS/FAIL per step.
4. Expect every step to pass, and `example.com` in `curl http://127.0.0.1:9333/json` to be untouched.
5. `uv run pytest tests/tools/test_browser_use_cli.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the full suite via `scripts/run_tests.sh` with the CI extras. 23 files fail on this macOS machine (launchd/update, computer-use driver, AF_UNIX path length, voice); all 23 fail identically on `origin/main` with the same venv, and none touch the browser stack. Everything else passes, including `tests/tools/test_browser_use_cli.py` (120 tests).
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26, Chrome 152, browser-harness from `uv tool install browser-use`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — preamble uses `os.getuid` guarded with `hasattr`, journal path falls back to `tempfile.gettempdir()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B7uTZ2uHp51EvCftNVCdQW
