### PR TITLE
fix(tui): surface the user's clarify answer in reloaded histories

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2863,6 +2863,90 @@ def test_history_to_messages_ships_full_tool_args():
     assert "args" not in argless[0]
 
 
+def test_history_to_messages_surfaces_clarify_user_response():
+    # The clarify tool returns the user's answer inside its result JSON, so
+    # the transcript carries it only on the role="tool" row — which the
+    # display projection collapsed to a name+args row, dropping the content.
+    # A reloaded session showed the question and the assistant's reaction but
+    # never the user's actual answer (#102267).
+    history = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "function": {
+                        "name": "clarify",
+                        "arguments": json.dumps(
+                            {"question": "Which channels?", "choices": ["a", "b"]}
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_1",
+            "tool_name": "clarify",
+            "content": json.dumps(
+                {
+                    "question": "Which channels?",
+                    "choices_offered": ["a", "b"],
+                    "user_response": "grab the DeepState mirror only",
+                }
+            ),
+        },
+        {"role": "assistant", "content": "got it — skipping the rest"},
+    ]
+
+    rows = server._history_to_messages(history)
+    assert rows[0]["role"] == "tool"
+    assert rows[1] == {
+        "role": "user",
+        "text": "grab the DeepState mirror only",
+        "display_kind": "clarify_response",
+    }
+    assert rows[2]["text"] == "got it — skipping the rest"
+
+
+def test_history_to_messages_clarify_projection_edge_shapes():
+    # Batch results project one user row per answered question; blanks (skips,
+    # walked-away timeouts) stay hidden; multi_select lists join into one row;
+    # non-clarify tool results and unparseable content are never projected.
+    batch = json.dumps(
+        {
+            "responses": [
+                {"question": "q1", "user_response": ["red", "blue"]},
+                {"question": "q2", "user_response": ""},
+            ]
+        }
+    )
+    rows = server._history_to_messages(
+        [{"role": "tool", "tool_name": "clarify", "content": batch}]
+    )
+    assert [r["role"] for r in rows] == ["tool", "user"]
+    assert rows[1]["text"] == "red, blue"
+
+    # Timeout sentinel is the tool narrating, not the user — stay hidden.
+    from tools.clarify_tool import TIMEOUT_RESPONSE
+
+    sentinel = json.dumps(
+        {"question": "q", "choices_offered": None, "user_response": TIMEOUT_RESPONSE}
+    )
+    assert server._history_to_messages(
+        [{"role": "tool", "tool_name": "clarify", "content": sentinel}]
+    ) == [{"role": "tool", "name": "clarify", "context": ""}]
+
+    # Other tools' results and non-JSON content never project user rows.
+    assert server._history_to_messages(
+        [{"role": "tool", "tool_name": "terminal", "content": "ok"}]
+    )[0]["role"] == "tool"
+    assert server._history_to_messages(
+        [{"role": "tool", "tool_name": "clarify", "content": "not json"}]
+    )[0]["role"] == "tool"
+
+
 def test_tool_start_ships_full_args(monkeypatch):
     # The desktop rebuilds the expanded row's `$` transcript from args. When
     # only the 80-char `context` preview shipped, the expanded command was

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -9846,6 +9846,55 @@ def _legacy_display_kind(role: str, text: str) -> str | None:
     return None
 
 
+def _clarify_response_display_lines(tool_name: str, content) -> list[dict]:
+    """Re-surface the user's clarify answer(s) from a persisted tool result.
+
+    The clarify tool returns the user's reply inside its result JSON, so the
+    durable transcript carries the answer only on the ``role="tool"`` row —
+    which this projection collapses to a name+args row, dropping the content.
+    A reloaded session therefore showed the question and the assistant's
+    reaction but never what the user actually answered (#102267). Project each
+    non-empty answer as a user-authored line; renderers that don't know the
+    ``clarify_response`` display kind fall back to a plain user row, which is
+    exactly the shape the thread was missing.
+    """
+    if tool_name != "clarify" or not isinstance(content, str) or not content.strip():
+        return []
+    try:
+        parsed = json.loads(content)
+    except (json.JSONDecodeError, TypeError):
+        return []
+    if not isinstance(parsed, dict):
+        return []
+    try:
+        from tools.clarify_tool import TIMEOUT_RESPONSE
+    except Exception:  # pragma: no cover - stdlib-only module, always importable
+        TIMEOUT_RESPONSE = None
+    answers: list = []
+    responses = parsed.get("responses")
+    if isinstance(responses, list):  # Batch shape: {"responses": [...]}.
+        answers.extend(
+            entry.get("user_response") for entry in responses if isinstance(entry, dict)
+        )
+    else:
+        answers.append(parsed.get("user_response"))
+    lines: list[dict] = []
+    for answer in answers:
+        if isinstance(answer, list):  # multi_select answers are lists
+            text = ", ".join(str(a).strip() for a in answer if str(a).strip())
+        elif isinstance(answer, str):
+            text = answer.strip()
+        else:
+            # None (unanswered / timed out) and non-text values stay hidden;
+            # the timeout sentinel is the tool talking, not the user.
+            continue
+        if text and text != TIMEOUT_RESPONSE:
+            lines.append(
+                {"role": "user", "text": text, "display_kind": "clarify_response"}
+            )
+    return lines
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -9895,6 +9944,10 @@ def _history_to_messages(history: list[dict]) -> list[dict]:
             if args:
                 tool_msg["args"] = args
             messages.append(tool_msg)
+            # The user's clarify answer lives in the tool result content this
+            # projection otherwise drops; re-surface it as a user row so the
+            # reloaded thread reads question → answer → reaction (#102267).
+            messages.extend(_clarify_response_display_lines(name, content_text))
             continue
         # An assistant turn may carry only reasoning/thinking content with no
         # visible text (extended-thinking turns, thinking-only recovery


### PR DESCRIPTION
## What does this PR do?

When the agent asks a question through the `clarify` tool, the user's answer travels back inside the tool result JSON — so the durable transcript carries it only on the `role="tool"` row. The `_history_to_messages` display projection collapses that row to a name+args row and drops the content, which means a reloaded session (TUI resume, desktop transcript, any surface reading `session.history`) shows the question and the assistant's reaction but never what the user actually answered. The thread reads as if the assistant replied to nothing.

This PR re-surfaces each non-empty clarify answer as a user-authored display row (`display_kind="clarify_response"`) projected right after the tool row, so the reloaded thread reads question → answer → reaction. Renderers that don't know the new display kind fall back to a plain user row, which is exactly the shape the thread was missing.

Scope of the projection:

- single-question results (`{"question", "choices_offered", "user_response"}`) project one row;
- batch results (`{"responses": [...]}`) project one row per **answered** question;
- `multi_select` list answers join into one row (`"red, blue"`);
- blank answers (skips / walked-away timeouts) and the `TIMEOUT_RESPONSE` sentinel stay hidden — the sentinel is the tool narrating, not the user speaking;
- non-clarify tool results and unparseable content are never touched.

The projection is display-only: the server-side history, the model-facing conversation, `session.undo`/rewind turn counting (which reads the raw history), and the persisted DB rows are all unchanged.

## Related Issue

Fixes #102267

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `tui_gateway/server.py` — new `_clarify_response_display_lines()` helper that parses a persisted clarify tool result and extracts the user's answer(s); the `role == "tool"` branch of `_history_to_messages` now appends those lines after the tool row.

## How to Test

1. `uv run pytest tests/test_tui_gateway_server.py -k "history_to_messages" -q`
   - Observed result: 16 passed (14 pre-existing + 2 new)
2. `uv run pytest tests/test_tui_gateway_server.py tests/tui_gateway -q`
   - Observed result: 639 passed / 976 passed, no regressions
3. Red/green check: with the `server.py` change stashed, `test_history_to_messages_surfaces_clarify_user_response` fails (the answer row is absent); with it restored, both new tests pass.

Manual check on top: run a session where the agent calls `clarify` with choices, pick "Other" and type a free-text answer, then reload the session — the answer now appears between the question and the assistant's follow-up instead of vanishing.

## Checklist

- [x] I have read the [CONTRIBUTING](CONTRIBUTING.md) document
- [x] My code follows the project's style guidelines (ruff check clean)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

Platform: macOS (arm64); tests run via the project's shared venv against upstream/main base.
