### PR TITLE
fix(hardware): use MemAvailable for Linux RAM

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -81,6 +81,41 @@ _pool_probe_cache: tuple[float, "tuple[int, bool | None] | None"] | None = None
 _DEVICE_LINE_RE = re.compile(r"CUDA\d+:.*\((\d+)\s*MiB,\s*\d+\s*MiB free\)\s*$")
 
 
+def _linux_ram_bytes(
+    meminfo_path: Path = Path("/proc/meminfo"),
+) -> tuple[int, int] | None:
+    """Return Linux physical RAM from procfs, including reclaimable cache.
+
+    ``getconf _AVPHYS_PAGES`` tracks only truly free pages on Linux, while
+    ``MemAvailable`` estimates how much memory can be used without swapping.
+    Older kernels may omit ``MemAvailable``; ``MemFree`` preserves the prior
+    conservative behavior in that case.
+    """
+    try:
+        fields: dict[str, int] = {}
+        for line in meminfo_path.read_text(encoding="utf-8").splitlines():
+            name, separator, value = line.partition(":")
+            if not separator or name not in {"MemTotal", "MemAvailable", "MemFree"}:
+                continue
+            parts = value.split()
+            if len(parts) != 2 or parts[1] != "kB":
+                continue
+            fields[name] = int(parts[0]) * 1024
+
+        total = fields.get("MemTotal")
+        available = fields.get("MemAvailable", fields.get("MemFree"))
+        if (
+            total is None
+            or total <= 0
+            or available is None
+            or not 0 <= available <= total
+        ):
+            return None
+        return total, available
+    except (OSError, ValueError):
+        return None
+
+
 def _ram_bytes() -> tuple[int, int]:
     """(total, available) physical memory, cross-platform stdlib."""
     try:
@@ -103,6 +138,10 @@ def _ram_bytes() -> tuple[int, int]:
         return stat.ullTotalPhys, stat.ullAvailPhys
     except (AttributeError, OSError):
         pass
+    if sys.platform.startswith("linux"):
+        linux_ram = _linux_ram_bytes()
+        if linux_ram is not None:
+            return linux_ram
     if sys.platform == "darwin":
         # macOS getconf has no _PHYS_PAGES/_AVPHYS_PAGES (exit 64, "no such
         # configuration parameter") — the POSIX branch below returns (0, 0)

--- a/tests/hermes_cli/test_linux_ram_probe.py
+++ b/tests/hermes_cli/test_linux_ram_probe.py
@@ -1,0 +1,92 @@
+"""Linux RAM availability must include reclaimable page cache (#102252)."""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import hermes_cli.local_runtime.hardware as hw
+
+
+GIB = 1 << 30
+
+
+def test_linux_ram_bytes_prefers_memavailable(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       67108864 kB\n"
+        "MemFree:        12582912 kB\n"
+        "MemAvailable:   56623104 kB\n"
+        "Cached:         44040192 kB\n",
+        encoding="utf-8",
+    )
+
+    assert hw._linux_ram_bytes(meminfo) == (64 * GIB, 54 * GIB)
+
+
+def test_linux_ram_bytes_falls_back_to_memfree_for_old_kernels(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       8388608 kB\nMemFree:        2097152 kB\n",
+        encoding="utf-8",
+    )
+
+    assert hw._linux_ram_bytes(meminfo) == (8 * GIB, 2 * GIB)
+
+
+def test_linux_ram_bytes_keeps_zero_memavailable_instead_of_memfree(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text(
+        "MemTotal:       8388608 kB\n"
+        "MemFree:        2097152 kB\n"
+        "MemAvailable:         0 kB\n",
+        encoding="utf-8",
+    )
+
+    assert hw._linux_ram_bytes(meminfo) == (8 * GIB, 0)
+
+
+def test_linux_ram_bytes_returns_none_when_procfs_is_missing(tmp_path: Path):
+    assert hw._linux_ram_bytes(tmp_path / "missing-meminfo") is None
+
+
+def test_linux_ram_bytes_rejects_incomplete_or_invalid_values(tmp_path: Path):
+    meminfo = tmp_path / "meminfo"
+    meminfo.write_text("MemAvailable: 1048576 kB\n", encoding="utf-8")
+    assert hw._linux_ram_bytes(meminfo) is None
+
+    meminfo.write_text(
+        "MemTotal: 1048576 kB\nMemAvailable: 2097152 kB\n",
+        encoding="utf-8",
+    )
+    assert hw._linux_ram_bytes(meminfo) is None
+
+
+def test_ram_bytes_uses_linux_memavailable_before_getconf(monkeypatch):
+    expected = (64 * GIB, 54 * GIB)
+    monkeypatch.setattr(hw.sys, "platform", "linux")
+    monkeypatch.setattr(hw, "_linux_ram_bytes", lambda: expected)
+    monkeypatch.setattr(
+        hw.subprocess,
+        "run",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("getconf must not run when /proc/meminfo is usable")
+        ),
+    )
+
+    assert hw._ram_bytes() == expected
+
+
+def test_ram_bytes_falls_back_to_getconf_when_meminfo_unavailable(monkeypatch):
+    monkeypatch.setattr(hw.sys, "platform", "linux")
+    monkeypatch.setattr(hw, "_linux_ram_bytes", lambda: None)
+    values = {
+        "PAGE_SIZE": "4096\n",
+        "_PHYS_PAGES": "2097152\n",
+        "_AVPHYS_PAGES": "524288\n",
+    }
+
+    def fake_run(command, **kwargs):
+        return SimpleNamespace(stdout=values[command[1]])
+
+    monkeypatch.setattr(hw.subprocess, "run", fake_run)
+
+    assert hw._ram_bytes() == (8 * GIB, 2 * GIB)


### PR DESCRIPTION
## What does this PR do?

The Desktop system-resources statusbar derives used RAM from the hardware API as `total - available`. On Linux, `_ram_bytes()` used `getconf _AVPHYS_PAGES`, which tracks truly free pages and excludes reclaimable page cache. Long-running hosts therefore appeared to use tens of gigabytes more RAM than tools such as `free` report.

This PR makes the Linux probe prefer `/proc/meminfo`:

- `MemTotal` provides total physical memory.
- `MemAvailable` provides the reclaimable-aware available amount.
- `MemFree` is used when older kernels do not expose `MemAvailable`.
- Invalid or unavailable procfs data falls back to the existing `getconf` implementation.

The Windows and macOS paths are unchanged. Existing cgroup/container limit behavior is also unchanged and can be handled separately.

## Related Issue

Fixes #102252

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests only
- [ ] Refactor

## Changes Made

- Add a focused Linux `/proc/meminfo` parser.
- Prefer `MemAvailable` over `MemFree`.
- Validate total and available values before accepting procfs data.
- Preserve the existing POSIX `getconf` fallback.
- Add regression coverage for page-cache-aware availability, old kernels, zero available RAM, invalid/missing procfs data, Linux dispatch, and getconf fallback.

## How to Test

```bash
scripts/run_tests.sh \
  tests/hermes_cli/test_linux_ram_probe.py \
  tests/hermes_cli/test_unified_pool_quirk.py \
  tests/hermes_cli/test_local_models_routes.py \
  tests/hermes_cli/test_local_recommendation.py \
  tests/hermes_cli/test_context_policy.py -q

.venv/bin/ruff check \
  hermes_cli/local_runtime/hardware.py \
  tests/hermes_cli/test_linux_ram_probe.py
```

Results:

- 88 tests passed
- Ruff passed
- `git diff --check` passed

## Checklist

### Code

- [x] Read the contributing guide
- [x] Commit follows Conventional Commits
- [x] Searched for existing PRs and issue claims
- [x] PR contains only changes related to this fix
- [ ] Ran the complete repository test suite
- [x] Added regression tests
- [x] Tested the platform-specific branches with focused mocks/fixtures

### Documentation & Housekeeping

- [x] Documentation update: N/A, no configuration changed
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered; macOS and Windows branches are unchanged
- [x] Tool descriptions/schemas update: N/A