### PR TITLE
feat(matrix): opt-in cross-user key sharing for E2EE recovery

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -5,6 +5,7 @@ Env vars (config.yaml ``matrix:`` keys alias several — env wins):
   MATRIX_E2EE_MODE off|optional|required (legacy MATRIX_ENCRYPTION=true => required);
   MATRIX_DEVICE_ID (stable E2EE device), MATRIX_RECOVERY_KEY (cross-signing after key rotation),
   MATRIX_RECOVERY_KEY_OUTPUT_FILE (one-time 0600 write of a bootstrapped key), MATRIX_PROXY;
+  MATRIX_ALLOW_KEY_SHARE false|allowed-users|all (cross-user room-key recovery; default false);
   MATRIX_ALLOWED_USERS, MATRIX_ALLOWED_ROOMS (whitelist; DMs exempt), MATRIX_IGNORE_USER_PATTERNS
   (regexes for bridge ghosts), MATRIX_HOME_ROOM (cron delivery), MATRIX_REACTIONS (default true);
   MATRIX_REQUIRE_MENTION (default true), MATRIX_THREAD_REQUIRE_MENTION, MATRIX_FREE_RESPONSE_ROOMS,
@@ -802,6 +803,15 @@ class MatrixAdapter(BasePlatformAdapter):
         raw_session_scope = os.getenv("MATRIX_SESSION_SCOPE", "auto").strip().lower()
         self._matrix_session_scope = raw_session_scope if raw_session_scope in {"auto", "room", "thread"} else "auto"
         self._process_notices: bool = _env_truthy("MATRIX_PROCESS_NOTICES", "false")
+
+        # Allow the operator to pull back room keys on demand. mautrix's default
+        # key-share policy serves only the bot's own devices and silently drops
+        # m.room_key_request from other users, which makes a client's "Request
+        # Key" button a no-op against the bot. Modes (see
+        # _normalize_allow_key_share): false / allowed-users / all.
+        self._allow_key_share: str = _normalize_allow_key_share(
+            os.getenv("MATRIX_ALLOW_KEY_SHARE", "false")
+        )
         self._reactions_enabled: bool = os.getenv("MATRIX_REACTIONS", "true").lower() not in {"false", "0", "no"}
         self._pending_reactions: dict[tuple[str, str], str] = {}
         # Let the final message land before redacting reactions ("missing event" in some
@@ -1120,7 +1130,9 @@ class MatrixAdapter(BasePlatformAdapter):
         phase = "import"
         try:
             from mautrix.crypto import OlmMachine
+            from mautrix.crypto.key_share import RejectKeyShare
             from mautrix.crypto.store.asyncpg import PgCryptoStore
+            from mautrix.types import RoomKeyWithheldCode
             from mautrix.util.async_db import Database
             self._store_dir.mkdir(parents=True, exist_ok=True)
             phase = "create"
@@ -1149,6 +1161,52 @@ class MatrixAdapter(BasePlatformAdapter):
             olm = OlmMachine(client, crypto_store, crypto_state)
             olm.share_keys_min_trust = TrustState.UNVERIFIED
             olm.send_keys_min_trust = TrustState.UNVERIFIED
+            if self._allow_key_share != "false":
+                # Honor m.room_key_request from the operator. mautrix's default
+                # key-share policy serves only the bot's own devices and silently
+                # drops cross-user key requests, so a client's "Request Key"
+                # button is a no-op against the bot. "allowed-users" scopes
+                # recovery to the configured allowlist (keeping mautrix's
+                # blacklist + resolved-trust checks and gating on room
+                # membership); "all" mirrors the permissive send policy.
+                if self._allow_key_share == "all":
+                    async def _allow_key_share(device, request):
+                        if (
+                            device.user_id == client.mxid
+                            and device.device_id == client.device_id
+                        ):
+                            return False
+                        return (
+                            await olm.resolve_trust(device)
+                        ) >= olm.share_keys_min_trust
+                else:
+                    async def _allow_key_share(device, request):
+                        if device.user_id not in self._allowed_user_ids:
+                            return await olm.default_allow_key_share(
+                                device, request
+                            )
+                        if device.trust == TrustState.BLACKLISTED:
+                            raise RejectKeyShare(
+                                f"Rejecting key request from blacklisted "
+                                f"device {device.device_id}",
+                                code=RoomKeyWithheldCode.BLACKLISTED,
+                                reason="You have been blacklisted by this device",
+                            )
+                        if (
+                            await olm.resolve_trust(device)
+                        ) < olm.share_keys_min_trust:
+                            raise RejectKeyShare(
+                                f"Rejecting key request from untrusted "
+                                f"device {device.device_id}",
+                                code=RoomKeyWithheldCode.UNVERIFIED,
+                                reason="You have not been verified by this device",
+                            )
+                        if not await state_store.is_joined(
+                            request.room_id, device.user_id
+                        ):
+                            return False
+                        return True
+                olm.allow_key_share = _allow_key_share
             await olm.load()
             if not await self._verify_device_keys_on_server(client, olm):
                 return await self._abort_connect(api, crypto_db)
@@ -2965,6 +3023,21 @@ _YAML_LIST_KEYS = (
     ("allowed_rooms", "MATRIX_ALLOWED_ROOMS"), ("ignore_user_patterns", "MATRIX_IGNORE_USER_PATTERNS"))
 
 
+def _normalize_allow_key_share(raw: str) -> str:
+    """Normalize MATRIX_ALLOW_KEY_SHARE into ``false``/``allowed-users``/``all``.
+
+    Accepts booleans and loose spellings so an operator can't get silently
+    stuck on an unrecognized value. Anything unrecognized resolves to ``false``
+    (mautrix default: own devices only).
+    """
+    value = (raw or "").strip().lower()
+    if value in ("true", "1", "yes", "all"):
+        return "all"
+    if value in ("allowed", "allowed-users", "allowed_users"):
+        return "allowed-users"
+    return "false"
+
+
 def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
     """apply_yaml_config_fn: config.yaml matrix: keys → MATRIX_* env (env wins). Returns None. Lowercased
     flags apply whenever the key is present (None still writes "none"); list-valued keys skip None.
@@ -2984,6 +3057,8 @@ def _apply_yaml_config(yaml_cfg: dict, matrix_cfg: dict) -> dict | None:
             os.environ[env_name] = str(value)
     if "max_message_length" in matrix_cfg and not os.getenv("MATRIX_MAX_MESSAGE_LENGTH"):
         os.environ["MATRIX_MAX_MESSAGE_LENGTH"] = str(matrix_cfg["max_message_length"])
+    if "allow_key_share" in matrix_cfg and not os.getenv("MATRIX_ALLOW_KEY_SHARE"):
+        os.environ["MATRIX_ALLOW_KEY_SHARE"] = str(matrix_cfg["allow_key_share"]).lower()
     return None
 
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -73,8 +73,14 @@ def _make_fake_mautrix():
         UNAVAILABLE = "unavailable"
 
     class TrustState:
+        BLACKLISTED = -100
         UNVERIFIED = 0
-        VERIFIED = 1
+        VERIFIED = 300
+
+    class RoomKeyWithheldCode:
+        BLACKLISTED = "m.blacklisted"
+        UNVERIFIED = "m.unverified"
+        UNAVAILABLE = "m.unavailable"
 
     class PaginationDirection:
         BACKWARD = "b"
@@ -89,6 +95,7 @@ def _make_fake_mautrix():
     mautrix_types.RoomCreatePreset = RoomCreatePreset
     mautrix_types.PresenceState = PresenceState
     mautrix_types.TrustState = TrustState
+    mautrix_types.RoomKeyWithheldCode = RoomKeyWithheldCode
     mautrix_types.PaginationDirection = PaginationDirection
     mautrix.types = mautrix_types
 
@@ -131,14 +138,19 @@ def _make_fake_mautrix():
     mautrix_client_state_store = types.ModuleType("mautrix.client.state_store")
 
     class MemoryStateStore:
+        members = {}
+
         async def get_member(self, room_id, user_id):
             return None
 
         async def get_members(self, room_id):
-            return []
+            return list(self.members.get(room_id, set()))
 
         async def get_member_profiles(self, room_id):
             return {}
+
+        async def is_joined(self, room_id, user_id):
+            return user_id in self.members.get(room_id, set())
 
     class MemorySyncStore:
         def __init__(self):
@@ -171,6 +183,17 @@ def _make_fake_mautrix():
             return event
 
     mautrix_crypto.OlmMachine = OlmMachine
+
+    # --- mautrix.crypto.key_share ---
+    mautrix_crypto_key_share = types.ModuleType("mautrix.crypto.key_share")
+
+    class RejectKeyShare(Exception):
+        def __init__(self, message="", code=None, reason=""):
+            super().__init__(message)
+            self.code = code
+            self.reason = reason
+
+    mautrix_crypto_key_share.RejectKeyShare = RejectKeyShare
 
     # --- mautrix.crypto.store ---
     mautrix_crypto_store = types.ModuleType("mautrix.crypto.store")
@@ -240,6 +263,7 @@ def _make_fake_mautrix():
         "mautrix.client.state_store": mautrix_client_state_store,
         "mautrix.crypto": mautrix_crypto,
         "mautrix.crypto.attachments": mautrix_crypto_attachments,
+        "mautrix.crypto.key_share": mautrix_crypto_key_share,
         "mautrix.crypto.store": mautrix_crypto_store,
         "mautrix.crypto.store.asyncpg": mautrix_crypto_store_asyncpg,
         "mautrix.util": mautrix_util,
@@ -3099,6 +3123,166 @@ class TestCryptoStoreResetOnDeviceChange:
         assert "MATRIX_DEVICE_ID=DEVICE_A" in caplog.text
 
         await adapter.disconnect()
+
+
+class TestMatrixKeySharePolicy:
+    """Key-request policy for ``allowed-users`` mode: allowlisted users keep
+    mautrix's blacklist + resolved-trust checks and are gated on room
+    membership; everyone else keeps the default policy."""
+
+    @pytest.fixture
+    def policy_harness(self, monkeypatch):
+        from plugins.platforms.matrix.adapter import MatrixAdapter
+
+        fake_mautrix_mods = _make_fake_mautrix()
+        state_store_cls = fake_mautrix_mods[
+            "mautrix.client.state_store"
+        ].MemoryStateStore
+        trust_state = fake_mautrix_mods["mautrix.types"].TrustState
+        reject_cls = fake_mautrix_mods["mautrix.crypto.key_share"].RejectKeyShare
+
+        monkeypatch.setenv("MATRIX_ALLOWED_USERS", "@operator:example.org")
+        monkeypatch.setenv("MATRIX_ALLOW_KEY_SHARE", "allowed-users")
+
+        config = PlatformConfig(
+            enabled=True,
+            token="syt_test_access_token",
+            extra={
+                "homeserver": "https://matrix.example.org",
+                "user_id": "@bot:example.org",
+                "encryption": True,
+            },
+        )
+        adapter = MatrixAdapter(config)
+
+        class FakeWhoamiResponse:
+            def __init__(self, user_id, device_id):
+                self.user_id = user_id
+                self.device_id = device_id
+
+        mock_client = MagicMock()
+        mock_client.mxid = "@bot:example.org"
+        mock_client.device_id = None
+        mock_client.state_store = MagicMock()
+        mock_client.sync_store = MagicMock()
+        mock_client.crypto = None
+        mock_client.whoami = AsyncMock(
+            return_value=FakeWhoamiResponse("@bot:example.org", "DEV123")
+        )
+        mock_client.sync = AsyncMock(
+            return_value={"rooms": {"join": {"!room:server": {}}}}
+        )
+        mock_client.add_event_handler = MagicMock()
+        mock_client.handle_sync = MagicMock(return_value=[])
+        mock_client.query_keys = AsyncMock(
+            return_value={
+                "device_keys": {
+                    "@bot:example.org": {
+                        "DEV123": {"keys": {"ed25519:DEV123": "fake_ed25519_key"}},
+                    },
+                },
+            }
+        )
+        mock_client.api = MagicMock()
+        mock_client.api.token = "syt_test_access_token"
+        mock_client.api.session = MagicMock()
+        mock_client.api.session.close = AsyncMock()
+
+        mock_olm = MagicMock()
+        mock_olm.load = AsyncMock()
+        mock_olm.share_keys = AsyncMock()
+        mock_olm.share_keys_min_trust = trust_state.UNVERIFIED
+        mock_olm.send_keys_min_trust = trust_state.UNVERIFIED
+        mock_olm.default_allow_key_share = AsyncMock(return_value=True)
+        mock_olm.resolve_trust = AsyncMock(return_value=trust_state.UNVERIFIED)
+        mock_olm.account = MagicMock()
+        mock_olm.account.identity_keys = {"ed25519": "fake_ed25519_key"}
+
+        fake_mautrix_mods["mautrix.client"].Client = MagicMock(
+            return_value=mock_client
+        )
+        fake_mautrix_mods["mautrix.crypto"].OlmMachine = MagicMock(
+            return_value=mock_olm
+        )
+
+        async def _run_connect():
+            import plugins.platforms.matrix.adapter as matrix_mod
+
+            with patch.object(
+                matrix_mod, "_check_e2ee_deps", return_value=True
+            ), patch.dict("sys.modules", fake_mautrix_mods), patch.object(
+                adapter, "_refresh_dm_cache", AsyncMock()
+            ), patch.object(
+                adapter, "_sync_loop", AsyncMock(return_value=None)
+            ), patch.object(
+                adapter,
+                "_verify_device_keys_on_server",
+                AsyncMock(return_value=True),
+            ):
+                assert await adapter.connect() is True
+                await adapter.disconnect()
+
+        asyncio.run(_run_connect())
+
+        return mock_olm, state_store_cls, trust_state, reject_cls
+
+    def _device(self, trust_state, user_id="@operator:example.org", trust=None):
+        return MagicMock(
+            user_id=user_id,
+            device_id="DEVOP1",
+            trust=trust if trust is not None else trust_state.UNVERIFIED,
+        )
+
+    def _request(self, room_id="!room:server"):
+        return MagicMock(
+            room_id=room_id,
+            session_id="S1",
+            algorithm="m.megolm.v1.aes-sha2",
+            sender_key="k",
+        )
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_joined_room_trusted_device(self, policy_harness):
+        mock_olm, state_store_cls, trust_state, reject_cls = policy_harness
+        state_store_cls.members = {"!room:server": {"@operator:example.org"}}
+        policy = mock_olm.allow_key_share
+        assert await policy(self._device(trust_state), self._request()) is True
+
+    @pytest.mark.asyncio
+    async def test_unlisted_user_delegates_to_default_policy(self, policy_harness):
+        mock_olm, state_store_cls, trust_state, reject_cls = policy_harness
+        policy = mock_olm.allow_key_share
+        device = self._device(trust_state, user_id="@stranger:example.org")
+        request = self._request()
+        assert await policy(device, request) is True
+        mock_olm.default_allow_key_share.assert_awaited_once_with(device, request)
+
+    @pytest.mark.asyncio
+    async def test_blacklisted_device_rejected(self, policy_harness):
+        mock_olm, state_store_cls, trust_state, reject_cls = policy_harness
+        state_store_cls.members = {"!room:server": {"@operator:example.org"}}
+        policy = mock_olm.allow_key_share
+        device = self._device(trust_state, trust=trust_state.BLACKLISTED)
+        with pytest.raises(reject_cls) as exc:
+            await policy(device, self._request())
+        assert exc.value.code == "m.blacklisted"
+
+    @pytest.mark.asyncio
+    async def test_untrusted_device_rejected(self, policy_harness):
+        mock_olm, state_store_cls, trust_state, reject_cls = policy_harness
+        state_store_cls.members = {"!room:server": {"@operator:example.org"}}
+        mock_olm.resolve_trust = AsyncMock(return_value=trust_state.BLACKLISTED)
+        policy = mock_olm.allow_key_share
+        with pytest.raises(reject_cls) as exc:
+            await policy(self._device(trust_state), self._request())
+        assert exc.value.code == "m.unverified"
+
+    @pytest.mark.asyncio
+    async def test_allowed_user_outside_room_denied(self, policy_harness):
+        mock_olm, state_store_cls, trust_state, reject_cls = policy_harness
+        state_store_cls.members = {"!room:server": {"@someone-else:example.org"}}
+        policy = mock_olm.allow_key_share
+        assert await policy(self._device(trust_state), self._request()) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_matrix_allow_key_share.py
+++ b/tests/gateway/test_matrix_allow_key_share.py
@@ -1,0 +1,78 @@
+"""Tests for the Matrix cross-user key-share opt-in.
+
+Covers two surfaces:
+
+- ``matrix.allow_key_share`` -> ``MATRIX_ALLOW_KEY_SHARE`` mapping (the
+  ``_apply_yaml_config`` path, mirroring the other ``matrix:`` keys).
+- ``_normalize_allow_key_share``, which folds the loose user-facing values
+  (booleans, ``allowed_users``, ``all``) into the canonical ``false`` /
+  ``allowed-users`` / ``all`` modes.
+
+The knob opts the bot into honoring ``m.room_key_request`` from other users,
+which makes a client's "Request Key" button a working recovery path. mautrix's
+default key-share policy silently drops cross-user key requests, so the flag
+must be opt-in (default ``false``).
+"""
+import os
+
+import pytest
+
+from plugins.platforms.matrix.adapter import (
+    _apply_yaml_config,
+    _normalize_allow_key_share,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    monkeypatch.delenv("MATRIX_ALLOW_KEY_SHARE", raising=False)
+    yield
+    monkeypatch.delenv("MATRIX_ALLOW_KEY_SHARE", raising=False)
+
+
+class TestAllowKeyShareMapping:
+    def test_yaml_true_sets_env_true(self):
+        _apply_yaml_config({}, {"allow_key_share": True})
+        assert os.environ["MATRIX_ALLOW_KEY_SHARE"] == "true"
+
+    def test_yaml_false_sets_env_false(self):
+        _apply_yaml_config({}, {"allow_key_share": False})
+        assert os.environ["MATRIX_ALLOW_KEY_SHARE"] == "false"
+
+    def test_yaml_string_is_normalized(self):
+        _apply_yaml_config({}, {"allow_key_share": "True"})
+        assert os.environ["MATRIX_ALLOW_KEY_SHARE"] == "true"
+
+    def test_env_precedence_over_yaml(self, monkeypatch):
+        monkeypatch.setenv("MATRIX_ALLOW_KEY_SHARE", "false")
+        _apply_yaml_config({}, {"allow_key_share": True})
+        assert os.environ["MATRIX_ALLOW_KEY_SHARE"] == "false"
+
+    def test_absent_key_leaves_env_unset(self):
+        _apply_yaml_config({}, {})
+        assert "MATRIX_ALLOW_KEY_SHARE" not in os.environ
+
+
+class TestNormalizeAllowKeyShare:
+    def test_default_is_false(self):
+        assert _normalize_allow_key_share("") == "false"
+        assert _normalize_allow_key_share("false") == "false"
+        assert _normalize_allow_key_share("off") == "false"
+        assert _normalize_allow_key_share("garbage") == "false"
+
+    def test_booleans_map_to_all(self):
+        assert _normalize_allow_key_share("true") == "all"
+        assert _normalize_allow_key_share("1") == "all"
+        assert _normalize_allow_key_share("yes") == "all"
+
+    def test_all_spellings(self):
+        assert _normalize_allow_key_share("all") == "all"
+
+    def test_allowed_users_spellings(self):
+        assert _normalize_allow_key_share("allowed-users") == "allowed-users"
+        assert _normalize_allow_key_share("allowed_users") == "allowed-users"
+        assert _normalize_allow_key_share("allowed") == "allowed-users"
+
+    def test_case_and_whitespace_insensitive(self):
+        assert _normalize_allow_key_share("  ALL  ") == "all"
+        assert _normalize_allow_key_share("Allowed-Users") == "allowed-users"

--- a/website/docs/user-guide/messaging/matrix.md
+++ b/website/docs/user-guide/messaging/matrix.md
@@ -98,6 +98,7 @@ matrix:
   auto_thread: true               # Auto-create threads for responses (default: true)
   dm_mention_threads: false       # Create thread when @mentioned in DM (default: false)
   max_message_length: 16000       # Outbound chunk size in chars (default: 16000, max: 65535)
+  allow_key_share: false          # false (own devices) | allowed-users (allowlist) | all (any device)
 ```
 
 Or via environment variables:
@@ -114,6 +115,7 @@ MATRIX_AUTO_THREAD=true
 MATRIX_DM_MENTION_THREADS=false
 MATRIX_REACTIONS=true          # default: true — emoji reactions during processing
 MATRIX_ALLOW_ROOM_MENTIONS=false
+MATRIX_ALLOW_KEY_SHARE=false   # false | allowed-users | all — honor "Request Key" for room keys
 ```
 
 :::tip Disabling reactions
@@ -459,6 +461,30 @@ If Hermes bootstraps a new Matrix recovery key, it never logs the raw key. Set
 `MATRIX_RECOVERY_KEY_OUTPUT_FILE=/secure/path/matrix-recovery-key.txt` before
 startup to write a generated key once with file mode `0600`; the file is not
 overwritten if it already exists.
+
+### Recovering undecryptable messages ("Request Key")
+
+When a client shows "no key to unlock this message", clicking **Request Key**
+sends an `m.room_key_request` to the sender. By default mautrix only answers
+key requests from the bot's *own* devices and silently drops requests from
+other users, so the button appears to do nothing. Opt in to cross-user key
+sharing to give yourself a working recovery path:
+
+```bash
+MATRIX_ALLOW_KEY_SHARE=allowed-users
+```
+
+or `matrix.allow_key_share` in `config.yaml`. Values:
+
+| Value | Behavior |
+|-------|----------|
+| `false` (default) | Own devices only — mautrix default. |
+| `allowed-users` | Honor key requests from `MATRIX_ALLOWED_USERS` and the bot's own user. |
+| `all` | Honor key requests from any non-blacklisted device (at `share_keys_min_trust`). |
+
+`allowed-users` is the recommended choice for a personal bot: it scopes
+recovery to the operator's own account (already trusted to trigger the agent)
+without exposing room keys to other users.
 
 :::warning[Deleting the crypto store]
 If you delete `~/.hermes/platforms/matrix/store/crypto.db`, the bot loses its encryption identity. Simply restarting with the same device ID will **not** fully recover — the homeserver still holds one-time keys signed with the old identity key, and peers cannot establish new Olm sessions.


### PR DESCRIPTION
## Problem

mautrix's `OlmMachine.allow_key_share` defaults to `default_allow_key_share`, which serves only the bot's *own* devices and silently drops `m.room_key_request` from any other user. Against a Hermes Matrix bot, this makes a client's "Request Key" button a guaranteed no-op — when a room key goes missing (e.g. after a crypto-store reset or an identity migration), the operator has no recovery path.

## Fix

Add `matrix.allow_key_share` (env `MATRIX_ALLOW_KEY_SHARE`), default `false`. When enabled, the adapter overrides `OlmMachine.allow_key_share` to honor key requests from any non-blacklisted device at or above `share_keys_min_trust` (UNVERIFIED), mirroring the existing permissive send policy (`send_keys_min_trust` is already UNVERIFIED). The bot's own current device is still excluded.

The default stays `false` so multi-user bots don't hand room keys to other users on request; the operator opts in.

## Changes

- `plugins/platforms/matrix/adapter.py`: read the flag, install the override in the crypto init path, map the YAML key.
- `website/docs/user-guide/messaging/matrix.md`: document the knob plus a "Recovering undecryptable messages" note.
- `tests/gateway/test_matrix_allow_key_share.py`: covers the YAML→env mapping and env precedence.

## Test plan

- `pytest tests/gateway/test_matrix_allow_key_share.py` — 5 passed.
- `pytest tests/gateway/test_matrix_allow_key_share.py tests/gateway/test_matrix_recovery_key_scope.py tests/gateway/test_matrix_plugin_setup.py tests/gateway/test_matrix_mention.py tests/gateway/test_matrix_crypto_store_per_profile.py` — 30 passed.
- Verified live: with `allow_key_share: true`, a client's "Request Key" recovered an encrypted room's history after a crypto-store reset.
