### PR TITLE
fix(launcher): fail clearly under unsupported Python

### DIFF
--- a/hermes
+++ b/hermes
@@ -6,6 +6,31 @@ This wrapper should behave like the installed `hermes` command, including
 subcommands such as `gateway`, `cron`, and `doctor`.
 """
 
+import os
+import sys
+
+
+def _ensure_supported_python() -> None:
+    """Keep direct source-tree launches on Hermes' supported interpreter."""
+    if sys.version_info >= (3, 11):
+        return
+
+    managed_python = os.path.join(os.path.dirname(__file__), "venv", "bin", "python")
+    if os.path.isfile(managed_python) and os.access(managed_python, os.X_OK):
+        os.execv(managed_python, [managed_python, __file__, *sys.argv[1:]])
+
+    version = f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    print(
+        "Hermes requires Python 3.11 or newer (and below 3.14); "
+        f"detected Python {version}. Install Hermes with its managed runtime "
+        "or run it with Python 3.11+.",
+        file=sys.stderr,
+    )
+    raise SystemExit(1)
+
+
+_ensure_supported_python()
+
 if __name__ == "__main__":
     from hermes_cli.main import main
     main()

--- a/tests/test_launcher_python_version.py
+++ b/tests/test_launcher_python_version.py
@@ -1,0 +1,36 @@
+"""Regression tests for the source-tree Hermes launcher."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import runpy
+import sys
+import types
+from collections import namedtuple
+from pathlib import Path
+
+import pytest
+
+
+LAUNCHER = Path(__file__).parents[1] / "hermes"
+
+
+def test_launcher_rejects_unsupported_python_before_cli_import(monkeypatch):
+    """Old interpreters get an actionable error instead of an annotation traceback."""
+    fake_cli = types.ModuleType("hermes_cli.main")
+    fake_cli.main = lambda: None
+    fake_package = types.ModuleType("hermes_cli")
+    fake_package.__path__ = []
+    monkeypatch.setitem(sys.modules, "hermes_cli", fake_package)
+    monkeypatch.setitem(sys.modules, "hermes_cli.main", fake_cli)
+    version_info = namedtuple("version_info", "major minor micro")
+    monkeypatch.setattr(sys, "version_info", version_info(3, 9, 21))
+
+    stderr = io.StringIO()
+    with pytest.raises(SystemExit) as exc_info, contextlib.redirect_stderr(stderr):
+        runpy.run_path(str(LAUNCHER), run_name="__main__")
+
+    assert exc_info.value.code == 1
+    assert "requires Python 3.11" in stderr.getvalue()
+    assert "detected Python 3.9.21" in stderr.getvalue()


### PR DESCRIPTION
## Summary

- Add an early Python-version guard to the repo-root `hermes` launcher.
- Re-exec under the checkout's managed `venv/bin/python` when available.
- Otherwise emit an actionable error before importing `hermes_cli.main`.
- Add a regression test for Python 3.9 startup.

This is related to #39536 and complements the existing launcher work in #98365. The Linux reproduction showed the same failure mode outside the desktop app: direct source-tree execution with Python 3.9 evaluates `str | None` and crashes during import.

## Root cause

The repository declares `requires-python = ">=3.11,<3.14"`, but the repo-root launcher uses `#!/usr/bin/env python3`. Direct execution can therefore select a system Python 3.9 before Hermes imports its application modules.

## Test plan

- `python -m py_compile hermes tests/test_launcher_python_version.py`
- Direct Python 3.9 simulation: passes with a clear non-zero error and no annotation traceback.
- `python hermes --help` under the host Python 3.9: passes the same clear guard.
- `python -m pytest -q tests/test_launcher_python_version.py` — not run successfully because pytest is not installed in this environment.
- `scripts/run_tests.sh` — not run successfully because the checkout has no test-enabled virtualenv.

## Scope

This PR intentionally changes only the repo-root launcher and its regression test. It does not change the supported Python range, installer dependencies, desktop Python discovery, or user configuration.

Related: #39536
