### PR TITLE
fix(discord): prevent typing indicator from sticking when HTTP request hangs

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -5604,6 +5604,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if chat_id in self._typing_tasks:
             return
 
+        task_ref: list = [None]
+
         async def _typing_loop() -> None:
             try:
                 while True:
@@ -5612,9 +5614,18 @@ class DiscordAdapter(BasePlatformAdapter):
                             "POST", "/channels/{channel_id}/typing",
                             channel_id=chat_id,
                         )
-                        await self._client.http.request(route)
+                        await asyncio.wait_for(
+                            self._client.http.request(route),
+                            timeout=10.0,
+                        )
                     except asyncio.CancelledError:
                         return
+                    except asyncio.TimeoutError:
+                        logger.debug(
+                            "Typing indicator HTTP request timed out for %s; will retry",
+                            chat_id,
+                        )
+                        continue
                     except Exception as e:
                         # Don't die on 429 — backoff and continue
                         retry_after = self._extract_discord_retry_after(e)
@@ -5635,9 +5646,13 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
             finally:
-                self._typing_tasks.pop(chat_id, None)
+                current = self._typing_tasks.get(chat_id)
+                if current is task_ref[0]:
+                    self._typing_tasks.pop(chat_id, None)
 
-        self._typing_tasks[chat_id] = asyncio.create_task(_typing_loop())
+        task = asyncio.create_task(_typing_loop())
+        task_ref[0] = task
+        self._typing_tasks[chat_id] = task
 
     async def stop_typing(self, chat_id: str) -> None:
         """Stop the persistent typing indicator for a channel."""
@@ -5645,8 +5660,8 @@ class DiscordAdapter(BasePlatformAdapter):
         if task:
             task.cancel()
             try:
-                await task
-            except (asyncio.CancelledError, Exception):
+                await asyncio.wait_for(task, timeout=5.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError, Exception):
                 pass
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary

- Wraps the `_typing_loop` HTTP request in `asyncio.wait_for(timeout=10)` so a hung `POST /channels/{id}/typing` no longer blocks the loop indefinitely
- Bounds `stop_typing`'s `await task` with a 5s timeout so a stuck loop can never block message delivery
- Identity-guards the `finally` cleanup so an old `_typing_loop` cannot remove a newer task's registry entry (prevents the orphan race where `stop_typing` loses track of a live loop)

Fixes #64874

## Test plan

- [ ] Verify typing indicator clears within seconds of agent response finishing under normal conditions
- [ ] Simulate a hanging HTTP request (e.g. mock `self._client.http.request` to block >10s) and confirm the loop retries instead of hanging
- [ ] Simulate the task-ownership race (cancel task A, create task B for same chat_id, let task A reach `finally`) and confirm B's entry is not removed
- [ ] Confirm `stop_typing` returns within ~5s even when the underlying task is stuck
- [ ] Run existing Discord gateway tests (`test_discord_send.py`, `test_keep_typing_timeout.py`)


Made with [Cursor](https://cursor.com)