### PR TITLE
fix(cli): route POST /api/profiles through the off-loop sweep

### DIFF
--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -815,7 +815,8 @@ async def create_profile_endpoint(body: ProfileCreate):
         clone = body.clone_from_default
         clone_from = "default" if clone else None
         clone_config = clone
-    try:
+
+    def _run():
         path = profiles_mod.create_profile(
             name=body.name,
             clone_from=clone_from,
@@ -837,75 +838,85 @@ async def create_profile_endpoint(body: ProfileCreate):
         collision = profiles_mod.check_alias_collision(body.name)
         if not collision:
             profiles_mod.create_wrapper_script(body.name)
+
+        # Optional explicit model assignment for the new profile. Best-effort:
+        # the profile already exists, so a model-write hiccup must not 500 the
+        # whole create — the user can set the model later from the Models page
+        # or `<profile> setup`.
+        provider = (body.provider or "").strip()
+        model = (body.model or "").strip()
+        model_set = False
+        if provider and model:
+            try:
+                _write_profile_model(path, provider, model)
+                model_set = True
+            except Exception:
+                _log.exception("Setting model for new profile %s failed", body.name)
+
+        # Optional MCP servers. Best-effort, same rationale as model assignment.
+        mcp_written = 0
+        if body.mcp_servers:
+            try:
+                mcp_written = _write_profile_mcp_servers(path, body.mcp_servers)
+            except Exception:
+                _log.exception("Writing MCP servers for new profile %s failed", body.name)
+
+        # Optional "keep" skill selection — replace semantics. When the builder
+        # sends an explicit keep list, disable every seeded skill not in it.
+        # Best-effort. Skipped when keep_skills is empty (legacy: keep the bundle).
+        skills_disabled = 0
+        if body.keep_skills:
+            try:
+                skills_disabled = _disable_unselected_skills(path, body.keep_skills)
+            except Exception:
+                _log.exception("Applying skill selection for new profile %s failed", body.name)
+
+        # Optional skills-hub installs. Spawned async, scoped to the new profile
+        # via `-p <name>` (a fresh subprocess re-binds skills_hub.SKILLS_DIR to the
+        # profile's HERMES_HOME at import). Returns PIDs for the UI to poll.
+        hub_installs: List[Dict[str, Any]] = []
+        for identifier in body.hub_skills:
+            ident = (identifier or "").strip()
+            if not ident:
+                continue
+            try:
+                proc = _spawn_hermes_action(
+                    ["-p", body.name, "skills", "install", ident, "--yes"],
+                    _hub_action_name("install", ident),
+                )
+                hub_installs.append({"identifier": ident, "pid": proc.pid})
+            except Exception:
+                _log.exception(
+                    "Spawning hub-skill install %s for new profile %s failed",
+                    ident,
+                    body.name,
+                )
+                hub_installs.append({"identifier": ident, "pid": None})
+
+        return {
+            "ok": True,
+            "name": body.name,
+            "path": str(path),
+            "model_set": model_set,
+            "mcp_written": mcp_written,
+            "skills_disabled": skills_disabled,
+            "hub_installs": hub_installs,
+        }
+
+    # The blocking work above (copytree-based create_profile, skill seeding,
+    # wrapper-script + model/MCP/skills-config writes, hub-install subprocess
+    # spawns) previously ran directly on the event loop — unlike every sibling
+    # profile-mutation endpoint in this router, all of which route their
+    # blocking work through run_in_threadpool. A profile create stalls every
+    # other concurrent request in the gateway process for as long as the
+    # copytree + writes take.
+    try:
+        return await run_in_threadpool(_run)
     except (ValueError, FileExistsError, FileNotFoundError) as e:
         raise HTTPException(status_code=400, detail=str(e))
     except Exception as e:
         _log.exception("POST /api/profiles failed")
         raise HTTPException(status_code=500, detail=str(e))
-
-    # Optional explicit model assignment for the new profile. Best-effort:
-    # the profile already exists, so a model-write hiccup must not 500 the
-    # whole create — the user can set the model later from the Models page
-    # or `<profile> setup`.
-    provider = (body.provider or "").strip()
-    model = (body.model or "").strip()
-    model_set = False
-    if provider and model:
-        try:
-            _write_profile_model(path, provider, model)
-            model_set = True
-        except Exception:
-            _log.exception("Setting model for new profile %s failed", body.name)
-
-    # Optional MCP servers. Best-effort, same rationale as model assignment.
-    mcp_written = 0
-    if body.mcp_servers:
-        try:
-            mcp_written = _write_profile_mcp_servers(path, body.mcp_servers)
-        except Exception:
-            _log.exception("Writing MCP servers for new profile %s failed", body.name)
-
-    # Optional "keep" skill selection — replace semantics. When the builder
-    # sends an explicit keep list, disable every seeded skill not in it.
-    # Best-effort. Skipped when keep_skills is empty (legacy: keep the bundle).
-    skills_disabled = 0
-    if body.keep_skills:
-        try:
-            skills_disabled = _disable_unselected_skills(path, body.keep_skills)
-        except Exception:
-            _log.exception("Applying skill selection for new profile %s failed", body.name)
-
-    # Optional skills-hub installs. Spawned async, scoped to the new profile
-    # via `-p <name>` (a fresh subprocess re-binds skills_hub.SKILLS_DIR to the
-    # profile's HERMES_HOME at import). Returns PIDs for the UI to poll.
-    hub_installs: List[Dict[str, Any]] = []
-    for identifier in body.hub_skills:
-        ident = (identifier or "").strip()
-        if not ident:
-            continue
-        try:
-            proc = _spawn_hermes_action(
-                ["-p", body.name, "skills", "install", ident, "--yes"],
-                _hub_action_name("install", ident),
-            )
-            hub_installs.append({"identifier": ident, "pid": proc.pid})
-        except Exception:
-            _log.exception(
-                "Spawning hub-skill install %s for new profile %s failed",
-                ident,
-                body.name,
-            )
-            hub_installs.append({"identifier": ident, "pid": None})
-
-    return {
-        "ok": True,
-        "name": body.name,
-        "path": str(path),
-        "model_set": model_set,
-        "mcp_written": mcp_written,
-        "skills_disabled": skills_disabled,
-        "hub_installs": hub_installs,
-    }
 
 
 @router.get("/api/profiles/active")

--- a/tests/hermes_cli/test_web_profiles_off_loop.py
+++ b/tests/hermes_cli/test_web_profiles_off_loop.py
@@ -420,3 +420,63 @@ def test_update_profile_model_runs_off_loop(client, monkeypatch, loop_probe):
 
     assert resp.status_code == 200, resp.text
     assert_off_loop(seen, "write_profile_model")
+
+
+# ── POST /api/profiles — copytree-based profile creation ─────────────────────
+
+
+def test_create_profile_runs_off_loop(client, monkeypatch, loop_probe, tmp_path):
+    seen, probe = loop_probe
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_create_profile(**kwargs):
+        probe("create_profile")
+        return tmp_path / "profiles" / kwargs["name"]
+
+    monkeypatch.setattr(profiles_mod, "create_profile", fake_create_profile)
+    monkeypatch.setattr(profiles_mod, "seed_profile_skills", lambda *a, **k: None)
+    # A collision short-circuits the wrapper-script write, keeping this test
+    # focused on the copytree-heavy create_profile() call.
+    monkeypatch.setattr(
+        profiles_mod, "check_alias_collision", lambda name: "reserved for the test"
+    )
+
+    resp = client.post("/api/profiles", json={"name": "newprof"})
+
+    assert resp.status_code == 200, resp.text
+    assert_off_loop(seen, "create_profile")
+
+
+def test_create_profile_does_not_block_the_dashboard(client, monkeypatch, tmp_path):
+    """``create_profile`` copytree()s a profile directory tree — the same
+    class of unbounded filesystem work as delete/rename, but unlike every
+    sibling profile-mutation endpoint it was never routed off the loop."""
+    from hermes_cli import profiles as profiles_mod
+
+    blocker = _Blocker(result=tmp_path / "profiles" / "newprof")
+    monkeypatch.setattr(profiles_mod, "create_profile", blocker)
+    monkeypatch.setattr(profiles_mod, "seed_profile_skills", lambda *a, **k: None)
+    monkeypatch.setattr(
+        profiles_mod, "check_alias_collision", lambda name: "reserved for the test"
+    )
+
+    assert_serves_concurrently(
+        client,
+        blocker,
+        lambda: client.post("/api/profiles", json={"name": "newprof"}),
+    )
+
+
+def test_create_profile_invalid_name_is_still_400(client, monkeypatch):
+    """``create_profile`` still runs its own validation inside the worker hop;
+    a ValueError from it must surface as a 400, not a 500."""
+    from hermes_cli import profiles as profiles_mod
+
+    def fake_create_profile(**kwargs):
+        raise ValueError("not a valid profile name")
+
+    monkeypatch.setattr(profiles_mod, "create_profile", fake_create_profile)
+
+    resp = client.post("/api/profiles", json={"name": "!!!"})
+
+    assert resp.status_code == 400, resp.text


### PR DESCRIPTION
## Summary

`create_profile_endpoint` (`POST /api/profiles`) was left out of the router's off-loop sweep completed in #101601 ("finish the dashboard profiles router off-loop sweep"). Every other profile-mutation endpoint in the same file — `delete_profile_endpoint`, `rename_profile_endpoint`, `update_profile_soul`, `update_profile_description_endpoint`, `update_profile_model_endpoint`, `describe_profile_auto_endpoint`, `export_profile_endpoint`, `import_profile_endpoint`, `get_profile_desktop_overlay` — already dispatches its blocking work through `run_in_threadpool`. Profile creation did not: `create_profile()` (a `shutil.copytree`-based clone for the common case), `seed_profile_skills()`, `check_alias_collision()` + `create_wrapper_script()`, and the best-effort model/MCP-servers/skills-config writes all still ran directly on the ASGI event loop.

While a create request is in flight, every other concurrent request in the dashboard/gateway process — including the `/api/ws` probes the desktop app and the dashboard's own Chat tab depend on — is stalled for as long as the clone + writes take.

## Fix

Wraps the entire handler body (the create call, its best-effort follow-ups, and the response dict construction) in a closure and dispatches it once via `await run_in_threadpool(_run)`, mirroring the exact pattern `delete_profile_endpoint`/`rename_profile_endpoint` already use in this file. The outer async function keeps the existing `(ValueError, FileExistsError, FileNotFoundError) → 400` / `Exception → 500` mapping unchanged, applied to whatever `_run()` raises.

No behavior change beyond where the blocking work executes — same request/response shape, same error codes.

## Verification

- Added `test_create_profile_runs_off_loop` and `test_create_profile_does_not_block_the_dashboard` to `tests/hermes_cli/test_web_profiles_off_loop.py`, mirroring the existing loop-probe / concurrency-proof pattern used for the other endpoints in that file. Added `test_create_profile_invalid_name_is_still_400` to confirm the exception-mapping behavior is unchanged.
- Mutation-verify: reverting the fix makes the concurrency-proof test fail with "a concurrent request waited 5.01s while the handler was busy" — confirms the test actually exercises the bug.
- `tests/hermes_cli/test_web_profiles_off_loop.py`: 21/21 pass.
- `tests/hermes_cli/test_web_server.py::TestNewEndpoints::test_profiles_create_builder_mcp_auth_is_profile_scoped` (the one existing test that exercises this endpoint end-to-end against the real, unmocked `create_profile()`): passes unchanged.
- Full `tests/hermes_cli/test_web_server.py`: 185 passed, 1 skipped — no regressions.

## Scope note

Two open PRs touch `create_profile_endpoint`'s body for unrelated concerns and don't conflict with this change: #86279 (credential-mirroring feature, inserts a new best-effort block inside the function) and #91381 (isolated-dashboard scoping, adds a single guard line at the top of the function). Both are additive/textually-adjacent rather than a semantic conflict with wrapping the body in a closure — a routine rebase either direction.

## Test plan

- [x] New off-loop + concurrency-proof + 400-mapping tests pass
- [x] Mutation-verify: fix reverted → concurrency-proof test fails as expected
- [x] Full `tests/hermes_cli/test_web_server.py` suite passes (185 passed, 1 skipped)
- [x] Existing `test_web_profiles_off_loop.py` suite passes (21/21)