### PR TITLE
fix(mcp): run death-supervisor updates off the shared MCP event loop

### DIFF
--- a/tests/tools/test_mcp_death_supervisor.py
+++ b/tests/tools/test_mcp_death_supervisor.py
@@ -677,6 +677,54 @@ def test_a_server_that_exited_is_released_on_teardown():
 
 
 @pytest.mark.skipif(not mcp_tool._MCP_AVAILABLE, reason="MCP SDK not installed")
+def test_register_and_unregister_run_off_the_mcp_event_loop():
+    """``_update_death_supervisor`` can spawn a subprocess (register, when no
+    supervisor is running yet) or block on ``proc.wait(timeout=5)`` releasing
+    one (unregister, when nothing is left to reap) -- both real blocking
+    work. It must not run directly on the shared MCP event loop, where every
+    other connected server's tool calls share that same loop -- the same
+    reasoning already applied to the orphan reaper a few lines above the
+    register call site in ``_run_stdio`` (``asyncio.to_thread(_kill_orphaned_
+    mcp_children)``).
+    """
+    fake = _FakeSupervisor()
+    seen: list = []
+    real = mcp_tool._update_death_supervisor
+
+    def probing(verb, pgids):
+        try:
+            asyncio.get_running_loop()
+            seen.append((verb, True))
+        except RuntimeError:
+            seen.append((verb, False))
+        return real(verb, pgids)
+
+    child = subprocess.Popen(_VICTIM, start_new_session=True)
+    try:
+        with (
+            patch("tools.mcp_tool._update_death_supervisor", probing),
+            _stdio_connection(child.pid, fake) as server,
+        ):
+
+            async def _connect_then_lose_the_child():
+                await server.start({"command": "echo", "args": ["hi"]})
+                child.kill()
+                child.wait(timeout=10)
+                await server.shutdown()
+
+            asyncio.run(_connect_then_lose_the_child())
+    finally:
+        _kill(child.pid)
+
+    assert ("register", False) in seen, (
+        f"register ran on the MCP event loop instead of a worker thread: {seen}"
+    )
+    assert ("unregister", False) in seen, (
+        f"unregister ran on the MCP event loop instead of a worker thread: {seen}"
+    )
+
+
+@pytest.mark.skipif(not mcp_tool._MCP_AVAILABLE, reason="MCP SDK not installed")
 def test_a_server_that_survived_teardown_stays_registered():
     # The case the whole module exists for: teardown did not manage to kill it.
     # Releasing it here would hand the orphan back to nobody.

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3665,8 +3665,14 @@ class MCPServerTask:
                     # descendants, e.g. mcp-remote's spawned `node` -- running
                     # forever. The graceful paths (MCPServerTask.shutdown,
                     # _kill_orphaned_mcp_children) still reap as before; this
-                    # only covers the case where they never get to run.
-                    _update_death_supervisor("register", new_pgids.values())
+                    # only covers the case where they never get to run. Run in
+                    # a worker thread like the orphan reaper above: spawning
+                    # the supervisor and waiting on its exit (release path)
+                    # are both blocking and would otherwise stall the shared
+                    # MCP event loop for every other connected server.
+                    await asyncio.to_thread(
+                        _update_death_supervisor, "register", new_pgids.values()
+                    )
                 # Track the spawned children on the connection object for
                 # fast-fail of in-flight calls when the subprocess dies
                 # (#81995).
@@ -3752,7 +3758,12 @@ class MCPServerTask:
                             dropped = _stdio_pgids.pop(pid, None)
                             if dropped is not None:
                                 released_pgids.append(dropped)
-                _update_death_supervisor("unregister", released_pgids)
+                # Same rationale as the register call above: this can spawn a
+                # supervisor or block on proc.wait(timeout=5) releasing one,
+                # so it must not run directly on the shared MCP event loop.
+                await asyncio.to_thread(
+                    _update_death_supervisor, "unregister", released_pgids
+                )
 
     # Content types a real MCP Streamable-HTTP endpoint may return on the
     # initial POST/GET. Anything else on a 2xx response means the URL is not


### PR DESCRIPTION
## Summary

`_update_death_supervisor()` (registers/unregisters a stdio MCP server's process group with the shared parent-death supervisor, added by #93517) does real blocking work:

- `_spawn_death_supervisor()` — `subprocess.Popen(...)`
- `proc.stdin.write()/flush()/close()`
- `proc.wait(timeout=5)`, when the last supervised group is released, to reap the supervisor rather than leave a ~15 MB zombie-prone process resident

Both call sites (register in the connect path, unregister in the disconnect/teardown path of `MCPServerTask._run_stdio()`) invoke it directly — no `await`, no executor — on the single shared `mcp-event-loop` thread. Every other connected MCP server's tool calls also run on that same loop (`_run_on_mcp_loop`, 9 call sites), so while this is in flight, the whole process's MCP layer stalls. Measured happy-path timing is small (~1ms spawn, ~40ms wait), but the worst case is bounded only by the 5 s timeout if the supervisor doesn't exit promptly.

This is the same class of bug the orphan reaper a few lines above the register call site was already fixed for, in the same function:

```python
# Run in a worker thread: the reaper blocks up to 2s (SIGTERM → wait →
# SIGKILL) when orphans exist, which would otherwise stall the shared
# MCP event loop.
await asyncio.to_thread(_kill_orphaned_mcp_children)
```

The death-supervisor calls, added by the same #93517 feature (and hardened through 4 further review rounds), never got the same treatment.

## Fix

Wraps both call sites in `await asyncio.to_thread(_update_death_supervisor, ...)`, mirroring the existing pattern verbatim. `_update_death_supervisor`'s own module-level lock (`_death_supervisor_lock`) already serializes concurrent callers regardless of which thread invokes it — it's the sole acquisition site for that lock — so this changes only where the blocking work executes, not its correctness.

## Verification

- Added `test_register_and_unregister_run_off_the_mcp_event_loop`, driving the real `MCPServerTask._run_stdio()` connect→lose-child→shutdown flow (the same harness `test_a_server_that_exited_is_released_on_teardown` uses) with a probe wrapper around `_update_death_supervisor` that records whether a running event loop is visible when it's called.
- Mutation-verify: reverting the fix makes the new test fail with `[('register', True), ('unregister', True)]` — both calls visibly on the event loop, confirming the test exercises the bug.
- `tests/tools/test_mcp_death_supervisor.py`: 34/34 pass.
- Full `tests/tools/test_mcp*.py` (63 files): 662 passed, no regressions.

## Scope note

Open PR #101979 ("reap stdio orphans mid-process", opened today) inserts an `if recorded_orphan: _maybe_start_orphan_janitor()` call immediately before the same `_update_death_supervisor("unregister", ...)` line this PR wraps. Different concern (starting a background janitor vs. dispatching this call off-loop) and no semantic conflict, but the two diffs are adjacent — a routine rebase either direction. It does not touch the register call site.

## Test plan

- [x] New off-loop regression test passes
- [x] Mutation-verify: fix reverted → new test fails as expected, both call sites shown running on the event loop
- [x] Full `tests/tools/test_mcp_death_supervisor.py` suite passes (34/34)
- [x] Full `tests/tools/test_mcp*.py` suite passes (662 passed)