### PR TITLE
fix(terminal): serialize list/dict terminal config values with json.dumps instead of str() (#101465)

### DIFF
--- a/tools/terminal_scope.py
+++ b/tools/terminal_scope.py
@@ -27,6 +27,7 @@ Two contracts distinguish this from a plain override dict:
 
 from __future__ import annotations
 
+import json
 import logging
 from contextlib import contextmanager
 from contextvars import ContextVar, Token
@@ -172,7 +173,10 @@ def build_profile_terminal_scope(hermes_home: "Any") -> Dict[str, str]:
 
         env_var = TERMINAL_CONFIG_ENV_MAP.get(cfg_key)
         if env_var:
-            scope[env_var] = str(value)
+            if isinstance(value, (list, dict)):
+                scope[env_var] = json.dumps(value)
+            else:
+                scope[env_var] = str(value)
 
     # 1) Defined defaults — the total baseline.
     for cfg_key, value in defaults.items():


### PR DESCRIPTION
Fixes #101465

**Problem:** `tools/terminal_scope.py` — `build_profile_terminal_scope()` serialized list and dict values from `config.yaml` `terminal:` section using `str()`, producing Python `repr` (e.g. `"['EMAIL_HOME_ADDRESS']"`) instead of valid JSON. Downstream `tools/terminal_tool.py` parses these with `json.loads()`, which fails on repr output. Result: any profile with `terminal.backend: docker` and list-valued keys (like `docker_forward_env`) served through the multiplexed unified dashboard loses terminal tool availability entirely.

**Fix:** Use `json.dumps()` for list/dict values, matching `hermes_cli/config.py::_terminal_env_value()`. Adds `import json` and branches in `_apply()`.

**Testing:**
- Manual reproduction with temp profile confirms scope now contains valid JSON and downstream `json.loads()` succeeds
- `tests/tools/test_terminal_scope_multiplex.py` — 8 passed
