### PR TITLE
fix(cli): warn when a web backend is missing from the install

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -308,8 +308,10 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
     rows: list[tuple[str, str, str]] = []
     try:
         from agent.web_search_registry import (
+            _read_config_key,
             get_active_extract_provider,
             get_active_search_provider,
+            get_provider,
         )
         from tools.web_tools import _ensure_web_plugins_loaded, _provider_is_ready
 
@@ -321,10 +323,26 @@ def _doctor_web_capability_rows() -> list[tuple[str, str, str]]:
     except Exception:
         return rows
 
-    for capability, getter in (
-        ("web search", get_active_search_provider),
-        ("web extract", get_active_extract_provider),
+    for capability, getter, config_keys in (
+        ("web search", get_active_search_provider, ("search_backend", "backend")),
+        ("web extract", get_active_extract_provider, ("extract_backend", "backend")),
     ):
+        configured = None
+        for key in config_keys:
+            configured = _read_config_key("web", key)
+            if configured:
+                break
+        if configured and get_provider(configured) is None:
+            # Explicit pick whose plugin is not in this tree (e.g. tavily
+            # dropped from a stable tag while config still names it, #101865).
+            rows.append(
+                (
+                    "warn",
+                    capability,
+                    f"({configured} selected; provider not in this install)",
+                )
+            )
+            continue
         try:
             provider = getter()
         except Exception:

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -88,6 +88,10 @@ class TestDoctorToolAvailabilitySummary:
 
         unavailable = _Unavailable()
         monkeypatch.setattr(
+            "agent.web_search_registry._read_config_key",
+            lambda *_path: None,
+        )
+        monkeypatch.setattr(
             "agent.web_search_registry.get_active_search_provider",
             lambda: unavailable,
         )
@@ -101,6 +105,30 @@ class TestDoctorToolAvailabilitySummary:
         assert all(status == "warn" for status, _, _ in rows)
         assert any("firecrawl selected; provider not configured" in detail for _, _, detail in rows)
 
+    def test_web_capability_rows_warn_when_configured_provider_missing_from_install(
+        self, monkeypatch
+    ):
+        """#101865: web.search_backend names a plugin this tree does not ship."""
+        monkeypatch.setattr(
+            "agent.web_search_registry._read_config_key",
+            lambda *path: "tavily" if path[-1] in ("search_backend", "extract_backend", "backend") else None,
+        )
+        monkeypatch.setattr("agent.web_search_registry.get_provider", lambda _name, **_kw: None)
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_search_provider",
+            lambda: None,
+        )
+        monkeypatch.setattr(
+            "agent.web_search_registry.get_active_extract_provider",
+            lambda: None,
+        )
+
+        rows = doctor._doctor_web_capability_rows()
+
+        assert rows
+        assert all(status == "warn" for status, _, _ in rows)
+        assert any("tavily selected; provider not in this install" in detail for _, _, detail in rows)
+
     def test_web_capability_rows_ok_when_provider_ready(self, monkeypatch):
         class _Ready:
             name = "ddgs"
@@ -109,6 +137,10 @@ class TestDoctorToolAvailabilitySummary:
                 return True
 
         ready = _Ready()
+        monkeypatch.setattr(
+            "agent.web_search_registry._read_config_key",
+            lambda *_path: None,
+        )
         monkeypatch.setattr(
             "agent.web_search_registry.get_active_search_provider",
             lambda: ready,


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` reports web search/extract readiness from the active provider. When `web.search_backend` (or `extract_backend`) names a plugin this install does not ship — the v2026.8.31 tag dropped `plugins/web/tavily/` while configs still pointed at it — the row read as "no provider selected or registered" and looked healthy next to everything else.

If the configured name is not in the registry, doctor now warns:

```
(tavily selected; provider not in this install)
```

This does not restore the missing plugin on old tags. It makes the misconfig visible.

## Related Issue

Fixes #101865

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/doctor.py` — `_doctor_web_capability_rows` checks `_read_config_key` against `get_provider` before the active-provider rows
- `tests/hermes_cli/test_doctor.py` — missing-from-install warn; existing getter-path tests pin `_read_config_key` to None so a local config cannot steal the path

## How to Test

```
cd <worktree>
uv run --extra dev python -m pytest tests/hermes_cli/test_doctor.py -q
# 71 passed
```

Not runtime-tested against a v2026.8.31 checkout. Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
