### PR TITLE
fix(desktop): dim unfocused panes without a grayscale filter

### DIFF
--- a/apps/desktop/src/styles-unfocused.test.ts
+++ b/apps/desktop/src/styles-unfocused.test.ts
@@ -1,6 +1,7 @@
 import { readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
+
 import { describe, expect, it } from 'vitest'
 
 const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'styles.css'), 'utf8')

--- a/apps/desktop/src/styles-unfocused.test.ts
+++ b/apps/desktop/src/styles-unfocused.test.ts
@@ -1,0 +1,15 @@
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { describe, expect, it } from 'vitest'
+
+const css = readFileSync(join(dirname(fileURLToPath(import.meta.url)), 'styles.css'), 'utf8')
+
+describe('unfocused chat surface (#101890)', () => {
+  it('dims with opacity and does not grayscale the streaming layer', () => {
+    const block = css.split('[data-chat-surface][data-chat-unfocused]')[1]?.split('[data-chat-surface]')[0] ?? ''
+
+    expect(block).toContain('opacity: var(--chat-unfocused-opacity)')
+    expect(block).not.toContain('grayscale')
+  })
+})

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -1705,8 +1705,8 @@ body.guest-pointer-lock :is(webview, iframe) {
   /* Unfocused chat surface (multi-pane): a pane the user isn't in recedes so
      the focused conversation reads as the one being worked in. Light needs a
      deeper cut — a dim over a bright surface loses contrast far more slowly
-     than the same dim over a dark one. Pairs with a grayscale pass on the same
-     element — one treatment for the whole pane, not per-part tuning. */
+     than the same dim over a dark one. Opacity only — a grayscale filter on
+     this layer re-filters on every streamed token and flashes the pane (#101890). */
   --chat-unfocused-opacity: 0.62;
 }
 
@@ -1716,18 +1716,13 @@ body.guest-pointer-lock :is(webview, iframe) {
 }
 
 /* The whole surface recedes as ONE layer — thread, timeline rail, composer,
-   header — fading and desaturating together rather than each part taking its
-   own treatment. Both properties on the surface root also composite the
-   already-painted layer instead of repainting descendants. */
+   header — fading together rather than each part taking its own treatment. */
 [data-chat-surface][data-chat-unfocused] {
   opacity: var(--chat-unfocused-opacity);
-  filter: grayscale(1);
 }
 
 [data-chat-surface] {
-  transition:
-    opacity 75ms ease-out,
-    filter 75ms ease-out;
+  transition: opacity 75ms ease-out;
 }
 
 /* Drag-region hatch — a diagonal ///// pattern (Photoshop-style) that fades into


### PR DESCRIPTION
## What does this PR do?

Unfocused split-session panes use both opacity and `filter: grayscale(1)` on `[data-chat-surface]`. A live transcript re-paints on every streamed token; Chromium re-filters the whole surface and the pane flashes.

Drop the grayscale filter (and its transition). Opacity still recedes the unfocused pane.

Reproduced in the issue by patching only the filter off; flashing stopped, focus distinction stayed.

## Related Issue

Fixes #101890

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/styles.css` — unfocused surface is opacity-only
- `apps/desktop/src/styles-unfocused.test.ts` — asserts the unfocused block has opacity and no grayscale

## How to Test

```
cd apps/desktop
npx vitest run src/styles-unfocused.test.ts
# 1 passed
```

Not runtime-tested in the packaged Desktop on macOS (the reporter's setup). Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
