### PR TITLE
fix(desktop): open plugin pages as tiles instead of replacing chat

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4157,6 +4157,39 @@ describe('selectSidebarItem', () => {
     expect(noteActiveTreeGroup).toHaveBeenCalledWith(null)
     expect(revealTreePane).toHaveBeenCalledWith('workspace')
   })
+
+  it('opens contributed plugin pages as closable tiles instead of replacing chat (#101593)', async () => {
+    const { registry } = await import('@/contrib/registry')
+    const { $routeTiles } = await import('@/store/route-tiles')
+    const dispose = registry.register({
+      id: 'page',
+      area: 'routes',
+      source: 'plugin:kanban',
+      data: { path: '/kanban' },
+      render: () => null
+    })
+
+    const navigate = vi.fn()
+    const requestGateway = vi.fn(async () => ({}) as never)
+    let handle: HarnessHandle | null = null
+
+    render(<Harness navigate={navigate} onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    $routeTiles.set([])
+    act(() => {
+      handle!.selectSidebarItem({
+        icon: (() => null) as never,
+        id: 'kanban',
+        label: 'Kanban',
+        route: '/kanban'
+      })
+    })
+
+    expect(navigate).not.toHaveBeenCalled()
+    expect($routeTiles.get().some(tile => tile.path === '/kanban')).toBe(true)
+    dispose()
+  })
 })
 
 const mockDeleteSession = vi.mocked(deleteSession)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -51,6 +51,7 @@ import {
 } from '@/store/profile'
 import { $projectScope, resolveNewSessionCwd } from '@/store/projects'
 import { setApprovalRequest } from '@/store/prompts'
+import { openRouteTile } from '@/store/route-tiles'
 import { clearStoredTranscriptReadOnly, markStoredTranscriptReadOnly } from '@/store/read-only-transcript'
 import {
   $activeSessionStoredIdRotation,
@@ -131,7 +132,7 @@ import {
 import { isWatchWindow } from '@/store/windows'
 import type { SessionCreateResponse, SessionMessage, SessionResumeResponse, UsageStats } from '@/types/hermes'
 
-import { navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
+import { contributedRoutes, navigateToWorkspacePage, NEW_CHAT_ROUTE, sessionRoute, SETTINGS_ROUTE } from '../../../routes'
 import type { ClientSessionState, SidebarNavItem } from '../../../types'
 import { sessionContextDrift } from '../session-context-drift'
 import { singleFlightSessionResume } from '../use-prompt-actions/single-flight-resume'
@@ -712,6 +713,15 @@ export function useSessionActions({
       }
 
       if (item.route) {
+        // Plugin pages (Kanban, …) open as closable tiles beside the live
+        // chat. Navigating the workspace to them hid the Bot Chat with no
+        // back path (#101593). Built-in rows (Capabilities/…) stay full-page.
+        if (contributedRoutes().some(route => route.path === item.route)) {
+          openRouteTile(item.route)
+
+          return
+        }
+
         navigateToWorkspacePage(navigate, item.route)
       }
     },

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -51,8 +51,8 @@ import {
 } from '@/store/profile'
 import { $projectScope, resolveNewSessionCwd } from '@/store/projects'
 import { setApprovalRequest } from '@/store/prompts'
-import { openRouteTile } from '@/store/route-tiles'
 import { clearStoredTranscriptReadOnly, markStoredTranscriptReadOnly } from '@/store/read-only-transcript'
+import { openRouteTile } from '@/store/route-tiles'
 import {
   $activeSessionStoredIdRotation,
   $connection,

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -201,6 +201,26 @@ describe('host.navigate contributed plugin pages (#101593)', () => {
     dispose()
   })
 
+  it('strips query and hash before matching a contributed path', async () => {
+    const { registry } = await import('@/contrib/registry')
+    const { $routeTiles } = await import('@/store/route-tiles')
+    const dispose = registry.register({
+      id: 'page',
+      area: 'routes',
+      source: 'plugin:kanban',
+      data: { path: '/kanban' },
+      render: () => null
+    })
+
+    $routeTiles.set([])
+    window.location.hash = '#/'
+    host.navigate('/kanban?board=ops#top')
+
+    expect($routeTiles.get().some(tile => tile.path === '/kanban')).toBe(true)
+    expect(window.location.hash).toBe('#/')
+    dispose()
+  })
+
   it('still hash-navigates built-in workspace pages', () => {
     window.location.hash = '#/'
     host.navigate('/skills')

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -174,6 +174,40 @@ describe('host.connections', () => {
   })
 })
 
+describe('host.navigate contributed plugin pages (#101593)', () => {
+  afterEach(async () => {
+    const { $routeTiles } = await import('@/store/route-tiles')
+    $routeTiles.set([])
+    window.location.hash = ''
+  })
+
+  it('opens a contributed route as a tile instead of replacing the workspace hash', async () => {
+    const { registry } = await import('@/contrib/registry')
+    const { $routeTiles } = await import('@/store/route-tiles')
+    const dispose = registry.register({
+      id: 'page',
+      area: 'routes',
+      source: 'plugin:kanban',
+      data: { path: '/kanban' },
+      render: () => null
+    })
+
+    $routeTiles.set([])
+    window.location.hash = '#/'
+    host.navigate('/kanban')
+
+    expect($routeTiles.get().some(tile => tile.path === '/kanban')).toBe(true)
+    expect(window.location.hash).toBe('#/')
+    dispose()
+  })
+
+  it('still hash-navigates built-in workspace pages', () => {
+    window.location.hash = '#/'
+    host.navigate('/skills')
+    expect(window.location.hash).toBe('#/skills')
+  })
+})
+
 describe('host workspace scope', () => {
   afterEach(async () => {
     host.setWorkspaceScope('sessions')

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -23,6 +23,7 @@ import type { ReactNode } from 'react'
 
 import { PRIMARY_SESSION_VIEW } from '@/app/chat/session-view'
 import { openSession, type OpenSessionIntent } from '@/app/open-session'
+import { contributedRoutes } from '@/app/routes'
 import type { ClientSessionState } from '@/app/types'
 import {
   $narrowViewport,
@@ -55,6 +56,7 @@ import {
   retireLocalProfileGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
+import { openRouteTile } from '@/store/route-tiles'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -637,8 +639,19 @@ export const host = {
   /** Tail an app log file (`agent` / `errors` / `gateway` / `gui` / …). */
   logs: async (...args: Parameters<typeof getLogs>) => getLogs(...args),
 
-  /** Navigate the app router (hash routes, e.g. '/command-center?section=system'). */
+  /** Navigate the app router (hash routes, e.g. '/command-center?section=system').
+   *  Contributed plugin pages open as route tiles so they don't replace the
+   *  live Bot Chat (#101593). */
   navigate: (path: string) => {
+    const raw = path.startsWith('#') ? path.slice(1) : path
+    const pathname = raw.split(/[?#]/, 1)[0] || raw
+
+    if (contributedRoutes().some(route => route.path === pathname)) {
+      openRouteTile(pathname)
+
+      return
+    }
+
     window.location.hash = path.startsWith('#') ? path : `#${path}`
   },
 

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -644,7 +644,7 @@ export const host = {
    *  live Bot Chat (#101593). */
   navigate: (path: string) => {
     const raw = path.startsWith('#') ? path.slice(1) : path
-    const pathname = raw.split(/[?#]/, 1)[0] || raw
+    const pathname = raw.split(/[?#]/)[0] || raw
 
     if (contributedRoutes().some(route => route.path === pathname)) {
       openRouteTile(pathname)

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -56,7 +56,6 @@ import {
   retireLocalProfileGateways
 } from '@/store/gateway'
 import { notify, notifyError } from '@/store/notifications'
-import { openRouteTile } from '@/store/route-tiles'
 import {
   $activeGatewayProfile,
   $gatewaySwapTarget,
@@ -72,6 +71,7 @@ import {
   setActiveProfile,
   setShowAllProfiles
 } from '@/store/profile'
+import { openRouteTile } from '@/store/route-tiles'
 import {
   $activeSessionId,
   $connection,


### PR DESCRIPTION
## What does this PR do?

Opening Kanban from Bot Chat used workspace hash navigation (`host.navigate('/kanban')` and the sidebar row). Kanban is a contributed plugin page, so that replaced the live chat with a workspace page that has no back path and no close control.

Contributed routes now open as route tiles (`openRouteTile`), the same closable pane already used for split pages. Built-in rows (Capabilities, …) still navigate as full workspace pages. Closing the tile leaves the Bot Chat in place.

## Related Issue

Fixes #101593

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/sdk/index.ts` — `host.navigate` opens contributed paths as tiles
- `apps/desktop/src/app/session/hooks/use-session-actions/index.ts` — sidebar contributed rows use `openRouteTile`
- `apps/desktop/src/sdk/index.test.ts` — navigate `/kanban` does not replace the hash; `/skills` still does
- `apps/desktop/src/app/session/hooks/use-session-actions.test.tsx` — selectSidebarItem for `/kanban` does not call `navigate`

## How to Test

```
cd apps/desktop
npx vitest run src/app/session/hooks/use-session-actions.test.tsx src/sdk/index.test.ts
# 111 passed
npx tsc --noEmit -p tsconfig.json
# clean
```

Not runtime-tested by clicking Kanban in a packaged Desktop. Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
