### PR TITLE
fix(desktop): load reasoning effort from the Applies-to profile

### DIFF
--- a/apps/desktop/src/app/settings/model-settings.test.tsx
+++ b/apps/desktop/src/app/settings/model-settings.test.tsx
@@ -38,8 +38,8 @@ vi.mock('@/hermes', () => ({
   getRecommendedDefaultModel: (slug: string) => getRecommendedDefaultModel(slug),
   saveMoaModels: (body: unknown) => saveMoaModels(body),
   setEnvVar: (key: string, value: string) => setEnvVar(key, value),
-  getHermesConfigRecord: () => getHermesConfigRecord(),
-  saveHermesConfig: (config: unknown) => saveHermesConfig(config),
+  getHermesConfigRecord: (profile?: string) => getHermesConfigRecord(profile),
+  saveHermesConfig: (config: unknown, profile?: string) => saveHermesConfig(config, profile),
   setApiRequestProfile: () => {}
 }))
 
@@ -122,6 +122,19 @@ describe('ModelSettings profile scope', () => {
     expect(getGlobalModelOptions).toHaveBeenCalledWith(undefined, 'research')
     expect(getAuxiliaryModels).toHaveBeenCalledWith('research')
     expect(getMoaModels).toHaveBeenCalledWith('research')
+  })
+
+  it('loads reasoning_effort from the scoped profile config (#100732)', async () => {
+    getHermesConfigRecord.mockImplementation(async (profile?: string) => ({
+      agent: {
+        reasoning_effort: profile === 'research' ? 'high' : 'medium',
+        service_tier: 'normal'
+      }
+    }))
+    await renderModelSettings('research')
+
+    await waitFor(() => expect(getHermesConfigRecord).toHaveBeenCalledWith('research'))
+    await waitFor(() => expect(screen.getAllByRole('combobox')[2].textContent).toContain('High'))
   })
 })
 
@@ -295,7 +308,8 @@ describe('ModelSettings', () => {
 
     await waitFor(() =>
       expect(saveHermesConfig).toHaveBeenCalledWith(
-        expect.objectContaining({ agent: expect.objectContaining({ service_tier: 'fast' }) })
+        expect.objectContaining({ agent: expect.objectContaining({ service_tier: 'fast' }) }),
+        undefined
       )
     )
   })


### PR DESCRIPTION
## What does this PR do?

Switching the settings "Applies to" chip must re-read that profile's `agent.reasoning_effort`. Production already keys `useHermesConfigRecord(scopeProfile)` and remounts `ConfigSettings` on the chip. The ModelSettings test mock dropped the profile argument (`() => getHermesConfigRecord()`), so a stale dropdown could regress without the suite noticing, and a scoped save looked like a single-arg call.

The mock now forwards `profile`. A test renders ModelSettings with `scopeProfile='research'`, stubs high vs medium by that argument, and asserts the Reasoning combobox shows High.

## Related Issue

Related #100732 — this PR is a test pin only. Production chip/cache is #97530.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/settings/model-settings.test.tsx` — forward `profile` on `getHermesConfigRecord` / `saveHermesConfig`; assert the scoped reasoning value

## How to Test

```
cd apps/desktop
npx vitest run src/app/settings/model-settings.test.tsx
# 25 passed
```

Did not run full `pytest tests/ -q`. Not runtime-tested against two live profile config.yaml files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

