### PR TITLE
fix(desktop): keep split transcripts across gateway-list wipes

### DIFF
--- a/apps/desktop/src/store/gateway-switch.test.ts
+++ b/apps/desktop/src/store/gateway-switch.test.ts
@@ -5,19 +5,23 @@ import {
   $activeSessionId,
   $cronSessions,
   $freshDraftReady,
+  $messages,
   $messagingSessions,
+  $selectedStoredSessionId,
   $sessionProfilesTruncated,
   $sessions,
   $sessionsLoading,
   setActiveSessionId,
   setCronSessions,
   setFreshDraftReady,
+  setMessages,
   setMessagingSessions,
+  setSelectedStoredSessionId,
   setSessionProfilesTruncated,
   setSessions,
   setSessionsLoading
 } from '@/store/session'
-import { $stalledSessionIds } from '@/store/session-states'
+import { $sessionTiles, $stalledSessionIds } from '@/store/session-states'
 
 import {
   $gatewaySwitching,
@@ -62,6 +66,10 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     setCronSessions([])
     setMessagingSessions([])
     $stalledSessionIds.set([])
+    $sessionTiles.set([])
+    setMessages([])
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
     setSessionsLoading(true)
     $gatewaySwitching.set(false)
   })
@@ -86,6 +94,22 @@ describe('wipeSessionListsForGatewaySwitch', () => {
     wipeSessionListsForGatewaySwitch()
 
     expect(invalidateProfileListFetches).toHaveBeenCalled()
+  })
+
+  it('keeps open split-pane transcripts when session tiles are mounted (#100675)', () => {
+    setActiveSessionId('rt-primary')
+    setSelectedStoredSessionId('stored-primary')
+    setMessages([{ id: 'keep-me', parts: [], role: 'user', timestamp: 0 } as never])
+    $sessionTiles.set([{ runtimeId: 'rt-tile', storedSessionId: 'stored-tile' }])
+
+    wipeSessionListsForGatewaySwitch()
+
+    expect($sessions.get()).toEqual([])
+    expect($sessionsLoading.get()).toBe(true)
+    expect($activeSessionId.get()).toBe('rt-primary')
+    expect($selectedStoredSessionId.get()).toBe('stored-primary')
+    expect($messages.get()).toEqual([{ id: 'keep-me', parts: [], role: 'user', timestamp: 0 }])
+    expect($freshDraftReady.get()).toBe(false)
   })
 })
 

--- a/apps/desktop/src/store/gateway-switch.ts
+++ b/apps/desktop/src/store/gateway-switch.ts
@@ -24,7 +24,7 @@ import {
   setSessionsLoading
 } from '@/store/session'
 import { resetSessionPinMirror } from '@/store/session-pin-sync'
-import { clearAllSessionStates } from '@/store/session-states'
+import { $sessionTiles, clearAllSessionStates } from '@/store/session-states'
 import { clearTranscriptTails } from '@/store/transcript-tail-cache'
 
 // True while a connection switch is mid-flight — a Settings → Gateway apply
@@ -212,19 +212,23 @@ export function wipeSessionListsForGatewaySwitch(): void {
   setSessionsLoading(true)
   resetSessionsLimit()
 
-  setActiveSessionId(null)
-  setSelectedStoredSessionId(null)
-  setMessages([])
-  setFreshDraftReady(true)
+  const keepSplitTranscripts = $sessionTiles.get().length > 0
+
+  // Split panes keep their own session tiles. Clearing the primary transcript
+  // here empties the unfocused pane on every backend warm (Bots page visit)
+  // and it rebuilds on a ~5s loop (#100675). A true source switch with no
+  // extra tiles still wipes in place.
+  if (!keepSplitTranscripts) {
+    setActiveSessionId(null)
+    setSelectedStoredSessionId(null)
+    setMessages([])
+    setFreshDraftReady(true)
+    clearTranscriptTails()
+  }
 
   // Artifacts are keyed by sessions on the previous backend, so both the
   // registry and any rail tab pointing into it go with them.
   clearArtifactRegistry()
-
-  // Cached transcript tails belong to the PREVIOUS backend's sessions; a
-  // different backend can recycle stored ids, and painting another machine's
-  // conversation under a same-named id is worse than a loader. Wipe them.
-  clearTranscriptTails()
 
   // Narrowed: account/marketplace/onboarding caches are global, not gateway-
   // scoped, so a mode swap must not refetch them.


### PR DESCRIPTION
## What does this PR do?

Visiting Bots with a split chat layout can warm other profile backends. Each warm still runs `wipeSessionListsForGatewaySwitch()`, which did `setMessages([])` / `setActiveSessionId(null)` / `clearTranscriptTails()`. The unfocused pane dropped to the empty splash and re-hydrated on the ~5s background poll.

When `$sessionTiles` is non-empty, skip the in-place transcript wipe. Sidebar lists still clear so skeletons retrigger. A true source switch with no extra tiles still empties in place.

## Related Issue

Fixes #100675

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/gateway-switch.ts` — keep primary transcript/ids when session tiles exist
- `apps/desktop/src/store/gateway-switch.test.ts` — split-pane path keeps `$messages` / `$activeSessionId`; lists still wipe

## How to Test

```
cd apps/desktop
npx vitest run src/store/gateway-switch.test.ts
# 13 passed
npx tsc --noEmit -p tsconfig.json
# clean
```

Not runtime-tested by visiting Bots with two live panes. Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
