### PR TITLE
fix(kanban): validate Telegram topic before wake-only delivery

### DIFF
--- a/gateway/kanban_watchers.py
+++ b/gateway/kanban_watchers.py
@@ -1024,6 +1024,62 @@ class GatewayKanbanWatchersMixin:
                             # by the best-effort except below) permanently
                             # lose the event. Mirrors the non-push
                             # (api_server) self-post ordering above.
+                            #
+                            # Some push adapters can validate the exact
+                            # destination without posting a message. Do that
+                            # before wake injection: handle_message() only
+                            # proves the agent started, not that its eventual
+                            # progress/final replies can reach the subscribed
+                            # chat/topic.
+                            _probe_route = getattr(adapter, "probe_delivery_route", None)
+                            if callable(_probe_route):
+                                try:
+                                    _probe_res = await _probe_route(
+                                        sub["chat_id"], metadata=metadata,
+                                    )
+                                except Exception as _probe_err:
+                                    logger.warning(
+                                        "kanban notifier: route probe raised for %s on %s; "
+                                        "retaining subscription for retry: %s",
+                                        sub["task_id"], platform_str, _probe_err,
+                                        exc_info=True,
+                                    )
+                                    _probe_res = None
+
+                                if getattr(_probe_res, "success", False) is False:
+                                    fails = sub_fail_counts.get(sub_key, 0) + 1
+                                    sub_fail_counts[sub_key] = fails
+                                    error_kind = getattr(
+                                        _probe_res, "error_kind", None
+                                    ) or "transient"
+                                    retryable = bool(
+                                        getattr(_probe_res, "retryable", True)
+                                    )
+                                    permanent = (
+                                        not retryable
+                                        and error_kind in {"forbidden", "not_found"}
+                                    )
+                                    logger.warning(
+                                        "kanban notifier: wake-only route probe failed "
+                                        "for %s on %s (kind=%s, attempt %d/%d)",
+                                        sub["task_id"], platform_str, error_kind,
+                                        fails, MAX_SEND_FAILURES,
+                                    )
+                                    if permanent or fails >= MAX_SEND_FAILURES:
+                                        await _to_thread_process_service(
+                                            self._kanban_unsub, sub, board_slug,
+                                        )
+                                        sub_fail_counts.pop(sub_key, None)
+                                    else:
+                                        await _to_thread_process_service(
+                                            self._kanban_rewind,
+                                            sub,
+                                            d["cursor"],
+                                            d.get("old_cursor", 0),
+                                            board_slug,
+                                        )
+                                    continue
+
                             try:
                                 await _push_wake()
                                 sub_fail_counts.pop(sub_key, None)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2754,6 +2754,7 @@ _SUBCHAT_NOT_FOUND_SUBSTRINGS = (
     "message to edit not found",
     "message to reply not found",
     "thread not found",
+    "topic_closed",
     "topic_deleted",
     "message_id_invalid",
 )

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -8714,6 +8714,55 @@ class TelegramAdapter(BasePlatformAdapter):
         self._telegram_typing_cooldown_until.pop(str(chat_id), None)
         return False
 
+    async def probe_delivery_route(
+        self,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Validate an exact Telegram chat/topic route without posting a message.
+
+        ``sendChatAction`` exercises the same chat and ``message_thread_id``
+        routing that a later response will use, while creating no durable
+        message.  Unlike :meth:`send_typing`, this probe deliberately does not
+        fall back outside the requested topic: a closed/missing topic must be
+        surfaced to callers before they wake an agent into that dead route.
+        """
+        if not self._bot:
+            return SendResult(
+                success=False,
+                error="Telegram bot is not connected",
+                retryable=True,
+                error_kind="transient",
+            )
+
+        try:
+            thread_id = self._metadata_thread_id(metadata)
+            message_thread_id = self._message_thread_id_for_typing(thread_id)
+        except (TypeError, ValueError):
+            return SendResult(
+                success=False,
+                error="Invalid Telegram thread route",
+                retryable=False,
+                error_kind="not_found",
+            )
+
+        try:
+            await self._bot.send_chat_action(
+                chat_id=normalize_telegram_chat_id(chat_id),
+                action="typing",
+                message_thread_id=message_thread_id,
+            )
+            return SendResult(success=True)
+        except Exception as exc:
+            error = _redact_telegram_error_text(exc)
+            error_kind = classify_send_error(exc, error)
+            return SendResult(
+                success=False,
+                error=error,
+                retryable=error_kind not in {"forbidden", "not_found"},
+                error_kind=error_kind,
+            )
+
     async def send_typing(self, chat_id: str, metadata: Optional[Dict[str, Any]] = None) -> None:
         """Send typing indicator."""
         if not self._bot or self._typing_in_cooldown(chat_id):

--- a/tests/gateway/test_kanban_notifier_wake_only_ordering.py
+++ b/tests/gateway/test_kanban_notifier_wake_only_ordering.py
@@ -13,6 +13,7 @@ Residual insight extracted from closed PR #84191 (@MaximCrabbe).
 import asyncio
 
 from gateway.config import Platform
+from gateway.platforms.base import SendResult
 from gateway.run import GatewayRunner
 from hermes_cli import kanban_db as kb
 
@@ -39,6 +40,32 @@ class FailingWakeAdapter(RecordingAdapter):
         raise RuntimeError("simulated wake failure")
 
 
+class InvalidRouteAdapter(RecordingAdapter):
+    def __init__(self):
+        super().__init__()
+        self.probes = []
+
+    async def probe_delivery_route(self, chat_id, metadata=None):
+        self.probes.append({"chat_id": chat_id, "metadata": metadata or {}})
+        return SendResult(
+            success=False,
+            error="closed topic",
+            retryable=False,
+            error_kind="not_found",
+        )
+
+
+class TransientRouteAdapter(InvalidRouteAdapter):
+    async def probe_delivery_route(self, chat_id, metadata=None):
+        self.probes.append({"chat_id": chat_id, "metadata": metadata or {}})
+        return SendResult(
+            success=False,
+            error="temporary network failure",
+            retryable=True,
+            error_kind="transient",
+        )
+
+
 async def _run_one_notifier_tick(monkeypatch, runner):
     real_sleep = asyncio.sleep
 
@@ -61,7 +88,7 @@ def _make_runner(adapter):
     return runner
 
 
-def _make_completed_task(delivery_mode):
+def _make_completed_task(delivery_mode, thread_id=None):
     conn = kb.connect()
     try:
         tid = kb.create_task(
@@ -75,6 +102,7 @@ def _make_completed_task(delivery_mode):
             task_id=tid,
             platform="telegram",
             chat_id="chat-1",
+            thread_id=thread_id,
             chat_type="dm",
             delivery_mode=delivery_mode,
         )
@@ -84,7 +112,7 @@ def _make_completed_task(delivery_mode):
         conn.close()
 
 
-def _unseen_terminal_events(tid):
+def _unseen_terminal_events(tid, thread_id=None):
     conn = kb.connect()
     try:
         _, events = kb.unseen_events_for_sub(
@@ -92,6 +120,7 @@ def _unseen_terminal_events(tid):
             task_id=tid,
             platform="telegram",
             chat_id="chat-1",
+            thread_id=thread_id,
             kinds=["completed", "blocked", "gave_up", "crashed", "timed_out"],
         )
         return events
@@ -200,3 +229,44 @@ def test_wake_only_failure_cap_drops_subscription(tmp_path, monkeypatch):
     assert runner._kanban_sub_fail_counts == {}, (
         "counter entry must clear when the subscription is dropped"
     )
+
+
+def test_wake_only_permanent_invalid_route_unsubscribes_without_wake(
+    tmp_path, monkeypatch,
+):
+    """A closed topic is removed before an agent can reply into it."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-closed.db"))
+    kb.init_db()
+    tid = _make_completed_task("wake", thread_id="10728")
+
+    adapter = InvalidRouteAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert adapter.probes == [
+        {"chat_id": "chat-1", "metadata": {"thread_id": "10728"}},
+    ]
+    assert adapter.handled == []
+    assert adapter.sent == []
+    assert _subs(tid) == []
+    assert runner._kanban_sub_fail_counts == {}
+
+
+def test_wake_only_transient_route_failure_rewinds_without_wake(
+    tmp_path, monkeypatch,
+):
+    """A transient probe failure retains both event and subscription."""
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "wake-transient.db"))
+    kb.init_db()
+    tid = _make_completed_task("wake")
+
+    adapter = TransientRouteAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.probes) == 1
+    assert adapter.handled == []
+    assert adapter.sent == []
+    assert len(_unseen_terminal_events(tid)) == 1
+    assert len(_subs(tid)) == 1
+    assert list(runner._kanban_sub_fail_counts.values()) == [1]

--- a/tests/gateway/test_send_error_classification.py
+++ b/tests/gateway/test_send_error_classification.py
@@ -12,6 +12,7 @@ from gateway.platforms.base import (
     SEND_ERROR_KINDS,
     SendResult,
     classify_send_error,
+    is_chat_level_not_found,
 )
 
 
@@ -31,6 +32,7 @@ class _FakeBadRequest(Exception):
         ("Bad Request: not enough rights to send text messages", "forbidden"),
         ("Bad Request: chat not found", "not_found"),
         ("Bad Request: message to edit not found", "not_found"),
+        ("Bad Request: Topic_closed", "not_found"),
         ("Too Many Requests: retry after 12", "rate_limited"),
         ("Flood control exceeded", "rate_limited"),
         ("ConnectError: connection refused", "transient"),
@@ -56,6 +58,10 @@ def test_every_classification_is_in_the_vocabulary():
     ]
     for s in samples:
         assert classify_send_error(None, s) in SEND_ERROR_KINDS
+
+
+def test_closed_topic_does_not_mark_parent_chat_dead():
+    assert is_chat_level_not_found(None, "Bad Request: Topic_closed") is False
 
 
 def test_telegram_send_failure_populates_error_kind():
@@ -85,5 +91,4 @@ def test_telegram_send_failure_populates_error_kind():
     # so a raw parse failure that still escapes is classified for consumers.
     assert result.error_kind in SEND_ERROR_KINDS
     assert result.error_kind != "unknown" or result.error
-
 

--- a/tests/gateway/test_telegram_typing_backoff.py
+++ b/tests/gateway/test_telegram_typing_backoff.py
@@ -84,3 +84,41 @@ async def test_typing_bad_thread_failure_does_not_cool_down(monkeypatch):
 
     assert adapter._bot.send_chat_action.await_count == 2
     assert "123" not in adapter._telegram_typing_cooldown_until
+
+
+@pytest.mark.asyncio
+async def test_route_probe_rejects_closed_topic_without_fallback():
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(
+        side_effect=ValueError("Bad Request: Topic_closed")
+    )
+
+    result = await adapter.probe_delivery_route(
+        "123", metadata={"thread_id": "10728"},
+    )
+
+    assert result.success is False
+    assert result.retryable is False
+    assert result.error_kind == "not_found"
+    adapter._bot.send_chat_action.assert_awaited_once_with(
+        chat_id=123,
+        action="typing",
+        message_thread_id=10728,
+    )
+
+
+@pytest.mark.asyncio
+async def test_route_probe_accepts_exact_topic():
+    adapter = _make_adapter()
+    adapter._bot.send_chat_action = AsyncMock(return_value=None)
+
+    result = await adapter.probe_delivery_route(
+        "123", metadata={"thread_id": "10728"},
+    )
+
+    assert result.success is True
+    adapter._bot.send_chat_action.assert_awaited_once_with(
+        chat_id=123,
+        action="typing",
+        message_thread_id=10728,
+    )


### PR DESCRIPTION
## Summary

- classify `Topic_closed` as a missing subchat without marking the parent chat dead
- probe the exact Telegram chat/topic with `sendChatAction` before wake-only injection
- unsubscribe permanently invalid routes before waking an agent and rewind transient failures
- add regression coverage for closed, transient, and valid routes

## Verification

- `scripts/run_tests.sh -j 3 tests/gateway/test_kanban_notifier_wake_only_ordering.py tests/gateway/test_send_error_classification.py tests/gateway/test_telegram_typing_backoff.py` — 30 passed
- `ruff check` on changed Python files — passed
- `git diff --check` — passed

Submitted by **Daré TI — Tamandaré**.