### PR TITLE
fix(agent): keep prose arg-tag mentions when stripping cut fragments

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -103,12 +103,14 @@ _STRAY_TOOL_CALL_CLOSER_PATTERN = re.compile(
 # A tool-call opener with no closer, or GLM-style argument markup
 # (<arg_key>/<arg_value>) outside any closed block, means the stream was
 # cut mid-serialization of a text-channel tool call (#101899). The call
-# can't be recovered; strip from the block-boundary opener (or the line
-# holding the first stray argument tag) to the end of the text.
+# can't be recovered; strip from the block-boundary opener to the end of
+# the text. Stray argument tags are stripped line-wise, and only when the
+# text before the tag is tag-soup (no spaces) — ordinary prose mentioning
+# the tags keeps its line and everything after it (#102303).
 _UNTERMINATED_TOOL_CALL_PATTERN = re.compile(
     rf'(?:^|\n)[ \t]*<(?:{"|".join(_TOOL_CALL_TAG_NAMES)})\b[^>]*>.*$'
-    r'|(?:^|\n)[^\n<]*</?arg_(?:key|value)\b.*$',
-    re.DOTALL | re.IGNORECASE,
+    r'|(?:^|\n)[ \t]*\S*?</?arg_(?:key|value)\b[^\n]*$',
+    re.DOTALL | re.IGNORECASE | re.MULTILINE,
 )
 
 

--- a/cli.py
+++ b/cli.py
@@ -315,13 +315,16 @@ def _strip_reasoning_tags(text: str) -> str:
         flags=re.IGNORECASE,
     )
     # Unterminated opener / stray <arg_key>/<arg_value> markup = stream cut
-    # mid tool-call serialization (#101899); strip to end of text.
+    # mid tool-call serialization (#101899); strip the opener to end of
+    # text, stray-argument lines line-wise. Only tag-soup lines are
+    # stripped — prose mentioning the tags keeps its line and tail (#102303).
+    # Must stay in sync with _UNTERMINATED_TOOL_CALL_PATTERN above.
     cleaned = re.sub(
         r'(?:^|\n)[ \t]*<(?:tool_call|tool_calls|tool_result|function_call|function_calls)\b[^>]*>.*$'
-        r'|(?:^|\n)[^\n<]*</?arg_(?:key|value)\b.*$',
+        r'|(?:^|\n)[ \t]*\S*?</?arg_(?:key|value)\b[^\n]*$',
         '',
         cleaned,
-        flags=re.DOTALL | re.IGNORECASE,
+        flags=re.DOTALL | re.IGNORECASE | re.MULTILINE,
     )
     return cleaned.strip()
 

--- a/tests/run_agent/test_strip_reasoning_tags_cli.py
+++ b/tests/run_agent/test_strip_reasoning_tags_cli.py
@@ -52,3 +52,17 @@ class TestToolCallStripping:
             assert out.rstrip().endswith("Done.")
             assert "<tool_call>" not in out
 
+    def test_bracketed_prose_mention_keeps_line_and_tail(self):
+        """#102303: a prose line mentioning <arg_key> in brackets is not a
+        stream cut — its line and everything after it must survive, in both
+        strippers (they must stay in sync)."""
+        text = (
+            "First line stays.\n"
+            "The <arg_key> holds the parameter name.\n"
+            "Third line must survive."
+        )
+        for out in (_strip_reasoning_tags(text),
+                    strip_think_blocks(None, text)):
+            assert "The <arg_key> holds the parameter name." in out
+            assert out.rstrip().endswith("Third line must survive.")
+


### PR DESCRIPTION
Hey — the #101899 fragment stripper has an over-strip regression: stray `<arg_key>`/`<arg_value>` markup is removed to end of *text*, so an ordinary prose line mentioning the tags in brackets deletes its own line plus the entire tail, in both the stored transcript and the display copy.

Fixed by stripping stray-argument lines line-wise, and only when the text before the tag is tag-soup (no spaces): genuine cut fragments still reduce to their clean prefix, prose mentions survive whole. Updated both stripper copies so they stay in sync.

Tests: added a regression test pinning that a bracketed prose mention keeps its line and tail in both strippers. Verified red on unfixed code, green after; the #101899 fragment cases still pass unchanged, plus neighboring stripper suites (30 passed). Footguns check clean. Tested on macOS, Python 3.11.

Fixes #102303
