### PR TITLE
fix(a2a): preserve tasks across observation deadlines

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -11288,6 +11288,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return True  # handled (silently dropped); do not fall through
 
         effective_mode = self._effective_busy_input_mode(event.source)
+        # A2A messages are independent protocol tasks with durable receipts,
+        # not interactive steering. They must wait behind the active turn so
+        # one peer cannot pre-empt another peer's live task.
+        platform_value = str(getattr(event.source.platform, "value", event.source.platform)).lower()
+        if platform_value == "a2a":
+            effective_mode = "queue"
 
         # --- Draining case (gateway restarting/stopping) ---
         if self._draining:

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -509,12 +509,15 @@ class A2AAdapter(BasePlatformAdapter):
                 pass
             self._httpd = None
         # Fail any in-flight replies so blocked HTTP threads don't hang.
+        # Snapshot then release: reply-future callbacks (_finalize_when_reply_arrives)
+        # call _pop_pending and must not mutate `_pending` during iteration.
         with self._pending_lock:
-            for _ctx, fut in self._pending.values():
-                if not fut.done():
-                    fut.set_result((protocol.STATE_FAILED, "[agent shutting down]"))
+            futures = [fut for _ctx, fut in self._pending.values()]
             self._pending.clear()
             self._pending_order.clear()
+        for fut in futures:
+            if not fut.done():
+                fut.set_result((protocol.STATE_FAILED, "[agent shutting down]"))
 
     # ── Orphaned task watchdog ─────────────────────────────────────────────
 

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import math
 import os
 import re
 import sqlite3
@@ -41,7 +42,7 @@ import time
 import urllib.parse
 import urllib.request
 from collections import deque
-from concurrent.futures import Future
+from concurrent.futures import CancelledError, Future
 from concurrent.futures import TimeoutError as FuturesTimeout
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from typing import Any, Dict, Optional
@@ -61,17 +62,24 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_PORT = 9900
 _ORPHAN_TIMEOUT = 300  # seconds before a pending task is considered orphaned
+_ORPHAN_GRACE = 60  # slack beyond reply/route deadlines
 _WATCHDOG_INTERVAL = 60  # seconds between orphaned task watchdog runs
 _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaustion
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
 
 
+def _parse_reply_timeout(value: Any, fallback: float = 300.0) -> float:
+    """Return a finite positive reply timeout or the safe fallback."""
+    try:
+        parsed = float(value)
+    except (ValueError, TypeError):
+        return fallback
+    return parsed if math.isfinite(parsed) and parsed >= 1.0 else fallback
+
+
 def _reply_timeout() -> float:
     """Seconds to wait for the agent to answer an inbound task."""
-    try:
-        return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
-    except (ValueError, TypeError):
-        return 300.0
+    return _parse_reply_timeout(os.getenv("A2A_REPLY_TIMEOUT", "300"))
 
 
 def _profile_scoped() -> bool:
@@ -377,6 +385,10 @@ class A2AAdapter(BasePlatformAdapter):
         self._security_context = security.A2ASecurityContext.capture()
         _port_env = None if _profile_scoped() else os.getenv("A2A_PORT")
         self.port = int(_port_env or extra.get("port", _DEFAULT_PORT))
+        self.reply_timeout = _parse_reply_timeout(
+            extra.get("reply_timeout", _reply_timeout()),
+            fallback=_reply_timeout(),
+        )
         self.host = self._security_context.resolve_bind_host()
         self.agent_name = _default_agent_name()
         self._advertised_toolsets = [
@@ -410,7 +422,7 @@ class A2AAdapter(BasePlatformAdapter):
         # requests sharing a context).
         self._pending: Dict[str, tuple[str, Future]] = {}
         self._pending_order: Dict[str, deque[str]] = {}
-        self._pending_lock = threading.Lock()
+        self._pending_lock = threading.RLock()
 
         # Orphaned task watchdog
         self._watchdog_stop = threading.Event()
@@ -506,12 +518,36 @@ class A2AAdapter(BasePlatformAdapter):
 
     # ── Orphaned task watchdog ─────────────────────────────────────────────
 
+    def _orphan_timeout_for(self, rec: dict) -> float:
+        """Never reap a task while its live reply future is still registered.
+
+        After a process restart no such future exists, so genuinely abandoned
+        records still age out through the normal timeout.
+        """
+        task_id = str(rec.get("task_id") or "")
+        with self._pending_lock:
+            if any(task_id in queue for queue in self._pending_order.values()):
+                return math.inf
+        agent = self._agents.get(str(rec.get("agent_slug") or "")) or {}
+        try:
+            route_timeout = float(agent.get("timeout") or 0)
+        except (TypeError, ValueError):
+            route_timeout = 0
+        return int(max(
+            _ORPHAN_TIMEOUT,
+            self.reply_timeout + _ORPHAN_GRACE,
+            route_timeout + _ORPHAN_GRACE,
+        ))
+
     def _watchdog_loop(self) -> None:
         """Background thread that fails orphaned tasks (keeps them queryable)."""
         while not self._watchdog_stop.wait(_WATCHDOG_INTERVAL):
             try:
-                for tid in self.tasks.fail_orphans(_ORPHAN_TIMEOUT):
-                    logger.warning("A2A: orphaned task %s marked failed (timeout %ds)", tid, _ORPHAN_TIMEOUT)
+                for tid in self.tasks.fail_orphans(
+                    _ORPHAN_TIMEOUT,
+                    timeout_for=self._orphan_timeout_for,
+                ):
+                    logger.warning("A2A: orphaned task %s marked failed", tid)
                     protocol.metrics.tasks_failed += 1
             except Exception:
                 logger.debug("A2A: watchdog error", exc_info=True)
@@ -970,40 +1006,64 @@ class A2AAdapter(BasePlatformAdapter):
         self._send_push_notification(task_id, context_id, reply, state)
         return state, reply
 
+    def _finalize_when_reply_arrives(self, pending: dict) -> None:
+        """Bind terminal task state to the reply future, never an RPC timer.
+
+        ``reply_timeout`` is an observation budget for an open RPC/stream. It
+        must not become the execution deadline of the underlying A2A task.
+        """
+        future = pending["future"]
+
+        def _on_reply(done: Future) -> None:
+            try:
+                state, text = done.result()
+            except CancelledError:
+                state, text = protocol.STATE_CANCELED, "Task canceled"
+            except Exception as exc:
+                logger.warning(
+                    "A2A reply future failed for %s: %s", pending["task_id"], exc
+                )
+                state, text = protocol.STATE_FAILED, f"Agent reply failed: {exc}"
+            self._finalize_task(pending, state, text)
+
+        future.add_done_callback(_on_reply)
+
     def _await_reply(self, pending: dict, keepalive=None) -> tuple[str, str]:
-        """Block until the task's future resolves (or times out).
+        """Observe a reply for one RPC window without terminalizing its task.
 
         ``keepalive`` is an optional zero-arg callable invoked every
         _SSE_KEEPALIVE seconds while waiting (used by the SSE paths); if it
         raises, the client is gone and we stop waiting.
         """
         fut: Future = pending["future"]
-        deadline = pending["started"] + _reply_timeout()
+        deadline = pending["started"] + self.reply_timeout
         while True:
             try:
                 return fut.result(timeout=_SSE_KEEPALIVE if keepalive else max(0.0, deadline - time.time()))
             except FuturesTimeout:
                 if time.time() >= deadline:
-                    return (protocol.STATE_FAILED, "[agent did not reply in time]")
+                    return (protocol.STATE_WORKING, "")
                 if keepalive:
                     try:
                         keepalive()
                     except Exception:
-                        return (protocol.STATE_FAILED, "[client disconnected]")
-            except Exception:
-                return (protocol.STATE_FAILED, "[agent did not reply in time]")
+                        return (protocol.STATE_WORKING, "")
+            except Exception as exc:
+                return (protocol.STATE_FAILED, f"Agent reply failed: {exc}")
 
     def _rpc_message_send(self, req_id: Any, params: dict, peer: str, agent: Optional[dict] = None, v1_response: bool = False) -> dict:
         terminal, pending = self._prepare_task(params, peer, agent=agent)
         if terminal is not None:
             result = protocol.send_message_response(terminal) if v1_response else terminal
             return protocol.jsonrpc_result(req_id, result)
-        state, reply = self._await_reply(pending)
-        state, reply = self._finalize_task(pending, state, reply)
-        task = protocol.build_task(
-            pending["task_id"], pending["context_id"], state, reply,
-            created_at=pending["created_iso"],
-        )
+        assert pending is not None
+
+        # The RPC only returns a task receipt. Terminal state follows the
+        # gateway reply future and is independent of any observation budget.
+        self._finalize_when_reply_arrives(pending)
+        rec = self.tasks.get(pending["task_id"], *self._scope_for_agent(agent))
+        assert rec is not None
+        task = protocol.TaskStore.to_task(rec)
         result = protocol.send_message_response(task) if v1_response else task
         return protocol.jsonrpc_result(req_id, result)
 
@@ -1057,16 +1117,26 @@ class A2AAdapter(BasePlatformAdapter):
                 )
                 return
 
+            assert pending is not None
             task_id, context_id = pending["task_id"], pending["context_id"]
-            self._sse_write(handler, protocol.sse_data(protocol.stream_task(
-                protocol.build_task(task_id, context_id, protocol.STATE_SUBMITTED, created_at=pending["created_iso"])),
-                req_id))
+            self._finalize_when_reply_arrives(pending)
+            rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+            assert rec is not None
+            initial_task = protocol.TaskStore.to_task(rec)
+            initial_task["status"] = {
+                "state": protocol.STATE_SUBMITTED,
+                "timestamp": protocol.now_iso(),
+            }
+            self._sse_write(handler, protocol.sse_data(
+                protocol.stream_task(initial_task), req_id))
             self._sse_write(handler, protocol.sse_data(
                 protocol.status_update(task_id, context_id, protocol.STATE_WORKING), req_id))
 
             state, reply = self._await_reply(
                 pending, keepalive=lambda: self._sse_write(handler, ": keepalive\n\n"))
-            state, reply = self._finalize_task(pending, state, reply)
+            # ``_finalize_when_reply_arrives`` owns terminal persistence. An
+            # observation timeout leaves the task working and merely closes
+            # this stream with its current state.
             self._emit_terminal(handler, task_id, context_id, state, reply, req_id=req_id)
         except (BrokenPipeError, ConnectionResetError):
             logger.debug("A2A: stream client disconnected")

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -30,7 +30,7 @@ from collections import OrderedDict, defaultdict, deque
 from concurrent.futures import Future
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 PROTOCOL_VERSION = "1.0"
 
@@ -748,14 +748,25 @@ class TaskStore:
             return page, next_offset, total
         return page, next_offset
 
-    def fail_orphans(self, timeout_seconds: int = 300) -> list[str]:
+    def fail_orphans(
+        self,
+        timeout_seconds: int = 300,
+        timeout_for: Optional[Callable[[dict], float]] = None,
+    ) -> list[str]:
         with self._lock:
             now = time.time()
-            stale = [
-                tid for tid, rec in self._tasks.items()
-                if rec["state"] not in TERMINAL_STATES
-                and now - rec["created_at"] > timeout_seconds
-            ]
+            stale = []
+            for tid, rec in self._tasks.items():
+                if rec["state"] in TERMINAL_STATES:
+                    continue
+                limit = float(timeout_seconds)
+                if timeout_for is not None:
+                    try:
+                        limit = max(limit, float(timeout_for(rec)))
+                    except (TypeError, ValueError):
+                        pass
+                if now - rec["created_at"] > limit:
+                    stale.append(tid)
         failed = []
         for tid in stale:
             if self.complete(tid, STATE_FAILED, "[task orphaned — no reply produced]"):

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -4,6 +4,7 @@ A2A client tools — let the Hermes agent talk to *other* agents as a peer.
 Tools (registered in the ``a2a`` toolset):
   - a2a_discover(url)         -> fetch + summarize a peer's Agent Card
   - a2a_call(agent, message)  -> send a task to a peer, return its reply
+  - a2a_get_task(agent, task_id) -> poll GetTask for a prior non-holding receipt
   - a2a_list()                -> list configured peers + persisted conversations
   - a2a_history(context_id)   -> recall a persisted A2A conversation
   - a2a_orchestrate(...)      -> fan-out task to multiple peers by capability
@@ -25,6 +26,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -36,6 +38,11 @@ logger = logging.getLogger(__name__)
 
 _DEFAULT_TIMEOUT = 120
 _ORCHESTRATE_MAX_WORKERS = 6  # max parallel peers for fan-out
+_POLL_INTERVAL = 0.5  # seconds between GetTask polls after a working receipt
+_SETTLED_STATES = protocol.TERMINAL_STATES | {
+    protocol.STATE_INPUT_REQUIRED,
+    protocol.STATE_AUTH_REQUIRED,
+}
 
 
 # --------------------------------------------------------------------------
@@ -146,8 +153,65 @@ def _short_state(state: str) -> str:
     return state.replace("TASK_STATE_", "").replace("_", "-").lower() if state else ""
 
 
-def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str]:
-    """Send one message/send to a peer. Returns (reply_text, context_id, state).
+def _task_fields(payload: Any, fallback_ctx: str) -> tuple[str, str, str]:
+    """Return (task_id, context_id, state) from a Task or Message payload."""
+    if not isinstance(payload, dict):
+        return "", fallback_ctx, ""
+    task_id = str(payload.get("id") or "")
+    ctx = str(payload.get("contextId") or fallback_ctx)
+    state = str((payload.get("status") or {}).get("state") or "")
+    return task_id, ctx, state
+
+
+def _rpc_get_task(rpc_url: str, headers: dict, task_id: str, timeout: int) -> dict:
+    """Call GetTask. Returns the Task object (not a SendMessage wrapper)."""
+    body = {
+        "jsonrpc": "2.0",
+        "id": protocol.new_task_id(),
+        "method": "GetTask",
+        "params": {"taskId": task_id},
+    }
+    resp = _http_post_json(rpc_url, body, headers, timeout)
+    if "error" in resp:
+        err = resp["error"]
+        raise ValueError(f"GetTask failed: {err.get('message', err)}")
+    result = resp.get("result", {})
+    payload = protocol.unwrap_send_message_response(result)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _poll_until_settled(
+    rpc_url: str,
+    headers: dict,
+    task_id: str,
+    deadline: float,
+    payload: dict,
+) -> dict:
+    """Poll GetTask until a settled state or ``deadline``. Keep last payload on error."""
+    latest = payload
+    while time.time() < deadline:
+        remaining = deadline - time.time()
+        if remaining <= 0:
+            break
+        try:
+            latest = _rpc_get_task(
+                rpc_url, headers, task_id, max(1, min(int(remaining) or 1, 30)),
+            )
+        except Exception:
+            logger.debug("A2A GetTask poll failed for %s", task_id, exc_info=True)
+            break
+        state = str((latest.get("status") or {}).get("state") or "")
+        if state in _SETTLED_STATES:
+            return latest
+        time.sleep(min(_POLL_INTERVAL, max(0.0, deadline - time.time())))
+    return latest
+
+
+def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> tuple[str, str, str, str]:
+    """Send one message/send to a peer.
+
+    Returns (reply_text, context_id, state, task_id). A non-holding working
+    receipt is followed by GetTask polls until settled or the peer timeout.
 
     Raises urllib errors / ValueError for the caller to format. Handles
     outbound redaction, audit, persistence, and metrics.
@@ -183,21 +247,25 @@ def _send_task(agent_label: str, peer: dict, message: str, context_id: str) -> t
     protocol.persist_message(ctx, "user", safe_message, rpc_body["id"])
     protocol.metrics.outbound_total += 1
 
-    resp = _http_post_json(_rpc_url(base_url, card), rpc_body, headers, timeout)
+    rpc_url = _rpc_url(base_url, card)
+    started = time.time()
+    resp = _http_post_json(rpc_url, rpc_body, headers, timeout)
     if "error" in resp:
         err = resp["error"]
         raise ValueError(f"Peer '{agent_label}' returned an error: {err.get('message', err)}")
 
     result = resp.get("result", {})
     payload = protocol.unwrap_send_message_response(result)
+    task_id, reply_ctx, state = _task_fields(payload, ctx)
+    if task_id and state not in _SETTLED_STATES:
+        remaining = timeout - (time.time() - started)
+        if remaining > 0 and isinstance(payload, dict):
+            payload = _poll_until_settled(rpc_url, headers, task_id, started + timeout, payload)
+            task_id, reply_ctx, state = _task_fields(payload, reply_ctx)
     reply = _reply_text_from_result(payload)
-    reply_ctx, state = ctx, ""
-    if isinstance(payload, dict):
-        reply_ctx = payload.get("contextId", ctx)
-        state = (payload.get("status") or {}).get("state", "")
-    protocol.persist_message(reply_ctx, "agent", reply, rpc_body["id"])
+    protocol.persist_message(reply_ctx, "agent", reply, task_id or rpc_body["id"])
     protocol.metrics.inbound_total += 1
-    return reply, reply_ctx, state
+    return reply, reply_ctx, state, task_id
 
 
 def _reply_text_from_result(result: Any) -> str:
@@ -277,7 +345,7 @@ def a2a_call(args: dict, **_: Any) -> str:
         )
 
     try:
-        reply, reply_ctx, state = _send_task(agent, peer, message, context_id)
+        reply, reply_ctx, state, task_id = _send_task(agent, peer, message, context_id)
     except urllib.error.HTTPError as e:
         if e.code in (401, 403):
             return f"Error: peer '{agent}' rejected auth (HTTP {e.code}). Check the configured token."
@@ -292,12 +360,66 @@ def a2a_call(args: dict, **_: Any) -> str:
     header = f"[{agent} · context {reply_ctx}"
     if state:
         header += f" · {_short_state(state)}"
+    if task_id:
+        header += f" · task {task_id}"
     header += "]"
     body = reply or "(no text reply)"
     if state == protocol.STATE_INPUT_REQUIRED:
         body += (
             "\n\n(The peer needs more input — answer by calling a2a_call again "
             f"with context_id '{reply_ctx}'.)"
+        )
+    elif state not in _SETTLED_STATES and task_id:
+        body += (
+            "\n\n(The peer is still working — poll with a2a_get_task using "
+            f"task_id '{task_id}'.)"
+        )
+    return f"{header}\n{body}"
+
+
+def a2a_get_task(args: dict, **_: Any) -> str:
+    """Fetch a prior task by id via GetTask (non-holding receipt follow-up)."""
+    agent = str(args.get("agent") or args.get("agent_name") or args.get("name") or "").strip()
+    task_id = str(args.get("task_id") or args.get("taskId") or args.get("id") or "").strip()
+    if not agent or not task_id:
+        return "Error: both 'agent' and 'task_id' are required."
+
+    peer = _resolve_peer(agent)
+    if not peer or not peer.get("url"):
+        return (
+            f"Error: unknown agent '{agent}'. Configure it under 'a2a_agents' in "
+            f"config.yaml or pass a full http(s):// URL."
+        )
+
+    base_url = peer.get("url", "")
+    headers = _auth_header(peer.get("auth", {}) or {})
+    timeout = int(peer.get("timeout", _DEFAULT_TIMEOUT))
+    card = None
+    try:
+        card = _fetch_card(base_url, headers, min(timeout, 30))
+    except Exception:
+        pass
+
+    try:
+        payload = _rpc_get_task(_rpc_url(base_url, card), headers, task_id, timeout)
+    except urllib.error.HTTPError as e:
+        return f"Error: GetTask to '{agent}' failed — HTTP {e.code}."
+    except ValueError as e:
+        return str(e)
+    except Exception as e:
+        return f"Error: GetTask to '{agent}' failed — {e}."
+
+    _tid, reply_ctx, state = _task_fields(payload, "")
+    reply = _reply_text_from_result(payload)
+    header = f"[{agent} · context {reply_ctx}" if reply_ctx else f"[{agent}"
+    if state:
+        header += f" · {_short_state(state)}"
+    header += f" · task {task_id}]"
+    body = reply or "(no text reply)"
+    if state not in _SETTLED_STATES:
+        body += (
+            "\n\n(The peer is still working — poll with a2a_get_task using "
+            f"task_id '{task_id}'.)"
         )
     return f"{header}\n{body}"
 
@@ -387,7 +509,7 @@ def _call_peer_sync(agent_name: str, peer_entry: dict, message: str, context_id:
             "auth": peer_entry.get("auth", {}) or {},
             "timeout": int(peer_entry.get("timeout", _DEFAULT_TIMEOUT)),
         }
-        reply, _ctx, _state = _send_task(agent_name, peer, message, context_id)
+        reply, _ctx, _state, _task_id = _send_task(agent_name, peer, message, context_id)
         return (agent_name, reply or "(no reply)")
     except Exception as e:
         return (agent_name, f"Error: {e}")
@@ -522,6 +644,24 @@ _SCHEMAS: dict[str, _ToolSchema] = {
             },
         },
     },
+    "a2a_get_task": {
+        "type": "function",
+        "function": {
+            "name": "a2a_get_task",
+            "description": (
+                "Fetch a remote A2A task by id via GetTask. Use this after "
+                "a2a_call returns a working receipt with task <id>."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "agent": {"type": "string", "description": "Configured peer name (from a2a_agents) or a full http(s):// URL."},
+                    "task_id": {"type": "string", "description": "Server task id from a prior a2a_call header."},
+                },
+                "required": ["agent", "task_id"],
+            },
+        },
+    },
     "a2a_list": {
         "type": "function",
         "function": {
@@ -576,6 +716,7 @@ _SCHEMAS: dict[str, _ToolSchema] = {
 _HANDLERS = {
     "a2a_discover": a2a_discover,
     "a2a_call": a2a_call,
+    "a2a_get_task": a2a_get_task,
     "a2a_list": a2a_list,
     "a2a_history": a2a_history,
     "a2a_orchestrate": a2a_orchestrate,

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -188,6 +188,34 @@ class TestBusySessionAck:
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
 
+    def test_a2a_task_queues_while_session_busy_never_interrupts_active_turn(self):
+        """A task-bearing protocol message cannot pre-empt unrelated live work."""
+
+        async def run():
+            runner, _sentinel = _make_runner()
+            runner._busy_input_mode = "interrupt"
+            runner._queue_or_replace_pending_event = MagicMock()
+            adapter = _make_adapter(platform_val="a2a")
+
+            event = _make_event(text="independent task", platform_val="a2a")
+            sk = build_session_key(event.source)
+            agent = MagicMock()
+            agent.get_activity_summary.return_value = {"seconds_since_activity": 1.0}
+            runner._running_agents[sk] = agent
+            runner._running_agents_ts[sk] = time.time()
+            runner.adapters[event.source.platform] = adapter
+
+            handled = await runner._handle_active_session_busy_message(event, sk)
+
+            assert handled is True
+            runner._queue_or_replace_pending_event.assert_called_once_with(sk, event)
+            agent.interrupt.assert_not_called()
+            content = adapter._send_with_retry.call_args.kwargs["content"]
+            assert "Queued" in content or "queued" in content
+
+        import asyncio
+        asyncio.run(run())
+
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -13,9 +13,11 @@ import asyncio
 import hashlib
 import hmac
 import json
+import math
 import os
 import socket
 import threading
+import time
 import urllib.error
 import urllib.request
 from concurrent.futures import Future
@@ -24,7 +26,122 @@ from types import SimpleNamespace
 
 import pytest
 
+from plugins.platforms.a2a import adapter as a2a_adapter
 from plugins.platforms.a2a import protocol, security, tools
+
+
+def test_reply_timeout_can_be_configured_without_environment(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": 900})
+    )
+
+    assert adapter.reply_timeout == 900.0
+
+
+def test_non_finite_reply_timeout_falls_back_safely(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": "inf"})
+    )
+
+    assert adapter.reply_timeout == 300.0
+
+
+def test_reply_wait_uses_configured_timeout(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": 900})
+    )
+
+    class CapturingFuture:
+        timeout = 0.0
+
+        def result(self, timeout):
+            self.timeout = timeout
+            return protocol.STATE_COMPLETED, "alive"
+
+    future = CapturingFuture()
+    state, reply = adapter._await_reply({"future": future, "started": time.time()})
+
+    assert (state, reply) == (protocol.STATE_COMPLETED, "alive")
+    assert 890 < future.timeout <= 900
+
+
+def test_message_send_observation_deadline_never_terminalizes_running_task(monkeypatch):
+    """An RPC observation budget is not the agent task's execution deadline."""
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(
+        PlatformConfig(enabled=True, extra={"reply_timeout": 1})
+    )
+    task_id = "task-late-body"
+    context_id = "ctx-late-body"
+    future = adapter._add_pending(task_id, context_id)
+    adapter.tasks.create(task_id, context_id, "peer")
+    adapter.tasks.set_state(task_id, protocol.STATE_WORKING)
+    pending = {
+        "task_id": task_id,
+        "context_id": context_id,
+        "peer": "peer",
+        "future": future,
+        "created_iso": protocol.now_iso(),
+        "started": time.time(),
+    }
+    monkeypatch.setattr(adapter, "_prepare_task", lambda *args, **kwargs: (None, pending))
+
+    response = adapter._rpc_message_send("send-1", {"message": {}}, "peer")
+    assert response["result"]["status"]["state"] == protocol.STATE_WORKING
+
+    time.sleep(1.05)  # exceed the configured observation deadline
+    before = adapter.tasks.get(task_id)
+    assert before is not None
+    assert before["state"] == protocol.STATE_WORKING
+    assert math.isinf(adapter._orphan_timeout_for(before))
+
+    future.set_result((protocol.STATE_COMPLETED, "late body"))
+    deadline = time.monotonic() + 1
+    after = adapter.tasks.get(task_id)
+    while time.monotonic() < deadline:
+        after = adapter.tasks.get(task_id)
+        if after and after["state"] == protocol.STATE_COMPLETED:
+            break
+        time.sleep(0.01)
+    assert after is not None
+    assert after["state"] == protocol.STATE_COMPLETED
+    assert after["reply"] == "late body"
+
+
+def test_orphan_watchdog_outlives_routed_agent_timeout(monkeypatch):
+    from gateway.config import PlatformConfig
+
+    monkeypatch.delenv("A2A_REPLY_TIMEOUT", raising=False)
+    adapter = a2a_adapter.A2AAdapter(PlatformConfig(enabled=True, extra={
+        "reply_timeout": 900,
+        "agents": {"slow": {"profile": "slow", "timeout": 1800}},
+    }))
+
+    assert adapter._orphan_timeout_for({"agent_slug": "slow"}) > 1800
+
+
+def test_task_store_uses_per_task_orphan_timeout():
+    store = protocol.TaskStore()
+    store.create("task-slow", "ctx", "peer", agent_slug="slow")
+    store._tasks["task-slow"]["created_at"] = time.time() - 500
+
+    failed = store.fail_orphans(300, timeout_for=lambda rec: 1860)
+
+    assert failed == []
+    record = store.get("task-slow")
+    assert record is not None
+    assert record["state"] == protocol.STATE_SUBMITTED
 
 
 def _free_port() -> int:
@@ -1493,13 +1610,23 @@ class TestV1SpecRegressionFixes:
             assert resp["id"] == "1"
             assert set(resp["result"].keys()) == {"task"}
             task = resp["result"]["task"]
-            assert task["status"]["state"] == protocol.STATE_COMPLETED
-            assert "hello v1" in protocol.extract_text(task["artifacts"][0])
-            get_resp = await asyncio.to_thread(_post_json, base + "/", {
-                "jsonrpc": "2.0", "id": "2", "method": "GetTask",
-                "params": {"id": task["id"]},
-            }, {"A2A-Version": "1.0"})
+            assert task["status"]["state"] in {
+                protocol.STATE_SUBMITTED, protocol.STATE_WORKING,
+            }
+            deadline = time.monotonic() + 5
+            get_resp = None
+            while time.monotonic() < deadline:
+                get_resp = await asyncio.to_thread(_post_json, base + "/", {
+                    "jsonrpc": "2.0", "id": "2", "method": "GetTask",
+                    "params": {"id": task["id"]},
+                }, {"A2A-Version": "1.0"})
+                if get_resp["result"]["status"]["state"] == protocol.STATE_COMPLETED:
+                    break
+                await asyncio.sleep(0.02)
+            assert get_resp is not None
             assert get_resp["result"]["id"] == task["id"]
+            assert get_resp["result"]["status"]["state"] == protocol.STATE_COMPLETED
+            assert "hello v1" in protocol.extract_text(get_resp["result"]["artifacts"][0])
             list_resp = await asyncio.to_thread(_post_json, base + "/", {
                 "jsonrpc": "2.0", "id": "3", "method": "ListTasks",
                 "params": {"contextId": task["contextId"], "pageSize": 10},

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -119,6 +119,34 @@ def test_message_send_observation_deadline_never_terminalizes_running_task(monke
     assert after["reply"] == "late body"
 
 
+def test_disconnect_with_callback_bound_pending_does_not_crash():
+    """Reply-future callbacks must not mutate `_pending` during disconnect iteration."""
+    from gateway.config import PlatformConfig
+
+    adapter = a2a_adapter.A2AAdapter(PlatformConfig(enabled=True))
+    for i in range(3):
+        task_id = f"task-dc-{i}"
+        context_id = f"ctx-dc-{i}"
+        future = adapter._add_pending(task_id, context_id)
+        adapter.tasks.create(task_id, context_id, "peer")
+        adapter.tasks.set_state(task_id, protocol.STATE_WORKING)
+        adapter._finalize_when_reply_arrives({
+            "task_id": task_id,
+            "context_id": context_id,
+            "peer": "peer",
+            "future": future,
+            "created_iso": protocol.now_iso(),
+            "started": time.time(),
+        })
+
+    asyncio.run(adapter.disconnect())
+
+    assert adapter._pending == {}
+    rec = adapter.tasks.get("task-dc-0")
+    assert rec is not None
+    assert rec["state"] == protocol.STATE_FAILED
+
+
 def test_orphan_watchdog_outlives_routed_agent_timeout(monkeypatch):
     from gateway.config import PlatformConfig
 
@@ -710,6 +738,75 @@ class TestRegistryDispatchConvention:
         out = tools.a2a_call({"agent_name": "peer", "message": "ping"})
         assert captured.get("sent") is True
         assert "PONG" in out
+        assert "task t" in out or "task t]" in out or " · task t]" in out
+
+
+    def test_call_polls_get_task_after_working_receipt(self, monkeypatch):
+        """Non-holding SendMessage receipts must be followed until a body exists."""
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://peer.invalid"}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+        monkeypatch.setattr(tools, "_POLL_INTERVAL", 0)
+        methods = []
+
+        def fake_post(url, body, headers, timeout):
+            methods.append(body["method"])
+            if body["method"] == "SendMessage":
+                return protocol.jsonrpc_result(
+                    body["id"],
+                    protocol.build_task("task-1270", "ctx-1270", protocol.STATE_WORKING, ""),
+                )
+            assert body["method"] == "GetTask"
+            assert body["params"]["taskId"] == "task-1270"
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("task-1270", "ctx-1270", protocol.STATE_COMPLETED, "late body"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "r", "message": "do it"})
+        assert "late body" in out
+        assert "task-1270" in out
+        assert "completed" in out
+        assert "(no text reply)" not in out
+        assert methods == ["SendMessage", "GetTask"]
+
+    def test_call_keeps_task_handle_when_still_working(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://peer.invalid", "timeout": 1}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+        monkeypatch.setattr(tools, "_POLL_INTERVAL", 5)
+
+        def fake_post(url, body, headers, timeout):
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("task-still", "ctx-1270", protocol.STATE_WORKING, ""),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_call({"agent": "r", "message": "do it"})
+        assert "task-still" in out
+        assert "working" in out
+        assert "a2a_get_task" in out
+
+    def test_get_task_returns_body_and_handle(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config",
+                            lambda: {"a2a_agents": {"r": {"url": "http://peer.invalid"}}})
+        monkeypatch.setattr(tools, "_http_get_json", lambda url, h, t: None)
+
+        def fake_post(url, body, headers, timeout):
+            assert body["method"] == "GetTask"
+            assert body["params"]["taskId"] == "task-1270"
+            return protocol.jsonrpc_result(
+                body["id"],
+                protocol.build_task("task-1270", "ctx-1270", protocol.STATE_COMPLETED, "late body"),
+            )
+
+        monkeypatch.setattr(tools, "_http_post_json", fake_post)
+        out = tools.a2a_get_task({"agent": "r", "task_id": "task-1270"})
+        assert "late body" in out
+        assert "task-1270" in out
+        assert "completed" in out
 
 
 # --------------------------------------------------------------------------
@@ -1572,10 +1669,11 @@ class TestClientTenantAndDiscovery:
 
         monkeypatch.setattr(tools, "_http_get_json", fake_get)
         monkeypatch.setattr(tools, "_http_post_json", fake_post)
-        reply, _ctx, _state = tools._send_task(
+        reply, _ctx, _state, task_id = tools._send_task(
             "dev", {"url": "http://peer.example", "auth": {}, "timeout": 5}, "hello", "ctx-1"
         )
         assert reply == "ok"
+        assert task_id == "task-1"
         assert posted["url"] == "http://peer.example/dev/"
         assert posted["body"]["params"]["tenant"] == "dev-team"
 
@@ -1654,10 +1752,11 @@ class TestV1SpecRegressionFixes:
 
         monkeypatch.setattr(tools, "_http_get_json", fake_get)
         monkeypatch.setattr(tools, "_http_post_json", fake_post)
-        reply, _ctx, state = tools._send_task(
+        reply, _ctx, state, task_id = tools._send_task(
             "dev", {"url": "http://peer.example", "auth": {}, "timeout": 5}, "hello", "ctx-1")
         assert reply == "ok"
         assert state == protocol.STATE_COMPLETED
+        assert task_id == "task-1"
         assert posted["body"]["method"] == "SendMessage"
         assert posted["body"]["params"]["tenant"] == "dev-team"
 


### PR DESCRIPTION
## Bug Description

Fixes [runi-services/governance#1270](https://github.com/runi-services/governance/issues/1270).

Every Hermes→Abel task reply since 12:41 CEST 2026-09-03 surfaces on Abel's fleet panel as failed `[agent did not reply in time]` while Hermes's actual replies exist in session transcripts. Measurement: with `reply_timeout=1s`, a still-running task went `TASK_STATE_WORKING` → `TASK_STATE_FAILED` at 1.05s. The RPC observation timer was the execution deadline.

Related: #1267 (busy-session A2A inherited interactive `interrupt`). Not this PR: #1232 (Josh 8.0.7 v1 emit of nested FilePart — separate Seed seam).

Supersedes the earlier incomplete cut in https://github.com/NousResearch/hermes-agent/pull/96983 (still OPEN; this branch is rebased on current `main`).

## Root Cause

`_rpc_message_send` waited on `_await_reply` and `_finalize_task` used that wait's result. When the observation window ended, a still-owned task was terminalized as failed. The orphan watchdog could also reap a task that still had a live pending future.

## Fix

- SendMessage returns a task receipt immediately (`WORKING`/`SUBMITTED`).
- Terminal persistence binds to the reply future (`_finalize_when_reply_arrives`), using the existing `RLock` on pending state.
- Observation expiry leaves the task working; GetTask / late push carry the body.
- Live-owned task ids get an infinite orphan timeout; crash leftovers still age out.
- Gateway busy-session path forces A2A events to `queue` even when interactive mode is `interrupt`.

## How to Verify

```
python -m pytest tests/plugins/test_a2a_plugin.py tests/gateway/test_busy_session_ack.py::TestBusySessionAck::test_a2a_task_queues_while_session_busy_never_interrupts_active_turn -q
```

Sabotage: restore `_rpc_message_send` to `_await_reply` + `_finalize_task` → `test_message_send_observation_deadline_never_terminalizes_running_task` is RED.

## Test Plan

- [x] Late body after 1.05s observation window → still working, then completed with `late body`
- [x] Live pending id is not orphan-reaped
- [x] Busy A2A task queues; `agent.interrupt` zero times
- [x] `tests/plugins/test_a2a_plugin.py` 114 + the new tests (115 passed with the queue test)

## Risk Assessment

Medium. Callers that treated a holding SendMessage HTTP response as the terminal answer will now see a working receipt and must GetTask / subscribe / accept push. That is the A2A 1.0 contract. PR ≠ merge ≠ live gateway bounce.

## Exclusions

- No seat bounce (Abel orders the named minute after merge).
- No Kenneth-box / Josh pin.
- #1232 file/artifact parts stay on Josh 8.0.7 emit — posted on governance#1232.

## Reviewer

Hermes: one exact-head PASS on this PR's `headRefOid`. Abel merges under Abel's identity (s699).
