### PR TITLE
fix(agent): repair truncated tool args with string-aware closer scan

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -234,13 +234,34 @@ def _repair_tool_call_arguments(raw_args: str, tool_name: str = "?") -> str:
     fixed = raw_stripped
     # 1. Strip trailing commas before } or ]
     fixed = re.sub(r',\s*([}\]])', r'\1', fixed)
-    # 2. Close unclosed structures
-    open_curly = fixed.count('{') - fixed.count('}')
-    open_bracket = fixed.count('[') - fixed.count(']')
-    if open_curly > 0:
-        fixed += '}' * open_curly
-    if open_bracket > 0:
-        fixed += ']' * open_bracket
+    # 2. Close unclosed structures (string-aware: braces inside string
+    #    literals don't count, an unterminated trailing string is closed
+    #    first, and closers unwind innermost-first). Naive counting
+    #    destroyed repairable payloads: '{"a": [1, 2' gained '}' before
+    #    ']', and '{"content": "hello } world' counted as balanced (#102311).
+    stack: list[str] = []
+    in_string = False
+    escaped = False
+    for ch in fixed:
+        if in_string:
+            if escaped:
+                escaped = False
+            elif ch == "\\":
+                escaped = True
+            elif ch == '"':
+                in_string = False
+        elif ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append(ch)
+        elif ch in "}]":
+            if stack and ((ch == "}" and stack[-1] == "{")
+                          or (ch == "]" and stack[-1] == "[")):
+                stack.pop()
+    if in_string:
+        fixed += '"'
+    for opener in reversed(stack):
+        fixed += "}" if opener == "{" else "]"
     # 3. Remove excess closing braces/brackets (bounded to 50 iterations)
     for _ in range(50):
         try:

--- a/tests/agent/test_canon_args_memo_parity.py
+++ b/tests/agent/test_canon_args_memo_parity.py
@@ -292,8 +292,9 @@ class TestUnrepairableArgsAreNotWrittenBackToHistory:
         cl._canonicalize_api_tool_calls(api_messages)
 
         sent = api_messages[0]["tool_calls"][0]["function"]["arguments"]
-        assert sent == "{}"
-        json.loads(sent)  # the whole point of the repair: never ship broken JSON
+        # Truncated mid-string values now complete instead of collapsing to
+        # {} (#102311) — still guaranteed parseable, now lossless.
+        assert json.loads(sent) == {"content": "# chapter draft\nline one\nline two"}
 
     def test_valid_calls_alongside_a_broken_one_are_untouched(self):
         """A broken call must not disturb its siblings' history entries."""
@@ -316,7 +317,7 @@ class TestUnrepairableArgsAreNotWrittenBackToHistory:
         assert history == before
         sent = api_messages[0]["tool_calls"]
         assert json.loads(sent[0]["function"]["arguments"]) == json.loads(good)
-        assert sent[1]["function"]["arguments"] == "{}"
+        assert json.loads(sent[1]["function"]["arguments"]) == {"content": "cut"}
 
     def test_repeated_sends_do_not_accumulate_damage(self):
         """Re-canonicalizing the same history every iteration stays lossless."""
@@ -324,7 +325,9 @@ class TestUnrepairableArgsAreNotWrittenBackToHistory:
         for _ in range(5):
             api_messages = [dict(m) for m in history]
             cl._canonicalize_api_tool_calls(api_messages)
-            assert api_messages[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+            assert json.loads(
+                api_messages[0]["tool_calls"][0]["function"]["arguments"]
+            ) == {"content": "# chapter draft\nline one\nline two"}
         assert (
             history[0]["tool_calls"][0]["function"]["arguments"] == truncated
         )

--- a/tests/run_agent/test_repair_tool_call_arguments.py
+++ b/tests/run_agent/test_repair_tool_call_arguments.py
@@ -30,6 +30,32 @@ class TestRepairToolCallArguments:
 
     # -- Stage 4: unclosed brackets --
 
+    def test_nested_array_closes_innermost_first(self):
+        """#102311: '{"a": [1, 2' must gain ']' before '}'."""
+        parsed = json.loads(_repair_tool_call_arguments('{"a": [1, 2', "t"))
+        assert parsed == {"a": [1, 2]}
+
+    def test_array_of_strings_closes_innermost_first(self):
+        parsed = json.loads(_repair_tool_call_arguments('{"items": ["x", "y"', "t"))
+        assert parsed == {"items": ["x", "y"]}
+
+    def test_brace_inside_string_does_not_count(self):
+        """#102311: braces inside string literals are not structure."""
+        parsed = json.loads(
+            _repair_tool_call_arguments('{"content": "hello } world', "write_file")
+        )
+        assert parsed == {"content": "hello } world"}
+
+    def test_unterminated_trailing_string_is_closed(self):
+        parsed = json.loads(
+            _repair_tool_call_arguments('{"content": "hello world', "write_file")
+        )
+        assert parsed == {"content": "hello world"}
+
+    def test_curly_only_still_repairs(self):
+        parsed = json.loads(_repair_tool_call_arguments('{"a": {"b": 1', "t"))
+        assert parsed == {"a": {"b": 1}}
+
 
 
     # -- Stage 5: excess closing delimiters --
@@ -40,8 +66,14 @@ class TestRepairToolCallArguments:
 
 
     def test_unrepairable_partial_returns_empty_object(self):
-        # Truncated in the middle of a string key — bracket closing won't help
-        assert _repair_tool_call_arguments('{"truncated": "val', "t") == "{}"
+        # No structure left to complete — bracket closing can't help.
+        assert _repair_tool_call_arguments('{"a": }', "t") == "{}"
+
+    def test_truncated_string_value_is_completed_not_dropped(self):
+        """Truncated mid-string-value: closing the string preserves the
+        received bytes instead of dropping the whole payload to {}."""
+        parsed = json.loads(_repair_tool_call_arguments('{"truncated": "val', "t"))
+        assert parsed == {"truncated": "val"}
 
     # -- Valid JSON passthrough (this path is via except, but still works) --
 


### PR DESCRIPTION
Hey — the truncated-argument repair in `_repair_tool_call_arguments` destroys payloads it could save. The close-unclosed-structures pass counts braces naively: curlies before brackets, and braces inside string literals count too. So `{"a": [1, 2` becomes `{"a": [1, 2}]` (invalid, falls through to `{}`), `{"content": "hello } world` counts as balanced (nothing appended, `{}`), and unterminated trailing strings are never closed. The tool then executes against `{}` with the real arguments silently dropped.

Fixed with a string-aware scan (escape-aware, literals don't count): close an open trailing string first, then unwind closers innermost-first. Previously pinned `{}` expectations for completable inputs now assert the completed payload; the genuinely-unrepairable `{}` path is unchanged.

Tests: five new regression tests plus three updated expectations in the memo-parity suite (that suite's own field report complained about `{}` replacement — this resolves that incident class). Verified red on unfixed code, green after; neighboring sanitization suites pass (24 + 58), footguns check clean. Tested on macOS, Python 3.11.

Fixes #102311
