### PR TITLE
fix(discord): notify users when clarify awaits a response

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1186,6 +1186,15 @@ def _clarify_send_then_wait(fut, *, clarify_id: str, session_key: str, clarify_m
     return response
 
 
+def _clarify_prompt_metadata(metadata: Optional[dict], source: Any) -> Optional[dict]:
+    """Add the initiating user to clarify-only delivery metadata."""
+    prompt_metadata = dict(metadata or {})
+    user_id = str(getattr(source, "user_id", None) or "").strip()
+    if user_id:
+        prompt_metadata["user_id"] = user_id
+    return prompt_metadata or None
+
+
 def _resolve_progress_thread_id(
     platform: Any,
     source_thread_id: Any,
@@ -6666,7 +6675,10 @@ class TurnRunner:
                     choices=list(choices) if choices else None,
                     clarify_id=clarify_id,
                     session_key=ctx.session_key or "",
-                    metadata=ctx._status_thread_metadata,
+                    metadata=_clarify_prompt_metadata(
+                        ctx._status_thread_metadata,
+                        ctx.source,
+                    ),
                 ),
                 ctx._loop_for_step,
                 logger=logger,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -7840,11 +7840,27 @@ class DiscordAdapter(BasePlatformAdapter):
                 if clean_choices
                 else "\n\nReply in this channel with your answer."
             )
+            target_user_id = str((metadata or {}).get("user_id") or "").strip()
+            allowed_mentions = None
+            if target_user_id.isdigit() and int(target_user_id) > 0:
+                allowed_mentions = discord.AllowedMentions(
+                    users=[discord.Object(id=int(target_user_id))],
+                    roles=False,
+                    everyone=False,
+                    replied_user=False,
+                )
+            header = "❓ **Hermes needs your input**"
+            if allowed_mentions is not None:
+                header = f"<@{target_user_id}>\n{header}"
             content = self._self_contained_prompt_content(
-                "❓ **Hermes needs your input**", str(question or "").strip(),
-                tail=clarify_tail,
+                header, str(question or "").strip(), tail=clarify_tail,
             )
-            msg = await channel.send(content=content, embed=embed, view=view) if view else await channel.send(content=content, embed=embed)
+            send_kwargs: Dict[str, Any] = {"content": content, "embed": embed}
+            if view:
+                send_kwargs["view"] = view
+            if allowed_mentions is not None:
+                send_kwargs["allowed_mentions"] = allowed_mentions
+            msg = await channel.send(**send_kwargs)
             if view:
                 view._message = msg  # store for on_timeout expiration editing
             return SendResult(success=True, message_id=str(msg.id))

--- a/tests/gateway/test_clarify_send_timeout_ambiguity.py
+++ b/tests/gateway/test_clarify_send_timeout_ambiguity.py
@@ -15,9 +15,14 @@ today's teardown + sentinel behavior.
 """
 
 import concurrent.futures
+from types import SimpleNamespace
 from unittest.mock import MagicMock
 
-from gateway.run import _clarify_send_disposition, _clarify_send_then_wait
+from gateway.run import (
+    _clarify_prompt_metadata,
+    _clarify_send_disposition,
+    _clarify_send_then_wait,
+)
 
 SENTINEL = "[clarify prompt could not be delivered]"
 
@@ -173,3 +178,15 @@ def test_failed_send_result_error_detail_is_logged(caplog):
     with caplog.at_level("WARNING", logger="gateway.run"):
         _clarify_send_disposition(fut, session_key="sk", clarify_mod=clarify_mod)
     assert "relay prompt op unavailable" in caplog.text
+
+
+def test_clarify_metadata_carries_the_initiating_user_without_mutating_routing():
+    routing = {"thread_id": "thread-1"}
+
+    metadata = _clarify_prompt_metadata(
+        routing,
+        SimpleNamespace(user_id="123"),
+    )
+
+    assert metadata == {"thread_id": "thread-1", "user_id": "123"}
+    assert routing == {"thread_id": "thread-1"}

--- a/tests/gateway/test_discord_prompt_content_siblings.py
+++ b/tests/gateway/test_discord_prompt_content_siblings.py
@@ -9,6 +9,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from gateway.config import PlatformConfig
+from plugins.platforms.discord import adapter as discord_adapter
 from plugins.platforms.discord.adapter import DiscordAdapter
 
 
@@ -65,5 +66,57 @@ async def test_clarify_with_choices_mirrors_question_into_content():
     assert "Hermes needs your input" in sent["content"]
     assert "Which environment should I deploy to?" in sent["content"]
     assert "Pick one below" in sent["content"]
+
+
+@pytest.mark.asyncio
+async def test_clarify_mentions_only_the_target_user(monkeypatch):
+    class FakeAllowedMentions:
+        def __init__(self, *, users, roles, everyone, replied_user):
+            self.users = users
+            self.roles = roles
+            self.everyone = everyone
+            self.replied_user = replied_user
+
+    monkeypatch.setattr(discord_adapter.discord, "AllowedMentions", FakeAllowedMentions)
+    monkeypatch.setattr(
+        discord_adapter.discord,
+        "Object",
+        lambda *, id: SimpleNamespace(id=id),
+    )
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_clarify(
+        chat_id="555",
+        question="Choose one, not <@999>.",
+        choices=["first", "second"],
+        clarify_id="cl2",
+        session_key="discord:555",
+        metadata={"user_id": "123"},
+    )
+
+    assert result.success is True
+    assert sent["content"].startswith("<@123>\n")
+    assert [user.id for user in sent["allowed_mentions"].users] == [123]
+    assert sent["allowed_mentions"].everyone is False
+    assert sent["allowed_mentions"].roles is False
+
+
+@pytest.mark.asyncio
+async def test_clarify_without_target_user_stays_unmentioned():
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    sent = _capture_channel(adapter)
+
+    result = await adapter.send_clarify(
+        chat_id="555",
+        question="Which environment should I deploy to?",
+        choices=None,
+        clarify_id="cl3",
+        session_key="discord:555",
+    )
+
+    assert result.success is True
+    assert sent["content"].startswith("❓ **Hermes needs your input**")
+    assert "allowed_mentions" not in sent
 
 


### PR DESCRIPTION
## What does this PR do?

Discord clarify prompts now mention the user who initiated the active turn, so a prompt waiting for input can trigger that user's notification instead of silently timing out while they are away from Discord. The gateway carries the initiating user ID only on clarify delivery, and the Discord adapter constrains mention parsing to that exact numeric user.

### Symptom

Discord renders clarify buttons and question text without mentioning the user who must answer.

### Impact

A user who switches away from Discord may miss the prompt notification and let clarify time out without their input.

### Bug Cause

**Trigger:** `gateway/run.py` / `TurnRunner._clarify_callback_sync`

**Causal chain:**
1. A Discord turn invokes the `clarify` tool and the gateway schedules `send_clarify` with thread-routing metadata only.
2. The Discord adapter mirrors the question into plain content but has no target user identity or explicit per-prompt mention policy.
3. Discord posts the prompt without notifying the user who must answer it.

**Why it is wrong:** Interactive clarify prompts require a response from the initiating user, but that identity was dropped before adapter delivery.

**Working sibling / contrast:** Ordinary final responses do not require an immediate interactive answer and therefore do not need this targeted prompt mention.

**Ruled out:** The existing approval mention setting is unrelated because it is optional, allowlist-wide, and only used by execution approval prompts.

### Fix

Carry the initiating user ID in clarify-only metadata. Discord validates it as a positive numeric snowflake, prepends only that user's mention, and supplies an `AllowedMentions` allowlist containing only that user while disabling role, everyone, and reply mentions. Missing or invalid user IDs retain the existing plain-message behavior.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` - preserve the initiating user ID for clarify prompt delivery without mutating shared routing metadata.
- `plugins/platforms/discord/adapter.py` - send a targeted, allowlisted user mention for clarify prompts.
- `tests/gateway/test_clarify_send_timeout_ambiguity.py` - cover clarify metadata propagation.
- `tests/gateway/test_discord_prompt_content_siblings.py` - cover targeted mention safety and the no-user fallback.

## How to Test

1. Run the focused clarify and Discord prompt tests.
2. Confirm a prompt with `metadata.user_id` includes only that user's mention in `allowed_mentions`.
3. Confirm a prompt without a user ID retains ordinary unmentioned content.

```bash
scripts/run_tests.sh tests/gateway/test_clarify_send_timeout_ambiguity.py tests/gateway/test_discord_prompt_content_siblings.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; no user-facing configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-independent payload construction
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused automated tests pass: 16 passed.
