### PR TITLE
fix(kimi-coding): return /v1 base URL for chat-completions transport (#102247)

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -657,19 +657,21 @@ def get_anthropic_key() -> str:
 # api.moonshot.ai/v1 (the old default).  Auto-detect when user hasn't set
 # KIMI_BASE_URL explicitly.
 #
-# Note: the base URL intentionally has NO /v1 suffix.  The /coding endpoint
-# speaks the Anthropic Messages protocol, and the anthropic SDK appends
-# "/v1/messages" internally — so "/coding" + SDK suffix → "/coding/v1/messages"
-# (the correct target). Using "/coding/v1" here would produce
-# "/coding/v1/v1/messages" (a 404).
-KIMI_CODE_BASE_URL = "https://api.kimi.com/coding"
+# Kimi Code has two wire protocols on the same hostname:
+#   - Anthropic Messages:  https://api.kimi.com/coding      (SDK appends /v1/messages)
+#   - Chat Completions:    https://api.kimi.com/coding/v1   (OpenAI-compatible /chat/completions)
+# The kimi-coding provider profile covers the chat_completions path, so we
+# return the /v1 base.  Callers using the Anthropic Messages wire should
+# override via KIMI_BASE_URL env var.
+KIMI_CODE_BASE_URL = "https://api.kimi.com/coding/v1"
 
 
 def _resolve_kimi_base_url(api_key: str, default_url: str, env_override: str) -> str:
     """Return the correct Kimi base URL based on the API key prefix.
 
     If the user has explicitly set KIMI_BASE_URL, that always wins.
-    Otherwise, sk-kimi- prefixed keys route to api.kimi.com/coding/v1.
+    Otherwise, sk-kimi- prefixed keys route to api.kimi.com/coding/v1
+    for the OpenAI-compatible chat-completions transport.
     """
     if env_override:
         return env_override


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where `kimi-coding` provider with `sk-kimi-` keys fails with HTTP 404 because the base URL is missing `/v1` for the chat-completions transport.

## Root cause

The `_resolve_kimi_base_url()` in `hermes_cli/auth.py` was returning `https://api.kimi.com/coding` (without `/v1`) — the correct base for the **Anthropic Messages** API where the SDK appends `/v1/messages`. But the `kimi-coding` provider profile uses the **chat-completions** transport (OpenAI-compatible), which needs `/v1` in the base URL to form the correct endpoint:

- Wrong: `https://api.kimi.com/coding/chat/completions` → HTTP 404
- Correct: `https://api.kimi.com/coding/v1/chat/completions` → HTTP 200

## The fix

Changed `KIMI_CODE_BASE_URL` to `https://api.kimi.com/coding/v1` since the `kimi-coding` provider profile covers the chat-completions path (as documented in the provider profile). The `fetch_models()` method in the provider profile correctly handles this and does not double-add `/v1`.

Users who need the Anthropic Messages wire can override via `KIMI_BASE_URL` env var.

## Testing

Verified locally:
- `sk-kimi-` keys now return `https://api.kimi.com/coding/v1`
- Env override `KIMI_BASE_URL` still takes precedence
- Non-kimi keys and no-key cases return the default URL
- Provider profile's `fetch_models()` does not double-add `/v1` when base URL already has it

## Related Issue

Fixes #102247