### PR TITLE
feat(custom): positively identify Ollama endpoints via /api/tags probe

### DIFF
--- a/plugins/model-providers/custom/__init__.py
+++ b/plugins/model-providers/custom/__init__.py
@@ -19,13 +19,43 @@ from providers import register_provider
 from providers.base import ProviderProfile
 
 
+def _probe_ollama_endpoint(raw_base_url: str) -> bool:
+    """Positively identify Ollama via ``/api/tags`` for local endpoints the
+    static hostname/port signatures below missed (#98006) — e.g.
+    ``OLLAMA_HOST=gpu-box:8080`` saved into ``model.base_url``, or a bare
+    LAN IP like ``http://192.168.1.50:8080``.
+
+    Gated to local endpoints only and delegated to
+    ``agent.model_metadata.detect_local_server_type``, which caches its own
+    verdict per host (in-process for the run, plus briefly on disk), so this
+    never round-trips more than once per endpoint. Mirrors the same gating
+    ``agent.image_routing._should_probe_ollama_vision`` uses (#89863):
+    remote relays are never probed — that would spend the probe waterfall's
+    connect timeout on hosts that were never local, and an unauthenticated
+    probe of a keyed remote endpoint returns nothing useful anyway.
+    """
+    probe_url = raw_base_url if "://" in raw_base_url else f"http://{raw_base_url}"
+    try:
+        from agent.model_metadata import detect_local_server_type, is_local_endpoint
+
+        if not is_local_endpoint(probe_url):
+            return False
+        return detect_local_server_type(probe_url) == "ollama"
+    except Exception:
+        return False
+
+
 def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
     """True when ``base_url`` is an Ollama host, not a generic OpenAI-compat relay.
 
     ``think`` is an Ollama-native extra_body field. Strict hosts (Mistral
-    ``extra=forbid``, Groq, …) reject it with HTTP 422. Match only explicit
-    Ollama signatures — default port 11434, or ``ollama`` as a hostname
-    label — not arbitrary localhost (llama.cpp / vLLM / LM Studio).
+    ``extra=forbid``, Groq, …) reject it with HTTP 422. Explicit Ollama
+    signatures — default port 11434, ``ollama`` as a hostname label, or
+    ollama.com — match for free, with no network call. A local endpoint
+    that matches none of those (non-standard port, unrelated hostname) is
+    positively identified via an ``/api/tags`` probe (#98006) rather than
+    assumed to be llama.cpp/vLLM/LM Studio; non-local hosts are never
+    probed.
     """
     raw = (base_url or "").strip()
     if not raw:
@@ -46,7 +76,9 @@ def _looks_like_ollama_endpoint(base_url: str | None) -> bool:
         return False
     if host == "ollama.com" or host.endswith(".ollama.com"):
         return True
-    return "ollama" in host.split(".")
+    if "ollama" in host.split("."):
+        return True
+    return _probe_ollama_endpoint(raw)
 
 
 class CustomProfile(ProviderProfile):

--- a/tests/plugins/model_providers/test_custom_profile.py
+++ b/tests/plugins/model_providers/test_custom_profile.py
@@ -18,6 +18,8 @@ These tests pin the wire-shape contract:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 
@@ -102,11 +104,81 @@ class TestCustomReasoningWireShape:
         ],
     )
     def test_disabled_omits_think_on_non_ollama_relays(self, custom_profile, base_url):
-        eb, tl = custom_profile.build_api_kwargs_extras(
-            reasoning_config={"effort": "none"},
-            model="llama3",
-            base_url=base_url,
-        )
+        # Non-standard ports on loopback (llama.cpp/vLLM/LM Studio) fall
+        # through to the #98006 /api/tags probe; stub it so the assertion
+        # doesn't depend on a real server (or lack of one) at that port —
+        # a genuinely non-Ollama local server answers the probe with None,
+        # same as this stub.
+        with patch(
+            "agent.model_metadata.detect_local_server_type", return_value=None
+        ):
+            eb, tl = custom_profile.build_api_kwargs_extras(
+                reasoning_config={"effort": "none"},
+                model="llama3",
+                base_url=base_url,
+            )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_sends_think_false_on_probed_local_ollama(self, custom_profile):
+        """A local endpoint on a non-standard port, positively probed as
+        Ollama (#98006), gets the same dual emission as the static
+        11434/``ollama``-hostname signatures — e.g. ``OLLAMA_HOST=gpu-box:8080``
+        saved verbatim into ``model.base_url``."""
+        with patch(
+            "agent.model_metadata.detect_local_server_type", return_value="ollama"
+        ) as mock_detect:
+            eb, tl = custom_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": False},
+                model="qwen3",
+                base_url="http://gpu-box:8080/v1",
+            )
+        assert eb == {"think": False}
+        assert tl == {"reasoning_effort": "none"}
+        mock_detect.assert_called_once_with("http://gpu-box:8080/v1")
+
+    def test_disabled_omits_think_on_probed_local_non_ollama(self, custom_profile):
+        """Same non-standard-port shape, but the probe says vLLM/llama.cpp —
+        must not send the Ollama-only flag."""
+        with patch(
+            "agent.model_metadata.detect_local_server_type", return_value="vllm"
+        ):
+            eb, tl = custom_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": False},
+                model="qwen3",
+                base_url="http://192.168.1.50:8080/v1",
+            )
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_never_probes_remote_endpoint(self, custom_profile):
+        """A remote (non-local) host must never reach the probe at all —
+        mirrors the ``is_local_endpoint`` gate in
+        ``agent.image_routing._should_probe_ollama_vision`` (#89863)."""
+        with patch(
+            "agent.model_metadata.detect_local_server_type"
+        ) as mock_detect:
+            eb, tl = custom_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": False},
+                model="qwen3",
+                base_url="https://inference.example.com/v1",
+            )
+        mock_detect.assert_not_called()
+        assert "think" not in eb
+        assert tl == {"reasoning_effort": "none"}
+
+    def test_disabled_probe_failure_is_swallowed(self, custom_profile):
+        """If the probe machinery itself raises, treat it as not-Ollama
+        rather than letting kwargs building blow up mid-turn."""
+        with patch(
+            "agent.model_metadata.detect_local_server_type",
+            side_effect=RuntimeError("boom"),
+        ):
+            eb, tl = custom_profile.build_api_kwargs_extras(
+                reasoning_config={"enabled": False},
+                model="qwen3",
+                base_url="http://gpu-box:8080/v1",
+            )
         assert "think" not in eb
         assert tl == {"reasoning_effort": "none"}
 


### PR DESCRIPTION
_looks_like_ollama_endpoint() in plugins/model-providers/custom/__init__.py only matched an explicit URL signature: port 11434, "ollama" as a hostname label, or ollama.com. A real Ollama instance reachable at a non-standard port on an unrelated hostname was missed -- e.g. OLLAMA_HOST=gpu-box:8080 saved verbatim into model.base_url, or a bare LAN IP like http://192.168.1.50:8080. Effect: the Ollama-only extra_body.think=False guard silently never fired for those endpoints (reasoning_effort="none" still worked, since Ollama honors that unconditionally).

Keep every static signature as a free, no-network first check, then fall back to positively probing local endpoints via the existing agent.model_metadata.detect_local_server_type() (/api/tags), gated through is_local_endpoint() so remote hosts are never probed -- the same pattern agent.image_routing._should_probe_ollama_vision() already uses for the identical class of endpoint (#89863). detect_local_server_type() caches its own verdict per host (in-process, plus briefly on disk), so this never adds more than one round trip per distinct endpoint, and probe failures are swallowed to "not Ollama" rather than raising mid-turn.

Added tests/plugins/model_providers/test_custom_profile.py coverage: a probed local endpoint identified as Ollama, one identified as vLLM (no think flag), a remote endpoint that must never reach the probe at all, and a probe-raises-an-exception case. The existing non-Ollama-local parametrized cases now stub detect_local_server_type so they don't depend on a live socket at those ports.

Fixes #98006

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

