### PR TITLE
fix(desktop): match live page URL when closing preview tabs (fixes #102166)

### DIFF
--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -210,9 +210,11 @@ describe('preview store', () => {
   })
 
   it('closes on host-case and trailing-slash differences', () => {
-    openPreview(urlTarget('https://example.com/App'), 'tool-result')
+    // Path case is significant — only the host and trailing slashes
+    // normalize. Same path, different host case + trailing slash.
+    openPreview(urlTarget('https://example.com/App/'), 'tool-result')
 
-    expect(closePreviewMatching('https://EXAMPLE.com/app/')).toBe(true)
+    expect(closePreviewMatching('https://EXAMPLE.com/App')).toBe(true)
     expect($previewTabs.get()).toHaveLength(0)
   })
 

--- a/apps/desktop/src/store/preview.test.ts
+++ b/apps/desktop/src/store/preview.test.ts
@@ -13,6 +13,7 @@ import {
   closeRightRailTab,
   commitBrowserTabLocation,
   newBrowserTab,
+  noteBrowserPage,
   openPreview,
   previewTabId,
   type PreviewTarget,
@@ -195,6 +196,23 @@ describe('preview store', () => {
     openPreview({ ...fileTarget('/work/demo.html'), label: 'Demo' }, 'tool-result')
 
     expect(closePreviewMatching('Demo')).toBe(true)
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('closes by the live page after a redirect, not just the open-time url', () => {
+    openPreview(urlTarget('https://dsh.cuicui.de:3080'), 'tool-result')
+    const id = $previewTabs.get()[0].id
+
+    noteBrowserPage(id, { url: 'https://dsh.cuicui.de:3080/app?session=1', title: 'App' })
+
+    expect(closePreviewMatching('https://dsh.cuicui.de:3080')).toBe(true)
+    expect($previewTabs.get()).toHaveLength(0)
+  })
+
+  it('closes on host-case and trailing-slash differences', () => {
+    openPreview(urlTarget('https://example.com/App'), 'tool-result')
+
+    expect(closePreviewMatching('https://EXAMPLE.com/app/')).toBe(true)
     expect($previewTabs.get()).toHaveLength(0)
   })
 

--- a/apps/desktop/src/store/preview.ts
+++ b/apps/desktop/src/store/preview.ts
@@ -425,6 +425,9 @@ export function closeRightRailTab(tabId: string) {
   const next = current.filter(tab => tab.id !== tabId)
 
   $previewTabs.set(next)
+  // Drop the live page with the tab — a stale entry would outlive the tab
+  // and could match a later close query against a recycled address.
+  forgetBrowserPage(tabId)
 
   if ($rightRailActiveTabId.get() === tabId) {
     selectRightRailTab(next[Math.min(index, next.length - 1)]?.id ?? null)
@@ -440,9 +443,36 @@ export function closePreviewForSource(source: string): boolean {
   return closePreviewMatching(source)
 }
 
-/** Close the first tab whose source, url, or label matches any candidate.
- *  Empty candidates are a no-op so a missed match cannot wipe the rail —
- *  closing the whole pane is `closeRightRail`. */
+/** Normalize an http(s) URL for close matching: lowercase host, drop the
+ *  fragment, strip trailing slashes. Returns null for anything else so file
+ *  paths and labels (case-sensitive on POSIX) only ever match exactly. */
+function normalizePreviewUrl(value: string): string | null {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return null
+  }
+
+  try {
+    const parsed = new URL(trimmed)
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      return null
+    }
+
+    parsed.hostname = parsed.hostname.toLowerCase()
+    parsed.pathname = parsed.pathname.replace(/\/+$/, '') || '/'
+    parsed.hash = ''
+
+    return parsed.toString()
+  } catch {
+    return null
+  }
+}
+
+/** Close the first tab whose source, url, label, or live page matches any
+ *  candidate. Empty candidates are a no-op so a missed match cannot wipe
+ *  the rail — closing the whole pane is `closeRightRail`. */
 export function closePreviewMatching(...candidates: string[]): boolean {
   const queries = [...new Set(candidates.map(value => value.trim()).filter(Boolean))]
 
@@ -451,9 +481,33 @@ export function closePreviewMatching(...candidates: string[]): boolean {
   }
 
   const tab = $previewTabs.get().find(item => {
+    // The webview's live address can differ from the open-time url after a
+    // redirect or rewrite — match it too, or close-by-original-URL silently
+    // misses and the tab can never be closed (#102166).
+    const liveUrl = $browserPages.get()[item.id]?.url
     const fields = [item.target.source, item.target.url, item.target.label]
 
-    return queries.some(query => fields.includes(query))
+    if (liveUrl) {
+      fields.push(liveUrl)
+    }
+
+    if (queries.some(query => fields.includes(query))) {
+      return true
+    }
+
+    const normalizedFields = fields
+      .map(normalizePreviewUrl)
+      .filter((url): url is string => url !== null)
+
+    if (normalizedFields.length === 0) {
+      return false
+    }
+
+    return queries.some(query => {
+      const normalizedQuery = normalizePreviewUrl(query)
+
+      return normalizedQuery !== null && normalizedFields.includes(normalizedQuery)
+    })
   })
 
   if (!tab) {


### PR DESCRIPTION
## What does this PR do?

Preview pane tabs could not be closed: `preview.close` returned `{"success":true}` but `read` still listed the tab, and `localStorage` restore resurrected it on restart. Root cause is in `closePreviewMatching()` (`apps/desktop/src/store/preview.ts:446`): it exact-matches the query against `[source, url, label]` — the *open-time* URL. After a redirect or `reachablePreviewUrl` rewrite, the webview's live address differs, so close-by-original-URL finds no tab while the backend already reported success.

This PR:

- Includes the webview's live page (`$browserPages[tab.id].url`) in the match fields, so a tab is found by either its open-time or current address.
- Adds a normalized-URL match layer (`normalizePreviewUrl`: lowercase host, strip fragment and trailing slashes, http(s) only) covering trivial differences; non-URL fields (file paths, labels) still match exactly only, so POSIX case-sensitivity is preserved.
- Drops the live-page entry in `closeRightRailTab()` via `forgetBrowserPage()` so stale addresses can't match later queries.
- Adds two regression tests in `preview.test.ts` (close-by-original-URL after redirect; host-case/trailing-slash close).

## Related Issue

Fixes #102166

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/preview.ts:438` — add `normalizePreviewUrl()` + live-URL/normalized matching in `closePreviewMatching()` with comment referencing #102166.
- `apps/desktop/src/store/preview.ts:417` — `closeRightRailTab()` now calls `forgetBrowserPage(tabId)`.
- `apps/desktop/src/store/preview.test.ts:201` — two new cases (redirect close, normalized close).

## How to Test

1. **Repro:** open `https://dsh.cuicui.de:3080` in the preview pane, let it redirect, then `preview.close` with the original URL. Before: `success:true` but tab remains (and restores after restart). After: tab closes and stays closed across restart.
2. `npx vitest run src/store/preview.test.ts` from `apps/desktop` — all cases green, including the two new ones.
3. Existing exact-match behavior unchanged (`Demo` label close, unknown query no-op — covered by existing tests).
4. CI: `JS & TS checks` pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass (N/A — TS-only; `npx vitest run src/store/preview.test.ts` covers it, CI `JS & TS checks` runs it)
- [x] I've added tests for my changes (two new vitest cases in `preview.test.ts`)
- [x] I've tested on my platform: Windows 11, Node 20

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (renderer URL logic, platform-agnostic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

Not applicable — pane behavior. Before: `preview.close` → `success:true`, tab still listed, ghost after restart. After: tab removed from rail + persistence on close.
