### PR TITLE
fix(plugins): portable-plugin hardening for community sources (diagnostics, cwd, scanner exemption)

### DIFF
--- a/hermes_cli/agent_plugins.py
+++ b/hermes_cli/agent_plugins.py
@@ -90,8 +90,20 @@ def _validate_manifest(root: Path) -> tuple[dict, list[AgentPluginDiagnostic]]:
         raise AgentPluginError("plugin.json must be a regular file within the plugin root")
     manifest = _read_json_object(manifest_path, label="plugin.json")
     diagnostics: list[AgentPluginDiagnostic] = []
+    _CURSOR_ONLY_FIELDS = {"agents", "commands", "hooks", "automations", "rules"}
     for field in sorted(set(manifest) - _PLUGIN_FIELDS):
-        diagnostics.append(AgentPluginDiagnostic("manifest", f"ignored unknown top-level field: {field}"))
+        if field in _CURSOR_ONLY_FIELDS:
+            # Loud diagnostic: silent success is the dangerous failure mode for
+            # Cursor ports. hermes discovers skills/ + mcp.json only.
+            diagnostics.append(
+                AgentPluginDiagnostic(
+                    "manifest",
+                    f"Cursor-only component '{field}' will NOT load: hermes discovers "
+                    "skills/ and mcp.json only from portable agent-plugins-v1 packages",
+                )
+            )
+        else:
+            diagnostics.append(AgentPluginDiagnostic("manifest", f"ignored unknown top-level field: {field}"))
         manifest.pop(field)
     if manifest.get("$schema") != PLUGIN_SCHEMA_V1:
         raise AgentPluginError("plugin.json declares an unsupported or missing Agent Plugins schema")

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -399,7 +399,17 @@ def _run_agent(
             session_db=session_db,
             credential_pool=runtime.get("credential_pool"),
             fallback_model=get_fallback_chain(cfg) or None,
-            ephemeral_system_prompt=skills_prompt,
+            # F-live-3 fix: tell the model where it is running. Without
+            # this, 'create a file in the current directory' resolves to
+            # the home root because the model invents an absolute path.
+            ephemeral_system_prompt=(
+                (skills_prompt or "")
+                + f"\n\n# Working directory\n"
+                f"Current working directory for this session: {os.getcwd()}\n"
+                "When a task says to create or modify files 'in the current "
+                "directory' or uses relative paths, resolve them against this "
+                "directory and pass absolute paths to file tools."
+            ),
             # The only interactive callback wired: no user sits at a terminal. Sudo prompts gate on
             # HERMES_INTERACTIVE (never set), hook approval via HERMES_ACCEPT_HOOKS=1, dangerous
             # commands via HERMES_YOLO_MODE=1, skill secret capture degrades gracefully.
@@ -409,6 +419,19 @@ def _run_agent(
         agent.suppress_status_output = True
         agent.stream_delta_callback = None
         agent.tool_gen_callback = None
+
+        # Seed the task-session cwd from the invoking process directory so
+        # file/terminal tools resolve "current directory" to where the user
+        # actually ran `hermes -z`, instead of the configured default
+        # workspace (tools/terminal_tool.py:get_session_cwd documents the
+        # process-cwd seed; gateway/TUI register the same via workspace
+        # overrides - oneshot is the only surface that never seeds it).
+        try:
+            from tools.terminal_tool import record_session_cwd
+
+            record_session_cwd(getattr(agent, "session_id", None), os.getcwd())
+        except Exception:
+            logging.debug("oneshot session-cwd seed failed", exc_info=True)
 
         result = agent.run_conversation(prompt)
         return (result.get("final_response") or "", result)

--- a/tests/tools/test_skills_guard.py
+++ b/tests/tools/test_skills_guard.py
@@ -261,6 +261,34 @@ class TestCheckStructure:
         findings = _check_structure(tmp_path / "skill")
         assert any(fi.pattern_id == "symlink_escape" for fi in findings)
 
+    def _fill_beyond_file_limit(self, tmp_path):
+        for i in range(MAX_FILE_COUNT + 5):
+            (tmp_path / f"file_{i}.txt").write_text("x")
+
+    def test_plugin_root_exempt_requires_valid_schema(self, tmp_path):
+        # A package over the file-count limit is exempt only when its
+        # plugin.json actually declares the agent-plugins-v1 $schema.
+        self._fill_beyond_file_limit(tmp_path)
+        (tmp_path / "plugin.json").write_text(
+            '{"$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json", "name": "probe"}'
+        )
+        ids = {fi.pattern_id for fi in _check_structure(tmp_path)}
+        assert "too_many_files" not in ids
+
+    def test_plugin_root_with_planted_manifest_fails_closed(self, tmp_path):
+        # Presence of plugin.json alone must NOT grant the exemption: a
+        # planted manifest without the v1 $schema fails closed.
+        self._fill_beyond_file_limit(tmp_path)
+        (tmp_path / "plugin.json").write_text('{"name": "sneaky"}')
+        ids = {fi.pattern_id for fi in _check_structure(tmp_path)}
+        assert "too_many_files" in ids
+
+    def test_plugin_root_with_malformed_manifest_fails_closed(self, tmp_path):
+        self._fill_beyond_file_limit(tmp_path)
+        (tmp_path / "plugin.json").write_text("{not json")
+        ids = {fi.pattern_id for fi in _check_structure(tmp_path)}
+        assert "too_many_files" in ids
+
     @pytest.mark.skipif(
         not _can_symlink(), reason="Symlinks need elevated privileges"
     )

--- a/tools/skills_guard.py
+++ b/tools/skills_guard.py
@@ -522,6 +522,19 @@ def format_scan_report(result: ScanResult) -> str:
     return "\n".join(lines + [f"Decision: {status} — {reason}"])
 
 
+def _declares_agent_plugins_v1(path: Path) -> bool:
+    """True only when *path* parses as a JSON object declaring the canonical
+    agent-plugins-v1 ``$schema``. Fail-closed: any read/parse error counts as
+    "not a plugin root" so a planted manifest cannot grant exemptions."""
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and (
+        data.get("$schema") == "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json"
+    )
+
+
 def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
     """Structural anomalies (counts, sizes, binaries, stray executables, escaping symlinks); *ignore(rel) -> bool*
     excludes paths from every count and finding."""
@@ -558,7 +571,15 @@ def _check_structure(skill_dir: Path, ignore=None) -> List[Finding]:
         if ext not in _SCRIPT_EXTENSIONS and st.st_mode & 0o111:
             add("unexpected_executable", "medium", "structural", rel, "executable bit set",
                 "file has executable permission but is not a recognized script type")
-    if file_count > MAX_FILE_COUNT:
+
+    # File count limit. Skipped for agent-plugin roots: a portable plugin
+    # package legitimately bundles many skills, so the per-skill file-count
+    # rule does not apply to the package as a whole. The exemption requires
+    # the manifest to actually declare the agent-plugins-v1 $schema — a
+    # planted plugin.json alone must not disable the structural heuristic.
+    plugin_json = skill_dir / "plugin.json"
+    is_plugin_root = plugin_json.is_file() and _declares_agent_plugins_v1(plugin_json)
+    if file_count > MAX_FILE_COUNT and not is_plugin_root:
         add("too_many_files", "medium", "structural", "(directory)", f"{file_count} files",
             f"skill has {file_count} files (limit: {MAX_FILE_COUNT})")
     if total_size > MAX_TOTAL_SIZE_KB * 1024:  # informational only: large skills are legitimate


### PR DESCRIPTION
Four related fixes found while porting a real Cursor agent-plugins-v1 plugin (pstack, now 45 skills) to hermes. Every change is behavior-verified against the running agent.

### 1. Loud diagnostics for Cursor-only components in portable manifests

`hermes_cli/agent_plugins.py` `_validate_manifest`: when a portable manifest declares Cursor-only component fields (`agents`, `commands`, `hooks`, `automations`, `rules`), emit an actionable diagnostic ("Cursor-only component 'agents' will NOT load: hermes discovers skills/ and mcp.json only") instead of the generic ignored-field warning. Prevents the silent-success failure mode where a Cursor plugin loads with its agents/commands/hooks doing nothing.

Verified: synthetic manifest with the three fields emits exactly 3 loud diagnostics; other unknown fields keep the generic warning.

### 2. One-shot (-z) sessions seed the task-session cwd

`hermes_cli/oneshot.py`: one-shot sessions never registered a workspace cwd override, so file/terminal tools resolved "current directory" to the configured default workspace (the last-used project) instead of where the user ran `hermes -z`. Seed `record_session_cwd(session_id, os.getcwd())` after agent construction — the seed source `tools/terminal_tool.py` `get_session_cwd` explicitly documents the process cwd as an intended seed.

Verified: a one-shot creating "a file named cwd-probe.txt in the current directory" now writes it to the invoking directory (previously: the home root).

### 3. One-shot ephemeral system prompt surfaces the working directory

Companion to #2: the model itself resolved "current directory" to the home root by inventing an absolute path, because nothing told it the cwd. The one-shot ephemeral system prompt now ends with a "Working directory" section (`Current working directory for this session: <cwd>` + relative-path resolution guidance).

Verified: same probe now lands in the invoking directory with the model quoting the correct absolute path.

### 4. skills_guard: exempt agent-plugin roots from the per-skill file-count rule

`tools/skills_guard.py` `_check_structure`: the 50-file `too_many_files` medium finding applies per-skill, but the plugin install path scans the whole package as one unit — making every multi-skill portable plugin (45 skills in our case) un-installable via the CLI without `--force` on the build this was developed against. A directory containing `plugin.json` is an agent-plugin root and now skips the file-count finding; the per-skill size, executable, and content rules still apply.

Verified: the package scans as safe verdict with the `too_many_files` finding gone; `should_allow_install` returns True.

## Commits

- 212b862137 fix(plugins): loud diagnostics for Cursor-only components in portable manifests
- ac74e42560 fix(oneshot): seed task-session cwd from the invoking process directory
- 0953d35c91 fix(oneshot): surface the working directory in the ephemeral system prompt
- ab6d3b9700 fix(skills_guard): exempt agent-plugin roots from the per-skill file-count rule

## Testing

- `python -m py_compile` on every touched file
- Behavioral verification per change (synthetic manifests + live one-shots + real scanner runs), all green on Windows (git install, venv 3.11)
- The skills_guard exemption independently exercised on macOS: a real 45-skill agent-plugins-v1 package (iap/pstack-hermes @ fca043c4) installs scanner-clean through `hermes plugins install <owner>/<repo>/<subdir>`

## Known follow-ups (from an adversarial self-review)

- The plugin-root exemption keys off `plugin.json` **presence** alone (`tools/skills_guard.py`, `_check_structure`). A malicious community package could plant a `plugin.json` to dodge the `too_many_files` structural heuristic. Suggested hardening: require the manifest to declare the agent-plugins-v1 `$schema` before granting the exemption — filed as a separate issue with details so it can be tracked independently of this PR.
- Empirical note for reviewers: pstack 0.14.4 (45 skills) also installed scanner-clean on the v0.21.0 build **without** this patch, so the `too_many_files` block may not reproduce on current main; the exemption is still the correct contract for multi-skill portable plugins. Happy to reconcile versions if maintainers see different behavior.
