### PR TITLE
mcp_oauth, docker: fix logging of credential material in warnings

### DIFF
--- a/tools/environments/docker.py
+++ b/tools/environments/docker.py
@@ -79,7 +79,7 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
     if not env:
         return {}
     if not isinstance(env, dict):
-        logger.warning("docker_env is not a dict: %r", env)
+        logger.warning("docker_env is not a dict: %s", type(env).__name__)
         return {}
 
     normalized: dict[str, str] = {}
@@ -94,7 +94,7 @@ def _normalize_env_dict(env: dict | None) -> dict[str, str]:
             if isinstance(value, (int, float, bool)):
                 value = str(value)
             else:
-                logger.warning("Ignoring non-string docker_env value for %r: %r", key, value)
+                logger.warning("Ignoring non-string docker_env value for %r: %s", key, type(value).__name__)
                 continue
         normalized[key] = value
 

--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -521,7 +521,18 @@ class HermesTokenStorage:
         try:
             return OAuthToken.model_validate(data)
         except (ValueError, TypeError, KeyError) as exc:
-            logger.warning("Corrupt tokens at %s -- ignoring: %s", self._tokens_path(), exc)
+            # Pydantic ValidationError includes raw input in its string repr.
+            # Use errors(include_input=False) to avoid logging token material.
+            err_detail = exc
+            if hasattr(exc, "errors"):
+                try:
+                    errs = exc.errors(include_input=False)
+                    if errs:
+                        fields = ", ".join(str(e.get("loc")) for e in errs)
+                        err_detail = f"validation failed for fields: {fields}"
+                except Exception:
+                    pass
+            logger.warning("Corrupt tokens at %s -- ignoring: %s", self._tokens_path(), err_detail)
             return None
 
     async def set_tokens(self, tokens: "OAuthToken") -> None:


### PR DESCRIPTION
Fixes #102308

Two warning paths were logging raw credential material:

1. mcp_oauth.py: Pydantic ValidationError's string repr includes raw input
   values (access_token, refresh_token). Now uses errors(include_input=False)
   to log only failing field names.

2. docker.py: docker_env normalization was logging raw env values
   (which can contain API keys). Now logs only the type name.

CONTRIBUTING's security guidance says: 'Don't log secrets. API keys, tokens,
and passwords should never appear in log output.' This fix ensures malformed
user input doesn't leak secrets to logs (and thus to bug reports via
'hermes debug share').