### PR TITLE
fix(bot-mode): let users compress hidden room member histories

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat-settings.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-settings.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { translateBots } from './i18n-test-helper'
+
+const { compressGroupChatSessions, host } = vi.hoisted(() => ({
+  compressGroupChatSessions: vi.fn(),
+  host: { notify: vi.fn() }
+}))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+  const base = await pluginSdkMock(host)
+  const Div = ({ children }: React.PropsWithChildren) => <div>{children}</div>
+
+  return {
+    ...base,
+    Button: ({ children, size: _size, variant: _variant, ...props }: React.ComponentProps<'button'> & { size?: string; variant?: string }) => (
+      <button type="button" {...props}>
+        {children}
+      </button>
+    ),
+    Codicon: () => null,
+    Dialog: ({ children, open }: React.PropsWithChildren<{ open?: boolean }>) => (open ? <div>{children}</div> : null),
+    DialogContent: Div,
+    DialogDescription: Div,
+    DialogFooter: Div,
+    DialogHeader: Div,
+    DialogTitle: Div,
+    Input: (props: React.ComponentProps<'input'>) => <input {...props} />,
+    useI18n: () => ({ t: { common: { cancel: 'Cancel', save: 'Save' } } }),
+    usePluginI18n: () => translateBots
+  }
+})
+
+vi.mock('./group-chat-parts', () => ({
+  GroupClarifyCard: () => null,
+  GroupImageControls: () => null,
+  GroupMentionInput: () => null
+}))
+
+vi.mock('./group-turns', () => ({
+  clearGroupClarify: vi.fn(),
+  compressGroupChatSessions
+}))
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+describe('group settings maintenance', () => {
+  it('makes hidden member-session compression reachable from the room', async () => {
+    compressGroupChatSessions.mockResolvedValue([
+      { member: 'builder', status: 'compressed' },
+      { member: 'critic', status: 'pending' }
+    ])
+    const { GroupChatSettingsDialog } = await import('./group-chat-view')
+    const members = [{ name: 'builder' }, { name: 'critic' }]
+
+    render(<GroupChatSettingsDialog group="Core" members={members} onClose={() => undefined} open />)
+    fireEvent.click(screen.getByRole('button', { name: 'Compress member histories' }))
+
+    await waitFor(() => expect(compressGroupChatSessions).toHaveBeenCalledWith('Core', members))
+    expect(host.notify).toHaveBeenCalledWith({
+      kind: 'success',
+      message: 'Compressed 1 member history; 1 still running.'
+    })
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-settings.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-settings.test.tsx
@@ -67,4 +67,25 @@ describe('group settings maintenance', () => {
       message: 'Compressed 1 member history; 1 still running.'
     })
   })
+
+  it.each([
+    ['aborted', 'No compression provider is configured.'],
+    ['lock-held', 'Another compression may still be running; try again shortly.']
+  ])('reports %s compression as an actionable failure', async (_case, error) => {
+    compressGroupChatSessions.mockResolvedValue([{ error, member: 'builder', status: 'failed' }])
+    const { GroupChatSettingsDialog } = await import('./group-chat-view')
+
+    render(<GroupChatSettingsDialog group="Core" members={[{ name: 'builder' }]} onClose={() => undefined} open />)
+    fireEvent.click(screen.getByRole('button', { name: 'Compress member histories' }))
+
+    await waitFor(() =>
+      expect(host.notify).toHaveBeenCalledWith({
+        kind: 'error',
+        message: `Could not compress 1 of 1 member histories. builder: ${error}`
+      })
+    )
+    expect(host.notify).not.toHaveBeenCalledWith(
+      expect.objectContaining({ kind: 'success', message: 'No existing member histories need compression.' })
+    )
+  })
 })

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -94,7 +94,7 @@ import {
 } from './group-panes'
 import type { GroupComposerDraft, GroupDraftSetter } from './group-panes'
 import { sendToGroupChat, stopGroupThread } from './group-rounds'
-import { clearGroupClarify } from './group-turns'
+import { clearGroupClarify, compressGroupChatSessions } from './group-turns'
 import { botsText, useBots } from './i18n'
 import { displayName, slugify, stripPreviewMarkdown } from './labels'
 import { botRosterMeta, setBotsWorkspaceOwner } from './routing'
@@ -363,13 +363,14 @@ interface GroupChatSettingsDialogProps {
 /** Edit an existing group chat's name and picture. Renames re-key the room
  *  and every local member's membership (renameGroupChat); the picture rides
  *  the room record. Both apply on Save so a cancelled dialog changes nothing. */
-function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
+export function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: GroupChatSettingsDialogProps) {
   const { t } = useI18n()
   const b = useBots()
   const rooms: Record<string, GroupChatRoom> = useValue($groupChats)
   const current = (rooms[group] || {}).image || null
   const [name, setName] = useState(group)
   const [image, setImage] = useState(current)
+  const [compressing, setCompressing] = useState(false)
   useEffect(() => {
     if (open) {
       setName(group)
@@ -393,6 +394,32 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: G
 
     if (finalName !== group) {
       onRenamed?.(finalName)
+    }
+  }
+
+  const compressHistories = async () => {
+    if (compressing || !(members || []).length) {
+      return
+    }
+
+    setCompressing(true)
+
+    try {
+      const outcomes = await compressGroupChatSessions(group, members || [])
+      const compressed = outcomes.filter(outcome => outcome.status === 'compressed').length
+      const pending = outcomes.filter(outcome => outcome.status === 'pending').length
+      const failed = outcomes.filter(outcome => outcome.status === 'failed').length
+
+      host.notify({
+        kind: failed ? 'error' : 'success',
+        message: failed
+          ? b.group.compressHistoryFailed(failed, outcomes.length)
+          : compressed || pending
+            ? b.group.compressHistoryDone(compressed, pending)
+            : b.group.compressHistoryNone
+      })
+    } finally {
+      setCompressing(false)
     }
   }
 
@@ -430,6 +457,22 @@ function GroupChatSettingsDialog({ group, members, open, onClose, onRenamed }: G
             value={name}
           />
         </form>
+        <div className="flex items-center justify-between gap-3 rounded-md border border-(--ui-stroke-secondary) px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-sm font-medium">{b.group.compressHistory}</div>
+            <div className="text-xs text-(--ui-text-tertiary)">{b.group.compressHistoryHint}</div>
+          </div>
+          <Button
+            disabled={compressing || !(members || []).length}
+            onClick={() => void compressHistories()}
+            size="sm"
+            type="button"
+            variant="secondary"
+          >
+            <Codicon name="fold-down" />
+            {compressing ? b.group.compressingHistory : b.group.compressHistory}
+          </Button>
+        </div>
         <DialogFooter>
           <Button onClick={onClose} variant="secondary">
             {t.common.cancel}

--- a/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx
@@ -410,10 +410,15 @@ export function GroupChatSettingsDialog({ group, members, open, onClose, onRenam
       const pending = outcomes.filter(outcome => outcome.status === 'pending').length
       const failed = outcomes.filter(outcome => outcome.status === 'failed').length
 
+      const failureDetails = outcomes
+        .filter(outcome => outcome.status === 'failed' && outcome.error)
+        .map(outcome => `${outcome.member}: ${outcome.error}`)
+        .join(' ')
+
       host.notify({
         kind: failed ? 'error' : 'success',
         message: failed
-          ? b.group.compressHistoryFailed(failed, outcomes.length)
+          ? `${b.group.compressHistoryFailed(failed, outcomes.length)}${failureDetails ? ` ${failureDetails}` : ''}`
           : compressed || pending
             ? b.group.compressHistoryDone(compressed, pending)
             : b.group.compressHistoryNone

--- a/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
@@ -298,6 +298,19 @@ export function createGroupGateway(options: GatewayOptions = {}): ScriptedGatewa
         : { attached: true }
     }
 
+    if (method === 'session.compress') {
+      const session = resolveSession(null, params.session_id)
+
+      if (!session) {
+        throw gatewayError(`session-scoped RPC rejected: ${String(params.session_id)} not in memory`, 4001)
+      }
+
+      const removed = Math.max(0, session.messages.length - 2)
+      session.messages = session.messages.slice(-2)
+
+      return { removed, status: 'compressed' }
+    }
+
     if (method === 'prompt.submit') {
       submits += 1
 

--- a/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-test-utils.ts
@@ -98,6 +98,8 @@ export interface GatewayOptions {
   onResumePoll?: (polls: number) => void
   /** Report the member inflight for the first N post-submit polls. */
   pollsBusy?: number
+  /** Structured result returned by session.compress. */
+  compressionResult?: Record<string, unknown>
   turn?: TurnScript
 }
 
@@ -308,7 +310,7 @@ export function createGroupGateway(options: GatewayOptions = {}): ScriptedGatewa
       const removed = Math.max(0, session.messages.length - 2)
       session.messages = session.messages.slice(-2)
 
-      return { removed, status: 'compressed' }
+      return options.compressionResult || { removed, status: 'compressed' }
     }
 
     if (method === 'prompt.submit') {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -186,6 +186,59 @@ describe('session resolution', () => {
     expect(result.stored).toBeTruthy()
     expect(result.stored).not.toBe('sid-gone')
   })
+
+  it('compresses existing member histories through live ids without minting sessions', async () => {
+    const room = await loadRoom()
+    const local: GroupMember = { name: 'research', title: '' }
+
+    const remote: GroupMember = {
+      connectionId: 'mini',
+      name: 'critic',
+      remoteSource: true,
+      route: { connectionId: 'mini', mode: 'remote', profile: 'critic', targetProfile: 'critic' }
+    }
+
+    room.chat.updateGroupChat('Core', current => {
+      current.roomId = 'r-core'
+
+      return current
+    })
+    await room.turns.ensureGroupChatSession('Core', local)
+    await room.turns.ensureGroupChatSession('Core', remote)
+
+    const beforeCreates = room.gateway.rpcFor('session.create').length
+    const outcomes = await room.turns.compressGroupChatSessions('Core', [local, remote])
+
+    expect(outcomes.map(outcome => outcome.status)).toEqual(['compressed', 'compressed'])
+    expect(room.gateway.rpcFor('session.create')).toHaveLength(beforeCreates)
+    expect(room.gateway.rpcFor('session.compress')).toHaveLength(2)
+
+    for (const call of room.gateway.rpcFor('session.compress')) {
+      expect(String(call.params.session_id)).toMatch(/^rt-/)
+    }
+
+    // Routed sessions stay leased for resume -> compress, so their runtime id
+    // cannot be reaped between the two session-scoped RPCs.
+    expect(room.gateway.timeline).toContain('session.compress')
+    expect(room.gateway.refcount()).toBe(0)
+  })
+
+  it('skips a member with no room session instead of creating empty plumbing', async () => {
+    const room = await loadRoom()
+
+    room.chat.updateGroupChat('Fresh', current => {
+      current.roomId = 'r-fresh'
+
+      return current
+    })
+
+    const outcomes = await room.turns.compressGroupChatSessions('Fresh', [{ name: 'research', title: '' }])
+
+    expect(outcomes).toEqual([{ member: 'research', status: 'skipped' }])
+    expect(room.gateway.rpcFor('session.resume')).toHaveLength(1)
+    expect(room.gateway.rpcFor('session.create')).toHaveLength(0)
+    expect(room.gateway.rpcFor('session.compress')).toHaveLength(0)
+  })
 })
 
 describe('session-gone classification', () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.test.ts
@@ -239,6 +239,45 @@ describe('session resolution', () => {
     expect(room.gateway.rpcFor('session.create')).toHaveLength(0)
     expect(room.gateway.rpcFor('session.compress')).toHaveLength(0)
   })
+
+  it('surfaces an aborted compression as a failure', async () => {
+    const room = await loadRoom({
+      compressionResult: {
+        status: 'aborted',
+        summary: { aborted: true, note: 'No compression provider is configured.' }
+      }
+    })
+
+    const member: GroupMember = { name: 'research', title: '' }
+
+    await room.turns.ensureGroupChatSession('Core', member)
+
+    await expect(room.turns.compressGroupChatSessions('Core', [member])).resolves.toEqual([
+      { error: 'No compression provider is configured.', member: 'research', status: 'failed' }
+    ])
+  })
+
+  it('surfaces lock contention instead of reporting compression success', async () => {
+    const room = await loadRoom({
+      compressionResult: {
+        compressed: false,
+        lock_held: true,
+        message: 'Another compression may still be running; try again shortly.'
+      }
+    })
+
+    const member: GroupMember = { name: 'research', title: '' }
+
+    await room.turns.ensureGroupChatSession('Core', member)
+
+    await expect(room.turns.compressGroupChatSessions('Core', [member])).resolves.toEqual([
+      {
+        error: 'Another compression may still be running; try again shortly.',
+        member: 'research',
+        status: 'failed'
+      }
+    ])
+  })
 })
 
 describe('session-gone classification', () => {

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -123,7 +123,15 @@ export interface GroupSessionCompressionOutcome {
 }
 
 interface GroupSessionCompressionResponse {
+  compressed?: boolean
+  lock_held?: boolean
+  message?: string
   status?: string
+  summary?: {
+    aborted?: boolean
+    headline?: string
+    note?: string
+  }
 }
 
 // session.compress can legitimately use the gateway's full compute-host wait
@@ -186,10 +194,23 @@ export async function compressGroupChatSessions(
           GROUP_SESSION_COMPRESS_TIMEOUT_MS
         )
 
-        return {
-          member: member.name,
-          status: result?.status === 'pending' ? 'pending' : result?.status === 'aborted' ? 'skipped' : 'compressed'
+        if (result?.status === 'pending') {
+          return { member: member.name, status: 'pending' }
         }
+
+        if (result?.status === 'aborted' || result?.summary?.aborted || result?.compressed === false) {
+          return {
+            error:
+              result?.message ||
+              result?.summary?.note ||
+              result?.summary?.headline ||
+              (result?.lock_held ? 'Compression is already in progress.' : 'Compression was not completed.'),
+            member: member.name,
+            status: 'failed'
+          }
+        }
+
+        return { member: member.name, status: 'compressed' }
       } catch (error) {
         return {
           error: error instanceof Error ? error.message : String(error),

--- a/apps/desktop/src/plugins/hermes-bots/group-turns.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-turns.ts
@@ -116,6 +116,93 @@ interface GroupMemberSessionHandle {
   stored?: null | string | true
 }
 
+export interface GroupSessionCompressionOutcome {
+  error?: string
+  member: string
+  status: 'compressed' | 'failed' | 'pending' | 'skipped'
+}
+
+interface GroupSessionCompressionResponse {
+  status?: string
+}
+
+// session.compress can legitimately use the gateway's full compute-host wait
+// ceiling. Match the focused-chat /compress budget so the room action does not
+// report a false timeout while compression is still committing (#97948).
+const GROUP_SESSION_COMPRESS_TIMEOUT_MS = 660_000
+
+/** Compress every EXISTING hidden member session for a room. Resolve durable
+ * ids (then the immutable room title for rehydrated/legacy rooms) to live ids,
+ * keep routed sockets leased across resume -> compress, and never mint a new
+ * empty plumbing session merely because the maintenance action was clicked. */
+export async function compressGroupChatSessions(
+  group: string,
+  members: GroupMember[]
+): Promise<GroupSessionCompressionOutcome[]> {
+  const room = $groupChats.get()[group] || {}
+  const title = `Group: ${room.roomId || group}`
+
+  return Promise.all(
+    members.map(async member => {
+      const release = await retainGroupTurnRoute(member)
+
+      try {
+        const key = groupMemberKey(member)
+        const known = room.sessions?.[key]
+        let runtime: null | string = null
+
+        for (const target of [known, title]) {
+          if (!target || target === true) {
+            continue
+          }
+
+          try {
+            const resumed = (await requestForBot(member, 'session.resume', {
+              session_id: target,
+              profile: member.name,
+              omit_messages: true
+            })) as GroupSessionSnapshot
+
+            if (resumed?.session_id) {
+              runtime = resumed.session_id
+
+              break
+            }
+          } catch (error: any) {
+            if (error?.code !== 4007) {
+              throw error
+            }
+          }
+        }
+
+        if (!runtime) {
+          return { member: member.name, status: 'skipped' }
+        }
+
+        const result = await requestForBot<GroupSessionCompressionResponse>(
+          member,
+          'session.compress',
+          { session_id: runtime },
+          GROUP_SESSION_COMPRESS_TIMEOUT_MS
+        )
+
+        return {
+          member: member.name,
+          status: result?.status === 'pending' ? 'pending' : result?.status === 'aborted' ? 'skipped' : 'compressed'
+        }
+      } catch (error) {
+        return {
+          error: error instanceof Error ? error.message : String(error),
+          member: member.name,
+          status: 'failed'
+        }
+      } finally {
+        release()
+      }
+    })
+  )
+}
+
 /** Ensure the member's per-group session exists and return a LIVE runtime
  *  session id for it. Gateway-native: session.create mints the session
  *  (lazy until its first message), session.resume by stored id — or by

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -155,6 +155,12 @@ type BotsMessages = {
     manageTitle: string
     settingsTitle: string
     settingsDesc: string
+    compressHistory: string
+    compressHistoryHint: string
+    compressingHistory: string
+    compressHistoryDone: (compressed: number, pending: number) => string
+    compressHistoryNone: string
+    compressHistoryFailed: (failed: number, total: number) => string
     nameLabel: string
     searchToAdd: string
     searchToAddPlaceholder: string
@@ -379,6 +385,13 @@ const en: BotsMessages = {
     manageTitle: 'Manage groups',
     settingsTitle: 'Group settings',
     settingsDesc: 'Rename the group or set a room picture. Members and history are kept.',
+    compressHistory: 'Compress member histories',
+    compressHistoryHint: 'Summarize the hidden session behind each bot to free context space.',
+    compressingHistory: 'Compressing member histories…',
+    compressHistoryDone: (compressed, pending) =>
+      `Compressed ${compressed} member ${compressed === 1 ? 'history' : 'histories'}${pending ? `; ${pending} still running` : ''}.`,
+    compressHistoryNone: 'No existing member histories need compression.',
+    compressHistoryFailed: (failed, total) => `Could not compress ${failed} of ${total} member histories.`,
     nameLabel: 'Group name',
     searchToAdd: 'Search bots to add',
     searchToAddPlaceholder: 'Search bots to add…',
@@ -596,6 +609,13 @@ const ja: BotsMessages = {
     manageTitle: 'グループを管理',
     settingsTitle: 'グループ設定',
     settingsDesc: 'グループ名の変更や部屋の画像の設定ができます。メンバーと履歴は保持されます。',
+    compressHistory: 'メンバー履歴を圧縮',
+    compressHistoryHint: '各ボットの非表示セッションを要約し、コンテキスト容量を確保します。',
+    compressingHistory: 'メンバー履歴を圧縮中…',
+    compressHistoryDone: (compressed, pending) =>
+      `${compressed} 件のメンバー履歴を圧縮しました${pending ? `（${pending} 件は引き続き処理中）` : ''}。`,
+    compressHistoryNone: '圧縮が必要な既存のメンバー履歴はありません。',
+    compressHistoryFailed: (failed, total) => `${total} 件中 ${failed} 件のメンバー履歴を圧縮できませんでした。`,
     nameLabel: 'グループ名',
     searchToAdd: '追加するボットを検索',
     searchToAddPlaceholder: '追加するボットを検索…',
@@ -809,6 +829,13 @@ const zh: BotsMessages = {
     manageTitle: '管理群组',
     settingsTitle: '群组设置',
     settingsDesc: '重命名群组或设置房间图片。成员和历史都会保留。',
+    compressHistory: '压缩成员历史',
+    compressHistoryHint: '总结每个机器人背后的隐藏会话，以释放上下文空间。',
+    compressingHistory: '正在压缩成员历史…',
+    compressHistoryDone: (compressed, pending) =>
+      `已压缩 ${compressed} 个成员历史${pending ? `；${pending} 个仍在后台处理` : ''}。`,
+    compressHistoryNone: '没有需要压缩的现有成员历史。',
+    compressHistoryFailed: (failed, total) => `${total} 个成员历史中有 ${failed} 个压缩失败。`,
     nameLabel: '群组名称',
     searchToAdd: '搜索要添加的机器人',
     searchToAddPlaceholder: '搜索要添加的机器人…',
@@ -1022,6 +1049,13 @@ const zhHant: BotsMessages = {
     manageTitle: '管理群組',
     settingsTitle: '群組設定',
     settingsDesc: '重新命名群組或設定房間圖片。成員和歷史都會保留。',
+    compressHistory: '壓縮成員歷史',
+    compressHistoryHint: '摘要每個機器人背後的隱藏工作階段，以釋放上下文空間。',
+    compressingHistory: '正在壓縮成員歷史…',
+    compressHistoryDone: (compressed, pending) =>
+      `已壓縮 ${compressed} 個成員歷史${pending ? `；${pending} 個仍在背景處理` : ''}。`,
+    compressHistoryNone: '沒有需要壓縮的現有成員歷史。',
+    compressHistoryFailed: (failed, total) => `${total} 個成員歷史中有 ${failed} 個壓縮失敗。`,
     nameLabel: '群組名稱',
     searchToAdd: '搜尋要加入的機器人',
     searchToAddPlaceholder: '搜尋要加入的機器人…',

--- a/apps/desktop/src/plugins/hermes-bots/routing.ts
+++ b/apps/desktop/src/plugins/hermes-bots/routing.ts
@@ -200,7 +200,8 @@ export function botBackendProfileScope(route: null | ProfileRoute | undefined, f
 export async function requestForBot<T = unknown>(
   bot: Partial<RosterRow> | null | undefined,
   method: string,
-  params: Record<string, unknown> = {}
+  params: Record<string, unknown> = {},
+  timeoutMs?: number
 ): Promise<T> {
   const route = botConnectionRoute(bot)
 
@@ -210,7 +211,11 @@ export async function requestForBot<T = unknown>(
     }
 
     try {
-      return await host.requestProfile(route, method, scopedBotParams(route, method, params))
+      const scoped = scopedBotParams(route, method, params)
+
+      return await (timeoutMs === undefined
+        ? host.requestProfile(route, method, scoped)
+        : host.requestProfile(route, method, scoped, timeoutMs))
     } catch (error) {
       // React 19 formats query errors with `(error.name || '').trim()`. IPC /
       // JSON-RPC rejections are often plain objects whose `name` is a number,
@@ -220,7 +225,7 @@ export async function requestForBot<T = unknown>(
   }
 
   try {
-    return await host.request(method, params)
+    return await (timeoutMs === undefined ? host.request(method, params) : host.request(method, params, timeoutMs))
   } catch (error) {
     throw asRpcError(error, `Gateway request ${method} failed`)
   }

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1377,15 +1377,16 @@ export const host = {
   },
 
   /** Gateway JSON-RPC — sessions, config, skills, cron, kanban, everything
-   *  the app itself uses. Lazy: resolves the LIVE socket per call. */
-  request: async <T>(method: string, params: Record<string, unknown> = {}): Promise<T> => {
+   *  the app itself uses. Lazy: resolves the LIVE socket per call. Long-running
+   *  plugin operations may opt into the same per-request timeout as core. */
+  request: async <T>(method: string, params: Record<string, unknown> = {}, timeoutMs?: number): Promise<T> => {
     const gateway = $gateway.get()
 
     if (!gateway) {
       throw new Error('Hermes gateway unavailable')
     }
 
-    return gateway.request<T>(method, params)
+    return timeoutMs === undefined ? gateway.request<T>(method, params) : gateway.request<T>(method, params, timeoutMs)
   },
 
   /** The LIVE gateway instance for the active profile (null before the first

--- a/apps/desktop/src/sdk/profile-routing.test.ts
+++ b/apps/desktop/src/sdk/profile-routing.test.ts
@@ -127,6 +127,7 @@ const { openSession: openSessionCore } = await import('@/app/open-session')
 const { deleteProfile, hermesApi } = await import('@/hermes')
 
 const {
+  $gateway,
   activeGatewayConnectionId,
   openGatewayForAgent,
   openGatewayForProfile,
@@ -196,10 +197,19 @@ afterEach(() => {
   setMockAtom($messages, [])
   $profiles.set([profile('cached-only')])
   setWorkspaceScope('sessions')
+  $gateway.set(null)
   delete (window as unknown as { hermesDesktop?: unknown }).hermesDesktop
 })
 
 describe('connection-aware plugin host APIs', () => {
+  it('forwards an explicit timeout through the active-gateway request door', async () => {
+    const request = vi.fn(async () => ({ ok: true }))
+    $gateway.set({ request } as never)
+
+    await expect(host.request('session.compress', { session_id: 'rt-1' }, 660_000)).resolves.toEqual({ ok: true })
+    expect(request).toHaveBeenCalledWith('session.compress', { session_id: 'rt-1' }, 660_000)
+  })
+
   it('retires a profile gateway before deleting it', async () => {
     const order: string[] = []
 


### PR DESCRIPTION
## What does this PR do?

Bot Mode users can now compress the hidden per-member sessions behind a group room from Group settings. Without this action, those invisible sessions can grow until member turns repeatedly return no response, while the existing focused-chat `/compress` command cannot target them.

### Symptom

A long-running room member can show `The model returned no response after processing tool results.` after its hidden plumbing session grows large. The room UI cannot focus that session, so users have no supported recovery path even though `session.compress` already works for it.

### Impact

Room members can stop producing useful replies while continuing to process large histories. The affected plumbing session is hidden from normal session navigation, leaving direct JSON-RPC calls as the only recovery path before this change.

### Bug Cause

**Trigger:** `apps/desktop/src/plugins/hermes-bots/group-turns.ts` creates and resumes hidden `room_plumbing` sessions, while `apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx` previously exposed no maintenance action for them.

**Causal chain:**
1. Each room drive appends work to a member-specific hidden session.
2. The normal desktop `/compress` action only targets the focused chat, and hidden room sessions cannot be focused from session navigation.
3. The member history keeps growing with no user-reachable compression path and can eventually fail post-tool response continuation.

**Why it is wrong:** A working session-scoped maintenance RPC existed, but the only UI that owns and can resolve room-member session identities did not expose it.

**Working sibling / contrast:** Focused one-to-one chats already call `session.compress` after resolving a durable session to its live runtime id.

**Ruled out:** Making room sessions visible was not required and would violate their plumbing-only role. The fix keeps them hidden and routes maintenance through the room that owns them.

### Fix

- Add a Group settings action that compresses every seated member's existing room session and reports compressed, pending, skipped, and failed outcomes.
- Resolve stored ids first and the immutable `Group: <roomId>` title second, then call `session.compress` with the live runtime id on the member's owning gateway.
- Keep routed sockets leased across resume and compression, never create an empty session just to compress it, and give plugin RPC calls an optional long-running timeout.
- Add localized labels plus behavior tests for the UI entry point, existing-session routing, no-session skipping, and timeout forwarding.

## Related Issue

Closes #102291

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/group-chat-view.tsx` - expose member-history compression in Group settings and report outcomes.
- `apps/desktop/src/plugins/hermes-bots/group-turns.ts` - resolve and compress existing hidden sessions without minting new ones.
- `apps/desktop/src/plugins/hermes-bots/routing.ts` - carry optional request timeouts across active and routed gateways.
- `apps/desktop/src/sdk/index.ts` - expose the existing gateway per-request timeout through the plugin host.
- `apps/desktop/src/plugins/hermes-bots/i18n.ts` - localize the new maintenance action and feedback.
- Desktop tests - verify the room UI entry point, session identity/routing behavior, and timeout propagation.

## How to Test

1. Open a Bot Mode group room, click Group settings, and choose `Compress member histories`.
2. Verify existing member sessions are compressed (or reported as still running), while members without a room session are skipped without creating one.
3. Run:

```bash
cd apps/desktop
npx vitest run src/plugins/hermes-bots src/sdk/profile-routing.test.ts
npm run typecheck
npx eslint src/plugins/hermes-bots/group-chat-settings.test.tsx src/plugins/hermes-bots/group-chat-view.tsx src/plugins/hermes-bots/group-test-utils.ts src/plugins/hermes-bots/group-turns.test.ts src/plugins/hermes-bots/group-turns.ts src/plugins/hermes-bots/i18n.ts src/plugins/hermes-bots/routing.ts src/sdk/index.ts src/sdk/profile-routing.test.ts
```

Result: 63 test files passed, 626 tests passed; typecheck and changed-file lint passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant desktop Vitest suite and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant inline documentation is updated; user documentation is N/A
- [x] `cli-config.yaml.example` update is N/A because no config keys changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update is N/A because no architecture or workflow changed
- [x] I've considered cross-platform impact; the implementation uses platform-neutral gateway RPCs
- [x] Tool description/schema updates are N/A because no model tool changed

## Screenshots / Logs

N/A. Automated component and room-engine tests cover the new action and gateway calls.
