### PR TITLE
fix(approval): surface eval payloads to the hardline floor

### DIFF
--- a/tests/tools/test_execution_flag_detection.py
+++ b/tests/tools/test_execution_flag_detection.py
@@ -197,6 +197,35 @@ def test_exec_flag_payload_reaches_hardline_floor(command):
 @pytest.mark.parametrize(
     "command",
     [
+        'eval "rm -rf --no-preserve-root /"',
+        "eval 'rm -rf --no-preserve-root /'",
+        'eval "sudo rm -rf --no-preserve-root /"',
+    ],
+)
+def test_eval_payload_reaches_hardline_floor(command):
+    """#102317: eval hands its arguments to another shell to execute,
+    exactly like sh -c — the payload must face the hardline floor."""
+    hardline, description = detect_hardline_command(command)
+    assert hardline is True
+    assert description == "recursive delete of root filesystem"
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'eval "$(ssh-agent -s)"',
+        'eval "export PATH=$PATH:/opt/bin"',
+    ],
+)
+def test_benign_eval_payloads_stay_clean(command):
+    """Payloads without a hardline trigger must not trip the floor."""
+    hardline, _ = detect_hardline_command(command)
+    assert hardline is False
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
         "node -c script.js",
         "node --check script.js",
         "ruby -c script.rb",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -1986,6 +1986,12 @@ def _execution_flag_findings(command: str):
                 found, payload = _bash_exec_payload(tokens[1:])
                 if found:
                     yield ("shell command via -c/-lc flag", payload)
+            if executable_name == "eval" and len(tokens) > 1:
+                # eval hands its arguments to another shell/parser to
+                # EXECUTE, exactly like sh -c (#102317). Surface the payload
+                # as its own raw variant so the hardline floor inspects the
+                # command that will actually run — quoting is not a bypass.
+                yield ("shell command via eval", " ".join(tokens[1:]))
             tool = executable_name
             if tool in _READ_TOOL_EXEC_FLAGS:
                 finding = _read_tool_exec_flag(tool, tokens[1:])


### PR DESCRIPTION
Hey — the hardline floor misses destructive payloads wrapped in `eval`: `eval "rm -rf /"` is approved while the identical `sh -c 'rm -rf /'` is blocked.

`_execution_flag_findings()` extracts `-c` payloads for bash/sh/zsh/ksh so the payload surfaces as its own raw variant (where the inner command is position-matched), but `eval` — which hands its arguments to another shell to execute exactly like `sh -c` — yields nothing. The codebase already lists `eval` in `_SHELL_CARRIER_NAMES` and its comments assume eval payloads surface as variants; the extraction just never implemented it. This yields the eval payload the same way. Benign uses without a hardline trigger stay clean, same parity `sh -c` already has.

Tests: new cases proving eval-wrapped destructive payloads hit the floor plus benign evals (ssh-agent, export) staying clean. Verified red on unfixed code, green after. Full approval suites pass except 4 failures that fail identically on unmodified main (environment-related, pre-existing). Footguns check clean. Tested on macOS, Python 3.11.

Fixes #102317
