### PR TITLE
docs(docker): derived-image example must not set USER hermes (breaks entrypoint UID remap)

### DIFF
--- a/website/docs/user-guide/docker.md
+++ b/website/docs/user-guide/docker.md
@@ -514,7 +514,7 @@ The container ENTRYPOINT is now the `entrypoint-dispatch.sh` dispatcher (which d
 :::
 
 :::warning Privilege model
-Do not override the image entrypoint unless you keep `/init` (or, equivalently, the legacy `docker/entrypoint.sh` shim that forwards to the stage2 hook) in the command chain. s6-overlay's `/init` runs as root so it can chown the volume on first boot, then drops to the `hermes` user via `s6-setuidgid` for every supervised service AND for the main program. Starting `hermes gateway run` as root inside the official image is refused by default because it can leave root-owned files in `/opt/data` and break later dashboard or gateway starts. Set `HERMES_ALLOW_ROOT_GATEWAY=1` only when you intentionally accept that risk.
+Do not override the image entrypoint unless you keep `/init` (or, equivalently, the legacy `docker/entrypoint.sh` shim that forwards to the stage2 hook) in the command chain. s6-overlay's `/init` runs as root so it can chown the volume on first boot, then drops to the `hermes` user via `s6-setuidgid` for every supervised service AND for the main program. For the same reason, do not start the container as a non-root user: no `user:` in Compose, no `--user` on `docker run`, and no trailing `USER hermes` in a derived Dockerfile — any of these skips the UID/GID remap and the volume ownership fix-up. Use `HERMES_UID`/`HERMES_GID` (or `PUID`/`PGID`) to control file ownership instead. Starting `hermes gateway run` as root inside the official image is refused by default because it can leave root-owned files in `/opt/data` and break later dashboard or gateway starts. Set `HERMES_ALLOW_ROOT_GATEWAY=1` only when you intentionally accept that risk.
 :::
 
 ### `docker exec` automatically drops to the `hermes` user
@@ -603,8 +603,9 @@ USER root
 RUN apt-get update \
     && apt-get install -y --no-install-recommends <your-package> \
     && rm -rf /var/lib/apt/lists/*
-USER hermes
 ```
+
+Leave the image at `USER root` — the base image's final user. The s6-overlay bootstrap has to start as root to apply `HERMES_UID`/`HERMES_GID` and fix ownership of `/opt/data`; it then drops every supervised process to the `hermes` user itself, and the `hermes` exec shim drops `docker exec` callers too. A trailing `USER hermes` in a derived image starts the container as UID 10000 instead: the bootstrap's `usermod` fails, the volume is never chowned, and the gateway cannot write to `/opt/data` (see the privilege model note above).
 
 Build it and use it in place of the official image:
 


### PR DESCRIPTION
## What does this PR do?

The "Durable installs — build a derived image" example in `website/docs/user-guide/docker.md` ends with `USER hermes`. Under the s6-overlay image that starts the container as UID 10000, so the stage2 bootstrap (`HERMES_UID`/`HERMES_GID` remap, data-volume chown, first-boot seeding) runs without root and fails. This is the same mistake #15832 removed from the base `Dockerfile` (`USER root` at `Dockerfile:298`, rationale in the comment at `:309-312`, verified at `v2026.8.31` / 29112bef).

The guard at `docker/stage2-hook.sh:49-50` only rejects an *arbitrary* non-root UID; a container started as the hermes user passes through. With `HERMES_UID` set, `usermod` fails and the hook aborts under `set -eu`; without it, the chown fails with a "rootless container?" warning that points operators in the wrong direction. Either way the gateway cannot write `/opt/data`. Observed on a production deployment that copied the docs example (derived image on v2026.8.13), then reproduced against `v2026.8.31` below.

This PR removes the trailing `USER hermes` from the example, adds a short note under it explaining why the image must stay at `USER root`, and adds one sentence to the "Privilege model" admonition so the rule is stated next to the other entrypoint rules. No code change.

## Related Issue

Same mechanism as #15832 (closed, base Dockerfile). This is the docs telling derived images to repeat it. Context: #1947 (why the example has `USER root` at all), #3969 (the root-at-start concern; the image already drops per service, a derived image must not undo the bootstrap).

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/docker.md`
  - "Durable installs — build a derived image": remove the trailing `USER hermes`; add a paragraph explaining that the image must stay at `USER root` and what happens otherwise.
  - "Privilege model" admonition: add one sentence — no `user:` in Compose, no `--user`, no trailing `USER hermes` in a derived Dockerfile; use `HERMES_UID`/`HERMES_GID` (`PUID`/`PGID`) instead.

## How to Test

Run against `nousresearch/hermes-agent:v2026.8.31` with Docker Engine 28.4.0 on Linux (WSL2 host). Both derived images are the docs example verbatim (`jq` as the package), differing only in the trailing `USER hermes` line. Each run bind-mounts an empty host directory (owned by host UID 1000) at `/opt/data` and passes `-e HERMES_UID=1234 -e HERMES_GID=1234`, then runs `sh -c 'id; touch /opt/data/probe-file; ls -lna /opt/data'` as the main program.

1. **Docs example as-is (ends with `USER hermes`)** — bootstrap aborts, volume untouched, container cannot write it:

   ```
   preinit: info: container permissions: uid=10000 (hermes), euid=0, gid=10000 (hermes), egid=10000
   cont-init: info: running /etc/cont-init.d/01-hermes-setup
   [stage2] Changing hermes UID to 1234
   usermod: user hermes is currently used by process 1
   cont-init: info: /etc/cont-init.d/01-hermes-setup exited 8
   cont-init: info: running /etc/cont-init.d/02-reconcile-profiles
   PermissionError: [Errno 13] Permission denied: '/opt/data/logs'
   cont-init: info: /etc/cont-init.d/02-reconcile-profiles exited 1
   mkdir: cannot create directory '/opt/data/logs': Permission denied
   s6-log: fatal: unable to mkdir /opt/data/logs/gateways/default: No such file or directory
   --- in-container: id=uid=10000(hermes) gid=10000(hermes) groups=10000(hermes)
   touch: cannot touch '/opt/data/probe-file': Permission denied
   drwxrwxr-x 2 1000 1000 4096 .        <- /opt/data still owned by the host user
   ```

   Same image without `HERMES_UID`/`HERMES_GID` set takes the other branch: `[stage2] Warning: chown /opt/data failed (rootless container?) — continuing`, followed by `mkdir: cannot create directory '/opt/data/<sub>': Permission denied` for every hermes-owned subdir, `01-hermes-setup exited 1`, and the same `PermissionError` from `02-reconcile-profiles`. The host directory stays owned by 1000.

2. **Corrected example (no trailing `USER`)** — remap and chown run, services start, files land owned by the requested UID:

   ```
   preinit: info: container permissions: uid=0 (root), euid=0, gid=0 (root), egid=0
   [stage2] Changing hermes UID to 1234
   [stage2] Changing hermes GID to 1234
   [stage2] Fixing ownership of /opt/data (targeted) to hermes (1234)
   [stage2] Setup complete; starting user services
   cont-init: info: /etc/cont-init.d/01-hermes-setup exited 0
   reconcile: profile=default prior_state=None action=registered
   --- in-container: id=uid=1234(hermes) gid=1234(hermes) groups=1234(hermes)
   touched
   drwx------ 18 1234 1234 4096 .
   ```

   On the host, the bind-mounted directory and `probe-file` are owned by `1234:1234`.

3. Docs-only change; `pytest` not applicable.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, docs only
- [ ] I've added tests for my changes — N/A, docs only
- [x] I've tested on my platform: Ubuntu (WSL2), Docker Engine 28.4.0, image `v2026.8.31`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — this PR
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) — N/A, Linux container image
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
