### PR TITLE
docs(deps): align dependency pinning guidance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,9 +22,9 @@ dependencies = [
   # exact, hash-verified install graph used by the preferred `uv sync --locked`
   # path; declared ranges apply when regenerating it and on pip fallback paths.
   #
-  # Existing exact pins are retained until they receive dependency-specific
-  # review. When updating a requirement, follow CONTRIBUTING.md and regenerate
-  # uv.lock so the declared constraint and locked resolution stay consistent.
+  # This documentation-only alignment leaves existing requirement forms
+  # unchanged. When adding or updating a requirement, follow CONTRIBUTING.md
+  # and regenerate uv.lock so the constraint and lock stay consistent.
   #
   # Scope rule: only packages used by EVERY hermes session belong here.
   # Anything that's provider-specific (`anthropic`, `firecrawl-py`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,19 +17,14 @@ authors = [{ name = "Nous Research" }]
 license = "MIT"
 license-files = ["LICENSE"]
 dependencies = [
-  # Core — every direct dep is exact-pinned to ==X.Y.Z (no ranges).
-  # Rationale: ranges allow PyPI to ship a fresh version of a transitive
-  # at any time without a code review on our side. Exact pins mean the
-  # only way a new package version reaches a user is via an intentional
-  # update on our end (bump the pin in this file, regenerate uv.lock).
-  # This was tightened on 2026-05-12 in response to the Mini Shai-Hulud
-  # worm hitting mistralai 2.4.6 on PyPI; if that release had been
-  # captured by `mistralai>=2.3.0,<3` rather than an exact pin, every
-  # install in the hours before the quarantine would have pulled it.
+  # Core dependency contribution policy lives in CONTRIBUTING.md: new
+  # PyPI dependencies use a reviewed floor and upper bound. uv.lock is the
+  # exact, hash-verified install graph used by the preferred `uv sync --locked`
+  # path; declared ranges apply when regenerating it and on pip fallback paths.
   #
-  # When updating: bump the version below AND regenerate uv.lock with
-  # `uv lock` so the transitive resolution stays consistent. Don't
-  # introduce ranges back without a written justification.
+  # Existing exact pins are retained until they receive dependency-specific
+  # review. When updating a requirement, follow CONTRIBUTING.md and regenerate
+  # uv.lock so the declared constraint and locked resolution stay consistent.
   #
   # Scope rule: only packages used by EVERY hermes session belong here.
   # Anything that's provider-specific (`anthropic`, `firecrawl-py`,


### PR DESCRIPTION
## What does this PR do?

The dependency header in `pyproject.toml` required exact pins while the contributor policy in `CONTRIBUTING.md` and `AGENTS.md` requires reviewed floor-and-ceiling ranges for new PyPI dependencies. This removes the contradictory mandate, points contributors to the canonical policy, and explains that `uv.lock` remains the exact, hash-verified graph for the preferred locked install path.

Existing exact pins are left unchanged until dependency-specific review; this documentation fix does not alter package resolution.

## Related Issue

Closes #102310

## Type of Change

- [x] Documentation update

## Changes Made

- `pyproject.toml` - align the core dependency header with the contributor policy and clarify the roles of declared constraints, `uv.lock`, and pip fallback installs.

## How to Test

1. Compare the dependency guidance in `pyproject.toml`, `CONTRIBUTING.md`, and `AGENTS.md`.
2. Run `uv lock --check` to confirm the metadata-only edit does not change dependency resolution.
3. Run the packaging metadata tests.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched for existing PRs to make sure this isn't a duplicate.
- [x] My PR contains only changes related to this documentation fix.
- [x] Tests are unchanged because this edit only corrects an explanatory TOML comment.
- [x] Platform-specific testing is not applicable to a documentation-only change.

### Documentation & Housekeeping

- [x] I've updated the relevant dependency guidance.
- [x] No config keys were added or changed.
- [x] The contributor workflow remains unchanged; this edit makes an existing policy consistent.
- [x] Cross-platform behavior is unchanged.
- [x] Tool descriptions and schemas are unchanged.
