### PR TITLE
fix(desktop): un-dismiss Scheduled jobs when Bot Mode re-registers it

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx
@@ -27,6 +27,7 @@ import type * as RoutingModule from './routing'
 const mocks = vi.hoisted(() => ({
   botChatOwnsWorkspace: vi.fn(() => false),
   paneVisibility: vi.fn(),
+  revealPane: vi.fn(),
   sessionOwnsWorkspace: vi.fn(() => false),
   setWorkspaceScope: vi.fn()
 }))
@@ -40,6 +41,7 @@ vi.mock('@hermes/plugin-sdk', async importOriginal => {
       ...original.host,
       onEvent: undefined,
       paneVisibility: mocks.paneVisibility,
+      revealPane: mocks.revealPane,
       setWorkspaceScope: mocks.setWorkspaceScope
     }
   }
@@ -203,6 +205,7 @@ describe('the Scheduled jobs pane', () => {
     // Glanceable, not something you sit in: it arrives as the right edge's
     // vertical tab and takes no width off the chat until the user opens it.
     expect(routines.data!.defaultCollapsed).toBe(true)
+    expect(mocks.revealPane).toHaveBeenCalledWith('hermes-bots:routines')
 
     harness.dispose()
   })

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -412,8 +412,8 @@ export default {
     // keeps the pane's spot, so re-registering re-adopts it where it was.
     // host.paneVisibility is feature-detected: older desktops without the SDK
     // export keep the always-registered behavior.
-    const registerRoutinesPane = () =>
-      ctx.register({
+    const registerRoutinesPane = () => {
+      const dispose = ctx.register({
         id: 'routines',
         area: 'panes',
         // The app's noun for these, so the tab agrees with the pane header and
@@ -436,6 +436,15 @@ export default {
         },
         render: () => <RoutinesPane />
       })
+
+      // Close remembers the pane in dismissedPanes.v1, so a later register
+      // would otherwise stay invisible until a full layout reset (#102224).
+      if (typeof host.revealPane === 'function') {
+        host.revealPane(`${ID}:routines`)
+      }
+
+      return dispose
+    }
 
     if (typeof host.paneVisibility === 'function') {
       // The contribution-scoped pane id (`register` prefixes `${ID}:`).

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1161,6 +1161,10 @@ export const host = {
     return close
   },
 
+  /** Undo a persisted Close for a contributed pane so adoption can re-add it.
+   *  Feature-detect on older desktops (`typeof host.revealPane === 'function'`). */
+  revealPane: (paneId: string) => revealTreePane(paneId),
+
   /** Name a workspace owner on its tabs (a bot's display name). A canonical
    *  chat's STORED title is an identity the backend resolves by name; this is
    *  the caption shown for it. Feature-detect on older desktops. */


### PR DESCRIPTION
## What does this PR do?

Closing the Bot Mode "Scheduled jobs" pane remembered `hermes-bots:routines` in `dismissedPanes.v1`. The plugin re-registers that pane whenever a bot chat owns the workspace, but adoption skips dismissed ids, so the cron surface stayed gone until a full layout reset.

On register, call `host.revealPane('hermes-bots:routines')` (new SDK door over `revealTreePane`, which already un-dismisses). Re-entering Bot Mode brings the pane back. Closing a different plugin pane still stays dismissed.

## Related Issue

Fixes #102224

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/sdk/index.ts` — `host.revealPane`
- `apps/desktop/src/plugins/hermes-bots/plugin.tsx` — reveal on routines register
- `apps/desktop/src/plugins/hermes-bots/plugin-panes.test.tsx` — asserts reveal of `hermes-bots:routines`

## How to Test

```
cd apps/desktop
npx vitest run src/plugins/hermes-bots/plugin-panes.test.tsx src/sdk/index.test.ts
# 17 passed
npx tsc --noEmit -p tsconfig.json
# clean
npx eslint src/sdk/index.ts src/plugins/hermes-bots/plugin.tsx src/plugins/hermes-bots/plugin-panes.test.tsx
# clean
```

Not runtime-tested by clicking ✕ in a packaged Desktop. Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
