### PR TITLE
fix(desktop): pin backend children to the Hermes-root HERMES_HOME

### DIFF
--- a/apps/desktop/electron/backend-env.test.ts
+++ b/apps/desktop/electron/backend-env.test.ts
@@ -10,6 +10,7 @@ import {
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
+  pinChildHermesHome,
   POSIX_SANE_PATH_ENTRIES
 } from './backend-env'
 
@@ -145,6 +146,24 @@ test('buildDesktopBackendEnv forces PYTHONUTF8 unless the user set it explicitly
   })
 
   assert.equal(optedOut.PYTHONUTF8, '0')
+})
+
+test('pinChildHermesHome drops profile-shaped and differently cased HERMES_HOME (#102315)', () => {
+  const env = pinChildHermesHome(
+    {
+      Path: 'C:\\Windows',
+      Hermes_Home: 'C:\\Users\\test\\AppData\\Local\\hermes\\profiles\\work',
+      HERMES_HOME: 'C:\\Users\\test\\AppData\\Local\\hermes\\profiles\\work',
+      OTHER: 'keep'
+    },
+    'C:\\Users\\test\\AppData\\Local\\hermes\\profiles\\work',
+    { pathModule: path.win32, platform: 'win32' }
+  )
+
+  assert.equal(env.Hermes_Home, undefined)
+  assert.equal(env.HERMES_HOME, 'C:\\Users\\test\\AppData\\Local\\hermes')
+  assert.equal(env.OTHER, 'keep')
+  assert.equal(env.Path, 'C:\\Windows')
 })
 
 test('normalizeHermesHomeRoot maps profile homes back to the global Hermes root', () => {

--- a/apps/desktop/electron/backend-env.ts
+++ b/apps/desktop/electron/backend-env.ts
@@ -118,6 +118,31 @@ function normalizeHermesHomeRoot(hermesHome, { pathModule = pathModuleForPlatfor
   return resolved
 }
 
+/** Build a child env whose HERMES_HOME is the global root, never a profile dir.
+ *
+ *  Windows env keys are case-insensitive: spreading `process.env` then setting
+ *  `HERMES_HOME` can leave a prior `Hermes_Home` / profile-shaped value in the
+ *  block that uv_spawn actually sends. Drop every casing, then pin the root
+ *  so `--profile default` cannot inherit another profile's home (#102315).
+ */
+function pinChildHermesHome(
+  env: Record<string, string | undefined>,
+  hermesHome: string,
+  { platform = process.platform, pathModule = pathModuleForPlatform(platform) }: any = {}
+) {
+  const next: Record<string, string | undefined> = { ...env }
+
+  for (const key of Object.keys(next)) {
+    if (key.toUpperCase() === 'HERMES_HOME') {
+      delete next[key]
+    }
+  }
+
+  next.HERMES_HOME = normalizeHermesHomeRoot(hermesHome, { pathModule })
+
+  return next
+}
+
 function buildDesktopBackendEnv({
   hermesHome,
   pythonPathEntries = [],
@@ -157,5 +182,6 @@ export {
   hermesManagedNodePathEntries,
   normalizeHermesHomeRoot,
   pathEnvKey,
+  pinChildHermesHome,
   POSIX_SANE_PATH_ENTRIES
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -48,7 +48,12 @@ import {
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
 import { BackendDialClaims } from './backend-dial-claim'
-import { buildDesktopBackendEnv, hermesManagedNodePathEntries, normalizeHermesHomeRoot } from './backend-env'
+import {
+  buildDesktopBackendEnv,
+  hermesManagedNodePathEntries,
+  normalizeHermesHomeRoot,
+  pinChildHermesHome
+} from './backend-env'
 import {
   isReauthRequiredError,
   makeNousCloudBackendDownError,
@@ -12451,25 +12456,27 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
     backend.args,
     hiddenWindowsChildOptions({
       cwd: hermesCwd,
-      env: {
-        ...process.env,
-        HERMES_HOME,
-        ...backend.env,
-        // Pin the gateway's tool/terminal cwd to the same directory we chose for
-        // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
-        // can still point at the install dir even when spawn cwd is home.
-        TERMINAL_CWD: hermesCwd,
-        HERMES_DASHBOARD_SESSION_TOKEN: token,
-        // Marks this dashboard backend as desktop-spawned so it runs the cron
-        // scheduler tick loop (the gateway isn't running under the app).
-        HERMES_DESKTOP: '1',
-        // Exact parent identity lets the backend self-exit after an unclean
-        // Desktop death without mistaking a reused PID for its owner. If the
-        // optional marker probe fails, retain legacy PID-only tracking.
-        ...parentIdentityEnv,
-        HERMES_WEB_DIST: webDist,
-        ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-      },
+      env: pinChildHermesHome(
+        {
+          ...process.env,
+          ...backend.env,
+          // Pin the gateway's tool/terminal cwd to the same directory we chose for
+          // the child process. Inherited TERMINAL_CWD (or a stale config bridge)
+          // can still point at the install dir even when spawn cwd is home.
+          TERMINAL_CWD: hermesCwd,
+          HERMES_DASHBOARD_SESSION_TOKEN: token,
+          // Marks this dashboard backend as desktop-spawned so it runs the cron
+          // scheduler tick loop (the gateway isn't running under the app).
+          HERMES_DESKTOP: '1',
+          // Exact parent identity lets the backend self-exit after an unclean
+          // Desktop death without mistaking a reused PID for its owner. If the
+          // optional marker probe fails, retain legacy PID-only tracking.
+          ...parentIdentityEnv,
+          HERMES_WEB_DIST: webDist,
+          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+        },
+        HERMES_HOME
+      ),
       shell: backend.shell,
       stdio: ['ignore', 'pipe', 'pipe']
     })
@@ -12868,30 +12875,24 @@ async function startHermes() {
       backend.args,
       hiddenWindowsChildOptions({
         cwd: hermesCwd,
-        env: {
-          ...process.env,
-          // Explicitly pin HERMES_HOME for the child so Python's get_hermes_home()
-          // resolves to the SAME location our resolveHermesHome() picked. Without
-          // this pin, Python falls back to ~/.hermes on every platform — fine on
-          // mac/linux (where our default matches), but on Windows our default is
-          // %LOCALAPPDATA%\hermes, which differs from C:\Users\<u>\.hermes.
-          // Mismatch would split config / sessions / .env / logs across two
-          // directories. install.ps1 sets HERMES_HOME via setx; the desktop
-          // can't reliably do that, so we set it inline for every spawn.
-          HERMES_HOME,
-          ...backend.env,
-          TERMINAL_CWD: hermesCwd,
-          HERMES_DASHBOARD_SESSION_TOKEN: token,
-          // Marks this dashboard backend as desktop-spawned so it runs the cron
-          // scheduler tick loop (the gateway isn't running under the app).
-          HERMES_DESKTOP: '1',
-          // Exact parent identity lets the backend self-exit after an unclean
-          // Desktop death without mistaking a reused PID for its owner. If the
-          // optional marker probe fails, retain legacy PID-only tracking.
-          ...parentIdentityEnv,
-          HERMES_WEB_DIST: webDist,
-          ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
-        },
+        env: pinChildHermesHome(
+          {
+            ...process.env,
+            ...backend.env,
+            TERMINAL_CWD: hermesCwd,
+            HERMES_DASHBOARD_SESSION_TOKEN: token,
+            // Marks this dashboard backend as desktop-spawned so it runs the cron
+            // scheduler tick loop (the gateway isn't running under the app).
+            HERMES_DESKTOP: '1',
+            // Exact parent identity lets the backend self-exit after an unclean
+            // Desktop death without mistaking a reused PID for its owner. If the
+            // optional marker probe fails, retain legacy PID-only tracking.
+            ...parentIdentityEnv,
+            HERMES_WEB_DIST: webDist,
+            ...(readyFile ? { HERMES_DESKTOP_READY_FILE: readyFile } : {})
+          },
+          HERMES_HOME
+        ),
         shell: backend.shell,
         stdio: ['ignore', 'pipe', 'pipe']
       })


### PR DESCRIPTION
## What does this PR do?

A Desktop child launched as `--profile default serve` could still inherit another profile's `HERMES_HOME` (Windows env keys are case-insensitive). Spreading `process.env` then setting `HERMES_HOME` can leave a prior `Hermes_Home` / profile-shaped value in the block uv_spawn sends, so both children open the same `state.db`.

`pinChildHermesHome` drops every `HERMES_HOME` casing, then sets the normalized Hermes root. `--profile` still re-homes named profiles. Used for the primary and pooled local backend spawns.

## Related Issue

Fixes #102315

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/electron/backend-env.ts` — `pinChildHermesHome`
- `apps/desktop/electron/backend-env.test.ts` — profile-shaped + mixed-case keys collapse to the root
- `apps/desktop/electron/main.ts` — primary and pool `spawn` env go through the helper

## How to Test

```
cd apps/desktop
npx vitest run electron/backend-env.test.ts
# 11 passed
npx eslint electron/backend-env.ts electron/backend-env.test.ts electron/main.ts
# clean
```

Not runtime-tested on Windows with two live profile backends. Did not run full `pytest tests/ -q`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu (Linux)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
