### PR TITLE
fix(gateway): accept is_voice kwarg in matrix/mattermost send_voice

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -2605,6 +2605,7 @@ class MatrixAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False,
     ) -> SendResult:
         """Upload an audio file as a voice message (MSC3245 native voice).
 

--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -500,6 +500,7 @@ class MattermostAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
+        is_voice: bool = False,
     ) -> SendResult:
         """Upload an audio file."""
         return await self._send_local_file(

--- a/tests/gateway/test_send_voice_signature_compat.py
+++ b/tests/gateway/test_send_voice_signature_compat.py
@@ -1,0 +1,45 @@
+"""#102221: every adapter send_voice override must accept the kwargs the
+shared media dispatch passes (chat_id, audio_path, metadata, is_voice).
+
+Matrix (and same-shaped Mattermost) overrides lacked `is_voice`, so every
+voice send raised TypeError and was swallowed as 'Error sending media' —
+total loss of voice delivery on those platforms.
+"""
+import inspect
+
+import pytest
+
+from gateway.platforms.base import BasePlatformAdapter
+from plugins.platforms.matrix.adapter import MatrixAdapter
+from plugins.platforms.mattermost.adapter import MattermostAdapter
+
+# Exactly what gateway/platforms/base.py passes in the send_voice branch.
+_DISPATCH_KWARGS = {
+    "chat_id": "chat-1",
+    "audio_path": "note.ogg",
+    "metadata": {},
+    "is_voice": True,
+}
+
+
+def _bind(cls):
+    sig = inspect.signature(cls.send_voice)
+    bound = sig.bind(object(), **_DISPATCH_KWARGS)
+    bound.apply_defaults()
+    return bound
+
+
+@pytest.mark.parametrize(
+    "cls",
+    [BasePlatformAdapter, MatrixAdapter, MattermostAdapter],
+    ids=["base", "matrix", "mattermost"],
+)
+def test_send_voice_accepts_dispatch_kwargs(cls):
+    # Binding the exact dispatch kwargs must not raise TypeError (that is
+    # the reported crash). An explicit is_voice parameter must receive the
+    # value; a **kwargs catch-all must capture it.
+    bound = _bind(cls)
+    if "is_voice" in bound.arguments:
+        assert bound.arguments["is_voice"] is True
+    else:
+        assert bound.arguments.get("kwargs", {}).get("is_voice") is True


### PR DESCRIPTION
Hey — the shared media dispatch passes `is_voice=is_voice` into `send_voice`, which the base absorbs with `**kwargs`, but the Matrix and Mattermost overrides take neither — so every voice send on those platforms raises TypeError and is swallowed as an 'Error sending media' log. Total silent loss of voice delivery.

Fixed by accepting the kwarg on both overrides, plus a signature-compat test pinning the dispatch contract across base, matrix and mattermost.

Tests: new compat test fails with TypeError on unfixed code (matrix + mattermost), passes after; full matrix suite passes (115 with the new tests). Footguns check clean. Tested on macOS, Python 3.11.

Fixes #102221
