### PR TITLE
fix(desktop): resolve tab titles from the cron and messaging slices

### DIFF
--- a/apps/desktop/src/app/chat/session-tile-slice-title.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-slice-title.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { $projectTree } from '@/store/projects'
+import { $cronSessions, $messagingSessions, $sessions } from '@/store/session'
+import type { SessionInfo } from '@/types/hermes'
+
+import { tileStoredRow } from './session-tile'
+
+const STORED = 'tg-chat-1'
+const TITLE = 'Debug the office sensor'
+
+function row(overrides: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    cwd: null,
+    ended_at: null,
+    id: STORED,
+    input_tokens: 0,
+    is_active: true,
+    last_active: 1,
+    message_count: 466,
+    model: null,
+    output_tokens: 0,
+    parent_session_id: null,
+    preview: null,
+    source: 'telegram',
+    started_at: 1,
+    title: TITLE,
+    tool_call_count: 0,
+    ...overrides
+  }
+}
+
+/** A tab for a gateway conversation used to read "New session" forever.
+ *  The sidebar fetch splits its rows into three source-scoped slices, and
+ *  recents EXCLUDES every messaging/cron source — so a telegram tab's row is
+ *  only ever in `$messagingSessions`. `tileStoredRow` searched recents alone,
+ *  missed it, and `tileTitle` fell through to NEW_SESSION_TITLE. No amount of
+ *  activity could fix it: the row is never eligible for recents. */
+describe('tileStoredRow resolves across every sidebar slice', () => {
+  afterEach(() => {
+    $sessions.set([])
+    $cronSessions.set([])
+    $messagingSessions.set([])
+    $projectTree.set([])
+  })
+
+  it('resolves a local recents row', () => {
+    $sessions.set([row({ source: 'desktop' })])
+
+    expect(tileStoredRow(STORED)?.title).toBe(TITLE)
+  })
+
+  it('resolves a telegram row listed only in the messaging slice', () => {
+    $messagingSessions.set([row()])
+
+    expect(tileStoredRow(STORED)?.title).toBe(TITLE)
+  })
+
+  it('resolves a cron row listed only in the cron slice', () => {
+    $cronSessions.set([row({ source: 'cron', title: 'nightly-report' })])
+
+    expect(tileStoredRow(STORED)?.title).toBe('nightly-report')
+  })
+
+  it('matches a messaging row across compression by lineage root', () => {
+    $messagingSessions.set([row({ _lineage_root_id: STORED, id: 'tg-chat-1-compressed-2' })])
+
+    expect(tileStoredRow(STORED)?.title).toBe(TITLE)
+  })
+
+  it('still misses an id no slice holds, so the placeholder path survives', () => {
+    $messagingSessions.set([row({ id: 'someone-else' })])
+
+    expect(tileStoredRow(STORED)).toBeUndefined()
+  })
+})

--- a/apps/desktop/src/app/chat/session-tile.tsx
+++ b/apps/desktop/src/app/chat/session-tile.tsx
@@ -47,6 +47,7 @@ import {
   $messagingSessions,
   $selectedStoredSessionId,
   $sessions,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   sessionPinId
 } from '@/store/session'
@@ -489,16 +490,23 @@ export function SessionTilePane({ storedSessionId }: { storedSessionId: string }
 // Tile -> pane contribution sync (call once from the app root).
 // ---------------------------------------------------------------------------
 
-/** Resolve a tile's stored row: the recents list first, then the project
- *  tree. A session opened as a tab from a project group is often older than
- *  the paginated recents page, so it has no `$sessions` row at all until new
- *  activity lands it there — resolving through the tree keeps its tab titled
- *  and tinted instead of a grey "Session" placeholder. */
+/** Resolve a tile's stored row: every loaded sidebar slice first, then the
+ *  project tree. A session opened as a tab from a project group is often older
+ *  than the paginated recents page, so it has no `$sessions` row at all until
+ *  new activity lands it there — resolving through the tree keeps its tab
+ *  titled and tinted instead of a grey "Session" placeholder.
+ *
+ *  The slice scan is `ownerLookupSessionRows`, not `$sessions`: the sidebar
+ *  fetch splits its rows three ways, and a telegram/discord/cron conversation
+ *  is listed ONLY in `$messagingSessions` / `$cronSessions` — recents excludes
+ *  those sources outright. Searching recents alone made every such tab read
+ *  "New session" forever, since the row it needed was one atom over and no
+ *  amount of activity would ever move it into recents. */
 export function tileStoredRow(storedSessionId: string): SessionInfo | undefined {
   const match = (s: SessionInfo) => sessionMatchesStoredId(s, storedSessionId)
 
   return (
-    $sessions.get().find(match) ??
+    ownerLookupSessionRows().find(match) ??
     $projectTree
       .get()
       .flatMap(p => [...p.repos.flatMap(r => r.groups.flatMap(g => g.sessions)), ...(p.previewSessions ?? [])])
@@ -749,9 +757,14 @@ export function WorkspaceTabMenu({ children }: { children: React.ReactElement })
 export const watchSessionTiles = paneMirror<SessionTile>({
   source: $sessionTiles,
   // $projectTree: a tile whose session is older than the recents page resolves
-  // its title through the tree, which loads after the tiles register. (The tab's
-  // status dot subscribes to color/state itself, so it needs no `also` entry.)
-  also: [$sessions, $projectTree, $workspaceOwnerLabels],
+  // its title through the tree, which loads after the tiles register.
+  // $cronSessions/$messagingSessions: `tileStoredRow` reads every sidebar
+  // slice, so the strip must re-sync when the slice that owns a gateway
+  // conversation lands — it arrives on its own fetch, after the tiles register,
+  // and without it the tab stays stuck on its "New session" placeholder.
+  // (The tab's status dot subscribes to color/state itself, so it needs no
+  // `also` entry.)
+  also: [$sessions, $cronSessions, $messagingSessions, $projectTree, $workspaceOwnerLabels],
   key: t => t.storedSessionId,
   prefix: 'session-tile',
   dir: t => t.dir,

--- a/apps/desktop/src/app/contrib/controller.tsx
+++ b/apps/desktop/src/app/contrib/controller.tsx
@@ -69,7 +69,16 @@ import {
   openReview,
   REVIEW_PANE_ID
 } from '@/store/review'
-import { $currentCwd, $selectedStoredSessionId, $sessions, $yoloActive, sessionMatchesStoredId } from '@/store/session'
+import {
+  $cronSessions,
+  $currentCwd,
+  $messagingSessions,
+  $selectedStoredSessionId,
+  $sessions,
+  $yoloActive,
+  ownerLookupSessionRows,
+  sessionMatchesStoredId
+} from '@/store/session'
 import { watchSessionPins } from '@/store/session-pin-sync'
 import { $botChatScopes } from '@/store/session-states'
 import { watchUnreadWriteGuard } from '@/store/session-unread-remote'
@@ -135,7 +144,7 @@ const workspaceDragPayload = (): SessionDragPayload | null => {
     return null
   }
 
-  const stored = $sessions.get().find(s => sessionMatchesStoredId(s, selected))
+  const stored = ownerLookupSessionRows().find(s => sessionMatchesStoredId(s, selected))
 
   return { id: selected, profile: stored?.profile ?? '', title: stored ? storedSessionTitle(stored) : '' }
 }
@@ -487,7 +496,12 @@ watchUnreadWriteGuard()
 // above, so the pane content never remounts.
 const syncWorkspaceTitle = () => {
   const selected = $selectedStoredSessionId.get()
-  const stored = selected ? $sessions.get().find(s => sessionMatchesStoredId(s, selected)) : null
+  // Every loaded slice, not just recents: a telegram/discord/cron conversation
+  // is listed ONLY in $messagingSessions / $cronSessions (recents excludes
+  // those sources), so a recents-only scan missed the row and fell through to
+  // the NEW_SESSION_TITLE placeholder — a loaded gateway chat titled
+  // "New session" in the tab while its sidebar row read correctly.
+  const stored = selected ? ownerLookupSessionRows().find(s => sessionMatchesStoredId(s, selected)) : null
 
   registry.register({
     id: 'workspace',
@@ -524,6 +538,11 @@ const syncWorkspaceTitle = () => {
 
 $selectedStoredSessionId.listen(syncWorkspaceTitle)
 $sessions.listen(syncWorkspaceTitle)
+// The cron and messaging slices arrive on their OWN fetch, after a restored
+// tab has already registered. Without these listens the workspace tab keeps
+// whatever it resolved at register time — "New session" for a gateway chat.
+$cronSessions.listen(syncWorkspaceTitle)
+$messagingSessions.listen(syncWorkspaceTitle)
 $botChatScopes.listen(syncWorkspaceTitle)
 $workspaceOwnerLabels.listen(syncWorkspaceTitle)
 $workspaceIsPage.listen(syncWorkspaceTitle)


### PR DESCRIPTION
## What does this PR do?

A session that originated on a messaging platform (Telegram, Discord, Matrix, ...) or from cron opens in Desktop with its tab labeled **`New session`** while the sidebar shows the real title. It never corrects itself, at any point, no matter how much the session is used.

The sidebar splits its fetch into three source-scoped slices — `$sessions` (recents), `$cronSessions`, `$messagingSessions`. That split is a **partition, not a cache tier**: `SIDEBAR_EXCLUDED_SOURCES` drops `cron` and every `MESSAGING_SESSION_SOURCE_IDS` entry from recents outright, so a gateway conversation is listed in exactly one non-recents slice.

Both title resolvers searched only `$sessions`, so the row could never be found and the lookup fell through to `NEW_SESSION_TITLE`. Because no later activity moves such a row into recents, the placeholder is **permanent**, not merely stale.

| Site | Before | Renders |
|---|---|---|
| `session-tile.tsx` `tileStoredRow()` | `$sessions.get().find(match)` | every tile tab's title + status dot |
| `contrib/controller.tsx` `syncWorkspaceTitle()` | `$sessions.get().find(...)` | the main workspace tab |
| `contrib/controller.tsx` `workspaceDragPayload()` | `$sessions.get().find(...)` | `@session` drag payload |

The fix routes all three through `ownerLookupSessionRows()` — the helper already added for **this exact partition miss** in the owner ladder (#95633) — and subscribes the tab strip and workspace title to the two extra slices, which arrive on their own fetch after the tiles register.

### Why this is not #94167

#94167 is a *timing* miss: a restored tile has no `runtimeId`, its pane never mounts, so the by-id resolution effect never runs. PR #101260 fixed it with a one-shot backfill.

That backfill cannot reach this bug:

- it is guarded on `!tileStoredRow(tile.storedSessionId)` — the same recents-only lookup, so it inherits the blind spot;
- it upserts through `setSessions()`, writing into the slice that excludes these sources by design;
- it is one-shot at gateway-open, while the messaging slice can land later.

Same class as #95633 (owner ladder) and #92593 (pin sync), both fixed the same way in their own subsystems. This is the third site.

## Related Issue

Fixes #95096

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/chat/session-tile.tsx` — `tileStoredRow()` resolves through `ownerLookupSessionRows()`; `watchSessionTiles`'s `also:` gains `$cronSessions` + `$messagingSessions` so the strip re-syncs when the owning slice arrives.
- `apps/desktop/src/app/contrib/controller.tsx` — same resolver in `syncWorkspaceTitle()` and `workspaceDragPayload()`; added `$cronSessions` / `$messagingSessions` listeners.
- `apps/desktop/src/app/chat/session-tile-slice-title.test.ts` — new; seeds one slice at a time and asserts the title resolves.

## How to Test

1. Start a session from Telegram (or any messaging platform) and let it acquire a real title.
2. Open it in Desktop as a tab.
3. Compare the tab label to the sidebar row.

Before: tab reads `New session` indefinitely. After: tab shows the session title.

Automated:

```bash
cd apps/desktop
npx vitest run --project ui src/app/chat/session-tile-slice-title.test.ts
```

- Reverted: **3 fail** — `expected undefined to be '<title>'`
- Applied: **5 pass**

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run: this is a renderer-only change with no Python surface.** Verified with the desktop vitest suite instead (below).
- [x] I've added tests for my changes
- [x] I've tested on my platform: Debian 12 (backend), Windows 11 (desktop client)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — no platform-specific code; store-level change
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Neighboring suites on this branch (`src/app/chat`, `src/app/contrib`, `src/store`): **2460 passed, 2 failed**. Both failures are React Compiler memoization tests (`session-row`, `sessions-section`) that fail identically on unmodified `main` in the same environment — pre-existing, unrelated.

`npx eslint` and `npx prettier --check` clean on all three files.
