### PR TITLE
fix(gateway): normalize JSON-array allowlist strings for WhatsApp gates

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -90,6 +90,9 @@ def _normalize_allow_list_value(raw: Any) -> str:
             if isinstance(parsed, list):
                 parts = [str(part).strip() for part in parsed]
             else:
+                # Bracket-polluted entries match nobody: log so the next
+                # silent-deaf report starts from the value, not from zero.
+                logger.warning("allowlist value looks like a list but parses as neither JSON nor Python literal: %r", text)
                 parts = [part.strip() for part in text.split(",")]
         else:
             parts = [part.strip() for part in text.split(",")]

--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -31,6 +31,7 @@ defined on the mixin and may be overridden per-adapter if needed.
 
 from __future__ import annotations
 
+import ast
 import json
 import logging
 import os
@@ -59,6 +60,40 @@ def _get_wsecret(name, default=None):
     return val if val is not None else default
 
 logger = logging.getLogger(__name__)
+
+
+def _normalize_allow_list_value(raw: Any) -> str:
+    """Render an allowlist-ish value as a clean comma string.
+
+    Accepts a YAML list, a JSON-array string (the shape ``hermes config
+    set`` produced before #88163, and easy to hand-write), or a plain
+    comma string. Bracket/quote pollution must never reach the gates or
+    the bridge env export: ``'["1555", "1555"]'`` split on commas yields
+    entries that can never match a sender, silently deafening the bot
+    (#102329). Python-literal lists (``"['1555']"``) are accepted too,
+    mirroring ``parse_config_string_list``.
+    """
+    if isinstance(raw, list):
+        parts = [str(part).strip() for part in raw]
+    else:
+        text = str(raw or "").strip()
+        if text.startswith("["):
+            try:
+                parsed = json.loads(text)
+            except ValueError:
+                parsed = None
+            if not isinstance(parsed, list):
+                try:
+                    parsed = ast.literal_eval(text)
+                except (ValueError, SyntaxError):
+                    parsed = None
+            if isinstance(parsed, list):
+                parts = [str(part).strip() for part in parsed]
+            else:
+                parts = [part.strip() for part in text.split(",")]
+        else:
+            parts = [part.strip() for part in text.split(",")]
+    return ",".join(part for part in parts if part)
 
 
 class WhatsAppBehaviorMixin:
@@ -141,18 +176,14 @@ class WhatsAppBehaviorMixin:
         raw = self.config.extra.get("free_response_chats")
         if raw is None:
             raw = _get_wsecret("WHATSAPP_FREE_RESPONSE_CHATS", default="") or ""
-        if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+        return set(filter(None, _normalize_allow_list_value(raw).split(",")))
 
     @staticmethod
     def _coerce_allow_list(raw) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""
         if raw is None:
             return set()
-        if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+        return set(filter(None, _normalize_allow_list_value(raw).split(",")))
 
     def _live_dm_allow_from(self) -> set[str]:
         """Allowlist currently enforced for DM intake / strict DM auth.

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -325,6 +325,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.whatsapp_common import WhatsAppBehaviorMixin
+from gateway.platforms.whatsapp_common import _normalize_allow_list_value
 from gateway.whatsapp_identity import to_whatsapp_jid
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1901,23 +1902,17 @@ def _apply_yaml_config(yaml_cfg: dict, whatsapp_cfg: dict) -> dict | None:
         os.environ["WHATSAPP_MENTION_PATTERNS"] = _json.dumps(whatsapp_cfg["mention_patterns"])
     frc = whatsapp_cfg.get("free_response_chats")
     if frc is not None and not os.getenv("WHATSAPP_FREE_RESPONSE_CHATS"):
-        if isinstance(frc, list):
-            frc = ",".join(str(v) for v in frc)
-        os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = str(frc)
+        os.environ["WHATSAPP_FREE_RESPONSE_CHATS"] = _normalize_allow_list_value(frc)
     if "dm_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_DM_POLICY"):
         os.environ["WHATSAPP_DM_POLICY"] = str(whatsapp_cfg["dm_policy"]).lower()
     af = whatsapp_cfg.get("allow_from")
     if af is not None and not os.getenv("WHATSAPP_ALLOWED_USERS"):
-        if isinstance(af, list):
-            af = ",".join(str(v) for v in af)
-        os.environ["WHATSAPP_ALLOWED_USERS"] = str(af)
+        os.environ["WHATSAPP_ALLOWED_USERS"] = _normalize_allow_list_value(af)
     if "group_policy" in whatsapp_cfg and not os.getenv("WHATSAPP_GROUP_POLICY"):
         os.environ["WHATSAPP_GROUP_POLICY"] = str(whatsapp_cfg["group_policy"]).lower()
     gaf = whatsapp_cfg.get("group_allow_from")
     if gaf is not None and not os.getenv("WHATSAPP_GROUP_ALLOWED_USERS"):
-        if isinstance(gaf, list):
-            gaf = ",".join(str(v) for v in gaf)
-        os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = str(gaf)
+        os.environ["WHATSAPP_GROUP_ALLOWED_USERS"] = _normalize_allow_list_value(gaf)
     return None
 
 

--- a/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
+++ b/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
@@ -147,6 +147,16 @@ class TestJsonArrayStringAllowlist:
 
         assert WhatsAppAdapter._coerce_allow_list("['15551234567']") == {"15551234567"}
 
+    def test_malformed_bracket_string_warns(self, caplog):
+        """A `[`-leading value that parses as neither JSON nor Python literal
+        falls back to comma-split (matching nobody) and must log, so the
+        next silent-deaf report starts from the value."""
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        with caplog.at_level("WARNING"):
+            assert WhatsAppAdapter._coerce_allow_list("[1555") == {"[1555"}
+        assert "parses as neither JSON nor Python literal" in caplog.text
+
     def test_intake_accepts_json_array_string_allowlist(self):
         """End to end: the reported deaf-bot scenario now processes."""
         _write_lid_mapping()

--- a/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
+++ b/tests/gateway/test_whatsapp_allowlist_lid_resolution.py
@@ -113,3 +113,62 @@ def test_should_process_message_dm_phone_allowlist_lid_sender():
         "mentionedIds": [],
     }
     assert adapter._should_process_message(data) is True
+
+
+class TestJsonArrayStringAllowlist:
+    """#102329: a JSON-array string (pre-#88163 `config set` shape, or
+    hand-written) must authorize exactly like the equivalent YAML list —
+    never as bracket-polluted entries that match nobody."""
+
+    def test_coerce_json_array_string(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        assert WhatsAppAdapter._coerce_allow_list('["15551234567", "15557654321"]') == {
+            "15551234567",
+            "15557654321",
+        }
+
+    def test_coerce_plain_shapes_unchanged(self):
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        assert WhatsAppAdapter._coerce_allow_list(["15551234567", "15557654321"]) == {
+            "15551234567",
+            "15557654321",
+        }
+        assert WhatsAppAdapter._coerce_allow_list("15551234567,15557654321") == {
+            "15551234567",
+            "15557654321",
+        }
+        assert WhatsAppAdapter._coerce_allow_list(None) == set()
+
+    def test_coerce_python_literal_list(self):
+        """Hand-written Python-literal shape, mirroring parse_config_string_list."""
+        from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+        assert WhatsAppAdapter._coerce_allow_list("['15551234567']") == {"15551234567"}
+
+    def test_intake_accepts_json_array_string_allowlist(self):
+        """End to end: the reported deaf-bot scenario now processes."""
+        _write_lid_mapping()
+        adapter = _make_adapter(dm_policy="allowlist", allow_from=f'["{PHONE}"]')
+
+        data = {
+            "isGroup": False,
+            "body": "hello",
+            "senderId": f"{LID}@lid",
+            "from": f"{LID}@lid",
+            "botIds": [],
+            "mentionedIds": [],
+        }
+        assert adapter._should_process_message(data) is True
+
+    def test_yaml_export_normalizes_json_array_string(self, monkeypatch):
+        """The bridge env export must carry clean comma values, so the Node
+        bridge parses the same membership the adapter enforces."""
+        from plugins.platforms.whatsapp.adapter import _apply_yaml_config
+
+        monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
+        _apply_yaml_config({}, {"allow_from": '["15551234567", "15557654321"]'})
+        import os
+
+        assert os.environ["WHATSAPP_ALLOWED_USERS"] == "15551234567,15557654321"


### PR DESCRIPTION
Hey — `allow_from` given as a JSON-array string was split on commas with brackets and quotes intact, producing entries that can never match a sender. Every inbound message gets rejected while startup, doctor and the bridge all look healthy — a silently deaf bot.

Fixed with one shared normalizer accepting YAML lists, JSON-array strings and plain comma strings, applied at the parse sites and the bridge env export so gates and bridge enforce the same membership. Same treatment for `group_allow_from` and `free_response_chats`, which shared the flawed pattern.

Tests: new cases proving a JSON-array string authorizes exactly like the equivalent list (including end-to-end intake), plain shapes unchanged, and the bridge export carrying clean values. Verified red on unfixed code, green after; neighboring WhatsApp suites pass (68), footguns check clean. Tested on macOS, Python 3.11.

Fixes #102329
