### PR TITLE
fix(whatsapp): route bare numeric group IDs to @g.us

### DIFF
--- a/gateway/whatsapp_identity.py
+++ b/gateway/whatsapp_identity.py
@@ -113,6 +113,13 @@ def to_whatsapp_jid(value: str) -> str:
     if _BARE_PHONE_RE.fullmatch(normalized):
         digits = re.sub(r"\D+", "", normalized)
         if digits:
+            # E.164 phone numbers are at most 15 digits.  Anything longer
+            # (e.g. 18-digit WhatsApp group IDs like 120363012345678901)
+            # is a group identifier — route to @g.us so the bridge delivers
+            # to the group rather than silently addressing a non-existent
+            # user.  See #102328.
+            if len(digits) > 15:
+                return f"{digits}@g.us"
             return f"{digits}@s.whatsapp.net"
 
     return normalized

--- a/tests/gateway/test_whatsapp_to_jid.py
+++ b/tests/gateway/test_whatsapp_to_jid.py
@@ -22,6 +22,8 @@ class TestToWhatsappJid:
             # human-formatted phone numbers get stripped to digits
             ("+1 (555) 123-4567", "15551234567@s.whatsapp.net"),
             ("+1.555.123.4567", "15551234567@s.whatsapp.net"),
+            # bare numeric group id (>15 digits) → group JID (#102328)
+            ("120363012345678901", "120363012345678901@g.us"),
         ],
     )
     def test_bare_phone_becomes_user_jid(self, raw, expected):
@@ -39,5 +41,3 @@ class TestToWhatsappJid:
     )
     def test_fully_qualified_jid_passes_through(self, jid):
         assert to_whatsapp_jid(jid) == jid
-
-


### PR DESCRIPTION
## Root Cause\n\n`to_whatsapp_jid()` in `gateway/whatsapp_identity.py` treats any string matching `_BARE_PHONE_RE` (digits, spaces, dots, dashes, parens) as a phone number and appends `@s.whatsapp.net`. WhatsApp group IDs like `120363012345678901` (18 digits) are purely numeric, so they match this regex and get incorrectly routed to a non-existent user JID.\n\nThe bridge then sends the message to `120363012345678901@s.whatsapp.net`, reports success, but the group never receives it. The only evidence is the outbound JID in the bridge log.\n\n## Fix\n\nE.164 phone numbers are at most 15 digits by specification. A bare numeric string longer than 15 digits cannot be a phone number and must be a group identifier. The fix adds a length check: digits > 15 → append `@g.us` instead of `@s.whatsapp.net`.\n\n## Changes\n\n- `gateway/whatsapp_identity.py`: 3-line conditional in `to_whatsapp_jid()`\n- `tests/gateway/test_whatsapp_to_jid.py`: added parametrized test case for 18-digit group IDs\n\n## Verification\n\n- Existing tests continue to pass (all test phone numbers are ≤ 11 digits)\n- New test case: `120363012345678901` → `120363012345678901@g.us`\n- The fix is backward-compatible: no existing valid phone number exceeds 15 digits\n\nFixes #102328