### PR TITLE
fix(windows): stop treating Task Scheduler as a gateway service during update

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1105,6 +1105,30 @@ def find_profile_gateway_processes(
     return processes
 
 
+_NON_GATEWAY_SUPERVISOR_SERVICES = frozenset(
+    {
+        # The Windows Task Scheduler ("Schedule") is a shared host whose
+        # svchost is an ancestor of every scheduled task, including a
+        # Scheduled-Task run Hermes gateway. It is not a gateway-owned
+        # service: `sc stop Schedule` always fails with ERROR 5 (Access
+        # denied) even as an administrator, so the updater must never treat
+        # it as a service supervising a gateway.
+        "schedule",
+    }
+)
+
+
+def _is_gateway_supervisor_service(service_name: str) -> bool:
+    """Return True if *service_name* could plausibly supervise a gateway.
+
+    Filters out shared svchost-hosted services that can never be stopped as
+    part of gateway management. Only add services here when a real Shared
+    Task / login-item deployment actually surfaces them, so the denylist
+    stays small and intentional.
+    """
+    return service_name.lower() not in _NON_GATEWAY_SUPERVISOR_SERVICES
+
+
 def find_windows_gateway_services(
     *,
     psutil_module=None,
@@ -1199,6 +1223,9 @@ def find_windows_gateway_services(
                     pid
                     for pid in ancestor_pids
                     if len(service_names_by_pid.get(pid, set())) == 1
+                    and _is_gateway_supervisor_service(
+                        next(iter(service_names_by_pid.get(pid, set())))
+                    )
                 ),
                 None,
             )


### PR DESCRIPTION
## Summary

On Windows, `hermes update` aborts on installs that run the gateway as a **Scheduled Task** (the standard `hermes gateway install` deployment) with:

```
RuntimeError: Could not stop Windows gateway service Schedule: [SC] OpenService FAILED 5: Access is denied.
```

The update's pause phase never actually pulls any code — it dies before fetching.

## Root cause

`find_windows_gateway_services()` (`hermes_cli/gateway.py`) identifies a "gateway service" by walking the gateway process's **parent chain** and picking the first ancestor PID that maps to exactly one running Windows service, then tells the updater to `sc stop <that service>` to pause the gateway.

For a gateway launched by a Scheduled Task, that ancestor is the **Task Scheduler svchost**, whose service name is `Schedule`. But `Schedule` is a shared, core host service that cannot be stopped even by an administrator — `sc stop Schedule` always returns `ERROR 5: Access denied`. The updater therefore treats an unstoppable shared host as "the gateway's service" and aborts.

This is **not** messaging-platform-specific. Hermes runs a single `gateway run` process that hosts all configured platforms (QQ, Telegram, Discord, WeChat, …); the bug triggers based purely on how the gateway is *launched* (Scheduled Task), so *any* Windows Scheduled-Task gateway hits it. The same discovery function feeds `update_inventory.py`, which would likewise misclassify a task-run gateway as `SCM-supervised` for the update plan / fleet check.

## Fix

Skip known shared, non-stoppable host services when selecting a gateway's supervising service, so Scheduled-Task gateways fall through to the existing, correct path (`update_cmd` force-kills the profile/unmapped gateway and respawns it after the update) instead of the SCM `sc stop` path.

The denylist is intentionally small and only extended if a real deployment surfaces another shared host (e.g. `EventSystem`, `SysMain`).

## Reproduction

With a gateway running as a Scheduled Task (`Hermes_Gateway`), on the latest `main`:

```python
>>> from hermes_cli.gateway import find_windows_gateway_services
>>> [s.name for s in find_windows_gateway_services()]
['Schedule']          # broken: treats the Task Scheduler as the gateway's service
```

With this change:

```python
>>> [s.name for s in find_windows_gateway_services()]
[]                    # fixed: Scheduled-Task gateway handled via the process path
```

## Suggested follow-up

A focused unit test for `find_windows_gateway_services` (mocking `psutil.win_service_iter` + process ancestry to present a `Schedule` svchost ancestor) would usefully guard against regressions; none could be added here without owning that harness.