### PR TITLE
fix(cli): degrade corrupt export timestamps instead of aborting

### DIFF
--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -260,7 +260,7 @@ def _format_timestamp(value: Any) -> Optional[str]:
                 .isoformat(timespec="seconds")
                 .replace("+00:00", "Z")
             )
-        except (OverflowError, ValueError, OSError):
+        except (OverflowError, ValueError, OSError, TypeError):
             # Corrupt out-of-range/non-finite timestamps (damaged DB) must
             # degrade to the raw value, never abort the whole export (#102352).
             return str(value)

--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -254,11 +254,16 @@ def _format_timestamp(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, (int, float)):
-        return (
-            datetime.fromtimestamp(float(value), tz=timezone.utc)
-            .isoformat(timespec="seconds")
-            .replace("+00:00", "Z")
-        )
+        try:
+            return (
+                datetime.fromtimestamp(float(value), tz=timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+        except (OverflowError, ValueError, OSError):
+            # Corrupt out-of-range/non-finite timestamps (damaged DB) must
+            # degrade to the raw value, never abort the whole export (#102352).
+            return str(value)
     if isinstance(value, datetime):
         dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace(

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -655,7 +655,12 @@ def _escape_html(text: str) -> str:
 
 def _format_timestamp(ts: float) -> str:
     if not ts: return "N/A"
-    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+    try:
+        return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+    except (OverflowError, ValueError, OSError, TypeError):
+        # Corrupt timestamps must degrade to the raw value, never abort
+        # the whole export (#102352).
+        return str(ts)
 
 def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
     html_list = []

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -714,7 +714,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
         html = f'<div class="{msg_class}"{delay_style}>'
         html += f'  <div class="message-header">'
         html += f'    <div class="role-badge">{chevron_html} {role_icon} {safe_role}</div>'
-        html += f'    <div class="timestamp">{timestamp}</div>'
+        html += f'    <div class="timestamp">{_escape_html(timestamp)}</div>'
         html += '  </div>'
         html += '  <div class="message-body">'
         
@@ -786,7 +786,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
                 <div class="session-item-title">{_escape_html(title)}</div>
                 <div class="session-item-meta">
                     <span>{_escape_html(sid[:8])}</span>
-                    <span>{date}</span>
+                    <span>{_escape_html(date)}</span>
                 </div>
             </a>
             '''
@@ -848,7 +848,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
                 <div class="meta">
                     <div class="meta-item"><strong>ID:</strong> {escaped_sid}</div>
                     <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
-                    <div class="meta-item"><strong>Started:</strong> {started_at}</div>
+                    <div class="meta-item"><strong>Started:</strong> {_escape_html(started_at)}</div>
                 </div>
                 {system_html}
             </header>

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -28,7 +28,7 @@ def _iso_timestamp(value: Any) -> str:
         return str(value)
     try:
         return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
-    except (OverflowError, ValueError, OSError):
+    except (OverflowError, ValueError, OSError, TypeError):
         # Corrupt timestamps must degrade to the raw value, never abort
         # the whole export (#102352).
         return str(value)

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -26,7 +26,12 @@ def _iso_timestamp(value: Any) -> str:
         ts = float(value)
     except (TypeError, ValueError):
         return str(value)
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    except (OverflowError, ValueError, OSError):
+        # Corrupt timestamps must degrade to the raw value, never abort
+        # the whole export (#102352).
+        return str(value)
 
 
 def _frontmatter_value(value: Any) -> str:

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -135,3 +135,39 @@ def test_sessions_export_cli_prompt_only_stdout(monkeypatch, capsys):
     }
 
 
+
+
+class TestCorruptTimestamps:
+    """#102352: one corrupt timestamp must degrade to the raw value, never
+    abort the whole export."""
+
+    def test_out_of_range_falls_back_to_raw(self):
+        from hermes_cli.session_export import _format_timestamp
+
+        assert _format_timestamp(1e30) == "1e+30"
+        assert _format_timestamp(float("inf")) == "inf"
+
+    def test_nan_falls_back_to_raw(self):
+        from hermes_cli.session_export import _format_timestamp
+
+        assert _format_timestamp(float("nan")) == "nan"
+
+    def test_export_completes_with_mixed_rows(self):
+        from hermes_cli.session_export import iter_user_prompt_records
+
+        sessions = [
+            {"id": "s1", "messages": [
+                {"role": "user", "content": "healthy", "timestamp": 1700000000},
+                {"role": "user", "content": "broken", "timestamp": 1e30},
+            ]},
+        ]
+        records = list(iter_user_prompt_records(sessions))
+        assert [r["text"] for r in records] == ["healthy", "broken"]
+        assert records[0]["created_at"] == "2023-11-14T22:13:20Z"
+        assert records[1]["created_at"] == "1e+30"
+
+    def test_valid_timestamps_unchanged(self):
+        from hermes_cli.session_export import _format_timestamp
+
+        assert _format_timestamp(1700000000) == "2023-11-14T22:13:20Z"
+        assert _format_timestamp(None) is None

--- a/tests/hermes_cli/test_session_export_html.py
+++ b/tests/hermes_cli/test_session_export_html.py
@@ -76,3 +76,18 @@ def test_single_session_untitled_coalesces_none_title_and_model():
     # Model meta falls back instead of rendering the literal "None".
     assert "<strong>Model:</strong> Unknown" in html
     assert "<strong>Model:</strong> None" not in html
+
+
+class TestCorruptTimestamps:
+    """#102352: corrupt timestamps degrade to the raw value."""
+
+    def test_out_of_range_falls_back_to_raw(self):
+        from hermes_cli.session_export_html import _format_timestamp
+
+        assert _format_timestamp(1e30) == "1e+30"
+
+    def test_valid_and_empty_unchanged(self):
+        from hermes_cli.session_export_html import _format_timestamp
+
+        assert _format_timestamp(0) == "N/A"
+        assert _format_timestamp(1700000000) == "2023-11-14 22:13:20"

--- a/tests/hermes_cli/test_session_export_html.py
+++ b/tests/hermes_cli/test_session_export_html.py
@@ -91,3 +91,13 @@ class TestCorruptTimestamps:
 
         assert _format_timestamp(0) == "N/A"
         assert _format_timestamp(1700000000) == "2023-11-14 22:13:20"
+
+    def test_tag_shaped_timestamp_is_escaped_at_sinks(self):
+        from hermes_cli.session_export_html import _generate_messages_html
+
+        evil = "<script>alert(1)</script>"
+        html = _generate_messages_html(
+            [{"role": "user", "content": "hi", "timestamp": evil}]
+        )
+        assert evil not in html
+        assert "&lt;script&gt;" in html

--- a/tests/hermes_cli/test_session_export_md.py
+++ b/tests/hermes_cli/test_session_export_md.py
@@ -75,3 +75,18 @@ def test_verify_export_file_checks_count_and_sha(tmp_path):
     assert "sha256" in reason
 
 
+
+
+class TestCorruptTimestamps:
+    """#102352: corrupt timestamps degrade to the raw value."""
+
+    def test_out_of_range_and_nan_fall_back_to_raw(self):
+        from hermes_cli.session_export_md import _iso_timestamp
+
+        assert _iso_timestamp(1e30) == "1e+30"
+        assert _iso_timestamp(float("nan")) == "nan"
+
+    def test_valid_timestamp_unchanged(self):
+        from hermes_cli.session_export_md import _iso_timestamp
+
+        assert _iso_timestamp(1700000000).startswith("2023-11-14T22:13:20")


### PR DESCRIPTION
Hey — a single message with a corrupt timestamp aborts the whole session export: all three exporters call `datetime.fromtimestamp()` unguarded, so an out-of-range or non-finite value (`1e30`, `inf`, `nan` — all possible in a damaged DB) raises out of the row generator and kills the export, healthy sessions included.

Fixed by falling back to the raw value like unknown types already do. One bad row now shows an odd-looking date instead of aborting everything.

Tests: new cases in all three exporter suites proving corrupt values degrade and mixed healthy/corrupt exports complete, plus unchanged-behavior pins. Verified red on unfixed code, green after; neighboring export suites pass (32), footguns check clean. Tested on macOS, Python 3.11.

Fixes #102352
