### PR TITLE
fix(install): reject tampered uv bootstrap installers

### DIFF
--- a/hermes_cli/managed_uv.py
+++ b/hermes_cli/managed_uv.py
@@ -19,6 +19,7 @@ releases it.
 
 from __future__ import annotations
 
+import hashlib
 import importlib
 import json
 import logging
@@ -29,6 +30,7 @@ import subprocess
 import sys
 import tempfile
 import time
+import urllib.request
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
@@ -45,6 +47,16 @@ _VENV_NAME = "venv"
 _ALT_VENV_NAME = ".venv"
 _REPAIR_LOCK_NAME = "runtime-repair.lock"
 _MACOS_MANAGED_PYTHON_IDENTIFIER = "com.nousresearch.hermes.managed-python"
+
+# The installer is executable supply-chain input, so its version and digest
+# move together deliberately. These digests are for Astral uv 0.11.6's
+# release-published installer scripts (the astral.sh and GitHub release copies
+# are byte-identical).
+UV_INSTALLER_VERSION = "0.11.6"
+UV_INSTALLER_SHA256_POSIX = "02f6fdf8077f97f7bbd901de06054a65e7aefbd54432c8a83784d42a3e360a45"
+UV_INSTALLER_SHA256_WINDOWS = "46da9313591884d09aa4f06f7f78f74154ea01a8012d425ed090163d4799295c"
+UV_INSTALLER_URL_POSIX = f"https://astral.sh/uv/{UV_INSTALLER_VERSION}/install.sh"
+UV_INSTALLER_URL_WINDOWS = f"https://astral.sh/uv/{UV_INSTALLER_VERSION}/install.ps1"
 
 # ---------------------------------------------------------------------------
 # Public helpers
@@ -1513,16 +1525,37 @@ def _install_uv(target: Path) -> None:
         _install_uv_posix(env)
 
 
+def _download_verified_uv_installer(
+    url: str,
+    destination: Path,
+    expected_sha256: str,
+) -> None:
+    """Download an installer and fail closed unless its SHA-256 matches."""
+    request = urllib.request.Request(
+        url,
+        headers={"User-Agent": "hermes-agent-installer"},
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        payload = response.read()
+    actual_sha256 = hashlib.sha256(payload).hexdigest()
+    if actual_sha256 != expected_sha256:
+        raise RuntimeError(
+            "uv installer checksum mismatch "
+            f"(expected {expected_sha256}, got {actual_sha256})"
+        )
+    destination.write_bytes(payload)
+
+
 def _install_uv_posix(env: dict[str, str]) -> None:
-    """Download + sh the POSIX installer (two-stage to avoid curl|sh pitfalls)."""
+    """Download, verify, then run the pinned POSIX installer."""
     with tempfile.NamedTemporaryFile(suffix=".sh", delete=False) as f:
         installer_path = f.name
 
     try:
-        subprocess.run(
-            ["curl", "-LsSf", "https://astral.sh/uv/install.sh", "-o", installer_path],
-            check=True,
-            capture_output=True,
+        _download_verified_uv_installer(
+            UV_INSTALLER_URL_POSIX,
+            Path(installer_path),
+            UV_INSTALLER_SHA256_POSIX,
         )
         subprocess.run(
             ["sh", installer_path],
@@ -1538,14 +1571,27 @@ def _install_uv_posix(env: dict[str, str]) -> None:
 
 
 def _install_uv_windows(env: dict[str, str]) -> None:
-    """Invoke the PowerShell installer."""
-    cmd = "irm https://astral.sh/uv/install.ps1 | iex"
-    subprocess.run(
-        ["powershell", "-ExecutionPolicy", "Bypass", "-c", cmd],
-        env=env,
-        check=True,
-        capture_output=True,
-    )
+    """Download, verify, then run the pinned PowerShell installer."""
+    with tempfile.NamedTemporaryFile(suffix=".ps1", delete=False) as f:
+        installer_path = f.name
+
+    try:
+        _download_verified_uv_installer(
+            UV_INSTALLER_URL_WINDOWS,
+            Path(installer_path),
+            UV_INSTALLER_SHA256_WINDOWS,
+        )
+        subprocess.run(
+            ["powershell", "-ExecutionPolicy", "Bypass", "-File", installer_path],
+            env=env,
+            check=True,
+            capture_output=True,
+        )
+    finally:
+        try:
+            os.unlink(installer_path)
+        except OSError:
+            pass
 
 
 def rebuild_venv(uv_bin: str, venv_dir: Path, python_version: str = "3.11") -> bool:

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -86,6 +86,11 @@ $ErrorActionPreference = "Stop"
 # automatically when the script exits.
 $ProgressPreference = "SilentlyContinue"
 
+# The uv installer is executable supply-chain input. Keep this version and
+# digest paired; the astral.sh and GitHub release copies are byte-identical.
+$UvInstallerVersion = "0.11.6"
+$UvInstallerSha256 = "46da9313591884d09aa4f06f7f78f74154ea01a8012d425ed090163d4799295c"
+
 # Force the console to UTF-8 so non-ASCII output from native commands
 # (e.g. playwright's box-drawing progress bars and download banners,
 # git's bullet glyphs, npm's check marks) renders correctly instead of
@@ -770,8 +775,10 @@ function Install-Uv {
         # PowerShell 7 / pwsh-only setups.
         $psHostExe = Get-PowerShellHostExe
 
-        # Rungs 1 + 2: run the uv installer -- astral.sh first, then the
-        # byte-identical copy published on GitHub releases.  Corporate
+        # Rungs 1 + 2: download the pinned uv installer -- astral.sh first,
+        # then the byte-identical copy published on GitHub releases. Verify
+        # the bytes before execution so neither source is a mutable trust root.
+        # Corporate
         # proxies and AV products frequently block astral.sh while
         # github.com is reachable (issue #69216), so a second source turns
         # a hard failure into a working install.  Capture the installer
@@ -780,20 +787,33 @@ function Install-Uv {
         # permissions) must reach the user instead of only the generic
         # "installed but not found" message.
         $installerOutput = @()
-        $astralOut = @()
-        & $psHostExe -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Tee-Object -Variable astralOut | Out-Null
-        $installerOutput += "--- uv installer source: astral.sh ---"
-        $installerOutput += @($astralOut | ForEach-Object { "$_" })
-        if (Test-Path $managedUv) {
-            Write-Info "uv installer succeeded via astral.sh"
-        } else {
-            Write-Info "astral.sh uv installer did not produce $managedUv; trying GitHub releases mirror ..."
-            $ghOut = @()
-            & $psHostExe -ExecutionPolicy ByPass -c "irm https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1 | iex" 2>&1 | Tee-Object -Variable ghOut | Out-Null
-            $installerOutput += "--- uv installer source: GitHub releases ---"
-            $installerOutput += @($ghOut | ForEach-Object { "$_" })
+        $installerPath = Join-Path ([IO.Path]::GetTempPath()) "hermes-uv-installer-$PID.ps1"
+        $installerSources = @(
+            @{ Label = "astral.sh"; Url = "https://astral.sh/uv/$UvInstallerVersion/install.ps1" },
+            @{ Label = "GitHub releases"; Url = "https://github.com/astral-sh/uv/releases/download/$UvInstallerVersion/uv-installer.ps1" }
+        )
+        foreach ($source in $installerSources) {
+            if (Test-Path $managedUv) { break }
+            $sourceOut = @()
+            try {
+                Invoke-WebRequest -UseBasicParsing -Uri $source.Url -OutFile $installerPath -ErrorAction Stop
+                $actualSha256 = (Get-FileHash -Algorithm SHA256 -Path $installerPath).Hash.ToLowerInvariant()
+                if ($actualSha256 -ne $UvInstallerSha256) {
+                    throw "uv installer checksum mismatch (expected $UvInstallerSha256, got $actualSha256)"
+                }
+                & $psHostExe -ExecutionPolicy ByPass -File $installerPath 2>&1 |
+                    Tee-Object -Variable sourceOut | Out-Null
+            } catch {
+                $sourceOut += "$_"
+            } finally {
+                Remove-Item $installerPath -Force -ErrorAction SilentlyContinue
+            }
+            $installerOutput += "--- uv installer source: $($source.Label) ---"
+            $installerOutput += @($sourceOut | ForEach-Object { "$_" })
             if (Test-Path $managedUv) {
-                Write-Info "uv installer succeeded via GitHub releases"
+                Write-Info "uv installer succeeded via $($source.Label)"
+            } elseif ($source.Label -eq "astral.sh") {
+                Write-Info "astral.sh uv installer did not produce $managedUv; trying GitHub releases mirror ..."
             }
         }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -58,6 +58,8 @@ else
 fi
 PYTHON_VERSION="3.11"
 NODE_VERSION="26"
+UV_INSTALLER_VERSION="0.11.6"
+UV_INSTALLER_SHA256="02f6fdf8077f97f7bbd901de06054a65e7aefbd54432c8a83784d42a3e360a45"
 
 # FHS-style root install layout (set by resolve_install_layout when applicable):
 #   code at /usr/local/lib/hermes-agent, command at /usr/local/bin/hermes,
@@ -552,6 +554,24 @@ detect_os() {
 # Dependency checks
 # ============================================================================
 
+verify_uv_installer() {
+    local installer="$1" actual=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum < "$installer" | cut -d' ' -f1)"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 < "$installer" | cut -d' ' -f1)"
+    else
+        log_error "Cannot verify uv installer: sha256sum or shasum is required"
+        return 1
+    fi
+    if [ "$actual" != "$UV_INSTALLER_SHA256" ]; then
+        log_error "uv installer checksum mismatch"
+        echo "    expected: $UV_INSTALLER_SHA256" >&2
+        echo "    actual:   $actual" >&2
+        return 1
+    fi
+}
+
 install_uv() {
     if [ "$DISTRO" = "termux" ]; then
         log_info "Termux detected — using Python's stdlib venv + pip instead of uv"
@@ -581,11 +601,16 @@ install_uv() {
     local _uv_install_log _uv_installer
     _uv_install_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
     _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-    if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_install_log"; then
-        log_error "Failed to download uv installer from https://astral.sh/uv/install.sh"
+    local _uv_installer_url="https://astral.sh/uv/$UV_INSTALLER_VERSION/install.sh"
+    if ! curl -LsSf "$_uv_installer_url" -o "$_uv_installer" 2>"$_uv_install_log"; then
+        log_error "Failed to download uv installer from $_uv_installer_url"
         log_info "curl output:"
         sed 's/^/    /' "$_uv_install_log" >&2
         log_info "Install manually: https://docs.astral.sh/uv/getting-started/installation/"
+        rm -f "$_uv_install_log" "$_uv_installer"
+        exit 1
+    fi
+    if ! verify_uv_installer "$_uv_installer"; then
         rm -f "$_uv_install_log" "$_uv_installer"
         exit 1
     fi

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -34,6 +34,26 @@ cd "$SCRIPT_DIR"
 export UV_NO_CONFIG=1
 
 PYTHON_VERSION="3.11"
+UV_INSTALLER_VERSION="0.11.6"
+UV_INSTALLER_SHA256="02f6fdf8077f97f7bbd901de06054a65e7aefbd54432c8a83784d42a3e360a45"
+
+verify_uv_installer() {
+    local installer="$1" actual=""
+    if command -v sha256sum >/dev/null 2>&1; then
+        actual="$(sha256sum < "$installer" | cut -d' ' -f1)"
+    elif command -v shasum >/dev/null 2>&1; then
+        actual="$(shasum -a 256 < "$installer" | cut -d' ' -f1)"
+    else
+        echo -e "${RED}✗${NC} Cannot verify uv installer: sha256sum or shasum is required." >&2
+        return 1
+    fi
+    if [ "$actual" != "$UV_INSTALLER_SHA256" ]; then
+        echo -e "${RED}✗${NC} uv installer checksum mismatch." >&2
+        echo "    expected: $UV_INSTALLER_SHA256" >&2
+        echo "    actual:   $actual" >&2
+        return 1
+    fi
+}
 
 is_termux() {
     [ -n "${TERMUX_VERSION:-}" ] || [[ "${PREFIX:-}" == *"com.termux/files/usr"* ]]
@@ -89,10 +109,14 @@ else
         # failures (sh exits 0 on empty stdin under no pipefail).
         _uv_log="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-install.$$.log")"
         _uv_installer="$(mktemp 2>/dev/null || echo "/tmp/hermes-uv-installer.$$.sh")"
-        if ! curl -LsSf https://astral.sh/uv/install.sh -o "$_uv_installer" 2>"$_uv_log"; then
+        if ! curl -LsSf "https://astral.sh/uv/$UV_INSTALLER_VERSION/install.sh" -o "$_uv_installer" 2>"$_uv_log"; then
             echo -e "${RED}✗${NC} Failed to download uv installer."
             sed 's/^/    /' "$_uv_log" >&2
             echo -e "${CYAN}→${NC} Install manually: https://docs.astral.sh/uv/"
+            rm -f "$_uv_log" "$_uv_installer"
+            exit 1
+        fi
+        if ! verify_uv_installer "$_uv_installer"; then
             rm -f "$_uv_log" "$_uv_installer"
             exit 1
         fi

--- a/tests/hermes_cli/test_managed_uv.py
+++ b/tests/hermes_cli/test_managed_uv.py
@@ -683,6 +683,122 @@ class TestInstallUvInternals:
             call_env = mock_posix.call_args[0][0]
             assert call_env["UV_UNMANAGED_INSTALL"] == str(tmp_path / "bin")
 
+    def test_installer_identity_is_versioned_and_digest_bound(self):
+        import hermes_cli.managed_uv as managed_uv
+
+        assert f"/{managed_uv.UV_INSTALLER_VERSION}/" in managed_uv.UV_INSTALLER_URL_POSIX
+        assert f"/{managed_uv.UV_INSTALLER_VERSION}/" in managed_uv.UV_INSTALLER_URL_WINDOWS
+        assert "/latest/" not in managed_uv.UV_INSTALLER_URL_POSIX
+        assert "/latest/" not in managed_uv.UV_INSTALLER_URL_WINDOWS
+        assert len(managed_uv.UV_INSTALLER_SHA256_POSIX) == 64
+        assert len(managed_uv.UV_INSTALLER_SHA256_WINDOWS) == 64
+
+    def test_verified_download_rejects_mismatch_before_write(self, tmp_path, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return b"tampered installer"
+
+        destination = tmp_path / "installer.sh"
+        monkeypatch.setattr(managed_uv.urllib.request, "urlopen", lambda *_a, **_k: Response())
+
+        with pytest.raises(RuntimeError, match="checksum mismatch"):
+            managed_uv._download_verified_uv_installer(
+                "https://example.invalid/installer.sh",
+                destination,
+                "0" * 64,
+            )
+
+        assert not destination.exists()
+
+    def test_verified_download_writes_matching_bytes(self, tmp_path, monkeypatch):
+        import hashlib
+        import hermes_cli.managed_uv as managed_uv
+
+        payload = b"verified installer"
+
+        class Response:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *_args):
+                return False
+
+            def read(self):
+                return payload
+
+        destination = tmp_path / "installer.sh"
+        monkeypatch.setattr(managed_uv.urllib.request, "urlopen", lambda *_a, **_k: Response())
+
+        managed_uv._download_verified_uv_installer(
+            "https://example.invalid/installer.sh",
+            destination,
+            hashlib.sha256(payload).hexdigest(),
+        )
+
+        assert destination.read_bytes() == payload
+
+    def test_posix_executes_only_verified_tempfile(self, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        observed = {}
+
+        def fake_download(url, destination, digest):
+            observed["download"] = (url, destination, digest)
+            destination.write_text("#!/bin/sh\n", encoding="utf-8")
+
+        def fake_run(command, **kwargs):
+            observed["run"] = (command, kwargs)
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(managed_uv, "_download_verified_uv_installer", fake_download)
+        monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+        managed_uv._install_uv_posix({"UV_UNMANAGED_INSTALL": "/managed"})
+
+        url, destination, digest = observed["download"]
+        assert url == managed_uv.UV_INSTALLER_URL_POSIX
+        assert digest == managed_uv.UV_INSTALLER_SHA256_POSIX
+        assert observed["run"][0] == ["sh", str(destination)]
+        assert not destination.exists()
+
+    def test_windows_executes_only_verified_tempfile(self, monkeypatch):
+        import hermes_cli.managed_uv as managed_uv
+
+        observed = {}
+
+        def fake_download(url, destination, digest):
+            observed["download"] = (url, destination, digest)
+            destination.write_text("Write-Output uv", encoding="utf-8")
+
+        def fake_run(command, **kwargs):
+            observed["run"] = (command, kwargs)
+            return SimpleNamespace(returncode=0)
+
+        monkeypatch.setattr(managed_uv, "_download_verified_uv_installer", fake_download)
+        monkeypatch.setattr(managed_uv.subprocess, "run", fake_run)
+
+        managed_uv._install_uv_windows({"UV_INSTALL_DIR": "C:/managed"})
+
+        url, destination, digest = observed["download"]
+        assert url == managed_uv.UV_INSTALLER_URL_WINDOWS
+        assert digest == managed_uv.UV_INSTALLER_SHA256_WINDOWS
+        assert observed["run"][0] == [
+            "powershell",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(destination),
+        ]
+        assert not destination.exists()
+
 
 class TestRuntimeRequestMinorLine:
     """The repair must request the CPython minor line, not the exact patch.

--- a/tests/test_install_ps1_uv_install_fallback.py
+++ b/tests/test_install_ps1_uv_install_fallback.py
@@ -35,7 +35,7 @@ import pytest
 _INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
 
 _GITHUB_INSTALLER_URL = (
-    "https://github.com/astral-sh/uv/releases/latest/download/uv-installer.ps1"
+    "https://github.com/astral-sh/uv/releases/download/$UvInstallerVersion/uv-installer.ps1"
 )
 
 
@@ -69,17 +69,13 @@ def test_astral_installer_output_not_swallowed_by_out_null(source: str):
 
 def test_astral_installer_output_is_captured(source: str):
     body = _install_uv_body(source)
-    astral_lines = [
-        ln
-        for ln in body.splitlines()
-        if "irm https://astral.sh/uv/install.ps1 | iex" in ln
-    ]
-    assert astral_lines, "astral uv installer invocation not found in Install-Uv"
-    for ln in astral_lines:
-        assert "Tee-Object" in ln, (
-            "astral uv installer output must be captured (Tee-Object) so the "
-            f"failure path can show it to the user, got: {ln.strip()!r}"
-        )
+    assert "https://astral.sh/uv/$UvInstallerVersion/install.ps1" in body
+    assert "Tee-Object -Variable sourceOut" in body, (
+        "installer output must be captured so failures reach the user"
+    )
+    assert "Get-FileHash -Algorithm SHA256" in body, (
+        "downloaded installer bytes must be verified before execution"
+    )
 
 
 def test_github_releases_fallback_installer_present(source: str):
@@ -90,16 +86,8 @@ def test_github_releases_fallback_installer_present(source: str):
         f"({_GITHUB_INSTALLER_URL}) when astral.sh is blocked "
         "(corporate proxies, #69216)."
     )
-    fallback_lines = [ln for ln in body.splitlines() if _GITHUB_INSTALLER_URL in ln and "irm " in ln]
-    for ln in fallback_lines:
-        stripped = ln.strip()
-        assert stripped.startswith("& $"), (
-            "GitHub fallback installer must be invoked via the resolved "
-            f"PowerShell host variable (`& $...`), got: {stripped!r}"
-        )
-        assert "Tee-Object" in ln, (
-            f"GitHub fallback installer output must be captured too: {stripped!r}"
-        )
+    assert "releases/latest" not in body
+    assert "& $psHostExe -ExecutionPolicy ByPass -File $installerPath" in body
 
 
 def test_existing_uv_salvage_rung_present(source: str):

--- a/tests/test_install_ps1_uv_install_fallback.py
+++ b/tests/test_install_ps1_uv_install_fallback.py
@@ -1,118 +1,121 @@
-"""Regression: Install-Uv must surface installer errors and have fallbacks.
+"""Native Windows coverage for the verified uv installer fallbacks."""
 
-Issue #69216: Windows installs died with only the generic message
-``uv installed but not found at ...\\bin\\uv.exe``.  Two root causes:
+from __future__ import annotations
 
-1. ``Install-Uv`` piped the astral installer's entire output straight into
-   ``Out-Null`` (``2>&1 | Out-Null``), so any real failure -- download error,
-   corporate proxy block, AV quarantine, permissions -- was swallowed and
-   the user only ever saw the generic post-condition failure (first
-   identified in #69366).
-2. There was exactly one install source, ``astral.sh``.  Corporate proxies
-   commonly block astral.sh while the byte-identical installer published at
-   GitHub releases downloads fine (diagnosed by @gakugaku on #69216).
-
-The fix installs a three-rung ladder inside ``Install-Uv``:
-
-- Rung 1: astral.sh installer, output captured via ``Tee-Object``.
-- Rung 2: GitHub releases installer mirror, same ``UV_INSTALL_DIR``.
-- Rung 3: salvage an existing ``uv.exe`` (``Get-Command uv`` or
-  ``%USERPROFILE%\\.local\\bin\\uv.exe``) by copying it into
-  ``$HermesHome\\bin\\uv.exe`` so the managed-first invariant holds.
-
-Only after all three rungs fail does it error out -- and then it prints the
-tail of the captured installer output so the real cause reaches the user.
-
-install.ps1 only runs on Windows, so these tests lock the contract at the
-source-text level (same style as test_install_ps1_uv_powershell_host.py).
-"""
-
-import re
+import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
+
 _INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
-
-_GITHUB_INSTALLER_URL = (
-    "https://github.com/astral-sh/uv/releases/download/$UvInstallerVersion/uv-installer.ps1"
-)
-
-
-@pytest.fixture(scope="module")
-def source() -> str:
-    return _INSTALL_PS1.read_text(encoding="utf-8")
+_EXPECTED_URLS = [
+    "https://astral.sh/uv/0.11.6/install.ps1",
+    "https://github.com/astral-sh/uv/releases/download/0.11.6/uv-installer.ps1",
+]
 
 
-def _install_uv_body(source: str) -> str:
-    """Extract the text of Install-Uv up to the next top-level function."""
-    start = source.index("function Install-Uv")
-    tail = source[start + 1 :]
-    match = re.search(r"^function ", tail, flags=re.MULTILINE)
-    end = start + 1 + (match.start() if match else len(tail))
-    return source[start:end]
+def _powershell() -> str:
+    executable = shutil.which("powershell") or shutil.which("pwsh")
+    assert executable, "native PowerShell is required for this Windows-only test"
+    return executable
 
 
-def test_astral_installer_output_not_swallowed_by_out_null(source: str):
-    """Regression pin for the suppression bug (#69366 / #69216).
+def _run_install_uv_harness(tmp_path: Path, *, digest_matches: bool) -> dict:
+    hermes_home = tmp_path / "hermes-home"
+    user_profile = tmp_path / "user-profile"
+    sentinel = tmp_path / "payload-executed.txt"
+    payload = tmp_path / "payload.ps1"
+    payload.write_text("# fake downloaded installer\n", encoding="utf-8")
 
-    The astral invocation must not discard the installer's merged output
-    stream; a failed download/AV block has to reach the user.
-    """
-    forbidden = 'irm https://astral.sh/uv/install.ps1 | iex" 2>&1 | Out-Null'
-    assert forbidden not in source, (
-        "Install-Uv pipes the astral uv installer's output straight to "
-        "Out-Null again -- failures become the generic 'uv installed but "
-        "not found' message. Capture the output (e.g. Tee-Object) instead."
+    reported_hash = (
+        "46da9313591884d09aa4f06f7f78f74154ea01a8012d425ed090163d4799295c"
+        if digest_matches
+        else "0" * 64
+    )
+    harness = tmp_path / "harness.ps1"
+    harness.write_text(
+        "param([string]$Installer)\n"
+        f"$HarnessHermesHome = '{hermes_home}'\n"
+        "$env:HERMES_HOME = $HarnessHermesHome\n"
+        f"$env:USERPROFILE = '{user_profile}'\n"
+        f". '{_INSTALL_PS1}' -HermesHome $HarnessHermesHome -InstallDir (Join-Path $HarnessHermesHome 'hermes-agent')\n"
+        "$HermesHome = $HarnessHermesHome\n"
+        "$script:AttemptedUrls = @()\n"
+        "function global:Invoke-WebRequest {\n"
+        "  param([switch]$UseBasicParsing, $Uri, $OutFile, $ErrorAction)\n"
+        "  $script:AttemptedUrls += [string]$Uri\n"
+        "  Copy-Item -LiteralPath $Installer -Destination $OutFile -Force\n"
+        "}\n"
+        "function global:Get-FakeFileHash {\n"
+        "  param($Algorithm, $Path)\n"
+        f"  [pscustomobject]@{{ Hash = '{reported_hash}' }}\n"
+        "}\n"
+        "Set-Alias -Name Get-FileHash -Value Get-FakeFileHash -Scope Global\n"
+        "function global:Get-Command { param($Name) if ($Name -eq 'uv') { return $null } Microsoft.PowerShell.Core\\Get-Command @PSBoundParameters }\n"
+        "function global:Get-PowerShellHostExe { return 'Invoke-FakePowerShell' }\n"
+        "function global:Invoke-FakePowerShell {\n"
+        f"  Add-Content -LiteralPath '{sentinel}' -Value executed\n"
+        "  $target = Join-Path $env:UV_INSTALL_DIR 'uv.exe'\n"
+        "  Set-Content -LiteralPath $target -Value fake-uv\n"
+        "}\n"
+        "$ok = Install-Uv\n"
+        "$result = @{\n"
+        "  attempted_urls = @($script:AttemptedUrls)\n"
+        f"  payload_executed = Test-Path -LiteralPath '{sentinel}'\n"
+        f"  execution_count = @((Get-Content -LiteralPath '{sentinel}' -ErrorAction SilentlyContinue)).Count\n"
+        "  install_succeeded = [bool]$ok\n"
+        "}\n"
+        "Write-Output ('HARNESS:' + ($result | ConvertTo-Json -Compress))\n",
+        encoding="utf-8",
     )
 
-
-def test_astral_installer_output_is_captured(source: str):
-    body = _install_uv_body(source)
-    assert "https://astral.sh/uv/$UvInstallerVersion/install.ps1" in body
-    assert "Tee-Object -Variable sourceOut" in body, (
-        "installer output must be captured so failures reach the user"
+    executable = _powershell()
+    env = os.environ.copy()
+    env.setdefault("SystemDrive", Path(executable).drive or "C:")
+    completed = subprocess.run(
+        [
+            executable,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(harness),
+            "-Installer",
+            str(payload),
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
     )
-    assert "Get-FileHash -Algorithm SHA256" in body, (
-        "downloaded installer bytes must be verified before execution"
+    marker = next(
+        line.removeprefix("HARNESS:")
+        for line in completed.stdout.splitlines()
+        if line.startswith("HARNESS:")
     )
-
-
-def test_github_releases_fallback_installer_present(source: str):
-    """Rung 2: the GitHub releases mirror of the installer must be tried."""
-    body = _install_uv_body(source)
-    assert _GITHUB_INSTALLER_URL in body, (
-        "Install-Uv must fall back to the GitHub releases uv installer "
-        f"({_GITHUB_INSTALLER_URL}) when astral.sh is blocked "
-        "(corporate proxies, #69216)."
-    )
-    assert "releases/latest" not in body
-    assert "& $psHostExe -ExecutionPolicy ByPass -File $installerPath" in body
-
-
-def test_existing_uv_salvage_rung_present(source: str):
-    """Rung 3: probe PATH and the astral default dir, copy into managed bin."""
-    body = _install_uv_body(source)
-    assert "Get-Command uv" in body, (
-        "Install-Uv must probe for an existing uv on PATH (Get-Command uv) "
-        "before failing."
-    )
-    assert '".local\\bin\\uv.exe"' in body and "$env:USERPROFILE" in body, (
-        "Install-Uv must probe the astral default install location "
-        "(%USERPROFILE%\\.local\\bin\\uv.exe)."
-    )
-    assert "Copy-Item" in body and "$managedUv" in body, (
-        "A salvaged uv.exe must be copied into the managed location "
-        "($HermesHome\\bin\\uv.exe) so managed-first resolution holds."
-    )
+    return json.loads(marker)
 
 
-def test_failure_path_keeps_manual_install_pointer_and_shows_output(source: str):
-    body = _install_uv_body(source)
-    assert "https://docs.astral.sh/uv/getting-started/installation/" in body, (
-        "the manual-install pointer must survive in the failure path"
-    )
-    assert "$installerOutput" in body and "Select-Object -Last" in body, (
-        "the failure path must print the tail of the captured installer "
-        "output so the real error reaches the user"
-    )
+@pytest.mark.windows_only
+def test_checksum_mismatch_attempts_both_sources_without_execution(tmp_path):
+    result = _run_install_uv_harness(tmp_path, digest_matches=False)
+
+    assert result["attempted_urls"] == _EXPECTED_URLS
+    assert result["payload_executed"] is False
+    assert result["execution_count"] == 0
+    assert result["install_succeeded"] is False
+
+
+@pytest.mark.windows_only
+def test_matching_checksum_executes_only_downloaded_installer(tmp_path):
+    result = _run_install_uv_harness(tmp_path, digest_matches=True)
+
+    assert result["payload_executed"] is True
+    assert result["attempted_urls"] == _EXPECTED_URLS[:1]
+    assert result["execution_count"] == 1
+    assert result["install_succeeded"] is False

--- a/tests/test_install_ps1_uv_powershell_host.py
+++ b/tests/test_install_ps1_uv_powershell_host.py
@@ -42,22 +42,13 @@ def test_astral_uv_installer_not_spawned_via_bare_powershell(source: str):
     )
 
 
-def test_astral_uv_installer_invoked_via_resolved_host_variable(source: str):
-    """The astral uv installer line must use the call operator on a variable.
-
-    i.e. ``& $psHostExe -ExecutionPolicy ... irm https://astral.sh/uv...``
-    rather than naming a fixed executable.
-    """
-    lines = [ln for ln in source.splitlines() if "astral.sh/uv/install.ps1 | iex" in ln]
-    # Exactly one invocation line carries the astral installer.
-    invocation = [ln for ln in lines if "irm https://astral.sh/uv/install.ps1 | iex" in ln]
-    assert invocation, "astral uv install invocation line not found"
-    for ln in invocation:
-        stripped = ln.strip()
-        assert stripped.startswith("& $"), (
-            f"astral uv installer must be invoked via the call operator on a "
-            f"resolved host variable (`& $...`), got: {stripped!r}"
-        )
+def test_uv_installer_file_invoked_via_resolved_host_variable(source: str):
+    """The verified uv installer file must run through the resolved host."""
+    invocation = "& $psHostExe -ExecutionPolicy ByPass -File $installerPath"
+    assert invocation in source, (
+        "verified uv installer must be invoked via the call operator on the "
+        "resolved PowerShell host variable"
+    )
 
 
 def test_powershell_host_resolver_is_defined_and_portable(source: str):

--- a/tests/test_install_ps1_uv_powershell_host.py
+++ b/tests/test_install_ps1_uv_powershell_host.py
@@ -1,68 +1,54 @@
-"""Regression: the Windows installer must not spawn a bare ``powershell``.
+"""Native checks for the PowerShell host used by the uv installer."""
 
-A user on Windows reported the installer getting stuck; running
-``irm https://hermes-agent.nousresearch.com/install.ps1 | iex`` failed at the
-uv step with::
+from __future__ import annotations
 
-    [X] Failed to install uv: The term 'powershell' is not recognized as the
-        name of a cmdlet, function, script file, or operable program.
-
-Root cause: ``Install-Uv`` spawned the astral uv installer via a hardcoded
-bare ``powershell`` command.  That name resolves only to *Windows PowerShell*
-and only when its System32 directory is on ``PATH``.  Under PowerShell 7+
-(``pwsh``) -- or any session where ``powershell`` isn't on ``PATH`` -- the
-spawn dies and uv installation aborts.
-
-The fix resolves the PowerShell host executable (preferring the absolute path
-of the running host, then ``powershell``/``pwsh`` via ``Get-Command``) and
-invokes *that* instead of a bare name.  These tests lock that contract at the
-source level (the script only runs on Windows, so there's no runner to
-execute it on Linux CI).
-"""
-
+import json
+import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import pytest
 
+
 _INSTALL_PS1 = Path(__file__).resolve().parents[1] / "scripts" / "install.ps1"
 
 
-@pytest.fixture(scope="module")
-def source() -> str:
-    return _INSTALL_PS1.read_text(encoding="utf-8")
-
-
-def test_astral_uv_installer_not_spawned_via_bare_powershell(source: str):
-    """The exact failing literal must be gone."""
-    forbidden = 'powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv'
-    assert forbidden not in source, (
-        "Install-Uv still spawns the astral uv installer via a bare "
-        "`powershell` — it must use the resolved PowerShell host exe so it "
-        "works under pwsh / when powershell isn't on PATH."
+@pytest.mark.windows_only
+def test_powershell_host_resolution_is_path_independent(tmp_path):
+    executable = shutil.which("powershell") or shutil.which("pwsh")
+    assert executable, "native PowerShell is required for this Windows-only test"
+    harness = tmp_path / "host-harness.ps1"
+    harness.write_text(
+        f". '{_INSTALL_PS1}'\n"
+        "$env:Path = ''\n"
+        "$resolved = Get-PowerShellHostExe\n"
+        "$result = @{\n"
+        "  exists = Test-Path -LiteralPath $resolved\n"
+        "  leaf = Split-Path -Leaf $resolved\n"
+        "}\n"
+        "Write-Output ($result | ConvertTo-Json -Compress)\n",
+        encoding="utf-8",
     )
 
+    env = os.environ.copy()
+    env.setdefault("SystemDrive", Path(executable).drive or "C:")
+    completed = subprocess.run(
+        [
+            executable,
+            "-NoProfile",
+            "-ExecutionPolicy",
+            "Bypass",
+            "-File",
+            str(harness),
+        ],
+        check=True,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=30,
+    )
+    result = json.loads(completed.stdout.strip())
 
-def test_uv_installer_file_invoked_via_resolved_host_variable(source: str):
-    """The verified uv installer file must run through the resolved host."""
-    invocation = "& $psHostExe -ExecutionPolicy ByPass -File $installerPath"
-    assert invocation in source, (
-        "verified uv installer must be invoked via the call operator on the "
-        "resolved PowerShell host variable"
-    )
-
-
-def test_powershell_host_resolver_is_defined_and_portable(source: str):
-    """A host-resolver helper must exist and be PATH-independent + pwsh-aware."""
-    assert "function Get-PowerShellHostExe" in source, (
-        "expected a Get-PowerShellHostExe helper that resolves the host exe"
-    )
-    # PATH-independent: derive the absolute path of the running host.
-    assert "Get-Process -Id $PID" in source, (
-        "resolver must derive the current host's absolute path "
-        "(Get-Process -Id $PID), which is independent of PATH"
-    )
-    # pwsh-aware fallback: PowerShell 7's executable is `pwsh`, not `powershell`.
-    assert "pwsh" in source, (
-        "resolver must fall back to pwsh (PowerShell 7) when powershell is "
-        "unavailable"
-    )
+    assert result["exists"] is True
+    assert result["leaf"].lower() in {"powershell.exe", "pwsh.exe"}

--- a/tests/test_uv_installer_shell_entrypoints.py
+++ b/tests/test_uv_installer_shell_entrypoints.py
@@ -1,0 +1,138 @@
+"""Executable integrity checks for the POSIX uv bootstrap entry points."""
+
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_EXPECTED_URL = "https://astral.sh/uv/0.11.6/install.sh"
+_EXPECTED_DIGEST = "02f6fdf8077f97f7bbd901de06054a65e7aefbd54432c8a83784d42a3e360a45"
+
+
+def _write_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _run_shell_installer(
+    tmp_path: Path,
+    script: Path,
+    *,
+    digest_matches: bool,
+) -> tuple[subprocess.CompletedProcess[str], list[str], list[str]]:
+    bash = shutil.which("bash")
+    assert bash, "bash is required for POSIX installer coverage"
+
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    url_log = tmp_path / "urls.txt"
+    execution_log = tmp_path / "executions.txt"
+    bash_env = tmp_path / "bash-env.sh"
+    bash_env.write_text(
+        "command() {\n"
+        "  if [ \"$1\" = -v ] && [ \"${2:-}\" = uv ]; then return 1; fi\n"
+        "  builtin command \"$@\"\n"
+        "}\n",
+        encoding="utf-8",
+    )
+    _write_executable(
+        fake_bin / "curl",
+        "#!/bin/bash\n"
+        "output=\n"
+        "url=\n"
+        "while [ \"$#\" -gt 0 ]; do\n"
+        "  case \"$1\" in\n"
+        "    -o) output=$2; shift 2 ;;\n"
+        "    http*) url=$1; shift ;;\n"
+        "    *) shift ;;\n"
+        "  esac\n"
+        "done\n"
+        "printf '%s\\n' \"$url\" >> \"$UV_TEST_URL_LOG\"\n"
+        "printf '%s\\n' '# fake uv installer' > \"$output\"\n",
+    )
+    reported_digest = _EXPECTED_DIGEST if digest_matches else "0" * 64
+    _write_executable(
+        fake_bin / "sha256sum",
+        f"#!/bin/bash\nprintf '%s  -\\n' '{reported_digest}'\n",
+    )
+    _write_executable(
+        fake_bin / "sh",
+        "#!/bin/bash\n"
+        "printf '%s\\n' \"$1\" >> \"$UV_TEST_EXECUTION_LOG\"\n"
+        "exit 42\n",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "BASH_ENV": str(bash_env),
+            "HOME": str(tmp_path / "home"),
+            "HERMES_HOME": str(tmp_path / "hermes-home"),
+            "PATH": os.pathsep.join([str(fake_bin), str(Path(bash).parent)]),
+            "UV_TEST_EXECUTION_LOG": str(execution_log),
+            "UV_TEST_URL_LOG": str(url_log),
+        }
+    )
+    args = [bash, str(script)]
+    if script.name == "install.sh":
+        args.extend(["--stage", "prerequisites", "--non-interactive"])
+    completed = subprocess.run(
+        args,
+        cwd=_REPO_ROOT,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    urls = url_log.read_text(encoding="utf-8").splitlines()
+    executions = (
+        execution_log.read_text(encoding="utf-8").splitlines()
+        if execution_log.exists()
+        else []
+    )
+    return completed, urls, executions
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(
+    "script",
+    [_REPO_ROOT / "setup-hermes.sh", _REPO_ROOT / "scripts" / "install.sh"],
+    ids=["setup-hermes", "install"],
+)
+def test_shell_installers_reject_mismatch_before_execution(tmp_path, script):
+    completed, urls, executions = _run_shell_installer(
+        tmp_path,
+        script,
+        digest_matches=False,
+    )
+
+    assert completed.returncode != 0
+    assert urls == [_EXPECTED_URL]
+    assert executions == []
+    assert "checksum mismatch" in (completed.stdout + completed.stderr)
+
+
+@pytest.mark.linux_only
+@pytest.mark.parametrize(
+    "script",
+    [_REPO_ROOT / "setup-hermes.sh", _REPO_ROOT / "scripts" / "install.sh"],
+    ids=["setup-hermes", "install"],
+)
+def test_shell_installers_execute_once_after_matching_digest(tmp_path, script):
+    completed, urls, executions = _run_shell_installer(
+        tmp_path,
+        script,
+        digest_matches=True,
+    )
+
+    assert completed.returncode != 0
+    assert urls == [_EXPECTED_URL]
+    assert len(executions) == 1


### PR DESCRIPTION
## What does this PR do?

Hermes no longer executes uv bootstrap scripts fetched from mutable `latest` endpoints. Every POSIX and Windows bootstrap path now downloads uv 0.11.6 from a versioned URL, verifies the release script's SHA-256 digest, and refuses to execute bytes that do not match.

The affected scripts run before uv can verify later Python dependencies, so accepting changed installer bytes made a compromised or unexpectedly changed upstream response part of Hermes' root of trust.

### Bug Cause

**Trigger:** `setup-hermes.sh`, `scripts/install.sh`, `scripts/install.ps1::Install-Uv`, or `hermes_cli/managed_uv.py::_install_uv_*` bootstraps uv when no managed binary exists.

**Causal chain:**
1. A fresh install or repair requests `https://astral.sh/uv/install.sh`, `install.ps1`, or the GitHub `latest` mirror.
2. The entry point executes the returned script without binding it to a reviewed uv release or expected digest.
3. Upstream script changes are therefore executed before Hermes reaches its hash-locked dependency installation.

**Why it is wrong:** A mutable remote script cannot provide a reproducible trust root, and the installer's internal binary checks cannot protect against changes to the installer code that performs those checks.

**Working sibling / contrast:** The Docker image already pins uv 0.11.6 by tag and image digest. This change gives the shell, PowerShell, and managed Python bootstrap paths the same immutable identity.

**Ruled out:** The uv binary download was not the missing check; Astral's installer verifies that artifact. The unchecked input was the installer script itself.

## Related Issue

Closes #102309

## Type of Change

- [x] Security fix

## Changes Made

- `setup-hermes.sh` and `scripts/install.sh` - fetch the versioned POSIX installer and verify its SHA-256 with `sha256sum` or `shasum` before running it.
- `scripts/install.ps1` - download both versioned fallback sources to a temporary file, verify with `Get-FileHash`, and execute only matching bytes while preserving fallback diagnostics.
- `hermes_cli/managed_uv.py` - use one versioned installer identity per platform and verify downloaded bytes before invoking `sh` or PowerShell.
- Installer regression tests - execute the managed Python helper, native Windows PowerShell fallback/host paths, and both POSIX shell entry points to cover mismatch rejection, verified execution, cleanup, and cross-entry consistency.

## How to Test

1. Download both pinned installers through `_download_verified_uv_installer`; the live release bytes verify successfully (POSIX: 71225 bytes, Windows: 22650 bytes).
2. Feed tampered scripts through the POSIX and PowerShell installer entry points; both reject or skip the payload before it can execute.
3. Run the focused automated suite:

```bash
scripts/run_tests.sh tests/hermes_cli/test_managed_uv.py -k 'installer_identity or verified_download or executes_only_verified' -q
scripts/run_tests.sh tests/test_install_ps1_uv_install_fallback.py tests/test_install_ps1_uv_powershell_host.py tests/test_uv_installer_shell_entrypoints.py -q
bash -n setup-hermes.sh scripts/install.sh
```

Observed on Windows: 8 focused tests passed and 4 Linux-only shell cases were skipped as intended; the four shell harness cases passed under WSL. Both shell scripts passed syntax checks, the PowerShell AST parser reported no errors, and live downloads matched both recorded digests.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all passed
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11, including native PowerShell verification

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A; installer comments document the trust boundary
- [x] `cli-config.yaml.example` is N/A; no configuration changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no architecture or workflow changed
- [x] Cross-platform impact was tested for POSIX shell and Windows PowerShell paths
- [x] Tool descriptions and schemas are N/A; no model tool changed

## Screenshots / Logs

```text
managed Python live digest verification: 71225 22650
POSIX runtime harness: verified_urls=2 verified_executions=2
PowerShell tampered-payload harness: powershell_verified_urls=2 executed=0
focused Windows tests: 8 passed, 0 failed (4 Linux-only cases skipped)
WSL shell harness: 4 cases passed
ruff: All checks passed!
```
