### PR TITLE
fix(tests): early-recovery stdlib-only test must allow relative imports

### DIFF
--- a/tests/hermes_cli/test_early_recovery.py
+++ b/tests/hermes_cli/test_early_recovery.py
@@ -115,6 +115,15 @@ def test_early_recovery_module_is_stdlib_only(tmp_path):
             real_import = builtins.__import__
 
             def guard(name, *args, **kwargs):
+                # Allow relative imports (level > 0) to pass through unchecked -
+                # they're resolved relative to the importing module's package,
+                # and we can't reliably validate them from this guard.
+                level = kwargs.get("level", 0)
+                if args and len(args) >= 4:
+                    level = args[3] if isinstance(args[3], int) else 0
+                if level > 0:
+                    return real_import(name, *args, **kwargs)
+
                 top = name.split(".")[0]
                 if top not in STDLIB:
                     raise ImportError(f"non-stdlib import blocked: {name}")


### PR DESCRIPTION
## Summary

Fixes the stdlib-only test for hermes_cli._early_recovery which was incorrectly blocking relative imports used by the Python standard library.

**Root cause:** The stdlib-only test's import guard was blocking relative imports (level > 0) used by the standard library itself. For example, e module's rom . import _compiler, _parser uses a relative import (level=1), which the guard was incorrectly blocking.

**Fix:** The guard now passes through relative imports (level > 0) unchecked, since they're resolved relative to the importing module's package and can't be reliably validated from this guard.

**Verified:** 	est_early_recovery_module_is_stdlib_only passes, and all 17 tests in 	est_early_recovery.py pass.

No production code touched — test-only fix.

Fixes: test flakiness on Windows where the stdlib's internal relative imports were being blocked.