### PR TITLE
fix(process): drop OOMPolicy from systemd-run --scope argv (breaks cron worker dispatch on Linux)

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -235,7 +235,6 @@ def _systemd_run_user_scope_available() -> bool:
                             "--collect",
                             "--property", "MemoryAccounting=yes",
                             "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-                            "--property", "OOMPolicy=kill",
                             "--",
                             "/bin/true",
                         ],
@@ -316,8 +315,6 @@ def _build_systemd_scope_argv(
         "MemoryAccounting=yes",
         "--property",
         f"MemoryMax={memory_max}",
-        "--property",
-        "OOMPolicy=kill",
         "--",
         *shell_argv,
     ]


### PR DESCRIPTION
## Problem

Since #70716's restart-safe worker isolation landed (and 83efdf5e5e widened the Linux path to supervised gateways via `not _IS_LINUX`), every cron job dispatched from a supervised systemd gateway fails with:

```
cannot create restart-safe systemd scope for gateway child: systemd-run --user --scope is unavailable
```

## Root cause

`_systemd_run_user_scope_available()` probes with `systemd-run --user --scope` passing `--property OOMPolicy=kill`. But `OOMPolicy` is a **service-unit property** — transient scopes reject it:

```
$ systemd-run --user --scope --property OOMPolicy=kill -- /bin/true
Unknown assignment: OOMPolicy=kill
```

The probe therefore always returns non-zero in any environment where `systemd-run --user --scope` actually works, the negative result is cached (TTL), and `restart_safe_gateway_child_argv()` raises — failing every restart-safe cron worker dispatch.

Same invalid property is in `_build_systemd_scope_argv()`, so even if the probe were bypassed the real worker spawn would fail identically.

## Fix

Drop `OOMPolicy=kill` from both the probe and the scope argv builder. `MemoryAccounting=yes` + `MemoryMax` remain; a transient scope has no service manager acting on the OOM event, so the property was a no-op intended for service units only.

Verified: probe returns True after the change, cron dispatch completes (job history: failed at 01:19/01:22 → ok at 01:26).