### PR TITLE
feat(mattermost): open continuable cron threads and honour explicit thread ids

### DIFF
--- a/plugins/platforms/mattermost/adapter.py
+++ b/plugins/platforms/mattermost/adapter.py
@@ -17,6 +17,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -143,6 +144,10 @@ class MattermostAdapter(BasePlatformAdapter):
 
         self._last_post_status: Optional[int] = None
         self._last_post_error: str = ""
+        # Seed posts from create_handoff_thread that no message has landed in
+        # yet. The first send into such a thread replaces the seed with its
+        # content (see send), so the content is the top-level post. Bounded.
+        self._empty_handoff_seeds: Dict[str, float] = {}
 
         # Dedup cache (prevent reprocessing)
         self._dedup = MessageDeduplicator()
@@ -208,10 +213,16 @@ class MattermostAdapter(BasePlatformAdapter):
         reply_to: Optional[str],
         metadata: Optional[Dict[str, Any]],
     ) -> Optional[str]:
-        """Resolve the Mattermost root_id from reply_to or metadata."""
-        if self._reply_mode != "thread":
-            return None
-        candidate = reply_to
+        """Resolve the Mattermost root_id from reply_to or metadata.
+
+        ``reply_mode`` decides whether a plain reply nests under the message
+        it answers (``reply_to``). An explicit ``metadata["thread_id"]`` or
+        ``metadata["root_id"]`` is honoured in every mode: the gateway only
+        sets it when the inbound message was already inside a thread, and the
+        cron scheduler sets it to route a continuable brief into the thread
+        it just opened, so ignoring it would post those flat.
+        """
+        candidate = reply_to if self._reply_mode == "thread" else None
         if not candidate and isinstance(metadata, dict):
             candidate = metadata.get("thread_id") or metadata.get("root_id")
         if not candidate:
@@ -385,6 +396,57 @@ class MattermostAdapter(BasePlatformAdapter):
             return data["root_id"]
         return post_id
 
+    async def create_handoff_thread(
+        self,
+        parent_chat_id: str,
+        name: str,
+    ) -> Optional[str]:
+        """Create a Mattermost thread anchor for a session handoff.
+
+        Mattermost threads hang off a root post (``root_id``), not a
+        channel-level construct, so post a seed message into the parent
+        channel and return its post id. The gateway's handoff watcher and the
+        continuable-cron delivery path use that id as the ``thread_id`` for
+        subsequent sends, and key the continuation session to it, so a reply
+        inside the thread sees only that thread's brief (Slack parity:
+        ``SlackAdapter.create_handoff_thread``).
+
+        The seed exists only because the caller needs a thread id before it
+        has the content. The first ``send`` into the thread therefore replaces
+        the seed's text with that content (``_empty_handoff_seeds``), so the
+        brief is the top-level post and the thread root rather than a reply
+        under a placeholder.
+
+        Returns the seed post id as a string, or ``None`` on failure so the
+        caller falls back to the flat channel or DM.
+        """
+        if not self._session:
+            return None
+        seed_text = f":thread: {(name or 'Hermes session').strip()[:80]}"
+        payload = _with_mentions_disabled({
+            "channel_id": parent_chat_id,
+            "message": seed_text,
+        })
+        try:
+            data = await self._api_post("posts", payload)
+        except Exception as exc:
+            logger.warning(
+                "[%s] Handoff thread: seed-post failed for channel %s: %s",
+                self.name, parent_chat_id, exc,
+            )
+            return None
+        post_id = (data or {}).get("id")
+        if not post_id:
+            logger.warning(
+                "[%s] Handoff thread: seed-post returned no id for channel %s: %s",
+                self.name, parent_chat_id, self._last_post_error,
+            )
+            return None
+        self._empty_handoff_seeds[str(post_id)] = time.monotonic()
+        while len(self._empty_handoff_seeds) > 64:
+            self._empty_handoff_seeds.pop(next(iter(self._empty_handoff_seeds)))
+        return str(post_id)
+
     async def send(
         self,
         chat_id: str,
@@ -407,6 +469,18 @@ class MattermostAdapter(BasePlatformAdapter):
             })
             # Thread support: reply_to or metadata["thread_id"] is the root post ID.
             resolved_root = await self._thread_root_for_send(reply_to, metadata)
+            if resolved_root and self._empty_handoff_seeds.pop(resolved_root, None) is not None:
+                # First message into a thread opened by create_handoff_thread:
+                # the seed post becomes this message, so the content sits at
+                # top level and later chunks and replies nest under it.
+                data = await self._api_put(
+                    f"posts/{resolved_root}/patch",
+                    _with_mentions_disabled({"message": chunk}),
+                )
+                if not data or "id" not in data:
+                    return SendResult(success=False, error="Failed to replace seed post")
+                last_id = data["id"]
+                continue
             if resolved_root:
                 payload["root_id"] = resolved_root
 

--- a/tests/gateway/test_mattermost.py
+++ b/tests/gateway/test_mattermost.py
@@ -709,3 +709,119 @@ class TestMultiplexProfileScope:
             # os.environ.
             assert "MATTERMOST_REQUIRE_MENTION" not in os.environ
 
+
+
+# ---------------------------------------------------------------------------
+# Continuable threads: create_handoff_thread + explicit thread routing
+# ---------------------------------------------------------------------------
+
+class TestMattermostHandoffThread:
+    """``create_handoff_thread`` anchors a continuable session on a seed post."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._session = MagicMock()
+
+    def _post_returning(self, body, status=200):
+        mock_resp = AsyncMock()
+        mock_resp.status = status
+        mock_resp.json = AsyncMock(return_value=body)
+        mock_resp.text = AsyncMock(return_value="" if status < 400 else "server error")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        self.adapter._session.post = MagicMock(return_value=mock_resp)
+
+    @pytest.mark.asyncio
+    async def test_seed_post_id_becomes_the_thread_id(self):
+        """Without the seed post id every cron send lands flat in the channel."""
+        self._post_returning({"id": "seed_post"})
+        thread_id = await self.adapter.create_handoff_thread("channel_1", "Inbox Triage")
+        assert thread_id == "seed_post"
+        call_args = self.adapter._session.post.call_args
+        assert "/api/v4/posts" in call_args[0][0]
+        payload = call_args[1]["json"]
+        assert payload["channel_id"] == "channel_1"
+        assert "Inbox Triage" in payload["message"]
+        assert "root_id" not in payload
+
+    @pytest.mark.asyncio
+    async def test_failed_seed_post_yields_no_thread(self):
+        """Callers fall back to the flat DM on ``None``; never raise."""
+        self._post_returning({}, status=500)
+        assert await self.adapter.create_handoff_thread("channel_1", "review") is None
+
+    @pytest.mark.asyncio
+    async def test_no_session_yields_no_thread(self):
+        self.adapter._session = None
+        assert await self.adapter.create_handoff_thread("channel_1", "review") is None
+
+
+class TestMattermostThreadRootForSend:
+    """``reply_mode`` gates nesting under ``reply_to``; explicit metadata wins in every mode."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._api_get = AsyncMock(return_value={"id": "root_post", "root_id": ""})
+
+    @pytest.mark.asyncio
+    async def test_off_mode_ignores_reply_to(self):
+        self.adapter._reply_mode = "off"
+        assert await self.adapter._thread_root_for_send("msg_1", None) is None
+
+    @pytest.mark.asyncio
+    async def test_off_mode_honours_explicit_thread_metadata(self):
+        """A cron brief routed into the thread it just opened must land there in every mode."""
+        self.adapter._reply_mode = "off"
+        root = await self.adapter._thread_root_for_send(None, {"thread_id": "root_post"})
+        assert root == "root_post"
+
+    @pytest.mark.asyncio
+    async def test_thread_mode_still_nests_under_reply_to(self):
+        self.adapter._reply_mode = "thread"
+        assert await self.adapter._thread_root_for_send("root_post", None) == "root_post"
+
+
+class TestMattermostSeedReplacement:
+    """The first send into a create_handoff_thread thread replaces the seed post."""
+
+    def setup_method(self):
+        self.adapter = _make_adapter()
+        self.adapter._session = MagicMock()
+        self.adapter._api_get = AsyncMock(return_value={"id": "seed_post", "root_id": ""})
+
+    def _http(self, method, body):
+        mock_resp = AsyncMock()
+        mock_resp.status = 200
+        mock_resp.json = AsyncMock(return_value=body)
+        mock_resp.text = AsyncMock(return_value="")
+        mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+        mock_resp.__aexit__ = AsyncMock(return_value=False)
+        setattr(self.adapter._session, method, MagicMock(return_value=mock_resp))
+
+    @pytest.mark.asyncio
+    async def test_first_send_replaces_seed_then_later_sends_nest(self):
+        """The brief must be the thread root, not a reply under a placeholder."""
+        self._http("post", {"id": "seed_post"})
+        self._http("put", {"id": "seed_post"})
+        assert await self.adapter.create_handoff_thread("channel_1", "Inbox Triage") == "seed_post"
+
+        first = await self.adapter.send("channel_1", "The brief", metadata={"thread_id": "seed_post"})
+        assert first.success and first.message_id == "seed_post"
+        put_args = self.adapter._session.put.call_args
+        assert put_args[0][0].endswith("/api/v4/posts/seed_post/patch")
+        assert put_args[1]["json"]["message"] == "The brief"
+        assert self.adapter._session.post.call_count == 1  # only the seed itself
+
+        self._http("post", {"id": "reply_post"})
+        second = await self.adapter.send("channel_1", "Applied.", metadata={"thread_id": "seed_post"})
+        assert second.message_id == "reply_post"
+        assert self.adapter._session.post.call_args[1]["json"]["root_id"] == "seed_post"
+
+    @pytest.mark.asyncio
+    async def test_unknown_thread_is_never_replaced(self):
+        """Only seeds this adapter created are replaced; any other root gets a reply."""
+        self._http("post", {"id": "reply_post"})
+        self._http("put", {"id": "should_not_happen"})
+        result = await self.adapter.send("channel_1", "Hi", metadata={"thread_id": "seed_post"})
+        assert result.message_id == "reply_post"
+        assert not self.adapter._session.put.called


### PR DESCRIPTION
## What does this PR do?

Gives the Mattermost adapter the `create_handoff_thread` hook that Slack, Discord, and Telegram already ship, so a continuable cron job delivers each brief into its own thread and a reply inside that thread continues a session seeded with exactly that brief. Two changes in `plugins/platforms/mattermost/adapter.py`:

1. **`create_handoff_thread(parent_chat_id, name)`** posts a seed message (`:thread: <name>`) in the parent channel and returns its post id, or `None` on failure so callers fall back to the flat channel/DM. `cron/scheduler.py::_open_continuable_cron_thread` and the gateway's handoff watcher already call this hook through `getattr`. The seed only exists because the caller needs a thread id before it has the content, so the first `send` into that thread replaces the seed's text with the message (`_empty_handoff_seeds`, bounded): the brief is the top-level post and the thread root, later messages and replies nest under it, and nothing is left showing a placeholder.
2. **`_thread_root_for_send` honours an explicit `metadata["thread_id"]` / `metadata["root_id"]` in every `reply_mode`.** `reply_mode` still decides whether a plain reply nests under `reply_to`. The explicit id is only ever set by the gateway for a message that was already inside a thread (`_thread_metadata_for_target` returns `None` otherwise) and by the scheduler for the thread it just opened, so in the default `reply_mode: off` the brief used to post flat next to its own seed.

Why this approach: it reuses the shipped scheduler path unchanged and mirrors `SlackAdapter.create_handoff_thread` (seed-message anchoring), the same shape Mattermost threads have (`root_id` on a post).

Observed before the change on a self-hosted Mattermost DM: every cron brief mirrored into the flat DM session; a reply inside a thread under the brief keyed to `…:dm:<chat>:<root_id>`, a session with no history, so "apply" in a thread acted on the newest batch instead of the one replied to.

## Related Issue

No open issue or PR covers this (searched open and closed PRs for `create_handoff_thread` / Mattermost thread delivery; #64270 seeds prior thread posts on first contact, which is adjacent but different).

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `plugins/platforms/mattermost/adapter.py`: add `create_handoff_thread`; `_thread_root_for_send` honours explicit thread metadata in every reply mode (docstring explains the split).
- `tests/gateway/test_mattermost.py`: `TestMattermostHandoffThread` (seed post id returned, HTTP failure → `None`, no session → `None`), `TestMattermostThreadRootForSend` (off mode ignores `reply_to`, off mode honours explicit metadata, thread mode nests under `reply_to`), and `TestMattermostSeedReplacement` (first send into a seed thread patches the seed and later sends nest; a root this adapter did not create is never patched).

## How to Test

1. `pytest tests/gateway/test_mattermost.py tests/cron/test_cron_thread_seed_dm_keying.py -q` → 40 passed (needs the `messaging` extra for `aiohttp`).
2. Live: with `cron.mirror_delivery: true` (or a job with `attach_to_session: true`) and a job whose origin is a Mattermost DM (`origin.chat_type: dm`), let the gateway scheduler fire it. Expect the brief as a top-level post that is also the thread root (the seed post is patched in place, so it shows as edited), and the log line `opened continuable thread <post_id> on mattermost:<chat> and seeded the brief`.
3. Reply inside that thread; the turn log shows `history=1` and the answer reflects the brief. Hermes's own reply lands in the thread.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run the Mattermost, cron thread-seed, plugin-setup, handoff, and conformance suites; all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 15 (tests), Synology DSM 7 / Docker `hermes-agent` (live)

### Documentation & Housekeeping

- [x] Docstrings updated — no user-facing config keys added (N/A for `cli-config.yaml.example`)
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact — N/A (pure Python, no filesystem or shell behaviour)
