### PR TITLE
fix: [Regression] /model command takes 7+ minutes on commits past v2026.7.20; works normally on tag (#74003)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -3475,7 +3475,10 @@ def list_authenticated_providers(
                 )
                 from hermes_cli.auth import get_provider_auth_state as _nous_state
 
-                _pricing = _nous_pricing("nous") or {}
+                # Cache-only: both Portal unions below discard the pricing map
+                # (``model_ids, _ = ...``) — only the appended IDs matter, so
+                # a live catalog fetch here buys nothing but latency.
+                _pricing = _nous_pricing("nous", cached_only=True) or {}
                 _portal = ""
                 try:
                     _st = _nous_state("nous") or {}


### PR DESCRIPTION
## What Problem This Solves
Fixes #74003 — [Regression] /model command takes 7+ minutes on commits past v2026.7.20; works normally on tag. Ponytail minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Tests: relevant suite passed (see worktree 74003).

Closes #74003