### PR TITLE
fix: Sessions sidebar blocks ~41s on startup: GET /api/profiles/sessions calls list_profiles(), which rglobs every profile's skills tree (#78325)

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -863,7 +863,9 @@ def _served_by_running_multiplexer(profile_name: str) -> bool:
 # when the dir tree's signature (skills_dir + immediate category dirs mtimes)
 # changes (catches skill add/remove) or after a short TTL (catches deep edits).
 _SKILL_COUNT_CACHE: dict[str, tuple[float, float, int]] = {}
-_SKILL_COUNT_TTL_SECONDS = 30.0
+# TTL must exceed the desktop cron tick (60s): at 30s every tick was a
+# guaranteed miss and an idle backend re-walked every skills tree forever.
+_SKILL_COUNT_TTL_SECONDS = 300.0
 
 
 def _skills_dir_signature(skills_dir: Path) -> float:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -654,11 +654,11 @@ def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000
     from tui_gateway import server as gateway_server
 
     try:
-        targets: List[Tuple[str, Path]] = [
-            (info.name, info.path) for info in profiles_mod.list_profiles()
-        ]
+        # Only name/path are used; the cheap enumerator skips the per-profile
+        # config/gateway/skills probes list_profiles() performs (#78325).
+        targets: List[Tuple[str, Path]] = profiles_mod.profiles_to_serve(multiplex=True)
     except Exception:
-        _log.exception("GET /api/profiles/projects/tree: list_profiles failed")
+        _log.exception("GET /api/profiles/projects/tree: profile enumeration failed")
         targets = []
     if not targets:
         targets.append(("default", profiles_mod.get_profile_dir("default")))
@@ -748,9 +748,11 @@ def post_profiles_sessions_pull_requests(body: SessionPrScanBody):
         return {"pull_requests": {}, "scanned": []}
 
     try:
-        targets = [(info.name, info.path) for info in profiles_mod.list_profiles()]
+        # Session scan only needs name/path; avoid list_profiles()' skills-tree
+        # walk per profile (#78325).
+        targets = profiles_mod.profiles_to_serve(multiplex=True)
     except Exception:
-        _log.exception("POST /api/profiles/sessions/pull-requests: list_profiles failed")
+        _log.exception("POST /api/profiles/sessions/pull-requests: profile enumeration failed")
         targets = []
     if not targets:
         targets.append(("default", profiles_mod.get_profile_dir("default")))


### PR DESCRIPTION
## What Problem This Solves
Fixes #78325 — Sessions sidebar blocks ~41s on startup: GET /api/profiles/sessions calls list_profiles(), which rglobs every profile's skills tree. Ponytail minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Tests: relevant suite passed (see worktree 78325).

Closes #78325