### PR TITLE
fix(compression): recover hard-ceiling attempts with configured fallback

### DIFF
--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -724,6 +724,11 @@ class CompressionCommitFence:
         self._last_progress = time.monotonic()
         self._progress_observed = False
         self._deadline: float | None = None
+        # Set only when the compression transaction catches a worker-side
+        # cancellation caused by this route's wall-clock deadline. The host
+        # uses it to distinguish that failure from an ordinary unchanged
+        # result (safe no-op, deferred, would-grow), which must not fall back.
+        self._route_deadline_aborted = False
         self._retain_cancelled_lock_until_worker_done = False
         # #97963: set by the worker (mark_commit_watermark_fenced) once its
         # commit path is watermark-fenced — i.e. it captured the session's
@@ -779,6 +784,15 @@ class CompressionCommitFence:
         ``auxiliary_client.aux_stream_deadline``).
         """
         return self._deadline
+
+    def mark_route_deadline_abort(self) -> None:
+        """Publish that the worker unwound because this deadline expired."""
+        self._route_deadline_aborted = True
+
+    @property
+    def route_deadline_aborted(self) -> bool:
+        """Whether the worker observed this route's deadline cancellation."""
+        return self._route_deadline_aborted
 
     def seconds_since_progress(self) -> float:
         """Seconds since the worker last reported forward progress."""
@@ -1612,6 +1626,53 @@ def run_compress_context_with_progress_timeout(
             )
             try:
                 result = future.result(timeout=wait_slice)
+                if (
+                    fence.route_deadline_aborted
+                    and isinstance(result, tuple)
+                    and result
+                    and result[0] is messages
+                ):
+                    # The worker can observe the shared hard deadline and
+                    # unwind just before Future.result() raises on the host.
+                    # Treat that scheduling order exactly like the timeout
+                    # branch below. The explicit marker is load-bearing: an
+                    # unchanged structural no-op alone never means the route
+                    # failed and must not consume a fallback candidate.
+                    waited = time.monotonic() - wait_started
+                    since_progress = fence.seconds_since_progress()
+                    if on_timeout_cause is not None:
+                        try:
+                            on_timeout_cause(True, fence.progress_observed)
+                        except Exception:
+                            logger.debug(
+                                "compress_context timeout-cause callback failed",
+                                exc_info=True,
+                            )
+                    if stall_fallback:
+                        recovered = _retry_compression_on_fallback_chain(
+                            worker=worker,
+                            messages=messages,
+                            system_prompt_fallback=system_prompt_fallback,
+                            idle_timeout_seconds=idle,
+                            total_ceiling_seconds=ceiling,
+                            on_commit_overrun=on_commit_overrun,
+                            on_timeout_cause=on_timeout_cause,
+                            telemetry_agent=telemetry_agent,
+                            new_fence=new_fence,
+                        )
+                        if recovered is not None:
+                            handled_exit = True
+                            return recovered
+                    if on_timeout is not None:
+                        try:
+                            on_timeout(idle, waited, since_progress)
+                        except Exception:
+                            logger.debug(
+                                "compress_context timeout callback failed",
+                                exc_info=True,
+                            )
+                    handled_exit = True
+                    return messages, _resolve_fallback_prompt()
                 handled_exit = True
                 return result
             except concurrent.futures.TimeoutError:
@@ -4312,6 +4373,20 @@ def compress_context(
                     agent.context_compressor, _attempt_generation
                 )
     except AuxiliaryExplicitCancellation:
+        # Freeze the route-deadline cause before returning an identity no-op to
+        # the waiting host. Without this attempt-local signal, a worker that
+        # unwinds a few milliseconds before Future.result() times out bypasses
+        # the configured fallback chain. Explicit user cancellation remains a
+        # distinct cause and never publishes this marker.
+        _hard_cancelled = bool(
+            _hard_cancel_event is not None and _hard_cancel_event.is_set()
+        )
+        if (
+            not _hard_cancelled
+            and commit_fence is not None
+            and commit_fence.deadline_exceeded
+        ):
+            commit_fence.mark_route_deadline_abort()
         try:
             _restore_compressor_attempt_state(
                 agent.context_compressor,
@@ -4364,9 +4439,13 @@ def compress_context(
             commit_status="aborted",
             split_status="aborted",
             failure_class=(
-                STALL_INTERRUPTED_FAILURE_CLASS
-                if _stall_backoff
-                else "explicit_interrupt"
+                "route_deadline"
+                if commit_fence is not None and commit_fence.route_deadline_aborted
+                else (
+                    STALL_INTERRUPTED_FAILURE_CLASS
+                    if _stall_backoff
+                    else "explicit_interrupt"
+                )
             ),
         )
         _existing_sp = getattr(agent, "_cached_system_prompt", None)

--- a/agent/conversation_compression.py
+++ b/agent/conversation_compression.py
@@ -1626,12 +1626,7 @@ def run_compress_context_with_progress_timeout(
             )
             try:
                 result = future.result(timeout=wait_slice)
-                if (
-                    fence.route_deadline_aborted
-                    and isinstance(result, tuple)
-                    and result
-                    and result[0] is messages
-                ):
+                if fence.route_deadline_aborted:
                     # The worker can observe the shared hard deadline and
                     # unwind just before Future.result() raises on the host.
                     # Treat that scheduling order exactly like the timeout

--- a/tests/agent/test_aux_stream_host_deadline.py
+++ b/tests/agent/test_aux_stream_host_deadline.py
@@ -123,7 +123,9 @@ def test_commit_fence_publishes_its_shared_deadline():
     assert not fence.deadline_exceeded
 
     fence.set_total_ceiling_seconds(0.001)
-    time.sleep(0.01)
+    wait_deadline = time.monotonic() + 1.0
+    while not fence.deadline_exceeded and time.monotonic() < wait_deadline:
+        time.sleep(0.001)
     assert fence.deadline_exceeded
     assert fence.deadline_monotonic <= time.monotonic()
 

--- a/tests/agent/test_compression_attempt_lifecycle.py
+++ b/tests/agent/test_compression_attempt_lifecycle.py
@@ -68,6 +68,60 @@ def _messages():
 
 
 class TestWorkerTeardownOnCeiling:
+    def test_worker_deadline_cancellation_is_published_to_waiting_host(
+        self, tmp_path: Path
+    ):
+        """The transaction must distinguish deadline unwind from safe no-op."""
+        _db, agent = _build_agent(tmp_path, "WORKER_DEADLINE_SIGNAL")
+        live = _messages()
+        fence = CompressionCommitFence(total_ceiling_seconds=5.0)
+
+        def abort_at_deadline(messages, **_kwargs):
+            fence._deadline = 0.0
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = abort_at_deadline
+        out, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=500_000,
+            force=True,
+            commit_fence=fence,
+        )
+
+        assert out == _messages()
+        assert fence.route_deadline_aborted is True
+
+    def test_explicit_user_cancellation_is_not_published_as_route_deadline(
+        self, tmp_path: Path
+    ):
+        """A simultaneous expired deadline must not relabel an explicit stop."""
+        _db, agent = _build_agent(tmp_path, "EXPLICIT_CANCEL_SIGNAL")
+        live = _messages()
+        fence = CompressionCommitFence(total_ceiling_seconds=5.0)
+        calls = []
+
+        def abort_for_user(messages, **_kwargs):
+            calls.append(messages)
+            fence._deadline = 0.0
+            agent._hard_interrupt_requested.set()
+            raise AuxiliaryExplicitCancellation()
+
+        agent.context_compressor.compress = abort_for_user
+        out, _prompt = compress_context(
+            agent,
+            live,
+            "sys",
+            approx_tokens=500_000,
+            force=True,
+            commit_fence=fence,
+        )
+
+        assert calls
+        assert out == _messages()
+        assert fence.route_deadline_aborted is False
+
     def test_cooperative_worker_joined_within_grace(self):
         """A worker that exits promptly after cancel is joined on the
         total-ceiling path; the lease is released normally (no retention) —

--- a/tests/agent/test_compression_stall_fallback_78981.py
+++ b/tests/agent/test_compression_stall_fallback_78981.py
@@ -91,7 +91,7 @@ class _StalledSummaryWorker:
             fence.finish_commit()
 
 
-def _run(worker, *, chain, timeouts, messages, idle=0.05, ceiling=0.2):
+def _run(worker, *, chain, timeouts, messages, idle=0.05, ceiling=3.0):
     with _patch_chain(chain):
         return run_compress_context_with_progress_timeout(
             worker=worker,
@@ -134,15 +134,17 @@ def test_stalled_summary_attempts_configured_fallback_chain():
 
 def test_worker_first_deadline_abort_attempts_fallback_exactly_once(monkeypatch):
     """A worker that publishes its deadline abort before the host timeout
-    branch wins must take the same single fallback path as host-first expiry."""
+    branch wins must take the same single fallback path as host-first expiry,
+    even when durable-parent adoption returns a distinct transcript list."""
     original = [{"role": "user", "content": "keep-me"}]
+    adopted = [*original, {"role": "assistant", "content": "concurrent growth"}]
     compressed = [{"role": "user", "content": "fallback summary"}]
     fallback = MagicMock(return_value=(compressed, "fallback-prompt"))
 
     def worker(fence: CompressionCommitFence):
         fence._deadline = 0.0
         fence.mark_route_deadline_abort()
-        return original, "primary-aborted"
+        return adopted, "primary-aborted"
 
     monkeypatch.setattr(cc, "_retry_compression_on_fallback_chain", fallback)
 

--- a/tests/agent/test_compression_stall_fallback_78981.py
+++ b/tests/agent/test_compression_stall_fallback_78981.py
@@ -22,8 +22,9 @@ from __future__ import annotations
 
 import threading
 from types import SimpleNamespace
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
+import agent.conversation_compression as cc
 from agent.context_compressor import (
     ContextCompressor,
     pin_summary_route,
@@ -129,6 +130,61 @@ def test_stalled_summary_attempts_configured_fallback_chain():
     assert msgs == compressed, "the fallback attempt's compression must be published"
     assert prompt == "summarized-prompt"
     assert not timeouts, "no continue-without-compression degrade after a recovery"
+
+
+def test_worker_first_deadline_abort_attempts_fallback_exactly_once(monkeypatch):
+    """A worker that publishes its deadline abort before the host timeout
+    branch wins must take the same single fallback path as host-first expiry."""
+    original = [{"role": "user", "content": "keep-me"}]
+    compressed = [{"role": "user", "content": "fallback summary"}]
+    fallback = MagicMock(return_value=(compressed, "fallback-prompt"))
+
+    def worker(fence: CompressionCommitFence):
+        fence._deadline = 0.0
+        fence.mark_route_deadline_abort()
+        return original, "primary-aborted"
+
+    monkeypatch.setattr(cc, "_retry_compression_on_fallback_chain", fallback)
+
+    msgs, prompt = run_compress_context_with_progress_timeout(
+        worker=worker,
+        messages=original,
+        system_prompt_fallback="degraded-prompt",
+        idle_timeout_seconds=1.0,
+        total_ceiling_seconds=1.0,
+    )
+
+    fallback.assert_called_once()
+    assert msgs == compressed
+    assert prompt == "fallback-prompt"
+
+
+def test_completed_structural_noop_never_attempts_deadline_fallback(monkeypatch):
+    """An unchanged result is not itself a route failure.
+
+    Safe no-op, deferred and would-grow outcomes all return the original
+    transcript without publishing a route-deadline abort.
+    """
+    original = [{"role": "user", "content": "keep-me"}]
+    fallback = MagicMock()
+
+    def worker(fence: CompressionCommitFence):
+        fence._deadline = 0.0
+        return original, "safe-noop"
+
+    monkeypatch.setattr(cc, "_retry_compression_on_fallback_chain", fallback)
+
+    msgs, prompt = run_compress_context_with_progress_timeout(
+        worker=worker,
+        messages=original,
+        system_prompt_fallback="degraded-prompt",
+        idle_timeout_seconds=1.0,
+        total_ceiling_seconds=1.0,
+    )
+
+    fallback.assert_not_called()
+    assert msgs is original
+    assert prompt == "safe-noop"
 
 
 def test_retry_runs_on_a_host_published_fence():


### PR DESCRIPTION
## What does this PR do?

Compression now honors `auxiliary.compression.fallback_chain` when the primary worker observes the shared hard ceiling just before the host timeout branch wins. This removes a millisecond-scale scheduling dependency that could preserve the oversized conversation and show a compression failure even though a healthy fallback route was configured.

### Symptom

A primary compression route can stream until the configured total ceiling, abort in the worker, and return the original transcript without attempting the configured fallback. Users then remain on the oversized context and see the compression-failed outcome.

### Impact

Affected sessions can spend the full compression ceiling and still fail unnecessarily, then retry against the same unchanged oversized context on a later turn. The configured fallback works only when the host side wins the deadline race.

### Bug Cause

**Trigger:** `agent/conversation_compression.py:run_compress_context_with_progress_timeout` when a streaming worker observes the shared route deadline just before `Future.result()` times out on the host.

**Causal chain:**
1. The shared commit fence deadline cancels the primary summary route in the worker.
2. `compress_context()` catches `AuxiliaryExplicitCancellation` and returns the original messages as a normal no-op result.
3. The host accepts that completed future at `Future.result()` and returns immediately, bypassing its timeout-only fallback branch.

**Why it is wrong:** A route deadline is the same route failure regardless of which thread observes it first. Collapsing the worker-side deadline into the same unchanged-result shape as safe no-op, deferred, and would-grow outcomes loses the cause needed to make the fallback decision.

**Working sibling / contrast:** When `Future.result()` times out first, the existing host branch cancels the fence and invokes the configured fallback exactly once.

**Ruled out:** An unchanged result alone is not enough to trigger fallback. Structural no-op, deferred, would-grow, and explicit user cancellation paths intentionally preserve the original transcript without retrying another route.

### Fix

- Publish an attempt-local `route_deadline_aborted` signal on the commit fence only when the compression transaction catches a deadline-driven cancellation.
- Route a worker-first completed future through the same one-shot fallback helper used by host-first timeout handling.
- Keep explicit user cancellation distinct and classify deadline telemetry as `route_deadline` rather than `explicit_interrupt`.
- Add deterministic regression coverage for worker-first and host-first scheduling, structural no-op exclusion, explicit cancellation, and deadline publication.

## Related Issue

Fixes #102339

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/conversation_compression.py` - preserve the worker-side deadline cause and invoke the configured fallback once.
- `tests/agent/test_compression_stall_fallback_78981.py` - cover worker-first recovery and unchanged non-deadline outcomes.
- `tests/agent/test_compression_attempt_lifecycle.py` - cover transaction-level deadline and explicit-cancel classification.
- `tests/agent/test_aux_stream_host_deadline.py` - make the shared-deadline assertion scheduler-safe.

## How to Test

1. Run the focused compression suites below.
2. Confirm worker-first and host-first deadline paths each invoke one fallback attempt.
3. Confirm explicit cancellation and structural unchanged results do not invoke fallback.

```bash
scripts/run_tests.sh tests/agent/test_compression_stall_fallback_78981.py tests/agent/test_compression_attempt_lifecycle.py tests/agent/test_compress_context_progress_timeout.py tests/agent/test_compression_interrupt_protection.py tests/agent/test_aux_stream_host_deadline.py -q
```

Result: 65 passed on Windows 11.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repository test entry on the relevant suites and all 65 tests pass
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation is N/A; behavior is documented in code and regression tests
- [x] `cli-config.yaml.example` is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` are N/A; no contributor workflow changed
- [x] Cross-platform impact considered; the change uses platform-independent Python thread and fence state
- [x] Tool descriptions and schemas are N/A; no model tool behavior changed
