### PR TITLE
fix: [Bug]: hermes from 0.15.1 udpate to 0.20.1  slow 4 seconds api server mode (#79047)

### DIFF
--- a/tests/tools/test_browser_extension_router.py
+++ b/tests/tools/test_browser_extension_router.py
@@ -424,10 +424,12 @@ def test_routeable_browser_tools_preserve_legacy_gate_without_bound_identity(mon
     assert browser_tool.check_browser_snapshot_requirements() is False
 
 
-def test_bound_browser_request_bypasses_availability_caches():
+def test_bound_browser_request_bypasses_availability_caches(monkeypatch):
+    from gateway import browser_control_broker
     from gateway.session_context import clear_session_vars, set_session_vars
     from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope
 
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: True)
     tokens = set_session_vars(
         session_id="session-fixture",
         browser_control_principal="principal-fixture",
@@ -435,6 +437,25 @@ def test_bound_browser_request_bypasses_availability_caches():
     )
     try:
         assert check_fn_cache_scope() == CHECK_FN_CACHE_BYPASS
+    finally:
+        clear_session_vars(tokens)
+
+
+def test_bound_identity_without_extension_control_keeps_cache_scope(monkeypatch):
+    """api_server binds a principal on every request; without the feature flag
+    that identity must not bypass the availability caches (#79047)."""
+    from gateway import browser_control_broker
+    from gateway.session_context import clear_session_vars, set_session_vars
+    from tools.registry import CHECK_FN_CACHE_BYPASS, check_fn_cache_scope
+
+    monkeypatch.setattr(browser_control_broker, "browser_control_enabled", lambda: False)
+    tokens = set_session_vars(
+        session_id="session-fixture",
+        browser_control_principal="principal-fixture",
+        browser_control_transport_family="local-api",
+    )
+    try:
+        assert check_fn_cache_scope() != CHECK_FN_CACHE_BYPASS
     finally:
         clear_session_vars(tokens)
 

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -325,7 +325,15 @@ def check_fn_cache_scope() -> Optional[str]:
             get_session_env("HERMES_BROWSER_CONTROL_TRANSPORT_FAMILY", ""),
         )
         if all(str(value or "").strip() for value in browser_identity):
-            return CHECK_FN_CACHE_BYPASS
+            try:
+                from gateway.browser_control_broker import browser_control_enabled
+            except Exception:
+                return CHECK_FN_CACHE_BYPASS
+            # ponytail: api_server binds a server-derived principal + family on
+            # every request, so identity-present != controller-attached; bypass
+            # only when extension control can actually move availability (#79047).
+            if browser_control_enabled():
+                return CHECK_FN_CACHE_BYPASS
     except Exception:
         pass
 


### PR DESCRIPTION
## What Problem This Solves
Fixes #79047 — [Bug]: hermes from 0.15.1 udpate to 0.20.1  slow 4 seconds api server mode. Ponytail minimal diff, single shared guard, no new deps.

## Evidence
- Repro: multiplex api_server session, before bypass every request (~3.3s recompute) → after cache hit 0.00s.
- Tests: router 18/18 + refresh/terminal 25/25 passed.

Closes #79047