### PR TITLE
fix(gateway): match mention_patterns against spoken wake words on group voice notes

### DIFF
--- a/gateway/platforms/whatsapp_common.py
+++ b/gateway/platforms/whatsapp_common.py
@@ -374,6 +374,52 @@ class WhatsAppBehaviorMixin:
         body = str(data.get("body") or "")
         return any(pattern.search(body) for pattern in self._mention_patterns)
 
+    def _transcript_matches_mention_patterns(self, transcript: str) -> bool:
+        if not transcript or not self._mention_patterns:
+            return False
+        return any(pattern.search(transcript) for pattern in self._mention_patterns)
+
+    def _is_captionless_audio(self, data: Dict[str, Any]) -> bool:
+        """True for a voice/audio payload whose body has no usable wake-word text."""
+        if not data.get("hasMedia"):
+            return False
+        media_type = str(data.get("mediaType") or "").lower()
+        if "ptt" not in media_type and "audio" not in media_type:
+            return False
+        body = str(data.get("body") or "").strip()
+        return (not body) or body.lower() == "[ptt received]"
+
+    def _needs_eager_voice_mention_gate(self, data: Dict[str, Any]) -> bool:
+        """True when only a spoken wake word could satisfy the group mention gate.
+
+        Called after ``_should_process_message`` has already returned False.
+        Extra STT is limited to group chats with ``require_mention`` +
+        ``mention_patterns`` and a captionless voice/audio note.
+        """
+        if not data.get("isGroup"):
+            return False
+        chat_id = str(data.get("chatId") or "")
+        if self._is_broadcast_chat(chat_id):
+            return False
+        if not self._is_group_allowed(chat_id):
+            return False
+        if chat_id in self._whatsapp_free_response_chats():
+            return False
+        if not self._whatsapp_require_mention():
+            return False
+        if not self._mention_patterns:
+            return False
+        if not self._is_captionless_audio(data):
+            return False
+        body = str(data.get("body") or "").strip()
+        if body.startswith("/"):
+            return False
+        if self._message_is_reply_to_bot(data):
+            return False
+        if self._message_mentions_bot(data):
+            return False
+        return True
+
     def _clean_bot_mention_text(self, text: str, data: Dict[str, Any]) -> str:
         if not text:
             return text

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9522,6 +9522,24 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._telegram_require_mention():
             return False
         chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
+        if self._telegram_exclusive_bot_mentions() and self._explicit_bot_mentions_exclude_self(message):
+            return False
+        allowed = self._telegram_allowed_chats()
+        if allowed and chat_id_str not in allowed:
+            return False
+        allowed_topics = self._telegram_allowed_topics()
+        if allowed_topics:
+            thread_id = self._effective_message_thread_id(message)
+            topic_id = str(thread_id) if thread_id is not None else self._GENERAL_TOPIC_THREAD_ID
+            if topic_id not in allowed_topics:
+                return False
+        thread_id = self._effective_message_thread_id(message)
+        if thread_id is not None:
+            try:
+                if int(thread_id) in self._telegram_ignored_threads():
+                    return False
+            except (TypeError, ValueError):
+                pass
         if chat_id_str in self._telegram_free_response_chats():
             return False
         if self._telegram_is_free_response_topic(message):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -9498,6 +9498,73 @@ class TelegramAdapter(BasePlatformAdapter):
                     return True
         return False
 
+    def _transcript_matches_mention_patterns(self, transcript: str) -> bool:
+        if not transcript or not self._mention_patterns:
+            return False
+        return any(pattern.search(transcript) for pattern in self._mention_patterns)
+
+    def _needs_eager_voice_mention_gate(self, message: Message) -> bool:
+        """True when only a spoken wake word could satisfy the group mention gate.
+
+        Captionless voice/audio in a ``require_mention`` group with
+        ``mention_patterns`` is dropped by ``_should_process_message`` because
+        the raw Telegram message has no ``text``/``caption``. Transcribe first
+        in that narrow case only.
+        """
+        if not getattr(self, "_mention_patterns", None):
+            return False
+        if not (getattr(message, "voice", None) or getattr(message, "audio", None)):
+            return False
+        if getattr(message, "text", None) or getattr(message, "caption", None):
+            return False
+        if not self._is_group_chat(message):
+            return False
+        if not self._telegram_require_mention():
+            return False
+        chat_id_str = str(getattr(getattr(message, "chat", None), "id", ""))
+        if chat_id_str in self._telegram_free_response_chats():
+            return False
+        if self._telegram_is_free_response_topic(message):
+            return False
+        if self._is_reply_to_bot(message):
+            return False
+        if self._is_guest_mention(message):
+            return False
+        if not self._telegram_guest_mode() and self._message_mentions_bot(message):
+            return False
+        return not self._message_matches_mention_patterns(message)
+
+    async def _eager_transcribe_voice(self, msg) -> tuple:
+        """Download voice/audio and run STT once for the mention gate.
+
+        Returns ``(transcript, cached_path)``. The path is reused by
+        ``_handle_media_message`` so the runner does not download twice.
+        """
+        try:
+            from tools.transcription_tools import transcribe_audio
+        except Exception as e:
+            logger.debug("[%s] STT module unavailable: %s", self.name, e)
+            return None, None
+        try:
+            if getattr(msg, "voice", None):
+                file_obj = await msg.voice.get_file()
+                ext = ".ogg"
+            elif getattr(msg, "audio", None):
+                file_obj = await msg.audio.get_file()
+                ext = ".mp3"
+            else:
+                return None, None
+            audio_bytes = await file_obj.download_as_bytearray()
+            cached_path = await cache_audio_from_bytes_async(bytes(audio_bytes), ext=ext)
+            result = await asyncio.to_thread(transcribe_audio, cached_path, None, "gateway")
+            if isinstance(result, dict) and result.get("success"):
+                text = (result.get("transcript") or result.get("text") or "").strip()
+                return (text or None), cached_path
+            return None, cached_path
+        except Exception as e:
+            logger.warning("[%s] Eager voice transcription failed: %s", self.name, e)
+            return None, None
+
     def _is_guest_mention(self, message: Message) -> bool:
         """Return True for the narrow guest-mode bypass: explicit bot mention.
 
@@ -9949,6 +10016,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # _message_mentions_bot above — skip the redundant second call.
         if not self._telegram_guest_mode() and self._message_mentions_bot(message):
             return True
+        if getattr(message, "_voice_accepted_by_transcript", False):
+            return True
         return self._message_matches_mention_patterns(message)
 
     async def _ensure_forum_commands(self, message) -> None:
@@ -10285,6 +10354,25 @@ class TelegramAdapter(BasePlatformAdapter):
                 getattr(getattr(update.message, "chat", None), "id", None),
             )
             return
+        gate_transcript = None
+        gate_audio_path = None
+        if getattr(self, "_mention_patterns", None) and self._needs_eager_voice_mention_gate(update.message):
+            gate_transcript, gate_audio_path = await self._eager_transcribe_voice(update.message)
+            if gate_transcript and self._transcript_matches_mention_patterns(gate_transcript):
+                setattr(update.message, "_voice_accepted_by_transcript", True)
+                logger.info(
+                    "[%s] Voice accepted via transcript mention match: %r",
+                    self.name,
+                    gate_transcript[:80],
+                )
+            else:
+                logger.info(
+                    "[%s] Voice dropped: %s",
+                    self.name,
+                    "no mention-pattern match in transcript"
+                    if gate_transcript
+                    else "STT failed or empty transcript",
+                )
         if not self._should_process_message(update.message):
             if self._should_observe_unmentioned_group_message(update.message):
                 _m = update.message
@@ -10307,6 +10395,12 @@ class TelegramAdapter(BasePlatformAdapter):
         # Add caption as text
         if msg.caption:
             event.text = self._clean_bot_trigger_text(msg.caption)
+        if gate_transcript and getattr(msg, "_voice_accepted_by_transcript", False):
+            setattr(event, "_gateway_pending_stt_text", f'"{gate_transcript}"')
+            setattr(event, "_gateway_pending_stt_transcripts", [gate_transcript])
+            if gate_audio_path:
+                event.media_urls = [gate_audio_path]
+                event.media_types = ["audio/ogg"] if msg.voice else ["audio/mp3"]
         
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:
@@ -10353,7 +10447,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 await self._surface_media_cache_failure(msg, event, "photo", e)
 
         # Download voice/audio messages to cache for STT transcription
-        if msg.voice:
+        if msg.voice and not event.media_urls:
             try:
                 allowed, note = self._telegram_media_size_allowed(msg.voice, "voice message")
                 if not allowed:
@@ -10370,7 +10464,7 @@ class TelegramAdapter(BasePlatformAdapter):
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache voice: %s", _redact_telegram_error_text(e), exc_info=True)
                 await self._surface_media_cache_failure(msg, event, "voice message", e)
-        elif msg.audio:
+        elif msg.audio and not event.media_urls:
             try:
                 allowed, note = self._telegram_media_size_allowed(msg.audio, "audio file")
                 if not allowed:

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -1493,11 +1493,69 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
 
+    async def _cache_audio_for_gate(self, data: Dict[str, Any]) -> Optional[str]:
+        """Download or accept an already-cached voice/audio path for gate STT."""
+        from gateway.platforms.base import cache_audio_from_url
+
+        raw_urls = data.get("mediaUrls") or []
+        for url in raw_urls:
+            if not url:
+                continue
+            url = str(url)
+            if url.startswith(("http://", "https://")):
+                try:
+                    return await cache_audio_from_url(url, ext=".ogg")
+                except Exception as e:
+                    print(f"[{self.name}] Failed to cache gate audio: {e}", flush=True)
+                    continue
+            if os.path.isabs(url) and _is_allowed_bridge_path(url):
+                return url
+        return None
+
+    async def _eager_transcribe_for_gate(self, data: Dict[str, Any]):
+        """Transcribe a captionless voice note once so mention_patterns can see it.
+
+        Returns ``(transcript, cached_path)``. ``cached_path`` is reused by
+        ``_build_message_event`` so the audio is not downloaded twice.
+        """
+        try:
+            from tools.transcription_tools import transcribe_audio
+        except Exception as e:
+            print(f"[{self.name}] STT module unavailable: {e}", flush=True)
+            return None, None
+        cached_path = await self._cache_audio_for_gate(data)
+        if not cached_path:
+            return None, None
+        try:
+            result = await asyncio.to_thread(transcribe_audio, cached_path, None, "gateway")
+        except Exception as e:
+            print(f"[{self.name}] Eager voice transcription failed: {e}", flush=True)
+            return None, cached_path
+        if isinstance(result, dict) and result.get("success"):
+            text = (result.get("transcript") or result.get("text") or "").strip()
+            return (text or None), cached_path
+        return None, cached_path
+
+    @staticmethod
+    def _apply_gate_transcript(event: MessageEvent, transcript: str) -> None:
+        """Cache the gate transcript so the runner does not run STT again."""
+        setattr(event, "_gateway_pending_stt_text", f'"{transcript}"')
+        setattr(event, "_gateway_pending_stt_transcripts", [transcript])
+
     async def _build_message_event(self, data: Dict[str, Any]) -> Optional[MessageEvent]:
         """Build a MessageEvent from bridge message data, downloading images to cache."""
         try:
+            gate_transcript = None
+            gate_audio_path = None
             if not self._should_process_message(data):
-                return None
+                if not self._needs_eager_voice_mention_gate(data):
+                    return None
+                gate_transcript, gate_audio_path = await self._eager_transcribe_for_gate(data)
+                if not gate_transcript or not self._transcript_matches_mention_patterns(gate_transcript):
+                    return None
+                data["_gate_transcript"] = gate_transcript
+                if gate_audio_path:
+                    data["_gate_audio_path"] = gate_audio_path
 
             # Determine message type
             msg_type = MessageType.TEXT
@@ -1536,6 +1594,12 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             raw_urls = data.get("mediaUrls", [])
             cached_urls = []
             media_types = []
+            if gate_audio_path:
+                cached_urls.append(gate_audio_path)
+                media_types.append(
+                    str(data.get("mime") or "").strip()
+                    or ("audio/ogg" if "ptt" in str(data.get("mediaType") or "").lower() else "audio/mpeg")
+                )
             for url in raw_urls:
                 bridge_mime = str(data.get("mime") or "").strip()
                 if msg_type == MessageType.PHOTO and url.startswith(("http://", "https://")):
@@ -1556,6 +1620,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                         print(f"[{self.name}] Using bridge-cached image: {url}", flush=True)
                     else:
                         print(f"[{self.name}] Rejected bridge image path outside cache dir: {url}", flush=True)
+                elif msg_type in {MessageType.VOICE, MessageType.AUDIO} and gate_audio_path:
+                    # Audio already cached for the mention-gate STT pass.
+                    continue
                 elif msg_type in {MessageType.VOICE, MessageType.AUDIO} and url.startswith(("http://", "https://")):
                     try:
                         cached_path = await cache_audio_from_url(url, ext=".ogg")
@@ -1677,7 +1744,7 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 if not body.startswith(_OWNER_REPLY_PREFIX):
                     body = f"{_OWNER_REPLY_PREFIX}{body}"
 
-            return MessageEvent(
+            event = MessageEvent(
                 text=body,
                 message_type=msg_type,
                 source=source,
@@ -1691,6 +1758,9 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
                 reply_to_author_id=reply_to_author_id,
                 reply_to_is_own_message=reply_to_is_own_message,
             )
+            if gate_transcript:
+                self._apply_gate_transcript(event, gate_transcript)
+            return event
         except Exception as e:
             print(f"[{self.name}] Error building event: {e}")
             return None

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -937,6 +937,13 @@ def test_needs_eager_voice_mention_gate_is_narrow():
     no_patterns = _make_adapter(require_mention=True, mention_patterns=[])
     assert no_patterns._needs_eager_voice_mention_gate(_voice_group_message()) is False
 
+    outside_allowlist = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        allowed_chats=["-999"],
+    )
+    assert outside_allowlist._needs_eager_voice_mention_gate(_voice_group_message()) is False
+
 
 @pytest.mark.asyncio
 async def test_handle_media_message_accepts_voice_via_transcript():

--- a/tests/gateway/test_telegram_group_gating.py
+++ b/tests/gateway/test_telegram_group_gating.py
@@ -3,6 +3,8 @@ import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig, load_gateway_config
 from gateway.platforms.base import MessageType
 from gateway.session import SessionSource
@@ -882,3 +884,105 @@ def test_identity_freshness_does_not_depend_on_host_uptime(monkeypatch):
 
     adapter._note_bot_username("new_helper_bot")
     assert adapter._bot_identity_is_fresh() is True
+
+
+def _voice_group_message(*, reply_to_bot=False, caption=None, text=None):
+    msg = _group_message(text, caption=caption, reply_to_bot=reply_to_bot)
+    msg.voice = SimpleNamespace(file_id="voice1", duration=3)
+    msg.audio = None
+    msg.sticker = None
+    msg.photo = None
+    msg.video = None
+    msg.document = None
+    msg.media_group_id = None
+    return msg
+
+
+def test_captionless_voice_does_not_match_mention_patterns_on_text():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+
+    assert adapter._should_process_message(_group_message("hermes, what's on today?")) is True
+    voice = _voice_group_message()
+    assert adapter._should_process_message(voice) is False
+    assert adapter._should_process_message(_voice_group_message(reply_to_bot=True)) is True
+    assert adapter._should_process_message(
+        _group_message(None, caption="hermes hello")
+    ) is True
+
+
+def test_voice_accepted_by_transcript_flag_passes_mention_gate():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+    voice = _voice_group_message()
+    assert adapter._should_process_message(voice) is False
+    voice._voice_accepted_by_transcript = True
+    assert adapter._should_process_message(voice) is True
+
+
+def test_needs_eager_voice_mention_gate_is_narrow():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+
+    assert adapter._needs_eager_voice_mention_gate(_voice_group_message()) is True
+    assert adapter._needs_eager_voice_mention_gate(
+        _voice_group_message(reply_to_bot=True)
+    ) is False
+    assert adapter._needs_eager_voice_mention_gate(
+        _group_message("hermes, what's on today?")
+    ) is False
+    assert adapter._needs_eager_voice_mention_gate(
+        _voice_group_message(caption="hermes hello")
+    ) is False
+    assert adapter._transcript_matches_mention_patterns("hermes, what's on today?") is True
+    assert adapter._transcript_matches_mention_patterns("no wake word here") is False
+
+    no_patterns = _make_adapter(require_mention=True, mention_patterns=[])
+    assert no_patterns._needs_eager_voice_mention_gate(_voice_group_message()) is False
+
+
+@pytest.mark.asyncio
+async def test_handle_media_message_accepts_voice_via_transcript():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+    handled = []
+
+    async def _handle(event):
+        handled.append(event)
+
+    adapter.handle_message = _handle
+    adapter._is_user_authorized_from_message = lambda _msg: True
+    adapter._apply_telegram_group_observe_attribution = lambda event: event
+    adapter._telegram_media_size_allowed = lambda *_a, **_k: (True, None)
+
+    async def _fake_transcribe(msg):
+        return "hermes, what's on today?", "/tmp/tg-gate.ogg"
+
+    adapter._eager_transcribe_voice = _fake_transcribe
+
+    update = SimpleNamespace(message=_voice_group_message(), update_id=1)
+    await adapter._handle_media_message(update, SimpleNamespace())
+
+    assert len(handled) == 1
+    event = handled[0]
+    assert getattr(event, "_gateway_pending_stt_text") == '"hermes, what\'s on today?"'
+    assert getattr(event, "_gateway_pending_stt_transcripts") == ["hermes, what's on today?"]
+    assert event.media_urls == ["/tmp/tg-gate.ogg"]
+
+
+@pytest.mark.asyncio
+async def test_handle_media_message_drops_voice_without_wake_word():
+    adapter = _make_adapter(require_mention=True, mention_patterns=[r"(?i)\bhermes\b"])
+    handled = []
+
+    async def _handle(event):
+        handled.append(event)
+
+    adapter.handle_message = _handle
+    adapter._is_user_authorized_from_message = lambda _msg: True
+
+    async def _fake_transcribe(msg):
+        return "weather looks fine", None
+
+    adapter._eager_transcribe_voice = _fake_transcribe
+
+    update = SimpleNamespace(message=_voice_group_message(), update_id=1)
+    await adapter._handle_media_message(update, SimpleNamespace())
+
+    assert handled == []

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -1,7 +1,10 @@
 import json
 from unittest.mock import AsyncMock
 
+import pytest
+
 from gateway.config import Platform, PlatformConfig, load_gateway_config
+from gateway.platforms.base import MessageType
 
 
 def _make_adapter(require_mention=None, mention_patterns=None, free_response_chats=None,
@@ -228,5 +231,122 @@ def test_broadcast_filter_runs_before_allowlist():
         senderId="34612345678@s.whatsapp.net",
     )
     assert adapter._should_process_message(msg) is False
+
+
+def _voice_note(body="", **overrides):
+    return _group_message(
+        body,
+        hasMedia=True,
+        mediaType="ptt",
+        mediaUrls=[],
+        **overrides,
+    )
+
+
+def test_captionless_voice_does_not_match_mention_patterns_on_body():
+    """The spoken wake word is not in the body at gate time."""
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+
+    assert adapter._should_process_message(_group_message("hermes, what's on today?")) is True
+    assert adapter._should_process_message(_voice_note("")) is False
+    assert adapter._should_process_message(_voice_note("[ptt received]")) is False
+    assert adapter._should_process_message(
+        _voice_note("", quotedParticipant="15551230000@lid")
+    ) is True
+
+
+def test_needs_eager_voice_mention_gate_is_narrow():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+
+    assert adapter._needs_eager_voice_mention_gate(_voice_note("[ptt received]")) is True
+    assert adapter._needs_eager_voice_mention_gate(_voice_note("")) is True
+    assert adapter._needs_eager_voice_mention_gate(_group_message("hermes hi")) is False
+    assert adapter._needs_eager_voice_mention_gate(
+        _voice_note("", quotedParticipant="15551230000@lid")
+    ) is False
+    assert adapter._transcript_matches_mention_patterns("hermes, what's on today?") is True
+    assert adapter._transcript_matches_mention_patterns("no wake word here") is False
+
+    no_patterns = _make_adapter(require_mention=True, group_policy="open")
+    assert no_patterns._needs_eager_voice_mention_gate(_voice_note("")) is False
+
+    open_group = _make_adapter(
+        require_mention=False,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+    assert open_group._needs_eager_voice_mention_gate(_voice_note("")) is False
+
+
+@pytest.mark.asyncio
+async def test_build_message_event_accepts_captionless_voice_via_transcript():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+
+    async def _fake_transcribe(data):
+        return "hermes, what's on today?", "/tmp/gate-audio.ogg"
+
+    adapter._eager_transcribe_for_gate = _fake_transcribe
+    event = await adapter._build_message_event(_voice_note("[ptt received]"))
+
+    assert event is not None
+    assert event.message_type == MessageType.VOICE
+    assert getattr(event, "_gateway_pending_stt_text") == '"hermes, what\'s on today?"'
+    assert getattr(event, "_gateway_pending_stt_transcripts") == ["hermes, what's on today?"]
+    assert event.media_urls == ["/tmp/gate-audio.ogg"]
+
+
+@pytest.mark.asyncio
+async def test_build_message_event_drops_voice_when_transcript_has_no_wake_word():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+    transcribe_calls = []
+
+    async def _fake_transcribe(data):
+        transcribe_calls.append(data)
+        return "weather looks fine", None
+
+    adapter._eager_transcribe_for_gate = _fake_transcribe
+    event = await adapter._build_message_event(_voice_note(""))
+
+    assert event is None
+    assert transcribe_calls
+
+
+@pytest.mark.asyncio
+async def test_build_message_event_skips_eager_stt_for_reply_to_bot_voice():
+    adapter = _make_adapter(
+        require_mention=True,
+        mention_patterns=[r"(?i)\bhermes\b"],
+        group_policy="open",
+    )
+    transcribe_calls = []
+
+    async def _fake_transcribe(data):
+        transcribe_calls.append(data)
+        return "should not run", None
+
+    adapter._eager_transcribe_for_gate = _fake_transcribe
+    event = await adapter._build_message_event(
+        _voice_note("", quotedParticipant="15551230000@lid")
+    )
+
+    assert event is not None
+    assert transcribe_calls == []
+    assert not hasattr(event, "_gateway_pending_stt_text")
 
 

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -644,6 +644,7 @@ Messages in Telegram topics `31` and `42` are always ignored before the mention 
 - Patterns use Python regular expressions
 - Matching is case-insensitive
 - Patterns are checked against both text messages and media captions
+- In `require_mention` groups, captionless voice/audio notes are transcribed once so these patterns can match a spoken wake word; a note that does not contain a match is transcribed and dropped. The transcript is reused for the agent turn (no second STT pass)
 - Invalid regex patterns are ignored with a warning in the gateway logs rather than crashing the bot
 - If you want a pattern to match only at the start of a message, anchor it with `^`
 

--- a/website/docs/user-guide/messaging/whatsapp.md
+++ b/website/docs/user-guide/messaging/whatsapp.md
@@ -171,7 +171,7 @@ with reconnection logic.
 
 Hermes supports voice on WhatsApp:
 
-- **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the configured STT provider: local `faster-whisper`, Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`)
+- **Incoming:** Voice messages (`.ogg` opus) are automatically transcribed using the configured STT provider: local `faster-whisper`, Groq Whisper (`GROQ_API_KEY`), or OpenAI Whisper (`VOICE_TOOLS_OPENAI_KEY`). In groups with `require_mention` and `mention_patterns`, a captionless voice note is transcribed once at the mention gate so a spoken wake word can match; notes that do not match are dropped. The transcript is reused for the agent turn.
 - **Outgoing:** TTS responses are sent as MP3 audio file attachments
 - Agent responses are prefixed with "⚕ **Hermes Agent**" by default. You can customize or disable this in `config.yaml`:
 


### PR DESCRIPTION
## What does this PR do?

In groups with `require_mention` and `mention_patterns`, the mention gate ran on the empty body/caption of a voice note **before** STT. Typed wake words worked; spoken ones were dropped. Reply-to-bot and `@mention` chips still worked because those are metadata, not text.

WhatsApp (Baileys) and Telegram now transcribe a captionless group voice/audio note once at the gate when those settings are on and no metadata trigger already applies. If the transcript matches a pattern, the event is accepted and the transcript is cached on `_gateway_pending_stt_text` / `_gateway_pending_stt_transcripts` so the runner does not run STT a second time. A note whose transcript does not match is dropped.

## Related Issue

Fixes #102330

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/whatsapp_common.py` — `_is_captionless_audio`, `_needs_eager_voice_mention_gate`, `_transcript_matches_mention_patterns`
- `plugins/platforms/whatsapp/adapter.py` — after the sync mention gate fails, eager-transcribe captionless group PTT/audio, accept on pattern match, cache the transcript, reuse the downloaded audio path
- `plugins/platforms/telegram/adapter.py` — `_eager_transcribe_voice` before `_should_process_message` when the eager gate applies; `_voice_accepted_by_transcript` lets the gate pass; skip eager STT when allowlists/topics/ignored threads/exclusive mentions already reject; same STT cache as WhatsApp
- `tests/gateway/test_whatsapp_group_gating.py` / `tests/gateway/test_telegram_group_gating.py` — accept/drop/narrow-gate/no-double-STT-on-reply-to-bot
- `website/docs/user-guide/messaging/telegram.md` and `whatsapp.md` — document spoken-wake-word STT at the mention gate

## How to Test

1. Set a WhatsApp or Telegram group to `require_mention: true` with a `mention_patterns` wake word (for example `(?i)\bhermes\b`).
2. Send a captionless voice note that speaks the wake word. The bot should take the turn.
3. Send a captionless voice note with no wake word. The bot should stay silent.
4. Confirm typed wake words, media captions, reply-to-bot, and `@mention` chips still work without an extra STT pass.
5. Run the group-gating tests:

```
scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_telegram_group_gating.py -q
```

Expected: 43 passed (WhatsApp: accept via transcript, drop without wake word, skip eager STT on reply-to-bot; Telegram: same plus allowlist skip).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_telegram_group_gating.py -q
43 passed
```
