### PR TITLE
fix(desktop-update): stop Windows hand-off hanging on gateway pipe chatter

### DIFF
--- a/hermes_cli/_scan_venv_blockers.py
+++ b/hermes_cli/_scan_venv_blockers.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import json
 import math
+import os
 import sys
 from pathlib import PureWindowsPath
 from typing import NoReturn
@@ -234,6 +235,53 @@ def _is_pausable_gateway(cmdline: str) -> bool:
     return looks_like_gateway_command_line(cmdline)
 
 
+def _is_stale_update_holder(cmdline: str) -> bool:
+    """True when *cmdline* is a leftover ``hermes update`` holding the venv.
+
+    A previous Desktop hand-off that stalled (#102283) leaves
+    ``python -m hermes_cli.main update --yes --gateway --force`` alive.
+    That zombie is reported as ``venv-blocked`` on the next Update click
+    until the user force-kills it. The next preflight can reap it: it is
+    the updater itself, not an operator REPL or a live user session.
+
+    Uses ``_hermes_holder_subcommand`` (token-based) so ``--branch update``
+    or a skill named update cannot forge the match.
+    """
+    try:
+        from hermes_cli.update_cmd import _hermes_holder_subcommand  # noqa: PLC0415
+    except Exception:
+        return False
+    return _hermes_holder_subcommand(cmdline) == "update"
+
+
+def _reap_stale_update_holder(pid: int) -> bool:
+    """Terminate a leftover ``hermes update`` tree. True when *pid* is gone."""
+    if pid <= 0 or pid == os.getpid():
+        return False
+    try:
+        import psutil  # noqa: PLC0415
+
+        process = psutil.Process(pid)
+        children = process.children(recursive=True)
+        targets = [*reversed(children), process]
+        for target in targets:
+            try:
+                target.terminate()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        _gone, alive = psutil.wait_procs(targets, timeout=3)
+        for target in alive:
+            try:
+                target.kill()
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        if alive:
+            psutil.wait_procs(alive, timeout=2)
+        return not psutil.pid_exists(pid)
+    except Exception:
+        return False
+
+
 def _is_updater_owned_backend(pid: int, cmdline: str) -> bool:
     """Return True when *pid* is a Hermes backend the CLI updater can stop.
 
@@ -369,11 +417,18 @@ def main() -> None:
 
     processes = []
     exempted_gateways = 0
+    reaped_stale_updates = 0
     deferred_entries: list[dict] = []
     for pid, name, cmdline in matches:
         if _is_pausable_gateway(cmdline):
             exempted_gateways += 1
             continue
+        if _is_stale_update_holder(cmdline):
+            # A leftover hand-off ``hermes update`` is the #102283 zombie:
+            # reap it so the next Desktop Update is not venv-blocked.
+            if _reap_stale_update_holder(int(pid)):
+                reaped_stale_updates += 1
+                continue
         deferred_entry = _updater_owned_backend_entry(pid, cmdline)
         if deferred_entry is not None:
             # Ledger-verified serve/dashboard backend the CLI updater's own
@@ -399,6 +454,7 @@ def main() -> None:
         # Diagnostic only: gateway processes present but not counted as
         # blockers because the downstream updater pauses them itself.
         "pausable_gateways": exempted_gateways,
+        "reaped_stale_updates": reaped_stale_updates,
         # Diagnostic only: ledger-verified serve/dashboard backends deferred
         # to the updater's stop/relaunch rungs (#98336).
         "deferred_backends": len(deferred_entries),

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -760,9 +760,28 @@ if ($env:HERMES_UPDATE_STEP_IDLE_SECONDS) {
 # growth of this file (size or mtime) as progress before declaring a stall.
 # Overridable so the pipe-drain self-test can point it at its own file; not
 # documented as a user knob.
+#
+# Pipe bytes are NOT progress (#102283). A resident gateway spawned by
+# `hermes update --gateway` inherits the step's redirected stdout and keeps
+# writing heartbeats after the update's visible work is done. Treating those
+# bytes as activity used to reset the idle clock forever -- hand-off log
+# stuck at "running: python ...", no result file, no relaunch, and a zombie
+# python.exe holding the venv shim for days. Observable progress is
+# update.log growth only.
 $script:StepProgressLogPath = Join-Path $LogDir "update.log"
 if ($env:HERMES_UPDATE_PROGRESS_LOG) {
     $script:StepProgressLogPath = $env:HERMES_UPDATE_PROGRESS_LOG
+}
+
+# Hard wall-clock backstop so a step that keeps touching update.log (or a
+# mis-aimed progress-log override) cannot live for days the way #102283 did.
+# Overridable for the self-test; not documented as a user knob.
+$script:StepMaxSeconds = 10800
+if ($env:HERMES_UPDATE_STEP_MAX_SECONDS) {
+    $parsedMax = 0
+    if ([int]::TryParse($env:HERMES_UPDATE_STEP_MAX_SECONDS, [ref]$parsedMax) -and $parsedMax -gt 0) {
+        $script:StepMaxSeconds = $parsedMax
+    }
 }
 
 function Get-StepProgressLogStamp {
@@ -1055,14 +1074,17 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
     $errTask = $stderrReader.ReadAsync($errBuffer, 0, $errBuffer.Length)
     $abandonAt = $null
     $abandoned = $false
-    $lastProgressAt = Get-Date
+    $stepStartedAt = Get-Date
+    $lastProgressAt = $stepStartedAt
     $progressLogStamp = Get-StepProgressLogStamp
     $stalled = $false
     while ($true) {
         $moved = $false
         $outDone = Step-PipeDrain $stdoutReader ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
         $errDone = Step-PipeDrain $stderrReader ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
-        if ($moved) { $lastProgressAt = Get-Date }
+        # Do not reset $lastProgressAt on $moved -- pipe chatter is not
+        # progress (#102283). A leaked gateway heartbeat would keep this
+        # clock fresh forever.
         if ($proc.HasExited) {
             if ($outDone -and $errDone) { break }
             # Clock starts at the step's exit, not at its start: a slow step is
@@ -1073,31 +1095,39 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
                 $abandoned = $true
                 break
             }
-        } elseif (-not $stalled -and $job -ne [IntPtr]::Zero -and ((Get-Date) - $lastProgressAt).TotalSeconds -ge $script:StepIdleTimeoutSeconds) {
-            # Quiet pipes are how a healthy `hermes update` looks for 40+
-            # minutes: its build output streams to logs/update.log, not the
-            # child's stdout. Growth of that file is progress -- reset the
-            # clock instead of cancelling. Stat'd only once the ceiling is
-            # otherwise reached (at most once per 150ms pass after that), so
-            # the hot drain path never touches the filesystem.
-            $currentLogStamp = Get-StepProgressLogStamp
-            if ($currentLogStamp -ne $progressLogStamp) {
-                $progressLogStamp = $currentLogStamp
-                $lastProgressAt = Get-Date
-            } else {
-                # The child is alive but has produced no observable progress
-                # -- neither on its pipes nor in the update log -- for the
-                # whole bound. Terminate the job, not just its direct process:
-                # retrying while a descendant still mutates the checkout,
-                # venv, or release tree can overlap two installers and
-                # corrupt the install.
-                Write-HandoffLog ("{0}!| step stalled: no stdout/stderr for {1}s and no update.log growth while pid {2} remained alive; cancelling its process tree." -f $Tag, $script:StepIdleTimeoutSeconds, $proc.Id)
-                $stalled = [HermesUpdateJob]::TerminateAndWait($job, 124, 10000)
-                if (-not $stalled) {
-                    Write-HandoffLog ("{0}!| process-tree cancellation could not prove quiescence; refusing the timeout retry." -f $Tag)
-                    $script:TreeSafeToFinalize = $false
-                    [HermesUpdateJob]::Close($job)
-                    throw "Unable to quiesce stalled update process tree"
+        } elseif (-not $stalled -and $job -ne [IntPtr]::Zero) {
+            $now = Get-Date
+            $ranFor = ($now - $stepStartedAt).TotalSeconds
+            $idleFor = ($now - $lastProgressAt).TotalSeconds
+            $hitWall = ($script:StepMaxSeconds -gt 0) -and ($ranFor -ge $script:StepMaxSeconds)
+            $hitIdle = ($script:StepIdleTimeoutSeconds -gt 0) -and ($idleFor -ge $script:StepIdleTimeoutSeconds)
+            if ($hitWall -or $hitIdle) {
+                # update.log growth is the only idle-progress signal. Stat'd
+                # only once a ceiling is otherwise reached so the hot drain
+                # path never touches the filesystem.
+                $currentLogStamp = Get-StepProgressLogStamp
+                if (-not $hitWall -and $currentLogStamp -ne $progressLogStamp) {
+                    $progressLogStamp = $currentLogStamp
+                    $lastProgressAt = $now
+                } else {
+                    # The child is alive but the update is not progressing:
+                    # no update.log growth for the idle bound, or the wall
+                    # clock expired. Terminate the job, not just its direct
+                    # process: retrying while a descendant still mutates the
+                    # checkout, venv, or release tree can overlap two
+                    # installers and corrupt the install.
+                    if ($hitWall) {
+                        Write-HandoffLog ("{0}!| step exceeded wall-clock limit of {1}s while pid {2} remained alive; cancelling its process tree (#102283)." -f $Tag, $script:StepMaxSeconds, $proc.Id)
+                    } else {
+                        Write-HandoffLog ("{0}!| step stalled: no update.log growth for {1}s while pid {2} remained alive (pipe chatter ignored); cancelling its process tree (#102283)." -f $Tag, $script:StepIdleTimeoutSeconds, $proc.Id)
+                    }
+                    $stalled = [HermesUpdateJob]::TerminateAndWait($job, 124, 10000)
+                    if (-not $stalled) {
+                        Write-HandoffLog ("{0}!| process-tree cancellation could not prove quiescence; refusing the timeout retry." -f $Tag)
+                        $script:TreeSafeToFinalize = $false
+                        [HermesUpdateJob]::Close($job)
+                        throw "Unable to quiesce stalled update process tree"
+                    }
                 }
             }
         }
@@ -1208,6 +1238,10 @@ if ($SelfTestUi) {
 #            goes to logs/update.log, not stdout, for 40+ minutes). Guards the
 #            watchdog's other cliff: the idle ceiling must count update.log
 #            growth as progress and must NOT kill the healthy step.
+#   chatter -- a step that stays alive and keeps writing to stdout (the
+#            resident-gateway heartbeat that defeated the idle clock in
+#            #102283). Pipe chatter must NOT count as progress: the idle
+#            ceiling must still terminate the tree.
 if ($SelfTestPipeDrain) {
     New-Item -ItemType Directory -Path $LogDir -Force -ErrorAction SilentlyContinue | Out-Null
     $hold = 60
@@ -1225,6 +1259,8 @@ if ($SelfTestPipeDrain) {
     $stallGrandchildPidFile = Join-Path $TempDir "hermes-step-stall-grandchild-$stamp.pid"
     $logStallPs1 = Join-Path $TempDir "hermes-step-logstall-$stamp.ps1"
     $logStallProgress = Join-Path $TempDir "hermes-step-logstall-$stamp.update.log"
+    $chatterPs1 = Join-Path $TempDir "hermes-step-chatter-$stamp.ps1"
+    $chatterProgress = Join-Path $TempDir "hermes-step-chatter-$stamp.missing.log"
     # UseShellExecute=$false with no redirection is what makes the grandchild
     # inherit our stdout/stderr -- the whole point of the fixture. Anything
     # that redirects (Start-Process, subprocess with stdout=DEVNULL) would
@@ -1280,10 +1316,23 @@ Write-Output "silent but logging"
 for ($i = 0; $i -lt $Hold; $i++) { Add-Content -LiteralPath $ProgressLog -Value ("build tick {0}" -f $i); Start-Sleep -Seconds 1 }
 exit 3
 '@
+    # Alive + chatty on stdout, no update.log growth: the #102283 zombie.
+    $chatterSource = @'
+param([int]$Hold)
+Write-Output "gateway-like chatter start"
+[Console]::Out.Flush()
+for ($i = 0; $i -lt $Hold; $i++) {
+    Write-Output ("heartbeat {0}" -f $i)
+    [Console]::Out.Flush()
+    Start-Sleep -Seconds 1
+}
+exit 0
+'@
     [System.IO.File]::WriteAllText($childPs1, $childSource)
     [System.IO.File]::WriteAllText($floodPs1, $floodSource)
     [System.IO.File]::WriteAllText($stallPs1, $stallSource)
     [System.IO.File]::WriteAllText($logStallPs1, $logStallSource)
+    [System.IO.File]::WriteAllText($chatterPs1, $chatterSource)
     $sw = [System.Diagnostics.Stopwatch]::StartNew()
     $res = Invoke-HermesStep $powershell @(
         "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $childPs1,
@@ -1349,7 +1398,24 @@ exit 3
     $logStallSw.Stop()
     $logStallElapsed = [Math]::Round($logStallSw.Elapsed.TotalSeconds, 2)
 
-    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $logStallPs1, $pidFile, $stallPidFile, $stallGrandchildPidFile, $logStallProgress -Force -ErrorAction SilentlyContinue
+    # chatter arm: pipes stay busy, progress log is absent -- idle must still
+    # cancel. Point the watchdog at a missing file so leftover update.log
+    # from a previous arm cannot count as growth.
+    $savedProgressLogPath = $script:StepProgressLogPath
+    $script:StepProgressLogPath = $chatterProgress
+    $chatterSw = [System.Diagnostics.Stopwatch]::StartNew()
+    try {
+        $chatter = Invoke-HermesStep $powershell @(
+            "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", $chatterPs1,
+            "-Hold", [string]$hold
+        ) "chatter"
+    } finally {
+        $script:StepProgressLogPath = $savedProgressLogPath
+    }
+    $chatterSw.Stop()
+    $chatterElapsed = [Math]::Round($chatterSw.Elapsed.TotalSeconds, 2)
+
+    Remove-Item -LiteralPath $childPs1, $floodPs1, $stallPs1, $logStallPs1, $chatterPs1, $pidFile, $stallPidFile, $stallGrandchildPidFile, $logStallProgress -Force -ErrorAction SilentlyContinue
 
     # The grandchild still being alive at return is what makes this a proof
     # rather than a timing coincidence: the pipe was demonstrably still open.
@@ -1377,8 +1443,12 @@ exit 3
     if ($logstall.Code -ne 3) { $problems += "logstall arm exit code $($logstall.Code), expected 3 -- the idle watchdog killed a pipe-silent step whose progress was visible as update.log growth (the shape of every real 40+ min build)" }
     if ($logstall.Output -notmatch "silent but logging") { $problems += "logstall arm step output was lost" }
     if ($logStallElapsed -ge $logStallBudget) { $problems += "logstall arm returned in ${logStallElapsed}s, over the ${logStallBudget}s budget" }
+    $chatterBudget = $script:StepIdleTimeoutSeconds + 30
+    if ($chatterElapsed -ge $chatterBudget) { $problems += "chatter arm returned in ${chatterElapsed}s, over the ${chatterBudget}s budget -- pipe heartbeats reset the idle clock (#102283)" }
+    if ($chatter.Code -ne 124) { $problems += "chatter arm exit code $($chatter.Code), expected 124 -- stdout heartbeats must not count as progress" }
+    if ($chatter.Output -notmatch "gateway-like chatter start") { $problems += "chatter arm step output was lost" }
 
-    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive descendantAlive=$stallGrandchildAlive quiesced=$($stall.TreeQuiesced) | logstall: elapsed=${logStallElapsed}s budget=${logStallBudget}s code=$($logstall.Code)"
+    $detail = "leak: elapsed=${elapsed}s budget=${budget}s code=$($res.Code) grandchildAlive=$leakAlive | flood: ${floodKb}KB in ${floodElapsed}s budget=${floodBudget}s bytes=$floodBytes code=$($flood.Code) | stall: elapsed=${stallElapsed}s budget=${stallBudget}s code=$($stall.Code) childAlive=$stallAlive descendantAlive=$stallGrandchildAlive quiesced=$($stall.TreeQuiesced) | logstall: elapsed=${logStallElapsed}s budget=${logStallBudget}s code=$($logstall.Code) | chatter: elapsed=${chatterElapsed}s budget=${chatterBudget}s code=$($chatter.Code)"
     if ($problems.Count -gt 0) {
         Write-Host "PIPE-DRAIN SELF-TEST: FAIL $detail -- $($problems -join '; ')"
         exit 1

--- a/scripts/desktop-update/windows.ps1
+++ b/scripts/desktop-update/windows.ps1
@@ -1082,9 +1082,8 @@ function Invoke-HermesStep([string]$Exe, [string[]]$HermesArgs, [string]$Tag) {
         $moved = $false
         $outDone = Step-PipeDrain $stdoutReader ([ref]$outTask) $outBuffer $outSink ([ref]$moved)
         $errDone = Step-PipeDrain $stderrReader ([ref]$errTask) $errBuffer $errSink ([ref]$moved)
-        # Do not reset $lastProgressAt on $moved -- pipe chatter is not
-        # progress (#102283). A leaked gateway heartbeat would keep this
-        # clock fresh forever.
+        # Do not reset $lastProgressAt on $moved -- pipe chatter is not progress
+        # (#102283). A leaked gateway heartbeat would keep this clock fresh forever.
         if ($proc.HasExited) {
             if ($outDone -and $errDone) { break }
             # Clock starts at the step's exit, not at its start: a slow step is
@@ -1321,11 +1320,7 @@ exit 3
 param([int]$Hold)
 Write-Output "gateway-like chatter start"
 [Console]::Out.Flush()
-for ($i = 0; $i -lt $Hold; $i++) {
-    Write-Output ("heartbeat {0}" -f $i)
-    [Console]::Out.Flush()
-    Start-Sleep -Seconds 1
-}
+for ($i = 0; $i -lt $Hold; $i++) { Write-Output ("heartbeat {0}" -f $i); [Console]::Out.Flush(); Start-Sleep -Seconds 1 }
 exit 0
 '@
     [System.IO.File]::WriteAllText($childPs1, $childSource)

--- a/tests/hermes_cli/test_scan_venv_blockers.py
+++ b/tests/hermes_cli/test_scan_venv_blockers.py
@@ -19,6 +19,7 @@ import agent.redact as redact_module
 from hermes_cli._scan_venv_blockers import (
     _classify_local_preview_args,
     _is_pausable_gateway,
+    _is_stale_update_holder,
     _probe_fail_json,
     _redact_sensitive_cmdline,
     _terminate_safe_preview,
@@ -490,3 +491,62 @@ def test_main_gateway_with_long_managed_runtime_path_is_exempt(monkeypatch, caps
     assert data["blocked"] is True
     assert [p["pid"] for p in data["processes"]] == [92]
     assert len(data["processes"][0]["cmdline"]) <= 120
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main update --yes --gateway --force --branch main",
+        r'"C:\u\uv\python\python.exe" -m hermes_cli.main update --yes --gateway --force',
+        "hermes.exe update --yes --gateway --force --branch main",
+    ],
+)
+def test_is_stale_update_holder_accepts_update_argv(cmdline: str) -> None:
+    assert _is_stale_update_holder(cmdline) is True
+
+
+@pytest.mark.parametrize(
+    "cmdline",
+    [
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main gateway run --replace",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main serve --host 127.0.0.1",
+        r"C:\x\venv\Scripts\python.exe",
+        r"C:\x\venv\Scripts\python.exe myscript.py update --yes",
+        "",
+    ],
+)
+def test_is_stale_update_holder_rejects_non_update(cmdline: str) -> None:
+    assert _is_stale_update_holder(cmdline) is False
+
+
+def test_main_reaps_stale_update_holder_instead_of_blocking(monkeypatch, capsys):
+    """A leftover ``hermes update`` zombie must be reaped, not venv-blocked."""
+    zombie = (
+        25876,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main update --yes --gateway --force --branch main",
+    )
+    import hermes_cli._scan_venv_blockers as scan
+
+    monkeypatch.setattr(scan, "_reap_stale_update_holder", lambda pid: pid == 25876)
+    code, data = _run_main_with_detector(monkeypatch, capsys, [zombie])
+    assert code == 0
+    assert data["blocked"] is False
+    assert data["processes"] == []
+    assert data["reaped_stale_updates"] == 1
+
+
+def test_main_failed_stale_update_reap_still_blocks(monkeypatch, capsys):
+    zombie = (
+        25876,
+        "python.exe",
+        r"C:\x\venv\Scripts\python.exe -m hermes_cli.main update --yes --gateway --force --branch main",
+    )
+    import hermes_cli._scan_venv_blockers as scan
+
+    monkeypatch.setattr(scan, "_reap_stale_update_holder", lambda pid: False)
+    code, data = _run_main_with_detector(monkeypatch, capsys, [zombie])
+    assert code == 0
+    assert data["blocked"] is True
+    assert [p["pid"] for p in data["processes"]] == [25876]
+    assert data["reaped_stale_updates"] == 0

--- a/tests/test_desktop_update_windows_pipe_drain.py
+++ b/tests/test_desktop_update_windows_pipe_drain.py
@@ -103,16 +103,25 @@ class TestIdleWatchdogCountsUpdateLogGrowth:
             "output goes to update.log would be killed at the idle ceiling"
         )
         assert "$currentLogStamp = Get-StepProgressLogStamp" in src, msg
-        assert "if ($currentLogStamp -ne $progressLogStamp)" in src, msg
+        assert "if (-not $hitWall -and $currentLogStamp -ne $progressLogStamp)" in src, msg
         # The growth check must gate the termination: compare-and-reset
         # appears before the 124 tree-termination inside the drain loop.
-        consult = src.index("if ($currentLogStamp -ne $progressLogStamp)")
+        consult = src.index("if (-not $hitWall -and $currentLogStamp -ne $progressLogStamp)")
         terminate = src.index("TerminateAndWait($job, 124")
         assert consult < terminate, msg
         # And the clock actually resets on growth.
         growth_block = src[consult:terminate]
         assert "$progressLogStamp = $currentLogStamp" in growth_block, msg
-        assert "$lastProgressAt = Get-Date" in growth_block, msg
+        assert "$lastProgressAt = Get-Date" in growth_block or "$lastProgressAt = $now" in growth_block, msg
+
+    def test_pipe_chatter_does_not_reset_idle_clock(self):
+        src = self._src()
+        assert "if ($moved) { $lastProgressAt = Get-Date }" not in src, (
+            "pipe bytes reset the idle clock again -- a resident gateway "
+            "heartbeat would strand the Desktop update hand-off (#102283)"
+        )
+        assert "pipe chatter is not progress" in src
+        assert "chatter" in src
 
     def test_self_test_has_silent_but_logging_arm(self):
         src = self._src()
@@ -157,6 +166,12 @@ def test_update_step_survives_pipe_leak_flood_and_live_child_stall(
     ``logs/update.log``, not stdout, for 40+ minutes. The idle watchdog must
     count that growth as progress and let the step run to its natural exit
     instead of killing it at the ceiling with 124.
+
+    *chatter* -- a step that stays alive and writes a stdout heartbeat every
+    second with no update.log growth. This is the #102283 zombie: a resident
+    ``--gateway`` descendant keeps the pipes busy after visible work is done.
+    The idle watchdog must still terminate the tree (124) and must not wait
+    out the hold.
 
     The existing leak/flood arms retain their measured Windows 11 / PowerShell
     5.1 budgets; the stall arm uses the same real runner and process table.


### PR DESCRIPTION
## What does this PR do?

Windows Desktop Update can finish the git/pip work and then sit forever on the hand-off script. `desktop-update-handoff.log` stops at `running: python -m hermes_cli.main update --yes --gateway --force`, no `.hermes-update-result.json` is written, Hermes.exe never relaunches, and the `python -m hermes_cli.main update` child stays alive holding the venv shim. The next Update click then dies with `venv-blocked`.

`Invoke-HermesStep` already had an idle watchdog, but any byte on the redirected pipes reset that clock. `hermes update --gateway` leaves a resident gateway that inherits those pipes and keeps heartbeating, so the watchdog never fires (field zombies lasted days). This change treats only `logs/update.log` growth as progress, adds a wall-clock backstop, and reaps leftover `hermes update` holders in the Desktop venv preflight so a later Update is not blocked by the previous zombie.

## Related Issue

Fixes #102283

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `scripts/desktop-update/windows.ps1`: idle watchdog no longer resets on pipe bytes; only `update.log` growth counts; 3h wall-clock cancel; new `chatter` arm on `-SelfTestPipeDrain`
- `hermes_cli/_scan_venv_blockers.py`: identify leftover `hermes update` via `_hermes_holder_subcommand` and reap it before reporting `venv-blocked`
- `tests/test_desktop_update_windows_pipe_drain.py`: chatter / no-pipe-progress contracts
- `tests/hermes_cli/test_scan_venv_blockers.py`: stale-update argv + reap success/fail

## How to Test

1. On Windows, run a step through `Invoke-HermesStep` that stays alive and prints a stdout heartbeat every few seconds with no `update.log` growth (the `-SelfTestPipeDrain` `chatter` arm, or `python` writing `gateway-like heartbeat`).
2. Confirm the hand-off logs `step stalled: no update.log growth ... (pipe chatter ignored)` and returns exit 124 within `HERMES_UPDATE_STEP_IDLE_SECONDS` (default 600s), instead of hanging.
3. Confirm a leftover `python -m hermes_cli.main update --yes --gateway --force` is reaped by `python -m hermes_cli._scan_venv_blockers` so the next Desktop Update is not `venv-blocked`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (GCP `hermes-desktop-win`)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before (hand-off never left `Invoke-HermesStep` while the child printed heartbeats): hung past 100s.

After (`HERMES_UPDATE_STEP_IDLE_SECONDS=45`):

```
chatter!| step stalled: no update.log growth for 45s while pid 5444 remained alive (pipe chatter ignored); cancelling its process tree (#102283).
CHATTER done code=124 elapsedSec=45
```