### PR TITLE
fix(approval): block shred/wipefs/blkdiscard on raw block devices

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -92,6 +92,13 @@ _HARDLINE_BLOCK = [
     "dd if=anything of=/dev/hda",
     "echo bad > /dev/sda",
     "cat /dev/urandom > /dev/sdb",
+    # Raw block device wipes — positional device operand (#102371)
+    "shred -n1 -z /dev/sda",
+    "shred /dev/nvme0n1",
+    "wipefs -a /dev/sdb",
+    "blkdiscard /dev/mmcblk0",
+    "sudo wipefs -a /dev/vda",
+    "true && blkdiscard /dev/sdc",
     # Fork bomb
     ":(){ :|:& };:",
     # System-wide kill
@@ -173,6 +180,12 @@ _HARDLINE_ALLOW = [
     # dd to regular files
     "dd if=/dev/zero of=./image.bin",
     "dd if=./data of=./backup.bin",
+    # Regular-file secure deletion must stay clean (#102371): no /dev/ block
+    # operand, so the wipe rules must not fire.
+    "shred file.txt",
+    "shred -u /tmp/secret.bin",
+    "shred -n 3 -z ./backup.tar.gz",
+    "wipefs --help",
     # Redirect to regular files / non-block devices
     "echo done > /tmp/flag",
     "echo test > /dev/null",
@@ -393,6 +406,10 @@ _QUOTED_PROSE_ALLOW_93392 = [
     'git commit -m "never run dd of=/dev/sda in prod"',
     'echo "dd if=/dev/zero of=/dev/sda wipes the disk"',
     "grep 'dd if=/dev/zero of=/dev/sda' notes.md",
+    # shred/wipefs/blkdiscard on block devices (#102371)
+    'git commit -m "never run wipefs -a /dev/sda in prod"',
+    'echo "blkdiscard /dev/nvme0n1 destroys the disk"',
+    "grep 'shred -n1 -z /dev/sda' notes.md",
     # kill -1
     'echo "kill -1 sends SIGHUP to every process"',
     'gh issue comment 7 --body "the agent must never run kill -1"',
@@ -438,6 +455,12 @@ _TRUE_POSITIVES_93392 = [
     "$(dd if=/dev/zero of=/dev/sda)",
     "`dd if=/dev/zero of=/dev/sda`",
     'sh -c "dd if=/dev/zero of=/dev/sda"',
+    # shred/wipefs/blkdiscard to raw block devices (#102371)
+    "shred -n1 -z /dev/sda",
+    "sudo wipefs -a /dev/nvme0n1",
+    "ls; blkdiscard /dev/mmcblk0",
+    "$(shred /dev/sda)",
+    'sh -c "blkdiscard /dev/sdb"',
     # redirect to raw block device (unquoted / carrier / substitution)
     "cat file > /dev/sda",
     "echo junk > /dev/sdb",
@@ -477,6 +500,7 @@ def test_true_positive_shapes_stay_hardline_blocked(command):
 _DANGEROUS_TIER_PROSE_ALLOW = [
     'echo "mkfs is a formatting tool"',
     'git commit -m "explain dd if=/dev/zero usage"',
+    'git commit -m "never run shred /dev/sda in prod"',
 ]
 
 _DANGEROUS_TIER_STILL_FLAGGED = [
@@ -484,6 +508,8 @@ _DANGEROUS_TIER_STILL_FLAGGED = [
     ("sudo mkfs -t vfat /dev/sdc1", "format filesystem"),
     ("dd if=backup.img of=restore.img", "disk copy"),
     ("true && dd if=a.img of=b.img", "disk copy"),
+    ("wipefs -a /dev/sda", "raw block device wipe (shred/wipefs/blkdiscard)"),
+    ("sudo blkdiscard /dev/nvme0n1", "raw block device wipe (shred/wipefs/blkdiscard)"),
 ]
 
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -578,6 +578,13 @@ HARDLINE_PATTERNS = [
     # argument, not a command. The argument tail ([^\n]*of=/dev/...) is kept
     # so flag order doesn't matter.
     (_CMDPOS + r'dd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
+    # Sibling raw-disk destruction tools whose device operand is positional
+    # instead of dd's of= spelling: shred/wipefs/blkdiscard against a block
+    # device have no recovery path, the same device class as the dd rule
+    # above (#102371). Command-position anchored so quoted prose mentioning
+    # them stays data; `shred file.txt` (secure delete of a regular file)
+    # has no /dev/ block operand and stays clean.
+    (_CMDPOS + r'(?:shred|wipefs|blkdiscard)\b[^\n]*\s/dev/(?:sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "raw block device wipe (shred/wipefs/blkdiscard)"),
     # The redirect rule has no command-name token to anchor (`>` appears
     # mid-command: `cat f > /dev/sda`), so command-position anchoring is the
     # wrong tool. It is instead matched against a QUOTE-MASKED variant of the
@@ -1033,6 +1040,10 @@ DANGEROUS_PATTERNS = [
     # quoted prose mentioning mkfs/dd must not require approval to echo.
     (_CMDPOS + r'mkfs\b', "format filesystem"),
     (_CMDPOS + r'dd\s+.*if=', "disk copy"),
+    # Positional-operand twins of the hardline wipe rule (#102371): kept in
+    # the approval tier so the tools are gated even where only
+    # detect_dangerous_command is consulted; regular-file targets stay clean.
+    (_CMDPOS + r'(?:shred|wipefs|blkdiscard)\b[^\n]*\s/dev/(?:sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "raw block device wipe (shred/wipefs/blkdiscard)"),
     (r'>\s*/dev/sd', "write to block device"),
     (r'\bDROP\s+(TABLE|DATABASE)\b', "SQL DROP"),
     # Use [^\n]* instead of .* so DOTALL mode does not cause a WHERE clause on the


### PR DESCRIPTION
## What does this PR do?

`shred`, `wipefs` and `blkdiscard` destroy raw block devices, but they take the device as a **positional operand**, so the existing `dd ... of=/dev/...` hardline rule never matched them: `detect_hardline_command('shred -n1 -z /dev/sda')` returned `(False, None)` and even `--yolo` ran them silently.

This adds command-position-anchored rules for the three tools to both the hardline floor and the dangerous (approval) tier, gated on the same block-device path class as the `dd` rule (`sd|nvme|hd|mmcblk|vd|xvd`). The anchoring mirrors the #93392 prose protections: quoted mentions are data, not commands, and regular-file targets (`shred file.txt`) stay clean because the rules require a `/dev/<block>` operand.

## Related Issue

Fixes #102371

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py`: added one `_CMDPOS`-anchored `(?:shred|wipefs|blkdiscard)` rule to `HARDLINE_PATTERNS` (unconditional floor, next to the `dd` rule) and its twin to `DANGEROUS_PATTERNS` (approval tier, next to the dangerous `dd if=` rule)
- `tests/tools/test_hardline_blocklist.py`: extended the hardline blocked list (bare/sudo/separator/\`\$()\`/`sh -c` shapes), the allow list (regular-file targets), the #93392 quoted-prose allow list, the true-positive list, and the dangerous-tier prose/flagged lists

## How to Test

1. Run the regression suite:
   ```
   pytest tests/tools/test_hardline_blocklist.py -q
   ```
   Observed result: 267 passed (includes the new block-device wipe cases and regular-file/prose non-cases).
2. Manual check of both tiers:
   ```python
   from tools.approval import detect_hardline_command, detect_dangerous_command
   detect_hardline_command("shred -n1 -z /dev/sda")     # (True, "raw block device wipe (shred/wipefs/blkdiscard)")
   detect_dangerous_command("blkdiscard /dev/sda")       # (True, ...)
   detect_hardline_command("shred file.txt")             # (False, None) — regular file stays clean
   detect_hardline_command('git commit -m "wipefs -a /dev/sda"')  # (False, None) — prose stays clean
   ```
   Observed result: all four behave as annotated.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-patibility) — or N/A (Linux block-device tools only; no Windows code path touched)
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A