### PR TITLE
fix(approval): block shred wipefs blkdiscard on raw block devices

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -92,6 +92,15 @@ _HARDLINE_BLOCK = [
     "dd if=anything of=/dev/hda",
     "echo bad > /dev/sda",
     "cat /dev/urandom > /dev/sdb",
+    # Raw-disk destruction siblings of dd (positional device path, #102371)
+    "shred -n1 -z /dev/sda",
+    "shred /dev/nvme0n1",
+    'shred "/dev/sda"',
+    "sudo shred /dev/sda",
+    "wipefs -a /dev/sda",
+    "wipefs --all /dev/nvme0n1",
+    "blkdiscard /dev/sda",
+    "blkdiscard -o 0 -l 1M /dev/sda",
     # Fork bomb
     ":(){ :|:& };:",
     # System-wide kill
@@ -173,6 +182,15 @@ _HARDLINE_ALLOW = [
     # dd to regular files
     "dd if=/dev/zero of=./image.bin",
     "dd if=./data of=./backup.bin",
+    # shredding regular files is legitimate secure deletion (#102371)
+    "shred secrets.txt",
+    "shred -u -n3 oldkey.pem",
+    # wipefs without an erase flag only lists signatures
+    "wipefs /dev/sda",
+    # disk-tool prose and lookalike binaries
+    'echo "shred /dev/sda"',
+    'git commit -m "shred /dev/sda"',
+    "shredder /dev/sda",
     # Redirect to regular files / non-block devices
     "echo done > /tmp/flag",
     "echo test > /dev/null",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -578,6 +578,15 @@ HARDLINE_PATTERNS = [
     # argument, not a command. The argument tail ([^\n]*of=/dev/...) is kept
     # so flag order doesn't matter.
     (_CMDPOS + r'dd\b[^\n]*\bof=/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*', "dd to raw block device"),
+    # Raw-disk destruction siblings of dd: shred/wipefs/blkdiscard take the
+    # device as a positional path, not an of= operand, so the dd rule never
+    # matches them. Gate on a block-device path so shredding regular files
+    # (legitimate secure deletion) stays clean, and accept a quote before
+    # the path so `shred "/dev/sda"` is not a bypass. wipefs without -a/--all
+    # only lists signatures, so the erase flag is required there (#102371).
+    (_CMDPOS + r'shred\b[^\n]*?["\'\s]/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "shred on raw block device"),
+    (_CMDPOS + r'wipefs\b(?=[^\n]*\s-(?:-all\b|[a-z]*a))[^\n]*?["\'\s]/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "wipefs erase on raw block device"),
+    (_CMDPOS + r'blkdiscard\b[^\n]*?["\'\s]/dev/(sd|nvme|hd|mmcblk|vd|xvd)[a-z0-9]*\b', "blkdiscard on raw block device"),
     # The redirect rule has no command-name token to anchor (`>` appears
     # mid-command: `cat f > /dev/sda`), so command-position anchoring is the
     # wrong tool. It is instead matched against a QUOTE-MASKED variant of the


### PR DESCRIPTION
Hey — raw-disk destruction through `shred`, `wipefs` and `blkdiscard` has zero hardline or dangerous coverage: they take the device as a positional path, not an `of=` operand, so the `dd` rule never matches and even `--yolo` runs them silently.

Fixed with command-position-anchored hardline rules gated on a block-device path, mirroring the `dd` rule's protections (sudo/env wrappers, quoted paths). Shredding regular files and list-only `wipefs` stay clean.

Tests: block/allow entries in the hardline suites proving destructive shapes trip the floor and benign shapes (secure deletion, listing, prose, lookalike binaries) don't. Verified red on unfixed code, green after; neighboring approval suites pass except 4 failures identical on unmodified main (environment-related, pre-existing). Footguns check clean. Tested on macOS, Python 3.11.

Fixes #102371
