### PR TITLE
fix(compression): prune native-compaction checkpoints a newer carrier shadows

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -447,6 +447,29 @@ def stamp_db_persisted_markers(messages: List[Dict[str, Any]]) -> None:
             msg[_DB_PERSISTED_MARKER] = True
 
 
+def _newest_checkpoint_carrier(messages: List[Dict[str, Any]], key: str) -> int:
+    """Index of the last assistant message carrying a native-compaction
+    checkpoint under *key*, or ``-1`` when the transcript has none.
+
+    This is the transcript-side mirror of
+    ``native_compaction.prune_pre_checkpoint_items``' "newest run wins" rule:
+    that function scans the converted Responses items for the last
+    ``type: "compaction"`` entry and drops everything before it, so this is
+    the only carrier whose checkpoints can still reach a request.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        items = msg.get(key)
+        if isinstance(items, list) and any(
+            isinstance(item, dict) and item.get("type") == "compaction"
+            for item in items
+        ):
+            return i
+    return -1
+
+
 def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
     """Strip stale per-turn replay items (``codex_reasoning_items``) from
     assistant messages that belong to turns older than the active one.
@@ -473,11 +496,21 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
       the last assistant message and would have stripped reasoning mid-chain
       from the in-flight turn.)
 
-    * **Native compaction checkpoints are exempt.** ``type: "compaction"``
-      items in the same sidecar are the server-side stand-in for already
-      pruned history (see ``agent/native_compaction.py``) — cumulative
-      context carriers, not per-turn reasoning.  They must survive on every
-      retained message, so pruning filters items instead of popping the key.
+    * **Only the newest native-compaction checkpoint is exempt.**
+      ``type: "compaction"`` items in the same sidecar are the server-side
+      stand-in for already pruned history (see ``agent/native_compaction.py``)
+      — cumulative context carriers, not per-turn reasoning — so pruning
+      filters items instead of popping the key.  But
+      ``native_compaction.prune_pre_checkpoint_items`` rebuilds every request
+      around the NEWEST checkpoint run and discards each earlier one, and the
+      replay gate drops checkpoints wholesale once native compaction is no
+      longer eligible.  A checkpoint shadowed by a newer carrier therefore has
+      no reader on any wire, while still being charged in full by
+      ``_ALWAYS_REPLAYED_BUDGET_KEYS`` (~120 KB of ciphertext each), replayed
+      into the child session, and persisted to
+      ``messages.codex_reasoning_items`` for the life of the DB.  Keep the
+      newest carrier — the same item the wire builder would have picked — and
+      drop the shadowed ones.
     """
     # Find the last real user message — everything after it is the active
     # turn.  Synthetic continuation rows and tool results never mark a turn
@@ -493,6 +526,11 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
         # prune nothing (fail open toward correctness, not size).
         return 0
 
+    newest_carrier = {
+        key: _newest_checkpoint_carrier(messages, key)
+        for key in _STALE_REPLAY_PRUNE_KEYS
+    }
+
     pruned = 0
     for i in range(last_user_idx):
         msg = messages[i]
@@ -502,11 +540,15 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
             items = msg.get(key)
             if not isinstance(items, list) or not items:
                 continue
-            kept = [
-                item
-                for item in items
-                if isinstance(item, dict) and item.get("type") == "compaction"
-            ]
+            kept = (
+                [
+                    item
+                    for item in items
+                    if isinstance(item, dict) and item.get("type") == "compaction"
+                ]
+                if i == newest_carrier[key]
+                else []
+            )
             if len(kept) == len(items):
                 continue  # nothing stale in this sidecar
             if kept:

--- a/tests/agent/test_stale_replay_prune.py
+++ b/tests/agent/test_stale_replay_prune.py
@@ -2,9 +2,10 @@
 
 Salvaged from PR #71077 (@webtecnica) with two correctness fixes:
 the prune boundary is the last USER message (a Codex turn spans multiple
-assistant messages whose reasoning items must replay together), and native
-compaction checkpoints (type="compaction") are exempt because they carry
-already-pruned history, not per-turn reasoning.
+assistant messages whose reasoning items must replay together), and the
+newest native compaction checkpoint (type="compaction") is exempt because
+it carries already-pruned history, not per-turn reasoning.  Checkpoints a
+newer carrier shadows are pruned: the wire builder discards them anyway.
 """
 
 from agent.context_compressor import (
@@ -164,3 +165,81 @@ class TestInterimMergePreservesCheckpoints:
         assert merge_interim_reasoning_items(None, None) == []
         assert merge_interim_reasoning_items(None, [_reasoning("r")]) == [_reasoning("r")]
         assert merge_interim_reasoning_items([_compaction()], None) == [_compaction()]
+
+
+class TestShadowedCheckpointsArePruned:
+    """A checkpoint that a newer carrier shadows can never reach a request:
+    ``native_compaction.prune_pre_checkpoint_items`` rebuilds every wire
+    around the newest checkpoint run and drops each earlier one.  Retaining
+    the shadowed copies charged them in full against the tail budget and
+    persisted ~120 KB of unreachable ciphertext per assistant row.
+    """
+
+    @staticmethod
+    def _checkpoint(tag):
+        return {"type": "compaction", "encrypted_content": f"ckpt-{tag}"}
+
+    def _transcript(self, turns):
+        messages = []
+        for t in range(turns):
+            messages.append({"role": "user", "content": f"u{t}"})
+            messages.append({
+                "role": "assistant",
+                "content": f"a{t}",
+                "codex_reasoning_items": [
+                    _reasoning(f"rs_{t}"),
+                    self._checkpoint(t),
+                ],
+            })
+        messages.append({"role": "user", "content": "now"})
+        return messages
+
+    def test_only_the_newest_carrier_keeps_its_checkpoint(self):
+        messages = self._transcript(4)
+        _prune_stale_reasoning_replay(messages)
+        surviving = [
+            (i, item)
+            for i, msg in enumerate(messages)
+            for item in (msg.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert surviving == [(7, self._checkpoint(3))]
+
+    def test_newest_carrier_inside_the_active_turn_shadows_every_stale_one(self):
+        messages = self._transcript(2)
+        # Active turn (after the last user message) mints its own checkpoint.
+        messages.append({
+            "role": "assistant",
+            "content": "live",
+            "codex_reasoning_items": [self._checkpoint("live")],
+        })
+        _prune_stale_reasoning_replay(messages)
+        assert "codex_reasoning_items" not in messages[1]
+        assert "codex_reasoning_items" not in messages[3]
+        assert messages[-1]["codex_reasoning_items"] == [self._checkpoint("live")]
+
+    def test_retained_checkpoints_match_what_the_wire_builder_keeps(self):
+        """The invariant behind the prune: after it runs, the transcript holds
+        exactly the checkpoints ``prune_pre_checkpoint_items`` would have kept."""
+        from agent.native_compaction import prune_pre_checkpoint_items
+
+        messages = self._transcript(5)
+        _prune_stale_reasoning_replay(messages)
+
+        items = []
+        for msg in messages:
+            items.extend(dict(i) for i in (msg.get("codex_reasoning_items") or []))
+            if msg["role"] == "user":
+                items.append({
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": msg["content"]}],
+                })
+        wire = [i for i in prune_pre_checkpoint_items(items) if i.get("type") == "compaction"]
+        retained = [
+            item
+            for msg in messages
+            for item in (msg.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert retained == wire


### PR DESCRIPTION
## What does this PR do?

`agent/context_compressor._prune_stale_reasoning_replay` exempted **every**
native-compaction checkpoint from pruning. This narrows that exemption to the
newest carrier — the only one the wire builder can ever use.

Fixes #102374.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[🧠 Codex Responses Turn] -->|type: compaction| B[🔒 Checkpoint Sidecar<br/>~120 KB ciphertext]
    B --> C{🛡️ Stale Replay Prune}
    C -->|before: ALL checkpoints exempt| D[💾 N blobs retained]
    C -->|after: newest carrier only| E[⚡ 1 blob retained]
    D --> F[📊 Tail Budget Overcharge<br/>N-1 x 30K phantom tokens]
    D --> G[🗄️ state.db Growth<br/>2473 MB of 3232 MB]
    G --> H[🔥 Single-Writer WAL Saturation]
    H --> I[⛔ database is locked >20s]
    I --> J[🔁 Retry Storm / Subagent Respawn Loop]
    E --> K[🚀 Wire Parity: retained == sent]
    K --> L[✅ No Phantom Charge, Bounded Storage]
```

## Root cause

The retention rule and the wire rule disagreed.

`native_compaction.prune_pre_checkpoint_items` rebuilds each request around the
**newest contiguous checkpoint run** and drops everything before it. When
native compaction is not eligible for a request,
`codex_responses_adapter._chat_messages_to_responses_input` drops checkpoints
wholesale instead. In both gate states, a checkpoint shadowed by a newer
carrier has **no reader on any wire**.

`_prune_stale_reasoning_replay` nevertheless kept all of them, and its
docstring made that explicit: *"They must survive on every retained message."*
So each shadowed checkpoint was:

1. charged in full against the protected tail — `codex_reasoning_items` sits in
   `_ALWAYS_REPLAYED_BUDGET_KEYS` and is charged unconditionally per message;
2. copied into compacted transcripts and forked/child sessions;
3. persisted to `messages.codex_reasoning_items` for the life of the DB.

This is the same class of defect the file already fixed one key over — #73624
found that charging provably-stripped thinking blocks spent *"19-24% of the
budget on bytes that never reach the wire, so the tail cut landed early and
each compaction discarded more real transcript than configured."*

## Measured impact

Reproduction on `main`, 8 turns each carrying a 120 KB checkpoint:

| | checkpoints | bytes |
|---|---|---|
| before prune | 8 | 0.96 MB |
| after `_prune_stale_reasoning_replay` (before this PR) | 8 | 0.96 MB |
| after `_prune_stale_reasoning_replay` (after this PR) | **1** | **0.12 MB** |
| what `prune_pre_checkpoint_items` sends | 1 | 0.12 MB |

Field forensics on a real 3 232 MB `state.db`:

- `messages.codex_reasoning_items` held **2 473 MB** of it; the entire
  `content` column was 225 MB.
- ~120 KB per assistant row, a 400-row sample carrying only **118 distinct
  blobs** (3.4x duplication).
- One session, 8 979 rows, was 782 MB on its own.

Downstream, a multi-GB `state.db` with two FTS5 indexes saturates SQLite's
single writer and yields `database is locked (>20s)`; parent agents read that
as retryable and respawn subagents. `state.db` lives under `HERMES_HOME`, not
under the checkout, so worktrees do not isolate any of it.

## The fix

`_newest_checkpoint_carrier()` finds the last assistant message carrying a
checkpoint — the transcript-side mirror of `prune_pre_checkpoint_items`' "newest
run wins" rule. Stale messages keep their checkpoints only when they *are* that
carrier.

Safety: the retained carrier is the newest one *within the compacted list*,
which is exactly the item the wire builder would have selected from that same
list. The set of checkpoints reaching the model is unchanged; only unreachable
copies are dropped. The newest carrier is also the one compaction is most
likely to retain, since it protects the tail.

## Testing

```
tests/agent/test_stale_replay_prune.py .............. 14 passed
tests/agent/test_context_compressor.py .............. 152 passed
tests/run_agent/test_native_compaction*.py ........... 120 passed
tests/agent/test_native_preflight_estimate.py ......... 6 passed
tests/agent/test_replay_budget_accounting.py .......... 9 passed
tests/hermes_state/test_reasoning_roundtrip.py ........ 6 passed
tests/agent/test_codex_responses_adapter.py .......... 26 passed
```

All 11 pre-existing tests in `test_stale_replay_prune.py` pass **unchanged** —
including `test_native_compaction_checkpoints_survive_pruning` and
`test_checkpoint_only_sidecar_untouched_and_uncounted`, because a transcript
with a single checkpoint has that checkpoint on its newest carrier.

Three regression tests added, the third pinning the contract directly to the
wire builder: after the prune, the checkpoints retained in the transcript must
equal the checkpoints `prune_pre_checkpoint_items` keeps.

## Scope / overlap

- #100611 — checkpoint ciphertext inflating the **preflight estimate**. Same
  blob, different consumer; untouched here.
- #101867 / PR #102059 — `codex_responses_compact_threshold` wiring. Threshold
  selection, not retention. No file overlap.
- PR #82571 (@Drexuxux) touches the same function for a different defect (the
  turn-boundary anchor landing on synthetic `role="user"` scaffolding). The two
  changes are orthogonal — that one picks `last_user_idx`, this one decides
  which checkpoints survive past it — but they will need a trivial textual
  rebase against each other.
- #71058 (closed) introduced this prune and its blanket exemption; this PR
  narrows it. No supersede is needed: no open PR claims checkpoint retention.


