### PR TITLE
fix(desktop): run /worktree in the session project cwd

### DIFF
--- a/tests/tui_gateway/test_slash_worktree_session_cwd.py
+++ b/tests/tui_gateway/test_slash_worktree_session_cwd.py
@@ -1,0 +1,99 @@
+"""Desktop /worktree must use the session project cwd, not the gateway launch dir.
+
+#102268: slash.exec runs /worktree in a worker spawned with os.getcwd() (the
+gateway process). Desktop sessions carry the project on session['cwd'], so
+the command either refused ('not inside a git repository') or created the
+tree in an unrelated repo, and the live session never moved.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import tui_gateway.server as server
+
+
+def test_slash_worker_cwd_prefers_session_directory(tmp_path):
+    session_cwd = tmp_path / "project"
+    session_cwd.mkdir()
+    assert server._slash_worker_cwd(str(session_cwd)) == str(session_cwd.resolve())
+
+
+def test_slash_worker_cwd_falls_back_when_missing(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    missing = tmp_path / "gone"
+    assert server._slash_worker_cwd(str(missing)) == str(tmp_path)
+
+
+def test_slash_worker_popen_uses_session_cwd(tmp_path):
+    session_cwd = tmp_path / "project"
+    session_cwd.mkdir()
+    with patch.dict("sys.modules", {
+        "hermes_constants": MagicMock(
+            get_hermes_home=MagicMock(return_value=Path("/tmp/hermes_test")),
+        ),
+    }):
+        with patch("subprocess.Popen") as mock_popen:
+            mock_popen.return_value.stdout = MagicMock()
+            mock_popen.return_value.stderr = MagicMock()
+            server._SlashWorker(
+                session_key="test_key",
+                model="test-model",
+                cwd=str(session_cwd),
+            )
+            assert mock_popen.call_args[1]["cwd"] == str(session_cwd.resolve())
+
+
+def test_parse_worktree_ready_path_from_worker_output():
+    output = (
+        "  ✓ Worktree created: /tmp/proj/.worktrees/repro-wt\n"
+        "  Branch: hermes/repro-wt\n"
+        "  Worktree ready: /tmp/proj/.worktrees/repro-wt\n"
+        "  Terminal and file tools now operate in the worktree.\n"
+    )
+    assert server._parse_worktree_ready_path(output) == "/tmp/proj/.worktrees/repro-wt"
+    assert server._parse_worktree_ready_path("nothing here") is None
+
+
+def test_mirror_worktree_new_retargets_session_cwd(tmp_path, monkeypatch):
+    tree = tmp_path / "proj" / ".worktrees" / "repro-wt"
+    tree.mkdir(parents=True)
+    session = {
+        "cwd": str(tmp_path / "proj"),
+        "session_key": "sess-1",
+        "agent": None,
+    }
+    emitted = []
+
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+    monkeypatch.setattr(server, "_git_branch_for_cwd", lambda cwd: "hermes/repro-wt")
+    monkeypatch.setattr(server, "_project_info_for_cwd", lambda cwd: None)
+    monkeypatch.setattr(server, "_register_session_cwd", lambda session: None)
+    monkeypatch.setattr(
+        server, "_persist_session_cwd_and_schedule_git_meta", lambda *a, **k: None
+    )
+    monkeypatch.setattr(server, "cleanup_vm", lambda *a, **k: None, raising=False)
+
+    with patch("tools.terminal_tool.cleanup_vm", lambda *a, **k: None):
+        warning = server._mirror_slash_side_effects(
+            "sid-1",
+            session,
+            "/worktree new repro-wt",
+            output=f"  Worktree ready: {tree}\n",
+        )
+
+    assert warning == ""
+    assert Path(session["cwd"]) == tree.resolve()
+    assert session["explicit_cwd"] is True
+    assert emitted and emitted[0][0] == "session.info"
+
+
+def test_mirror_worktree_list_does_not_move_cwd(tmp_path):
+    session = {"cwd": str(tmp_path), "session_key": "sess-1", "agent": None}
+    warning = server._mirror_slash_side_effects(
+        "sid-1",
+        session,
+        "/worktree list",
+        output="  /tmp/proj  abc123 [main]\n",
+    )
+    assert warning == ""
+    assert session["cwd"] == str(tmp_path)

--- a/tests/tui_gateway/test_slash_worktree_session_cwd.py
+++ b/tests/tui_gateway/test_slash_worktree_session_cwd.py
@@ -35,12 +35,13 @@ def test_slash_worker_popen_uses_session_cwd(tmp_path):
         with patch("subprocess.Popen") as mock_popen:
             mock_popen.return_value.stdout = MagicMock()
             mock_popen.return_value.stderr = MagicMock()
-            server._SlashWorker(
+            worker = server._SlashWorker(
                 session_key="test_key",
                 model="test-model",
                 cwd=str(session_cwd),
             )
             assert mock_popen.call_args[1]["cwd"] == str(session_cwd.resolve())
+            assert worker.cwd == str(session_cwd.resolve())
 
 
 def test_parse_worktree_ready_path_from_worker_output():

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1316,6 +1316,7 @@ def _(rid, params: dict) -> dict:
                         session["session_key"],
                         getattr(session.get("agent"), "model", _resolve_model()),
                         profile_home=session.get("profile_home"),
+                        cwd=_session_cwd(session),
                     )
                     _attach_worker(params.get("session_id", ""), session, worker)
                 except Exception as e:
@@ -1323,7 +1324,9 @@ def _(rid, params: dict) -> dict:
 
     try:
         output = worker.run(cmd)
-        warning = _mirror_slash_side_effects(params.get("session_id", ""), session, cmd)
+        warning = _mirror_slash_side_effects(
+            params.get("session_id", ""), session, cmd, output=output
+        )
         payload = {"output": output or "(no output)"}
         if warning:
             payload["warning"] = warning

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1299,6 +1299,13 @@ def _(rid, params: dict) -> dict:
             return _ok(rid, {"output": f"Plugin command error: {e}"})
 
     worker = session.get("slash_worker")
+    wanted_cwd = _slash_worker_cwd(_session_cwd(session))
+    # A later session.cwd.set (folder tag, workspace.move) does not restart
+    # the persistent worker. Reusing the spawn cwd would create /worktree
+    # in the previous project (#102268 follow-up).
+    if worker is not None and getattr(worker, "cwd", None) != wanted_cwd:
+        _restart_slash_worker(params.get("session_id", ""), session)
+        worker = session.get("slash_worker")
     if not worker:
         # On-demand spawn is now the ONLY spawn path for a fresh session
         # (eager pre-warm removed), and slash.exec handlers run on the RPC

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -480,10 +480,32 @@ def _prepend_tool_paths(env: dict[str, str]) -> dict[str, str]:
     return env
 
 
+def _slash_worker_cwd(cwd: str | None) -> str:
+    """Directory the slash-command worker should inherit.
+
+    Desktop sessions keep their project on ``session['cwd']`` while the
+    gateway process often sits in a launch directory that is not a git
+    repo (or is a different one). ``/worktree`` runs ``git rev-parse`` in
+    the worker's process cwd, so spawning with the gateway's cwd creates
+    the tree in the wrong place — or refuses altogether.
+    """
+    if cwd:
+        resolved = os.path.abspath(os.path.expanduser(str(cwd)))
+        if os.path.isdir(resolved):
+            return resolved
+    return os.getcwd()
+
+
 class _SlashWorker:
     """Persistent HermesCLI subprocess for slash commands."""
 
-    def __init__(self, session_key: str, model: str, profile_home: str | None = None):
+    def __init__(
+        self,
+        session_key: str,
+        model: str,
+        profile_home: str | None = None,
+        cwd: str | None = None,
+    ):
         self._lock = threading.Lock()
         self._seq = 0
         self.stderr_tail: list[str] = []
@@ -543,7 +565,7 @@ class _SlashWorker:
             encoding="utf-8",
             errors="replace",
             bufsize=1,
-            cwd=os.getcwd(),
+            cwd=_slash_worker_cwd(cwd),
             env=env,
             creationflags=windows_hide_flags(),
             start_new_session=True,
@@ -6429,6 +6451,7 @@ def _restart_slash_worker(sid: str, session: dict):
             session["session_key"],
             getattr(session.get("agent"), "model", _resolve_model()),
             profile_home=session.get("profile_home"),
+            cwd=_session_cwd(session),
         )
     except Exception:
         session["slash_worker"] = None
@@ -16870,7 +16893,50 @@ def _live_slash_command_output(sid: str, session: Optional[dict], name: str, arg
 
 
 
-def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
+def _parse_worktree_ready_path(output: str) -> str | None:
+    """Extract the path from a ``/worktree new`` success line.
+
+    The slash worker prints ``Worktree ready: <path>`` after creating the
+    tree. Desktop tools follow ``session['cwd']``, not the worker's
+    ``os.chdir``, so the gateway has to adopt that path.
+    """
+    marker = "Worktree ready:"
+    for line in (output or "").splitlines():
+        stripped = line.strip()
+        if marker in stripped:
+            path = stripped.split(marker, 1)[1].strip()
+            return path or None
+    return None
+
+
+def _mirror_worktree_session_cwd(
+    sid: str, session: dict, arg: str, output: str
+) -> str:
+    """Retarget the live session after a successful ``/worktree new``."""
+    sub = arg.split(None, 1)[0].lower() if arg else ""
+    if sub not in {"new", "add", "create"}:
+        return ""
+    path = _parse_worktree_ready_path(output)
+    if not path:
+        return ""
+    try:
+        cwd = _set_session_cwd(session, path)
+    except ValueError as e:
+        return f"worktree created but session cwd was not updated: {e}"
+    agent = session.get("agent")
+    info = _session_info(agent, session) if agent is not None else {
+        "cwd": cwd,
+        "branch": _git_branch_for_cwd(cwd),
+        "project": _project_info_for_cwd(cwd),
+        "lazy": True,
+    }
+    _emit("session.info", sid, info)
+    return ""
+
+
+def _mirror_slash_side_effects(
+    sid: str, session: dict, command: str, output: str = ""
+) -> str:
     """Apply side effects that must also hit the gateway's live agent."""
     parts = command.lstrip("/").split(None, 1)
     if not parts:
@@ -17029,6 +17095,10 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
             from tools.process_registry import process_registry
 
             process_registry.kill_all()
+        elif name == "worktree":
+            warning = _mirror_worktree_session_cwd(sid, session, arg, output)
+            if warning:
+                return warning
     except Exception as e:
         if name == "compress" and agent:
             from agent.conversation_compression import (

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -570,6 +570,7 @@ class _SlashWorker:
             creationflags=windows_hide_flags(),
             start_new_session=True,
         )
+        self.cwd = _slash_worker_cwd(cwd)
         threading.Thread(target=self._drain_stdout, daemon=True).start()
         threading.Thread(target=self._drain_stderr, daemon=True).start()
 


### PR DESCRIPTION
## What does this PR do?

Desktop `/worktree new` ran inside the slash-command worker, and that worker inherited the **gateway process cwd**. A Desktop session's project lives on `session['cwd']` (folder tag / `session.create`), which is often a different directory than the one `hermes serve` was launched from.

Two failures followed:

1. Gateway launched from a non-repo (or a different repo) → `/worktree new` printed `requires being inside a git repository` or created the tree in the wrong repo.
2. Even on a success, the handler only `os.chdir`'d the worker. File/terminal tools follow the live session cwd, so the chat never moved.

This spawns the slash worker with the session project directory and, after a successful `/worktree new`, adopts `Worktree ready: <path>` as the session workspace (`session.cwd.set` equivalent) and emits `session.info`.

## Related Issue

Fixes #102268

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tui_gateway/server.py` — `_SlashWorker` takes `cwd`; `_mirror_slash_side_effects` retargets the session after `/worktree new`
- `tui_gateway/methods_tools.py` — `slash.exec` passes `_session_cwd(session)` into the worker
- `tests/tui_gateway/test_slash_worktree_session_cwd.py` — worker cwd, parse path, mirror retarget, list no-op

## How to Test

```bash
cd /tmp/hermes-102268
uv run --extra dev python -m pytest tests/tui_gateway/test_slash_worktree_session_cwd.py tests/tui_gateway/test_slash_worker_profile_home.py tests/tui_gateway/test_subprocess_encoding.py tests/hermes_cli/test_worktree_command.py -q
# 20 passed
```

Not runtime-tested against a live Desktop session (no UI session here). The regression is the gateway launch dir vs `session.create` cwd, which the worker Popen + mirror tests cover.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (pytest of the files above)

The full `pytest tests/ -q` suite was not run; only the commands listed in How to Test.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
