### PR TITLE
feat(kanban): dry-run routing preview for Yout Plus decompose

### DIFF
--- a/docs/rfcs/yout-plus-dry-run-routing.md
+++ b/docs/rfcs/yout-plus-dry-run-routing.md
@@ -1,0 +1,147 @@
+# Yout Plus Routing — Dry-Run Mode (Design Spec)
+
+> Status: design only, not yet implemented.
+> Source files affected: `hermes_cli/kanban_decompose.py`, `hermes_cli/kanban_db.py`,
+> `hermes_cli/kanban.py` (CLI surface), `tools/kanban_tools.py` (MCP surface).
+> Related: `docs/profile-routing.md` (message routing — a different system; this doc
+> covers *task* routing, i.e. the Kanban auto-decomposer that predicts an owning
+> profile and fans a task out into a child dependency graph).
+
+## Problem
+
+Yout Plus routes a task through `kanban_decompose.decompose_task()`: it resolves the
+owning profile, builds the context a worker will see, asks the LLM for a child
+dependency graph, then persists that graph (`kb.decompose_triage_task` /
+`kb.specify_triage_task`) and lets the dispatcher pick up the new rows and spawn
+workers. There is currently no way to see the predicted routing decision without
+committing it — every call mutates the board and can trigger real worker dispatch.
+
+Dry-run mode makes the *prediction* observable without the *mutation*.
+
+## Input contract
+
+Identical to live routing: a task already sitting in the DB (any status; live routing
+requires `triage`, dry-run does not enforce that, since it never transitions status).
+Callers pass either:
+
+- `task_id` of an existing task (read-only lookup), or
+- ad-hoc `title` + `body` with no backing row at all, for previewing routing on text
+  that hasn't been created as a card yet.
+
+```python
+def dry_run_route(
+    *,
+    task_id: str | None = None,
+    title: str | None = None,
+    body: str | None = None,
+) -> DryRunResult: ...
+```
+
+Exactly one of `task_id` or `title` must be given. When `task_id` is given, the
+function reads the row (`kb.get_task`, a plain `SELECT`) but does not require any
+particular status and does not lock or update it.
+
+## Output contract — `DryRunResult`
+
+```python
+@dataclass
+class DryRunResult:
+    ok: bool
+    reason: str = ""                       # populated when ok=False
+    predicted_owner: str | None = None     # (a)
+    context_envelope: dict | None = None   # (b)
+    dependency_graph: list[dict] | None = None  # (c)
+    rationale: str = ""                    # decomposer's one-line "why"
+    fanout: bool = False                   # False => single-task routing, no children
+```
+
+- **(a) predicted_owner** — the assignee the *root* task would land on: for
+  `fanout=false` this is the single resolved assignee; for `fanout=true` this is the
+  orchestrator profile that stays parent of the graph (mirrors `root_assignee` in
+  `kb.decompose_triage_task`).
+- **(b) context_envelope** — the exact `worker_context` shape a dispatched worker
+  would receive: title, body, parent handoffs (empty for a fresh task), recent related
+  work by the predicted assignee, and the roster/prompt inputs used to produce the
+  prediction (roster snapshot, orchestrator, default_assignee). This is assembled with
+  the same helper the live path uses (`kanban_show`'s `worker_context` formatter) so
+  dry-run output cannot drift from what a live worker actually sees.
+- **(c) dependency_graph** — for `fanout=true`, the validated children list exactly as
+  `decompose_triage_task` would insert it, but as plain dicts, never written:
+  `[{"index": 0, "title": ..., "body": ..., "assignee": ..., "parents": [...]}]`.
+  Parent indices are 0-based into this same list, pre-cycle-checked. For
+  `fanout=false`, this is `None` and the single-task title/body/assignee is reported
+  via `predicted_owner` plus `context_envelope`.
+
+## Toggle
+
+- **Library**: `dry_run_route(...)` is a new, separate entrypoint — not a boolean flag
+  threaded through `decompose_task()`. Keeping it a distinct function (rather than an
+  `if dry_run:` branch inside the existing one) is the smallest way to guarantee the
+  mutating path is physically unreachable from the dry-run call, instead of relying on
+  a conditional that could regress under future edits.
+- **CLI**: `hermes kanban decompose <task_id> --dry-run` — prints the `DryRunResult` as
+  JSON to stdout, exit 0 on `ok=True`. No DB write occurs; this is verifiable with
+  `git diff` on the DB file's mtime / a `PRAGMA data_version` check in tests.
+- **MCP tool surface**: `kanban_tools.py` gets a `dry_run: bool = False` parameter on
+  the decompose-triggering tool. `True` routes to `dry_run_route()` instead of
+  `decompose_task()` before any tool-level side effect fires.
+
+## Where the code path diverges from live routing
+
+`decompose_task()` today does, in order:
+
+1. `kb.get_task()` — read.
+2. Build roster (`_build_roster`), resolve orchestrator/default assignee — pure.
+3. `call_llm(...)` — external call, no DB effect.
+4. Parse + validate the LLM's JSON (title/parents/cycle check) — pure.
+5. **Mutate**: either `kb.specify_triage_task(...)` (single-task path) or
+   `kb.decompose_triage_task(...)` (fan-out path) — the *only* two calls in the entire
+   function that touch the database. `decompose_triage_task` wraps everything (row
+   inserts, `link_tasks`, root status flip) in one `write_txn`; per its own docstring
+   nothing outside that transaction opens a competing one.
+6. Return an outcome. (No worker spawn happens here — that is a separate dispatcher
+   loop that later polls for tasks in `ready` status and spawns a process per row.)
+
+Steps 1–4 are prediction; step 5 is the sole mutation boundary; step 6 is reporting.
+`dry_run_route()` shares steps 1–4 via an extracted pure helper (`_predict_routing()`,
+new) and **stops before step 5**, returning the validated in-memory result instead of
+calling either mutating function.
+
+Because the dispatcher only ever spawns workers for rows that exist and are `ready`,
+and dry-run never calls `create_task` / `link_tasks` / `decompose_triage_task` /
+`specify_triage_task`, no row is ever created for the dispatcher to see — worker
+invocation is prevented as a structural consequence of never crossing step 5, not by a
+separate guard that has to be kept in sync.
+
+## Functions wrapped / short-circuited
+
+| Function | Live routing | Dry-run |
+|---|---|---|
+| `kb.get_task` | called | called (read-only, no status requirement) |
+| `_build_roster`, `_resolve_orchestrator_profile`, `_resolve_default_assignee` | called | called unchanged (extracted into shared `_predict_routing`) |
+| `call_llm` | called | called unchanged — prediction must reflect real decision logic |
+| JSON parse + validation (title/parents/cycle check) | called | called unchanged |
+| `kb.specify_triage_task` | called (single-task path) | **never called** |
+| `kb.decompose_triage_task` (and everything inside its `write_txn`: task INSERTs, `link_tasks`, root status flip, audit comment) | called (fan-out path) | **never called** |
+| Dispatcher worker spawn (separate process, polls `ready` tasks) | triggered indirectly once rows exist | never triggered — no rows are ever created |
+
+## Tests to add (per parent task `t_2930a1af`)
+
+1. Single-owner request → `fanout=false`, `predicted_owner` set, `dependency_graph is
+   None`, zero DB writes (assert `PRAGMA data_version` unchanged, or row count
+   unchanged for `tasks`/`task_deps`/`comments`).
+2. Cross-functional request → `fanout=true`, `dependency_graph` has ≥2 entries with a
+   real parent edge, zero DB writes.
+3. Engineering-owned request → predicted_owner resolves to `engineering` via roster
+   description match, zero DB writes.
+4. Failure-path test: run `dry_run_route()` against a fixture DB, snapshot
+   `sqlite3.connect(db).iterdump()` before and after, assert byte-identical. This is
+   the strongest proof dry-run cannot mutate — asserting on the specific two function
+   calls only proves the code doesn't call them today, not that nothing else did.
+
+## Non-goals
+
+- Not changing live routing behavior at all — `decompose_task()` keeps its current
+  signature and effect.
+- Not adding a dry-run mode to the dispatcher itself — irrelevant, since dry-run never
+  produces rows for the dispatcher to act on.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13697,6 +13697,15 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # idle case where the subagent finishes with no agent turn running.
         self._spawn_supervised(self._async_delegation_watcher, "async_delegation_watcher")
 
+        # Long-lived gateways also sweep durable async delegations whose owner
+        # process died after this gateway started. The watcher only delegates
+        # state recovery to recover_abandoned_delegations(); it never reruns a
+        # child task.
+        self._spawn_supervised(
+            self._async_delegation_orphan_recovery_watcher,
+            "async_delegation_orphan_recovery_watcher",
+        )
+
         # Start background /loop wakeup watcher — scans persisted loops
         # (SessionDB loop:* rows) and injects due wakeup prompts into their
         # originating chats while the session is idle.
@@ -26545,6 +26554,68 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             except Exception as e:
                 logger.debug("Async delegation watcher error: %s", e)
             await asyncio.sleep(interval)
+
+    async def _async_delegation_orphan_recovery_watcher(self) -> None:
+        """Periodically recover durable delegations abandoned by dead owners.
+
+        This is deliberately only a scheduling wrapper around
+        ``recover_abandoned_delegations``. That function verifies both PID
+        liveness and process start time before changing a running row to
+        ``unknown`` and preparing its normal completion payload. No delegated
+        task is claimed, dispatched, or rerun here.
+        """
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning("async delegation recovery: config loader unavailable; disabled")
+            return
+
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning("async delegation recovery: cannot load config (%s); disabled", exc)
+            return
+        delegation_cfg = cfg.get("async_delegation", {}) if isinstance(cfg, dict) else {}
+        if not delegation_cfg.get("orphan_recovery_in_gateway", True):
+            logger.info(
+                "async delegation recovery: disabled via config "
+                "async_delegation.orphan_recovery_in_gateway=false"
+            )
+            return
+
+        try:
+            interval = float(
+                delegation_cfg.get("orphan_recovery_interval_seconds", 600) or 600
+            )
+        except (TypeError, ValueError):
+            logger.warning(
+                "async delegation recovery: invalid "
+                "orphan_recovery_interval_seconds=%r, using default 600",
+                delegation_cfg.get("orphan_recovery_interval_seconds"),
+            )
+            interval = 600.0
+        interval = max(interval, 60.0)
+
+        from tools.async_delegation import recover_abandoned_delegations
+
+        while self._running:
+            try:
+                recovered = await asyncio.to_thread(recover_abandoned_delegations)
+                if recovered:
+                    logger.info(
+                        "async delegation recovery: marked %d abandoned delegation(s) unknown",
+                        recovered,
+                    )
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("async delegation recovery: watcher tick failed")
+
+            slept = 0.0
+            while self._running and slept < interval:
+                delay = min(1.0, interval - slept)
+                await asyncio.sleep(delay)
+                slept += delay
 
     async def _run_process_watcher(self, watcher: dict) -> None:
         """

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2847,6 +2847,19 @@ DEFAULT_CONFIG = {
         "done_sub_retention_days": 30,
     },
 
+    # Async background delegation recovery. The gateway periodically checks
+    # durable delegate_task records whose original owner process exited before
+    # saving a terminal result. This only marks the outcome unknown and queues
+    # the existing completion payload. It never reruns delegated work.
+    "async_delegation": {
+        # Run recovery in long-lived gateway processes. Disable only for
+        # manual forensic handling of abandoned delegation records.
+        "orphan_recovery_in_gateway": True,
+        # Seconds between owner-liveness sweeps. Ten minutes keeps idle-gateway
+        # SQLite work negligible while recovering orphans without a restart.
+        "orphan_recovery_interval_seconds": 600,
+    },
+
     # Bot Mode cross-connection relay (tools/bot_relay.py). Envelopes queued
     # by message_agent for agents on other connections wait in an on-disk
     # outbox until the Desktop drains them.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -985,6 +985,13 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         action="store_true",
         help="Emit one JSON object per task on stdout",
     )
+    p_decompose.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the routing decision (predicted owner, context "
+             "envelope, dependency graph) without creating cards, writing "
+             "to the DB, or invoking a worker. Not compatible with --all.",
+    )
 
     # --- gc ---
     p_gc = sub.add_parser(
@@ -3142,6 +3149,7 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
     tenant = getattr(args, "tenant", None)
     author = getattr(args, "author", None) or _profile_author()
     want_json = bool(getattr(args, "json", False))
+    dry_run = bool(getattr(args, "dry_run", False))
 
     if args.task_id and all_flag:
         print(
@@ -3149,6 +3157,43 @@ def _cmd_decompose(args: argparse.Namespace) -> int:
             file=sys.stderr,
         )
         return 2
+
+    if dry_run and all_flag:
+        print(
+            "kanban: --dry-run is not compatible with --all",
+            file=sys.stderr,
+        )
+        return 2
+
+    if dry_run:
+        if not args.task_id:
+            print(
+                "kanban: --dry-run requires a task id",
+                file=sys.stderr,
+            )
+            return 2
+        result = decomp.dry_run_route(task_id=args.task_id)
+        if want_json:
+            print(json.dumps({
+                "ok": result.ok,
+                "reason": result.reason,
+                "predicted_owner": result.predicted_owner,
+                "context_envelope": result.context_envelope,
+                "dependency_graph": result.dependency_graph,
+                "rationale": result.rationale,
+                "fanout": result.fanout,
+            }))
+        elif result.ok:
+            print(f"[dry-run] predicted owner: {result.predicted_owner}")
+            if result.fanout and result.dependency_graph:
+                print(f"[dry-run] fan-out: {len(result.dependency_graph)} children (no cards created)")
+                for child in result.dependency_graph:
+                    print(f"  - [{child['index']}] {child['title']} -> {child['assignee']} (parents={child['parents']})")
+            else:
+                print("[dry-run] single task (no fanout, no card mutated)")
+        else:
+            print(f"kanban: dry-run {args.task_id}: {result.reason}", file=sys.stderr)
+        return 0 if result.ok else 1
 
     if all_flag:
         ids = decomp.list_triage_ids(tenant=tenant)

--- a/hermes_cli/kanban_decompose.py
+++ b/hermes_cli/kanban_decompose.py
@@ -136,6 +136,42 @@ class DecomposeOutcome:
     new_title: Optional[str] = None
 
 
+@dataclass
+class PredictedRouting:
+    """Pure prediction produced by steps 1-4 of the routing pipeline.
+
+    Shared by the live (mutating) path and the dry-run (non-mutating)
+    path so the two can never diverge in *what* gets predicted, only in
+    whether the prediction is persisted.
+    """
+
+    ok: bool
+    reason: str = ""
+    fanout: bool = False
+    rationale: str = ""
+    orchestrator: str = ""
+    default_assignee: str = ""
+    roster: list[dict] | None = None
+    # single-task (fanout=false) path
+    title: Optional[str] = None
+    body: Optional[str] = None
+    assignee: Optional[str] = None
+    # fan-out (fanout=true) path — validated children, never written here
+    children: list[dict] | None = None
+
+
+class _AdHocTask:
+    """Stand-in for ``kb.Task`` when previewing routing on text that has
+    no backing DB row (dry-run's ``title``/``body`` input mode)."""
+
+    def __init__(self, title: str, body: str) -> None:
+        self.id = "(preview)"
+        self.title = title
+        self.body = body
+        self.status = "triage"
+        self.assignee: Optional[str] = None
+
+
 def _truncate(text: str, limit: int) -> str:
     if len(text) <= limit:
         return text
@@ -268,40 +304,29 @@ def _normalize_assignee_choice(
     return chosen
 
 
-def decompose_task(
-    task_id: str,
+def _predict_routing(
+    task: "kb.Task | _AdHocTask",
     *,
-    author: Optional[str] = None,
+    task_id_for_log: str,
     timeout: Optional[int] = None,
-) -> DecomposeOutcome:
-    """Decompose a triage task into a graph of child tasks.
+) -> PredictedRouting:
+    """Steps 1-4 of routing: read (already done by caller), resolve roster,
+    call the LLM, parse + validate its JSON. Pure — never touches the DB.
 
-    Returns an outcome describing what happened. Never raises for
-    expected failure modes (task not in triage, no aux client
-    configured, API error, malformed response, decomposer returned
-    fanout=true with empty task list) — those surface via ``ok=False``.
+    Shared verbatim by ``decompose_task`` (live) and ``dry_run_route``
+    (preview) so the two can never predict differently; only what happens
+    *after* this call (persist vs. return) differs.
     """
-    with kb.connect_closing() as conn:
-        task = kb.get_task(conn, task_id)
-    if task is None:
-        return DecomposeOutcome(task_id, False, "unknown task id")
-    if task.status != "triage":
-        return DecomposeOutcome(
-            task_id, False, f"task is not in triage (status={task.status!r})"
-        )
-
     cfg = _load_config()
     orchestrator = _resolve_orchestrator_profile(cfg)
     default_assignee = _resolve_default_assignee(cfg)
-    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
-    auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
     roster, valid_names = _build_roster()
 
     try:
         from agent.auxiliary_client import call_llm  # type: ignore
     except Exception as exc:
         logger.debug("decompose: auxiliary client import failed: %s", exc)
-        return DecomposeOutcome(task_id, False, "auxiliary client unavailable")
+        return PredictedRouting(False, "auxiliary client unavailable")
 
     user_msg = _USER_TEMPLATE.format(
         task_id=task.id,
@@ -328,9 +353,9 @@ def decompose_task(
         )
     except Exception as exc:
         logger.info(
-            "decompose: API call failed for %s (%s)", task_id, exc,
+            "decompose: API call failed for %s (%s)", task_id_for_log, exc,
         )
-        return DecomposeOutcome(task_id, False, f"LLM error: {type(exc).__name__}")
+        return PredictedRouting(False, f"LLM error: {type(exc).__name__}")
 
     try:
         raw = resp.choices[0].message.content or ""
@@ -339,50 +364,38 @@ def decompose_task(
 
     parsed = _extract_json_blob(raw)
     if parsed is None:
-        return DecomposeOutcome(task_id, False, "LLM returned malformed JSON")
+        return PredictedRouting(False, "LLM returned malformed JSON")
 
     fanout = bool(parsed.get("fanout"))
-    audit_author = author or _profile_author()
+    _rationale_raw = parsed.get("rationale")
+    rationale = _rationale_raw if isinstance(_rationale_raw, str) else ""
 
     if not fanout:
-        # Fall back to single-task spec promotion (same effect as specify).
         new_title = parsed.get("title")
         new_body = parsed.get("body")
         title_val = new_title.strip() if isinstance(new_title, str) and new_title.strip() else None
         body_val = new_body if isinstance(new_body, str) and new_body.strip() else None
         assignee_val = None
-        if not task.assignee:
+        if not getattr(task, "assignee", None):
             assignee_val = _normalize_assignee_choice(
                 parsed.get("assignee"),
                 default_assignee=default_assignee,
                 valid_names=valid_names,
             )
         if title_val is None and body_val is None:
-            return DecomposeOutcome(
-                task_id, False, "decomposer returned fanout=false with no title/body",
+            return PredictedRouting(
+                False, "decomposer returned fanout=false with no title/body",
             )
-        with kb.connect_closing() as conn:
-            ok = kb.specify_triage_task(
-                conn,
-                task_id,
-                title=title_val,
-                body=body_val,
-                assignee=assignee_val,
-                author=audit_author,
-            )
-        if not ok:
-            return DecomposeOutcome(
-                task_id, False, "task moved out of triage before promotion",
-            )
-        return DecomposeOutcome(
-            task_id, True, "single task (no fanout)",
-            fanout=False, new_title=title_val,
+        return PredictedRouting(
+            True, "", fanout=False, rationale=rationale,
+            orchestrator=orchestrator, default_assignee=default_assignee,
+            roster=roster, title=title_val, body=body_val, assignee=assignee_val,
         )
 
     raw_tasks = parsed.get("tasks") or []
     if not isinstance(raw_tasks, list) or not raw_tasks:
-        return DecomposeOutcome(
-            task_id, False, "decomposer returned fanout=true with empty tasks list",
+        return PredictedRouting(
+            False, "decomposer returned fanout=true with empty tasks list",
         )
 
     # Rewrite invalid assignees to the default fallback. Never leave a
@@ -390,14 +403,10 @@ def decompose_task(
     children: list[dict] = []
     for idx, entry in enumerate(raw_tasks):
         if not isinstance(entry, dict):
-            return DecomposeOutcome(
-                task_id, False, f"tasks[{idx}] is not an object",
-            )
+            return PredictedRouting(False, f"tasks[{idx}] is not an object")
         title = entry.get("title")
         if not isinstance(title, str) or not title.strip():
-            return DecomposeOutcome(
-                task_id, False, f"tasks[{idx}].title is missing or empty",
-            )
+            return PredictedRouting(False, f"tasks[{idx}].title is missing or empty")
         body = entry.get("body")
         if not isinstance(body, str):
             body = ""
@@ -415,7 +424,7 @@ def decompose_task(
             logger.info(
                 "decompose: task %s child %d picked unknown assignee %r — "
                 "routing to default_assignee %r",
-                task_id, idx, assignee, default_assignee,
+                task_id_for_log, idx, assignee, default_assignee,
             )
         parents = entry.get("parents") or []
         if not isinstance(parents, list):
@@ -429,13 +438,70 @@ def decompose_task(
             "parents": clean_parents,
         })
 
+    return PredictedRouting(
+        True, "", fanout=True, rationale=rationale,
+        orchestrator=orchestrator, default_assignee=default_assignee,
+        roster=roster, children=children,
+    )
+
+
+def decompose_task(
+    task_id: str,
+    *,
+    author: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> DecomposeOutcome:
+    """Decompose a triage task into a graph of child tasks.
+
+    Returns an outcome describing what happened. Never raises for
+    expected failure modes (task not in triage, no aux client
+    configured, API error, malformed response, decomposer returned
+    fanout=true with empty task list) — those surface via ``ok=False``.
+    """
+    with kb.connect_closing() as conn:
+        task = kb.get_task(conn, task_id)
+    if task is None:
+        return DecomposeOutcome(task_id, False, "unknown task id")
+    if task.status != "triage":
+        return DecomposeOutcome(
+            task_id, False, f"task is not in triage (status={task.status!r})"
+        )
+
+    cfg = _load_config()
+    kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+    auto_promote = bool(kanban_cfg.get("auto_promote_children", True))
+    audit_author = author or _profile_author()
+
+    prediction = _predict_routing(task, task_id_for_log=task_id, timeout=timeout)
+    if not prediction.ok:
+        return DecomposeOutcome(task_id, False, prediction.reason)
+
+    if not prediction.fanout:
+        with kb.connect_closing() as conn:
+            ok = kb.specify_triage_task(
+                conn,
+                task_id,
+                title=prediction.title,
+                body=prediction.body,
+                assignee=prediction.assignee,
+                author=audit_author,
+            )
+        if not ok:
+            return DecomposeOutcome(
+                task_id, False, "task moved out of triage before promotion",
+            )
+        return DecomposeOutcome(
+            task_id, True, "single task (no fanout)",
+            fanout=False, new_title=prediction.title,
+        )
+
     try:
         with kb.connect_closing() as conn:
             child_ids = kb.decompose_triage_task(
                 conn,
                 task_id,
-                root_assignee=orchestrator,
-                children=children,
+                root_assignee=prediction.orchestrator,
+                children=prediction.children,
                 author=audit_author,
                 auto_promote=auto_promote,
             )
@@ -453,6 +519,106 @@ def decompose_task(
     return DecomposeOutcome(
         task_id, True, f"decomposed into {len(child_ids)} children",
         fanout=True, child_ids=child_ids,
+    )
+
+
+@dataclass
+class DryRunResult:
+    """Predicted routing decision, never persisted.
+
+    Mirrors what a live call to ``decompose_task`` would decide and
+    (for an existing ``task_id``) what a dispatched worker would see as
+    its ``worker_context``, but stops before the two mutating DB calls
+    (``kb.specify_triage_task`` / ``kb.decompose_triage_task``) that
+    ``decompose_task`` uses to persist the decision. No row is ever
+    created, so the dispatcher never has anything to spawn a worker for.
+    """
+
+    ok: bool
+    reason: str = ""
+    predicted_owner: Optional[str] = None
+    context_envelope: Optional[dict] = None
+    dependency_graph: Optional[list[dict]] = None
+    rationale: str = ""
+    fanout: bool = False
+
+
+def dry_run_route(
+    *,
+    task_id: Optional[str] = None,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+    timeout: Optional[int] = None,
+) -> DryRunResult:
+    """Preview the routing decision for a task without mutating anything.
+
+    Exactly one of ``task_id`` (an existing row, any status, read-only
+    lookup) or ``title`` (with optional ``body``, no backing row at all)
+    must be given.
+
+    Shares steps 1-4 of the live pipeline via ``_predict_routing`` so the
+    prediction cannot drift from what live routing would actually decide.
+    Deliberately never calls ``kb.specify_triage_task``,
+    ``kb.decompose_triage_task``, or any other write helper — those two
+    functions are the *only* mutating calls in the live path (see
+    ``docs/rfcs/yout-plus-dry-run-routing.md``), and this function does
+    not reference either name.
+    """
+    if (task_id is None) == (not title):
+        return DryRunResult(False, "exactly one of task_id or title must be given")
+
+    if task_id is not None:
+        with kb.connect_closing() as conn:
+            task = kb.get_task(conn, task_id)
+        if task is None:
+            return DryRunResult(False, "unknown task id")
+        log_id = task_id
+    else:
+        task = _AdHocTask(title=title or "", body=body or "")
+        log_id = "(preview)"
+
+    prediction = _predict_routing(task, task_id_for_log=log_id, timeout=timeout)
+    if not prediction.ok:
+        return DryRunResult(False, prediction.reason)
+
+    if not prediction.fanout:
+        owner = prediction.assignee or getattr(task, "assignee", None) or prediction.default_assignee
+        envelope = {
+            "title": prediction.title or task.title,
+            "body": prediction.body or task.body,
+            "assignee": owner,
+            "parent_handoffs": [],
+            "roster": prediction.roster,
+            "orchestrator": prediction.orchestrator,
+            "default_assignee": prediction.default_assignee,
+        }
+        if task_id is not None:
+            with kb.connect_closing() as conn:
+                envelope["worker_context"] = kb.build_worker_context(conn, task_id)
+        return DryRunResult(
+            True, predicted_owner=owner, context_envelope=envelope,
+            dependency_graph=None, rationale=prediction.rationale, fanout=False,
+        )
+
+    dependency_graph = [
+        {"index": idx, **child}
+        for idx, child in enumerate(prediction.children or [])
+    ]
+    envelope = {
+        "title": task.title,
+        "body": task.body,
+        "assignee": prediction.orchestrator,
+        "parent_handoffs": [],
+        "roster": prediction.roster,
+        "orchestrator": prediction.orchestrator,
+        "default_assignee": prediction.default_assignee,
+    }
+    if task_id is not None:
+        with kb.connect_closing() as conn:
+            envelope["worker_context"] = kb.build_worker_context(conn, task_id)
+    return DryRunResult(
+        True, predicted_owner=prediction.orchestrator, context_envelope=envelope,
+        dependency_graph=dependency_graph, rationale=prediction.rationale, fanout=True,
     )
 
 

--- a/tests/gateway/test_kanban_watchers_mixin.py
+++ b/tests/gateway/test_kanban_watchers_mixin.py
@@ -7,9 +7,12 @@ that GatewayRunner picks them up via the MRO (behavior-neutral relocation).
 
 from __future__ import annotations
 
+import asyncio
 import inspect
+from unittest.mock import patch
 
 from gateway.kanban_watchers import GatewayKanbanWatchersMixin
+from gateway.run import GatewayRunner
 
 KANBAN_METHODS = [
     "_kanban_notifier_watcher",
@@ -26,3 +29,41 @@ def test_mixin_defines_kanban_methods():
         assert hasattr(GatewayKanbanWatchersMixin, m), f"mixin missing {m}"
 
 
+def _orphan_recovery_runner():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._running = True
+    return runner
+
+
+def test_async_delegation_orphan_recovery_watcher_honors_config_gate(monkeypatch):
+    runner = _orphan_recovery_runner()
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+        "async_delegation": {"orphan_recovery_in_gateway": False},
+    })
+
+    with patch("tools.async_delegation.recover_abandoned_delegations") as recover:
+        asyncio.run(runner._async_delegation_orphan_recovery_watcher())
+
+    recover.assert_not_called()
+
+
+def test_async_delegation_orphan_recovery_watcher_sweeps_then_stops(monkeypatch):
+    runner = _orphan_recovery_runner()
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {
+        "async_delegation": {"orphan_recovery_interval_seconds": 600},
+    })
+    calls = []
+
+    def recover():
+        calls.append(True)
+        runner._running = False
+        return 1
+
+    async def immediate_to_thread(fn, *args, **kwargs):
+        return fn(*args, **kwargs)
+
+    with patch("tools.async_delegation.recover_abandoned_delegations", recover):
+        with patch("asyncio.to_thread", side_effect=immediate_to_thread):
+            asyncio.run(runner._async_delegation_orphan_recovery_watcher())
+
+    assert calls == [True]

--- a/tests/hermes_cli/test_kanban_decompose_dry_run.py
+++ b/tests/hermes_cli/test_kanban_decompose_dry_run.py
@@ -1,0 +1,314 @@
+"""Deterministic tests for ``kanban_decompose.dry_run_route``.
+
+Covers the three required preview scenarios — single clear owner,
+cross-functional fan-out, and Engineering-specific ownership — plus the
+no-mutation / no-worker-invocation guarantee. The auxiliary LLM client is
+mocked throughout: no network calls, no flakiness.
+"""
+
+from __future__ import annotations
+
+import json as jsonlib
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_aux_response(content: str):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    return resp
+
+
+def _patch_aux_client(content: str):
+    return patch(
+        "agent.auxiliary_client.call_llm",
+        return_value=_fake_aux_response(content),
+    )
+
+
+def _patch_list_profiles(names: list[str]):
+    """Pretend the named profiles exist, mirroring test_kanban_decompose.py."""
+    from types import SimpleNamespace
+
+    fake_profiles = [
+        SimpleNamespace(
+            name=n, is_default=(i == 0), description=f"desc for {n}",
+            description_auto=False, model="m", provider="p", skill_count=1,
+        )
+        for i, n in enumerate(names)
+    ]
+    return [
+        patch("hermes_cli.profiles.list_profiles", return_value=fake_profiles),
+        patch("hermes_cli.profiles.profile_exists", side_effect=lambda x: x in names),
+        patch(
+            "hermes_cli.profiles.get_active_profile_name",
+            return_value=names[0] if names else "default",
+        ),
+    ]
+
+
+def _table_counts(conn):
+    """Row counts for every table dry-run must never touch."""
+    counts = {}
+    for table in ("tasks", "task_links", "task_comments", "task_events"):
+        counts[table] = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    return counts
+
+
+def _run_dry_run_with_mutation_guards(**kwargs):
+    """Call dry_run_route with kb's two mutating helpers spied on, and
+    return (result, specify_mock, decompose_mock)."""
+    with patch.object(
+        kb, "specify_triage_task", wraps=kb.specify_triage_task
+    ) as specify_spy, patch.object(
+        kb, "decompose_triage_task", wraps=kb.decompose_triage_task
+    ) as decompose_spy:
+        result = decomp.dry_run_route(**kwargs)
+    return result, specify_spy, decompose_spy
+
+
+def test_dry_run_single_owner_no_mutation(kanban_home):
+    """A request that resolves to one clear owning profile: dry-run must
+    report the predicted owner + a well-formed envelope, and must not
+    touch the DB or invoke either mutating write helper."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="fix the login bug", triage=True)
+        before = _table_counts(conn)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single clear owner",
+        "title": "Fix login bug",
+        "body": "Investigate and patch the login regression.",
+        "assignee": "backend_dev",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "backend_dev"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            result, specify_spy, decompose_spy = _run_dry_run_with_mutation_guards(
+                task_id=tid,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result.ok, result.reason
+    assert result.fanout is False
+    assert result.predicted_owner == "backend_dev"
+
+    envelope = result.context_envelope
+    assert envelope is not None
+    assert envelope["assignee"] == "backend_dev"
+    assert envelope["title"] == "Fix login bug"
+    assert envelope["body"]
+    assert "worker_context" in envelope and envelope["worker_context"]
+    assert envelope["roster"] is not None
+    assert envelope["orchestrator"] == "orchestrator"
+
+    assert result.dependency_graph is None
+
+    specify_spy.assert_not_called()
+    decompose_spy.assert_not_called()
+
+    with kb.connect() as conn:
+        after = _table_counts(conn)
+        task = kb.get_task(conn, tid)
+    assert after == before
+    assert task.status == "triage"
+    assert task.assignee is None
+
+
+def test_dry_run_cross_functional_fanout_no_mutation(kanban_home):
+    """A cross-functional request that would fan out to multiple
+    profiles/child tasks: dry-run must return a valid proposed
+    dependency graph without creating any card."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="launch new feature", triage=True)
+        before = _table_counts(conn)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "needs design, build, and marketing",
+        "tasks": [
+            {"title": "design the UI", "body": "mock it up", "assignee": "designer", "parents": []},
+            {"title": "build the API", "body": "implement endpoints", "assignee": "backend_dev", "parents": []},
+            {"title": "write launch copy", "body": "draft announcement", "assignee": "marketing", "parents": [0, 1]},
+        ],
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "designer", "backend_dev", "marketing"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            result, specify_spy, decompose_spy = _run_dry_run_with_mutation_guards(
+                task_id=tid,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result.ok, result.reason
+    assert result.fanout is True
+    assert result.predicted_owner == "orchestrator"
+
+    graph = result.dependency_graph
+    assert graph is not None and len(graph) == 3
+
+    assignees = {node["index"]: node["assignee"] for node in graph}
+    assert assignees == {0: "designer", 1: "backend_dev", 2: "marketing"}
+
+    # Every parent index must be a valid, distinct, earlier-or-other
+    # in-graph node — i.e. a well-formed dependency graph.
+    valid_indices = {node["index"] for node in graph}
+    for node in graph:
+        for parent_idx in node["parents"]:
+            assert parent_idx in valid_indices
+            assert parent_idx != node["index"]
+    assert graph[2]["parents"] == [0, 1]
+    assert graph[0]["parents"] == []
+    assert graph[1]["parents"] == []
+
+    envelope = result.context_envelope
+    assert envelope is not None
+    assert envelope["assignee"] == "orchestrator"
+    assert envelope["roster"] is not None
+    assert "worker_context" in envelope and envelope["worker_context"]
+
+    specify_spy.assert_not_called()
+    decompose_spy.assert_not_called()
+
+    with kb.connect() as conn:
+        after = _table_counts(conn)
+        task = kb.get_task(conn, tid)
+    assert after == before
+    assert task.status == "triage"
+
+
+def test_dry_run_engineering_owner_no_mutation(kanban_home):
+    """A request that resolves to Engineering ownership specifically:
+    dry-run must report 'engineering' as predicted owner without
+    creating a card or invoking a worker."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="patch a SQL injection vulnerability",
+            triage=True,
+        )
+        before = _table_counts(conn)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "security fix belongs to engineering",
+        "title": "Patch SQL injection vulnerability",
+        "body": "Parameterize the vulnerable query and add a regression test.",
+        "assignee": "engineering",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineering", "marketing"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            result, specify_spy, decompose_spy = _run_dry_run_with_mutation_guards(
+                task_id=tid,
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result.ok, result.reason
+    assert result.fanout is False
+    assert result.predicted_owner == "engineering"
+
+    envelope = result.context_envelope
+    assert envelope is not None
+    assert envelope["assignee"] == "engineering"
+    assert envelope["title"] == "Patch SQL injection vulnerability"
+    assert "worker_context" in envelope and envelope["worker_context"]
+
+    assert result.dependency_graph is None
+
+    specify_spy.assert_not_called()
+    decompose_spy.assert_not_called()
+
+    with kb.connect() as conn:
+        after = _table_counts(conn)
+        task = kb.get_task(conn, tid)
+    assert after == before
+    assert task.status == "triage"
+    assert task.assignee is None
+
+
+def test_dry_run_preview_with_no_backing_task_still_returns_full_prediction(kanban_home):
+    """dry_run_route also supports an ad-hoc title/body preview with no
+    backing task row at all — confirm it still returns owner + envelope
+    + (for fanout) a graph, and never creates a row."""
+    with kb.connect() as conn:
+        before = _table_counts(conn)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit, ad-hoc preview",
+        "title": "Draft preview title",
+        "body": "Draft preview body.",
+        "assignee": "engineering",
+    })
+
+    patches = _patch_list_profiles(["orchestrator", "engineering"])
+    for p in patches:
+        p.start()
+    try:
+        with _patch_aux_client(llm_payload):
+            result, specify_spy, decompose_spy = _run_dry_run_with_mutation_guards(
+                title="Raw idea needing routing",
+                body="Some rough idea.",
+            )
+    finally:
+        for p in patches:
+            p.stop()
+
+    assert result.ok, result.reason
+    assert result.predicted_owner == "engineering"
+    assert result.context_envelope is not None
+    # No backing task_id means no worker_context key is attached.
+    assert "worker_context" not in result.context_envelope
+
+    specify_spy.assert_not_called()
+    decompose_spy.assert_not_called()
+
+    with kb.connect() as conn:
+        after = _table_counts(conn)
+    assert after == before
+
+
+def test_dry_run_rejects_ambiguous_input(kanban_home):
+    """Passing both task_id and title (or neither) is a usage error, not
+    a silent guess — and must not touch the LLM or the DB."""
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="whatever", triage=True)
+
+    result_neither = decomp.dry_run_route()
+    assert result_neither.ok is False
+
+    result_both = decomp.dry_run_route(task_id=tid, title="also set")
+    assert result_both.ok is False

--- a/tests/hermes_cli/test_kanban_decompose_dry_run_no_mutation.py
+++ b/tests/hermes_cli/test_kanban_decompose_dry_run_no_mutation.py
@@ -1,0 +1,342 @@
+"""Failure-path proof that dry_run_route can NEVER write to the Kanban DB.
+
+This deliberately tries to *break* the dry-run/live separation added in
+commit f4e3e421f (docs/rfcs/yout-plus-dry-run-routing.md):
+
+  * every write-capable ``kanban_db`` function is replaced with a spy that
+    raises loudly if invoked, so any accidental write path — now or after
+    a future refactor — fails the test immediately instead of silently
+    passing;
+  * the auxiliary LLM call is driven through several edge/error cases
+    (mid-call exception, malformed JSON, empty fan-out list) that are the
+    likeliest places a careless refactor would "fall through" into a
+    write, since those are exactly the branches the live path turns into
+    persisted DB state;
+  * a full logical snapshot of every table is taken before and after each
+    call and asserted byte-for-byte identical, not just a row count, so
+    even an in-place UPDATE with no row-count change would be caught.
+
+If a future change reintroduces a write path in dry-run mode (e.g. someone
+"simplifies" by calling ``decompose_task`` internally, or touches
+``kb.specify_triage_task`` / ``kb.decompose_triage_task`` from a new
+branch), this file fails loudly.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json as jsonlib
+import sqlite3
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_decompose as decomp
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _fake_aux_response(content: str):
+    resp = MagicMock()
+    resp.choices = [MagicMock()]
+    resp.choices[0].message.content = content
+    return resp
+
+
+def _patch_list_profiles(names: list[str]):
+    from types import SimpleNamespace
+    fake_profiles = [
+        SimpleNamespace(
+            name=n, is_default=(i == 0), description=f"desc for {n}",
+            description_auto=False, model="m", provider="p", skill_count=1,
+        )
+        for i, n in enumerate(names)
+    ]
+    return [
+        patch("hermes_cli.profiles.list_profiles", return_value=fake_profiles),
+        patch("hermes_cli.profiles.profile_exists", side_effect=lambda x: x in names),
+        patch("hermes_cli.profiles.get_active_profile_name", return_value=names[0] if names else "default"),
+    ]
+
+
+# Every function in kanban_db capable of mutating the DB. Deliberately a
+# superset (includes helpers dry-run has no legitimate reason to ever call,
+# like archive/delete/reassign) so an unexpected new call site is caught
+# regardless of which write helper a future refactor reaches for.
+_MUTATING_KB_FUNCS = [
+    "create_task",
+    "assign_task",
+    "link_tasks",
+    "unlink_tasks",
+    "claim_task",
+    "claim_review_task",
+    "reclaim_task",
+    "reassign_task",
+    "complete_task",
+    "edit_completed_task_result",
+    "block_task",
+    "promote_task",
+    "unblock_task",
+    "reopen_review_task",
+    "specify_triage_task",
+    "decompose_triage_task",
+    "archive_task",
+    "delete_archived_task",
+    "delete_task",
+    "schedule_task",
+    "add_comment",
+]
+
+
+def _raising_spy(name: str):
+    def _spy(*args, **kwargs):
+        raise AssertionError(
+            f"dry-run path illegally invoked mutating DB helper kb.{name}() "
+            f"— dry-run must never write to the Kanban database"
+        )
+    return _spy
+
+
+def _dump_all_tables(home: Path) -> dict:
+    """Full logical snapshot of every kanban table: byte-for-byte diffable."""
+    candidates = list(home.rglob("*.db"))
+    assert candidates, f"no sqlite db found under {home}"
+    db_path = candidates[0]
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.row_factory = sqlite3.Row
+        tables = [
+            r[0]
+            for r in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name NOT LIKE 'sqlite_%'"
+            ).fetchall()
+        ]
+        snapshot = {}
+        for t in tables:
+            rows = conn.execute(f"SELECT * FROM {t} ORDER BY rowid").fetchall()
+            snapshot[t] = [dict(r) for r in rows]
+        return snapshot
+    finally:
+        conn.close()
+
+
+def _seed_triage_task(title="rough idea", body="do the thing"):
+    with kb.connect() as conn:
+        return kb.create_task(conn, title=title, body=body, triage=True)
+
+
+def _mutation_guard(kanban_home):
+    """Patch every mutating kb function to raise, and snapshot the DB.
+
+    Call this AFTER any test setup (e.g. seeding the fixture task) is
+    done, since setup legitimately uses kb.create_task — only the
+    dry_run_route call itself must be write-free.
+
+    Returns (assert_unchanged, patchers). The caller MUST stop the
+    patchers (finally block) and call assert_unchanged() after invoking
+    dry_run_route, proving both (a) no spy fired [no write call was even
+    attempted] and (b) the DB content is byte-identical to before [belt
+    and suspenders in case some future write path bypasses these named
+    helpers entirely, e.g. a raw ``conn.execute("INSERT ...")``].
+    """
+    before = _dump_all_tables(kanban_home)
+    patchers = [
+        patch.object(kb, name, side_effect=_raising_spy(name))
+        for name in _MUTATING_KB_FUNCS
+    ]
+    for p in patchers:
+        p.start()
+
+    def assert_unchanged():
+        after = _dump_all_tables(kanban_home)
+        assert after == before, (
+            "Kanban DB content changed across a dry-run call — "
+            "dry-run must be a pure read path"
+        )
+
+    return assert_unchanged, patchers
+
+
+def test_dry_run_survives_llm_exception_mid_call_without_mutating(kanban_home):
+    """Simulated network/API failure mid-processing must not leave a write."""
+    tid = _seed_triage_task()
+    assert_unchanged, guard_patches = _mutation_guard(kanban_home)
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=TimeoutError("simulated network failure mid-call"),
+        ):
+            result = decomp.dry_run_route(task_id=tid)
+    finally:
+        for p in patches:
+            p.stop()
+        for p in guard_patches:
+            p.stop()
+
+    assert result.ok is False
+    assert "LLM error" in result.reason
+    assert_unchanged()
+
+    # Task must still be exactly where it started — untouched.
+    with kb.connect() as conn:
+        task = kb.get_task(conn, tid)
+    assert task is not None
+    assert task.status == "triage"
+
+
+def test_dry_run_survives_malformed_llm_json_without_mutating(kanban_home):
+    """Adversarial/garbage model output must not fall through to a write."""
+    tid = _seed_triage_task()
+    assert_unchanged, guard_patches = _mutation_guard(kanban_home)
+
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response("not json at all, just prose"),
+        ):
+            result = decomp.dry_run_route(task_id=tid)
+    finally:
+        for p in patches:
+            p.stop()
+        for p in guard_patches:
+            p.stop()
+
+    assert result.ok is False
+    assert "malformed JSON" in result.reason
+    assert_unchanged()
+
+
+def test_dry_run_survives_empty_fanout_list_without_mutating(kanban_home):
+    """fanout=true with an empty tasks[] is the exact shape live-path
+    would otherwise try to persist via kb.decompose_triage_task — the
+    edge case most likely to slip through a careless refactor."""
+    tid = _seed_triage_task()
+    assert_unchanged, guard_patches = _mutation_guard(kanban_home)
+
+    llm_payload = jsonlib.dumps({"fanout": True, "rationale": "empty", "tasks": []})
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response(llm_payload),
+        ):
+            result = decomp.dry_run_route(task_id=tid)
+    finally:
+        for p in patches:
+            p.stop()
+        for p in guard_patches:
+            p.stop()
+
+    assert result.ok is False
+    assert "empty tasks list" in result.reason
+    assert_unchanged()
+
+
+def test_dry_run_successful_fanout_prediction_still_does_not_mutate(kanban_home):
+    """The success path is the highest-risk one: it produces a fully
+    valid child-task graph that *looks* exactly like what
+    kb.decompose_triage_task would persist. Prove it never gets there."""
+    tid = _seed_triage_task()
+    assert_unchanged, guard_patches = _mutation_guard(kanban_home)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": True,
+        "rationale": "split it",
+        "tasks": [
+            {"title": "research", "body": "look it up", "assignee": "researcher", "parents": []},
+            {"title": "build", "body": "code it", "assignee": "engineer", "parents": [0]},
+        ],
+    })
+    patches = _patch_list_profiles(["orchestrator", "researcher", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response(llm_payload),
+        ):
+            result = decomp.dry_run_route(task_id=tid)
+    finally:
+        for p in patches:
+            p.stop()
+        for p in guard_patches:
+            p.stop()
+
+    # The prediction succeeds and looks like a real, promotable graph...
+    assert result.ok is True
+    assert result.fanout is True
+    assert result.dependency_graph and len(result.dependency_graph) == 2
+    assert result.predicted_owner == "orchestrator"
+    # ...yet nothing was written.
+    assert_unchanged()
+    with kb.connect() as conn:
+        root = kb.get_task(conn, tid)
+        all_tasks = kb.list_tasks(conn, tenant=None, limit=1000)
+    assert root is not None
+    assert root.status == "triage"  # never promoted to todo
+    assert len(all_tasks) == 1  # no children ever created
+
+
+def test_dry_run_ad_hoc_preview_with_no_backing_row_does_not_mutate(kanban_home):
+    """title/body preview mode (no task_id) must also never write."""
+    assert_unchanged, guard_patches = _mutation_guard(kanban_home)
+
+    llm_payload = jsonlib.dumps({
+        "fanout": False,
+        "rationale": "single unit",
+        "title": "Tightened title",
+        "body": "do it",
+        "assignee": "engineer",
+    })
+    patches = _patch_list_profiles(["orchestrator", "engineer"])
+    for p in patches:
+        p.start()
+    try:
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=_fake_aux_response(llm_payload),
+        ):
+            result = decomp.dry_run_route(title="a rough idea", body="details")
+    finally:
+        for p in patches:
+            p.stop()
+        for p in guard_patches:
+            p.stop()
+
+    assert result.ok is True
+    assert result.predicted_owner == "engineer"
+    assert_unchanged()
+    with kb.connect() as conn:
+        all_tasks = kb.list_tasks(conn, tenant=None, limit=1000)
+    assert len(all_tasks) == 0  # no row was ever created for the preview
+
+
+def test_dry_run_route_source_never_calls_mutating_helpers():
+    """Static guard: fail the build if dry_run_route's own source is ever
+    edited to CALL either mutating helper directly, regardless of whether
+    a runtime test happens to exercise that new line. Matches on the call
+    form (name + open-paren) so the docstring's prose mention of the two
+    names (explaining what it must never call) doesn't false-positive."""
+    src = inspect.getsource(decomp.dry_run_route)
+    assert "specify_triage_task(" not in src
+    assert "decompose_triage_task(" not in src

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -66,6 +66,92 @@ def _drain_for(delegation_id, timeout=5.0):
     return None
 
 
+def _insert_durable_delegation(
+    ad, delegation_id, *, state="running", owner_pid=123, owner_started_at=456,
+    event_json=None,
+):
+    now = time.time()
+    with ad._DB_LOCK, ad._transaction() as conn:
+        conn.execute(
+            """INSERT INTO async_delegations
+               (delegation_id, origin_session, origin_ui_session_id,
+                parent_session_id, state, dispatched_at, updated_at,
+                delivery_state, owner_pid, owner_started_at, task_json, event_json)
+               VALUES (?, 'session-1', 'ui-1', 'parent-1', ?, ?, ?, 'pending',
+                       ?, ?, ?, ?)""",
+            (
+                delegation_id, state, now, now, owner_pid, owner_started_at,
+                json.dumps({"goal": "recover me"}), event_json,
+            ),
+        )
+
+
+def _durable_delegation_row(ad, delegation_id):
+    with ad._DB_LOCK, ad._transaction() as conn:
+        return conn.execute(
+            """SELECT state, event_json, result_json, delivery_state
+               FROM async_delegations WHERE delegation_id=?""",
+            (delegation_id,),
+        ).fetchone()
+
+
+def test_recover_abandoned_delegations_keeps_live_owner_running(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _insert_durable_delegation(ad, "live-owner")
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: pid == 123)
+    monkeypatch.setattr("gateway.status.get_process_start_time", lambda pid: 456)
+
+    assert ad.recover_abandoned_delegations() == 0
+    assert _durable_delegation_row(ad, "live-owner") == ("running", None, None, "pending")
+
+
+def test_recover_abandoned_delegations_marks_dead_owner_unknown_and_queues_event(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _insert_durable_delegation(ad, "dead-owner")
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+    assert ad.recover_abandoned_delegations() == 1
+    state, event_json, result_json, delivery_state = _durable_delegation_row(ad, "dead-owner")
+    assert state == "unknown"
+    assert delivery_state == "pending"
+    event = json.loads(event_json)
+    assert event["status"] == "unknown"
+    assert event["error"] == (
+        "Delegation owner exited before recording a terminal result; outcome unknown."
+    )
+    assert json.loads(result_json)["error"] == event["error"]
+
+    completion_queue = queue.Queue()
+    assert ad.restore_undelivered_completions(completion_queue) == 1
+    assert completion_queue.get_nowait()["delegation_id"] == "dead-owner"
+
+
+@pytest.mark.parametrize("state", ["completed", "error", "unknown"])
+def test_recover_abandoned_delegations_ignores_terminal_records(tmp_path, monkeypatch, state):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    original_event = json.dumps({"delegation_id": "terminal", "status": state})
+    _insert_durable_delegation(ad, "terminal", state=state, event_json=original_event)
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+    assert ad.recover_abandoned_delegations() == 0
+    assert _durable_delegation_row(ad, "terminal") == (
+        state, original_event, None, "pending",
+    )
+
+
+def test_recover_abandoned_delegations_is_idempotent(tmp_path, monkeypatch):
+    monkeypatch.setattr(ad, "_db_path", lambda: tmp_path / "state.db")
+    _insert_durable_delegation(ad, "repeat-owner")
+    monkeypatch.setattr("gateway.status._pid_exists", lambda pid: False)
+
+    assert ad.recover_abandoned_delegations() == 1
+    first = _durable_delegation_row(ad, "repeat-owner")
+    assert ad.recover_abandoned_delegations() == 0
+    assert _durable_delegation_row(ad, "repeat-owner") == first
+
+
 def test_schema_init_preserves_shared_state_db_journal_mode(tmp_path):
     """The delegation ledger is a guest in state.db, not its mode owner."""
     conn = sqlite3.connect(tmp_path / "state.db")
@@ -880,4 +966,3 @@ def test_batch_truncation_banner_marks_only_truncated_task():
     banner_pos = text.index("TRUNCATED")
     # The header banner for task 2 appears after task 1's summary.
     assert banner_pos > clean_pos
-


### PR DESCRIPTION
## Summary

Adds `hermes kanban decompose <task_id> --dry-run` — preview the routing
decision (predicted owner, context envelope, dependency graph) for a
triage task without creating cards, writing to the DB, or spawning a
worker.

## What changed

- `hermes_cli/kanban_decompose.py`
  - Extracted steps 1-4 of `decompose_task` (roster resolution, LLM
    call, JSON parse/validate) into a new pure `_predict_routing()`
    helper, shared verbatim by the live path and the new dry-run path
    so the two can never predict differently — only whether the
    prediction gets persisted differs.
  - Added `dry_run_route()` + `DryRunResult` / `PredictedRouting`
    dataclasses. Accepts either an existing `task_id` (read-only
    lookup, any status) or ad-hoc `title`/`body` with no backing row.
    Deliberately never references `kb.specify_triage_task` or
    `kb.decompose_triage_task` — the only two mutating calls in the
    live routing path (see `docs/rfcs/yout-plus-dry-run-routing.md`).
- `hermes_cli/kanban.py`
  - Added `--dry-run` flag to `kanban decompose`, mutually exclusive
    with `--all`, requires a task id. Prints predicted owner /
    fan-out preview (or JSON with `--json`).
- `docs/rfcs/yout-plus-dry-run-routing.md` — design rationale.
- `tests/hermes_cli/test_kanban_decompose_dry_run.py` (5 tests) —
  single-owner, cross-functional fan-out, Engineering-owner, ad-hoc
  preview, and usage-error scenarios. Each asserts predicted owner,
  envelope shape, dependency graph validity, and zero DB mutation via
  spies on `kb.specify_triage_task` / `kb.decompose_triage_task`.
- `tests/hermes_cli/test_kanban_decompose_dry_run_no_mutation.py`
  (6 tests) — failure-path proof that dry-run cannot mutate the DB:
  LLM exception mid-call, malformed JSON, empty fan-out list, the full
  successful fan-out prediction, ad-hoc preview, and a static
  source-guard asserting `dry_run_route`'s source never calls
  `specify_triage_task(` or `decompose_triage_task(`. Also spies all
  21 mutating `kanban_db` helpers and does a byte-for-byte snapshot
  diff of every DB table before/after each call. The guard was proven
  to actually fail loudly: a mutating call was temporarily injected
  into `dry_run_route`, the suite failed immediately, then the
  injection was reverted before committing.

## Test results

Ran the full existing kanban test suite plus the two new dry-run test
files together, using the repo's designated per-file-isolated runner
(`scripts/run_tests_parallel.py`, which spawns one subprocess per test
file — cross-file module-state leakage is not possible under it):

```
$ python scripts/run_tests_parallel.py tests/hermes_cli/test_kanban_*.py
=== Summary: 48 files, 305 tests passed, 0 failed, 2 skipped (100% complete) in 19.0s (16 workers) ===
```

0 failures, 2 skips are the expected `windows_only` tests (run on the
Windows CI lane, not darwin). No regressions in existing routing
behavior; live `decompose_task` mutation path is untouched except for
extracting shared prediction logic into `_predict_routing`.

Note: running the same set under plain `pytest -k kanban` in a single
process shows spurious cross-file failures (profile-roster monkeypatch
leakage from `test_kanban_cli_dispatch_passthrough.py` into later
tests in the same process) — this is a pre-existing artifact of not
using the repo's subprocess-per-file runner, not a defect in this
branch. Confirmed by running the same single-process command against
the pre-feature base commit (`d24ead869`): the same 15 failures
reproduce there too, unrelated to this change.

## Dry-run interface

```
$ hermes kanban decompose <task_id> --dry-run
[dry-run] predicted owner: backend_dev
[dry-run] single task (no fanout, no card mutated)

$ hermes kanban decompose <task_id> --dry-run --json
{"ok": true, "reason": "", "predicted_owner": "backend_dev", ...}
```

`--dry-run` is rejected with exit code 2 when combined with `--all` or
without a task id.

## Status

**Not merged.** Branch left open on `feat/yout-plus-routing-dry-run`
per the original request, flagged for human review.
