### PR TITLE
lsp: add release_workspace() to free clients when worktrees are removed

### DIFF
--- a/agent/lsp/manager.py
+++ b/agent/lsp/manager.py
@@ -662,8 +662,16 @@ class LSPService:
                 for key in self._clients
                 if self._last_used.get(key, 0) < cutoff
             ]
-            clients = [self._clients.pop(key) for key in idle_keys]
-            for key in idle_keys:
+            # Also check for deleted workspace roots
+            deleted_root_keys = [
+                key
+                for key in self._clients
+                if not os.path.exists(key[1])
+            ]
+            # Combine both sets
+            reap_keys = list(set(idle_keys) | set(deleted_root_keys))
+            clients = [self._clients.pop(key) for key in reap_keys]
+            for key in reap_keys:
                 self._last_used.pop(key, None)
         if clients:
             eventlog.log_reaped(
@@ -674,6 +682,80 @@ class LSPService:
                 *(client.shutdown() for client in clients),
                 return_exceptions=True,
             )
+
+    def release_workspace(self, workspace_root: str) -> int:
+        """Release all LSP clients for a specific workspace root.
+
+        Called when a git worktree is being removed to immediately shut down
+        associated language servers rather than waiting for idle timeout.
+        Returns the number of clients released.
+
+        Idempotent and best-effort — safe to call multiple times or for
+        paths that have no active clients.
+        """
+        if not self._enabled:
+            return 0
+
+        # Normalize the path
+        abs_root = os.path.abspath(workspace_root)
+        if not abs_root:
+            return 0
+
+        released_count = 0
+
+        with self._state_lock:
+            # Find all keys whose workspace_root matches or is under the given path
+            keys_to_release = []
+            for key in self._clients:
+                client_root = os.path.abspath(key[1])
+                # Match exact workspace or any child path (for multi-root servers)
+                if client_root == abs_root or client_root.startswith(abs_root + os.sep):
+                    keys_to_release.append(key)
+
+            # Also check _spawning to prevent re-insertion after release
+            for key in keys_to_release:
+                if key in self._spawning:
+                    # Cancel the spawn future
+                    fut = self._spawning.pop(key, None)
+                    if fut is not None and not fut.done():
+                        fut.cancel()
+
+            # Detach clients
+            clients = [self._clients.pop(key) for key in keys_to_release]
+            for key in keys_to_release:
+                self._last_used.pop(key, None)
+                self._broken.discard(key)
+
+            # Clear delta baseline entries under the workspace
+            baseline_keys_to_remove = [
+                path for path in self._delta_baseline
+                if path == abs_root or path.startswith(abs_root + os.sep)
+            ]
+            for path in baseline_keys_to_remove:
+                self._delta_baseline.pop(path, None)
+
+        # Shutdown clients outside the lock
+        if clients:
+            try:
+                self._loop.run(
+                    asyncio.gather(
+                        *(c.shutdown() for c in clients),
+                        return_exceptions=True,
+                    ),
+                    timeout=5.0,
+                )
+            except Exception as e:
+                logger.debug("Error shutting down released clients: %s", e)
+
+        released_count = len(clients)
+        if released_count:
+            eventlog.log_reaped(
+                [(c.server_id, c.workspace_root) for c in clients],
+                self._idle_timeout,
+            )
+            logger.info("LSP: released %d client(s) for workspace %s", released_count, workspace_root)
+
+        return released_count
 
     async def _shutdown_async(self) -> None:
         reaper = self._idle_reaper_task

--- a/cli.py
+++ b/cli.py
@@ -2565,6 +2565,17 @@ def _cleanup_worktree(info: Dict[str, str] = None) -> None:
     if not info:
         return
 
+    # Release LSP workspace clients before removing the worktree
+    # to avoid leaking language server processes (tsserver, pyright, etc.)
+    try:
+        from agent.lsp import get_service
+        svc = get_service()
+        if svc:
+            svc.release_workspace(info["path"])
+    except Exception as e:
+        # Best-effort — LSP cleanup must not block worktree removal
+        logger.debug("LSP workspace release failed for %s: %s", info.get("path"), e)
+
     import subprocess
 
     wt_path = info["path"]


### PR DESCRIPTION
Fixes #102345

The process-wide LSP service kept clients for deleted git worktrees
indefinitely, leaking language server processes (up to 4.91 GiB in
long-running gateways). This adds:

1. LSPService.release_workspace(path) -> int: explicit API to detach
   and shut down all clients for a workspace root (and children),
   canceling any in-flight spawns and clearing delta baselines.

2. Calls release_workspace() in cli._cleanup_worktree() BEFORE
   git worktree remove --force, so the path is still valid for lookup.

3. Idle reaper now also reaps clients whose workspace root no longer
   exists, as a backstop for externally deleted roots or missed cleanup.

4. Idempotent and best-effort — safe to call multiple times or for
   paths with no active clients.