### PR TITLE
fix(telegram): report a healthy-but-deaf ingress instead of nothing (#102260)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -447,6 +447,29 @@ def stamp_db_persisted_markers(messages: List[Dict[str, Any]]) -> None:
             msg[_DB_PERSISTED_MARKER] = True
 
 
+def _newest_checkpoint_carrier(messages: List[Dict[str, Any]], key: str) -> int:
+    """Index of the last assistant message carrying a native-compaction
+    checkpoint under *key*, or ``-1`` when the transcript has none.
+
+    This is the transcript-side mirror of
+    ``native_compaction.prune_pre_checkpoint_items``' "newest run wins" rule:
+    that function scans the converted Responses items for the last
+    ``type: "compaction"`` entry and drops everything before it, so this is
+    the only carrier whose checkpoints can still reach a request.
+    """
+    for i in range(len(messages) - 1, -1, -1):
+        msg = messages[i]
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        items = msg.get(key)
+        if isinstance(items, list) and any(
+            isinstance(item, dict) and item.get("type") == "compaction"
+            for item in items
+        ):
+            return i
+    return -1
+
+
 def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
     """Strip stale per-turn replay items (``codex_reasoning_items``) from
     assistant messages that belong to turns older than the active one.
@@ -473,11 +496,21 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
       the last assistant message and would have stripped reasoning mid-chain
       from the in-flight turn.)
 
-    * **Native compaction checkpoints are exempt.** ``type: "compaction"``
-      items in the same sidecar are the server-side stand-in for already
-      pruned history (see ``agent/native_compaction.py``) — cumulative
-      context carriers, not per-turn reasoning.  They must survive on every
-      retained message, so pruning filters items instead of popping the key.
+    * **Only the newest native-compaction checkpoint is exempt.**
+      ``type: "compaction"`` items in the same sidecar are the server-side
+      stand-in for already pruned history (see ``agent/native_compaction.py``)
+      — cumulative context carriers, not per-turn reasoning — so pruning
+      filters items instead of popping the key.  But
+      ``native_compaction.prune_pre_checkpoint_items`` rebuilds every request
+      around the NEWEST checkpoint run and discards each earlier one, and the
+      replay gate drops checkpoints wholesale once native compaction is no
+      longer eligible.  A checkpoint shadowed by a newer carrier therefore has
+      no reader on any wire, while still being charged in full by
+      ``_ALWAYS_REPLAYED_BUDGET_KEYS`` (~120 KB of ciphertext each), replayed
+      into the child session, and persisted to
+      ``messages.codex_reasoning_items`` for the life of the DB.  Keep the
+      newest carrier — the same item the wire builder would have picked — and
+      drop the shadowed ones.
     """
     # Find the last real user message — everything after it is the active
     # turn.  Synthetic continuation rows and tool results never mark a turn
@@ -493,6 +526,11 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
         # prune nothing (fail open toward correctness, not size).
         return 0
 
+    newest_carrier = {
+        key: _newest_checkpoint_carrier(messages, key)
+        for key in _STALE_REPLAY_PRUNE_KEYS
+    }
+
     pruned = 0
     for i in range(last_user_idx):
         msg = messages[i]
@@ -502,11 +540,15 @@ def _prune_stale_reasoning_replay(messages: List[Dict[str, Any]]) -> int:
             items = msg.get(key)
             if not isinstance(items, list) or not items:
                 continue
-            kept = [
-                item
-                for item in items
-                if isinstance(item, dict) and item.get("type") == "compaction"
-            ]
+            kept = (
+                [
+                    item
+                    for item in items
+                    if isinstance(item, dict) and item.get("type") == "compaction"
+                ]
+                if i == newest_carrier[key]
+                else []
+            )
             if len(kept) == len(items):
                 continue  # nothing stale in this sidecar
             if kept:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3242,6 +3242,16 @@ class BasePlatformAdapter(ABC):
         self.config = config
         self.platform = platform
         self._message_handler: Optional[MessageHandler] = None
+        # Ingress delivery counter (#102260). Incremented every time an inbound
+        # event actually reaches the gateway's message handler. Adapters whose
+        # transport reports healthy can still discard 100% of inbound (no
+        # handler installed, a wedged dispatcher, a filter that never matches);
+        # without a delivered-side counter a deaf gateway is indistinguishable
+        # from an idle one, which is exactly what made #102260 undiagnosable
+        # for three weeks.
+        self._inbound_delivered_total: int = 0
+        self._last_inbound_delivered_monotonic: Optional[float] = None
+        self._no_message_handler_logged: bool = False
         # Optional gateway-supplied fan-out for platform-native emoji
         # reaction events (see ``set_reaction_handler``).
         self._reaction_handler: Optional[
@@ -3933,6 +3943,21 @@ class BasePlatformAdapter(ABC):
     def is_connected(self) -> bool:
         """Check if adapter is currently connected."""
         return self._running
+
+    def note_inbound_delivered(self) -> None:
+        """Record that one inbound event reached the gateway message handler.
+
+        The delivered side of the ingress accounting introduced for #102260.
+        Adapters that observe their own wire traffic (Telegram's getUpdates
+        instrumentation) compare their received counter against this one to
+        tell "nothing is arriving" apart from "everything arriving is being
+        dropped downstream" — two failures that look identical from every
+        transport-level health probe.
+        """
+        self._inbound_delivered_total = (
+            getattr(self, "_inbound_delivered_total", 0) + 1
+        )
+        self._last_inbound_delivered_monotonic = time.monotonic()
 
     def set_message_handler(self, handler: MessageHandler) -> None:
         """
@@ -6386,7 +6411,21 @@ class BasePlatformAdapter(ABC):
         enabling interruption support.
         """
         if not self._message_handler:
+            # A connected adapter with no message handler is silently deaf: it
+            # polls, publishes "connected", and can still send — while every
+            # inbound message is discarded here with no log at all. Say so once
+            # per adapter so the failure is diagnosable (#102260).
+            if not getattr(self, "_no_message_handler_logged", False):
+                self._no_message_handler_logged = True
+                logger.error(
+                    "[%s] Dropping inbound message: no gateway message handler "
+                    "is installed on this adapter. The adapter is connected and "
+                    "can send, but every inbound message is discarded.",
+                    self.name,
+                )
             return
+
+        self.note_inbound_delivered()
 
         if event.allow_gateway_control:
             coerce_plaintext_gateway_command(event)

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -585,6 +585,17 @@ _POLLING_PROGRESS_TIMEOUT = 60.0
 # can see it. ~3x the worst-case poll window leaves ample margin against false
 # positives while still recovering within a few heartbeat intervals.
 _POLLING_STALL_TIMEOUT = 150.0
+# Ingress delivery gap (#102260). Every probe above measures the *transport*:
+# a getUpdates round-trip that returns 200 proves bytes are moving, nothing
+# more. An update that arrives and is then dropped downstream — a wedged
+# dispatcher, a filter that never matches, a missing gateway handler — leaves
+# every transport probe healthy and produces no log line at all, so the gateway
+# reports "connected" while being permanently deaf. This is the window after
+# which received-but-never-delivered updates are reported. Generous on purpose:
+# updates legitimately reach no gateway turn (the bot's own messages, reactions,
+# unmentioned group chatter), so this reports a diagnosis and never triggers
+# recovery on its own.
+_INGRESS_DELIVERY_GAP_TIMEOUT = 300.0
 # Telegram transcodes an uploaded video before it answers sendVideo, so the
 # wait for the response is unrelated to how fast the bytes went out and can
 # outlast the 20s read timeout the rest of the Bot API is tuned for. Only
@@ -792,6 +803,16 @@ class TelegramAdapter(BasePlatformAdapter):
         # getUpdates round-trip completed. None = unknown / not yet observed.
         self._polling_generation_started_monotonic: Optional[float] = None
         self._polling_last_progress_monotonic: Optional[float] = None
+        # Ingress accounting (#102260). ``received`` counts updates Telegram
+        # handed this process on the getUpdates wire; ``dispatched`` counts
+        # updates PTB's dispatcher actually carried through the handler chain.
+        # Together with the base adapter's delivered counter they split a deaf
+        # gateway into its three distinguishable causes: nothing arriving, the
+        # dispatcher stalled, or Hermes dropping what arrives.
+        self._updates_received_total: int = 0
+        self._updates_dispatched_total: int = 0
+        self._last_update_received_monotonic: Optional[float] = None
+        self._ingress_gap_reported_at_received: Optional[int] = None
         # Live @username, refreshed whenever Telegram tells us what it is.
         # PTB caches getMe() in Bot._bot_user at initialize() and only rewrites
         # it inside get_me(), so a BotFather rename leaves self._bot.username
@@ -2733,6 +2754,22 @@ class TelegramAdapter(BasePlatformAdapter):
             and "result" in envelope
         ):
             self._record_polling_progress(generation)
+            self._record_updates_received(envelope.get("result"))
+
+    def _record_updates_received(self, result) -> None:
+        """Count updates Telegram handed us on the getUpdates wire (#102260).
+
+        ``_record_polling_progress`` above proves the transport works; it says
+        nothing about whether anything arrived. Only a non-empty ``result``
+        means real updates entered this process, and that is the number the
+        delivered counter has to be compared against.
+        """
+        if not isinstance(result, list) or not result:
+            return
+        self._updates_received_total = (
+            getattr(self, "_updates_received_total", 0) + len(result)
+        )
+        self._last_update_received_monotonic = time.monotonic()
 
     def _instrument_polling_request(self, request):
         """Instrument one dedicated PTB getUpdates request with progress tracking.
@@ -3358,6 +3395,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # successful round-trip past the stall threshold is dead
                 # (#92991). Pure local-state check — no Bot API call needed.
                 await self._check_polling_stall()
+                # Transport health is not delivery health: updates can arrive
+                # and then die downstream with every probe above still green
+                # (#102260). Pure local-state check — no Bot API call.
+                self._check_ingress_delivery_gap()
             except asyncio.CancelledError:
                 return
             except (asyncio.TimeoutError, OSError) as probe_err:
@@ -3477,6 +3518,74 @@ class TelegramAdapter(BasePlatformAdapter):
                     RuntimeError("getUpdates consumer wedged: pending updates not draining")
                 )
             )
+
+    def _check_ingress_delivery_gap(self) -> None:
+        """Report updates that arrived on the wire but reached no gateway turn.
+
+        Every other probe in this adapter measures the transport. When the
+        transport is healthy and updates are still not being acted on, the
+        gateway publishes ``connected``, logs nothing, and looks exactly like
+        an idle bot — the failure mode of #102260, which stayed undiagnosed for
+        three weeks because no counter existed on the delivered side.
+
+        Three counters split the failure into its distinguishable causes:
+
+        * ``received``   — updates Telegram handed this process (getUpdates).
+        * ``dispatched`` — updates PTB's dispatcher carried through the whole
+          handler chain. ``received > dispatched`` means the dispatcher is not
+          draining; the transport is innocent.
+        * ``delivered``  — inbound events that reached the gateway's message
+          handler. ``dispatched > delivered`` means Hermes itself is dropping
+          what arrives (authorization, mention/topic gating, a missing handler).
+
+        Deliberately diagnostic only. A received update legitimately reaches no
+        gateway turn (the bot's own messages, reactions, unmentioned group
+        chatter), so this must never drive recovery on its own — reconnecting a
+        healthy transport would not fix a dropped update anyway. It reports
+        once per received-count so a persistent gap does not spam the log.
+        """
+        if self._webhook_mode:
+            return
+        if getattr(self, "_polling_teardown_started", False):
+            return
+        if self.has_fatal_error:
+            return
+        received = getattr(self, "_updates_received_total", 0)
+        if not received:
+            return
+        last_received = getattr(self, "_last_update_received_monotonic", None)
+        if last_received is None:
+            return
+        delivered = getattr(self, "_inbound_delivered_total", 0)
+        last_delivered = getattr(self, "_last_inbound_delivered_monotonic", None)
+        # Something was delivered after the last update arrived: the chain is
+        # working end to end. Re-arm so a later gap is reported again.
+        if last_delivered is not None and last_delivered >= last_received:
+            self._ingress_gap_reported_at_received = None
+            return
+        if time.monotonic() - last_received <= _INGRESS_DELIVERY_GAP_TIMEOUT:
+            return
+        if self._ingress_gap_reported_at_received == received:
+            return
+        self._ingress_gap_reported_at_received = received
+        dispatched = getattr(self, "_updates_dispatched_total", 0)
+        if dispatched < received:
+            where = (
+                "PTB's dispatcher is not draining them (received > dispatched)"
+            )
+        else:
+            where = (
+                "they are being dropped inside Hermes before the gateway "
+                "handler (dispatched > delivered) — check authorization, "
+                "mention/topic gating, and the held-inbound queue"
+            )
+        logger.error(
+            "[%s] Telegram ingress is healthy but deaf: %d update(s) received "
+            "on the getUpdates wire, %d dispatched, %d delivered to the "
+            "gateway, none delivered in the last %.0fs. Polling is fine — %s.",
+            self.name, received, dispatched, delivered,
+            time.monotonic() - last_received, where,
+        )
 
     async def _check_polling_stall(self) -> None:
         """Watchdog the last successful getUpdates round-trip (#92991).
@@ -4327,7 +4436,15 @@ class TelegramAdapter(BasePlatformAdapter):
         post-auth boundary. Registered in a dedicated high group so it observes
         alongside, never displaces, the core handlers. Malformed updates and
         dispatch errors cannot raise into PTB's update loop.
+
+        Being the last handler group PTB runs also makes this the one place
+        that proves the dispatcher carried an update all the way through the
+        handler chain, so the ingress counter is stamped here before any early
+        return (#102260).
         """
+        self._updates_dispatched_total = (
+            getattr(self, "_updates_dispatched_total", 0) + 1
+        )
         handler: Optional[Callable[[Dict[str, Any], Any], Awaitable[None]]] = getattr(
             self, "_platform_event_handler", None
         )

--- a/tests/agent/test_stale_replay_prune.py
+++ b/tests/agent/test_stale_replay_prune.py
@@ -2,9 +2,10 @@
 
 Salvaged from PR #71077 (@webtecnica) with two correctness fixes:
 the prune boundary is the last USER message (a Codex turn spans multiple
-assistant messages whose reasoning items must replay together), and native
-compaction checkpoints (type="compaction") are exempt because they carry
-already-pruned history, not per-turn reasoning.
+assistant messages whose reasoning items must replay together), and the
+newest native compaction checkpoint (type="compaction") is exempt because
+it carries already-pruned history, not per-turn reasoning.  Checkpoints a
+newer carrier shadows are pruned: the wire builder discards them anyway.
 """
 
 from agent.context_compressor import (
@@ -164,3 +165,81 @@ class TestInterimMergePreservesCheckpoints:
         assert merge_interim_reasoning_items(None, None) == []
         assert merge_interim_reasoning_items(None, [_reasoning("r")]) == [_reasoning("r")]
         assert merge_interim_reasoning_items([_compaction()], None) == [_compaction()]
+
+
+class TestShadowedCheckpointsArePruned:
+    """A checkpoint that a newer carrier shadows can never reach a request:
+    ``native_compaction.prune_pre_checkpoint_items`` rebuilds every wire
+    around the newest checkpoint run and drops each earlier one.  Retaining
+    the shadowed copies charged them in full against the tail budget and
+    persisted ~120 KB of unreachable ciphertext per assistant row.
+    """
+
+    @staticmethod
+    def _checkpoint(tag):
+        return {"type": "compaction", "encrypted_content": f"ckpt-{tag}"}
+
+    def _transcript(self, turns):
+        messages = []
+        for t in range(turns):
+            messages.append({"role": "user", "content": f"u{t}"})
+            messages.append({
+                "role": "assistant",
+                "content": f"a{t}",
+                "codex_reasoning_items": [
+                    _reasoning(f"rs_{t}"),
+                    self._checkpoint(t),
+                ],
+            })
+        messages.append({"role": "user", "content": "now"})
+        return messages
+
+    def test_only_the_newest_carrier_keeps_its_checkpoint(self):
+        messages = self._transcript(4)
+        _prune_stale_reasoning_replay(messages)
+        surviving = [
+            (i, item)
+            for i, msg in enumerate(messages)
+            for item in (msg.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert surviving == [(7, self._checkpoint(3))]
+
+    def test_newest_carrier_inside_the_active_turn_shadows_every_stale_one(self):
+        messages = self._transcript(2)
+        # Active turn (after the last user message) mints its own checkpoint.
+        messages.append({
+            "role": "assistant",
+            "content": "live",
+            "codex_reasoning_items": [self._checkpoint("live")],
+        })
+        _prune_stale_reasoning_replay(messages)
+        assert "codex_reasoning_items" not in messages[1]
+        assert "codex_reasoning_items" not in messages[3]
+        assert messages[-1]["codex_reasoning_items"] == [self._checkpoint("live")]
+
+    def test_retained_checkpoints_match_what_the_wire_builder_keeps(self):
+        """The invariant behind the prune: after it runs, the transcript holds
+        exactly the checkpoints ``prune_pre_checkpoint_items`` would have kept."""
+        from agent.native_compaction import prune_pre_checkpoint_items
+
+        messages = self._transcript(5)
+        _prune_stale_reasoning_replay(messages)
+
+        items = []
+        for msg in messages:
+            items.extend(dict(i) for i in (msg.get("codex_reasoning_items") or []))
+            if msg["role"] == "user":
+                items.append({
+                    "type": "message",
+                    "role": "user",
+                    "content": [{"type": "input_text", "text": msg["content"]}],
+                })
+        wire = [i for i in prune_pre_checkpoint_items(items) if i.get("type") == "compaction"]
+        retained = [
+            item
+            for msg in messages
+            for item in (msg.get("codex_reasoning_items") or [])
+            if item.get("type") == "compaction"
+        ]
+        assert retained == wire

--- a/tests/gateway/test_telegram_ingress_delivery_gap.py
+++ b/tests/gateway/test_telegram_ingress_delivery_gap.py
@@ -1,0 +1,288 @@
+"""Telegram ingress delivery accounting (#102260).
+
+Every existing Telegram health probe measures the *transport*: a getUpdates
+round-trip that returns 200 proves bytes are moving and nothing else. When
+updates arrive and then die downstream — a dispatcher that never drains, a
+filter that never matches, an adapter with no gateway handler installed — the
+gateway publishes ``connected``, logs nothing at all, and is indistinguishable
+from an idle bot. That is #102260: three weeks of a bot reporting
+``telegram.state: "connected"`` and ``polling confirmed healthy`` while not one
+inbound message reached a handler.
+
+These tests pin the three counters that split the failure into causes:
+
+* ``_updates_received_total``   — updates Telegram handed the process.
+* ``_updates_dispatched_total`` — updates PTB carried through the handler chain.
+* ``_inbound_delivered_total``  — inbound events that reached the gateway.
+"""
+import asyncio
+import logging
+import time as _time
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageEvent, MessageType, Platform, SessionSource
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+def _make_adapter() -> TelegramAdapter:
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter._webhook_mode = False
+    adapter._app = MagicMock()
+    adapter._app.updater.running = True
+    return adapter
+
+
+def _envelope_request(result):
+    """A PTB request double whose parser returns a getUpdates envelope."""
+    request = MagicMock()
+    request.parse_json_payload = MagicMock(
+        return_value={"ok": True, "result": result}
+    )
+    return request
+
+
+# ---------------------------------------------------------------------------
+# received counter
+# ---------------------------------------------------------------------------
+
+
+def test_empty_getupdates_result_counts_no_updates():
+    """An idle long-poll proves the transport, not that anything arrived."""
+    adapter = _make_adapter()
+    adapter._polling_generation = 1
+    adapter._polling_progress_accepting = True
+    adapter._polling_progress_event = asyncio.Event()
+
+    adapter._observe_polling_request_result(_envelope_request([]), 1, (200, b"{}"))
+
+    assert adapter._updates_received_total == 0
+    assert adapter._last_update_received_monotonic is None
+    # ...while transport progress is still recorded.
+    assert adapter._polling_last_progress_monotonic is not None
+
+
+def test_non_empty_getupdates_result_counts_every_update():
+    adapter = _make_adapter()
+    adapter._polling_generation = 1
+    adapter._polling_progress_accepting = True
+    adapter._polling_progress_event = asyncio.Event()
+
+    adapter._observe_polling_request_result(
+        _envelope_request([{"update_id": 1}, {"update_id": 2}]), 1, (200, b"{}")
+    )
+
+    assert adapter._updates_received_total == 2
+    assert adapter._last_update_received_monotonic is not None
+
+
+# ---------------------------------------------------------------------------
+# delivered counter
+# ---------------------------------------------------------------------------
+
+
+def _text_event() -> MessageEvent:
+    return MessageEvent(
+        text="hi",
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="6053106869",
+            user_id="6053106869",
+            chat_type="dm",
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_missing_message_handler_is_logged_once_not_silent(caplog):
+    """A connected adapter with no handler discards 100% of inbound.
+
+    Before #102260 this returned with no log line at all, so a mis-wired
+    adapter looked exactly like a quiet chat.
+    """
+    adapter = _make_adapter()
+    adapter._message_handler = None
+
+    with caplog.at_level(logging.ERROR):
+        await adapter.handle_message(_text_event())
+        await adapter.handle_message(_text_event())
+
+    matches = [r for r in caplog.records if "no gateway message handler" in r.message]
+    assert len(matches) == 1, "must report the deaf adapter exactly once"
+    assert adapter._inbound_delivered_total == 0
+
+
+@pytest.mark.asyncio
+async def test_delivery_to_gateway_handler_increments_counter():
+    adapter = _make_adapter()
+    adapter.note_inbound_delivered()
+
+    assert adapter._inbound_delivered_total == 1
+    assert adapter._last_inbound_delivered_monotonic is not None
+
+
+# ---------------------------------------------------------------------------
+# gap watchdog
+# ---------------------------------------------------------------------------
+
+
+def _armed_gap_adapter(*, received=3, dispatched=3, delivered=0, age=600.0):
+    adapter = _make_adapter()
+    now = _time.monotonic()
+    adapter._updates_received_total = received
+    adapter._updates_dispatched_total = dispatched
+    adapter._inbound_delivered_total = delivered
+    adapter._last_update_received_monotonic = now - age
+    adapter._last_inbound_delivered_monotonic = None
+    return adapter
+
+
+def test_no_report_while_within_the_gap_window(caplog):
+    adapter = _armed_gap_adapter(age=10.0)
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert not [r for r in caplog.records if "healthy but deaf" in r.message]
+
+
+def test_no_report_when_nothing_was_ever_received(caplog):
+    """An idle bot must never be accused of being deaf."""
+    adapter = _make_adapter()
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert not [r for r in caplog.records if "healthy but deaf" in r.message]
+
+
+def test_no_report_when_delivery_followed_the_last_update(caplog):
+    adapter = _armed_gap_adapter()
+    adapter._inbound_delivered_total = 3
+    adapter._last_inbound_delivered_monotonic = (
+        adapter._last_update_received_monotonic + 1
+    )
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert not [r for r in caplog.records if "healthy but deaf" in r.message]
+
+
+def test_dispatched_shortfall_names_the_dispatcher(caplog):
+    """received > dispatched: PTB never carried the updates to the handlers."""
+    adapter = _armed_gap_adapter(received=5, dispatched=1)
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    (record,) = [r for r in caplog.records if "healthy but deaf" in r.message]
+    assert "dispatcher is not draining" in record.getMessage()
+
+
+def test_delivery_shortfall_names_hermes(caplog):
+    """dispatched == received but nothing delivered: Hermes drops them."""
+    adapter = _armed_gap_adapter(received=4, dispatched=4)
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    (record,) = [r for r in caplog.records if "healthy but deaf" in r.message]
+    message = record.getMessage()
+    assert "dropped inside Hermes" in message
+    assert "4 update(s) received" in message
+
+
+def test_report_is_not_repeated_until_more_updates_arrive(caplog):
+    adapter = _armed_gap_adapter()
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+        adapter._check_ingress_delivery_gap()
+    assert len([r for r in caplog.records if "healthy but deaf" in r.message]) == 1
+
+    # A further update with still no delivery is a new, reportable data point.
+    adapter._updates_received_total += 1
+    adapter._updates_dispatched_total += 1
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert len([r for r in caplog.records if "healthy but deaf" in r.message]) == 2
+
+
+def test_gap_check_never_triggers_recovery():
+    """Reconnecting a healthy transport cannot fix a dropped update.
+
+    The reconnect ladder belongs to the transport probes; this check is
+    diagnosis only, so it must leave the ladder untouched.
+    """
+    adapter = _armed_gap_adapter()
+    adapter._check_ingress_delivery_gap()
+    assert adapter._polling_error_task is None
+
+
+def test_gap_check_skipped_in_webhook_mode(caplog):
+    adapter = _armed_gap_adapter()
+    adapter._webhook_mode = True
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert not [r for r in caplog.records if "healthy but deaf" in r.message]
+
+
+def test_gap_check_skipped_during_teardown(caplog):
+    adapter = _armed_gap_adapter()
+    adapter._polling_teardown_started = True
+    with caplog.at_level(logging.ERROR):
+        adapter._check_ingress_delivery_gap()
+    assert not [r for r in caplog.records if "healthy but deaf" in r.message]
+
+
+# ---------------------------------------------------------------------------
+# dispatched counter
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_catch_all_observer_counts_dispatch_before_early_return():
+    """The counter must be stamped even when no plugin hook is installed.
+
+    ``_on_platform_update`` returns immediately without a platform-event
+    handler; if the counter sat after that return, every gateway without the
+    hook would report a permanent dispatcher stall.
+    """
+    adapter = _make_adapter()
+    adapter._platform_event_handler = None
+
+    await adapter._on_platform_update(MagicMock(), MagicMock())
+
+    assert adapter._updates_dispatched_total == 1
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_runs_the_gap_check():
+    """The check has to be wired into the loop that actually runs."""
+    adapter = _make_adapter()
+    bot = MagicMock()
+    bot.get_me = AsyncMock()
+    adapter._app.bot = bot
+    adapter._bot = bot
+    called = []
+    adapter._check_ingress_delivery_gap = lambda: called.append(True)
+    adapter._probe_pending_updates = AsyncMock()
+    adapter._check_polling_stall = AsyncMock()
+
+    real_sleep = asyncio.sleep
+
+    async def fast_sleep(_delay, *args, **kwargs):
+        await real_sleep(0)
+
+    task = asyncio.get_running_loop().create_task(adapter._polling_heartbeat_loop())
+    import plugins.platforms.telegram.adapter as tg_adapter
+
+    original = tg_adapter.asyncio.sleep
+    tg_adapter.asyncio.sleep = fast_sleep
+    try:
+        for _ in range(50):
+            await real_sleep(0)
+            if called:
+                break
+    finally:
+        tg_adapter.asyncio.sleep = original
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    assert called, "_polling_heartbeat_loop must run the ingress gap check"


### PR DESCRIPTION
## Summary

Closes #102260.

A Telegram gateway can be **healthy and deaf at the same time**, and nothing in the process can currently tell you so. Every probe this adapter owns measures the *transport*:

| probe | what it actually proves |
|---|---|
| `_record_polling_progress` | a `getUpdates` HTTP round-trip returned `200 {"ok":true,...}` |
| `_check_polling_stall` (#92991) | *some* round-trip completed within 150s |
| `_probe_pending_updates` (#42909/#55769) | the server-side queue is draining |
| `get_me()` heartbeat (#66377) | the general request path is up |

None of them observes whether a single update ever reached a handler. So when updates arrive and then die downstream, the adapter publishes `connected`, logs nothing at all, and is indistinguishable from a bot nobody has messaged. That is exactly #102260: three weeks of `telegram.state: "connected"` plus `polling confirmed healthy: getUpdates progressing (generation 1)` with zero inbound reaching the agent, surviving every restart.

This PR adds the missing **delivered side** of the accounting, and makes the one genuinely silent drop on the shared ingress funnel speak.

## Findings on the reported hypotheses

Two of the three suspicions in the issue are refuted by the code as it stands on `63279301bc`:

1. **"`_record_polling_progress` may only fire at `start_polling`."** It fires on *every* `getUpdates` round-trip. `_instrument_polling_request` re-tags the dedicated polling request's class, so `_observe_polling_request_result` runs inside `do_request` and records progress per response — not once at bootstrap.
2. **"`_send_path_degraded` is set at startup and never cleared."** It is cleared on the first confirmed round-trip of the generation, which is precisely why the published state is `connected` rather than `retrying`.

The third — "polling died" — is contradicted by the reporter's own strongest datapoint: after `deleteWebhook?drop_pending_updates=true`, *"bot can now receive fresh messages but still doesn't process them."* Updates are entering the process. And had the long-poll actually stopped, `_check_polling_stall` (150s) and `_probe_pending_updates` (2 x 90s) would both have escalated with loud `ERROR`/`WARNING` lines. Silence on those means the transport is alive.

So the failure is **downstream of the transport**, in a stretch that has no instrumentation whatsoever.

## What this changes

Three counters that split "deaf" into its distinguishable causes:

- **received** — updates Telegram handed the process, taken from the `getUpdates` envelope the adapter *already* parses (an empty `result` proves the transport, not arrival, so only non-empty results count).
- **dispatched** — updates PTB's dispatcher carried through the whole handler chain, stamped in the existing group-99 catch-all before its early returns.
- **delivered** — inbound events that reached the gateway's message handler, stamped in `BasePlatformAdapter.handle_message` (all platforms).

`_check_ingress_delivery_gap()` runs on the existing 90s heartbeat and, when updates arrived but nothing was delivered for 300s, logs which hop broke:

- `received > dispatched` → PTB's dispatcher is not draining them.
- `dispatched > delivered` → Hermes is dropping them (authorization, mention/topic gating, held-inbound).

Plus: `BasePlatformAdapter.handle_message` opened with `if not self._message_handler: return` — a **completely silent** discard of 100% of inbound on a connected, sending, polling adapter. It now says so once per adapter.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#00f0ff', 'mainBkg': '#0a0a16', 'primaryTextColor': '#ffffff', 'primaryBorderColor': '#ff007f', 'lineColor': '#00f0ff'}}}%%
graph TD
    A[Telegram getUpdates] -->|non-empty result| B[Counter: received]
    B --> C[PTB Dispatcher]
    C -->|handler chain completed| D[Counter: dispatched]
    D --> E[Hermes Ingress Filters]
    E -->|reached message handler| F[Counter: delivered]
    F --> G[Agent Turn]
    B -.->|received > dispatched| H[Diagnosis: Dispatcher Not Draining]
    D -.->|dispatched > delivered| I[Diagnosis: Dropped Inside Hermes]
    E -.->|no handler installed| J[Silent Discard - Now Logged]
```

## Deliberately diagnostic, never a new recovery path

A received update legitimately reaches no gateway turn — the bot's own messages, reactions, unmentioned group chatter. So this check **never** drives recovery: reconnecting a healthy transport cannot repair a dropped update, and a false-positive reconnect would be strictly worse than a log line. It reports once per received-count, and re-arms as soon as a delivery lands after the last update.

## Scope and non-overlap with open work

This deliberately does **not** touch layers other PRs already own:

- **#71240** (`fix(telegram): detect stalled local update dispatch`) owns the *recovery* for a stalled PTB dispatcher via `Application.running` + `update_queue.qsize()`. This PR adds no queue inspection and no escalation — where its counters point at that layer they simply name it. The two compose: #71240 acts, this explains.
- **#97446** (durable ingress across reconnects), **#92408** (persistent update-id dedup), **#96627** (rewire plugin handlers after app rebuild), **#84495** / **#95234** / **#98641** / **#93440** (transport, sticky IP, generations, degraded sends) are all untouched.
- The merged transport watchdogs (#92991, #66377, #55769, #42909) are untouched — this only reads the envelope they already parse.

No supersede is needed: no open PR claims the received/dispatched/delivered boundary, and none reports a deaf-but-healthy ingress.

## Tests

`tests/gateway/test_telegram_ingress_delivery_gap.py` — 15 tests:

- empty `getUpdates` result records transport progress but counts no arrivals; non-empty counts every update
- missing message handler is logged exactly once and delivers nothing
- gap check stays quiet inside the window, with nothing ever received, and when a delivery followed the last update
- `received > dispatched` names the dispatcher; `dispatched > delivered` names Hermes
- the report is not repeated until more updates arrive
- the gap check never touches `_polling_error_task` (no recovery), and is skipped in webhook mode and during teardown
- the group-99 catch-all counts dispatch *before* its early return (otherwise every gateway without the plugin hook would report a permanent stall)
- `_polling_heartbeat_loop` actually runs the check

```
python -m pytest tests/gateway/test_telegram_ingress_delivery_gap.py -q
15 passed
```

Regression (25 passed): `test_telegram_polling_stall_watchdog.py`, `test_telegram_pending_update_probe.py`, `test_telegram_polling_progress.py`, `test_telegram_polling_health_confirmation.py`. Ruff clean on all changed files.

## What the reporter should see next

With this on `termite`, the next occurrence produces one of two explicit lines instead of silence, which finally discriminates the remaining candidates (a wedged dispatcher vs. an authorization/gating/hold drop) without another three weeks of `getWebhookInfo` archaeology.

## Risk and rollback

Counters and log lines only. No config, no schema, no behavior change on the delivery path. Plain revert.
