### PR TITLE
fix(whatsapp-bridge): classify modern voice notes as ptt so auto-STT runs

### DIFF
--- a/scripts/whatsapp-bridge/bridge.native.test.mjs
+++ b/scripts/whatsapp-bridge/bridge.native.test.mjs
@@ -184,6 +184,72 @@ import {
   console.log('  ✓ MIME extension is preserved when document filename has none');
 }
 
+// -- voice-note vs audio-file classification (ptv / ptt / bare ogg audio) ---
+{
+  const cases = [
+    {
+      name: 'ptvMessage is classified as ptt voice note',
+      message: { ptvMessage: { mimetype: 'audio/ogg;codecs=opus' } },
+      expectedType: 'ptt',
+      expectedNative: 'ptvMessage',
+    },
+    {
+      name: 'legacy pttMessage is classified as ptt voice note',
+      message: { pttMessage: { mimetype: 'audio/ogg;codecs=opus' } },
+      expectedType: 'ptt',
+      expectedNative: 'pttMessage',
+    },
+    {
+      name: 'audioMessage with ptt flag is classified as ptt voice note',
+      message: { audioMessage: { mimetype: 'audio/ogg;codecs=opus', ptt: true } },
+      expectedType: 'ptt',
+      expectedNative: 'audioMessage',
+    },
+    {
+      // WhatsApp Business 2025+ sends voice notes as bare audioMessage with
+      // ptt unset; ogg/opus without a fileName is the voice-note signature.
+      name: 'bare ogg/opus audioMessage without fileName is classified as ptt',
+      message: { audioMessage: { mimetype: 'audio/ogg;codecs=opus' } },
+      expectedType: 'ptt',
+      expectedNative: 'audioMessage',
+    },
+    {
+      name: 'shared mp3 audio file stays audio',
+      message: { audioMessage: { mimetype: 'audio/mpeg', fileName: 'song.mp3' } },
+      expectedType: 'audio',
+      expectedNative: 'audioMessage',
+    },
+    {
+      name: 'ogg audio file with fileName stays audio',
+      message: { audioMessage: { mimetype: 'audio/ogg', fileName: 'recording.ogg' } },
+      expectedType: 'audio',
+      expectedNative: 'audioMessage',
+    },
+  ];
+
+  for (const { name, message, expectedType, expectedNative } of cases) {
+    const cacheDir = mkdtempSync(path.join(tmpdir(), 'hermes-wa-audio-'));
+    const event = await extractBridgeEvent({
+      msg: {
+        key: { id: 'aud-1', remoteJid: '15551234567@s.whatsapp.net', fromMe: false },
+        messageTimestamp: 123,
+        message,
+      },
+      chatId: '15551234567@s.whatsapp.net',
+      senderId: '15550001111@s.whatsapp.net',
+      senderNumber: '15550001111',
+      downloadMedia: async () => Buffer.from('ogg'),
+      cacheDirs: { audio: cacheDir },
+    });
+
+    assert.equal(event.hasMedia, true, name);
+    assert.equal(event.mediaType, expectedType, name);
+    assert.equal(event.nativeType, expectedNative, name);
+    assert.equal(event.nativeMetadata.audio.ptt, expectedType === 'ptt', name);
+  }
+  console.log('  ✓ voice notes (ptv/ptt/bare ogg) classify as ptt, audio files stay audio');
+}
+
 {
   const event = await extractBridgeEvent({
     msg: {

--- a/scripts/whatsapp-bridge/bridge_helpers.js
+++ b/scripts/whatsapp-bridge/bridge_helpers.js
@@ -372,11 +372,17 @@ export async function extractBridgeEvent({
     mime = item.mimetype || 'video/mp4';
     nativeMetadata.video = { gifPlayback: !!item.gifPlayback };
     await saveMedia({ mediaMessage: item, dir: cacheDirs.document, prefix: 'vid', fallbackExt: '.mp4', type: mediaType });
-  } else if (messageContent.audioMessage || messageContent.pttMessage) {
-    const item = messageContent.pttMessage || messageContent.audioMessage;
+  } else if (messageContent.audioMessage || messageContent.pttMessage || messageContent.ptvMessage) {
+    // ptvMessage = newer WhatsApp push-to-talk voice notes (2025+ protocol)
+    const item = messageContent.ptvMessage || messageContent.pttMessage || messageContent.audioMessage;
     hasMedia = true;
-    mediaType = item.ptt || messageContent.pttMessage ? 'ptt' : 'audio';
-    nativeType = messageContent.pttMessage ? 'pttMessage' : 'audioMessage';
+    const _mime0 = item.mimetype || '';
+    // Some clients (WhatsApp Business 2025+) send voice notes as a bare
+    // audioMessage with ptt unset. Voice notes are always ogg/opus and carry
+    // no fileName; shared audio files have a fileName or a non-opus mimetype.
+    const _voiceish = (_mime0.includes('ogg') || _mime0.includes('opus')) && !item.fileName;
+    mediaType = item.ptt || messageContent.ptvMessage || messageContent.pttMessage || _voiceish ? 'ptt' : 'audio';
+    nativeType = messageContent.ptvMessage ? 'ptvMessage' : (messageContent.pttMessage ? 'pttMessage' : 'audioMessage');
     mime = item.mimetype || 'audio/ogg';
     nativeMetadata.audio = { ptt: mediaType === 'ptt' };
     await saveMedia({ mediaMessage: item, dir: cacheDirs.audio, prefix: 'aud', fallbackExt: '.ogg', type: 'audio' });


### PR DESCRIPTION
## Problem

WhatsApp voice memos silently stop working on the gateway STT path with current WhatsApp Business clients.

`extractBridgeEvent()` recognized voice notes only via `pttMessage`, or `audioMessage` with `ptt: true`. Observed in the wild (WhatsApp Business, Android, Sep 2026):

- voice notes arriving as `**ptvMessage**` (newer push-to-talk container)
- voice notes arriving as bare `audioMessage` with `mimetype: audio/ogg;codecs=opus` and **no** `ptt` flag, **no** `fileName`

Both fall through to `mediaType = 'audio'`. The gateway deliberately never auto-STTs AUDIO-typed attachments (so a shared MP3 isn't transcribed), so the event is delivered to the agent as "user sent an audio file" and the voice-memo feature degrades to the agent apologizing about a missing transcription tool. Debug log evidence (redacted):

```json
{"event":"debug","stage":"queued","hasMedia":true,"mediaType":"audio","bodyLength":16}
```
for a push-to-talk voice note that rendered as a voice bubble in the app.

## Fix

`scripts/whatsapp-bridge/bridge_helpers.js`, audio branch only:

1. Recognize `ptvMessage` (checked first, like `pttMessage` was).
2. Heuristic for the unflagged case: ogg/opus mimetype **without** a `fileName` is the voice-note signature (WhatsApp voice notes are always ogg/opus and unnamed; user-shared audio files carry a `fileName` or a non-opus mimetype). These classify as `ptt`; real audio files keep classifying as `audio`.
3. `nativeType` now reflects the actual container (`ptvMessage`/`pttMessage`/`audioMessage`) instead of being pinned to the legacy two-way name.

## Tests

`bridge.native.test.mjs`: table-driven block asserting `mediaType`/`nativeType`/`nativeMetadata.audio.ptt` for ptv, legacy ptt, ptt-flagged audio, bare ogg voice note, plus two negatives (mp3 with fileName, ogg with fileName) that must stay `audio`. All existing tests pass (`node bridge.native.test.mjs`).

## Validation

Verified end-to-end on a live WhatsApp Business account: before the patch, voice notes logged `mediaType: "audio"` and the gateway skipped STT; after, the same notes classify `ptt`, enter the STT pipeline, and the German memo transcribes correctly (whisper medium, `de` @ 0.99).