### PR TITLE
fix(cli): tolerate corrupt timestamps in session exports

### DIFF
--- a/hermes_cli/session_export.py
+++ b/hermes_cli/session_export.py
@@ -254,11 +254,15 @@ def _format_timestamp(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, (int, float)):
-        return (
-            datetime.fromtimestamp(float(value), tz=timezone.utc)
-            .isoformat(timespec="seconds")
-            .replace("+00:00", "Z")
-        )
+        try:
+            return (
+                datetime
+                .fromtimestamp(float(value), tz=timezone.utc)
+                .isoformat(timespec="seconds")
+                .replace("+00:00", "Z")
+            )
+        except (OverflowError, OSError, ValueError):
+            return str(value)
     if isinstance(value, datetime):
         dt = value if value.tzinfo else value.replace(tzinfo=timezone.utc)
         return dt.astimezone(timezone.utc).isoformat(timespec="seconds").replace(

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -715,7 +715,7 @@ def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
         html = f'<div class="{msg_class}"{delay_style}>'
         html += f'  <div class="message-header">'
         html += f'    <div class="role-badge">{chevron_html} {role_icon} {safe_role}</div>'
-        html += f'    <div class="timestamp">{timestamp}</div>'
+        html += f'    <div class="timestamp">{_escape_html(timestamp)}</div>'
         html += '  </div>'
         html += '  <div class="message-body">'
         
@@ -787,7 +787,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
                 <div class="session-item-title">{_escape_html(title)}</div>
                 <div class="session-item-meta">
                     <span>{_escape_html(sid[:8])}</span>
-                    <span>{date}</span>
+                    <span>{_escape_html(date)}</span>
                 </div>
             </a>
             '''
@@ -849,7 +849,7 @@ def generate_multi_session_html_export(sessions: List[Dict[str, Any]]) -> str:
                 <div class="meta">
                     <div class="meta-item"><strong>ID:</strong> {escaped_sid}</div>
                     <div class="meta-item"><strong>Model:</strong> {_escape_html(model)}</div>
-                    <div class="meta-item"><strong>Started:</strong> {started_at}</div>
+                    <div class="meta-item"><strong>Started:</strong> {_escape_html(started_at)}</div>
                 </div>
                 {system_html}
             </header>

--- a/hermes_cli/session_export_html.py
+++ b/hermes_cli/session_export_html.py
@@ -653,9 +653,15 @@ def _escape_html(text: str) -> str:
         text = str(text)
     return text.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;").replace('"', "&quot;").replace("'", "&#39;")
 
-def _format_timestamp(ts: float) -> str:
-    if not ts: return "N/A"
-    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+
+def _format_timestamp(ts: Any) -> str:
+    if not ts:
+        return "N/A"
+    try:
+        return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M:%S")
+    except (OverflowError, OSError, TypeError, ValueError):
+        return str(ts)
+
 
 def _generate_messages_html(messages: List[Dict[str, Any]]) -> str:
     html_list = []

--- a/hermes_cli/session_export_md.py
+++ b/hermes_cli/session_export_md.py
@@ -26,7 +26,15 @@ def _iso_timestamp(value: Any) -> str:
         ts = float(value)
     except (TypeError, ValueError):
         return str(value)
-    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat().replace("+00:00", "Z")
+    try:
+        return (
+            datetime
+            .fromtimestamp(ts, tz=timezone.utc)
+            .isoformat()
+            .replace("+00:00", "Z")
+        )
+    except (OverflowError, OSError, ValueError):
+        return str(value)
 
 
 def _frontmatter_value(value: Any) -> str:

--- a/tests/hermes_cli/test_session_export.py
+++ b/tests/hermes_cli/test_session_export.py
@@ -95,6 +95,20 @@ def test_export_record_count_switches_unit_for_prompt_only_exports():
     )
 
 
+def test_markdown_export_preserves_messages_with_corrupt_timestamp():
+    session = _sample_session()
+    session["messages"] = [
+        {"role": "user", "content": "damaged row", "timestamp": 1e30},
+        {"role": "assistant", "content": "healthy row", "timestamp": 1700000002},
+    ]
+
+    rendered = render_sessions_export([session], fmt="markdown")
+
+    assert "damaged row" in rendered
+    assert "1e+30" in rendered
+    assert "healthy row" in rendered
+
+
 def test_sessions_export_cli_prompt_only_stdout(monkeypatch, capsys):
     import hermes_cli.main as main_mod
     import hermes_state
@@ -133,5 +147,4 @@ def test_sessions_export_cli_prompt_only_stdout(monkeypatch, capsys):
         "exported": "sess-123",
         "closed": True,
     }
-
 

--- a/tests/hermes_cli/test_session_export_html.py
+++ b/tests/hermes_cli/test_session_export_html.py
@@ -75,6 +75,27 @@ def test_html_export_preserves_messages_with_corrupt_timestamp():
     assert "healthy row" in html
 
 
+def test_html_export_escapes_corrupt_timestamp_fallbacks():
+    payload = '<img src=x onerror="alert(1)">'
+    sessions = [
+        {
+            "id": "abc",
+            "started_at": payload,
+            "messages": [
+                {"role": "user", "content": "damaged row", "timestamp": payload},
+                {"role": "assistant", "content": "healthy row", "timestamp": 1700000002},
+            ],
+        },
+        {"id": "def", "started_at": 1700000000, "messages": []},
+    ]
+
+    html = generate_multi_session_html_export(sessions)
+
+    assert payload not in html
+    assert "&lt;img src=x onerror=&quot;alert(1)&quot;&gt;" in html
+    assert "healthy row" in html
+
+
 def test_single_session_untitled_coalesces_none_title_and_model():
     """An un-named session (title/model still ``None`` until async title
     generation completes) is the default state, so the single-session export

--- a/tests/hermes_cli/test_session_export_html.py
+++ b/tests/hermes_cli/test_session_export_html.py
@@ -61,6 +61,20 @@ def test_multi_session_export_keeps_switcher_script():
     assert 'id="view-bbbb2222"' in html
 
 
+def test_html_export_preserves_messages_with_corrupt_timestamp():
+    html = generate_html_export({
+        "id": "abc",
+        "messages": [
+            {"role": "user", "content": "damaged row", "timestamp": float("nan")},
+            {"role": "assistant", "content": "healthy row", "timestamp": 1700000002},
+        ],
+    })
+
+    assert "damaged row" in html
+    assert "nan" in html
+    assert "healthy row" in html
+
+
 def test_single_session_untitled_coalesces_none_title_and_model():
     """An un-named session (title/model still ``None`` until async title
     generation completes) is the default state, so the single-session export

--- a/tests/hermes_cli/test_session_export_md.py
+++ b/tests/hermes_cli/test_session_export_md.py
@@ -61,6 +61,21 @@ def test_safe_session_filename_is_deterministic_and_path_safe():
 
 
 
+def test_markdown_export_preserves_messages_with_corrupt_timestamp():
+    session = _session(
+        messages=[
+            {"role": "user", "content": "damaged row", "created_at": float("inf")},
+            {"role": "assistant", "content": "healthy row", "created_at": 1783331698.0},
+        ]
+    )
+
+    rendered = render_session_markdown(session)
+
+    assert "damaged row" in rendered
+    assert "inf" in rendered
+    assert "healthy row" in rendered
+
+
 def test_verify_export_file_checks_count_and_sha(tmp_path):
     session = _session()
     path = write_session_markdown(session, tmp_path)
@@ -73,5 +88,4 @@ def test_verify_export_file_checks_count_and_sha(tmp_path):
     ok, reason = verify_export_file(path, session)
     assert ok is False
     assert "sha256" in reason
-
 


### PR DESCRIPTION
## What does this PR do?

Session exports now preserve damaged rows when a stored timestamp cannot be converted by `datetime.fromtimestamp()`. Instead of aborting the entire export on out-of-range or non-finite values, all three export paths fall back to the raw timestamp string and continue rendering the remaining messages and sessions.

This keeps the existing behavior for valid timestamps and matches the existing raw-string fallback for unknown timestamp types. In the HTML renderer, fallback values are escaped at all three output sinks (message timestamp, multi-session sidebar date, and session header) so corrupt string values remain display text rather than becoming markup.

## Related Issue

Fixes #102352

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Guard numeric timestamp conversion in `hermes_cli/session_export.py`.
- Guard converted timestamps in `hermes_cli/session_export_md.py`.
- Guard HTML timestamp conversion in `hermes_cli/session_export_html.py`.
- Escape timestamp display text at every HTML insertion point: message headers, multi-session sidebar dates, and session metadata.
- Add public-renderer regression coverage for out-of-range, infinite, and NaN timestamps while asserting healthy sibling messages remain in the export.
- Add an HTML injection regression using a tag-shaped corrupt timestamp and assert only the escaped display value is emitted.

## How to Test

1. Run `uv run pytest -q tests/hermes_cli/test_session_export.py tests/hermes_cli/test_session_export_md.py tests/hermes_cli/test_session_export_html.py tests/hermes_cli/test_session_export_html_escape.py`.
2. Confirm all 16 tests pass.
3. Run `uv run ruff check` against the changed renderer modules and tests.
4. Run `uv run ty check hermes_cli/session_export.py hermes_cli/session_export_md.py hermes_cli/session_export_html.py`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, arm64, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A; behavior is internal error recovery with regression tests
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Focused verification:

```text
16 passed
ruff: All checks passed!
ty: All checks passed!
```

The HTML regression covers a tag-shaped corrupt timestamp in the message header, multi-session sidebar, and session metadata. The raw tag is absent from the generated document; its escaped display value remains visible.

The CI-parity parallel suite was also started with the same extras as `.github/workflows/tests.yml`. Under 16-way local load, two unrelated compression timing tests failed at about 4.5%; both files passed immediately in an isolated rerun (`23 passed`). The export test files remained green. The full-suite checkbox is intentionally left unchecked so this local timing result is not overstated; GitHub CI can provide the clean-room full-suite result.
