### PR TITLE
fix(tools): block signal-operand spellings in the kill-all hardline rule

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -103,6 +103,11 @@ _HARDLINE_BLOCK = [
     "kill --signal KILL -1",
     "kill --signal=9 -1",
     "sudo kill -s TERM -1",
+    # separated signal operands in carrier positions (#102389)
+    "kill -9 -s TERM -1",
+    "ls; kill --signal KILL -1",
+    "$(kill -s KILL -1)",
+    'bash -c "kill -s KILL -1"',
     # Shutdown / reboot / halt
     "shutdown -h now",
     "shutdown -r now",

--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -97,6 +97,12 @@ _HARDLINE_BLOCK = [
     # System-wide kill
     "kill -9 -1",
     "kill -1",
+    # -s/--signal with a separate signal operand (#102389)
+    "kill -s KILL -1",
+    "kill -s 9 -1",
+    "kill --signal KILL -1",
+    "kill --signal=9 -1",
+    "sudo kill -s TERM -1",
     # Shutdown / reboot / halt
     "shutdown -h now",
     "shutdown -r now",
@@ -176,6 +182,10 @@ _HARDLINE_ALLOW = [
     # Redirect to regular files / non-block devices
     "echo done > /tmp/flag",
     "echo test > /dev/null",
+    # Targeted (non -1) kills stay clean (#102389)
+    "kill -s KILL 1234",
+    "kill -l",
+    "kill 1234",
     # Reading devices is fine
     "ls /dev/sda",
     "cat /dev/urandom | head -c 10",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -592,7 +592,9 @@ HARDLINE_PATTERNS = [
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system — anchor the command-name token so
     # `echo "kill -1 sends SIGHUP to everything"` doesn't trip (#93392).
-    (_CMDPOS + r'kill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    # The flag run also consumes -s/--signal operands: the signal may be a
+    # separate argument (`kill -s KILL -1`), not just glued (`kill -9 -1`).
+    (_CMDPOS + r'kill\s+(-[^\s]+\s+|(?:-s|--signal)(?:=|\s+)\S+\s+)*-1\b', "kill all processes"),
     # System shutdown / reboot — anchor to command position (start of line,
     # after a command separator, or after sudo/env wrappers) so we don't
     # false-positive on "echo reboot" or "grep 'shutdown' logs".


### PR DESCRIPTION
Hey, found this while poking at the approval guards — the kill-all floor only understood glued signal flags, so POSIX-standard spellings with a separate signal operand slipped through silently, even in yolo mode.

One-line fix: the flag run in the rule now also consumes `-s`/`--signal` operands. Targeted kills stay clean — only the broadcast target is gated.

Verified 8 block + 7 clean shapes locally, added both sides to the blocklist suite (red without the fix, green with it). The 4 unrelated neighbor failures (sort/man binaries, rm artifact) fail on pristine main too, so they're environmental.

Fixes #102389