### PR TITLE
fix(agent): retry 503/529 capacity overloads over a bounded window, then fall back

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -95,6 +95,9 @@ from agent.prompt_caching import (
 from agent.provider_projection import splice_provider_projection
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
+    capacity_overload_backoff,
+    capacity_overload_retry_ceiling,
+    is_capacity_overload_error,
     is_zai_coding_overload_error,
     jittered_backoff,
     zai_coding_overload_retry_ceiling,
@@ -5989,9 +5992,41 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
+                # #38929 / #68771: generic provider 503/529 "upstream capacity
+                # limits" overloads get the same retry-over-time treatment as
+                # Z.AI Coding overloads — a bounded long-backoff window on the
+                # PRIMARY before the fallback chain activates. Capacity outages
+                # often clear in seconds-to-minutes; falling back (or giving up
+                # when no fallback chain exists) after one ~2s retry is too
+                # eager. Eager fallback is suppressed for the duration of the
+                # window; after the ceiling the normal max-retries path
+                # activates the fallback chain.
+                _is_capacity_overload = (
+                    not _is_zai_coding_overload
+                    and is_capacity_overload_error(api_error)
+                )
+                if _is_capacity_overload:
+                    max_retries = max(
+                        max_retries, capacity_overload_retry_ceiling()
+                    )
+                # Eager fallback is suppressed for capacity overloads during
+                # the retry window, but once retry_count reaches the capacity
+                # ceiling the normal transport-failure fallback path must
+                # activate — otherwise the primary fails permanently without
+                # ever consulting the configured fallback chain. The
+                # `retry_count >= 2` floor is preserved for non-capacity
+                # transport failures (transient blips recover on retry).
+                _capacity_fallback_floor = (
+                    capacity_overload_retry_ceiling() - 1
+                    if _is_capacity_overload
+                    else 2
+                )
                 _should_fallback = (
                     (is_rate_limited and _wrapped_output_cap_budget is None)
-                    or (_is_transport_failure and retry_count >= 2)
+                    or (
+                        _is_transport_failure
+                        and retry_count >= _capacity_fallback_floor
+                    )
                 )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
@@ -7222,18 +7257,38 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
-                if is_rate_limited or _is_zai_coding_overload:
+                # #38929: capacity overloads use a separate schedule; only
+                # fires when the Z.AI overload adaptive backoff above did
+                # not (i.e. this is a generic 503/529, not a Z.AI Coding
+                # 429). Precedence: rate-limit / Z.AI / capacity all
+                # mutually exclusive because the error classifier picks
+                # exactly one FailoverReason and _is_zai_coding_overload
+                # is detected from the URL/model so it shadows the generic
+                # 503/529 detection.
+                if _is_capacity_overload and _backoff_policy is None and not _retry_after:
+                    wait_time, _backoff_policy = capacity_overload_backoff(
+                        retry_count + 1, wait_time
+                    )
+                if is_rate_limited or _is_zai_coding_overload or _is_capacity_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    elif _backoff_policy == "capacity_overload_long":
+                        _policy_note = " (upstream capacity overload — waiting for the model to come back)"
+                    elif _backoff_policy == "capacity_overload_short":
+                        _policy_note = " (upstream capacity overload short retry)"
+                    _wait_reason = (
+                        "Provider overloaded"
+                        if (_is_zai_coding_overload or _is_capacity_overload) and not is_rate_limited
+                        else "Rate limited"
+                    )
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
-                    # Z.AI Coding waits are different: they can last minutes, so surface
-                    # progress immediately instead of making the TUI look frozen.
-                    if _backoff_policy == "zai_coding_overload_long":
+                    # Z.AI Coding / capacity waits are different: they can last minutes, so
+                    # surface progress immediately instead of making the TUI look frozen.
+                    if _backoff_policy in ("zai_coding_overload_long", "capacity_overload_long"):
                         agent._emit_status(_rate_limit_status)
                     else:
                         agent._buffer_status(_rate_limit_status)

--- a/agent/retry_utils.py
+++ b/agent/retry_utils.py
@@ -34,6 +34,20 @@ _ZAI_CODING_OVERLOAD_LONG_BACKOFF = (30.0, 60.0, 90.0, 120.0)
 # the two from silently desyncing if the short-retry count is ever tuned.
 _ZAI_CODING_OVERLOAD_SHORT_ATTEMPTS = 3
 
+# #38929 / #68771: provider 503/529 "upstream capacity limits" overloads.
+# A capacity outage typically lasts tens of seconds to a few minutes, so a
+# single quick retry followed by eager fallback (or give-up when no fallback
+# chain exists) is too aggressive. Keep the first retry on the normal short
+# schedule, then walk a longer backoff table so the primary gets a few retries
+# over ~75s before the fallback chain activates.
+_CAPACITY_OVERLOAD_LONG_BACKOFF = (5.0, 10.0, 20.0, 40.0)
+
+# Number of initial short retries before the capacity long-backoff tier kicks
+# in. Shared by ``capacity_overload_backoff`` and
+# ``capacity_overload_retry_ceiling`` for the same desync-prevention reason
+# as the Z.AI constants above.
+_CAPACITY_OVERLOAD_SHORT_ATTEMPTS = 1
+
 
 def parse_retry_after_seconds(value_or_headers: Any) -> Optional[float]:
     """Parse a ``Retry-After`` value into non-negative seconds.
@@ -206,3 +220,94 @@ def zai_coding_overload_retry_ceiling(short_attempts: int = _ZAI_CODING_OVERLOAD
     value for Z.AI Coding overload 429s so the 30/60/90/120s waits run.
     """
     return short_attempts + len(_ZAI_CODING_OVERLOAD_LONG_BACKOFF) + 1
+
+
+def is_capacity_overload_error(error: Any) -> bool:
+    """True when ``error`` is a provider 503/529 capacity overload.
+
+    Status-code based — the reliable signal; message wording varies wildly
+    across providers (Anthropic/OpenRouter: "temporarily unavailable due to
+    upstream capacity limits"; Cloudflare 529: origin overload). 503 Service
+    Unavailable and Cloudflare 529 both mean the model cannot serve right now
+    but may recover in seconds-to-minutes.
+
+    Walks the error's ``__cause__``/``__context__`` chain and checks every
+    attribute SDKs use to expose status codes: ``.status_code`` (openai,
+    most SDKs), ``.status`` (anthropic streaming), ``.code`` (urllib,
+    gRPC, google-genai), and ``.response.status_code`` (httpx, requests).
+    This matches the traversal done by
+    ``agent.error_classifier._extract_status_code`` so we don't miss errors
+    the classifier itself would recognise as 503/529.
+    """
+    stack: list[Any] = [error]
+    seen: set[int] = set()
+    while stack:
+        current = stack.pop()
+        if current is None or id(current) in seen:
+            continue
+        seen.add(id(current))
+        if isinstance(current, BaseException):
+            for attr in ("status_code", "status", "code"):
+                code = getattr(current, attr, None)
+                if isinstance(code, int) and code in {503, 529}:
+                    return True
+            response = getattr(current, "response", None)
+            if response is not None:
+                resp_code = getattr(response, "status_code", None)
+                if isinstance(resp_code, int) and resp_code in {503, 529}:
+                    return True
+        # Push both branches so a 503 buried under a context chain is
+        # not silently ignored when __cause__ is also set.
+        for link in (
+            getattr(current, "__cause__", None),
+            getattr(current, "__context__", None),
+        ):
+            if link is not None and link is not current:
+                stack.append(link)
+    return False
+
+
+def capacity_overload_backoff(
+    attempt: int,
+    default_wait: float,
+    short_attempts: int = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS,
+) -> tuple[float, str | None]:
+    """Adaptive 503/529 capacity-overload backoff.
+
+    The first ``short_attempts`` retries keep the caller's default wait
+    (normal short schedule); subsequent attempts walk
+    ``_CAPACITY_OVERLOAD_LONG_BACKOFF`` (5/10/20/40s) with light jitter, so a
+    capacity outage gets a few retries over roughly a minute instead of one
+    quick retry then fallback (or give-up when no fallback chain exists).
+
+    ``attempt`` is 1-based, matching the retry loop's logged attempt number.
+    Returns ``(wait_seconds, policy_label)`` where ``policy_label`` is suitable
+    for status/log decoration.
+    """
+    if attempt <= short_attempts:
+        return default_wait, "capacity_overload_short"
+    idx = min(
+        attempt - short_attempts - 1,
+        len(_CAPACITY_OVERLOAD_LONG_BACKOFF) - 1,
+    )
+    base_delay = _CAPACITY_OVERLOAD_LONG_BACKOFF[idx]
+    return (
+        jittered_backoff(
+            1, base_delay=base_delay, max_delay=base_delay, jitter_ratio=0.2
+        ),
+        "capacity_overload_long",
+    )
+
+
+def capacity_overload_retry_ceiling(
+    short_attempts: int = _CAPACITY_OVERLOAD_SHORT_ATTEMPTS,
+) -> int:
+    """Retry-loop ceiling needed for the full capacity backoff schedule.
+
+    Same rationale as ``zai_coding_overload_retry_ceiling``: the retry loop
+    gives up as soon as ``retry_count >= ceiling``, and that check runs
+    *before* the attempt's backoff is computed, so the ceiling must sit one
+    past the final long-backoff entry for every long tier to actually
+    execute.
+    """
+    return short_attempts + len(_CAPACITY_OVERLOAD_LONG_BACKOFF) + 1

--- a/tests/agent/test_capacity_overload_retry.py
+++ b/tests/agent/test_capacity_overload_retry.py
@@ -1,0 +1,180 @@
+"""#38929 / #68771: 503/529 "upstream capacity limits" overloads retry over a
+bounded backoff window on the primary BEFORE the fallback chain activates.
+
+The Z.AI overload path already gets a long adaptive backoff; this generalises
+that policy to provider-agnostic 503/529 overloads so a capacity outage gets
+a few retries over ~75s instead of one quick retry then fallback (or give-up
+when no fallback chain is configured).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agent.error_classifier import FailoverReason, classify_api_error
+from agent.retry_utils import (
+    capacity_overload_backoff,
+    capacity_overload_retry_ceiling,
+    is_capacity_overload_error,
+)
+
+
+class _Err(Exception):
+    def __init__(self, status_code, message="Service Unavailable"):
+        super().__init__(message)
+        self.status_code = status_code
+        self.response = None
+
+
+class _ErrWithStatusAttr(Exception):
+    """Some SDKs put the code on .status instead of .status_code."""
+
+    def __init__(self, status, message="Service Unavailable"):
+        super().__init__(message)
+        self.status = status
+        self.response = None
+
+
+class _ErrWithCause(Exception):
+    """httpx/SDK wrappers sometimes nest the real error on __cause__."""
+
+    def __init__(self, cause):
+        super().__init__(str(cause))
+        self.__cause__ = cause
+        self.response = None
+
+
+def test_503_and_529_are_capacity_overloads():
+    assert is_capacity_overload_error(_Err(503)) is True
+    assert is_capacity_overload_error(_Err(529)) is True
+
+
+def test_other_5xx_are_not_capacity_overloads():
+    assert is_capacity_overload_error(_Err(500)) is False
+    assert is_capacity_overload_error(_Err(502)) is False
+
+
+def test_4xx_and_2xx_are_not_capacity_overloads():
+    assert is_capacity_overload_error(_Err(429)) is False
+    assert is_capacity_overload_error(_Err(400)) is False
+    assert is_capacity_overload_error(_Err(200)) is False
+    assert is_capacity_overload_error(ValueError("no status")) is False
+
+
+def test_status_attr_also_works():
+    """Some SDKs use .status instead of .status_code; we should catch both."""
+    assert is_capacity_overload_error(_ErrWithStatusAttr(503)) is True
+    assert is_capacity_overload_error(_ErrWithStatusAttr(529)) is True
+    assert is_capacity_overload_error(_ErrWithStatusAttr(500)) is False
+
+
+def test_cause_chain_is_walked():
+    """httpx wraps the real error on __cause__; we should walk the chain."""
+    inner = _Err(503)
+    outer = _ErrWithCause(inner)
+    assert is_capacity_overload_error(outer) is True
+
+    # Even on context (not cause) chain.
+    try:
+        try:
+            raise _Err(503)
+        except _Err as inner_exc:
+            raise ValueError("wrapper") from None  # context, not cause
+    except ValueError as exc:
+        assert is_capacity_overload_error(exc) is True
+
+
+def test_cycle_in_cause_chain_does_not_loop():
+    """Defensive: a cycle in the cause chain must not hang."""
+    a = _Err(500)
+    b = _Err(500)
+    a.__cause__ = b
+    b.__cause__ = a
+    assert is_capacity_overload_error(a) is False  # both 500, not 503/529
+
+
+def test_httpx_response_status_code_works():
+    """httpx.HTTPStatusError puts the code on error.response.status_code."""
+    response = type("R", (), {"status_code": 503})()
+    err = type("E", (Exception,), {"response": response})()
+    assert is_capacity_overload_error(err) is True
+
+
+def test_requests_http_error_response_status_code_works():
+    """requests.exceptions.HTTPError also uses response.status_code."""
+    response = type("R", (), {"status_code": 529})()
+    err = type("E", (Exception,), {"response": response})()
+    assert is_capacity_overload_error(err) is True
+
+
+def test_urllib_style_code_attribute_works():
+    """urllib.error.HTTPError and gRPC wrappers expose status as .code."""
+    err = type("E", (Exception,), {"code": 503})()
+    assert is_capacity_overload_error(err) is True
+
+
+def test_both_cause_and_context_are_walked():
+    """When an exception has both __cause__ and __context__, we walk both."""
+    target = _Err(503)
+
+    class WithBoth(Exception):
+        pass
+
+    err = WithBoth("outer")
+    err.__cause__ = ValueError("unrelated")  # 0, not a 503
+    err.__context__ = target  # 503 — must be reached
+    assert is_capacity_overload_error(err) is True
+
+
+def test_self_referential_cause_does_not_loop():
+    """An exception whose __cause__ is itself must terminate."""
+    err = _Err(500)
+    err.__cause__ = err
+    assert is_capacity_overload_error(err) is False
+
+
+def test_503_classified_as_retryable_overloaded():
+    result = classify_api_error(_Err(503), provider="nous")
+    assert result.reason == FailoverReason.overloaded
+    assert result.retryable is True
+
+
+def test_capacity_backoff_first_retry_keeps_short_wait():
+    wait, policy = capacity_overload_backoff(1, 2.0)
+    assert wait == 2.0
+    assert policy == "capacity_overload_short"
+
+
+def test_capacity_backoff_walks_long_schedule():
+    # Long tier: 5/10/20/40 with light jitter (delay in [base, base*1.2])
+    waits = [capacity_overload_backoff(a, 2.0)[0] for a in range(2, 8)]
+    expected_bases = [5.0, 10.0, 20.0, 40.0, 40.0, 40.0]
+    for got, base in zip(waits, expected_bases):
+        assert base <= got <= base * 1.2, f"{got} not in [{base}, {base * 1.2}]"
+
+
+def test_capacity_backoff_caps_at_last_long_entry():
+    # After the 4-entry table, further attempts stay at 40s
+    waits = [capacity_overload_backoff(a, 2.0)[0] for a in range(6, 10)]
+    for w in waits:
+        assert 40.0 <= w <= 40.0 * 1.2
+
+
+def test_capacity_backoff_policy_labels():
+    assert (
+        capacity_overload_backoff(1, 2.0)[1] == "capacity_overload_short"
+    )
+    for a in range(2, 10):
+        assert capacity_overload_backoff(a, 2.0)[1] == "capacity_overload_long"
+
+
+def test_capacity_ceiling_reaches_all_long_tiers():
+    # 1 short + 4 long + 1 (the pre-backoff ceiling check) = 6
+    assert capacity_overload_retry_ceiling() == 6
+
+
+def test_capacity_ceiling_exceeds_default_api_max_retries():
+    """The ceiling must sit past the default api_max_retries (3) so the
+    long-backoff tiers actually run."""
+    ceiling = capacity_overload_retry_ceiling()
+    assert ceiling > 3


### PR DESCRIPTION
## Summary

Fixes #38929 — paid subscription users were hitting HTTP 503 "upstream capacity limits" on `qwen/qwen3.7-max` (and any provider 503/529), the loop retried the same model 3× (~24s with the old backoff), then either burned a configured fallback on a transient blip or dropped the turn entirely when no fallback chain existed.

This change gives provider-agnostic 503/529 capacity overloads the same retry-over-time treatment that the Z.AI Coding overload path already has: a bounded long-backoff window on the primary (~75s with a 5/10/20/40s schedule), then the normal transport-failure fallback path activates the configured fallback chain.

## How it works

| Stage | Behaviour |
|---|---|
| First retry | Keeps the normal short backoff (caller's `default_wait`) |
| Attempts 2–5 | 5s → 10s → 20s → 40s with light jitter (cap at 40s for further attempts) |
| Attempt 6 | The retry_count reaches `capacity_overload_retry_ceiling() - 1 = 5`, so the `_should_fallback` gate fires and the configured fallback chain activates — no further wait |
| `max_retries` | Raised from 3 (default) to 6 (capacity ceiling) so the long tier is reachable |
| Eager fallback | Suppressed during the window; activates when `retry_count` reaches the ceiling |
| Long waits | Surface immediately in the TUI via `_emit_status` instead of buffering |

**Latency tradeoff:** for a *persistent* (non-transient) capacity outage, the user waits up to ~75s before the fallback chain activates, compared to ~24s previously. This is intentional — a transient outage (the common case) clears within the window and the user never sees a fallback at all. A persistent outage burns the full window then falls back. For users with no fallback chain configured, the window is the difference between "transient blip recovered" and "turn failed."

The capacity detection is status-code based (`is_capacity_overload_error` walks the error's `__cause__`/`__context__` chain and reads `status_code` / `status` / `code` / `response.status_code` so httpx, requests, urllib, gRPC, and google-genai wrappers all get caught) — message wording varies too much across providers to be reliable.

## Why this approach (vs. immediate fallback)

Capacity outages are usually transient — they clear in seconds-to-minutes. Falling back (or giving up when no fallback chain exists) after one ~2s retry throws away a healthy primary for a temporary blip. The 5/10/20/40s schedule gives the primary ~75s to recover while keeping the user-visible wait bounded. After the ceiling, the fallback chain takes over.

## Relationship to other PRs/issues

- **#83754** (@DeseretSaint) proposed this same retry-over-time design. The approach is correct, but the PR is stalled (CONFLICTING, 3 weeks no activity, 6 CI workflows awaiting approval, 3 review findings unaddressed). I reused the Z.AI overload pattern but added: cause-chain walk (vs. shallow `getattr`), broader status attribute coverage (httpx `response.status_code`, `code`), and the post-window fallback activation that #83754 left open.
- **#68886** proposes the fallback-trigger half separately. Folded into this PR so the full "retry a few times, then fall back" behavior ships together.
- **#68771** is the umbrella feature request asking for 5xx to be treated as a fallback-chain trigger.

## Test plan

- [x] 18 new tests in `tests/agent/test_capacity_overload_retry.py` cover: status code detection across 4 attribute shapes, cause/context chain walking (both branches, cycle protection, self-referential cause), backoff schedule, policy labels, ceiling math, and 503 classification.
- [x] `pytest tests/agent/test_capacity_overload_retry.py` → 18/18 pass
- [x] `pytest tests/test_retry_utils.py tests/agent/test_error_classifier.py` → 133/133 pass (no regressions)
- [x] Existing Z.AI Coding overload behavior unchanged (Z.AI overload detection shadows the generic 503/529 path)

## Out of scope / open questions

- **Paid-user priority queue / SLA:** out of scope for this change — that requires backend coordination with Nous. The user's issue asks for it but it's not something we can ship in the agent.
- **Status page / capacity dashboard:** same — backend-owned.
- **Better error messages distinguishing rate-limit vs capacity:** partially addressed by the new "upstream capacity overload — waiting for the model to come back" policy note in the TUI. A full overhaul of the error message UX is a separate piece of work.

## Notes for reviewers

The cross-vendor review caught two real issues during implementation: (1) suppressing `_should_fallback` for capacity overloads meant the fallback chain was never reached after the window — fixed by gating the floor on `capacity_overload_retry_ceiling() - 1`; (2) an off-by-one in the attempt parameter — fixed by passing `retry_count + 1` to the 1-based `capacity_overload_backoff`.
