### PR TITLE
fix(approval): catch separated -s/--signal spellings in the kill-all floor

### DIFF
--- a/tests/tools/test_hardline_blocklist.py
+++ b/tests/tools/test_hardline_blocklist.py
@@ -97,6 +97,12 @@ _HARDLINE_BLOCK = [
     # System-wide kill
     "kill -9 -1",
     "kill -1",
+    # separated signal operands still hit the kill-all floor (#102389)
+    "kill -s KILL -1",
+    "kill -s 9 -1",
+    "kill --signal KILL -1",
+    "kill --signal=KILL -1",
+    "kill -9 -s TERM -1",
     # Shutdown / reboot / halt
     "shutdown -h now",
     "shutdown -r now",
@@ -201,6 +207,8 @@ _HARDLINE_ALLOW = [
     # targeted kill
     "kill -9 12345",
     "kill -HUP 1234",
+    "kill -s KILL 1234",
+    "kill --signal TERM 1234",
     "pkill python",
     # Ordinary ops
     "git status",
@@ -455,6 +463,11 @@ _TRUE_POSITIVES_93392 = [
     "true && kill -HUP -1",
     "$(kill -1)",
     'bash -c "kill -1"',
+    # separated signal operands in carrier positions (#102389)
+    "sudo kill -s KILL -1",
+    "ls; kill --signal KILL -1",
+    "$(kill -s KILL -1)",
+    'bash -c "kill -s KILL -1"',
     # fork bomb
     ":(){ :|:& };:",
     "true && :(){ :|:& };:",

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -592,7 +592,11 @@ HARDLINE_PATTERNS = [
     (r':\(\)\s*\{\s*:\s*\|\s*:\s*&\s*\}\s*;\s*:', "fork bomb"),
     # Kill every process on the system — anchor the command-name token so
     # `echo "kill -1 sends SIGHUP to everything"` doesn't trip (#93392).
-    (_CMDPOS + r'kill\s+(-[^\s]+\s+)*-1\b', "kill all processes"),
+    # Each flag round also consumes one separated operand (POSIX kill's
+    # `-s KILL` / `--signal KILL`) so signal spellings can't dodge the `-1`
+    # target (#102389); the operand is rejected from starting with `-` so a
+    # following flag — or the kill-all `-1` itself — is never swallowed.
+    (_CMDPOS + r'kill\s+(?:-[^\s]+(?:\s+(?!-)[^\s]+)?\s+)*-1\b', "kill all processes"),
     # System shutdown / reboot — anchor to command position (start of line,
     # after a command separator, or after sudo/env wrappers) so we don't
     # false-positive on "echo reboot" or "grep 'shutdown' logs".


### PR DESCRIPTION
## What does this PR do?

The `kill all processes` hardline rule (`kill\s+(-[^\s]+\s+)*-1\b`) assumed every dash token is a self-contained flag, so POSIX-standard spellings that take a **separated** signal operand sailed through the kill-all floor — including in `--yolo` mode:

```python
detect_hardline_command("kill -9 -1")            # blocked
detect_hardline_command("kill -s KILL -1")       # APPROVED  (bypass)
detect_hardline_command("kill -s 9 -1")          # APPROVED  (bypass)
detect_hardline_command("kill --signal KILL -1") # APPROVED  (bypass)
```

The flag run consumed `-s` as a generic flag but never consumed the signal-name token after it, so the trailing `-1` never lined up (`kill --signal=KILL -1` was the only spelling already caught, because the `=` form is a single token).

The fix lets each flag round optionally consume one separated operand (`-s KILL` / `--signal KILL`), so all spellings of signal-every-process hit the floor. The operand is rejected from starting with `-` (`(?!-)`) so a following flag — or the kill-all `-1` target itself — can never be swallowed as a value. Specific-PID kills (`kill -s KILL 1234`, `kill -9 12345`) stay clean; only `-1` as the target is gated.

## Related Issue

Fixes #102389

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/approval.py` — the `kill all processes` hardline pattern's flag run now consumes one optional separated operand per flag (`(?:\s+(?!-)[^\s]+)?`) so `-s KILL -1` / `--signal KILL -1` / `-s 9 -1` line up on the `-1` target; comment updated to document the operand rule and why the operand cannot start with `-`.
- `tests/tools/test_hardline_blocklist.py` — added the bypass spellings to the blocked list (incl. mixed `kill -9 -s TERM -1`), the specific-PID signal spellings to the allowed list, and carrier-position variants (`sudo`, `ls;`, `$(...)`, `bash -c`) to the true-positives list.

## How to Test

1. `pytest tests/tools/test_hardline_blocklist.py -q` — 257 passed, including the new cases (the new blocked cases fail on the pre-fix pattern, verified red/green).
2. `pytest tests/tools/test_approval.py -q` — 117 passed, 1 pre-existing failure unrelated to this change (`TestDetectDangerousRm::test_nonrecursive_verification_artifact_cleanup_is_not_dangerous`, also red on clean upstream/main).
3. Direct check:

```python
from tools.approval import detect_hardline_command
detect_hardline_command("kill -s KILL -1")       # (True, "kill all processes")
detect_hardline_command("kill --signal KILL -1") # (True, "kill all processes")
detect_hardline_command("kill -s KILL 1234")     # (False, None)  specific PID stays clean
```

Observed result: all three behave as shown.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A