### PR TITLE
fix(web/exa): surface per-URL fetch failures from response.statuses

### DIFF
--- a/plugins/web/exa/provider.py
+++ b/plugins/web/exa/provider.py
@@ -11,7 +11,7 @@ from typing import Any, Dict, List
 
 from plugins.web._common import (
     BaseWebSearchProvider, cached_sdk_client, document, keyless_extract, keyless_search, keyless_variant_schema,
-    provider_env, run_extract, run_search, search_ok, use_keyless, web_hit,
+    page_error, provider_env, run_extract, run_search, search_ok, use_keyless, web_hit,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,44 @@ class ExaWebSearchProvider(BaseWebSearchProvider):
                 return keyless_extract("Exa", "exa", urls, logger)
             logger.info("Exa extract: %d URL(s)", len(urls))
             response = _get_exa_client().get_contents(urls, text=True)
-            return [document(r.url or "", r.title or "", r.text or "") for r in response.results or []]
+            # Exa reports per-URL failures in response.statuses (e.g.
+            # CRAWL_NOT_FOUND for a dead link) — NOT in response.results.
+            # Without this, a single 404 made the whole call return [] and
+            # callers saw a silent empty result instead of an honest per-URL
+            # error. Surface each failed status as an error doc so the
+            # 1-doc-per-URL contract holds regardless of how many results or
+            # statuses the API returns.
+            by_url = {
+                r.url: r
+                for r in response.results or []
+                if getattr(r, "url", None)
+            }
+            status_by_id = {
+                s.id: s
+                for s in response.statuses or []
+                if getattr(s, "id", None)
+            }
+            docs: List[Dict[str, Any]] = []
+            for url in urls:
+                result = by_url.get(url)
+                if result is not None:
+                    docs.append(document(result.url or "", result.title or "", result.text or ""))
+                    continue
+                status = status_by_id.get(url)
+                if status is None:
+                    # Status id may not match the raw URL (redirect or
+                    # normalization) — fall back to a generic per-URL error
+                    # rather than dropping the URL silently.
+                    docs.append(page_error(url, f"Exa could not fetch {url}"))
+                    continue
+                error = (status.status or "").strip()
+                docs.append(
+                    page_error(
+                        url,
+                        f"Exa fetch failed ({error})" if error else f"Exa could not fetch {url}",
+                    )
+                )
+            return docs
 
         return run_extract("Exa", logger, urls, _body, sdk=True)
 

--- a/tests/tools/test_web_providers_exa.py
+++ b/tests/tools/test_web_providers_exa.py
@@ -1,0 +1,88 @@
+"""Exa web provider — extract() surfaces per-URL failures from response.statuses.
+
+Covers the 1-doc-per-URL extract contract when Exa's SDK reports dead URLs in
+``response.statuses`` instead of ``response.results``:
+
+- Every requested URL yields exactly one doc.
+- A result URL maps to content (``document`` shape).
+- A statused URL maps to an ``error`` doc (``page_error`` shape).
+- A URL absent from both results and statuses still yields a generic error doc
+  (never a silent drop).
+
+Per the dev skill, these tests import the real provider and stub only the SDK
+client, so the ABC / _common glue and the extract body stay exercised together.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from plugins.web.exa.provider import ExaWebSearchProvider
+
+
+def _result(url: str, title: str = "T", text: str = "body") -> MagicMock:
+    r = MagicMock()
+    r.url = url
+    r.title = title
+    r.text = text
+    return r
+
+
+def _status(url: str, status: str = "CRAWL_NOT_FOUND") -> MagicMock:
+    s = MagicMock()
+    s.id = url
+    s.status = status
+    return s
+
+
+def _run_extract(provider: ExaWebSearchProvider, urls, results, statuses):
+    """Call provider.extract with a stubbed SDK response, bypassing keyless."""
+    client = MagicMock()
+    client.get_contents.return_value = MagicMock(results=results, statuses=statuses)
+    with patch("plugins.web.exa.provider._get_exa_client", return_value=client), \
+         patch("plugins.web.exa.provider.use_keyless", return_value=False):
+        return provider.extract(urls)
+
+
+class TestExaExtractPerUrlContract:
+    def test_all_live_urls_return_content_docs(self) -> None:
+        urls = ["https://a.example", "https://b.example"]
+        docs = _run_extract(ExaWebSearchProvider(), urls, [_result(urls[0]), _result(urls[1])], [])
+        assert len(docs) == len(urls)
+        assert all("error" not in d for d in docs)
+        assert {d["url"] for d in docs} == set(urls)
+        assert docs[0]["content"] == "body"
+
+    def test_dead_url_becomes_error_doc_not_empty_list(self) -> None:
+        urls = ["https://dead.example"]
+        docs = _run_extract(ExaWebSearchProvider(), urls, [], [_status(urls[0])])
+        assert len(docs) == 1
+        assert docs[0]["url"] == urls[0]
+        assert docs[0]["error"] == "Exa fetch failed (CRAWL_NOT_FOUND)"
+
+    def test_mixed_batch_yields_one_doc_per_url(self) -> None:
+        live, dead = "https://live.example", "https://dead.example"
+        urls = [live, dead]
+        docs = _run_extract(ExaWebSearchProvider(), urls, [_result(live, text="ok body")], [_status(dead)])
+        assert len(docs) == 2
+        by_url = {d["url"]: d for d in docs}
+        assert "error" not in by_url[live]
+        assert by_url[live]["content"] == "ok body"
+        assert by_url[dead]["error"] == "Exa fetch failed (CRAWL_NOT_FOUND)"
+
+    def test_url_absent_from_both_still_gets_generic_error_doc(self) -> None:
+        # Regression for review point 1: the backfill iterates *requested URLs*,
+        # so a URL missing from results AND statuses is reported, never dropped.
+        urls = ["https://missing.example"]
+        docs = _run_extract(ExaWebSearchProvider(), urls, [], [])
+        assert len(docs) == 1
+        assert docs[0]["url"] == urls[0]
+        assert docs[0]["error"] == f"Exa could not fetch {urls[0]}"
+
+    def test_status_id_normalized_away_still_reports_generic_error(self) -> None:
+        # Redirect-normalized URL on the status id (review point 2): benign —
+        # the doc is still an error, never silence.
+        urls = ["https://example.com/page"]
+        docs = _run_extract(ExaWebSearchProvider(), urls, [], [_status("https://example.com/page/")])
+        assert len(docs) == 1
+        assert docs[0]["error"] == f"Exa could not fetch {urls[0]}"


### PR DESCRIPTION
## Summary
Exa's `get_contents()` reports dead URLs (404/`CRAWL_NOT_FOUND`) in `response.statuses`, not `response.results`. The provider iterated only `results`, so a single dead URL made the whole `extract()` return `[]` — callers saw a silent empty result instead of an honest per-URL error, and cascading providers treated it as a broken link (triggering cooldowns).

## Fix
Each status without a matching result now becomes an error doc (`Exa fetch failed (error)`), preserving the 1-doc-per-URL contract.

## Test Plan
- [x] Dead URL (404) → single doc with `error` field, no empty `[]`
- [x] Live URL → full content returned
- [x] Mixed batch → 1 OK doc + 1 error doc, each in its place