### PR TITLE
fix(cli): render corrupt timestamps as unknown instead of crashing sessions list

### DIFF
--- a/hermes_cli/timefmt.py
+++ b/hermes_cli/timefmt.py
@@ -10,11 +10,23 @@ from __future__ import annotations
 
 import time as _time
 from datetime import datetime
+import math
 
 
 def relative_time(ts) -> str:
-    """Format a timestamp as relative time (e.g., '2h ago', 'yesterday')."""
+    """Format a timestamp as relative time (e.g., '2h ago', 'yesterday').
+
+    Non-numeric values (corrupt TEXT rows under SQLite dynamic typing)
+    render as "?" instead of raising TypeError (#102399); numeric
+    strings coerce to float.
+    """
     if not ts:
+        return "?"
+    try:
+        ts = float(ts)
+    except (TypeError, ValueError):
+        return "?"
+    if not math.isfinite(ts):
         return "?"
     delta = _time.time() - ts
     if delta < 60:
@@ -27,4 +39,7 @@ def relative_time(ts) -> str:
         return "yesterday"
     if delta < 604800:
         return f"{int(delta / 86400)}d ago"
-    return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+    try:
+        return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
+    except (OverflowError, OSError, ValueError):
+        return "?"

--- a/tests/hermes_cli/test_timefmt_corrupt.py
+++ b/tests/hermes_cli/test_timefmt_corrupt.py
@@ -1,0 +1,39 @@
+"""Corrupt-timestamp hardening for hermes_cli.timefmt.relative_time (#102399).
+
+Kept in a separate module from test_timefmt.py (open PR #98670 owns
+that path) to avoid colliding with it.
+"""
+
+import time
+
+from hermes_cli.timefmt import relative_time
+
+
+class TestCorruptTimestampsRenderUnknown:
+    def test_text_timestamp(self):
+        assert relative_time("not-a-timestamp") == "?"
+
+    def test_iso_string(self):
+        assert relative_time("2026-01-01") == "?"
+
+    def test_short_string(self):
+        assert relative_time("abc") == "?"
+
+    def test_list_and_dict(self):
+        assert relative_time([1]) == "?"
+        assert relative_time({"t": 1}) == "?"
+
+    def test_non_finite_floats(self):
+        assert relative_time(float("nan")) == "?"
+        assert relative_time(float("inf")) == "?"
+        # finite but out of fromtimestamp range -> "?" not OverflowError
+        assert relative_time(-1e300) == "?"
+
+    def test_numeric_string_coerces(self):
+        assert relative_time(str(time.time() - 30)) == "just now"
+
+    def test_valid_epochs_unchanged(self):
+        assert relative_time(None) == "?"
+        assert relative_time(0) == "?"
+        assert relative_time(time.time() - 30) == "just now"
+        assert relative_time(time.time() - 7200) == "2h ago"


### PR DESCRIPTION
Hey — one corrupt timestamp row in state.db killed the entire `sessions list` / browse output with a raw TypeError traceback, since `relative_time` assumed a numeric epoch.

Small fix: coerce numeric strings, render anything else (TEXT, non-finite and out-of-range floats) as `?`, matching the existing `None` handling. One bad row now degrades to one `?` cell instead of a dead command.

Added a regression suite (kept in its own file to avoid stepping on the open test-only PR #98670). All green plus the browse neighbors.

Fixes #102399