### PR TITLE
fix(api_server): never re-resolve a bare provider kind on session resume

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2979,6 +2979,7 @@ class APIServerAdapter(BasePlatformAdapter):
             GatewayRunner,
         )
         from hermes_cli.tools_config import _get_platform_tools
+        from hermes_state import _BARE_BILLING_PROVIDERS
 
         # Catch RuntimeError ONLY around this call, not the wider
         # _create_agent()+run_conversation() span --
@@ -3050,6 +3051,19 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
                 return None
 
+        def _routable_ambient_provider(name: Any) -> Optional[str]:
+            # ``"custom"``/``"auto"`` are the ambient runtime's provider *kind*
+            # labels for a named custom provider, not names under
+            # ``providers:`` — re-resolving them through
+            # _resolve_provider_runtime yields a credential-less fallback
+            # runtime that clobbers the working ambient credentials already in
+            # runtime_kwargs (#102384). Mirrors the resume-side guard in
+            # hermes_state.session_gateway_runtime (_BARE_BILLING_PROVIDERS).
+            cleaned = _clean_request_string(name)
+            if cleaned and cleaned.strip().lower() in _BARE_BILLING_PROVIDERS:
+                return None
+            return cleaned
+
         # Final precedence mirrors the gateway contract:
         # confirmed Browser model lock → session /model override →
         # session-persisted model (POST /api/sessions {"model": ...}) →
@@ -3072,7 +3086,7 @@ class APIServerAdapter(BasePlatformAdapter):
         if session_override:
             override_model = resolve_effective_model(session_override, None, model)
             session_provider = _clean_request_string(session_override.get("provider"))
-            current_provider = _clean_request_string(runtime_kwargs.get("provider"))
+            current_provider = _routable_ambient_provider(runtime_kwargs.get("provider"))
             provider_runtime = _resolve_provider_runtime(
                 session_provider or current_provider,
                 target_model=override_model,
@@ -3092,7 +3106,7 @@ class APIServerAdapter(BasePlatformAdapter):
             # alias).  Pins this session's turns ahead of per-request body
             # values — a session's chosen model is a standing selection,
             # matching the native gateway's session-model semantics.
-            current_provider = _clean_request_string(runtime_kwargs.get("provider"))
+            current_provider = _routable_ambient_provider(runtime_kwargs.get("provider"))
             provider_runtime = _resolve_provider_runtime(
                 current_provider,
                 target_model=session_row_model,

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -3087,3 +3087,110 @@ class TestCreateAgentModelRecovery:
         )
         adapter._create_agent(session_id="s2", gateway_session_key="ch")
         assert captured[1]["model"] == "anthropic/claude-opus-4.6"
+
+
+class TestCreateAgentBareProviderKind:
+    """A named custom provider's ambient runtime carries provider="custom" —
+    a billing *kind* label, not a name under ``providers:``. On the turn
+    after the session row persists a model, _create_agent re-resolved that
+    label and clobbered the working credentials with a credential-less
+    fallback runtime, 500ing every subsequent turn (#102384)."""
+
+    def test_persisted_session_model_keeps_ambient_custom_credentials(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        # Ambient runtime of a named custom provider: resolved credentials
+        # plus the "custom" kind label.
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom",
+                "api_key": "sk-live",
+                "base_url": "https://gateway.example.com/v1",
+                "api_mode": "responses",
+            },
+        )
+        # What re-resolving "custom" actually returns (issue #102384 probe):
+        # the OpenRouter fallback with no credentials.
+        resolved_names = []
+
+        def fake_request_runtime(provider, target_model=None):
+            resolved_names.append(provider)
+            return {
+                "provider": "custom",
+                "api_key": "",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(
+            "gateway.platforms.api_server._resolve_request_runtime_agent_kwargs",
+            fake_request_runtime,
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+
+        # Turn-2 shape: the session row has a persisted model.
+        agent = adapter._create_agent(session_id="s", session_model="some-model")
+
+        assert isinstance(agent, FakeAgent)
+        # The ambient credentials survive — the kind label is never re-resolved.
+        assert captured["api_key"] == "sk-live"
+        assert captured["base_url"] == "https://gateway.example.com/v1"
+        assert captured["provider"] == "custom"
+        assert resolved_names == []
+
+    def test_session_model_override_keeps_ambient_custom_credentials(self, monkeypatch):
+        captured = {}
+
+        class FakeAgent:
+            def __init__(self, **kwargs):
+                captured.update(kwargs)
+
+        _patch_create_agent_runtime(monkeypatch, captured, FakeAgent)
+        monkeypatch.setattr(
+            "gateway.run._resolve_runtime_agent_kwargs",
+            lambda: {
+                "provider": "custom",
+                "api_key": "sk-live",
+                "base_url": "https://gateway.example.com/v1",
+                "api_mode": "responses",
+            },
+        )
+        resolved_names = []
+
+        def fake_request_runtime(provider, target_model=None):
+            resolved_names.append(provider)
+            return {
+                "provider": "custom",
+                "api_key": "",
+                "base_url": "https://openrouter.ai/api/v1",
+                "api_mode": "chat_completions",
+            }
+
+        monkeypatch.setattr(
+            "gateway.platforms.api_server._resolve_request_runtime_agent_kwargs",
+            fake_request_runtime,
+        )
+
+        adapter = APIServerAdapter(PlatformConfig(enabled=True))
+        monkeypatch.setattr(adapter, "_ensure_session_db", lambda: None)
+        # Override carries a model but no provider — the ambient "custom"
+        # label is the fallback and must not be re-resolved either.
+        monkeypatch.setattr(
+            adapter, "_session_model_override_for", lambda _k: {"model": "other-model"}
+        )
+
+        agent = adapter._create_agent(session_id="s")
+
+        assert isinstance(agent, FakeAgent)
+        assert captured["api_key"] == "sk-live"
+        assert captured["base_url"] == "https://gateway.example.com/v1"
+        assert captured["model"] == "other-model"
+        assert resolved_names == []


### PR DESCRIPTION
## What does this PR do?

When `model.provider` is a **named custom provider**, the API server cannot resume its own sessions: `POST /api/sessions/{id}/chat` succeeds on the first turn and returns **HTTP 500 on every turn after that** (breaking `hermes peer dm` outright — agent-to-agent messaging works exactly once per gateway restart).

Root cause: the ambient runtime of a named custom provider carries `provider="custom"` — a billing **kind** label, not a name under `providers:`. On turn 2 the `elif session_row_model` branch of `_create_agent` feeds that label back into `_resolve_provider_runtime()`, which resolves it to the credential-less fallback runtime (`base_url=https://openrouter.ai/api/v1`, empty key) and `_apply_runtime_agent_overrides` clobbers the working credentials. `init_agent` then raises "No LLM provider configured".

The state layer already guards against exactly this — `hermes_state.session_gateway_runtime` filters `_BARE_BILLING_PROVIDERS = {"auto", "custom"}` and falls back to ambient resolution — but the api_server `_create_agent` path never went through that helper. This PR mirrors that guard: a new `_routable_ambient_provider()` helper clears bare kind labels from the ambient `runtime_kwargs["provider"]` before the session-override and session-persisted-model branches re-resolve it, so the ambient credentials already in `runtime_kwargs` are kept. Specific PID-style explicit values (a session override or request body naming a real provider) are untouched — only the ambient kind label fallback is cleared.

## Related Issue

Fixes #102384

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py` — added `_routable_ambient_provider()` inside `_create_agent` (mirrors `hermes_state._BARE_BILLING_PROVIDERS`, imported as the single source of truth per the `tui_gateway` precedent); the `session_override` and `session_row_model` branches now use it for their ambient `current_provider` fallback so a bare kind label is never re-resolved.
- `tests/gateway/test_api_server.py` — new `TestCreateAgentBareProviderKind` with two regressions: turn-2 shape (persisted `session_model` with `provider="custom"` ambient runtime) and session-override shape (override without provider falling back to the ambient label); both assert the ambient credentials survive and `_resolve_request_runtime_agent_kwargs` is never called with the kind label.

## How to Test

1. `pytest tests/gateway/test_api_server.py -q` — 112 passed (2 new; both fail on the pre-fix code, verified red/green).
2. `pytest tests/gateway/test_session_api.py -q` — 20 passed.
3. End-to-end shape from the issue (custom provider in config): create a session, chat twice. Observed result with the fix: both turns succeed; the ambient `base_url`/`api_key` are kept on turn 2 instead of being overwritten by the credential-less fallback runtime.

## Checklist

### Code

- [x] I have read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this is not a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I have run `pytest tests/ -q` and all tests pass
- [x] I have added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I have tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I have updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I have updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I have updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I have considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I have updated tool descriptions/schemas if I changed tool behavior — or N/A