### PR TITLE
feat(desktop): sequence built-in slash commands

### DIFF
--- a/apps/desktop/e2e/slash-sequencing.spec.ts
+++ b/apps/desktop/e2e/slash-sequencing.spec.ts
@@ -1,0 +1,44 @@
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+const FIRST_SESSION_MARKER = 'E2E_SLASH_SEQUENCE_FIRST_SESSION'
+const GOAL_TEXT = 'E2E slash sequence goal'
+const ACTIVE_SURFACE = '[data-composer-target]:not([data-pane-hidden] [data-composer-target])'
+
+let fixture: MockBackendFixture | null = null
+
+const activeSurface = () => fixture!.page.locator(ACTIVE_SURFACE).last()
+
+test.beforeAll(async () => {
+  fixture = await setupMockBackend()
+  await waitForAppReady(fixture, 120_000)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+})
+
+test('desktop runs /goal on the fresh session created by a leading /new', async () => {
+  test.setTimeout(180_000)
+  const page = fixture!.page
+  const composer = activeSurface().locator('[contenteditable="true"]').first()
+  const initialTranscript = activeSurface().locator('[data-slot="aui_thread-viewport"]')
+
+  await composer.click()
+  await composer.type(FIRST_SESSION_MARKER, { delay: 2 })
+  await page.keyboard.press('Enter')
+  await expect(initialTranscript).toContainText(FIRST_SESSION_MARKER, { timeout: 15_000 })
+  await expect(initialTranscript).toContainText('mock inference server', { timeout: 60_000 })
+
+  await composer.click()
+  await composer.type(`/new /goal ${GOAL_TEXT}`, { delay: 2 })
+  await page.keyboard.press('Enter')
+
+  await expect.poll(() => fixture!.mock.receivedPrompts.some(prompt => prompt.includes(GOAL_TEXT)), {
+    timeout: 60_000
+  }).toBe(true)
+  await expect(page.locator('body')).toContainText(GOAL_TEXT, { timeout: 30_000 })
+  const goalSurface = page.locator('[data-composer-target]').filter({ hasText: GOAL_TEXT }).last()
+  await expect(goalSurface).not.toContainText(FIRST_SESSION_MARKER)
+})

--- a/apps/desktop/src/app/chat/composer/slash-refs.test.ts
+++ b/apps/desktop/src/app/chat/composer/slash-refs.test.ts
@@ -51,6 +51,14 @@ describe('slashCommandMatches', () => {
     expect(commands('start over with /some-skill ')).toEqual(['skill:/some-skill'])
   })
 
+  it('offers leading bare built-ins as a command sequence, but stops inside prose', () => {
+    expect(commands('/new /yolo /goal ship it /branch ')).toEqual(['command:/new', 'command:/yolo'])
+  })
+
+  it('does not turn slash-looking path fragments into built-in invocations', () => {
+    expect(commands('/new /yolo/config ')).toEqual(['command:/new'])
+  })
+
   it('disqualifies a leading token when the text lands mid-word', () => {
     expect(commands('/some-skill ', { boundaryBefore: false })).toEqual([])
   })

--- a/apps/desktop/src/app/chat/composer/slash-refs.ts
+++ b/apps/desktop/src/app/chat/composer/slash-refs.ts
@@ -12,6 +12,7 @@
 import type { SlashChipKind } from '@/components/assistant-ui/directive-text'
 import {
   desktopSlashCommandArgumentMode,
+  desktopSlashCommandSequenceSegments,
   isDesktopSlashCommand,
   resolveDesktopCommand
 } from '@/lib/desktop-slash-commands'
@@ -70,6 +71,10 @@ export function slashCommandMatches(text: string, options: SlashCommandScanOptio
 
   const matches: SlashCommandMatch[] = []
 
+  const invocationStarts = new Set(
+    boundaryBefore && text.startsWith('/') ? desktopSlashCommandSequenceSegments(text).map(segment => segment.start) : []
+  )
+
   for (const match of text.matchAll(SLASH_COMMAND_RE)) {
     const start = match.index ?? 0
     const command = match[0]
@@ -82,11 +87,12 @@ export function slashCommandMatches(text: string, options: SlashCommandScanOptio
       continue
     }
 
-    // Only the FIRST token can be an invocation, and only when the text lands
-    // on a token boundary — `foo` + a pasted `/clean` is `foo/clean`.
-    const invocation = start === 0
+    // A built-in can invoke at each unambiguous command boundary in the
+    // leading sequence. Tokens inside a text/mixed command's prose are not
+    // sequence segments and remain inert references.
+    const invocation = invocationStarts.has(start)
 
-    if (invocation && !boundaryBefore) {
+    if (start === 0 && !boundaryBefore) {
       continue
     }
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -7,6 +7,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getSession } from '@/hermes'
 import { textPart } from '@/lib/chat-messages'
 import { createClientSessionState } from '@/lib/chat-runtime'
+import { rememberDesktopCommandsCatalog } from '@/lib/desktop-slash-commands'
 import { $composerAttachments, $composerDraft, type ComposerAttachment, setComposerDraft } from '@/store/composer'
 import { $queuedPromptsBySession, getQueuedPrompts } from '@/store/composer-queue'
 import { requestGatewayForAgent } from '@/store/gateway'
@@ -125,6 +126,7 @@ function Harness({
   seedStreamId,
   seedTurnStartedAt,
   selectedStoredSessionIdRef: selectedStoredSessionIdRefProp,
+  startFreshSessionDraft,
   storedSessionId,
   activeSessionId,
   createBackendSessionForSend
@@ -150,6 +152,7 @@ function Harness({
   seedStreamId?: null | string
   seedTurnStartedAt?: null | number
   selectedStoredSessionIdRef?: MutableRefObject<string | null>
+  startFreshSessionDraft?: () => void
   storedSessionId?: null | string
   activeSessionId?: null | string
   createBackendSessionForSend?: (preview?: null | string) => Promise<null | string>
@@ -202,7 +205,7 @@ function Harness({
     resumeStoredSession: resumeStoredSession ?? (() => undefined),
     runtimeIdByStoredSessionIdRef,
     selectedStoredSessionIdRef,
-    startFreshSessionDraft: () => undefined,
+    startFreshSessionDraft: startFreshSessionDraft ?? (() => undefined),
     sttEnabled: false,
     updateSessionState: (sessionId, updater, storedSessionId) => {
       // Seed with interrupted:true so we can prove a fresh submit clears it.
@@ -410,6 +413,183 @@ describe('usePromptActions /stop', () => {
 
     expect(requestGateway).toHaveBeenCalledWith('session.interrupt', { session_id: RUNTIME_SESSION_ID })
     expect(requestGateway).toHaveBeenCalledWith('process.stop', {})
+  })
+})
+
+describe('usePromptActions slash sequencing', () => {
+  afterEach(() => {
+    cleanup()
+    dropSessionState('rt-sequenced')
+    $goalsBySession.set({})
+    rememberDesktopCommandsCatalog(undefined)
+    vi.restoreAllMocks()
+  })
+
+  it('runs /goal on the fresh session created by a preceding /new', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const startFreshSessionDraft = vi.fn(() => {
+      activeSessionIdRef.current = null
+      selectedStoredSessionIdRef.current = null
+    })
+
+    const createBackendSessionForSend = vi.fn(async () => {
+      activeSessionIdRef.current = 'rt-sequenced'
+      selectedStoredSessionIdRef.current = 'stored-sequenced'
+      publishSessionState('rt-sequenced', createClientSessionState('stored-sequenced'))
+
+      return 'rt-sequenced'
+    })
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'commands.catalog') {
+        return { commands: { '/goal': { argument_mode: 'mixed', desktop: null } } } as never
+      }
+
+      if (method === 'slash.exec') {
+        return {
+          type: 'send',
+          notice: '⊙ Goal set (20-turn budget): ship the sequenced change',
+          message: 'ship the sequenced change'
+        } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        createBackendSessionForSend={createBackendSessionForSend}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        startFreshSessionDraft={startFreshSessionDraft}
+      />
+    )
+
+    await handle!.submitText('/new /goal ship the sequenced change')
+
+    expect(startFreshSessionDraft).toHaveBeenCalledTimes(1)
+    expect(createBackendSessionForSend).toHaveBeenCalledTimes(1)
+    expect(calls).toContainEqual({
+      method: 'slash.exec',
+      params: { command: 'goal ship the sequenced change', session_id: 'rt-sequenced' }
+    })
+    expect(calls).toContainEqual({
+      method: 'prompt.submit',
+      params: expect.objectContaining({ session_id: 'rt-sequenced', text: 'ship the sequenced change' })
+    })
+    expect($goalsBySession.get()['rt-sequenced']).toMatchObject({
+      status: 'active',
+      title: 'ship the sequenced change'
+    })
+  })
+
+  it('hydrates an uncached catalog before splitting an option command from a later built-in', async () => {
+    rememberDesktopCommandsCatalog(undefined)
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'commands.catalog') {
+        return { commands: { '/goal': { argument_mode: 'mixed', desktop: null } } } as never
+      }
+
+      if (method === 'session.status') {
+        return { cwd: '/repo', status: 'idle' } as never
+      }
+
+      if (method === 'wake.status') {
+        return {
+          available: true,
+          configured_surface: 'gui',
+          enabled: false,
+          listening: false,
+          owner_surface: null,
+          phrase: 'hey hermes',
+          provider: 'openwakeword'
+        } as never
+      }
+
+      if (method === 'slash.exec') {
+        return { output: 'No active goal.' } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness onReady={h => (handle = h)} refreshSessions={async () => undefined} requestGateway={requestGateway} />
+    )
+
+    await handle!.submitText('/status /wake status /goal show')
+
+    expect(calls.map(call => call.method)).toEqual([
+      'commands.catalog',
+      'session.status',
+      'wake.status',
+      'slash.exec'
+    ])
+    expect(calls.at(-1)?.params).toEqual({ command: 'goal show', session_id: RUNTIME_SESSION_ID })
+  })
+
+  it('pins the sequence when navigation changes while the catalog hydrates', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: RUNTIME_SESSION_ID }
+    const calls: Array<{ method: string; params?: Record<string, unknown> }> = []
+
+    const requestGateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      calls.push({ method, params })
+
+      if (method === 'commands.catalog') {
+        activeSessionIdRef.current = 'rt-user-navigated'
+
+        return { commands: {} } as never
+      }
+
+      if (method === 'session.status') {
+        return { status: 'idle' } as never
+      }
+
+      if (method === 'session.interrupt') {
+        return { status: 'interrupted' } as never
+      }
+
+      if (method === 'process.stop') {
+        return { killed: 0 } as never
+      }
+
+      return {} as never
+    })
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionIdRef={activeSessionIdRef}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+      />
+    )
+
+    await handle!.submitText('/status /stop')
+
+    expect(calls).toContainEqual({
+      method: 'session.interrupt',
+      params: { session_id: RUNTIME_SESSION_ID }
+    })
+    expect(calls).not.toContainEqual({
+      method: 'session.interrupt',
+      params: { session_id: 'rt-user-navigated' }
+    })
   })
 })
 

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.ts
@@ -591,6 +591,7 @@ export function usePromptActions({
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRouteToken,
     getRuntimeIdForStoredSession,
     handleSkinCommand,
     handoffSession,

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/slash.ts
@@ -6,13 +6,16 @@ import type { Translations } from '@/i18n'
 import { type ChatMessage, toChatMessages } from '@/lib/chat-messages'
 import { parseCommandDispatch, parseSlashCommand, sessionTitle } from '@/lib/chat-runtime'
 import {
+  canonicalDesktopSlashCommand,
   type CommandsCatalogLike,
   type DesktopActionId,
   type DesktopCommandSurface,
   type DesktopPickerId,
   desktopSlashUnavailableMessage,
   isDesktopSlashCommand,
-  resolveDesktopCommand
+  rememberDesktopCommandsCatalog,
+  resolveDesktopCommand,
+  splitDesktopSlashCommandSequence
 } from '@/lib/desktop-slash-commands'
 import { isMissingRpcMethod } from '@/lib/gateway-rpc'
 import { setSessionYolo } from '@/lib/yolo-session'
@@ -141,6 +144,7 @@ interface SlashCommandDeps {
   copy: Translations['desktop']
   createBackendSessionForSend: (preview?: string | null) => Promise<string | null>
   getRoutedStoredSessionId: () => null | string
+  getRouteToken: () => string
   getRuntimeIdForStoredSession: (storedSessionId: string) => null | string
   handleSkinCommand: (arg: string) => string
   handoffSession: (
@@ -171,6 +175,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
     copy,
     createBackendSessionForSend,
     getRoutedStoredSessionId,
+    getRouteToken,
     getRuntimeIdForStoredSession,
     handleSkinCommand,
     handoffSession,
@@ -496,7 +501,16 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       // new branch in a dispatch ladder.
       const actionHandlers: Record<DesktopActionId, (ctx: SlashActionCtx) => Promise<void>> = {
         new: async () => {
+          const routeBefore = getRouteToken()
           startFreshSessionDraft()
+
+          // createBackendSessionForSend aborts if navigation changes while its
+          // request is in flight. Wait until React publishes `/new` before a
+          // sequenced command starts that request; a fixed one-tick yield is
+          // insufficient under a loaded renderer.
+          for (let attempt = 0; attempt < 20 && getRouteToken() === routeBefore; attempt += 1) {
+            await new Promise<void>(resolve => window.setTimeout(resolve, 0))
+          }
         },
         branch: async () => {
           await branchCurrentSession()
@@ -1217,7 +1231,48 @@ export function useSlashCommand(deps: SlashCommandDeps) {
         }
       }
 
-      await runSlash(rawCommand, options?.sessionId, options?.recordInput ?? true)
+      let sequence = splitDesktopSlashCommandSequence(rawCommand)
+      const slashTokenCount = [...rawCommand.matchAll(/(?:^|\s)\/[^\s/]+/g)].length
+      let sessionHint = options?.sessionId ?? activeSessionIdRef.current ?? undefined
+
+      // The local table intentionally contains only Desktop-owned commands;
+      // backend-owned built-ins (for example /goal) get their argument grammar
+      // from commands.catalog. A fast paste+Enter can beat the completion
+      // request, so hydrate once here before deciding that a second slash token
+      // is merely part of the first command's argument.
+      if (slashTokenCount > 1) {
+        const catalogSessionId = sessionHint
+
+        try {
+          const catalog = await requestGateway<CommandsCatalogLike>('commands.catalog', {
+            ...(catalogSessionId ? { session_id: catalogSessionId } : {})
+          })
+
+          rememberDesktopCommandsCatalog(catalog)
+          sequence = splitDesktopSlashCommandSequence(rawCommand)
+        } catch {
+          // Preserve today's single-command interpretation if an older or
+          // disconnected backend cannot provide the grammar catalog.
+        }
+      }
+
+      for (const command of sequence) {
+        const activeBefore = activeSessionIdRef.current
+        await runSlash(command, sessionHint, options?.recordInput ?? true)
+
+        // Keep an ordinary sequence pinned to its invocation-time session even
+        // if the user navigates while an async command is running. Only a
+        // command whose purpose is to select/create another chat may re-home
+        // the remaining segments.
+        const commandName = canonicalDesktopSlashCommand(parseSlashCommand(command).name)
+
+        if (
+          ['/branch', '/new', '/resume'].includes(commandName) &&
+          activeSessionIdRef.current !== activeBefore
+        ) {
+          sessionHint = activeSessionIdRef.current ?? undefined
+        }
+      }
     },
     [
       activeSessionIdRef,
@@ -1227,6 +1282,7 @@ export function useSlashCommand(deps: SlashCommandDeps) {
       copy,
       createBackendSessionForSend,
       getRoutedStoredSessionId,
+      getRouteToken,
       getRuntimeIdForStoredSession,
       handleSkinCommand,
       handoffSession,

--- a/apps/desktop/src/lib/desktop-slash-commands.test.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.test.ts
@@ -16,7 +16,8 @@ import {
   rankSkillCommands,
   rememberDesktopCommandsCatalog,
   resolveDesktopCommand,
-  slashCompletionGroup
+  slashCompletionGroup,
+  splitDesktopSlashCommandSequence
 } from './desktop-slash-commands'
 
 function registryCatalog(
@@ -60,7 +61,8 @@ const REGISTRY_CATALOG = registryCatalog(
     '/tools': 'options',
     '/undo': null,
     '/loop': 'mixed',
-    '/lcm': 'text'
+    '/lcm': 'text',
+    '/worktree': 'text'
   },
   { '/tasks': '/agents', '/background': '/bg', '/q': '/queue', '/proactive': '/loop' }
 )
@@ -410,6 +412,76 @@ describe('desktop slash command curation', () => {
     expect(resolveDesktopCommand('/clear')?.surface).toEqual({ kind: 'unavailable', reason: 'terminal' })
     // Skill / quick commands aren't in the registry.
     expect(resolveDesktopCommand('/gif-search')).toBeNull()
+  })
+})
+
+describe('splitDesktopSlashCommandSequence', () => {
+  beforeEach(() => {
+    rememberDesktopCommandsCatalog(REGISTRY_CATALOG)
+  })
+
+  afterEach(() => {
+    rememberDesktopCommandsCatalog(undefined)
+  })
+
+  it('chains bare and option commands before a prose command', () => {
+    expect(splitDesktopSlashCommandSequence('/yolo /wake on /goal ship the auth refactor')).toEqual([
+      '/yolo',
+      '/wake on',
+      '/goal ship the auth refactor'
+    ])
+  })
+
+  it('uses Desktop action arity instead of conflicting backend catalog metadata', () => {
+    rememberDesktopCommandsCatalog({ commands: { '/new': { argument_mode: 'text' }, '/goal': { argument_mode: 'mixed' } } })
+    expect(desktopSlashCommandArgumentMode('/new')).toBe('text')
+    expect(splitDesktopSlashCommandSequence('/new /goal ship it')).toEqual(['/new', '/goal ship it'])
+  })
+
+  it('preserves arguments for local actions and pickers that consume them', () => {
+    expect(desktopSlashCommandArgumentMode('/hatch')).toBe('text')
+    expect(desktopSlashCommandArgumentMode('/model')).toBe('text')
+    expect(desktopSlashCommandArgumentMode('/profile')).toBe('options')
+    expect(splitDesktopSlashCommandSequence('/hatch /yolo')).toEqual(['/hatch /yolo'])
+    expect(splitDesktopSlashCommandSequence('/model /yolo')).toEqual(['/model /yolo'])
+    expect(splitDesktopSlashCommandSequence('/profile coder /new')).toEqual(['/profile coder', '/new'])
+  })
+
+  it('overrides the backend catalog mode for bounded /worktree subcommands', () => {
+    expect(desktopSlashCommandArgumentMode('/worktree')).toBe('text')
+    expect(splitDesktopSlashCommandSequence('/worktree new named-tree /goal ship it')).toEqual([
+      '/worktree new named-tree',
+      '/goal ship it'
+    ])
+  })
+
+  it('does not reinterpret slash-looking prose after a text or mixed command', () => {
+    expect(splitDesktopSlashCommandSequence('/goal ship it /branch')).toEqual(['/goal ship it /branch'])
+    expect(splitDesktopSlashCommandSequence('/queue review /tmp/output then /status')).toEqual([
+      '/queue review /tmp/output then /status'
+    ])
+  })
+
+  it('hands an unknown extension tail to the backend after a bare command', () => {
+    expect(splitDesktopSlashCommandSequence('/yolo /unknown /goal ship it')).toEqual([
+      '/yolo',
+      '/unknown /goal ship it'
+    ])
+  })
+
+  it('does not execute slash-looking path fragments without whitespace boundaries', () => {
+    expect(splitDesktopSlashCommandSequence('/new /yolo/config')).toEqual(['/new /yolo/config'])
+    expect(splitDesktopSlashCommandSequence('/yolo/config')).toEqual(['/yolo/config'])
+    expect(splitDesktopSlashCommandSequence('/worktree new foo /yolo/config')).toEqual([
+      '/worktree new foo /yolo/config'
+    ])
+  })
+
+  it('only chains a bare command when the next token is another known command', () => {
+    expect(splitDesktopSlashCommandSequence('/new /goal ship it')).toEqual(['/new', '/goal ship it'])
+    expect(splitDesktopSlashCommandSequence('/new draft words /goal ship it')).toEqual([
+      '/new draft words /goal ship it'
+    ])
   })
 })
 

--- a/apps/desktop/src/lib/desktop-slash-commands.ts
+++ b/apps/desktop/src/lib/desktop-slash-commands.ts
@@ -198,7 +198,12 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     surface: action('handoff'),
     argumentMode: 'options'
   },
-  { name: '/profile', description: 'Switch the active Hermes profile', surface: action('profile') },
+  {
+    name: '/profile',
+    description: 'Switch the active Hermes profile',
+    surface: action('profile'),
+    argumentMode: 'options'
+  },
   {
     name: '/skin',
     description: 'Switch desktop theme or cycle to the next one',
@@ -221,7 +226,13 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
   },
 
   // Overlay pickers
-  { name: '/model', description: 'Switch the model for this session', surface: picker('model'), hidden: true },
+  {
+    name: '/model',
+    description: 'Switch the model for this session',
+    surface: picker('model'),
+    hidden: true,
+    argumentMode: 'text'
+  },
   {
     name: '/resume',
     description: 'Resume a saved session',
@@ -266,7 +277,8 @@ const DESKTOP_COMMAND_SPECS: readonly DesktopCommandSpec[] = [
     name: '/hatch',
     description: 'Generate a new pet (opens the pet generator)',
     aliases: ['/generate-pet'],
-    surface: action('hatch')
+    surface: action('hatch'),
+    argumentMode: 'text'
   },
   {
     name: '/save',
@@ -591,6 +603,151 @@ export function desktopSlashDescription(command: string, fallback = ''): string 
 
 export function desktopSlashCommandArgumentMode(command: string): DesktopSlashArgumentMode | null {
   return resolveDesktopCommand(command)?.argumentMode ?? asArgumentMode(catalogMeta(command)?.argument_mode) ?? null
+}
+
+const SEQUENCE_ARGUMENT_MODE_OVERRIDES: Partial<
+  Record<string, DesktopSlashArgumentMode>
+> = {
+  // The backend catalog's coarse text mode predates subcommand sequencing;
+  // /worktree has bounded subcommands whose arguments end at the next command.
+  '/worktree': 'options'
+}
+
+/** A command slice in the original, untrimmed composer text. */
+export interface DesktopSlashCommandSequenceSegment {
+  end: number
+  start: number
+  text: string
+}
+
+/**
+ * Locate the unambiguous command slices in one Desktop composer submission.
+ * Bare commands consume only their token when another known command follows.
+ * Option commands retain every argument token up to the next known command, so
+ * multi-part forms such as `/browser connect <url>` and `/worktree new <name>`
+ * remain intact. The first text/mixed command owns the complete tail. Unknown
+ * extension commands also own the tail; their grammar belongs to the backend.
+ */
+export function desktopSlashCommandSequenceSegments(input: string): DesktopSlashCommandSequenceSegment[] {
+  const leading = input.search(/\S/)
+
+  if (leading < 0) {
+    return []
+  }
+
+  const text = input.slice(leading).trimEnd()
+
+  if (!text.startsWith('/')) {
+    return [{ end: leading + text.length, start: leading, text }]
+  }
+
+  const segments: DesktopSlashCommandSequenceSegment[] = []
+  let start = 0
+
+  const slashTokenAt = (index: number): { end: number; token: string } | null => {
+    const match = text.slice(index).match(/^\/[^\s/]+(?=\s|$)/)
+
+    return match ? { end: index + match[0].length, token: match[0] } : null
+  }
+
+  const tokenAt = (index: number): { end: number; local: boolean; spec: DesktopCommandSpec } | null => {
+    const token = slashTokenAt(index)
+
+    if (!token) {
+      return null
+    }
+
+    const canonical = canonicalDesktopSlashCommand(token.token)
+    const spec = resolveDesktopCommand(token.token)
+
+    return spec ? { end: token.end, local: SPEC_BY_NAME.has(canonical), spec } : null
+  }
+
+  const nextKnownCommand = (from: number): number => {
+    const re = /(?:^|\s)(\/[^\s/]+)(?=\s|$)/g
+    re.lastIndex = from
+
+    for (let match = re.exec(text); match; match = re.exec(text)) {
+      const index = (match.index ?? 0) + match[0].length - match[1].length
+
+      if (resolveDesktopCommand(match[1])) {
+        return index
+      }
+    }
+
+    return -1
+  }
+
+  const push = (from: number, to = text.length) => {
+    const raw = text.slice(from, to)
+    const end = from + raw.trimEnd().length
+    segments.push({ end: leading + end, start: leading + from, text: raw.trim() })
+  }
+
+  while (start < text.length) {
+    const current = tokenAt(start)
+
+    // A skill / quick command has backend-owned grammar. Keep it and all of its
+    // instruction text together instead of guessing where its arguments end.
+    if (!current) {
+      push(start)
+
+      break
+    }
+
+    const mode = current.local
+      ? current.spec.argumentMode ?? null
+      : (SEQUENCE_ARGUMENT_MODE_OVERRIDES[current.spec.name] ??
+        desktopSlashCommandArgumentMode(current.spec.name))
+
+    if (mode === 'text' || mode === 'mixed') {
+      push(start)
+
+      break
+    }
+
+    if (mode === 'options') {
+      const boundary = nextKnownCommand(current.end)
+
+      if (boundary < 0) {
+        push(start)
+
+        break
+      }
+
+      push(start, boundary)
+      start = boundary
+
+      continue
+    }
+
+    const next = text.slice(current.end).search(/\S/)
+
+    if (next < 0) {
+      push(start)
+
+      break
+    }
+
+    const boundary = current.end + next
+
+    // Bare commands only chain across adjacent slash tokens. Once ordinary
+    // prose starts, preserve the historical single-command interpretation.
+    if (!slashTokenAt(boundary)) {
+      push(start)
+
+      break
+    }
+
+    push(start, current.end)
+    start = boundary
+  }
+
+  return segments
+}
+
+export function splitDesktopSlashCommandSequence(input: string): string[] {
+  return desktopSlashCommandSequenceSegments(input).map(segment => segment.text)
 }
 
 export function desktopSkinSlashCompletions(


### PR DESCRIPTION
## Summary

- sequences unambiguous built-in Desktop slash commands in submission order
- uses command argument metadata to keep text/mixed commands terminal and split option commands only at full, known command-token boundaries
- keeps stacked skills and unknown extension tails as one backend-owned dispatch
- pins ordinary sequences to their invocation-time session and re-homes only after commands that intentionally select or create a session
- treats `/worktree` subcommands as bounded options even when an older backend catalog reports the command as prose-taking, so this composes with #102379
- updates slash-reference rendering and adds focused unit plus packaged-Electron coverage

## Problem

Desktop parsed only the first slash command and passed the entire remainder as its argument, so workflows such as `/new /goal ship it` could not run atomically in one submission.

## Approach

The parser now returns ordered segments under conservative rules:

- Desktop actions with no arguments consume only their token when followed by another slash token.
- `options` commands consume arguments until the next complete known command token.
- `text` and `mixed` commands consume the remaining message and terminate sequencing.
- Unknown/skill tails remain intact for backend stacked-skill handling.

The dispatcher awaits each segment before starting the next. Catalog hydration happens before splitting multi-command input, including fast paste-and-submit paths.

## Test plan

- `npm run test:ui`
- `npm run typecheck`
- `npx vitest run --project ui src/lib/desktop-slash-commands.test.ts src/app/chat/composer/slash-refs.test.ts src/app/session/hooks/use-prompt-actions/index.test.tsx`
- `npm run build`
- `npx playwright test e2e/slash-sequencing.spec.ts --reporter=list`
- ESLint on the changed Desktop files (one pre-existing hook dependency warning remains in the test harness)

## Risk

The grammar is deliberately conservative: prose-taking commands preserve existing remainder semantics, and unknown tails are never split client-side. Tests cover stale/missing catalog data, slash-looking path fragments, multi-token options, session-navigation races, and `/new` followed by `/goal` in packaged Electron.

- [x] Change is focused and backwards-compatible for single-command submissions
- [x] Tests and type checking pass
- [x] No credentials, personal paths, or private project data are included
- [ ] Full Python test suite (not applicable to this Desktop-only change)

Closes #102127
