### PR TITLE
feat: add gated Executive Capability Bus delegation

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4497,7 +4497,7 @@ def _format_gateway_process_notification(evt: dict) -> "str | None":
         text += "]"
         return text
 
-    if evt_type == "async_delegation":
+    if evt_type in {"async_delegation", "profile_delegation"}:
         # Reuse the shared rich formatter (self-contained task-source block).
         from tools.process_registry import format_process_notification
         return format_process_notification(evt)
@@ -28945,48 +28945,41 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         return delivered
 
     async def _async_delegation_watcher(self, interval: float = 2.0) -> None:
-        """Drain async-delegation completions and inject them as new turns.
+        """Drain internal delegation completions and inject them as new turns.
 
-        Background subagents (``delegate_task(background=true)``) run on the
-        async-delegation daemon executor — they have no per-process watcher
-        task, so their completion events would only be seen by the post-turn
-        queue drain. This watcher covers the IDLE case: when a background
-        subagent finishes while no agent turn is running, its result still
-        re-enters the originating session promptly.
-
-        Mirrors the CLI's idle ``process_loop`` drain. Stays silent when the
-        queue has nothing for us; ignores non-async event types (those are
-        handled by ``_run_process_watcher`` / the post-turn drain).
+        Background subagents and profile delegations complete outside a live
+        agent loop. Their results must re-enter as fresh internal turns, grouped
+        by originating session so same-tick fan-outs do not flood the user.
         """
         await asyncio.sleep(3)  # let platforms finish connecting
         from tools.process_registry import process_registry as _pr
         while self._running:
             try:
-                # Peek the queue for async-delegation events. We must NOT
+                # Peek the queue for internal delegation events. We must NOT
                 # consume watch/completion events here (other drains own them),
                 # so requeue anything that isn't ours.
                 requeue = []
-                async_events = []
+                internal_events = []
                 while not _pr.completion_queue.empty():
                     try:
                         evt = _pr.completion_queue.get_nowait()
                     except Exception:
                         break
-                    if evt.get("type") == "async_delegation":
-                        async_events.append(evt)
+                    if evt.get("type") in {"async_delegation", "profile_delegation"}:
+                        internal_events.append(evt)
                     else:
                         requeue.append(evt)
                 for evt in requeue:
                     _pr.completion_queue.put(evt)
+
                 # A same-tick drain often carries several completions for the
-                # SAME originating session (a fan-out of background subagents
-                # finishing together).  Delivering each one individually floods
-                # the session with N synthetic turns (#70300) — group by full
-                # gateway route + parent session and inject one consolidated
-                # turn per group.  Events for different sessions never coalesce.
+                # SAME originating session. Delivering each one individually
+                # floods the session with N synthetic turns (#70300) — group by
+                # full gateway route + parent session and inject one consolidated
+                # turn per group. Events for different sessions never coalesce.
                 groups: dict[tuple[str, ...], list[dict]] = {}
                 group_order: list[tuple[str, ...]] = []
-                for evt in async_events:
+                for evt in internal_events:
                     self._enrich_async_delegation_routing(evt)
                     key = self._async_delegation_group_key(evt)
                     if key not in groups:
@@ -29003,9 +28996,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     except Exception as e:
                         for evt in group:
                             _pr.completion_queue.put(evt)
-                        logger.error("Async delegation injection error: %s", e)
+                        logger.error("Internal delegation injection error: %s", e)
             except Exception as e:
-                logger.debug("Async delegation watcher error: %s", e)
+                logger.debug("Internal delegation watcher error: %s", e)
             await asyncio.sleep(interval)
 
     async def _run_process_watcher(self, watcher: dict) -> None:

--- a/hermes_cli/capability_registry.py
+++ b/hermes_cli/capability_registry.py
@@ -1,0 +1,437 @@
+"""Redacted runtime capability registry for Hermes profiles."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Iterable, Literal, Optional
+
+import yaml
+
+from hermes_cli.profiles import get_profile_dir, list_profiles as _list_profile_infos, normalize_profile_name, profile_exists
+
+CapabilityKind = Literal["tool", "toolset", "mcp", "composio"]
+RiskClass = Literal["READ", "PREPARE", "CONSEQUENTIAL_WRITE", "CREDENTIAL_EXPORT"]
+
+# Toolkits Composio can satisfy for the Executive Capability Bus.  Phase 1
+# keeps this deliberately explicit and redacted: the registry records that a
+# profile can route a capability through its configured Composio MCP server;
+# Composio itself remains the credential boundary and no account/token values
+# are exposed here.
+_COMPOSIO_TOOLKIT_CAPABILITIES: dict[str, tuple[str, ...]] = {
+    "vercel": ("mcp:vercel", "composio:vercel", "toolkit:vercel"),
+}
+
+
+@dataclass
+class WorkloadInfo:
+    running_count: int = 0
+    max_concurrency: Optional[int] = None
+    queued_count: int = 0
+
+    @property
+    def capacity_remaining(self) -> Optional[int]:
+        if self.max_concurrency is None:
+            return None
+        return max(0, int(self.max_concurrency) - int(self.running_count))
+
+    @property
+    def saturated(self) -> bool:
+        return self.capacity_remaining == 0 if self.max_concurrency is not None else False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "running_count": self.running_count,
+            "max_concurrency": self.max_concurrency,
+            "queued_count": self.queued_count,
+            "capacity_remaining": self.capacity_remaining,
+            "saturated": self.saturated,
+        }
+
+
+@dataclass
+class ProfileCapability:
+    profile: str
+    capability: str
+    kind: CapabilityKind
+    configured: bool = False
+    enabled: bool = False
+    tool_exists: bool = False
+    credential_present: bool = False
+    credential_usable: Optional[bool] = None
+    credential_check: str = "not_tested"
+    gateway_running: bool = False
+    worker_available: bool = False
+    risk_class: RiskClass = "READ"
+    source: str = ""
+    notes: list[str] = field(default_factory=list)
+    workload: WorkloadInfo = field(default_factory=WorkloadInfo)
+    rank_score: float = 0.0
+    rank_reasons: list[str] = field(default_factory=list)
+
+    @property
+    def executable(self) -> bool:
+        if self.kind == "mcp":
+            return self.configured and self.enabled and self.worker_available
+        if self.kind == "composio":
+            return self.configured and self.enabled and self.worker_available and self.credential_present
+        return self.enabled and self.worker_available
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["workload"] = self.workload.to_dict()
+        data["executable"] = self.executable
+        return data
+
+
+@dataclass
+class CapabilityQueryResult:
+    capability: str
+    profiles: list[ProfileCapability]
+    generated_at: float
+    recommendation: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "capability": self.capability,
+            "profiles": [p.to_dict() for p in self.profiles],
+            "generated_at": self.generated_at,
+            "recommendation": self.recommendation,
+        }
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except Exception:
+        return {}
+
+
+def _boolish(value: Any, default: bool = True) -> bool:
+    if value is None:
+        return default
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() not in {"0", "false", "no", "off", "disabled"}
+
+
+def list_profiles(include_default: bool = True) -> list[str]:
+    names = [p.name for p in _list_profile_infos()]
+    # Some non-interactive/import-only contexts do not return every on-disk
+    # profile through the CLI helper. Fall back to the profile directory so
+    # cross-profile capability discovery can still see worker profiles such as
+    # the VPS `director` profile.
+    try:
+        base = Path.home() / ".hermes" / "profiles"
+        if base.exists():
+            names.extend(p.name for p in base.iterdir() if p.is_dir())
+    except Exception:
+        pass
+    if include_default and "default" not in names:
+        names.insert(0, "default")
+    if not include_default:
+        names = [n for n in names if n != "default"]
+    return sorted(set(names), key=lambda n: (n != "default", n))
+
+
+def profile_home(profile: str) -> Path:
+    return get_profile_dir(normalize_profile_name(profile))
+
+
+def _credential_present(home: Path, server_name: str, cfg: dict[str, Any]) -> bool:
+    token_dir = home / "mcp-tokens"
+    for suffix in (".json", ".client.json", ".meta.json"):
+        if (token_dir / f"{server_name}{suffix}").exists():
+            return True
+    headers = cfg.get("headers")
+    if isinstance(headers, dict) and headers:
+        return True
+    env_keys = cfg.get("env") or cfg.get("env_vars")
+    if isinstance(env_keys, dict):
+        return any(bool(v) for v in env_keys.values())
+    if isinstance(env_keys, list):
+        return any(bool(os.getenv(str(v))) for v in env_keys)
+    return False
+
+
+def collect_workload(*, profiles: Optional[Iterable[str]] = None, max_concurrency: Optional[int] = None) -> dict[str, WorkloadInfo]:
+    wanted = {normalize_profile_name(p) for p in profiles} if profiles else None
+    info: dict[str, WorkloadInfo] = {}
+    if wanted:
+        for p in wanted:
+            info[p] = WorkloadInfo(max_concurrency=max_concurrency)
+    try:
+        from hermes_cli import kanban_db as kb
+        with kb.connect_closing() as conn:
+            rows = conn.execute(
+                "SELECT assignee, status, COUNT(*) AS n FROM tasks "
+                "WHERE assignee IS NOT NULL AND status IN ('running','ready') "
+                "GROUP BY assignee, status"
+            ).fetchall()
+            for row in rows:
+                assignee = normalize_profile_name(row["assignee"])
+                if wanted and assignee not in wanted:
+                    continue
+                item = info.setdefault(assignee, WorkloadInfo(max_concurrency=max_concurrency))
+                if row["status"] == "running":
+                    item.running_count = int(row["n"])
+                elif row["status"] == "ready":
+                    item.queued_count = int(row["n"])
+    except Exception:
+        pass
+    return info
+
+
+def inspect_profile_capabilities(
+    profile: str,
+    *,
+    test_credentials: bool = False,
+    include_disabled: bool = True,
+    workload: Optional[WorkloadInfo] = None,
+) -> list[ProfileCapability]:
+    profile = normalize_profile_name(profile)
+    home = profile_home(profile)
+    cfg = _read_yaml(home / "config.yaml")
+    worker = profile_exists(profile)
+    gateway = False
+    try:
+        for p in _list_profile_infos():
+            if p.name == profile:
+                gateway = bool(p.gateway_running)
+                break
+    except Exception:
+        gateway = False
+    wl = workload or WorkloadInfo()
+    capabilities: list[ProfileCapability] = []
+
+    raw_toolsets: list[Any] = []
+    top_toolsets = cfg.get("toolsets") or cfg.get("tools", {}).get("toolsets") or []
+    if isinstance(top_toolsets, str):
+        raw_toolsets.append(top_toolsets)
+    elif isinstance(top_toolsets, list):
+        raw_toolsets.extend(top_toolsets)
+
+    # Tool enablement is platform-scoped in normal gateway setups
+    # (`platform_toolsets.discord`, `platform_toolsets.cli`, etc.). The
+    # capability bus needs to advertise a profile as capable when the toolset
+    # is enabled on any platform, not only when it appears in the legacy
+    # top-level `toolsets` list.
+    platform_toolsets = cfg.get("platform_toolsets") or {}
+    if isinstance(platform_toolsets, dict):
+        for values in platform_toolsets.values():
+            if isinstance(values, str):
+                raw_toolsets.append(values)
+            elif isinstance(values, list):
+                raw_toolsets.extend(values)
+
+    for ts in sorted({str(t) for t in raw_toolsets if t}):
+        capabilities.append(ProfileCapability(
+            profile=profile,
+            capability=f"toolset:{ts}",
+            kind="toolset",
+            configured=True,
+            enabled=True,
+            tool_exists=True,
+            gateway_running=gateway,
+            worker_available=worker,
+            source=str(home / "config.yaml"),
+            workload=wl,
+        ))
+        try:
+            from toolsets import resolve_toolset
+            for tool in resolve_toolset(ts):
+                capabilities.append(ProfileCapability(
+                    profile=profile,
+                    capability=f"tool:{tool}",
+                    kind="tool",
+                    configured=True,
+                    enabled=True,
+                    tool_exists=True,
+                    gateway_running=gateway,
+                    worker_available=worker,
+                    source=f"toolset:{ts}",
+                    workload=wl,
+                ))
+        except Exception:
+            pass
+
+    mcp_servers = cfg.get("mcp_servers") or {}
+    if isinstance(mcp_servers, dict):
+        for name, server_cfg in sorted(mcp_servers.items()):
+            if not isinstance(server_cfg, dict):
+                server_cfg = {}
+            enabled = _boolish(server_cfg.get("enabled"), default=True)
+            if not enabled and not include_disabled:
+                continue
+            credential_present = _credential_present(home, str(name), server_cfg)
+            credential_check = "not_tested"
+            usable: Optional[bool] = None
+            if not enabled:
+                credential_check = "disabled"
+            elif not test_credentials:
+                credential_check = "not_tested"
+            cap = ProfileCapability(
+                profile=profile,
+                capability=f"mcp:{name}",
+                kind="mcp",
+                configured=True,
+                enabled=enabled,
+                tool_exists=enabled,
+                credential_present=credential_present,
+                credential_usable=usable,
+                credential_check=credential_check,
+                gateway_running=gateway,
+                worker_available=worker,
+                source=str(home / "config.yaml"),
+                workload=wl,
+            )
+            if not enabled:
+                cap.notes.append("MCP server is configured but disabled.")
+            if credential_present:
+                cap.notes.append("Credential material appears present; values redacted.")
+            capabilities.append(cap)
+
+    composio_cfg = mcp_servers.get("composio") if isinstance(mcp_servers, dict) else None
+    if isinstance(composio_cfg, dict):
+        composio_enabled = _boolish(composio_cfg.get("enabled"), default=True)
+        if composio_enabled or include_disabled:
+            for toolkit, aliases in sorted(_COMPOSIO_TOOLKIT_CAPABILITIES.items()):
+                for alias in aliases:
+                    cap = ProfileCapability(
+                        profile=profile,
+                        capability=alias,
+                        kind="composio",
+                        configured=True,
+                        enabled=composio_enabled,
+                        tool_exists=composio_enabled,
+                        credential_present=composio_enabled,
+                        credential_usable=None,
+                        credential_check="composio_connection_assumed" if composio_enabled else "disabled",
+                        gateway_running=gateway,
+                        worker_available=worker,
+                        source=f"mcp:composio/toolkit:{toolkit}",
+                        workload=wl,
+                    )
+                    cap.notes.append(
+                        f"Routed through the profile's Composio MCP server for toolkit:{toolkit}; "
+                        "Composio owns credential isolation and token values remain hidden."
+                    )
+                    if not composio_enabled:
+                        cap.notes.append("Composio MCP server is configured but disabled.")
+                    capabilities.append(cap)
+    return capabilities
+
+
+def _score(cap: ProfileCapability) -> tuple[float, list[str]]:
+    score = 0.0
+    reasons: list[str] = []
+    if cap.executable:
+        score += 100; reasons.append("executable")
+    if cap.enabled:
+        score += 25; reasons.append("enabled")
+    if cap.credential_present:
+        score += 20; reasons.append("credential_present")
+    if cap.credential_usable is True:
+        score += 15; reasons.append("credential_usable")
+    elif cap.credential_usable is False:
+        score -= 50; reasons.append("credential_failed")
+    if cap.worker_available:
+        score += 10; reasons.append("worker_available")
+    if cap.gateway_running:
+        score += 5; reasons.append("gateway_running")
+    if cap.workload.max_concurrency is not None:
+        if cap.workload.saturated:
+            score -= 40; reasons.append("profile_saturated")
+        else:
+            score += 5; reasons.append("capacity_available")
+    # Workload is intentionally heavy enough to beat small domain hints; an
+    # idle capable peer should outrank a busy preferred owner in Phase 1.
+    score -= cap.workload.running_count * 20
+    score -= cap.workload.queued_count * 10
+    if cap.workload.running_count:
+        reasons.append(f"running_count={cap.workload.running_count}")
+    if cap.workload.queued_count:
+        reasons.append(f"queued_count={cap.workload.queued_count}")
+    if cap.profile == "cto" and cap.capability.startswith(("mcp:github", "tool:terminal")):
+        score += 3; reasons.append("domain_hint_cto")
+    if cap.profile == "default" and cap.source.startswith("mcp:composio/toolkit:vercel"):
+        score += 8; reasons.append("domain_hint_default_composio_vercel")
+    if cap.profile == "cto" and cap.capability.startswith("mcp:vercel") and cap.kind != "composio":
+        score += 3; reasons.append("domain_hint_cto_native_vercel")
+    return score, reasons
+
+
+def build_capability_registry(
+    *,
+    profiles: Optional[list[str]] = None,
+    test_credentials: bool = False,
+    include_disabled: bool = True,
+    max_concurrency: Optional[int] = None,
+) -> dict[str, list[ProfileCapability]]:
+    names = profiles or list_profiles()
+    workload = collect_workload(profiles=names, max_concurrency=max_concurrency)
+    registry: dict[str, list[ProfileCapability]] = {}
+    for name in names:
+        wl = workload.get(normalize_profile_name(name), WorkloadInfo(max_concurrency=max_concurrency))
+        for cap in inspect_profile_capabilities(
+            name,
+            test_credentials=test_credentials,
+            include_disabled=include_disabled,
+            workload=wl,
+        ):
+            cap.rank_score, cap.rank_reasons = _score(cap)
+            registry.setdefault(cap.capability, []).append(cap)
+    for caps in registry.values():
+        caps.sort(key=lambda c: c.rank_score, reverse=True)
+    return registry
+
+
+def find_capability(
+    capability: str,
+    *,
+    requester_profile: Optional[str] = None,
+    risk: RiskClass = "READ",
+    test_credentials: bool = False,
+    include_disabled: bool = False,
+    profiles: Optional[list[str]] = None,
+    max_concurrency: Optional[int] = None,
+) -> CapabilityQueryResult:
+    registry = build_capability_registry(
+        profiles=profiles,
+        test_credentials=test_credentials,
+        include_disabled=include_disabled,
+        max_concurrency=max_concurrency,
+    )
+    caps = list(registry.get(capability, []))
+    if requester_profile:
+        requester = normalize_profile_name(requester_profile)
+        # Prefer another executor when scores tie; requester can still win if it is the only/best owner.
+        for cap in caps:
+            if cap.profile == requester:
+                cap.rank_score -= 1
+                cap.rank_reasons.append("requester_profile_deprioritized")
+        caps.sort(key=lambda c: c.rank_score, reverse=True)
+    executable = [c for c in caps if c.executable and not c.workload.saturated]
+    best = executable[0] if executable else (caps[0] if caps else None)
+    recommendation = {
+        "status": "executable" if executable else ("configured_not_executable" if caps else "not_found"),
+        "best_profile": best.profile if best else None,
+        "reason": ("best workload-aware executor selected" if executable else ("capability found but not currently executable" if caps else "no profile advertises this capability")),
+    }
+    return CapabilityQueryResult(capability=capability, profiles=caps, generated_at=time.time(), recommendation=recommendation)
+
+
+def to_json(result: CapabilityQueryResult | dict[str, list[ProfileCapability]]) -> str:
+    if isinstance(result, CapabilityQueryResult):
+        data = result.to_dict()
+    else:
+        data = {k: [c.to_dict() for c in v] for k, v in result.items()}
+    return json.dumps(data, ensure_ascii=False, indent=2, sort_keys=True)

--- a/hermes_cli/delegation_policy.py
+++ b/hermes_cli/delegation_policy.py
@@ -1,0 +1,174 @@
+"""Policy primitives for cross-profile delegation.
+
+The MVP still uses conservative text heuristics, but callers pass a structured
+``DelegationAction`` so future enforcement can authorize concrete tool/action
+calls (for example ``mcp:vercel`` tool ``list_projects`` read vs
+``deploy_project`` write) without redesigning the API.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from enum import Enum
+from typing import Any, Optional
+
+
+class DelegationRisk(str, Enum):
+    READ = "READ"
+    PREPARE = "PREPARE"
+    CONSEQUENTIAL_WRITE = "CONSEQUENTIAL_WRITE"
+    CREDENTIAL_EXPORT = "CREDENTIAL_EXPORT"
+
+
+class PolicyDecisionStatus(str, Enum):
+    ALLOW = "allow"
+    BLOCK_APPROVAL = "block_approval"
+    DENY = "deny"
+
+
+@dataclass(frozen=True)
+class ToolActionRequest:
+    """Future-facing permission atom for a concrete tool action."""
+
+    capability: str
+    tool_name: Optional[str] = None
+    action_name: Optional[str] = None
+    operation: Optional[str] = None
+    arguments_schema: Optional[dict[str, Any]] = None
+
+
+@dataclass(frozen=True)
+class DelegationAction:
+    requester_profile: str
+    executor_profile: str
+    task: str
+    required_capability: str
+    requested_risk: DelegationRisk = DelegationRisk.READ
+    tool_action: Optional[ToolActionRequest] = None
+    approval_id: Optional[str] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        data["requested_risk"] = self.requested_risk.value
+        return data
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    status: PolicyDecisionStatus
+    risk: DelegationRisk
+    reason: str
+    approval_required: bool = False
+
+    @property
+    def allowed(self) -> bool:
+        return self.status == PolicyDecisionStatus.ALLOW
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status.value,
+            "risk": self.risk.value,
+            "reason": self.reason,
+            "approval_required": self.approval_required,
+            "allowed": self.allowed,
+        }
+
+
+_CREDENTIAL_EXPORT_TERMS = (
+    "api key", "apikey", "secret", "token", "oauth", "authorization",
+    "bearer", "cookie", "credential", "password", "private key",
+)
+_WRITE_TERMS = (
+    "deploy", "delete", "remove", "publish", "send", "transfer", "trade",
+    "buy", "sell", "charge", "pay", "spend", "modify", "update", "change",
+    "create", "provision", "rotate", "revoke", "grant", "permission",
+)
+_PREPARE_TERMS = ("draft", "prepare", "plan", "generate", "summarize", "review")
+_READ_TERMS = ("read", "inspect", "list", "get", "check", "query", "status", "view", "analyze")
+
+
+def _coerce_risk(value: str | DelegationRisk | None) -> DelegationRisk:
+    if isinstance(value, DelegationRisk):
+        return value
+    if not value:
+        return DelegationRisk.READ
+    try:
+        return DelegationRisk(str(value).upper())
+    except ValueError:
+        return DelegationRisk.READ
+
+
+def classify_delegation_risk(
+    *,
+    requested_risk: str | DelegationRisk = DelegationRisk.READ,
+    task: str = "",
+    required_capability: str = "",
+    tool_action: Optional[ToolActionRequest] = None,
+) -> DelegationRisk:
+    """Conservative MVP classifier over a structured policy interface.
+
+    Future versions should primarily use ``tool_action`` metadata emitted by
+    tool wrappers/MCP descriptors. Text classification is deliberately kept as
+    a fallback, not the permanent authorization model.
+    """
+
+    requested = _coerce_risk(requested_risk)
+    haystack = " ".join(
+        str(x or "") for x in (
+            task,
+            required_capability,
+            getattr(tool_action, "tool_name", None),
+            getattr(tool_action, "action_name", None),
+            getattr(tool_action, "operation", None),
+        )
+    ).lower()
+
+    if any(term in haystack for term in _CREDENTIAL_EXPORT_TERMS) and any(
+        verb in haystack for verb in ("show", "print", "export", "send", "return", "reveal")
+    ):
+        return DelegationRisk.CREDENTIAL_EXPORT
+
+    if requested in {DelegationRisk.CONSEQUENTIAL_WRITE, DelegationRisk.CREDENTIAL_EXPORT}:
+        return requested
+
+    if any(term in haystack for term in _WRITE_TERMS):
+        # A caller may explicitly mark a non-mutating preparation task as PREPARE.
+        if requested == DelegationRisk.PREPARE and any(term in haystack for term in _PREPARE_TERMS):
+            return DelegationRisk.PREPARE
+        return DelegationRisk.CONSEQUENTIAL_WRITE
+
+    if requested == DelegationRisk.PREPARE:
+        return DelegationRisk.PREPARE
+
+    if any(term in haystack for term in _READ_TERMS):
+        return DelegationRisk.READ
+
+    return requested
+
+
+def enforce_delegation_policy(action: DelegationAction) -> PolicyDecision:
+    risk = classify_delegation_risk(
+        requested_risk=action.requested_risk,
+        task=action.task,
+        required_capability=action.required_capability,
+        tool_action=action.tool_action,
+    )
+
+    if risk == DelegationRisk.CREDENTIAL_EXPORT:
+        return PolicyDecision(
+            status=PolicyDecisionStatus.DENY,
+            risk=risk,
+            reason="Credential export is never allowed; executor must perform the action and return non-secret results only.",
+        )
+    if risk == DelegationRisk.CONSEQUENTIAL_WRITE and not action.approval_id:
+        return PolicyDecision(
+            status=PolicyDecisionStatus.BLOCK_APPROVAL,
+            risk=risk,
+            reason="Consequential external writes require explicit Michael approval before worker execution.",
+            approval_required=True,
+        )
+    return PolicyDecision(
+        status=PolicyDecisionStatus.ALLOW,
+        risk=risk,
+        reason="Allowed by Phase 1 delegation policy.",
+    )

--- a/hermes_cli/executive_bus_gate.py
+++ b/hermes_cli/executive_bus_gate.py
@@ -1,0 +1,86 @@
+"""Availability checks for the Executive Capability Bus toolset."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+
+def _as_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, (list, tuple, set)):
+        return [str(item) for item in value if item]
+    return []
+
+
+def _current_platform() -> str:
+    """Return the platform scope used for per-platform tool config."""
+
+    try:
+        from agent.runtime_env import get_session_env
+
+        platform = os.getenv("HERMES_PLATFORM") or get_session_env("HERMES_SESSION_PLATFORM")
+    except Exception:
+        platform = os.getenv("HERMES_PLATFORM")
+    return str(platform or "cli").strip() or "cli"
+
+
+def _executive_bus_configured(config: dict[str, Any], platform: str) -> bool:
+    """Return True when config explicitly enables ``executive_bus``.
+
+    The bus is an inter-profile coordination surface, so it should never be
+    exposed merely because its Python modules import successfully. Users or
+    profile owners must deliberately opt in via ``platform_toolsets`` (normal
+    gateway/CLI path) or the legacy top-level ``toolsets`` list.
+    """
+
+    platform_toolsets = config.get("platform_toolsets")
+    if isinstance(platform_toolsets, dict):
+        for key in (platform, "default"):
+            if "executive_bus" in _as_list(platform_toolsets.get(key)):
+                return True
+    if "executive_bus" in _as_list(config.get("toolsets")):
+        return True
+    tools_cfg = config.get("tools")
+    if isinstance(tools_cfg, dict) and "executive_bus" in _as_list(tools_cfg.get("toolsets")):
+        return True
+    return False
+
+
+def executive_bus_prerequisites_available() -> bool:
+    """Return True when Bus storage/dispatch modules can be imported.
+
+    This check is intentionally local and side-effect free: no network calls, no
+    credential reads beyond the normal config loader, and no DB writes. Runtime
+    credential usability remains the executor profile's responsibility.
+    """
+
+    try:
+        from hermes_cli import kanban_db as _kb  # noqa: F401
+        from hermes_cli.capability_registry import find_capability as _find  # noqa: F401
+        from hermes_cli.profile_delegation import delegate_to_profile as _delegate  # noqa: F401
+        from tools.process_registry import process_registry as _registry  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def executive_bus_enabled_for_current_context() -> bool:
+    """Tool ``check_fn`` for the Executive Capability Bus.
+
+    The toolset is available only when the current profile/platform explicitly
+    enables ``executive_bus`` and the local Kanban/profile-delegation modules are
+    importable. This keeps the two model-facing Bus tools out of ordinary
+    sessions while preserving deliberate profile-level opt-in.
+    """
+
+    if not executive_bus_prerequisites_available():
+        return False
+    try:
+        from hermes_cli.config import load_config
+
+        config = load_config()
+    except Exception:
+        return False
+    return _executive_bus_configured(config if isinstance(config, dict) else {}, _current_platform())

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1524,6 +1524,34 @@ CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, start
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_attachments_task      ON task_attachments(task_id, created_at);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+
+CREATE TABLE IF NOT EXISTS profile_delegations (
+    id                    TEXT PRIMARY KEY,
+    task_id               TEXT NOT NULL,
+    requester_profile     TEXT NOT NULL,
+    executor_profile      TEXT NOT NULL,
+    requester_session_key TEXT,
+    requester_session_id  TEXT,
+    requester_platform    TEXT,
+    requester_chat_id     TEXT,
+    requester_thread_id   TEXT,
+    capability            TEXT NOT NULL,
+    risk                  TEXT NOT NULL,
+    request_json          TEXT NOT NULL,
+    status                TEXT NOT NULL,
+    approval_id           TEXT,
+    result_json           TEXT,
+    error                 TEXT,
+    created_at            INTEGER NOT NULL,
+    started_at            INTEGER,
+    completed_at          INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_profile_delegations_task
+    ON profile_delegations(task_id);
+CREATE INDEX IF NOT EXISTS idx_profile_delegations_requester_session
+    ON profile_delegations(requester_session_key, created_at);
+CREATE INDEX IF NOT EXISTS idx_profile_delegations_executor_status
+    ON profile_delegations(executor_profile, status);
 """
 
 
@@ -4330,6 +4358,108 @@ def _append_event(
         "VALUES (?, ?, ?, ?, ?)",
         (task_id, run_id, kind, pl, now),
     )
+
+
+def create_profile_delegation(
+    conn: sqlite3.Connection,
+    *,
+    delegation_id: str,
+    task_id: str,
+    requester_profile: str,
+    executor_profile: str,
+    requester_session_key: Optional[str] = None,
+    requester_session_id: Optional[str] = None,
+    requester_platform: Optional[str] = None,
+    requester_chat_id: Optional[str] = None,
+    requester_thread_id: Optional[str] = None,
+    capability: str,
+    risk: str,
+    request: dict,
+    approval_id: Optional[str] = None,
+    status: str = "queued",
+) -> None:
+    """Create an audit row for a cross-profile delegation request."""
+    now = int(time.time())
+    conn.execute(
+        """
+        INSERT OR REPLACE INTO profile_delegations (
+            id, task_id, requester_profile, executor_profile,
+            requester_session_key, requester_session_id, requester_platform,
+            requester_chat_id, requester_thread_id, capability, risk,
+            request_json, status, approval_id, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            delegation_id, task_id, requester_profile, executor_profile,
+            requester_session_key, requester_session_id, requester_platform,
+            requester_chat_id, requester_thread_id, capability, risk,
+            json.dumps(request, ensure_ascii=False), status, approval_id, now,
+        ),
+    )
+    _append_event(conn, task_id, "profile_delegation_created", {
+        "delegation_id": delegation_id,
+        "requester_profile": requester_profile,
+        "executor_profile": executor_profile,
+        "capability": capability,
+        "risk": risk,
+        "status": status,
+        "requester_session_key": requester_session_key,
+    })
+
+
+def get_profile_delegation(conn: sqlite3.Connection, delegation_id: str) -> Optional[dict]:
+    row = conn.execute("SELECT * FROM profile_delegations WHERE id = ?", (delegation_id,)).fetchone()
+    return _profile_delegation_from_row(row) if row else None
+
+
+def get_profile_delegation_by_task(conn: sqlite3.Connection, task_id: str) -> Optional[dict]:
+    row = conn.execute("SELECT * FROM profile_delegations WHERE task_id = ? ORDER BY created_at DESC LIMIT 1", (task_id,)).fetchone()
+    return _profile_delegation_from_row(row) if row else None
+
+
+def _profile_delegation_from_row(row: sqlite3.Row) -> dict:
+    data = dict(row)
+    for key in ("request_json", "result_json"):
+        val = data.get(key)
+        if val:
+            try:
+                data[key[:-5] if key.endswith("_json") else key] = json.loads(val)
+            except Exception:
+                data[key[:-5] if key.endswith("_json") else key] = None
+    return data
+
+
+def mark_profile_delegation_running(conn: sqlite3.Connection, delegation_id: str) -> None:
+    now = int(time.time())
+    row = get_profile_delegation(conn, delegation_id)
+    conn.execute(
+        "UPDATE profile_delegations SET status = ?, started_at = COALESCE(started_at, ?) WHERE id = ?",
+        ("running", now, delegation_id),
+    )
+    if row:
+        _append_event(conn, row["task_id"], "profile_delegation_running", {"delegation_id": delegation_id, "status": "running"})
+
+
+def complete_profile_delegation(conn: sqlite3.Connection, delegation_id: str, *, result: dict) -> None:
+    now = int(time.time())
+    row = get_profile_delegation(conn, delegation_id)
+    conn.execute(
+        "UPDATE profile_delegations SET status = ?, result_json = ?, completed_at = ? WHERE id = ?",
+        ("completed", json.dumps(result, ensure_ascii=False), now, delegation_id),
+    )
+    if row:
+        _append_event(conn, row["task_id"], "profile_delegation_completed", {"delegation_id": delegation_id, "status": "completed"})
+
+
+def fail_profile_delegation(conn: sqlite3.Connection, delegation_id: str, *, status: str = "failed", error: str) -> None:
+    now = int(time.time())
+    row = get_profile_delegation(conn, delegation_id)
+    conn.execute(
+        "UPDATE profile_delegations SET status = ?, error = ?, completed_at = ? WHERE id = ?",
+        (status, error, now, delegation_id),
+    )
+    if row:
+        _append_event(conn, row["task_id"], f"profile_delegation_{status}", {"delegation_id": delegation_id, "status": status, "error": error})
 
 
 def _end_run(

--- a/hermes_cli/profile_delegation.py
+++ b/hermes_cli/profile_delegation.py
@@ -1,0 +1,371 @@
+"""Kanban-backed cross-profile delegation orchestration."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import time
+import uuid
+from dataclasses import asdict, dataclass
+from typing import Any, Optional
+
+from agent.redact import redact_sensitive_text
+from hermes_cli.capability_registry import ProfileCapability, find_capability
+from hermes_cli.delegation_policy import (
+    DelegationAction,
+    DelegationRisk,
+    PolicyDecision,
+    ToolActionRequest,
+    enforce_delegation_policy,
+)
+from hermes_cli.profiles import normalize_profile_name
+
+
+@dataclass
+class ProfileDelegationRequest:
+    profile: Optional[str]
+    task: str
+    required_capability: str
+    risk: str = "READ"
+    requester_profile: str = "default"
+    requester_session_key: Optional[str] = None
+    requester_session_id: Optional[str] = None
+    requester_platform: Optional[str] = None
+    requester_chat_id: Optional[str] = None
+    requester_thread_id: Optional[str] = None
+    return_to: str = "current_session"
+    timeout_seconds: int = 300
+    max_runtime_seconds: int = 300
+    board: Optional[str] = None
+    idempotency_key: Optional[str] = None
+    approval_id: Optional[str] = None
+    tool_action: Optional[ToolActionRequest] = None
+    max_concurrency: Optional[int] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        if self.tool_action:
+            data["tool_action"] = asdict(self.tool_action)
+        return data
+
+
+@dataclass
+class ProfileDelegationResult:
+    status: str
+    delegation_id: str
+    task_id: Optional[str]
+    executor_profile: Optional[str]
+    requester_profile: str
+    capability: str
+    risk: str
+    result: Optional[dict[str, Any]] = None
+    summary: Optional[str] = None
+    error: Optional[str] = None
+    audit_ref: Optional[str] = None
+    ranking: Optional[list[dict[str, Any]]] = None
+    policy: Optional[dict[str, Any]] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _idempotency_key(req: ProfileDelegationRequest, executor: str) -> str:
+    if req.idempotency_key:
+        return req.idempotency_key
+    h = hashlib.sha256()
+    h.update("\0".join([
+        req.requester_session_key or "",
+        req.requester_profile,
+        executor,
+        req.required_capability,
+        " ".join(req.task.split()),
+    ]).encode("utf-8"))
+    return "profile-delegation:" + h.hexdigest()[:32]
+
+
+def _candidate_rows(caps: list[ProfileCapability]) -> list[dict[str, Any]]:
+    return [
+        {
+            "profile": c.profile,
+            "capability": c.capability,
+            "executable": c.executable,
+            "enabled": c.enabled,
+            "credential_present": c.credential_present,
+            "credential_check": c.credential_check,
+            "worker_available": c.worker_available,
+            "gateway_running": c.gateway_running,
+            "rank_score": c.rank_score,
+            "rank_reasons": c.rank_reasons,
+            "workload": c.workload.to_dict(),
+            "notes": c.notes,
+        }
+        for c in caps
+    ]
+
+
+def select_executor(
+    *,
+    required_capability: str,
+    requester_profile: str = "default",
+    profile: Optional[str] = None,
+    include_disabled: bool = True,
+    max_concurrency: Optional[int] = None,
+) -> tuple[Optional[ProfileCapability], list[dict[str, Any]], str]:
+    query = find_capability(
+        required_capability,
+        requester_profile=requester_profile,
+        include_disabled=include_disabled,
+        max_concurrency=max_concurrency,
+    )
+    candidates = query.profiles
+    if profile:
+        target = normalize_profile_name(profile)
+        matches = [c for c in candidates if c.profile == target]
+        chosen = matches[0] if matches else None
+        reason = "explicit_executor" if chosen else f"explicit executor {target!r} does not advertise {required_capability}"
+        return chosen, _candidate_rows(candidates), reason
+    executable = [c for c in candidates if c.executable and not c.workload.saturated]
+    if executable:
+        return executable[0], _candidate_rows(candidates), "auto_selected_workload_aware_executor"
+    if candidates:
+        return candidates[0], _candidate_rows(candidates), "best_candidate_not_currently_executable"
+    return None, [], "no_candidate"
+
+
+def build_delegation_worker_body(
+    req: ProfileDelegationRequest,
+    delegation_id: str,
+    executor: str,
+    capability_route: Optional[ProfileCapability] = None,
+) -> str:
+    route_source = capability_route.source if capability_route else "unknown"
+    route_kind = capability_route.kind if capability_route else "unknown"
+    composio_hint = ""
+    if capability_route and capability_route.kind == "composio":
+        composio_hint = (
+            "\n## Capability route\n"
+            f"Use Composio for this capability: {capability_route.source}. "
+            "Do not try to enable or use the native Vercel MCP server for this delegated request.\n"
+        )
+    return f"""# INTERNAL PROFILE DELEGATION REQUEST
+
+You are executing a delegated subtask for another Hermes executive profile.
+
+## Delegation
+- delegation_id: {delegation_id}
+- requester_profile: {req.requester_profile}
+- executor_profile: {executor}
+- required_capability: {req.required_capability}
+- risk: {req.risk}
+- credential_export_allowed: false
+- capability_route_kind: {route_kind}
+- capability_route_source: {route_source}
+{composio_hint}
+## Task
+{req.task}
+
+## Hard rules
+1. Run under your own profile only. Do not ask requester for credentials.
+2. Do not reveal OAuth tokens, API keys, Authorization headers, cookies, or credential file contents.
+3. For READ risk, inspect only. Do not deploy, delete, mutate config, change permissions, or spend money.
+4. If the required capability is unavailable, block/complete with structured failure.
+5. Finish using kanban_complete with metadata.profile_delegation exactly in this shape:
+
+{{
+  "delegation_id": "{delegation_id}",
+  "capability": "{req.required_capability}",
+  "risk": "{req.risk}",
+  "status": "completed|failed|blocked_approval",
+  "structured_result": {{ }},
+  "redaction": {{"secrets_returned": false}}
+}}
+"""
+
+
+def _safe_json_result(data: dict[str, Any]) -> dict[str, Any]:
+    text = json.dumps(data, ensure_ascii=False, default=str)
+    redacted = redact_sensitive_text(text, force=True)
+    try:
+        return json.loads(redacted)
+    except Exception:
+        return {"redacted_text": redacted}
+
+
+def _extract_structured_result(run) -> tuple[dict[str, Any], str]:
+    metadata = run.metadata or {}
+    pd = metadata.get("profile_delegation") if isinstance(metadata, dict) else None
+    if not isinstance(pd, dict):
+        pd = {}
+    if pd.get("redaction", {}).get("secrets_returned") is True:
+        raise ValueError("Executor reported credential material in result; result withheld.")
+    result = pd.get("structured_result") if isinstance(pd.get("structured_result"), dict) else {}
+    if not result and run.summary:
+        result = {"summary": run.summary}
+    if run.error:
+        result.setdefault("error", run.error)
+    return _safe_json_result(result), run.summary or ""
+
+
+def _emit_completion_event(result: ProfileDelegationResult, session_key: Optional[str]) -> None:
+    if not session_key:
+        return
+    try:
+        from tools.process_registry import process_registry
+        process_registry.completion_queue.put({
+            "type": "profile_delegation",
+            "delegation_id": result.delegation_id,
+            "task_id": result.task_id,
+            "session_key": session_key,
+            "requester_profile": result.requester_profile,
+            "executor_profile": result.executor_profile,
+            "capability": result.capability,
+            "risk": result.risk,
+            "status": result.status,
+            "summary": result.summary,
+            "result": result.result,
+            "error": result.error,
+            "completed_at": time.time(),
+        })
+    except Exception:
+        pass
+
+
+def delegate_to_profile(req: ProfileDelegationRequest, *, spawn_fn=None) -> ProfileDelegationResult:
+    from hermes_cli import kanban_db as kb
+
+    req.requester_profile = normalize_profile_name(req.requester_profile or "default")
+    chosen, ranking, select_reason = select_executor(
+        required_capability=req.required_capability,
+        requester_profile=req.requester_profile,
+        profile=req.profile,
+        include_disabled=True,
+        max_concurrency=req.max_concurrency,
+    )
+    delegation_id = "pd_" + uuid.uuid4().hex[:12]
+
+    if not chosen:
+        return ProfileDelegationResult(
+            status="failed", delegation_id=delegation_id, task_id=None,
+            executor_profile=None, requester_profile=req.requester_profile,
+            capability=req.required_capability, risk=req.risk,
+            error=f"No executor candidate found for {req.required_capability} ({select_reason}).",
+            ranking=ranking,
+        )
+
+    executor = chosen.profile
+    action = DelegationAction(
+        requester_profile=req.requester_profile,
+        executor_profile=executor,
+        task=req.task,
+        required_capability=req.required_capability,
+        requested_risk=DelegationRisk(req.risk) if req.risk in DelegationRisk._value2member_map_ else DelegationRisk.READ,
+        tool_action=req.tool_action,
+        approval_id=req.approval_id,
+    )
+    decision: PolicyDecision = enforce_delegation_policy(action)
+    req.risk = decision.risk.value
+    if not decision.allowed:
+        return ProfileDelegationResult(
+            status="blocked_approval" if decision.approval_required else "denied",
+            delegation_id=delegation_id, task_id=None, executor_profile=executor,
+            requester_profile=req.requester_profile, capability=req.required_capability,
+            risk=decision.risk.value, error=decision.reason, ranking=ranking,
+            policy=decision.to_dict(),
+        )
+
+    if not chosen.executable:
+        reasons = []
+        if not chosen.enabled:
+            reasons.append("capability is disabled")
+        if not chosen.worker_available:
+            reasons.append("executor profile is not worker-available")
+        if chosen.workload.saturated:
+            reasons.append("executor is at max concurrency")
+        return ProfileDelegationResult(
+            status="failed", delegation_id=delegation_id, task_id=None,
+            executor_profile=executor, requester_profile=req.requester_profile,
+            capability=req.required_capability, risk=decision.risk.value,
+            error=f"Executor {executor} cannot currently run {req.required_capability}: {', '.join(reasons) or select_reason}.",
+            ranking=ranking, policy=decision.to_dict(),
+        )
+
+    with kb.connect_closing(board=req.board) as conn:
+        idem = _idempotency_key(req, executor)
+        task_id = kb.create_task(
+            conn,
+            title=f"[internal delegation] {req.requester_profile} → {executor}: {req.required_capability}",
+            body=build_delegation_worker_body(req, delegation_id, executor, chosen),
+            assignee=executor,
+            created_by=req.requester_profile,
+            tenant=f"profile-delegation:{req.requester_profile}",
+            priority=100,
+            idempotency_key=idem,
+            max_runtime_seconds=req.max_runtime_seconds,
+            max_retries=2,
+            initial_status="blocked",
+            session_id=req.requester_session_id,
+            board=req.board,
+        )
+        # create_task only allows running/blocked as initial states; promote
+        # after the audit row exists so the dispatcher sees a ready card.
+        kb.promote_task(conn, task_id, actor=req.requester_profile, reason="profile delegation dispatch", force=True)
+        kb.create_profile_delegation(
+            conn,
+            delegation_id=delegation_id,
+            task_id=task_id,
+            requester_profile=req.requester_profile,
+            executor_profile=executor,
+            requester_session_key=req.requester_session_key,
+            requester_session_id=req.requester_session_id,
+            requester_platform=req.requester_platform,
+            requester_chat_id=req.requester_chat_id,
+            requester_thread_id=req.requester_thread_id,
+            capability=req.required_capability,
+            risk=decision.risk.value,
+            request=req.to_dict(),
+            approval_id=req.approval_id,
+        )
+        conn.commit()
+        kb.dispatch_once(conn, spawn_fn=spawn_fn, max_spawn=1, max_in_progress_per_profile=req.max_concurrency, board=req.board)
+        deadline = time.time() + max(0, min(int(req.timeout_seconds), 900))
+        while time.time() <= deadline:
+            task = kb.get_task(conn, task_id)
+            if task and task.status == "running":
+                kb.mark_profile_delegation_running(conn, delegation_id)
+                conn.commit()
+            if task and task.status in {"done", "blocked"}:
+                runs = kb.list_runs(conn, task_id, include_active=False)
+                latest = runs[-1] if runs else None
+                if task.status == "done" and latest:
+                    structured, summary = _extract_structured_result(latest)
+                    kb.complete_profile_delegation(conn, delegation_id, result=structured)
+                    conn.commit()
+                    result = ProfileDelegationResult(
+                        status="completed", delegation_id=delegation_id, task_id=task_id,
+                        executor_profile=executor, requester_profile=req.requester_profile,
+                        capability=req.required_capability, risk=decision.risk.value,
+                        result=structured, summary=summary, audit_ref=f"profile_delegations:{delegation_id}",
+                        ranking=ranking, policy=decision.to_dict(),
+                    )
+                    return result
+                error = (latest.error or latest.summary) if latest else (task.result or "delegated task blocked")
+                kb.fail_profile_delegation(conn, delegation_id, status="failed", error=error or "delegated task blocked")
+                conn.commit()
+                return ProfileDelegationResult(
+                    status="failed", delegation_id=delegation_id, task_id=task_id,
+                    executor_profile=executor, requester_profile=req.requester_profile,
+                    capability=req.required_capability, risk=decision.risk.value,
+                    error=error, audit_ref=f"profile_delegations:{delegation_id}",
+                    ranking=ranking, policy=decision.to_dict(),
+                )
+            time.sleep(0.2)
+        result = ProfileDelegationResult(
+            status="queued", delegation_id=delegation_id, task_id=task_id,
+            executor_profile=executor, requester_profile=req.requester_profile,
+            capability=req.required_capability, risk=decision.risk.value,
+            summary="Delegation is queued/running; result will be returned via session continuation when available.",
+            audit_ref=f"profile_delegations:{delegation_id}", ranking=ranking,
+            policy=decision.to_dict(),
+        )
+        return result

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -117,6 +117,7 @@ CONFIGURABLE_TOOLSETS = [
     ("session_search",  "🔎 Session Search",            "search past conversations"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
+    ("executive_bus",   "🏛️  Executive Capability Bus", "find_capability, delegate_to_profile"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),

--- a/tests/gateway/test_profile_delegation_continuation.py
+++ b/tests/gateway/test_profile_delegation_continuation.py
@@ -1,0 +1,20 @@
+def test_profile_delegation_notification_formatter():
+    from tools.process_registry import format_process_notification
+
+    text = format_process_notification({
+        "type": "profile_delegation",
+        "delegation_id": "pd_123",
+        "task_id": "t_1",
+        "session_key": "agent:main:discord:channel:1",
+        "requester_profile": "cmo",
+        "executor_profile": "cto",
+        "capability": "mcp:vercel",
+        "risk": "READ",
+        "status": "completed",
+        "summary": "Vercel inspected.",
+        "result": {"project": "ConnectMe", "status": "ok"},
+    })
+    assert "INTERNAL PROFILE DELEGATION RESULT" in text
+    assert "executor_profile: cto" in text
+    assert "mcp:vercel" in text
+    assert "Continue the original task" in text

--- a/tests/hermes_cli/test_capability_registry.py
+++ b/tests/hermes_cli/test_capability_registry.py
@@ -1,0 +1,83 @@
+import os
+from pathlib import Path
+
+import yaml
+
+
+def _home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    (home / "profiles" / "cto" / "mcp-tokens").mkdir(parents=True)
+    (home / "profiles" / "cmo").mkdir(parents=True)
+    (home / "config.yaml").write_text("toolsets: [hermes-cli]\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    return home
+
+
+def test_capability_registry_finds_disabled_vercel_with_redacted_token_presence(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    cto = home / "profiles" / "cto"
+    (cto / "config.yaml").write_text(yaml.safe_dump({
+        "toolsets": ["hermes-cli"],
+        "mcp_servers": {"vercel": {"url": "https://mcp.vercel.com", "enabled": False, "auth": "oauth"}},
+    }), encoding="utf-8")
+    (cto / "mcp-tokens" / "vercel.json").write_text("super-secret-token", encoding="utf-8")
+
+    from hermes_cli.capability_registry import find_capability
+
+    result = find_capability("mcp:vercel", requester_profile="cmo", include_disabled=True)
+    assert result.profiles
+    cap = result.profiles[0]
+    assert cap.profile == "cto"
+    assert cap.configured is True
+    assert cap.enabled is False
+    assert cap.credential_present is True
+    assert cap.credential_check == "disabled"
+    assert "super-secret-token" not in str(result.to_dict())
+
+
+def test_composio_vercel_route_beats_disabled_native_vercel(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "mcp_servers": {"composio": {"url": "https://connect.composio.dev/mcp"}},
+    }), encoding="utf-8")
+    cto = home / "profiles" / "cto"
+    (cto / "config.yaml").write_text(yaml.safe_dump({
+        "mcp_servers": {"vercel": {"enabled": False, "auth": "oauth"}},
+    }), encoding="utf-8")
+    (cto / "mcp-tokens" / "vercel.json").write_text("native-secret", encoding="utf-8")
+
+    from hermes_cli.capability_registry import find_capability
+
+    result = find_capability("mcp:vercel", requester_profile="cmo", include_disabled=True)
+    assert result.recommendation["best_profile"] == "default"
+    best = result.profiles[0]
+    assert best.kind == "composio"
+    assert best.source == "mcp:composio/toolkit:vercel"
+    assert best.executable is True
+    assert "native-secret" not in str(result.to_dict())
+
+
+def test_workload_aware_ranking_prefers_less_busy_executor(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    for profile in ("cto", "coo"):
+        p = home / "profiles" / profile
+        (p / "mcp-tokens").mkdir(parents=True, exist_ok=True)
+        (p / "config.yaml").write_text(yaml.safe_dump({
+            "mcp_servers": {"vercel": {"enabled": True, "auth": "oauth"}},
+        }), encoding="utf-8")
+        (p / "mcp-tokens" / "vercel.json").write_text("secret", encoding="utf-8")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.capability_registry import find_capability
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="busy", assignee="cto", initial_status="running")
+        conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (tid,))
+        conn.commit()
+
+    result = find_capability("mcp:vercel", requester_profile="cmo", include_disabled=False, max_concurrency=2)
+    assert result.profiles[0].profile == "coo"
+    cto = next(c for c in result.profiles if c.profile == "cto")
+    assert cto.workload.running_count == 1
+    assert "running_count=1" in cto.rank_reasons

--- a/tests/hermes_cli/test_executive_bus_gate.py
+++ b/tests/hermes_cli/test_executive_bus_gate.py
@@ -1,0 +1,57 @@
+"""Tests for Executive Bus availability gating."""
+
+from __future__ import annotations
+
+
+def test_executive_bus_gate_requires_explicit_platform_enable(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from hermes_cli import config as config_mod
+    from hermes_cli.executive_bus_gate import executive_bus_enabled_for_current_context
+
+    monkeypatch.setenv("HERMES_PLATFORM", "discord")
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"discord": ["terminal"]}})
+    invalidate_check_fn_cache()
+
+    assert executive_bus_enabled_for_current_context() is False
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"discord": ["terminal", "executive_bus"]}})
+    invalidate_check_fn_cache()
+
+    assert executive_bus_enabled_for_current_context() is True
+
+
+def test_executive_bus_gate_is_platform_scoped(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache
+    from hermes_cli import config as config_mod
+    from hermes_cli.executive_bus_gate import executive_bus_enabled_for_current_context
+
+    monkeypatch.setenv("HERMES_PLATFORM", "telegram")
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"platform_toolsets": {"discord": ["executive_bus"], "telegram": ["terminal"]}},
+    )
+    invalidate_check_fn_cache()
+
+    assert executive_bus_enabled_for_current_context() is False
+
+
+def test_executive_bus_tools_hidden_until_gate_passes(monkeypatch):
+    from tools.registry import invalidate_check_fn_cache, registry
+    from hermes_cli import config as config_mod
+    import tools.capability_registry_tool  # noqa: F401 - registers tool
+    import tools.profile_delegation_tool  # noqa: F401 - registers tool
+
+    requested = {"find_capability", "delegate_to_profile"}
+    monkeypatch.setenv("HERMES_PLATFORM", "cli")
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["terminal"]}})
+    invalidate_check_fn_cache()
+
+    hidden = registry.get_definitions(requested, quiet=True)
+    assert hidden == []
+
+    monkeypatch.setattr(config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["terminal", "executive_bus"]}})
+    invalidate_check_fn_cache()
+
+    visible = registry.get_definitions(requested, quiet=True)
+    assert {entry["function"]["name"] for entry in visible} == requested

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -1647,3 +1647,32 @@ def test_bare_connect_does_not_close_on_context_exit(tmp_path):
     # Still usable after with-block exit (the leak).
     conn.execute("SELECT 1").fetchone()
     conn.close()  # explicit close to avoid leaking THIS test
+
+
+def test_existing_db_missing_profile_delegations_gets_migrated(kanban_home):
+    """Opening an existing board from before profile delegation creates audit tables."""
+    db_path = kanban_home / "kanban" / "default" / "kanban.db"
+    with kb.connect(db_path) as conn:
+        conn.execute("DROP INDEX IF EXISTS idx_profile_delegations_task")
+        conn.execute("DROP INDEX IF EXISTS idx_profile_delegations_requester_session")
+        conn.execute("DROP INDEX IF EXISTS idx_profile_delegations_executor_status")
+        conn.execute("DROP TABLE IF EXISTS profile_delegations")
+        conn.commit()
+
+    with kb._INIT_LOCK:
+        kb._INITIALIZED_PATHS.discard(str(db_path.resolve()))
+
+    with kb.connect(db_path) as conn:
+        tables = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")
+        }
+        indexes = {
+            row["name"]
+            for row in conn.execute("SELECT name FROM sqlite_master WHERE type='index'")
+        }
+
+    assert "profile_delegations" in tables
+    assert "idx_profile_delegations_task" in indexes
+    assert "idx_profile_delegations_requester_session" in indexes
+    assert "idx_profile_delegations_executor_status" in indexes

--- a/tests/hermes_cli/test_profile_delegation.py
+++ b/tests/hermes_cli/test_profile_delegation.py
@@ -1,0 +1,144 @@
+import yaml
+
+
+def _home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    for profile in ("cto", "coo", "cmo"):
+        (home / "profiles" / profile / "mcp-tokens").mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def _enable_cap(home, profile, server="vercel"):
+    p = home / "profiles" / profile
+    (p / "config.yaml").write_text(yaml.safe_dump({"mcp_servers": {server: {"enabled": True, "auth": "oauth"}}}), encoding="utf-8")
+    (p / "mcp-tokens" / f"{server}.json").write_text("secret", encoding="utf-8")
+
+
+def test_auto_executor_selection_and_delegated_read_completes(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    _enable_cap(home, "cto")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.profile_delegation import ProfileDelegationRequest, delegate_to_profile
+
+    def spawn(task, workspace, board):
+        deleg = kb.get_profile_delegation_by_task(conn, task.id)
+        kb.complete_task(
+            conn,
+            task.id,
+            summary="Vercel inspected.",
+            result="No secrets.",
+            metadata={"profile_delegation": {
+                "delegation_id": deleg["id"],
+                "capability": "mcp:vercel",
+                "risk": "READ",
+                "status": "completed",
+                "structured_result": {"project": "ConnectMe", "status": "ok"},
+                "redaction": {"secrets_returned": False},
+            }},
+        )
+        return 12345
+
+    with kb.connect_closing() as conn:
+        req = ProfileDelegationRequest(
+            profile=None,
+            task="Inspect Vercel project ConnectMe status",
+            required_capability="mcp:vercel",
+            requester_profile="cmo",
+            timeout_seconds=1,
+            max_concurrency=2,
+        )
+        result = delegate_to_profile(req, spawn_fn=spawn)
+
+    assert result.status == "completed"
+    assert result.executor_profile == "cto"
+    assert result.result["project"] == "ConnectMe"
+    assert result.result["status"] == "ok"
+    assert result.ranking[0]["profile"] == "cto"
+
+
+def test_composio_route_is_embedded_in_worker_prompt(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    (home / "config.yaml").write_text(yaml.safe_dump({
+        "mcp_servers": {"composio": {"url": "https://connect.composio.dev/mcp"}},
+    }), encoding="utf-8")
+
+    from hermes_cli.profile_delegation import ProfileDelegationRequest, build_delegation_worker_body, select_executor
+
+    chosen, ranking, reason = select_executor(required_capability="mcp:vercel", requester_profile="cmo")
+    assert chosen.profile == "default"
+    assert chosen.kind == "composio"
+    body = build_delegation_worker_body(
+        ProfileDelegationRequest(profile=None, task="Inspect Vercel through Composio", required_capability="mcp:vercel", requester_profile="cmo"),
+        "pd_test",
+        chosen.profile,
+        chosen,
+    )
+    assert "Use Composio for this capability" in body
+    assert "Do not try to enable or use the native Vercel MCP" in body
+
+
+def test_consequential_write_is_blocked_before_task_spawn(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    _enable_cap(home, "cto")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.profile_delegation import ProfileDelegationRequest, delegate_to_profile
+
+    spawned = []
+    def spawn(task, workspace, board):
+        spawned.append(task.id)
+        return 1
+
+    req = ProfileDelegationRequest(
+        profile=None,
+        task="Deploy ConnectMe to production on Vercel",
+        required_capability="mcp:vercel",
+        requester_profile="cmo",
+        risk="CONSEQUENTIAL_WRITE",
+        timeout_seconds=0,
+    )
+    result = delegate_to_profile(req, spawn_fn=spawn)
+    assert result.status == "blocked_approval"
+    assert not spawned
+    with kb.connect_closing() as conn:
+        assert conn.execute("SELECT COUNT(*) FROM tasks").fetchone()[0] == 0
+
+
+def test_busy_executor_ranking_uses_running_count(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    _enable_cap(home, "cto")
+    _enable_cap(home, "coo")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.profile_delegation import ProfileDelegationRequest, select_executor
+
+    with kb.connect_closing() as conn:
+        tid = kb.create_task(conn, title="busy", assignee="cto", initial_status="running")
+        conn.execute("UPDATE tasks SET status = 'running' WHERE id = ?", (tid,))
+        conn.commit()
+    chosen, ranking, reason = select_executor(required_capability="mcp:vercel", requester_profile="cmo", max_concurrency=2)
+    assert chosen.profile == "coo"
+    assert any(r["profile"] == "cto" and r["workload"]["running_count"] == 1 for r in ranking)
+    assert reason == "auto_selected_workload_aware_executor"
+
+
+def test_executor_failure_returns_structured_error(tmp_path, monkeypatch):
+    home = _home(tmp_path, monkeypatch)
+    _enable_cap(home, "cto")
+
+    from hermes_cli import kanban_db as kb
+    from hermes_cli.profile_delegation import ProfileDelegationRequest, delegate_to_profile
+
+    def spawn(task, workspace, board):
+        kb.block_task(conn, task.id, reason="Vercel MCP authentication failed")
+        return 222
+
+    with kb.connect_closing() as conn:
+        result = delegate_to_profile(ProfileDelegationRequest(
+            profile="cto", task="Inspect Vercel", required_capability="mcp:vercel", requester_profile="cmo", timeout_seconds=1,
+        ), spawn_fn=spawn)
+    assert result.status == "failed"
+    assert "Vercel MCP authentication failed" in (result.error or "")

--- a/tests/tools/test_capability_registry_tool.py
+++ b/tests/tools/test_capability_registry_tool.py
@@ -1,0 +1,19 @@
+import json
+import yaml
+
+
+def test_find_capability_tool_returns_workload_ranking(tmp_path, monkeypatch):
+    home = tmp_path / "hermes"
+    p = home / "profiles" / "cto"
+    (p / "mcp-tokens").mkdir(parents=True)
+    p.joinpath("config.yaml").write_text(yaml.safe_dump({"mcp_servers": {"vercel": {"enabled": True, "auth": "oauth"}}}), encoding="utf-8")
+    p.joinpath("mcp-tokens", "vercel.json").write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    from tools.capability_registry_tool import find_capability_tool
+
+    data = json.loads(find_capability_tool("mcp:vercel", requester_profile="cmo"))
+    assert data["recommendation"]["best_profile"] == "cto"
+    assert data["profiles"][0]["credential_present"] is True
+    assert "secret" not in json.dumps(data)

--- a/tests/tools/test_profile_delegation_tool.py
+++ b/tests/tools/test_profile_delegation_tool.py
@@ -1,0 +1,32 @@
+import json
+import yaml
+
+
+def test_delegate_to_profile_tool_accepts_auto_executor_and_structured_policy(monkeypatch, tmp_path):
+    home = tmp_path / "hermes"
+    p = home / "profiles" / "cto"
+    (p / "mcp-tokens").mkdir(parents=True)
+    p.joinpath("config.yaml").write_text(yaml.safe_dump({"mcp_servers": {"vercel": {"enabled": True, "auth": "oauth"}}}), encoding="utf-8")
+    p.joinpath("mcp-tokens", "vercel.json").write_text("secret", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "cmo")
+
+    from hermes_cli.profile_delegation import ProfileDelegationResult
+    import tools.profile_delegation_tool as tool
+
+    def fake_delegate(req):
+        assert req.profile is None
+        assert req.requester_profile == "cmo"
+        assert req.tool_action.tool_name == "mcp:vercel"
+        return ProfileDelegationResult(
+            status="queued", delegation_id="pd_test", task_id="t_test",
+            executor_profile="cto", requester_profile="cmo", capability="mcp:vercel",
+            risk="READ", ranking=[])
+
+    monkeypatch.setattr(tool, "delegate_to_profile", fake_delegate)
+    data = json.loads(tool.delegate_to_profile_tool(
+        task="Inspect Vercel", required_capability="mcp:vercel", tool_name="mcp:vercel", action_name="list_projects"
+    ))
+    assert data["executor_profile"] == "cto"
+    assert data["status"] == "queued"

--- a/tools/capability_registry_tool.py
+++ b/tools/capability_registry_tool.py
@@ -1,0 +1,64 @@
+"""Model-facing Executive Capability Registry tools."""
+
+from __future__ import annotations
+
+import json
+from typing import Optional
+
+from hermes_cli.capability_registry import find_capability, to_json
+from hermes_cli.executive_bus_gate import executive_bus_enabled_for_current_context
+from tools.registry import registry
+
+
+def find_capability_tool(
+    capability: str,
+    risk: str = "READ",
+    include_disabled: bool = False,
+    test_credentials: bool = False,
+    requester_profile: Optional[str] = None,
+    max_concurrency: Optional[int] = None,
+) -> str:
+    result = find_capability(
+        capability,
+        requester_profile=requester_profile,
+        risk=risk,  # retained for API shape / future ranking policy
+        include_disabled=include_disabled,
+        test_credentials=test_credentials,
+        max_concurrency=max_concurrency,
+    )
+    return to_json(result)
+
+
+registry.register(
+    name="find_capability",
+    toolset="executive_bus",
+    schema={
+        "name": "find_capability",
+        "description": (
+            "Find which Hermes executive profile owns a capability such as mcp:vercel, "
+            "mcp:composio, tool:terminal, or toolset:browser. Returns redacted, "
+            "workload-aware ranking metadata only; never returns credentials."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "capability": {"type": "string", "description": "Capability identifier, e.g. mcp:vercel"},
+                "risk": {"type": "string", "enum": ["READ", "PREPARE", "CONSEQUENTIAL_WRITE"], "default": "READ"},
+                "include_disabled": {"type": "boolean", "default": False},
+                "test_credentials": {"type": "boolean", "default": False},
+                "requester_profile": {"type": "string", "description": "Optional requesting profile; defaults to current profile."},
+                "max_concurrency": {"type": "integer", "description": "Optional simple per-profile concurrency cap used for ranking."},
+            },
+            "required": ["capability"],
+        },
+    },
+    handler=lambda args, **kw: find_capability_tool(
+        capability=args.get("capability", ""),
+        risk=args.get("risk", "READ"),
+        include_disabled=bool(args.get("include_disabled", False)),
+        test_credentials=bool(args.get("test_credentials", False)),
+        requester_profile=args.get("requester_profile"),
+        max_concurrency=args.get("max_concurrency"),
+    ),
+    check_fn=executive_bus_enabled_for_current_context,
+)

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -3279,6 +3279,42 @@ def _delegation_attribution_line(evt: dict) -> "str | None":
     return line
 
 
+def _format_profile_delegation(evt: dict) -> str:
+    """Format profile-delegation completion for same-session re-entry."""
+    import json as _json
+
+    deleg_id = evt.get("delegation_id", "unknown")
+    executor = evt.get("executor_profile") or "unknown"
+    capability = evt.get("capability") or "unknown"
+    risk = evt.get("risk") or "READ"
+    status = evt.get("status") or "completed"
+    summary = evt.get("summary") or ""
+    result = evt.get("result") or {}
+    error = evt.get("error")
+    lines = [
+        f"[INTERNAL PROFILE DELEGATION RESULT — {deleg_id}]",
+        f"executor_profile: {executor}",
+        f"capability: {capability}",
+        f"risk: {risk}",
+        f"status: {status}",
+    ]
+    if summary:
+        lines.append(f"summary: {summary}")
+    if error:
+        lines.append(f"error: {error}")
+    lines.extend([
+        "",
+        "Structured result:",
+        _json.dumps(result, ensure_ascii=False, indent=2, default=str),
+        "[/INTERNAL PROFILE DELEGATION RESULT]",
+        "",
+        "Continue the original task using this delegated result. Do not ask Michael "
+        "to coordinate this handoff. Do not reveal or request executor credentials.",
+    ])
+    return "\n".join(lines)
+
+
+
 def format_process_notification(evt: dict) -> "str | None":
     """Format a process notification event into a [IMPORTANT: ...] message.
 
@@ -3320,6 +3356,9 @@ def format_process_notification(evt: dict) -> "str | None":
 
     if evt_type == "async_delegation":
         return _format_async_delegation(evt)
+
+    if evt_type == "profile_delegation":
+        return _format_profile_delegation(evt)
 
     _exit = evt.get("exit_code", "?")
     _out = evt.get("output", "")

--- a/tools/profile_delegation_tool.py
+++ b/tools/profile_delegation_tool.py
@@ -1,0 +1,110 @@
+"""Model-facing cross-profile delegation tool."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Optional
+
+from hermes_cli.delegation_policy import ToolActionRequest
+from hermes_cli.executive_bus_gate import executive_bus_enabled_for_current_context
+from hermes_cli.profile_delegation import ProfileDelegationRequest, delegate_to_profile
+from tools.registry import registry
+
+
+def _current_session_key() -> Optional[str]:
+    try:
+        from tools.approval import get_current_session_key
+        return get_current_session_key()
+    except Exception:
+        return os.environ.get("HERMES_GATEWAY_SESSION_KEY")
+
+
+def delegate_to_profile_tool(
+    task: str,
+    required_capability: str,
+    profile: Optional[str] = None,
+    risk: str = "READ",
+    return_to: str = "current_session",
+    timeout_seconds: int = 300,
+    max_runtime_seconds: int = 300,
+    board: Optional[str] = None,
+    tool_name: Optional[str] = None,
+    action_name: Optional[str] = None,
+    operation: Optional[str] = None,
+    max_concurrency: Optional[int] = None,
+) -> str:
+    requester_profile = os.environ.get("HERMES_PROFILE") or "default"
+    tool_action = None
+    if tool_name or action_name or operation:
+        tool_action = ToolActionRequest(
+            capability=required_capability,
+            tool_name=tool_name,
+            action_name=action_name,
+            operation=operation,
+        )
+    req = ProfileDelegationRequest(
+        profile=profile,
+        task=task,
+        required_capability=required_capability,
+        risk=risk,
+        requester_profile=requester_profile,
+        requester_session_key=_current_session_key(),
+        requester_session_id=os.environ.get("HERMES_SESSION_ID"),
+        return_to=return_to,
+        timeout_seconds=int(timeout_seconds),
+        max_runtime_seconds=int(max_runtime_seconds),
+        board=board,
+        tool_action=tool_action,
+        max_concurrency=max_concurrency,
+    )
+    result = delegate_to_profile(req)
+    return json.dumps(result.to_dict(), ensure_ascii=False, indent=2, sort_keys=True)
+
+
+registry.register(
+    name="delegate_to_profile",
+    toolset="executive_bus",
+    schema={
+        "name": "delegate_to_profile",
+        "description": (
+            "Delegate a bounded subtask to another Hermes profile, executed under that "
+            "profile's own HERMES_HOME/config/tools/credentials. If profile is omitted, "
+            "the executor is selected automatically using capability and workload ranking. "
+            "Uses Kanban internally; credentials are never exposed to the requester."
+        ),
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "profile": {"type": "string", "description": "Optional executor profile, e.g. cto. Omit for auto-selection."},
+                "task": {"type": "string", "description": "Exact bounded subtask for the executor."},
+                "required_capability": {"type": "string", "description": "Capability required, e.g. mcp:vercel."},
+                "risk": {"type": "string", "enum": ["READ", "PREPARE", "CONSEQUENTIAL_WRITE"], "default": "READ"},
+                "return_to": {"type": "string", "enum": ["current_session"], "default": "current_session"},
+                "timeout_seconds": {"type": "integer", "default": 300, "minimum": 0, "maximum": 900},
+                "max_runtime_seconds": {"type": "integer", "default": 300, "minimum": 5, "maximum": 1800},
+                "board": {"type": "string", "description": "Optional Kanban board slug."},
+                "tool_name": {"type": "string", "description": "Future policy atom: concrete tool name, if known."},
+                "action_name": {"type": "string", "description": "Future policy atom: concrete tool action, if known."},
+                "operation": {"type": "string", "description": "Future policy atom: read/write/delete/etc., if known."},
+                "max_concurrency": {"type": "integer", "description": "Optional simple per-profile concurrency cap for ranking/dispatch."},
+            },
+            "required": ["task", "required_capability"],
+        },
+    },
+    handler=lambda args, **kw: delegate_to_profile_tool(
+        profile=args.get("profile"),
+        task=args.get("task", ""),
+        required_capability=args.get("required_capability", ""),
+        risk=args.get("risk", "READ"),
+        return_to=args.get("return_to", "current_session"),
+        timeout_seconds=args.get("timeout_seconds", 300),
+        max_runtime_seconds=args.get("max_runtime_seconds", 300),
+        board=args.get("board"),
+        tool_name=args.get("tool_name"),
+        action_name=args.get("action_name"),
+        operation=args.get("operation"),
+        max_concurrency=args.get("max_concurrency"),
+    ),
+    check_fn=executive_bus_enabled_for_current_context,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -285,6 +285,16 @@ TOOLSETS = {
         "includes": []
     },
 
+    "executive_bus": {
+        "description": (
+            "Executive Capability Bus tools: discover capabilities across Hermes "
+            "profiles and delegate bounded work to another profile using profile "
+            "credential isolation and workload-aware executor ranking."
+        ),
+        "tools": ["find_capability", "delegate_to_profile"],
+        "includes": []
+    },
+
     # "honcho" toolset removed — Honcho is now a memory provider plugin.
     # Tools are injected via MemoryManager, not the toolset system.
 


### PR DESCRIPTION
# PR: feat: add gated Executive Capability Bus delegation

## Summary

Adds a service-gated Executive Capability Bus for Hermes profiles:

- discover which profile owns a capability via `find_capability`
- delegate bounded work to a selected/auto-ranked profile via `delegate_to_profile`
- execute under the executor profile's own config/credentials
- return structured results through Kanban/profile-delegation audit rows
- keep credentials out of requester-visible results
- expose the Bus only when `executive_bus` is explicitly enabled for the current profile/platform

This is intentionally not an always-on core surface. It is a narrow, opt-in toolset for orchestrator profiles such as Phantom/Director.

## Why

Michael's operating model needs Phantom/Director to coordinate Mr Crabs/CEO and department-head Hermes profiles without sharing all credentials into one monolithic runtime.

The Bus gives Director a safe route to ask:

```text
Who can do X?
Delegate bounded work to that profile.
Return the result/audit trail.
Do not expose credentials.
```

## Design

### Capability registry

New module:

```text
hermes_cli/capability_registry.py
```

It inspects profile configs and ranks matching capabilities such as:

```text
tool:<name>
toolset:<name>
mcp:<server>
composio:<toolkit>
```

Returned data is redacted capability/workload metadata only.

### Delegation policy

New module:

```text
hermes_cli/delegation_policy.py
```

Phase 1 policy is conservative:

- READ tasks allowed
- PREPARE tasks allowed
- consequential writes require explicit approval
- credential export is denied

### Profile delegation

New module:

```text
hermes_cli/profile_delegation.py
```

Creates a Kanban task for the executor profile and stores an audit row in `profile_delegations`.

### Tool gating

New module:

```text
hermes_cli/executive_bus_gate.py
```

The model-facing tools only appear when:

- `executive_bus` is explicitly enabled in profile/platform toolset config
- required Kanban/delegation/process-registry modules import successfully

### Model-facing tools

New tools:

```text
tools/capability_registry_tool.py
tools/profile_delegation_tool.py
```

Tool names:

```text
find_capability
delegate_to_profile
```

### Runtime continuation

Existing gateway/process notification paths are extended so profile-delegation completion events can re-enter the requester session with a structured internal result block.

## Files changed

```text
M gateway/run.py
A hermes_cli/capability_registry.py
A hermes_cli/delegation_policy.py
A hermes_cli/executive_bus_gate.py
M hermes_cli/kanban_db.py
A hermes_cli/profile_delegation.py
M hermes_cli/tools_config.py
A tests/gateway/test_profile_delegation_continuation.py
A tests/hermes_cli/test_capability_registry.py
A tests/hermes_cli/test_executive_bus_gate.py
M tests/hermes_cli/test_kanban_db.py
A tests/hermes_cli/test_profile_delegation.py
A tests/tools/test_capability_registry_tool.py
A tests/tools/test_profile_delegation_tool.py
A tools/capability_registry_tool.py
M tools/process_registry.py
A tools/profile_delegation_tool.py
M toolsets.py
```

Diff stat:

```text
18 files changed, 1824 insertions(+), 25 deletions(-)
```

## Tests run

Local branch after rebase onto current `origin/main`:

```text
PY_COMPILE_OK
15 passed in 1.35s
33 passed in 1.74s
231 passed, 12 skipped, 20 deselected in 15.50s
```

Phantom deployment branch before restart:

```text
PY_COMPILE_OK
38 passed in 6.73s
```

Runtime smoke on Phantom/Director:

```text
Director profile: executive_bus enabled
Default profile: executive_bus disabled
find_capability("toolset:terminal", requester_profile="director", risk="READ") -> executable, best_profile=director
profile_delegation audit smoke -> completed, risk=READ, audit_ref present
```

## Production pilot evidence

Phantom Director pilot is already running this code on a deployment branch:

```text
Phantom branch: deploy/executive-bus-830543e7c
Phantom commit: 21dd0aa44b feat: add gated executive bus delegation
Director service: active/running, PID 669820
```

Post-fix logs show no new `nemo_relay`, `snowballstemmer`, Relay initialization, Traceback, or ERROR matches since dependency drift was fixed.

## Safety notes

- Does not reapply Phantom's preserved dirty stash.
- Does not include Squilvia in Executive Bus trust boundary.
- Does not export credentials.
- Consequential writes are blocked pending explicit approval.
- Tool exposure is opt-in via `executive_bus` toolset gating.

## Follow-up after merge

- Decide whether to keep the Phantom branch as-is until upstream lands, or fast-forward/redeploy after PR merge.
- Add a user-facing docs page if this becomes a supported cross-profile orchestration feature.
- Consider moving the runtime synthetic smoke into a CLI command once the feature graduates from pilot.
