### PR TITLE
fix(skills): stop OS junk files from freezing bundled skill updates

### DIFF
--- a/tests/tools/test_skills_sync.py
+++ b/tests/tools/test_skills_sync.py
@@ -1002,3 +1002,108 @@ class TestCallTimeDirResolution:
                 ss._rmtree_writable(foreign)
         finally:
             reset_hermes_home_override(token)
+
+
+class TestOsJunkIgnoredByModificationDetector:
+    """OS metadata junk must not read as a user modification of a skill.
+
+    Browsing a bundled skill's directory in Finder drops ``.DS_Store`` (and
+    AppleDouble ``._*`` companions) into it with zero user intent; counting
+    that stray file as divergence froze all future bundled updates for the
+    skill (#102408). The detector must ignore OS junk — but only OS junk:
+    a genuine edit still reads as user-modified even when junk is present.
+    """
+
+    def _patches(self, bundled, skills_dir, manifest_file):
+        from contextlib import ExitStack
+        stack = ExitStack()
+        stack.enter_context(patch("tools.skills_sync._get_bundled_dir", return_value=bundled))
+        stack.enter_context(
+            patch(
+                "tools.skills_sync._get_optional_dir",
+                return_value=bundled.parent / "optional-skills",
+            )
+        )
+        stack.enter_context(patch("tools.skills_sync.SKILLS_DIR", skills_dir))
+        stack.enter_context(patch("tools.skills_sync.MANIFEST_FILE", manifest_file))
+        return stack
+
+    def _skill(self, root, rel, body="# Body\n", name="demo-skill"):
+        d = root / rel
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "SKILL.md").write_text(f"---\nname: {name}\n---\n{body}", encoding="utf-8")
+        return d
+
+    def test_dir_hash_and_file_list_ignore_os_junk(self, tmp_path):
+        """Identical trees with/without junk hash and enumerate the same."""
+        from tools.skills_sync import _skill_file_list
+
+        clean = self._skill(tmp_path, "clean/demo-skill")
+        junky = self._skill(tmp_path, "junky/demo-skill")
+        for junk in (".DS_Store", "._SKILL.md", "Icon\r", "Thumbs.db"):
+            (junky / junk).write_bytes(b"\x00junk")
+        (junky / "nested").mkdir()
+        (junky / "nested" / ".DS_Store").write_bytes(b"\x00junk")
+
+        assert _dir_hash(clean) == _dir_hash(junky)
+        assert _skill_file_list(clean) == _skill_file_list(junky) == ["SKILL.md"]
+
+    def test_sync_updates_skill_when_only_junk_was_added(self, tmp_path):
+        """Junk-only divergence must not freeze the package: an upstream
+        update still lands (pre-fix this read as user-modified forever)."""
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        # Baseline: the user's synced copy matches the recorded origin hash…
+        origin = self._skill(bundled, "cat/demo-skill", body="# v1\n")
+        user = self._skill(skills_dir, "cat/demo-skill", body="# v1\n")
+        manifest_file.parent.mkdir(parents=True, exist_ok=True)
+        manifest_file.write_text(f"demo-skill:{_dir_hash(origin)}\n", encoding="utf-8")
+        # …then Finder drops junk into the user's copy…
+        (user / ".DS_Store").write_bytes(b"\x00junk")
+        (user / "._SKILL.md").write_bytes(b"\x00junk")
+        # …and upstream ships a newer version.
+        self._skill(bundled, "cat/demo-skill", body="# v2 upstream\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert result["user_modified"] == []
+        assert "demo-skill" in result["updated"]
+        assert "# v2 upstream" in (skills_dir / "cat" / "demo-skill" / "SKILL.md").read_text()
+
+    def test_genuine_edit_still_flagged_alongside_junk(self, tmp_path):
+        """The junk exemption must not mask a real user edit."""
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "user_skills"
+        manifest_file = skills_dir / ".bundled_manifest"
+
+        origin = self._skill(bundled, "cat/demo-skill", body="# v1\n")
+        user = self._skill(skills_dir, "cat/demo-skill", body="# my edit\n")
+        manifest_file.parent.mkdir(parents=True, exist_ok=True)
+        manifest_file.write_text(f"demo-skill:{_dir_hash(origin)}\n", encoding="utf-8")
+        (user / ".DS_Store").write_bytes(b"\x00junk")
+        self._skill(bundled, "cat/demo-skill", body="# v2 upstream\n")
+
+        with self._patches(bundled, skills_dir, manifest_file):
+            result = sync_skills(quiet=True)
+
+        assert "demo-skill" in result["user_modified"]
+        assert "demo-skill" not in result["updated"]
+
+    def test_diff_does_not_report_junk_as_added(self, tmp_path):
+        """`hermes skills diff` must not surface junk as 'only in your copy'."""
+        from tools.skills_sync import diff_bundled_skill
+
+        bundled = tmp_path / "bundled"
+        skills_dir = tmp_path / "user_skills"
+        self._skill(bundled, "cat/demo-skill", body="# v1\n")
+        self._skill(skills_dir, "cat/demo-skill", body="# v1\n")
+        (skills_dir / "cat" / "demo-skill" / ".DS_Store").write_bytes(b"\x00junk")
+
+        with self._patches(bundled, skills_dir, skills_dir / ".bundled_manifest"):
+            result = diff_bundled_skill("demo-skill")
+
+        assert result["ok"] is True
+        assert result["modified"] is False

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -287,6 +287,23 @@ def _compute_relative_dest(skill_dir: Path, bundled_dir: Path) -> Path:
     return _skills_dir() / rel
 
 
+_OS_JUNK_FILENAMES = frozenset({".DS_Store", "Thumbs.db"})
+
+
+def _is_os_junk_file(rel: Path) -> bool:
+    """Whether ``rel`` is OS/metadata junk rather than skill content.
+
+    Finder drops ``.DS_Store`` (and AppleDouble ``._*`` companions, plus the
+    ``Icon\\r`` custom-icon file) into any folder a user browses on macOS;
+    Windows Explorer leaves ``Thumbs.db`` behind. None of these represent a
+    user modification of the skill, so the modification detector must not
+    count them — otherwise browsing a bundled skill's directory in Finder
+    freezes all future bundled updates for it (#102408).
+    """
+    name = rel.name
+    return name in _OS_JUNK_FILENAMES or name.startswith("._") or name == "Icon\r"
+
+
 def _dir_hash(directory: Path) -> str:
     """Compute a hash of all file contents in a directory for change detection."""
     hasher = hashlib.md5()
@@ -294,6 +311,8 @@ def _dir_hash(directory: Path) -> str:
         for fpath in sorted(directory.rglob("*")):
             if fpath.is_file():
                 rel = fpath.relative_to(directory)
+                if _is_os_junk_file(rel):
+                    continue
                 hasher.update(str(rel).encode("utf-8"))
                 hasher.update(fpath.read_bytes())
     except (OSError, IOError):
@@ -317,7 +336,10 @@ def _skill_file_list(skill_dir: Path) -> List[str]:
     files: List[str] = []
     for fpath in sorted(skill_dir.rglob("*")):
         if fpath.is_file():
-            files.append(fpath.relative_to(skill_dir).as_posix())
+            rel = fpath.relative_to(skill_dir)
+            if _is_os_junk_file(rel):
+                continue
+            files.append(rel.as_posix())
     return files
 
 


### PR DESCRIPTION
## What does this PR do?

The bundled-skill modification detector counted **every** file under a skill directory, so OS metadata junk with zero user intent — a `.DS_Store` dropped by Finder, an AppleDouble `._*` companion, Finder's `Icon\r`, Windows' `Thumbs.db` — read as a user modification. The skill was then flagged `user-modified` and `hermes update` preserved the whole package forever, silently withholding upstream references, scripts, and SKILL.md fixes. The only recovery was manual discovery plus `hermes skills reset <name> --restore`.

This filters OS junk in the two enumeration primitives the entire detector chain is built on — `_dir_hash` (sync / list-modified change detection) and `_skill_file_list` (`hermes skills diff` rendering, lock file lists) — so junk no longer counts as divergence while a genuine user edit (even one sitting next to junk) still reads as user-modified. Recorded origin hashes are unaffected: they are computed from the stock source tree, so no manifest migration is needed.

## Related Issue

Fixes #102408

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_sync.py` — added `_is_os_junk_file()` (matches `.DS_Store`, `Thumbs.db`, `._*`, `Icon\r`) applied inside `_dir_hash` and `_skill_file_list`; no other call sites needed changes because sync's user-modification check, `list_user_modified_bundled_skills`, and `diff_bundled_skill` all route through these two primitives.
- `tests/tools/test_skills_sync.py` — new `TestOsJunkIgnoredByModificationDetector` covering: identical trees with/without junk hash and enumerate identically; a junk-only divergence no longer freezes the package (upstream update lands); a genuine edit next to junk is still flagged user-modified; `hermes skills diff` no longer reports junk as "only in your copy".

## How to Test

1. Run `python -m pytest tests/tools/test_skills_sync.py tests/tools/test_skills_list_modified_diff.py tests/tools/test_skills_hub.py tests/tools/test_skills_sync_client.py -q` — Observed result: 38 + 169 passed (incl. the 4 new tests).
2. Run `python -m pytest tests/hermes_cli/test_update_modified_notice.py -q` — Observed result: 1 passed.
3. Manual repro from the issue: sync a bundled skill, drop a `.DS_Store` into the user's copy, change the bundled source, re-run sync — the skill should take the update (pre-fix it was kept as user-modified forever).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the junk set itself is cross-platform (.DS_Store/._*/Icon\r on macOS, Thumbs.db on Windows)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A