### PR TITLE
fix(desktop): correct archive shortcut in Archived Chats copy

### DIFF
--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1276,7 +1276,7 @@ export const en: Translations = {
       loading: 'Loading archived sessions…',
       archivedTitle: 'Archived sessions',
       archivedIntro:
-        'Archived chats are hidden from the sidebar but keep all their messages. Ctrl/⌘-click a chat in the sidebar to archive it.',
+        'Archived chats are hidden from the sidebar but keep all their messages. Alt/Option+Shift-click a chat in the sidebar to archive it.',
       emptyArchivedTitle: 'Nothing archived',
       emptyArchivedDesc: 'Archive a chat to hide it here.',
       unarchive: 'Unarchive',


### PR DESCRIPTION
## What does this PR do?

Fixes the Archived Chats settings copy, which describes the wrong modifier for the archive gesture.

## Related Issue

No existing issue — searched open/closed issues and PRs for "archive", "ctrl-click", "copy" and found nothing.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/i18n/en.ts`: `sessions.archivedIntro` now says "Alt/Option+Shift-click a chat in the sidebar to archive it." instead of "Ctrl/⌘-click a chat in the sidebar to archive it."

## How to Test

1. Open Settings → Archived Chats.
2. Read the description text under "Auto-archive stale chats" / above the archived list.
3. Confirm it now matches the actual gesture implemented in `apps/desktop/src/app/chat/sidebar/session-row-gesture.ts` (`altKey && shiftKey` → archive), rather than the old Ctrl/⌘-click text which does nothing when tried.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a JS/TS string-only change with no Python touched
- [ ] I've added tests for my changes — N/A, this is a static copy string with no logic change
- [x] I've tested on my platform: macOS 15 (Hermes Desktop v0.21.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — this string is the documentation
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — the fix uses "Alt/Option" to match the existing "Ctrl/⌘" cross-platform phrasing convention used elsewhere in this file
- [ ] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

Before: `Ctrl/⌘-click a chat in the sidebar to archive it.`
After: `Alt/Option+Shift-click a chat in the sidebar to archive it.`

Confirmed against the gesture resolver:

```ts
// apps/desktop/src/app/chat/sidebar/session-row-gesture.ts
if (altKey && shiftKey) {
  return 'archive'
}
```
