### PR TITLE
feat: add safe turn-boundary session rollover

### DIFF
--- a/acp_adapter/provenance.py
+++ b/acp_adapter/provenance.py
@@ -52,10 +52,9 @@ def build_session_provenance(
     parent_id = row.get("parent_session_id")
     end_reason = row.get("end_reason")
 
-    # Walk parents to the lineage root and count compression depth. Only
-    # compression-split parents (parent.end_reason == 'compression') count
-    # toward depth — delegate/branch children share the parent_session_id
-    # column but are not compaction boundaries.
+    # Walk parents to the lineage root and count actual compression depth.
+    # Turn-boundary rollover is a continuation, but not a compaction boundary.
+    # Delegate/branch children also share parent_session_id without being either.
     root_id = current_hermes_session_id
     compression_depth = 0
     cursor_parent = parent_id
@@ -71,13 +70,14 @@ def build_session_provenance(
         if not prow:
             break
         root_id = cursor_parent
-        if is_continuation_end_reason(prow.get("end_reason")):
+        if prow.get("end_reason") == "compression":
             compression_depth += 1
         cursor_parent = prow.get("parent_session_id")
 
-    # A session is a compression continuation when its parent was ended with
-    # end_reason='compression'. Determine that from the immediate parent.
+    # A session continues when its parent was ended by any continuation reason.
+    # Keep that lineage classification separate from compression provenance.
     is_continuation = False
+    immediate_end_reason = None
     if parent_id:
         try:
             immediate_parent = db.get_session(parent_id)
@@ -85,6 +85,7 @@ def build_session_provenance(
             immediate_parent = None
         if immediate_parent and is_continuation_end_reason(immediate_parent.get("end_reason")):
             is_continuation = True
+            immediate_end_reason = immediate_parent.get("end_reason")
 
     rotated = bool(
         previous_hermes_session_id
@@ -102,10 +103,17 @@ def build_session_provenance(
     if previous_hermes_session_id:
         provenance["previousHermesSessionId"] = previous_hermes_session_id
     if rotated:
-        # The head moved during the last turn. The only mechanism that rotates
-        # the internal id mid-turn is compression-driven session splitting.
-        provenance["reason"] = "compression"
-        provenance["creatorKind"] = "compression"
+        # Tell clients which continuation mechanism moved the internal head.
+        # Preserve the established compression payload exactly while exposing
+        # rollover as its own truthful non-compression creator kind.
+        if immediate_end_reason == "compression":
+            provenance["reason"] = "compression"
+            provenance["creatorKind"] = "compression"
+        elif immediate_end_reason in {
+            "turn_boundary_rollover", "turn_boundary_rollover_recovered",
+        }:
+            provenance["reason"] = immediate_end_reason
+            provenance["creatorKind"] = "rollover"
 
     return provenance
 

--- a/acp_adapter/provenance.py
+++ b/acp_adapter/provenance.py
@@ -15,6 +15,8 @@ from __future__ import annotations
 
 from typing import Any, Dict, Optional
 
+from hermes_state_common import is_continuation_end_reason
+
 # Bound defensive walks; compression chains this deep are pathological.
 _MAX_WALK = 100
 
@@ -69,7 +71,7 @@ def build_session_provenance(
         if not prow:
             break
         root_id = cursor_parent
-        if prow.get("end_reason") == "compression":
+        if is_continuation_end_reason(prow.get("end_reason")):
             compression_depth += 1
         cursor_parent = prow.get("parent_session_id")
 
@@ -81,7 +83,7 @@ def build_session_provenance(
             immediate_parent = db.get_session(parent_id)
         except Exception:
             immediate_parent = None
-        if immediate_parent and immediate_parent.get("end_reason") == "compression":
+        if immediate_parent and is_continuation_end_reason(immediate_parent.get("end_reason")):
             is_continuation = True
 
     rotated = bool(

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2330,10 +2330,11 @@ class HermesACPAgent(acp.Agent):
 
         current_provider = getattr(state.agent, "provider", None) or "openrouter"
         target_provider, new_model = self._resolve_model_selection(args, current_provider)
+        persistence_session_id = state.persistence_session_id or state.session_id
 
         state.model = new_model
         state.agent = self.session_manager._make_agent(
-            session_id=state.session_id,
+            session_id=persistence_session_id,
             cwd=state.cwd,
             model=new_model,
             requested_provider=target_provider,
@@ -2582,8 +2583,9 @@ class HermesACPAgent(acp.Agent):
             provider_changed = bool(current_provider and requested_provider != current_provider)
             current_base_url = None if provider_changed else getattr(state.agent, "base_url", None)
             current_api_mode = None if provider_changed else getattr(state.agent, "api_mode", None)
+            persistence_session_id = state.persistence_session_id or state.session_id
             state.agent = self.session_manager._make_agent(
-                session_id=session_id,
+                session_id=persistence_session_id,
                 cwd=state.cwd,
                 model=resolved_model,
                 requested_provider=requested_provider,

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -2129,6 +2129,13 @@ class HermesACPAgent(acp.Agent):
                 state.current_prompt_text = ""
             return PromptResponse(stop_reason="end_turn")
 
+        # Advance the internal persistence tip before any updated history/model
+        # metadata is saved. The ACP session id stays a stable client handle,
+        # while agent.session_id can roll from parent -> child -> grandchild.
+        post_turn_hermes_id = getattr(state.agent, "session_id", None)
+        if post_turn_hermes_id:
+            state.persistence_session_id = post_turn_hermes_id
+
         if result.get("messages"):
             state.history = result["messages"]
             # Persist updated history so sessions survive process restarts.
@@ -2138,7 +2145,6 @@ class HermesACPAgent(acp.Agent):
         # DB head moved during the turn, emit a session_info_update carrying
         # _meta.hermes.sessionProvenance so ACP clients can render the boundary
         # and keep old/new ids in lineage. The ACP session_id is unchanged.
-        post_turn_hermes_id = getattr(state.agent, "session_id", None)
         if (
             conn
             and post_turn_hermes_id

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -515,7 +515,8 @@ class SessionManager:
             return None
 
         try:
-            row = db.get_session(session_id)
+            resolved_session_id = db.resolve_resume_session_id(session_id)
+            row = db.get_session(resolved_session_id)
         except Exception:
             logger.debug("Failed to query DB for ACP session %s", session_id, exc_info=True)
             return None
@@ -553,7 +554,7 @@ class SessionManager:
         # for the rest of the session (see hermes_state.get_messages_as_conversation).
         try:
             history = db.get_messages_as_conversation(
-                session_id, repair_alternation=True
+                resolved_session_id, repair_alternation=True
             )
         except Exception:
             logger.warning("Failed to load messages for ACP session %s", session_id, exc_info=True)
@@ -561,7 +562,7 @@ class SessionManager:
 
         try:
             agent = self._make_agent(
-                session_id=session_id,
+                session_id=resolved_session_id,
                 cwd=cwd,
                 model=model,
                 requested_provider=requested_provider,
@@ -583,7 +584,10 @@ class SessionManager:
         with self._lock:
             self._sessions[session_id] = state
         _register_task_cwd(session_id, cwd)
-        logger.info("Restored ACP session %s from DB (%d messages)", session_id, len(history))
+        logger.info(
+            "Restored ACP session %s from DB tip %s (%d messages)",
+            session_id, resolved_session_id, len(history),
+        )
         return state
 
     def _delete_persisted(self, session_id: str) -> bool:

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -172,6 +172,9 @@ class SessionState:
 
     session_id: str
     agent: Any  # AIAgent instance
+    # ACP exposes session_id as a stable client handle. A rollover can resolve
+    # it to a child tip, which must own agent recreation and durable writes.
+    persistence_session_id: str = ""
     cwd: str = "."
     model: str = ""
     history: List[Dict[str, Any]] = field(default_factory=list)
@@ -217,6 +220,7 @@ class SessionManager:
         state = SessionState(
             session_id=session_id,
             agent=agent,
+            persistence_session_id=session_id,
             cwd=cwd,
             model=getattr(agent, "model", "") or "",
             cancel_event=threading.Event(),
@@ -268,6 +272,7 @@ class SessionManager:
         state = SessionState(
             session_id=new_id,
             agent=agent,
+            persistence_session_id=new_id,
             cwd=cwd,
             model=getattr(agent, "model", original.model) or original.model,
             history=copy.deepcopy(original.history),
@@ -429,6 +434,7 @@ class SessionManager:
         db = self._get_db()
         if db is None:
             return
+        persistence_session_id = state.persistence_session_id or state.session_id
 
         # Ensure model is a plain string (not a MagicMock or other proxy).
         model_str = str(state.model) if state.model else None
@@ -446,10 +452,10 @@ class SessionManager:
 
         try:
             # Ensure the session record exists.
-            existing = db.get_session(state.session_id)
+            existing = db.get_session(persistence_session_id)
             if existing is None:
                 db.create_session(
-                    session_id=state.session_id,
+                    session_id=persistence_session_id,
                     source="acp",
                     model=model_str,
                     model_config={"cwd": state.cwd},
@@ -457,7 +463,7 @@ class SessionManager:
             else:
                 # Update model_config (contains cwd) if changed.
                 try:
-                    db.update_session_meta(state.session_id, cwd_json, model_str)
+                    db.update_session_meta(persistence_session_id, cwd_json, model_str)
                 except Exception:
                     logger.debug("Failed to update ACP session metadata", exc_info=True)
 
@@ -501,7 +507,7 @@ class SessionManager:
                 # archive_and_compact — the same probe failure mode #80216's
                 # /retry fix (gateway/slash_commands.py) deliberately avoids.
                 db.replace_messages(
-                    state.session_id, state.history, active_only=True
+                    persistence_session_id, state.history, active_only=True
                 )
         except Exception:
             logger.warning("Failed to persist ACP session %s", state.session_id, exc_info=True)
@@ -576,6 +582,7 @@ class SessionManager:
         state = SessionState(
             session_id=session_id,
             agent=agent,
+            persistence_session_id=resolved_session_id,
             cwd=cwd,
             model=model or getattr(agent, "model", "") or "",
             history=history,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2546,6 +2546,14 @@ def run_conversation(
             # never mutated beyond the api_content stamp, so nothing leaks
             # into the clean transcript content.
             if idx == current_turn_user_idx and msg.get("role") == "user":
+                # A fresh turn-boundary child gets a one-shot, non-transcript
+                # recovery pointer. Consume only at the actual first request,
+                # after retries/tool loops have their shared API copy.
+                try:
+                    from session_rollover import consume_handoff_note
+                    _handoff_note = consume_handoff_note(agent)
+                except Exception:
+                    _handoff_note = ""
                 if isinstance(_api_content, str) and _api_content:
                     # Stamped by the prologue from the same composition —
                     # reuse it so the persisted sidecar and the wire cannot
@@ -2562,6 +2570,8 @@ def run_conversation(
                     )
                     if _composed is not None:
                         api_msg["content"] = _composed
+                if _handoff_note and isinstance(api_msg.get("content"), str):
+                    api_msg["content"] = api_msg["content"] + "\n\n" + _handoff_note
             elif (
                 isinstance(_api_content, str)
                 and _api_content
@@ -9324,11 +9334,6 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
-    try:
-        from session_rollover import mark_completed_turn
-        mark_completed_turn(agent, result)
-    except Exception:
-        logger.debug("turn-boundary rollover marking failed", exc_info=True)
     if _compression_timeout_exhausted:
         # Reuse the gateway's existing context-recovery contract (#98722,
         # salvaged from #98741). The bloated transcript remains intact while
@@ -9337,6 +9342,11 @@ def run_conversation(
         result["error"] = _COMPRESSION_TIMEOUT_FINAL_RESPONSE
         result["partial"] = True
         result["compression_exhausted"] = True
+    try:
+        from session_rollover import mark_completed_turn
+        mark_completed_turn(agent, result)
+    except Exception:
+        logger.debug("turn-boundary rollover marking failed", exc_info=True)
     return result
 
 

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -9324,6 +9324,11 @@ def run_conversation(
         _pending_verification_response=_pending_verification_response,
         _pending_verification_response_previewed=_pending_verification_response_previewed,
     )
+    try:
+        from session_rollover import mark_completed_turn
+        mark_completed_turn(agent, result)
+    except Exception:
+        logger.debug("turn-boundary rollover marking failed", exc_info=True)
     if _compression_timeout_exhausted:
         # Reuse the gateway's existing context-recovery contract (#98722,
         # salvaged from #98741). The bloated transcript remains intact while

--- a/agent/session_lifecycle.py
+++ b/agent/session_lifecycle.py
@@ -76,7 +76,10 @@ def evaluate_lifecycle(budget: LifecycleBudget) -> LifecycleDecision:
     draining = (
         not window
         or remaining_context <= checkpoint_boundary
-        or closeout_exhausted
+        # A turn-count closeout protects a real checkpoint/output reserve. With
+        # zero reserve it becomes a model-independent early fence, so ratio-only
+        # policy remains healthy until live context says otherwise.
+        or (checkpoint_boundary > 0 and closeout_exhausted)
     )
     heavy = draining or remaining_context <= heavy_boundary or utilization >= float(budget.heavy_utilization_ratio)
     state = LifecycleState.DRAINING if draining else LifecycleState.HEAVY if heavy else LifecycleState.HEALTHY

--- a/agent/session_lifecycle.py
+++ b/agent/session_lifecycle.py
@@ -44,6 +44,9 @@ class LifecycleDecision:
     accept_new_tools: bool
     accept_new_delegations: bool
     allow_in_flight_completion: bool = True
+    #: Tokens deliberately withheld from ordinary work so a checkpoint and a
+    #: final response always fit. Published for status/doctor observability.
+    reserved_headroom_tokens: int = 0
 
 
 def evaluate_lifecycle(budget: LifecycleBudget) -> LifecycleDecision:
@@ -84,4 +87,5 @@ def evaluate_lifecycle(budget: LifecycleBudget) -> LifecycleDecision:
         remaining_iterations=remaining_iterations,
         accept_new_tools=state is LifecycleState.HEALTHY,
         accept_new_delegations=state is LifecycleState.HEALTHY,
+        reserved_headroom_tokens=checkpoint_boundary,
     )

--- a/agent/session_lifecycle.py
+++ b/agent/session_lifecycle.py
@@ -1,0 +1,87 @@
+"""Model-relative lifecycle decisions for bounded long-running turns.
+
+Historical call/cache counters are recorded by callers for observability only.
+They intentionally do not participate in the admission decision: only live
+context headroom and the configured turn budget can drain a session.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+import sys
+
+
+class LifecycleState(StrEnum):
+    HEALTHY = "healthy"
+    HEAVY = "heavy"
+    DRAINING = "draining"
+
+
+@dataclass(frozen=True)
+class LifecycleBudget:
+    context_window_tokens: int
+    prompt_tokens: int
+    reserved_output_tokens: int
+    reserved_tool_result_tokens: int
+    reserved_checkpoint_tokens: int
+    max_iterations: int
+    iterations_used: int
+    api_calls: int = 0
+    cache_read_tokens: int = 0
+    compactions: int = 0
+    in_flight_workers: int = 0
+    closeout_iterations: int = 2
+    heavy_utilization_ratio: float = 0.70
+
+
+@dataclass(frozen=True)
+class LifecycleDecision:
+    state: LifecycleState
+    context_utilization: float
+    remaining_context_tokens: int
+    remaining_iterations: int | None
+    accept_new_tools: bool
+    accept_new_delegations: bool
+    allow_in_flight_completion: bool = True
+
+
+def evaluate_lifecycle(budget: LifecycleBudget) -> LifecycleDecision:
+    """Classify a turn without fixed token thresholds.
+
+    ``draining`` starts while the checkpoint reserve still fits. That is the
+    last safe point to stop admitting new work and persist a continuation.
+    """
+    window = max(0, int(budget.context_window_tokens))
+    prompt = max(0, int(budget.prompt_tokens))
+    reserve_output = max(0, int(budget.reserved_output_tokens))
+    reserve_tools = max(0, int(budget.reserved_tool_result_tokens))
+    reserve_checkpoint = max(0, int(budget.reserved_checkpoint_tokens))
+    utilization = (prompt / window) if window else 1.0
+    remaining_context = max(0, window - prompt)
+
+    max_iterations = int(budget.max_iterations)
+    if max_iterations >= sys.maxsize:
+        remaining_iterations = None
+        closeout_exhausted = False
+    else:
+        remaining_iterations = max(0, max_iterations - max(0, int(budget.iterations_used)))
+        closeout_exhausted = remaining_iterations <= max(1, int(budget.closeout_iterations))
+
+    checkpoint_boundary = reserve_output + reserve_tools + reserve_checkpoint
+    heavy_boundary = reserve_output + reserve_tools
+    draining = (
+        not window
+        or remaining_context <= checkpoint_boundary
+        or closeout_exhausted
+    )
+    heavy = draining or remaining_context <= heavy_boundary or utilization >= float(budget.heavy_utilization_ratio)
+    state = LifecycleState.DRAINING if draining else LifecycleState.HEAVY if heavy else LifecycleState.HEALTHY
+    return LifecycleDecision(
+        state=state,
+        context_utilization=utilization,
+        remaining_context_tokens=remaining_context,
+        remaining_iterations=remaining_iterations,
+        accept_new_tools=state is LifecycleState.HEALTHY,
+        accept_new_delegations=state is LifecycleState.HEALTHY,
+    )

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -1109,6 +1109,15 @@ def execute_tool_calls_concurrent(agent, assistant_message, messages: list, effe
     tool_calls = assistant_message.tool_calls
     num_tools = len(tool_calls)
 
+    try:
+        from session_rollover import allows_new_work
+        if not allows_new_work(agent):
+            _append_cancelled_tool_results(messages, tool_calls, reason="session drain")
+            return
+    except Exception:
+        _append_cancelled_tool_results(messages, tool_calls, reason="session drain admission check")
+        return
+
     # Resolve the context-scaled tool-output budget once per turn (cheap, but
     # avoids rebuilding it per result inside the loop below).
     _tool_budget = _budget_for_agent(agent)
@@ -1963,6 +1972,19 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
     """
     # Resolve the context-scaled tool-output budget once per turn.
     _tool_budget = _budget_for_agent(agent)
+
+    try:
+        from session_rollover import allows_new_work
+        if not allows_new_work(agent):
+            _append_cancelled_tool_results(
+                messages, assistant_message.tool_calls, reason="session drain"
+            )
+            return
+    except Exception:
+        _append_cancelled_tool_results(
+            messages, assistant_message.tool_calls, reason="session drain admission check"
+        )
+        return
 
     # Keep every runtime-tool branch on one bounded execution funnel without
     # duplicating timeout policy across the branch-specific callbacks below.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -720,6 +720,9 @@ def finalize_turn(
         "last_reasoning": last_reasoning,
         "messages": messages,
         "api_calls": api_call_count,
+        # The actual bounded loop count for this completed turn. ``api_calls``
+        # remains a compatibility/observability metric on result consumers.
+        "turn_iterations": api_call_count,
         "completed": completed,
         "turn_exit_reason": _turn_exit_reason,
         "failed": failed,

--- a/cli.py
+++ b/cli.py
@@ -13615,7 +13615,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
+            # Completion is a durable display event, never permission for a
+            # recursive parent model turn. The next user-authorized turn sees
+            # this row in normal session context. Keep the queue fallback for
+            # old/no-persistence CLI embeddings only.
+            db = getattr(self, "_session_db", None)
+            append_delivery = getattr(db, "append_message", None)
+            if event.get("type") == "async_delegation" and callable(append_delivery):
+                append_delivery(
+                    session_key,
+                    "user",
+                    content=synthetic_message,
+                    display_kind="async_delegation_complete",
+                )
+            else:
+                self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:

--- a/cli.py
+++ b/cli.py
@@ -13631,12 +13631,14 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # The next CLI turn uses this live list rather than reloading
                 # SQLite. Keep the durable display event in the same transcript,
                 # without queueing a synthetic model turn.
-                self.conversation_history.append({
-                    "role": "user",
-                    "content": synthetic_message,
-                    "display_kind": "async_delegation_complete",
-                    "_db_persisted": True,
-                })
+                conversation_history = getattr(self, "conversation_history", None)
+                if isinstance(conversation_history, list):
+                    conversation_history.append({
+                        "role": "user",
+                        "content": synthetic_message,
+                        "display_kind": "async_delegation_complete",
+                        "_db_persisted": True,
+                    })
             else:
                 self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)

--- a/cli.py
+++ b/cli.py
@@ -13605,6 +13605,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         from tools.async_delegation import (
             claim_event_delivery,
             complete_event_delivery,
+            release_event_delivery,
         )
 
         session_key = getattr(self, "session_id", "") or ""
@@ -13621,26 +13622,67 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             # old/no-persistence CLI embeddings only.
             db = getattr(self, "_session_db", None)
             append_delivery = getattr(db, "append_message", None)
-            if event.get("type") == "async_delegation" and callable(append_delivery):
-                append_delivery(
-                    session_key,
-                    "user",
-                    content=synthetic_message,
-                    display_kind="async_delegation_complete",
-                )
-                # The next CLI turn uses this live list rather than reloading
-                # SQLite. Keep the durable display event in the same transcript,
-                # without queueing a synthetic model turn.
-                conversation_history = getattr(self, "conversation_history", None)
-                if isinstance(conversation_history, list):
-                    conversation_history.append({
-                        "role": "user",
-                        "content": synthetic_message,
-                        "display_kind": "async_delegation_complete",
-                        "_db_persisted": True,
-                    })
+            append_once = getattr(db, "append_async_delegation_completion", None)
+            if event.get("type") == "async_delegation" and (
+                callable(append_once) or callable(append_delivery)
+            ):
+                metadata = {"delegation_id": str(event.get("delegation_id") or "")}
+                try:
+                    if callable(append_once):
+                        append_result = append_once(
+                            session_key, synthetic_message, metadata,
+                        )
+                        if not (
+                            isinstance(append_result, tuple)
+                            and len(append_result) == 2
+                        ):
+                            raise TypeError("invalid async completion append result")
+                        row_id = append_result[0]
+                    else:
+                        if not callable(append_delivery):
+                            raise TypeError("SessionDB cannot append completion delivery")
+                        # Compatibility only for lightweight embedded SessionDB
+                        # stand-ins. Production SessionDB uses the transactional
+                        # identity seam above.
+                        row_id = append_delivery(
+                            session_key,
+                            "user",
+                            content=synthetic_message,
+                            display_kind="async_delegation_complete",
+                            display_metadata=metadata,
+                        )
+                    # The next CLI turn uses this live list rather than reloading
+                    # SQLite. Keep this identity exactly once in the same
+                    # transcript, without queueing a synthetic model turn.
+                    conversation_history = getattr(self, "conversation_history", None)
+                    if isinstance(conversation_history, list) and not any(
+                        message.get("display_kind") == "async_delegation_complete"
+                        and isinstance(message.get("display_metadata"), dict)
+                        and message["display_metadata"].get("delegation_id") == metadata["delegation_id"]
+                        for message in conversation_history
+                        if isinstance(message, dict)
+                    ):
+                        completion = {
+                            "role": "user",
+                            "content": synthetic_message,
+                            "display_kind": "async_delegation_complete",
+                            "display_metadata": metadata,
+                            "_db_persisted": True,
+                        }
+                        if isinstance(row_id, int):
+                            completion["_row_id"] = row_id
+                        conversation_history.append(completion)
+                    # A completion is an immediate CLI-visible display event,
+                    # not a queued synthetic prompt/model turn.
+                    _cli_visible_print(synthetic_message)
+                except Exception:
+                    # Leave retryable failures pending.  Ack follows durable,
+                    # live-history, and visible-display acceptance only.
+                    release_event_delivery(event, claim)
+                    continue
             else:
                 self._pending_input.put(synthetic_message)
+                _cli_visible_print(synthetic_message)
             complete_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:

--- a/cli.py
+++ b/cli.py
@@ -3927,6 +3927,9 @@ def _prepend_note_to_message(message, note: str):
     return message
 
 
+_LEGACY_ASYNC_DELEGATION_ACCEPTANCE_REGISTRY: set[str] = set()
+
+
 def _cli_visible_print(text: str = "") -> None:
     """Print normally unless prompt_toolkit owns the live terminal.
 
@@ -13623,11 +13626,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             db = getattr(self, "_session_db", None)
             append_delivery = getattr(db, "append_message", None)
             append_once = getattr(db, "append_async_delegation_completion", None)
-            inserted = not callable(append_once)
+            delegation_id = str(event.get("delegation_id") or "")
+            # Lightweight embedded DB stand-ins predate the durable transactional
+            # identity seam. Keep a process-local acceptance record for those
+            # append-only implementations only: it closes the ack-failure replay
+            # window without claiming cross-process exactly-once semantics.
+            legacy_replay_accepted = (
+                not callable(append_once)
+                and bool(delegation_id)
+                and delegation_id in _LEGACY_ASYNC_DELEGATION_ACCEPTANCE_REGISTRY
+            )
+            inserted = not callable(append_once) and not legacy_replay_accepted
             if event.get("type") == "async_delegation" and (
                 callable(append_once) or callable(append_delivery)
-            ):
-                metadata = {"delegation_id": str(event.get("delegation_id") or "")}
+            ) and not legacy_replay_accepted:
+                metadata = {"delegation_id": delegation_id}
                 try:
                     if callable(append_once):
                         append_result = append_once(
@@ -13677,12 +13690,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     # not a queued synthetic prompt/model turn.
                     if not callable(append_once) or inserted:
                         _cli_visible_print(synthetic_message)
+                    # Register only after durable, live, and visible acceptance.
+                    # An append/display failure must remain retryable.
+                    if not callable(append_once) and delegation_id:
+                        _LEGACY_ASYNC_DELEGATION_ACCEPTANCE_REGISTRY.add(delegation_id)
                 except Exception:
                     # Leave retryable failures pending.  Ack follows durable,
                     # live-history, and visible-display acceptance only.
                     release_event_delivery(event, claim)
                     continue
-            else:
+            elif not legacy_replay_accepted:
                 self._pending_input.put(synthetic_message)
                 _cli_visible_print(synthetic_message)
             try:
@@ -13691,6 +13708,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 # Durable/live/display acceptance succeeded, but a failed ack
                 # must immediately release the claim for a safe replay.
                 release_event_delivery(event, claim)
+            else:
+                # The registry bridges only the outstanding ack window. Once
+                # acknowledgement succeeds, forget it so an unrelated future
+                # legacy event with a reused/empty identity is never suppressed.
+                if not callable(append_once) and delegation_id:
+                    _LEGACY_ASYNC_DELEGATION_ACCEPTANCE_REGISTRY.discard(delegation_id)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.

--- a/cli.py
+++ b/cli.py
@@ -13623,6 +13623,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             db = getattr(self, "_session_db", None)
             append_delivery = getattr(db, "append_message", None)
             append_once = getattr(db, "append_async_delegation_completion", None)
+            inserted = not callable(append_once)
             if event.get("type") == "async_delegation" and (
                 callable(append_once) or callable(append_delivery)
             ):
@@ -13637,7 +13638,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                             and len(append_result) == 2
                         ):
                             raise TypeError("invalid async completion append result")
-                        row_id = append_result[0]
+                        row_id, inserted = append_result
                     else:
                         if not callable(append_delivery):
                             raise TypeError("SessionDB cannot append completion delivery")
@@ -13674,7 +13675,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         conversation_history.append(completion)
                     # A completion is an immediate CLI-visible display event,
                     # not a queued synthetic prompt/model turn.
-                    _cli_visible_print(synthetic_message)
+                    if not callable(append_once) or inserted:
+                        _cli_visible_print(synthetic_message)
                 except Exception:
                     # Leave retryable failures pending.  Ack follows durable,
                     # live-history, and visible-display acceptance only.
@@ -13683,7 +13685,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             else:
                 self._pending_input.put(synthetic_message)
                 _cli_visible_print(synthetic_message)
-            complete_event_delivery(event, claim)
+            try:
+                complete_event_delivery(event, claim)
+            except Exception:
+                # Durable/live/display acceptance succeeded, but a failed ack
+                # must immediately release the claim for a safe replay.
+                release_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
         """Move stray messages from ``_interrupt_queue`` into ``_pending_input``.

--- a/cli.py
+++ b/cli.py
@@ -13628,6 +13628,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     content=synthetic_message,
                     display_kind="async_delegation_complete",
                 )
+                # The next CLI turn uses this live list rather than reloading
+                # SQLite. Keep the durable display event in the same transcript,
+                # without queueing a synthetic model turn.
+                self.conversation_history.append({
+                    "role": "user",
+                    "content": synthetic_message,
+                    "display_kind": "async_delegation_complete",
+                    "_db_persisted": True,
+                })
             else:
                 self._pending_input.put(synthetic_message)
             complete_event_delivery(event, claim)

--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -685,3 +685,25 @@ session_reset:
 ```
 
 Platform-specific overrides can be set under `platforms.<name>.session_reset`.
+
+### Opt-in turn-boundary rollover
+
+`session_rollover` is disabled by default. It finishes the current response,
+then marks a session only when live prompt usage reaches a trigger resolved from
+the active model/provider window and actual compression threshold. On the next
+safe inbound turn it atomically closes the old session with
+`turn_boundary_rollover`, creates an empty child linked to it, and accepts the
+message once. The child keeps only the previous id and session_search guidance;
+Hermes copies, compacts, and summarizes no transcript.
+
+```yaml
+session_rollover:
+  enabled: true
+  ratio: 0.75
+  safety_margin_tokens: 2000
+  threshold_tokens: null # optional expert ceiling
+```
+
+The policy is re-read each turn and follows model switches and fallbacks. Its
+trigger is clamped below the active compression trigger. Live turns, tools, and
+delegated children defer adoption to a later safe boundary.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21298,13 +21298,6 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # activity themselves. Otherwise periodic Kanban/process
             # notifications keep the stable routing key alive across every
             # daily/idle boundary.
-            # This inbound event is admitted but no agent/tool/child work has
-            # started. Publish a completed pending rollover before its message
-            # is accepted; the durable transition itself is exactly-once.
-            await asyncio.to_thread(
-                self.session_store.adopt_turn_boundary_rollover,
-                self._session_key_for_source(source),
-            )
             session_entry = await self.async_session_store.get_or_create_session(
                 source,
                 touch_activity=not bool(getattr(event, "internal", False)),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18379,7 +18379,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _end_reason,
                 )
                 return None
-            if _end_reason != "compression":
+            from hermes_state_common import is_continuation_end_reason
+            if not is_continuation_end_reason(_end_reason):
                 # Idle/timeout/lifecycle end (scale-to-zero norm): the chat
                 # route remains valid and ``session_entry`` IS the routing
                 # key's current session for this same chat, so deliver the
@@ -18447,7 +18448,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         await session_db.get_compression_tip(session_entry.session_id)
                         if route_row is not None
                         and route_row.get("ended_at")
-                        and route_row.get("end_reason") == "compression"
+                        and is_continuation_end_reason(route_row.get("end_reason"))
                         else None
                     )
                 except Exception:
@@ -28465,7 +28466,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not parent.get("ended_at"):
             return "deliver"
         end_reason = str(parent.get("end_reason") or "")
-        if end_reason != "compression":
+        from hermes_state_common import is_continuation_end_reason
+        if not is_continuation_end_reason(end_reason):
             # An ended parent is only unreachable when the USER closed the
             # thread of work (explicit boundary: /new -> session_reset /
             # new_session, user_exit, session_switch). Idle/timeout ends are

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28360,6 +28360,21 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     raw_sid, e,
                 )
                 return False
+        if evt.get("type") == "async_delegation":
+            # A completed delegation is a user-visible delivery, not a new
+            # user prompt. Push it directly so the client sees the result
+            # without a recursive agent turn, then let the durable claim ack
+            # below provide cross-process exact-once admission.
+            try:
+                await adapter.send(
+                    source.chat_id,
+                    synth_text,
+                    metadata=self._thread_metadata_for_source(source),
+                )
+                return True
+            except Exception as e:
+                logger.error("Async delegation display delivery error: %s", e)
+                return False
         try:
             metadata = {}
             parent_session_id = str(evt.get("parent_session_id") or "").strip()

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -21298,6 +21298,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # activity themselves. Otherwise periodic Kanban/process
             # notifications keep the stable routing key alive across every
             # daily/idle boundary.
+            # This inbound event is admitted but no agent/tool/child work has
+            # started. Publish a completed pending rollover before its message
+            # is accepted; the durable transition itself is exactly-once.
+            await asyncio.to_thread(
+                self.session_store.adopt_turn_boundary_rollover,
+                self._session_key_for_source(source),
+            )
             session_entry = await self.async_session_store.get_or_create_session(
                 source,
                 touch_activity=not bool(getattr(event, "internal", False)),

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -3781,6 +3781,42 @@ class SessionStore:
             self._save()
             return entry
 
+    def adopt_turn_boundary_rollover(
+        self, session_key: str, *, active_work: bool = False
+    ) -> Optional[SessionEntry]:
+        """CAS-rebind a gateway route to a pending empty rollover child."""
+        if not session_key or active_work:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            parent_id = entry.session_id
+        db = self._db_for_key(session_key)
+        if db is None:
+            return None
+        try:
+            from session_rollover import TurnBoundaryRollover
+            child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary(
+                parent_id, active_work=False
+            )
+        except Exception:
+            logger.debug("turn-boundary rollover adoption failed", exc_info=True)
+            return None
+        if not child_id:
+            return None
+        with self._lock:
+            self._ensure_loaded_locked()
+            current = self._entries.get(session_key)
+            if current is None or current.session_id != parent_id:
+                return None
+            current.session_id = child_id
+            current.created_at = _now()
+            current.updated_at = _now()
+            self._save()
+            return current
+
     def switch_session(self, session_key: str, target_session_id: str) -> Optional[SessionEntry]:
         """Switch a session key to point at an existing session ID.
 

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -167,6 +167,11 @@ async def persist_delegation_delivery(
             "persist_delegation_delivery: api_server SessionDB unavailable — "
             f"cannot persist completion for session {session_id}"
         )
+    resolved_session_id = await asyncio.to_thread(
+        db.resolve_resume_session_id, session_id
+    )
+    if resolved_session_id:
+        session_id = resolved_session_id
     metadata = _delegation_display_metadata(evt or {})
     if metadata["delegation_id"]:
         await asyncio.to_thread(

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -167,14 +167,25 @@ async def persist_delegation_delivery(
             "persist_delegation_delivery: api_server SessionDB unavailable — "
             f"cannot persist completion for session {session_id}"
         )
-    await asyncio.to_thread(
-        db.append_message,
-        session_id,
-        "user",
-        content=text,
-        display_kind="async_delegation_complete",
-        display_metadata=_delegation_display_metadata(evt or {}),
-    )
+    metadata = _delegation_display_metadata(evt or {})
+    if metadata["delegation_id"]:
+        await asyncio.to_thread(
+            db.append_async_delegation_completion,
+            session_id,
+            text,
+            metadata,
+        )
+    else:
+        # ``evt`` is optional for legacy API callers. It has no durable event
+        # identity to deduplicate, so retain the historical display-row path.
+        await asyncio.to_thread(
+            db.append_message,
+            session_id,
+            "user",
+            content=text,
+            display_kind="async_delegation_complete",
+            display_metadata=metadata,
+        )
     logger.info(
         "async delegation completion persisted as delivery row for "
         "api_server session %s (no wake turn)",

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -864,6 +864,12 @@ DEFAULT_CONFIG = {
         "ratio": 0.0,
         "safety_margin_tokens": 0,
         "threshold_tokens": None,
+        # The reserves are interpreted relative to the active model window;
+        # zero keeps the feature opt-in and preserves current behavior.
+        "reserved_output_tokens": 0,
+        "reserved_tool_result_tokens": 0,
+        "reserved_checkpoint_tokens": 0,
+        "closeout_iterations": 2,
     },
 
     "compression": {

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -857,6 +857,15 @@ DEFAULT_CONFIG = {
         },
     },
 
+    # Disabled by default. The trigger is derived from the active compressor,
+    # never from a fixed context-window token default.
+    "session_rollover": {
+        "enabled": False,
+        "ratio": 0.0,
+        "safety_margin_tokens": 0,
+        "threshold_tokens": None,
+    },
+
     "compression": {
         "enabled": True,
         "checkpoint_required": False, # Fail closed before lossy compaction unless an

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -64,6 +64,8 @@ import hermes_state_holders as _state_holders
 from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _BRANCH_CHILD_SQL,
     _COMPRESSION_CHILD_SQL,
+    _CONTINUATION_END_REASONS,
+    _CONTINUATION_END_REASONS_SQL,
     _FTS_CJK_TRIGGERS,
     _FTS_TRIGGERS,
     _LISTABLE_CHILD_SQL,
@@ -72,6 +74,7 @@ from hermes_state_common import (  # noqa: F401  (re-exported for back-compat)
     _RECOVERABLE_END_REASONS,
     _RECOVERABLE_END_REASONS_SQL,
     is_automatic_end_reason,
+    is_continuation_end_reason,
     _RESET_END_REASONS,
     _RESET_END_REASONS_SQL,
     _ephemeral_child_sql,
@@ -7270,7 +7273,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 # inherit routing keys, or peer recovery could repoint gateway
                 # traffic into a subagent's session.
                 conn.execute(
-                    """UPDATE sessions
+                    f"""UPDATE sessions
                        SET user_id = COALESCE(sessions.user_id,
                                      (SELECT p.user_id FROM sessions p
                                        WHERE p.id = sessions.parent_session_id)),
@@ -7296,7 +7299,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                        AND EXISTS (
                            SELECT 1 FROM sessions p
                            WHERE p.id = sessions.parent_session_id
-                             AND p.end_reason = 'compression'
+                             AND p.end_reason IN ({_CONTINUATION_END_REASONS_SQL})
                        )""",
                     (session_id,),
                 )
@@ -11724,13 +11727,13 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     FROM sessions parent
                     JOIN sessions child ON child.parent_session_id = parent.id
                     WHERE parent.id = ?
-                      AND parent.end_reason = 'compression'
+                      AND parent.end_reason IN ({_CONTINUATION_END_REASONS_SQL})
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._branched_from') IS NULL
                       AND json_extract(COALESCE(child.model_config, '{{}}'), '$._delegate_from') IS NULL
                       AND COALESCE(child.source, '') != 'tool'
                     ORDER BY
                       CASE
-                        WHEN child.end_reason = 'compression' THEN 0
+                        WHEN child.end_reason IN ({_CONTINUATION_END_REASONS_SQL}) THEN 0
                         WHEN child.ended_at IS NULL THEN 1
                         ELSE 2
                       END,
@@ -15266,7 +15269,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         if not parent_id or self._is_explicit_fork_child_row(child):
             return False
         parent = self.get_session(parent_id)
-        return bool(parent and parent.get("end_reason") == "compression")
+        return bool(parent and is_continuation_end_reason(parent.get("end_reason")))
 
     def get_compression_lineage(self, session_id: str) -> List[str]:
         """Return compression ancestors through tip in chronological order."""
@@ -15286,7 +15289,7 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         lineage = [root["id"]]
         seen = {root["id"]}
         current = root
-        while current.get("end_reason") == "compression":
+        while is_continuation_end_reason(current.get("end_reason")):
             with self._read_ctx() as conn:
                 rows = conn.execute(
                     """

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -12839,6 +12839,63 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
         )
 
+    def append_async_delegation_completion(
+        self,
+        session_id: str,
+        content: str,
+        display_metadata: Dict[str, Any],
+    ) -> tuple[int, bool]:
+        """Idempotently append one async-delegation completion display row.
+
+        The durable delegation ledger can replay after a process dies between
+        transcript commit and delivery acknowledgement.  The delegation id is
+        therefore the delivery identity, rather than the formatted completion
+        text.  The lookup and insert share a write transaction so competing
+        CLI, TUI, and gateway consumers cannot create duplicate rows.
+
+        Returns ``(message_id, inserted)``.  A false ``inserted`` result names
+        the existing durable row for callers rebuilding their live history.
+        """
+        metadata = dict(display_metadata or {})
+        delegation_id = str(metadata.get("delegation_id") or "")
+        if not delegation_id:
+            raise ValueError("async delegation completion requires delegation_id metadata")
+        metadata["delegation_id"] = delegation_id
+        metadata_json = self._encode_display_metadata(metadata)
+        stored_content = self._encode_content(content)
+        message_timestamp = time.time()
+
+        def _do(conn):
+            self._check_transcript_write_guards(conn, session_id, None)
+            existing = conn.execute(
+                """SELECT id FROM messages
+                   WHERE session_id = ? AND active = 1
+                     AND display_kind = 'async_delegation_complete'
+                     AND CASE WHEN json_valid(display_metadata)
+                              THEN json_extract(display_metadata, '$.delegation_id')
+                         END = ?
+                   ORDER BY id LIMIT 1""",
+                (session_id, delegation_id),
+            ).fetchone()
+            if existing is not None:
+                return int(existing[0]), False
+            cursor = conn.execute(
+                """INSERT INTO messages (session_id, role, content, timestamp, active,
+                   display_kind, display_metadata)
+                   VALUES (?, 'user', ?, ?, 1, 'async_delegation_complete', ?)""",
+                (session_id, stored_content, message_timestamp, metadata_json),
+            )
+            message_id = int(cursor.lastrowid)
+            conn.execute(
+                "UPDATE sessions SET message_count = message_count + 1 WHERE id = ?",
+                (session_id,),
+            )
+            return message_id, True
+
+        return self._execute_write(
+            _do, patience_s=self._TRANSCRIPT_WRITE_PATIENCE_S
+        )
+
     def append_messages_batch(
         self,
         session_id: str,

--- a/hermes_state_common.py
+++ b/hermes_state_common.py
@@ -184,10 +184,25 @@ _BRANCH_CHILD_SQL = (
 )
 
 
+_CONTINUATION_END_REASONS = (
+    "compression",
+    "turn_boundary_rollover",
+    "turn_boundary_rollover_recovered",
+)
+_CONTINUATION_END_REASONS_SQL = ", ".join(
+    f"'{reason}'" for reason in _CONTINUATION_END_REASONS
+)
+
+
+def is_continuation_end_reason(reason: object) -> bool:
+    """True for a parent whose child continues the same conversation."""
+    return isinstance(reason, str) and reason in _CONTINUATION_END_REASONS
+
+
 _COMPRESSION_CHILD_SQL = (
     "EXISTS (SELECT 1 FROM sessions p"
     "        WHERE p.id = {a}.parent_session_id"
-    "        AND p.end_reason = 'compression')"
+    f"        AND p.end_reason IN ({_CONTINUATION_END_REASONS_SQL}))"
 )
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9136,6 +9136,9 @@ class AIAgent:
         New DELEGATE_TASK_SCHEMA fields only need to be added here to reach all
         invocation paths (concurrent, sequential, inline).
         """
+        from session_rollover import allows_new_delegation
+        if not allows_new_delegation(self):
+            return "[Delegation admission closed — session is draining; in-flight workers may finish.]"
         from tools.delegate_tool import (
             _strip_model_hidden_task_fields,
             delegate_task as _delegate_task,

--- a/run_agent.py
+++ b/run_agent.py
@@ -9270,18 +9270,6 @@ class AIAgent:
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
-        # Only a finished prior response can request this transition. It occurs
-        # before the inbound message is admitted and never copies/summarizes it.
-        try:
-            from session_rollover import adopt_agent_at_turn_boundary
-            adopt_agent_at_turn_boundary(
-                self,
-                active_work=bool(getattr(self, "_executing_tools", False))
-                or bool(getattr(self, "_active_children", ()) or ()),
-            )
-        except Exception:
-            logger.debug("turn-boundary rollover adoption failed", exc_info=True)
-
         # A review deliberately shares this agent's session_id for prompt-cache
         # parity. Fence review startup or interrupt an admitted request, then
         # await that request's exit before opening any live-turn Relay or task
@@ -9335,6 +9323,7 @@ class AIAgent:
         relay_lease = None
         relay_turn = None
         durable_turn_lease = None
+        durable_turn_lease_session_id = None
         durable_turn_lease_stop = None
         durable_turn_lease_refresh = None
         durable_turn_liveness_watchdog = None
@@ -9526,8 +9515,37 @@ class AIAgent:
                 # the agent attr so a late flush after reclaim is fenced in
                 # the same SQLite write transaction as the transcript insert.
                 durable_turn_lease = _durable_holder
+                durable_turn_lease_session_id = session_id
                 self._active_session_turn_lease_holder = _durable_holder
                 self._active_session_turn_lease_ttl_seconds = _lease_ttl
+                # The durable lease serializes parent adoption with every
+                # alias-key caller. Adopt before any caller-provided history is
+                # copied into the shared turn prologue: CLI passes
+                # conversation_history[:-1], ACP passes state.history, and
+                # build_turn_context copies either value. A child starts with
+                # the inbound message only, never its parent's transcript.
+                try:
+                    from session_rollover import adopt_agent_at_turn_boundary
+
+                    adopted_id = adopt_agent_at_turn_boundary(
+                        self,
+                        active_work=bool(getattr(self, "_executing_tools", False))
+                        or bool(getattr(self, "_active_children", ()) or ()),
+                        turn_lease_holder=durable_turn_lease,
+                    )
+                except Exception:
+                    logger.debug("turn-boundary rollover adoption failed", exc_info=True)
+                    adopted_id = None
+                if adopted_id:
+                    session_id = adopted_id
+                    durable_turn_lease_session_id = adopted_id
+                    task_context["session_id"] = adopted_id
+                    conversation_history = []
+                    # The registry follows the child so alias-key traffic must
+                    # wait through its inbound persistence and final response.
+                    # The SQLite durable lease remains held on the parent until
+                    # this turn exits, which serializes the adoption itself.
+                    self._session_messages = []
                 if _lease_waited:
                     self._emit_status(
                         "Session is free; loading the latest transcript..."
@@ -9706,7 +9724,7 @@ class AIAgent:
                         return False
                     try:
                         if not _turn_db.refresh_session_turn_lease(
-                            getattr(self, "session_id", None) or session_id,
+                            durable_turn_lease_session_id or session_id,
                             durable_turn_lease,
                             ttl_seconds=_lease_ttl,
                         ):
@@ -9717,7 +9735,7 @@ class AIAgent:
                                 return False
                             logger.error(
                                 "Lost session turn lease while turn is active: %s",
-                                getattr(self, "session_id", None) or session_id,
+                                durable_turn_lease_session_id or session_id,
                             )
                             _interrupt_turn(
                                 "Session turn lease lost; stopping to protect "
@@ -9729,7 +9747,7 @@ class AIAgent:
                             return False
                         logger.warning(
                             "Failed to refresh session turn lease: %s",
-                            getattr(self, "session_id", None) or session_id,
+                            durable_turn_lease_session_id or session_id,
                             exc_info=True,
                         )
                         _interrupt_turn(
@@ -9905,7 +9923,8 @@ class AIAgent:
                     if durable_turn_lease is not None:
                         try:
                             _turn_db.release_session_turn_lease(
-                                session_id, durable_turn_lease
+                                durable_turn_lease_session_id or session_id,
+                                durable_turn_lease,
                             )
                         except Exception:
                             logger.error(

--- a/run_agent.py
+++ b/run_agent.py
@@ -9270,6 +9270,18 @@ class AIAgent:
         moa_config: Optional[dict[str, Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
+        # Only a finished prior response can request this transition. It occurs
+        # before the inbound message is admitted and never copies/summarizes it.
+        try:
+            from session_rollover import adopt_agent_at_turn_boundary
+            adopt_agent_at_turn_boundary(
+                self,
+                active_work=bool(getattr(self, "_executing_tools", False))
+                or bool(getattr(self, "_active_children", ()) or ()),
+            )
+        except Exception:
+            logger.debug("turn-boundary rollover adoption failed", exc_info=True)
+
         # A review deliberately shares this agent's session_id for prompt-cache
         # parity. Fence review startup or interrupt an admitted request, then
         # await that request's exit before opening any live-turn Relay or task

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -9,6 +9,8 @@ and session_search guidance, never a compaction or an LLM-produced summary.
 from __future__ import annotations
 
 import json
+from pathlib import Path
+import subprocess
 import sys
 import uuid
 from dataclasses import dataclass
@@ -120,11 +122,15 @@ class TurnBoundaryRollover:
         patch = getattr(self._db, "patch_session_model_config", None)
         if not callable(patch):
             return False
+        lifecycle_data = dict(lifecycle or {})
+        checkpoint = lifecycle_data.get("checkpoint")
+        lifecycle_data["checkpoint"] = _checkpoint_with_repo_evidence(
+            checkpoint if isinstance(checkpoint, Mapping) else {}, row
+        )
         patch_data: dict[str, Any] = {
             _PENDING_KEY: {"threshold_tokens": int(threshold_tokens)},
         }
-        if lifecycle:
-            patch_data[_LIFECYCLE_KEY] = dict(lifecycle)
+        patch_data[_LIFECYCLE_KEY] = lifecycle_data
         patch(session_id, patch_data)
         return True
 
@@ -221,6 +227,33 @@ def _model_config(row: Mapping[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _checkpoint_with_repo_evidence(checkpoint: Mapping[str, Any], row: Mapping[str, Any]) -> dict[str, Any]:
+    """Capture bounded work evidence without inspecting secrets or arbitrary cwd."""
+    payload = dict(checkpoint)
+    cwd = str(payload.get("worktree") or row.get("cwd") or "").strip()
+    payload["worktree"] = cwd or None
+    for key in ("changed_files", "verification_evidence", "pending_workers", "result_pointers", "external_effects", "external_readback"):
+        payload.setdefault(key, [])
+    payload.setdefault("branch", None)
+    payload.setdefault("head", None)
+    worktree = Path(cwd) if cwd else None
+    if worktree is None or not worktree.is_dir() or not (worktree / ".git").exists():
+        return payload
+    try:
+        def git(*args: str) -> str:
+            return subprocess.run(
+                ["git", *args], cwd=worktree, check=True, text=True,
+                stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=2,
+            ).stdout.strip()
+        payload["branch"] = git("branch", "--show-current") or None
+        payload["head"] = git("rev-parse", "HEAD") or None
+        if not payload["changed_files"]:
+            payload["changed_files"] = [line for line in git("status", "--porcelain").splitlines() if line]
+    except (OSError, subprocess.SubprocessError):
+        pass
+    return payload
+
+
 def allows_new_work(agent: Any) -> bool:
     """Fail closed for new tools/delegations once a parent is draining."""
     db = getattr(agent, "_session_db", None)
@@ -232,6 +265,11 @@ def allows_new_work(agent: Any) -> bool:
     except Exception:
         return False
     return not isinstance(state, Mapping) or state.get("state") != "draining"
+
+
+def allows_new_delegation(agent: Any) -> bool:
+    """Dedicated pre-dispatch delegation admission gate while draining."""
+    return allows_new_work(agent)
 
 
 def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -1,0 +1,218 @@
+"""Opt-in, lossless session rollover at a completed-turn boundary.
+
+This module deliberately owns no prompt/history manipulation.  A completed
+turn marks a durable request; the next inbound turn may atomically replace the
+route with an empty child session.  The child carries only a lineage pointer
+and session_search guidance, never a compaction or an LLM-produced summary.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from typing import Any, Mapping, Optional
+
+
+END_REASON = "turn_boundary_rollover"
+RECOVERY_GUIDANCE = "Use session_search to recover earlier details if needed."
+_PENDING_KEY = "_turn_boundary_rollover_pending"
+_HANDOFF_KEY = "turn_boundary_handoff"
+
+
+@dataclass(frozen=True)
+class RolloverPolicy:
+    """Dynamic policy derived afresh from the active config and model window."""
+
+    enabled: bool = False
+    ratio: float = 0.0
+    safety_margin_tokens: int = 0
+    threshold_tokens: Optional[int] = None
+
+    @classmethod
+    def from_config(cls, config: Mapping[str, Any] | None) -> "RolloverPolicy":
+        raw = config if isinstance(config, Mapping) else {}
+        enabled = raw.get("enabled") is True
+        try:
+            ratio = float(raw.get("ratio", 0.0))
+        except (TypeError, ValueError):
+            ratio = 0.0
+        # A zero/invalid ratio is disabled rather than inheriting a fixed window.
+        if not 0.0 < ratio < 1.0:
+            enabled = False
+        try:
+            margin = max(0, int(raw.get("safety_margin_tokens", 0) or 0))
+        except (TypeError, ValueError):
+            margin = 0
+        try:
+            cap = int(raw.get("threshold_tokens"))
+            if cap <= 0:
+                cap = None
+        except (TypeError, ValueError):
+            cap = None
+        return cls(enabled, ratio, margin, cap)
+
+    def resolve(self, context_length: int, compression_threshold: int) -> Optional[int]:
+        """Return a trigger strictly below the actual compression threshold.
+
+        The caller supplies the *live* compressor threshold, which already
+        includes model/provider-specific output reserve and fallback changes.
+        There is intentionally no fallback context-length constant here.
+        """
+        if not self.enabled:
+            return None
+        try:
+            window = int(context_length)
+            compression = int(compression_threshold)
+        except (TypeError, ValueError):
+            return None
+        if window <= 0 or compression <= 1:
+            return None
+        candidate = int(window * self.ratio)
+        if self.threshold_tokens is not None:
+            candidate = min(candidate, self.threshold_tokens)
+        # Strictly less than compression even when the configured headroom is 0.
+        ceiling = compression - max(self.safety_margin_tokens, 1)
+        if ceiling <= 0:
+            return None
+        return min(candidate, ceiling) if candidate > 0 else None
+
+
+class TurnBoundaryRollover:
+    """SessionDB persistence seam shared by CLI, TUI, and gateway owners."""
+
+    def __init__(self, db: Any) -> None:
+        self._db = db
+
+    def mark_pending(self, session_id: str, *, threshold_tokens: int) -> bool:
+        """Persist a request after a response has fully committed."""
+        if not session_id or threshold_tokens <= 0:
+            return False
+        row = self._db.get_session(session_id)
+        if not row or row.get("ended_at") is not None:
+            return False
+        config = _model_config(row)
+        if config.get(_PENDING_KEY):
+            return True
+        config[_PENDING_KEY] = {"threshold_tokens": int(threshold_tokens)}
+        self._set_model_config(session_id, config)
+        return True
+
+    def adopt_at_turn_boundary(self, session_id: str, *, active_work: bool) -> Optional[str]:
+        """Atomically close a pending parent and create one empty child.
+
+        ``active_work`` is supplied by the lifecycle owner.  The database
+        transition itself is idempotent: concurrent arrivals can observe only
+        one successful replacement because the pending parent is consumed in
+        the same SQLite write transaction that inserts the child.
+        """
+        if active_work or not session_id:
+            return None
+        child_id = uuid.uuid4().hex
+
+        def _write(conn: Any) -> Optional[str]:
+            row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if row is None or row["ended_at"] is not None:
+                return None
+            parent = dict(row)
+            config = _model_config(parent)
+            if not config.pop(_PENDING_KEY, None):
+                return None
+            child_config = {_HANDOFF_KEY: {
+                "previous_session_id": session_id,
+                "recovery": RECOVERY_GUIDANCE,
+            }}
+            # Keep routing identity, source, cwd, profile, model and role
+            # namespace intact.  The transcript is intentionally not copied.
+            conn.execute(
+                """INSERT INTO sessions (
+                    id, source, user_id, session_key, chat_id, chat_type, thread_id,
+                    display_name, origin_json, model, model_config, system_prompt,
+                    parent_session_id, cwd, profile_name, started_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, strftime('%s','now'))""",
+                (child_id, parent.get("source"), parent.get("user_id"),
+                 parent.get("session_key"), parent.get("chat_id"), parent.get("chat_type"),
+                 parent.get("thread_id"), parent.get("display_name"), parent.get("origin_json"),
+                 parent.get("model"), json.dumps(child_config, separators=(",", ":")),
+                 parent.get("system_prompt"), session_id, parent.get("cwd"),
+                 parent.get("profile_name")),
+            )
+            changed = conn.execute(
+                "UPDATE sessions SET ended_at = strftime('%s','now'), end_reason = ? "
+                "WHERE id = ? AND ended_at IS NULL",
+                (END_REASON, session_id),
+            ).rowcount
+            if changed != 1:
+                raise RuntimeError("turn-boundary rollover parent changed during adoption")
+            return child_id
+
+        return self._db._execute_write(_write)
+
+    def _set_model_config(self, session_id: str, config: dict[str, Any]) -> None:
+        def _write(conn: Any) -> None:
+            conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ? AND ended_at IS NULL",
+                (json.dumps(config, separators=(",", ":")), session_id),
+            )
+        self._db._execute_write(_write)
+
+
+def _model_config(row: Mapping[str, Any]) -> dict[str, Any]:
+    value = row.get("model_config")
+    if isinstance(value, dict):
+        return dict(value)
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except json.JSONDecodeError:
+            return {}
+        if isinstance(parsed, dict):
+            return parsed
+    return {}
+
+
+def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
+    """Re-read policy and live model budget after a durably completed response."""
+    if not isinstance(result, Mapping) or result.get("failed") or result.get("interrupted"):
+        return False
+    if result.get("completed") is False:
+        return False
+    db = getattr(agent, "_session_db", None)
+    session_id = str(getattr(agent, "session_id", "") or "")
+    compressor = getattr(agent, "context_compressor", None)
+    if db is None or not session_id or compressor is None:
+        return False
+    try:
+        from hermes_cli.config import load_config
+        config = load_config() or {}
+        trigger = RolloverPolicy.from_config(config.get("session_rollover")).resolve(
+            getattr(compressor, "context_length", 0),
+            getattr(compressor, "threshold_tokens", 0),
+        )
+        used = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
+        if trigger is None or used < trigger:
+            return False
+        return TurnBoundaryRollover(db).mark_pending(session_id, threshold_tokens=trigger)
+    except Exception:
+        return False
+
+
+def adopt_agent_at_turn_boundary(agent: Any, *, active_work: bool = False) -> Optional[str]:
+    """Adopt a pending child before loading the next inbound user turn."""
+    db = getattr(agent, "_session_db", None)
+    old_id = str(getattr(agent, "session_id", "") or "")
+    if db is None or not old_id:
+        return None
+    try:
+        child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary(old_id, active_work=active_work)
+    except Exception:
+        return None
+    if not child_id:
+        return None
+    previous = list(getattr(agent, "_session_messages", []) or [])
+    agent.session_id = child_id
+    agent._session_messages = []
+    reset = getattr(agent, "reset_session_state", None)
+    if callable(reset):
+        reset(previous_messages=previous, old_session_id=old_id, carry_over_context=False)
+    return child_id

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -210,7 +210,7 @@ class TurnBoundaryRollover:
         one successful replacement because the pending parent is consumed in
         the same SQLite write transaction that inserts the child.
         """
-        if active_work or not session_id:
+        if not session_id:
             return None
         try:
             if not _current_policy().enabled:
@@ -218,6 +218,8 @@ class TurnBoundaryRollover:
                 return None
         except Exception:
             # Config failure cannot authorize an opt-in parent-ending action.
+            return None
+        if active_work:
             return None
         child_id = uuid.uuid4().hex
 

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -26,6 +26,7 @@ RECOVERY_GUIDANCE = "Use session_search to recover earlier details if needed."
 _PENDING_KEY = "_turn_boundary_rollover_pending"
 _HANDOFF_KEY = "turn_boundary_handoff"
 _LIFECYCLE_KEY = "turn_boundary_lifecycle"
+_POLICY_KEY = "_turn_boundary_rollover_policy"
 
 
 @dataclass(frozen=True)
@@ -116,6 +117,12 @@ class TurnBoundaryRollover:
         """Persist a request after a response has fully committed."""
         if not session_id or threshold_tokens <= 0:
             return False
+        try:
+            if not _current_policy().enabled:
+                _cancel_disabled_rollover_state(self._db, session_id)
+                return False
+        except Exception:
+            return False
         arm_key = f"turn-boundary:{uuid.uuid4().hex}"
         return self._claim_pending(
             session_id,
@@ -135,6 +142,12 @@ class TurnBoundaryRollover:
         this method only guarantees at-most-one continuation per session.
         """
         if not session_id or not idempotency_key:
+            return None
+        try:
+            if not _current_policy().enabled:
+                _cancel_disabled_rollover_state(self._db, session_id)
+                return None
+        except Exception:
             return None
         pending = {
             "threshold_tokens": 0,
@@ -166,6 +179,8 @@ class TurnBoundaryRollover:
             if isinstance(existing, Mapping):
                 return dict(existing), False
             config[_PENDING_KEY] = dict(pending)
+            # This persisted fact keeps normal admission checks off config I/O.
+            config[_POLICY_KEY] = {"enabled": True}
             if lifecycle is not None:
                 lifecycle_data = dict(lifecycle)
                 checkpoint = lifecycle_data.get("checkpoint")
@@ -196,6 +211,13 @@ class TurnBoundaryRollover:
         the same SQLite write transaction that inserts the child.
         """
         if active_work or not session_id:
+            return None
+        try:
+            if not _current_policy().enabled:
+                _cancel_disabled_rollover_state(self._db, session_id)
+                return None
+        except Exception:
+            # Config failure cannot authorize an opt-in parent-ending action.
             return None
         child_id = uuid.uuid4().hex
 
@@ -289,6 +311,43 @@ def _model_config(row: Mapping[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def _current_policy() -> RolloverPolicy:
+    """Read configuration only at rollover state-transition boundaries."""
+    from hermes_cli.config import load_config
+
+    config = load_config() or {}
+    return RolloverPolicy.from_config(config.get("session_rollover"))
+
+
+def _patch_rollover_state(db: Any, session_id: str, patch: Mapping[str, Any]) -> None:
+    """Atomically merge rollover keys without overwriting unrelated runtime config."""
+    def _write(conn: Any) -> None:
+        row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+        if row is None or row["ended_at"] is not None:
+            return
+        config = _model_config(dict(row))
+        for key, value in patch.items():
+            if value is None:
+                config.pop(key, None)
+            else:
+                config[key] = value
+        conn.execute(
+            "UPDATE sessions SET model_config = ? WHERE id = ? AND ended_at IS NULL",
+            (json.dumps(config, separators=(",", ":")), session_id),
+        )
+
+    db._execute_write(_write)
+
+
+def _cancel_disabled_rollover_state(db: Any, session_id: str) -> None:
+    """Atomically cancel stale arms and their admission fence."""
+    _patch_rollover_state(db, session_id, {
+        _PENDING_KEY: None,
+        _LIFECYCLE_KEY: None,
+        _POLICY_KEY: {"enabled": False},
+    })
+
+
 def _checkpoint_with_repo_evidence(checkpoint: Mapping[str, Any], row: Mapping[str, Any]) -> dict[str, Any]:
     """Capture bounded work evidence without inspecting secrets or arbitrary cwd."""
     payload = dict(checkpoint)
@@ -317,16 +376,31 @@ def _checkpoint_with_repo_evidence(checkpoint: Mapping[str, Any], row: Mapping[s
 
 
 def allows_new_work(agent: Any) -> bool:
-    """Fail closed for new tools/delegations once a parent is draining."""
+    """Fence enabled drains without loading config before every tool execution."""
     db = getattr(agent, "_session_db", None)
     session_id = str(getattr(agent, "session_id", "") or "")
     if db is None or not session_id:
         return True
     try:
-        state = _model_config(db.get_session(session_id) or {}).get(_LIFECYCLE_KEY)
+        config = _model_config(db.get_session(session_id) or {})
     except Exception:
         return False
-    return not isinstance(state, Mapping) or state.get("state") != "draining"
+    state = config.get(_LIFECYCLE_KEY)
+    if not isinstance(state, Mapping) or state.get("state") != "draining":
+        return True
+    marker = config.get(_POLICY_KEY)
+    if isinstance(marker, Mapping):
+        return marker.get("enabled") is not True
+    try:
+        if _current_policy().enabled:
+            _patch_rollover_state(db, session_id, {_POLICY_KEY: {"enabled": True}})
+            return False
+        _cancel_disabled_rollover_state(db, session_id)
+        return True
+    except Exception:
+        # An unmarked legacy drain is never a reason to fence work when the
+        # disabled-by-default policy cannot be read.
+        return True
 
 
 def allows_new_delegation(agent: Any) -> bool:
@@ -342,9 +416,10 @@ def _publish_lifecycle_status(
     Doctor recovery decisions read these fields, so they must exist on every
     completed turn — not only on the turn that happens to arm a rollover.
     """
-    patch = getattr(db, "patch_session_model_config", None)
-    if callable(patch):
-        patch(session_id, {_LIFECYCLE_KEY: dict(status)})
+    _patch_rollover_state(db, session_id, {
+        _LIFECYCLE_KEY: dict(status),
+        _POLICY_KEY: {"enabled": True},
+    })
 
 
 def _lifecycle_status(
@@ -410,15 +485,11 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
     if db is None or not session_id or compressor is None:
         return False
     try:
-        from hermes_cli.config import load_config
-        config = load_config() or {}
-        policy = RolloverPolicy.from_config(config.get("session_rollover"))
+        policy = _current_policy()
         if not policy.enabled:
             # This is opt-in behavior. Do not publish a derived draining state
             # from zero reserves or iteration bookkeeping while it is off.
-            patch = getattr(db, "patch_session_model_config", None)
-            if callable(patch):
-                patch(session_id, {_LIFECYCLE_KEY: None})
+            _cancel_disabled_rollover_state(db, session_id)
             return False
         trigger = policy.resolve(
             getattr(compressor, "context_length", 0),

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -91,14 +91,23 @@ class TurnBoundaryRollover:
         row = self._db.get_session(session_id)
         if not row or row.get("ended_at") is not None:
             return False
-        config = _model_config(row)
-        if config.get(_PENDING_KEY):
+        if _model_config(row).get(_PENDING_KEY):
             return True
-        config[_PENDING_KEY] = {"threshold_tokens": int(threshold_tokens)}
-        self._set_model_config(session_id, config)
+        # Do not read/replace model_config: /model, /reasoning and /yolo can
+        # mutate independent keys between the read above and this write.
+        patch = getattr(self._db, "patch_session_model_config", None)
+        if not callable(patch):
+            return False
+        patch(session_id, {_PENDING_KEY: {"threshold_tokens": int(threshold_tokens)}})
         return True
 
-    def adopt_at_turn_boundary(self, session_id: str, *, active_work: bool) -> Optional[str]:
+    def adopt_at_turn_boundary(
+        self,
+        session_id: str,
+        *,
+        active_work: bool,
+        turn_lease_holder: str | None = None,
+    ) -> Optional[str]:
         """Atomically close a pending parent and create one empty child.
 
         ``active_work`` is supplied by the lifecycle owner.  The database
@@ -118,10 +127,13 @@ class TurnBoundaryRollover:
             config = _model_config(parent)
             if not config.pop(_PENDING_KEY, None):
                 return None
-            child_config = {_HANDOFF_KEY: {
+            # A child is a fresh runtime, not a fresh identity. Preserve every
+            # parent runtime/model setting except the consumed rollover marker.
+            child_config = dict(config)
+            child_config[_HANDOFF_KEY] = {
                 "previous_session_id": session_id,
                 "recovery": RECOVERY_GUIDANCE,
-            }}
+            }
             # Keep routing identity, source, cwd, profile, model and role
             # namespace intact.  The transcript is intentionally not copied.
             conn.execute(
@@ -137,6 +149,17 @@ class TurnBoundaryRollover:
                  parent.get("system_prompt"), session_id, parent.get("cwd"),
                  parent.get("profile_name")),
             )
+            if turn_lease_holder:
+                # A rollover is a new lease domain. Move ownership inside this
+                # transaction so alias-key arrivals cannot run in the gap
+                # between adoption and the child's inbound persistence.
+                moved = conn.execute(
+                    "UPDATE session_turn_leases SET conversation_id = ? "
+                    "WHERE conversation_id = ? AND holder = ?",
+                    (child_id, session_id, turn_lease_holder),
+                ).rowcount
+                if moved != 1:
+                    raise RuntimeError("turn-boundary rollover lease was not owned")
             changed = conn.execute(
                 "UPDATE sessions SET ended_at = strftime('%s','now'), end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
@@ -175,7 +198,15 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
     """Re-read policy and live model budget after a durably completed response."""
     if not isinstance(result, Mapping) or result.get("failed") or result.get("interrupted"):
         return False
-    if result.get("completed") is False:
+    # A response is eligible only after its final durable transcript write
+    # succeeded. finalize_turn reports that exact failure in cleanup_errors.
+    # Partial/compression recovery results are not completed boundaries.
+    if (
+        result.get("completed") is not True
+        or result.get("partial")
+        or result.get("compression_exhausted")
+        or any(str(error).startswith("persist_session:") for error in result.get("cleanup_errors", ()) or ())
+    ):
         return False
     db = getattr(agent, "_session_db", None)
     session_id = str(getattr(agent, "session_id", "") or "")
@@ -197,14 +228,23 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
         return False
 
 
-def adopt_agent_at_turn_boundary(agent: Any, *, active_work: bool = False) -> Optional[str]:
+def adopt_agent_at_turn_boundary(
+    agent: Any,
+    *,
+    active_work: bool = False,
+    turn_lease_holder: str | None = None,
+) -> Optional[str]:
     """Adopt a pending child before loading the next inbound user turn."""
     db = getattr(agent, "_session_db", None)
     old_id = str(getattr(agent, "session_id", "") or "")
     if db is None or not old_id:
         return None
     try:
-        child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary(old_id, active_work=active_work)
+        child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary(
+            old_id,
+            active_work=active_work,
+            turn_lease_holder=turn_lease_holder,
+        )
     except Exception:
         return None
     if not child_id:
@@ -216,3 +256,29 @@ def adopt_agent_at_turn_boundary(agent: Any, *, active_work: bool = False) -> Op
     if callable(reset):
         reset(previous_messages=previous, old_session_id=old_id, carry_over_context=False)
     return child_id
+
+
+def consume_handoff_note(agent: Any) -> str:
+    """Consume the child's recovery pointer for one API request only.
+
+    It is deliberately not a transcript message or api_content sidecar: the
+    next user turn remains exactly the user's inbound content on disk.
+    """
+    db = getattr(agent, "_session_db", None)
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if db is None or not session_id:
+        return ""
+    row = db.get_session(session_id)
+    config = _model_config(row or {})
+    handoff = config.get(_HANDOFF_KEY)
+    if not isinstance(handoff, Mapping):
+        return ""
+    previous = str(handoff.get("previous_session_id") or "").strip()
+    recovery = str(handoff.get("recovery") or "").strip()
+    if not previous or not recovery:
+        return ""
+    patch = getattr(db, "patch_session_model_config", None)
+    if not callable(patch):
+        return ""
+    patch(session_id, {_HANDOFF_KEY: None})
+    return f"[Fresh session handoff: previous session {previous}. {recovery}]"

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -9,6 +9,7 @@ and session_search guidance, never a compaction or an LLM-produced summary.
 from __future__ import annotations
 
 import json
+import sys
 import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
@@ -18,6 +19,7 @@ END_REASON = "turn_boundary_rollover"
 RECOVERY_GUIDANCE = "Use session_search to recover earlier details if needed."
 _PENDING_KEY = "_turn_boundary_rollover_pending"
 _HANDOFF_KEY = "turn_boundary_handoff"
+_LIFECYCLE_KEY = "turn_boundary_lifecycle"
 
 
 @dataclass(frozen=True)
@@ -28,6 +30,10 @@ class RolloverPolicy:
     ratio: float = 0.0
     safety_margin_tokens: int = 0
     threshold_tokens: Optional[int] = None
+    reserved_output_tokens: int = 0
+    reserved_tool_result_tokens: int = 0
+    reserved_checkpoint_tokens: int = 0
+    closeout_iterations: int = 2
 
     @classmethod
     def from_config(cls, config: Mapping[str, Any] | None) -> "RolloverPolicy":
@@ -50,7 +56,19 @@ class RolloverPolicy:
                 cap = None
         except (TypeError, ValueError):
             cap = None
-        return cls(enabled, ratio, margin, cap)
+        def _nonnegative(name: str, default: int = 0) -> int:
+            try:
+                return max(0, int(raw.get(name, default) or 0))
+            except (TypeError, ValueError):
+                return default
+
+        return cls(
+            enabled, ratio, margin, cap,
+            _nonnegative("reserved_output_tokens"),
+            _nonnegative("reserved_tool_result_tokens"),
+            _nonnegative("reserved_checkpoint_tokens"),
+            max(1, _nonnegative("closeout_iterations", 2)),
+        )
 
     def resolve(self, context_length: int, compression_threshold: int) -> Optional[int]:
         """Return a trigger strictly below the actual compression threshold.
@@ -68,9 +86,10 @@ class RolloverPolicy:
             return None
         if window <= 0 or compression <= 1:
             return None
+        # ``threshold_tokens`` is retained for config-file compatibility and
+        # observability only. A fixed count must never decide rollover across
+        # models with different context windows.
         candidate = int(window * self.ratio)
-        if self.threshold_tokens is not None:
-            candidate = min(candidate, self.threshold_tokens)
         # Strictly less than compression even when the configured headroom is 0.
         ceiling = compression - max(self.safety_margin_tokens, 1)
         if ceiling <= 0:
@@ -84,7 +103,10 @@ class TurnBoundaryRollover:
     def __init__(self, db: Any) -> None:
         self._db = db
 
-    def mark_pending(self, session_id: str, *, threshold_tokens: int) -> bool:
+    def mark_pending(
+        self, session_id: str, *, threshold_tokens: int,
+        lifecycle: Mapping[str, Any] | None = None,
+    ) -> bool:
         """Persist a request after a response has fully committed."""
         if not session_id or threshold_tokens <= 0:
             return False
@@ -98,7 +120,12 @@ class TurnBoundaryRollover:
         patch = getattr(self._db, "patch_session_model_config", None)
         if not callable(patch):
             return False
-        patch(session_id, {_PENDING_KEY: {"threshold_tokens": int(threshold_tokens)}})
+        patch_data: dict[str, Any] = {
+            _PENDING_KEY: {"threshold_tokens": int(threshold_tokens)},
+        }
+        if lifecycle:
+            patch_data[_LIFECYCLE_KEY] = dict(lifecycle)
+        patch(session_id, patch_data)
         return True
 
     def adopt_at_turn_boundary(
@@ -194,6 +221,19 @@ def _model_config(row: Mapping[str, Any]) -> dict[str, Any]:
     return {}
 
 
+def allows_new_work(agent: Any) -> bool:
+    """Fail closed for new tools/delegations once a parent is draining."""
+    db = getattr(agent, "_session_db", None)
+    session_id = str(getattr(agent, "session_id", "") or "")
+    if db is None or not session_id:
+        return True
+    try:
+        state = _model_config(db.get_session(session_id) or {}).get(_LIFECYCLE_KEY)
+    except Exception:
+        return False
+    return not isinstance(state, Mapping) or state.get("state") != "draining"
+
+
 def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
     """Re-read policy and live model budget after a durably completed response."""
     if not isinstance(result, Mapping) or result.get("failed") or result.get("interrupted"):
@@ -216,14 +256,47 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
     try:
         from hermes_cli.config import load_config
         config = load_config() or {}
-        trigger = RolloverPolicy.from_config(config.get("session_rollover")).resolve(
+        policy = RolloverPolicy.from_config(config.get("session_rollover"))
+        trigger = policy.resolve(
             getattr(compressor, "context_length", 0),
             getattr(compressor, "threshold_tokens", 0),
         )
         used = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
-        if trigger is None or used < trigger:
+        if trigger is None:
             return False
-        return TurnBoundaryRollover(db).mark_pending(session_id, threshold_tokens=trigger)
+        from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
+
+        decision = evaluate_lifecycle(LifecycleBudget(
+            context_window_tokens=int(getattr(compressor, "context_length", 0) or 0),
+            prompt_tokens=used,
+            reserved_output_tokens=policy.reserved_output_tokens,
+            reserved_tool_result_tokens=policy.reserved_tool_result_tokens,
+            reserved_checkpoint_tokens=policy.reserved_checkpoint_tokens,
+            max_iterations=int(getattr(agent, "max_iterations", sys.maxsize) or sys.maxsize),
+            iterations_used=int(result.get("api_calls", 0) or 0),
+            api_calls=int(result.get("api_calls", 0) or 0),
+            cache_read_tokens=int(result.get("cache_read_tokens", 0) or 0),
+            compactions=int(result.get("compactions", 0) or 0),
+            in_flight_workers=len(getattr(agent, "_active_children", ()) or ()),
+            closeout_iterations=policy.closeout_iterations,
+        ))
+        if decision.state is not LifecycleState.DRAINING and used < trigger:
+            return False
+        lifecycle = {
+            "state": decision.state.value,
+            "context_utilization": decision.context_utilization,
+            "remaining_context_tokens": decision.remaining_context_tokens,
+            "remaining_iterations": decision.remaining_iterations,
+            "checkpoint": {
+                "goal": str(getattr(agent, "current_goal", "") or ""),
+                "cwd": str(getattr(agent, "cwd", "") or ""),
+                "api_calls": int(result.get("api_calls", 0) or 0),
+                "in_flight_workers": len(getattr(agent, "_active_children", ()) or ()),
+            },
+        }
+        return TurnBoundaryRollover(db).mark_pending(
+            session_id, threshold_tokens=trigger, lifecycle=lifecycle,
+        )
     except Exception:
         return False
 

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -116,31 +116,12 @@ class TurnBoundaryRollover:
         """Persist a request after a response has fully committed."""
         if not session_id or threshold_tokens <= 0:
             return False
-        row = self._db.get_session(session_id)
-        if not row or row.get("ended_at") is not None:
-            return False
-        if _model_config(row).get(_PENDING_KEY):
-            return True
-        # Do not read/replace model_config: /model, /reasoning and /yolo can
-        # mutate independent keys between the read above and this write.
-        patch = getattr(self._db, "patch_session_model_config", None)
-        if not callable(patch):
-            return False
-        lifecycle_data = dict(lifecycle or {})
-        checkpoint = lifecycle_data.get("checkpoint")
-        lifecycle_data["checkpoint"] = _checkpoint_with_repo_evidence(
-            checkpoint if isinstance(checkpoint, Mapping) else {}, row
-        )
         arm_key = f"turn-boundary:{uuid.uuid4().hex}"
-        patch_data: dict[str, Any] = {
-            _PENDING_KEY: {
-                "threshold_tokens": int(threshold_tokens),
-                "idempotency_key": arm_key,
-            },
-        }
-        patch_data[_LIFECYCLE_KEY] = lifecycle_data
-        patch(session_id, patch_data)
-        return True
+        return self._claim_pending(
+            session_id,
+            {"threshold_tokens": int(threshold_tokens), "idempotency_key": arm_key},
+            lifecycle=lifecycle,
+        ) is not None
 
     def request_recovery(
         self, session_id: str, *, idempotency_key: str
@@ -155,25 +136,50 @@ class TurnBoundaryRollover:
         """
         if not session_id or not idempotency_key:
             return None
-        row = self._db.get_session(session_id)
-        if not row or row.get("ended_at") is not None:
-            return None
-        if _model_config(row).get(_PENDING_KEY):
-            return "already_armed"
-        patch = getattr(self._db, "patch_session_model_config", None)
-        if not callable(patch):
-            return None
-        patch(session_id, {_PENDING_KEY: {
+        pending = {
             "threshold_tokens": 0,
             "recovery_key": str(idempotency_key),
             "idempotency_key": str(idempotency_key),
             "requested_at": time.time(),
-        }})
-        # Re-read: a concurrent doctor/core arm resolves to exactly one owner.
-        pending = _model_config(self._db.get_session(session_id) or {}).get(_PENDING_KEY)
-        if not isinstance(pending, Mapping):
+        }
+        claim = self._claim_pending(session_id, pending)
+        if claim is None:
             return None
-        return "armed" if pending.get("recovery_key") == str(idempotency_key) else "already_armed"
+        _, claimed = claim
+        return "armed" if claimed else "already_armed"
+
+    def _claim_pending(
+        self,
+        session_id: str,
+        pending: Mapping[str, Any],
+        *,
+        lifecycle: Mapping[str, Any] | None = None,
+    ) -> Optional[tuple[dict[str, Any], bool]]:
+        """Claim the pending marker with one SessionDB write transaction."""
+        def _write(conn: Any) -> Optional[tuple[dict[str, Any], bool]]:
+            row = conn.execute("SELECT * FROM sessions WHERE id = ?", (session_id,)).fetchone()
+            if row is None or row["ended_at"] is not None:
+                return None
+            session = dict(row)
+            config = _model_config(session)
+            existing = config.get(_PENDING_KEY)
+            if isinstance(existing, Mapping):
+                return dict(existing), False
+            config[_PENDING_KEY] = dict(pending)
+            if lifecycle is not None:
+                lifecycle_data = dict(lifecycle)
+                checkpoint = lifecycle_data.get("checkpoint")
+                lifecycle_data["checkpoint"] = _checkpoint_with_repo_evidence(
+                    checkpoint if isinstance(checkpoint, Mapping) else {}, session,
+                )
+                config[_LIFECYCLE_KEY] = lifecycle_data
+            changed = conn.execute(
+                "UPDATE sessions SET model_config = ? WHERE id = ? AND ended_at IS NULL",
+                (json.dumps(config, separators=(",", ":")), session_id),
+            ).rowcount
+            return (dict(pending), True) if changed == 1 else None
+
+        return self._db._execute_write(_write)
 
     def adopt_at_turn_boundary(
         self,
@@ -422,9 +428,14 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
         from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
 
         api_calls = int(result.get("api_calls", 0) or 0)
+        turn_iterations = int(result.get("turn_iterations", api_calls) or 0)
         cache_read_tokens = int(result.get("cache_read_tokens", 0) or 0)
         compactions = int(result.get("compactions", 0) or 0)
-        in_flight_workers = len(getattr(agent, "_active_children", ()) or ())
+        supplied_workers = result.get("pending_workers")
+        if isinstance(supplied_workers, (list, tuple, set, frozenset)):
+            in_flight_workers = len(supplied_workers)
+        else:
+            in_flight_workers = len(getattr(agent, "_active_children", ()) or ())
         active_tool_call = bool(getattr(agent, "_executing_tools", False))
         decision = evaluate_lifecycle(LifecycleBudget(
             context_window_tokens=int(getattr(compressor, "context_length", 0) or 0),
@@ -433,7 +444,7 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
             reserved_tool_result_tokens=policy.reserved_tool_result_tokens,
             reserved_checkpoint_tokens=policy.reserved_checkpoint_tokens,
             max_iterations=int(getattr(agent, "max_iterations", sys.maxsize) or sys.maxsize),
-            iterations_used=api_calls,
+            iterations_used=turn_iterations,
             api_calls=api_calls,
             cache_read_tokens=cache_read_tokens,
             compactions=compactions,
@@ -461,12 +472,13 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
             "goal": str(getattr(agent, "current_goal", "") or ""),
             "worktree": str(getattr(agent, "cwd", "") or ""),
             "api_calls": api_calls,
+            "turn_iterations": turn_iterations,
             "in_flight_workers": in_flight_workers,
             **{
                 key: list(result.get(key) or ())
                 for key in (
-                    "verification_evidence", "result_pointers",
-                    "external_effects", "external_readback",
+                    "changed_files", "verification_evidence", "pending_workers",
+                    "result_pointers", "external_effects", "external_readback",
                 )
                 if result.get(key)
             },

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -131,8 +131,12 @@ class TurnBoundaryRollover:
         lifecycle_data["checkpoint"] = _checkpoint_with_repo_evidence(
             checkpoint if isinstance(checkpoint, Mapping) else {}, row
         )
+        arm_key = f"turn-boundary:{uuid.uuid4().hex}"
         patch_data: dict[str, Any] = {
-            _PENDING_KEY: {"threshold_tokens": int(threshold_tokens)},
+            _PENDING_KEY: {
+                "threshold_tokens": int(threshold_tokens),
+                "idempotency_key": arm_key,
+            },
         }
         patch_data[_LIFECYCLE_KEY] = lifecycle_data
         patch(session_id, patch_data)
@@ -162,6 +166,7 @@ class TurnBoundaryRollover:
         patch(session_id, {_PENDING_KEY: {
             "threshold_tokens": 0,
             "recovery_key": str(idempotency_key),
+            "idempotency_key": str(idempotency_key),
             "requested_at": time.time(),
         }})
         # Re-read: a concurrent doctor/core arm resolves to exactly one owner.
@@ -197,13 +202,17 @@ class TurnBoundaryRollover:
             pending = config.pop(_PENDING_KEY, None)
             if not pending:
                 return None
-            recovery_key = (
-                str(pending.get("recovery_key") or "")
+            recovery_key = str(pending.get("recovery_key") or "") if isinstance(pending, Mapping) else ""
+            arm_key = (
+                str(pending.get("idempotency_key") or recovery_key)
                 if isinstance(pending, Mapping) else ""
             )
             # A child is a fresh runtime, not a fresh identity. Preserve every
             # parent runtime/model setting except the consumed rollover marker.
             child_config = dict(config)
+            # The parent was deliberately draining. Its child is a fresh
+            # runtime and must not inherit that admission fence.
+            child_config[_LIFECYCLE_KEY] = {"state": "healthy"}
             child_config[_HANDOFF_KEY] = {
                 "previous_session_id": session_id,
                 "recovery": RECOVERY_GUIDANCE,
@@ -212,6 +221,8 @@ class TurnBoundaryRollover:
                 # Binds the continuation to the exact recovery request so a
                 # doctor read-back can prove which arm produced this child.
                 child_config[_HANDOFF_KEY]["recovery_key"] = recovery_key
+            if arm_key:
+                child_config[_HANDOFF_KEY]["idempotency_key"] = arm_key
             # Keep routing identity, source, cwd, profile, model and role
             # namespace intact.  The transcript is intentionally not copied.
             conn.execute(
@@ -396,6 +407,13 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
         from hermes_cli.config import load_config
         config = load_config() or {}
         policy = RolloverPolicy.from_config(config.get("session_rollover"))
+        if not policy.enabled:
+            # This is opt-in behavior. Do not publish a derived draining state
+            # from zero reserves or iteration bookkeeping while it is off.
+            patch = getattr(db, "patch_session_model_config", None)
+            if callable(patch):
+                patch(session_id, {_LIFECYCLE_KEY: None})
+            return False
         trigger = policy.resolve(
             getattr(compressor, "context_length", 0),
             getattr(compressor, "threshold_tokens", 0),
@@ -441,9 +459,17 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
             return False
         lifecycle["checkpoint"] = {
             "goal": str(getattr(agent, "current_goal", "") or ""),
-            "cwd": str(getattr(agent, "cwd", "") or ""),
+            "worktree": str(getattr(agent, "cwd", "") or ""),
             "api_calls": api_calls,
             "in_flight_workers": in_flight_workers,
+            **{
+                key: list(result.get(key) or ())
+                for key in (
+                    "verification_evidence", "result_pointers",
+                    "external_effects", "external_readback",
+                )
+                if result.get(key)
+            },
         }
         return TurnBoundaryRollover(db).mark_pending(
             session_id, threshold_tokens=trigger, lifecycle=lifecycle,

--- a/session_rollover.py
+++ b/session_rollover.py
@@ -12,12 +12,16 @@ import json
 from pathlib import Path
 import subprocess
 import sys
+import time
 import uuid
 from dataclasses import dataclass
 from typing import Any, Mapping, Optional
 
 
 END_REASON = "turn_boundary_rollover"
+#: Distinct from ``END_REASON`` so a read-back can tell a core-armed drain
+#: apart from a doctor-requested recovery of a stalled lifecycle.
+RECOVERY_END_REASON = "turn_boundary_rollover_recovered"
 RECOVERY_GUIDANCE = "Use session_search to recover earlier details if needed."
 _PENDING_KEY = "_turn_boundary_rollover_pending"
 _HANDOFF_KEY = "turn_boundary_handoff"
@@ -134,6 +138,38 @@ class TurnBoundaryRollover:
         patch(session_id, patch_data)
         return True
 
+    def request_recovery(
+        self, session_id: str, *, idempotency_key: str
+    ) -> Optional[str]:
+        """Arm exactly one doctor-driven rollover for a stalled session.
+
+        Returns ``"armed"`` for the request that actually armed the pending
+        marker, ``"already_armed"`` when any request (this key or another) is
+        already pending, and ``None`` when the session cannot be recovered.
+        The caller is responsible for having verified the safety conditions;
+        this method only guarantees at-most-one continuation per session.
+        """
+        if not session_id or not idempotency_key:
+            return None
+        row = self._db.get_session(session_id)
+        if not row or row.get("ended_at") is not None:
+            return None
+        if _model_config(row).get(_PENDING_KEY):
+            return "already_armed"
+        patch = getattr(self._db, "patch_session_model_config", None)
+        if not callable(patch):
+            return None
+        patch(session_id, {_PENDING_KEY: {
+            "threshold_tokens": 0,
+            "recovery_key": str(idempotency_key),
+            "requested_at": time.time(),
+        }})
+        # Re-read: a concurrent doctor/core arm resolves to exactly one owner.
+        pending = _model_config(self._db.get_session(session_id) or {}).get(_PENDING_KEY)
+        if not isinstance(pending, Mapping):
+            return None
+        return "armed" if pending.get("recovery_key") == str(idempotency_key) else "already_armed"
+
     def adopt_at_turn_boundary(
         self,
         session_id: str,
@@ -158,8 +194,13 @@ class TurnBoundaryRollover:
                 return None
             parent = dict(row)
             config = _model_config(parent)
-            if not config.pop(_PENDING_KEY, None):
+            pending = config.pop(_PENDING_KEY, None)
+            if not pending:
                 return None
+            recovery_key = (
+                str(pending.get("recovery_key") or "")
+                if isinstance(pending, Mapping) else ""
+            )
             # A child is a fresh runtime, not a fresh identity. Preserve every
             # parent runtime/model setting except the consumed rollover marker.
             child_config = dict(config)
@@ -167,6 +208,10 @@ class TurnBoundaryRollover:
                 "previous_session_id": session_id,
                 "recovery": RECOVERY_GUIDANCE,
             }
+            if recovery_key:
+                # Binds the continuation to the exact recovery request so a
+                # doctor read-back can prove which arm produced this child.
+                child_config[_HANDOFF_KEY]["recovery_key"] = recovery_key
             # Keep routing identity, source, cwd, profile, model and role
             # namespace intact.  The transcript is intentionally not copied.
             conn.execute(
@@ -196,7 +241,7 @@ class TurnBoundaryRollover:
             changed = conn.execute(
                 "UPDATE sessions SET ended_at = strftime('%s','now'), end_reason = ? "
                 "WHERE id = ? AND ended_at IS NULL",
-                (END_REASON, session_id),
+                (RECOVERY_END_REASON if recovery_key else END_REASON, session_id),
             ).rowcount
             if changed != 1:
                 raise RuntimeError("turn-boundary rollover parent changed during adoption")
@@ -272,6 +317,62 @@ def allows_new_delegation(agent: Any) -> bool:
     return allows_new_work(agent)
 
 
+def _publish_lifecycle_status(
+    db: Any, session_id: str, status: Mapping[str, Any]
+) -> None:
+    """Write the recovery-visible lifecycle fields without arming anything.
+
+    Doctor recovery decisions read these fields, so they must exist on every
+    completed turn — not only on the turn that happens to arm a rollover.
+    """
+    patch = getattr(db, "patch_session_model_config", None)
+    if callable(patch):
+        patch(session_id, {_LIFECYCLE_KEY: dict(status)})
+
+
+def _lifecycle_status(
+    db: Any, session_id: str, decision: Any, *, made_progress: bool,
+    in_flight_workers: int, active_tool_call: bool, api_calls: int,
+    cache_read_tokens: int, compactions: int, now: float,
+) -> dict[str, Any]:
+    """Merge a new decision with the session's persisted lifecycle history."""
+    try:
+        previous = _model_config(db.get_session(session_id) or {}).get(_LIFECYCLE_KEY)
+    except Exception:
+        previous = None
+    previous = dict(previous) if isinstance(previous, Mapping) else {}
+
+    state = decision.state.value
+    # A state's entry time only moves when the state itself changes; a stall
+    # is measured from when the session ENTERED the state, not from the last
+    # status write (which happens on every completed turn).
+    if previous.get("state") == state:
+        state_entered_at = float(previous.get("state_entered_at") or now)
+    else:
+        state_entered_at = now
+    # "Meaningful progress" is real model work this turn. A completed turn
+    # that made zero API calls must not refresh the stall clock.
+    last_progress_at = (
+        now if made_progress else float(previous.get("last_progress_at") or now)
+    )
+    return {
+        "state": state,
+        "state_entered_at": state_entered_at,
+        "last_progress_at": last_progress_at,
+        "updated_at": now,
+        "context_utilization": decision.context_utilization,
+        "remaining_context_tokens": decision.remaining_context_tokens,
+        "remaining_iterations": decision.remaining_iterations,
+        "reserved_headroom_tokens": decision.reserved_headroom_tokens,
+        "in_flight_workers": int(in_flight_workers),
+        "active_tool_call": bool(active_tool_call),
+        # Observability only — never a lifecycle decision input.
+        "api_calls": int(api_calls),
+        "cache_read_tokens": int(cache_read_tokens),
+        "compactions": int(compactions),
+    }
+
+
 def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
     """Re-read policy and live model budget after a durably completed response."""
     if not isinstance(result, Mapping) or result.get("failed") or result.get("interrupted"):
@@ -300,10 +401,13 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
             getattr(compressor, "threshold_tokens", 0),
         )
         used = int(getattr(compressor, "last_prompt_tokens", 0) or 0)
-        if trigger is None:
-            return False
         from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
 
+        api_calls = int(result.get("api_calls", 0) or 0)
+        cache_read_tokens = int(result.get("cache_read_tokens", 0) or 0)
+        compactions = int(result.get("compactions", 0) or 0)
+        in_flight_workers = len(getattr(agent, "_active_children", ()) or ())
+        active_tool_call = bool(getattr(agent, "_executing_tools", False))
         decision = evaluate_lifecycle(LifecycleBudget(
             context_window_tokens=int(getattr(compressor, "context_length", 0) or 0),
             prompt_tokens=used,
@@ -311,26 +415,35 @@ def mark_completed_turn(agent: Any, result: Mapping[str, Any]) -> bool:
             reserved_tool_result_tokens=policy.reserved_tool_result_tokens,
             reserved_checkpoint_tokens=policy.reserved_checkpoint_tokens,
             max_iterations=int(getattr(agent, "max_iterations", sys.maxsize) or sys.maxsize),
-            iterations_used=int(result.get("api_calls", 0) or 0),
-            api_calls=int(result.get("api_calls", 0) or 0),
-            cache_read_tokens=int(result.get("cache_read_tokens", 0) or 0),
-            compactions=int(result.get("compactions", 0) or 0),
-            in_flight_workers=len(getattr(agent, "_active_children", ()) or ()),
+            iterations_used=api_calls,
+            api_calls=api_calls,
+            cache_read_tokens=cache_read_tokens,
+            compactions=compactions,
+            in_flight_workers=in_flight_workers,
             closeout_iterations=policy.closeout_iterations,
         ))
-        if decision.state is not LifecycleState.DRAINING and used < trigger:
+        lifecycle = _lifecycle_status(
+            db, session_id, decision,
+            made_progress=api_calls > 0,
+            in_flight_workers=in_flight_workers,
+            active_tool_call=active_tool_call,
+            api_calls=api_calls,
+            cache_read_tokens=cache_read_tokens,
+            compactions=compactions,
+            now=time.time(),
+        )
+        if trigger is None or (
+            decision.state is not LifecycleState.DRAINING and used < trigger
+        ):
+            # Status stays observable even when this turn arms nothing: doctor
+            # stall detection depends on it existing for healthy sessions too.
+            _publish_lifecycle_status(db, session_id, lifecycle)
             return False
-        lifecycle = {
-            "state": decision.state.value,
-            "context_utilization": decision.context_utilization,
-            "remaining_context_tokens": decision.remaining_context_tokens,
-            "remaining_iterations": decision.remaining_iterations,
-            "checkpoint": {
-                "goal": str(getattr(agent, "current_goal", "") or ""),
-                "cwd": str(getattr(agent, "cwd", "") or ""),
-                "api_calls": int(result.get("api_calls", 0) or 0),
-                "in_flight_workers": len(getattr(agent, "_active_children", ()) or ()),
-            },
+        lifecycle["checkpoint"] = {
+            "goal": str(getattr(agent, "current_goal", "") or ""),
+            "cwd": str(getattr(agent, "cwd", "") or ""),
+            "api_calls": api_calls,
+            "in_flight_workers": in_flight_workers,
         }
         return TurnBoundaryRollover(db).mark_pending(
             session_id, threshold_tokens=trigger, lifecycle=lifecycle,

--- a/tests/acp/test_session_provenance.py
+++ b/tests/acp/test_session_provenance.py
@@ -78,3 +78,28 @@ def test_meta_wrapper_shape(db):
     assert set(meta.keys()) == {"hermes"}
     assert "sessionProvenance" in meta["hermes"]
     assert meta["hermes"]["sessionProvenance"]["currentHermesSessionId"] == "root1"
+
+
+@pytest.mark.parametrize(
+    ("end_reason", "expected_reason"),
+    [
+        ("turn_boundary_rollover", "turn_boundary_rollover"),
+        ("turn_boundary_rollover_recovered", "turn_boundary_rollover_recovered"),
+    ],
+)
+def test_rollover_continuation_is_not_compression_provenance(
+    db, end_reason, expected_reason,
+):
+    _mk(db, "old")
+    db.end_session("old", end_reason)
+    time.sleep(0.001)
+    _mk(db, "new", parent="old")
+
+    prov = build_session_provenance(
+        db, "acp-1", "new", previous_hermes_session_id="old"
+    )
+
+    assert prov["sessionKind"] == "continuation"
+    assert prov["compressionDepth"] == 0
+    assert prov["reason"] == expected_reason
+    assert prov["creatorKind"] == "rollover"

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -1,3 +1,4 @@
+import json
 import sys
 from types import ModuleType, SimpleNamespace
 
@@ -6,6 +7,8 @@ from acp.schema import TextContentBlock
 
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
+from hermes_state import SessionDB
+from session_rollover import TurnBoundaryRollover
 
 
 class FakeAgent:
@@ -118,6 +121,66 @@ def test_acp_real_agent_gets_session_db_for_recall(monkeypatch):
     assert captured["session_db"] is sentinel_db
     assert captured["platform"] == "acp"
     assert captured["session_id"] == "acp-session"
+
+
+def test_acp_restart_parent_handle_restores_turn_boundary_child_tip(monkeypatch, tmp_path):
+    """The ACP handle remains stable while its agent resumes the rollover tip."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "acp-parent",
+        source="acp",
+        model="parent-model",
+        model_config={"cwd": "/parent"},
+    )
+    db.append_message("acp-parent", "user", "ended parent transcript")
+    child_id = TurnBoundaryRollover(db).mark_pending("acp-parent", threshold_tokens=1)
+    assert child_id is True
+    child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary("acp-parent", active_work=False)
+    assert child_id
+    db.update_session_meta(
+        child_id,
+        json.dumps({"cwd": "/child", "provider": "child-provider"}),
+        "child-model",
+    )
+    db.append_message(child_id, "user", "child continuation transcript")
+
+    made = []
+
+    class _Agent:
+        model = "factory-model"
+
+    def factory(**_kwargs):
+        return _Agent()
+
+    manager = SessionManager(agent_factory=factory, db=db)
+    original_make_agent = manager._make_agent
+
+    def capture_make_agent(**kwargs):
+        made.append(kwargs)
+        return original_make_agent(**kwargs)
+
+    manager._make_agent = capture_make_agent
+    restored = manager.get_session("acp-parent")
+
+    assert restored is not None
+    assert restored.session_id == "acp-parent"
+    assert restored.cwd == "/child"
+    assert restored.model == "child-model"
+    assert [message["content"] for message in restored.history] == [
+        "child continuation transcript"
+    ]
+    assert made == [{
+        "session_id": child_id,
+        "cwd": "/child",
+        "model": "child-model",
+        "requested_provider": "child-provider",
+        "base_url": None,
+        "api_mode": None,
+    }]
 
 
 @pytest.mark.asyncio

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -184,6 +184,67 @@ def test_acp_restart_parent_handle_restores_turn_boundary_child_tip(monkeypatch,
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("switch_path", ("slash", "protocol"))
+async def test_acp_model_switch_persists_to_rollover_child_not_stable_parent(
+    monkeypatch, tmp_path, switch_path,
+):
+    """The ACP handle stays stable while model/history writes target the child tip."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "acp-parent", source="acp", model="parent-model", model_config={"cwd": "/parent"},
+    )
+    db.append_message("acp-parent", "user", "parent-only")
+    assert TurnBoundaryRollover(db).mark_pending("acp-parent", threshold_tokens=1) is True
+    child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary("acp-parent", active_work=False)
+    assert child_id
+    db.update_session_meta(child_id, json.dumps({"cwd": "/child"}), "child-model")
+    db.append_message(child_id, "user", "child-only")
+
+    made = []
+
+    class _Agent:
+        model = "factory-model"
+        provider = "factory-provider"
+
+    manager = SessionManager(agent_factory=_Agent, db=db)
+    original_make_agent = manager._make_agent
+
+    def capture_make_agent(**kwargs):
+        made.append(kwargs)
+        return original_make_agent(**kwargs)
+
+    manager._make_agent = capture_make_agent
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.get_session("acp-parent")
+    assert state is not None
+
+    if switch_path == "slash":
+        assert "Model switched to: next-model" in acp_agent._cmd_model("next-model", state)
+    else:
+        assert await acp_agent.set_session_model("next-model", "acp-parent") is not None
+
+    parent = db.get_session("acp-parent")
+    child = db.get_session(child_id)
+    assert parent is not None
+    assert child is not None
+    assert parent["model"] == "parent-model"
+    assert [message["content"] for message in db.get_messages_as_conversation("acp-parent")] == ["parent-only"]
+    assert child["model"] == "next-model"
+    assert [message["content"] for message in db.get_messages_as_conversation(child_id)] == ["child-only"]
+    assert made[-1]["session_id"] == child_id
+
+    restarted = SessionManager(agent_factory=_Agent, db=db).get_session("acp-parent")
+    assert restarted is not None
+    assert restarted.session_id == "acp-parent"
+    assert restarted.model == "next-model"
+    assert [message["content"] for message in restarted.history] == ["child-only"]
+
+
+@pytest.mark.asyncio
 async def test_acp_steer_slash_command_injects_into_running_agent():
     acp_agent, state, fake, _conn = make_agent_and_state()
     state.is_running = True

--- a/tests/acp_adapter/test_acp_commands.py
+++ b/tests/acp_adapter/test_acp_commands.py
@@ -245,6 +245,63 @@ async def test_acp_model_switch_persists_to_rollover_child_not_stable_parent(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("switch_path", ("slash", "protocol"))
+async def test_acp_prompt_moves_persistence_tip_before_grandchild_model_switch(
+    monkeypatch, tmp_path, switch_path,
+):
+    """A turn rollover must move durable ACP writes and later switches to its tip."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("acp-parent", source="acp", model="parent-model", model_config={"cwd": "/parent"})
+    assert TurnBoundaryRollover(db).mark_pending("acp-parent", threshold_tokens=1) is True
+    child_id = TurnBoundaryRollover(db).adopt_at_turn_boundary("acp-parent", active_work=False)
+    assert child_id
+    db.update_session_meta(child_id, json.dumps({"cwd": "/child"}), "child-model")
+
+    class _Agent:
+        model = "factory-model"
+        provider = "factory-provider"
+
+    manager = SessionManager(agent_factory=_Agent, db=db)
+    acp_agent = HermesACPAgent(session_manager=manager)
+    state = manager.get_session("acp-parent")
+    assert state is not None
+
+    class RolloverAgent(FakeAgent):
+        session_id = child_id
+
+        def run_conversation(self, **kwargs):
+            assert TurnBoundaryRollover(db).mark_pending(child_id, threshold_tokens=1) is True
+            grandchild_id = TurnBoundaryRollover(db).adopt_at_turn_boundary(child_id, active_work=False)
+            assert grandchild_id
+            self.session_id = grandchild_id
+            return {"final_response": "rolled", "messages": [{"role": "assistant", "content": "rolled"}]}
+
+    state.agent = RolloverAgent()
+    await acp_agent.prompt(
+        session_id="acp-parent",
+        prompt=[TextContentBlock(type="text", text="continue")],
+    )
+    grandchild_id = state.agent.session_id
+    assert state.persistence_session_id == grandchild_id
+
+    if switch_path == "slash":
+        assert "Model switched to: next-model" in acp_agent._cmd_model("next-model", state)
+    else:
+        assert await acp_agent.set_session_model("next-model", "acp-parent") is not None
+
+    assert db.get_session(child_id)["model"] == "child-model"
+    assert db.get_session(grandchild_id)["model"] == "next-model"
+    restarted = SessionManager(agent_factory=_Agent, db=db).get_session("acp-parent")
+    assert restarted is not None
+    assert restarted.model == "next-model"
+    assert [message["content"] for message in restarted.history] == ["rolled"]
+
+
+@pytest.mark.asyncio
 async def test_acp_steer_slash_command_injects_into_running_agent():
     acp_agent, state, fake, _conn = make_agent_and_state()
     state.is_running = True

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -75,19 +75,22 @@ def test_cli_completion_is_durable_display_only_not_a_recursive_turn(monkeypatch
     monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
     monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: "claim")
     monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda *_args: None)
+    monkeypatch.setattr("cli._cli_visible_print", lambda _text: None)
 
     cli._drain_process_notifications("cli-idle")
 
     assert cli._pending_input.empty()
     assert persisted == [(
         ("visible-session", "user"),
-        {"content": "completion payload", "display_kind": "async_delegation_complete"},
+        {"content": "completion payload", "display_kind": "async_delegation_complete",
+         "display_metadata": {"delegation_id": "deleg"}},
     )]
     # The immediate next authorized turn reads this live list, not SQLite.
     assert cli.conversation_history[-1] == {
         "role": "user",
         "content": "completion payload",
         "display_kind": "async_delegation_complete",
+        "display_metadata": {"delegation_id": "deleg"},
         "_db_persisted": True,
     }
 
@@ -115,6 +118,95 @@ def test_cli_duplicate_completion_is_persisted_once(monkeypatch):
 
     assert len(persisted) == 1
     assert not hasattr(cli, "conversation_history")
+    assert cli._pending_input.empty()
+
+
+def test_cli_stale_replay_after_crash_does_not_duplicate_durable_or_live_history(
+    monkeypatch, tmp_path,
+):
+    """A crash after durable append but before ack replays the same identity once."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("visible-session", source="cli")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-crash-window",
+        "session_key": "visible-session",
+    }
+    # Simulate the first process committing the row and dying before its ack.
+    db.append_async_delegation_completion(
+        "visible-session", "completion payload", {"delegation_id": "deleg-crash-window"},
+    )
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._session_db = db
+    cli._pending_input = queue.Queue()
+    cli.conversation_history = db.get_messages_as_conversation("visible-session")
+    delivered = []
+    visible = []
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload")]
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    # This token represents the stale-claim reclaim after restart.
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: "stale-claim")
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *_args: delivered.append(_args),
+    )
+    monkeypatch.setattr("cli._cli_visible_print", visible.append)
+
+    cli._drain_process_notifications("cli-idle")
+
+    rows = db.get_messages("visible-session")
+    assert len(rows) == 1
+    assert sum(
+        message.get("display_metadata", {}).get("delegation_id") == "deleg-crash-window"
+        for message in cli.conversation_history
+    ) == 1
+    assert cli._pending_input.empty()
+    assert visible == ["completion payload"]
+    assert delivered == [(event, "stale-claim")]
+
+
+def test_cli_releases_claim_when_durable_delivery_fails(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    cli.conversation_history = []
+    event = {"type": "async_delegation", "delegation_id": "deleg", "session_key": "visible-session"}
+    released = []
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload")]
+
+    class FailingDb:
+        def append_message(self, *_args, **_kwargs):
+            raise AssertionError("legacy append must not run")
+
+        def append_async_delegation_completion(self, *_args):
+            raise OSError("database busy")
+
+    cli.__dict__["_session_db"] = FailingDb()
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: "claim")
+    monkeypatch.setattr("tools.async_delegation.release_event_delivery", lambda *args: released.append(args))
+    acknowledged = []
+    monkeypatch.setattr(
+        "tools.async_delegation.complete_event_delivery",
+        lambda *args: acknowledged.append(args),
+    )
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert released == [(event, "claim")]
+    assert acknowledged == []
+    assert cli.conversation_history == []
     assert cli._pending_input.empty()
 
 

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -84,6 +84,30 @@ def test_cli_completion_is_durable_display_only_not_a_recursive_turn(monkeypatch
     )]
 
 
+def test_cli_duplicate_completion_is_persisted_once(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    persisted = []
+    cli._session_db = type("DB", (), {
+        "append_message": lambda _self, *args, **kwargs: persisted.append((args, kwargs)),
+    })()
+    event = {"type": "async_delegation", "delegation_id": "deleg", "session_key": "visible-session"}
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload"), (event, "completion payload")]
+
+    claims = iter(("claim", None))
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: next(claims))
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda *_args: None)
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert len(persisted) == 1
+
+
 def test_cli_completion_ownership_accepts_compression_lineage():
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -225,6 +225,89 @@ def test_cli_ack_failure_releases_claim_then_replay_acks_without_reprinting(monk
     assert acknowledged == [(event, "retry-claim")]
 
 
+def test_cli_legacy_append_ack_replay_is_accepted_once_per_process(monkeypatch):
+    """Embedded append-only DBs cannot replay an accepted completion visibly."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    cli.conversation_history = []
+    writes = []
+    visible = []
+    released = []
+    acknowledged = []
+    cli.__dict__["_session_db"] = type("LegacyDb", (), {
+        "append_message": lambda _self, *args, **kwargs: writes.append((args, kwargs)),
+    })()
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "legacy-ack-retry",
+        "session_key": "visible-session",
+    }
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload")]
+
+    claims = iter(("first-claim", "retry-claim"))
+
+    def complete(_event, claim):
+        if claim == "first-claim":
+            raise OSError("ack unavailable")
+        acknowledged.append((_event, claim))
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: next(claims))
+    monkeypatch.setattr("tools.async_delegation.release_event_delivery", lambda *args: released.append(args))
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", complete)
+    monkeypatch.setattr("cli._cli_visible_print", visible.append)
+
+    cli._drain_process_notifications("cli-idle")
+    replay_cli = HermesCLI.__new__(HermesCLI)
+    replay_cli.session_id = "visible-session"
+    replay_cli.__dict__["_session_db"] = cli._session_db
+    replay_cli._pending_input = queue.Queue()
+    replay_cli.conversation_history = []
+    replay_cli._drain_process_notifications("cli-idle")
+
+    assert len(writes) == 1
+    assert len(cli.conversation_history) == 1
+    assert visible == ["completion payload"]
+    assert released == [(event, "first-claim")]
+    assert acknowledged == [(event, "retry-claim")]
+    assert cli._pending_input.empty()
+    assert replay_cli._pending_input.empty()
+
+
+def test_cli_legacy_empty_delegation_ids_do_not_suppress_unrelated_events(monkeypatch):
+    """Only a non-empty delegation id may activate the legacy replay guard."""
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    writes = []
+    visible = []
+    cli.__dict__["_session_db"] = type("LegacyDb", (), {
+        "append_message": lambda _self, *args, **kwargs: writes.append((args, kwargs)),
+    })()
+    events = [
+        {"type": "async_delegation", "delegation_id": "", "session_key": "visible-session"},
+        {"type": "async_delegation", "session_key": "visible-session"},
+    ]
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, f"completion {index}") for index, event in enumerate(events)]
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda event, *_args: event)
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda *_args: None)
+    monkeypatch.setattr("cli._cli_visible_print", visible.append)
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert len(writes) == 2
+    assert visible == ["completion 0", "completion 1"]
+
+
 def test_cli_releases_claim_when_durable_delivery_fails(monkeypatch):
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -57,6 +57,33 @@ def test_cli_completion_ownership_rejects_foreign_session():
     )
 
 
+def test_cli_completion_is_durable_display_only_not_a_recursive_turn(monkeypatch):
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._pending_input = queue.Queue()
+    persisted = []
+    cli.__dict__["_session_db"] = type("DB", (), {
+        "append_message": lambda _self, *args, **kwargs: persisted.append((args, kwargs)),
+    })()
+    event = {"type": "async_delegation", "delegation_id": "deleg", "session_key": "visible-session"}
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload")]
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: "claim")
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", lambda *_args: None)
+
+    cli._drain_process_notifications("cli-idle")
+
+    assert cli._pending_input.empty()
+    assert persisted == [(
+        ("visible-session", "user"),
+        {"content": "completion payload", "display_kind": "async_delegation_complete"},
+    )]
+
+
 def test_cli_completion_ownership_accepts_compression_lineage():
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -61,6 +61,7 @@ def test_cli_completion_is_durable_display_only_not_a_recursive_turn(monkeypatch
     cli = HermesCLI.__new__(HermesCLI)
     cli.session_id = "visible-session"
     cli._pending_input = queue.Queue()
+    cli.conversation_history = [{"role": "user", "content": "earlier turn"}]
     persisted = []
     cli.__dict__["_session_db"] = type("DB", (), {
         "append_message": lambda _self, *args, **kwargs: persisted.append((args, kwargs)),
@@ -82,6 +83,13 @@ def test_cli_completion_is_durable_display_only_not_a_recursive_turn(monkeypatch
         ("visible-session", "user"),
         {"content": "completion payload", "display_kind": "async_delegation_complete"},
     )]
+    # The immediate next authorized turn reads this live list, not SQLite.
+    assert cli.conversation_history[-1] == {
+        "role": "user",
+        "content": "completion payload",
+        "display_kind": "async_delegation_complete",
+        "_db_persisted": True,
+    }
 
 
 def test_cli_duplicate_completion_is_persisted_once(monkeypatch):

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -114,6 +114,8 @@ def test_cli_duplicate_completion_is_persisted_once(monkeypatch):
     cli._drain_process_notifications("cli-idle")
 
     assert len(persisted) == 1
+    assert not hasattr(cli, "conversation_history")
+    assert cli._pending_input.empty()
 
 
 def test_cli_completion_ownership_accepts_compression_lineage():

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -169,8 +169,60 @@ def test_cli_stale_replay_after_crash_does_not_duplicate_durable_or_live_history
         for message in cli.conversation_history
     ) == 1
     assert cli._pending_input.empty()
-    assert visible == ["completion payload"]
+    # The durable row predates this replay, so it was already accepted for
+    # display. A reclaimed stale claim still gets acknowledged, but does not
+    # print the completion again.
+    assert visible == []
     assert delivered == [(event, "stale-claim")]
+
+
+def test_cli_ack_failure_releases_claim_then_replay_acks_without_reprinting(monkeypatch, tmp_path):
+    """Ack failures retry immediately without duplicating durable/live/visible delivery."""
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("visible-session", source="cli")
+    event = {
+        "type": "async_delegation",
+        "delegation_id": "deleg-ack-retry",
+        "session_key": "visible-session",
+    }
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.session_id = "visible-session"
+    cli._session_db = db
+    cli._pending_input = queue.Queue()
+    cli.conversation_history = []
+    visible = []
+    released = []
+    acknowledged = []
+    claims = iter(("first-claim", "retry-claim"))
+
+    class FakeRegistry:
+        def drain_notifications(self, **_kwargs):
+            return [(event, "completion payload")]
+
+    def complete(_event, claim):
+        if claim == "first-claim":
+            raise OSError("ack unavailable")
+        acknowledged.append((_event, claim))
+
+    monkeypatch.setattr("tools.process_registry.process_registry", FakeRegistry())
+    monkeypatch.setattr("tools.async_delegation.claim_event_delivery", lambda *_args: next(claims))
+    monkeypatch.setattr("tools.async_delegation.release_event_delivery", lambda *args: released.append(args))
+    monkeypatch.setattr("tools.async_delegation.complete_event_delivery", complete)
+    monkeypatch.setattr("cli._cli_visible_print", visible.append)
+
+    cli._drain_process_notifications("cli-idle")
+    cli._drain_process_notifications("cli-idle")
+
+    assert len(db.get_messages("visible-session")) == 1
+    assert sum(
+        message.get("display_metadata", {}).get("delegation_id") == "deleg-ack-retry"
+        for message in cli.conversation_history
+    ) == 1
+    assert visible == ["completion payload"]
+    assert released == [(event, "first-claim")]
+    assert acknowledged == [(event, "retry-claim")]
 
 
 def test_cli_releases_claim_when_durable_delivery_fails(monkeypatch):

--- a/tests/gateway/test_completion_delivery.py
+++ b/tests/gateway/test_completion_delivery.py
@@ -34,6 +34,11 @@ def isolated_registry(tmp_path, monkeypatch):
 
 
 def _runner(adapter, *, origins=None):
+    if not hasattr(adapter, "send"):
+        async def _send(_chat_id, text, metadata=None):
+            await adapter.handle_message(SimpleNamespace(text=text, metadata=metadata))
+
+        adapter.send = AsyncMock(side_effect=_send)
     runner = object.__new__(GatewayRunner)
     runner._running = True
     runner.adapters = {Platform.TELEGRAM: adapter}

--- a/tests/gateway/test_completion_session_boundary.py
+++ b/tests/gateway/test_completion_session_boundary.py
@@ -221,6 +221,27 @@ def test_completion_after_idle_end_still_delivers(
     adapter.handle_message.assert_awaited_once()
 
 
+@pytest.mark.parametrize("end_reason", [
+    "turn_boundary_rollover",
+    "turn_boundary_rollover_recovered",
+])
+def test_completion_follows_each_turn_boundary_continuation(end_reason):
+    """A finished child task must follow either rollover reason to its live tip."""
+    class _RolloverDB:
+        async def get_session(self, session_id):
+            if session_id == "parent":
+                return {"ended_at": 1.0, "end_reason": end_reason}
+            return {"ended_at": None}
+
+        async def get_compression_tip(self, session_id):
+            assert session_id == "parent"
+            return "child"
+
+    runner = _runner(SimpleNamespace(), session_db=_RolloverDB())
+
+    assert asyncio.run(runner._classify_completion_target("parent")) == "deliver"
+
+
 def test_completion_from_live_session_delivers(monkeypatch, isolated_registry):
     _finished_session(isolated_registry)
     adapter = SimpleNamespace(handle_message=AsyncMock())

--- a/tests/gateway/test_wake_delivery.py
+++ b/tests/gateway/test_wake_delivery.py
@@ -168,6 +168,47 @@ def test_persist_delegation_delivery_appends_delivery_row(tmp_path):
     assert meta["duration_seconds"] == 12.5
 
 
+def test_persist_delegation_delivery_follows_rollover_tip_and_replay_is_once(tmp_path):
+    """A completion addressed to an ended API parent belongs on its live child."""
+    from pathlib import Path
+
+    from gateway.wake import persist_delegation_delivery
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=Path(tmp_path) / "state.db")
+    parent = "api-parent"
+    child = "api-child"
+    db.create_session(parent, source="api_server")
+    db.append_message(parent, "user", content="before rollover")
+    db.end_session(parent, "compression")
+    db.create_session(child, source="api_server", parent_session_id=parent)
+    db.append_message(child, "assistant", content="continued after rollover")
+    assert db.resolve_resume_session_id(parent) == child
+
+    class DbAdapter(ApiServerLikeAdapter):
+        def _ensure_session_db(self):
+            return db
+
+    evt = {"delegation_id": "deleg_rollover", "results": [{"status": "completed"}]}
+    for _ in range(2):
+        asyncio.run(persist_delegation_delivery(
+            DbAdapter(), text="[ASYNC DELEGATION BATCH COMPLETE]",
+            session_id=parent, evt=evt,
+        ))
+
+    parent_deliveries = [
+        row for row in db.get_messages(parent)
+        if row["display_kind"] == "async_delegation_complete"
+    ]
+    child_deliveries = [
+        row for row in db.get_messages(child)
+        if row["display_kind"] == "async_delegation_complete"
+    ]
+    assert parent_deliveries == []
+    assert len(child_deliveries) == 1
+    assert child_deliveries[0]["display_metadata"]["delegation_id"] == "deleg_rollover"
+
+
 def test_persist_delegation_delivery_raises_without_db():
     """DB unavailable must RAISE so the durable claim is released for retry."""
     from gateway.wake import persist_delegation_delivery

--- a/tests/hermes_state/test_doctor_recovery_integration.py
+++ b/tests/hermes_state/test_doctor_recovery_integration.py
@@ -1,0 +1,157 @@
+"""End-to-end Stage 2A: doctor arms recovery, core consumes it, doctor verifies.
+
+This is the seam the two halves of Epic 5 meet at. The doctor never ends a
+live session itself — it only arms ``_turn_boundary_rollover_pending`` with a
+recovery key — so the contract that matters is that the *installed core*
+consumes exactly that marker and produces a continuation the doctor can then
+read back by the same key.
+"""
+
+import importlib.util
+import json
+import os
+from pathlib import Path
+import pwd
+import sys
+
+import pytest
+
+from hermes_state import SessionDB
+from session_rollover import RECOVERY_END_REASON, TurnBoundaryRollover
+
+
+def _doctor_path() -> Path:
+    """Locate the ops script without trusting the test sandbox's HOME.
+
+    conftest rewires HOME/HERMES_HOME to a tempdir, so ``Path.home()`` points
+    at the sandbox. The real account home comes from the password database.
+    """
+    override = os.environ.get("HERMES_SESSION_DOCTOR", "").strip()
+    if override:
+        return Path(override)
+    return (
+        Path(pwd.getpwuid(os.getuid()).pw_dir)
+        / ".hermes" / "scripts" / "hermes-session-doctor.py"
+    )
+
+
+DOCTOR = _doctor_path()
+
+
+def load_doctor():
+    if not DOCTOR.exists():  # pragma: no cover - local ops script only
+        pytest.skip(f"doctor script not installed at {DOCTOR}")
+    spec = importlib.util.spec_from_file_location("hermes_session_doctor", DOCTOR)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+# The exact incident counters (12h, 1,123 calls, 142,130,176 cache-read,
+# 16 compactions, iteration budget exhausted).
+INCIDENT_LIFECYCLE = {
+    "state": "draining",
+    "state_entered_at": 1_000.0,
+    "last_progress_at": 1_000.0,
+    "updated_at": 1_000.0,
+    "context_utilization": 0.74,
+    "remaining_context_tokens": 70_000,
+    "reserved_headroom_tokens": 36_000,
+    "remaining_iterations": 0,
+    "in_flight_workers": 0,
+    "active_tool_call": False,
+    "api_calls": 1_123,
+    "cache_read_tokens": 142_130_176,
+    "compactions": 16,
+}
+
+
+def test_doctor_request_is_consumed_by_core_and_reads_back_as_recovered(tmp_path: Path):
+    doctor = load_doctor()
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    db.create_session(
+        "stalled", source="cli", session_key="tui:1", model_config={
+            "provider": "openrouter",
+            "turn_boundary_lifecycle": dict(INCIDENT_LIFECYCLE),
+        },
+    )
+    db.append_message("stalled", "user", "long running integration")
+
+    # 1. No blockers: nothing risky is in flight.
+    assert doctor.recovery_blockers(db_path, "stalled", now=5_000.0) == []
+
+    # 2. The doctor requests exactly one rollover; a second request is a no-op.
+    first = doctor.recover_stalled_session(
+        db_path, "stalled", label="Oh My Feed", idempotency_key="k1",
+        core_supported=True, dry_run=False,
+    )
+    second = doctor.recover_stalled_session(
+        db_path, "stalled", label="Oh My Feed", idempotency_key="k2",
+        core_supported=True, dry_run=False,
+    )
+    assert first.status == "armed"
+    assert second.status == "already_armed"
+
+    # 3. Read-back before the core has acted is pending, never an alert.
+    early = doctor.verify_recovery_readback(
+        db_path, "stalled", "k1", [], now=5_000.0, deadline_seconds=1_800
+    )
+    assert early.status == "pending"
+    assert early.issue is None
+
+    # 4. The CORE consumes the doctor's marker at its next turn boundary.
+    db = SessionDB(db_path=db_path)
+    child = TurnBoundaryRollover(db).adopt_at_turn_boundary("stalled", active_work=False)
+    assert child
+
+    old = db.get_session("stalled")
+    assert old is not None and old["end_reason"] == RECOVERY_END_REASON
+    child_row = db.get_session(child)
+    assert child_row is not None
+    child_config = json.loads(child_row["model_config"])
+    # Runtime settings survive; the consumed marker does not.
+    assert child_config["provider"] == "openrouter"
+    assert "_turn_boundary_rollover_pending" not in child_config
+    assert child_config["turn_boundary_handoff"]["recovery_key"] == "k1"
+    assert db.get_messages_as_conversation(child) == []
+
+    # 5. The doctor now verifies all three read-back conditions.
+    agents = [{
+        "agent_status": "working",
+        "agent_session": {"value": child},
+        "pane_id": "w1T:p1",
+    }]
+    result = doctor.verify_recovery_readback(
+        db_path, "stalled", "k1", agents, now=6_000.0, deadline_seconds=1_800
+    )
+    assert result.status == "recovered"
+    assert result.continuation_session_id == child
+    assert result.evidence["old_end_reason"] == RECOVERY_END_REASON
+    assert result.evidence["new_session_status"] == "working"
+    assert result.issue is None
+
+    # 6. A second adoption cannot produce a duplicate continuation.
+    assert TurnBoundaryRollover(db).adopt_at_turn_boundary(
+        "stalled", active_work=False
+    ) is None
+
+
+def test_doctor_holds_off_while_the_core_still_has_active_work(tmp_path: Path):
+    doctor = load_doctor()
+    db_path = tmp_path / "state.db"
+    db = SessionDB(db_path=db_path)
+    lifecycle = dict(INCIDENT_LIFECYCLE, active_tool_call=True)
+    db.create_session("busy", source="cli", model_config={
+        "turn_boundary_lifecycle": lifecycle
+    })
+
+    blockers = doctor.recovery_blockers(db_path, "busy", now=5_000.0)
+
+    assert "실행 중 tool call" in blockers
+    # A blocked session is never armed, so the core sees no pending marker.
+    row = db.get_session("busy")
+    assert row is not None
+    assert "_turn_boundary_rollover_pending" not in json.loads(row["model_config"])

--- a/tests/hermes_state/test_doctor_recovery_integration.py
+++ b/tests/hermes_state/test_doctor_recovery_integration.py
@@ -68,8 +68,12 @@ INCIDENT_LIFECYCLE = {
 }
 
 
-def test_doctor_request_is_consumed_by_core_and_reads_back_as_recovered(tmp_path: Path):
+def test_doctor_request_is_consumed_by_core_and_reads_back_as_recovered(monkeypatch, tmp_path: Path):
     doctor = load_doctor()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
     db_path = tmp_path / "state.db"
     db = SessionDB(db_path=db_path)
     db.create_session(

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -4,7 +4,12 @@ import json
 from pathlib import Path
 
 from hermes_state import SessionDB
-from session_rollover import RolloverPolicy, TurnBoundaryRollover
+from session_rollover import (
+    RolloverPolicy,
+    TurnBoundaryRollover,
+    consume_handoff_note,
+    mark_completed_turn,
+)
 
 
 def test_rollover_is_pending_until_a_safe_next_turn_then_preserves_lineage(
@@ -94,3 +99,130 @@ def test_adoption_is_exactly_once_and_preserves_gateway_identity(tmp_path: Path)
         "cwd": "/project", "profile_name": "default",
     }
     assert db.get_messages_as_conversation(child) == []
+
+
+def test_child_preserves_parent_runtime_config_but_consumes_pending_marker(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    parent_config = {
+        "provider": "openrouter",
+        "base_url": "https://example.invalid/v1",
+        "api_mode": "responses",
+        "reasoning_effort": "high",
+        "request_timeout": 91,
+        "gateway_runtime": {"profile": "nightly"},
+        "yolo": True,
+    }
+    db.create_session("old", source="acp", model="provider/model", model_config=parent_config)
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=10)
+
+    child = rollover.adopt_at_turn_boundary("old", active_work=False)
+    assert child
+
+    child_row = db.get_session(child)
+    assert child_row is not None
+    child_config = json.loads(child_row["model_config"])
+    for key, value in parent_config.items():
+        assert child_config[key] == value
+    assert "_turn_boundary_rollover_pending" not in child_config
+    assert child_config["turn_boundary_handoff"]["previous_session_id"] == "old"
+
+
+def test_mark_pending_merges_without_clobbering_concurrent_model_mutation(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli", model_config={"provider": "first"})
+    original_patch = db.patch_session_model_config
+
+    def patch_with_concurrent_change(session_id, patch):
+        original_patch(session_id, {"reasoning_effort": "xhigh", "yolo": True})
+        original_patch(session_id, patch)
+
+    db.patch_session_model_config = patch_with_concurrent_change
+    assert TurnBoundaryRollover(db).mark_pending("old", threshold_tokens=10)
+    row = db.get_session("old")
+    assert row is not None
+    config = json.loads(row["model_config"])
+    assert config["provider"] == "first"
+    assert config["reasoning_effort"] == "xhigh"
+    assert config["yolo"] is True
+    assert config["_turn_boundary_rollover_pending"]["threshold_tokens"] == 10
+
+
+def test_completed_turn_never_arms_after_final_persistence_failure(monkeypatch, tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli")
+
+    class Agent:
+        session_id = "old"
+        _session_db = db
+        context_compressor = type("Compressor", (), {
+            "context_length": 1000,
+            "threshold_tokens": 900,
+            "last_prompt_tokens": 800,
+        })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    result = {"completed": True, "cleanup_errors": ["persist_session: disk full"]}
+    assert mark_completed_turn(Agent(), result) is False
+    row = db.get_session("old")
+    assert row is not None
+    assert "_turn_boundary_rollover_pending" not in json.loads(row["model_config"] or "{}")
+
+
+def test_completed_turn_reloads_active_profile_policy_and_live_fallback_budget(monkeypatch, tmp_path: Path) -> None:
+    """No default-profile snapshot or pre-fallback window may arm a rollover."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("active-profile", source="cli")
+
+    class Agent:
+        session_id = "active-profile"
+        _session_db = db
+        context_compressor = type("Compressor", (), {
+            "context_length": 2000,
+            "threshold_tokens": 1800,
+            "last_prompt_tokens": 1600,
+        })()
+
+    agent = Agent()
+    active_profile = {"session_rollover": {"enabled": True, "ratio": 0.75}}
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: active_profile)
+    assert mark_completed_turn(agent, {"completed": True})
+
+    # The fallback's smaller live window now resolves to a new trigger and its
+    # active-profile policy disables the next boundary rather than reusing the
+    # first call's default config/window.
+    row = db.get_session("active-profile")
+    assert row is not None
+    db.patch_session_model_config("active-profile", {"_turn_boundary_rollover_pending": None})
+    active_profile["session_rollover"] = {"enabled": False, "ratio": 0.75}
+    agent.context_compressor = type("FallbackCompressor", (), {
+        "context_length": 800,
+        "threshold_tokens": 700,
+        "last_prompt_tokens": 650,
+    })()
+    assert mark_completed_turn(agent, {"completed": True}) is False
+    row = db.get_session("active-profile")
+    assert row is not None
+    assert "_turn_boundary_rollover_pending" not in json.loads(row["model_config"] or "{}")
+
+
+def test_handoff_note_is_visible_once_without_transcript_message(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli")
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=10)
+    child = rollover.adopt_at_turn_boundary("old", active_work=False)
+    assert child
+    agent = type("Agent", (), {"_session_db": db, "session_id": child})()
+
+    first = consume_handoff_note(agent)
+    assert "old" in first
+    assert "session_search" in first
+    assert consume_handoff_note(agent) == ""
+    assert db.get_messages_as_conversation(child) == []
+    row = db.get_session(child)
+    assert row is not None
+    assert "turn_boundary_handoff" not in json.loads(row["model_config"] or "{}")

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -6,6 +6,8 @@ from pathlib import Path
 
 from hermes_state import SessionDB
 from session_rollover import (
+    END_REASON,
+    RECOVERY_END_REASON,
     RolloverPolicy,
     TurnBoundaryRollover,
     allows_new_work,
@@ -14,6 +16,173 @@ from session_rollover import (
     mark_completed_turn,
 )
 from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
+
+
+# The exact production incident, session ``20260903_112822_b3a7b6``. These
+# numbers are the regression fixture for Stage 2A recovery: 12h wall clock,
+# 1,123 API calls, 142,130,176 cache-read tokens, 16 terminal compactions and
+# an exhausted iteration budget.
+OH_MY_FEED_INCIDENT = {
+    "elapsed_seconds": 12 * 3600,
+    "api_calls": 1_123,
+    "cache_read_tokens": 142_130_176,
+    "compactions": 16,
+    "max_iterations": 150,
+    "iterations_used": 150,
+}
+
+
+def test_oh_my_feed_incident_fixture_drains_on_iteration_closeout_reserve() -> None:
+    """The exact incident counters must drain via the relative budget only."""
+    incident = LifecycleBudget(
+        context_window_tokens=272_000,
+        # Context alone is still comfortable; the closeout reserve is what
+        # must stop new work, so the fixture cannot pass by accident.
+        prompt_tokens=120_000,
+        reserved_output_tokens=16_000,
+        reserved_tool_result_tokens=12_000,
+        reserved_checkpoint_tokens=8_000,
+        max_iterations=OH_MY_FEED_INCIDENT["max_iterations"],
+        iterations_used=OH_MY_FEED_INCIDENT["iterations_used"],
+        api_calls=OH_MY_FEED_INCIDENT["api_calls"],
+        cache_read_tokens=OH_MY_FEED_INCIDENT["cache_read_tokens"],
+        compactions=OH_MY_FEED_INCIDENT["compactions"],
+        in_flight_workers=2,
+        closeout_iterations=2,
+    )
+
+    decision = evaluate_lifecycle(incident)
+
+    assert decision.state is LifecycleState.DRAINING
+    assert decision.remaining_iterations == 0
+    assert decision.reserved_headroom_tokens == 36_000
+    # 142M cache-read and 16 compactions are evidence, never the rule: with a
+    # fresh iteration budget the very same counters stay healthy.
+    assert evaluate_lifecycle(replace(incident, iterations_used=1)).state is LifecycleState.HEALTHY
+
+
+def test_completed_turn_records_recovery_status_without_arming_a_rollover(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A healthy turn must still publish the fields doctor recovery reads."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("live", source="cli")
+
+    class Agent:
+        session_id = "live"
+        _session_db = db
+        _executing_tools = False
+        _active_children = ()
+        max_iterations = 150
+        context_compressor = type("Compressor", (), {
+            "context_length": 272_000,
+            "threshold_tokens": 250_000,
+            "last_prompt_tokens": 10_000,
+        })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    assert mark_completed_turn(Agent(), {"completed": True, "api_calls": 3}) is False
+
+    config = json.loads(db.get_session("live")["model_config"] or "{}")
+    assert "_turn_boundary_rollover_pending" not in config
+    status = config["turn_boundary_lifecycle"]
+    assert status["state"] == "healthy"
+    assert status["reserved_headroom_tokens"] == 0
+    assert status["in_flight_workers"] == 0
+    assert status["active_tool_call"] is False
+    assert status["context_utilization"] == 10_000 / 272_000
+    assert status["last_progress_at"] >= status["state_entered_at"] > 0
+
+
+def test_stalled_turn_does_not_advance_last_meaningful_progress(
+    monkeypatch, tmp_path: Path
+) -> None:
+    """A completed turn that did no API work must not look like progress."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("live", source="cli")
+
+    class Agent:
+        session_id = "live"
+        _session_db = db
+        max_iterations = 150
+        context_compressor = type("Compressor", (), {
+            "context_length": 272_000,
+            "threshold_tokens": 250_000,
+            "last_prompt_tokens": 10_000,
+        })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    agent = Agent()
+    mark_completed_turn(agent, {"completed": True, "api_calls": 4})
+    first = json.loads(db.get_session("live")["model_config"])["turn_boundary_lifecycle"]
+
+    mark_completed_turn(agent, {"completed": True, "api_calls": 0})
+    second = json.loads(db.get_session("live")["model_config"])["turn_boundary_lifecycle"]
+
+    assert second["last_progress_at"] == first["last_progress_at"]
+    assert second["updated_at"] >= first["updated_at"]
+
+
+def test_doctor_recovery_request_is_idempotent_and_ends_with_explicit_reason(
+    tmp_path: Path,
+) -> None:
+    """Exactly one rollover per idempotency key, with a doctor-specific reason."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stalled", source="cli")
+    rollover = TurnBoundaryRollover(db)
+
+    assert rollover.request_recovery("stalled", idempotency_key="k1") == "armed"
+    assert rollover.request_recovery("stalled", idempotency_key="k1") == "already_armed"
+    assert rollover.request_recovery("stalled", idempotency_key="k2") == "already_armed"
+
+    child = rollover.adopt_at_turn_boundary("stalled", active_work=False)
+    assert child
+    old = db.get_session("stalled")
+    assert old["end_reason"] == RECOVERY_END_REASON
+    handoff = json.loads(db.get_session(child)["model_config"])["turn_boundary_handoff"]
+    assert handoff["previous_session_id"] == "stalled"
+    assert handoff["recovery_key"] == "k1"
+    # The consumed request cannot arm a second continuation.
+    assert rollover.adopt_at_turn_boundary("stalled", active_work=False) is None
+
+
+def test_recovery_request_preserves_runtime_config_and_refuses_ended_sessions(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("live", source="cli", model_config={"provider": "openrouter"})
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.request_recovery("live", idempotency_key="k1") == "armed"
+    config = json.loads(db.get_session("live")["model_config"])
+    assert config["provider"] == "openrouter"
+    assert config["_turn_boundary_rollover_pending"]["recovery_key"] == "k1"
+
+    db.create_session("done", source="cli")
+    db.end_session("done", "user_exit")
+    assert rollover.request_recovery("done", idempotency_key="k1") is None
+    assert rollover.request_recovery("missing", idempotency_key="k1") is None
+
+
+def test_core_armed_rollover_keeps_the_plain_turn_boundary_end_reason(
+    tmp_path: Path,
+) -> None:
+    """Stage 1's own drain must stay distinguishable from doctor recovery."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli")
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=10)
+
+    child = rollover.adopt_at_turn_boundary("old", active_work=False)
+    assert child
+    assert db.get_session("old")["end_reason"] == END_REASON
+    handoff = json.loads(db.get_session(child)["model_config"])["turn_boundary_handoff"]
+    assert "recovery_key" not in handoff
 
 
 def test_oh_my_feed_runaway_fixture_drains_on_relative_budget_before_exhaustion() -> None:

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -261,10 +261,10 @@ def test_rollover_is_pending_until_a_safe_next_turn_then_preserves_lineage(
     new = db.get_session(new_session_id)
     assert old["end_reason"] == "turn_boundary_rollover"
     assert new["parent_session_id"] == "old"
-    assert json.loads(new["model_config"])["turn_boundary_handoff"] == {
-        "previous_session_id": "old",
-        "recovery": "Use session_search to recover earlier details if needed.",
-    }
+    handoff = json.loads(new["model_config"])["turn_boundary_handoff"]
+    assert handoff["previous_session_id"] == "old"
+    assert handoff["recovery"] == "Use session_search to recover earlier details if needed."
+    assert handoff["idempotency_key"].startswith("turn-boundary:")
     assert db.get_messages_as_conversation(new_session_id) == []
 
 
@@ -356,6 +356,108 @@ def test_child_preserves_parent_runtime_config_but_consumes_pending_marker(tmp_p
         assert child_config[key] == value
     assert "_turn_boundary_rollover_pending" not in child_config
     assert child_config["turn_boundary_handoff"]["previous_session_id"] == "old"
+
+
+def test_adopted_child_starts_admissible_without_inheriting_parent_drain(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "old",
+        source="cli",
+        model_config={
+            "provider": "openrouter",
+            "turn_boundary_lifecycle": {"state": "draining"},
+        },
+    )
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=10)
+
+    child = rollover.adopt_at_turn_boundary("old", active_work=False)
+
+    assert child
+    child_config = json.loads(db.get_session(child)["model_config"])
+    assert child_config["provider"] == "openrouter"
+    assert child_config["turn_boundary_lifecycle"]["state"] == "healthy"
+    child_agent = type("Agent", (), {"_session_db": db, "session_id": child})()
+    assert allows_new_work(child_agent) is True
+    assert allows_new_delegation(child_agent) is True
+
+
+def test_disabled_policy_does_not_publish_a_draining_lifecycle(monkeypatch, tmp_path: Path) -> None:
+    """Opt-in rollover cannot change admission or doctor state while disabled."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("live", source="cli")
+
+    class Agent:
+        session_id = "live"
+        _session_db = db
+        max_iterations = 1
+        context_compressor = type("Compressor", (), {
+            "context_length": 272_000,
+            "threshold_tokens": 250_000,
+            "last_prompt_tokens": 2_000,
+        })()
+
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"session_rollover": {"enabled": False}})
+    assert mark_completed_turn(Agent(), {"completed": True, "api_calls": 1}) is False
+
+    config = json.loads(db.get_session("live")["model_config"] or "{}")
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+
+
+def test_rollover_reasons_resolve_to_the_child_tip_and_preserve_arm_identity(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("core", source="cli")
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("core", threshold_tokens=10)
+
+    child = rollover.adopt_at_turn_boundary("core", active_work=False)
+
+    assert child
+    parent_config = json.loads(db.get_session("core")["model_config"])
+    child_config = json.loads(db.get_session(child)["model_config"])
+    assert parent_config["_turn_boundary_rollover_pending"]["idempotency_key"]
+    assert child_config["turn_boundary_handoff"]["idempotency_key"] == parent_config["_turn_boundary_rollover_pending"]["idempotency_key"]
+    assert db.get_compression_tip("core") == child
+    assert db.resolve_resume_session_id("core") == child
+
+
+def test_core_checkpoint_carries_available_result_evidence(monkeypatch, tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli", cwd=str(tmp_path))
+
+    class Agent:
+        session_id = "old"
+        _session_db = db
+        cwd = str(tmp_path)
+        current_goal = "close review blockers"
+        context_compressor = type("Compressor", (), {
+            "context_length": 1_000,
+            "threshold_tokens": 900,
+            "last_prompt_tokens": 800,
+        })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
+    assert mark_completed_turn(Agent(), {
+        "completed": True,
+        "api_calls": 1,
+        "verification_evidence": ["pytest tests/hermes_state: passed"],
+        "result_pointers": ["artifact://review/42"],
+        "external_effects": ["local commit created"],
+        "external_readback": ["git status clean"],
+    })
+
+    config = json.loads(db.get_session("old")["model_config"])
+    checkpoint = config["turn_boundary_lifecycle"]["checkpoint"]
+    assert checkpoint["goal"] == "close review blockers"
+    assert checkpoint["worktree"] == str(tmp_path)
+    assert checkpoint["verification_evidence"] == ["pytest tests/hermes_state: passed"]
+    assert checkpoint["result_pointers"] == ["artifact://review/42"]
+    assert checkpoint["external_effects"] == ["local commit created"]
+    assert checkpoint["external_readback"] == ["git status clean"]
 
 
 def test_mark_pending_merges_without_clobbering_concurrent_model_mutation(tmp_path: Path) -> None:

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -9,6 +9,7 @@ from session_rollover import (
     RolloverPolicy,
     TurnBoundaryRollover,
     allows_new_work,
+    allows_new_delegation,
     consume_handoff_note,
     mark_completed_turn,
 )
@@ -50,6 +51,26 @@ def test_draining_parent_refuses_new_work_but_not_completion_delivery(tmp_path: 
     agent = type("Agent", (), {"_session_db": db, "session_id": "parent"})()
 
     assert allows_new_work(agent) is False
+    assert allows_new_delegation(agent) is False
+
+
+def test_checkpoint_captures_repo_and_result_evidence_without_non_repo_git(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    non_repo = tmp_path / "not-a-repo"
+    non_repo.mkdir()
+    db.create_session("parent", source="cli", cwd=str(non_repo))
+    agent = type("Agent", (), {"_session_db": db, "session_id": "parent", "cwd": str(non_repo)})()
+    rollover = TurnBoundaryRollover(db)
+
+    assert rollover.mark_pending(
+        "parent", threshold_tokens=10,
+        lifecycle={"state": "draining", "checkpoint": {"verification_evidence": ["tests/x"]}},
+    )
+    payload = json.loads(db.get_session("parent")["model_config"])["turn_boundary_lifecycle"]["checkpoint"]
+    assert payload["worktree"] == str(non_repo)
+    assert payload["branch"] is None
+    assert payload["head"] is None
+    assert payload["verification_evidence"] == ["tests/x"]
 
 
 def test_rollover_is_pending_until_a_safe_next_turn_then_preserves_lineage(

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -5,6 +5,8 @@ from dataclasses import replace
 from pathlib import Path
 import threading
 
+import pytest
+
 from hermes_state import SessionDB
 from session_rollover import (
     END_REASON,
@@ -17,6 +19,15 @@ from session_rollover import (
     mark_completed_turn,
 )
 from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
+
+
+@pytest.fixture(autouse=True)
+def enabled_rollover_policy(monkeypatch):
+    """Direct persistence tests model an arm created while the opt-in is enabled."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
 
 
 # The exact production incident, session ``20260903_112822_b3a7b6``. These
@@ -451,6 +462,128 @@ def test_disabled_policy_does_not_publish_a_draining_lifecycle(monkeypatch, tmp_
     monkeypatch.setattr("hermes_cli.config.load_config", lambda: {"session_rollover": {"enabled": False}})
     assert mark_completed_turn(Agent(), {"completed": True, "api_calls": 1}) is False
 
+    config = json.loads(db.get_session("live")["model_config"] or "{}")
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+
+
+def test_disabling_after_an_arm_cancels_it_before_adoption_and_reopens_admission(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Regression for the independent review's exact disabled-after-arm trace."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("live", source="cli")
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending(
+        "live", threshold_tokens=10, lifecycle={"state": "draining"},
+    )
+    agent = type("Agent", (), {
+        "session_id": "live", "_session_db": db,
+        "context_compressor": type("Compressor", (), {
+            "context_length": 1_000, "threshold_tokens": 900, "last_prompt_tokens": 800,
+        })(),
+    })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": False}},
+    )
+    assert mark_completed_turn(agent, {"completed": True, "api_calls": 1}) is False
+    config = json.loads(db.get_session("live")["model_config"] or "{}")
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+    assert rollover.adopt_at_turn_boundary("live", active_work=False) is None
+    assert db.get_session("live")["end_reason"] is None
+
+    db.create_session(
+        "stale", source="cli",
+        model_config={"turn_boundary_lifecycle": {"state": "draining"}},
+    )
+    stale = type("Agent", (), {"session_id": "stale", "_session_db": db})()
+    assert allows_new_work(stale) is True
+    assert allows_new_delegation(stale) is True
+    assert "turn_boundary_lifecycle" not in json.loads(
+        db.get_session("stale")["model_config"] or "{}"
+    )
+
+
+def test_disabled_cleanup_preserves_concurrent_unrelated_model_config(tmp_path: Path) -> None:
+    """Cancellation is one merge transaction and cannot clobber runtime settings."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "live", source="cli", model_config={
+            "provider": "openrouter",
+            "_turn_boundary_rollover_pending": {"threshold_tokens": 10},
+            "turn_boundary_lifecycle": {"state": "draining"},
+        },
+    )
+    start = threading.Barrier(2)
+
+    def mutate_runtime_config() -> None:
+        start.wait()
+        db.patch_session_model_config("live", {"reasoning_effort": "xhigh", "yolo": True})
+
+    writer = threading.Thread(target=mutate_runtime_config)
+    writer.start()
+    start.wait()
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": False}},
+    )
+    try:
+        assert TurnBoundaryRollover(db).adopt_at_turn_boundary("live", active_work=False) is None
+    finally:
+        monkeypatch.undo()
+    writer.join()
+
+    config = json.loads(db.get_session("live")["model_config"] or "{}")
+    assert config["provider"] == "openrouter"
+    assert config["reasoning_effort"] == "xhigh"
+    assert config["yolo"] is True
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+
+
+def test_enabled_policy_marker_fences_without_reloading_config(monkeypatch, tmp_path: Path) -> None:
+    """Tool admission uses the persisted decision, not config I/O on every call."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "draining", source="cli", model_config={
+            "turn_boundary_lifecycle": {"state": "draining"},
+            "_turn_boundary_rollover_policy": {"enabled": True},
+        },
+    )
+    agent = type("Agent", (), {"session_id": "draining", "_session_db": db})()
+    calls = 0
+
+    def unexpected_config_read():
+        nonlocal calls
+        calls += 1
+        raise AssertionError("admission reloaded config")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", unexpected_config_read)
+    assert allows_new_work(agent) is False
+    assert allows_new_delegation(agent) is False
+    assert calls == 0
+
+
+def test_disabled_policy_refuses_and_cleans_new_rollover_arms(monkeypatch, tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "live", source="cli", model_config={
+            "_turn_boundary_rollover_pending": {"threshold_tokens": 10},
+            "turn_boundary_lifecycle": {"state": "draining"},
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": False}},
+    )
+
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("live", threshold_tokens=10) is False
+    assert rollover.request_recovery("live", idempotency_key="doctor") is None
     config = json.loads(db.get_session("live")["model_config"] or "{}")
     assert "_turn_boundary_rollover_pending" not in config
     assert "turn_boundary_lifecycle" not in config

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -1,15 +1,55 @@
 """Turn-boundary fresh-session rollover persists a compact recovery pointer."""
 
 import json
+from dataclasses import replace
 from pathlib import Path
 
 from hermes_state import SessionDB
 from session_rollover import (
     RolloverPolicy,
     TurnBoundaryRollover,
+    allows_new_work,
     consume_handoff_note,
     mark_completed_turn,
 )
+from agent.session_lifecycle import LifecycleBudget, LifecycleState, evaluate_lifecycle
+
+
+def test_oh_my_feed_runaway_fixture_drains_on_relative_budget_before_exhaustion() -> None:
+    """The incident must reserve closeout work without an absolute token cap."""
+    incident = LifecycleBudget(
+        context_window_tokens=272_000,
+        prompt_tokens=201_000,
+        reserved_output_tokens=16_000,
+        reserved_tool_result_tokens=12_000,
+        reserved_checkpoint_tokens=8_000,
+        max_iterations=150,
+        iterations_used=148,
+        api_calls=1_123,
+        cache_read_tokens=142_130_176,
+        compactions=16,
+        in_flight_workers=2,
+        closeout_iterations=2,
+    )
+
+    decision = evaluate_lifecycle(incident)
+
+    assert decision.state is LifecycleState.DRAINING
+    assert decision.accept_new_tools is False
+    assert decision.accept_new_delegations is False
+    assert decision.allow_in_flight_completion is True
+    assert decision.context_utilization == 201_000 / 272_000
+    # High historical counters are observability evidence, not a rollover rule.
+    assert evaluate_lifecycle(replace(incident, api_calls=0, cache_read_tokens=0)).state is LifecycleState.DRAINING
+
+
+def test_draining_parent_refuses_new_work_but_not_completion_delivery(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("parent", source="cli")
+    db.patch_session_model_config("parent", {"turn_boundary_lifecycle": {"state": "draining"}})
+    agent = type("Agent", (), {"_session_db": db, "session_id": "parent"})()
+
+    assert allows_new_work(agent) is False
 
 
 def test_rollover_is_pending_until_a_safe_next_turn_then_preserves_lineage(
@@ -52,7 +92,7 @@ def test_ratio_policy_resolves_every_window_and_stays_below_compression() -> Non
     assert policy.resolve(context_length=900_000, compression_threshold=850_000) == 675_000
 
 
-def test_policy_re_resolves_on_model_switch_and_expert_cap_never_crosses_compression() -> None:
+def test_policy_re_resolves_on_model_switch_without_fixed_token_decision() -> None:
     policy = RolloverPolicy.from_config(
         {
             "enabled": True,
@@ -62,7 +102,7 @@ def test_policy_re_resolves_on_model_switch_and_expert_cap_never_crosses_compres
         }
     )
 
-    assert policy.resolve(context_length=900_000, compression_threshold=810_000) == 800_000
+    assert policy.resolve(context_length=900_000, compression_threshold=810_000) == 808_000
     assert policy.resolve(context_length=272_000, compression_threshold=230_000) == 228_000
 
 

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -1,0 +1,96 @@
+"""Turn-boundary fresh-session rollover persists a compact recovery pointer."""
+
+import json
+from pathlib import Path
+
+from hermes_state import SessionDB
+from session_rollover import RolloverPolicy, TurnBoundaryRollover
+
+
+def test_rollover_is_pending_until_a_safe_next_turn_then_preserves_lineage(
+    tmp_path: Path,
+) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli")
+    db.append_message("old", "user", "first request")
+    db.append_message("old", "assistant", "first answer")
+
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=159_000) is True
+    assert rollover.adopt_at_turn_boundary("old", active_work=True) is None
+
+    new_session_id = rollover.adopt_at_turn_boundary("old", active_work=False)
+
+    assert new_session_id
+    old = db.get_session("old")
+    new = db.get_session(new_session_id)
+    assert old["end_reason"] == "turn_boundary_rollover"
+    assert new["parent_session_id"] == "old"
+    assert json.loads(new["model_config"])["turn_boundary_handoff"] == {
+        "previous_session_id": "old",
+        "recovery": "Use session_search to recover earlier details if needed.",
+    }
+    assert db.get_messages_as_conversation(new_session_id) == []
+
+
+def test_ratio_policy_resolves_every_window_and_stays_below_compression() -> None:
+    policy = RolloverPolicy.from_config(
+        {
+            "enabled": True,
+            "ratio": 0.75,
+            "safety_margin_tokens": 1_000,
+        }
+    )
+
+    assert policy.resolve(context_length=32_000, compression_threshold=28_000) == 24_000
+    assert policy.resolve(context_length=272_000, compression_threshold=250_000) == 204_000
+    assert policy.resolve(context_length=900_000, compression_threshold=850_000) == 675_000
+
+
+def test_policy_re_resolves_on_model_switch_and_expert_cap_never_crosses_compression() -> None:
+    policy = RolloverPolicy.from_config(
+        {
+            "enabled": True,
+            "ratio": 0.90,
+            "threshold_tokens": 800_000,
+            "safety_margin_tokens": 2_000,
+        }
+    )
+
+    assert policy.resolve(context_length=900_000, compression_threshold=810_000) == 800_000
+    assert policy.resolve(context_length=272_000, compression_threshold=230_000) == 228_000
+
+
+def test_disabled_policy_never_resolves_a_trigger() -> None:
+    assert RolloverPolicy.from_config({}).resolve(272_000, 240_000) is None
+
+
+def test_adoption_is_exactly_once_and_preserves_gateway_identity(tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "old",
+        source="telegram",
+        model="provider/model",
+        session_key="telegram:chat:1",
+        user_id="user",
+        chat_id="chat",
+        chat_type="dm",
+        thread_id="thread",
+        cwd="/project",
+        profile_name="default",
+    )
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending("old", threshold_tokens=10) is True
+
+    child = rollover.adopt_at_turn_boundary("old", active_work=False)
+    assert child
+    assert rollover.adopt_at_turn_boundary("old", active_work=False) is None
+
+    row = db.get_session(child)
+    assert row is not None
+    assert {key: row[key] for key in ("source", "model", "session_key", "user_id", "chat_id", "chat_type", "thread_id", "cwd", "profile_name")} == {
+        "source": "telegram", "model": "provider/model", "session_key": "telegram:chat:1",
+        "user_id": "user", "chat_id": "chat", "chat_type": "dm", "thread_id": "thread",
+        "cwd": "/project", "profile_name": "default",
+    }
+    assert db.get_messages_as_conversation(child) == []

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -784,3 +784,84 @@ def test_handoff_note_is_visible_once_without_transcript_message(tmp_path: Path)
     row = db.get_session(child)
     assert row is not None
     assert "turn_boundary_handoff" not in json.loads(row["model_config"] or "{}")
+
+
+def test_disabled_adoption_cleans_an_active_parent_without_ending_it(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """In-flight work delays adoption, never authoritative disabled cleanup."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "live", source="cli", model_config={
+            "provider": "openrouter",
+            "unrelated": {"keep": 1},
+        },
+    )
+    rollover = TurnBoundaryRollover(db)
+    assert rollover.mark_pending(
+        "live", threshold_tokens=10, lifecycle={"state": "draining"},
+    )
+    agent = type("Agent", (), {"session_id": "live", "_session_db": db})()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": False}},
+    )
+
+    assert rollover.adopt_at_turn_boundary("live", active_work=True) is None
+
+    row = db.get_session("live")
+    assert row is not None
+    assert row["ended_at"] is None
+    assert row["end_reason"] is None
+    config = json.loads(row["model_config"] or "{}")
+    assert config["provider"] == "openrouter"
+    assert config["unrelated"] == {"keep": 1}
+    assert config["_turn_boundary_rollover_policy"] == {"enabled": False}
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+    assert allows_new_work(agent) is True
+    assert allows_new_delegation(agent) is True
+
+
+def test_disabled_active_cleanup_preserves_concurrent_config_and_parent_lease(
+    monkeypatch, tmp_path: Path,
+) -> None:
+    """Disabled cleanup cannot clobber a concurrent write or move an active lease."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session(
+        "live", source="cli", model_config={
+            "provider": "openrouter",
+            "_turn_boundary_rollover_pending": {"threshold_tokens": 10},
+            "turn_boundary_lifecycle": {"state": "draining"},
+        },
+    )
+    holder = "pid=test:turn=active"
+    assert db.try_acquire_session_turn_lease("live", holder, ttl_seconds=5)
+    start = threading.Barrier(2)
+
+    def mutate_runtime_config() -> None:
+        start.wait()
+        db.patch_session_model_config("live", {"reasoning_effort": "xhigh", "yolo": True})
+
+    writer = threading.Thread(target=mutate_runtime_config)
+    writer.start()
+    start.wait()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": False}},
+    )
+    assert TurnBoundaryRollover(db).adopt_at_turn_boundary("live", active_work=True) is None
+    writer.join()
+
+    row = db.get_session("live")
+    assert row is not None
+    assert row["ended_at"] is None
+    config = json.loads(row["model_config"] or "{}")
+    assert config["provider"] == "openrouter"
+    assert config["reasoning_effort"] == "xhigh"
+    assert config["yolo"] is True
+    assert "_turn_boundary_rollover_pending" not in config
+    assert "turn_boundary_lifecycle" not in config
+    assert db.refresh_session_turn_lease("live", holder, ttl_seconds=5)
+    db.release_session_turn_lease("live", holder)

--- a/tests/hermes_state/test_turn_boundary_session_rollover.py
+++ b/tests/hermes_state/test_turn_boundary_session_rollover.py
@@ -3,6 +3,7 @@
 import json
 from dataclasses import replace
 from pathlib import Path
+import threading
 
 from hermes_state import SessionDB
 from session_rollover import (
@@ -97,6 +98,23 @@ def test_completed_turn_records_recovery_status_without_arming_a_rollover(
     assert status["last_progress_at"] >= status["state_entered_at"] > 0
 
 
+def test_zero_headroom_does_not_turn_closeout_iterations_into_a_fixed_drain() -> None:
+    """Ratio-only rollout must not fence a healthy low-usage 272K model."""
+    decision = evaluate_lifecycle(LifecycleBudget(
+        context_window_tokens=272_000,
+        prompt_tokens=2_000,
+        reserved_output_tokens=0,
+        reserved_tool_result_tokens=0,
+        reserved_checkpoint_tokens=0,
+        max_iterations=3,
+        iterations_used=1,
+        closeout_iterations=2,
+    ))
+
+    assert decision.state is LifecycleState.HEALTHY
+    assert decision.accept_new_tools is True
+
+
 def test_stalled_turn_does_not_advance_last_meaningful_progress(
     monkeypatch, tmp_path: Path
 ) -> None:
@@ -150,6 +168,39 @@ def test_doctor_recovery_request_is_idempotent_and_ends_with_explicit_reason(
     assert handoff["recovery_key"] == "k1"
     # The consumed request cannot arm a second continuation.
     assert rollover.adopt_at_turn_boundary("stalled", active_work=False) is None
+
+
+def test_concurrent_doctor_recovery_arms_one_key_and_child_binds_that_key(tmp_path: Path) -> None:
+    """The check-and-arm transition is one write transaction, not read/patch/reread."""
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("stalled", source="cli", model_config={"provider": "openrouter"})
+    start = threading.Barrier(3)
+    results: dict[str, str | None] = {}
+
+    def arm(key: str) -> None:
+        start.wait()
+        results[key] = TurnBoundaryRollover(db).request_recovery(
+            "stalled", idempotency_key=key,
+        )
+
+    first = threading.Thread(target=arm, args=("k1",))
+    second = threading.Thread(target=arm, args=("k2",))
+    first.start()
+    second.start()
+    start.wait()
+    first.join()
+    second.join()
+
+    winners = [key for key, outcome in results.items() if outcome == "armed"]
+    assert len(winners) == 1
+    winner = winners[0]
+    config = json.loads(db.get_session("stalled")["model_config"])
+    assert config["provider"] == "openrouter"
+    assert config["_turn_boundary_rollover_pending"]["recovery_key"] == winner
+    child = TurnBoundaryRollover(db).adopt_at_turn_boundary("stalled", active_work=False)
+    assert child
+    handoff = json.loads(db.get_session(child)["model_config"])["turn_boundary_handoff"]
+    assert handoff["recovery_key"] == winner
 
 
 def test_recovery_request_preserves_runtime_config_and_refuses_ended_sessions(
@@ -444,6 +495,8 @@ def test_core_checkpoint_carries_available_result_evidence(monkeypatch, tmp_path
     assert mark_completed_turn(Agent(), {
         "completed": True,
         "api_calls": 1,
+        "pending_workers": ["worker-1", "worker-2"],
+        "changed_files": ["session_rollover.py"],
         "verification_evidence": ["pytest tests/hermes_state: passed"],
         "result_pointers": ["artifact://review/42"],
         "external_effects": ["local commit created"],
@@ -451,26 +504,66 @@ def test_core_checkpoint_carries_available_result_evidence(monkeypatch, tmp_path
     })
 
     config = json.loads(db.get_session("old")["model_config"])
+    assert config["turn_boundary_lifecycle"]["in_flight_workers"] == 2
     checkpoint = config["turn_boundary_lifecycle"]["checkpoint"]
     assert checkpoint["goal"] == "close review blockers"
     assert checkpoint["worktree"] == str(tmp_path)
+    assert checkpoint["pending_workers"] == ["worker-1", "worker-2"]
+    assert checkpoint["changed_files"] == ["session_rollover.py"]
     assert checkpoint["verification_evidence"] == ["pytest tests/hermes_state: passed"]
     assert checkpoint["result_pointers"] == ["artifact://review/42"]
     assert checkpoint["external_effects"] == ["local commit created"]
     assert checkpoint["external_readback"] == ["git status clean"]
 
 
+def test_completed_turn_uses_turn_iterations_not_lineage_wide_api_calls(monkeypatch, tmp_path: Path) -> None:
+    db = SessionDB(db_path=tmp_path / "state.db")
+    db.create_session("old", source="cli")
+
+    class Agent:
+        session_id = "old"
+        _session_db = db
+        max_iterations = 3
+        context_compressor = type("Compressor", (), {
+            "context_length": 272_000,
+            "threshold_tokens": 250_000,
+            "last_prompt_tokens": 2_000,
+        })()
+
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {
+            "enabled": True, "ratio": 0.75,
+            "reserved_checkpoint_tokens": 1,
+        }},
+    )
+    assert mark_completed_turn(Agent(), {
+        "completed": True,
+        "turn_iterations": 0,
+        "api_calls": 1_123,
+    }) is False
+
+    status = json.loads(db.get_session("old")["model_config"])["turn_boundary_lifecycle"]
+    assert status["state"] == "healthy"
+    assert status["api_calls"] == 1_123
+
+
 def test_mark_pending_merges_without_clobbering_concurrent_model_mutation(tmp_path: Path) -> None:
     db = SessionDB(db_path=tmp_path / "state.db")
     db.create_session("old", source="cli", model_config={"provider": "first"})
-    original_patch = db.patch_session_model_config
+    start = threading.Barrier(2)
 
-    def patch_with_concurrent_change(session_id, patch):
-        original_patch(session_id, {"reasoning_effort": "xhigh", "yolo": True})
-        original_patch(session_id, patch)
+    def mutate_runtime_config() -> None:
+        start.wait()
+        db.patch_session_model_config(
+            "old", {"reasoning_effort": "xhigh", "yolo": True},
+        )
 
-    db.patch_session_model_config = patch_with_concurrent_change
+    writer = threading.Thread(target=mutate_runtime_config)
+    writer.start()
+    start.wait()
     assert TurnBoundaryRollover(db).mark_pending("old", threshold_tokens=10)
+    writer.join()
     row = db.get_session("old")
     assert row is not None
     config = json.loads(row["model_config"])

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from agent import relay_runtime
 from hermes_state import SessionDB
 from run_agent import AIAgent
+from session_rollover import TurnBoundaryRollover
 
 
 class _DB:
@@ -63,6 +64,10 @@ def _agent_with_db(db, *, session_id="stale-parent", platform="desktop"):
     agent._pending_redirect = None
     agent._execution_thread_id = None
     agent._interrupt_thread_signal_pending = False
+    agent._session_messages = []
+    agent._executing_tools = False
+    agent.__dict__["_active_children"] = []
+    agent.reset_session_state = lambda previous_messages=None, old_session_id=None, carry_over_context=False: None
     return agent
 
 
@@ -635,3 +640,75 @@ def test_flush_messages_to_session_db_fences_stale_holder_on_live_db(tmp_path):
     second.release_session_turn_lease("shared", next_holder)
     first.close()
     second.close()
+
+
+def test_cli_explicit_history_is_replaced_before_the_real_turn_prologue(monkeypatch, tmp_path):
+    """The CLI passes an explicit parent snapshot; it must never reach the child."""
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="cli")
+    db.append_message("parent", "user", "parent request")
+    db.append_message("parent", "assistant", "parent answer")
+    assert TurnBoundaryRollover(db).mark_pending("parent", threshold_tokens=10)
+    agent = _agent_with_db(db, session_id="parent", platform="cli")
+    observed = {}
+
+    def fake_run(live_agent, inbound, _system, history, *_args, **_kwargs):
+        observed.update(session_id=live_agent.session_id, inbound=inbound, history=history)
+        # This is the production handoff boundary: the loop owns the one inbound
+        # row, and callers must not provide it in history as well.
+        assert history == []
+        db.append_message(live_agent.session_id, "user", inbound)
+        return {"final_response": "ok", "messages": [{"role": "user", "content": inbound}]}
+
+    monkeypatch.setattr("agent.conversation_loop.run_conversation", fake_run)
+    result = AIAgent.run_conversation(
+        agent,
+        "fresh inbound",
+        conversation_history=[
+            {"role": "user", "content": "parent request"},
+            {"role": "assistant", "content": "parent answer"},
+        ],
+    )
+
+    child = agent.session_id
+    assert child != "parent"
+    assert observed == {"session_id": child, "inbound": "fresh inbound", "history": []}
+    assert result["messages"] == [{"role": "user", "content": "fresh inbound"}]
+    child_messages = db.get_messages_as_conversation(child)
+    assert [message["content"] for message in child_messages] == ["fresh inbound"]
+    assert len(child_messages) == 1
+    assert [message["content"] for message in db.get_messages_as_conversation("parent")] == [
+        "parent request",
+        "parent answer",
+    ]
+
+
+def test_adoption_transfers_the_held_lease_and_defers_for_active_work(monkeypatch, tmp_path):
+    db = SessionDB(tmp_path / "state.db")
+    db.create_session("parent", source="gateway")
+    assert TurnBoundaryRollover(db).mark_pending("parent", threshold_tokens=10)
+    agent = _agent_with_db(db, session_id="parent", platform="gateway")
+    agent._executing_tools = True
+    started = []
+    monkeypatch.setattr(
+        "agent.conversation_loop.run_conversation",
+        lambda live_agent, inbound, _system, history, *_args, **_kwargs: (
+            started.append((live_agent.session_id, inbound, history))
+            or {"final_response": "ok", "messages": history}
+        ),
+    )
+
+    AIAgent.run_conversation(agent, "deferred", conversation_history=[])
+    assert agent.session_id == "parent"
+    assert started == [("parent", "deferred", [])]
+    parent = db.get_session("parent")
+    assert parent is not None and parent["ended_at"] is None
+
+    agent._executing_tools = False
+    AIAgent.run_conversation(agent, "adopted", conversation_history=[])
+    child = agent.session_id
+    assert child != "parent"
+    # The successor can acquire immediately after the child turn releases. A
+    # parent-key release would leave the child lease stranded until TTL expiry.
+    assert db.try_acquire_session_turn_lease(child, "successor", ttl_seconds=5)
+    db.release_session_turn_lease(child, "successor")

--- a/tests/run_agent/test_cross_process_turn_lease.py
+++ b/tests/run_agent/test_cross_process_turn_lease.py
@@ -644,6 +644,10 @@ def test_flush_messages_to_session_db_fences_stale_holder_on_live_db(tmp_path):
 
 def test_cli_explicit_history_is_replaced_before_the_real_turn_prologue(monkeypatch, tmp_path):
     """The CLI passes an explicit parent snapshot; it must never reach the child."""
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
     db = SessionDB(tmp_path / "state.db")
     db.create_session("parent", source="cli")
     db.append_message("parent", "user", "parent request")
@@ -684,6 +688,10 @@ def test_cli_explicit_history_is_replaced_before_the_real_turn_prologue(monkeypa
 
 
 def test_adoption_transfers_the_held_lease_and_defers_for_active_work(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config",
+        lambda: {"session_rollover": {"enabled": True, "ratio": 0.75}},
+    )
     db = SessionDB(tmp_path / "state.db")
     db.create_session("parent", source="gateway")
     assert TurnBoundaryRollover(db).mark_pending("parent", threshold_tokens=10)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -5192,6 +5192,49 @@ class TestDisplayMetadataPersistence:
         assert conv[0]["display_kind"] == "async_delegation_complete"
         assert conv[0]["display_metadata"] == meta
 
+    def test_async_delegation_completion_append_is_idempotent_by_delegation_id(self, db):
+        db.create_session("s1", source="cli")
+        metadata = {"delegation_id": "deleg-1", "task_count": 1}
+
+        first_id, first_inserted = db.append_async_delegation_completion(
+            "s1", "first rendering", metadata,
+        )
+        replay_id, replay_inserted = db.append_async_delegation_completion(
+            "s1", "changed rendering must not define identity", metadata,
+        )
+
+        assert first_inserted is True
+        assert (replay_id, replay_inserted) == (first_id, False)
+        rows = db.get_messages("s1")
+        assert len(rows) == 1
+        assert rows[0]["content"] == "first rendering"
+        assert rows[0]["display_metadata"]["delegation_id"] == "deleg-1"
+
+    def test_async_delegation_completion_append_is_concurrent_exactly_once(self, db):
+        db.create_session("s1", source="cli")
+        barrier = threading.Barrier(2)
+        results = []
+        errors = []
+
+        def append_from_competing_consumer():
+            try:
+                barrier.wait(timeout=2)
+                results.append(db.append_async_delegation_completion(
+                    "s1", "completion", {"delegation_id": "deleg-concurrent"},
+                ))
+            except Exception as exc:
+                errors.append(exc)
+
+        workers = [threading.Thread(target=append_from_competing_consumer) for _ in range(2)]
+        for worker in workers:
+            worker.start()
+        for worker in workers:
+            worker.join(timeout=5)
+
+        assert not errors
+        assert sorted(inserted for _row_id, inserted in results) == [False, True]
+        assert len(db.get_messages("s1")) == 1
+
     def test_replace_messages_preserves_display_metadata(self, db):
         db.create_session("s1", source="cli")
         meta = {"task_count": 3, "delegation_id": "del-2", "duration_seconds": 12.5}

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11756,9 +11756,9 @@ def test_async_delegation_completion_is_in_live_tui_history_once():
     persisted = []
 
     class _Db:
-        def append_message(self, *_args, **kwargs):
-            persisted.append(kwargs)
-            return 17
+        def append_async_delegation_completion(self, *_args):
+            persisted.append(_args)
+            return 17, True
 
     agent = types.SimpleNamespace(session_id="rollover-child")
     session = _session(agent=agent, history=[{"role": "user", "content": "earlier turn"}])
@@ -11782,11 +11782,7 @@ def test_async_delegation_completion_is_in_live_tui_history_once():
     }
     assert session["history"].count(completion) == 1
     assert agent._session_messages is session["history"]
-    assert persisted == [{
-        "content": "completion payload",
-        "display_kind": "async_delegation_complete",
-        "display_metadata": completion["display_metadata"],
-    }]
+    assert persisted == [("rollover-child", "completion payload", completion["display_metadata"])]
 
 
 # ── session.steer ────────────────────────────────────────────────────

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1,3 +1,5 @@
+import ast
+import inspect
 import json
 import logging
 import os
@@ -11783,6 +11785,39 @@ def test_async_delegation_completion_is_in_live_tui_history_once():
     assert session["history"].count(completion) == 1
     assert agent._session_messages is session["history"]
     assert persisted == [("rollover-child", "completion payload", completion["display_metadata"])]
+
+
+def test_async_delegation_replays_are_acknowledged_without_a_second_tui_display():
+    """Every delivery path must gate display on a newly persisted completion.
+
+    A stale/replayed delegation event is still acknowledged by its lease owner,
+    but it must not create another visible ``status.update`` after the durable
+    or live-history dedupe rejects it. Keep this structural assertion across the
+    live poller, shutdown drain, and post-turn drain so a future edit cannot fix
+    only one delivery path.
+    """
+    tree = ast.parse(inspect.getsource(server))
+    parents = {child: parent for parent in ast.walk(tree) for child in ast.iter_child_nodes(parent)}
+    completion_calls = [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "_append_async_delegation_completion"
+    ]
+
+    assert len(completion_calls) == 3
+    for call in completion_calls:
+        parent = parents[call]
+        assert isinstance(parent, ast.Assign)
+        guarded = parents[parent]
+        assert isinstance(guarded, ast.If)
+        assert any(
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "_emit"
+            for node in ast.walk(guarded)
+        )
 
 
 # ── session.steer ────────────────────────────────────────────────────

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -11751,6 +11751,44 @@ def test_rollback_restore_skips_legacy_compaction_handoff(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_async_delegation_completion_is_in_live_tui_history_once():
+    """The next real prompt must see the durable completion without a fake turn."""
+    persisted = []
+
+    class _Db:
+        def append_message(self, *_args, **kwargs):
+            persisted.append(kwargs)
+            return 17
+
+    agent = types.SimpleNamespace(session_id="rollover-child")
+    session = _session(agent=agent, history=[{"role": "user", "content": "earlier turn"}])
+    event = {"delegation_id": "deleg-1", "results": []}
+
+    server._append_async_delegation_completion(
+        session, _Db(), "rollover-child", "completion payload", event
+    )
+    server._append_async_delegation_completion(
+        session, _Db(), "rollover-child", "completion payload", event
+    )
+
+    completion = {
+        "role": "user",
+        "content": "completion payload",
+        "display_kind": "async_delegation_complete",
+        "display_metadata": {"delegation_id": "deleg-1", "task_count": 1,
+                             "completed_count": 1, "failed_count": 0},
+        "_row_id": 17,
+        "_db_persisted": True,
+    }
+    assert session["history"].count(completion) == 1
+    assert agent._session_messages is session["history"]
+    assert persisted == [{
+        "content": "completion payload",
+        "display_kind": "async_delegation_complete",
+        "display_metadata": completion["display_metadata"],
+    }]
+
+
 # ── session.steer ────────────────────────────────────────────────────
 
 

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -37,7 +37,7 @@ import json
 import logging
 from typing import Any, Dict, List, Optional, Union
 
-from hermes_state_common import _RESET_END_REASONS
+from hermes_state_common import _RESET_END_REASONS, is_continuation_end_reason as _is_continuation_end_reason
 
 # Sources that are excluded from session browsing/searching by default.
 # Third-party integrations tag their sessions with HERMES_SESSION_SOURCE=tool;
@@ -152,7 +152,7 @@ def _resolve_to_parent(db, session_id: str) -> tuple[str, bool]:
             s = db.get_session(cur)
             if not s:
                 break
-            if s.get("end_reason") == "compression":
+            if _is_continuation_end_reason(s.get("end_reason")):
                 has_compression = True
             parent = s.get("parent_session_id")
             if not parent:
@@ -192,7 +192,7 @@ def _is_compression_ended(db, session_id: str) -> bool:
     ``end_reason`` is ``None`` — its content is still live to the parent agent,
     so it must stay excluded from discovery.
     """
-    return _session_end_reason(db, session_id) == "compression"
+    return _is_continuation_end_reason(_session_end_reason(db, session_id))
 
 
 def _session_left_live_context(db, session_id: str) -> bool:
@@ -212,7 +212,7 @@ def _session_left_live_context(db, session_id: str) -> bool:
     their content IS the current context.
     """
     end_reason = _session_end_reason(db, session_id)
-    return end_reason == "compression" or _is_fresh_reset_session(end_reason)
+    return _is_continuation_end_reason(end_reason) or _is_fresh_reset_session(end_reason)
 
 
 def _is_fresh_reset_session(end_reason: Optional[str]) -> bool:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12734,7 +12734,8 @@ def _notification_poller_loop(
         # visible independently.
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            if evt.get("type") != "async_delegation":
+                _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
 
         _requeued = False
@@ -12757,19 +12758,30 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
             continue
         try:
-            _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
+                db = getattr(session.get("agent"), "_session_db", None)
+                target_session_id = str(
+                    getattr(session.get("agent"), "session_id", "")
+                    or session.get("session_key")
+                )
+                if db is None or not target_session_id:
+                    raise RuntimeError("no durable session for delegation display")
+                db.append_message(
+                    target_session_id,
+                    "user",
+                    content=text,
                     display_kind="async_delegation_complete",
                     display_metadata=_async_delegation_display_metadata(evt),
                 )
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                with session["history_lock"]:
+                    session["running"] = False
             else:
+                _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
@@ -12820,7 +12832,8 @@ def _notification_poller_loop(
 
         _dedup_key = _notification_event_dedup_key(evt)
         if _dedup_key not in _emitted:
-            _emit("status.update", sid, {"kind": "process", "text": text})
+            if evt.get("type") != "async_delegation":
+                _emit("status.update", sid, {"kind": "process", "text": text})
             _emitted.add(_dedup_key)
 
         with session["history_lock"]:
@@ -12835,19 +12848,30 @@ def _notification_poller_loop(
         )
         _claim = claim_event_delivery(evt, "tui-poller")
         if _claim is None:
+            with session["history_lock"]:
+                session["running"] = False
             continue
         try:
-            _emit("message.start", sid)
             if evt.get("type") == "async_delegation":
-                _run_prompt_submit(
-                    rid,
-                    sid,
-                    session,
-                    text,
+                db = getattr(session.get("agent"), "_session_db", None)
+                target_session_id = str(
+                    getattr(session.get("agent"), "session_id", "")
+                    or session.get("session_key")
+                )
+                if db is None or not target_session_id:
+                    raise RuntimeError("no durable session for delegation display")
+                db.append_message(
+                    target_session_id,
+                    "user",
+                    content=text,
                     display_kind="async_delegation_complete",
                     display_metadata=_async_delegation_display_metadata(evt),
                 )
+                _emit("status.update", sid, {"kind": "process", "text": text})
+                with session["history_lock"]:
+                    session["running"] = False
             else:
+                _emit("message.start", sid)
                 _run_prompt_submit(rid, sid, session, text)
             complete_event_delivery(evt, _claim)
         except Exception as exc:
@@ -14242,10 +14266,31 @@ def _run_prompt_submit(
                 )
                 _claim = claim_event_delivery(_evt, "tui-post-turn")
                 if _claim is None:
+                    with session["history_lock"]:
+                        session["running"] = False
                     continue
                 try:
-                    _emit("message.start", sid)
-                    _run_prompt_submit(rid, sid, session, synth)
+                    if _evt.get("type") == "async_delegation":
+                        db = getattr(session.get("agent"), "_session_db", None)
+                        target_session_id = str(
+                            getattr(session.get("agent"), "session_id", "")
+                            or session.get("session_key")
+                        )
+                        if db is None or not target_session_id:
+                            raise RuntimeError("no durable session for delegation display")
+                        db.append_message(
+                            target_session_id,
+                            "user",
+                            content=synth,
+                            display_kind="async_delegation_complete",
+                            display_metadata=_async_delegation_display_metadata(_evt),
+                        )
+                        _emit("status.update", sid, {"kind": "process", "text": synth})
+                        with session["history_lock"]:
+                            session["running"] = False
+                    else:
+                        _emit("message.start", sid)
+                        _run_prompt_submit(rid, sid, session, synth)
                     complete_event_delivery(_evt, _claim)
                 except Exception as _n_exc:
                     release_event_delivery(_evt, _claim)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12770,10 +12770,11 @@ def _notification_poller_loop(
                 )
                 if db is None or not target_session_id:
                     raise RuntimeError("no durable session for delegation display")
-                _append_async_delegation_completion(
+                displayed = _append_async_delegation_completion(
                     session, db, target_session_id, text, evt,
                 )
-                _emit("status.update", sid, {"kind": "process", "text": text})
+                if displayed:
+                    _emit("status.update", sid, {"kind": "process", "text": text})
                 with session["history_lock"]:
                     session["running"] = False
             else:
@@ -12856,10 +12857,11 @@ def _notification_poller_loop(
                 )
                 if db is None or not target_session_id:
                     raise RuntimeError("no durable session for delegation display")
-                _append_async_delegation_completion(
+                displayed = _append_async_delegation_completion(
                     session, db, target_session_id, text, evt,
                 )
-                _emit("status.update", sid, {"kind": "process", "text": text})
+                if displayed:
+                    _emit("status.update", sid, {"kind": "process", "text": text})
                 with session["history_lock"]:
                     session["running"] = False
             else:
@@ -14317,10 +14319,11 @@ def _run_prompt_submit(
                         )
                         if db is None or not target_session_id:
                             raise RuntimeError("no durable session for delegation display")
-                        _append_async_delegation_completion(
+                        displayed = _append_async_delegation_completion(
                             session, db, target_session_id, synth, _evt,
                         )
-                        _emit("status.update", sid, {"kind": "process", "text": synth})
+                        if displayed:
+                            _emit("status.update", sid, {"kind": "process", "text": synth})
                         with session["history_lock"]:
                             session["running"] = False
                     else:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12929,13 +12929,11 @@ def _append_async_delegation_completion(
             if isinstance(message, dict)
         ):
             return False
-        row_id = db.append_message(
-            target_session_id,
-            "user",
-            content=text,
-            display_kind="async_delegation_complete",
-            display_metadata=metadata,
+        row_id, inserted = db.append_async_delegation_completion(
+            target_session_id, text, metadata,
         )
+        if not inserted:
+            return False
         completion = {
             "role": "user",
             "content": text,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12770,12 +12770,8 @@ def _notification_poller_loop(
                 )
                 if db is None or not target_session_id:
                     raise RuntimeError("no durable session for delegation display")
-                db.append_message(
-                    target_session_id,
-                    "user",
-                    content=text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
+                _append_async_delegation_completion(
+                    session, db, target_session_id, text, evt,
                 )
                 _emit("status.update", sid, {"kind": "process", "text": text})
                 with session["history_lock"]:
@@ -12860,12 +12856,8 @@ def _notification_poller_loop(
                 )
                 if db is None or not target_session_id:
                     raise RuntimeError("no durable session for delegation display")
-                db.append_message(
-                    target_session_id,
-                    "user",
-                    content=text,
-                    display_kind="async_delegation_complete",
-                    display_metadata=_async_delegation_display_metadata(evt),
+                _append_async_delegation_completion(
+                    session, db, target_session_id, text, evt,
                 )
                 _emit("status.update", sid, {"kind": "process", "text": text})
                 with session["history_lock"]:
@@ -12914,6 +12906,55 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
     return metadata
+
+
+def _append_async_delegation_completion(
+    session: dict, db, target_session_id: str, text: str, evt: dict,
+) -> bool:
+    """Persist a display completion and append it to the live model history.
+
+    Delivery is display-only and must never launch a model turn. The next real
+    user turn consumes ``session[\"history\"]`` directly, including after a
+    rollover child replaces the agent session id.
+    """
+    metadata = _async_delegation_display_metadata(evt)
+    delegation_id = metadata["delegation_id"]
+    with session["history_lock"]:
+        history = session.setdefault("history", [])
+        if delegation_id and any(
+            message.get("display_kind") == "async_delegation_complete"
+            and isinstance(message.get("display_metadata"), dict)
+            and message["display_metadata"].get("delegation_id") == delegation_id
+            for message in history
+            if isinstance(message, dict)
+        ):
+            return False
+        row_id = db.append_message(
+            target_session_id,
+            "user",
+            content=text,
+            display_kind="async_delegation_complete",
+            display_metadata=metadata,
+        )
+        completion = {
+            "role": "user",
+            "content": text,
+            "display_kind": "async_delegation_complete",
+            "display_metadata": metadata,
+            "_db_persisted": True,
+        }
+        if isinstance(row_id, int):
+            completion["_row_id"] = row_id
+        history.append(completion)
+        session["history_version"] = int(session.get("history_version", 0)) + 1
+        agent = session.get("agent")
+        if agent is not None:
+            agent._session_messages = history
+            if hasattr(agent, "_last_flushed_db_idx"):
+                agent._last_flushed_db_idx = len(history)
+            if hasattr(agent, "_db_flush_scan_prefix"):
+                agent._db_flush_scan_prefix = history[:]
+    return True
 
 
 def _wire_agent_terminal_output() -> None:
@@ -14278,12 +14319,8 @@ def _run_prompt_submit(
                         )
                         if db is None or not target_session_id:
                             raise RuntimeError("no durable session for delegation display")
-                        db.append_message(
-                            target_session_id,
-                            "user",
-                            content=synth,
-                            display_kind="async_delegation_complete",
-                            display_metadata=_async_delegation_display_metadata(_evt),
+                        _append_async_delegation_completion(
+                            session, db, target_session_id, synth, _evt,
                         )
                         _emit("status.update", sid, {"kind": "process", "text": synth})
                         with session["history_lock"]:


### PR DESCRIPTION
## Summary

- add model-relative turn-boundary session lifecycle and rollover
- block new work while draining, checkpoint durably, and adopt exactly one continuation at a real turn boundary
- preserve async delegation completions as exactly-once display/context events without synthetic parent turns
- add doctor-based stall detection and safe idempotent recovery
- preserve rollover lineage across CLI, TUI, gateway, API wake, ACP restart/model switching, and session search

## Safety and integration

- selectively cherry-picked only the 15 rollover commits onto current upstream `main`
- excluded all 8 unrelated Kanban admission commits from the source branch
- reconciled the sole `run_agent.py` conflict by retaining upstream's shared periodic scheduler while refreshing/releasing the adopted child lease identity
- one integration-only fix routes late API delegation completions from an ended parent to the active continuation tip

## Verification

- independent cumulative source review: APPROVE
- selective integration suite: 1,012 passed, 1 deselected
- API wake rollover regression: 74 passed, 3 deselected
- independent API wake adversarial review: APPROVE
- changed Python sources: `py_compile` PASS
- `git diff --check`: PASS
- conflict-marker scan: PASS
- all excluded Kanban SHAs verified absent from ancestry

A full repository `pytest -q` invocation was attempted once but exceeded the verifier's 420-second execution limit at 12%, so it produced no final summary. A subsequent parallel shard experiment was invalidated by shared global environment/port/credential interference and is not presented as a green gate. The changed-area integration suite and all independently reproduced blockers pass.

One unrelated test failure was reproduced unchanged on exact upstream `main` (`63279301bcbdc185c1b07b98a9312eb0c862f26d`):
`tests/test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` expects a legacy SQL trace shape.
