### PR TITLE
fix(hooks): keep fail-closed gates from permitting crashed hooks

### DIFF
--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -64,7 +64,8 @@ message is taken from the stdout block JSON when present, then the first
 400 characters of stderr, then a generic default.  For events whose block
 directive is not honored, exit 2 is logged at warning like any other
 non-zero exit.  All other non-zero exits log a warning and stdout is still
-parsed normally.
+parsed normally; a ``fail_closed`` ``pre_tool_call`` hook blocks when parsing
+produces no recognized directive.
 
 **failure semantics**
 
@@ -72,7 +73,8 @@ Hooks fail *open* by default: a spawn error, timeout, or unparseable
 stdout logs a warning and contributes nothing.  A ``pre_tool_call`` entry
 can opt into fail-*closed* semantics with ``fail_closed: true``
 (``failClosed`` also accepted for Cursor/Claude-Code config compat) —
-spawn errors, timeouts, and malformed stdout then BLOCK the tool call
+spawn errors, timeouts, non-zero exits without a directive, and malformed
+stdout then BLOCK the tool call
 with ``hook <command> failed closed: <reason>``.  Use this for
 security-gating hooks (secret scanners, policy checks) where a crashed
 hook must not silently allow the action.  On non-blocking events

--- a/agent/shell_hooks.py
+++ b/agent/shell_hooks.py
@@ -673,7 +673,8 @@ def _evaluate_result(
     * exit code 2 on a blocking-capable event — block, with the message
       taken from stdout block JSON, then stderr, then a default
       (Claude-Code / Cursor compatible);
-    * other non-zero exits — warn, then parse stdout normally;
+    * other non-zero exits — warn, then parse stdout normally; a
+      ``fail_closed`` hook blocks if no directive was produced;
     * non-JSON / unparseable stdout on a ``fail_closed`` blocking hook —
       block instead of silently contributing nothing.
 
@@ -735,6 +736,11 @@ def _evaluate_result(
 
     stdout = (r["stdout"] or "").strip()
     parsed = _parse_response(spec.event, stdout)
+
+    if parsed is None and fail_closed and r["returncode"] != 0:
+        return _fail_closed_block(
+            spec, f"hook exited {r['returncode']} with no directive",
+        )
 
     if parsed is None and fail_closed and stdout:
         # The hook produced output we could not turn into a directive.

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -644,6 +644,14 @@ class TestEvaluateResult:
         assert r["action"] == "block"
         assert "unparseable stdout" in r["message"]
 
+    def test_nonzero_exit_without_directive_fail_closed_blocks(self):
+        r = shell_hooks._evaluate_result(
+            self._spec(fail_closed=True),
+            _spawn_result(returncode=1, stderr="Traceback: hook crashed"),
+        )
+        assert r["action"] == "block"
+        assert "hook exited 1 with no directive" in r["message"]
+
     def test_unparseable_stdout_fails_open_by_default(self):
         r = shell_hooks._evaluate_result(
             self._spec(),

--- a/tests/agent/test_shell_hooks.py
+++ b/tests/agent/test_shell_hooks.py
@@ -9,6 +9,7 @@ covered in ``test_shell_hooks_consent.py``.
 from __future__ import annotations
 
 import json
+import sys
 from pathlib import Path
 
 import pytest
@@ -686,6 +687,20 @@ class TestEvaluateResult:
 
 
 class TestFailSemanticsEndToEnd:
+    def test_fail_closed_crashed_process_blocks(self, tmp_path):
+        script = _write_script(
+            tmp_path, "crash.py", 'raise RuntimeError("hook crashed")\n',
+        )
+        spec = shell_hooks.ShellHookSpec(
+            event="pre_tool_call",
+            command=f'"{sys.executable}" "{script}"',
+            fail_closed=True,
+        )
+        cb = shell_hooks._make_callback(spec)
+        result = cb(tool_name="terminal", args={"command": "rm -rf /"})
+        assert result is not None and result["action"] == "block"
+        assert "hook exited 1 with no directive" in result["message"]
+
     def test_exit_2_script_blocks(self, tmp_path):
         script = _write_script(
             tmp_path, "exit2.sh",

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -1658,7 +1658,7 @@ Each time the event fires, Hermes spawns a subprocess for every matching hook (m
 // Silent no-op — any empty / non-matching output is fine:
 ```
 
-Malformed JSON, non-zero exit codes, and timeouts log a warning but never abort the agent loop.
+Except for `pre_tool_call` exit code 2 described below, malformed JSON, ordinary non-zero exit codes, and timeouts fail open by default: they log a warning but do not abort the agent loop. A `fail_closed` hook changes the behavior as described below.
 
 ### Exit code 2 = block (Claude Code / Cursor compatible)
 
@@ -1699,6 +1699,7 @@ With `fail_closed: true`, each of these now **blocks** the tool call with `hook 
 |---------|--------------------|--------------------|
 | Command not found / not executable | warn, proceed | **block** |
 | Timeout | warn, proceed | **block** |
+| Non-zero exit with no recognized directive | warn, proceed | **block** |
 | Non-JSON stdout (e.g. a stack trace) | warn, proceed | **block** |
 | Clean exit, valid no-op JSON (`{}`) | proceed | proceed |
 


### PR DESCRIPTION
## What does this PR do?

A `pre_tool_call` hook configured with `fail_closed: true` now blocks when its process exits non-zero without producing a parseable directive. This prevents a crashed policy hook from silently permitting the tool action while preserving successful empty-output hooks and explicit exit-code-2 blocks.

### Symptom

A hook that crashes and writes its traceback only to stderr exits non-zero with empty stdout, but the protected tool call is permitted despite `fail_closed: true`.

### Impact

Operators relying on fail-closed hooks for policy or integrity gates can have actions silently permitted when the hook process fails before emitting a directive.

### Bug Cause

**Trigger:** `agent/shell_hooks.py:739` in `_evaluate_result()` when `parsed is None`, `fail_closed` is enabled, stdout is empty, and the hook return code is non-zero.

**Causal chain:**
1. A blocking `pre_tool_call` hook crashes and exits non-zero while writing only to stderr.
2. `_evaluate_result()` logs the exit but gates fail-closed handling on non-empty stdout.
3. It returns `None`, which the caller treats as no directive and permits the tool call.

**Why it is wrong:** The documented fail-closed contract must deny when the hook fails without producing a trustworthy directive, regardless of whether failure output was written to stdout.

**Working sibling / contrast:** A successful exit with empty stdout still means the hook ran and had no directive, while exit code 2 retains its dedicated explicit-block path.

**Ruled out:** Hook registration is not involved because the failing hook runs and returns a captured process result before evaluation makes the incorrect permit decision.

### Fix

Fail closed when a non-zero hook result produces no parsed directive, then retain the existing malformed-stdout handling for successful processes. A regression test covers the empty-stdout, non-zero-exit branch and existing tests cover successful empty output and explicit block behavior.

## Related Issue

Closes #102405

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/shell_hooks.py` - block fail-closed hooks that exit non-zero without a directive.
- `tests/agent/test_shell_hooks.py` - add regression coverage for the silent-permit branch.

## How to Test

1. Run the focused evaluation semantics tests.
2. Confirm the non-zero empty-output case blocks and the successful empty-output case remains permitted.
3. Confirm existing exit-code-2 behavior remains covered.

```bash
scripts/run_tests.sh tests/agent/test_shell_hooks.py -k TestEvaluateResult -q
```

Result: 16 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all focused tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - function contract updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-neutral evaluation logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - covered by focused automated regression tests.
