### PR TITLE
fix(install): add hermes_state_holders and hermes_state_registry to py-modules (#102358)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -576,6 +576,8 @@ py-modules = [
   "hermes_state_portability",
   "hermes_state_schema",
   "hermes_state_search",
+  "hermes_state_holders",
+  "hermes_state_registry",
   "hermes_startup_watchdog",
   "hermes_time",
   "hermes_logging",


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where the managed Python runtime repair (`hermes update` SQLite WAL-reset fix) never completes because the candidate sealed venv is missing `hermes_state_holders` and `hermes_state_registry` modules.

## Root cause

`pyproject.toml` `[tool.setuptools] py-modules` lists top-level single-file modules for uv2nix's sealed venv. Two modules imported by core runtime code were missing:

- `hermes_state_holders.py` — imported by `hermes_state.py`
- `hermes_state_registry.py` — imported by `hermes_state.py` and `gateway/run.py`

An editable install works (resolves from source tree), but the candidate replacement venv built with `uv venv --relocatable` + `uv sync --locked --extra all` installs the project as a sealed wheel, which omits unlisted modules. The import smoke test then fails:

```
ModuleNotFoundError: No module named 'hermes_state_holders'
```

The comment above the `py-modules` list already documents this exact failure mode — the two newer state modules just never got added.

## The fix

Add both modules to the `py-modules` list in `pyproject.toml`.

## Verification

With just those two lines added locally, the next `hermes update` completed the runtime swap:
```
✓ Managed Python runtime repaired (SQLite 3.50.4 → 3.53.1)
```
and `hermes doctor` now reports `✓ SQLite 3.53.1` with no WAL-reset warnings.

## Related Issue

Fixes #102358