### PR TITLE
feat(web): expose ddgs region/safesearch/timelimit/backend config knobs

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -530,6 +530,24 @@ browser:
   # snapshot_threshold: 15000
 
 # =============================================================================
+# Web Search / Extract Backends
+# =============================================================================
+# Blank backend = auto-detect (API keys first, then the keyless free-tier
+# ring; ddgs is the keyless last resort for search). All keys optional.
+web:
+  # Shared fallback for both capabilities, or per-capability overrides:
+  # backend: ""            # e.g. "searxng" — applies to search AND extract
+  # search_backend: ""     # e.g. "ddgs", "brave-free", "searxng" — web_search only
+  # extract_backend: ""    # e.g. "native", "firecrawl" — web_extract only
+
+  # ddgs search backend knobs (only used when search resolves to ddgs).
+  # Blank = ddgs library default, so an unset config changes nothing.
+  # ddgs_region: ""        # region code, e.g. "de-ch", "uk-en" (default us-en)
+  # ddgs_safesearch: ""    # "on" | "moderate" | "off"
+  # ddgs_timelimit: ""     # result freshness: "d" | "w" | "m" | "y"
+  # ddgs_backend: ""       # engine hint, e.g. "html" or "auto,html"
+
+# =============================================================================
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -557,6 +557,12 @@ DEFAULT_CONFIG = {
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
         "extract_char_limit": 15000,  # per-page char budget for web_extract; larger pages truncate + store full text in cache/web
+        # ddgs search backend knobs (#102412). Blank = ddgs library default,
+        # so an unset config keeps the previous behaviour bit-for-bit.
+        "ddgs_region": "",       # ddgs region code, e.g. "de-ch" / "uk-en" (default us-en)
+        "ddgs_safesearch": "",   # "on" | "moderate" | "off"
+        "ddgs_timelimit": "",    # result freshness: "d" | "w" | "m" | "y"
+        "ddgs_backend": "",      # engine hint, e.g. "html" or "auto,html"
         # Keyless free-tier ring: with NO web backend configured or keyed,
         # web_search/web_extract rotate round-robin across four vendors'
         # public free tiers (exa, parallel, firecrawl, keenable),

--- a/plugins/web/ddgs/_search_worker.py
+++ b/plugins/web/ddgs/_search_worker.py
@@ -5,7 +5,11 @@ parent provider). Reads one JSON request from stdin, writes one JSON envelope
 to stdout, then exits.
 
 Request::
-    {"query": str, "safe_limit": int}
+    {"query": str, "safe_limit": int,
+     "region"?: str, "safesearch"?: str, "timelimit"?: str, "backend"?: str}
+
+    The four optional search options (#102412) map to the corresponding
+    ``web.ddgs_*`` config keys; absent entries keep the ddgs defaults.
 
 Envelope::
     {"ok": true, "results": [...]}
@@ -97,11 +101,16 @@ def main() -> int:
 
     query = str(request.get("query") or "")
     safe_limit = max(1, int(request.get("safe_limit") or 1))
+    opts = {
+        name: request[name]
+        for name in ("region", "safesearch", "timelimit", "backend")
+        if isinstance(request.get(name), str) and request[name]
+    }
     try:
         # Import inside main so script startup stays light / patchable.
         from plugins.web.ddgs.provider import _run_ddgs_search
 
-        results = _run_ddgs_search(query, safe_limit)
+        results = _run_ddgs_search(query, safe_limit, **opts)
         _write_envelope({"ok": True, "results": results})
         return 0
     except Exception as exc:  # noqa: BLE001

--- a/plugins/web/ddgs/provider.py
+++ b/plugins/web/ddgs/provider.py
@@ -9,6 +9,16 @@ The ``ddgs`` package is an optional dependency. ``is_available()`` reflects
 whether the package is importable; the plugin still registers either way so
 ``hermes tools`` can prompt the user to install it.
 
+Config keys this provider responds to (all optional; blank/absent = the ddgs
+library default, so unset behaviour is unchanged, #102412)::
+
+    web:
+      search_backend: "ddgs"
+      ddgs_region: "de-ch"         # ddgs region code (library default: us-en)
+      ddgs_safesearch: "moderate"  # on | moderate | off
+      ddgs_timelimit: "d"          # d | w | m | y
+      ddgs_backend: "html"         # engine hint, e.g. "auto" or "auto,html"
+
 Isolation note (#68096): ``ddgs``/``primp`` can block inside native code while
 holding the Python GIL. A ``ThreadPoolExecutor`` + ``future.result(timeout=…)``
 cap (see #52118) cannot fire in that state — the waiter never reacquires the
@@ -49,19 +59,65 @@ class _SearchInterrupted(Exception):
     """Raised when tools.interrupt.is_interrupted() trips during a search wait."""
 
 
-def _run_ddgs_search(query: str, safe_limit: int) -> list[dict[str, Any]]:
+# ``web.ddgs_*`` search options forwarded to ``DDGS().text()`` (#102412).
+# Keys without a non-blank ``web.ddgs_<name>`` config value are omitted so
+# the ddgs library defaults keep applying.
+_DDGS_TEXT_OPTIONS = ("region", "safesearch", "timelimit", "backend")
+
+
+def _read_ddgs_options() -> Dict[str, str]:
+    """Read the ``web.ddgs_*`` search options from ``config.yaml``.
+
+    Delegates to the registry's ``_read_config_key`` chokepoint (same
+    rationale as ``plugins/web/keyless_mcp.py``: ``web.*`` resolution lives
+    in one place). Returns only the options the user explicitly set.
+    """
+    opts: Dict[str, str] = {}
+    try:
+        from agent.web_search_registry import _read_config_key
+
+        for name in _DDGS_TEXT_OPTIONS:
+            val = _read_config_key("web", f"ddgs_{name}")
+            if val:
+                opts[name] = val
+    except Exception as exc:  # noqa: BLE001 — config layer optional in stripped envs
+        logger.debug("ddgs option read failed: %s", exc)
+    return opts
+
+
+def _run_ddgs_search(
+    query: str,
+    safe_limit: int,
+    *,
+    region: Optional[str] = None,
+    safesearch: Optional[str] = None,
+    timelimit: Optional[str] = None,
+    backend: Optional[str] = None,
+) -> list[dict[str, Any]]:
     """Run the blocking ddgs query and return normalized hits.
 
     Module-level (not a closure) so the child worker can import it and so
     tests can patch it for in-process unit tests. ``DDGS(timeout=…)`` bounds
     each individual HTTP request; the overall wall-clock cap is enforced by
-    the parent via process timeout (#68096).
+    the parent via process timeout (#68096). Unset options are omitted from
+    the ``text()`` call so library defaults apply (#102412).
     """
     from ddgs import DDGS  # type: ignore
 
+    text_kwargs: dict[str, Any] = {
+        name: val
+        for name, val in (
+            ("region", region),
+            ("safesearch", safesearch),
+            ("timelimit", timelimit),
+            ("backend", backend),
+        )
+        if val
+    }
+
     results: list[dict[str, Any]] = []
     with DDGS(timeout=10) as client:
-        for i, hit in enumerate(client.text(query, max_results=safe_limit)):
+        for i, hit in enumerate(client.text(query, max_results=safe_limit, **text_kwargs)):
             if i >= safe_limit:
                 break
             url = str(hit.get("href") or hit.get("url") or "")
@@ -139,13 +195,22 @@ def _terminate_and_reap(
         logger.debug("DDGS worker reap error: %s", exc)
 
 
-def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]]:
+def _run_ddgs_search_bounded(
+    query: str,
+    safe_limit: int,
+    *,
+    region: Optional[str] = None,
+    safesearch: Optional[str] = None,
+    timelimit: Optional[str] = None,
+    backend: Optional[str] = None,
+) -> list[dict[str, Any]]:
     """Run ``_run_ddgs_search`` in a disposable process with a hard deadline.
 
     The parent never joins the child while it may be inside native code holding
     *its* GIL — it only polls a communicator thread and, on timeout/interrupt,
     terminates the child OS process. Raises ``TimeoutError``,
-    ``_SearchInterrupted``, or ``RuntimeError``.
+    ``_SearchInterrupted``, or ``RuntimeError``. Set search options are
+    forwarded through the JSON request so the worker applies them (#102412).
     """
     # Imported lazily so plugin import stays light for ``hermes tools`` probes.
     from tools.interrupt import is_interrupted
@@ -153,6 +218,14 @@ def _run_ddgs_search_bounded(query: str, safe_limit: int) -> list[dict[str, Any]
     global _last_worker_proc
 
     request: dict[str, Any] = {"query": query, "safe_limit": safe_limit}
+    for name, val in (
+        ("region", region),
+        ("safesearch", safesearch),
+        ("timelimit", timelimit),
+        ("backend", backend),
+    ):
+        if val:
+            request[name] = val
     if _test_hook:
         request["test_hook"] = _test_hook
 
@@ -318,9 +391,10 @@ class DDGSWebSearchProvider(WebSearchProvider):
         # DDGS().text yields at most `max_results` items; we cap defensively
         # in case the package ignores the hint.
         safe_limit = max(1, int(limit))
+        opts = _read_ddgs_options()
 
         try:
-            web_results = _run_ddgs_search_bounded(query, safe_limit)
+            web_results = _run_ddgs_search_bounded(query, safe_limit, **opts)
         except TimeoutError:
             logger.warning(
                 "DDGS search timed out after %ds for query: %r",

--- a/tests/tools/test_web_providers_ddgs.py
+++ b/tests/tools/test_web_providers_ddgs.py
@@ -33,6 +33,10 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text
     fake = types.ModuleType("ddgs")
 
     class _FakeDDGS:
+        # Last kwargs received by text() — lets option-forwarding tests
+        # assert exactly what the provider passed through (#102412).
+        last_text_kwargs: dict = {}
+
         def __init__(self, **kwargs):
             # Accept timeout= (and any other constructor kwargs) — the provider
             # now passes DDGS(timeout=10).
@@ -41,7 +45,8 @@ def _install_fake_ddgs(monkeypatch, *, text_results=None, text_raises=None, text
             return self
         def __exit__(self, *_a):
             return False
-        def text(self, query, max_results=5):
+        def text(self, query, max_results=5, **kwargs):
+            type(self).last_text_kwargs = dict(kwargs)
             if text_sleep is not None:
                 _time.sleep(text_sleep)
             if text_raises is not None:
@@ -64,7 +69,7 @@ def _force_inprocess_search(monkeypatch, prov):
     monkeypatch.setattr(
         prov,
         "_run_ddgs_search_bounded",
-        lambda query, safe_limit: prov._run_ddgs_search(query, safe_limit),
+        lambda query, safe_limit, **opts: prov._run_ddgs_search(query, safe_limit, **opts),
         raising=True,
     )
 
@@ -152,6 +157,136 @@ class TestDDGSProviderSearch:
         assert result["success"] is True
         assert result["data"]["web"][0]["url"] == "https://e.com"
         assert result["data"]["web"][0]["title"] == "T"
+
+
+# ---------------------------------------------------------------------------
+# web.ddgs_* search options (#102412)
+# ---------------------------------------------------------------------------
+
+
+class TestDDGSSearchOptions:
+    """Configured ``web.ddgs_*`` knobs flow through to ``DDGS().text()``.
+
+    Blank/absent keys must be omitted so the ddgs library defaults — and
+    therefore existing behaviour — are unchanged.
+    """
+
+    def test_options_forwarded_to_text(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch, text_results=[
+            {"title": "T", "href": "https://e.com", "body": "B"},
+        ])
+        import plugins.web.ddgs.provider as prov
+        _force_inprocess_search(monkeypatch, prov)
+        monkeypatch.setattr(
+            prov,
+            "_read_ddgs_options",
+            lambda: {
+                "region": "de-ch",
+                "safesearch": "off",
+                "timelimit": "m",
+                "backend": "html",
+            },
+            raising=True,
+        )
+
+        result = prov.DDGSWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert sys.modules["ddgs"].DDGS.last_text_kwargs == {
+            "region": "de-ch",
+            "safesearch": "off",
+            "timelimit": "m",
+            "backend": "html",
+        }
+
+    def test_no_options_by_default_keeps_text_call_minimal(self, monkeypatch):
+        _install_fake_ddgs(monkeypatch, text_results=[
+            {"title": "T", "href": "https://e.com", "body": "B"},
+        ])
+        import plugins.web.ddgs.provider as prov
+        _force_inprocess_search(monkeypatch, prov)
+        monkeypatch.setattr(prov, "_read_ddgs_options", lambda: {}, raising=True)
+
+        result = prov.DDGSWebSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert sys.modules["ddgs"].DDGS.last_text_kwargs == {}
+
+    def test_read_ddgs_options_skips_blank_values(self, monkeypatch):
+        import plugins.web.ddgs.provider as prov
+        from agent import web_search_registry as reg
+
+        values = {
+            ("web", "ddgs_region"): "de-ch",
+            ("web", "ddgs_safesearch"): None,   # blank — must be dropped
+            ("web", "ddgs_timelimit"): None,
+            ("web", "ddgs_backend"): None,
+        }
+        monkeypatch.setattr(reg, "_read_config_key", lambda *path: values.get(tuple(path)))
+
+        assert prov._read_ddgs_options() == {"region": "de-ch"}
+
+    def test_bounded_worker_request_includes_options(self, monkeypatch):
+        """The JSON request handed to the worker process carries the options."""
+        import plugins.web.ddgs.provider as prov
+
+        captured: dict = {}
+
+        class _FakeProc:
+            pid = 4242
+            def __init__(self, *args, **kwargs):
+                pass
+            def communicate(self, input=None):
+                captured["payload"] = input
+                return (json.dumps({"ok": True, "results": []}), None)
+            def poll(self):
+                return 0
+            def terminate(self):
+                pass
+            def kill(self):
+                pass
+
+        monkeypatch.setattr(prov.subprocess, "Popen", _FakeProc, raising=True)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False)
+
+        results = prov._run_ddgs_search_bounded("q", 5, region="de-ch", timelimit="w")
+
+        assert results == []
+        payload = json.loads(captured["payload"])
+        assert payload == {"query": "q", "safe_limit": 5, "region": "de-ch", "timelimit": "w"}
+
+    def test_worker_forwards_options_to_search(self, monkeypatch, capsys):
+        """The worker entrypoint parses the options out of the request JSON."""
+        import io
+
+        import plugins.web.ddgs._search_worker as worker
+        import plugins.web.ddgs.provider as prov
+
+        captured: dict = {}
+
+        def _fake_run(query, safe_limit, **opts):
+            captured.update(query=query, safe_limit=safe_limit, opts=opts)
+            return [{"title": "T", "url": "https://e.com", "description": "B", "position": 1}]
+
+        monkeypatch.setattr(prov, "_run_ddgs_search", _fake_run, raising=True)
+        request = json.dumps({
+            "query": "q",
+            "safe_limit": 5,
+            "region": "de-ch",
+            "safesearch": "off",
+        })
+        monkeypatch.setattr("sys.stdin", io.StringIO(request))
+
+        rc = worker.main()
+
+        assert rc == 0
+        envelope = json.loads(capsys.readouterr().out)
+        assert envelope["ok"] is True
+        assert captured == {
+            "query": "q",
+            "safe_limit": 5,
+            "opts": {"region": "de-ch", "safesearch": "off"},
+        }
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Adds user-facing configuration for the `ddgs` search backend. Previously every search option was hardcoded in `plugins/web/ddgs/provider.py` — with `web.search_backend: ddgs` there was no way to set region, safesearch, timelimit, or the engine hint (#102412).

This PR introduces four optional config keys (blank/absent = ddgs library default, so existing behaviour is unchanged bit-for-bit):

- `web.ddgs_region` — ddgs region code, e.g. `"de-ch"`, `"uk-en"` (library default `us-en`)
- `web.ddgs_safesearch` — `"on"` | `"moderate"` | `"off"`
- `web.ddgs_timelimit` — result freshness `"d"` | `"w"` | `"m"` | `"y"`
- `web.ddgs_backend` — engine hint, e.g. `"html"` or `"auto,html"`

The keys are vendor-scoped (`ddgs_` prefix) rather than generic `web.search_region` because only the ddgs provider consumes them today; a generic name would imply every backend honors it.

Implementation notes:
- Options are read per search via the registry's `_read_config_key` chokepoint (same pattern as `plugins/web/keyless_mcp.py`), and only keys the user explicitly set are forwarded.
- The provider runs searches in a disposable worker process (#68096), so the options travel through the JSON request and the worker passes them to `DDGS().text(...)`. All four are long-standing keyword parameters of the ddgs `text()` API (verified against ddgs 9.16.0).

## Related Issue

Fixes #102412

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/config_defaults.py` — added the four `web.ddgs_*` defaults (blank) so `hermes config set web.ddgs_region ...` validates
- `plugins/web/ddgs/provider.py` — `_read_ddgs_options()` helper; `_run_ddgs_search` / `_run_ddgs_search_bounded` accept and forward the options; `search()` reads config per call
- `plugins/web/ddgs/_search_worker.py` — parse the optional options out of the request JSON and forward them to `_run_ddgs_search`
- `tests/tools/test_web_providers_ddgs.py` — 5 new tests (forwarding, default-minimal call, blank-value skip, request payload, worker entrypoint)
- `cli-config.yaml.example` — new `web:` section documenting backend selection and the ddgs knobs

## How to Test

1. `pytest tests/tools/test_web_providers_ddgs.py -q` — Observed result: **18 passed** (13 pre-existing + 5 new).
2. Schema acceptance: `_validate_config_key("web.ddgs_region")` returns `(True, None)` for all four keys.
3. `python scripts/check_subprocess_stdin.py plugins/web/ddgs/provider.py plugins/web/ddgs/_search_worker.py` — Observed result: **All TUI-context subprocess calls have explicit stdin=**.
4. Adjacent suites (`test_web_providers.py`, `test_web_providers_searxng.py`, `test_web_tools_config.py`, `test_config_dotted_key_names.py`): 100 passed; the 2 `TestParallelClientConfig` failures reproduce on clean `upstream/main` (environment/SDK-related, unrelated to this change).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
