### PR TITLE
fix(kanban): preserve initial blocked state

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3565,6 +3565,22 @@ def create_task(
                         "provider_override": provider_override,
                     },
                 )
+                # ``recompute_ready`` distinguishes a dependency/circuit-breaker
+                # block from an operator-owned sticky block via the latest
+                # blocked/unblocked event.  Creating directly in ``blocked``
+                # must therefore establish that same durable event contract;
+                # status alone is deliberately recoverable and would otherwise
+                # be promoted on the next dispatcher tick.
+                if initial_status == "blocked":
+                    _append_event(
+                        conn,
+                        task_id,
+                        "blocked",
+                        {
+                            "reason": "created with initial_status=blocked",
+                            "initial": True,
+                        },
+                    )
                 _inherit_notify_subs(conn, task_id, parents, created_at=now)
             return task_id
         except sqlite3.IntegrityError:

--- a/tests/hermes_cli/test_kanban_blocked_sticky.py
+++ b/tests/hermes_cli/test_kanban_blocked_sticky.py
@@ -53,6 +53,30 @@ def kanban_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def test_initial_blocked_status_is_sticky_across_recompute_ready(
+    kanban_home: Path,
+) -> None:
+    """Creation-time blocked tasks are operator-owned, not dependency waits."""
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="parked pending operator review",
+            initial_status="blocked",
+        )
+
+        assert kb.get_task(conn, tid).status == "blocked"
+        events = conn.execute(
+            "SELECT kind, payload FROM task_events WHERE task_id = ? ORDER BY id",
+            (tid,),
+        ).fetchall()
+        assert [row["kind"] for row in events] == ["created", "blocked"]
+        assert '"initial": true' in events[-1]["payload"]
+
+        for _ in range(5):
+            assert kb.recompute_ready(conn) == 0
+            assert kb.get_task(conn, tid).status == "blocked"
+
+
 def test_worker_block_is_not_auto_promoted_by_recompute_ready(kanban_home: Path) -> None:
     """A standalone task that a worker explicitly blocks for review
     must stay blocked across an arbitrary number of dispatcher ticks.


### PR DESCRIPTION
## Summary

- append a durable `blocked` event when a task is created with `initial_status="blocked"`
- preserve the existing event-driven distinction between operator-owned sticky blocks and dependency/circuit-breaker waits
- prove repeated `recompute_ready()` calls cannot silently promote the task

This fixes the upstream Kanban primitive used by the North Star control plane.

## Verification

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_blocked_sticky.py -q` — 3/3 passed
- `git diff --name-only origin/main...HEAD` — `hermes_cli/kanban_db.py` plus its focused behavior test

`GATE=PASS`
`GATE_REASON=Exact-head focused Hermes tests pass; upstream maintainer review is still required.`
