### PR TITLE
feat(gateway): expose per-member driver task status via groups.tasks

### DIFF
--- a/tests/tui_gateway/test_groups_methods.py
+++ b/tests/tui_gateway/test_groups_methods.py
@@ -462,6 +462,79 @@ def test_create_list_send_and_log_roundtrip(home):
     }
 
 
+def test_groups_tasks_returns_the_admitted_task_for_the_targeted_member(home):
+    """Regression for issue #102196: groups.tasks exposes per-member driver
+    task rows (the real queued/running/settled/... status per task) that
+    groups.state's aggregate driver_status never surfaced."""
+    _create_room()
+
+    sent = _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {"text": "hello", "thread_id": "thread-1"},
+            },
+        )
+    )
+    assert sent["driver_started"] is True
+
+    tasks = _result(srv._methods["groups.tasks"](3, {"room_id": "room-1"}))["tasks"]
+
+    assert len(tasks) >= 1
+    assert all(task["identity"]["room_id"] == "room-1" for task in tasks)
+    assert all(
+        task["status"]
+        in {
+            "queued",
+            "running",
+            "settled",
+            "failed",
+            "cancelled",
+            "indeterminate",
+            "deferred",
+            "stopping",
+        }
+        for task in tasks
+    )
+
+
+def test_groups_tasks_status_filter_narrows_the_result(home):
+    _create_room()
+    _result(
+        srv._methods["groups.send"](
+            2,
+            {
+                "room_id": "room-1",
+                "event_id": "event-1",
+                "actor": {"kind": "user", "id": "desktop-user"},
+                "payload": {"text": "hello", "thread_id": "thread-1"},
+            },
+        )
+    )
+
+    unfiltered = _result(srv._methods["groups.tasks"](3, {"room_id": "room-1"}))["tasks"]
+    matching_status = unfiltered[0]["status"]
+
+    filtered = _result(
+        srv._methods["groups.tasks"](4, {"room_id": "room-1", "status": matching_status})
+    )["tasks"]
+
+    assert len(filtered) == len([t for t in unfiltered if t["status"] == matching_status])
+    assert all(task["status"] == matching_status for task in filtered)
+
+
+def test_groups_tasks_on_unknown_room_matches_groups_state_error_shape(home):
+    """A bad room_id must return the same room-lookup error groups.state
+    uses (4114) -- not a silently empty task list masking a typo."""
+    result = srv._methods["groups.tasks"](1, {"room_id": "does-not-exist"})
+
+    assert "error" in result
+    assert result["error"]["code"] == 4114
+
+
 def test_groups_list_returns_bounded_pages(home):
     _create_room()
     _result(

--- a/tui_gateway/methods_groups.py
+++ b/tui_gateway/methods_groups.py
@@ -18,6 +18,7 @@ LONG_HANDLERS = frozenset({
     "groups.capabilities",
     "groups.create",
     "groups.state",
+    "groups.tasks",
     "groups.send",
     "groups.rename",
     "groups.log",
@@ -559,6 +560,56 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 4114, str(exc), {"reason": reason} if reason else None)
     except Exception as exc:
         return _err(rid, 5115, str(exc))
+
+
+@method("groups.tasks")
+def _(rid, params: dict) -> dict:
+    """Return one hosted room's per-member driver task rows (issue #102196).
+
+    Thin-wraps ``gateway.hosted_room_driver.list_tasks``, the same real
+    per-member status (``queued``/``running``/``settled``/``failed``/
+    ``cancelled``/``indeterminate``/``deferred``/``stopping``) each task
+    already carries, which ``groups.state``'s ``driver_status`` only ever
+    surfaced as aggregate counts. Optional ``status`` param filters to one
+    status. Validated against ``room_state`` first (same as ``groups.state``)
+    so a bad ``room_id`` returns the room-lookup error rather than a
+    silently empty task list.
+    """
+    from gateway.hosted_room_driver import DriverStateError, list_tasks
+    from gateway.hosted_rooms import HostedRoomError, default_db_path, room_state
+    import dataclasses
+
+    try:
+        room = room_state(
+            default_db_path(),
+            room_id=params.get("room_id"),
+            include_disbanded=params.get("include_disbanded") is True,
+        )
+    except HostedRoomError as exc:
+        reason = getattr(exc, "reason", None)
+        return _err(rid, 4114, str(exc), {"reason": reason} if reason else None)
+    except Exception as exc:
+        return _err(rid, 5115, str(exc))
+
+    try:
+        tasks = list_tasks(
+            default_db_path(),
+            room_id=room["room_id"],
+            status=params.get("status"),
+        )
+        return _ok(
+            rid,
+            {
+                "tasks": [
+                    {**task, "identity": dataclasses.asdict(task["identity"])}
+                    for task in tasks
+                ]
+            },
+        )
+    except DriverStateError as exc:
+        return _err(rid, 4124, str(exc))
+    except Exception as exc:
+        return _err(rid, 5125, str(exc))
 
 
 @method("groups.send")


### PR DESCRIPTION
Fixes #102196.

## Problem

The hosted-room driver already tracks real per-member live status while a turn is in progress -- via `gateway.hosted_room_driver.list_tasks()` -- but no `groups.*` method exposed that per-task detail to a client. `groups.state` only surfaces aggregate counts, never a per-member breakdown of who is currently generating vs. settled vs. passed.

## Fix

Added `groups.tasks(room_id, status=None)`, thin-wrapping `list_tasks()` as the issue's own suggested fix describes. Validates the room exists first via `room_state()` (same pattern `groups.state` uses), so a bad `room_id` returns the same `4114` error rather than a silently empty list. Registered in `LONG_HANDLERS` alongside every other SQLite-backed `groups.*` method.

## Bugs found and fixed during testing

1. **Real bug**: `TaskIdentity` is a frozen dataclass, not JSON-serializable by default -- a real wire response would have raised `TypeError`. Converts it via `dataclasses.asdict()` before returning.
2. **Architecture pitfall**: `HandlerRegistry.install()` rebinds every `@method`-decorated handler's `__globals__` to `server.py`'s own namespace, so a module-level import in `methods_groups.py` is invisible to the handler at runtime. My first attempt used a module-level `import dataclasses`, which failed at call time with "name 'dataclasses' is not defined" -- moved the import inside the handler body, matching every other handler in this file.

## Verification

Verified as a genuine regression by reverting the entire new method and confirming all 3 new tests fail with `KeyError: 'groups.tasks'`. Also confirmed the `TaskIdentity` serialization bug directly by reverting just the `dataclasses.asdict()` conversion.

Added 3 regression tests following the existing file's established `_create_room()`/`_result()` helper pattern. 39/39 pass in the full existing test file (no regression).