### PR TITLE
fix(models_dev): resolve model_overrides for custom: provider ids

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -925,6 +925,12 @@ def _provider_override_section(provider: str) -> Optional[Dict[str, Any]]:
     for hermes_id in _models_dev_to_hermes_ids(provider_key):
         if hermes_id != provider_key:
             candidates.append(hermes_id)
+    # Custom providers travel under both ids: config/model-switch surfaces
+    # pass ``custom:<name>`` while users key overrides by the bare name.
+    if provider_key.startswith("custom:"):
+        stripped = provider_key[len("custom:"):].strip()
+        if stripped:
+            candidates.append(stripped)
 
     for key in candidates:
         section = overrides.get(key)

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -13,6 +13,7 @@ from agent.models_dev import (
     _explicit_model_override,
     _override_context_window,
     _override_for,
+    _provider_override_section,
     _NotModified,
     _validate_registry,
     fetch_models_dev,
@@ -889,6 +890,39 @@ class TestModelOverrides:
         assert result is not None
         assert result["context_window"] == 222222
 
+    def test_custom_provider_prefix_resolves_bare_key(self):
+        """``custom:<name>`` callers resolve overrides keyed by the bare name.
+
+        Config and dashboard surfaces pass the prefixed id, but users key
+        ``model_overrides`` by the bare custom provider name (#102425).
+        """
+        overrides = {
+            "jerrita": {
+                "_default": {"supports_reasoning": True},
+            },
+        }
+        with self._setup_overrides(overrides):
+            section = _provider_override_section("custom:jerrita")
+            assert section is not None
+            result = _default_model_override("custom:jerrita")
+        assert result is not None
+        assert result["supports_reasoning"] is True
+        # A ``custom:`` prefix with nothing behind it adds no empty candidate.
+        with self._setup_overrides({"": {"_default": {"context_window": 1}}}):
+            assert _provider_override_section("custom:") is None
+            assert _provider_override_section("custom:   ") is None
+
+    def test_custom_prefix_exact_key_still_wins(self):
+        """A config explicitly keyed ``custom:<name>`` keeps direct priority."""
+        overrides = {
+            "custom:jerrita": {"_default": {"context_window": 111111}},
+            "jerrita": {"_default": {"context_window": 222222}},
+        }
+        with self._setup_overrides(overrides):
+            result = _default_model_override("custom:jerrita")
+        assert result is not None
+        assert result["context_window"] == 111111
+
     def test_default_fills_gap_for_unknown_model(self):
         """_default applies to models the catalog does not know."""
         overrides = {
@@ -1089,6 +1123,23 @@ class TestModelOverrides:
             caps = get_model_capabilities("custom:my-vllm", "some-new-model")
         assert caps is not None
         assert caps.context_window == 32768
+        assert caps.supports_tools is True
+
+    def test_caps_custom_provider_bare_key_fills_gap(self):
+        """Bare-name override keys work for prefixed custom providers (#102425)."""
+        overrides = {
+            "my-vllm": {
+                "_default": {
+                    "supports_reasoning": True,
+                    "supports_tools": True,
+                },
+            },
+        }
+        with self._setup_overrides(overrides), \
+             patch("agent.models_dev.fetch_models_dev", return_value={}):
+            caps = get_model_capabilities("custom:my-vllm", "glm-5.3-flash")
+        assert caps is not None
+        assert caps.supports_reasoning is True
         assert caps.supports_tools is True
 
     # --- lookup_models_dev_context with overrides ---


### PR DESCRIPTION
## What does this PR do?

`_provider_override_section()` in `agent/models_dev.py` builds a candidate list of config keys for a provider id (the raw key, the models.dev mapping, and the reverse mapping), but never tries the bare name behind a `custom:` prefix. Config and dashboard surfaces pass providers around as `custom:<name>` (built by `hermes_cli/model_switch.py`), while users key `model_overrides` by the bare provider name — so every override for a custom provider was silently ignored, and `get_model_capabilities()` returned `None` for the fill-gap `_default` path (the #8731 self-unblock mechanism) for exactly the custom/local-model users that path was built for.

This strips the `custom:` prefix into the existing candidate list, matching the multi-candidate design the function already documents (`copilot` / `github-copilot` both work). Minimal, single-direction: a config explicitly keyed `custom:<name>` still wins via the direct match on the raw key.

## Related Issue

Fixes #102425

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/models_dev.py` — `_provider_override_section()`: append the `custom:`-stripped bare name to the candidate list (empty-after-strip adds nothing).
- `tests/agent/test_models_dev.py` — three regression tests: bare-key section/_default resolution for prefixed callers, exact `custom:<name>` config key keeps priority, and an end-to-end `get_model_capabilities()` fill-gap assertion (the issue's observable symptom).

## How to Test

1. `python -m pytest tests/agent/test_models_dev.py -q` — Observed result: 71 passed.
2. Red/green check: reverting only the `agent/models_dev.py` hunk makes `test_custom_provider_prefix_resolves_bare_key` and `test_caps_custom_provider_bare_key_fills_gap` fail (the issue's two reported symptoms); restoring it makes all pass.
3. Manual repro from the issue: with `model_overrides: {jerrita: {_default: {supports_reasoning: true}}}`, `get_model_capabilities(provider="custom:jerrita", model="glm-5.3-flash").supports_reasoning` should now return `True` instead of `None`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A