### PR TITLE
fix(desktop): complete remote quit on first request

### DIFF
--- a/apps/desktop/electron/backend-connection-state.test.ts
+++ b/apps/desktop/electron/backend-connection-state.test.ts
@@ -105,3 +105,19 @@ test('an invalidated attempt cannot attach a late-spawned process', () => {
   assert.equal(state.attachProcess(staleAttempt, { id: 'late' }), null)
   assert.equal(state.getProcess(), null)
 })
+
+test('distinguishes a pending connection attempt from a cached settled descriptor', async () => {
+  const state = createBackendConnectionState<FakeProcess, string>()
+  const connection = deferred<string>()
+  const attempt = state.startAttempt()
+
+  state.setPromise(attempt, connection.promise)
+  assert.equal(state.getPendingPromise(), connection.promise)
+
+  connection.resolve('https://remote.example')
+  await connection.promise
+  await Promise.resolve()
+
+  assert.equal(state.getPromise(), connection.promise)
+  assert.equal(state.getPendingPromise(), null)
+})

--- a/apps/desktop/electron/backend-connection-state.ts
+++ b/apps/desktop/electron/backend-connection-state.ts
@@ -12,6 +12,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
   let generation = 0
   let process: TProcess | null = null
   let promise: Promise<TConnection> | null = null
+  let pendingPromise: Promise<TConnection> | null = null
 
   return {
     startAttempt(): BackendConnectionAttempt<TConnection> {
@@ -25,6 +26,20 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       attempt.promise = nextPromise
       promise = nextPromise
+      pendingPromise = nextPromise
+
+      void nextPromise.then(
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        },
+        () => {
+          if (attempt.generation === generation && promise === nextPromise) {
+            pendingPromise = null
+          }
+        }
+      )
 
       return true
     },
@@ -53,6 +68,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
 
       process = null
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -63,6 +79,7 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       }
 
       promise = null
+      pendingPromise = null
 
       return true
     },
@@ -75,12 +92,17 @@ export function createBackendConnectionState<TProcess, TConnection>() {
       return promise
     },
 
+    getPendingPromise(): Promise<TConnection> | null {
+      return pendingPromise
+    },
+
     invalidate(): TProcess | null {
       const currentProcess = process
 
       generation += 1
       process = null
       promise = null
+      pendingPromise = null
 
       return currentProcess
     }

--- a/apps/desktop/electron/backend-ownership.test.ts
+++ b/apps/desktop/electron/backend-ownership.test.ts
@@ -314,8 +314,8 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
 
   assert.equal(first, second)
   assert.equal(coordinator.hasStarted(), true)
-  await Promise.resolve()
   assert.equal(teardown.mock.calls.length, 1)
+  assert.equal(coordinator.isPending(), true)
 
   let finished = false
   first.then(() => {
@@ -327,6 +327,7 @@ test('shutdown coordinator returns one promise and awaits teardown exactly once'
   completion.resolve()
   await second
   assert.equal(finished, true)
+  assert.equal(coordinator.isPending(), false)
   assert.equal(coordinator.run(), first)
 })
 

--- a/apps/desktop/electron/backend-ownership.ts
+++ b/apps/desktop/electron/backend-ownership.ts
@@ -320,17 +320,36 @@ export function backendCommandMatches(command: unknown): boolean {
 /** Coordinates all quit paths so asynchronous backend teardown runs once. */
 export function createBackendShutdownCoordinator(teardown: () => Promise<void> | void) {
   let completion: Promise<void> | undefined
+  let settled = false
 
   return {
     run(): Promise<void> {
       if (!completion) {
-        completion = Promise.resolve().then(teardown)
+        try {
+          // Invoke synchronously so no-wait quit paths still invalidate cached
+          // connection state and stop timers before Electron exits.
+          completion = Promise.resolve(teardown())
+        } catch (error) {
+          completion = Promise.reject(error)
+        }
+
+        void completion.then(
+          () => {
+            settled = true
+          },
+          () => {
+            settled = true
+          }
+        )
       }
 
       return completion
     },
     hasStarted(): boolean {
       return completion !== undefined
+    },
+    isPending(): boolean {
+      return completion !== undefined && !settled
     }
   }
 }

--- a/apps/desktop/electron/connection-apply.test.ts
+++ b/apps/desktop/electron/connection-apply.test.ts
@@ -4,7 +4,6 @@ import {
   applyConnectionChange,
   commitConnectionFailure,
   resolveTerminalConnection,
-  sshQuitShouldBlock,
   teardownSshState
 } from './connection-apply'
 
@@ -89,48 +88,6 @@ describe('resolveTerminalConnection', () => {
         async () => undefined
       )
     ).rejects.toThrow('not ready')
-  })
-})
-
-describe('sshQuitShouldBlock', () => {
-  it('waits when connections exist and teardown has not finished', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 1, bootstrapPending: 0, inFlight: null })).toBe(
-      true
-    )
-  })
-
-  it('waits when bootstrap is still running', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 1, inFlight: null })).toBe(
-      true
-    )
-  })
-
-  it('waits when the map is empty but a remote kill is already in flight', () => {
-    expect(
-      sshQuitShouldBlock({
-        teardownDone: false,
-        connectionCount: 0,
-        bootstrapPending: 0,
-        inFlight: Promise.resolve()
-      })
-    ).toBe(true)
-  })
-
-  it('does not block a second quit after teardown finished', () => {
-    expect(
-      sshQuitShouldBlock({
-        teardownDone: true,
-        connectionCount: 1,
-        bootstrapPending: 1,
-        inFlight: Promise.resolve()
-      })
-    ).toBe(false)
-  })
-
-  it('does not block quit when there is nothing to tear down', () => {
-    expect(sshQuitShouldBlock({ teardownDone: false, connectionCount: 0, bootstrapPending: 0, inFlight: null })).toBe(
-      false
-    )
   })
 })
 

--- a/apps/desktop/electron/connection-apply.ts
+++ b/apps/desktop/electron/connection-apply.ts
@@ -61,21 +61,6 @@ async function resolveTerminalConnectionForSender(webContentsId, getTarget, ensu
   )
 }
 
-/** A second before-quit must still wait for an in-flight remote kill.
- *
- *  teardownSshConnection deletes the sshConnections entry first, then
- *  SSH-execs kill. backendShutdown's finally() calls app.quit() and
- *  re-enters before-quit with an empty map. Without `inFlight`, Electron
- *  exits while disconnect is running and the detached serve --isolated
- *  stays at pid 1 (post-#95085 leftover on #91668: window X on Windows). */
-function sshQuitShouldBlock({ teardownDone, connectionCount, bootstrapPending, inFlight }) {
-  if (teardownDone) {
-    return false
-  }
-
-  return connectionCount > 0 || bootstrapPending > 0 || Boolean(inFlight)
-}
-
 async function teardownSshState(state, { cleanupRemote }) {
   // Remote process first, while the SSH channel can still exec kill.
   // Then drop the local forward and close the transport. Each step is
@@ -106,6 +91,5 @@ export {
   commitConnectionFailure,
   resolveTerminalConnection,
   resolveTerminalConnectionForSender,
-  sshQuitShouldBlock,
   teardownSshState
 }

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -90,7 +90,7 @@ import {
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
 import { detectBundleSwap } from './bundle-swap'
-import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
+import { applyConnectionChange, teardownSshState } from './connection-apply'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -322,6 +322,7 @@ import {
 } from './profile-session-routing'
 import { createQuickEntryShortcut, quickEntryWindowBounds, sanitizeQuickEntrySettings } from './quick-entry'
 import { type ActiveWork, mergeActiveWork, normalizeActiveWork, quitPromptFor } from './quit-guard'
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
 import * as remoteLifecycle from './remote-lifecycle'
 import {
   attachPowerResumeRemoteRevalidation,
@@ -10177,10 +10178,6 @@ function clearManagedSshRecovery(connectionId, correlationId) {
 
 const sshBootstrapCoordinator = createBootstrapCoordinator()
 
-let sshQuitTeardownDone = false
-let sshQuitTeardownPromise: Promise<void> | null = null
-let backendQuitTeardownDone = false
-
 function sshScopeKey(profile) {
   return connectionScopeKey(profile) || ''
 }
@@ -12612,6 +12609,7 @@ async function stopAllPoolBackends() {
 }
 
 const backendShutdown = createBackendShutdownCoordinator(async () => {
+  const pendingConnection = backendConnectionState.getPendingPromise()
   const primary = backendConnectionState.invalidate()
 
   stopBackendChild(primary)
@@ -12622,8 +12620,29 @@ const backendShutdown = createBackendShutdownCoordinator(async () => {
     poolIdleReaper = null
   }
 
-  await Promise.all([waitForBackendExit(primary), pooledStops])
+  const pendingConnectionSettled = pendingConnection?.then(
+    () => undefined,
+    () => undefined
+  )
+
+  await Promise.all([waitForBackendExit(primary), pooledStops, pendingConnectionSettled])
 })
+
+const quitTeardown = createQuitTeardownCoordinator(() => app.quit())
+
+async function teardownSshForQuit() {
+  const scopes = [...sshConnections.keys()]
+
+  const pending = Promise.allSettled([
+    ...scopes.map(scope => teardownSshConnection(scope || null)),
+    ...sshBootstrapCoordinator.promises()
+  ])
+
+  // cleanupStale waits up to 5s for an owned pid to exit (50 * 100ms).
+  // Keep the existing 6s boundary, then force-clean any remaining bootstrap.
+  await Promise.race([pending, new Promise<void>(resolve => setTimeout(resolve, 6_000))])
+  await sshBootstrapCoordinator.forceCleanupAll()
+}
 
 async function exitAfterBackendShutdown(code) {
   await backendShutdown.run()
@@ -18053,50 +18072,22 @@ app.on('before-quit', event => {
   // already quitting (#91668).
   sshBootstrapCoordinator.shutdown()
 
-  if (!backendQuitTeardownDone) {
-    event.preventDefault()
-    void backendShutdown.run().finally(() => {
-      backendQuitTeardownDone = true
-      app.quit()
-    })
+  const backendNeedsWait = backendQuitNeedsWait({
+    connectionPending: backendConnectionState.getPendingPromise() !== null,
+    poolPending: poolStopper.hasPending(),
+    processAttached: backendConnectionState.getProcess() !== null,
+    shutdownPending: backendShutdown.isPending()
+  })
+
+  const sshNeedsWait = sshConnections.size > 0 || sshBootstrapCoordinator.promises().length > 0
+  const teardownTasks = [{ run: () => backendShutdown.run(), waitForCompletion: backendNeedsWait }]
+
+  if (sshNeedsWait) {
+    teardownTasks.push({ run: teardownSshForQuit, waitForCompletion: true })
   }
 
-  // backendShutdown.finally() re-enters before-quit. teardownSshConnection
-  // already deleted the map entries, so size===0 would skip the kill wait
-  // and let window-X quit finish while SSH exec is still running (#91668).
-  if (
-    sshQuitShouldBlock({
-      teardownDone: sshQuitTeardownDone,
-      connectionCount: sshConnections.size,
-      bootstrapPending: sshBootstrapCoordinator.promises().length,
-      inFlight: sshQuitTeardownPromise
-    })
-  ) {
+  if (quitTeardown.begin(teardownTasks)) {
     event.preventDefault()
-
-    if (!sshQuitTeardownPromise) {
-      const scopes = [...sshConnections.keys()]
-
-      const pending = Promise.allSettled([
-        ...scopes.map(scope => teardownSshConnection(scope || null)),
-        ...sshBootstrapCoordinator.promises()
-      ])
-
-      // cleanupStale waits up to 5s for the owned pid to exit (50 * 100ms).
-      // The previous 4s race could close SSH first and leave serve --isolated
-      // reparented to pid 1. Latch this promise BEFORE those deletes land so
-      // a re-entrant quit still waits.
-      sshQuitTeardownPromise = Promise.race([pending, new Promise<void>(resolve => setTimeout(resolve, 6_000))]).then(
-        async () => {
-          await sshBootstrapCoordinator.forceCleanupAll()
-        }
-      )
-    }
-
-    void sshQuitTeardownPromise.then(() => {
-      sshQuitTeardownDone = true
-      app.quit()
-    })
   }
 
   // Clean quit mid-boot should not trip next-launch --no-sandbox (#38216).

--- a/apps/desktop/electron/pool-stop.test.ts
+++ b/apps/desktop/electron/pool-stop.test.ts
@@ -89,6 +89,14 @@ test('stop of an unknown key resolves without signalling anything', async () => 
   assert.equal(stopper.inFlight('ghost'), undefined)
 })
 
+test('a remote pooled descriptor without a local child does not require quit deferral', () => {
+  const { pool, stopper } = harness()
+
+  pool.set('remote', {})
+
+  assert.equal(stopper.hasPending(), false)
+})
+
 test('stopAll stops every pooled backend and resolves after all exits', async () => {
   const { addChild, exitResolvers, pool, stopper } = harness()
   const a = addChild('a')
@@ -111,6 +119,31 @@ test('stopAll stops every pooled backend and resolves after all exits', async ()
   exitResolvers.get(b)?.()
   await all
   assert.equal(settled, true)
+})
+
+test('stopAll joins a stop whose pool entry was already evicted', async () => {
+  const { addChild, exitResolvers, pool, stopper } = harness()
+  const child = addChild('already-stopping')
+
+  const first = stopper.stop('already-stopping')
+
+  assert.equal(pool.size, 0)
+  assert.equal(stopper.hasPending(), true)
+
+  let settled = false
+
+  const all = stopper.stopAll().then(() => {
+    settled = true
+  })
+
+  await Promise.resolve()
+
+  assert.equal(settled, false)
+
+  exitResolvers.get(child)?.()
+  await Promise.all([first, all])
+  assert.equal(settled, true)
+  assert.equal(stopper.hasPending(), false)
 })
 
 test('a respawn can await the in-flight stop before reusing the key', async () => {

--- a/apps/desktop/electron/pool-stop.ts
+++ b/apps/desktop/electron/pool-stop.ts
@@ -38,9 +38,11 @@ export interface PoolStopperDeps {
 export interface PoolStopper {
   /** The in-flight stop for a key, if any — await before respawning it. */
   inFlight: (key: string) => Promise<void> | undefined
+  /** Whether the pool has a local child or an already-evicted stop in flight. */
+  hasPending: () => boolean
   /** Stop one pooled backend; concurrent calls share the same promise. */
   stop: (key: string) => Promise<void>
-  /** Stop every pooled backend currently in the pool. */
+  /** Stop every pooled backend and join stops already in flight. */
   stopAll: () => Promise<void>
 }
 
@@ -78,9 +80,12 @@ export function createPoolStopper(deps: PoolStopperDeps): PoolStopper {
 
   return {
     inFlight: key => stops.get(key),
+    hasPending: () => stops.size > 0 || [...deps.pool.values()].some(entry => entry.process != null),
     stop,
     stopAll: async () => {
-      await Promise.all([...deps.pool.keys()].map(stop))
+      const currentStops = [...deps.pool.keys()].map(stop)
+
+      await Promise.all(new Set([...stops.values(), ...currentStops]))
     }
   }
 }

--- a/apps/desktop/electron/quit-teardown.test.ts
+++ b/apps/desktop/electron/quit-teardown.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict'
+
+import { test, vi } from 'vitest'
+
+import { backendQuitNeedsWait, createQuitTeardownCoordinator } from './quit-teardown'
+
+function deferred() {
+  let resolve!: () => void
+
+  const promise = new Promise<void>(done => {
+    resolve = done
+  })
+
+  return { promise, resolve }
+}
+
+test('remote-only cleanup does not cancel the original quit', () => {
+  const cleanup = vi.fn()
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const shouldPrevent = coordinator.begin([{ run: cleanup, waitForCompletion: false }])
+
+  assert.equal(shouldPrevent, false)
+  assert.equal(cleanup.mock.calls.length, 1)
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+})
+
+test('a settled remote descriptor is not backend work that requires a deferred quit', () => {
+  assert.equal(
+    backendQuitNeedsWait({
+      connectionPending: false,
+      poolPending: false,
+      processAttached: false,
+      shutdownPending: false
+    }),
+    false
+  )
+
+  for (const key of ['connectionPending', 'poolPending', 'processAttached', 'shutdownPending'] as const) {
+    assert.equal(
+      backendQuitNeedsWait({
+        connectionPending: false,
+        poolPending: false,
+        processAttached: false,
+        shutdownPending: false,
+        [key]: true
+      }),
+      true,
+      `${key} must defer quit`
+    )
+  }
+})
+
+test('one final quit waits for every required teardown branch', async () => {
+  const backend = deferred()
+  const ssh = deferred()
+  const requestFinalQuit = vi.fn()
+  const backendRun = vi.fn(() => backend.promise)
+  const sshRun = vi.fn(() => ssh.promise)
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  const tasks = [
+    { run: backendRun, waitForCompletion: true },
+    { run: sshRun, waitForCompletion: true }
+  ]
+
+  assert.equal(coordinator.begin(tasks), true)
+  assert.equal(coordinator.begin(tasks), true, 'a re-entrant quit stays deferred while teardown is pending')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+
+  backend.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 0)
+
+  ssh.resolve()
+  await Promise.all([backend.promise, ssh.promise])
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+
+  assert.equal(coordinator.begin(tasks), false, 'the coordinator must not cancel its own final quit')
+  assert.equal(backendRun.mock.calls.length, 1)
+  assert.equal(sshRun.mock.calls.length, 1)
+})
+
+test('teardown failure still releases the final quit after all branches settle', async () => {
+  const requestFinalQuit = vi.fn()
+  const coordinator = createQuitTeardownCoordinator(requestFinalQuit)
+
+  assert.equal(
+    coordinator.begin([
+      {
+        run: () => {
+          throw new Error('cleanup failed')
+        },
+        waitForCompletion: true
+      }
+    ]),
+    true
+  )
+
+  await Promise.resolve()
+  await Promise.resolve()
+  assert.equal(requestFinalQuit.mock.calls.length, 1)
+})

--- a/apps/desktop/electron/quit-teardown.ts
+++ b/apps/desktop/electron/quit-teardown.ts
@@ -1,0 +1,74 @@
+export interface QuitTeardownTask {
+  /** Whether Electron must defer this quit until the task settles. */
+  waitForCompletion: boolean
+  /** Starts teardown. This is invoked synchronously from before-quit. */
+  run: () => Promise<unknown> | unknown
+}
+
+export interface QuitTeardownCoordinator {
+  /**
+   * Starts teardown once and reports whether the current quit must be
+   * prevented. Re-entrant quit requests are held until all required teardown
+   * settles; the coordinator then requests exactly one final quit.
+   */
+  begin: (tasks: readonly QuitTeardownTask[]) => boolean
+}
+
+export interface BackendQuitActivity {
+  connectionPending: boolean
+  poolPending: boolean
+  processAttached: boolean
+  shutdownPending: boolean
+}
+
+export function backendQuitNeedsWait(activity: BackendQuitActivity): boolean {
+  return activity.shutdownPending || activity.processAttached || activity.connectionPending || activity.poolPending
+}
+
+function runTask(task: QuitTeardownTask): Promise<unknown> {
+  try {
+    return Promise.resolve(task.run())
+  } catch (error) {
+    return Promise.reject(error)
+  }
+}
+
+/**
+ * Coordinates Electron's before-quit teardown without cancelling a quit that
+ * has no asynchronous work to wait for.
+ */
+export function createQuitTeardownCoordinator(requestFinalQuit: () => void): QuitTeardownCoordinator {
+  let completion: Promise<void> | null = null
+  let finished = false
+
+  return {
+    begin(tasks): boolean {
+      if (finished) {
+        return false
+      }
+
+      if (completion) {
+        return true
+      }
+
+      const executions = tasks.map(task => ({ promise: runTask(task), waitForCompletion: task.waitForCompletion }))
+      const mustWait = executions.some(task => task.waitForCompletion)
+
+      if (!mustWait) {
+        // Observe asynchronous no-wait cleanup so a late rejection cannot
+        // become unhandled, but let Electron continue the original quit.
+        void Promise.allSettled(executions.map(task => task.promise))
+        finished = true
+
+        return false
+      }
+
+      completion = Promise.allSettled(executions.map(task => task.promise)).then(() => {
+        finished = true
+        requestFinalQuit()
+      })
+
+      return true
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Fixes Desktop quit coordination for URL-backed remote sessions. The existing `before-quit` handler always cancelled the first quit while backend shutdown ran, even when the cached connection was already settled and Desktop owned no local backend process. On macOS, Command+Q could therefore leave the Electron process and helper processes alive.

This introduces one quit-teardown coordinator that starts cleanup exactly once, only prevents the quit when there is real asynchronous work to await, and requests one final quit after required local or SSH teardown settles. Settled remote descriptors now allow the original quit to continue normally.

## Related Issue

N/A. Reported through support.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Track whether the primary backend connection promise is still pending instead of treating a settled remote descriptor as active shutdown work.
- Track pending local pool and backend shutdown work so quit waits only when required.
- Replace independent backend and SSH re-entry loops with a single idempotent quit coordinator.
- Preserve the existing bounded SSH cleanup and ensure already-evicted pool stops are joined.
- Add behavioral coverage for remote-only quit, re-entrant quit, cleanup failure, pending connection state, and pooled shutdown.

## How to Test

1. Configure Desktop to use a URL-backed remote backend and let the connection settle.
2. On macOS, press Command+Q once and confirm the app and its Electron helper processes exit.
3. Confirm local-backend and SSH sessions still wait for their owned teardown before the final quit.

Automated verification:

- `npx --no-install vitest run --project electron electron/quit-teardown.test.ts electron/backend-connection-state.test.ts electron/backend-ownership.test.ts electron/pool-stop.test.ts electron/connection-apply.test.ts` (45 passed)
- `npm run typecheck`
- Focused ESLint over all touched Electron files

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 focused unit tests, lint, and typecheck; native macOS verification remains for review

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. The regression is covered by focused lifecycle tests without including customer diagnostics.