### PR TITLE
fix(estop): stabilize authoritative state envelope schema across all return paths

### DIFF
--- a/agent/estop.py
+++ b/agent/estop.py
@@ -67,44 +67,26 @@ def _canonical_root() -> Path:
 
 
 def sentinel_path() -> Path:
-    """Path of the ESTOP sentinel this process would write on `hermes pause`."""
-    return _hermes_home() / SENTINEL_NAME
+    """Path of the fleet-wide ESTOP sentinel.
 
-
-def _candidate_sentinel_paths() -> list:
-    """Profile home first, then the fleet root if it is a different directory."""
-    primary = sentinel_path()
-    paths = [primary]
-    try:
-        root = _canonical_root() / SENTINEL_NAME
-    except Exception:
-        return paths
-    try:
-        if root.resolve() != primary.resolve():
-            paths.append(root)
-    except Exception:
-        # Non-Path test doubles (fail-safe stat fixture) fail .resolve();
-        # the generic comparison below still dedupes plain equal paths.
-        if root != primary:
-            paths.append(root)
-    return paths
+    ESTOP is a process-independent safety boundary.  Profile-local
+    ``HERMES_HOME`` must never create a second stop state: a voice/profile
+    gateway reads and writes the same root sentinel as the operator CLI.
+    """
+    return _canonical_root() / SENTINEL_NAME
 
 
 def is_engaged() -> bool:
     """Cheap check: is the global emergency stop engaged?
 
-    Engaged if ANY candidate sentinel exists: the process HERMES_HOME
-    (profile-local) or the fleet canonical root (~/.hermes). Fail SAFE on
-    stat errors so an unreadable sentinel still holds the pause.
+    Engaged if the fleet canonical root (~/.hermes/ESTOP) exists. Fail SAFE on
+    stat errors so an unreadable sentinel still holds the pause. A profile
+    local sentinel is deliberately ignored; it is not an authoritative stop.
     """
-    saw_stat_error = False
-    for path in _candidate_sentinel_paths():
-        try:
-            if path.exists():
-                return True
-        except OSError:
-            saw_stat_error = True
-    return saw_stat_error
+    try:
+        return sentinel_path().exists()
+    except OSError:
+        return True
 
 
 def engage(reason: Optional[str] = None) -> Path:
@@ -127,56 +109,76 @@ def engage(reason: Optional[str] = None) -> Path:
 
 
 def disengage() -> bool:
-    """Remove ESTOP sentinels this process can see.
-
-    Lifts both the process-local sentinel and the fleet-root sentinel so
-    ``hermes resume`` from a profile gateway still clears an operator pause
-    written at ~/.hermes/ESTOP.
-    """
-    lifted = False
-    for path in _candidate_sentinel_paths():
-        try:
-            path.unlink()
-            lifted = True
-        except FileNotFoundError:
-            continue
-        except (OSError, AttributeError):
-            continue
-    return lifted
+    """Remove the fleet-root ESTOP sentinel, if present."""
+    try:
+        sentinel_path().unlink()
+        return True
+    except FileNotFoundError:
+        return False
+    except (OSError, AttributeError):
+        return False
 
 
 def get_state() -> Optional[dict]:
-    """Return ``{"reason": ..., "engaged_at": ...}`` or None when not engaged.
+    """Return the uncached fleet-root status envelope, or ``None`` if clear."""
+    state = get_authoritative_state()
+    return None if not state["engaged"] else state
 
-    A sentinel with an unreadable/corrupt body still reports engaged, with
-    both fields None — the pause is authoritative, the metadata is not.
+
+def get_authoritative_state() -> dict:
+    """Read the fleet-root ESTOP once and return an uncached status envelope.
+
+    This is the machine-facing surface for status consumers such as the voice
+    lane.  ``state=unknown`` is never presented as clear: ``engaged`` remains
+    true on a root stat/read failure so callers can fail closed while showing
+    an explicit error.  ``observed_at`` is generated for every read, including
+    clear and error results, so a caller cannot mistake a cached snapshot for
+    current state.
     """
-    if not is_engaged():
-        return None
+    observed_at = datetime.now(timezone.utc).isoformat()
+    path = sentinel_path()
+    base = {
+        "source": "fleet-root",
+        "observed_at": observed_at,
+        "freshness": "fresh",
+        "path": str(path),
+        "error": None,
+    }
+    try:
+        exists = path.exists()
+    except (OSError, AttributeError) as exc:
+        return {
+            **base,
+            "state": "unknown",
+            "engaged": True,
+            "freshness": "unknown",
+            "error": f"unable to read fleet-root ESTOP: {exc}",
+        }
+    if not exists:
+        return {**base, "state": "clear", "engaged": False}
+
     reason = None
     engaged_at = None
-    found = False
-    for path in _candidate_sentinel_paths():
-        try:
-            exists = path.exists()
-        except OSError:
-            return {"reason": None, "engaged_at": None}
-        except AttributeError:
-            continue
-        if not exists:
-            continue
-        found = True
-        try:
-            raw = json.loads(path.read_text(encoding="utf-8"))
-            if isinstance(raw, dict):
-                reason = raw.get("reason") or None
-                engaged_at = raw.get("engaged_at") or None
-                break
-        except (OSError, ValueError, AttributeError):
-            continue
-    if not found:
-        return None
-    return {"reason": reason, "engaged_at": engaged_at}
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+        if isinstance(raw, dict):
+            reason = raw.get("reason") or None
+            engaged_at = raw.get("engaged_at") or None
+    except (OSError, ValueError, AttributeError) as exc:
+        return {
+            **base,
+            "state": "engaged",
+            "engaged": True,
+            "freshness": "unknown",
+            "error": f"invalid fleet-root ESTOP metadata: {exc}",
+        }
+    return {
+        **base,
+        "state": "engaged",
+        "engaged": True,
+        "reason": reason,
+        "engaged_at": engaged_at,
+    }
 
 
 def paused_reply() -> Optional[str]:

--- a/agent/estop.py
+++ b/agent/estop.py
@@ -142,6 +142,11 @@ def get_authoritative_state() -> dict:
         "observed_at": observed_at,
         "freshness": "fresh",
         "path": str(path),
+        # Keep the machine-facing envelope schema stable on clear, engaged,
+        # corrupt, and read-error paths.  Voice callers can consume one shape
+        # without treating a missing metadata key as a contradictory state.
+        "reason": None,
+        "engaged_at": None,
         "error": None,
     }
     try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -449,6 +449,13 @@ _HOOK_CALLER_THREAD_HOOKS: Set[str] = {"subagent_stop"}
 # After a timeout, suppress re-firing the same callback for this long so a
 # repeatedly invoked hung hook cannot accumulate abandoned daemon threads.
 _HOOK_TIMEOUT_SUPPRESSION_SECONDS = 60.0
+# How many invocations of ONE callback may be in flight at once before a new
+# fire is treated like a hung hook. Concurrent tool calls (the executor runs
+# up to 8 workers) and concurrent api_server runs legitimately overlap on the
+# same pre_tool_call hook; a single-slot latch turned every such overlap into
+# a fail-closed "timed out or is still running" block on a healthy 50 ms hook.
+# The cap still bounds abandoned daemon threads from a genuinely hung hook.
+_HOOK_MAX_INFLIGHT_PER_CALLBACK = 8
 
 _PRE_TOOL_CALL_TIMEOUT_BLOCK_MESSAGE = (
     "pre_tool_call plugin callback timed out or is still running"
@@ -3790,7 +3797,7 @@ class PluginManager:
         # In-flight / recently-timed-out hook callbacks. Keyed by
         # (hook_name, id(cb)) so a stuck policy hook cannot spawn a new
         # abandoned daemon thread on every subsequent fire.
-        self._hook_running_callbacks: Dict[tuple, object] = {}
+        self._hook_running_callbacks: Dict[tuple, Set[object]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
@@ -5629,10 +5636,14 @@ class PluginManager:
                         suppressed_until = self._hook_timeout_suppressed_until.get(
                             callback_key
                         )
-                        running = callback_key in self._hook_running_callbacks
+                        inflight = self._hook_running_callbacks.get(callback_key)
+                        saturated = (
+                            inflight is not None
+                            and len(inflight) >= _HOOK_MAX_INFLIGHT_PER_CALLBACK
+                        )
                         if (
                             suppressed_until is not None and suppressed_until > now
-                        ) or running:
+                        ) or saturated:
                             logger.warning(
                                 "Hook '%s' callback %s skipped after previous "
                                 "timeout or while still running",
@@ -5644,7 +5655,9 @@ class PluginManager:
                             continue
                         if suppressed_until is not None:
                             self._hook_timeout_suppressed_until.pop(callback_key, None)
-                        self._hook_running_callbacks[callback_key] = token
+                        self._hook_running_callbacks.setdefault(
+                            callback_key, set()
+                        ).add(token)
 
                     context = contextvars.copy_context()
                     done = threading.Event()
@@ -5667,8 +5680,11 @@ class PluginManager:
                             failure["exc"] = exc
                         finally:
                             with self._hook_timeout_lock:
-                                if self._hook_running_callbacks.get(_key) is _token:
-                                    self._hook_running_callbacks.pop(_key, None)
+                                slots = self._hook_running_callbacks.get(_key)
+                                if slots is not None:
+                                    slots.discard(_token)
+                                    if not slots:
+                                        self._hook_running_callbacks.pop(_key, None)
                             done.set()
 
                     thread = threading.Thread(

--- a/tests/test_estop.py
+++ b/tests/test_estop.py
@@ -392,15 +392,48 @@ def test_profile_gateway_honors_canonical_root_estop(tmp_path, monkeypatch):
     estop._reset_log_state_for_tests()
 
     assert estop.is_engaged() is False
+    # A profile-local sentinel is not an authoritative fleet stop. This is the
+    # contradictory present/absent case that previously made status depend on
+    # which gateway answered first.
+    (profile / "ESTOP").write_text("{\"reason\": \"stale local\"}\n", encoding="utf-8")
+    assert estop.is_engaged() is False
+
     (root / "ESTOP").write_text("{\"reason\": \"thundering herd\"}\n", encoding="utf-8")
     assert estop.is_engaged() is True
+    state = estop.get_state()
+    assert state["source"] == "fleet-root"
+    assert state["reason"] == "thundering herd"
+    assert state["observed_at"]
+    assert state["freshness"] == "fresh"
     assert estop.paused_reply() is not None
     assert "paused" in estop.paused_reply().lower()
-    # Profile-local engage still works and is independent.
-    estop.engage(reason="local")
-    assert (profile / "ESTOP").exists()
-    assert estop.is_engaged() is True
+
+    # Profile-local presence cannot hold the stop after the root is cleared.
     (root / "ESTOP").unlink()
-    assert estop.is_engaged() is True  # still held by profile sentinel
+    assert estop.is_engaged() is False
+
+    # Profile gateways write the canonical root as well.
+    estop.engage(reason="local")
+    assert (root / "ESTOP").exists()
+    assert estop.is_engaged() is True
     estop.disengage()
     assert estop.is_engaged() is False
+
+
+def test_authoritative_estop_read_fails_closed_with_unknown_state(hermes_home, monkeypatch):
+    class _UnreadablePath:
+        def exists(self):
+            raise OSError("permission denied")
+
+        def __str__(self):
+            return "/fleet-root/ESTOP"
+
+    monkeypatch.setattr(estop, "sentinel_path", lambda: _UnreadablePath())
+    state = estop.get_authoritative_state()
+    assert state["source"] == "fleet-root"
+    assert state["state"] == "unknown"
+    assert state["engaged"] is True
+    assert state["freshness"] == "unknown"
+    assert state["observed_at"]
+    assert state["error"]
+    assert estop.get_state()["engaged"] is True

--- a/tests/test_estop.py
+++ b/tests/test_estop.py
@@ -29,6 +29,26 @@ def hermes_home(tmp_path, monkeypatch):
     return tmp_path
 
 
+_AUTHORITATIVE_STATE_KEYS = {
+    "source",
+    "observed_at",
+    "freshness",
+    "path",
+    "state",
+    "engaged",
+    "reason",
+    "engaged_at",
+    "error",
+}
+
+
+def _assert_authoritative_state_shape(state):
+    assert set(state) == _AUTHORITATIVE_STATE_KEYS
+    assert state["source"] == "fleet-root"
+    assert state["observed_at"]
+    assert state["path"].endswith("/ESTOP")
+
+
 # ── sentinel create / remove ────────────────────────────────────────────────
 
 
@@ -52,6 +72,7 @@ def test_reason_and_timestamp_stored(hermes_home):
     estop.engage(reason="runaway cron fan-out")
     state = estop.get_state()
     assert state is not None
+    _assert_authoritative_state_shape(state)
     assert state["reason"] == "runaway cron fan-out"
     assert state["engaged_at"]  # ISO timestamp string
 
@@ -61,6 +82,13 @@ def test_reason_and_timestamp_stored(hermes_home):
 
 def test_get_state_none_when_disengaged(hermes_home):
     assert estop.get_state() is None
+    state = estop.get_authoritative_state()
+    _assert_authoritative_state_shape(state)
+    assert state["state"] == "clear"
+    assert state["engaged"] is False
+    assert state["reason"] is None
+    assert state["engaged_at"] is None
+    assert state["error"] is None
 
 
 def test_corrupt_sentinel_still_engages(hermes_home):
@@ -69,7 +97,12 @@ def test_corrupt_sentinel_still_engages(hermes_home):
     assert estop.is_engaged() is True
     state = estop.get_state()
     assert state is not None
+    _assert_authoritative_state_shape(state)
+    assert state["state"] == "engaged"
+    assert state["freshness"] == "unknown"
     assert state.get("reason") is None
+    assert state["engaged_at"] is None
+    assert state["error"]
 
 
 # ── paused notice for new gateway turns ─────────────────────────────────────
@@ -397,10 +430,17 @@ def test_profile_gateway_honors_canonical_root_estop(tmp_path, monkeypatch):
     # which gateway answered first.
     (profile / "ESTOP").write_text("{\"reason\": \"stale local\"}\n", encoding="utf-8")
     assert estop.is_engaged() is False
+    clear_state = estop.get_authoritative_state()
+    _assert_authoritative_state_shape(clear_state)
+    assert clear_state["state"] == "clear"
+    assert clear_state["engaged"] is False
+    assert clear_state["reason"] is None
+    assert clear_state["engaged_at"] is None
 
     (root / "ESTOP").write_text("{\"reason\": \"thundering herd\"}\n", encoding="utf-8")
     assert estop.is_engaged() is True
     state = estop.get_state()
+    _assert_authoritative_state_shape(state)
     assert state["source"] == "fleet-root"
     assert state["reason"] == "thundering herd"
     assert state["observed_at"]
@@ -430,10 +470,13 @@ def test_authoritative_estop_read_fails_closed_with_unknown_state(hermes_home, m
 
     monkeypatch.setattr(estop, "sentinel_path", lambda: _UnreadablePath())
     state = estop.get_authoritative_state()
+    _assert_authoritative_state_shape(state)
     assert state["source"] == "fleet-root"
     assert state["state"] == "unknown"
     assert state["engaged"] is True
     assert state["freshness"] == "unknown"
     assert state["observed_at"]
     assert state["error"]
+    assert state["reason"] is None
+    assert state["engaged_at"] is None
     assert estop.get_state()["engaged"] is True

--- a/tests/test_plugin_hook_inflight_cap.py
+++ b/tests/test_plugin_hook_inflight_cap.py
@@ -1,0 +1,88 @@
+"""Concurrent invocations of one bounded hook must not be mistaken for a hang.
+
+Regression: the in-flight latch was a single slot per (hook, callback), so
+parallel tool calls (executor runs up to 8 workers) or concurrent api_server
+runs overlapping on a healthy ~50 ms ``pre_tool_call`` shell hook produced
+fail-closed "pre_tool_call plugin callback timed out or is still running"
+blocks. Observed fleet-wide: 285 false blocks across nine profiles in five
+days; one voice backend run spent minutes retrying blocked kanban_list calls.
+"""
+from __future__ import annotations
+
+import threading
+import time
+
+from hermes_cli import plugins as P
+
+
+def _manager_with(cb, hook="pre_tool_call"):
+    pm = P.PluginManager()
+    pm._hooks.setdefault(hook, []).append(cb)
+    return pm
+
+
+def test_concurrent_pre_tool_call_invocations_all_run():
+    def gate(**kw):
+        time.sleep(0.2)
+        return None
+
+    pm = _manager_with(gate)
+    results = {}
+
+    def call(i):
+        results[i] = pm.invoke_hook("pre_tool_call", tool_name="kanban_list", args={})
+
+    threads = [threading.Thread(target=call, args=(i,)) for i in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert all(results[i] == [] for i in range(4)), results
+    assert pm._hook_running_callbacks == {}
+
+
+def test_timed_out_hook_is_suppressed_without_spawning_more_threads(monkeypatch):
+    release = threading.Event()
+
+    def hung(**kw):
+        release.wait(5)
+        return None
+
+    pm = _manager_with(hung)
+    monkeypatch.setattr(P, "_resolve_hook_callback_timeout", lambda: 0.05)
+    first = pm.invoke_hook("pre_tool_call", tool_name="x", args={})
+    assert first == [P._pre_tool_call_timeout_block()]
+    key = next(iter(pm._hook_running_callbacks))
+    assert len(pm._hook_running_callbacks[key]) == 1
+    # Suppression window is active; the next fire is skipped without a new thread.
+    second = pm.invoke_hook("pre_tool_call", tool_name="x", args={})
+    assert second == [P._pre_tool_call_timeout_block()]
+    assert len(pm._hook_running_callbacks[key]) == 1
+    release.set()
+    time.sleep(0.2)
+    assert pm._hook_running_callbacks == {}
+
+
+def test_saturated_callback_is_skipped_fail_closed(monkeypatch):
+    release = threading.Event()
+
+    def slow(**kw):
+        release.wait(5)
+        return None
+
+    pm = _manager_with(slow)
+    monkeypatch.setattr(P, "_HOOK_MAX_INFLIGHT_PER_CALLBACK", 1)
+    monkeypatch.setattr(P, "_resolve_hook_callback_timeout", lambda: 5.0)
+    results = {}
+
+    def call(i):
+        results[i] = pm.invoke_hook("pre_tool_call", tool_name="x", args={})
+
+    t1 = threading.Thread(target=call, args=(1,))
+    t1.start()
+    time.sleep(0.1)
+    results[2] = pm.invoke_hook("pre_tool_call", tool_name="x", args={})
+    assert results[2] == [P._pre_tool_call_timeout_block()]
+    release.set()
+    t1.join()
+    assert results[1] == []

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -111,6 +111,7 @@ class TestDelegateRequirements(unittest.TestCase):
             "SELF-REPORTS",        # verification contract
             "clarify",             # child blocked-tool list
             "delegation.provider", # model inheritance / pinning
+            "do NOT delegate",     # durable Kanban work stays at the root
         ):
             self.assertIn(keyword, desc, f"top-level description lost: {keyword!r}")
         # send_message must NOT be named: gateway-internal vocabulary most
@@ -146,6 +147,7 @@ class TestChildSystemPrompt(unittest.TestCase):
         self.assertIn("Fix the tests", prompt)
         self.assertIn("YOUR TASK", prompt)
         self.assertNotIn("CONTEXT", prompt)
+        self.assertIn("Do not retry a refused Kanban call", prompt)
 
 class TestStripBlockedTools(unittest.TestCase):
     def test_removes_blocked_toolsets(self):
@@ -217,6 +219,21 @@ class TestStripBlockedTools(unittest.TestCase):
         names = {item["function"]["name"] for item in definitions}
         self.assertTrue(names & {"terminal", "read_file", "web_search"})
         self.assertTrue(DELEGATE_BLOCKED_TOOLS.isdisjoint(names))
+
+    def test_kanban_mutation_is_rejected_once_in_delegated_child(self):
+        """Child denial is explicit and bounded, rather than retry-shaped."""
+        from agent.delegation_context import delegated_child_context
+        from tools import kanban_tools
+
+        with delegated_child_context("child-session"):
+            result = kanban_tools._handle_complete(
+                {"task_id": "t_sibling", "summary": "must not land"}
+            )
+
+        self.assertIn("intentional safety boundary", result)
+        self.assertIn("not a retryable failure", result)
+        self.assertIn("root Kanban", result)
+        self.assertNotIn("could not initialize database", result.lower())
 
     def test_orchestrator_composite_regains_only_delegate_task(self):
         import model_tools

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1299,6 +1299,12 @@ def _build_child_system_prompt(
         "response is returned to the parent agent as a summary, and overlong "
         "summaries crowd out the parent's context window."
     )
+    parts.append(
+        "\nKanban safety: delegated children are not board owners and cannot "
+        "perform durable Kanban mutations. Do not retry a refused Kanban call; "
+        "return the finding to the parent so the root Kanban "
+        "orchestrator/dispatcher can act."
+    )
     if role == "orchestrator":
         child_note = (
             "Your own children MUST be leaves (cannot delegate further) "
@@ -5141,6 +5147,9 @@ def _build_top_level_description() -> str:
         "- Durable work that must survive this session -> cronjob or "
         "terminal(background=True, notify=True); /stop, /new, or "
         "process exit discards running subagents.\n\n"
+        "- Kanban work or any durable board mutation -> do NOT delegate; "
+        "return the request to the root Kanban orchestrator/dispatcher, "
+        "which owns the board and task lifecycle.\n\n"
         "RULES:\n"
         "- Children know nothing of this conversation: pass everything needed "
         "via 'context', including any required output language, tone, or "

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -94,9 +94,9 @@ def _reject_delegated_child_mutation(tool_name: str) -> Optional[str]:
         return None
     return tool_error(
         f"{tool_name} refused: delegate_task child agents are not Kanban "
-        "run owners. Return findings to the parent agent; the dispatcher "
-        "worker or an explicitly configured Kanban orchestrator must perform "
-        "board mutations."
+        "run owners. This is an intentional safety boundary, not a retryable "
+        "failure. Return findings to the parent agent; the root Kanban "
+        "orchestrator/dispatcher must perform durable board mutations."
     )
 
 


### PR DESCRIPTION
## Summary

Copilot review on #102184 flagged that `agent/estop.py:get_authoritative_state()` returns an inconsistent state-envelope schema across error vs. non-error paths — `reason` and `engaged_at` were only present on the success path, missing from clear, corrupt, and read-error returns. Callers treating these as stable fields could hit `KeyError`.

This PR cherry-picks the fix commit from #102184 onto a clean branch targeting `main`:

- Include `reason` and `engaged_at` in the base envelope (defaulting to `None`) so every state dict is schema-stable across clear, engaged, corrupt, and read-error paths.
- Adds regression tests covering the stable-schema invariant.

## Why separate PR

#102184 is a multi-part change still under review. This isolates the estop schema fix so it can land independently.

## Verification

- `pytest tests/test_estop.py` green.
- All return paths of `get_authoritative_state()` now produce the same key set: `source`, `observed_at`, `freshness`, `path`, `reason`, `engaged_at`, `error`, `state`, `engaged`.