### PR TITLE
fix(compression): stream the summary call so the idle timeout ticks

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -5518,6 +5518,13 @@ This compaction should PRIORITISE preserving all information related to the focu
                 # summaries and compaction loops. Omitting lets the adapter
                 # fall back to the model's native output ceiling.
                 # timeout resolved from auxiliary.compression.timeout config by call_llm
+                # stream=True: a slow (e.g. local thinking-model) backend can
+                # take minutes for this single call. Without streaming,
+                # CompressionCommitFence.touch_progress never ticks (it fires
+                # from the SSE delta accumulator's progress hook), so the
+                # idle-window timeout degenerates into a hard wall-clock cap
+                # instead of the inactivity budget it's meant to be (#102407).
+                "stream": True,
             }
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model

--- a/tests/agent/test_lean_single_aux_call.py
+++ b/tests/agent/test_lean_single_aux_call.py
@@ -142,6 +142,23 @@ class TestLeanSingleAuxiliaryCall:
         assert len(prompt) <= c._SUMMARY_INPUT_MAX_CHARS + 20_000
         assert "chars elided" in prompt
 
+    def test_summary_call_streams_so_the_idle_window_ticks(self):
+        """Regression for issue #102407, defect 1: without stream=True, a
+        slow (e.g. local thinking-model) backend never fires
+        CompressionCommitFence.touch_progress via the SSE delta
+        accumulator's progress hook, so the idle-window timeout
+        (hygiene_timeout_seconds / context_timeout_seconds) degenerates
+        into a hard wall-clock cap instead of an inactivity budget."""
+        c = _mk_compressor()
+        turns = _big_region()
+        with patch(
+            "agent.context_compressor.call_llm",
+            return_value=_llm_response(SUMMARY_BODY),
+        ) as mock_call:
+            c._generate_summary(turns)
+        assert mock_call.call_count == 1
+        assert mock_call.call_args.kwargs.get("stream") is True
+
 
 class TestSampledSummaryInput:
     def test_small_input_passes_through(self):


### PR DESCRIPTION
Fixes #102407 (defect 1 of 2).

## Root cause

The compression summary call (the current, single-call replacement for the old per-chunk digest loop #96603 eliminated) used `call_llm`'s default `stream=False`. Without streaming, `CompressionCommitFence.touch_progress` never fires -- the progress hook only ticks from the SSE delta accumulator's `_notify_aux_progress()` inside the streaming-chunk path, which a non-streaming call never exercises. The idle-window timeouts degenerate into hard wall-clock caps instead of inactivity budgets.

This matters most for slow backends -- local thinking-capable models via OpenAI-compatible endpoints, where a single summary call regularly takes 134-327s (measured in the issue) against a 120s default window, always exceeding it even while actively producing tokens.

## Scope note

The issue's root-cause description cites a call site and constant (`_LEAN_DIGEST_MAX_TOKENS`) that don't exist on current `main` -- #96603 already replaced the old per-chunk digest loop with the single-call path this fix targets, and that path has no `max_tokens` cap at all (already addressing what the issue calls "defect 2"). The underlying "defect 1" concern (non-streaming defeats progress detection) still applies to the current call site, so this fix targets that.

## Fix

Added `stream=True` to the summary `call_kwargs`. Verified this is an already-established, tested pattern elsewhere in the codebase before adding it here. Verified `stream` isn't among `_PINNED_ROUTE_FIELDS`, so a pinned-route override can't silently strip it.

## Verification

Ran the existing `test_lean_single_aux_call.py` with the fix applied -- all 8 existing tests pass unchanged. Added a new regression test asserting `stream=True` is passed. Verified as a genuine regression by reverting just the fix and confirming the new test fails.

9/9 pass in the modified test file; 165/165 across three additional related compression test files (no regression).