### PR TITLE
fix(line): scope postback/copy fields per profile (sibling gap after #100609)

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -747,10 +747,13 @@ class LineAdapter(BasePlatformAdapter):
             os.getenv("LINE_ALLOWED_ROOMS", "")
         ) | set(extra.get("allowed_rooms", []))
 
-        # Slow-LLM postback button threshold
+        # Slow-LLM postback button threshold. Scope-aware (see
+        # _get_scoped_secret's docstring): a secondary multiplex profile
+        # must not borrow the default profile's bridged env values here
+        # either — same leak mechanism as host/port/allowlists above.
         try:
             self.slow_response_threshold = float(
-                os.getenv("LINE_SLOW_RESPONSE_THRESHOLD")
+                _get_scoped_secret("LINE_SLOW_RESPONSE_THRESHOLD")
                 or extra.get("slow_response_threshold", DEFAULT_SLOW_RESPONSE_THRESHOLD)
             )
         except (TypeError, ValueError):
@@ -758,19 +761,19 @@ class LineAdapter(BasePlatformAdapter):
 
         # User-overridable copy
         self.pending_text = (
-            os.getenv("LINE_PENDING_TEXT")
+            _get_scoped_secret("LINE_PENDING_TEXT")
             or extra.get("pending_text", DEFAULT_PENDING_REPLY_TEXT)
         )
         self.button_label = (
-            os.getenv("LINE_BUTTON_LABEL")
+            _get_scoped_secret("LINE_BUTTON_LABEL")
             or extra.get("button_label", DEFAULT_BUTTON_LABEL)
         )
         self.delivered_text = (
-            os.getenv("LINE_DELIVERED_TEXT")
+            _get_scoped_secret("LINE_DELIVERED_TEXT")
             or extra.get("delivered_text", DEFAULT_DELIVERED_TEXT)
         )
         self.interrupted_text = (
-            os.getenv("LINE_INTERRUPTED_TEXT")
+            _get_scoped_secret("LINE_INTERRUPTED_TEXT")
             or extra.get("interrupted_text", DEFAULT_INTERRUPTED_TEXT)
         )
 

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -46,6 +46,11 @@ validate_config = _line.validate_config
 _standalone_send = _line._standalone_send
 _env_enablement = _line._env_enablement
 _MessageDeduplicator = _line._MessageDeduplicator
+DEFAULT_SLOW_RESPONSE_THRESHOLD = _line.DEFAULT_SLOW_RESPONSE_THRESHOLD
+DEFAULT_PENDING_REPLY_TEXT = _line.DEFAULT_PENDING_REPLY_TEXT
+DEFAULT_BUTTON_LABEL = _line.DEFAULT_BUTTON_LABEL
+DEFAULT_DELIVERED_TEXT = _line.DEFAULT_DELIVERED_TEXT
+DEFAULT_INTERRUPTED_TEXT = _line.DEFAULT_INTERRUPTED_TEXT
 
 
 # ---------------------------------------------------------------------------
@@ -510,4 +515,114 @@ class TestMediaPublicUrlGuard:
         result = asyncio.run(ad.send_image_file("Uchat", str(img)))
         assert not result.success
         assert "LINE_PUBLIC_URL" in (result.error or "")
+
+
+# ---------------------------------------------------------------------------
+# 12. Multiplex secondary-profile scope — postback/copy fields
+# ---------------------------------------------------------------------------
+#
+# slow_response_threshold/pending_text/button_label/delivered_text/
+# interrupted_text previously read raw os.getenv unconditionally, same as
+# the host/port/public_url/allowlist fields fixed separately (see #100609).
+# Under multiplex, os.environ holds the DEFAULT profile's YAML-to-env
+# bridge output — a secondary profile with its own (different or absent)
+# LINE config would silently inherit the default profile's postback button
+# copy/threshold instead of its own, or (with no config at all) fail
+# closed to the wrong DEFAULT_* constant only by accident of env-var
+# absence rather than by design.
+
+@pytest.fixture
+def multiplex_scope():
+    """Install multiplex + a secondary-profile secret scope; restore after."""
+    tokens = []
+
+    def install(scope=None):
+        from agent.secret_scope import set_multiplex_active, set_secret_scope
+
+        set_multiplex_active(True)
+        tokens.append(set_secret_scope(scope or {}))
+        return tokens[-1]
+
+    yield install
+
+    from agent.secret_scope import reset_secret_scope, set_multiplex_active
+
+    for token in reversed(tokens):
+        reset_secret_scope(token)
+    set_multiplex_active(False)
+
+
+@pytest.fixture
+def default_profile_postback_env(monkeypatch):
+    """The default profile's YAML-to-env bridge output in os.environ."""
+    monkeypatch.setenv("LINE_SLOW_RESPONSE_THRESHOLD", "5")
+    monkeypatch.setenv("LINE_PENDING_TEXT", "default pending")
+    monkeypatch.setenv("LINE_BUTTON_LABEL", "default button")
+    monkeypatch.setenv("LINE_DELIVERED_TEXT", "default delivered")
+    monkeypatch.setenv("LINE_INTERRUPTED_TEXT", "default interrupted")
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "default-token")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "default-secret")
+
+
+class TestMultiplexProfileScopePostback:
+
+    def test_secondary_extra_wins_over_default_profile_env(
+        self, multiplex_scope, default_profile_postback_env
+    ):
+        """The secondary profile's own config is authoritative, not the
+        default profile's bridged threshold/copy."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        cfg = PlatformConfig(
+            enabled=True,
+            extra={
+                "slow_response_threshold": 30,
+                "pending_text": "profile pending",
+                "button_label": "profile button",
+                "delivered_text": "profile delivered",
+                "interrupted_text": "profile interrupted",
+            },
+        )
+        adapter = LineAdapter(cfg)
+        assert adapter.slow_response_threshold == 30
+        assert adapter.pending_text == "profile pending"
+        assert adapter.button_label == "profile button"
+        assert adapter.delivered_text == "profile delivered"
+        assert adapter.interrupted_text == "profile interrupted"
+
+    def test_secondary_missing_keys_fall_back_to_defaults_not_leaked_env(
+        self, multiplex_scope, default_profile_postback_env
+    ):
+        """Keys absent from the profile's config must NOT borrow the
+        default profile's bridged env values — they should fall back to
+        the adapter's own DEFAULT_* constants instead."""
+        from gateway.config import PlatformConfig
+
+        multiplex_scope()
+        adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        assert adapter.slow_response_threshold == DEFAULT_SLOW_RESPONSE_THRESHOLD
+        assert adapter.pending_text == DEFAULT_PENDING_REPLY_TEXT
+        assert adapter.button_label == DEFAULT_BUTTON_LABEL
+        assert adapter.delivered_text == DEFAULT_DELIVERED_TEXT
+        assert adapter.interrupted_text == DEFAULT_INTERRUPTED_TEXT
+
+    def test_default_profile_unscoped_keeps_env_precedence(
+        self, monkeypatch, default_profile_postback_env
+    ):
+        """Multiplex ON but no scope (the DEFAULT profile constructs
+        unscoped): env is its own bridge output and still wins."""
+        from agent.secret_scope import set_multiplex_active
+        from gateway.config import PlatformConfig
+
+        set_multiplex_active(True)
+        try:
+            adapter = LineAdapter(PlatformConfig(enabled=True, extra={}))
+        finally:
+            set_multiplex_active(False)
+        assert adapter.slow_response_threshold == 5
+        assert adapter.pending_text == "default pending"
+        assert adapter.button_label == "default button"
+        assert adapter.delivered_text == "default delivered"
+        assert adapter.interrupted_text == "default interrupted"
 


### PR DESCRIPTION
## Summary

- #100609 (still open, not yet merged) scopes `host`/`port`/`public_url`/`allowed_users`/`allowed_groups`/`allowed_rooms`/`home_channel` for the LINE adapter via the file's established `_get_scoped_secret()` helper, but its diff does not touch five sibling `LineAdapter.__init__` reads that are still on raw `os.getenv(...)`:
  - `LINE_SLOW_RESPONSE_THRESHOLD` → `self.slow_response_threshold`
  - `LINE_PENDING_TEXT` → `self.pending_text`
  - `LINE_BUTTON_LABEL` → `self.button_label`
  - `LINE_DELIVERED_TEXT` → `self.delivered_text`
  - `LINE_INTERRUPTED_TEXT` → `self.interrupted_text`
- Under multiplex, `os.environ` holds the DEFAULT profile's YAML-to-env bridge output. A secondary profile constructing its own `LineAdapter` with a different (or absent) `platforms.line.extra` block would silently inherit the default profile's slow-response threshold and postback button copy through the leaked env var — all five sites read `os.getenv(...) or extra.get(...)`, so the (possibly foreign) env value is checked *before* the profile's own explicit config.
- This PR routes all five through the same `_get_scoped_secret()` helper already used in this file for credentials and (in #100609) the allowlist/webhook fields: under a profile scope it reads that profile's own `.env` value, or returns `None` (falling through to the adapter's own `DEFAULT_*` constant / the profile's `extra` value) rather than borrowing another profile's env; it only falls back to raw `os.environ` when unscoped (the default profile's own construction path, where `os.environ` is legitimately its own value).

## Scope notes

- This file has no `_apply_yaml_config()`-style write-side YAML→env bridge function, so there is no write-side `_skip_env_bridge` guard to add here (unlike WhatsApp/DingTalk/Mattermost). `_env_enablement()` is a read-side seed function and is unaffected by this PR — its own `os.getenv` reads for `port`/`host`/`public_url`/`home_channel` are in scope for #100609, not this PR, and are left untouched.
- All five fields currently use the `os.getenv(...) or extra.get(...)` ordering (env-first). Per this repo's own bug-class notes, this is the milder of the two orderings — an explicit `config.yaml` value only loses if the field is *also* absent from `extra`, not unconditionally overridden — but it's still a real leak for any profile that configures these fields purely via `.env` rather than `config.yaml`, or omits them from `extra` and expects the adapter's own default.
- Left the six fields #100609 already covers (`host`/`port`/`public_url`/`allowed_users`/`allowed_groups`/`allowed_rooms`/`_env_enablement`'s seeds) untouched to avoid semantic overlap with that open PR.

## Test plan

- [x] Extended `tests/gateway/test_line_plugin.py` with a new `TestMultiplexProfileScopePostback` class (mirrors the `multiplex_scope`/`default_profile_env` fixture convention already used for Mattermost and in #100609's own LINE test diff), covering:
  - a secondary profile's own `extra` config wins over a leaked default-profile env value
  - a secondary profile with no `extra` config falls back to the adapter's own `DEFAULT_*` constants, not the leaked env value
  - the unscoped default profile (multiplex on, no scope) still reads its own bridged env correctly (no regression)
- [x] `uv run --frozen python -m pytest tests/gateway/test_line_plugin.py -q` → 34 passed
- [x] Mutation-verify: reverted the adapter.py change via a patch-file (not `git stash`, per this worktree's shared-stash-stack constraint), re-ran the new tests — 2 of 3 failed exactly as expected (leaked default-profile values observed instead of the profile's own config / the adapter's own defaults), confirming the tests actually exercise the bug. Re-applied the fix — all 34 pass again.
- [x] Fresh competitor search right before push: `gh pr list --search "LINE_PENDING_TEXT"`, `"slow_response_threshold"`, `"line postback scope"`, `"in:title line adapter"` — no open PR touches these five fields' scoping. #71656 (an unrelated, unmerged "budget-aware slow delivery" feature) inserts new code near the same `__init__` block but does not modify these `os.getenv(...)` lines themselves — pure textual proximity, not a semantic conflict.