### PR TITLE
fix(gateway): keep constrained profile setup out of member chats

### DIFF
--- a/agent/secret_scope.py
+++ b/agent/secret_scope.py
@@ -120,6 +120,21 @@ def _is_global_env(name: str) -> bool:
     return any(name.startswith(p) for p in _GLOBAL_ENV_PREFIXES)
 
 
+def get_scoped_secret(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Return a profile credential only from the active secret scope.
+
+    Unlike :func:`get_secret`, this never reads ``os.environ``. It is for
+    isolation-critical plugin/subprocess capabilities where an env fallback
+    could cross profile boundaries. Missing scope or missing key is fail-closed.
+    """
+    if _is_global_env(name):
+        raise ValueError(f"global environment variable is not a scoped secret: {name}")
+    scope = _SECRET_SCOPE.get()
+    if scope is None:
+        return default
+    return scope.get(name, default)
+
+
 def get_secret(name: str, default: Optional[str] = None) -> Optional[str]:
     """Resolve a credential by env-var name, honoring the active profile scope.
 

--- a/agent/transports/base.py
+++ b/agent/transports/base.py
@@ -7,14 +7,58 @@ It does NOT own: client construction, streaming, credential refresh,
 prompt caching, interrupt handling, or retry logic.  Those stay on AIAgent.
 """
 
+import logging
 from abc import ABC, abstractmethod
 from typing import Any, Dict, List, Optional
 
 from agent.transports.types import NormalizedResponse
+from utils import TOOL_REQUEST_KEYS, explicit_no_tools
+
+logger = logging.getLogger(__name__)
 
 
 class ProviderTransport(ABC):
     """Base class for provider-specific format conversion and normalization."""
+
+    @staticmethod
+    def sanitize_request_overrides(
+        overrides: Optional[Dict[str, Any]],
+        *,
+        context: str = "request_overrides",
+    ) -> Optional[Dict[str, Any]]:
+        """Drop tool-offering keys from a user-config override dict.
+
+        ``request_overrides`` comes from the user's ``config.yaml`` and is
+        merged into the outgoing kwargs *after* the transport has decided which
+        tools to expose — so ``request_overrides: {tools: [...]}`` would
+        otherwise reinstate a tool surface that ``--no-tools`` removed. Under
+        the explicit no-tools boundary those keys are stripped here, before any
+        merge, on every transport that supports overrides.
+
+        Strips rather than raises: a gateway serving live traffic must degrade
+        to "no tools" — which is what the operator asked for — instead of
+        aborting the turn. This mirrors how the rest of the tool pipeline
+        handles bad input (``model_tools`` logs and continues when schema
+        sanitization or tool-search assembly fails). Every dropped key is
+        logged at warning level by name so the misconfiguration is visible.
+
+        Returns the dict unchanged when the boundary is not in force, so this
+        is a no-op on every normal request.
+        """
+        if not overrides or not explicit_no_tools():
+            return overrides
+        offending = [k for k in overrides if k in TOOL_REQUEST_KEYS]
+        if not offending:
+            return overrides
+        for key in offending:
+            logger.warning(
+                "HERMES_NO_TOOLS=1: dropping %r from %s — an explicit no-tools "
+                "run must not offer a tool surface. Remove it from config.yaml's "
+                "request_overrides, or drop --no-tools.",
+                key,
+                context,
+            )
+        return {k: v for k, v in overrides.items() if k not in TOOL_REQUEST_KEYS}
 
     @property
     @abstractmethod

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -364,12 +364,14 @@ class ChatCompletionsTransport(ProviderTransport):
         if timeout is not None:
             api_kwargs["timeout"] = timeout
 
-        # Tools
-        if tools:
+        # Tools. An explicit empty list is a capability boundary (for example
+        # `hermes chat --no-tools`), so preserve it on the provider wire as
+        # `tools: []`; only None means this caller has no tools contract.
+        if tools is not None:
             # Moonshot/Kimi uses a stricter flavored JSON Schema.  Rewriting
             # tool parameters here keeps aggregator routes (Nous, OpenRouter,
             # etc.) compatible, in addition to direct moonshot.ai endpoints.
-            if is_moonshot_model(model):
+            if tools and is_moonshot_model(model):
                 tools = sanitize_moonshot_tools(tools)
             api_kwargs["tools"] = tools
 

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -506,8 +506,13 @@ class ChatCompletionsTransport(ProviderTransport):
         if extra_body:
             api_kwargs["extra_body"] = extra_body
 
-        # Request overrides last (service_tier etc.)
-        overrides = params.get("request_overrides")
+        # Request overrides last (service_tier etc.). Sanitized first: under
+        # --no-tools this merge is the one remaining way a config file could
+        # put a tool surface back on the wire.
+        overrides = self.sanitize_request_overrides(
+            params.get("request_overrides"),
+            context="request_overrides (chat_completions legacy path)",
+        )
         if overrides:
             api_kwargs.update(overrides)
 
@@ -620,8 +625,12 @@ class ChatCompletionsTransport(ProviderTransport):
         if additions:
             extra_body.update(additions)
 
-        # Request overrides (user config)
-        overrides = params.get("request_overrides")
+        # Request overrides (user config), sanitized against the no-tools
+        # boundary before anything is merged. See the legacy path above.
+        overrides = self.sanitize_request_overrides(
+            params.get("request_overrides"),
+            context="request_overrides (chat_completions profile path)",
+        )
         if overrides:
             for k, v in overrides.items():
                 if k == "extra_body" and isinstance(v, dict):

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -230,7 +230,14 @@ class ResponsesApiTransport(ProviderTransport):
             _effort_clamp.update({"xhigh": "high", "max": "high", "ultra": "high"})
         reasoning_effort = _effort_clamp.get(reasoning_effort, reasoning_effort)
 
+        # Preserve an explicit empty list as an on-the-wire capability
+        # boundary (`hermes chat --no-tools`). `_responses_tools` collapses an
+        # empty list to None for legacy callers, so recover the distinction
+        # from the original argument; None itself remains omitted because the
+        # OpenAI SDK rejects `tools=None` before issuing a request.
         response_tools = _responses_tools(tools)
+        if tools == []:
+            response_tools = []
 
         # xAI server-side web search.
         #
@@ -290,14 +297,9 @@ class ResponsesApiTransport(ProviderTransport):
                 filtered.append({"type": "web_search"})
                 response_tools = filtered
 
-        # ``tools`` MUST be omitted entirely when there are no functions to
-        # expose: the openai SDK's ``responses.stream()`` / ``responses.parse()``
-        # eagerly call ``_make_tools(tools)`` which does ``for tool in tools``
-        # without a None guard, so passing ``tools=None`` raises
-        # ``TypeError: 'NoneType' object is not iterable`` before any HTTP
-        # request is issued (openai==2.24.0).  Reported for the
-        # ``openai-codex`` / ``gpt-5.5`` combo on chatgpt.com/backend-api/codex
-        # (#32892) when the agent runs without external tools registered.
+        # `tools=None` is omitted: the OpenAI SDK eagerly iterates it. An
+        # explicit `tools=[]` is valid and must remain visible to the provider
+        # as a deliberate no-tools capability boundary.
         kwargs = {
             "model": model,
             "instructions": instructions,
@@ -310,10 +312,11 @@ class ResponsesApiTransport(ProviderTransport):
             ),
             "store": False,
         }
-        if response_tools:
+        if response_tools is not None:
             kwargs["tools"] = response_tools
-            kwargs["tool_choice"] = "auto"
-            kwargs["parallel_tool_calls"] = True
+            if response_tools:
+                kwargs["tool_choice"] = "auto"
+                kwargs["parallel_tool_calls"] = True
 
         session_id = params.get("session_id")
         # prompt_cache_key is content-addressed from the static prefix

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -368,7 +368,14 @@ class ResponsesApiTransport(ProviderTransport):
         elif not is_github_responses and not is_xai_responses:
             kwargs["include"] = []
 
-        request_overrides = params.get("request_overrides")
+        # Sanitized before the merge: under --no-tools this is the one
+        # remaining way a config file could put a tool surface back on the
+        # wire (it would also re-add tool_choice/parallel_tool_calls, which
+        # the explicit `tools: []` above deliberately omits).
+        request_overrides = self.sanitize_request_overrides(
+            params.get("request_overrides"),
+            context="request_overrides (codex responses)",
+        )
         if request_overrides:
             kwargs.update(request_overrides)
 

--- a/cli.py
+++ b/cli.py
@@ -16733,6 +16733,7 @@ def main(
     q: str = None,
     image: str = None,
     toolsets: str = None,
+    no_tools: bool = False,
     skills: str | list[str] | tuple[str, ...] = None,
     model: str = None,
     provider: str = None,
@@ -16843,7 +16844,11 @@ def main(
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools
     toolsets_list = None
-    if toolsets:
+    if no_tools:
+        if toolsets:
+            raise ValueError("--no-tools cannot be combined with --toolsets")
+        toolsets_list = []
+    elif toolsets:
         if isinstance(toolsets, str):
             toolsets_list = [t.strip() for t in toolsets.split(",")]
         elif isinstance(toolsets, (list, tuple)):

--- a/cli.py
+++ b/cli.py
@@ -16848,6 +16848,13 @@ def main(
         if toolsets:
             raise ValueError("--no-tools cannot be combined with --toolsets")
         toolsets_list = []
+        # An explicit empty tool surface is a process-wide capability
+        # boundary, not a per-call preference. Publish it the same way the
+        # other boundary flags do (HERMES_SAFE_MODE, HERMES_IGNORE_RULES) so
+        # every downstream tool-resolution site — including ones that only
+        # see ``enabled_toolsets=[]`` and cannot tell "explicitly none" from
+        # "config resolved to none" — can refuse to re-add a toolset.
+        os.environ["HERMES_NO_TOOLS"] = "1"
     elif toolsets:
         if isinstance(toolsets, str):
             toolsets_list = [t.strip() for t in toolsets.split(",")]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3119,7 +3119,21 @@ class BasePlatformAdapter(ABC):
     def is_connected(self) -> bool:
         """Check if adapter is currently connected."""
         return self._running
-    
+
+    def emit_plugin_event(self, event_type: str, payload: Dict[str, Any]) -> None:
+        """Emit allowlisted adapter metadata without message/LLM dispatch."""
+        try:
+            from hermes_cli.plugins import invoke_hook
+            invoke_hook(
+                "gateway_platform_event",
+                platform=getattr(self.platform, "value", str(self.platform)),
+                event_type=event_type,
+                payload=payload,
+                adapter=self,
+            )
+        except Exception:
+            logger.exception("Platform event plugin hook failed: %s", event_type)
+
     def set_message_handler(self, handler: MessageHandler) -> None:
         """
         Set the handler for incoming messages.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10978,6 +10978,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
+        #   {"action": "reply_and_skip", "text": ...}-> send fixed reply; terminate before auth/LLM
         #   {"action": "allow"}   /   None          -> normal dispatch
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
@@ -10998,6 +10999,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 if not isinstance(_result, dict):
                     continue
                 _action = _result.get("action")
+                if _action == "reply_and_skip":
+                    _text = _result.get("text")
+                    if isinstance(_text, str) and _text.strip():
+                        return _text
+                    logger.warning("pre_gateway_dispatch reply_and_skip ignored: missing text")
+                    return None
                 if _action == "skip":
                     logger.info(
                         "pre_gateway_dispatch skip: reason=%s platform=%s chat=%s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10490,8 +10490,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # never rebuild a secondary adapter with the default profile's credentials.
 
     def _active_profile_message_handler(self):
-        """Return the primary adapter handler with the active profile stamped."""
-        return self._make_profile_message_handler(self._active_profile_name())
+        """Stamp the primary profile without replacing its protected secret scope.
+
+        A dedicated launcher may install credentials in the ContextVar scope
+        before starting a single-profile gateway.  The multiplex handler also
+        loads a profile `.env`, which is correct for secondary adapters but
+        would erase those launcher-protected credentials for every primary
+        inbound message.
+        """
+        profile_name = self._active_profile_name()
+
+        async def _handler(event):
+            try:
+                if getattr(event, "source", None) is not None and not event.source.profile:
+                    event.source.profile = profile_name
+            except Exception:
+                pass
+            return await self._handle_message(event)
+
+        return _handler
 
     def _make_profile_message_handler(self, profile_name: str):
         """Return a message handler that stamps source.profile then delegates.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1587,6 +1587,22 @@ def _ensure_ssl_certs() -> None:
             os.environ["SSL_CERT_FILE"] = candidate
             return
 
+def _home_channel_prompt_enabled(user_config: dict) -> bool:
+    """Whether first-contact chat surfaces may offer `/sethome`.
+
+    A dedicated, constrained profile (for example a youth/community bot) may
+    intentionally have no Hermes home channel.  In that profile, teaching an
+    ordinary member to configure one is both confusing and an internal-control
+    leak.  Keep the historical opt-in-by-default behavior everywhere else;
+    only an explicit ``onboarding.home_channel_prompt: false`` suppresses it.
+    """
+    onboarding = user_config.get("onboarding") if isinstance(user_config, dict) else None
+    value = onboarding.get("home_channel_prompt", True) if isinstance(onboarding, dict) else True
+    if isinstance(value, str):
+        return value.strip().lower() not in {"false", "no", "0", "off"}
+    return bool(value)
+
+
 def _home_target_env_var(platform_name: str) -> str:
     """Return the configured home-target env var for a platform.
 
@@ -8328,8 +8344,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     logger.warning("No adapter available for %s", _pval)
                 continue
             
-            # Set up message + fatal error handlers
-            adapter.set_message_handler(self._handle_message)
+            # Always stamp the active profile as well as secondary multiplexed
+            # profiles.  Without this, a single-profile gateway persisted
+            # ``profile_name=NULL``: profile-scoped plugins then fail closed and
+            # see an apparently unverified Telegram actor.
+            adapter.set_message_handler(self._active_profile_message_handler())
             adapter.set_fatal_error_handler(self._handle_adapter_fatal_error)
             adapter.set_session_store(self.session_store)
             adapter.set_busy_session_handler(self._handle_active_session_busy_message)
@@ -10469,6 +10488,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         )
         # Reconnect is scoped to the profile's own config and secret mapping;
         # never rebuild a secondary adapter with the default profile's credentials.
+
+    def _active_profile_message_handler(self):
+        """Return the primary adapter handler with the active profile stamped."""
+        return self._make_profile_message_handler(self._active_profile_name())
 
     def _make_profile_message_handler(self, profile_name: str):
         """Return a message handler that stamps source.profile then delegates.
@@ -14002,7 +14025,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         
         # One-time prompt if no home channel is set for this platform
         # Skip for webhooks - they deliver directly to configured targets (github_comment, etc.)
-        if not history and source.platform and source.platform != Platform.LOCAL and source.platform != Platform.WEBHOOK:
+        if (
+            _home_channel_prompt_enabled(_load_gateway_config())
+            and not history
+            and source.platform
+            and source.platform != Platform.LOCAL
+            and source.platform != Platform.WEBHOOK
+        ):
             platform_name = source.platform.value
             env_key = _home_target_env_var(platform_name)
             # Multiplex: home channel may live only in the profile secret

--- a/hermes_cli/_parser.py
+++ b/hermes_cli/_parser.py
@@ -154,6 +154,12 @@ def build_top_level_parser():
         help="Comma-separated toolsets to enable for this invocation. Applies to -z/--oneshot and --tui.",
     )
     parser.add_argument(
+        "--no-tools",
+        action="store_true",
+        default=False,
+        help="Run with an explicit empty tool surface; cannot be combined with --toolsets.",
+    )
+    parser.add_argument(
         "--resume",
         "-r",
         metavar="SESSION",
@@ -298,6 +304,13 @@ def build_top_level_parser():
         "-t", "--toolsets",
         default=argparse.SUPPRESS,
         help="Comma-separated toolsets to enable",
+    )
+    _inherited_flag(
+        chat_parser,
+        "--no-tools",
+        action="store_true",
+        default=argparse.SUPPRESS,
+        help="Run with an explicit empty tool surface; cannot be combined with --toolsets.",
     )
     _inherited_flag(
         chat_parser,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -170,6 +170,7 @@ def _run_and_exit_oneshot(
     model: object = None,
     provider: object = None,
     toolsets: object = None,
+    no_tools: bool = False,
     usage_file: object = None,
 ) -> None:
     try:
@@ -180,6 +181,7 @@ def _run_and_exit_oneshot(
             model=model,
             provider=provider,
             toolsets=toolsets,
+            no_tools=no_tools,
             usage_file=usage_file,
         )
     except KeyboardInterrupt:
@@ -2457,6 +2459,32 @@ def _resolve_use_tui(args) -> bool:
     "exited cleanly without calling kanban_complete — protocol violation"
     on every attempt (found dogfooding the desktop kanban board). A user
     who *explicitly* passes ``--tui`` still gets the informative bail-out.
+
+    ``--no-tools`` is refused here rather than silently ignored. The TUI runs
+    the agent inside the Node app's own gateway, which resolves its toolsets
+    from ``HERMES_TUI_TOOLSETS`` / config and has no channel for an explicit
+    empty tool surface. Proceeding would hand the operator a fully tooled
+    session under a flag that promised the opposite, so the combination fails
+    closed with an actionable message instead.
+    """
+    use_tui = _tui_preference(args)
+    if use_tui and getattr(args, "no_tools", False):
+        print(
+            "Error: --no-tools is not supported by the TUI.\n"
+            "  The TUI's gateway resolves its own toolsets, so an explicit "
+            "empty tool surface cannot be guaranteed there.\n"
+            "  Run the classic REPL instead:  hermes chat --cli --no-tools ...",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+    return use_tui
+
+
+def _tui_preference(args) -> bool:
+    """The raw TUI/classic decision, before capability-boundary checks.
+
+    Split out of :func:`_resolve_use_tui` so the ``--no-tools`` refusal has a
+    single choke point that every caller passes through.
     """
     if getattr(args, "cli", False):
         return False
@@ -15424,6 +15452,7 @@ def _try_termux_fast_cli_launch() -> bool:
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            no_tools=getattr(args, "no_tools", False),
             usage_file=getattr(args, "usage_file", None),
         )
 
@@ -18070,6 +18099,7 @@ def main():
             model=getattr(args, "model", None),
             provider=getattr(args, "provider", None),
             toolsets=getattr(args, "toolsets", None),
+            no_tools=getattr(args, "no_tools", False),
             usage_file=getattr(args, "usage_file", None),
         )
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2666,6 +2666,11 @@ def cmd_chat(args):
         "model": args.model,
         "provider": getattr(args, "provider", None),
         "toolsets": args.toolsets,
+        # An explicit empty tool surface is a distinct capability boundary,
+        # not merely a parser/UI preference. Pass it through to cli.main so
+        # the actual agent construction receives toolsets=[] (and therefore
+        # the model request has no tools), including `hermes chat --no-tools`.
+        "no_tools": getattr(args, "no_tools", False),
         "skills": getattr(args, "skills", None),
         "verbose": getattr(args, "verbose", None),
         "quiet": getattr(args, "quiet", False),

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -30,6 +30,7 @@ from typing import Optional
 
 from gateway.session_context import declare_stateless_channel
 from hermes_cli.fallback_config import get_fallback_chain
+from utils import NO_TOOLS_ENV_VAR
 
 
 def _normalize_toolsets(toolsets: object = None) -> list[str] | None:
@@ -172,6 +173,7 @@ def run_oneshot(
     model: Optional[str] = None,
     provider: Optional[str] = None,
     toolsets: object = None,
+    no_tools: bool = False,
     usage_file: Optional[str] = None,
 ) -> int:
     """Execute a single prompt and print only the final content block.
@@ -183,6 +185,9 @@ def run_oneshot(
         provider: Optional provider override. Falls back to config.yaml's
             model.provider, then "auto".
         toolsets: Optional comma-separated string or iterable of toolsets.
+        no_tools: Run with an explicit empty tool surface. Mutually exclusive
+            with ``toolsets``; publishes the ``HERMES_NO_TOOLS`` boundary so no
+            downstream site can re-add a toolset.
         usage_file: Optional path; when set, a JSON usage report (estimated
             cost, token counts, model, api_calls) is written there after the
             run — even when the run fails — so pipelines can account for
@@ -210,11 +215,25 @@ def run_oneshot(
         )
         return 2
 
+    # --no-tools is a capability boundary, and it must mean the same thing on
+    # -z/--oneshot as it does on `hermes chat`. Validated before the toolset
+    # resolution below so the contradictory combination fails closed instead of
+    # silently picking one of the two.
+    if no_tools and _normalize_toolsets(toolsets) is not None:
+        sys.stderr.write(
+            "hermes -z: --no-tools cannot be combined with --toolsets.\n"
+        )
+        return 2
+
     explicit_toolsets, toolsets_error = _validate_explicit_toolsets(toolsets)
     if toolsets_error:
         sys.stderr.write(toolsets_error)
         return 2
-    use_config_toolsets = _normalize_toolsets(toolsets) is None
+    use_config_toolsets = _normalize_toolsets(toolsets) is None and not no_tools
+    if no_tools:
+        # Mirrors cli.main: publish the boundary process-wide so
+        # model_tools/the transports refuse to re-add a tool surface.
+        os.environ[NO_TOOLS_ENV_VAR] = "1"
 
     # Auto-approve any shell / tool approvals.  Non-interactive by
     # definition — a prompt would hang forever.
@@ -248,6 +267,7 @@ def run_oneshot(
                     provider=provider,
                     toolsets=explicit_toolsets,
                     use_config_toolsets=use_config_toolsets,
+                    no_tools=no_tools,
                 )
             except BaseException as exc:  # noqa: BLE001
                 # Capture anything that escapes the agent (including OSError
@@ -316,9 +336,15 @@ def _run_agent(
     provider: Optional[str] = None,
     toolsets: object = None,
     use_config_toolsets: bool = True,
+    no_tools: bool = False,
 ) -> tuple[str, dict]:
     """Build an AIAgent exactly like a normal CLI chat turn would, then
-    run a single conversation.  Returns ``(final_response, run_result)``."""
+    run a single conversation.  Returns ``(final_response, run_result)``.
+
+    ``no_tools`` forces ``enabled_toolsets=[]``. It must be threaded in
+    explicitly: falling back on ``use_config_toolsets=False`` alone would leave
+    ``toolsets_list`` at ``None``, which means "every toolset", not "none".
+    """
     # Imports are local so they don't run when hermes is invoked for
     # other commands (keeps top-level CLI startup cheap).
     from hermes_cli.config import load_config
@@ -391,7 +417,7 @@ def _run_agent(
     # Pull in explicit toolsets when provided; otherwise use whatever the user
     # has enabled for "cli". sorted() gives stable ordering for config-derived
     # sets; explicit values preserve user order.
-    toolsets_list = _normalize_toolsets(toolsets)
+    toolsets_list = [] if no_tools else _normalize_toolsets(toolsets)
     if toolsets_list is None and use_config_toolsets:
         toolsets_list = sorted(_get_platform_tools(cfg, "cli"))
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -172,6 +172,11 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Observer-only platform-native event.  This is deliberately separate from
+    # MessageEvent dispatch: payloads are adapter-normalized metadata and never
+    # enter auth, pairing, transcript, or LLM paths.  Returns are ignored.
+    # Kwargs: platform, event_type, payload (allowlisted primitive data), adapter.
+    "gateway_platform_event",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs an approval decision -- fires for CLI-interactive prompts,
     # gateway/ACP approvals, and smart-mode auxiliary-LLM decisions.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -168,6 +168,7 @@ VALID_HOOKS: Set[str] = {
     # dispatch. Plugins may return a dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
+    #   {"action": "reply_and_skip", "text": "..."}-> fixed reply; terminate before auth/LLM
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",

--- a/model_tools.py
+++ b/model_tools.py
@@ -31,6 +31,7 @@ from typing import Dict, Any, List, Optional, Tuple
 
 from tools.registry import discover_builtin_tools, registry
 from toolsets import resolve_toolset, validate_toolset
+from utils import explicit_no_tools
 
 logger = logging.getLogger(__name__)
 
@@ -59,8 +60,11 @@ def _explicit_no_tools() -> bool:
     Deliberately distinct from "no toolsets configured": an ``enabled_toolsets``
     list that merely *resolved* to empty (platform_toolsets, assignee profile)
     is still a configuration, and the kanban re-entry continues to serve it.
+
+    Thin alias for the canonical predicate in ``utils``; the transport layer
+    reads the same flag to sanitize ``request_overrides``.
     """
-    return os.environ.get("HERMES_NO_TOOLS") == "1"
+    return explicit_no_tools()
 
 
 # =============================================================================

--- a/model_tools.py
+++ b/model_tools.py
@@ -48,6 +48,21 @@ def _is_delegated_child_context() -> bool:
         return False
 
 
+def _explicit_no_tools() -> bool:
+    """True when this process was launched with an explicit empty tool surface.
+
+    ``hermes --no-tools`` / ``hermes chat --no-tools`` sets ``HERMES_NO_TOOLS=1``
+    (see ``cli.main``). That is a capability boundary the caller asked for by
+    name, and no code path may re-add a toolset to it — not even the kanban
+    lifecycle re-entry below.
+
+    Deliberately distinct from "no toolsets configured": an ``enabled_toolsets``
+    list that merely *resolved* to empty (platform_toolsets, assignee profile)
+    is still a configuration, and the kanban re-entry continues to serve it.
+    """
+    return os.environ.get("HERMES_NO_TOOLS") == "1"
+
+
 # =============================================================================
 # Async Bridging  (single source of truth -- used by registry.dispatch too)
 # =============================================================================
@@ -331,6 +346,7 @@ def get_tool_definitions(
             registry._generation,
             cfg_fp,
             bool(os.environ.get("HERMES_KANBAN_TASK")),
+            _explicit_no_tools(),
             bool(skip_tool_search_assembly),
             _is_delegated_child_context(),
         )
@@ -378,6 +394,7 @@ def _compute_tool_definitions(
         effective_enabled_toolsets = list(enabled_toolsets)
         if (
             os.environ.get("HERMES_KANBAN_TASK")
+            and not _explicit_no_tools()
             and not _is_delegated_child_context()
             and "kanban" not in effective_enabled_toolsets
         ):

--- a/plugins/platforms/slack/adapter.py
+++ b/plugins/platforms/slack/adapter.py
@@ -1760,17 +1760,14 @@ class SlackAdapter(BasePlatformAdapter):
             return False
 
         raw_token = self.config.token
-        # Multiplex: profile secrets live in the secret scope, not process
-        # os.environ. When a scope is installed (secondary-profile connect),
-        # it is AUTHORITATIVE — do not fall through to os.getenv, or a
-        # secondary profile missing SLACK_APP_TOKEN silently inherits the
-        # default profile's Socket Mode app (#59739). Only an UNSCOPED read
-        # under multiplex (default-profile startup loop, background reconnect
-        # rebuild) falls back to process env, which is that profile's own.
+        # In multiplex mode an unscoped credential read is a configuration
+        # breach, not permission to inherit a process-global token. Fail closed
+        # so a reconnect/default-profile path cannot attach another profile's
+        # Slack app token.
         try:
             app_token = get_secret("SLACK_APP_TOKEN")
         except UnscopedSecretError:
-            app_token = os.getenv("SLACK_APP_TOKEN")
+            app_token = None
 
         if not raw_token:
             logger.error(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -226,6 +226,7 @@ try:
         Application,
         CommandHandler,
         CallbackQueryHandler,
+        ChatJoinRequestHandler,
         MessageHandler as TelegramMessageHandler,
         ContextTypes,
         filters,
@@ -244,6 +245,7 @@ except ImportError:
     Application = Any
     CommandHandler = Any
     CallbackQueryHandler = Any
+    ChatJoinRequestHandler = Any
     TelegramMessageHandler = Any
     HTTPXRequest = Any
     filters = None
@@ -3790,6 +3792,7 @@ class TelegramAdapter(BasePlatformAdapter):
             ))
             # Handle inline keyboard button callbacks (update prompts)
             self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+            self._app.add_handler(ChatJoinRequestHandler(self._handle_chat_join_request))
             
             # Start polling — retry initialize() for transient TLS resets.
             # Each attempt is capped by _init_timeout so a single unreachable
@@ -3921,6 +3924,7 @@ class TelegramAdapter(BasePlatformAdapter):
                             self._handle_media_message
                         ))
                         self._app.add_handler(CallbackQueryHandler(self._handle_callback_query))
+                        self._app.add_handler(ChatJoinRequestHandler(self._handle_chat_join_request))
                         # Best-effort discard the old app's resources
                         try:
                             await _shutdown_abandoned_app(old_app)
@@ -8658,6 +8662,26 @@ class TelegramAdapter(BasePlatformAdapter):
         await self._cache_replied_media(msg, event)
         event = self._apply_telegram_group_observe_attribution(event)
         await self.handle_message(event)
+
+    async def _handle_chat_join_request(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        """Emit only allowlisted join-request identifiers to observer plugins."""
+        del context
+        request = getattr(update, "chat_join_request", None)
+        chat = getattr(request, "chat", None)
+        user = getattr(request, "from_user", None)
+        private_chat_id = getattr(request, "user_chat_id", None)
+        if request is None or chat is None or user is None or private_chat_id is None:
+            return
+        self.emit_plugin_event(
+            "chat_join_request",
+            {
+                "schema_version": 1,
+                "chat_id": str(chat.id),
+                "user_id": str(user.id),
+                "private_chat_id": str(private_chat_id),
+                "update_id": int(getattr(update, "update_id", 0) or 0),
+            },
+        )
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         """Handle incoming location/venue pin messages."""

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -3933,7 +3933,11 @@ class TelegramAdapter(BasePlatformAdapter):
             await self._app.start()
 
             # Decide between webhook and polling mode
-            webhook_url = os.getenv("TELEGRAM_WEBHOOK_URL", "").strip()
+            # Webhook routing credentials are profile secrets.  Resolve via
+            # the active scope so multiplexed profiles cannot inherit another
+            # profile's process environment values.
+            from agent.secret_scope import get_secret
+            webhook_url = (get_secret("TELEGRAM_WEBHOOK_URL", "") or "").strip()
 
             if webhook_url:
                 # ── Webhook mode ─────────────────────────────────────
@@ -3948,7 +3952,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 # start rather than silently run in fail-open mode.
                 # See GHSA-3vpc-7q5r-276h.
                 webhook_port = env_int("TELEGRAM_WEBHOOK_PORT", 8443)
-                webhook_secret = os.getenv("TELEGRAM_WEBHOOK_SECRET", "").strip()
+                webhook_secret = (get_secret("TELEGRAM_WEBHOOK_SECRET", "") or "").strip()
                 if not webhook_secret:
                     raise RuntimeError(
                         "TELEGRAM_WEBHOOK_SECRET is required when "

--- a/tests/gateway/test_home_target_env_var.py
+++ b/tests/gateway/test_home_target_env_var.py
@@ -8,7 +8,21 @@ to env vars nothing read on startup — the home channel appeared to set
 successfully but was lost on every new gateway session.
 """
 
-from gateway.run import _home_target_env_var, _home_thread_env_var
+from gateway.run import (
+    _home_channel_prompt_enabled,
+    _home_target_env_var,
+    _home_thread_env_var,
+)
+
+
+def test_home_channel_prompt_defaults_to_enabled():
+    assert _home_channel_prompt_enabled({}) is True
+    assert _home_channel_prompt_enabled({"onboarding": {}}) is True
+
+
+def test_profile_can_suppress_home_channel_prompt():
+    assert _home_channel_prompt_enabled({"onboarding": {"home_channel_prompt": False}}) is False
+    assert _home_channel_prompt_enabled({"onboarding": {"home_channel_prompt": "off"}}) is False
 
 
 def test_matrix_home_target_env_var_uses_home_room():

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -129,6 +129,28 @@ class TestProfileMessageHandler:
         assert seen["profile"] == "coder"
 
     @pytest.mark.asyncio
+    async def test_primary_handler_stamps_active_profile(self):
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._active_profile_name = lambda: "nova-teen-club"
+        seen = {}
+
+        async def _fake_handle(event):
+            seen["profile"] = event.source.profile
+            return "ok"
+
+        runner._handle_message = _fake_handle
+        handler = runner._active_profile_message_handler()
+
+        class _Src:
+            profile = None
+
+        class _Evt:
+            source = _Src()
+
+        assert await handler(_Evt()) == "ok"
+        assert seen["profile"] == "nova-teen-club"
+
+    @pytest.mark.asyncio
     async def test_does_not_override_existing_profile(self):
         runner = GatewayRunner.__new__(GatewayRunner)
         seen = {}

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock
 
 import pytest
 
+from agent.secret_scope import get_scoped_secret, reset_secret_scope, set_secret_scope
 import gateway.run as gateway_run
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.run import GatewayRunner
@@ -149,6 +150,33 @@ class TestProfileMessageHandler:
 
         assert await handler(_Evt()) == "ok"
         assert seen["profile"] == "nova-teen-club"
+
+    @pytest.mark.asyncio
+    async def test_primary_handler_preserves_launcher_secret_scope(self):
+        """Primary protected launchers own their ContextVar secret scope."""
+        runner = GatewayRunner.__new__(GatewayRunner)
+        runner._active_profile_name = lambda: "nova-teen-club"
+
+        async def _fake_handle(event):
+            assert event.source.profile == "nova-teen-club"
+            assert get_scoped_secret("NOVA_OWNER_TELEGRAM_ID") == "owner-from-launcher"
+            return "ok"
+
+        runner._handle_message = _fake_handle
+        handler = runner._active_profile_message_handler()
+
+        class _Src:
+            profile = None
+
+        class _Evt:
+            source = _Src()
+
+        token = set_secret_scope({"NOVA_OWNER_TELEGRAM_ID": "owner-from-launcher"})
+        try:
+            assert await handler(_Evt()) == "ok"
+            assert get_scoped_secret("NOVA_OWNER_TELEGRAM_ID") == "owner-from-launcher"
+        finally:
+            reset_secret_scope(token)
 
     @pytest.mark.asyncio
     async def test_does_not_override_existing_profile(self):

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -82,6 +82,28 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_hook_reply_and_skip_returns_fixed_reply_before_auth(monkeypatch):
+    """Fixed hook reply terminates dispatch before pairing or agent execution."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "reply_and_skip", "text": "Как тебя называть?"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = AsyncMock()  # noqa: SLF001
+
+    result = await runner._handle_message(_make_event("what now?"))
+
+    assert result == "Как тебя называть?"
+    adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_hook_rewrite_replaces_event_text(monkeypatch):
     """A plugin returning {'action': 'rewrite', 'text': ...} mutates event.text."""
     _clear_auth_env(monkeypatch)

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -642,11 +642,8 @@ class TestAppMentionHandler:
         assert created_handlers[0].app_token == "xapp-profile"
 
     @pytest.mark.asyncio
-    async def test_connect_unscoped_multiplex_falls_back_to_env(self):
-        """Default-profile connect (multiplex active, NO scope installed) must
-        fall back to process env instead of raising UnscopedSecretError —
-        the primary startup loop and background reconnect rebuild both call
-        connect() unscoped (#59739 salvage follow-up)."""
+    async def test_connect_unscoped_multiplex_rejects_process_env_token(self):
+        """An unscoped multiplex connect must fail closed despite a poison env token."""
         config = PlatformConfig(enabled=True, token="xoxb-default")
         adapter = SlackAdapter(config)
 
@@ -704,9 +701,8 @@ class TestAppMentionHandler:
         finally:
             secret_scope.set_multiplex_active(False)
 
-        assert result is True
-        assert created_handlers
-        assert created_handlers[0].app_token == "xapp-default"
+        assert result is False
+        assert created_handlers == []
 
 
 class TestSlackConnectCleanup:

--- a/tests/hermes_cli/test_no_tools_payload.py
+++ b/tests/hermes_cli/test_no_tools_payload.py
@@ -148,20 +148,49 @@ def test_cli_without_no_tools_still_resolves_a_real_toolset_list(monkeypatch):
 
 
 _TRANSPORTS = {
-    # api_mode: (transport module, class name, base_url, provider)
-    "chat_completions": (
-        "agent.transports.chat_completions",
-        "ChatCompletionsTransport",
-        "https://openrouter.ai/api/v1",
-        "openrouter",
-    ),
-    "codex_responses": (
-        "agent.transports.codex",
-        "ResponsesApiTransport",
-        "https://chatgpt.com/backend-api/codex",
-        "openai-codex",
-    ),
+    # api_mode: transport module, class name, base_url, provider, model
+    "chat_completions": {
+        "module": "agent.transports.chat_completions",
+        "cls": "ChatCompletionsTransport",
+        "base_url": "https://openrouter.ai/api/v1",
+        "provider": "openrouter",
+        "model": None,
+    },
+    "codex_responses": {
+        "module": "agent.transports.codex",
+        "cls": "ResponsesApiTransport",
+        "base_url": "https://chatgpt.com/backend-api/codex",
+        "provider": "openai-codex",
+        "model": None,
+    },
+    "anthropic_messages": {
+        "module": "agent.transports.anthropic",
+        "cls": "AnthropicTransport",
+        "base_url": "https://api.anthropic.com",
+        "provider": "anthropic",
+        "model": "claude-sonnet-4-20250514",
+    },
+    "bedrock_converse": {
+        "module": "agent.transports.bedrock",
+        "cls": "BedrockTransport",
+        "base_url": None,
+        "provider": "bedrock",
+        "model": "anthropic.claude-sonnet-4-20250514-v1:0",
+    },
 }
+
+# Every wire spelling of "here is a tool surface", across all four transports:
+# OpenAI chat/responses (`tools`), Bedrock Converse (`toolConfig`), plus the
+# steering keys and the deprecated OpenAI function-calling pair.
+_TOOL_WIRE_KEYS = (
+    "tools",
+    "toolConfig",
+    "tool_choice",
+    "toolChoice",
+    "parallel_tool_calls",
+    "functions",
+    "function_call",
+)
 
 
 def _spy_on_transport(monkeypatch, api_mode: str) -> list[dict[str, Any]]:
@@ -172,8 +201,8 @@ def _spy_on_transport(monkeypatch, api_mode: str) -> list[dict[str, Any]]:
     """
     import importlib
 
-    mod_name, cls_name, _base_url, _provider = _TRANSPORTS[api_mode]
-    cls = getattr(importlib.import_module(mod_name), cls_name)
+    spec = _TRANSPORTS[api_mode]
+    cls = getattr(importlib.import_module(spec["module"]), spec["cls"])
     original = cls.build_kwargs
     calls: list[dict[str, Any]] = []
 
@@ -186,7 +215,7 @@ def _spy_on_transport(monkeypatch, api_mode: str) -> list[dict[str, Any]]:
     return calls
 
 
-def _build_agent(api_mode: str, toolsets):
+def _build_agent(api_mode: str, toolsets, request_overrides=None):
     """A real ``AIAgent`` using the real ``get_tool_definitions``.
 
     Only the OpenAI client class is patched out, so nothing can reach the
@@ -194,25 +223,33 @@ def _build_agent(api_mode: str, toolsets):
     """
     from run_agent import AIAgent
 
-    _mod, _cls, base_url, provider = _TRANSPORTS[api_mode]
+    spec = _TRANSPORTS[api_mode]
+    kwargs: dict[str, Any] = dict(
+        api_key="test-key-1234567890",
+        provider=spec["provider"],
+        api_mode=api_mode,
+        enabled_toolsets=toolsets,
+        max_iterations=1,
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    if spec["base_url"]:
+        kwargs["base_url"] = spec["base_url"]
+    if spec["model"]:
+        kwargs["model"] = spec["model"]
+    if request_overrides is not None:
+        kwargs["request_overrides"] = request_overrides
     with patch("run_agent.OpenAI"):
-        return AIAgent(
-            api_key="test-key-1234567890",
-            base_url=base_url,
-            provider=provider,
-            api_mode=api_mode,
-            enabled_toolsets=toolsets,
-            max_iterations=1,
-            quiet_mode=True,
-            skip_context_files=True,
-            skip_memory=True,
-        )
+        return AIAgent(**kwargs)
 
 
-def _wire_payload(monkeypatch, api_mode: str, toolsets) -> dict[str, Any]:
+def _wire_payload(
+    monkeypatch, api_mode: str, toolsets, request_overrides=None
+) -> dict[str, Any]:
     """Return the kwargs the provider SDK would be called with."""
     calls = _spy_on_transport(monkeypatch, api_mode)
-    agent = _build_agent(api_mode, toolsets)
+    agent = _build_agent(api_mode, toolsets, request_overrides=request_overrides)
     assert agent.api_mode == api_mode, (
         f"agent resolved api_mode={agent.api_mode!r}; the {api_mode!r} transport "
         "would not be exercised and the assertion below would be vacuous"
@@ -236,8 +273,13 @@ def _assert_offers_no_tools(payload: dict[str, Any], api_mode: str) -> None:
         f"{api_mode}: outgoing request must offer no tools, got "
         f"tools={payload.get('tools')!r}"
     )
-    assert "tool_choice" not in payload
-    assert "parallel_tool_calls" not in payload
+    for key in _TOOL_WIRE_KEYS:
+        if key == "tools":
+            continue
+        assert key not in payload, (
+            f"{api_mode}: {key!r} must not appear on a no-tools request, got "
+            f"{payload[key]!r}"
+        )
 
 
 @pytest.mark.parametrize("api_mode", sorted(_TRANSPORTS))
@@ -296,6 +338,301 @@ def test_kanban_reentry_is_otherwise_live(monkeypatch):
     model_tools._clear_tool_defs_cache()
 
     assert model_tools.get_tool_definitions(enabled_toolsets=[], quiet_mode=True) == []
+
+
+# ---------------------------------------------------------------------------
+# request_overrides: the config-file bypass
+# ---------------------------------------------------------------------------
+#
+# ``request_overrides`` is a raw user-config dict merged into the outgoing
+# kwargs *after* the tools decision, at three sites:
+#   chat_completions.py  legacy path   — api_kwargs.update(overrides)
+#   chat_completions.py  profile path  — per-key assignment
+#   codex.py                           — kwargs.update(request_overrides)
+# Under the boundary all tool-offering keys must be stripped before the merge.
+
+
+_HOSTILE_OVERRIDES = {
+    "tools": [
+        {
+            "type": "function",
+            "function": {
+                "name": "terminal",
+                "description": "Run a shell command.",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+    ],
+    "tool_choice": "required",
+    "parallel_tool_calls": True,
+    "functions": [{"name": "terminal", "parameters": {}}],
+    "function_call": "auto",
+    # A benign key alongside them: sanitization must be surgical, not a
+    # blanket drop of the whole override dict.
+    "service_tier": "priority",
+}
+
+
+def test_request_overrides_cannot_reintroduce_tools_codex(monkeypatch):
+    """codex.py: ``kwargs.update(request_overrides)`` merge site."""
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+
+    payload = _wire_payload(
+        monkeypatch,
+        "codex_responses",
+        toolsets,
+        request_overrides=dict(_HOSTILE_OVERRIDES),
+    )
+    _assert_offers_no_tools(payload, "codex_responses")
+    assert payload["service_tier"] == "priority", (
+        "sanitization must drop only the tool keys, not the whole override dict"
+    )
+
+
+def test_request_overrides_cannot_reintroduce_tools_chat_profile_path(monkeypatch):
+    """chat_completions.py ``_build_kwargs_from_profile`` merge site.
+
+    Reached for any *registered* provider — the common case (openrouter here).
+    """
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+
+    import providers
+
+    assert providers.get_provider_profile("openrouter") is not None, (
+        "this test must exercise the profile path; openrouter has no profile"
+    )
+
+    payload = _wire_payload(
+        monkeypatch,
+        "chat_completions",
+        toolsets,
+        request_overrides=dict(_HOSTILE_OVERRIDES),
+    )
+    _assert_offers_no_tools(payload, "chat_completions")
+    assert payload["service_tier"] == "priority"
+
+
+def test_request_overrides_cannot_reintroduce_tools_chat_legacy_path(monkeypatch):
+    """chat_completions.py legacy ``api_kwargs.update(overrides)`` merge site.
+
+    Reached only when ``get_provider_profile()`` returns None — an entirely
+    unregistered provider.  Simulated by patching the lookup, which is what a
+    user-defined ``providers:`` entry in config.yaml produces.
+    """
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+
+    import providers
+
+    monkeypatch.setattr(providers, "get_provider_profile", lambda *_a, **_k: None)
+
+    payload = _wire_payload(
+        monkeypatch,
+        "chat_completions",
+        toolsets,
+        request_overrides=dict(_HOSTILE_OVERRIDES),
+    )
+    _assert_offers_no_tools(payload, "chat_completions")
+    assert payload["service_tier"] == "priority"
+
+
+@pytest.mark.parametrize("api_mode", ["anthropic_messages", "bedrock_converse"])
+def test_request_overrides_never_reach_anthropic_or_bedrock(monkeypatch, api_mode):
+    """These two transports are not handed ``request_overrides`` at all.
+
+    ``build_api_kwargs`` forwards overrides only on the chat-completions and
+    codex paths.  Pinning that here means a future refactor that starts
+    forwarding them has to come back and add sanitization.
+    """
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+
+    payload = _wire_payload(
+        monkeypatch, api_mode, toolsets, request_overrides=dict(_HOSTILE_OVERRIDES)
+    )
+    _assert_offers_no_tools(payload, api_mode)
+    assert "service_tier" not in payload
+
+
+def test_sanitizer_is_a_noop_without_the_boundary():
+    """Normal runs are untouched: overrides pass through byte-for-byte."""
+    from agent.transports.base import ProviderTransport
+
+    overrides = dict(_HOSTILE_OVERRIDES)
+    assert ProviderTransport.sanitize_request_overrides(overrides) is overrides
+
+
+def test_sanitizer_logs_every_dropped_key(monkeypatch, caplog):
+    """A stripped key must be visible to the operator, named, at WARNING."""
+    import logging
+
+    from agent.transports.base import ProviderTransport
+
+    monkeypatch.setenv("HERMES_NO_TOOLS", "1")
+    with caplog.at_level(logging.WARNING, logger="agent.transports.base"):
+        cleaned = ProviderTransport.sanitize_request_overrides(
+            dict(_HOSTILE_OVERRIDES), context="unit test"
+        )
+
+    assert cleaned == {"service_tier": "priority"}
+    logged = caplog.text
+    for key in ("tools", "tool_choice", "parallel_tool_calls", "functions", "function_call"):
+        assert repr(key) in logged, f"dropped key {key!r} was not logged"
+    assert "unit test" in logged
+
+
+# ---------------------------------------------------------------------------
+# Route parity: -z/--oneshot and --tui must not accept-and-ignore the flag
+# ---------------------------------------------------------------------------
+
+
+def test_oneshot_honors_no_tools(monkeypatch):
+    """``hermes -z --no-tools`` builds the agent with ``toolsets=[]``.
+
+    Before this fix ``run_oneshot`` never saw ``no_tools`` and fell back to the
+    configured platform toolsets — the flag was accepted and ignored.
+    """
+    import hermes_cli.main as main_mod
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run_oneshot(prompt, **kwargs):
+        captured["prompt"] = prompt
+        captured.update(kwargs)
+        return 0
+
+    import hermes_cli.oneshot as oneshot_mod
+
+    monkeypatch.setattr(oneshot_mod, "run_oneshot", _fake_run_oneshot)
+    monkeypatch.setattr(main_mod, "_cleanup_oneshot_runtime", lambda: None)
+    monkeypatch.setattr(main_mod, "_exit_after_oneshot", lambda rc: (_ for _ in ()).throw(SystemExit(rc)))
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._run_and_exit_oneshot("hello", no_tools=True)
+
+    assert exc.value.code == 0
+    assert captured["no_tools"] is True
+
+
+def test_run_oneshot_publishes_boundary_and_forwards_no_tools(monkeypatch):
+    """``run_oneshot`` publishes the boundary and hands it to the agent builder."""
+    import hermes_cli.oneshot as oneshot_mod
+
+    captured: dict[str, Any] = {}
+
+    def _fake_run_agent(prompt, **kwargs):
+        captured.update(kwargs)
+        assert os.environ.get("HERMES_NO_TOOLS") == "1", (
+            "the boundary must already be published before the agent is built"
+        )
+        return "ok", {}
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _fake_run_agent)
+
+    oneshot_mod.run_oneshot("hello", no_tools=True)
+
+    assert captured["no_tools"] is True
+    assert captured["use_config_toolsets"] is False
+    assert os.environ.get("HERMES_NO_TOOLS") == "1"
+
+
+def test_oneshot_agent_builder_resolves_empty_toolsets(monkeypatch):
+    """The real ``_run_agent`` toolset resolution under ``no_tools=True``.
+
+    This is the hop the original bug lived in: ``use_config_toolsets=False``
+    alone leaves ``toolsets_list`` at ``None``, which means *every* toolset.
+    """
+    import hermes_cli.oneshot as oneshot_mod
+    import hermes_cli.runtime_provider as runtime_provider_mod
+    import run_agent as run_agent_mod
+
+    captured: dict[str, Any] = {}
+
+    def _fake_agent(**kwargs):
+        captured.update(kwargs)
+        raise _StopAtAgentConstruction
+
+    # The hermetic conftest strips every credential env var, so provider
+    # resolution would raise before the toolset decision is reached.
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda **_kw: {
+            "api_key": "test-key-1234567890",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "openrouter",
+            "requested_provider": "openrouter",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr(run_agent_mod, "AIAgent", _fake_agent)
+
+    with pytest.raises(_StopAtAgentConstruction):
+        oneshot_mod._run_agent("hello", no_tools=True, use_config_toolsets=False)
+
+    assert captured["enabled_toolsets"] == []
+
+
+def test_run_oneshot_rejects_no_tools_with_toolsets(monkeypatch, capsys):
+    """Fail closed on the contradictory combination, same as ``chat``."""
+    import hermes_cli.oneshot as oneshot_mod
+
+    def _never(prompt, **kwargs):
+        raise AssertionError("no agent may be built on a rejected flag combo")
+
+    monkeypatch.setattr(oneshot_mod, "_run_agent", _never)
+
+    rc = oneshot_mod.run_oneshot("hello", no_tools=True, toolsets="web")
+
+    assert rc == 2
+    assert "--no-tools cannot be combined with --toolsets" in capsys.readouterr().err
+    assert "HERMES_NO_TOOLS" not in os.environ
+
+
+def test_tui_with_no_tools_fails_closed(monkeypatch, capsys):
+    """``--tui --no-tools`` exits 2 instead of silently running with tools.
+
+    The TUI's Node gateway resolves its own toolsets and has no channel for an
+    explicit empty surface, so the combination is refused at the point the
+    interface is chosen — never accepted and ignored.
+    """
+    import hermes_cli.main as main_mod
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=main_mod.cmd_chat)
+    args = parser.parse_args(["chat", "--tui", "--no-tools", "-q", "hello"])
+
+    launched: list[object] = []
+    monkeypatch.setattr(main_mod, "_launch_tui", lambda *a, **k: launched.append(k))
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod._resolve_use_tui(args)
+
+    assert exc.value.code == 2
+    assert launched == [], "the TUI must not be launched under --no-tools"
+    assert "--no-tools is not supported by the TUI" in capsys.readouterr().err
+
+
+def test_tui_without_no_tools_still_resolves(monkeypatch):
+    """The guard is scoped to the flag; ordinary ``--tui`` is unaffected."""
+    import hermes_cli.main as main_mod
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=main_mod.cmd_chat)
+
+    assert main_mod._resolve_use_tui(parser.parse_args(["chat", "--tui"])) is True
+    assert (
+        main_mod._resolve_use_tui(parser.parse_args(["chat", "--cli", "--no-tools"]))
+        is False
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_no_tools_payload.py
+++ b/tests/hermes_cli/test_no_tools_payload.py
@@ -1,0 +1,358 @@
+"""Payload-level proof that ``--no-tools`` reaches the wire with zero tools.
+
+``tests/hermes_cli/test_safe_mode.py`` only proves the *flag* survives
+subcommand dispatch.  That is not evidence: a flag can be accepted, plumbed,
+and then silently undone further down (it was — see the kanban re-entry
+below).  These tests follow the real chain instead, hop by hop, and assert on
+the dict that is handed to the provider SDK:
+
+    argv
+      → hermes_cli._parser.build_top_level_parser()
+      → hermes_cli.main.cmd_chat            (kwargs["no_tools"])
+      → cli.main                            (toolsets_list = [], HERMES_NO_TOOLS=1)
+      → HermesCLI(toolsets=[])              (captured here)
+      → AIAgent(enabled_toolsets=[])        (real model_tools.get_tool_definitions)
+      → agent._build_api_kwargs()           (agent/chat_completion_helpers.build_api_kwargs)
+      → <Transport>.build_kwargs()          (spied, real implementation runs)
+
+**Wire representation of "no tools offered" differs per transport, and both
+forms are asserted for exactly what they are:**
+
+* ``ChatCompletionsTransport`` — for a *registered* provider (the profile
+  path, ``_build_kwargs_from_profile``) the ``tools`` key is **omitted
+  entirely**; ``tools: []`` is only emitted on the legacy/unknown-provider
+  path.  Either way the request offers no callable tool.
+* ``ResponsesApiTransport`` (codex) — emits an explicit ``tools: []`` and
+  omits ``tool_choice`` / ``parallel_tool_calls``.  It must not omit the key,
+  because ``tools=None`` crashes the OpenAI SDK before the request is sent
+  (see ``tests/run_agent/test_codex_no_tools_nonetype.py``).
+
+So the assertion used throughout is ``kwargs.get("tools", []) == []`` — "no
+tools key, or an empty one" — plus a check that the transport was *handed*
+``[]`` and never a populated list.
+
+No network call is possible: ``run_agent.OpenAI`` is patched out and only
+kwargs assembly is exercised.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+_BOUNDARY_VARS = ("HERMES_NO_TOOLS", "HERMES_KANBAN_TASK", "HERMES_INTERACTIVE")
+
+_MESSAGES = [
+    {"role": "system", "content": "You are Hermes."},
+    {"role": "user", "content": "hello"},
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_boundary_env(monkeypatch):
+    """No boundary/kanban env leaks in or out, and no memoized tool lists."""
+    for var in _BOUNDARY_VARS:
+        monkeypatch.delenv(var, raising=False)
+    import model_tools
+
+    model_tools._clear_tool_defs_cache()
+    yield
+    for var in _BOUNDARY_VARS:
+        os.environ.pop(var, None)
+    model_tools._clear_tool_defs_cache()
+
+
+# ---------------------------------------------------------------------------
+# Hop 1: argv → cmd_chat → cli.main → HermesCLI(toolsets=...)
+# ---------------------------------------------------------------------------
+
+
+class _StopAtAgentConstruction(Exception):
+    """Raised by the HermesCLI stand-in once its kwargs are captured."""
+
+
+def _run_cli_main_capturing_hermescli(monkeypatch, argv: list[str]) -> dict[str, Any]:
+    """Drive the real argv → ``cmd_chat`` → ``cli.main`` path.
+
+    Everything up to (and including) toolset resolution is the production
+    implementation; only ``cli.HermesCLI`` is replaced, so the test can read
+    the toolset list the CLI would really have built the agent with.
+    """
+    import hermes_cli.main as main_mod
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=main_mod.cmd_chat)
+    args = parser.parse_args(argv)
+
+    # Startup side effects that are irrelevant to tool resolution (and would
+    # touch the network / the user's install). Mirrors test_safe_mode.py.
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
+
+    import cli as cli_mod
+
+    captured: dict[str, Any] = {}
+
+    class _CapturingHermesCLI:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            captured["_constructed"] = True
+            raise _StopAtAgentConstruction
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", _CapturingHermesCLI)
+
+    try:
+        main_mod.cmd_chat(args)
+    except _StopAtAgentConstruction:
+        pass
+    return captured
+
+
+def test_cli_resolves_no_tools_to_an_empty_toolset_list(monkeypatch):
+    """``hermes chat --no-tools`` builds the agent with ``toolsets=[]``."""
+    captured = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )
+
+    assert captured["_constructed"] is True
+    assert captured["toolsets"] == [], (
+        "cli.main must hand HermesCLI an explicitly empty toolset list, "
+        f"got {captured['toolsets']!r}"
+    )
+    assert captured["max_turns"] == 1
+    # The capability boundary is published process-wide so downstream tool
+    # resolution can tell "explicitly none" from "config resolved to none".
+    assert os.environ.get("HERMES_NO_TOOLS") == "1"
+
+
+def test_cli_without_no_tools_still_resolves_a_real_toolset_list(monkeypatch):
+    """Inverse control: the boundary is opt-in, not the default."""
+    captured = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "-q", "hello"]
+    )
+
+    assert captured["toolsets"] != []
+    assert "HERMES_NO_TOOLS" not in os.environ
+
+
+# ---------------------------------------------------------------------------
+# Hop 2: toolsets=[] → AIAgent → transport.build_kwargs → wire payload
+# ---------------------------------------------------------------------------
+
+
+_TRANSPORTS = {
+    # api_mode: (transport module, class name, base_url, provider)
+    "chat_completions": (
+        "agent.transports.chat_completions",
+        "ChatCompletionsTransport",
+        "https://openrouter.ai/api/v1",
+        "openrouter",
+    ),
+    "codex_responses": (
+        "agent.transports.codex",
+        "ResponsesApiTransport",
+        "https://chatgpt.com/backend-api/codex",
+        "openai-codex",
+    ),
+}
+
+
+def _spy_on_transport(monkeypatch, api_mode: str) -> list[dict[str, Any]]:
+    """Wrap the real ``build_kwargs`` of one transport and record every call.
+
+    The production implementation still runs — this is a spy, not a stub, so
+    the recorded payload is the genuine one.
+    """
+    import importlib
+
+    mod_name, cls_name, _base_url, _provider = _TRANSPORTS[api_mode]
+    cls = getattr(importlib.import_module(mod_name), cls_name)
+    original = cls.build_kwargs
+    calls: list[dict[str, Any]] = []
+
+    def _spy(self, model, messages, tools=None, **params):
+        result = original(self, model, messages, tools=tools, **params)
+        calls.append({"tools_argument": tools, "payload": result})
+        return result
+
+    monkeypatch.setattr(cls, "build_kwargs", _spy)
+    return calls
+
+
+def _build_agent(api_mode: str, toolsets):
+    """A real ``AIAgent`` using the real ``get_tool_definitions``.
+
+    Only the OpenAI client class is patched out, so nothing can reach the
+    network — exactly the pattern used by ``tests/run_agent/test_run_agent.py``.
+    """
+    from run_agent import AIAgent
+
+    _mod, _cls, base_url, provider = _TRANSPORTS[api_mode]
+    with patch("run_agent.OpenAI"):
+        return AIAgent(
+            api_key="test-key-1234567890",
+            base_url=base_url,
+            provider=provider,
+            api_mode=api_mode,
+            enabled_toolsets=toolsets,
+            max_iterations=1,
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+def _wire_payload(monkeypatch, api_mode: str, toolsets) -> dict[str, Any]:
+    """Return the kwargs the provider SDK would be called with."""
+    calls = _spy_on_transport(monkeypatch, api_mode)
+    agent = _build_agent(api_mode, toolsets)
+    assert agent.api_mode == api_mode, (
+        f"agent resolved api_mode={agent.api_mode!r}; the {api_mode!r} transport "
+        "would not be exercised and the assertion below would be vacuous"
+    )
+    assert agent.tools == [], f"agent tool snapshot must be empty, got {agent.tools!r}"
+
+    payload = agent._build_api_kwargs(list(_MESSAGES))
+
+    assert calls, f"{api_mode} transport build_kwargs was never reached"
+    assert calls[-1]["tools_argument"] == [], (
+        "the transport must be handed an explicitly empty tool list, got "
+        f"{calls[-1]['tools_argument']!r}"
+    )
+    assert calls[-1]["payload"] is payload
+    return payload
+
+
+def _assert_offers_no_tools(payload: dict[str, Any], api_mode: str) -> None:
+    """No callable tool on the wire — key absent, or present and empty."""
+    assert payload.get("tools", []) == [], (
+        f"{api_mode}: outgoing request must offer no tools, got "
+        f"tools={payload.get('tools')!r}"
+    )
+    assert "tool_choice" not in payload
+    assert "parallel_tool_calls" not in payload
+
+
+@pytest.mark.parametrize("api_mode", sorted(_TRANSPORTS))
+def test_no_tools_yields_empty_wire_tool_list(monkeypatch, api_mode):
+    """End to end: ``--no-tools`` → ``tools == []`` at the model-request boundary."""
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+    assert toolsets == []
+
+    payload = _wire_payload(monkeypatch, api_mode, toolsets)
+    _assert_offers_no_tools(payload, api_mode)
+
+
+@pytest.mark.parametrize("api_mode", sorted(_TRANSPORTS))
+def test_kanban_env_cannot_reenter_tools(monkeypatch, api_mode):
+    """Negative control for the kanban re-entry hole.
+
+    ``model_tools._compute_tool_definitions`` force-appends the ``kanban``
+    toolset whenever ``HERMES_KANBAN_TASK`` is set — even to an
+    ``enabled_toolsets == []``.  A Captain subprocess that inherits that env
+    var would therefore have been handed the kanban tool surface despite
+    ``--no-tools``.  With the boundary published, the append is refused.
+    """
+    toolsets = _run_cli_main_capturing_hermescli(
+        monkeypatch, ["chat", "-Q", "--max-turns", "1", "--no-tools", "-q", "hello"]
+    )["toolsets"]
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "ntc-g2-proof")
+
+    payload = _wire_payload(monkeypatch, api_mode, toolsets)
+    _assert_offers_no_tools(payload, api_mode)
+
+
+def test_kanban_reentry_is_otherwise_live(monkeypatch):
+    """Guard against a vacuous negative control.
+
+    If the kanban toolset were simply unregistered in this process, the test
+    above would pass for the wrong reason.  Here the *same* empty toolset list
+    is resolved with ``HERMES_KANBAN_TASK`` set but the ``--no-tools`` boundary
+    absent: the kanban tools must come back.  If this ever stops holding, the
+    negative control has lost its teeth and needs rewriting.
+    """
+    import model_tools
+    from tools.registry import discover_builtin_tools
+
+    discover_builtin_tools()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "ntc-g2-proof")
+    model_tools._clear_tool_defs_cache()
+
+    reentered = model_tools.get_tool_definitions(enabled_toolsets=[], quiet_mode=True)
+    names = {t["function"]["name"] for t in reentered}
+    if not any(n.startswith("kanban") for n in names):
+        pytest.skip("kanban toolset not registered in this environment")
+
+    monkeypatch.setenv("HERMES_NO_TOOLS", "1")
+    model_tools._clear_tool_defs_cache()
+
+    assert model_tools.get_tool_definitions(enabled_toolsets=[], quiet_mode=True) == []
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: --no-tools is mutually exclusive with --toolsets
+# ---------------------------------------------------------------------------
+
+
+def test_no_tools_with_toolsets_raises_in_cli_main():
+    """``cli.main`` refuses the contradictory combination outright."""
+    import cli as cli_mod
+
+    with pytest.raises(ValueError, match="--no-tools cannot be combined with --toolsets"):
+        cli_mod.main(query="hello", no_tools=True, toolsets="web")
+
+    # The boundary env var must not be published by a rejected invocation.
+    assert "HERMES_NO_TOOLS" not in os.environ
+
+
+def test_no_tools_with_toolsets_fails_closed_through_cmd_chat(monkeypatch, capsys):
+    """``hermes chat --no-tools -t web`` exits non-zero and builds no agent.
+
+    Fail *closed*: the run must abort, not silently drop one of the two flags
+    and proceed with a tool surface the operator did not ask for.
+    """
+    import hermes_cli.main as main_mod
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=main_mod.cmd_chat)
+    args = parser.parse_args(["chat", "--no-tools", "-t", "web", "-q", "hello"])
+
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
+
+    # cmd_chat calls the real ``cli.main``; only agent construction is stubbed,
+    # so the mutual-exclusion guard under test actually runs.
+    import cli as cli_mod
+
+    constructed: list[object] = []
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kw: constructed.append(kw))
+
+    with pytest.raises(SystemExit) as exc:
+        main_mod.cmd_chat(args)
+
+    assert exc.value.code == 1
+    assert constructed == [], "no agent may be constructed on a rejected flag combo"
+    assert "--no-tools cannot be combined with --toolsets" in capsys.readouterr().out
+    assert "HERMES_NO_TOOLS" not in os.environ
+
+
+def test_parser_accepts_no_tools_on_root_and_chat():
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, _chat = build_top_level_parser()
+
+    assert parser.parse_args(["--no-tools"]).no_tools is True
+    assert parser.parse_args(["chat", "--no-tools"]).no_tools is True
+    assert parser.parse_args(["chat"]).no_tools is False

--- a/tests/hermes_cli/test_safe_mode.py
+++ b/tests/hermes_cli/test_safe_mode.py
@@ -132,6 +132,32 @@ def test_parser_accepts_safe_mode_on_root_and_chat():
     assert parser.parse_args(["chat"]).safe_mode is False
 
 
+def test_cmd_chat_no_tools_reaches_cli_main(monkeypatch):
+    """The parsed flag must reach cli.main, not be lost in subcommand dispatch."""
+    import hermes_cli.main as main_mod
+    from hermes_cli._parser import build_top_level_parser
+
+    parser, _subparsers, chat_parser = build_top_level_parser()
+    chat_parser.set_defaults(func=main_mod.cmd_chat)
+    args = parser.parse_args(["chat", "--no-tools", "-q", "hello"])
+    captured: dict[str, object] = {}
+    fake_cli = types.ModuleType("cli")
+
+    monkeypatch.setattr(main_mod, "_has_any_provider_configured", lambda: True)
+    monkeypatch.setattr(main_mod, "_pin_kanban_board_env", lambda: None)
+    monkeypatch.setattr(main_mod, "_sync_bundled_skills_for_startup", lambda: None)
+    monkeypatch.setattr(main_mod, "_termux_should_prefetch_update_check", lambda: False)
+    setattr(fake_cli, "main", lambda **kwargs: captured.update(kwargs))
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    main_mod.cmd_chat(args)
+
+    assert captured["no_tools"] is True
+    # None-valued toolsets are filtered before invoking cli.main; no_tools
+    # itself tells cli.main to construct toolsets=[] instead.
+    assert "toolsets" not in captured
+
+
 def test_shell_hooks_skipped(monkeypatch):
     monkeypatch.setenv("HERMES_SAFE_MODE", "1")
     from agent.shell_hooks import register_from_config

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -402,6 +402,7 @@ def test_termux_fast_cli_launch_oneshot_uses_light_parser(monkeypatch, main_mod)
         "model": "gpt-test",
         "provider": "openai",
         "toolsets": None,
+        "no_tools": False,
         "usage_file": "usage.json",
     }
 
@@ -656,6 +657,7 @@ def test_main_top_level_oneshot_accepts_toolsets(monkeypatch, main_mod):
         "model": None,
         "provider": None,
         "toolsets": "web,terminal",
+        "no_tools": False,
         "usage_file": "usage.json",
     }
 

--- a/tests/run_agent/test_codex_no_tools_nonetype.py
+++ b/tests/run_agent/test_codex_no_tools_nonetype.py
@@ -145,9 +145,8 @@ def test_build_kwargs_emits_tools_when_tools_present(transport, codex_messages):
     assert kwargs["parallel_tool_calls"] is True
 
 
-def test_build_kwargs_drops_empty_tools_list(transport, codex_messages):
-    """``tools=[]`` collapses to ``None`` inside ``_responses_tools`` —
-    the resulting kwargs must therefore also omit the key."""
+def test_build_kwargs_preserves_explicit_empty_tools_list(transport, codex_messages):
+    """`tools=[]` is distinct from None: it is the no-tools wire contract."""
     kwargs = transport.build_kwargs(
         model="gpt-5.5",
         messages=codex_messages,
@@ -155,7 +154,7 @@ def test_build_kwargs_drops_empty_tools_list(transport, codex_messages):
         is_codex_backend=True,
     )
 
-    assert "tools" not in kwargs
+    assert kwargs["tools"] == []
     assert "tool_choice" not in kwargs
     assert "parallel_tool_calls" not in kwargs
 

--- a/utils.py
+++ b/utils.py
@@ -35,6 +35,36 @@ def env_var_enabled(name: str, default: str = "") -> bool:
     return is_truthy_value(os.getenv(name, default), default=False)
 
 
+# ── Explicit no-tools capability boundary ───────────────────────────────────
+#
+# ``hermes --no-tools`` / ``hermes chat --no-tools`` / ``hermes -z --no-tools``
+# publishes ``HERMES_NO_TOOLS=1`` for the whole process (see ``cli.main`` and
+# ``hermes_cli.oneshot.run_oneshot``).  It means "this run offers the model no
+# callable tool at all" — a capability boundary the operator asked for by
+# name, not a preference that later config may soften.
+#
+# Two independent enforcement points read it:
+#   * ``model_tools._compute_tool_definitions`` — refuses to re-add a toolset
+#     to an explicitly empty ``enabled_toolsets`` (the kanban re-entry).
+#   * ``ProviderTransport.sanitize_request_overrides`` — refuses to let a
+#     user-config ``request_overrides`` dict put tool keys on the wire.
+
+NO_TOOLS_ENV_VAR = "HERMES_NO_TOOLS"
+
+# Every wire key that offers a tool surface or steers tool use, in both the
+# current (``tools`` / ``tool_choice`` / ``parallel_tool_calls``) and the
+# deprecated OpenAI (``functions`` / ``function_call``) spellings.  Under the
+# boundary none of these may reach an outgoing model request from any source.
+TOOL_REQUEST_KEYS = frozenset(
+    {"tools", "tool_choice", "parallel_tool_calls", "functions", "function_call"}
+)
+
+
+def explicit_no_tools() -> bool:
+    """True when this process runs under the explicit no-tools boundary."""
+    return env_var_enabled(NO_TOOLS_ENV_VAR)
+
+
 def _preserve_file_mode(path: Path) -> "int | None":
     """Capture the permission bits of *path* if it exists, else ``None``."""
     try:


### PR DESCRIPTION
## Bug
A constrained Telegram profile could persist primary-adapter sessions with `profile_name=NULL`, so a profile-scoped plugin correctly failed closed and gave a confusing user-facing response. First contact also exposed the generic Hermes `/sethome` notice in the member DM.

## Fix
- stamp the active primary adapter profile through the same handler used for secondary multiplexed profiles;
- allow a profile config to explicitly disable the generic home-channel onboarding notice; default behavior remains enabled.

## Tests
- `python3 -m pytest -q tests/gateway/test_home_target_env_var.py tests/gateway/test_multiplex_adapter_registry.py` → 42 passed

The consuming Nova profile will set `onboarding.home_channel_prompt: false` in its reviewed release configuration.