### PR TITLE
fix(kanban): fix board remove on Windows (WinError 5/32)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1037,12 +1037,60 @@ def remove_board(slug: str, *, archive: bool = True) -> dict:
         while target.exists():
             target = archive_root / f"{normed}-{ts}-{suffix}"
             suffix += 1
-        d.rename(target)
+        _win_retry_rename(d, target)
         return {"slug": normed, "action": "archived", "new_path": str(target)}
     else:
         import shutil
-        shutil.rmtree(d)
+        _win_retry_rmtree(d)
         return {"slug": normed, "action": "deleted", "new_path": ""}
+
+
+def _win_retry_rename(src: Path, dst: Path, max_attempts: int = 10, base_delay: float = 0.2) -> None:
+    """Rename with retry on Windows for file-locking race conditions.
+
+    On Windows, a just-closed SQLite handle may still hold the file for a
+    brief moment, causing rename to fail with WinError 5 (Access denied).
+    Retry with exponential backoff.
+    """
+    if os.name != "nt":
+        src.rename(dst)
+        return
+    last_exc = None
+    for attempt in range(max_attempts):
+        try:
+            src.rename(dst)
+            return
+        except OSError as e:
+            last_exc = e
+            if e.winerror not in (5, 32):  # Access denied / Sharing violation
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+    raise last_exc
+
+
+def _win_retry_rmtree(path: Path, max_attempts: int = 10, base_delay: float = 0.2) -> None:
+    """Recursive remove with retry on Windows for file-locking race conditions.
+
+    On Windows, a just-closed SQLite handle may still hold the file for a
+    brief moment, causing rmtree to fail with WinError 32 (Sharing violation).
+    Retry with exponential backoff.
+    """
+    if os.name != "nt":
+        import shutil
+        shutil.rmtree(path)
+        return
+    import shutil
+    last_exc = None
+    for attempt in range(max_attempts):
+        try:
+            shutil.rmtree(path)
+            return
+        except OSError as e:
+            last_exc = e
+            if e.winerror != 32:  # Sharing violation
+                raise
+            time.sleep(base_delay * (2 ** attempt))
+    raise last_exc
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_boards.py
+++ b/tests/hermes_cli/test_kanban_boards.py
@@ -153,7 +153,9 @@ class TestBoardCRUD:
         # downstream readers hit `no such table: task_events`.
         kb.create_board("recycle")
         # First connect populates _INITIALIZED_PATHS for this DB.
-        with kb.connect(board="recycle") as conn:
+        # Use connect_closing to ensure the connection is fully closed on Windows,
+        # avoiding file-locking issues when remove_board runs immediately after.
+        with kb.connect_closing(board="recycle") as conn:
             kb.create_task(conn, title="t1", assignee="dev")
         db_path = kb.board_dir("recycle") / "kanban.db"
         assert str(db_path.resolve()) in kb._INITIALIZED_PATHS


### PR DESCRIPTION
## Summary

Fixes the 	est_remove_clears_init_cache_for_recreated_db test on Windows, which was failing with WinError 5 (Access denied) and WinError 32 (Sharing violation) when emove_board tried to rename/rmtree a directory that SQLite had just closed.

**Root cause:** On Windows, SQLite connections hold file locks briefly after the connection closes. The test used kb.connect() (which doesn't fully release the file handle on Windows), then immediately called emove_board() which tried to rename/rmtree the still-locked directory.

**Fix:**
1. Test: Use kb.connect_closing() instead of kb.connect() - this guarantees the file descriptor is closed before returning.
2. Production code: Added _win_retry_rename() and _win_retry_rmtree() helpers with exponential backoff (10 attempts, 0.2s base delay) to emove_board() so it handles transient Windows file locks gracefully.

**Verification:**
- 	est_remove_clears_init_cache_for_recreated_db now passes on Windows (both rchive=True/False).
- Full kanban test suite: 61 passed, 1 pre-existing failure in unrelated test.
- No regression on Linux (retry logic only activates on Windows).