### PR TITLE
feat(cli): support non-interactive model selection

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1797,21 +1797,13 @@ cmd_import_agent = _forward_command("cmd_import_agent", "hermes_cli.agent_import
 
 
 def cmd_model(args):
-    """Select default model — starts with provider selection, then model picker."""
-    _require_tty("model")
-    if getattr(args, "refresh", False):
-        try:
-            from hermes_cli.models import clear_provider_models_cache
-            clear_provider_models_cache()
-            print("  Cleared model picker cache.")
-        except Exception:
-            pass
-    from hermes_cli.setup import run_setup_action_with_navigation
+    """Select the default model interactively or from complete CLI flags."""
+    from hermes_cli.model_command import run_model_command
 
-    run_setup_action_with_navigation(
-        "Model & Provider",
-        lambda: select_provider_and_model(args=args),
-        cancelled_message="No change.",
+    return run_model_command(
+        args,
+        require_tty=_require_tty,
+        interactive_select=select_provider_and_model,
     )
 
 

--- a/hermes_cli/model_command.py
+++ b/hermes_cli/model_command.py
@@ -1,0 +1,98 @@
+"""Top-level ``hermes model`` command orchestration."""
+
+from __future__ import annotations
+
+import sys
+from typing import Callable
+
+
+def _clear_model_cache() -> None:
+    try:
+        from hermes_cli.models import clear_provider_models_cache
+
+        clear_provider_models_cache()
+        print("  Cleared model picker cache.")
+    except Exception:
+        pass
+
+
+def _run_noninteractive(provider: str, model_id: str) -> None:
+    from cli import save_config_value
+    from hermes_cli.config import get_compatible_custom_providers, load_config
+    from hermes_cli.model_switch import switch_model
+
+    config = load_config() or {}
+    raw_model_config = config.get("model")
+    if isinstance(raw_model_config, dict):
+        model_config = raw_model_config
+    elif isinstance(raw_model_config, str) and raw_model_config.strip():
+        model_config = {"default": raw_model_config.strip()}
+    else:
+        model_config = {}
+
+    result = switch_model(
+        raw_input=model_id,
+        current_provider=str(model_config.get("provider") or "auto"),
+        current_model=str(model_config.get("default") or ""),
+        current_base_url=str(model_config.get("base_url") or ""),
+        current_api_key=str(model_config.get("api_key") or ""),
+        is_global=True,
+        explicit_provider=provider,
+        user_providers=(
+            config.get("providers")
+            if isinstance(config.get("providers"), dict)
+            else None
+        ),
+        custom_providers=get_compatible_custom_providers(config),
+    )
+    if not result.success:
+        print(f"Error: {result.error_message}", file=sys.stderr)
+        raise SystemExit(1)
+    if not result.model_verified:
+        print(
+            f"Error: model '{model_id}' could not be verified for provider "
+            f"'{provider}'; configuration was not changed.",
+            file=sys.stderr,
+        )
+        raise SystemExit(1)
+
+    save_config_value("model.default", result.new_model)
+    save_config_value("model.provider", result.target_provider)
+    save_config_value("model.base_url", result.base_url or None)
+    save_config_value("model.api_mode", result.api_mode or None)
+    print(
+        f"Default model set to: {result.new_model} "
+        f"(via {result.provider_label or result.target_provider})"
+    )
+
+
+def run_model_command(
+    args,
+    *,
+    require_tty: Callable[[str], None],
+    interactive_select: Callable,
+) -> None:
+    """Run flag-driven selection when complete, otherwise retain the picker."""
+    provider = str(getattr(args, "provider", None) or "").strip()
+    model_id = str(getattr(args, "model_id", None) or "").strip()
+    if bool(provider) != bool(model_id):
+        print(
+            "Error: --provider and --model must be supplied together.",
+            file=sys.stderr,
+        )
+        raise SystemExit(2)
+
+    if getattr(args, "refresh", False):
+        _clear_model_cache()
+    if provider:
+        _run_noninteractive(provider, model_id)
+        return
+
+    require_tty("model")
+    from hermes_cli.setup import run_setup_action_with_navigation
+
+    run_setup_action_with_navigation(
+        "Model & Provider",
+        lambda: interactive_select(args=args),
+        cancelled_message="No change.",
+    )

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -440,6 +440,7 @@ class ModelSwitchResult:
     runtime_capabilities: Optional[dict[str, bool]] = None
     model_info: Optional[ModelInfo] = None
     is_global: bool = False
+    model_verified: bool = False
 
 
 @dataclass(frozen=True)
@@ -1052,6 +1053,7 @@ class _Switch:
     validation_headers: dict = field(default_factory=dict)
     suppress_ollama_headers: bool = False
     validation: dict = field(default_factory=dict)
+    model_verified: bool = False
 
     def fail(self, message: str, **fields) -> ModelSwitchResult:
         return ModelSwitchResult(success=False, is_global=self.is_global, error_message=message, **fields)
@@ -1362,15 +1364,18 @@ def _validate_switch(st: _Switch) -> Optional[ModelSwitchResult]:
         validation = {"accepted": False, "persist": False, "recognized": False,
                       "message": f"Could not validate `{st.new_model}`: {e}"}
 
+    declared_model = _config_declares_model(
+        st.new_model, st.target_provider, st.base_url,
+        st.user_providers, st.custom_providers)
     if not validation.get("accepted"):
-        if not _config_declares_model(
-                st.new_model, st.target_provider, st.base_url, st.user_providers, st.custom_providers):
+        if not declared_model:
             return st.fail(
                 validation.get("message", "Invalid model"),
                 new_model=st.new_model, target_provider=st.target_provider, provider_label=st.provider_label)
         validation = {"accepted": True, "persist": True, "recognized": False, "message": validation.get("message", "")}
     st.new_model = validation.get("corrected_model") or st.new_model
     st.validation = validation
+    st.model_verified = bool(validation.get("recognized") or declared_model)
     return None
 
 
@@ -1448,7 +1453,7 @@ def _build_switch_result(st: _Switch) -> ModelSwitchResult:
         provider_label=st.provider_label, resolved_via_alias=st.resolved_alias, capabilities=capabilities,
         runtime_capabilities={
             k: v for k, v in runtime_capabilities.items() if isinstance(k, str) and isinstance(v, bool)},
-        model_info=model_info, is_global=st.is_global)
+        model_info=model_info, is_global=st.is_global, model_verified=st.model_verified)
 
 
 def switch_model(

--- a/hermes_cli/subcommands/model.py
+++ b/hermes_cli/subcommands/model.py
@@ -9,10 +9,16 @@ def build_model_parser(subparsers, *, cmd_model: Callable) -> None:
     """Attach the ``model`` subcommand to ``subparsers``."""
     model_parser = subparsers.add_parser(
         "model", help="Select default model and provider",
-        description="Interactively select your inference provider and default model")
+        description="Select your inference provider and default model")
     model_parser.add_argument(
         "--refresh", action="store_true",
         help="Wipe the model picker disk cache and re-fetch every provider's live /v1/models list.")
+    model_parser.add_argument(
+        "--provider",
+        help="Provider ID to select non-interactively (requires --model).")
+    model_parser.add_argument(
+        "--model", dest="model_id",
+        help="Model ID to select non-interactively (requires --provider).")
     model_parser.add_argument(
         "--portal-url", help="Portal base URL for Nous login (default: production portal)")
     model_parser.add_argument(

--- a/tests/hermes_cli/test_model_command_noninteractive.py
+++ b/tests/hermes_cli/test_model_command_noninteractive.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_cli.model_switch import ModelSwitchResult
+from hermes_cli.subcommands.model import build_model_parser
+
+
+def test_verified_noninteractive_selection_skips_tty_and_persists(monkeypatch, capsys):
+    import cli
+    from hermes_cli import config, main, model_switch
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_model_parser(subparsers, cmd_model=main.cmd_model)
+    args = parser.parse_args(
+        ["model", "--provider", "anthropic", "--model", "claude-sonnet-4-6"])
+    result = ModelSwitchResult(
+        success=True, new_model="claude-sonnet-4-6", target_provider="anthropic",
+        base_url="https://api.anthropic.com", api_mode="anthropic_messages",
+        provider_label="Anthropic", is_global=True, model_verified=True)
+    switch_calls, writes = [], []
+    monkeypatch.setattr(
+        main, "_require_tty",
+        lambda *_: pytest.fail("flag-driven selection must not require a TTY"))
+    monkeypatch.setattr(
+        config, "load_config",
+        lambda: {"model": {"default": "old", "provider": "openrouter"}})
+    monkeypatch.setattr(config, "get_compatible_custom_providers", lambda _: [])
+    monkeypatch.setattr(
+        model_switch, "switch_model",
+        lambda **kwargs: switch_calls.append(kwargs) or result)
+    monkeypatch.setattr(cli, "save_config_value", lambda *values: writes.append(values))
+
+    args.func(args)
+
+    assert switch_calls[0]["explicit_provider"] == "anthropic"
+    assert switch_calls[0]["raw_input"] == "claude-sonnet-4-6"
+    assert writes == [
+        ("model.default", "claude-sonnet-4-6"),
+        ("model.provider", "anthropic"),
+        ("model.base_url", "https://api.anthropic.com"),
+        ("model.api_mode", "anthropic_messages"),
+    ]
+    assert "Default model set" in capsys.readouterr().out
+
+
+def test_noninteractive_selection_fails_closed_without_writing(monkeypatch, capsys):
+    import cli
+    from hermes_cli import config, main, model_switch
+
+    writes = []
+    monkeypatch.setattr(config, "load_config", lambda: {})
+    monkeypatch.setattr(config, "get_compatible_custom_providers", lambda _: [])
+    monkeypatch.setattr(
+        model_switch, "switch_model",
+        lambda **_: ModelSwitchResult(
+            success=True, new_model="typo-model", target_provider="anthropic",
+            model_verified=False))
+    monkeypatch.setattr(cli, "save_config_value", lambda *values: writes.append(values))
+
+    with pytest.raises(SystemExit) as incomplete:
+        main.cmd_model(
+            SimpleNamespace(provider="anthropic", model_id=None, refresh=False))
+    with pytest.raises(SystemExit) as unverified:
+        main.cmd_model(
+            SimpleNamespace(
+                provider="anthropic", model_id="typo-model", refresh=False))
+
+    assert incomplete.value.code == 2
+    assert unverified.value.code == 1
+    assert writes == []
+    assert "could not be verified" in capsys.readouterr().err


### PR DESCRIPTION
## What does this PR do?

Add non-interactive provider and model selection to `hermes model`.

## Related Issue

Fixes #102263

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Adds paired `--provider` / `--model` flags while preserving the interactive fallback.
- Moves command orchestration into `hermes_cli/model_command.py`, keeping `main.py` as a thin facade in the current CLI architecture.
- Reuses the shared switch pipeline and rejects models that are neither catalog-recognized nor explicitly declared in user configuration.
- Tracks `model_verified` separately, without changing the existing `validation["recognized"]` semantics.
- Persists only the selected route keys after validation succeeds; failed validation performs no writes.
- Covers parser wiring, non-interactive TTY bypass, persistence, paired-flag validation, and unverified-model failure behavior.

## How to Test

1. `scripts/run_tests.sh tests/hermes_cli/test_model_command_noninteractive.py -q`
2. `uv run ruff check hermes_cli/main.py hermes_cli/model_command.py hermes_cli/model_switch.py hermes_cli/subcommands/model.py tests/hermes_cli/test_model_command_noninteractive.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable.
