### PR TITLE
fix(kanban): scope active PR guard to implementers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -9397,6 +9397,23 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
 _clear_spawn_failures = _clear_failure_counter
 
 
+def _is_developer_dispatch_lane(assignee: Optional[str]) -> bool:
+    """Return whether an assignee names an implementation/developer lane.
+
+    ``active_pr`` is intentionally scoped to implementation reruns.  QA and
+    release workers consume the PR produced by the implementation worker, so
+    applying that guard to every ready card would strand downstream work.  The
+    board has no separate role column; use the established implementation
+    profile names and fail open for other profile names. ``worker`` and
+    ``builder`` are retained because they are the generic implementation
+    profiles used by existing boards.
+    """
+    if not isinstance(assignee, str):
+        return False
+    role = assignee.strip().lower()
+    return role in {"builder", "coder", "developer", "implementer", "worker"}
+
+
 def check_respawn_guard(
     conn: sqlite3.Connection, task_id: str, *, lane: str = "ready",
 ) -> Optional[str]:
@@ -9456,7 +9473,7 @@ def check_respawn_guard(
     genuinely dead (no live PID on this host).
     """
     row = conn.execute(
-        "SELECT last_failure_error FROM tasks WHERE id = ?",
+        "SELECT assignee, last_failure_error FROM tasks WHERE id = ?",
         (task_id,),
     ).fetchone()
     if row is None:
@@ -9538,12 +9555,13 @@ def check_respawn_guard(
 
     # 4. GitHub PR URL in a recent comment — prior worker already opened a PR.
     pr_cutoff = now - _RESPAWN_GUARD_PR_WINDOW
-    for c in conn.execute(
-        "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
-        (task_id, pr_cutoff),
-    ).fetchall():
-        if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
-            return "active_pr"
+    if _is_developer_dispatch_lane(row["assignee"]):
+        for c in conn.execute(
+            "SELECT body FROM task_comments WHERE task_id = ? AND created_at >= ?",
+            (task_id, pr_cutoff),
+        ).fetchall():
+            if c["body"] and _RESPAWN_GUARD_PR_URL_RE.search(c["body"]):
+                return "active_pr"
 
     return None
 

--- a/tests/hermes_cli/test_kanban_review_lifecycle.py
+++ b/tests/hermes_cli/test_kanban_review_lifecycle.py
@@ -452,12 +452,38 @@ def test_active_pr_guard_skipped_for_review_lane_but_defers_ready_lane(
         assert kb.check_respawn_guard(conn, ready_id) == "active_pr"
         assert kb.check_respawn_guard(conn, review_id, lane="review") is None
 
+        for assignee in ("builder", "coder", "developer", "implementer", "worker"):
+            implementation_id = kb.create_task(
+                conn, title=f"{assignee} existing PR", assignee=assignee,
+            )
+            kb.add_comment(conn, implementation_id, author="worker", body=pr_comment)
+            assert kb.check_respawn_guard(conn, implementation_id) == "active_pr"
+
+        # A PR is a duplicate-work signal only for the implementation lane.
+        # QA and release lanes consume the existing PR and must remain
+        # dispatchable even when their card contains the same link.
+        for assignee in ("qa", "release"):
+            downstream_id = kb.create_task(
+                conn, title=f"{assignee} existing PR", assignee=assignee,
+            )
+            kb.add_comment(conn, downstream_id, author="worker", body=pr_comment)
+            assert kb.check_respawn_guard(conn, downstream_id) is None
+
         res = kb.dispatch_once(conn, dry_run=True)
         spawned_ids = [s[0] for s in res.spawned]
         guarded = dict(res.respawn_guarded)
         assert review_id in spawned_ids
         assert ready_id not in spawned_ids
         assert guarded.get(ready_id) == "active_pr"
+        assert all(
+            task_id in spawned_ids
+            for task_id in (
+                row["id"]
+                for row in conn.execute(
+                    "SELECT id FROM tasks WHERE assignee IN ('qa', 'release')"
+                )
+            )
+        )
 
         # Rate-limit cooldown still defers the review lane.
         _now = int(__import__("time").time())


### PR DESCRIPTION
## Summary

Fix the Kanban dispatcher `active_pr` respawn guard so an open PR blocks only duplicate implementation workers, not downstream QA, review, or release work.

## Problem

The guard previously treated every recent GitHub PR URL as evidence that a task was an implementation task with an existing PR. In a linear workflow (`development -> QA -> review -> release`), downstream cards can legitimately contain the same PR URL because they consume and verify that artifact. Guarding those cards leaves actionable work in `ready` with no worker.

## Change

- Add a small implementation-lane predicate for the established implementation profiles: `builder`, `coder`, `developer`, `implementer`, and generic `worker`.
- Apply the `active_pr` comment guard only to those implementation lanes.
- Preserve the duplicate-implementation protection.
- Allow QA, release, and other non-implementation lanes to dispatch while an existing PR is open.
- Add regression coverage for all implementation aliases and downstream QA/release behavior.

## Verification

- `python -m pytest -q tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_review_lifecycle.py`
  - 50 passed, 1 skipped
- `python -m compileall -q hermes_cli`
- `git diff --check`
- Added-line security scan: no hardcoded secrets or dangerous execution patterns

No configuration, credentials, gateway behavior, or unrelated package files are changed by this PR.
