### PR TITLE
fix(whatsapp): honor custom bridge edit capability

### DIFF
--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -463,6 +463,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
         )
+        # Bridge transports are not all capability-equivalent.  The bundled
+        # Baileys bridge supports message edits, while custom Web bridges may
+        # intentionally expose final-message delivery only.  Declare the actual
+        # transport capability so GatewayRunner skips edit-based streaming rather
+        # than creating a stream consumer that can never deliver a preview.
+        self.SUPPORTS_MESSAGE_EDITING = bool(
+            config.extra.get("supports_message_editing", True)
+        )
         self._session_path: Path = Path(config.extra.get(
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")

--- a/tests/gateway/test_whatsapp_transport_capabilities.py
+++ b/tests/gateway/test_whatsapp_transport_capabilities.py
@@ -1,0 +1,20 @@
+from gateway.config import PlatformConfig
+
+
+def test_whatsapp_bundled_bridge_keeps_edit_support_by_default():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter.SUPPORTS_MESSAGE_EDITING is True
+
+
+def test_whatsapp_custom_bridge_can_declare_final_only_delivery():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"supports_message_editing": False},
+        )
+    )
+    assert adapter.SUPPORTS_MESSAGE_EDITING is False


### PR DESCRIPTION
## Summary

Allow custom WhatsApp bridges to declare whether they support message editing via `platforms.whatsapp.extra.supports_message_editing`.

The bundled bridge remains editing-capable by default. Final-only custom transports can opt out so GatewayRunner does not start edit-based streaming that the bridge cannot satisfy.

## Why

RHODIZ uses a custom WhatsApp Web transport for self-chat. WhatsApp self-chat can surface `@lid` identifiers for which edit operations are not reliable. Without a capability override, Hermes assumes editing support and creates a streaming consumer even though the custom bridge can only guarantee final-message delivery.

## Compatibility

- Default remains `true`; existing and bundled transports are unchanged.
- Custom bridges can set `supports_message_editing: false`.
- No protocol change is required for existing bridges.

## Tests

`9 passed` across the new transport-capability test plus the existing WhatsApp reply-prefix and text-batching tests on current upstream `main`.
