### PR TITLE
fix(gateway): show channel model in reset notices

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23952,6 +23952,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         When multiplexing, resolve model/provider/context inside the profile
         serving ``source`` — otherwise the banner advertises the base config's
         model while the session actually runs on the profile's (#59003).
+        Apply the source channel's model override for the same reason: the
+        reset banner should describe the route the next turn will use.
         Mirrors ``_run_agent``'s gating so single-profile gateways never
         enter the scope.
 
@@ -23961,19 +23963,35 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         inside this method, so contextvars behave correctly in the worker
         thread.
         """
+        channel_override = _get_channel_override(
+            self.config,
+            source.platform,
+            str(source.chat_id) if source.chat_id else "",
+            thread_id=(
+                str(source.thread_id)
+                if getattr(source, "thread_id", None)
+                else None
+            ),
+            parent_id=(
+                str(source.parent_chat_id)
+                if getattr(source, "parent_chat_id", None)
+                else None
+            ),
+        )
+        channel_model = channel_override.model if channel_override else None
         if getattr(getattr(self, "config", None), "multiplex_profiles", False):
             with _profile_runtime_scope(self._resolve_profile_home_for_source(source)):
-                return self._format_session_info()
-        return self._format_session_info()
+                return self._format_session_info(model=channel_model)
+        return self._format_session_info(model=channel_model)
 
-    def _format_session_info(self) -> str:
+    def _format_session_info(self, model: Optional[str] = None) -> str:
         """Resolve current model config and return a formatted info block.
 
         Surfaces model, provider, context length, and endpoint so gateway
         users can immediately see if context detection went wrong (e.g.
         local models falling to the 128K default).
         """
-        resolved = _resolve_gateway_model_context()
+        resolved = _resolve_gateway_model_context(model=model)
         model = resolved.model
         provider = resolved.provider
         base_url = resolved.base_url

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -154,3 +154,30 @@ class TestResetNoticeSessionInfo:
         assert "anthropic" in info
         assert "base-model" not in info
 
+    def test_reset_notice_uses_channel_model_override(self, runner, tmp_path):
+        from types import SimpleNamespace
+
+        base, profile = self._homes(tmp_path)
+        source = self._source()
+        runner.config = SimpleNamespace(multiplex_profiles=True)
+        with (
+            patch("gateway.run._hermes_home", base),
+            patch.object(
+                GatewayRunner,
+                "_resolve_profile_home_for_source",
+                return_value=profile,
+            ),
+            patch(
+                "gateway.run._get_channel_override",
+                return_value=SimpleNamespace(model="channel-model"),
+            ),
+            patch.object(
+                GatewayRunner,
+                "_format_session_info",
+                return_value="channel-info",
+            ) as format_info,
+        ):
+            assert runner._reset_notice_session_info(source) == "channel-info"
+
+        format_info.assert_called_once_with(model="channel-model")
+


### PR DESCRIPTION
## Summary

- resolve the current channel override before formatting `/new`, `/reset`, and automatic reset notices
- pass the channel model into the existing session-info resolver inside the serving profile scope
- add a regression test proving the reset notice uses the channel model

## Why

Runtime routing already honors `channel_overrides`, but the reset banner does not. It calls `_format_session_info()` without the channel model, so a channel can correctly run one model while the new-session notice advertises the profile or gateway default.

This is a display-only fix. It does not change model selection for agent turns.

This addresses the reset-banner portion of #79468. It is intentionally narrower than #65463, which is currently conflicting and also changes session/provider route resolution.

## How to test

1. Set a global or profile default model.
2. Configure a different model for one channel through `channel_overrides`.
3. Run `/new` or `/reset` in that channel.
4. Confirm the notice reports the channel model rather than the global default.

```bash
/usr/local/lib/hermes-agent/venv/bin/python -m pytest -q \
  tests/gateway/test_session_info.py \
  tests/gateway/test_session_model_reset.py \
  tests/gateway/test_session_boundary_hooks.py \
  tests/gateway/test_title_command.py \
  tests/gateway/test_35994_reset_button_deadlock.py
```

Result: `20 passed`.

Additional checks:

- `git diff --check`
- Python compilation for both changed files
- manual A/B reproduction against clean `main` and the patched build

## Platform

Tested on Linux, aarch64.
