### PR TITLE
fix(mcp): preserve snake-case tool metadata in cache

### DIFF
--- a/tests/tools/test_mcp_trust_gating.py
+++ b/tests/tools/test_mcp_trust_gating.py
@@ -245,3 +245,37 @@ class TestAnnotationCaptureAtDiscovery:
         assert mcp_tool._annotation_read_only_hint(
             SimpleNamespace()
         ) is False
+
+    def test_snake_case_mcp_fields_preserve_schema_and_read_only_hint(self):
+        """MCP 2.x field names survive discovery and schema-cache writes."""
+        from tools.registry import ToolRegistry
+
+        schema = {
+            "type": "object",
+            "properties": {"sql": {"type": "string"}},
+            "required": ["sql"],
+        }
+        server = mcp_tool.MCPServerTask("srv")
+        server.session = MagicMock()
+        server._tools = [
+            SimpleNamespace(
+                name="query",
+                description="Run a query",
+                input_schema=schema,
+                annotations=SimpleNamespace(read_only_hint=True),
+            )
+        ]
+        config = {
+            "trust": "untrusted",
+            "tools": {"resources": False, "prompts": False},
+        }
+
+        with patch("tools.registry.registry", ToolRegistry()), \
+             patch("tools.mcp_tool._track_mcp_tool_server"), \
+             patch("tools.mcp_schema_cache.write_cache_entry") as write_cache:
+            mcp_tool._register_server_tools("srv", server, config)
+
+        assert mcp_tool._tool_read_only_hints["srv"]["query"] is True
+        cached_tool = write_cache.call_args.kwargs["tools"][0]
+        assert cached_tool["inputSchema"] == schema
+        assert cached_tool["annotations"] == {"readOnlyHint": True}

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4984,7 +4984,7 @@ def _annotation_read_only_hint(mcp_tool: Any) -> bool:
     if isinstance(annotations, dict):
         hint = annotations.get("readOnlyHint")
     else:
-        hint = getattr(annotations, "readOnlyHint", None)
+        hint = mcp_field(annotations, "read_only_hint", "readOnlyHint")
     return hint is True
 
 
@@ -7930,7 +7930,7 @@ def _register_server_tools(name: str, server: MCPServerTask, config: dict) -> Li
             for mcp_tool in server._tools:
                 if not _should_register(mcp_tool.name):
                     continue
-                schema_obj = getattr(mcp_tool, "inputSchema", None)
+                schema_obj = mcp_field(mcp_tool, "input_schema", "inputSchema")
                 tools_payload.append({
                     "name": mcp_tool.name,
                     "description": mcp_tool.description or "",


### PR DESCRIPTION
## What does this PR do?

Fixes the MCP 2.x compatibility reads that populate the schema cache and read-only trust metadata. Both paths now use `mcp_field()` so snake-case SDK attributes are preferred while MCP 1.x camel-case attributes remain supported.

## Related Issue

Fixes #94970

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`: read `input_schema` and `read_only_hint` through the cross-version MCP field accessor before persisting tool metadata.
- `tests/tools/test_mcp_trust_gating.py`: cover discovery and cache write-through with MCP 2.x-style snake-case tool and annotation fields.

## How to Test

1. Run `$VIRTUAL_ENV/bin/pytest tests/tools/test_mcp_trust_gating.py -q`; this passes (12 tests).
2. Run the reproduction against an MCP 2.x `Tool` with `input_schema` and `ToolAnnotations(read_only_hint=True)`; confirm the persisted cache entry retains the schema and `readOnlyHint: true`.
3. Run `/opt/homebrew/bin/timeout -k 30 480 sh -c 'pytest tests/ -q -x --timeout=60 "$@"' sh`. In this sandbox it exits 3 during unrelated dashboard collection because FastAPI/Uvicorn cannot be installed from the blocked cache. The direct MCP-import suite completed with 949 passed; its 18 failures are pre-existing environment limitations (MCP 1.27 rather than the locked 2.0 API, blocked localhost binds, and process guard restrictions).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (darwin-arm64); targeted regression tests pass

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

test verification unavailable: the recorded local test command exited 3

<!-- autocontrib:worker-id=issue-new-4811ba18 kind=pr-open -->