### PR TITLE
fix(gateway): shutdown watchdog must outlast the restart after-turn wait

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7678,6 +7678,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_via_service = False
         self._detached_restart_helper_started = False
         self._restart_command_source: Optional[SessionSource] = None
+        # Monotonic deadline of an in-flight restart after-turn wait, or None.
+        # Published by _await_active_work_before_restart so the stop() shutdown
+        # watchdog can size its leash to cover that wait (see
+        # _resolve_shutdown_leash).
+        self._restart_after_turn_deadline: Optional[float] = None
         # Monotonic-ish wall clock of when this GatewayRunner was constructed.
         # Used by the /restart redelivery guard to bound the window in which a
         # missing dedup marker is treated as a stale redelivery.
@@ -10148,6 +10153,42 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             )
         except Exception:
             pass
+
+    def _remaining_after_turn_wait(self) -> float:
+        """Seconds still owed to an in-flight restart after-turn wait.
+
+        Returns 0.0 when no wait is running or its deadline has passed.
+        ``_await_active_work_before_restart`` publishes the deadline; the
+        shutdown watchdog uses this to size its leash so it never force-kills
+        a gateway that is still legitimately waiting for in-flight turns.
+        """
+        deadline = getattr(self, "_restart_after_turn_deadline", None)
+        if deadline is None:
+            return 0.0
+        return max(0.0, float(deadline) - time.monotonic())
+
+    def _resolve_shutdown_leash(self) -> float:
+        """Wall-clock leash for the stop() shutdown watchdog.
+
+        Normally ``restart_drain_timeout + grace``. When ``stop()`` is entered
+        while the in-band restart after-turn wait is still running, that wait's
+        remaining budget is the real lower bound: ``restart_drain_timeout``
+        defaults to 0, so the plain leash is just the 60s grace and the
+        watchdog would kill a healthy gateway mid-wait (and orphan its external
+        supervisor). Takes whichever budget is larger; never raises.
+        """
+        base = resolve_shutdown_watchdog_delay(self._restart_drain_timeout)
+        try:
+            deadline = getattr(self, "_restart_after_turn_deadline", None)
+            if deadline is None:
+                return base
+            remaining = max(0.0, float(deadline) - time.monotonic())
+        except (TypeError, ValueError):
+            # Only a malformed deadline degrades to the plain contract.
+            return base
+        if remaining <= 0:
+            return base
+        return max(base, resolve_shutdown_watchdog_delay(remaining))
 
     def _persist_active_agents(self) -> None:
         """Persist the live in-flight agent count to ``gateway_state.json``.
@@ -12820,32 +12861,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         loop = asyncio.get_running_loop()
         deadline = loop.time() + timeout
+        # Publish the deadline so stop()'s shutdown watchdog can extend its
+        # leash to cover this wait. Without it stop() arms only
+        # drain_timeout+grace (60s by default) and force-kills a gateway that
+        # is still legitimately waiting out its after-turn budget.
+        self._restart_after_turn_deadline = time.monotonic() + timeout
         last_status_at = 0.0
-        while self._awaitable_work_count() > 0:
-            now = loop.time()
-            if now >= deadline:
-                logger.warning(
-                    "Restart after-turn wait timed out after %.0fs with %d "
-                    "still active; proceeding to stop()/drain which may "
-                    "interrupt remaining work (#77184)",
-                    timeout,
-                    self._active_work_count(),
-                )
-                return False
-            if (now - last_status_at) >= 30.0:
-                logger.info(
-                    "Restart deferred: waiting on %d active work unit(s) "
-                    "(%d wedged and excluded; %.0fs remaining before force drain)",
-                    self._awaitable_work_count(),
-                    self._wedged_agent_count(),
-                    deadline - now,
-                )
-                try:
-                    self._update_runtime_status("draining")
-                except Exception:
-                    pass
-                last_status_at = now
-            await asyncio.sleep(0.1)
+        try:
+            while self._awaitable_work_count() > 0:
+                now = loop.time()
+                if now >= deadline:
+                    logger.warning(
+                        "Restart after-turn wait timed out after %.0fs with %d "
+                        "still active; proceeding to stop()/drain which may "
+                        "interrupt remaining work (#77184)",
+                        timeout,
+                        self._active_work_count(),
+                    )
+                    return False
+                if (now - last_status_at) >= 30.0:
+                    logger.info(
+                        "Restart deferred: waiting on %d active work unit(s) "
+                        "(%d wedged and excluded; %.0fs remaining before force drain)",
+                        self._awaitable_work_count(),
+                        self._wedged_agent_count(),
+                        deadline - now,
+                    )
+                    try:
+                        self._update_runtime_status("draining")
+                    except Exception:
+                        pass
+                    last_status_at = now
+                await asyncio.sleep(0.1)
+        finally:
+            self._restart_after_turn_deadline = None
 
         if self._active_work_count() > 0:
             logger.warning(
@@ -16523,9 +16572,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         lambda: 0,
                     )(),
                     "restart_drain_timeout": self._restart_drain_timeout,
-                    "watchdog_delay_s": resolve_shutdown_watchdog_delay(
-                        self._restart_drain_timeout
-                    ),
+                    "after_turn_wait_remaining_s": self._remaining_after_turn_wait(),
+                    "watchdog_delay_s": self._resolve_shutdown_leash(),
                     "phase_elapsed_s": (
                         time.monotonic() - started if started is not None else None
                     ),
@@ -16533,7 +16581,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
             if not os.environ.get("PYTEST_CURRENT_TEST"):
                 arm_shutdown_watchdog(
-                    resolve_shutdown_watchdog_delay(self._restart_drain_timeout),
+                    self._resolve_shutdown_leash(),
                     done_event=_watchdog_done,
                     snapshot_fn=_shutdown_watchdog_snapshot,
                     exit_code=1,

--- a/tests/gateway/test_restart_after_turn_watchdog_leash.py
+++ b/tests/gateway/test_restart_after_turn_watchdog_leash.py
@@ -1,0 +1,149 @@
+"""Shutdown watchdog must not fire during a legitimate after-turn wait.
+
+In-band restart (``/restart``, SIGUSR1, fleet restart) defers ``stop()`` and
+waits up to ``agent.restart_after_turn_timeout`` (default 1800s) for in-flight
+turns to finish (#77184). ``stop()`` arms a thread watchdog whose leash is
+``resolve_shutdown_watchdog_delay(restart_drain_timeout)`` —
+``restart_drain_timeout`` defaults to **0**, so the leash is just the 60s
+grace.
+
+When something enters ``stop()`` while the after-turn wait is still running,
+the watchdog kills a process that is behaving correctly.
+
+Observed 2026-09-03 on Shane's gateway::
+
+    12:35:57 Restart requested with 4 active work unit(s); deferring stop() (cap=1800s)
+    12:36:58 Stopping gateway for restart...        <- stop() entered, watchdog armed
+    12:36:58 Restart deferred: waiting on 4 ... (1739s remaining)
+    12:37:56 Restart deferred: waiting on 4 ... (1680s remaining)
+    12:37:58 CRITICAL shutdown watchdog fired after 60s — forcing process exit
+
+The force-exit killed the Windows Task Scheduler supervisor's blocked
+``shell.Run``, leaving the gateway with no external supervision.
+
+The leash must cover whatever remains of the after-turn budget.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from gateway.run import GatewayRunner
+from gateway.shutdown_watchdog import (
+    DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S,
+    resolve_shutdown_watchdog_delay,
+)
+
+
+class _Runner:
+    """Minimal double exposing only what the leash calculation touches."""
+
+    def __init__(self, *, drain_timeout: float = 0.0, remaining: float = 0.0):
+        self._restart_drain_timeout = drain_timeout
+        # Mirrors the real attribute published by
+        # ``_await_active_work_before_restart``: a monotonic deadline, or None.
+        self._restart_after_turn_deadline = (
+            time.monotonic() + remaining if remaining > 0 else None
+        )
+        self._remaining = remaining
+
+
+def test_leash_covers_remaining_after_turn_wait():
+    """The reported bug: 60s leash vs 1739s of legitimate remaining wait."""
+    runner = _Runner(drain_timeout=0.0, remaining=1739.0)
+
+    leash = GatewayRunner._resolve_shutdown_leash(runner)
+
+    assert leash >= 1739.0, (
+        f"watchdog leash {leash}s is shorter than the {runner._remaining}s of "
+        "after-turn budget still legitimately in flight — this force-kills a "
+        "healthy gateway and orphans its supervisor"
+    )
+
+
+def test_leash_keeps_grace_on_top_of_remaining_wait():
+    runner = _Runner(drain_timeout=0.0, remaining=100.0)
+    leash = GatewayRunner._resolve_shutdown_leash(runner)
+    # Wall-clock elapses between constructing the double and reading the
+    # deadline, so assert the contract (grace on top, bounded) not an exact value.
+    assert 100.0 < leash <= 100.0 + DEFAULT_SHUTDOWN_WATCHDOG_GRACE_S
+
+
+def test_leash_unchanged_when_no_after_turn_wait_is_active():
+    """Normal shutdown keeps the existing drain+grace contract."""
+    runner = _Runner(drain_timeout=180.0, remaining=0.0)
+    assert GatewayRunner._resolve_shutdown_leash(runner) == pytest.approx(
+        resolve_shutdown_watchdog_delay(180.0)
+    )
+
+
+def test_leash_uses_whichever_budget_is_larger():
+    """A long drain budget must not be shortened by a small remaining wait."""
+    runner = _Runner(drain_timeout=600.0, remaining=30.0)
+    assert GatewayRunner._resolve_shutdown_leash(runner) == pytest.approx(
+        resolve_shutdown_watchdog_delay(600.0)
+    )
+
+
+def test_leash_survives_a_malformed_deadline():
+    """A corrupt deadline must degrade to the old behaviour, never crash stop()."""
+
+    class _Bad:
+        _restart_drain_timeout = 0.0
+        _restart_after_turn_deadline = "not-a-number"
+
+    assert GatewayRunner._resolve_shutdown_leash(_Bad()) == pytest.approx(
+        resolve_shutdown_watchdog_delay(0.0)
+    )
+
+
+def test_leash_reads_the_deadline_directly_not_via_a_helper():
+    """Regression: the leash must not depend on a helper method being present.
+
+    An earlier implementation called ``self._remaining_after_turn_wait()``
+    inside a bare ``except Exception``. Any object without that method — or any
+    bug inside it — silently fell back to the 60s leash, reintroducing the
+    force-kill while every unit test still passed.
+    """
+
+    class _NoHelper:
+        """Has the deadline but deliberately no ``_remaining_after_turn_wait``."""
+
+        _restart_drain_timeout = 0.0
+
+        def __init__(self, remaining: float):
+            self._restart_after_turn_deadline = time.monotonic() + remaining
+
+    leash = GatewayRunner._resolve_shutdown_leash(_NoHelper(1739.0))
+    assert leash > 1739.0, (
+        f"leash collapsed to {leash}s — the deadline is being read through a "
+        "helper whose absence is silently swallowed"
+    )
+
+
+# --- the deadline probe itself -----------------------------------------
+
+
+def test_remaining_is_zero_when_no_restart_wait_is_running():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._restart_after_turn_deadline = None
+    assert GatewayRunner._remaining_after_turn_wait(runner) == 0.0
+
+
+def test_remaining_is_zero_after_the_deadline_passes():
+    import time
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._restart_after_turn_deadline = time.monotonic() - 5.0
+    assert GatewayRunner._remaining_after_turn_wait(runner) == 0.0
+
+
+def test_remaining_reports_time_left_while_waiting():
+    import time
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._restart_after_turn_deadline = time.monotonic() + 120.0
+    remaining = GatewayRunner._remaining_after_turn_wait(runner)
+    assert 100.0 < remaining <= 120.0


### PR DESCRIPTION
## Summary

In-band restart defers `stop()` and waits up to `agent.restart_after_turn_timeout` (default **1800s**) for in-flight turns to finish (#77184). `stop()` then arms the thread shutdown watchdog with `resolve_shutdown_watchdog_delay(self._restart_drain_timeout)` — and `agent.restart_drain_timeout` defaults to **0**, so that leash is just the **60s** grace.

If `stop()` is entered while the after-turn wait is still running, the watchdog force-kills a gateway that is behaving exactly as designed.

## Evidence

Observed on a Windows host (`gateway.log`):

```
12:35:57 Received UNKNOWN as a planned gateway stop — exiting cleanly
12:35:57 Restart requested with 4 active work unit(s); deferring stop() until they finish (cap=1800s)
12:36:58 Stopping gateway for restart...          <- stop() entered, watchdog armed
12:36:58 Restart deferred: waiting on 4 active work unit(s) (1739s remaining before force drain)
12:37:56 Restart deferred: waiting on 4 active work unit(s) (1680s remaining before force drain)
12:37:58 CRITICAL gateway.shutdown_watchdog: Shutdown watchdog fired after 60s — forcing process exit
```

`12:36:58 + 60s == 12:37:58` exactly. The wait still had **1739s** of legitimate budget.

The faulthandler dump confirms the loop was inside the after-turn wait, **not** a wedged drain:

```
gateway/run.py ... in _await_active_work_before_restart
gateway/run.py ... in _run_restart
```

Second-order damage: the force-exit killed the external supervisor's blocked child wait (a Windows Task Scheduler VBS `shell.Run(..., True)`), which returned `0x80070001` and exited. The gateway was restarted by its own internal supervision, so everything *looked* healthy while the outer supervision layer was silently gone until the next logon. The same shape applies to any supervisor that blocks on the gateway process.

## Fix

- `_await_active_work_before_restart` publishes its monotonic deadline and clears it in a `finally`.
- New `_resolve_shutdown_leash()` sizes the watchdog to `max(drain + grace, remaining_after_turn_wait + grace)`.
- The watchdog snapshot now reports `after_turn_wait_remaining_s` for diagnosis.

Contracts preserved:

- **Normal shutdown** (no wait in flight) is byte-for-byte the old `drain + grace`.
- **Still bounded** — a genuinely wedged turn is force-exited after the real budget (~30 min) instead of never; not infinite.
- **A larger `restart_drain_timeout` is never shortened** by a smaller remaining wait.

The deadline is read directly rather than through a helper method. An earlier draft called `self._remaining_after_turn_wait()` inside a bare `except Exception`; any failure was silently swallowed and the leash collapsed back to 60s **while all unit tests still passed**. Only a malformed deadline degrades to the plain contract now, and `test_leash_reads_the_deadline_directly_not_via_a_helper` pins that regression.

## Test plan

New `tests/gateway/test_restart_after_turn_watchdog_leash.py` — 9 tests, all RED before the change:

- leash covers the remaining after-turn wait (the reported 1739s case)
- grace is kept on top of the remaining wait
- leash unchanged when no wait is active
- larger drain budget wins over a smaller remaining wait
- malformed deadline degrades safely
- leash does not depend on a helper being present (regression)
- deadline probe: absent / expired / in-flight

Verification performed:

- `tests/gateway/test_restart_after_turn_watchdog_leash.py` — **9 passed**
- `tests/gateway -k "restart or shutdown or watchdog or drain"` — **450 passed, 10 failed**
- All 10 failures **reproduced on unmodified `63279301b`** (9 identical; `test_external_drain_control::test_watcher_enters_then_exits_with_marker` is a pre-existing flake that fails ~1 in 5 runs on a clean baseline). None are caused by this change.
