### PR TITLE
fix(agent): make max-iteration finalization bounded and reliable

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2248,9 +2248,10 @@ def _summary_text(agent, response, **normalize_kwargs) -> str:
 
 def _codex_summary_attempt(agent, api_messages: list, api_request_id: str):
     def _attempt(retry_count: int) -> str:
-        codex_kwargs = agent._build_api_kwargs(api_messages)
-        codex_kwargs.pop("tools", None)
-        return _summary_text(agent, agent._run_codex_stream(codex_kwargs))
+        codex_kwargs = agent._build_api_kwargs(api_messages, tools_for_api=[])
+        for key in ("tools", "tool_choice", "parallel_tool_calls"):
+            codex_kwargs.pop(key, None)
+        return _summary_text(agent, agent._run_codex_stream(codex_kwargs, max_retries=0))
     return _attempt
 
 
@@ -2261,7 +2262,11 @@ def _anthropic_summary_attempt(agent, api_messages: list, api_request_id: str):
             reasoning_config=agent.reasoning_config, is_oauth=agent._is_anthropic_oauth,
             preserve_dots=agent._anthropic_preserve_dots(), base_url=getattr(agent, "_anthropic_base_url", None))
         ant_kw = _merge_nous_portal_messages_extra_body(agent, ant_kw)
-        response = _managed_summary_call(agent, api_request_id, ant_kw, agent._anthropic_messages_create, retry_count=retry_count)
+        response = _managed_summary_call(
+            agent, api_request_id, ant_kw,
+            lambda request: agent._anthropic_messages_create(request, prefer_stream=False),
+            retry_count=retry_count,
+        )
         return _summary_text(agent, response, strip_tool_prefix=agent._is_anthropic_oauth)
     return _attempt
 
@@ -2295,33 +2300,28 @@ def handle_max_iterations(agent, messages: list, api_call_count: int) -> str:
     summary_api_request_id = f"iteration-summary:{uuid.uuid4()}"
     summary_call_outcome = "failed"
 
-    # Shared constant so compaction recognizers can identify this runtime nudge by its stable
-    # content after SessionDB projection strips metadata flags.
-    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST
-    append_message(messages, {"role": "user", "content": MAX_ITERATIONS_SUMMARY_REQUEST})
+    from agent.context_compressor import MAX_ITERATIONS_SUMMARY_REQUEST, build_static_handoff
+    local_handoff = build_static_handoff(
+        messages, reason=f"iteration budget exhausted ({api_call_count}/{agent.max_iterations})",
+    )
+    api_messages = [
+        {"role": "system", "content": (
+            "Return a concise user-facing final status from the supplied handoff. "
+            "Do not call tools and do not invent work."
+        )},
+        {"role": "user", "content": f"{MAX_ITERATIONS_SUMMARY_REQUEST}\n\n{local_handoff}"},
+    ]
 
     try:
-        api_messages = _iteration_summary_api_messages(agent, messages)
         build_attempt = _SUMMARY_ATTEMPT_BUILDERS.get(agent.api_mode, _chat_summary_attempt)
         attempt = build_attempt(agent, api_messages, summary_api_request_id)
-
-        # One retry on an empty summary; a summary empty once its <think> block is stripped is NOT retried.
-        final_response = _EMPTY_SUMMARY_RESPONSE
-        for retry_count in (0, 1):
-            text = attempt(retry_count)
-            if not text:
-                continue
-            if "<think>" in text:
-                text = re.sub(r'<think>.*?</think>\s*', '', text, flags=re.DOTALL).strip()
-            if text:
-                summary_call_outcome = "success"
-                append_message(messages, {"role": "assistant", "content": text})
-                final_response = text
-            break
+        text = agent._strip_think_blocks(attempt(0)).strip()
+        final_response = text or local_handoff
+        summary_call_outcome = "success" if text else "failed"
 
     except Exception as e:
         logger.warning("Failed to get summary response: %s", e)
-        final_response = f"I reached the maximum iterations ({agent.max_iterations}) but couldn't summarize. Error: {str(e)}"
+        final_response = local_handoff
     finally:
         from agent import relay_llm
         relay_llm.complete_logical_call(summary_api_request_id, outcome=summary_call_outcome)

--- a/agent/client_lifecycle.py
+++ b/agent/client_lifecycle.py
@@ -846,7 +846,9 @@ class ClientLifecycleMixin:
             logger.debug("custom-provider TLS resolution skipped on credential rotation", exc_info=True)
         self._apply_client_headers_for_base_url(self.base_url, apply_user_headers=not route_changed)
 
-    def _anthropic_messages_create(self, api_kwargs: dict, *, client: Any = None):
+    def _anthropic_messages_create(
+        self, api_kwargs: dict, *, client: Any = None, prefer_stream: bool | None = None,
+    ):
         # A supplied request-local client was already refreshed in _create_request_anthropic_client.
         if client is None and self.api_mode == "anthropic_messages":
             self._try_refresh_anthropic_client_credentials()
@@ -855,7 +857,8 @@ class ClientLifecycleMixin:
         # on_response: rate-limit + credits state live in response headers, which the parsed Message drops.
         return create_anthropic_message(
             client or self._anthropic_client, api_kwargs, log_prefix=getattr(self, "log_prefix", ""),
-            prefer_stream=not bool(getattr(self, "_disable_streaming", False)),
+            prefer_stream=(not bool(getattr(self, "_disable_streaming", False))
+                           if prefer_stream is None else prefer_stream),
             on_response=self._capture_anthropic_response_headers,
         )
 

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -819,14 +819,14 @@ def _bypass_sdk_request_transform(stream_kwargs: dict) -> dict:
     return bypassed
 
 
-def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None):
+def run_codex_stream(agent, api_kwargs: dict, client: Any = None, on_first_delta=None, *, max_retries: int = 1):
     """One streaming Responses API request over raw ``responses.create(stream=True)`` events."""
     import httpx as _httpx
     from openai import APIConnectionError as _APIConnectionError
     from agent import relay_llm
     transport_errors = (_httpx.RemoteProtocolError, _httpx.ReadTimeout, _httpx.ConnectError, ConnectionError)
     active_client = client or agent._ensure_primary_openai_client(reason="codex_stream_direct")
-    max_stream_retries, model = 1, api_kwargs.get("model")
+    max_stream_retries, model = max(0, int(max_retries)), api_kwargs.get("model")
     # Accumulate streamed text so callers / compat shims can read it.
     agent._codex_streamed_text_parts: list = []
     # Retirement token for THIS request (installed by ``interruptible_api_call``). A watchdog that kills the

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1058,9 +1058,25 @@ def _compact_fallback_turn(value: Any) -> str:
     """One-line, redacted, length-capped rendering of a turn's content for the static fallback."""
     text = _redact_compaction_text(_content_text_for_contains(value))
     text = re.sub(r"\bgh[pousr]_[A-Za-z0-9_]{8,}\b", "[REDACTED]", text)
+    # Raw blobs and repeated fixture markers commonly arrive as one enormous token;
+    # retaining the whole token adds no recovery value, but keep a non-periodic suffix
+    # because tool errors are often appended there.
+    text = re.sub(r"([A-Za-z0-9_])\1{999,}", "[long run omitted]", text)
+
+    def _compact_long_token(match: re.Match[str]) -> str:
+        token = match.group(0)
+        period = (token + token).find(token, 1)
+        if 0 < period < len(token) and len(token) % period == 0:
+            return "[repeated token omitted]"
+        return "[long token omitted]" + token[-200:]
+
+    text = re.sub(r"[A-Za-z0-9_]{1000,}", _compact_long_token, text)
     text = re.sub(r"\s+", " ", text).strip()
     if len(text) > _FALLBACK_TURN_MAX_CHARS:
-        text = text[: _FALLBACK_TURN_MAX_CHARS - 15].rstrip() + " ...[truncated]"
+        marker = " ...[truncated]... "
+        tail_chars = 220
+        head_chars = _FALLBACK_TURN_MAX_CHARS - len(marker) - tail_chars
+        text = text[:head_chars].rstrip() + marker + text[-tail_chars:].lstrip()
     return re.sub(r"\bgh[pousr]_[A-Za-z0-9_.-]+", "[REDACTED]", text)
 
 
@@ -2982,7 +2998,11 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
             elif role == "tool":
                 tool_name, tool_args = call_id_to_tool.get(str(msg.get("tool_call_id") or ""), ("unknown", ""))
                 tool_actions.append(_summarize_tool_result(tool_name, tool_args, text or ""))
-                if re.search(r"\b(error|failed|exception|traceback|timeout|timed out|fatal)\b", text, re.I):
+                if re.search(
+                    r"(?:\b(?:failed|exception|traceback|timeout|timed out|fatal)\b|\b\w*error\b)",
+                    text,
+                    re.I,
+                ):
                     blockers.append(text[:500])
         return {
             "user_asks": user_asks,
@@ -2999,7 +3019,19 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
         actions, files, errors) in the normal summary structure so downstream prompts recover gracefully."""
         anchors = self._fallback_anchors(turns_to_summarize)
         user_asks = anchors["user_asks"]
-        completed = anchors["completed"]
+        def _bounded(items: list[str], *, count: int, chars: int) -> list[str]:
+            marker = " ... "
+            bounded = []
+            for item in items[:count]:
+                if len(item) > chars:
+                    head = chars - len(marker) - 120
+                    item = item[:head].rstrip() + marker + item[-120:].lstrip()
+                bounded.append(item)
+            return bounded
+
+        completed = _bounded(anchors["completed"], count=6, chars=260)
+        blockers = _bounded(anchors["blockers"], count=4, chars=380)
+        last_dropped_turns = _bounded(anchors["last_dropped_turns"], count=6, chars=320)
         active_task = f"User asked: {user_asks[-1]!r}" if user_asks else _NO_USER_TASK_SENTINEL
         previous_summary_note = ""
         if self._previous_summary:
@@ -3033,7 +3065,7 @@ Recovered from a deterministic fallback because the LLM context summarizer was u
 Unknown from deterministic fallback. Inspect current repository/session state if needed.
 
 ## Blocked
-{_bullets(anchors["blockers"], limit=5)}
+{_bullets(blockers, limit=4)}
 
 ## Key Decisions
 None recoverable from deterministic fallback.
@@ -3045,7 +3077,7 @@ None recoverable from deterministic fallback.
 {_bullets(anchors["relevant_files"], limit=12)}
 
 ## Last Dropped Turns
-{_bullets(anchors["last_dropped_turns"], limit=8)}
+{_bullets(last_dropped_turns, limit=6)}
 
 ## Critical Context
 Summary generation was unavailable, so this is a best-effort deterministic fallback for {len(turns_to_summarize)} compacted message(s).{reason_text}"""
@@ -3057,11 +3089,14 @@ Summary generation was unavailable, so this is a best-effort deterministic fallb
         _pruned_names = _collect_ghosted_skill_names(turns_to_summarize)
         del _pruned_names[_MAX_PRUNED_SKILL_MARKERS:]
         summary = self._with_summary_prefix(_redact_compaction_text(body.strip()))
-        if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
-            summary = summary[: _FALLBACK_SUMMARY_MAX_CHARS - 42].rstrip() + "\n...[fallback summary truncated]"
-        # Re-inject AFTER the size cap: markers live at the end, where truncation cuts.
+        summary = self._augment_summary_lean(summary, turns_to_summarize)
         summary = _reinject_pruned_skill_markers(summary, _pruned_names)
-        return self._augment_summary_lean(summary, turns_to_summarize)
+        if len(summary) > _FALLBACK_SUMMARY_MAX_CHARS:
+            marker = "\n...[fallback summary middle truncated]...\n"
+            tail_chars = 5_000
+            head_chars = _FALLBACK_SUMMARY_MAX_CHARS - len(marker) - tail_chars
+            summary = summary[:head_chars].rstrip() + marker + summary[-tail_chars:].lstrip()
+        return summary
 
     def _demote_stale_tail_tools(self, messages: List[Dict[str, Any]], tail_start: int) -> List[Dict[str, Any]]:
         """Lean mode: demote tail tool results older than the newest ``_LEAN_TAIL_KEEP_TOOL_ROUNDS`` rounds to
@@ -4894,6 +4929,17 @@ def reference_handoff_would_drive_next_model_call(messages: Optional[List[Dict[s
 def is_user_originated_turn(message: Any) -> bool:
     """True for human-authored user turns (not compaction scaffolding); dispatchers must use this, not a bare role check."""
     return user_originated_turn_view(message) is not None
+
+
+def build_static_handoff(
+    turns_to_summarize: List[Dict[str, Any]],
+    reason: str | None = None,
+) -> str:
+    """Build the bounded deterministic handoff without initializing a provider."""
+    compressor = object.__new__(ContextCompressor)
+    compressor._previous_summary = None
+    compressor.tail_mode = "legacy"
+    return compressor._build_static_fallback_summary(turns_to_summarize, reason)
 
 
 # ---- BEGIN PLUGIN-COMPAT (revert-scheduled; see COMPAT_MANIFEST.md) ----

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -410,6 +410,116 @@ class TestCompress:
             f"#49307), found {count}x:\n{summary}"
         )
 
+    def test_static_handoff_is_bounded_redacted_and_keeps_anchors(
+        self, compressor, monkeypatch
+    ):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "ghp_" + "a" * 40
+        turns = [
+            {
+                "role": "assistant",
+                "content": "Inspecting the failure",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {
+                            "name": "terminal",
+                            "arguments": (
+                                '{"workdir":"/tmp/project","command":"pytest"}'
+                            ),
+                        },
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "content": f"fatal timeout writing /tmp/report.md with {secret}",
+            },
+            *(
+                {"role": "assistant", "content": "x" * 1_000}
+                for _ in range(20)
+            ),
+            {"role": "user", "content": "Continue the long task safely"},
+        ]
+
+        handoff = compressor._build_static_fallback_summary(
+            turns,
+            reason=f"provider failed: {secret}",
+        )
+
+        assert len(handoff) <= 8_000
+        assert "Continue the long task safely" in handoff
+        assert "/tmp/project" in handoff
+        assert "/tmp/report.md" in handoff
+        assert "fatal timeout" in handoff
+        assert secret not in handoff
+
+    def test_static_handoff_preserves_error_at_end_of_long_tool_result(
+        self, compressor
+    ):
+        anchor = "TAIL_RECOVERY_ANCHOR ValueError: checkout fixture exploded"
+        handoff = compressor._build_static_fallback_summary(
+            [
+                {"role": "user", "content": "Diagnose the fixture"},
+                {
+                    "role": "tool",
+                    "tool_call_id": "call_1",
+                    "content": "x" * 2_000 + anchor,
+                },
+            ]
+        )
+
+        assert anchor in handoff
+        assert "## Blocked" in handoff
+
+    def test_static_handoff_keeps_head_and_recovery_tail_when_saturated(
+        self, compressor
+    ):
+        final_anchor = "FINAL_TURN_ANCHOR RuntimeError: final failure"
+        turns = [{"role": "user", "content": "LATEST_TASK_ANCHOR"}]
+        turns.extend(
+            {"role": "assistant", "content": f"turn-{idx}-" + "x" * 1_000}
+            for idx in range(30)
+        )
+        turns.append(
+            {"role": "tool", "content": "y" * 1_000 + final_anchor}
+        )
+
+        handoff = compressor._build_static_fallback_summary(turns)
+
+        assert len(handoff) <= 8_000
+        assert "LATEST_TASK_ANCHOR" in handoff
+        assert final_anchor in handoff
+        assert "## Blocked" in handoff
+        assert "## Last Dropped Turns" in handoff
+
+    def test_static_handoff_force_redacts_secret_when_live_redaction_is_disabled(
+        self, compressor, monkeypatch
+    ):
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        secret = "ghp_" + "a" * 40
+        handoff = compressor._build_static_fallback_summary(
+            [{"role": "user", "content": f"Continue safely; token {secret}"}],
+            reason=f"provider failed with {secret}",
+        )
+
+        assert secret not in handoff
+        assert "[REDACTED]" in handoff
+
+    def test_static_handoff_classifies_runtimeerror_as_blocker(self, compressor):
+        anchor = "RuntimeError: final failure"
+        handoff = compressor._build_static_fallback_summary(
+            [
+                {"role": "user", "content": "Continue the task"},
+                {"role": "tool", "content": anchor},
+            ]
+        )
+        blocked = handoff.split("## Blocked", 1)[1].split("\n## ", 1)[0]
+
+        assert anchor in blocked
+
     def test_threshold_below_window_at_minimum_ctx(self):
         """Regression for #14690: at context_length == MINIMUM_CONTEXT_LENGTH
         the floored threshold used to equal the whole window, so

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2687,11 +2687,99 @@ class TestHandleMaxIterations:
         assert len(result) > 0
         assert "summary" in result.lower()
 
-    def test_summary_retries_share_relay_identity(self, agent):
-        agent.client.chat.completions.create.side_effect = [
-            _mock_response(content=""),
-            _mock_response(content="Summary"),
+    def test_summary_request_is_bounded_for_large_history(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Safe handoff"
+        )
+        raw_marker = "RAW_TOOL_BULK_7f3b"
+        messages = [
+            {"role": "user", "content": "Investigate the checkout failure"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_large",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_large",
+                "content": raw_marker * 10_000,
+            },
+            {"role": "assistant", "content": "Wrote findings to /tmp/report.txt"},
+            {"role": "user", "content": "Continue; blocked by the fixture"},
         ]
+        original_messages = json.loads(json.dumps(messages))
+
+        agent._handle_max_iterations(messages, 90)
+
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs[
+            "messages"
+        ]
+        sent_text = json.dumps(sent_messages)
+        assert len(sent_text) < 20_000
+        assert raw_marker not in sent_text
+        assert "Investigate the checkout failure" in sent_text
+        assert "/tmp/report.txt" in sent_text
+        assert "blocked by the fixture" in sent_text
+        assert messages == original_messages
+
+    def test_summary_request_replaces_unfinished_tool_protocol_with_handoff(
+        self, agent
+    ):
+        agent.client.chat.completions.create.return_value = _mock_response(
+            content="Summary"
+        )
+        messages = [
+            {"role": "user", "content": "do stuff"},
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": "call_no_result",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+
+        assert agent._handle_max_iterations(messages, 60) == "Summary"
+        sent_messages = agent.client.chat.completions.create.call_args.kwargs[
+            "messages"
+        ]
+        assert not any(
+            message.get("role") == "tool" or message.get("tool_calls")
+            for message in sent_messages
+        )
+        assert "terminal" in json.dumps(sent_messages)
+
+    @pytest.mark.parametrize(
+        "think_only",
+        [
+            "<think>internal reasoning only</think>",
+            "<THINK>internal reasoning only</THINK>",
+            "<think>internal reasoning only",
+        ],
+    )
+    def test_think_only_summary_returns_local_handoff(self, agent, think_only):
+        agent.client.chat.completions.create.return_value = _mock_response(content=think_only)
+        messages = [
+            {"role": "user", "content": "THINK_ONLY_TASK_ANCHOR"},
+            {"role": "assistant", "content": "Saved /tmp/think-only.txt"},
+        ]
+
+        result = agent._handle_max_iterations(messages, 90)
+
+        assert agent.client.chat.completions.create.call_count == 1
+        assert "THINK_ONLY_TASK_ANCHOR" in result
+        assert "/tmp/think-only.txt" in result
+        assert "internal reasoning only" not in result
+
+    def test_empty_summary_is_not_retried(self, agent):
+        agent.client.chat.completions.create.return_value = _mock_response(content="")
         agent._cached_system_prompt = "You are helpful."
         relay_calls = []
 
@@ -2708,16 +2796,14 @@ class TestHandleMaxIterations:
                 60,
             )
 
-        assert result == "Summary"
-        assert [call["metadata"]["retry_count"] for call in relay_calls] == [0, 1]
-        assert relay_calls[0]["metadata"]["api_request_id"] == (
-            relay_calls[1]["metadata"]["api_request_id"]
-        )
+        assert agent.client.chat.completions.create.call_count == 1
+        assert "do stuff" in result
+        assert [call["metadata"]["retry_count"] for call in relay_calls] == [0]
         assert relay_calls[0]["metadata"]["call_role"] == "iteration_summary"
         assert all(call["defer_logical_completion"] is True for call in relay_calls)
         complete_logical.assert_called_once_with(
             relay_calls[0]["metadata"]["api_request_id"],
-            outcome="success",
+            outcome="failed",
         )
 
     def test_suppress_status_output_keeps_iteration_warning_off_stdout(self, agent, capsys):
@@ -2756,15 +2842,21 @@ class TestHandleMaxIterations:
         combined = "\n".join(printed) + capsys.readouterr().out
         assert "Reached maximum iterations" in combined
 
-    def test_api_failure_returns_error(self, agent):
-        agent.client.chat.completions.create.side_effect = Exception("API down")
+    def test_api_failure_returns_safe_local_handoff(self, agent):
+        raw_error = "Your input exceeds the context window of this model"
+        agent.client.chat.completions.create.side_effect = Exception(raw_error)
         agent._cached_system_prompt = "You are helpful."
-        messages = [{"role": "user", "content": "do stuff"}]
+        messages = [
+            {"role": "user", "content": "Investigate the checkout failure"},
+            {"role": "assistant", "content": "Wrote /tmp/report.txt; blocked by fixture"},
+        ]
         with patch("agent.relay_llm.complete_logical_call") as complete_logical:
             result = agent._handle_max_iterations(messages, 60)
-        assert isinstance(result, str)
-        assert "error" in result.lower()
-        assert "API down" in result
+        assert agent.client.chat.completions.create.call_count == 1
+        assert "Investigate the checkout failure" in result
+        assert "/tmp/report.txt" in result
+        assert "blocked by fixture" in result
+        assert raw_error not in result
         complete_logical.assert_called_once()
         assert complete_logical.call_args.kwargs == {"outcome": "failed"}
 
@@ -2843,10 +2935,54 @@ class TestHandleMaxIterations:
         assert messages[2]["tool_name"] == "execute_code"
         assert messages[1]["codex_reasoning_items"] == [{"id": "rs_1"}]
 
+    def test_anthropic_summary_uses_one_bounded_handoff_call(self, agent):
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "anthropic"
+        agent.model = "claude-sonnet-4-20250514"
+        raw_marker = "RAW_ANTHROPIC_TOOL_BULK_7f3b"
+        messages = [
+            {"role": "user", "content": "Investigate the checkout failure"},
+            {
+                "role": "tool",
+                "tool_call_id": "call_large",
+                "content": raw_marker * 10_000,
+            },
+        ]
+        original_messages = json.loads(json.dumps(messages))
+        transport = MagicMock()
+        transport.build_kwargs.return_value = {
+            "model": agent.model,
+            "messages": [],
+        }
+        transport.normalize_response.return_value = SimpleNamespace(
+            content="Anthropic summary"
+        )
+        agent._anthropic_client = MagicMock()
+        agent._anthropic_client.messages.create.return_value = object()
 
+        with (
+            patch.object(agent, "_get_transport", return_value=transport),
+            patch.object(
+                agent,
+                "_try_refresh_anthropic_client_credentials",
+                return_value=False,
+            ),
+        ):
+            result = agent._handle_max_iterations(messages, 90)
 
-
-
+        assert result == "Anthropic summary"
+        agent._anthropic_client.messages.create.assert_called_once()
+        agent._anthropic_client.messages.stream.assert_not_called()
+        sent_messages = transport.build_kwargs.call_args.kwargs["messages"]
+        sent_text = json.dumps(sent_messages)
+        assert len(sent_text) < 20_000
+        assert raw_marker not in sent_text
+        assert "Investigate the checkout failure" in sent_text
+        assert not any(
+            message.get("role") == "tool" or message.get("tool_calls")
+            for message in sent_messages
+        )
+        assert messages == original_messages
 
     def test_codex_summary_sanitizes_orphan_tool_results(self, agent):
         agent.api_mode = "codex_responses"
@@ -2858,8 +2994,9 @@ class TestHandleMaxIterations:
         agent._cached_system_prompt = "You are helpful."
         captured = {}
 
-        def fake_run_codex_stream(kwargs):
+        def fake_run_codex_stream(kwargs, *, max_retries):
             captured.update(kwargs)
+            captured["max_retries"] = max_retries
             return SimpleNamespace(
                 status="completed",
                 output=[
@@ -2884,12 +3021,31 @@ class TestHandleMaxIterations:
             result = agent._handle_max_iterations(messages, 90)
 
         assert result == "Summary"
+        assert captured["max_retries"] == 0
+        assert not {"tools", "tool_choice", "parallel_tool_calls"} & captured.keys()
         input_items = captured["input"]
         assert not any(
             item.get("type") == "function_call_output"
             and item.get("call_id") == "call_orphan"
             for item in input_items
         )
+
+    def test_codex_stream_zero_retries_makes_one_provider_call(self):
+        from agent.codex_runtime import run_codex_stream
+
+        client = MagicMock()
+        client.responses.create.side_effect = ConnectionError("provider unavailable")
+        fake_agent = SimpleNamespace(_interrupt_requested=False)
+
+        with pytest.raises(ConnectionError):
+            run_codex_stream(
+                fake_agent,
+                {"model": "gpt-test"},
+                client=client,
+                max_retries=0,
+            )
+
+        client.responses.create.assert_called_once()
 
     def test_api_sanitizer_matches_responses_call_id_when_id_differs(self, agent):
         messages = [


### PR DESCRIPTION
## Problem

When the agent reaches its iteration limit, the fallback summary path can resend the full, already oversized conversation, retry it, and expose a generic failure instead of preserving actionable state.

## Solution

- build a deterministic local handoff before any provider call;
- redact and cap the handoff at 8,000 characters;
- send only the handoff in one tool-less provider attempt;
- disable Codex retries and Anthropic stream-to-create fallback for this emergency path;
- return the local handoff on exceptions, empty output, or think-only output;
- leave the original message history unchanged;
- retain task, artifact, blocker, and recovery anchors.

The Codex request explicitly omits `tools`, `tool_choice`, and `parallel_tool_calls`.

## Scope

Covered transports: Chat Completions, Codex Responses, Anthropic Messages.

No dependency, configuration, schema, or iteration-limit changes. This does not change the guardrail default discussed in #25823 / #26015.

Related overlapping work reviewed: #99458, #70132, #36246, #95796, #58220. This PR sends a bounded handoff on the first and only attempt rather than retrying the full history.

## Tests

- targeted max-iteration/context-compressor suite: 178 passed;
- run-agent/context-compressor regression: 447 passed;
- Codex/Anthropic regression: 187 passed;
- Ruff, py_compile, and git diff --check: passed.