### PR TITLE
fix(cron): avoid reopening finalized session on teardown

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7240,6 +7240,15 @@ def run_job(
                 _session_db.end_session(
                     _final_cron_session_id, _end_reason
                 )
+                # run_job owns cron-session finalization. AIAgent.close() also
+                # finalizes owned session rows by default; if we release the
+                # shared SessionDB first and then call agent.close(), that second
+                # end_session() reopens the just-closed SQLite handle (#94736).
+                # Once the scheduler has durably booked this terminal reason,
+                # disarm only the agent's redundant row-finalization step. Its
+                # remaining resource teardown still runs normally below.
+                if agent is not None:
+                    agent._end_session_on_close = False
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -588,6 +588,64 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+        assert mock_agent._end_session_on_close is False
+
+
+    def test_run_job_disarms_agent_close_after_scheduler_finalizes_session(self, tmp_path):
+        """Cron owns the terminal session reason; agent.close must not end it twice.
+
+        Regression for the #94736 teardown warning seen after every healthy cron
+        run: the scheduler closed its shared SessionDB, then AIAgent.close() tried
+        another end_session("agent_close"), forcing SessionDB to reopen solely
+        for a redundant write.
+        """
+        job = {"id": "single-finalize", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        closed = False
+        calls_after_close = []
+
+        def close_db():
+            nonlocal closed
+            closed = True
+
+        def end_session(*args):
+            if closed:
+                calls_after_close.append(args)
+
+        fake_db.close.side_effect = close_db
+        fake_db.end_session.side_effect = end_session
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.get_shared_session_db", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+            def close_agent():
+                if mock_agent._end_session_on_close:
+                    fake_db.end_session(mock_agent.session_id, "agent_close")
+
+            mock_agent.close.side_effect = close_agent
+            mock_agent_cls.return_value = mock_agent
+            success, *_ = run_job(job)
+
+        assert success is True
+        assert fake_db.end_session.call_count == 1
+        assert calls_after_close == []
+        assert mock_agent._end_session_on_close is False
 
 
     @contextlib.contextmanager


### PR DESCRIPTION
## Summary

Avoid a redundant cron-session finalization during agent teardown.

`run_job()` already persists the terminal `cron_complete` / incomplete reason and releases its shared `SessionDB`. The later `AIAgent.close()` used to call `end_session(..., "agent_close")` on that same already-released handle, forcing the #94736 self-heal path to reopen SQLite solely for a no-op terminal reason.

After the scheduler successfully finalizes the row, this change sets the existing `_end_session_on_close` ownership flag to `False`. Resource teardown still runs normally. If scheduler finalization itself fails, the flag remains enabled so `AIAgent.close()` retains its fallback behavior.

## Regression coverage

A new scheduler test models the exact failure shape: scheduler finalizes and closes the shared DB, then `agent.close()` would attempt another `end_session` if not disarmed.

Targeted validation on current upstream `main`:

- 13/13 focused session/cleanup/#94736 tests passed.
- 136/136 scheduler, run-one-job, completion, cleanup, created-delivery, and gateway cron drain tests passed.
- Two pre-existing test warnings were emitted; no test failures.
