### PR TITLE
fix(auth): Nous 401 recovery refreshes once across concurrent subagents; WAF/5xx are transient, not re-login

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -1658,11 +1658,31 @@ class CredentialPool:
         except Exception as exc:
             logger.debug("Failed to sync %s pool entry back to auth store: %s", self.provider, exc)
 
-    def _refresh_entry(self, entry: PooledCredential, *, force: bool) -> Optional[PooledCredential]:
+    def _refresh_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+        stale_access_token: Optional[str] = None,
+    ) -> Optional[PooledCredential]:
+        """Refresh ``entry``'s OAuth material.
+
+        ``stale_access_token`` is the bearer that just failed upstream (401).
+        For providers whose refresh token is shared across many callers it
+        turns the forced refresh into refresh-*if-stale*: when the pool row —
+        or the on-disk store — already holds a different, usable token, a
+        sibling rotated first and this caller adopts it instead of spending
+        the refresh token again.
+        """
         if entry.auth_type != AUTH_TYPE_OAUTH or not entry.refresh_token:
             if force:
                 self._mark_exhausted(entry, None)
             return None
+
+        if self.provider == "nous":
+            return self._refresh_nous_entry(
+                entry, force=force, stale_access_token=stale_access_token
+            )
 
         # Codex and xAI OAuth refresh tokens are single-use.  The
         # sync→POST→write-back sequence below must run atomically across Hermes
@@ -1732,6 +1752,49 @@ class CredentialPool:
                     return synced
                 return self._refresh_entry_impl(synced, force=force)
         return self._refresh_entry_impl(entry, force=force)
+
+    def _refresh_nous_entry(
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+        stale_access_token: Optional[str] = None,
+    ) -> Optional[PooledCredential]:
+        """Nous refresh: adopt a sibling's rotation before spending the grant.
+
+        Mirrors the Codex/xAI "sync, then skip the POST if a peer already
+        rotated" guard in :meth:`_refresh_entry`, in three layers:
+
+        1. In-process: the pool row itself. Children of one session share
+           the parent's pool and its RLock, so by the time a waiter gets in
+           here a sibling may already have rewritten the row — its runtime
+           key is then no longer the bearer that failed, and the waiter just
+           takes it.
+        2. Cross-process, pre-lock: ``_sync_nous_entry_from_auth_store``
+           inside :meth:`_refresh_entry_impl` picks up a rotation another
+           Hermes process persisted to auth.json.
+        3. Cross-process, in-lock: ``resolve_nous_runtime_credentials``
+           re-checks under ``_auth_store_lock`` + the shared Nous lock and
+           only POSTs when the stored token is still the failed one.
+
+        Without ``stale_access_token`` (explicit user/keepalive force) the
+        forced refresh keeps its refresh-always semantics.
+        """
+        if (
+            force
+            and stale_access_token
+            and entry.runtime_api_key
+            and entry.runtime_api_key != stale_access_token
+        ):
+            logger.info(
+                "nous: adopting token rotated by concurrent refresh, skipping POST "
+                "(pool entry %s already carries a token other than the failed one)",
+                entry.id,
+            )
+            return entry
+        return self._refresh_entry_impl(
+            entry, force=force, stale_access_token=stale_access_token
+        )
 
     def _claude_code_credentials_lock(self):
         """Cross-process lock over the shared claude_code credentials file.
@@ -1838,7 +1901,11 @@ class CredentialPool:
         )
 
     def _refresh_entry_impl(
-        self, entry: PooledCredential, *, force: bool
+        self,
+        entry: PooledCredential,
+        *,
+        force: bool,
+        stale_access_token: Optional[str] = None,
     ) -> Optional[PooledCredential]:
         try:
             if self.provider == "anthropic":
@@ -1962,7 +2029,16 @@ class CredentialPool:
                     last_refresh=refreshed.get("last_refresh"),
                 )
             elif self.provider == "nous":
-                stale_key = entry.runtime_api_key or entry.agent_key or entry.access_token
+                # The bearer to compare against is the one that actually
+                # 401'd. With no hint (keepalive / explicit force) fall back
+                # to the entry's own key, which preserves the older "adopt a
+                # peer-rotated token after the sync" behaviour.
+                stale_key = (
+                    stale_access_token
+                    or entry.runtime_api_key
+                    or entry.agent_key
+                    or entry.access_token
+                )
                 synced = self._sync_nous_entry_from_auth_store(entry)
                 if synced is not entry:
                     entry = synced
@@ -1970,7 +2046,11 @@ class CredentialPool:
                     # this process was still holding the failed one: adopt it
                     # without consuming the (single-use) refresh token again.
                     if force and entry.runtime_api_key and entry.runtime_api_key != stale_key:
-                        logger.debug("Nous entry %s: adopting peer-rotated token, skipping refresh", entry.id)
+                        logger.info(
+                            "nous: adopting token rotated by concurrent refresh, skipping POST "
+                            "(auth.json already holds a token other than the failed one, entry %s)",
+                            entry.id,
+                        )
                         return entry
                 auth_mod.resolve_nous_runtime_credentials(
                     force_refresh=force,
@@ -2233,6 +2313,20 @@ class CredentialPool:
                     # entry untouched; the caller's retry re-syncs once the
                     # winner has persisted.
                     logger.debug("Nous refresh skipped: auth store lock busy; not benching entry")
+                    return entry
+                if auth_mod._is_transient_nous_refresh_error(exc):
+                    # Token endpoint said "not now" (429 slow_down / WAF /
+                    # 5xx) after the resolver's own bounded retries. The
+                    # grant is intact; marking the entry exhausted would
+                    # turn a one-minute WAF block into a benched credential
+                    # and a bogus re-login prompt. Leave it for the next
+                    # attempt.
+                    logger.info(
+                        "nous: transient token-endpoint failure during refresh of "
+                        "entry %s (%s); leaving credential untouched",
+                        entry.id,
+                        exc,
+                    )
                     return entry
                 if auth_mod._is_terminal_nous_refresh_error(exc):
                     logger.debug("Nous refresh token is terminally invalid; clearing local token state")
@@ -2865,6 +2959,24 @@ class CredentialPool:
         with self._lock:
             return self._try_refresh_current_unlocked()
 
+    @staticmethod
+    def _entry_supplied_key(entry: PooledCredential, api_key_hint: str) -> bool:
+        """True when ``entry`` is the row that handed out ``api_key_hint``.
+
+        ``runtime_api_key`` masks a token that is no longer usable (for Nous,
+        an invoke JWT past its ``exp``) as ``""``. That is exactly the state
+        a 401'd bearer is in by the time recovery runs, so matching on the
+        runtime key alone can never attribute an expiry-401 to its entry —
+        the refresh is skipped and the pool "rotates" to nothing. Fall back
+        to the raw stored tokens: same credential, expiry mask removed.
+        """
+        if entry.runtime_api_key == api_key_hint:
+            return True
+        return api_key_hint in {
+            str(entry.agent_key or ""),
+            str(entry.access_token or ""),
+        }
+
     def try_refresh_matching(
         self,
         api_key_hint: Optional[str] = None,
@@ -2895,7 +3007,7 @@ class CredentialPool:
                         (
                             candidate
                             for candidate in self._entries
-                            if candidate.runtime_api_key == api_key_hint
+                            if self._entry_supplied_key(candidate, api_key_hint)
                         ),
                         None,
                     )
@@ -2906,13 +3018,24 @@ class CredentialPool:
             if entry is None:
                 return None
             self._current_id = entry.id
-            return self._try_refresh_current_unlocked()
+            # Hand the refresh the bearer that actually failed. Once a sibling
+            # (same pool, same process) has rotated the row, the entry's own
+            # runtime key is already the NEW token — comparing against it
+            # would make every follow-up 401 look like "still stale" and
+            # re-POST the shared grant (Sep 2026 refresh stampede).
+            return self._try_refresh_current_unlocked(
+                stale_access_token=api_key_hint or None
+            )
 
-    def _try_refresh_current_unlocked(self) -> Optional[PooledCredential]:
+    def _try_refresh_current_unlocked(
+        self, *, stale_access_token: Optional[str] = None
+    ) -> Optional[PooledCredential]:
         entry = self._current_unlocked()
         if entry is None:
             return None
-        refreshed = self._refresh_entry(entry, force=True)
+        refreshed = self._refresh_entry(
+            entry, force=True, stale_access_token=stale_access_token
+        )
         if refreshed is not None:
             self._current_id = refreshed.id
         return refreshed

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -114,6 +114,11 @@ DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
 DEFAULT_NOUS_INFERENCE_URL = "https://inference-api.nousresearch.com/v1"
 DEFAULT_NOUS_CLIENT_ID = "hermes-cli"
 NOUS_INFERENCE_INVOKE_SCOPE = "inference:invoke"
+# AuthError.code for a Nous token-endpoint failure that says nothing about the
+# grant itself: 429 ``slow_down`` (another caller holds the rotation lock for
+# this refresh token), a 429 with a non-JSON body (Vercel WAF), or any 5xx.
+# Callers back off and retry; nothing is quarantined and no re-login is asked.
+NOUS_REFRESH_TRANSIENT_CODE = "refresh_transient"
 NOUS_BILLING_MANAGE_SCOPE = "billing:manage"
 DEFAULT_NOUS_SCOPE = NOUS_INFERENCE_INVOKE_SCOPE
 NOUS_DEVICE_CODE_SOURCE = "device_code"
@@ -1022,11 +1027,15 @@ class AuthError(RuntimeError):
         provider: str = "",
         code: Optional[str] = None,
         relogin_required: bool = False,
+        retry_after: Optional[float] = None,
     ) -> None:
         super().__init__(message)
         self.provider = provider
         self.code = code
         self.relogin_required = relogin_required
+        # Seconds the token endpoint asked us to wait (``Retry-After``) before
+        # retrying a transient failure. ``None`` when the server sent no hint.
+        self.retry_after = retry_after
 
 
 def is_rate_limited_auth_error(error: Exception) -> bool:
@@ -6348,6 +6357,23 @@ def _is_terminal_nous_refresh_error(exc: Exception) -> bool:
     )
 
 
+def _is_transient_nous_refresh_error(exc: Exception) -> bool:
+    """True when a Nous refresh failed for a reason unrelated to the grant.
+
+    ``refresh_transient`` covers 429 ``slow_down`` (another caller is mid-
+    rotation on this exact token), a 429 with a non-JSON body (Vercel WAF
+    after 25 POSTs/IP/60s) and any 5xx. The stored credential is still good;
+    the right move is to back off, re-check whether a sibling already rotated,
+    and retry — never quarantine, never ask for a re-login.
+    """
+    return (
+        isinstance(exc, AuthError)
+        and exc.provider == "nous"
+        and exc.code == NOUS_REFRESH_TRANSIENT_CODE
+        and not exc.relogin_required
+    )
+
+
 def _is_terminal_xai_oauth_refresh_error(exc: Exception) -> bool:
     """True when retrying the same xAI OAuth refresh token cannot succeed.
 
@@ -6600,14 +6626,45 @@ def _refresh_access_token(
                             provider="nous", code="invalid_token", relogin_required=True)
         return payload
 
+    status = int(response.status_code or 0)
+    retry_after = _parse_retry_after_seconds(getattr(response, "headers", None))
+
     try:
         error_payload = response.json()
+        if not isinstance(error_payload, dict):
+            raise ValueError("token endpoint error body is not a JSON object")
     except Exception as exc:
-        raise AuthError("Refresh token exchange failed",
-                        provider="nous", relogin_required=True) from exc
+        # A non-JSON body is never the portal's OAuth handler: it is the
+        # Vercel WAF (429 + HTML after 25 POSTs/IP/60s), a CDN/5xx error
+        # page, or a proxy. None of those say anything about the grant, so
+        # never demand a re-login for them — surface a transient error the
+        # caller can back off from and retry.
+        raise AuthError(
+            f"Refresh token exchange failed (HTTP {status}, non-JSON response)",
+            provider="nous",
+            code=NOUS_REFRESH_TRANSIENT_CODE,
+            relogin_required=False,
+            retry_after=retry_after,
+        ) from exc
 
     code = str(error_payload.get("error", "invalid_grant"))
     description = str(error_payload.get("error_description") or "Refresh token exchange failed")
+
+    # Transient token-endpoint outcomes. The portal returns 429
+    # ``slow_down`` while another caller holds the rotation lock for this
+    # exact refresh token (retry shortly with whatever token is stored by
+    # then), and deliberately rethrows DB blips as 5xx rather than
+    # ``invalid_grant``. Any other 429 is throttling. None of these
+    # invalidate the credential.
+    if status >= 500 or status == 429:
+        raise AuthError(
+            description,
+            provider="nous",
+            code=NOUS_REFRESH_TRANSIENT_CODE,
+            relogin_required=False,
+            retry_after=retry_after,
+        )
+
     relogin = code in {"invalid_grant", "invalid_token", "refresh_token_reused"}
 
     # Detect the OAuth 2.1 "refresh token reuse" signal from the Nous portal
@@ -7062,6 +7119,23 @@ def _sync_nous_pool_from_auth_store() -> None:
         logger.debug("Failed to sync Nous credential pool from auth store: %s", exc)
 
 
+# Bounded in-turn retry for transient token-endpoint failures (see
+# ``_is_transient_nous_refresh_error``). Delays are the default backoff when
+# the server sends no ``Retry-After``; a ``Retry-After`` beyond the max wait
+# (a Vercel WAF block is a full minute) stops the retry loop instead of
+# stalling the turn — the caller surfaces the transient error, nothing is
+# quarantined, and the next turn tries again.
+_NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS = 3
+_NOUS_REFRESH_TRANSIENT_BACKOFF_SECONDS: tuple[float, ...] = (1.0, 2.0, 4.0)
+_NOUS_REFRESH_TRANSIENT_MAX_WAIT_SECONDS = 8.0
+
+
+def _nous_refresh_backoff_sleep(seconds: float) -> None:
+    """Sleep between transient-refresh retries (patched to a no-op in tests)."""
+    if seconds > 0:
+        time.sleep(seconds)
+
+
 def resolve_nous_runtime_credentials(
     *,
     timeout_seconds: float = 15.0,
@@ -7084,7 +7158,61 @@ def resolve_nous_runtime_credentials(
     processes hitting the same hourly expiry issue N refreshes, and each
     rotation invalidates the token a sibling just adopted (Sep 2026: 120
     subagents, 81 refreshes, ~540 401s in eight minutes).
+
+    Transient token-endpoint failures (429 ``slow_down``, WAF 429, 5xx) are
+    retried a bounded number of times with backoff. Every attempt re-enters
+    the store transaction from scratch, so the peer-rotation check above runs
+    again before each POST and a sibling's success short-circuits the retry.
+    Terminal errors (``invalid_grant`` & co.) are never retried.
     """
+    attempts = max(1, int(_NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS))
+    for attempt in range(attempts):
+        try:
+            return _resolve_nous_runtime_credentials_once(
+                timeout_seconds=timeout_seconds,
+                insecure=insecure,
+                ca_bundle=ca_bundle,
+                force_refresh=force_refresh,
+                stale_access_token=stale_access_token,
+            )
+        except AuthError as exc:
+            if not _is_transient_nous_refresh_error(exc) or attempt >= attempts - 1:
+                raise
+            if exc.retry_after is not None:
+                delay = float(exc.retry_after)
+            else:
+                schedule = _NOUS_REFRESH_TRANSIENT_BACKOFF_SECONDS
+                delay = float(schedule[min(attempt, len(schedule) - 1)])
+            if delay > _NOUS_REFRESH_TRANSIENT_MAX_WAIT_SECONDS:
+                logger.info(
+                    "nous: token endpoint asked to retry in %.0fs, beyond the %.0fs "
+                    "in-turn budget — surfacing transient refresh error (%s)",
+                    delay,
+                    _NOUS_REFRESH_TRANSIENT_MAX_WAIT_SECONDS,
+                    exc,
+                )
+                raise
+            logger.info(
+                "nous: transient token-endpoint failure (%s); retrying refresh in "
+                "%.1fs (attempt %d/%d)",
+                exc,
+                delay,
+                attempt + 2,
+                attempts,
+            )
+            _nous_refresh_backoff_sleep(delay)
+    raise AssertionError("unreachable: retry loop exhausted without raising")  # pragma: no cover
+
+
+def _resolve_nous_runtime_credentials_once(
+    *,
+    timeout_seconds: float = 15.0,
+    insecure: Optional[bool] = None,
+    ca_bundle: Optional[str] = None,
+    force_refresh: bool = False,
+    stale_access_token: Optional[str] = None,
+) -> Dict[str, Any]:
+    """One attempt of :func:`resolve_nous_runtime_credentials` (no retry)."""
     sequence_id = uuid.uuid4().hex[:12]
 
     with _provider_state_transaction("nous") as (
@@ -7109,6 +7237,21 @@ def resolve_nous_runtime_credentials(
                     scope=state.get("scope"),
                     expires_at=state.get("expires_at"),
                 ) is None
+            )
+
+        def _note_peer_rotation(token: Any, *, where: str) -> None:
+            _oauth_trace(
+                "refresh_skipped_peer_rotated",
+                sequence_id=sequence_id,
+                access_token_fp=_token_fingerprint(token),
+                where=where,
+            )
+            logger.info(
+                "nous: adopting token rotated by concurrent refresh, skipping POST "
+                "(failed=%s adopted=%s, %s)",
+                _token_fingerprint(stale_access_token),
+                _token_fingerprint(token),
+                where,
             )
 
         persisted_state = dict(state)
@@ -7260,11 +7403,7 @@ def resolve_nous_runtime_credentials(
             # longer the one on disk and the on-disk one is usable, a peer
             # already rotated — adopt, never re-POST the shared grant.
             if _already_rotated_by_peer(access_token):
-                _oauth_trace(
-                    "refresh_skipped_peer_rotated",
-                    sequence_id=sequence_id,
-                    access_token_fp=_token_fingerprint(access_token),
-                )
+                _note_peer_rotation(access_token, where="profile store")
                 force_refresh = False
             if force_refresh or invoke_jwt_status is not None:
                 with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
@@ -7284,11 +7423,7 @@ def resolve_nous_runtime_credentials(
                         )
                         _persist_state("post_shared_merge_access_unusable")
                         if _already_rotated_by_peer(access_token):
-                            _oauth_trace(
-                                "refresh_skipped_peer_rotated",
-                                sequence_id=sequence_id,
-                                access_token_fp=_token_fingerprint(access_token),
-                            )
+                            _note_peer_rotation(access_token, where="shared store")
                             force_refresh = False
 
                     if force_refresh or invoke_jwt_status is not None:

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -18,6 +18,7 @@ from hermes_cli.auth import (
     _auth_store_lock,
     _is_terminal_nous_refresh_error,
     _nous_inference_env_override,
+    _nous_invoke_jwt_is_usable,
     _quarantine_nous_oauth_state,
     _quarantine_nous_pool_entries,
     _save_auth_store,
@@ -103,6 +104,22 @@ class NousPortalAdapter(UpstreamAdapter):
                     "Not logged into Nous Portal. Run `hermes auth add nous` first."
                 )
 
+            # Refresh-if-stale (mirrors the credential pool's Nous guard):
+            # proxy requests queue on ``self._lock``, so by the time a
+            # second 401'd request gets here the first may already have
+            # rotated the token. If the stored bearer is no longer the one
+            # that failed and is usable, adopt it — never re-POST the shared
+            # grant. ``resolve_nous_runtime_credentials`` repeats this check
+            # under the cross-process locks for rotations by other processes.
+            if force_refresh and stale_access_token:
+                adopted = self._usable_token_other_than(state, stale_access_token)
+                if adopted is not None:
+                    logger.info(
+                        "nous: adopting token rotated by concurrent refresh, "
+                        "skipping POST (proxy)"
+                    )
+                    return adopted
+
             try:
                 refreshed = resolve_nous_runtime_credentials(
                     force_refresh=force_refresh,
@@ -160,6 +177,35 @@ class NousPortalAdapter(UpstreamAdapter):
     # Internal helpers — auth.json access. Kept local rather than added
     # to hermes_cli.auth to avoid expanding that module's public surface.
     # ------------------------------------------------------------------
+
+    def _usable_token_other_than(
+        self, state: Dict[str, Any], failed_bearer: str
+    ) -> Optional[UpstreamCredential]:
+        """Return the stored inference JWT when it is usable and != ``failed_bearer``."""
+        for token, expires_at in (
+            (state.get("agent_key"), state.get("agent_key_expires_at")),
+            (state.get("access_token"), state.get("expires_at")),
+        ):
+            if not isinstance(token, str) or not token.strip():
+                continue
+            token = token.strip()
+            if token == failed_bearer:
+                continue
+            if not _nous_invoke_jwt_is_usable(
+                token, scope=state.get("scope"), expires_at=expires_at
+            ):
+                continue
+            base_url = (
+                _nous_inference_env_override()
+                or _validate_nous_inference_url_from_network(state.get("inference_base_url"))
+                or DEFAULT_NOUS_INFERENCE_URL
+            )
+            return UpstreamCredential(
+                bearer=token,
+                base_url=base_url.rstrip("/"),
+                expires_at=expires_at,
+            )
+        return None
 
     def _read_state(self) -> Optional[Dict[str, Any]]:
         try:

--- a/tests/agent/test_nous_refresh_idempotent_across_subagents.py
+++ b/tests/agent/test_nous_refresh_idempotent_across_subagents.py
@@ -1,0 +1,567 @@
+"""Nous OAuth 401 recovery must be idempotent across concurrent subagents.
+
+Many ``delegate_task`` children share the parent's credential pool (and its
+lock). When the Nous access token expires mid-flight every child 401s at the
+same instant. Before this change each child's recovery forced a refresh-token
+rotation against ``POST /api/oauth/token`` even though a sibling had rotated
+the grant milliseconds earlier: N children + parent = N+1 sequential POSTs.
+Several Hermes processes on one egress IP then trip the portal's WAF rule
+(25 POSTs/IP/60s), the WAF 429 body is HTML, and the client turned any
+non-JSON refresh error into ``relogin_required=True`` — users were told to
+re-authenticate over a perfectly valid credential.
+
+Invariants pinned here:
+
+* One pool, 1 parent + 10 children, all 401 on the same bearer → exactly ONE
+  POST, and all eleven end up on the new token.
+* Two processes (two pools, one auth.json + shared store): the loser of the
+  lock race sees the winner's rotation and skips its POST.
+* The stored token is still the failed one → exactly one POST (no more, no
+  fewer).
+* 429 ``slow_down`` / 429 HTML+``Retry-After`` / 5xx are transient: retried
+  with backoff, never ``relogin_required``, never quarantined.
+* 400 ``invalid_grant`` stays terminal: one POST, quarantined,
+  ``relogin_required=True`` — unchanged.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import threading
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+import hermes_cli.auth as auth_mod
+from agent.credential_pool import load_pool
+from tests.hermes_cli.test_auth_nous_provider import _invoke_jwt, _setup_nous_auth
+
+
+# ── Fixtures / helpers ───────────────────────────────────────────────────────
+
+
+def _iso_in(seconds: float) -> str:
+    return datetime.fromtimestamp(
+        auth_mod.time.time() + seconds, tz=timezone.utc
+    ).isoformat()
+
+
+@pytest.fixture
+def nous_home(tmp_path, monkeypatch):
+    """A HERMES_HOME + shared auth dir holding one EXPIRED Nous grant."""
+    hermes_home = tmp_path / "hermes"
+    shared_dir = tmp_path / "shared"
+    shared_dir.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_SHARED_AUTH_DIR", str(shared_dir))
+    # Retry delays are exercised by asserting on the sleep calls, not by
+    # actually sleeping.
+    monkeypatch.setattr(auth_mod, "_nous_refresh_backoff_sleep", lambda _s: None)
+
+    expired = _invoke_jwt(seconds=-30)
+    _setup_nous_auth(
+        hermes_home,
+        access_token=expired,
+        refresh_token="rt-0",
+        scope=auth_mod.DEFAULT_NOUS_SCOPE,
+        expires_at=_iso_in(-30),
+        expires_in=0,
+    )
+    return SimpleNamespace(home=hermes_home, shared=shared_dir, expired=expired)
+
+
+class _TokenEndpoint:
+    """Scripted stand-in for ``POST /api/oauth/token``.
+
+    ``script`` is a list of responses handed out in order; the last one is
+    repeated once the script is exhausted. Each entry is either
+    ``("ok", n)`` → 200 with a fresh rotated pair, ``("json", status, body,
+    headers)`` or ``("raw", status, text, headers)``.
+    """
+
+    def __init__(self, script: List[tuple]):
+        self.script = list(script)
+        self.posts: List[str] = []
+        self.issued: List[str] = []
+        self._lock = threading.Lock()
+
+    def install(self, monkeypatch) -> "_TokenEndpoint":
+        endpoint = self
+
+        def _fake_refresh(*, client, portal_base_url, client_id, refresh_token):
+            with endpoint._lock:
+                endpoint.posts.append(refresh_token)
+                spec = endpoint.script.pop(0) if len(endpoint.script) > 1 else endpoint.script[0]
+                idx = len(endpoint.posts)
+            kind = spec[0]
+            if kind == "ok":
+                token = _invoke_jwt(seconds=3600)
+                with endpoint._lock:
+                    endpoint.issued.append(token)
+                return {
+                    "access_token": token,
+                    "refresh_token": f"rt-{idx}",
+                    "expires_in": 3600,
+                    "token_type": "Bearer",
+                    "scope": auth_mod.DEFAULT_NOUS_SCOPE,
+                }
+            status = spec[1]
+            headers = spec[3] if len(spec) > 3 else {}
+            request = httpx.Request("POST", f"{portal_base_url}/api/oauth/token")
+            if kind == "json":
+                response = httpx.Response(status, json=spec[2], headers=headers, request=request)
+            else:
+                response = httpx.Response(status, text=spec[2], headers=headers, request=request)
+            # Route through the REAL classifier so the test exercises the
+            # status/body → AuthError mapping, not a hand-built exception.
+            return _real_refresh_access_token_from_response(response)
+
+        monkeypatch.setattr(auth_mod, "_refresh_access_token", _fake_refresh)
+        return self
+
+
+def _real_refresh_access_token_from_response(response: httpx.Response) -> Dict[str, Any]:
+    class _Client:
+        def post(self, *_a, **_k):
+            return response
+
+    return _ORIGINAL_REFRESH(
+        client=_Client(),
+        portal_base_url="https://portal.example.com",
+        client_id="hermes-cli",
+        refresh_token="rt-irrelevant",
+    )
+
+
+_ORIGINAL_REFRESH = auth_mod._refresh_access_token
+
+
+def _stored_nous_state(home: Path) -> Dict[str, Any]:
+    return json.loads((home / "auth.json").read_text())["providers"]["nous"]
+
+
+def _make_agent(pool, api_key: str, *, bind_entry_id: bool = True):
+    """Minimal agent double for ``recover_with_credential_pool``.
+
+    ``bind_entry_id`` mirrors production: the parent binds
+    ``_credential_pool_entry_id`` via ``sync_credential_pool_entry_id`` at
+    init and every child via ``_swap_credential`` when it leases the pool.
+    """
+    entry_id = None
+    if bind_entry_id:
+        entry = next((e for e in pool.entries() if e.access_token == api_key), None)
+        entry_id = entry.id if entry is not None else None
+    agent = SimpleNamespace(
+        provider="nous",
+        api_mode="chat_completions",
+        base_url="https://inference.example.com/v1",
+        api_key=api_key,
+        _credential_pool=pool,
+        _credential_pool_entry_id=entry_id,
+        _auth_pool_refresh_counts={},
+        _fallback_activated=False,
+    )
+    agent._is_entitlement_failure = lambda *_a, **_k: False
+
+    def _swap(entry):
+        agent.api_key = entry.runtime_api_key or entry.access_token
+        agent._credential_pool_entry_id = entry.id
+
+    agent._swap_credential = _swap
+    return agent
+
+
+def _recover_401(agent):
+    from agent.agent_runtime_helpers import recover_with_credential_pool
+
+    recovered, _ = recover_with_credential_pool(
+        agent, status_code=401, has_retried_429=False
+    )
+    return recovered
+
+
+# ── 1 parent + 10 children, one pool ─────────────────────────────────────────
+
+
+def test_eleven_agents_one_pool_one_post(nous_home, monkeypatch, caplog):
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    pool = load_pool("nous")
+    assert len(pool.entries()) == 1
+
+    agents = [_make_agent(pool, nous_home.expired) for _ in range(11)]
+    results: Dict[int, bool] = {}
+    errors: List[BaseException] = []
+    start = threading.Barrier(len(agents))
+
+    def _run(idx: int):
+        try:
+            start.wait(timeout=10)
+            results[idx] = _recover_401(agents[idx])
+        except BaseException as exc:  # pragma: no cover - surfaced below
+            errors.append(exc)
+
+    with caplog.at_level(logging.INFO):
+        threads = [threading.Thread(target=_run, args=(i,)) for i in range(len(agents))]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=60)
+
+    assert not errors, errors
+    assert endpoint.posts == ["rt-0"], f"expected exactly one POST, got {endpoint.posts}"
+    assert all(results[i] for i in range(len(agents))), results
+    new_token = endpoint.issued[0]
+    assert {a.api_key for a in agents} == {new_token}
+    assert _stored_nous_state(nous_home.home)["refresh_token"] == "rt-1"
+    assert "adopting token rotated by concurrent refresh, skipping POST" in caplog.text
+
+
+# ── Two processes sharing auth.json ──────────────────────────────────────────
+
+
+def test_second_process_adopts_rotation_after_lock(nous_home, monkeypatch):
+    """Two pools loaded from the same auth.json model two Hermes processes.
+
+    The first refresh POSTs and persists. The second pool still carries the
+    expired bearer in memory; its forced refresh must re-read the store
+    under the lock, see the rotated token and skip its POST.
+    """
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    pool_a = load_pool("nous")
+    pool_b = load_pool("nous")
+
+    refreshed_a = pool_a.try_refresh_matching(api_key_hint=nous_home.expired)
+    assert refreshed_a is not None
+    assert endpoint.posts == ["rt-0"]
+
+    # Process B is still holding the pre-rotation entry.
+    assert pool_b.entries()[0].access_token == nous_home.expired
+    refreshed_b = pool_b.try_refresh_matching(api_key_hint=nous_home.expired)
+
+    assert endpoint.posts == ["rt-0"], "process B must adopt, not re-rotate"
+    assert refreshed_b is not None
+    assert refreshed_b.runtime_api_key == refreshed_a.runtime_api_key == endpoint.issued[0]
+
+
+def test_second_process_races_for_lock_and_skips_post(nous_home, monkeypatch):
+    """Same as above but genuinely concurrent: B blocks on the flock while A
+    is mid-refresh, then adopts under the lock."""
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    pools = [load_pool("nous") for _ in range(4)]
+    barrier = threading.Barrier(len(pools))
+    out: Dict[int, Any] = {}
+
+    def _run(i):
+        barrier.wait(timeout=10)
+        out[i] = pools[i].try_refresh_matching(api_key_hint=nous_home.expired)
+
+    threads = [threading.Thread(target=_run, args=(i,)) for i in range(len(pools))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=60)
+
+    assert endpoint.posts == ["rt-0"]
+    assert {getattr(out[i], "runtime_api_key", None) for i in out} == {endpoint.issued[0]}
+
+
+# ── Stored token is STILL the failed one → exactly one POST ──────────────────
+
+
+def test_stale_stored_token_posts_exactly_once(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    pool = load_pool("nous")
+    agent = _make_agent(pool, nous_home.expired)
+
+    assert _recover_401(agent) is True
+    assert endpoint.posts == ["rt-0"]
+    assert agent.api_key == endpoint.issued[0]
+
+
+def test_expired_bearer_is_attributed_without_entry_id(nous_home, monkeypatch):
+    """``runtime_api_key`` masks an expired invoke JWT as ``""``; the 401'd
+    bearer must still resolve to its pool row when no entry id is bound,
+    or the refresh never runs and the single-entry pool "rotates" to nothing."""
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    pool = load_pool("nous")
+    assert pool.entries()[0].runtime_api_key == ""
+    agent = _make_agent(pool, nous_home.expired, bind_entry_id=False)
+
+    assert _recover_401(agent) is True
+    assert endpoint.posts == ["rt-0"]
+    assert agent.api_key == endpoint.issued[0]
+
+
+def test_resolver_still_posts_when_store_holds_failed_token(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    creds = auth_mod.resolve_nous_runtime_credentials(
+        force_refresh=True, stale_access_token=nous_home.expired
+    )
+    assert endpoint.posts == ["rt-0"]
+    assert creds["api_key"] == endpoint.issued[0]
+
+
+# ── Transient token-endpoint failures ────────────────────────────────────────
+
+
+def test_slow_down_then_ok_is_retried_without_relogin(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [
+            ("json", 429, {"error": "slow_down", "error_description": "Refresh already in progress"}),
+            ("ok",),
+        ]
+    ).install(monkeypatch)
+
+    creds = auth_mod.resolve_nous_runtime_credentials(
+        force_refresh=True, stale_access_token=nous_home.expired
+    )
+
+    assert endpoint.posts == ["rt-0", "rt-0"]
+    assert creds["api_key"] == endpoint.issued[0]
+    state = _stored_nous_state(nous_home.home)
+    assert state["refresh_token"] == "rt-2", "rotated pair must be persisted"
+    assert "last_auth_error" not in state, "transient failure must not quarantine"
+
+
+def test_slow_down_retry_adopts_sibling_rotation_instead_of_reposting(nous_home, monkeypatch):
+    """Between the 429 and the retry a sibling persisted a rotation: the
+    retry must re-run the stale check and adopt, not POST again."""
+    fresh = _invoke_jwt(seconds=3600)
+    calls: List[str] = []
+
+    def _refresh(*, client, portal_base_url, client_id, refresh_token):
+        calls.append(refresh_token)
+        # Simulate the sibling winning: rewrite auth.json with a rotated pair
+        # while we are "waiting" for our own retry.
+        state = _stored_nous_state(nous_home.home)
+        store = json.loads((nous_home.home / "auth.json").read_text())
+        state.update(
+            access_token=fresh,
+            refresh_token="rt-sibling",
+            expires_at=_iso_in(3600),
+            expires_in=3600,
+        )
+        store["providers"]["nous"] = state
+        (nous_home.home / "auth.json").write_text(json.dumps(store))
+        request = httpx.Request("POST", "https://portal.example.com/api/oauth/token")
+        return _real_refresh_access_token_from_response(
+            httpx.Response(
+                429,
+                json={"error": "slow_down", "error_description": "Refresh already in progress"},
+                request=request,
+            )
+        )
+
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", _refresh)
+
+    creds = auth_mod.resolve_nous_runtime_credentials(
+        force_refresh=True, stale_access_token=nous_home.expired
+    )
+
+    assert calls == ["rt-0"], "second attempt must adopt the sibling's token, not POST"
+    assert creds["api_key"] == fresh
+
+
+def test_waf_html_429_with_retry_after_is_transient(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [("raw", 429, "<html><body>Too Many Requests</body></html>", {"Retry-After": "3"})]
+    ).install(monkeypatch)
+    sleeps: List[float] = []
+    monkeypatch.setattr(auth_mod, "_nous_refresh_backoff_sleep", sleeps.append)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        auth_mod.resolve_nous_runtime_credentials(
+            force_refresh=True, stale_access_token=nous_home.expired
+        )
+
+    exc = exc_info.value
+    assert exc.relogin_required is False
+    assert exc.retry_after == 3
+    assert exc.code == auth_mod.NOUS_REFRESH_TRANSIENT_CODE
+    assert not auth_mod._is_terminal_nous_refresh_error(exc)
+    assert auth_mod._is_transient_nous_refresh_error(exc)
+    # Bounded retries, honouring Retry-After for the delay.
+    assert len(endpoint.posts) == auth_mod._NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS
+    assert sleeps == [3.0] * (auth_mod._NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS - 1)
+    state = _stored_nous_state(nous_home.home)
+    assert state["refresh_token"] == "rt-0", "grant must be intact"
+    assert "last_auth_error" not in state
+
+
+def test_waf_retry_after_beyond_budget_surfaces_without_stalling(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [("raw", 429, "<html>blocked</html>", {"Retry-After": "60"})]
+    ).install(monkeypatch)
+    sleeps: List[float] = []
+    monkeypatch.setattr(auth_mod, "_nous_refresh_backoff_sleep", sleeps.append)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        auth_mod.resolve_nous_runtime_credentials(force_refresh=True)
+
+    assert exc_info.value.retry_after == 60
+    assert exc_info.value.relogin_required is False
+    assert endpoint.posts == ["rt-0"], "a 60s Retry-After must not be waited out in-turn"
+    assert sleeps == []
+
+
+def test_500_then_ok_is_retried_and_not_quarantined(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [("json", 500, {"error": "server_error", "error_description": "db blip"}), ("ok",)]
+    ).install(monkeypatch)
+    sleeps: List[float] = []
+    monkeypatch.setattr(auth_mod, "_nous_refresh_backoff_sleep", sleeps.append)
+
+    creds = auth_mod.resolve_nous_runtime_credentials(force_refresh=True)
+
+    assert endpoint.posts == ["rt-0", "rt-0"]
+    assert sleeps == [1.0]
+    assert creds["api_key"] == endpoint.issued[0]
+    assert "last_auth_error" not in _stored_nous_state(nous_home.home)
+
+
+def test_transient_failure_does_not_bench_pool_entry(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint([("raw", 503, "Service Unavailable")]).install(monkeypatch)
+    pool = load_pool("nous")
+    entry_before = pool.entries()[0]
+
+    result = pool.try_refresh_matching(api_key_hint=nous_home.expired)
+
+    assert len(endpoint.posts) == auth_mod._NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS
+    assert result is not None and result.id == entry_before.id
+    assert pool.entries()[0].last_status is None, "transient failure must not exhaust the entry"
+    assert pool.entries()[0].refresh_token == "rt-0"
+    assert len(pool.entries()) == 1, "singleton entry must not be quarantined"
+
+
+# ── Terminal errors are unchanged ────────────────────────────────────────────
+
+
+def test_invalid_grant_is_terminal_one_post_quarantined(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [("json", 400, {"error": "invalid_grant", "error_description": "Refresh token expired"})]
+    ).install(monkeypatch)
+    sleeps: List[float] = []
+    monkeypatch.setattr(auth_mod, "_nous_refresh_backoff_sleep", sleeps.append)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        auth_mod.resolve_nous_runtime_credentials(
+            force_refresh=True, stale_access_token=nous_home.expired
+        )
+
+    exc = exc_info.value
+    assert exc.code == "invalid_grant"
+    assert exc.relogin_required is True
+    assert auth_mod._is_terminal_nous_refresh_error(exc)
+    assert endpoint.posts == ["rt-0"], "terminal errors are never retried"
+    assert sleeps == []
+    state = _stored_nous_state(nous_home.home)
+    assert not state.get("refresh_token"), "dead grant must be quarantined"
+    assert state.get("last_auth_error", {}).get("relogin_required") is True
+
+
+def test_invalid_grant_via_pool_removes_singleton_entry(nous_home, monkeypatch):
+    endpoint = _TokenEndpoint(
+        [("json", 400, {"error": "invalid_grant", "error_description": "revoked"})]
+    ).install(monkeypatch)
+    pool = load_pool("nous")
+
+    assert pool.try_refresh_matching(api_key_hint=nous_home.expired) is None
+    assert endpoint.posts == ["rt-0"]
+    assert pool.entries() == []
+
+
+# ── Classifier unit checks (real response objects, real parser) ──────────────
+
+
+@pytest.mark.parametrize(
+    "status, body, headers, expected_retry_after",
+    [
+        (429, {"error": "slow_down", "error_description": "in progress"}, {}, None),
+        (429, "<html>waf</html>", {"Retry-After": "7"}, 7),
+        (502, "<html>bad gateway</html>", {}, None),
+        (500, {"error": "server_error"}, {"Retry-After": "2"}, 2),
+        (503, "", {}, None),
+    ],
+)
+def test_refresh_access_token_transient_classification(status, body, headers, expected_retry_after):
+    request = httpx.Request("POST", "https://portal.example.com/api/oauth/token")
+    if isinstance(body, dict):
+        response = httpx.Response(status, json=body, headers=headers, request=request)
+    else:
+        response = httpx.Response(status, text=body, headers=headers, request=request)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        _real_refresh_access_token_from_response(response)
+
+    exc = exc_info.value
+    assert exc.code == auth_mod.NOUS_REFRESH_TRANSIENT_CODE
+    assert exc.relogin_required is False
+    assert exc.retry_after == expected_retry_after
+    assert auth_mod._is_transient_nous_refresh_error(exc)
+    assert not auth_mod._is_terminal_nous_refresh_error(exc)
+
+
+def test_refresh_access_token_non_json_4xx_never_demands_relogin():
+    """A 403 HTML page from a CDN/WAF is not the portal saying the grant is dead."""
+    request = httpx.Request("POST", "https://portal.example.com/api/oauth/token")
+    response = httpx.Response(403, text="<html>Forbidden</html>", request=request)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        _real_refresh_access_token_from_response(response)
+
+    assert exc_info.value.relogin_required is False
+    assert not auth_mod._is_terminal_nous_refresh_error(exc_info.value)
+
+
+@pytest.mark.parametrize("code", ["invalid_grant", "invalid_token", "refresh_token_reused"])
+def test_refresh_access_token_terminal_codes_unchanged(code):
+    request = httpx.Request("POST", "https://portal.example.com/api/oauth/token")
+    response = httpx.Response(400, json={"error": code, "error_description": "nope"}, request=request)
+
+    with pytest.raises(auth_mod.AuthError) as exc_info:
+        _real_refresh_access_token_from_response(response)
+
+    assert exc_info.value.code == code
+    assert exc_info.value.relogin_required is True
+    assert auth_mod._is_terminal_nous_refresh_error(exc_info.value)
+    assert not auth_mod._is_transient_nous_refresh_error(exc_info.value)
+
+
+# ── Proxy adapter ────────────────────────────────────────────────────────────
+
+
+def test_proxy_retry_credential_adopts_rotated_token_without_post(nous_home, monkeypatch):
+    from hermes_cli.proxy.adapters.base import UpstreamCredential
+    from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    adapter = NousPortalAdapter()
+
+    failed = UpstreamCredential(bearer=nous_home.expired, base_url="https://inference.example.com/v1")
+    first = adapter.get_retry_credential(failed_credential=failed, status_code=401)
+    assert endpoint.posts == ["rt-0"]
+    assert first is not None and first.bearer == endpoint.issued[0]
+
+    # A second request that 401'd on the OLD bearer arrives after rotation.
+    second = adapter.get_retry_credential(failed_credential=failed, status_code=401)
+    assert endpoint.posts == ["rt-0"], "proxy must adopt the rotated token, not re-POST"
+    assert second is not None and second.bearer == first.bearer
+
+
+def test_proxy_retry_credential_posts_when_stored_token_is_the_failed_one(nous_home, monkeypatch):
+    from hermes_cli.proxy.adapters.base import UpstreamCredential
+    from hermes_cli.proxy.adapters.nous_portal import NousPortalAdapter
+
+    endpoint = _TokenEndpoint([("ok",)]).install(monkeypatch)
+    adapter = NousPortalAdapter()
+    failed = UpstreamCredential(bearer=nous_home.expired, base_url="https://inference.example.com/v1")
+
+    cred = adapter.get_retry_credential(failed_credential=failed, status_code=401)
+
+    assert endpoint.posts == ["rt-0"]
+    assert cred is not None and cred.bearer == endpoint.issued[0]


### PR DESCRIPTION
## What does this PR do?

**Aim:** make Nous OAuth 401 recovery refresh the grant **once** when many concurrent agents expire together, and stop misreporting transient token-endpoint failures (Vercel WAF 429, portal `slow_down`, 5xx) as "please re-authenticate".

### The problem

A session with many `delegate_task` children shares one credential pool. When the Nous access token expires mid-flight, every child 401s at the same instant. Each child's recovery forced a refresh-token rotation against `POST /api/oauth/token` even though a sibling had rotated milliseconds earlier: N children + parent = N+1 sequential POSTs, each allowed two attempts. A few Hermes processes on one egress IP (gateway + TUI + cron, or Hermes Cloud behind shared Fly egress) then trip the portal's WAF rule (25 POSTs/IP/60s → 1-minute block). The WAF 429 body is HTML, and `_refresh_access_token` turned any non-JSON error body into `AuthError(relogin_required=True)`, so the user was told to log in again over a perfectly valid credential.

Commit 3312947e14 (Sep 2) had already added the in-lock `_already_rotated_by_peer` check to `resolve_nous_runtime_credentials(stale_access_token=…)`, but the failed bearer never reached it from the pool's 401-recovery path, and there was a second bug underneath: `PooledCredential.runtime_api_key` masks an expired invoke JWT as `""`, so `try_refresh_matching(api_key_hint=<expired bearer>)` matched **no entry at all** whenever `_credential_pool_entry_id` wasn't bound. Recovery "rotated without marking" and the refresh silently never ran.

### Approach

Refresh-**if-stale** instead of refresh-always, applied at three layers so each one holds on its own:

1. **In-process (pool row).** New `CredentialPool._refresh_nous_entry` mirrors the existing Codex/xAI sync-then-skip guard: if the row already carries a runtime key other than the bearer that failed, a sibling rotated first — adopt it and skip the POST. This is the layer that collapses 11 same-process agents to one POST; the file-lock layer alone cannot, because the winner rewrites the shared row before the waiters even reach the lock.
2. **Cross-process, pre-lock.** `_refresh_entry_impl` compares the on-disk `auth.json` against the *failed* bearer (not the entry's own, possibly-already-rotated key) after `_sync_nous_entry_from_auth_store`.
3. **Cross-process, in-lock.** `resolve_nous_runtime_credentials` (unchanged check, now actually reached with the hint) re-reads under `_auth_store_lock` → `_nous_shared_store_lock` and only POSTs when the stored token is still the failed one.

`force_refresh=True` with no fingerprint (keepalive / explicit user force) keeps refresh-always semantics. The proxy adapter's `get_retry_credential` gets the same rule under its own `self._lock`.

Transient failures become transient: `_refresh_access_token` now raises `AuthError(code="refresh_transient", relogin_required=False, retry_after=<Retry-After>)` for 429 `slow_down`, any 429 with a non-JSON body, and any 5xx. A non-JSON 4xx no longer demands re-login either. `resolve_nous_runtime_credentials` wraps a single attempt in a bounded retry (3 attempts, 1s/2s/4s or `Retry-After`); each attempt re-enters the store transaction so the stale check runs again and a sibling's success short-circuits the retry. A `Retry-After` beyond 8s raises immediately rather than stalling the turn on a WAF block — nothing is quarantined, the next turn tries again. The pool's except-path returns the entry untouched on transient errors instead of `_mark_exhausted`.

Terminal errors (`invalid_grant`, `invalid_token`, `refresh_token_reused`, "reuse detected") quarantine exactly as before. No behaviour change for other OAuth providers.

## Related Issue

Fixes the Sep 2 2026 Nous refresh stampede follow-up (WAF 429 → false re-login). No standalone issue; see 3312947e14 for the first half of the incident.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/credential_pool.py`
  - `try_refresh_matching` → `_try_refresh_current_unlocked` → `_refresh_entry` → `_refresh_entry_impl` thread `stale_access_token` (the bearer that 401'd).
  - New `_refresh_nous_entry`: in-pool adopt-or-POST guard for the `nous` provider (docstring explains the three layers).
  - New `_entry_supplied_key`: `try_refresh_matching` matches the hint against raw `agent_key`/`access_token` too, so an expired JWT still resolves to its entry.
  - Nous except-path: `_is_transient_nous_refresh_error` → return the entry untouched (no `_mark_exhausted`, no quarantine).
- `hermes_cli/auth.py`
  - `AuthError.retry_after`; `NOUS_REFRESH_TRANSIENT_CODE = "refresh_transient"`.
  - `_refresh_access_token`: status/body → transient vs terminal classification described above; `Retry-After` parsed via the existing `_parse_retry_after_seconds`.
  - `_is_transient_nous_refresh_error` next to the (unchanged) `_is_terminal_nous_refresh_error`.
  - `resolve_nous_runtime_credentials` is now a retry wrapper over `_resolve_nous_runtime_credentials_once` (`_NOUS_REFRESH_TRANSIENT_MAX_ATTEMPTS/BACKOFF_SECONDS/MAX_WAIT_SECONDS`; `_nous_refresh_backoff_sleep` is the patch point for tests).
  - INFO log `nous: adopting token rotated by concurrent refresh, skipping POST` at every skip site (pool row, auth.json sync, profile store, shared store, proxy) so the effect is visible in gateway logs.
- `hermes_cli/proxy/adapters/nous_portal.py`
  - `_get_credential`: when `force_refresh` + `stale_access_token`, adopt a usable stored token that differs from the failed bearer before calling the resolver (`_usable_token_other_than`).
- `tests/agent/test_nous_refresh_idempotent_across_subagents.py` (new, 25 tests)

## How to Test

All tests use the real `load_pool("nous")`, a real `auth.json` + shared store under a temp `HERMES_HOME`, and real flocks. Only the HTTP POST is stubbed, and even that routes `httpx.Response` objects through the real `_refresh_access_token` classifier rather than hand-building exceptions.

1. `scripts/run_tests.sh tests/agent/test_nous_refresh_idempotent_across_subagents.py -q`
   - 1 parent + 10 children on one pool, all 401 on the same bearer → token endpoint records exactly **one** POST; all 11 hold the new token; the "adopting token rotated by concurrent refresh" INFO line is logged.
   - Two pools loaded from the same `auth.json` (two processes): the second's forced refresh sees the rotation after the lock and skips its POST. Same with 4 pools racing on the flock concurrently.
   - Stored token still the failed one → exactly one POST (via pool recovery, via the resolver directly, and via the proxy adapter).
   - Expired bearer with no `_credential_pool_entry_id` bound still attributes to its entry and refreshes.
   - 429 `slow_down` then 200 → retried, succeeds, rotated pair persisted, no `relogin_required`, no quarantine. Variant where a sibling persists a rotation between the 429 and the retry → the retry adopts instead of POSTing.
   - 429 HTML + `Retry-After: 3` → `retry_after == 3`, `relogin_required=False`, retried up to the cap with 3s waits, grant intact, no quarantine. `Retry-After: 60` → surfaces after one POST without sleeping.
   - 500 then 200 → retried, succeeds, no quarantine. 503 via the pool → entry not benched, singleton not removed.
   - 400 `invalid_grant` → terminal: one POST, no retries, quarantined, `relogin_required=True` (unchanged). Also via the pool: singleton entry removed.
   - Parametrised classifier checks for 429/5xx/non-JSON → transient and for the three terminal codes → unchanged.
2. Regression suites named in the task: `tests/hermes_cli/test_auth*.py`, `tests/agent/test_credential_pool*.py` — all green (see Verification).
3. To see the effect live: run a Nous-backed session with ~10 parallel `delegate_task` children past the hourly JWT expiry and grep `gateway.log` for `skipping POST`; `HERMES_OAUTH_TRACE=1` additionally emits `refresh_skipped_peer_rotated` with the `where` field.

## Verification

Run on macOS 26.5.2, Python 3.14.3, via `scripts/run_tests.sh` (CI-parity wrapper).

| Suite | Result |
|---|---|
| `tests/agent/test_nous_refresh_idempotent_across_subagents.py` | 25 passed (race tests rerun 3× — stable) |
| `tests/hermes_cli/test_auth*.py` + `tests/agent/test_credential_pool*.py` | all passed |
| proxy, keepalive, session-validity, nous-account, runtime-provider, xAI/Codex/Anthropic OAuth stress + persist-failure, managed gateways (17 files) | 398 passed, 1 skipped, 0 failed |
| `tests/tools/test_delegate*.py` | 48 failures — **fail identically on `main` (63279301bc) with this branch stashed**: `DaemonThreadPoolExecutor has no attribute '_initializer'` under Python 3.14. Unrelated to this change. |

Layer isolation probe (not committed): with `_refresh_nous_entry` bypassed so only the auth.py lock layer remains, the 11-agent scenario produced 11 POSTs; with the hint threaded through, 1. Both layers are needed and both are exercised.

`ruff check` clean on all touched files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — via `scripts/run_tests.sh` on the auth/credential-pool/proxy/delegate suites; the only failures are the pre-existing Python 3.14 `tests/tools/test_delegate*` ones noted above
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.5.2, Python 3.14.3

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docstrings on every changed function; no user-facing docs change needed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no config keys; retry bounds are module constants, not user settings)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses the existing `_file_lock` (fcntl/msvcrt) and `time.sleep`; nothing platform-specific added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no tool schema touched)

## Screenshots / Logs

Log lines a gateway operator will now see during a fan-out expiry (INFO level):

```
nous: adopting token rotated by concurrent refresh, skipping POST (pool entry f41649 already carries a token other than the failed one)
nous: adopting token rotated by concurrent refresh, skipping POST (failed=3f9c1a… adopted=b71e02…, profile store)
nous: transient token-endpoint failure (Refresh already in progress); retrying refresh in 1.0s (attempt 2/3)
nous: transient token-endpoint failure during refresh of entry f41649 (Refresh token exchange failed (HTTP 429, non-JSON response)); leaving credential untouched
```
