### PR TITLE
fix(agent): isolate periodic scheduler callbacks from blocking siblings

### DIFF
--- a/agent/periodic_scheduler.py
+++ b/agent/periodic_scheduler.py
@@ -2,9 +2,10 @@
 
 Replaces the per-child ``while not stop.wait(interval): body()`` daemon
 threads (delegate heartbeat, durable turn-lease refresher, turn-liveness
-watchdog).  With ~130 in-process subagents those added 2-3 sleeping OS
-threads per child; this module runs every periodic body on ONE daemon
-thread ordered by a heap of due times.
+watchdog). With ~130 in-process subagents those added 2-3 sleeping OS
+threads per child. One daemon scheduler owns the heap of due times; each due
+body runs on a per-handle daemon worker so a blocking callback cannot starve
+unrelated lease or liveness timers. A handle never overlaps itself.
 
 Semantics match the loop they replace: the first call happens ``interval``
 seconds after :func:`schedule`, and each following call ``interval`` seconds
@@ -26,18 +27,26 @@ from typing import Callable, Optional
 logger = logging.getLogger(__name__)
 
 _THREAD_NAME = "hermes-periodic-scheduler"
+_CALLBACK_THREAD_PREFIX = "hermes-periodic-callback"
 
 
 class ScheduledHandle:
     """Cancel token for one scheduled periodic callback."""
 
-    __slots__ = ("_fn", "_interval", "_cancelled", "_scheduler")
+    __slots__ = (
+        "_fn",
+        "_interval",
+        "_cancelled",
+        "_scheduler",
+        "_runner_thread",
+    )
 
     def __init__(self, scheduler: "PeriodicScheduler", fn: Callable[[], object], interval: float):
         self._scheduler = scheduler
         self._fn = fn
         self._interval = interval
         self._cancelled = False
+        self._runner_thread: Optional[threading.Thread] = None
 
     @property
     def cancelled(self) -> bool:
@@ -56,7 +65,6 @@ class PeriodicScheduler:
         self._heap: list = []  # (due, seq, handle)
         self._seq = itertools.count()
         self._thread: Optional[threading.Thread] = None
-        self._running: Optional[ScheduledHandle] = None
 
     def schedule(self, fn: Callable[[], object], interval: float) -> ScheduledHandle:
         handle = ScheduledHandle(self, fn, float(interval))
@@ -72,8 +80,30 @@ class PeriodicScheduler:
         with self._cond:
             handle._cancelled = True
             self._cond.notify()
-            if wait and self._running is handle and threading.current_thread() is not self._thread:
-                self._cond.wait_for(lambda: self._running is not handle, timeout=wait)
+            runner = handle._runner_thread
+            if wait and runner is not None and threading.current_thread() is not runner:
+                self._cond.wait_for(
+                    lambda: handle._runner_thread is None,
+                    timeout=wait,
+                )
+
+    def _run_callback(self, handle: ScheduledHandle) -> None:
+        stop = False
+        try:
+            stop = handle._fn() is False
+        except Exception:
+            logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
+        finally:
+            with self._cond:
+                handle._runner_thread = None
+                if stop:
+                    handle._cancelled = True
+                elif not handle._cancelled:
+                    heapq.heappush(
+                        self._heap,
+                        (time.monotonic() + handle._interval, next(self._seq), handle),
+                    )
+                self._cond.notify_all()
 
     def _run(self) -> None:
         while True:
@@ -91,28 +121,31 @@ class PeriodicScheduler:
                         self._cond.wait(delay)
                         continue
                     heapq.heappop(self._heap)
-                    self._running = handle
-                    break
-            stop = False
-            try:
-                stop = handle._fn() is False
-            except Exception:
-                logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
-            with self._cond:
-                self._running = None
-                if stop:
-                    handle._cancelled = True
-                elif not handle._cancelled:
-                    heapq.heappush(
-                        self._heap,
-                        (time.monotonic() + handle._interval, next(self._seq), handle),
+                    runner = threading.Thread(
+                        target=self._run_callback,
+                        args=(handle,),
+                        name=f"{_CALLBACK_THREAD_PREFIX}-{id(handle):x}",
+                        daemon=True,
                     )
-                self._cond.notify_all()
+                    handle._runner_thread = runner
+                    try:
+                        runner.start()
+                    except Exception:
+                        handle._runner_thread = None
+                        handle._cancelled = True
+                        logger.debug(
+                            "failed to start periodic callback worker %r",
+                            handle._fn,
+                            exc_info=True,
+                        )
+                        self._cond.notify_all()
+                        continue
+                    break
 
 
 _DEFAULT = PeriodicScheduler()
 
 
 def schedule(fn: Callable[[], object], interval: float) -> ScheduledHandle:
-    """Run ``fn()`` every ``interval`` seconds on the shared scheduler thread."""
+    """Run ``fn()`` periodically through the shared timer scheduler."""
     return _DEFAULT.schedule(fn, interval)

--- a/agent/turn_liveness.py
+++ b/agent/turn_liveness.py
@@ -157,8 +157,8 @@ def resolve_turn_liveness_settings(
 
 
 class TurnLivenessWatchdog:
-    """Sampled-idle watchdog bound to one conversation turn (polls on the
-    shared periodic scheduler thread).
+    """Sampled-idle watchdog bound to one conversation turn (timed by the
+    shared scheduler and executed on an isolated callback worker).
 
     ``run_agent.py`` owns the turn-lease state (stop event, turn-active
     flag, interrupt plumbing); this class only reads the activity clock
@@ -191,7 +191,7 @@ class TurnLivenessWatchdog:
         self._deactivate_turn = deactivate_turn
 
     def schedule(self):
-        """Start polling on the shared periodic scheduler thread.
+        """Start polling through the shared periodic scheduler.
 
         ``run_agent.py`` creates the watchdog before the turn begins but
         schedules it at turn entry, right after the turn-active flag and

--- a/run_agent.py
+++ b/run_agent.py
@@ -9688,7 +9688,7 @@ class AIAgent:
                         return durable_turn_lease_turn_active
 
                 def _refresh_durable_turn_lease():
-                    # One periodic tick on the shared scheduler thread every
+                    # One isolated tick dispatched by the shared scheduler every
                     # _lease_refresh_interval; returning False stops it.
                     if durable_turn_lease_stop.is_set():
                         return False

--- a/tests/agent/test_periodic_scheduler.py
+++ b/tests/agent/test_periodic_scheduler.py
@@ -1,4 +1,4 @@
-"""agent/periodic_scheduler: one shared thread runs every periodic timer."""
+"""agent/periodic_scheduler: one timer thread dispatches isolated callbacks."""
 
 import threading
 import time
@@ -24,7 +24,7 @@ def test_two_intervals_fire_proportionally_and_cancel_stops_one():
 
     assert _wait_until(lambda: len(slow) >= 3)
     assert len(fast) > len(slow)  # 5x interval ratio -> clearly more fast ticks
-    # Both ran on this scheduler's single thread, not on new threads.
+    # Scheduling another timer creates no persistent per-handle thread.
     before = threading.active_count()
     sched.schedule(lambda: None, 0.01).cancel()
     assert threading.active_count() == before
@@ -51,6 +51,57 @@ def test_raising_callback_is_rescheduled_and_does_not_kill_sibling():
     assert _wait_until(lambda: len(boom) >= 3 and len(ok) >= 3)
     h1.cancel()
     h2.cancel()
+
+
+def test_blocking_callback_does_not_starve_sibling():
+    sched = PeriodicScheduler()
+    entered = threading.Event()
+    release = threading.Event()
+    sibling_fired = threading.Event()
+
+    def blocking():
+        entered.set()
+        release.wait(2.0)
+
+    blocked = sched.schedule(blocking, 0.01)
+    sibling = sched.schedule(sibling_fired.set, 0.02)
+    try:
+        assert entered.wait(2.0)
+        assert sibling_fired.wait(0.5), (
+            "one blocked periodic callback starved an unrelated sibling"
+        )
+    finally:
+        release.set()
+        blocked.cancel(wait=2.0)
+        sibling.cancel(wait=2.0)
+
+
+def test_slow_callback_never_overlaps_itself():
+    sched = PeriodicScheduler()
+    lock = threading.Lock()
+    second_run_finished = threading.Event()
+    running = 0
+    peak_running = 0
+    completed = 0
+
+    def slow():
+        nonlocal running, peak_running, completed
+        with lock:
+            running += 1
+            peak_running = max(peak_running, running)
+        time.sleep(0.05)
+        with lock:
+            running -= 1
+            completed += 1
+            if completed >= 2:
+                second_run_finished.set()
+
+    handle = sched.schedule(slow, 0.01)
+    try:
+        assert second_run_finished.wait(2.0)
+        assert peak_running == 1
+    finally:
+        handle.cancel(wait=2.0)
 
 
 def test_returning_false_stops_callback_and_cancel_wait_joins_inflight():

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2683,8 +2683,8 @@ def _run_single_child(
     # gateway inactivity timeout doesn't fire while the subagent is working.
     # Without this, the parent's _last_activity_ts freezes when delegate_task
     # starts and the gateway eventually kills the agent for "no activity".
-    # Runs on the shared periodic scheduler thread (agent/periodic_scheduler)
-    # rather than one daemon thread per child; returning False stops it.
+    # Timed by the shared scheduler (agent/periodic_scheduler) and dispatched
+    # on an isolated callback worker; returning False stops it.
     # Stale detection: track the child's (tool, iteration, activity_ts) across
     # heartbeat cycles. If none advances, count the cycle as stale.
     # Different thresholds for idle vs in-tool (see _HEARTBEAT_STALE_CYCLES_*).


### PR DESCRIPTION
## Summary

Isolate periodic-scheduler callbacks so a single blocked timer can no longer starve every other turn's lease renewal and turn-liveness watchdog.

## Root cause

Since `561b053f794a` (`perf(agents): run per-child timers on one shared scheduler thread`), all periodic bodies (delegate heartbeat, durable turn-lease refresh, turn-liveness watchdog) run **inline on one process-wide scheduler thread** (`agent/periodic_scheduler.py::PeriodicScheduler._run`). One blocked callback therefore delays every other callback.

This produced a real gateway wedge: on 2026-09-03, three turns stopped progressing at ~13:08 EDT; their lease refreshers and liveness watchdog ticks were starved, leases expired ~5 minutes later, yet the turns stayed falsely listed in `active_agents`, no `Turn liveness watchdog fired` event ever occurred, and the gateway only recovered via a forced process restart. The merged PR that introduced the scheduler even documents the coupling as a known caveat: *"a body that blocks (slow lease-refresh DB call) delays other ticks; the old per-thread design had no such coupling."*

## Change

`agent/periodic_scheduler.py`:
- The single daemon scheduler thread remains the **heap owner** (timing/dispatch decisions under `self._cond`).
- Each due body now runs on a **per-handle daemon worker** (`hermes-periodic-callback-*`), so a blocking callback cannot delay an unrelated lease/liveness timer.
- A handle never overlaps itself: it is re-pushed to the heap only after its prior run completes (`_run_callback` `finally`).
- `cancel(wait=)` still blocks for an in-flight run (per-handle runner thread join), preserving the old `join(timeout)` semantics; the `current_thread() is not runner` guard prevents cancel-from-within-callback deadlock.
- A worker `start()` failure clears the handle state, cancels the callback, logs at debug, and lets the scheduler continue.

Comment/docstring-only updates in `run_agent.py`, `agent/turn_liveness.py`, `tools/delegate_tool.py` to match the new execution model.

## Tests

`tests/agent/test_periodic_scheduler.py`:
- `test_blocking_callback_does_not_starve_sibling` — **fails on base `63279301`** (one blocked callback starves an unrelated sibling; reproduces the incident defect), passes after the fix.
- `test_slow_callback_never_overlaps_self` — a slow callback never overlaps itself.

Verified with the canonical hermetic runner:
- `tests/agent/test_periodic_scheduler.py`: 6/6 pass.
- Consumer suites (delegate heartbeat, turn-lease refresh, liveness watchdog, tool-activity heartbeat): 122/123 pass. The one failure is a pre-existing wall-clock timing flake in `tests/run_agent/test_tool_activity_heartbeat.py` (byte-identical to base, passes standalone, fails only under the 56-worker parallel load) — unrelated to this change.
- `git diff --check` clean; static scan clean (no credentials, eval/exec, shell injection, SQL injection).

## Follow-ups (non-blocking)

- Consider a pooled worker executor instead of a fresh daemon thread per tick under heavy subagent fan-out.
- The heap-pop → `runner.start()` window means a callback can fire once unjoined if `cancel(wait=True)` lands in that window — parity with the pre-change behavior, not a regression.
- The two new tests are timing-sensitive (same class as the file's existing asserts).
