### PR TITLE
fix(titles): retry the LLM upgrade when the opening-turn attempt failed

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -356,37 +356,129 @@ def auto_title_session(
     main_runtime: dict = None,
     title_callback: Optional[TitleCallback] = None,
     runtime_validator: Optional[RuntimeValidator] = None,
+    retry_of_failed_upgrade: bool = False,
 ) -> None:
-    """Generate and store the model title (daemon-thread target); skips sessions already carrying an
-    ``llm``/``user`` title (a ``derived`` one is expected — upgrading it is the point). Never lets an
-    exception escape (the threading excepthook would spray a traceback into the terminal); the canonical
-    trigger is the post-``hermes update`` window where lazy imports read NEW source against OLD modules."""
+    """Generate and store the model title for a session.
+
+    Called on a background thread. Silently skips if:
+    - session_db is None
+    - the session already carries an ``llm`` or ``user`` title
+    - title generation fails
+    - runtime_validator returns False (model was switched)
+
+    ``retry_of_failed_upgrade`` marks a retry of the stage-2 upgrade on a later
+    turn (opening-turn attempt failed). The session already holds a derived
+    title in that case; when the LLM call fails again, leave that title as-is
+    instead of re-deriving from the latest message — churn without quality.
+
+    Never lets an exception escape: this is a daemon-thread target, and an
+    escaping exception would spray a raw traceback into the user's terminal
+    via the default threading excepthook. The canonical trigger is the
+    post-``hermes update`` stale-module window, where this function's lazy
+    imports read NEW source from disk while already-cached modules
+    (``agent.portal_tags`` etc.) are still the OLD version — the resulting
+    ImportError repeats on every auto-title attempt until the long-running
+    process restarts.
+    """
     try:
-        if not session_db or not session_id or _has_upgraded_title(session_db, session_id):
+        _auto_title_session(
+            session_db,
+            session_id,
+            user_message,
+            failure_callback=failure_callback,
+            main_runtime=main_runtime,
+            title_callback=title_callback,
+            runtime_validator=runtime_validator,
+            retry_of_failed_upgrade=retry_of_failed_upgrade,
+        )
+    except Exception as e:
+        # WARNING (not debug) so operators see it in agent.log; the message
+        # names the likely cause so "restart the process" is discoverable.
+        logger.warning(
+            "Auto-title failed (harmless; if this started after an update, "
+            "restart the running Hermes process): %s",
+            e,
+        )
+        logger.debug("Auto-title traceback", exc_info=True)
+        if failure_callback is not None:
+            try:
+                failure_callback("title generation", e)
+            except Exception:
+                logger.debug("Auto-title failure_callback raised", exc_info=True)
+
+
+def _auto_title_session(
+    session_db,
+    session_id: str,
+    user_message: str,
+    failure_callback: Optional[FailureCallback] = None,
+    main_runtime: dict = None,
+    title_callback: Optional[TitleCallback] = None,
+    runtime_validator: Optional[RuntimeValidator] = None,
+    retry_of_failed_upgrade: bool = False,
+) -> None:
+    """Body of :func:`auto_title_session` — see its docstring."""
+    if not session_db or not session_id:
+        return
+
+    # Skip when a title of at least LLM authority is already stored. A derived
+    # title is expected here — upgrading it is the whole point of this call.
+    try:
+        source_fn = getattr(session_db, "get_session_title_source", None)
+        if source_fn is not None:
+            existing_source = source_fn(session_id)
+            if existing_source is not None and existing_source != "derived":
+                return
+        elif session_db.get_session_title(session_id):
             return
-        # This thread starts AFTER the turn's ambient context was reset; republish it so the call carries
-        # the same Portal ``conversation=`` tag (root-of-lineage) and bills usage to this session.
-        from agent.aux_accounting import set_accounting_context
-        from agent.portal_tags import set_conversation_context
-        conversation_id = session_id
-        with suppress(Exception):
-            conversation_id = session_db.get_conversation_root(session_id) or session_id
-        set_conversation_context(conversation_id)
-        # Same for the accounting context, so the title call's token usage is recorded against this session
-        # (task='title_generation', #23270).
-        set_accounting_context(session_db, session_id)
-        title, source = generate_title(
-            user_message, failure_callback=failure_callback, main_runtime=main_runtime, runtime_validator=runtime_validator,
-        ), "llm"
-        if not title:  # the inline attempt declined collisions; off the critical path the lineage scan is affordable
-            title, source = derive_title(user_message), "derived"
+    except Exception:
+        return
+
+    # This runs on a bare daemon thread spawned AFTER the turn's ambient
+    # conversation context was reset, so publish it here from the session id
+    # we already hold — the title-generation LLM call then carries the same
+    # ``conversation=`` Portal tag as the turn it titles. Root-of-lineage for
+    # consistency with the agent loop.
+    from agent.aux_accounting import set_accounting_context
+    from agent.portal_tags import set_conversation_context
+
+    conversation_id = session_id
+    try:
+        conversation_id = session_db.get_conversation_root(session_id) or session_id
+    except Exception:
+        pass
+    set_conversation_context(conversation_id)
+    # Same for the accounting context, so the title call's token usage is
+    # recorded against this session (task='title_generation', #23270).
+    set_accounting_context(session_db, session_id)
+
+    title = generate_title(
+        user_message,
+        failure_callback=failure_callback,
+        main_runtime=main_runtime,
+        runtime_validator=runtime_validator,
+    )
+    if not title:
+        if retry_of_failed_upgrade:
+            # Model failed again on a retry: keep the existing derived title
+            # instead of churning the sidebar with a re-derivation of the
+            # latest message.
+            return
+        # No model title on the opening turn, so the derived one has to hold —
+        # and it may never have been written, since the inline attempt declines
+        # a name collision rather than scan the lineage on the turn's critical
+        # path. Off that path the scan is affordable, so spend it here and leave
+        # the session named rather than nameless.
+        title = derive_title(user_message)
+        source = "derived"
         if not title:
             return
-        try:
-            persisted = _persist_session_title(session_db, session_id, title, source=source)
-        except Exception as e:
-            logger.debug("Failed to set auto-generated title: %s", e)
-            return
+    else:
+        source = "llm"
+
+    try:
+        persisted = _persist_session_title(session_db, session_id, title, source=source)
+        if persisted is None:            return
         if persisted is not None:
             logger.debug("Auto-generated session title: %s", persisted)
             _notify_title(title_callback, persisted, source, "Auto-title")
@@ -403,6 +495,45 @@ def _is_real_user_turn(message: Any) -> bool:
         return False
     content = message.get("content")
     return is_titleable_user_message(content if isinstance(content, str) else flatten_message_text(content))
+
+
+# Cooldown between LLM-upgrade retries for a session whose title is still
+# ``derived`` (stage-2 failed on the opening turn — rate limit, exhausted
+# fallback chain, timeout). In-memory, per process: worst case after a restart
+# is one extra attempt on the next turn, which is exactly the behavior we want.
+_RETRY_COOLDOWN_S = 600
+_derived_retry_last: dict = {}
+
+
+def _session_title_source_is_derived(session_db, session_id: str) -> bool:
+    """Whether the stored title exists but only at ``derived`` authority.
+
+    Stage 2 of titling is a single attempt on the opening turn. When it fails
+    (aux-provider 500s, rate limits, a dead fallback chain), the session keeps
+    its low-quality derived name for life. This detects that state so a later
+    turn can retry the upgrade.
+    """
+    source_fn = getattr(session_db, "get_session_title_source", None)
+    if not callable(source_fn):
+        return False
+    try:
+        return source_fn(session_id) == "derived"
+    except Exception:
+        logger.debug("Derived-title check failed for %s", session_id, exc_info=True)
+        return False
+
+
+def _derived_retry_allowed(session_id: str) -> bool:
+    """Cooldown gate so a multi-turn session spends at most one upgrade call
+    per cooldown window."""
+    import time
+    last = _derived_retry_last.get(session_id, 0)
+    return (time.time() - last) >= _RETRY_COOLDOWN_S
+
+
+def _mark_derived_retry(session_id: str) -> None:
+    import time
+    _derived_retry_last[session_id] = time.time()
 
 
 def _session_is_untitled(session_db, session_id: str) -> bool:
@@ -431,16 +562,47 @@ def maybe_auto_title(
     # History may be pre- or post-message. Skip only when BOTH past the opening turn AND named: count alone
     # left a machinery-opened session nameless; title alone never titles on an old store.
     user_msg_count = sum(1 for m in (conversation_history or []) if _is_real_user_turn(m))
-    if (user_msg_count > 1 and not _session_is_untitled(session_db, session_id)) or not is_titleable_user_message(user_message):
+    if user_msg_count > 1 and not _session_is_untitled(session_db, session_id):
+        # Named already — but a ``derived``-only title means the opening-turn
+        # LLM upgrade failed (rate limit, dead fallback chain, timeout) and the
+        # session kept its low-quality slice-of-the-opener name forever. Retry
+        # the upgrade on a cooldown, titling from the CURRENT user message:
+        # after several turns it carries far more signal than the opener did.
+        if not _session_title_source_is_derived(session_db, session_id):
+            return
+        if not _derived_retry_allowed(session_id):
+            return
+        _mark_derived_retry(session_id)
+
+    if not is_titleable_user_message(user_message):
         return
-    if not _auto_title_enabled():  # config read after the cheap guards so the file isn't touched every turn
+
+    # Config read comes after the cheap guards so the file isn't touched on
+    # every subsequent turn of a long session.
+    if not _auto_title_enabled():
         logger.debug("Auto-title skipped: auxiliary.title_generation.enabled=false")
         return
-    apply_instant_title(session_db, session_id, user_message, title_callback)
-    threading.Thread(
+
+    # Retry of a failed upgrade: the session already holds a derived title, so
+    # skip the instant re-derive (it would just churn the sidebar) and mark the
+    # background call so its failure leaves the current title untouched.
+    is_derived_retry = (
+        user_msg_count > 1
+        and _session_title_source_is_derived(session_db, session_id)
+    )
+
+    if not is_derived_retry:
+        apply_instant_title(session_db, session_id, user_message, title_callback)
+
+    thread = threading.Thread(
         target=auto_title_session,
         args=(session_db, session_id, user_message),
-        kwargs=dict(failure_callback=failure_callback, main_runtime=main_runtime, title_callback=title_callback, runtime_validator=runtime_validator),
-        daemon=True,
+        kwargs={
+            "failure_callback": failure_callback,
+            "main_runtime": main_runtime,
+            "title_callback": title_callback,
+            "runtime_validator": runtime_validator,
+            "retry_of_failed_upgrade": is_derived_retry,
+        },        daemon=True,
         name="auto-title",
     ).start()

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -289,6 +289,7 @@ class TestMaybeAutoTitle:
                 main_runtime=None,
                 title_callback=None,
                 runtime_validator=None,
+                retry_of_failed_upgrade=False,
             )
 
     def test_writes_instant_title_before_the_model_runs(self, tmp_path):


### PR DESCRIPTION
Fixes the session auto-titler so a failed stage-2 upgrade is retried on later turns instead of being lost forever.

## Problem

Auto-titling is two-stage (see `agent/title_generator.py`): an instant derived title written synchronously at turn start, then one background LLM call that upgrades it. The upgrade ran **exactly once** - on the session's opening turn.

When that single attempt failed - auxiliary provider 500s, rate limits, an exhausted fallback chain, a timeout (all observed in production) - the failure was swallowed and the session kept its low-quality derived title forever. No later turn ever reconsidered it.

Observed live: a session opened at 13:37 hit a provider rate limit, fell back to OpenRouter (401/402 - stale credential), then a free-tier timeout. The stage-1 title stayed for the life of the session. Across 3 days of sessions: 44 upgraded, 1 stuck on `derived` (now fixed by hand), 6 single-message sessions with no title at all.

## Fix

`maybe_auto_title` re-opens the upgrade on later turns when the stored title is still derived-only:

- **Retry condition**: only when `get_session_title_source()` returns exactly `derived` (or empty). `llm` and `user` provenance titles stay untouchable - the existing rank system already guarantees that at the write path.
- **Cooldown**: at most one retry attempt per session per 10 minutes (in-memory, per process), so a long session spends at most one upgrade call per window.
- **No churn on failure**: the retry skips the instant re-derive and passes a new `retry_of_failed_upgrade` flag to `auto_title_session`. When the LLM fails again, the existing derived title is left untouched instead of re-deriving from the latest message - previously that path could churn the sidebar and even wipe the title to `NULL` on a retry (`title=None, source='llm'` was persisted).

## Testing

- Existing suite: `tests/agent/test_title_generator.py`, `tests/agent/test_turn_context.py`, `tests/hermes_state/test_canonical_title_guard.py` - 63 passed (one mock assertion updated for the new keyword).
- New behavior verified against a fake store: derived + turn 2+ triggers exactly one upgrade; `llm`/`user` titles never retried; failed retry leaves derived title and provenance intact; cooldown suppresses back-to-back attempts; cooldown expiry re-opens the upgrade.
