### PR TITLE
fix: Telegram edit streaming freezes mid-text: 5s flood wait cap drops 18–35s RetryAfter edits (#102402)

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -248,13 +248,22 @@ from utils import atomic_replace, env_float, env_int
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 
-# Max seconds a send/edit coroutine may sleep inline on a Telegram
+# Max seconds a send coroutine may sleep inline on a Telegram
 # flood-control RetryAfter. Longer server penalties fail closed with a
 # ``flood_control:{wait}`` SendResult so the caller's retry machinery
 # (delivery ledger, streaming fallback) owns the wait instead of the
 # coroutine pinning its worker — a 97-minute penalty on the boot path
 # froze inbound on every platform (#91969).
 _FLOOD_INLINE_WAIT_CAP_SECS = 5.0
+
+# ``edit_message`` (streaming preview + finalize) routinely eats Telegram's
+# 18–35s ``editMessageText`` RetryAfter (~20 edits/min envelope); failing
+# those closed at the 5s boot ceiling froze the bubble mid-text (#102402).
+# Edits never run at boot, so they get their own ceiling — pathological
+# penalties (minutes–hours, #91969) still fail closed.
+# ponytail: inline sleep pins the streaming worker up to the cap; hand the
+# wait to the delivery ledger if that ever matters.
+_FLOOD_EDIT_INLINE_WAIT_CAP_SECS = 45.0
 
 
 def _flood_cap_result(wait: float) -> "SendResult":
@@ -5993,6 +6002,10 @@ class TelegramAdapter(BasePlatformAdapter):
             # Flood control / RetryAfter — short waits are retried inline,
             # long waits return a failure immediately so streaming can fall back
             # to a normal final send instead of leaving a truncated partial.
+            # Edits use their own ceiling (#102402): routine 18–35s stream
+            # penalties sleep inline and retry the same message_id; only
+            # pathological waits fail closed. The send path keeps the 5s
+            # boot-safe cap (#91969).
             retry_after = getattr(e, "retry_after", None)
             if retry_after is not None or "retry after" in err_str:
                 wait = retry_after if retry_after else 1.0
@@ -6000,7 +6013,7 @@ class TelegramAdapter(BasePlatformAdapter):
                     "[%s] Telegram flood control, waiting %.1fs",
                     self.name, wait,
                 )
-                if wait > _FLOOD_INLINE_WAIT_CAP_SECS:
+                if wait > _FLOOD_EDIT_INLINE_WAIT_CAP_SECS:
                     return _flood_cap_result(wait)
                 await asyncio.sleep(wait)
                 try:

--- a/tests/gateway/test_telegram_final_delivery.py
+++ b/tests/gateway/test_telegram_final_delivery.py
@@ -150,20 +150,44 @@ async def test_complete_preview_survives_long_flood_fallback_failure(monkeypatch
 
 
 @pytest.mark.asyncio
-async def test_telegram_long_flood_result_keeps_retry_after():
-    """The real adapter contract preserves the server delay for consumers."""
+async def test_telegram_long_flood_result_keeps_retry_after(monkeypatch):
+    """An over-ceiling edit penalty still fails closed for consumers."""
     class FloodError(Exception):
-        retry_after = 30.0
+        retry_after = 120.0
 
     adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
     adapter._bot = MagicMock()
-    adapter._bot.edit_message_text = AsyncMock(side_effect=FloodError("Retry after 30"))
+    adapter._bot.edit_message_text = AsyncMock(side_effect=FloodError("Retry after 120"))
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
 
     result = await adapter.edit_message("123", "456", "Final answer", finalize=False)
 
     assert result.success is False
-    assert result.error == "flood_control:30.0"
-    assert result.retry_after == 30.0
+    assert result.error == "flood_control:120.0"
+    assert result.retry_after == 120.0
+    sleep.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_telegram_stream_flood_sleeps_inline_and_retries_same_message(monkeypatch):
+    """A routine 18–35s stream penalty must not drop the edit (#102402)."""
+    class FloodError(Exception):
+        retry_after = 33.0
+
+    adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._bot = MagicMock()
+    ok = MagicMock()
+    adapter._bot.edit_message_text = AsyncMock(side_effect=[FloodError("Retry after 33"), ok])
+    sleep = AsyncMock()
+    monkeypatch.setattr("plugins.platforms.telegram.adapter.asyncio.sleep", sleep)
+
+    result = await adapter.edit_message("123", "456", "Final answer", finalize=False)
+
+    assert result.success is True
+    assert result.message_id == "456"
+    sleep.assert_awaited_once_with(33.0)
+    assert adapter._bot.edit_message_text.await_count == 2
 
 
 


### PR DESCRIPTION
## What Problem This Solves
Fixes #102402 — Telegram edit streaming freezes mid-text: 5s flood wait cap drops 18–35s RetryAfter edits. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102402).

Closes #102402