### PR TITLE
fix: [Bug] Desktop sidebar renders group headers but ZERO sessions after auto-update — survives restart AND new messages; only clearing renderer Local/Session Storage fixes it (macOS) (#97762)

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -153,7 +153,6 @@ import { ProfileRail } from './profile-switcher'
 import { ProjectDialog } from './project-dialog'
 import {
   excludeProjectSessions,
-  liveSessionProjectId,
   orderProjectsByIds,
   overlayLiveLanes,
   overlayLivePreviews,
@@ -162,6 +161,8 @@ import {
   ProjectMenu,
   projectTreeCwd,
   reconcileEnteredProjectSessions,
+  sanitizeProjectFilter,
+  sessionMatchesProjectFilter,
   sessionRecency as sessionTime,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -498,6 +499,14 @@ export function ChatSidebar({
   // project lanes narrow by the same rule. A project lane holds rows the loaded
   // page may not, so it has to be answerable per session rather than by
   // membership in the filtered set.
+  // The project filter is sanitized against the live tree: persisted ids go
+  // stale across updates/deletes and must be inert, never a blank sidebar
+  // (#97762). Detached rows file under the Home bucket id (same rule as the
+  // overview overlay), so filtering to Home keeps Home's rows.
+  const effectiveProjectFilter = useMemo(
+    () => sanitizeProjectFilter(projectFilter, projectTree),
+    [projectFilter, projectTree]
+  )
   const sessionMatchesFilters = useCallback(
     (session: SessionInfo) => {
       if (statusFilter.length && !statusFilter.includes(sessionStatusBucket(dotStates[session.id]))) {
@@ -520,14 +529,14 @@ export function ChatSidebar({
 
       // Same membership the sidebar groups and colors by, so a filtered row
       // lands in the lane the user picked it from.
-      return !projectFilter.length || projectFilter.includes(liveSessionProjectId(session, projects) ?? '')
+      return sessionMatchesProjectFilter(session, effectiveProjectFilter, projects)
     },
-    [statusFilter, projectFilter, profileFilter, showAllProfiles, prFilter, pullRequests, projects, dotStates]
+    [statusFilter, effectiveProjectFilter, profileFilter, showAllProfiles, prFilter, pullRequests, projects, dotStates]
   )
 
   const filtersNarrow =
     statusFilter.length > 0 ||
-    projectFilter.length > 0 ||
+    effectiveProjectFilter.length > 0 ||
     prFilter.length > 0 ||
     (showAllProfiles && profileFilter.length > 0)
 
@@ -906,7 +915,7 @@ export function ChatSidebar({
       filterVisibleProjects(projectTree, dismissedAutoProjects)
         // A filtered-out project drops its whole lane, header included — hiding
         // only its rows would leave a row of empty folders behind.
-        .filter(project => !projectFilter.length || projectFilter.includes(project.id))
+        .filter(project => !effectiveProjectFilter.length || effectiveProjectFilter.includes(project.id))
         .map(project =>
           excludeProjectSessions(
             {
@@ -931,7 +940,7 @@ export function ChatSidebar({
     dismissedAutoProjects,
     orderRepos,
     activeProjectId,
-    projectFilter,
+    effectiveProjectFilter,
     projectOrderIds,
     isHiddenFromProjects,
     s

--- a/apps/desktop/src/app/chat/sidebar/projects/index.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/index.ts
@@ -16,6 +16,8 @@ export {
   overlayLiveLanes,
   overlayLivePreviews,
   reconcileEnteredProjectSessions,
+  sanitizeProjectFilter,
+  sessionMatchesProjectFilter,
   sessionRecency,
   type SidebarProjectTree,
   type SidebarSessionGroup,

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.test.ts
@@ -14,6 +14,8 @@ import {
   overlayLiveLanes,
   overlayLivePreviews,
   reconcileEnteredProjectSessions,
+  sanitizeProjectFilter,
+  sessionMatchesProjectFilter,
   sessionProjectColor,
   type SidebarProjectTree,
   type SidebarSessionGroup,
@@ -1229,5 +1231,24 @@ describe('excludeProjectSessions', () => {
     const overlaid = overlayLiveLanes(filtered, [], new Set(['someone-else']))
 
     expect(overlaid.repos[0].groups.map(g => g.id)).toEqual(['wt'])
+  })
+})
+
+describe('project filter fail-open (#97762)', () => {
+  const tree = [{ id: 'p_app' }, { id: NO_PROJECT_ID }]
+  const projects = [makeProject('p_app', ['/www/app'])]
+  const appRow = makeCwdSession('/www/app/src', { git_repo_root: '/www/app' })
+  const homeRow = makeCwdSession(null)
+  it('stale persisted ids are inert instead of blanking the sidebar', () => {
+    expect(sanitizeProjectFilter(['p_dead'], tree)).toEqual([])
+    expect(sessionMatchesProjectFilter(appRow, sanitizeProjectFilter(['p_dead'], tree), projects)).toBe(true)
+  })
+  it('filtering to Home keeps the detached Home rows', () => {
+    expect(sessionMatchesProjectFilter(homeRow, [NO_PROJECT_ID], projects)).toBe(true)
+    expect(sessionMatchesProjectFilter(appRow, [NO_PROJECT_ID], projects)).toBe(false)
+  })
+  it('a live id still narrows', () => {
+    expect(sessionMatchesProjectFilter(appRow, ['p_app'], projects)).toBe(true)
+    expect(sessionMatchesProjectFilter(homeRow, ['p_app'], projects)).toBe(false)
   })
 })

--- a/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
+++ b/apps/desktop/src/app/chat/sidebar/projects/workspace-groups.ts
@@ -429,6 +429,48 @@ export function liveSessionProjectId(session: SessionInfo, explicitProjects: Pro
 }
 
 /**
+ * Fail-open project filter (#97762, #96246): the persisted filter names tree
+ * node ids, which go stale when a project is deleted/recreated or an update
+ * rebuilds the tree — and each stale id then blanks the flat list AND the
+ * overview (headers, zero rows) until Local Storage is wiped. Ids the live
+ * tree no longer names are inert. Memo-only, never written back: the tree
+ * loads async, so persisting the boot-time (empty-tree) result would destroy
+ * a valid filter.
+ */
+export function sanitizeProjectFilter(
+  filter: readonly string[],
+  tree: readonly Pick<SidebarProjectTree, 'id'>[]
+): string[] {
+  if (!filter.length) {
+    return []
+  }
+
+  const known = new Set(tree.map(project => project.id))
+
+  return filter.filter(id => known.has(id))
+}
+
+/**
+ * The ONE row-level project-filter rule the flat list and the project lanes
+ * narrow by. Detached (cwd-less) rows belong to the Home bucket
+ * (`NO_PROJECT_ID`, like the overview preview overlay) — filing them under
+ * `''` meant filtering to Home hid Home's own rows.
+ */
+export function sessionMatchesProjectFilter(
+  session: SessionInfo,
+  filter: readonly string[],
+  explicitProjects: ProjectInfo[]
+): boolean {
+  if (!filter.length) {
+    return true
+  }
+
+  const id = liveSessionProjectId(session, explicitProjects) ?? (isDetachedSession(session) ? NO_PROJECT_ID : null)
+
+  return id !== null && filter.includes(id)
+}
+
+/**
  * The color a session inherits from its owning project — the explicit project
  * whose folder is the longest prefix of the session's cwd/repo-root, when that
  * project carries a user-set color. Auto-promoted repo projects have no color


### PR DESCRIPTION
## What Problem This Solves
Fixes #97762 — [Bug] Desktop sidebar renders group headers but ZERO sessions after auto-update — survives restart AND new messages; only clearing renderer Local/Session Storage fixes it (macOS). Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 97762).

Closes #97762