### PR TITLE
fix(tests): codex-migration test must read config.toml as UTF-8, not the locale codec

### DIFF
--- a/tests/hermes_cli/test_codex_runtime_plugin_migration.py
+++ b/tests/hermes_cli/test_codex_runtime_plugin_migration.py
@@ -179,7 +179,7 @@ class TestMigrate:
         monkeypatch.setattr(crpm, "_query_codex_plugins", fake_query)
 
         report = migrate({}, codex_home=tmp_path, discover_plugins=True)
-        text = (tmp_path / "config.toml").read_text()
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
         assert '[plugins."github@openai-curated"]' in text
         assert '[plugins."google-calendar@openai-curated"]' in text
         assert "enabled = true" in text
@@ -224,7 +224,7 @@ class TestMigrate:
         }
         report = migrate(hermes_cfg, codex_home=tmp_path, expose_hermes_tools=False)
         assert report.written
-        text = (tmp_path / "config.toml").read_text()
+        text = (tmp_path / "config.toml").read_text(encoding="utf-8")
         assert "[mcp_servers.filesystem]" in text
         assert "[mcp_servers.github]" in text
         assert 'command = "npx"' in text
@@ -242,25 +242,27 @@ class TestMigrate:
         target.write_text(
             "[mcp_servers.user-above]\n"
             'command = "/usr/bin/above-server"\n'
-            'args = ["--above"]\n'
+            'args = ["--above"]\n',
+            encoding="utf-8",
         )
         # First migrate — adds managed block below user content
         migrate({"mcp_servers": {"hermes-mcp": {"command": "npx"}}},
                 codex_home=tmp_path, discover_plugins=False,
                 expose_hermes_tools=False)
-        text = target.read_text()
+        text = target.read_text(encoding="utf-8")
         assert "user-above" in text, "user MCP server above managed block got nuked"
         assert 'command = "/usr/bin/above-server"' in text
 
         # Append another user entry below the managed block
         target.write_text(
-            text + "\n[mcp_servers.user-below]\ncommand = \"below-server\"\n"
+            text + "\n[mcp_servers.user-below]\ncommand = \"below-server\"\n",
+            encoding="utf-8",
         )
         # Re-migrate — both should survive
         migrate({"mcp_servers": {"hermes-mcp": {"command": "npx"}}},
                 codex_home=tmp_path, discover_plugins=False,
                 expose_hermes_tools=False)
-        final = target.read_text()
+        final = target.read_text(encoding="utf-8")
         assert "user-above" in final
         assert "user-below" in final
         # And our managed block is still there with the new content
@@ -351,7 +353,8 @@ class TestStripUnmanagedPluginTables:
             'command = "x"\n'
             "\n"
             '[plugins."tasks@openai-curated"]\n'
-            "enabled = true\n"
+            "enabled = true\n",
+            encoding="utf-8",
         )
 
         # Simulate codex's plugin/list reporting the same plugin tasks@openai-curated.
@@ -366,7 +369,7 @@ class TestStripUnmanagedPluginTables:
             fake_query,
         )
         migrate({}, codex_home=tmp_path, discover_plugins=True, expose_hermes_tools=False)
-        new_text = target.read_text()
+        new_text = target.read_text(encoding="utf-8")
         # Only ONE [plugins."tasks@openai-curated"] header should remain — inside
         # the managed block — not the original outside-the-block copy.
         assert new_text.count('[plugins."tasks@openai-curated"]') == 1


### PR DESCRIPTION
## Summary

	est_migrate_dedups_codex_owned_plugin_tables fails on any host whose locale codec is not UTF-8 (Windows defaults to cp1252):

```
ValueError: substring not found
    managed_start = new_text.index(MIGRATION_MARKER)
```

## Root cause: the test's reader, not the writer

`migrate()` writes `~/.codex/config.toml` with an explicit `encoding="utf-8"` (`codex_runtime_plugin_migration.py:743`) and reads it back the same way (`:711`). The **test** asserted against `Path.read_text()` with **no encoding**, so it decoded a UTF-8 file with cp1252 - the em dash inside `MIGRATION_MARKER` came back as mojibake and the marker lookup failed.

Verified the production writer is correct:

```
locale preferred encoding: cp1252
file bytes contain UTF-8 em dash E2 80 94: True
marker found with default read_text():            False
marker found with read_text(encoding='utf-8'):    True
```

So the bytes on disk are well-formed; only the test's reader was wrong. Notably this means the em dash in the marker constant is **not** the bug - an earlier instinct to strip it would have masked a test defect by editing production output.

## Fix

Pass `encoding="utf-8"` on the five `read_text()` calls and the three `write_text()` calls in this test file, matching the production contract.

The `write_text()` calls need it too: once the reader is strict UTF-8, a cp1252-encoded fixture write makes the round-trip fail with `UnicodeDecodeError` instead (hit exactly this in `test_preserves_user_mcp_server_outside_managed_block` while iterating).

**No production code touched.**

## Verification

Native Windows, cp1252 locale, Python 3.12:

```
tests/hermes_cli/test_codex_runtime_plugin_migration.py
before: 1 failed, 19 passed
after:  20 passed
```

One commit on current `main`; test-only, 11 insertions / 8 deletions.