### PR TITLE
fix(desktop): restore profile recolor in Manage Profiles

### DIFF
--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -18,6 +18,12 @@ import { ProfilesView } from './index'
 
 afterEach(cleanup)
 
+globalThis.ResizeObserver ??= class ResizeObserver {
+  disconnect() {}
+  observe() {}
+  unobserve() {}
+}
+
 // Real i18n (useI18n falls back to English with no provider), so labels are the
 // actual strings — no brittle key snapshot to maintain here.
 

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { deleteProfile } from '@/hermes'
 import { retireLocalProfileGateways } from '@/store/gateway'
-import { refreshProfiles, selectProfile, setActiveProfile } from '@/store/profile'
+import { refreshProfiles, selectProfile, setActiveProfile, setProfileColor } from '@/store/profile'
 import type { ProfileInfo } from '@/types/hermes'
 
 import { ProfilesView } from './index'
@@ -61,7 +61,8 @@ vi.mock('@/store/profile', () => ({
     (profile.display_name ?? '').trim() || profile.name,
   refreshProfiles: vi.fn(async () => [] as ProfileInfo[]),
   selectProfile: vi.fn(),
-  setActiveProfile: vi.fn()
+  setActiveProfile: vi.fn(),
+  setProfileColor: vi.fn()
 }))
 
 // The one non-default profile these tests act on. Its name doubles as the row's
@@ -130,6 +131,21 @@ describe('ProfilesView', () => {
 
     expect(soul.tagName).toBe('TEXTAREA')
     expect(soul.getAttribute('id')).toBe('new-profile-soul')
+  })
+
+  it('offers the existing color picker for named profiles and can reset to auto color', async () => {
+    vi.mocked(setProfileColor).mockClear()
+    vi.mocked(refreshProfiles).mockResolvedValue([makeProfile('default', true), makeProfile(NAMED_PROFILE)])
+
+    await renderProfilesView()
+
+    realClick(await findRowMenu(NAMED_PROFILE))
+    fireEvent.click(await screen.findByRole('menuitem', { name: 'Color…' }))
+
+    const reset = await screen.findByRole('button', { name: 'Auto' })
+    fireEvent.click(reset)
+
+    expect(setProfileColor).toHaveBeenCalledWith(NAMED_PROFILE, null)
   })
 
   it('re-homes to default when the active profile is deleted', async () => {

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -5,15 +5,23 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
+import { ColorSwatches } from '@/components/ui/color-swatches'
+import { Popover, PopoverAnchor, PopoverContent } from '@/components/ui/popover'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
 import { getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { displayPath } from '@/lib/display-path'
 import { AlertTriangle, Save } from '@/lib/icons'
-import { resolveProfileColor } from '@/lib/profile-color'
+import { PROFILE_SWATCHES, resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
 import { notify, notifyError } from '@/store/notifications'
-import { $profileColors, profileLabel, refreshProfiles } from '@/store/profile'
+import {
+  $profileColors,
+  normalizeProfileKey,
+  profileLabel,
+  refreshProfiles,
+  setProfileColor
+} from '@/store/profile'
 
 import { useRefreshHotkey } from '../hooks/use-refresh-hotkey'
 import {
@@ -201,25 +209,60 @@ function ProfileRow({
   onSelect: () => void
   profile: ProfileInfo
 }) {
+  const { t } = useI18n()
+  const p = t.profiles
   const colors = useStore($profileColors)
+  const [pickerOpen, setPickerOpen] = useState(false)
+  const color = colors[normalizeProfileKey(profile.name)] ?? null
+  const rowMenuItems = profile.is_default
+    ? menuItems
+    : [
+        menuItems[0],
+        { icon: 'symbol-color', label: p.color, onSelect: () => setPickerOpen(true) },
+        ...menuItems.slice(1)
+      ]
+
+  const pickColor = (next: null | string) => {
+    setProfileColor(profile.name, next)
+    setPickerOpen(false)
+  }
 
   return (
-    <PanelListRow
-      active={active}
-      lead={
-        <ProfileGlyph
-          aria-hidden="true"
-          color={resolveProfileColor(profile.name, colors)}
-          isDefault={profile.is_default}
-          name={profile.name}
-        />
-      }
-      menuItems={menuItems}
-      menuLabel={profileLabel(profile)}
-      onSelect={onSelect}
-      rowKey={profile.name}
-      title={profileLabel(profile)}
-    />
+    <Popover onOpenChange={setPickerOpen} open={pickerOpen}>
+      <PopoverAnchor asChild>
+        <div>
+          <PanelListRow
+            active={active}
+            lead={
+              <ProfileGlyph
+                aria-hidden="true"
+                color={resolveProfileColor(profile.name, colors)}
+                isDefault={profile.is_default}
+                name={profile.name}
+              />
+            }
+            menuItems={rowMenuItems}
+            menuLabel={profileLabel(profile)}
+            onSelect={onSelect}
+            rowKey={profile.name}
+            title={profileLabel(profile)}
+          />
+        </div>
+      </PopoverAnchor>
+
+      {!profile.is_default ? (
+        <PopoverContent aria-label={p.colorFor} className="w-auto p-2" side="right">
+          <ColorSwatches
+            clearIcon="sync"
+            clearLabel={p.autoColor}
+            onChange={pickColor}
+            swatches={PROFILE_SWATCHES}
+            swatchLabel={p.setColor}
+            value={color}
+          />
+        </PopoverContent>
+      ) : null}
+    </Popover>
   )
 }
 


### PR DESCRIPTION
## What does this PR do?

Restores the profile color control after the sidebar rail condenses past 13 profiles.

`ProfileRail` already removes the colored square controls in condensed mode, while Manage Profiles only exposed Rename/Delete. That made named-profile color overrides impossible to change or reset once the rail crossed the threshold.

This keeps the fix deliberately narrow:
- adds **Color…** to non-default rows in Manage Profiles;
- reuses the existing `ColorSwatches`, `PROFILE_SWATCHES`, `setProfileColor`, and auto-color reset behavior used by the rail;
- keeps the existing row menu as the source for both kebab and right-click actions;
- does not add a second color surface to the condensed dropdown.

## Tests

Adds a regression case to `apps/desktop/src/app/profiles/index.test.tsx` that opens the named-profile row menu, opens the existing color picker, resets to Auto, and verifies `setProfileColor(profile, null)`.

I could not execute the Desktop test suite locally from this automation environment, so hosted PR checks are the execution gate; the change is limited to the existing Profiles UI and its focused test file.

Fixes #102460