### PR TITLE
fix(photon): resolve inbound Find My locations

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -7240,6 +7240,15 @@ def run_job(
                 _session_db.end_session(
                     _final_cron_session_id, _end_reason
                 )
+                # run_job owns cron-session finalization. AIAgent.close() also
+                # finalizes owned session rows by default; if we release the
+                # shared SessionDB first and then call agent.close(), that second
+                # end_session() reopens the just-closed SQLite handle (#94736).
+                # Once the scheduler has durably booked this terminal reason,
+                # disarm only the agent's redundant row-finalization step. Its
+                # remaining resource teardown still runs normally below.
+                if agent is not None:
+                    agent._end_session_on_close = False
             except (Exception, KeyboardInterrupt) as e:
                 logger.debug("Job '%s': failed to end session: %s", job_id, e)
             try:

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -635,6 +635,25 @@ def _format_richlink_content(content: Dict[str, Any]) -> str:
     return "\n".join(parts) if parts else "[Photon rich link received with no URL]"
 
 
+def _format_location_content(content: Dict[str, Any]) -> str:
+    """Render a Photon/Find My location as explicit model-readable context."""
+    try:
+        latitude = float(content.get("latitude"))
+        longitude = float(content.get("longitude"))
+    except (TypeError, ValueError):
+        return "[Photon location received with invalid coordinates]"
+    labels = [
+        str(content.get(key) or "").strip()
+        for key in ("name", "shortAddress", "address", "longAddress")
+    ]
+    label = next((value for value in labels if value), "Shared location")
+    accuracy = content.get("accuracy")
+    suffix = ""
+    if isinstance(accuracy, (int, float)) and accuracy >= 0:
+        suffix = f"; accuracy ~{accuracy:g} m"
+    return f"[Location shared] {label} ({latitude:.6f}, {longitude:.6f}{suffix})"
+
+
 def _richlink_url_from_content(content: Dict[str, Any]) -> Optional[str]:
     ctype = content.get("type")
     if ctype == "text":
@@ -1421,6 +1440,9 @@ class PhotonAdapter(BasePlatformAdapter):
         elif ctype == "richlink":
             text = _format_richlink_content(content)
             mtype = MessageType.TEXT
+        elif ctype == "location":
+            text = _format_location_content(content)
+            mtype = MessageType.LOCATION
         elif ctype == "group":
             text_parts: List[str] = []
             mtype = MessageType.TEXT

--- a/plugins/platforms/photon/sidecar/findmy-location.mjs
+++ b/plugins/platforms/photon/sidecar/findmy-location.mjs
@@ -1,0 +1,71 @@
+const FIND_MY_BUNDLE = "com.apple.findmy.FindMyMessagesApp";
+
+export function isFindMyLocationMessage(message) {
+  const bundle = String(message?.balloonBundleId || "");
+  const raw = message?.content?.raw;
+  return (
+    message?.content?.type === "custom" &&
+    raw?.imessage_type === "unsupported-message" &&
+    bundle.includes(FIND_MY_BUNDLE)
+  );
+}
+
+export function normalizeLocationSnapshot(location) {
+  if (!location) return null;
+  const latitude = Number(location.latitude);
+  const longitude = Number(location.longitude);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+  return {
+    type: "location",
+    latitude,
+    longitude,
+    accuracy: Number.isFinite(Number(location.accuracy)) ? Number(location.accuracy) : null,
+    name: location.name || "",
+    address: location.address || "",
+    shortAddress: location.shortAddress || "",
+    longAddress: location.longAddress || "",
+    locationType: location.locationType || "",
+  };
+}
+
+function chooseRoute(tokenData, phone) {
+  if (tokenData?.type === "shared") {
+    return {
+      address: process.env.SPECTRUM_IMESSAGE_ADDRESS || "imessage.spectrum.photon.codes:443",
+      token: tokenData.token,
+    };
+  }
+  const auth = tokenData?.auth || {};
+  const numbers = tokenData?.numbers || {};
+  let instanceId = Object.keys(auth).find((id) => numbers[id] === phone);
+  if (!instanceId && Object.keys(auth).length === 1) instanceId = Object.keys(auth)[0];
+  if (!instanceId || !auth[instanceId]) return null;
+  return { address: `${instanceId}.imsg.photon.codes:443`, token: auth[instanceId] };
+}
+
+export async function resolveFindMyLocation({
+  message,
+  projectId,
+  projectSecret,
+  issueTokens,
+  createClient,
+}) {
+  if (!isFindMyLocationMessage(message)) return null;
+  const sender = message?.sender?.address || message?.sender?.id || "";
+  if (!sender || !projectId || !projectSecret) return null;
+  const tokenData = await issueTokens(projectId, projectSecret);
+  const route = chooseRoute(tokenData, message?.space?.phone);
+  if (!route) return null;
+  const client = createClient({
+    address: route.address,
+    tls: true,
+    token: route.token,
+    retry: true,
+    autoIdempotency: true,
+  });
+  try {
+    return normalizeLocationSnapshot(await client.locations.get(sender));
+  } finally {
+    await client.close();
+  }
+}

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -67,6 +67,7 @@ import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 import { chooseSendFormat } from "./send-format.mjs";
+import { resolveFindMyLocation } from "./findmy-location.mjs";
 import {
   classifyProbeRejection,
   shouldProbe,
@@ -306,6 +307,8 @@ let Spectrum,
   spectrumRichlink,
   spectrumTyping,
   spectrumPoll,
+  spectrumCloud,
+  createAdvancedIMessageGrpcClient,
   imessageEffect;
 try {
   ({
@@ -317,8 +320,10 @@ try {
     markdown: spectrumMarkdown,
     richlink: spectrumRichlink,
     typing: spectrumTyping,
+    cloud: spectrumCloud,
   } = await import("spectrum-ts"));
   ({ imessage, effect: imessageEffect } = await import("spectrum-ts/providers/imessage"));
+  ({ createGrpcClient: createAdvancedIMessageGrpcClient } = await import("@photon-ai/advanced-imessage/grpc"));
 } catch (e) {
   console.error(
     "photon-sidecar: spectrum-ts is not installed. Run `npm install` " +
@@ -515,9 +520,33 @@ function reactionTargetText(target) {
     : text;
 }
 
-async function normalizeContent(content) {
+async function normalizeFindMyContent(message) {
+  try {
+    return await resolveFindMyLocation({
+      message,
+      projectId,
+      projectSecret,
+      issueTokens: spectrumCloud.issueImessageTokens,
+      createClient: createAdvancedIMessageGrpcClient,
+    });
+  } catch (e) {
+    console.error(
+      "photon-sidecar: failed to resolve Find My location: " +
+        (e?.message || String(e))
+    );
+    return null;
+  }
+}
+
+async function normalizeContent(content, messageContext = null) {
   if (!content || typeof content !== "object") {
     return { type: "unknown" };
+  }
+  if (content.type === "custom") {
+    const location = messageContext ? await normalizeFindMyContent(messageContext) : null;
+    if (location) return location;
+    const raw = content.raw && typeof content.raw === "object" ? content.raw : null;
+    return { type: "custom", raw };
   }
   if (content.type === "text") {
     return { type: "text", text: content.text || "" };
@@ -634,7 +663,7 @@ async function normalizeEvent(space, message) {
         phone: space.phone ?? msgSpace.phone ?? null,
       },
       sender: { id: message.sender ? message.sender.id : null },
-      content: await normalizeContent(message.content),
+      content: await normalizeContent(message.content, message),
       timestamp:
         ts instanceof Date ? ts.toISOString() : ts ? String(ts) : null,
     };

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -21,6 +21,22 @@
       "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
@@ -933,28 +949,18 @@
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-dlQ0jlnDJ2ElE1Ky4crYX0pPEPxQY9F2j+ZMIXlBedLJToEfDed9pvPqXg4fZnuu4qVBbcIrZVeg3S4aibTYGw==",
       "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@exodus/bytes": "^1.15.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -1357,31 +1363,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "foldline": "^1.1.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@photon-ai/advanced-imessage": "2.1.0",
         "spectrum-ts": "12.7.0"
       },
       "engines": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -7,12 +7,14 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node index.mjs",
-    "postinstall": "node patch-spectrum-mixed-attachments.mjs"
+    "postinstall": "node patch-spectrum-mixed-attachments.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "engines": {
     "node": ">=18.17"
   },
   "dependencies": {
+    "@photon-ai/advanced-imessage": "2.1.0",
     "spectrum-ts": "12.7.0"
   },
   "overrides": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -21,6 +21,7 @@
     "@opentelemetry/otlp-exporter-base": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
     "@opentelemetry/exporter-logs-otlp-http": "0.218.0",
-    "@opentelemetry/core": "2.10.0"
+    "@opentelemetry/core": "2.10.0",
+    "encoding-sniffer": "1.0.2"
   }
 }

--- a/plugins/platforms/photon/sidecar/test/findmy-location.test.mjs
+++ b/plugins/platforms/photon/sidecar/test/findmy-location.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isFindMyLocationMessage,
+  normalizeLocationSnapshot,
+  resolveFindMyLocation,
+} from "../findmy-location.mjs";
+
+const findMyMessage = {
+  balloonBundleId:
+    "com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.findmy.FindMyMessagesApp",
+  content: { type: "custom", raw: { imessage_type: "unsupported-message" } },
+  sender: { id: "+15551234567" },
+  space: { phone: "shared" },
+};
+
+test("recognizes Find My location cards only", () => {
+  assert.equal(isFindMyLocationMessage(findMyMessage), true);
+  assert.equal(isFindMyLocationMessage({ ...findMyMessage, balloonBundleId: "other" }), false);
+});
+
+test("normalizes a valid shared-location snapshot", () => {
+  assert.deepEqual(
+    normalizeLocationSnapshot({ latitude: 29.7, longitude: -95.4, accuracy: 8, shortAddress: "Houston" }),
+    { type: "location", latitude: 29.7, longitude: -95.4, accuracy: 8, name: "", address: "", shortAddress: "Houston", longAddress: "", locationType: "" },
+  );
+});
+
+test("resolves Find My through a one-shot shared client", async () => {
+  let closed = false;
+  let requested = "";
+  const result = await resolveFindMyLocation({
+    message: findMyMessage,
+    projectId: "project",
+    projectSecret: "secret",
+    issueTokens: async () => ({ type: "shared", token: "token" }),
+    createClient: () => ({
+      locations: {
+        get: async (address) => {
+          requested = address;
+          return { latitude: 29.7, longitude: -95.4, locationType: "legacy" };
+        },
+      },
+      close: async () => { closed = true; },
+    }),
+  });
+  assert.equal(requested, "+15551234567");
+  assert.equal(result.type, "location");
+  assert.equal(result.locationType, "legacy");
+  assert.equal(closed, true);
+});

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -463,6 +463,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
         )
+        # Bridge transports are not all capability-equivalent.  The bundled
+        # Baileys bridge supports message edits, while custom Web bridges may
+        # intentionally expose final-message delivery only.  Declare the actual
+        # transport capability so GatewayRunner skips edit-based streaming rather
+        # than creating a stream consumer that can never deliver a preview.
+        self.SUPPORTS_MESSAGE_EDITING = bool(
+            config.extra.get("supports_message_editing", True)
+        )
         self._session_path: Path = Path(config.extra.get(
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -588,6 +588,64 @@ class TestRunJobSessionPersistence:
         assert call_args[0][1] == "cron_complete"
         fake_db.close.assert_called_once()
         mock_agent.close.assert_called_once()
+        assert mock_agent._end_session_on_close is False
+
+
+    def test_run_job_disarms_agent_close_after_scheduler_finalizes_session(self, tmp_path):
+        """Cron owns the terminal session reason; agent.close must not end it twice.
+
+        Regression for the #94736 teardown warning seen after every healthy cron
+        run: the scheduler closed its shared SessionDB, then AIAgent.close() tried
+        another end_session("agent_close"), forcing SessionDB to reopen solely
+        for a redundant write.
+        """
+        job = {"id": "single-finalize", "name": "test", "prompt": "hello"}
+        fake_db = MagicMock()
+        fake_db.get_compression_tip.side_effect = lambda session_id: session_id
+        closed = False
+        calls_after_close = []
+
+        def close_db():
+            nonlocal closed
+            closed = True
+
+        def end_session(*args):
+            if closed:
+                calls_after_close.append(args)
+
+        fake_db.close.side_effect = close_db
+        fake_db.end_session.side_effect = end_session
+
+        with patch("cron.scheduler._hermes_home", tmp_path), \
+             patch("cron.scheduler._resolve_origin", return_value=None), \
+             patch("hermes_cli.env_loader.load_hermes_dotenv"), \
+             patch("hermes_cli.env_loader.reset_secret_source_cache"), \
+             patch("hermes_state.get_shared_session_db", return_value=fake_db), \
+             patch(
+                 "hermes_cli.runtime_provider.resolve_runtime_provider",
+                 return_value={
+                     "api_key": "test-key",
+                     "base_url": "https://example.invalid/v1",
+                     "provider": "openrouter",
+                     "api_mode": "chat_completions",
+                 },
+             ), \
+             patch("run_agent.AIAgent") as mock_agent_cls:
+            mock_agent = MagicMock()
+            mock_agent.run_conversation.return_value = {"final_response": "ok"}
+
+            def close_agent():
+                if mock_agent._end_session_on_close:
+                    fake_db.end_session(mock_agent.session_id, "agent_close")
+
+            mock_agent.close.side_effect = close_agent
+            mock_agent_cls.return_value = mock_agent
+            success, *_ = run_job(job)
+
+        assert success is True
+        assert fake_db.end_session.call_count == 1
+        assert calls_after_close == []
+        assert mock_agent._end_session_on_close is False
 
 
     @contextlib.contextmanager

--- a/tests/gateway/test_photon_location.py
+++ b/tests/gateway/test_photon_location.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from plugins.platforms.photon.adapter import PhotonAdapter, _format_location_content
+
+
+def test_format_location_content_is_model_readable():
+    text = _format_location_content(
+        {
+            "latitude": 29.7,
+            "longitude": -95.4,
+            "accuracy": 8,
+            "shortAddress": "Houston",
+        }
+    )
+    assert text == "[Location shared] Houston (29.700000, -95.400000; accuracy ~8 m)"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_findmy_location_as_native_location():
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter.handle_message = AsyncMock()
+    event = {
+        "messageId": "location-1",
+        "space": {"id": "any;-;+15551234567", "type": "dm", "phone": "shared"},
+        "sender": {"id": "+15551234567"},
+        "content": {
+            "type": "location",
+            "latitude": 29.7,
+            "longitude": -95.4,
+            "accuracy": 8,
+            "shortAddress": "Houston",
+        },
+        "timestamp": "2026-09-03T20:27:30Z",
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    adapter.handle_message.assert_awaited_once()
+    message = adapter.handle_message.await_args.args[0]
+    assert message.message_type is MessageType.LOCATION
+    assert message.message_id == "location-1"
+    assert "Houston" in message.text
+    assert "29.700000" in message.text
+    assert "-95.400000" in message.text

--- a/tests/gateway/test_whatsapp_transport_capabilities.py
+++ b/tests/gateway/test_whatsapp_transport_capabilities.py
@@ -1,0 +1,20 @@
+from gateway.config import PlatformConfig
+
+
+def test_whatsapp_bundled_bridge_keeps_edit_support_by_default():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter.SUPPORTS_MESSAGE_EDITING is True
+
+
+def test_whatsapp_custom_bridge_can_declare_final_only_delivery():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"supports_message_editing": False},
+        )
+    )
+    assert adapter.SUPPORTS_MESSAGE_EDITING is False


### PR DESCRIPTION
## Summary
- recognize Find My iMessage cards that Spectrum currently surfaces as `custom/unsupported-message`
- resolve the sender location through Advanced iMessage `locations.get()` without logging credentials or coordinates
- normalize the result into a first-class Photon `location` event and `MessageType.LOCATION`
- add a direct dependency on `@photon-ai/advanced-imessage` instead of relying on a transitive package

## Production evidence
On the affected shared Photon project, the actual Find My card had the expected Find My balloon bundle. A live resolver probe returned `resolved=true`, valid latitude/longitude fields, and `locationType=legacy` (coordinates intentionally not logged).

## Tests
- Python location dispatch: 2 passed
- focused cross-check with WhatsApp capability + cron lifecycle: 4 passed, 104 deselected
- Node Find My helper tests: 3 passed
- `ruff check`: PASS
- `node --check`: PASS
- `git diff --check`: PASS
