### PR TITLE
fix(desktop): refresh busy Bot Chat on explicit open

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
@@ -71,7 +71,7 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
     })
   })
 
-  it('fronting an already-open Bot Chat refreshes its transcript in place', async () => {
+  it('fronting a busy, already-open Bot Chat refreshes its transcript in place', async () => {
     // The front is presentation-only: the pane keeps whatever transcript it
     // last painted, which can predate rows the bot wrote while the user was
     // elsewhere (a cron delivery, a teammate's message_agent, another bot's
@@ -82,11 +82,16 @@ describe('a row click lands on the canonical chat, never a remembered side tab',
       only?.includes('bot-chat-tip') ? 'bot-chat-tip' : null
     ) as never
     $selectedStoredSessionId.set('bot-chat-tip')
+    const busy = vi.spyOn(host.state.busy, 'get').mockReturnValue(true)
 
-    await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
+    try {
+      await expect(openRosterBot(canonicalBot)).resolves.toBe(true)
 
-    expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
-    $selectedStoredSessionId.set(null)
+      expect(openBotCanonicalChat).toHaveBeenCalledWith(canonicalBot, expect.any(Function))
+    } finally {
+      busy.mockRestore()
+      $selectedStoredSessionId.set(null)
+    }
   })
 
   it('resolves the registry when only a side thread is open', async () => {
@@ -142,5 +147,21 @@ describe('the open Bot Chat follows its session on the gateway', () => {
 
     expect(openBotCanonicalChat).not.toHaveBeenCalled()
     $selectedStoredSessionId.set(null)
+  })
+
+  it('does not re-open a focused Bot Chat from roster activity while its turn is busy', () => {
+    $selectedBot.set('alpha')
+    $selectedStoredSessionId.set('bot-chat-tip')
+    const busy = vi.spyOn(host.state.busy, 'get').mockReturnValue(true)
+
+    try {
+      trackInboundActivity([activeBot(500)])
+      trackInboundActivity([activeBot(600)])
+
+      expect(openBotCanonicalChat).not.toHaveBeenCalled()
+    } finally {
+      busy.mockRestore()
+      $selectedStoredSessionId.set(null)
+    }
   })
 })

--- a/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-actions.ts
@@ -116,11 +116,11 @@ export function trackInboundActivity(roster: RosterRow[]) {
  *  session — a group room or another tab owning the center must not be
  *  yanked away by background activity — and never mid-turn, when the
  *  activity is the turn itself, already streaming. */
-function refreshOpenBotChat(bot: RosterRow) {
+function refreshOpenBotChat(bot: RosterRow, { allowWhileBusy = false }: { allowWhileBusy?: boolean } = {}) {
   const canonicalIds = [bot.canonical_session?.id, bot.canonical_session?.resolved_id].filter(Boolean).map(String)
   const focused = String(host.state.focusedStoredSessionId?.get?.() || '')
 
-  if (!focused || !canonicalIds.includes(focused) || host.state.busy.get()) {
+  if (!focused || !canonicalIds.includes(focused) || (!allowWhileBusy && host.state.busy.get())) {
     return
   }
 
@@ -252,7 +252,7 @@ export async function openRosterBot(bot: RosterRow): Promise<boolean> {
     // message_agent). Force a registry open so forceResume re-pulls the
     // latest transcript instead of leaving a stale snapshot until the next
     // user turn (#99393 class; #95600 only covered the not-yet-open path).
-    refreshOpenBotChat(bot)
+    refreshOpenBotChat(bot, { allowWhileBusy: true })
 
     return true
   }


### PR DESCRIPTION
## What does this PR do?

When a Bot Chat tile was already open, selecting that bot fronted the tile and then asked the canonical-chat path to refresh its transcript. That refresh reused the same helper as background roster activity, including its `busy` guard. If the direct Bot Chat still had an active turn while the user switched through a group, selecting the bot again could therefore bring forward the older cached transcript without refreshing it.

This keeps the mid-turn guard for automatic roster polling, but lets an explicit bot-row selection refresh the transcript it just brought to the front. The existing tile refresh merges persisted rows into the live state, so it does not replace the in-flight transcript.

## Related Issue

Follow-up to #101155 and #101955.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/plugins/hermes-bots/roster-actions.ts`: allow the explicit already-open Bot Chat path to refresh while busy without changing background activity behavior.
- `apps/desktop/src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts`: cover the busy explicit-open regression and preserve the background mid-turn guard.

## How to Test

1. Start a turn in a bot's direct Bot Chat.
2. Open a group that includes that bot, then select the bot again while its direct turn is still busy.
3. Confirm the direct Bot Chat refreshes instead of showing its older cached transcript, while roster polling alone still does not reopen a busy chat.

Focused verification from `apps/desktop`:

```bash
npm test -- src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts src/plugins/hermes-bots/roster-actions.test.ts
npm run typecheck
npx eslint src/plugins/hermes-bots/roster-actions.ts src/plugins/hermes-bots/bot-row-opens-canonical-chat.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, focused Vitest, ESLint, and TypeScript checks

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - platform-neutral renderer logic
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

Focused Vitest: 2 files passed, 16 tests passed.
