### PR TITLE
fix(kanban): base child worktrees on parent commits

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1838,6 +1838,7 @@ def _cmd_show(args: argparse.Namespace) -> int:
                     "summary": r.summary,
                     "error": r.error,
                     "metadata": r.metadata,
+                    "resolved_base_sha": r.resolved_base_sha,
                     "worker_pid": r.worker_pid,
                     "started_at": r.started_at,
                     "ended_at": r.ended_at,
@@ -3146,6 +3147,7 @@ def _cmd_runs(args: argparse.Namespace) -> int:
                 "outcome": r.outcome, "started_at": r.started_at,
                 "ended_at": r.ended_at, "summary": r.summary,
                 "error": r.error, "metadata": r.metadata,
+                "resolved_base_sha": r.resolved_base_sha,
                 "worker_pid": r.worker_pid, "step_key": r.step_key,
             } for r in runs
         ], indent=2, ensure_ascii=False))

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2199,7 +2199,7 @@ def _cmd_claim(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 1
-        workspace = kb.resolve_workspace(task)
+        workspace = kb.resolve_workspace(task, conn=conn)
         kb.set_workspace_path(conn, task.id, str(workspace))
     print(f"Claimed {task.id}")
     print(f"Workspace: {workspace}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -7986,7 +7986,12 @@ def _resolve_worktree_workspace(
     return requested, branch_name
 
 
-def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
+def resolve_workspace(
+    task: Task,
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
+) -> Path:
     """Resolve (and create if needed) the workspace for a task.
 
     - ``scratch``: a fresh dir under ``<board-root>/workspaces/<id>/``,
@@ -8043,7 +8048,9 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         p.mkdir(parents=True, exist_ok=True)
         return p
     if kind == "worktree":
-        p, _branch_name = _resolve_worktree_workspace(task, board=board)
+        p, _branch_name = _resolve_worktree_workspace(
+            task, board=board, conn=conn
+        )
         return p
     raise ValueError(f"unknown workspace_kind: {kind}")
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1265,6 +1265,7 @@ class Run:
     summary: Optional[str]
     metadata: Optional[dict]
     error: Optional[str]
+    resolved_base_sha: Optional[str] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Run":
@@ -1289,6 +1290,9 @@ class Run:
             summary=row["summary"],
             metadata=meta,
             error=row["error"],
+            resolved_base_sha=(
+                row["resolved_base_sha"] if "resolved_base_sha" in row.keys() else None
+            ),
         )
 
 
@@ -1474,7 +1478,8 @@ CREATE TABLE IF NOT EXISTS task_runs (
     --          gave_up | reclaimed | (null while still running)
     summary             TEXT,
     metadata            TEXT,
-    error               TEXT
+    error               TEXT,
+    resolved_base_sha   TEXT
 );
 
 -- Files attached to a task (PDFs, images, source documents). The blob
@@ -2688,6 +2693,12 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
             "tasks",
             "block_recurrences",
             "block_recurrences INTEGER NOT NULL DEFAULT 0",
+        )
+
+    run_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_runs)")}
+    if run_cols and "resolved_base_sha" not in run_cols:
+        _add_column_if_missing(
+            conn, "task_runs", "resolved_base_sha", "resolved_base_sha TEXT"
         )
 
     # Indexes over additive ``tasks`` columns must be created after the
@@ -7721,7 +7732,13 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
-def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
+def _ensure_git_worktree(
+    repo_root: Path,
+    target: Path,
+    branch_name: str,
+    *,
+    base_ref: str = "HEAD",
+) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
@@ -7735,7 +7752,7 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
     else:
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            str(target), base_ref,
         ]
     result = subprocess.run(
         cmd,
@@ -7751,8 +7768,133 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         )
 
 
+_FULL_GIT_SHA_RE = re.compile(r"^[0-9a-fA-F]{40}$")
+
+
+def _resolve_single_parent_base_sha(
+    conn: Optional[sqlite3.Connection], task: Task, repo_root: Path
+) -> Optional[str]:
+    """Return the completed direct parent's structured commit, if applicable."""
+    if conn is None:
+        return None
+    parents = conn.execute(
+        "SELECT p.id, p.status FROM task_links l "
+        "JOIN tasks p ON p.id = l.parent_id "
+        "WHERE l.child_id = ? ORDER BY p.id",
+        (task.id,),
+    ).fetchall()
+    if not parents:
+        return None
+    if len(parents) != 1:
+        raise ValueError(
+            f"task {task.id} has {len(parents)} parents; worktree base is ambiguous"
+        )
+    parent = parents[0]
+    if parent["status"] not in {"done", "archived"}:
+        raise ValueError(f"task {task.id} parent {parent['id']} is not completed")
+    run = conn.execute(
+        "SELECT outcome, metadata FROM task_runs "
+        "WHERE task_id = ? AND ended_at IS NOT NULL "
+        "ORDER BY ended_at DESC, id DESC LIMIT 1",
+        (parent["id"],),
+    ).fetchone()
+    if run is None or run["outcome"] != "completed":
+        raise ValueError(
+            f"task {task.id} parent {parent['id']} has no successful terminal run"
+        )
+    try:
+        metadata = json.loads(run["metadata"]) if run["metadata"] else None
+    except (TypeError, json.JSONDecodeError):
+        metadata = None
+    commit = metadata.get("commit") if isinstance(metadata, dict) else None
+    if not isinstance(commit, str) or not _FULL_GIT_SHA_RE.fullmatch(commit):
+        raise ValueError(
+            f"task {task.id} parent {parent['id']} has no full metadata.commit SHA"
+        )
+    sha = commit.lower()
+    exists = subprocess.run(
+        ["git", "-C", str(repo_root), "cat-file", "-e", f"{sha}^{{commit}}"],
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+        timeout=30,
+        check=False,
+    )
+    if exists.returncode != 0:
+        raise ValueError(
+            f"task {task.id} parent commit {sha} is unavailable in {repo_root}"
+        )
+    return sha
+
+
+def _record_resolved_base_sha(
+    conn: Optional[sqlite3.Connection], task: Task, sha: Optional[str]
+) -> None:
+    if conn is None or sha is None or task.current_run_id is None:
+        return
+    with write_txn(conn):
+        conn.execute(
+            "UPDATE task_runs SET resolved_base_sha = ? WHERE id = ? AND ended_at IS NULL",
+            (sha, int(task.current_run_id)),
+        )
+        event = conn.execute(
+            "SELECT id, payload FROM task_events "
+            "WHERE task_id = ? AND run_id = ? AND kind = 'claimed' "
+            "ORDER BY id DESC LIMIT 1",
+            (task.id, int(task.current_run_id)),
+        ).fetchone()
+        if event is not None:
+            try:
+                payload = json.loads(event["payload"]) if event["payload"] else {}
+            except (TypeError, json.JSONDecodeError):
+                payload = {}
+            payload["resolved_base_sha"] = sha
+            conn.execute(
+                "UPDATE task_events SET payload = ? WHERE id = ?",
+                (json.dumps(payload, ensure_ascii=False), int(event["id"])),
+            )
+
+
+def _ensure_task_worktree(
+    conn: Optional[sqlite3.Connection],
+    task: Task,
+    repo_root: Path,
+    target: Path,
+    branch_name: str,
+) -> None:
+    base_sha = _resolve_single_parent_base_sha(conn, task, repo_root)
+    _record_resolved_base_sha(conn, task, base_sha)
+    _ensure_git_worktree(
+        repo_root, target, branch_name, base_ref=base_sha or "HEAD"
+    )
+    if base_sha is None:
+        return
+    ancestry = subprocess.run(
+        ["git", "-C", str(target), "merge-base", "--is-ancestor", base_sha, "HEAD"],
+        capture_output=True,
+        text=True, encoding="utf-8", errors="replace",
+        timeout=30,
+        check=False,
+    )
+    if ancestry.returncode != 0:
+        dirty = subprocess.run(
+            ["git", "-C", str(target), "status", "--porcelain"],
+            capture_output=True,
+            text=True, encoding="utf-8", errors="replace",
+            timeout=30,
+            check=False,
+        ).stdout.strip()
+        state = "dirty" if dirty else "clean"
+        raise RuntimeError(
+            f"task {task.id} existing {state} worktree HEAD does not descend "
+            f"from resolved parent base {base_sha}; refusing to reset it"
+        )
+
+
 def _resolve_worktree_workspace(
-    task: Task, *, board: Optional[str] = None
+    task: Task,
+    *,
+    board: Optional[str] = None,
+    conn: Optional[sqlite3.Connection] = None,
 ) -> tuple[Path, str]:
     """Resolve + materialize a linked git worktree for ``task``.
 
@@ -7791,7 +7933,7 @@ def _resolve_worktree_workspace(
                 f"{board_slug!r} default_workdir {board_default!r} is not inside a git repo"
             )
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_task_worktree(conn, task, repo_root, target, branch_name)
         return target, branch_name
 
     requested = Path(task.workspace_path).expanduser()
@@ -7805,6 +7947,9 @@ def _resolve_worktree_workspace(
     if requested.exists() and _is_linked_worktree_checkout(requested):
         actual_branch = _git_current_branch(requested)
         if actual_branch == branch_name:
+            repo_root = _git_toplevel(requested)
+            if repo_root is not None:
+                _ensure_task_worktree(conn, task, repo_root, requested, branch_name)
             return requested_resolved, actual_branch
         # The requested path is an existing checkout of a DIFFERENT
         # task's branch. Decompose children inherit the root's
@@ -7817,17 +7962,18 @@ def _resolve_worktree_workspace(
         if fallback_root is not None:
             fallback = fallback_root / ".worktrees" / task.id
             if fallback.resolve(strict=False) != requested_resolved:
-                _ensure_git_worktree(fallback_root, fallback, branch_name)
+                _ensure_task_worktree(conn, task, fallback_root, fallback, branch_name)
                 return fallback.resolve(strict=False), branch_name
-        # No repo to anchor a fallback on (or the occupied path IS this
-        # task's own canonical worktree): keep the legacy reuse rather
-        # than failing dispatch.
+            _ensure_task_worktree(conn, task, fallback_root, requested, branch_name)
+        # No repo to anchor a fallback on: keep the legacy reuse rather than
+        # failing dispatch. When this is the task's own canonical worktree,
+        # the branch may differ but its ancestry was validated above.
         return requested_resolved, actual_branch or branch_name
 
     repo_root = _git_toplevel(requested)
     if repo_root is not None and requested_resolved == repo_root:
         target = repo_root / ".worktrees" / task.id
-        _ensure_git_worktree(repo_root, target, branch_name)
+        _ensure_task_worktree(conn, task, repo_root, target, branch_name)
         return target, branch_name
 
     repo_root = _repo_root_for_worktree_target(requested.parent)
@@ -7836,7 +7982,7 @@ def _resolve_worktree_workspace(
             f"task {task.id} worktree path {task.workspace_path!r} is not inside a git repo "
             "and does not point at a git repo root"
         )
-    _ensure_git_worktree(repo_root, requested, branch_name)
+    _ensure_task_worktree(conn, task, repo_root, requested, branch_name)
     return requested, branch_name
 
 
@@ -10244,7 +10390,7 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board, conn=conn)
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:
@@ -10371,7 +10517,7 @@ def _dispatch_once_locked(
         try:
             resolved_branch_name = None
             if claimed.workspace_kind == "worktree":
-                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board)
+                workspace, resolved_branch_name = _resolve_worktree_workspace(claimed, board=board, conn=conn)
             else:
                 workspace = resolve_workspace(claimed, board=board)
         except Exception as exc:

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -232,6 +232,7 @@ def _run_dict(r: kanban_db.Run) -> dict[str, Any]:
         "summary": r.summary,
         "metadata": r.metadata,
         "error": r.error,
+        "resolved_base_sha": r.resolved_base_sha,
     }
 
 

--- a/tests/hermes_cli/test_kanban_parent_worktree_base.py
+++ b/tests/hermes_cli/test_kanban_parent_worktree_base.py
@@ -77,6 +77,65 @@ def test_single_parent_worktree_starts_at_completed_parent_commit(tmp_path: Path
         db.close()
 
 
+def test_manual_claim_starts_worktree_at_completed_parent_commit(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from argparse import Namespace
+    from contextlib import closing
+
+    from hermes_cli import kanban
+
+    repo, stale_head = _repo(tmp_path)
+    db_path = tmp_path / "kanban.db"
+    db = kb.connect(db_path)
+
+    parent_id = kb.create_task(db, title="parent", assignee="builder")
+    parent = kb.claim_task(db, parent_id)
+    assert parent is not None
+    (repo / "parent.txt").write_text("reviewed parent work\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "parent work")
+    parent_sha = _git(repo, "rev-parse", "HEAD")
+    assert kb.complete_task(
+        db,
+        parent_id,
+        metadata={"commit": parent_sha},
+        expected_run_id=parent.current_run_id,
+    )
+
+    _git(repo, "reset", "--hard", stale_head)
+    child_id = kb.create_task(
+        db,
+        title="child",
+        assignee="builder",
+        parents=[parent_id],
+        workspace_kind="worktree",
+        workspace_path=str(repo),
+        branch_name="fix/manual-child",
+    )
+    monkeypatch.setattr(kanban.kb, "connect_closing", lambda: closing(db))
+
+    assert kanban._cmd_claim(Namespace(task_id=child_id, ttl=900)) == 0
+
+    verify = kb.connect(db_path)
+    try:
+        child = kb.get_task(verify, child_id)
+        assert child is not None
+        assert child.workspace_path is not None
+        assert _git(Path(child.workspace_path), "rev-parse", "HEAD") == parent_sha
+        run = kb.get_run(verify, child.current_run_id)
+        assert run is not None
+        assert run.resolved_base_sha == parent_sha
+        claimed = [
+            event
+            for event in kb.list_events(verify, child_id)
+            if event.kind == "claimed"
+        ][-1]
+        assert claimed.payload["resolved_base_sha"] == parent_sha
+    finally:
+        verify.close()
+
+
 @pytest.mark.parametrize("commit", [None, "abc123", "f" * 40])
 def test_single_parent_worktree_rejects_unusable_parent_commit(
     tmp_path: Path, commit: str | None

--- a/tests/hermes_cli/test_kanban_parent_worktree_base.py
+++ b/tests/hermes_cli/test_kanban_parent_worktree_base.py
@@ -1,0 +1,247 @@
+"""Regression coverage for parent-derived Kanban worktree bases."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def _git(repo: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def _repo(tmp_path: Path) -> tuple[Path, str]:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init", "-b", "main")
+    _git(repo, "config", "user.email", "kanban@example.com")
+    _git(repo, "config", "user.name", "Kanban Test")
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "base")
+    return repo, _git(repo, "rev-parse", "HEAD")
+
+
+def test_single_parent_worktree_starts_at_completed_parent_commit(tmp_path: Path) -> None:
+    repo, stale_head = _repo(tmp_path)
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(db, title="parent", assignee="builder")
+        parent = kb.claim_task(db, parent_id)
+        assert parent is not None
+
+        (repo / "parent.txt").write_text("reviewed parent work\n", encoding="utf-8")
+        _git(repo, "add", ".")
+        _git(repo, "commit", "-m", "parent work")
+        parent_sha = _git(repo, "rev-parse", "HEAD")
+        assert kb.complete_task(
+            db,
+            parent_id,
+            summary="reviewed",
+            metadata={"commit": parent_sha},
+            expected_run_id=parent.current_run_id,
+        )
+
+        _git(repo, "reset", "--hard", stale_head)
+        child_id = kb.create_task(
+            db,
+            title="child",
+            assignee="builder",
+            parents=[parent_id],
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="fix/child",
+        )
+        child = kb.claim_task(db, child_id)
+        assert child is not None
+
+        workspace, branch = kb._resolve_worktree_workspace(child, conn=db)
+
+        assert branch == "fix/child"
+        assert _git(workspace, "rev-parse", "HEAD") == parent_sha
+        run = kb.get_run(db, child.current_run_id)
+        assert run is not None
+        assert run.resolved_base_sha == parent_sha
+        claimed = [event for event in kb.list_events(db, child_id) if event.kind == "claimed"][-1]
+        assert claimed.payload["resolved_base_sha"] == parent_sha
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("commit", [None, "abc123", "f" * 40])
+def test_single_parent_worktree_rejects_unusable_parent_commit(
+    tmp_path: Path, commit: str | None
+) -> None:
+    repo, _ = _repo(tmp_path)
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(db, title="parent", assignee="builder")
+        parent = kb.claim_task(db, parent_id)
+        assert parent is not None
+        metadata = {"commit": commit} if commit is not None else {}
+        assert kb.complete_task(
+            db,
+            parent_id,
+            metadata=metadata,
+            expected_run_id=parent.current_run_id,
+        )
+        child_id = kb.create_task(
+            db,
+            title="child",
+            parents=[parent_id],
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        child = kb.claim_task(db, child_id)
+        assert child is not None
+
+        with pytest.raises(ValueError, match="metadata.commit|unavailable"):
+            kb._resolve_worktree_workspace(child, conn=db)
+    finally:
+        db.close()
+
+
+def test_dispatch_records_parent_base_diagnostic_before_spawn(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    repo, _ = _repo(tmp_path)
+    db = kb.connect(tmp_path / "kanban.db")
+    spawned = False
+
+    def spawn(*_args, **_kwargs):
+        nonlocal spawned
+        spawned = True
+        return 1
+
+    try:
+        parent_id = kb.create_task(db, title="parent", assignee="dev")
+        assert kb.complete_task(db, parent_id, metadata={"commit": "abc123"})
+        child_id = kb.create_task(
+            db,
+            title="child",
+            assignee="dev",
+            parents=[parent_id],
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        monkeypatch.setattr("hermes_cli.profiles.profile_exists", lambda _name: True)
+
+        result = kb._dispatch_once_locked(db, spawn_fn=spawn, max_spawn=1)
+
+        assert spawned is False
+        assert not result.spawned
+        failure = [
+            event
+            for event in kb.list_events(db, child_id)
+            if event.kind == "spawn_failed"
+        ][-1]
+        assert "metadata.commit" in failure.payload["error"]
+    finally:
+        db.close()
+
+
+def test_multi_parent_worktree_rejects_implicit_base(tmp_path: Path) -> None:
+    repo, _ = _repo(tmp_path)
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        parents = []
+        for title in ("left", "right"):
+            parent_id = kb.create_task(db, title=title, assignee="builder")
+            assert kb.complete_task(db, parent_id, metadata={"commit": _git(repo, "rev-parse", "HEAD")})
+            parents.append(parent_id)
+        child_id = kb.create_task(
+            db,
+            title="integration",
+            parents=parents,
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+        )
+        child = kb.claim_task(db, child_id)
+        assert child is not None
+
+        with pytest.raises(ValueError, match="2 parents.*ambiguous"):
+            kb._resolve_worktree_workspace(child, conn=db)
+    finally:
+        db.close()
+
+
+@pytest.mark.parametrize("dirty", [False, True])
+def test_existing_worktree_not_descending_from_parent_is_preserved(
+    tmp_path: Path, dirty: bool
+) -> None:
+    repo, stale_head = _repo(tmp_path)
+    existing = repo / ".worktrees" / "child"
+    _git(repo, "worktree", "add", "-b", "fix/child", str(existing), stale_head)
+
+    (repo / "parent.txt").write_text("parent\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "parent")
+    parent_sha = _git(repo, "rev-parse", "HEAD")
+    if dirty:
+        (existing / "wip.txt").write_text("keep me\n", encoding="utf-8")
+
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(db, title="parent", assignee="builder")
+        assert kb.complete_task(db, parent_id, metadata={"commit": parent_sha})
+        child_id = kb.create_task(
+            db,
+            title="child",
+            parents=[parent_id],
+            workspace_kind="worktree",
+            workspace_path=str(existing),
+            branch_name="fix/child",
+        )
+        child = kb.claim_task(db, child_id)
+        assert child is not None
+
+        with pytest.raises(RuntimeError, match=f"existing {'dirty' if dirty else 'clean'} worktree"):
+            kb._resolve_worktree_workspace(child, conn=db)
+
+        assert _git(existing, "rev-parse", "HEAD") == stale_head
+        if dirty:
+            assert (existing / "wip.txt").read_text(encoding="utf-8") == "keep me\n"
+    finally:
+        db.close()
+
+
+def test_canonical_child_worktree_on_wrong_branch_still_checks_parent_base(
+    tmp_path: Path,
+) -> None:
+    repo, stale_head = _repo(tmp_path)
+    (repo / "parent.txt").write_text("parent\n", encoding="utf-8")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-m", "parent")
+    parent_sha = _git(repo, "rev-parse", "HEAD")
+    db = kb.connect(tmp_path / "kanban.db")
+    try:
+        parent_id = kb.create_task(db, title="parent", assignee="builder")
+        assert kb.complete_task(db, parent_id, metadata={"commit": parent_sha})
+        child_id = kb.create_task(
+            db,
+            title="child",
+            parents=[parent_id],
+            workspace_kind="worktree",
+            workspace_path=str(repo),
+            branch_name="fix/child",
+        )
+        canonical = repo / ".worktrees" / child_id
+        _git(repo, "worktree", "add", "-b", "wrong/branch", str(canonical), stale_head)
+        kb.set_workspace_path(db, child_id, canonical)
+        child = kb.claim_task(db, child_id)
+        assert child is not None
+
+        with pytest.raises(RuntimeError, match="does not descend"):
+            kb._resolve_worktree_workspace(child, conn=db)
+        assert _git(canonical, "rev-parse", "HEAD") == stale_head
+    finally:
+        db.close()

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,23 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_show_serializes_resolved_run_base(worker_env):
+    from hermes_cli import kanban_db as kb
+    from tools import kanban_tools as kt
+
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, worker_env)
+        assert task is not None
+        base_sha = "a" * 40
+        kb._record_resolved_base_sha(conn, task, base_sha)
+    finally:
+        conn.close()
+
+    shown = json.loads(kt._handle_show({}))
+    assert shown["runs"][-1]["resolved_base_sha"] == base_sha
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -563,6 +563,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "status": r.status, "outcome": r.outcome,
                     "summary": r.summary, "error": r.error,
                     "metadata": r.metadata,
+                    "resolved_base_sha": r.resolved_base_sha,
                     "started_at": r.started_at, "ended_at": r.ended_at,
                 }
 


### PR DESCRIPTION
## Summary

- resolve a single completed parent's structured `metadata.commit` before materializing a child worktree
- create new child branches from that immutable commit instead of the repository's mutable `HEAD`
- reject ambiguous, malformed, unavailable, or ancestry-incompatible bases before worker spawn
- persist `resolved_base_sha` on the run and claim event for diagnostics

## Problem

Dependency status gating ensures a parent is complete, but worktree creation still used the board repository's current `HEAD`. A serial child could therefore start from an older commit and omit its direct parent's reviewed work.

## Approach

The dispatcher now passes its board connection into worktree resolution. Single-parent worktree tasks require the parent's latest successful terminal run to contain a full Git SHA in `metadata.commit`; the object is validated before use. New branches are created from that SHA, while existing worktrees must already descend from it and are never reset automatically. Multi-parent worktrees fail closed because there is no unambiguous integration base.

## Tests

- `scripts/run_tests.sh tests/hermes_cli/test_kanban_parent_worktree_base.py tests/hermes_cli/test_kanban_db_init.py tests/plugins/test_kanban_board_lifecycle_api.py -q` (19 passed)
- `C:/workspace/hermes-agent/.venv/Scripts/python.exe -m ruff check hermes_cli/kanban_db.py hermes_cli/kanban.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_parent_worktree_base.py`
- sabotage check: restoring `HEAD` as the branch base makes the stale-HEAD regression fail
- three unrelated Windows-sensitive tests in `tests/hermes_cli/test_kanban_db.py` also fail unchanged on the upstream base; the migration regression introduced during development was fixed and passes

## Risk

Worktree tasks with direct parents now fail closed unless the parent exposes an unambiguous full commit SHA. Parentless worktrees retain the existing `HEAD` behavior.

## Related Issue

Closes #102456
