### PR TITLE
fix(cli): guard pt_key_to_sequence binding when voice config import fails (#101757)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -19640,11 +19640,25 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         # has no super modifier — log a warning so users notice the
         # TUI/CLI split instead of a silent mismatch (round-11).
         _raw_key: object = "ctrl+b"
+        _voice_key = "c-b"
+        # Hoist pt_key_to_sequence so it is always bound even if config/voice
+        # imports fail — otherwise the @kb.add below raises UnboundLocalError
+        # (Docker minimal env, #101757). Keep the same alt-key semantics.
+        try:
+            from hermes_cli.voice import pt_key_to_sequence as _pt_key_to_sequence  # noqa: F401
+
+            pt_key_to_sequence = _pt_key_to_sequence  # type: ignore[no-redef]
+        except Exception:
+
+            def pt_key_to_sequence(pt_key: str) -> tuple[str, ...]:  # type: ignore[no-redef]
+                if isinstance(pt_key, str) and pt_key.startswith("a-"):
+                    return ("escape", pt_key[2:])
+                return (pt_key,)
+
         try:
             from hermes_cli.config import load_config
             from hermes_cli.voice import (
                 normalize_voice_record_key_for_prompt_toolkit,
-                pt_key_to_sequence,
                 voice_record_key_from_config,
             )
             _raw_key = voice_record_key_from_config(load_config())


### PR DESCRIPTION
Fixes #101757

**Problem:** `hermes tui` in Docker crashes with `UnboundLocalError: cannot access local variable 'pt_key_to_sequence'` at `cli.py:19673`. The symbol was imported inside the voice-config `try` block but used outside it via `@kb.add(*pt_key_to_sequence(_voice_key))`. When `load_config` or `hermes_cli.voice` import raised (minimal Docker image / missing deps), the `except` only bound `_voice_key = "c-b"`, leaving `pt_key_to_sequence` unbound.

**Fix:** Hoist `pt_key_to_sequence` import with a fallback definition so it is always bound. The fallback preserves the same `a-*` → `("escape", key)` semantics as `hermes_cli.voice.pt_key_to_sequence`. The voice-config loading stays in its own `try` and still falls back to `c-b` on error.

**Testing:** `python -m py_compile cli.py` passes; simulated Docker import-failure path confirms fallback returns `('c-b',)` and `('escape','v')`; `pytest tests/hermes_cli/test_voice_wrapper.py` — 23 passed.