### PR TITLE
fix(cli,plugins): suppress streaming only for MUTATING transform_llm_output hooks, re-checked per token (#102203)

### DIFF
--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -610,7 +610,7 @@ class CLIAgentSetupMixin:
             return False
 
     def _transform_llm_output_hook_active(self) -> bool:
-        """True when a transform_llm_output hook is registered (#102203).
+        """True when a transform_llm_output hook that MUTATES is registered (#102203).
 
         A mutating hook replaces the final response after streaming has
         already printed tokens; any post-hoc suffix repair (banner /
@@ -618,16 +618,22 @@ class CLIAgentSetupMixin:
         no way to revoke bytes already rendered. Skip token streaming for
         those sessions and let run_conversation's final-response Panel
         branch (cli.py ~17664) print the transformed text once.
+
+        Purely observational hooks (``register_hook(..., mutates=False)``,
+        the default) keep streaming enabled — they cannot alter the final
+        text, so the streamed bytes match the final render.
         """
         try:
             from cli import logger
-            from hermes_cli.plugins import has_hook
+            from hermes_cli.plugins import has_mutating_hook
 
-            return has_hook("transform_llm_output")
+            return has_mutating_hook("transform_llm_output")
         except Exception:  # pragma: no cover - plugin manager may be unavailable
             try:
                 from cli import logger
-                logger.debug("transform_llm_output hook check failed", exc_info=True)
+                logger.debug(
+                    "transform_llm_output mutating-hook check failed", exc_info=True
+                )
             except Exception:
                 pass
             return False

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -563,7 +563,7 @@ class CLIAgentSetupMixin:
                 skip_memory=self.ignore_rules, tool_progress_callback=self._on_tool_progress,
                 tool_start_callback=self._on_tool_start if self._inline_diffs_enabled else None,
                 tool_complete_callback=self._on_tool_complete if self._inline_diffs_enabled else None,
-                stream_delta_callback=self._stream_delta if self.streaming_enabled else None,
+                stream_delta_callback=self._resolve_stream_delta_callback(),
                 tool_gen_callback=self._on_tool_gen_start if self.streaming_enabled else None,
                 notice_callback=self._on_notice, notice_clear_callback=self._on_notice_clear,
                 reaction_callback=self._on_reaction)
@@ -608,6 +608,42 @@ class CLIAgentSetupMixin:
             for line in partial_update_hint(e):
                 console.print(line)
             return False
+
+    def _transform_llm_output_hook_active(self) -> bool:
+        """True when a transform_llm_output hook is registered (#102203).
+
+        A mutating hook replaces the final response after streaming has
+        already printed tokens; any post-hoc suffix repair (banner /
+        divergent suffix) leaves garbled output on screen, since the CLI has
+        no way to revoke bytes already rendered. Skip token streaming for
+        those sessions and let run_conversation's final-response Panel
+        branch (cli.py ~17664) print the transformed text once.
+        """
+        try:
+            from cli import logger
+            from hermes_cli.plugins import has_hook
+
+            return has_hook("transform_llm_output")
+        except Exception:  # pragma: no cover - plugin manager may be unavailable
+            try:
+                from cli import logger
+                logger.debug("transform_llm_output hook check failed", exc_info=True)
+            except Exception:
+                pass
+            return False
+
+    def _resolve_stream_delta_callback(self):
+        """Decide the ``stream_delta_callback`` value for ``_init_agent``.
+
+        Extracted as a named method so tests can drive the same wiring
+        decision the production path executes, without duplicating the
+        expression: suppress token streaming whenever a mutating
+        ``transform_llm_output`` hook is registered (#102203)."""
+        if not self.streaming_enabled:
+            return None
+        if self._transform_llm_output_hook_active():
+            return None
+        return self._stream_delta
 
     def _resume_history_limit_error(self, tip_only: bool = False):
         """Return a safe-resume error without materializing transcript rows.

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -632,18 +632,43 @@ class CLIAgentSetupMixin:
                 pass
             return False
 
+    def _stream_delta_with_hook_gate(self, text):
+        """Stream delta callback that re-checks the hook gate per token.
+
+        ``_init_agent`` runs once at boot, but plugins register hooks at /
+        after startup too. A late-registered ``transform_llm_output`` with a
+        callback baked at ``_init_agent`` time would still garble output.
+
+        Gating per token keeps the CLI safe regardless of registration order:
+        the moment any ``transform_llm_output`` hook is live, we stop
+        forwarding deltas. The agent still accumulates ``final_response`` so
+        the post-transform Panel renders the final text exactly once.
+
+        The gate is evaluated on every call (cheap dict lookup in the plugin
+        manager) so a hook can turn streaming off mid-turn. We deliberately
+        do not gate on ``text is None`` — a turn-boundary ``None`` flush is
+        always passed through so stream state resets cleanly even when the
+        hook is active.
+        """
+        if text is None:
+            if self._stream_delta is not None:
+                self._stream_delta(text)
+            return
+        if self._transform_llm_output_hook_active():
+            return
+        if self._stream_delta is not None:
+            self._stream_delta(text)
+
     def _resolve_stream_delta_callback(self):
         """Decide the ``stream_delta_callback`` value for ``_init_agent``.
 
-        Extracted as a named method so tests can drive the same wiring
-        decision the production path executes, without duplicating the
-        expression: suppress token streaming whenever a mutating
-        ``transform_llm_output`` hook is registered (#102203)."""
+        Returns the per-token wrapper ``_stream_delta_with_hook_gate`` so the
+        hook gate is re-evaluated for every delta (handles late registration)
+        rather than a baked-yes/no decision made once at startup.
+        """
         if not self.streaming_enabled:
             return None
-        if self._transform_llm_output_hook_active():
-            return None
-        return self._stream_delta
+        return self._stream_delta_with_hook_gate
 
     def _resume_history_limit_error(self, tip_only: bool = False):
         """Return a safe-resume error without materializing transcript rows.

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -897,9 +897,18 @@ class PluginContext:
         logger.debug("Plugin %s registered %d redaction pattern(s)", self.manifest.name, count)
         return count
 
-    def register_hook(self, hook_name: str, callback: Callable) -> PluginRegistration:
-        """Register a lifecycle hook callback (unknown names warn but are still stored)."""
-        return self._track_callback("hook", hook_name, callback, self._manager._hooks, VALID_HOOKS)
+    def register_hook(self, hook_name: str, callback: Callable, *, mutates: bool = False) -> PluginRegistration:
+        """Register a lifecycle hook callback (unknown names warn but are still stored).
+
+        ``mutates`` is metadata-only: it tells the host whether the hook's return value REPLACES
+        the streamed/final payload (``True``) or is purely observational (``False``). Surfaces
+        that stream deltas to users need this to decide whether token streaming must be
+        suppressed up-front. Defaults to ``False`` so existing plugins keep working unchanged.
+        """
+        handle = self._track_callback("hook", hook_name, callback, self._manager._hooks, VALID_HOOKS)
+        flags = self._manager._hooks_mutating_flags.setdefault(hook_name, [])
+        flags.append(bool(mutates))
+        return handle
 
     def register_middleware(self, kind: str, callback: Callable) -> PluginRegistration:
         """Register behavior-changing middleware (request kinds rewrite the payload, execution kinds
@@ -1134,8 +1143,14 @@ class PluginManager(PluginLoaderMixin, PluginDispatchMixin, PluginLedgerMixin):
         # (matcher, callback, plugin_name), platform handler factories (lowercase platform -> list).
         self._plugins: Dict[str, LoadedPlugin] = {}
         self._hooks: Dict[str, List[Callable]] = {}
-        # Fallback hooks registered by a memory provider before general discovery.
+# Fallback hooks registered by a memory provider before general discovery.
         self._memory_hook_registrations: Dict[Tuple[str, str], List[PluginRegistration]] = {}
+        # Parallel bookkeeping to ``_hooks``: for each registered callback, whether it declared
+        # ``mutates=True`` at registration. Pairs of entries at the same index across both
+        # structures describe a single registration. Two registrations can share the same
+        # callable object, so a correspondence keyed by ``id(callback)`` would collapse —
+        # keep them aligned by index instead.
+        self._hooks_mutating_flags: Dict[str, List[bool]] = {}
         self._middleware: Dict[str, List[Callable]] = {}
         self._plugin_tool_names: Set[str] = set()
         self._plugin_platform_names: Set[str] = set()
@@ -1727,6 +1742,14 @@ def has_hook(hook_name: str) -> bool:
     Lazy-discovers first — same gate-before-invoke rationale as :func:`has_middleware` (tracking #64178).
     """
     return _delivery_manager().has_hook(hook_name)
+
+
+def has_mutating_hook(hook_name: str) -> bool:
+    """True when a loaded plugin handles a hook and marked it ``mutates=True`` at registration.
+
+    Lazy-discovers first — same gate-before-invoke rationale as :func:`has_hook` (tracking #64178).
+    """
+    return _delivery_manager().has_mutating_hook(hook_name)
 
 
 def iter_hook_callbacks(hook_name: str) -> tuple[Callable, ...]:

--- a/hermes_cli/plugins_dispatch.py
+++ b/hermes_cli/plugins_dispatch.py
@@ -391,6 +391,16 @@ class PluginDispatchMixin:
         """Return True when at least one callback is registered for a hook."""
         return bool(self._hooks.get(hook_name))
 
+    def has_mutating_hook(self, hook_name: str) -> bool:
+        """Return True when any registered callback declared ``mutates=True``.
+
+        Surfaces that stream deltas to users consult this to decide whether
+        they must suppress token streaming up-front — observational hooks do
+        not trigger suppression, so a plugin that only reads the payload
+        keeps streaming on.
+        """
+        return any(self._hooks_mutating_flags.get(hook_name, ()))
+
     def iter_hook_callbacks(self, hook_name: str) -> tuple[Callable, ...]:
         """Return a stable snapshot of callbacks registered for a hook."""
         return tuple(self._hooks.get(hook_name, ()))

--- a/hermes_cli/plugins_ledger.py
+++ b/hermes_cli/plugins_ledger.py
@@ -131,9 +131,24 @@ class PluginLedgerMixin:
         callbacks = mapping.get(key)
         if callbacks is None:
             return
+        # ``_remove_identity`` removes the LAST exact match. Find the same index first so we
+        # can drop the parallel mutating-flag entry too — two registrations can share the same
+        # callable object, so identity alone cannot disambiguate the pair.
+        target_index: Optional[int] = None
+        if mapping is self._hooks:
+            for index in range(len(callbacks) - 1, -1, -1):
+                if callbacks[index] is callback:
+                    target_index = index
+                    break
         self._remove_identity(callbacks, callback)
         if not callbacks:
             mapping.pop(key, None)
+        if mapping is self._hooks and target_index is not None:
+            flags = self._hooks_mutating_flags.get(key)
+            if flags is not None and target_index < len(flags):
+                del flags[target_index]
+                if not flags:
+                    self._hooks_mutating_flags.pop(key, None)
 
     def _restore_mapping(self, mapping: Dict[str, Any], key: str, current: Any, previous: Optional[Any]) -> bool:
         """Restore a manager-local mapping only when *current* is still present."""
@@ -286,7 +301,7 @@ class PluginLedgerMixin:
         carryover_ids = {id(r) for r in self._persistent_carryover}
         self._persistent_carryover.extend(r for r in self._active_persistent() if id(r) not in carryover_ids)
         for container in (
-            self._ownership_ledger, self._plugins, self._hooks, self._middleware,
+            self._ownership_ledger, self._plugins, self._hooks, self._hooks_mutating_flags, self._middleware,
             self._plugin_tool_names, self._plugin_platform_names, self._cli_commands,
             self._plugin_commands, self._plugin_skills, self._portable_mcp_servers,
             self._aux_tasks, self._system_prompt_sections, self._approval_transports,

--- a/tests/cli/test_transform_stream_buffered_102203.py
+++ b/tests/cli/test_transform_stream_buffered_102203.py
@@ -1,0 +1,79 @@
+"""Regression tests for the #102203 buffered fix.
+
+When a transform_llm_output hook is registered, the CLI must NOT stream
+token-by-token — a mutating transform is applied AFTER streaming, so any
+post-hoc print (suffix or banner) lands after already-rendered bytes and
+garbles the terminal (see review of the ba0969505a approach on PR #102239).
+
+The fix gates ``stream_delta_callback`` via
+``CLIAgentSetupMixin._resolve_stream_delta_callback``, wired from
+``_init_agent``. Tests drive THAT method (not a copy of its expression), so
+a refactor that drops the hook gate breaks the suite.
+
+Pinned against origin/main 63279301bc: the tests must FAIL on main (the
+resolver method does not exist there).
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.cli_agent_setup_mixin import CLIAgentSetupMixin
+
+
+def _make_cli(*, streaming_enabled: bool) -> CLIAgentSetupMixin:
+    cli = CLIAgentSetupMixin()
+    cli.streaming_enabled = streaming_enabled
+    cli._stream_delta = lambda *_a, **_k: None
+    return cli
+
+
+class TestTransformHookGate:
+    """The predicate behind the gate."""
+
+    def test_gate_true_when_hook_registered(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", return_value=True):
+            assert cli._transform_llm_output_hook_active() is True
+
+    def test_gate_false_without_hook(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", return_value=False):
+            assert cli._transform_llm_output_hook_active() is False
+
+    def test_gate_fail_open_on_plugin_error(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch("hermes_cli.plugins.has_hook", side_effect=RuntimeError("boom")):
+            assert cli._transform_llm_output_hook_active() is False
+
+
+class TestResolveStreamDeltaCallback:
+    """The actual wiring decision — invoked from _init_agent at line ~581."""
+
+    def test_hook_active_suppresses_streaming(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            assert cli._resolve_stream_delta_callback() is None
+
+    def test_no_hook_streams_normally(self):
+        cli = _make_cli(streaming_enabled=True)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            assert cli._resolve_stream_delta_callback() is cli._stream_delta
+
+    def test_streaming_disabled_still_none(self):
+        cli = _make_cli(streaming_enabled=False)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            assert cli._resolve_stream_delta_callback() is None
+
+    def test_hook_active_with_streaming_disabled_still_none(self):
+        cli = _make_cli(streaming_enabled=False)
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            assert cli._resolve_stream_delta_callback() is None

--- a/tests/cli/test_transform_stream_buffered_102203.py
+++ b/tests/cli/test_transform_stream_buffered_102203.py
@@ -49,17 +49,19 @@ class TestTransformHookGate:
 
     def test_gate_true_when_hook_registered(self):
         cli = _make_cli(streaming_enabled=True)
-        with patch("hermes_cli.plugins.has_hook", return_value=True):
+        with patch("hermes_cli.plugins.has_mutating_hook", return_value=True):
             assert cli._transform_llm_output_hook_active() is True
 
     def test_gate_false_without_hook(self):
         cli = _make_cli(streaming_enabled=True)
-        with patch("hermes_cli.plugins.has_hook", return_value=False):
+        with patch("hermes_cli.plugins.has_mutating_hook", return_value=False):
             assert cli._transform_llm_output_hook_active() is False
 
     def test_gate_fail_open_on_plugin_error(self):
         cli = _make_cli(streaming_enabled=True)
-        with patch("hermes_cli.plugins.has_hook", side_effect=RuntimeError("boom")):
+        with patch(
+            "hermes_cli.plugins.has_mutating_hook", side_effect=RuntimeError("boom")
+        ):
             assert cli._transform_llm_output_hook_active() is False
 
 

--- a/tests/cli/test_transform_stream_buffered_102203.py
+++ b/tests/cli/test_transform_stream_buffered_102203.py
@@ -1,17 +1,33 @@
-"""Regression tests for the #102203 buffered fix.
+"""Regression tests for the #102203 buffered fix — per-token hook gate.
 
 When a transform_llm_output hook is registered, the CLI must NOT stream
-token-by-token — a mutating transform is applied AFTER streaming, so any
+token-by-token: a mutating transform is applied AFTER streaming, so any
 post-hoc print (suffix or banner) lands after already-rendered bytes and
-garbles the terminal (see review of the ba0969505a approach on PR #102239).
+garbles the terminal (see PR #102216 Chunk5 review).
 
-The fix gates ``stream_delta_callback`` via
-``CLIAgentSetupMixin._resolve_stream_delta_callback``, wired from
-``_init_agent``. Tests drive THAT method (not a copy of its expression), so
-a refactor that drops the hook gate breaks the suite.
+The wiring decision happens in
+``CLIAgentSetupMixin._resolve_stream_delta_callback`` (called once from
+``_init_agent``), which now returns a per-token wrapper
+(``_stream_delta_with_hook_gate``) instead of a baked yes/no value. That
+means a hook registered AFTER ``_init_agent`` — plugin discovery running
+lazily, ``/plugins enable``, programmatic registration — still suppresses
+streaming from the moment it goes live; we don't need to re-init the agent.
+
+Invariants the tests pin:
+
+- ``_resolve_stream_delta_callback`` no longer consults the hook; it only
+  honours ``streaming_enabled``.
+- The wrapper forwards ``text=None`` unconditionally: this marks a turn
+  boundary and MUST reach ``_stream_delta`` so its ``_flush_stream()`` /
+  ``_reset_stream_state()`` path runs even when a hook suppressed every
+  visible token of a prior turn.
+- The wrapper drops visible text ONLY when the hook predicate is active.
+- The wrapper delegates to the predicate via ``self.`` and uses the
+  ``_stream_delta`` attribute dynamically, so tests that patch either on the
+  class see the same behaviour as production.
 
 Pinned against origin/main 63279301bc: the tests must FAIL on main (the
-resolver method does not exist there).
+resolver and wrapper do not exist there).
 """
 
 from __future__ import annotations
@@ -29,7 +45,7 @@ def _make_cli(*, streaming_enabled: bool) -> CLIAgentSetupMixin:
 
 
 class TestTransformHookGate:
-    """The predicate behind the gate."""
+    """The predicate behind the gate — consulted per token by the wrapper."""
 
     def test_gate_true_when_hook_registered(self):
         cli = _make_cli(streaming_enabled=True)
@@ -48,32 +64,96 @@ class TestTransformHookGate:
 
 
 class TestResolveStreamDeltaCallback:
-    """The actual wiring decision — invoked from _init_agent at line ~581."""
+    """The wiring decision — must not bake the hook verdict into the agent."""
 
-    def test_hook_active_suppresses_streaming(self):
+    def test_returns_wrapper_when_streaming_enabled(self):
         cli = _make_cli(streaming_enabled=True)
-        with patch.object(
-            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
-        ):
-            assert cli._resolve_stream_delta_callback() is None
+        cb = cli._resolve_stream_delta_callback()
+        # Identity: the SAME function that runs the per-token gate.
+        assert cb == cli._stream_delta_with_hook_gate
 
-    def test_no_hook_streams_normally(self):
+    def test_returns_none_when_streaming_disabled(self):
+        cli = _make_cli(streaming_enabled=False)
+        assert cli._resolve_stream_delta_callback() is None
+
+    def test_hook_state_at_init_does_not_change_returned_callback(self):
+        """Late-registration safety: the resolver must NOT consult the hook.
+
+        A hook registered after ``_init_agent`` must not need the agent to be
+        re-initialised for the gate to engage. The wrapper converges on the
+        right behaviour the moment the hook shows up.
+        """
         cli = _make_cli(streaming_enabled=True)
         with patch.object(
             CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
         ):
-            assert cli._resolve_stream_delta_callback() is cli._stream_delta
-
-    def test_streaming_disabled_still_none(self):
-        cli = _make_cli(streaming_enabled=False)
-        with patch.object(
-            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
-        ):
-            assert cli._resolve_stream_delta_callback() is None
-
-    def test_hook_active_with_streaming_disabled_still_none(self):
-        cli = _make_cli(streaming_enabled=False)
+            cb_no_hook = cli._resolve_stream_delta_callback()
         with patch.object(
             CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
         ):
-            assert cli._resolve_stream_delta_callback() is None
+            cb_with_hook = cli._resolve_stream_delta_callback()
+        assert cb_no_hook == cb_with_hook  # same wrapper either way
+
+
+class TestStreamDeltaWithHookGate:
+    """The per-token gate itself."""
+
+    def test_forwards_text_when_no_hook(self):
+        cli = _make_cli(streaming_enabled=True)
+        seen: list = []
+        cli._stream_delta = seen.append
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            cli._stream_delta_with_hook_gate("hello")
+        assert seen == ["hello"]
+
+    def test_drops_text_when_hook_active(self):
+        cli = _make_cli(streaming_enabled=True)
+        seen: list = []
+        cli._stream_delta = seen.append
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            cli._stream_delta_with_hook_gate("hello")
+        assert seen == []
+
+    def test_none_always_forwarded_regardless_of_hook(self):
+        """Turn-boundary None must flush/reset even with a hook active."""
+        cli = _make_cli(streaming_enabled=True)
+        seen: list = []
+        cli._stream_delta = seen.append
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            cli._stream_delta_with_hook_gate(None)
+        assert seen == [None]
+
+    def test_hook_late_registration_engages_gate(self):
+        """The motivating case: hook arrives between agent init and turn N."""
+        cli = _make_cli(streaming_enabled=True)
+        seen: list = []
+        cli._stream_delta = seen.append
+        cb = cli._resolve_stream_delta_callback()
+        # First turn: no hook → text flows.
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=False
+        ):
+            cb("early-token")
+        # Late register (simulated by flipping the predicate mid-session).
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            cb("late-token")
+        assert seen == ["early-token"]
+
+    def test_safe_when_stream_delta_is_none(self):
+        """No display callback wired → wrapper becomes a no-op, not a crash."""
+        cli = _make_cli(streaming_enabled=True)
+        cli._stream_delta = None
+        with patch.object(
+            CLIAgentSetupMixin, "_transform_llm_output_hook_active", return_value=True
+        ):
+            # Must not raise even when both _stream_delta is None AND hook is on.
+            cli._stream_delta_with_hook_gate("anything")
+            cli._stream_delta_with_hook_gate(None)

--- a/tests/hermes_cli/test_plugin_hook_mutates_metadata.py
+++ b/tests/hermes_cli/test_plugin_hook_mutates_metadata.py
@@ -1,0 +1,81 @@
+"""Coverage for the ``mutates=True`` hook metadata (PR-102481 follow-up).
+
+Plugin behavior contracts:
+
+  - ``register_hook(name, cb)`` without ``mutates=`` is observational by
+    default. Streaming surfaces must not pay the suppress cost.
+  - ``register_hook(name, cb, mutates=True)`` declares that the callback's
+    return value REPLACES the streamed payload — a surface that streams
+    deltas must buffer instead of repaint.
+  - Unloading the only mutating callback restores streaming (bookkeeping
+    must leave no stale mutator entry behind).
+
+These tests target the plugin manager surface directly. For the actual
+gating decision consumed by the CLI see
+``tests/cli/test_transform_stream_buffered_102203.py``.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+
+def _noop(**_kw):
+    return None
+
+
+def _ctx(mgr: PluginManager, name: str = "test-plugin") -> PluginContext:
+    manifest = PluginManifest(name=name, source="user")
+    return PluginContext(manifest, mgr)
+
+
+def test_register_hook_default_is_observational():
+    mgr = PluginManager()
+    ctx = _ctx(mgr)
+    ctx.register_hook("transform_llm_output", _noop)
+
+    assert mgr.has_hook("transform_llm_output") is True
+    assert mgr.has_mutating_hook("transform_llm_output") is False
+
+
+def test_register_hook_with_mutates_true_marks_mutating():
+    mgr = PluginManager()
+    ctx = _ctx(mgr)
+    ctx.register_hook("transform_llm_output", _noop, mutates=True)
+
+    assert mgr.has_hook("transform_llm_output") is True
+    assert mgr.has_mutating_hook("transform_llm_output") is True
+
+
+def test_multiple_hooks_some_observational_still_mutating():
+    """One mutator in the pool is enough — the surface must suppress."""
+    mgr = PluginManager()
+    ctx = _ctx(mgr)
+    ctx.register_hook("transform_llm_output", lambda **kw: None)  # observer
+    ctx.register_hook("transform_llm_output", _noop, mutates=True)
+
+    assert mgr.has_mutating_hook("transform_llm_output") is True
+
+
+def test_unloading_mutating_hook_clears_mutating_index():
+    mgr = PluginManager()
+    ctx = _ctx(mgr)
+    handle = ctx.register_hook("transform_llm_output", _noop, mutates=True)
+
+    assert mgr.has_mutating_hook("transform_llm_output") is True
+
+    handle.release()
+
+    assert mgr.has_hook("transform_llm_output") is False
+    assert mgr.has_mutating_hook("transform_llm_output") is False
+
+
+def test_unloading_one_of_two_mutating_hooks_keeps_flag():
+    mgr = PluginManager()
+    ctx = _ctx(mgr)
+    handle_a = ctx.register_hook("transform_llm_output", _noop, mutates=True)
+    ctx.register_hook("transform_llm_output", _noop, mutates=True)
+
+    handle_a.release()
+
+    assert mgr.has_mutating_hook("transform_llm_output") is True


### PR DESCRIPTION
## Problem

Two linked issues with the `transform_llm_output` + CLI streaming interaction:

1. **Late-registered hooks are missed.** PR #102216 closes the reported bug by gating
   `stream_delta_callback` once at `_init_agent` time, but plugins can register hooks
   *after* agent construction (`/plugins enable`, lazy discovery, programmatic setup) —
   the baked callback never changes, so a hook going live mid-session still garbles the
   terminal.
2. **Observational hooks are over-penalised.** The gate suppresses streaming whenever
   ANY `transform_llm_output` hook is loaded, including purely read-only ones. Marcus
   Chen's review on #102216 flagged this as acceptable-but-broad; this PR makes it
   precise.

Both fixes compose cleanly with #102216.

## Fix

### Per-token gate (handles late registration)

`_resolve_stream_delta_callback` no longer consults the hook. It always returns a
wrapper — `_stream_delta_with_hook_gate` — when `streaming_enabled` is true. The
wrapper consults the hook predicate on every delta (a dict lookup on the plugin manager),
so a hook engaging mid-turn suppresses further tokens; `text=None` (turn boundary)
always passes through so the stream-state reset still runs.

### `mutates=True` declaration (avoids over-suppress)

`PluginContext.register_hook(name, cb, *, mutates=False)` gains an opt-in flag.
`PluginManager.has_mutating_hook(name)` is a sibling to `has_hook` answering "any
mutating callback registered?" The CLI's gate consults it, so plugins that observe only
keep streaming.

Implementation detail that drove the design: two registrations can share the same
callable object, so an `id(callback)` set collapses. The bookkeeping parallel
`_hooks_mutating_flags: List[bool]` is kept index-aligned with `_hooks` across
register and `_remove_callback`.

## Tests

New file `tests/hermes_cli/test_plugin_hook_mutates_metadata.py` — 5 tests covering
backward-compat default, opt-in flag, mixed registrations, unload of one / two mutators.

Rewritten `tests/cli/test_transform_stream_buffered_102203.py` — 11 tests covering the
per-token gate; the three hook-state tests now use `has_mutating_hook` to match the
new predicate.

Sabotage runs:

- All 5 mutates-metadata tests fail on the parent SHA (helpers don't exist yet).
- The `test_gate_true_when_hook_registered` test fails against the old mixin
  (`has_hook` name still patched, new code consults `has_mutating_hook`).

## How to Test

    scripts/run_tests.sh tests/hermes_cli/test_plugin_hook_mutates_metadata.py tests/cli/test_transform_stream_buffered_102203.py

This PR bases on `main`; the diff contains #102216's commit (`9592bc6446`) plus
this PR's two commits and will shrink on merge of #102216.