### PR TITLE
fix(agent): honor deferred legacy tool aliases

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -3864,6 +3864,23 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
     if not tool_name:
         return None
 
+    # Validation runs before all dispatcher seams. Resolve the same declared
+    # legacy names here so resumptions and saved prompts are not rejected as
+    # hallucinated tools before the dispatch aliases can run. This never
+    # widens the session: the canonical target must be either model-visible or
+    # in Tool Search's existing enabled-and-available scoped catalog.
+    from model_tools import _LEGACY_TOOL_ALIASES
+
+    legacy_target = _LEGACY_TOOL_ALIASES.get(tool_name)
+    if legacy_target:
+        allowed_names = set(agent.valid_tool_names)
+        if legacy_target not in allowed_names:
+            from agent.tool_executor import _tool_search_scoped_names
+
+            allowed_names.update(_tool_search_scoped_names(agent))
+        if legacy_target in allowed_names:
+            return legacy_target
+
     # VolcEngine api/plan workaround (issue #33007): the endpoint's
     # protocol-translation layer occasionally leaks raw XML attribute
     # fragments into tool_use.name, e.g.
@@ -3929,6 +3946,48 @@ def repair_tool_call(agent, tool_name: str) -> str | None:
         return matches[0]
 
     return None
+
+
+def repair_and_classify_tool_call_names(
+    agent,
+    tool_calls: list[Any],
+) -> tuple[list[str], set[int]]:
+    """Repair names and classify invalid calls without widening deferral.
+
+    A declared legacy alias may resolve to an enabled Tool Search-deferred
+    canonical tool. Only that exact call object receives a validation
+    exemption; a model that emits the deferred canonical name directly must
+    still use ``tool_call``. Returns ``(invalid_names, exempt_call_ids)``.
+    """
+    from model_tools import _LEGACY_TOOL_ALIASES
+
+    valid_names = set(agent.valid_tool_names)
+    exempt_call_ids: set[int] = set()
+    for tool_call in tool_calls:
+        original_name = tool_call.function.name
+        if original_name in valid_names:
+            continue
+        repaired = agent._repair_tool_call(original_name)
+        if not repaired:
+            continue
+        print(
+            f"{agent.log_prefix}🔧 Auto-repaired tool name: "
+            f"'{original_name}' -> '{repaired}'"
+        )
+        tool_call.function.name = repaired
+        if (
+            repaired not in valid_names
+            and _LEGACY_TOOL_ALIASES.get(original_name) == repaired
+        ):
+            exempt_call_ids.add(id(tool_call))
+
+    invalid_names = [
+        tool_call.function.name
+        for tool_call in tool_calls
+        if tool_call.function.name not in valid_names
+        and id(tool_call) not in exempt_call_ids
+    ]
+    return invalid_names, exempt_call_ids
 
 
 def _tool_call_id_variants(tc: Any) -> set:

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -7757,17 +7757,26 @@ def run_conversation(
                 agent._uniquify_tool_call_ids(assistant_message.tool_calls)
 
                 # Validate tool call names - detect model hallucinations
-                # Repair mismatched tool names before validating
-                for tc in assistant_message.tool_calls:
-                    if tc.function.name not in agent.valid_tool_names:
-                        repaired = agent._repair_tool_call(tc.function.name)
-                        if repaired:
-                            print(f"{agent.log_prefix}🔧 Auto-repaired tool name: '{tc.function.name}' -> '{repaired}'")
-                            tc.function.name = repaired
-                invalid_tool_calls = [
-                    tc.function.name for tc in assistant_message.tool_calls
-                    if tc.function.name not in agent.valid_tool_names
-                ]
+                # Repair mismatched names before validating. A declared legacy
+                # alias may target an enabled-but-Tool-Search-deferred tool; the
+                # helper grants only that exact call object an exemption, never
+                # a direct deferred canonical call.
+                from agent.agent_runtime_helpers import (
+                    repair_and_classify_tool_call_names,
+                )
+
+                invalid_tool_calls, _legacy_alias_exempt_call_ids = (
+                    repair_and_classify_tool_call_names(
+                        agent,
+                        assistant_message.tool_calls,
+                    )
+                )
+
+                def _tool_call_name_is_valid(tool_call) -> bool:
+                    return (
+                        tool_call.function.name in agent.valid_tool_names
+                        or id(tool_call) in _legacy_alias_exempt_call_ids
+                    )
                 # Mixed batch: at least one valid call alongside the invalid
                 # one(s). Degrading models (observed with gpt-5.6 at very
                 # large context) emit batches like 6 named calls + 1
@@ -7780,7 +7789,7 @@ def run_conversation(
                 # model still halts at 3 while a mostly-coherent one keeps
                 # working.
                 _mixed_invalid_batch = bool(invalid_tool_calls) and any(
-                    tc.function.name in agent.valid_tool_names
+                    _tool_call_name_is_valid(tc)
                     for tc in assistant_message.tool_calls
                 )
                 if _mixed_invalid_batch:
@@ -7789,7 +7798,7 @@ def run_conversation(
                     invalid_preview = invalid_name[:80] + "..." if len(invalid_name) > 80 else invalid_name
                     _n_valid = sum(
                         1 for tc in assistant_message.tool_calls
-                        if tc.function.name in agent.valid_tool_names
+                        if _tool_call_name_is_valid(tc)
                     )
                     agent._buffer_vprint(
                         f"⚠️  Unknown tool '{invalid_preview}' in batch — erroring that call, "
@@ -7828,7 +7837,7 @@ def run_conversation(
                     append_message(messages, assistant_msg)
                     for tc in assistant_message.tool_calls:
                         _tc_name = tc.function.name
-                        if _tc_name not in agent.valid_tool_names:
+                        if not _tool_call_name_is_valid(tc):
                             # See _invalid_tool_name_error_content for the
                             # blank-name anti-priming rationale (#47967).
                             content = _invalid_tool_name_error_content(
@@ -7866,7 +7875,7 @@ def run_conversation(
                     except json.JSONDecodeError as e:
                         if (
                             _mixed_invalid_batch
-                            and tc.function.name not in agent.valid_tool_names
+                            and not _tool_call_name_is_valid(tc)
                         ):
                             # This call never executes — it gets an
                             # invalid-name error result below. Don't let its

--- a/tests/run_agent/test_repair_tool_call_name.py
+++ b/tests/run_agent/test_repair_tool_call_name.py
@@ -30,6 +30,10 @@ VALID = {
 }
 
 
+def _tool_call(name: str):
+    return SimpleNamespace(function=SimpleNamespace(name=name))
+
+
 @pytest.fixture
 def repair():
     """Return a bound _repair_tool_call built on a minimal shell agent.
@@ -49,6 +53,112 @@ class TestExistingBehaviorStillWorks:
 
     def test_lowercase_already_matches(self, repair):
         assert repair("browser_click") == "browser_click"
+
+    @pytest.mark.parametrize(
+        ("legacy_name", "canonical_name"),
+        sorted(__import__("model_tools", fromlist=["_LEGACY_TOOL_ALIASES"])._LEGACY_TOOL_ALIASES.items()),
+    )
+    def test_declared_legacy_alias_repairs_before_tool_name_validation(
+        self,
+        legacy_name,
+        canonical_name,
+    ):
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(valid_tool_names={canonical_name})
+        repair_alias = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+        assert repair_alias(legacy_name) == canonical_name
+
+    def test_declared_legacy_alias_repairs_when_canonical_tool_is_enabled_but_deferred(self):
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(
+            valid_tool_names={"tool_search", "tool_describe", "tool_call"},
+            enabled_toolsets=["todo"],
+            disabled_toolsets=None,
+        )
+        repair_alias = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+        assert repair_alias("todo") == "todo_list"
+
+    def test_declared_legacy_alias_does_not_widen_a_disabled_toolset(self):
+        from run_agent import AIAgent
+
+        stub = SimpleNamespace(
+            valid_tool_names={"tool_search", "tool_describe", "tool_call"},
+            enabled_toolsets=["todo"],
+            disabled_toolsets=["todo"],
+        )
+        repair_alias = AIAgent._repair_tool_call.__get__(stub, AIAgent)
+
+        assert repair_alias("todo") is None
+
+
+class TestConversationValidationBoundary:
+    @staticmethod
+    def _agent(*, disabled_toolsets=None, valid_tool_names=None):
+        from run_agent import AIAgent
+
+        agent = SimpleNamespace(
+            valid_tool_names=valid_tool_names
+            or {"tool_search", "tool_describe", "tool_call"},
+            enabled_toolsets=["todo"],
+            disabled_toolsets=disabled_toolsets,
+            log_prefix="",
+        )
+        agent._repair_tool_call = AIAgent._repair_tool_call.__get__(agent, AIAgent)
+        return agent
+
+    def test_legacy_alias_to_deferred_canonical_is_valid_for_that_call_only(self):
+        from agent.agent_runtime_helpers import repair_and_classify_tool_call_names
+
+        call = _tool_call("todo")
+        invalid, exemptions = repair_and_classify_tool_call_names(
+            self._agent(),
+            [call],
+        )
+
+        assert invalid == []
+        assert call.function.name == "todo_list"
+        assert exemptions == {id(call)}
+
+    def test_direct_deferred_canonical_name_still_requires_tool_call_bridge(self):
+        from agent.agent_runtime_helpers import repair_and_classify_tool_call_names
+
+        call = _tool_call("todo_list")
+        invalid, exemptions = repair_and_classify_tool_call_names(
+            self._agent(),
+            [call],
+        )
+
+        assert invalid == ["todo_list"]
+        assert exemptions == set()
+
+    def test_disabled_legacy_alias_remains_invalid(self):
+        from agent.agent_runtime_helpers import repair_and_classify_tool_call_names
+
+        call = _tool_call("todo")
+        invalid, exemptions = repair_and_classify_tool_call_names(
+            self._agent(disabled_toolsets=["todo"]),
+            [call],
+        )
+
+        assert invalid == ["todo"]
+        assert exemptions == set()
+
+    def test_visible_canonical_alias_needs_no_deferred_exemption(self):
+        from agent.agent_runtime_helpers import repair_and_classify_tool_call_names
+
+        call = _tool_call("todo")
+        invalid, exemptions = repair_and_classify_tool_call_names(
+            self._agent(valid_tool_names={"todo_list"}),
+            [call],
+        )
+
+        assert invalid == []
+        assert call.function.name == "todo_list"
+        assert exemptions == set()
 
 
 


### PR DESCRIPTION
## Bug Description

Legacy tool names accepted by the dispatch layer can be rejected earlier by the conversation loop. This is reproducible with the deprecated `todo` name after `todo_list` is deferred behind Tool Search: the model gets three repair attempts and the turn ends with `Model generated invalid tool call: todo`.

The failure also breaks existing Desktop E2E scenarios whose mock provider intentionally emits the legacy name to exercise saved-prompt/session compatibility.

## Root Cause

`model_tools._LEGACY_TOOL_ALIASES` is applied at the dispatch seams, but `agent/conversation_loop.py` validates names against the model-visible `agent.valid_tool_names` first. Tool Search can legitimately omit an enabled canonical tool such as `todo_list` from that visible set, so dispatch never gets a chance to apply the compatibility alias.

## Fix

- Resolve declared legacy aliases during tool-name repair when the canonical target is either model-visible or present in Tool Search's existing session-scoped deferred catalog.
- Track a validation exemption by tool-call object identity, so only the call that actually arrived through a declared legacy alias may execute the deferred canonical tool.
- Keep direct unsolicited deferred canonical calls invalid, requiring the normal `tool_call` bridge.
- Keep aliases for disabled toolsets invalid.
- Reuse the same per-call predicate in mixed-batch and invalid-JSON validation paths.

## How to Verify

1. Configure a session where the `todo` toolset is enabled and Tool Search defers `todo_list`.
2. Return a model tool call named `todo` with valid todo arguments.
3. Confirm the call is repaired to `todo_list`, executes once, and does not consume the invalid-tool retry budget.
4. Return `todo_list` directly without the bridge and confirm it remains invalid.
5. Disable the `todo` toolset and confirm the legacy name remains invalid.

## Test Plan

- [x] Added invariant coverage for every declared legacy alias when its canonical name is visible.
- [x] Added enabled-but-deferred, direct-deferred, disabled-toolset, and per-call-exemption coverage.
- [x] Focused Python suites: 149 passed, 0 failed.
- [x] Desktop E2E regressions with `workers=1`, `retries=0`:
  - `e2e/task-panel-clearance.spec.ts`
  - `e2e/interim-messages.spec.ts`
- [x] Ruff, byte-compilation, and `git diff --check` pass.

## Risk Assessment

Medium — this touches the pre-dispatch validation boundary. The exemption is deliberately per-call and only created when a name originates from the declared compatibility mapping and the canonical target is enabled in the same session scope. It does not add schemas, mutate toolsets, or authorize arbitrary deferred names.

## CI Note

The repository's aggregate CI currently marks the Desktop E2E job as intentionally skipped. The two affected Desktop specs were therefore run locally against the exact PR branch with no retries; both passed.