### PR TITLE
feat(plugins): await async pre-gateway dispatch hooks

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18900,10 +18900,18 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # Hook runs BEFORE auth so plugins can handle unauthorized senders
         # (e.g. customer handover ingest) without triggering the pairing flow.
         if not is_internal:
+            def _pre_gateway_stop_when(_result):
+                return isinstance(_result, dict) and _result.get("action") in {
+                    "skip", "rewrite", "allow",
+                }
+
             try:
-                from hermes_cli.lifecycle import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
+                from hermes_cli.lifecycle import (
+                    ainvoke_hook_ordered as _ainvoke_hook_ordered,
+                )
+                _hook_results = await _ainvoke_hook_ordered(
                     "pre_gateway_dispatch",
+                    stop_when=_pre_gateway_stop_when,
                     event=event,
                     gateway=self,
                     # getattr: bare-runner tests build GatewayRunner via

--- a/hermes_cli/lifecycle.py
+++ b/hermes_cli/lifecycle.py
@@ -22,6 +22,31 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return plugins.invoke_hook(hook_name, **kwargs)
 
 
+async def ainvoke_hook_ordered(
+    hook_name: str,
+    *,
+    timeout: float | None = None,
+    stop_when=None,
+    **kwargs: Any,
+) -> List[Any]:
+    """Notify observers, then invoke plugin callbacks in awaited order."""
+    try:
+        from hermes_cli.observability import observe_lifecycle
+
+        observe_lifecycle(hook_name, **kwargs)
+    except Exception:
+        logger.warning("Built-in observability hook failed", exc_info=True)
+
+    from hermes_cli import plugins
+
+    return await plugins.ainvoke_hook_ordered(
+        hook_name,
+        timeout=timeout,
+        stop_when=stop_when,
+        **kwargs,
+    )
+
+
 def has_hook(hook_name: str) -> bool:
     """Return whether a first-party observer or plugin consumes a hook."""
     try:

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -6483,6 +6483,50 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     return _delivery_manager().invoke_hook(hook_name, **kwargs)
 
 
+async def ainvoke_hook_ordered(
+    hook_name: str,
+    *,
+    timeout: Optional[float] = None,
+    stop_when: Optional[Callable[[Any], bool]] = None,
+    **kwargs: Any,
+) -> List[Any]:
+    """Invoke callbacks sequentially, awaiting and short-circuiting in order.
+
+    Directive hooks need stronger semantics than :func:`invoke_hook`: a
+    decisive result must prevent later callbacks from running at all. Callback
+    failures and optional timeouts remain isolated from the caller.
+    """
+    callbacks = _delivery_manager().iter_hook_callbacks(hook_name)
+    results: List[Any] = []
+    for callback in callbacks:
+        try:
+            result = callback(**kwargs)
+            if inspect.isawaitable(result):
+                if timeout is not None and timeout > 0:
+                    result = await asyncio.wait_for(result, timeout=timeout)
+                else:
+                    result = await result
+            if result is not None:
+                results.append(result)
+                if stop_when is not None and stop_when(result):
+                    break
+        except TimeoutError:
+            logger.warning(
+                "Hook '%s' callback %s timed out after %.1fs",
+                hook_name,
+                getattr(callback, "__name__", repr(callback)),
+                timeout or 0,
+            )
+        except Exception as exc:
+            logger.warning(
+                "Hook '%s' callback %s raised: %s",
+                hook_name,
+                getattr(callback, "__name__", repr(callback)),
+                exc,
+            )
+    return results
+
+
 def render_system_prompt_sections(
     session_info: Mapping[str, Any],
 ) -> List[RenderedPluginSystemPromptSection]:

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -68,14 +68,14 @@ async def test_internal_events_bypass_hook(monkeypatch):
 
     called = {"count": 0}
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         called["count"] += 1
         return [{"action": "skip"}]
 
     async def _capture(event, source, _quick_key, _run_generation):
         return "ok"
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.lifecycle.ainvoke_hook_ordered", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
     runner._handle_message_with_agent = _capture  # noqa: SLF001
@@ -102,13 +102,13 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
 
     seen = {}
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             seen["session_store"] = kwargs.get("session_store", "MISSING")
             return [{"action": "skip", "reason": "plugin-handled"}]
         return []
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.lifecycle.ainvoke_hook_ordered", _fake_hook)
 
     runner, adapter = _make_runner(Platform.WHATSAPP)
     del runner.session_store
@@ -117,4 +117,32 @@ async def test_hook_fires_without_session_store_attribute(monkeypatch):
     assert result is None
     # Hook actually fired (skip short-circuited before auth) with a None store.
     assert seen == {"session_store": None}
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_async_hook_result_is_awaited_before_agent_dispatch(monkeypatch):
+    """Async directive callbacks can intercept before the agent runs."""
+    _clear_auth_env(monkeypatch)
+    monkeypatch.setenv("WHATSAPP_ALLOWED_USERS", "*")
+
+    seen = {"awaited": False}
+
+    async def _async_result():
+        seen["awaited"] = True
+        return {"action": "skip", "reason": "async-plugin-handled"}
+
+    async def _fake_hook(name, **kwargs):
+        return [await _async_result()] if name == "pre_gateway_dispatch" else []
+
+    monkeypatch.setattr("hermes_cli.lifecycle.ainvoke_hook_ordered", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+    runner._handle_message_with_agent = AsyncMock(return_value="agent-ran")  # noqa: SLF001
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result is None
+    assert seen == {"awaited": True}
+    runner._handle_message_with_agent.assert_not_awaited()
     adapter.send.assert_not_awaited()

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -11,12 +11,14 @@ from unittest.mock import MagicMock, patch
 import pytest
 import yaml
 
+import hermes_cli.plugins as plugins_module
 from hermes_cli.plugins import (
     ENTRY_POINTS_GROUP,
     VALID_HOOKS,
     PluginContext,
     PluginManager,
     PluginManifest,
+    ainvoke_hook_ordered,
     _dispatch_pre_tool_call_hooks,
     get_plugin_command_handler,
     get_plugin_commands,
@@ -2377,3 +2379,52 @@ class TestDispatchToolWithoutCliRef:
             assert calls[0][1].get("parent_agent") is None
         finally:
             registry.deregister("_test_dispatch_probe")
+
+
+class TestAsyncOrderedHooks:
+    @pytest.mark.asyncio
+    async def test_awaits_and_stops_before_later_callback(self, monkeypatch):
+        seen = []
+
+        async def first(**_kwargs):
+            seen.append("first")
+            return {"action": "skip"}
+
+        def second(**_kwargs):
+            seen.append("second")
+            return {"action": "allow"}
+
+        manager = types.SimpleNamespace(
+            iter_hook_callbacks=lambda _name: (first, second),
+        )
+        monkeypatch.setattr(plugins_module, "_delivery_manager", lambda: manager)
+
+        results = await ainvoke_hook_ordered(
+            "pre_gateway_dispatch",
+            stop_when=lambda result: result.get("action") == "skip",
+        )
+
+        assert results == [{"action": "skip"}]
+        assert seen == ["first"]
+
+    @pytest.mark.asyncio
+    async def test_isolates_failure_and_runs_later_callback(self, monkeypatch):
+        seen = []
+
+        async def broken(**_kwargs):
+            seen.append("broken")
+            raise RuntimeError("plugin failed")
+
+        def second(**_kwargs):
+            seen.append("second")
+            return {"action": "rewrite", "text": "safe"}
+
+        manager = types.SimpleNamespace(
+            iter_hook_callbacks=lambda _name: (broken, second),
+        )
+        monkeypatch.setattr(plugins_module, "_delivery_manager", lambda: manager)
+
+        results = await ainvoke_hook_ordered("pre_gateway_dispatch")
+
+        assert results == [{"action": "rewrite", "text": "safe"}]
+        assert seen == ["broken", "second"]


### PR DESCRIPTION
## Summary
- add an ordered async lifecycle path for directive hooks
- invoke `pre_gateway_dispatch` callbacks sequentially and await each result
- stop before later callbacks once `skip`, `rewrite`, or `allow` wins
- isolate callback failures and optional timeouts while preserving observer delivery

## Motivation
Directive hooks often need non-blocking policy or reply I/O. Today an `async def` callback returns a coroutine object, which is ignored as a non-dict and can allow the message to fall through to agent dispatch. Invoking every callback synchronously before awaiting also violates short-circuit semantics: callbacks after a decisive directive may already have run.

## Verification
- `tests/gateway/test_pre_gateway_dispatch.py`
- `tests/hermes_cli/test_plugins.py`
- 80 tests passed
- ordered short-circuit and callback-isolation cases covered
- gitleaks clean