### PR TITLE
feat(gateway): clone bots between local and remote gateways

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -988,6 +988,11 @@ group_sessions_per_user: true
 #
 # gateway:
 #   room_link_url: "https://hermes.example.net"
+#   # Authenticated remote clients may push bot clones only when explicitly
+#   # enabled. Per-bot pull access is controlled with
+#   # `hermes profile share <name> --allow-pull`.
+#   bot_sharing:
+#     allow_push: false
 #
 # The equivalent environment override is HERMES_ROOM_LINK_URL. After changing
 # it, restart the gateway and reopen New Group Chat > Advanced; Hermes will

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -140,6 +140,7 @@ except ImportError:
     web = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms import api_server_bot_clone as _bot_clone
 from gateway.platforms import api_server_room_dispatch as _room_dispatch
 from gateway.platforms import api_server_room_grants as _room_grants
 from gateway.platforms import api_server_runs as _api_runs
@@ -2236,8 +2237,6 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/artifacts/download/{artifact_id}", self._handle_artifact_download),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
-            ("GET", "/v1/bots/{profile_name}/clone", self._handle_bot_clone_download),
-            ("POST", "/v1/bots/clone", self._handle_bot_clone_upload),
             ("GET", "/api/sessions", self._handle_list_sessions),
             ("POST", "/api/sessions", self._handle_create_session),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
@@ -2265,6 +2264,7 @@ class APIServerAdapter(BasePlatformAdapter):
             ("POST", "/api/jobs/{job_id}/resume", self._handle_resume_job),
             ("POST", "/api/jobs/{job_id}/run", self._handle_run_job),
         ]
+        routes.extend(_bot_clone._http_routes(self))
         routes.extend(_room_grants._http_routes(self))
         routes.extend(_api_runs._http_routes(self))
         if _CRON_AVAILABLE:
@@ -3536,11 +3536,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
-                "bot_clone_download": {
-                    "method": "GET",
-                    "path": "/v1/bots/{profile_name}/clone",
-                },
-                "bot_clone_upload": {"method": "POST", "path": "/v1/bots/clone"},
+                **_bot_clone._capabilities(),
                 "sessions": {"method": "GET", "path": "/api/sessions"},
                 "session_create": {"method": "POST", "path": "/api/sessions"},
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
@@ -4192,137 +4188,16 @@ class APIServerAdapter(BasePlatformAdapter):
 
     @staticmethod
     def _bot_push_enabled() -> bool:
-        """Read the gateway owner's explicit remote-push policy."""
-        try:
-            from hermes_cli.config import cfg_get, load_config
-
-            raw = cfg_get(
-                load_config(), "gateway", "bot_sharing", "allow_push", default=False
-            )
-            return _coerce_request_bool(raw, default=False)
-        except Exception:
-            return False
+        return _bot_clone._bot_push_enabled(coerce_bool=_coerce_request_bool)
 
     async def _handle_bot_clone_download(self, request: "web.Request") -> "web.Response":
-        """Return a bounded, credential-free clone of an owner-enabled bot."""
-        auth_err = self._check_auth(request)
-        if auth_err:
-            return auth_err
-
-        from hermes_cli.bot_transfer import export_bot_profile, profile_is_cloneable
-        from hermes_cli.profiles import normalize_profile_name
-
-        try:
-            name = normalize_profile_name(request.match_info.get("profile_name", ""))
-            if not profile_is_cloneable(name):
-                # Do not reveal whether a non-shared profile exists.
-                return web.json_response(
-                    _openai_error(
-                        "Bot is not available for cloning.", code="bot_clone_unavailable"
-                    ),
-                    status=404,
-                )
-
-            def _export() -> tuple[bytes, str]:
-                import tempfile
-
-                with tempfile.TemporaryDirectory(prefix="hermes_api_bot_pull_") as tmpdir:
-                    archive, bot_id = export_bot_profile(
-                        name, str(Path(tmpdir) / f"{name}.tar.gz")
-                    )
-                    return archive.read_bytes(), bot_id
-
-            payload, bot_id = await asyncio.to_thread(_export)
-        except FileNotFoundError:
-            return web.json_response(
-                _openai_error("Bot is not available for cloning.", code="bot_clone_unavailable"),
-                status=404,
-            )
-        except ValueError as exc:
-            return web.json_response(
-                _openai_error(str(exc), code="invalid_bot_clone"), status=400
-            )
-        except Exception:
-            logger.exception("[%s] bot clone export failed", self.name)
-            return web.json_response(
-                _openai_error("Bot clone export failed.", code="bot_clone_export_failed"),
-                status=500,
-            )
-
-        return web.Response(
-            body=payload,
-            content_type="application/gzip",
-            headers={
-                "Content-Disposition": f'attachment; filename="{name}.tar.gz"',
-                "X-Hermes-Bot-Id": bot_id,
-                "X-Hermes-Profile-Name": name,
-            },
+        return await _bot_clone._handle_bot_clone_download(
+            self, request, error_factory=_openai_error, web_module=web
         )
 
     async def _handle_bot_clone_upload(self, request: "web.Request") -> "web.Response":
-        """Install an uploaded bot clone without overwriting any local bot."""
-        auth_err = self._check_auth(request)
-        if auth_err:
-            return auth_err
-        if not self._bot_push_enabled():
-            return web.json_response(
-                _openai_error(
-                    "This gateway does not accept pushed bot clones.",
-                    code="bot_clone_push_disabled",
-                ),
-                status=403,
-            )
-        if request.content_type not in {"application/gzip", "application/x-gzip"}:
-            return web.json_response(
-                _openai_error(
-                    "Content-Type must be application/gzip.", code="invalid_content_type"
-                ),
-                status=415,
-            )
-
-        from hermes_cli.bot_transfer import import_bot_profile
-
-        try:
-            payload = await request.read()
-            if not payload:
-                raise ValueError("Bot clone archive is empty.")
-
-            def _import() -> tuple[Path, str]:
-                import tempfile
-
-                with tempfile.TemporaryDirectory(prefix="hermes_api_bot_push_") as tmpdir:
-                    archive = Path(tmpdir) / "bot.tar.gz"
-                    archive.write_bytes(payload)
-                    return import_bot_profile(
-                        str(archive), name=(request.query.get("name") or "").strip() or None
-                    )
-
-            profile_dir, bot_id = await asyncio.to_thread(_import)
-            try:
-                from hermes_cli.profiles import check_alias_collision, create_wrapper_script
-
-                if not check_alias_collision(profile_dir.name):
-                    await asyncio.to_thread(create_wrapper_script, profile_dir.name)
-            except Exception:
-                logger.exception("Creating wrapper for cloned bot %s failed", profile_dir.name)
-        except FileExistsError as exc:
-            return web.json_response(
-                _openai_error(str(exc), code="bot_clone_conflict"), status=409
-            )
-        except (ValueError, FileNotFoundError) as exc:
-            return web.json_response(
-                _openai_error(str(exc), code="invalid_bot_clone"), status=400
-            )
-        except Exception:
-            logger.exception("[%s] bot clone import failed", self.name)
-            return web.json_response(
-                _openai_error("Bot clone import failed.", code="bot_clone_import_failed"),
-                status=500,
-            )
-
-        return web.json_response(
-            {"object": "hermes.bot_clone", "name": profile_dir.name, "bot_id": bot_id},
-            status=201,
+        return await _bot_clone._handle_bot_clone_upload(
+            self, request, error_factory=_openai_error, web_module=web
         )
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -20,6 +20,8 @@ Exposes an HTTP server with endpoints:
 - POST /v1/runs/{run_id}/approval — resolve a pending run approval
 - POST /v1/runs/{run_id}/steer      — inject guidance into a running agent
 - POST /v1/runs/{run_id}/stop       — interrupt a running agent
+- GET  /v1/bots/{profile}/clone     — download an owner-enabled bot clone
+- POST /v1/bots/clone               — push a bot clone when the owner permits it
 - GET  /health                     — health check
 - GET  /health/detailed            — rich status for cross-container dashboard probing
 
@@ -2234,6 +2236,8 @@ class APIServerAdapter(BasePlatformAdapter):
             ("GET", "/v1/artifacts/download/{artifact_id}", self._handle_artifact_download),
             ("GET", "/v1/skills", self._handle_skills),
             ("GET", "/v1/toolsets", self._handle_toolsets),
+            ("GET", "/v1/bots/{profile_name}/clone", self._handle_bot_clone_download),
+            ("POST", "/v1/bots/clone", self._handle_bot_clone_upload),
             ("GET", "/api/sessions", self._handle_list_sessions),
             ("POST", "/api/sessions", self._handle_create_session),
             ("GET", "/api/sessions/{session_id}", self._handle_get_session),
@@ -3480,6 +3484,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "jobs_admin": False,
                 "memory_write_api": False,
                 "skills_api": True,
+                "bot_cloning": {
+                    "pull": True,
+                    "push": self._bot_push_enabled(),
+                    "max_bytes": MAX_REQUEST_BYTES,
+                },
                 "audio_api": False,
                 "realtime_voice": False,
                 "session_continuity_header": "X-Hermes-Session-Id",
@@ -3527,6 +3536,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
                 "skills": {"method": "GET", "path": "/v1/skills"},
                 "toolsets": {"method": "GET", "path": "/v1/toolsets"},
+                "bot_clone_download": {
+                    "method": "GET",
+                    "path": "/v1/bots/{profile_name}/clone",
+                },
+                "bot_clone_upload": {"method": "POST", "path": "/v1/bots/clone"},
                 "sessions": {"method": "GET", "path": "/api/sessions"},
                 "session_create": {"method": "POST", "path": "/api/sessions"},
                 "session": {"method": "GET", "path": "/api/sessions/{session_id}"},
@@ -4174,6 +4188,141 @@ class APIServerAdapter(BasePlatformAdapter):
                 "X-Artifact-Id": receipt.artifact_id,
                 "Content-Disposition": f'attachment; filename="{receipt.filename}"',
             },
+        )
+
+    @staticmethod
+    def _bot_push_enabled() -> bool:
+        """Read the gateway owner's explicit remote-push policy."""
+        try:
+            from hermes_cli.config import cfg_get, load_config
+
+            raw = cfg_get(
+                load_config(), "gateway", "bot_sharing", "allow_push", default=False
+            )
+            return _coerce_request_bool(raw, default=False)
+        except Exception:
+            return False
+
+    async def _handle_bot_clone_download(self, request: "web.Request") -> "web.Response":
+        """Return a bounded, credential-free clone of an owner-enabled bot."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        from hermes_cli.bot_transfer import export_bot_profile, profile_is_cloneable
+        from hermes_cli.profiles import normalize_profile_name
+
+        try:
+            name = normalize_profile_name(request.match_info.get("profile_name", ""))
+            if not profile_is_cloneable(name):
+                # Do not reveal whether a non-shared profile exists.
+                return web.json_response(
+                    _openai_error(
+                        "Bot is not available for cloning.", code="bot_clone_unavailable"
+                    ),
+                    status=404,
+                )
+
+            def _export() -> tuple[bytes, str]:
+                import tempfile
+
+                with tempfile.TemporaryDirectory(prefix="hermes_api_bot_pull_") as tmpdir:
+                    archive, bot_id = export_bot_profile(
+                        name, str(Path(tmpdir) / f"{name}.tar.gz")
+                    )
+                    return archive.read_bytes(), bot_id
+
+            payload, bot_id = await asyncio.to_thread(_export)
+        except FileNotFoundError:
+            return web.json_response(
+                _openai_error("Bot is not available for cloning.", code="bot_clone_unavailable"),
+                status=404,
+            )
+        except ValueError as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="invalid_bot_clone"), status=400
+            )
+        except Exception:
+            logger.exception("[%s] bot clone export failed", self.name)
+            return web.json_response(
+                _openai_error("Bot clone export failed.", code="bot_clone_export_failed"),
+                status=500,
+            )
+
+        return web.Response(
+            body=payload,
+            content_type="application/gzip",
+            headers={
+                "Content-Disposition": f'attachment; filename="{name}.tar.gz"',
+                "X-Hermes-Bot-Id": bot_id,
+                "X-Hermes-Profile-Name": name,
+            },
+        )
+
+    async def _handle_bot_clone_upload(self, request: "web.Request") -> "web.Response":
+        """Install an uploaded bot clone without overwriting any local bot."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+        if not self._bot_push_enabled():
+            return web.json_response(
+                _openai_error(
+                    "This gateway does not accept pushed bot clones.",
+                    code="bot_clone_push_disabled",
+                ),
+                status=403,
+            )
+        if request.content_type not in {"application/gzip", "application/x-gzip"}:
+            return web.json_response(
+                _openai_error(
+                    "Content-Type must be application/gzip.", code="invalid_content_type"
+                ),
+                status=415,
+            )
+
+        from hermes_cli.bot_transfer import import_bot_profile
+
+        try:
+            payload = await request.read()
+            if not payload:
+                raise ValueError("Bot clone archive is empty.")
+
+            def _import() -> tuple[Path, str]:
+                import tempfile
+
+                with tempfile.TemporaryDirectory(prefix="hermes_api_bot_push_") as tmpdir:
+                    archive = Path(tmpdir) / "bot.tar.gz"
+                    archive.write_bytes(payload)
+                    return import_bot_profile(
+                        str(archive), name=(request.query.get("name") or "").strip() or None
+                    )
+
+            profile_dir, bot_id = await asyncio.to_thread(_import)
+            try:
+                from hermes_cli.profiles import check_alias_collision, create_wrapper_script
+
+                if not check_alias_collision(profile_dir.name):
+                    await asyncio.to_thread(create_wrapper_script, profile_dir.name)
+            except Exception:
+                logger.exception("Creating wrapper for cloned bot %s failed", profile_dir.name)
+        except FileExistsError as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="bot_clone_conflict"), status=409
+            )
+        except (ValueError, FileNotFoundError) as exc:
+            return web.json_response(
+                _openai_error(str(exc), code="invalid_bot_clone"), status=400
+            )
+        except Exception:
+            logger.exception("[%s] bot clone import failed", self.name)
+            return web.json_response(
+                _openai_error("Bot clone import failed.", code="bot_clone_import_failed"),
+                status=500,
+            )
+
+        return web.json_response(
+            {"object": "hermes.bot_clone", "name": profile_dir.name, "bot_id": bot_id},
+            status=201,
         )
 
     async def _handle_skills(self, request: "web.Request") -> "web.Response":

--- a/gateway/platforms/api_server_bot_clone.py
+++ b/gateway/platforms/api_server_bot_clone.py
@@ -1,0 +1,177 @@
+"""Authenticated API handlers for cloning bot profiles between gateways."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import tempfile
+from pathlib import Path
+from typing import Any, Callable
+
+try:
+    from aiohttp import web
+except ImportError:
+    web = None  # type: ignore[assignment]
+
+logger = logging.getLogger("gateway.platforms.api_server")
+
+
+def _http_routes(self) -> list[tuple[str, str, Any]]:
+    return [
+        ("GET", "/v1/bots/{profile_name}/clone", self._handle_bot_clone_download),
+        ("POST", "/v1/bots/clone", self._handle_bot_clone_upload),
+    ]
+
+
+def _capabilities() -> dict[str, dict[str, str]]:
+    return {
+        "bot_clone_download": {
+            "method": "GET",
+            "path": "/v1/bots/{profile_name}/clone",
+        },
+        "bot_clone_upload": {"method": "POST", "path": "/v1/bots/clone"},
+    }
+
+
+def _bot_push_enabled(*, coerce_bool: Callable[..., bool]) -> bool:
+    """Read the gateway owner's explicit remote-push policy."""
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        raw = cfg_get(
+            load_config(), "gateway", "bot_sharing", "allow_push", default=False
+        )
+        return coerce_bool(raw, default=False)
+    except Exception:
+        return False
+
+
+async def _handle_bot_clone_download(
+    self,
+    request: "web.Request",
+    *,
+    error_factory: Callable[..., dict[str, Any]],
+    web_module: Any,
+) -> "web.Response":
+    """Return a bounded, credential-free clone of an owner-enabled bot."""
+    auth_err = self._check_auth(request)
+    if auth_err:
+        return auth_err
+
+    from hermes_cli.bot_transfer import export_bot_profile, profile_is_cloneable
+    from hermes_cli.profiles import normalize_profile_name
+
+    try:
+        name = normalize_profile_name(request.match_info.get("profile_name", ""))
+        if not profile_is_cloneable(name):
+            return web_module.json_response(
+                error_factory(
+                    "Bot is not available for cloning.", code="bot_clone_unavailable"
+                ),
+                status=404,
+            )
+
+        def _export() -> tuple[bytes, str]:
+            with tempfile.TemporaryDirectory(prefix="hermes_api_bot_pull_") as tmpdir:
+                archive, bot_id = export_bot_profile(
+                    name, str(Path(tmpdir) / f"{name}.tar.gz")
+                )
+                return archive.read_bytes(), bot_id
+
+        payload, bot_id = await asyncio.to_thread(_export)
+    except FileNotFoundError:
+        return web_module.json_response(
+            error_factory("Bot is not available for cloning.", code="bot_clone_unavailable"),
+            status=404,
+        )
+    except ValueError as exc:
+        return web_module.json_response(
+            error_factory(str(exc), code="invalid_bot_clone"), status=400
+        )
+    except Exception:
+        logger.exception("[%s] bot clone export failed", self.name)
+        return web_module.json_response(
+            error_factory("Bot clone export failed.", code="bot_clone_export_failed"),
+            status=500,
+        )
+
+    return web_module.Response(
+        body=payload,
+        content_type="application/gzip",
+        headers={
+            "Content-Disposition": f'attachment; filename="{name}.tar.gz"',
+            "X-Hermes-Bot-Id": bot_id,
+            "X-Hermes-Profile-Name": name,
+        },
+    )
+
+
+async def _handle_bot_clone_upload(
+    self,
+    request: "web.Request",
+    *,
+    error_factory: Callable[..., dict[str, Any]],
+    web_module: Any,
+) -> "web.Response":
+    """Install an uploaded bot clone without overwriting any local bot."""
+    auth_err = self._check_auth(request)
+    if auth_err:
+        return auth_err
+    if not self._bot_push_enabled():
+        return web_module.json_response(
+            error_factory(
+                "This gateway does not accept pushed bot clones.",
+                code="bot_clone_push_disabled",
+            ),
+            status=403,
+        )
+    if request.content_type not in {"application/gzip", "application/x-gzip"}:
+        return web_module.json_response(
+            error_factory(
+                "Content-Type must be application/gzip.", code="invalid_content_type"
+            ),
+            status=415,
+        )
+
+    from hermes_cli.bot_transfer import import_bot_profile
+
+    try:
+        payload = await request.read()
+        if not payload:
+            raise ValueError("Bot clone archive is empty.")
+
+        def _import() -> tuple[Path, str]:
+            with tempfile.TemporaryDirectory(prefix="hermes_api_bot_push_") as tmpdir:
+                archive = Path(tmpdir) / "bot.tar.gz"
+                archive.write_bytes(payload)
+                return import_bot_profile(
+                    str(archive), name=(request.query.get("name") or "").strip() or None
+                )
+
+        profile_dir, bot_id = await asyncio.to_thread(_import)
+        try:
+            from hermes_cli.profiles import check_alias_collision, create_wrapper_script
+
+            if not check_alias_collision(profile_dir.name):
+                await asyncio.to_thread(create_wrapper_script, profile_dir.name)
+        except Exception:
+            logger.exception("Creating wrapper for cloned bot %s failed", profile_dir.name)
+    except FileExistsError as exc:
+        return web_module.json_response(
+            error_factory(str(exc), code="bot_clone_conflict"), status=409
+        )
+    except (ValueError, FileNotFoundError) as exc:
+        return web_module.json_response(
+            error_factory(str(exc), code="invalid_bot_clone"), status=400
+        )
+    except Exception:
+        logger.exception("[%s] bot clone import failed", self.name)
+        return web_module.json_response(
+            error_factory("Bot clone import failed.", code="bot_clone_import_failed"),
+            status=500,
+        )
+
+    return web_module.json_response(
+        {"object": "hermes.bot_clone", "name": profile_dir.name, "bot_id": bot_id},
+        status=201,
+    )

--- a/hermes_cli/archive_safe.py
+++ b/hermes_cli/archive_safe.py
@@ -143,7 +143,12 @@ def safe_extract_targz(
                 pass
 
 
-def archive_root_dirs(archive: Path, *, max_members: int | None = None) -> set[str]:
+def archive_root_dirs(
+    archive: Path,
+    *,
+    max_bytes: int | None = None,
+    max_members: int | None = None,
+) -> set[str]:
     """Return the archive's top-level directory names.
 
     Transfer archives carry exactly one root directory, which names the
@@ -152,10 +157,17 @@ def archive_root_dirs(archive: Path, *, max_members: int | None = None) -> set[s
     without first mutating a live tree.
     """
     roots: set[str] = set()
+    declared_bytes = 0
     with tarfile.open(archive, "r:gz") as tf:
         for member_count, member in enumerate(tf, start=1):
             if max_members is not None and member_count > max_members:
                 raise ValueError(f"Archive exceeds the {max_members} member limit.")
+            if member.isfile():
+                declared_bytes += member.size
+                if max_bytes is not None and declared_bytes > max_bytes:
+                    raise ValueError(
+                        f"Archive exceeds the {max_bytes} byte expanded-size limit."
+                    )
             parts = normalize_archive_parts(member.name)
             if len(parts) > 1 or member.isdir():
                 roots.add(parts[0])

--- a/hermes_cli/archive_safe.py
+++ b/hermes_cli/archive_safe.py
@@ -80,15 +80,29 @@ def make_targz(base: str, root_dir: str, base_dir: str) -> str:
     return archive_path
 
 
-def safe_extract_targz(archive: Path, destination: Path) -> None:
+def safe_extract_targz(
+    archive: Path,
+    destination: Path,
+    *,
+    max_bytes: int | None = None,
+    max_members: int | None = None,
+) -> None:
     """Extract ``archive`` into ``destination`` without path escapes or links.
 
     Only directories and regular files are extracted; symlinks, hardlinks,
     and device nodes raise rather than being silently skipped, so a
     tampered archive fails the import instead of landing a partial tree.
+    Optional limits bound the expanded object rather than only its compressed
+    representation. The byte limit is checked both against member metadata and
+    while streaming so a dishonest header cannot bypass it.
     """
+    extracted_bytes = 0
     with tarfile.open(archive, "r:gz") as tf:
-        for member in tf.getmembers():
+        for member_count, member in enumerate(tf, start=1):
+            if max_members is not None and member_count > max_members:
+                raise ValueError(
+                    f"Archive exceeds the {max_members} member extraction limit."
+                )
             parts = normalize_archive_parts(member.name)
             target = destination.joinpath(*parts)
 
@@ -100,14 +114,28 @@ def safe_extract_targz(archive: Path, destination: Path) -> None:
                 raise ValueError(
                     f"Unsupported archive member type: {member.name}"
                 )
+            if max_bytes is not None and member.size > max_bytes - extracted_bytes:
+                raise ValueError(
+                    f"Archive exceeds the {max_bytes} byte expanded-size limit."
+                )
 
             target.parent.mkdir(parents=True, exist_ok=True)
             extracted = tf.extractfile(member)
             if extracted is None:
                 raise ValueError(f"Cannot read archive member: {member.name}")
 
-            with extracted, open(target, "wb") as dst:
-                shutil.copyfileobj(extracted, dst)
+            try:
+                with extracted, open(target, "wb") as dst:
+                    while chunk := extracted.read(1024 * 1024):
+                        extracted_bytes += len(chunk)
+                        if max_bytes is not None and extracted_bytes > max_bytes:
+                            raise ValueError(
+                                f"Archive exceeds the {max_bytes} byte expanded-size limit."
+                            )
+                        dst.write(chunk)
+            except BaseException:
+                target.unlink(missing_ok=True)
+                raise
 
             try:
                 os.chmod(target, member.mode & 0o777)
@@ -115,7 +143,7 @@ def safe_extract_targz(archive: Path, destination: Path) -> None:
                 pass
 
 
-def archive_root_dirs(archive: Path) -> set[str]:
+def archive_root_dirs(archive: Path, *, max_members: int | None = None) -> set[str]:
     """Return the archive's top-level directory names.
 
     Transfer archives carry exactly one root directory, which names the
@@ -123,13 +151,15 @@ def archive_root_dirs(archive: Path) -> set[str]:
     the caller resolve the target name (and refuse a malformed archive)
     without first mutating a live tree.
     """
+    roots: set[str] = set()
     with tarfile.open(archive, "r:gz") as tf:
-        return {
-            parts[0]
-            for member in tf.getmembers()
-            for parts in [normalize_archive_parts(member.name)]
-            if len(parts) > 1 or member.isdir()
-        }
+        for member_count, member in enumerate(tf, start=1):
+            if max_members is not None and member_count > max_members:
+                raise ValueError(f"Archive exceeds the {max_members} member limit.")
+            parts = normalize_archive_parts(member.name)
+            if len(parts) > 1 or member.isdir():
+                roots.add(parts[0])
+    return roots
 
 
 def copy_regular_files(src: Path, dst: Path) -> int:

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -1,0 +1,359 @@
+"""Safe profile cloning between authenticated Hermes API gateways.
+
+A bot clone carries the bot's runnable definition (SOUL, config, skills,
+plugins, cron, and desktop appearance), never credentials, memories, sessions,
+or runtime state.  A persistent UUID travels with every clone so a target can
+reject a second copy even when the first copy was renamed.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import tempfile
+import time
+import uuid
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator, Optional
+from urllib.parse import quote
+
+import httpx
+
+from hermes_cli.archive_safe import archive_root_dirs, make_targz, safe_extract_targz
+
+MAX_BOT_CLONE_BYTES = 10_000_000
+BOT_ID_FILENAME = ".hermes-bot-id"
+
+# Deliberately excludes USER/MEMORY, sessions, memories, databases, logs,
+# credentials, and caches.  This is a shareable agent definition, not a backup.
+BOT_CLONE_ROOTS = frozenset(
+    {
+        BOT_ID_FILENAME,
+        ".cursorrules",
+        ".no-bundled-skills",
+        "AGENTS.md",
+        "CLAUDE.md",
+        "SOUL.md",
+        "config.yaml",
+        "cron",
+        "desktop.json",
+        "mcp.json",
+        "plugins",
+        "profile.yaml",
+        "scripts",
+        "skills",
+        "system_prompt.md",
+    }
+)
+
+
+class BotTransferError(RuntimeError):
+    """A remote clone request failed without changing the target profile."""
+
+
+def _valid_bot_id(value: str) -> str:
+    try:
+        return str(uuid.UUID(str(value).strip()))
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise ValueError("Bot identity is missing or invalid.") from exc
+
+
+def get_profile_bot_id(profile_dir: Path) -> Optional[str]:
+    """Return a profile's stable clone identity, or ``None`` when unassigned."""
+    path = profile_dir / BOT_ID_FILENAME
+    if not path.is_file():
+        return None
+    return _valid_bot_id(path.read_text(encoding="utf-8"))
+
+
+def ensure_profile_bot_id(profile_dir: Path) -> str:
+    """Atomically assign and return the profile's stable clone identity."""
+    existing = get_profile_bot_id(profile_dir)
+    if existing:
+        return existing
+
+    candidate = str(uuid.uuid4())
+    path = profile_dir / BOT_ID_FILENAME
+    try:
+        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+    except FileExistsError:
+        # A concurrent exporter won the identity race.
+        return _valid_bot_id(path.read_text(encoding="utf-8"))
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        handle.write(candidate + "\n")
+    return candidate
+
+
+def set_profile_cloneable(name: str, allowed: bool) -> str:
+    """Set the per-bot pull policy and return its stable bot UUID."""
+    from hermes_cli.profiles import get_profile_dir, write_profile_meta
+
+    profile_dir = get_profile_dir(name)
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"Profile '{name}' does not exist.")
+    bot_id = ensure_profile_bot_id(profile_dir)
+    write_profile_meta(profile_dir, cloneable=bool(allowed))
+    return bot_id
+
+
+def profile_is_cloneable(name: str) -> bool:
+    from hermes_cli.profiles import get_profile_dir, read_profile_meta
+
+    profile_dir = get_profile_dir(name)
+    return profile_dir.is_dir() and bool(read_profile_meta(profile_dir).get("cloneable"))
+
+
+def _reject_symlinks(root: Path) -> None:
+    for path in root.rglob("*"):
+        if path.is_symlink():
+            raise ValueError(f"Bot clone cannot include symbolic link: {path.relative_to(root)}")
+
+
+def _reset_owner_policies(staged: Path) -> None:
+    """Do not transfer the source owner's inbound sharing decisions."""
+    from hermes_cli.profiles import write_profile_meta
+
+    write_profile_meta(staged, cloneable=False)
+    config_path = staged / "config.yaml"
+    if not config_path.is_file():
+        return
+    try:
+        import yaml
+
+        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        gateway = config.get("gateway") if isinstance(config, dict) else None
+        if not isinstance(gateway, dict) or "bot_sharing" not in gateway:
+            return
+        gateway.pop("bot_sharing", None)
+        from utils import atomic_yaml_write
+
+        atomic_yaml_write(config_path, config, sort_keys=False)
+    except Exception as exc:
+        raise ValueError("Could not remove owner-only sharing policy from bot clone.") from exc
+
+
+def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
+    """Create a bounded, credential-free bot clone archive."""
+    from hermes_cli.profiles import (
+        _scrub_export_secrets,
+        get_profile_dir,
+        normalize_profile_name,
+        validate_profile_name,
+    )
+
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    profile_dir = get_profile_dir(canon)
+    if not profile_dir.is_dir():
+        raise FileNotFoundError(f"Profile '{canon}' does not exist.")
+    bot_id = ensure_profile_bot_id(profile_dir)
+
+    output = Path(output_path)
+    output.parent.mkdir(parents=True, exist_ok=True)
+    base = str(output).removesuffix(".tar.gz").removesuffix(".tgz")
+    with tempfile.TemporaryDirectory(prefix="hermes_bot_export_") as tmpdir:
+        staged = Path(tmpdir) / canon
+        staged.mkdir()
+        for entry in sorted(BOT_CLONE_ROOTS):
+            source = profile_dir / entry
+            if not source.exists():
+                continue
+            if source.is_symlink():
+                raise ValueError(f"Bot clone cannot include symbolic link: {entry}")
+            target = staged / entry
+            if source.is_dir():
+                _reject_symlinks(source)
+                shutil.copytree(source, target)
+            elif source.is_file():
+                shutil.copy2(source, target)
+        _reset_owner_policies(staged)
+        _scrub_export_secrets(staged)
+        result = Path(make_targz(base, tmpdir, canon))
+
+    if result.stat().st_size > MAX_BOT_CLONE_BYTES:
+        result.unlink(missing_ok=True)
+        raise ValueError(
+            f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
+        )
+    return result, bot_id
+
+
+def _validate_bot_archive(archive: Path) -> tuple[str, str]:
+    if not archive.is_file():
+        raise FileNotFoundError(f"Archive not found: {archive}")
+    if archive.stat().st_size > MAX_BOT_CLONE_BYTES:
+        raise ValueError(
+            f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
+        )
+    roots = archive_root_dirs(archive)
+    if len(roots) != 1:
+        raise ValueError("Bot clone must contain exactly one top-level directory.")
+    archive_root = next(iter(roots))
+    with tempfile.TemporaryDirectory(prefix="hermes_bot_validate_") as tmpdir:
+        staging = Path(tmpdir)
+        safe_extract_targz(archive, staging)
+        extracted = staging / archive_root
+        unexpected = {path.name for path in extracted.iterdir()} - BOT_CLONE_ROOTS
+        if unexpected:
+            raise ValueError(
+                "Bot clone contains disallowed profile data: " + ", ".join(sorted(unexpected))
+            )
+        bot_id = get_profile_bot_id(extracted)
+        if not bot_id:
+            raise ValueError("Bot clone has no stable identity.")
+    return archive_root, bot_id
+
+
+def _iter_profile_dirs() -> Iterator[Path]:
+    from hermes_cli.profiles import _get_default_hermes_home, _get_profiles_root
+
+    default = _get_default_hermes_home()
+    if default.is_dir():
+        yield default
+    root = _get_profiles_root()
+    if root.is_dir():
+        for path in root.iterdir():
+            if path.is_dir():
+                yield path
+
+
+@contextmanager
+def _clone_import_lock(timeout: float = 30.0) -> Iterator[None]:
+    """Cross-process exclusion for identity/name checks plus profile install."""
+    from hermes_cli.profiles import _get_profiles_root
+
+    root = _get_profiles_root()
+    root.mkdir(parents=True, exist_ok=True)
+    lock = root / ".bot-clone.lock"
+    deadline = time.monotonic() + timeout
+    while True:
+        try:
+            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+            break
+        except FileExistsError:
+            try:
+                stale = time.time() - lock.stat().st_mtime > max(timeout * 2, 60.0)
+            except OSError:
+                stale = False
+            if stale:
+                try:
+                    lock.unlink()
+                    continue
+                except OSError:
+                    pass
+            if time.monotonic() >= deadline:
+                raise TimeoutError("Timed out waiting for another bot clone import.")
+            time.sleep(0.05)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(json.dumps({"pid": os.getpid(), "created": time.time()}))
+        yield
+    finally:
+        lock.unlink(missing_ok=True)
+
+
+def import_bot_profile(archive_path: str, name: Optional[str] = None) -> tuple[Path, str]:
+    """Install a bot clone without overwriting a name or duplicate bot UUID."""
+    from hermes_cli.profiles import import_profile
+
+    archive = Path(archive_path)
+    archive_root, bot_id = _validate_bot_archive(archive)
+    with _clone_import_lock():
+        for profile_dir in _iter_profile_dirs():
+            try:
+                existing_id = get_profile_bot_id(profile_dir)
+            except (OSError, ValueError):
+                continue
+            if existing_id == bot_id:
+                raise FileExistsError(
+                    f"Bot {bot_id} already exists as profile '{profile_dir.name}'."
+                )
+        profile_dir = import_profile(str(archive), name=name or archive_root)
+    return profile_dir, bot_id
+
+
+def _remote_settings(remote: Optional[str]) -> tuple[str, str]:
+    from agent.secret_scope import UnscopedSecretError, get_secret
+    from hermes_cli.config import cfg_get, load_config
+
+    configured = cfg_get(load_config(), "gateway", "proxy_url", default="")
+    base = str(remote or configured or "").strip().rstrip("/")
+    if base.endswith("/v1"):
+        base = base[:-3]
+    if not base:
+        raise ValueError("Remote gateway URL is required (--from/--to or gateway.proxy_url).")
+    if not base.startswith(("http://", "https://")):
+        raise ValueError("Remote gateway URL must start with http:// or https://.")
+    try:
+        key = str(get_secret("GATEWAY_PROXY_KEY", "") or "").strip()
+    except UnscopedSecretError:
+        key = os.getenv("GATEWAY_PROXY_KEY", "").strip()
+    if not key:
+        raise ValueError("GATEWAY_PROXY_KEY is required for bot cloning.")
+    return base, key
+
+
+def _response_error(response: httpx.Response) -> BotTransferError:
+    try:
+        payload = response.json()
+        error = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(error, dict):
+            detail = str(error.get("message") or error.get("code") or "")
+        else:
+            detail = str(error or payload.get("detail") or "") if isinstance(payload, dict) else ""
+    except Exception:
+        detail = ""
+    return BotTransferError(detail or f"Remote gateway returned HTTP {response.status_code}.")
+
+
+def pull_bot_profile(
+    remote_profile: str,
+    *,
+    remote: Optional[str] = None,
+    name: Optional[str] = None,
+) -> tuple[Path, str]:
+    """Pull one clone-enabled remote bot into a new local profile."""
+    base, key = _remote_settings(remote)
+    url = f"{base}/v1/bots/{quote(remote_profile, safe='')}/clone"
+    headers = {"Authorization": f"Bearer {key}", "Accept": "application/gzip"}
+    with tempfile.TemporaryDirectory(prefix="hermes_bot_pull_") as tmpdir:
+        archive = Path(tmpdir) / "bot.tar.gz"
+        with httpx.Client(timeout=120.0, follow_redirects=False) as client:
+            with client.stream("GET", url, headers=headers) as response:
+                if response.status_code != 200:
+                    response.read()
+                    raise _response_error(response)
+                total = 0
+                with archive.open("wb") as handle:
+                    for chunk in response.iter_bytes():
+                        total += len(chunk)
+                        if total > MAX_BOT_CLONE_BYTES:
+                            raise BotTransferError("Remote bot clone exceeds the 10 MB transfer limit.")
+                        handle.write(chunk)
+        return import_bot_profile(str(archive), name=name)
+
+
+def push_bot_profile(
+    local_profile: str,
+    *,
+    remote: Optional[str] = None,
+    name: Optional[str] = None,
+) -> tuple[str, str]:
+    """Push one local bot into a new profile on an opt-in remote gateway."""
+    base, key = _remote_settings(remote)
+    with tempfile.TemporaryDirectory(prefix="hermes_bot_push_") as tmpdir:
+        archive, _ = export_bot_profile(local_profile, str(Path(tmpdir) / "bot.tar.gz"))
+        headers = {
+            "Authorization": f"Bearer {key}",
+            "Content-Type": "application/gzip",
+            "Accept": "application/json",
+        }
+        params = {"name": name} if name else None
+        with archive.open("rb") as body, httpx.Client(timeout=120.0, follow_redirects=False) as client:
+            response = client.post(f"{base}/v1/bots/clone", headers=headers, params=params, content=body)
+        if response.status_code != 201:
+            raise _response_error(response)
+        payload = response.json()
+        return str(payload["name"]), _valid_bot_id(payload["bot_id"])

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -17,7 +17,7 @@ import uuid
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Optional
-from urllib.parse import quote
+from urllib.parse import quote, urlsplit
 
 import httpx
 
@@ -286,6 +286,11 @@ def _remote_settings(remote: Optional[str]) -> tuple[str, str]:
         raise ValueError("Remote gateway URL is required (--from/--to or gateway.proxy_url).")
     if not base.startswith(("http://", "https://")):
         raise ValueError("Remote gateway URL must start with http:// or https://.")
+    parsed = urlsplit(base)
+    if parsed.username or parsed.password or parsed.query or parsed.fragment:
+        raise ValueError("Remote gateway URL cannot contain credentials, a query, or a fragment.")
+    if parsed.scheme == "http" and parsed.hostname not in {"127.0.0.1", "::1", "localhost"}:
+        raise ValueError("Remote gateway URL must use HTTPS (HTTP is allowed only on loopback).")
     try:
         key = str(get_secret("GATEWAY_PROXY_KEY", "") or "").strip()
     except UnscopedSecretError:

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -47,6 +47,24 @@ BOT_CLONE_ROOTS = frozenset(
         "system_prompt.md",
     }
 )
+BOT_CLONE_DENIED_NAMES = frozenset(
+    {".env", ".netrc", "auth.json", "credentials.json", "secrets.json"}
+)
+BOT_CLONE_DENIED_SUFFIXES = frozenset({".key", ".p12", ".pem", ".pfx"})
+BOT_CLONE_SAFE_BINARY_SUFFIXES = frozenset(
+    {
+        ".gif",
+        ".ico",
+        ".jpeg",
+        ".jpg",
+        ".otf",
+        ".png",
+        ".ttf",
+        ".webp",
+        ".woff",
+        ".woff2",
+    }
+)
 
 
 class BotTransferError(RuntimeError):
@@ -148,6 +166,19 @@ def _check_clone_source_budget(profile_dir: Path) -> None:
         if source.is_dir():
             candidates.extend(source.rglob("*"))
         for path in candidates:
+            relative = path.relative_to(profile_dir)
+            if (
+                path.name.lower() in BOT_CLONE_DENIED_NAMES
+                or path.suffix.lower() in BOT_CLONE_DENIED_SUFFIXES
+                or "__pycache__" in relative.parts
+                or path.name.endswith((".sock", ".tmp"))
+                or (
+                    relative.parts[0] == "cron"
+                    and len(relative.parts) > 1
+                    and relative.parts[1] != "jobs.json"
+                )
+            ):
+                continue
             if path.is_symlink():
                 raise ValueError(
                     f"Bot clone cannot include symbolic link: {path.relative_to(profile_dir)}"
@@ -167,6 +198,53 @@ def _check_clone_source_budget(profile_dir: Path) -> None:
                     raise ValueError(
                         "Bot clone exceeds the 10 MB expanded-size limit."
                     )
+
+
+def _copy_clone_tree(source: Path, target: Path, *, cron_root: bool = False) -> None:
+    """Copy a definition tree while excluding credentials and runtime state."""
+
+    def _ignore(directory: str, contents: list[str]) -> set[str]:
+        ignored = {
+            name
+            for name in contents
+            if name.lower() in BOT_CLONE_DENIED_NAMES
+            or Path(name).suffix.lower() in BOT_CLONE_DENIED_SUFFIXES
+            or name == "__pycache__"
+            or name.endswith((".sock", ".tmp"))
+        }
+        if cron_root and Path(directory) == source:
+            ignored.update(name for name in contents if name != "jobs.json")
+        return ignored
+
+    shutil.copytree(source, target, ignore=_ignore)
+
+
+def _scrub_clone_files(staged: Path) -> None:
+    """Redact every text file and reject unclassified binary profile data."""
+    from agent.redact import redact_sensitive_text
+
+    for path in staged.rglob("*"):
+        if not path.is_file():
+            continue
+        name = path.name.lower()
+        suffix = path.suffix.lower()
+        if name in BOT_CLONE_DENIED_NAMES or suffix in BOT_CLONE_DENIED_SUFFIXES:
+            raise ValueError(f"Bot clone contains credential file: {path.relative_to(staged)}")
+        if suffix in BOT_CLONE_SAFE_BINARY_SUFFIXES:
+            continue
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError as exc:
+            raise ValueError(
+                f"Bot clone contains unsupported binary file: {path.relative_to(staged)}"
+            ) from exc
+        if "\x00" in text:
+            raise ValueError(
+                f"Bot clone contains unsupported binary file: {path.relative_to(staged)}"
+            )
+        redacted = redact_sensitive_text(text, force=True)
+        if redacted != text:
+            path.write_text(redacted, encoding="utf-8")
 
 
 def _reset_owner_policies(staged: Path) -> None:
@@ -192,10 +270,24 @@ def _reset_owner_policies(staged: Path) -> None:
         raise ValueError("Could not remove owner-only sharing policy from bot clone.") from exc
 
 
+def _prepare_imported_clone(staged: Path) -> None:
+    """Enforce receiver-owned policy and data boundaries before publication."""
+    cron_dir = staged / "cron"
+    if cron_dir.is_dir():
+        for entry in cron_dir.iterdir():
+            if entry.name == "jobs.json":
+                continue
+            if entry.is_dir():
+                shutil.rmtree(entry)
+            else:
+                entry.unlink()
+    _scrub_clone_files(staged)
+    _reset_owner_policies(staged)
+
+
 def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
     """Create a bounded, credential-free bot clone archive."""
     from hermes_cli.profiles import (
-        _scrub_export_secrets,
         get_profile_dir,
         normalize_profile_name,
         validate_profile_name,
@@ -224,11 +316,11 @@ def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
             target = staged / entry
             if source.is_dir():
                 _reject_symlinks(source)
-                shutil.copytree(source, target)
+                _copy_clone_tree(source, target, cron_root=entry == "cron")
             elif source.is_file():
                 shutil.copy2(source, target)
         _reset_owner_policies(staged)
-        _scrub_export_secrets(staged)
+        _scrub_clone_files(staged)
         result = Path(make_targz(base, tmpdir, canon))
 
     try:
@@ -369,6 +461,7 @@ def import_bot_profile(archive_path: str, name: Optional[str] = None) -> tuple[P
             name=name or archive_root,
             max_extract_bytes=MAX_BOT_CLONE_BYTES,
             max_archive_members=MAX_BOT_CLONE_MEMBERS,
+            prepare_staged=_prepare_imported_clone,
         )
     return profile_dir, bot_id
 

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -8,6 +8,7 @@ reject a second copy even when the first copy was renamed.
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
 import tempfile
@@ -63,6 +64,31 @@ BOT_CLONE_SAFE_BINARY_SUFFIXES = frozenset(
         ".webp",
         ".woff",
         ".woff2",
+    }
+)
+
+# Cron clones carry runnable definitions, not the source gateway's scheduler,
+# delivery, filesystem, or execution state. Keep this allowlist aligned with
+# create_job's caller-owned inputs rather than its persisted runtime record.
+BOT_CLONE_CRON_FIELDS = frozenset(
+    {
+        "id",
+        "name",
+        "prompt",
+        "skills",
+        "skill",
+        "model",
+        "provider",
+        "base_url",
+        "script",
+        "no_agent",
+        "monitor_script",
+        "monitor_url",
+        "context_from",
+        "schedule",
+        "schedule_display",
+        "enabled_toolsets",
+        "reasoning_effort",
     }
 )
 
@@ -270,6 +296,42 @@ def _reset_owner_policies(staged: Path) -> None:
         raise ValueError("Could not remove owner-only sharing policy from bot clone.") from exc
 
 
+def _sanitize_clone_cron_jobs(staged: Path) -> None:
+    """Retain cron definitions while dropping source-owned state and routing."""
+    jobs_path = staged / "cron" / "jobs.json"
+    if not jobs_path.is_file():
+        return
+    try:
+        payload = json.loads(jobs_path.read_text(encoding="utf-8-sig"))
+        jobs = payload.get("jobs", []) if isinstance(payload, dict) else payload
+        if not isinstance(jobs, list) or any(not isinstance(job, dict) for job in jobs):
+            raise ValueError("jobs must be a list of objects")
+
+        sanitized = []
+        for job in jobs:
+            clone = {key: job[key] for key in BOT_CLONE_CRON_FIELDS if key in job}
+            repeat = job.get("repeat")
+            if isinstance(repeat, dict):
+                clone["repeat"] = {"times": repeat.get("times"), "completed": 0}
+            clone.update(
+                {
+                    "enabled": False,
+                    "state": "paused",
+                    "paused_at": None,
+                    "paused_reason": "Imported bot clone requires review.",
+                    "next_run_at": None,
+                    "deliver": "local",
+                }
+            )
+            sanitized.append(clone)
+        jobs_path.write_text(
+            json.dumps({"jobs": sanitized}, indent=2, ensure_ascii=False) + "\n",
+            encoding="utf-8",
+        )
+    except (OSError, UnicodeError, json.JSONDecodeError, ValueError) as exc:
+        raise ValueError("Bot clone contains invalid cron job definitions.") from exc
+
+
 def _prepare_imported_clone(staged: Path) -> None:
     """Enforce receiver-owned policy and data boundaries before publication."""
     cron_dir = staged / "cron"
@@ -281,6 +343,7 @@ def _prepare_imported_clone(staged: Path) -> None:
                 shutil.rmtree(entry)
             else:
                 entry.unlink()
+    _sanitize_clone_cron_jobs(staged)
     _scrub_clone_files(staged)
     _reset_owner_policies(staged)
 
@@ -319,6 +382,7 @@ def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
                 _copy_clone_tree(source, target, cron_root=entry == "cron")
             elif source.is_file():
                 shutil.copy2(source, target)
+        _sanitize_clone_cron_jobs(staged)
         _reset_owner_policies(staged)
         _scrub_clone_files(staged)
         result = Path(make_targz(base, tmpdir, canon))

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -296,7 +296,35 @@ def _reset_owner_policies(staged: Path) -> None:
         raise ValueError("Could not remove owner-only sharing policy from bot clone.") from exc
 
 
-def _sanitize_clone_cron_jobs(staged: Path) -> None:
+def _normalize_clone_script_path(
+    value: object,
+    *,
+    scripts_root: Path,
+    allow_absolute: bool,
+) -> str:
+    """Return a portable path for a regular file owned by ``scripts_root``."""
+    if not isinstance(value, str) or not value.strip() or "\x00" in value:
+        raise ValueError("cron script path must be a non-empty string")
+    try:
+        raw = Path(value).expanduser()
+        if raw.is_absolute() and not allow_absolute:
+            raise ValueError("imported cron script path must be relative")
+        root = scripts_root.resolve()
+        resolved = raw.resolve() if raw.is_absolute() else (root / raw).resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ValueError("cron script path is invalid") from exc
+    try:
+        relative = resolved.relative_to(root)
+    except ValueError as exc:
+        raise ValueError("cron script path resolves outside the scripts directory") from exc
+    if not resolved.is_file():
+        raise ValueError("cron script path does not identify a regular file")
+    return relative.as_posix()
+
+
+def _sanitize_clone_cron_jobs(
+    staged: Path, *, source_scripts_root: Optional[Path] = None
+) -> None:
     """Retain cron definitions while dropping source-owned state and routing."""
     jobs_path = staged / "cron" / "jobs.json"
     if not jobs_path.is_file():
@@ -310,6 +338,20 @@ def _sanitize_clone_cron_jobs(staged: Path) -> None:
         sanitized = []
         for job in jobs:
             clone = {key: job[key] for key in BOT_CLONE_CRON_FIELDS if key in job}
+            scripts_root = source_scripts_root or staged / "scripts"
+            for field in ("script", "monitor_script"):
+                if clone.get(field) is None:
+                    continue
+                relative = _normalize_clone_script_path(
+                    clone[field],
+                    scripts_root=scripts_root,
+                    allow_absolute=source_scripts_root is not None,
+                )
+                if source_scripts_root is not None and not (
+                    staged / "scripts" / Path(relative)
+                ).is_file():
+                    raise ValueError("cron script file is excluded from the bot clone")
+                clone[field] = relative
             repeat = job.get("repeat")
             if isinstance(repeat, dict):
                 clone["repeat"] = {"times": repeat.get("times"), "completed": 0}
@@ -382,7 +424,9 @@ def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
                 _copy_clone_tree(source, target, cron_root=entry == "cron")
             elif source.is_file():
                 shutil.copy2(source, target)
-        _sanitize_clone_cron_jobs(staged)
+        _sanitize_clone_cron_jobs(
+            staged, source_scripts_root=profile_dir / "scripts"
+        )
         _reset_owner_policies(staged)
         _scrub_clone_files(staged)
         result = Path(make_targz(base, tmpdir, canon))

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -187,7 +187,11 @@ def _validate_bot_archive(archive: Path) -> tuple[str, str]:
         raise ValueError(
             f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
         )
-    roots = archive_root_dirs(archive, max_members=MAX_BOT_CLONE_MEMBERS)
+    roots = archive_root_dirs(
+        archive,
+        max_bytes=MAX_BOT_CLONE_BYTES,
+        max_members=MAX_BOT_CLONE_MEMBERS,
+    )
     if len(roots) != 1:
         raise ValueError("Bot clone must contain exactly one top-level directory.")
     archive_root = next(iter(roots))

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -8,7 +8,6 @@ reject a second copy even when the first copy was renamed.
 
 from __future__ import annotations
 
-import json
 import os
 import shutil
 import tempfile
@@ -24,6 +23,7 @@ import httpx
 from hermes_cli.archive_safe import archive_root_dirs, make_targz, safe_extract_targz
 
 MAX_BOT_CLONE_BYTES = 10_000_000
+MAX_BOT_CLONE_MEMBERS = 10_000
 BOT_ID_FILENAME = ".hermes-bot-id"
 
 # Deliberately excludes USER/MEMORY, sessions, memories, databases, logs,
@@ -120,9 +120,9 @@ def _reset_owner_policies(staged: Path) -> None:
     if not config_path.is_file():
         return
     try:
-        import yaml
+        from hermes_cli.config import read_user_config_raw
 
-        config = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        config = read_user_config_raw(config_path)
         gateway = config.get("gateway") if isinstance(config, dict) else None
         if not isinstance(gateway, dict) or "bot_sharing" not in gateway:
             return
@@ -187,13 +187,18 @@ def _validate_bot_archive(archive: Path) -> tuple[str, str]:
         raise ValueError(
             f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
         )
-    roots = archive_root_dirs(archive)
+    roots = archive_root_dirs(archive, max_members=MAX_BOT_CLONE_MEMBERS)
     if len(roots) != 1:
         raise ValueError("Bot clone must contain exactly one top-level directory.")
     archive_root = next(iter(roots))
     with tempfile.TemporaryDirectory(prefix="hermes_bot_validate_") as tmpdir:
         staging = Path(tmpdir)
-        safe_extract_targz(archive, staging)
+        safe_extract_targz(
+            archive,
+            staging,
+            max_bytes=MAX_BOT_CLONE_BYTES,
+            max_members=MAX_BOT_CLONE_MEMBERS,
+        )
         extracted = staging / archive_root
         unexpected = {path.name for path in extracted.iterdir()} - BOT_CLONE_ROOTS
         if unexpected:
@@ -227,31 +232,49 @@ def _clone_import_lock(timeout: float = 30.0) -> Iterator[None]:
     root = _get_profiles_root()
     root.mkdir(parents=True, exist_ok=True)
     lock = root / ".bot-clone.lock"
+    handle = open(lock, "a+b")
+    handle.seek(0, os.SEEK_END)
+    if handle.tell() == 0:
+        handle.write(b"\0")
+        handle.flush()
     deadline = time.monotonic() + timeout
-    while True:
-        try:
-            fd = os.open(lock, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-            break
-        except FileExistsError:
+    acquired = False
+    try:
+        while not acquired:
             try:
-                stale = time.time() - lock.stat().st_mtime > max(timeout * 2, 60.0)
-            except OSError:
-                stale = False
-            if stale:
-                try:
-                    lock.unlink()
-                    continue
-                except OSError:
-                    pass
+                handle.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_NBLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                acquired = True
+            except (BlockingIOError, OSError):
+                pass
+            if acquired:
+                break
             if time.monotonic() >= deadline:
                 raise TimeoutError("Timed out waiting for another bot clone import.")
             time.sleep(0.05)
-    try:
-        with os.fdopen(fd, "w", encoding="utf-8") as handle:
-            handle.write(json.dumps({"pid": os.getpid(), "created": time.time()}))
         yield
     finally:
-        lock.unlink(missing_ok=True)
+        if acquired:
+            try:
+                handle.seek(0)
+                if os.name == "nt":
+                    import msvcrt
+
+                    msvcrt.locking(handle.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        handle.close()
 
 
 def import_bot_profile(archive_path: str, name: Optional[str] = None) -> tuple[Path, str]:
@@ -270,7 +293,12 @@ def import_bot_profile(archive_path: str, name: Optional[str] = None) -> tuple[P
                 raise FileExistsError(
                     f"Bot {bot_id} already exists as profile '{profile_dir.name}'."
                 )
-        profile_dir = import_profile(str(archive), name=name or archive_root)
+        profile_dir = import_profile(
+            str(archive),
+            name=name or archive_root,
+            max_extract_bytes=MAX_BOT_CLONE_BYTES,
+            max_archive_members=MAX_BOT_CLONE_MEMBERS,
+        )
     return profile_dir, bot_id
 
 

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -111,6 +111,39 @@ def _reject_symlinks(root: Path) -> None:
             raise ValueError(f"Bot clone cannot include symbolic link: {path.relative_to(root)}")
 
 
+def _check_clone_source_budget(profile_dir: Path) -> None:
+    """Reject a clone definition that cannot satisfy the import contract."""
+    members = 1  # The archive's profile root directory.
+    total_bytes = 0
+    for entry in sorted(BOT_CLONE_ROOTS):
+        source = profile_dir / entry
+        if not source.exists():
+            continue
+        candidates = [source]
+        if source.is_dir():
+            candidates.extend(source.rglob("*"))
+        for path in candidates:
+            if path.is_symlink():
+                raise ValueError(
+                    f"Bot clone cannot include symbolic link: {path.relative_to(profile_dir)}"
+                )
+            if not (path.is_dir() or path.is_file()):
+                raise ValueError(
+                    f"Bot clone cannot include special file: {path.relative_to(profile_dir)}"
+                )
+            members += 1
+            if members > MAX_BOT_CLONE_MEMBERS:
+                raise ValueError(
+                    f"Bot clone exceeds the {MAX_BOT_CLONE_MEMBERS} member limit."
+                )
+            if path.is_file():
+                total_bytes += path.stat().st_size
+                if total_bytes > MAX_BOT_CLONE_BYTES:
+                    raise ValueError(
+                        "Bot clone exceeds the 10 MB expanded-size limit."
+                    )
+
+
 def _reset_owner_policies(staged: Path) -> None:
     """Do not transfer the source owner's inbound sharing decisions."""
     from hermes_cli.profiles import write_profile_meta
@@ -149,6 +182,7 @@ def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
     if not profile_dir.is_dir():
         raise FileNotFoundError(f"Profile '{canon}' does not exist.")
     bot_id = ensure_profile_bot_id(profile_dir)
+    _check_clone_source_budget(profile_dir)
 
     output = Path(output_path)
     output.parent.mkdir(parents=True, exist_ok=True)
@@ -172,11 +206,19 @@ def export_bot_profile(name: str, output_path: str) -> tuple[Path, str]:
         _scrub_export_secrets(staged)
         result = Path(make_targz(base, tmpdir, canon))
 
-    if result.stat().st_size > MAX_BOT_CLONE_BYTES:
-        result.unlink(missing_ok=True)
-        raise ValueError(
-            f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
+    try:
+        archive_root_dirs(
+            result,
+            max_bytes=MAX_BOT_CLONE_BYTES,
+            max_members=MAX_BOT_CLONE_MEMBERS,
         )
+        if result.stat().st_size > MAX_BOT_CLONE_BYTES:
+            raise ValueError(
+                f"Bot clone exceeds the {MAX_BOT_CLONE_BYTES // 1_000_000} MB transfer limit."
+            )
+    except BaseException:
+        result.unlink(missing_ok=True)
+        raise
     return result, bot_id
 
 

--- a/hermes_cli/bot_transfer.py
+++ b/hermes_cli/bot_transfer.py
@@ -76,21 +76,36 @@ def ensure_profile_bot_id(profile_dir: Path) -> str:
 
     candidate = str(uuid.uuid4())
     path = profile_dir / BOT_ID_FILENAME
+    fd, temporary = tempfile.mkstemp(
+        dir=profile_dir, prefix=f".{BOT_ID_FILENAME}.", suffix=".tmp"
+    )
     try:
-        fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
-    except FileExistsError:
-        # A concurrent exporter won the identity race.
-        return _valid_bot_id(path.read_text(encoding="utf-8"))
-    with os.fdopen(fd, "w", encoding="utf-8") as handle:
-        handle.write(candidate + "\n")
-    return candidate
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(candidate + "\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(temporary, 0o600)
+        try:
+            os.link(temporary, path)
+            return candidate
+        except FileExistsError:
+            return _valid_bot_id(path.read_text(encoding="utf-8"))
+    finally:
+        Path(temporary).unlink(missing_ok=True)
 
 
 def set_profile_cloneable(name: str, allowed: bool) -> str:
     """Set the per-bot pull policy and return its stable bot UUID."""
-    from hermes_cli.profiles import get_profile_dir, write_profile_meta
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        normalize_profile_name,
+        validate_profile_name,
+        write_profile_meta,
+    )
 
-    profile_dir = get_profile_dir(name)
+    canon = normalize_profile_name(name)
+    validate_profile_name(canon)
+    profile_dir = get_profile_dir(canon)
     if not profile_dir.is_dir():
         raise FileNotFoundError(f"Profile '{name}' does not exist.")
     bot_id = ensure_profile_bot_id(profile_dir)
@@ -99,9 +114,19 @@ def set_profile_cloneable(name: str, allowed: bool) -> str:
 
 
 def profile_is_cloneable(name: str) -> bool:
-    from hermes_cli.profiles import get_profile_dir, read_profile_meta
+    from hermes_cli.profiles import (
+        get_profile_dir,
+        normalize_profile_name,
+        read_profile_meta,
+        validate_profile_name,
+    )
 
-    profile_dir = get_profile_dir(name)
+    canon = normalize_profile_name(name)
+    try:
+        validate_profile_name(canon)
+    except (TypeError, ValueError):
+        return False
+    profile_dir = get_profile_dir(canon)
     return profile_dir.is_dir() and bool(read_profile_meta(profile_dir).get("cloneable"))
 
 
@@ -399,18 +424,23 @@ def pull_bot_profile(
     headers = {"Authorization": f"Bearer {key}", "Accept": "application/gzip"}
     with tempfile.TemporaryDirectory(prefix="hermes_bot_pull_") as tmpdir:
         archive = Path(tmpdir) / "bot.tar.gz"
-        with httpx.Client(timeout=120.0, follow_redirects=False) as client:
-            with client.stream("GET", url, headers=headers) as response:
-                if response.status_code != 200:
-                    response.read()
-                    raise _response_error(response)
-                total = 0
-                with archive.open("wb") as handle:
-                    for chunk in response.iter_bytes():
-                        total += len(chunk)
-                        if total > MAX_BOT_CLONE_BYTES:
-                            raise BotTransferError("Remote bot clone exceeds the 10 MB transfer limit.")
-                        handle.write(chunk)
+        try:
+            with httpx.Client(timeout=120.0, follow_redirects=False) as client:
+                with client.stream("GET", url, headers=headers) as response:
+                    if response.status_code != 200:
+                        response.read()
+                        raise _response_error(response)
+                    total = 0
+                    with archive.open("wb") as handle:
+                        for chunk in response.iter_bytes():
+                            total += len(chunk)
+                            if total > MAX_BOT_CLONE_BYTES:
+                                raise BotTransferError(
+                                    "Remote bot clone exceeds the 10 MB transfer limit."
+                                )
+                            handle.write(chunk)
+        except httpx.HTTPError as exc:
+            raise BotTransferError(f"Remote bot clone request failed: {exc}") from exc
         return import_bot_profile(str(archive), name=name)
 
 
@@ -430,9 +460,27 @@ def push_bot_profile(
             "Accept": "application/json",
         }
         params = {"name": name} if name else None
-        with archive.open("rb") as body, httpx.Client(timeout=120.0, follow_redirects=False) as client:
-            response = client.post(f"{base}/v1/bots/clone", headers=headers, params=params, content=body)
+        try:
+            with archive.open("rb") as body, httpx.Client(
+                timeout=120.0, follow_redirects=False
+            ) as client:
+                response = client.post(
+                    f"{base}/v1/bots/clone",
+                    headers=headers,
+                    params=params,
+                    content=body,
+                )
+        except httpx.HTTPError as exc:
+            raise BotTransferError(f"Remote bot clone request failed: {exc}") from exc
         if response.status_code != 201:
             raise _response_error(response)
-        payload = response.json()
-        return str(payload["name"]), _valid_bot_id(payload["bot_id"])
+        try:
+            payload = response.json()
+            remote_name = payload["name"]
+            if not isinstance(remote_name, str) or not remote_name:
+                raise ValueError("missing name")
+            return remote_name, _valid_bot_id(payload["bot_id"])
+        except (KeyError, TypeError, ValueError) as exc:
+            raise BotTransferError(
+                "Remote gateway returned an invalid bot clone response."
+            ) from exc

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3440,6 +3440,12 @@ DEFAULT_CONFIG = {
             # request flood. Set to 0 to disable the cap entirely.
             "max_concurrent_runs": 10,
         },
+        # Authenticated profile cloning over the API gateway. Pull permission
+        # is opt-in per profile (`hermes profile share --allow-pull`); remote
+        # pushes are additionally disabled gateway-wide by default.
+        "bot_sharing": {
+            "allow_push": False,
+        },
     },
 
     # Real-time token streaming to messaging platforms (Telegram, Discord,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -473,7 +473,7 @@ from hermes_cli.subcommands._shared import add_accept_hooks_flag as _add_accept_
 from hermes_cli.subcommands.cron import build_cron_parser
 from hermes_cli.subcommands.sync import build_sync_parser
 from hermes_cli.subcommands.gateway import build_gateway_parser
-from hermes_cli.subcommands.profile import build_profile_parser
+from hermes_cli.subcommands.profile import build_profile_parser, handle_bot_transfer_action
 from hermes_cli.subcommands.model import build_model_parser
 from hermes_cli.subcommands.setup import build_setup_parser
 
@@ -11271,6 +11271,9 @@ def cmd_profile(args):
 
     action = getattr(args, "profile_action", None)
 
+    if handle_bot_transfer_action(args):
+        return
+
     if action is None:
         # Bare `hermes profile` — show current profile status
         from hermes_cli.profiles import format_profile_label
@@ -11681,65 +11684,6 @@ def cmd_profile(args):
                 print(f"\nProfile renamed: {args.old_name} → {args.new_name}")
                 print(f"Path: {new_dir}\n")
         except (ValueError, FileExistsError, FileNotFoundError) as e:
-            print(f"Error: {e}")
-            sys.exit(1)
-
-    elif action == "share":
-        from hermes_cli.bot_transfer import (
-            ensure_profile_bot_id,
-            get_profile_bot_id,
-            profile_is_cloneable,
-            set_profile_cloneable,
-        )
-        from hermes_cli.profiles import get_profile_dir
-
-        name = args.profile_name
-        try:
-            profile_dir = get_profile_dir(name)
-            if not profile_dir.is_dir():
-                raise FileNotFoundError(f"Profile '{name}' does not exist.")
-            if args.allow_pull or args.deny_pull:
-                allowed = bool(args.allow_pull)
-                bot_id = set_profile_cloneable(name, allowed)
-            else:
-                allowed = profile_is_cloneable(name)
-                bot_id = get_profile_bot_id(profile_dir)
-            state = "allowed" if allowed else "denied"
-            print(f"Remote pull: {state} for '{name}'")
-            if bot_id:
-                print(f"Bot ID:      {bot_id}")
-            elif args.allow_pull:
-                print(f"Bot ID:      {ensure_profile_bot_id(profile_dir)}")
-        except (ValueError, FileNotFoundError, OSError) as e:
-            print(f"Error: {e}")
-            sys.exit(1)
-
-    elif action == "pull":
-        from hermes_cli.bot_transfer import BotTransferError, pull_bot_profile
-
-        try:
-            profile_dir, bot_id = pull_bot_profile(
-                args.profile_name,
-                remote=getattr(args, "remote_url", None),
-                name=getattr(args, "clone_name", None),
-            )
-            print(f"✓ Pulled bot '{profile_dir.name}' ({bot_id})")
-            print(f"  Path: {profile_dir}")
-        except (BotTransferError, ValueError, FileExistsError, FileNotFoundError, OSError) as e:
-            print(f"Error: {e}")
-            sys.exit(1)
-
-    elif action == "push":
-        from hermes_cli.bot_transfer import BotTransferError, push_bot_profile
-
-        try:
-            remote_name, bot_id = push_bot_profile(
-                args.profile_name,
-                remote=getattr(args, "remote_url", None),
-                name=getattr(args, "clone_name", None),
-            )
-            print(f"✓ Pushed bot '{remote_name}' ({bot_id})")
-        except (BotTransferError, ValueError, FileExistsError, FileNotFoundError, OSError) as e:
             print(f"Error: {e}")
             sys.exit(1)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11684,6 +11684,65 @@ def cmd_profile(args):
             print(f"Error: {e}")
             sys.exit(1)
 
+    elif action == "share":
+        from hermes_cli.bot_transfer import (
+            ensure_profile_bot_id,
+            get_profile_bot_id,
+            profile_is_cloneable,
+            set_profile_cloneable,
+        )
+        from hermes_cli.profiles import get_profile_dir
+
+        name = args.profile_name
+        try:
+            profile_dir = get_profile_dir(name)
+            if not profile_dir.is_dir():
+                raise FileNotFoundError(f"Profile '{name}' does not exist.")
+            if args.allow_pull or args.deny_pull:
+                allowed = bool(args.allow_pull)
+                bot_id = set_profile_cloneable(name, allowed)
+            else:
+                allowed = profile_is_cloneable(name)
+                bot_id = get_profile_bot_id(profile_dir)
+            state = "allowed" if allowed else "denied"
+            print(f"Remote pull: {state} for '{name}'")
+            if bot_id:
+                print(f"Bot ID:      {bot_id}")
+            elif args.allow_pull:
+                print(f"Bot ID:      {ensure_profile_bot_id(profile_dir)}")
+        except (ValueError, FileNotFoundError, OSError) as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
+    elif action == "pull":
+        from hermes_cli.bot_transfer import BotTransferError, pull_bot_profile
+
+        try:
+            profile_dir, bot_id = pull_bot_profile(
+                args.profile_name,
+                remote=getattr(args, "remote_url", None),
+                name=getattr(args, "clone_name", None),
+            )
+            print(f"✓ Pulled bot '{profile_dir.name}' ({bot_id})")
+            print(f"  Path: {profile_dir}")
+        except (BotTransferError, ValueError, FileExistsError, FileNotFoundError, OSError) as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
+    elif action == "push":
+        from hermes_cli.bot_transfer import BotTransferError, push_bot_profile
+
+        try:
+            remote_name, bot_id = push_bot_profile(
+                args.profile_name,
+                remote=getattr(args, "remote_url", None),
+                name=getattr(args, "clone_name", None),
+            )
+            print(f"✓ Pushed bot '{remote_name}' ({bot_id})")
+        except (BotTransferError, ValueError, FileExistsError, FileNotFoundError, OSError) as e:
+            print(f"Error: {e}")
+            sys.exit(1)
+
     elif action == "export":
         from hermes_cli.profiles import export_profile, get_profile_export_path
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2476,6 +2476,7 @@ def import_profile(
     profile_dir = get_profile_dir(canon)
     if profile_dir.exists():
         raise FileExistsError(f"Profile '{canon}' already exists at {profile_dir}")
+    was_tombstoned = named_profile_is_deleted(profile_dir)
 
     profiles_root = _get_profiles_root()
     profiles_root.mkdir(parents=True, exist_ok=True)
@@ -2503,7 +2504,13 @@ def import_profile(
             final_source = staging_root / canon
             extracted.rename(final_source)
 
-        shutil.move(str(final_source), str(profile_dir))
+        clear_named_profile_deleted(profile_dir)
+        try:
+            shutil.move(str(final_source), str(profile_dir))
+        except BaseException:
+            if was_tombstoned:
+                mark_named_profile_deleted(profile_dir)
+            raise
 
     return profile_dir
 

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -31,7 +31,7 @@ import sys
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 from agent.skill_utils import is_excluded_skill_path
 from hermes_cli.archive_safe import (
@@ -2432,6 +2432,7 @@ def import_profile(
     *,
     max_extract_bytes: Optional[int] = None,
     max_archive_members: Optional[int] = None,
+    prepare_staged: Optional[Callable[[Path], None]] = None,
 ) -> Path:
     """Import a profile from a tar.gz archive.
 
@@ -2493,6 +2494,9 @@ def import_profile(
             raise ValueError(
                 f"Profile archive root is missing or invalid: {archive_root}"
             )
+
+        if prepare_staged is not None:
+            prepare_staged(extracted)
 
         final_source = extracted
         if archive_root != canon:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2444,7 +2444,11 @@ def import_profile(
     if not archive.exists():
         raise FileNotFoundError(f"Archive not found: {archive}")
 
-    top_dirs = archive_root_dirs(archive, max_members=max_archive_members)
+    top_dirs = archive_root_dirs(
+        archive,
+        max_bytes=max_extract_bytes,
+        max_members=max_archive_members,
+    )
     archive_root = top_dirs.pop() if len(top_dirs) == 1 else None
     inferred_name = name or archive_root
     if not inferred_name:

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -2426,7 +2426,13 @@ def export_profile(name: str, output_path: str, extra_files: Optional[Dict[str, 
         return Path(result)
 
 
-def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
+def import_profile(
+    archive_path: str,
+    name: Optional[str] = None,
+    *,
+    max_extract_bytes: Optional[int] = None,
+    max_archive_members: Optional[int] = None,
+) -> Path:
     """Import a profile from a tar.gz archive.
 
     If *name* is not given, infers it from the archive's top-level directory.
@@ -2438,7 +2444,7 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
     if not archive.exists():
         raise FileNotFoundError(f"Archive not found: {archive}")
 
-    top_dirs = archive_root_dirs(archive)
+    top_dirs = archive_root_dirs(archive, max_members=max_archive_members)
     archive_root = top_dirs.pop() if len(top_dirs) == 1 else None
     inferred_name = name or archive_root
     if not inferred_name:
@@ -2471,7 +2477,12 @@ def import_profile(archive_path: str, name: Optional[str] = None) -> Path:
 
     with tempfile.TemporaryDirectory(prefix="hermes_profile_import_") as tmpdir:
         staging_root = Path(tmpdir)
-        safe_extract_targz(archive, staging_root)
+        safe_extract_targz(
+            archive,
+            staging_root,
+            max_bytes=max_extract_bytes,
+            max_members=max_archive_members,
+        )
 
         extracted = staging_root / archive_root
         if not extracted.is_dir():

--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -940,12 +940,17 @@ def _profile_yaml_path(profile_dir: Path) -> Path:
 def read_profile_meta(profile_dir: Path) -> dict:
     """Read ``<profile_dir>/profile.yaml`` and return a dict.
 
-    Returns ``{"description": "", "description_auto": False,
-    "display_name": ""}`` when the file is missing or unreadable. Never
+    Returns empty presentation metadata plus ``cloneable: false`` when the
+    file is missing or unreadable. Never
     raises — a corrupt profile.yaml on an unrelated profile must not
     break ``hermes profile list``.
     """
-    empty = {"description": "", "description_auto": False, "display_name": ""}
+    empty = {
+        "description": "",
+        "description_auto": False,
+        "display_name": "",
+        "cloneable": False,
+    }
     path = _profile_yaml_path(profile_dir)
     if not path.is_file():
         return empty
@@ -961,6 +966,9 @@ def read_profile_meta(profile_dir: Path) -> dict:
         "description": str(data.get("description") or "").strip(),
         "description_auto": bool(data.get("description_auto", False)),
         "display_name": str(data.get("display_name") or "").strip(),
+        # Fail closed for hand-edited malformed values (e.g. the string
+        # "false", which Python would otherwise coerce to True).
+        "cloneable": data.get("cloneable") is True,
     }
 
 
@@ -970,6 +978,7 @@ def write_profile_meta(
     description: Optional[str] = None,
     description_auto: Optional[bool] = None,
     display_name: Optional[str] = None,
+    cloneable: Optional[bool] = None,
 ) -> None:
     """Update ``<profile_dir>/profile.yaml`` in place.
 
@@ -1000,6 +1009,8 @@ def write_profile_meta(
             existing["display_name"] = display_name.strip()
         else:
             existing.pop("display_name", None)
+    if cloneable is not None:
+        existing["cloneable"] = bool(cloneable)
     # Atomic write: bare open("w") truncates before the dump, and the read
     # path above swallows parse errors as {}, so a crashed write would
     # silently drop unspecified fields on the next call (#51356, #16743).

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -6,7 +6,71 @@ Handler injected to avoid importing ``main``.
 
 from __future__ import annotations
 
+import sys
 from typing import Callable
+
+
+def handle_bot_transfer_action(args) -> bool:
+    """Handle profile share/pull/push actions outside the CLI godfile."""
+    action = getattr(args, "profile_action", None)
+    if action not in {"share", "pull", "push"}:
+        return False
+
+    from hermes_cli.bot_transfer import (
+        BotTransferError,
+        ensure_profile_bot_id,
+        get_profile_bot_id,
+        profile_is_cloneable,
+        pull_bot_profile,
+        push_bot_profile,
+        set_profile_cloneable,
+    )
+
+    try:
+        if action == "share":
+            from hermes_cli.profiles import get_profile_dir
+
+            name = args.profile_name
+            profile_dir = get_profile_dir(name)
+            if not profile_dir.is_dir():
+                raise FileNotFoundError(f"Profile '{name}' does not exist.")
+            if args.allow_pull or args.deny_pull:
+                allowed = bool(args.allow_pull)
+                bot_id = set_profile_cloneable(name, allowed)
+            else:
+                allowed = profile_is_cloneable(name)
+                bot_id = get_profile_bot_id(profile_dir)
+            state = "allowed" if allowed else "denied"
+            print(f"Remote pull: {state} for '{name}'")
+            if bot_id:
+                print(f"Bot ID:      {bot_id}")
+            elif args.allow_pull:
+                print(f"Bot ID:      {ensure_profile_bot_id(profile_dir)}")
+        elif action == "pull":
+            profile_dir, bot_id = pull_bot_profile(
+                args.profile_name,
+                remote=getattr(args, "remote_url", None),
+                name=getattr(args, "clone_name", None),
+            )
+            print(f"✓ Pulled bot '{profile_dir.name}' ({bot_id})")
+            print(f"  Path: {profile_dir}")
+        else:
+            remote_name, bot_id = push_bot_profile(
+                args.profile_name,
+                remote=getattr(args, "remote_url", None),
+                name=getattr(args, "clone_name", None),
+            )
+            print(f"✓ Pushed bot '{remote_name}' ({bot_id})")
+    except (
+        BotTransferError,
+        ValueError,
+        FileExistsError,
+        FileNotFoundError,
+        OSError,
+    ) as exc:
+        print(f"Error: {exc}")
+        sys.exit(1)
+    return True
 
 
 def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -28,9 +28,14 @@ def handle_bot_transfer_action(args) -> bool:
 
     try:
         if action == "share":
-            from hermes_cli.profiles import get_profile_dir
+            from hermes_cli.profiles import (
+                get_profile_dir,
+                normalize_profile_name,
+                validate_profile_name,
+            )
 
-            name = args.profile_name
+            name = normalize_profile_name(args.profile_name)
+            validate_profile_name(name)
             profile_dir = get_profile_dir(name)
             if not profile_dir.is_dir():
                 raise FileNotFoundError(f"Profile '{name}' does not exist.")

--- a/hermes_cli/subcommands/profile.py
+++ b/hermes_cli/subcommands/profile.py
@@ -151,6 +151,48 @@ def build_profile_parser(subparsers, *, cmd_profile: Callable) -> None:
         help="Profile name (default: inferred from archive)",
     )
 
+    profile_share = profile_subparsers.add_parser(
+        "share", help="Control whether a profile may be pulled from this gateway"
+    )
+    profile_share.add_argument("profile_name", help="Profile to share")
+    share_policy = profile_share.add_mutually_exclusive_group()
+    share_policy.add_argument(
+        "--allow-pull",
+        action="store_true",
+        help="Allow authenticated remote clients to clone this bot",
+    )
+    share_policy.add_argument(
+        "--deny-pull",
+        action="store_true",
+        help="Disable remote cloning for this bot",
+    )
+
+    profile_pull = profile_subparsers.add_parser(
+        "pull", help="Clone a bot from an authenticated remote gateway"
+    )
+    profile_pull.add_argument("profile_name", help="Remote profile to clone")
+    profile_pull.add_argument(
+        "--from",
+        dest="remote_url",
+        help="Remote gateway URL (default: gateway.proxy_url)",
+    )
+    profile_pull.add_argument(
+        "--name", dest="clone_name", help="Local name for the cloned bot"
+    )
+
+    profile_push = profile_subparsers.add_parser(
+        "push", help="Clone a local bot to an opt-in remote gateway"
+    )
+    profile_push.add_argument("profile_name", help="Local profile to clone")
+    profile_push.add_argument(
+        "--to",
+        dest="remote_url",
+        help="Remote gateway URL (default: gateway.proxy_url)",
+    )
+    profile_push.add_argument(
+        "--name", dest="clone_name", help="Name to use on the remote gateway"
+    )
+
     # ---------- Distribution subcommands (issue #20456) ----------
     profile_install = profile_subparsers.add_parser(
         "install",

--- a/tests/gateway/test_api_server_bot_clone.py
+++ b/tests/gateway/test_api_server_bot_clone.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import APIServerAdapter
+
+
+def _adapter() -> APIServerAdapter:
+    return APIServerAdapter(PlatformConfig(enabled=True, extra={"key": "clone-secret"}))
+
+
+def _request(*, profile: str = "helper", content_type: str = "application/gzip"):
+    request = MagicMock()
+    request.headers = {"Authorization": "Bearer clone-secret"}
+    request.match_info = {"profile_name": profile}
+    request.query = {}
+    request.content_type = content_type
+    return request
+
+
+def _json(response) -> dict:
+    return json.loads(response.body.decode("utf-8"))
+
+
+def test_bot_clone_routes_are_advertised():
+    routes = {(method, path) for method, path, _ in _adapter()._http_route_table()}
+
+    assert ("GET", "/v1/bots/{profile_name}/clone") in routes
+    assert ("POST", "/v1/bots/clone") in routes
+
+
+@pytest.mark.asyncio
+async def test_download_hides_profiles_that_did_not_opt_in(monkeypatch):
+    request = _request()
+    monkeypatch.setattr("hermes_cli.bot_transfer.profile_is_cloneable", lambda _name: False)
+
+    response = await _adapter()._handle_bot_clone_download(request)
+
+    assert response.status == 404
+    assert _json(response)["error"]["code"] == "bot_clone_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_download_returns_clone_identity_and_archive(monkeypatch, tmp_path):
+    archive = tmp_path / "helper.tar.gz"
+    archive.write_bytes(b"archive")
+    monkeypatch.setattr("hermes_cli.bot_transfer.profile_is_cloneable", lambda _name: True)
+    monkeypatch.setattr(
+        "hermes_cli.bot_transfer.export_bot_profile",
+        lambda _name, _output: (archive, "a8c214f7-37ee-4f50-95a4-939a51631283"),
+    )
+
+    response = await _adapter()._handle_bot_clone_download(_request())
+
+    assert response.status == 200
+    assert response.body == b"archive"
+    assert response.headers["X-Hermes-Bot-Id"] == "a8c214f7-37ee-4f50-95a4-939a51631283"
+    assert response.headers["X-Hermes-Profile-Name"] == "helper"
+
+
+@pytest.mark.asyncio
+async def test_upload_is_fail_closed_until_gateway_owner_enables_push(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_bot_push_enabled", lambda: False)
+
+    response = await adapter._handle_bot_clone_upload(_request())
+
+    assert response.status == 403
+    assert _json(response)["error"]["code"] == "bot_clone_push_disabled"
+
+
+@pytest.mark.asyncio
+async def test_upload_never_overwrites_an_existing_bot(monkeypatch):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_bot_push_enabled", lambda: True)
+    monkeypatch.setattr(
+        "hermes_cli.bot_transfer.import_bot_profile",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(FileExistsError("already exists")),
+    )
+    request = _request()
+    request.read = AsyncMock(return_value=b"archive")
+
+    response = await adapter._handle_bot_clone_upload(request)
+
+    assert response.status == 409
+    assert _json(response)["error"]["code"] == "bot_clone_conflict"
+
+
+@pytest.mark.asyncio
+async def test_upload_installs_under_requested_name(monkeypatch, tmp_path):
+    adapter = _adapter()
+    monkeypatch.setattr(adapter, "_bot_push_enabled", lambda: True)
+    profile_dir = tmp_path / "renamed"
+    profile_dir.mkdir()
+    imported = MagicMock(return_value=(profile_dir, "a8c214f7-37ee-4f50-95a4-939a51631283"))
+    monkeypatch.setattr("hermes_cli.bot_transfer.import_bot_profile", imported)
+    monkeypatch.setattr("hermes_cli.profiles.check_alias_collision", lambda _name: "collision")
+    request = _request()
+    request.query = {"name": "renamed"}
+    request.read = AsyncMock(return_value=b"archive")
+
+    response = await adapter._handle_bot_clone_upload(request)
+
+    assert response.status == 201
+    assert _json(response) == {
+        "object": "hermes.bot_clone",
+        "name": "renamed",
+        "bot_id": "a8c214f7-37ee-4f50-95a4-939a51631283",
+    }
+    assert imported.call_args.kwargs["name"] == "renamed"

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -319,6 +319,129 @@ def test_bot_import_resanitizes_cron_jobs_and_keeps_them_paused(profile_root, tm
     } & job.keys()
 
 
+def test_bot_clone_rehomes_cron_scripts_and_runs_them_from_receiver(
+    profile_root, tmp_path, monkeypatch
+):
+    source = _source_profile(profile_root)
+    scripts = source / "scripts"
+    (scripts / "checks").mkdir(parents=True)
+    script = scripts / "probe.py"
+    monitor_script = scripts / "checks" / "monitor.py"
+    script.write_text("print('copied job')\n", encoding="utf-8")
+    monitor_script.write_text("print('copied monitor')\n", encoding="utf-8")
+    (source / "cron").mkdir()
+    (source / "cron" / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "script-job",
+                        "prompt": "",
+                        "schedule": {"kind": "interval", "minutes": 5},
+                        "script": str(script.resolve()),
+                        "no_agent": True,
+                    },
+                    {
+                        "id": "monitor-job",
+                        "prompt": "Check changes",
+                        "schedule": {"kind": "interval", "minutes": 5},
+                        "monitor_script": str(monitor_script.resolve()),
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    archive, _ = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))
+    shutil.rmtree(source)
+    imported, _ = import_bot_profile(str(archive), name="receiver")
+    jobs = json.loads((imported / "cron" / "jobs.json").read_text(encoding="utf-8"))[
+        "jobs"
+    ]
+
+    assert jobs[0]["script"] == "probe.py"
+    assert jobs[1]["monitor_script"] == "checks/monitor.py"
+    from cron import scheduler
+
+    monkeypatch.setattr(scheduler, "_hermes_home", imported)
+    assert scheduler._run_job_script(jobs[0]["script"]) == (True, "copied job")
+    assert scheduler._run_job_script(jobs[1]["monitor_script"]) == (
+        True,
+        "copied monitor",
+    )
+
+
+@pytest.mark.parametrize("field", ["script", "monitor_script"])
+@pytest.mark.parametrize("path_kind", ["outside", "missing"])
+def test_bot_export_rejects_uncloneable_cron_script_paths(
+    profile_root, tmp_path, field, path_kind
+):
+    source = _source_profile(profile_root)
+    (source / "cron").mkdir()
+    outside = tmp_path / "outside.py"
+    outside.write_text("print('outside')\n", encoding="utf-8")
+    value = str(outside.resolve()) if path_kind == "outside" else "missing.py"
+    (source / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "unsafe", field: value}]}),
+        encoding="utf-8",
+    )
+    archive = tmp_path / f"unsafe-export-{field}-{path_kind}.tar.gz"
+
+    with pytest.raises(ValueError, match="invalid cron job definitions"):
+        export_bot_profile("helper", str(archive))
+
+    assert not archive.exists()
+
+
+@pytest.mark.parametrize("field", ["script", "monitor_script"])
+@pytest.mark.parametrize("value", ["../outside.py", "missing.py"])
+def test_bot_import_rejects_unsafe_or_missing_cron_script_paths(
+    profile_root, tmp_path, field, value
+):
+    staged = tmp_path / "staged" / "unsafe-script"
+    (staged / "cron").mkdir(parents=True)
+    (staged / "scripts").mkdir()
+    (staged / BOT_ID_FILENAME).write_text(
+        "a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8"
+    )
+    (staged / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "unsafe", field: value}]}),
+        encoding="utf-8",
+    )
+    archive = tmp_path / f"unsafe-{field}-{Path(value).name}.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="unsafe-script")
+
+    with pytest.raises(ValueError, match="invalid cron job definitions"):
+        import_bot_profile(str(archive))
+
+    assert not (profile_root / "profiles" / "unsafe-script").exists()
+
+
+def test_bot_import_rejects_absolute_cron_script_path(profile_root, tmp_path):
+    staged = tmp_path / "staged" / "absolute-script"
+    (staged / "cron").mkdir(parents=True)
+    (staged / "scripts").mkdir()
+    script = staged / "scripts" / "probe.py"
+    script.write_text("print('must stay relative')\n", encoding="utf-8")
+    (staged / BOT_ID_FILENAME).write_text(
+        "a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8"
+    )
+    (staged / "cron" / "jobs.json").write_text(
+        json.dumps({"jobs": [{"id": "absolute", "script": str(script.resolve())}]}),
+        encoding="utf-8",
+    )
+    archive = tmp_path / "absolute-script.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="absolute-script")
+
+    with pytest.raises(ValueError, match="invalid cron job definitions"):
+        import_bot_profile(str(archive))
+
+    assert not (profile_root / "profiles" / "absolute-script").exists()
+
+
 def test_bot_import_reactivates_a_deleted_profile_name(profile_root, tmp_path):
     source = _source_profile(profile_root)
     archive, _ = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import multiprocessing
 import shutil
 import tarfile
@@ -89,7 +90,37 @@ def test_bot_export_excludes_nested_credentials_and_cron_runtime(profile_root, t
     (source / "plugins" / "demo").mkdir(parents=True)
     (source / "plugins" / "demo" / "credentials.bin").write_bytes(b"\x00private")
     (source / "cron" / "output").mkdir(parents=True)
-    (source / "cron" / "jobs.json").write_text("{}\n", encoding="utf-8")
+    (source / "cron" / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "daily",
+                        "name": "Daily summary",
+                        "prompt": "Summarize the day",
+                        "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+                        "repeat": {"times": None, "completed": 7},
+                        "enabled": True,
+                        "state": "scheduled",
+                        "next_run_at": "2099-01-01T09:00:00+00:00",
+                        "last_run_at": "2026-01-01T09:00:00+00:00",
+                        "last_status": "success",
+                        "last_delivery_unverified": {"platform": "telegram"},
+                        "monitor_state": {"last_output_hash": "secret-state"},
+                        "run_claim": {"by": "source"},
+                        "fire_claim": {"by": "source"},
+                        "failure_streak": 3,
+                        "deliver": "telegram:123456:99",
+                        "failure_deliver": "discord:private",
+                        "origin": {"chat_id": "123456", "thread_id": "99"},
+                        "workdir": "C:/source/private",
+                        "attach_to_session": True,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
     (source / "cron" / "output" / "last.txt").write_text(
         "private\n", encoding="utf-8"
     )
@@ -102,10 +133,28 @@ def test_bot_export_excludes_nested_credentials_and_cron_runtime(profile_root, t
     archive, _ = export_bot_profile("helper", str(tmp_path / "safe.tar.gz"))
     with tarfile.open(archive, "r:gz") as tar:
         names = set(tar.getnames())
+        cron_jobs = json.loads(tar.extractfile("helper/cron/jobs.json").read())[
+            "jobs"
+        ]
     assert "helper/cron/jobs.json" in names
     assert not any(name.endswith("/.env") for name in names)
     assert not any("cron/output" in name for name in names)
     assert "helper/cron/ticker-heartbeat" not in names
+    assert cron_jobs == [
+        {
+            "id": "daily",
+            "name": "Daily summary",
+            "prompt": "Summarize the day",
+            "schedule": {"kind": "cron", "expr": "0 9 * * *"},
+            "repeat": {"times": None, "completed": 0},
+            "enabled": False,
+            "state": "paused",
+            "paused_at": None,
+            "paused_reason": "Imported bot clone requires review.",
+            "next_run_at": None,
+            "deliver": "local",
+        }
+    ]
 
 
 def test_pull_policy_is_per_profile_and_fails_closed_for_malformed_yaml(profile_root):
@@ -215,6 +264,96 @@ def test_bot_import_resets_sender_sharing_policies(profile_root, tmp_path):
 
     assert profile_is_cloneable("shared") is False
     assert "bot_sharing" not in (imported / "config.yaml").read_text(encoding="utf-8")
+
+
+def test_bot_import_resanitizes_cron_jobs_and_keeps_them_paused(profile_root, tmp_path):
+    staged = tmp_path / "staged" / "scheduled"
+    (staged / "cron").mkdir(parents=True)
+    (staged / BOT_ID_FILENAME).write_text(
+        "a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8"
+    )
+    (staged / "cron" / "jobs.json").write_text(
+        json.dumps(
+            {
+                "jobs": [
+                    {
+                        "id": "source-job",
+                        "prompt": "Run safely",
+                        "schedule": {"kind": "interval", "minutes": 5},
+                        "repeat": {"times": 10, "completed": 4},
+                        "enabled": True,
+                        "next_run_at": "2000-01-01T00:00:00+00:00",
+                        "deliver": "telegram:123456:99",
+                        "failure_deliver": "telegram:123456:99",
+                        "origin": {"chat_id": "123456", "thread_id": "99"},
+                        "monitor_state": {"last_output_hash": "source"},
+                        "last_run_at": "1999-01-01T00:00:00+00:00",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    archive = tmp_path / "scheduled.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="scheduled")
+
+    imported, _ = import_bot_profile(str(archive))
+    job = json.loads((imported / "cron" / "jobs.json").read_text(encoding="utf-8"))[
+        "jobs"
+    ][0]
+
+    assert job["enabled"] is False
+    assert job["state"] == "paused"
+    assert job["next_run_at"] is None
+    assert job["deliver"] == "local"
+    assert job["repeat"] == {"times": 10, "completed": 0}
+    from cron.jobs import is_job_runnable
+
+    assert is_job_runnable(job) is False
+    assert not {
+        "origin",
+        "failure_deliver",
+        "monitor_state",
+        "last_run_at",
+    } & job.keys()
+
+
+def test_bot_import_reactivates_a_deleted_profile_name(profile_root, tmp_path):
+    source = _source_profile(profile_root)
+    archive, _ = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))
+    shutil.rmtree(source)
+    destination = profile_root / "profiles" / "helper"
+    profiles.mark_named_profile_deleted(destination)
+
+    imported, _ = import_bot_profile(str(archive))
+
+    assert imported == destination
+    assert profiles.profile_exists("helper") is True
+    assert any(item.name == "helper" for item in profiles.list_profiles())
+    assert ("helper", destination) in profiles.profiles_to_serve(multiplex=True)
+    assert profiles.named_profile_is_deleted(destination) is False
+
+
+def test_profile_import_restores_deleted_marker_when_publication_fails(
+    profile_root, tmp_path, monkeypatch
+):
+    source = _source_profile(profile_root)
+    archive, _ = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))
+    shutil.rmtree(source)
+    destination = profile_root / "profiles" / "helper"
+    profiles.mark_named_profile_deleted(destination)
+    monkeypatch.setattr(
+        profiles.shutil,
+        "move",
+        lambda *_args: (_ for _ in ()).throw(OSError("publish failed")),
+    )
+
+    with pytest.raises(OSError, match="publish failed"):
+        import_bot_profile(str(archive))
+
+    assert profiles.named_profile_is_deleted(destination) is True
+    assert profiles.profile_exists("helper") is False
 
 
 def test_bot_import_bounds_expanded_archive_and_leaves_no_profile(

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -81,6 +81,33 @@ def test_bot_export_is_definition_only_and_identity_is_stable(profile_root, tmp_
     assert "cloneable: false" in profile_meta
 
 
+def test_bot_export_excludes_nested_credentials_and_cron_runtime(profile_root, tmp_path):
+    source = _source_profile(profile_root)
+    (source / "skills" / "demo" / ".env").write_text(
+        "TOKEN=private\n", encoding="utf-8"
+    )
+    (source / "plugins" / "demo").mkdir(parents=True)
+    (source / "plugins" / "demo" / "credentials.bin").write_bytes(b"\x00private")
+    (source / "cron" / "output").mkdir(parents=True)
+    (source / "cron" / "jobs.json").write_text("{}\n", encoding="utf-8")
+    (source / "cron" / "output" / "last.txt").write_text(
+        "private\n", encoding="utf-8"
+    )
+    (source / "cron" / "ticker-heartbeat").write_text("runtime\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="unsupported binary file"):
+        export_bot_profile("helper", str(tmp_path / "binary.tar.gz"))
+
+    (source / "plugins" / "demo" / "credentials.bin").unlink()
+    archive, _ = export_bot_profile("helper", str(tmp_path / "safe.tar.gz"))
+    with tarfile.open(archive, "r:gz") as tar:
+        names = set(tar.getnames())
+    assert "helper/cron/jobs.json" in names
+    assert not any(name.endswith("/.env") for name in names)
+    assert not any("cron/output" in name for name in names)
+    assert "helper/cron/ticker-heartbeat" not in names
+
+
 def test_pull_policy_is_per_profile_and_fails_closed_for_malformed_yaml(profile_root):
     source = _source_profile(profile_root)
 
@@ -167,6 +194,27 @@ def test_bot_import_rejects_user_state_even_from_safe_tar(profile_root, tmp_path
 
     with pytest.raises(ValueError, match="disallowed profile data: sessions"):
         import_bot_profile(str(archive))
+
+
+def test_bot_import_resets_sender_sharing_policies(profile_root, tmp_path):
+    staged = tmp_path / "staged" / "shared"
+    staged.mkdir(parents=True)
+    (staged / BOT_ID_FILENAME).write_text(
+        "a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8"
+    )
+    (staged / "profile.yaml").write_text("cloneable: true\n", encoding="utf-8")
+    (staged / "config.yaml").write_text(
+        "model: test\ngateway:\n  bot_sharing:\n    allow_push: true\n",
+        encoding="utf-8",
+    )
+    archive = tmp_path / "shared.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="shared")
+
+    imported, _ = import_bot_profile(str(archive))
+
+    assert profile_is_cloneable("shared") is False
+    assert "bot_sharing" not in (imported / "config.yaml").read_text(encoding="utf-8")
 
 
 def test_bot_import_bounds_expanded_archive_and_leaves_no_profile(

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import shutil
+import tarfile
+from pathlib import Path
+
+import httpx
+import pytest
+
+from hermes_cli import profiles
+from hermes_cli import bot_transfer
+from hermes_cli.bot_transfer import (
+    BOT_ID_FILENAME,
+    export_bot_profile,
+    get_profile_bot_id,
+    import_bot_profile,
+    pull_bot_profile,
+    profile_is_cloneable,
+    push_bot_profile,
+    set_profile_cloneable,
+)
+
+
+@pytest.fixture
+def profile_root(tmp_path, monkeypatch):
+    root = tmp_path / "hermes"
+    profile_root = root / "profiles"
+    profile_root.mkdir(parents=True)
+    monkeypatch.setattr(profiles, "_get_default_hermes_home", lambda: root)
+    monkeypatch.setattr(profiles, "_get_profiles_root", lambda: profile_root)
+    return root
+
+
+def _source_profile(root: Path, name: str = "helper") -> Path:
+    source = root / "profiles" / name
+    (source / "skills" / "demo").mkdir(parents=True)
+    (source / "memories").mkdir()
+    (source / "sessions").mkdir()
+    (source / "SOUL.md").write_text("Helpful bot\n", encoding="utf-8")
+    (source / "config.yaml").write_text(
+        "model: test\ngateway:\n  bot_sharing:\n    allow_push: true\n",
+        encoding="utf-8",
+    )
+    (source / "skills" / "demo" / "SKILL.md").write_text("# Demo\n", encoding="utf-8")
+    (source / "memories" / "MEMORY.md").write_text("private memory\n", encoding="utf-8")
+    (source / "sessions" / "chat.json").write_text("private chat\n", encoding="utf-8")
+    (source / ".env").write_text("OPENAI_API_KEY=private\n", encoding="utf-8")
+    (source / "auth.json").write_text('{"token":"private"}\n', encoding="utf-8")
+    return source
+
+
+def test_bot_export_is_definition_only_and_identity_is_stable(profile_root, tmp_path):
+    source = _source_profile(profile_root)
+
+    first, first_id = export_bot_profile("helper", str(tmp_path / "first.tar.gz"))
+    second, second_id = export_bot_profile("helper", str(tmp_path / "second.tar.gz"))
+
+    assert first_id == second_id == get_profile_bot_id(source)
+    with tarfile.open(first, "r:gz") as archive:
+        names = set(archive.getnames())
+    assert "helper/SOUL.md" in names
+    assert "helper/skills/demo/SKILL.md" in names
+    assert f"helper/{BOT_ID_FILENAME}" in names
+    assert not any("memories" in name for name in names)
+    assert not any("sessions" in name for name in names)
+    assert not any(name.endswith(("/.env", "/auth.json")) for name in names)
+    with tarfile.open(first, "r:gz") as archive:
+        config = archive.extractfile("helper/config.yaml").read().decode("utf-8")
+        profile_meta = archive.extractfile("helper/profile.yaml").read().decode("utf-8")
+    assert "bot_sharing" not in config
+    assert "cloneable: false" in profile_meta
+
+
+def test_pull_policy_is_per_profile_and_fails_closed_for_malformed_yaml(profile_root):
+    source = _source_profile(profile_root)
+
+    assert profile_is_cloneable("helper") is False
+    bot_id = set_profile_cloneable("helper", True)
+    assert profile_is_cloneable("helper") is True
+    assert bot_id == get_profile_bot_id(source)
+
+    (source / "profile.yaml").write_text("cloneable: 'false'\n", encoding="utf-8")
+    assert profile_is_cloneable("helper") is False
+
+
+def test_bot_import_allows_rename_but_rejects_name_and_identity_collisions(profile_root, tmp_path):
+    source = _source_profile(profile_root)
+    archive, bot_id = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))
+    shutil.rmtree(source)
+
+    imported, imported_id = import_bot_profile(str(archive), name="helper-copy")
+
+    assert imported.name == "helper-copy"
+    assert imported_id == bot_id == get_profile_bot_id(imported)
+    assert (imported / "SOUL.md").read_text(encoding="utf-8") == "Helpful bot\n"
+    assert profile_is_cloneable("helper-copy") is False
+
+    with pytest.raises(FileExistsError, match="already exists as profile"):
+        import_bot_profile(str(archive), name="another-name")
+
+    other = _source_profile(profile_root, "occupied")
+    (other / BOT_ID_FILENAME).unlink(missing_ok=True)
+    other_archive, _ = export_bot_profile("occupied", str(tmp_path / "occupied.tar.gz"))
+    shutil.rmtree(other)
+    (profile_root / "profiles" / "occupied").mkdir()
+    with pytest.raises(FileExistsError, match="already exists"):
+        import_bot_profile(str(other_archive), name="occupied")
+
+
+def test_bot_import_rejects_user_state_even_from_safe_tar(profile_root, tmp_path):
+    staged = tmp_path / "staged" / "unsafe"
+    staged.mkdir(parents=True)
+    (staged / BOT_ID_FILENAME).write_text("a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8")
+    (staged / "sessions").mkdir()
+    (staged / "sessions" / "chat.json").write_text("private\n", encoding="utf-8")
+    archive = tmp_path / "unsafe.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="unsafe")
+
+    with pytest.raises(ValueError, match="disallowed profile data: sessions"):
+        import_bot_profile(str(archive))
+
+
+def test_pull_downloads_and_imports_remote_clone(profile_root, tmp_path, monkeypatch):
+    source = _source_profile(profile_root)
+    archive, bot_id = export_bot_profile("helper", str(tmp_path / "helper.tar.gz"))
+    payload = archive.read_bytes()
+    shutil.rmtree(source)
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "GET"
+        assert str(request.url) == "https://remote.example/v1/bots/helper/clone"
+        assert request.headers["Authorization"] == "Bearer remote-secret"
+        return httpx.Response(200, content=payload, headers={"Content-Type": "application/gzip"})
+
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+    monkeypatch.setattr(
+        bot_transfer.httpx,
+        "Client",
+        lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    imported, imported_id = pull_bot_profile(
+        "helper", remote="https://remote.example", name="local-helper"
+    )
+
+    assert imported.name == "local-helper"
+    assert imported_id == bot_id
+
+
+def test_push_uploads_clone_with_requested_remote_name(profile_root, monkeypatch):
+    _source_profile(profile_root)
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        assert request.method == "POST"
+        assert str(request.url) == "https://remote.example/v1/bots/clone?name=remote-helper"
+        assert request.headers["Authorization"] == "Bearer remote-secret"
+        assert request.headers["Content-Type"] == "application/gzip"
+        assert 0 < len(request.content) <= bot_transfer.MAX_BOT_CLONE_BYTES
+        return httpx.Response(
+            201,
+            json={
+                "object": "hermes.bot_clone",
+                "name": "remote-helper",
+                "bot_id": "a8c214f7-37ee-4f50-95a4-939a51631283",
+            },
+        )
+
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+    monkeypatch.setattr(
+        bot_transfer.httpx,
+        "Client",
+        lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    name, bot_id = push_bot_profile(
+        "helper", remote="https://remote.example/v1", name="remote-helper"
+    )
+
+    assert name == "remote-helper"
+    assert bot_id == "a8c214f7-37ee-4f50-95a4-939a51631283"

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -151,6 +151,31 @@ def test_bot_import_bounds_expanded_archive_and_leaves_no_profile(
     assert not (profile_root / "profiles" / "large").exists()
 
 
+def test_bot_export_rejects_source_outside_import_budget(
+    profile_root, tmp_path, monkeypatch
+):
+    source = _source_profile(profile_root)
+    (source / "SOUL.md").write_bytes(b"0" * 2048)
+    monkeypatch.setattr(bot_transfer, "MAX_BOT_CLONE_BYTES", 1024)
+
+    with pytest.raises(ValueError, match="expanded-size limit"):
+        export_bot_profile("helper", str(tmp_path / "large.tar.gz"))
+
+    assert not (tmp_path / "large.tar.gz").exists()
+
+
+def test_bot_export_rejects_too_many_archive_members(
+    profile_root, tmp_path, monkeypatch
+):
+    _source_profile(profile_root)
+    monkeypatch.setattr(bot_transfer, "MAX_BOT_CLONE_MEMBERS", 3)
+
+    with pytest.raises(ValueError, match="member limit"):
+        export_bot_profile("helper", str(tmp_path / "many.tar.gz"))
+
+    assert not (tmp_path / "many.tar.gz").exists()
+
+
 def test_clone_import_lock_cannot_be_stolen_and_recovers_after_owner_death(
     profile_root,
 ):

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -4,6 +4,7 @@ import multiprocessing
 import shutil
 import tarfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import httpx
@@ -90,6 +91,44 @@ def test_pull_policy_is_per_profile_and_fails_closed_for_malformed_yaml(profile_
 
     (source / "profile.yaml").write_text("cloneable: 'false'\n", encoding="utf-8")
     assert profile_is_cloneable("helper") is False
+
+
+def test_clone_policy_rejects_profile_path_traversal(profile_root):
+    outside = profile_root / "outside"
+    outside.mkdir()
+
+    assert profile_is_cloneable("../outside") is False
+    with pytest.raises(ValueError, match="Invalid profile name"):
+        set_profile_cloneable("../outside", True)
+
+    assert not (outside / BOT_ID_FILENAME).exists()
+    assert not (outside / "profile.yaml").exists()
+
+
+def test_bot_identity_is_published_atomically_for_concurrent_exporters(
+    profile_root,
+):
+    source = _source_profile(profile_root)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        identities = set(pool.map(lambda _: bot_transfer.ensure_profile_bot_id(source), range(8)))
+
+    assert len(identities) == 1
+    assert get_profile_bot_id(source) == identities.pop()
+    assert not list(source.glob(f".{BOT_ID_FILENAME}.*.tmp"))
+
+
+def test_bot_identity_publish_failure_leaves_no_partial_file(
+    profile_root, monkeypatch
+):
+    source = _source_profile(profile_root)
+    monkeypatch.setattr(bot_transfer.os, "link", lambda *_args: (_ for _ in ()).throw(OSError("fail")))
+
+    with pytest.raises(OSError, match="fail"):
+        bot_transfer.ensure_profile_bot_id(source)
+
+    assert not (source / BOT_ID_FILENAME).exists()
+    assert not list(source.glob(f".{BOT_ID_FILENAME}.*.tmp"))
 
 
 def test_bot_import_allows_rename_but_rejects_name_and_identity_collisions(profile_root, tmp_path):
@@ -265,3 +304,56 @@ def test_remote_clone_refuses_cleartext_bearer_auth_off_loopback(monkeypatch):
 
     with pytest.raises(ValueError, match="must use HTTPS"):
         pull_bot_profile("helper", remote="http://gateway.example")
+
+
+def test_pull_wraps_network_failures(profile_root, monkeypatch):
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+    monkeypatch.setattr(
+        bot_transfer.httpx,
+        "Client",
+        lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    with pytest.raises(bot_transfer.BotTransferError, match="request failed"):
+        pull_bot_profile("helper", remote="https://remote.example")
+
+
+def test_push_wraps_network_failures(profile_root, monkeypatch):
+    _source_profile(profile_root)
+    real_client = httpx.Client
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        raise httpx.ConnectError("offline", request=request)
+
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+    monkeypatch.setattr(
+        bot_transfer.httpx,
+        "Client",
+        lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    with pytest.raises(bot_transfer.BotTransferError, match="request failed"):
+        push_bot_profile("helper", remote="https://remote.example")
+
+
+def test_push_rejects_malformed_success_response(profile_root, monkeypatch):
+    _source_profile(profile_root)
+    real_client = httpx.Client
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={"object": "hermes.bot_clone"})
+
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+    monkeypatch.setattr(
+        bot_transfer.httpx,
+        "Client",
+        lambda **kwargs: real_client(transport=httpx.MockTransport(handler), **kwargs),
+    )
+
+    with pytest.raises(bot_transfer.BotTransferError, match="invalid bot clone response"):
+        push_bot_profile("helper", remote="https://remote.example")

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -181,3 +181,10 @@ def test_push_uploads_clone_with_requested_remote_name(profile_root, monkeypatch
 
     assert name == "remote-helper"
     assert bot_id == "a8c214f7-37ee-4f50-95a4-939a51631283"
+
+
+def test_remote_clone_refuses_cleartext_bearer_auth_off_loopback(monkeypatch):
+    monkeypatch.setenv("GATEWAY_PROXY_KEY", "remote-secret")
+
+    with pytest.raises(ValueError, match="must use HTTPS"):
+        pull_bot_profile("helper", remote="http://gateway.example")

--- a/tests/hermes_cli/test_bot_transfer.py
+++ b/tests/hermes_cli/test_bot_transfer.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import multiprocessing
 import shutil
 import tarfile
+import time
 from pathlib import Path
 
 import httpx
@@ -47,6 +49,13 @@ def _source_profile(root: Path, name: str = "helper") -> Path:
     (source / ".env").write_text("OPENAI_API_KEY=private\n", encoding="utf-8")
     (source / "auth.json").write_text('{"token":"private"}\n', encoding="utf-8")
     return source
+
+
+def _hold_clone_lock(profiles_root: str, ready) -> None:
+    profiles._get_profiles_root = lambda: Path(profiles_root)
+    with bot_transfer._clone_import_lock():
+        ready.set()
+        time.sleep(30)
 
 
 def test_bot_export_is_definition_only_and_identity_is_stable(profile_root, tmp_path):
@@ -119,6 +128,49 @@ def test_bot_import_rejects_user_state_even_from_safe_tar(profile_root, tmp_path
 
     with pytest.raises(ValueError, match="disallowed profile data: sessions"):
         import_bot_profile(str(archive))
+
+
+def test_bot_import_bounds_expanded_archive_and_leaves_no_profile(
+    profile_root, tmp_path, monkeypatch
+):
+    staged = tmp_path / "staged" / "large"
+    staged.mkdir(parents=True)
+    (staged / BOT_ID_FILENAME).write_text(
+        "a8c214f7-37ee-4f50-95a4-939a51631283\n", encoding="utf-8"
+    )
+    (staged / "SOUL.md").write_bytes(b"0" * 2048)
+    archive = tmp_path / "large.tar.gz"
+    with tarfile.open(archive, "w:gz") as tar:
+        tar.add(staged, arcname="large")
+    assert archive.stat().st_size < 1024
+    monkeypatch.setattr(bot_transfer, "MAX_BOT_CLONE_BYTES", 1024)
+
+    with pytest.raises(ValueError, match="expanded-size limit"):
+        import_bot_profile(str(archive))
+
+    assert not (profile_root / "profiles" / "large").exists()
+
+
+def test_clone_import_lock_cannot_be_stolen_and_recovers_after_owner_death(
+    profile_root,
+):
+    profiles_root = profile_root / "profiles"
+    context = multiprocessing.get_context("spawn")
+    ready = context.Event()
+    holder = context.Process(target=_hold_clone_lock, args=(str(profiles_root), ready))
+    holder.start()
+    try:
+        assert ready.wait(timeout=10)
+        with pytest.raises(TimeoutError):
+            with bot_transfer._clone_import_lock(timeout=0.1):
+                pass
+    finally:
+        holder.terminate()
+        holder.join(timeout=10)
+    assert not holder.is_alive()
+
+    with bot_transfer._clone_import_lock(timeout=1):
+        pass
 
 
 def test_pull_downloads_and_imports_remote_clone(profile_root, tmp_path, monkeypatch):

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -323,6 +323,7 @@ hermes profile push research-bot --to https://gateway.example --name team-resear
 Both commands authenticate with `GATEWAY_PROXY_KEY`, which must match the
 remote gateway's `API_SERVER_KEY`. `--from` / `--to` may be omitted when
 `gateway.proxy_url` is configured. The remote API server must be enabled.
+Non-loopback gateways must use HTTPS so the bearer key is never sent in cleartext.
 
 | Option | Meaning |
 |---|---|

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -26,6 +26,9 @@ Top-level command for managing profiles. Running `hermes profile` without a subc
 | `rename` | Rename a profile. |
 | `export` | Export a profile to a tar.gz archive. |
 | `import` | Import a profile from a tar.gz archive. |
+| `share` | Allow or deny authenticated pulls of a profile from this gateway. |
+| `pull` | Clone a shared bot from a remote gateway. |
+| `push` | Clone a local bot to an opt-in remote gateway. |
 | `install` | Install a profile distribution from a git URL or local directory. See [Profile Distributions](../user-guide/profile-distributions.md). |
 | `update` | Re-pull a distribution-managed profile and re-apply its bundle. |
 | `info` | Show distribution metadata for a profile (origin URL, commit, last update). |

--- a/website/docs/reference/profile-commands.md
+++ b/website/docs/reference/profile-commands.md
@@ -292,6 +292,50 @@ hermes profile import ./work-2026-03-29.tar.gz
 hermes profile import ./work-2026-03-29.tar.gz --name work-restored
 ```
 
+## `hermes profile share`
+
+Controls whether authenticated clients of this gateway may pull a bot profile.
+Remote pull is denied per profile until its owner explicitly enables it.
+
+```bash
+hermes profile share research-bot --allow-pull
+hermes profile share research-bot                 # show policy and Bot ID
+hermes profile share research-bot --deny-pull
+```
+
+The first policy change assigns a persistent Bot ID. The ID survives renames
+and cloning, so a gateway refuses to install the same bot twice under different
+names.
+
+## `hermes profile pull` and `push`
+
+Clone bot definitions directly between API gateways:
+
+```bash
+# Remote owner first enables this bot for pulls.
+hermes profile pull research-bot --from https://gateway.example --name research-local
+
+# Remote gateway owner first opts in to receiving pushed bots:
+hermes config set gateway.bot_sharing.allow_push true
+hermes profile push research-bot --to https://gateway.example --name team-research
+```
+
+Both commands authenticate with `GATEWAY_PROXY_KEY`, which must match the
+remote gateway's `API_SERVER_KEY`. `--from` / `--to` may be omitted when
+`gateway.proxy_url` is configured. The remote API server must be enabled.
+
+| Option | Meaning |
+|---|---|
+| `--from <url>` / `--to <url>` | Remote Hermes API gateway (default: `gateway.proxy_url`). |
+| `--name <name>` | New profile name on the receiving gateway. |
+
+Cloning never overwrites an existing name or Bot ID. A name conflict returns an
+error; choose a different `--name`. Transfer archives are capped at 10 MB and
+contain runnable bot definition only: configuration, SOUL, skills, plugins,
+cron, scripts, MCP configuration, profile metadata, and desktop appearance.
+Credentials, memories, sessions, databases, logs, and caches never cross the
+gateway.
+
 ## Distribution commands
 
 :::tip

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -673,6 +673,37 @@ The profile name is inferred from the archive unless you pass `--name`. Importin
 
 Importing in the desktop app also applies the `desktop.json` overlay and drops you into the new profile on a fresh chat. Importing a desktop-made archive from the CLI is fine — the overlay file rides along on disk and applies the next time you open that profile in the desktop.
 
+### Clone directly between gateways
+
+When both machines expose the authenticated Hermes API server, you can move a
+bot definition without first saving and sending an archive. The bot owner opts
+in per profile:
+
+```bash
+# On the remote gateway host
+hermes profile share research-bot --allow-pull
+
+# On the receiving Hermes host
+hermes profile pull research-bot --from https://gateway.example
+```
+
+Pushing in the other direction requires a separate gateway-owner opt-in:
+
+```bash
+# On the receiving gateway host
+hermes config set gateway.bot_sharing.allow_push true
+
+# On the sender
+hermes profile push research-bot --to https://gateway.example
+```
+
+Clients authenticate with `GATEWAY_PROXY_KEY`; the remote server validates it
+against `API_SERVER_KEY`. A direct clone is intentionally narrower than a
+profile export: it carries the runnable agent definition and desktop overlay,
+but never memories, sessions, credentials, databases, logs, or caches. Each
+shared bot receives a stable UUID. The receiver refuses both name collisions
+and duplicate UUIDs; pass `--name another-name` to resolve only a name conflict.
+
 :::note
 You cannot import as `default` — that name is the built-in root profile (`~/.hermes`). Pass `--name something-else`.
 :::

--- a/website/docs/user-guide/profile-distributions.md
+++ b/website/docs/user-guide/profile-distributions.md
@@ -698,7 +698,8 @@ hermes profile push research-bot --to https://gateway.example
 ```
 
 Clients authenticate with `GATEWAY_PROXY_KEY`; the remote server validates it
-against `API_SERVER_KEY`. A direct clone is intentionally narrower than a
+against `API_SERVER_KEY`. Non-loopback gateway URLs must use HTTPS. A direct
+clone is intentionally narrower than a
 profile export: it carries the runnable agent definition and desktop overlay,
 but never memories, sessions, credentials, databases, logs, or caches. Each
 shared bot receives a stable UUID. The receiver refuses both name collisions


### PR DESCRIPTION
## What does this PR do?

Adds authenticated push and pull cloning for Hermes bot profiles between API gateways. Bot owners opt profiles into pull access individually, gateway owners opt into receiving pushes globally, and receiving gateways refuse both name and stable Bot ID collisions rather than overwriting an existing bot.

### Motivation

Sharing a bot between a local Hermes installation and a remote gateway currently requires manually exporting, moving, and importing a profile archive. This adds a direct gateway path while preserving owner control and excluding credentials and user history from the transfer.

### Behavior

- `hermes profile share <name> --allow-pull` enables authenticated pulls for one bot and assigns its persistent UUID.
- `hermes profile pull` downloads an enabled bot from a remote API gateway.
- `hermes profile push` uploads a local bot only when the receiver has enabled `gateway.bot_sharing.allow_push`.
- `--name` resolves a profile-name conflict without changing bot identity; an existing name or Bot ID is never overwritten.
- Clone archives are limited to 10 MB and omit credentials, memories, sessions, databases, logs, caches, and source-owner sharing policy.

### Implementation

The API server advertises and serves two authenticated clone endpoints. `hermes_cli.bot_transfer` owns the bounded archive contract, stable UUID lifecycle, cross-process import lock, collision checks, HTTP client, and policy reset. Existing profile metadata and CLI parsers expose the owner controls without adding a model tool.

## Related Issue

Closes #102478

## Type of Change

- [x] New feature (non-breaking change that adds functionality)

## Changes Made

- `gateway/platforms/api_server.py` - expose authenticated bot clone upload/download endpoints and capability metadata.
- `hermes_cli/bot_transfer.py` - build, validate, transfer, and import safe bot-definition archives.
- `hermes_cli/profiles.py` - persist fail-closed per-profile clone permission.
- `hermes_cli/subcommands/profile.py`, `hermes_cli/main.py` - add `profile share`, `pull`, and `push` commands.
- `hermes_cli/config_defaults.py`, `cli-config.yaml.example` - add the default-deny remote push policy.
- `tests/` and `website/docs/` - cover and document authorization, identity, conflict, and data-boundary behavior.

## How to Test

1. Enable an API server with `API_SERVER_KEY`, set the client's matching `GATEWAY_PROXY_KEY`, and run `hermes profile share research-bot --allow-pull` on the source.
2. Run `hermes profile pull research-bot --from https://source.example --name research-copy`; verify the new profile exists and a second pull is rejected by Bot ID.
3. Set `gateway.bot_sharing.allow_push: true` on a receiver, run `hermes profile push research-bot --to https://receiver.example`, and verify disabled receivers and name collisions fail closed.
4. Automated checks run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_bot_transfer.py tests/gateway/test_api_server_bot_clone.py -q
scripts/run_tests.sh tests/gateway/test_api_server.py tests/gateway/test_api_server_profile_prefix_misdelivery.py tests/hermes_cli/test_profile_display_name.py tests/hermes_cli/test_subcommands_profile_gateway.py -q
uv run ruff check hermes_cli/bot_transfer.py hermes_cli/profiles.py hermes_cli/subcommands/profile.py hermes_cli/main.py gateway/platforms/api_server.py tests/hermes_cli/test_bot_transfer.py tests/gateway/test_api_server_bot_clone.py
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run the repository test entry on relevant tests and all relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] Architecture/workflow documentation is N/A; the API capability and user guides document the new contract
- [x] I've considered Windows, macOS, and Linux behavior; transfer paths use cross-platform Python APIs
- [x] Tool descriptions/schemas are N/A; this feature extends the CLI and authenticated API rather than adding a model tool

## Screenshots / Logs

N/A - CLI and API behavior is covered by the commands and automated tests above.
