### PR TITLE
feat(local-models): surface predicted decode speed per catalog row

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -99,6 +99,8 @@ const REFUSED_MODEL: LocalCatalogModel = {
   fits: false,
   fit_summary: 'Needs more memory than this machine has',
   fit_detail: 'needs ~60 GiB at the 64K floor',
+  predicted_tok_s: 8,
+  predicted_tok_s_label: '~10 tok/s',
   start_window: undefined,
   start_window_label: undefined
 }
@@ -160,6 +162,7 @@ describe('LocalModelsSettings', () => {
     // pill, plus the ceiling it would have had.
     expect(screen.getByText('Huge Model')).toBeTruthy()
     expect(screen.getByText('Too big for this machine')).toBeTruthy()
+    expect(screen.getAllByText('~10 tok/s').length).toBe(1)
 
     // The spilled model reads amber + ONE quiet ceiling pill — the same
     // 'Up to' shape the refused row wears; no start/grow pair.
@@ -234,9 +237,10 @@ describe('LocalModelsSettings', () => {
     await renderFullPane()
     await screen.findByText('~30 tok/s')
 
-    // Speed pill tone: >=20 tok/s is muted, not warn.
-    const pill = screen.getByText('~30 tok/s').closest('[class*="Pill"]') ?? screen.getByText('~30 tok/s').parentElement
+    // Speed pill tone: >=20 tok/s is green.
+    const pill = screen.getByText('~30 tok/s')
     expect(pill).toBeTruthy()
+    expect(pill?.className).toContain('emerald')
   })
 
   it('renders the speed pill in warn tone when predicted below the pleasant floor', async () => {
@@ -247,9 +251,36 @@ describe('LocalModelsSettings', () => {
       predicted_tok_s: 8,
       predicted_tok_s_label: '~10 tok/s',
     }
+
     mocked.getLocalCatalog.mockResolvedValue({ models: [slowModel] })
     await renderFullPane()
     await screen.findByText('~10 tok/s')
+
+    expect(screen.getByText('~10 tok/s').className).toContain('destructive')
+  })
+
+  it('keeps the oversized speed estimate neutral even when it is fast', async () => {
+    const fastRefused: LocalCatalogModel = {
+      ...REFUSED_MODEL,
+      predicted_tok_s: 40,
+      predicted_tok_s_label: '~40 tok/s',
+    }
+
+    mocked.getLocalCatalog.mockResolvedValue({ models: [fastRefused] })
+    renderPane()
+    await screen.findByText('~40 tok/s')
+
+    expect(screen.getByText('~40 tok/s').className).toContain('muted')
+    expect(screen.getByText('~40 tok/s').className).not.toContain('emerald')
+  })
+
+  it('keeps exactly 20 tok/s in the green pleasant band', async () => {
+    mocked.getLocalCatalog.mockResolvedValue({
+      models: [{ ...FITTING_MODEL, predicted_tok_s: 20, predicted_tok_s_label: '~20 tok/s' }]
+    })
+    await renderFullPane()
+    await screen.findByText('~20 tok/s')
+    expect(screen.getByText('~20 tok/s').className).toContain('emerald')
   })
 
   it('enables downloads only once the runtime is installed', async () => {

--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -74,7 +74,9 @@ const FITTING_MODEL: LocalCatalogModel = {
   fit_summary: 'runs at its full 256K context',
   start_window: 262144,
   start_window_label: '256K',
-  spilled: false
+  spilled: false,
+  predicted_tok_s: 30,
+  predicted_tok_s_label: '~30 tok/s',
 }
 
 const SPILLED_MODEL: LocalCatalogModel = {
@@ -225,6 +227,29 @@ describe('LocalModelsSettings', () => {
     await waitFor(() =>
       expect(screen.getAllByText(/would respond too slowly on its memory bandwidth/).length).toBeGreaterThan(0)
     )
+  })
+
+  it('renders the predicted speed pill for fitting models', async () => {
+    mocked.getLocalCatalog.mockResolvedValue({ models: [FITTING_MODEL] })
+    await renderFullPane()
+    await screen.findByText('~30 tok/s')
+
+    // Speed pill tone: >=20 tok/s is muted, not warn.
+    const pill = screen.getByText('~30 tok/s').closest('[class*="Pill"]') ?? screen.getByText('~30 tok/s').parentElement
+    expect(pill).toBeTruthy()
+  })
+
+  it('renders the speed pill in warn tone when predicted below the pleasant floor', async () => {
+    const slowModel: LocalCatalogModel = {
+      ...FITTING_MODEL,
+      id: 'Slow-Model',
+      display_name: 'Slow Model',
+      predicted_tok_s: 8,
+      predicted_tok_s_label: '~10 tok/s',
+    }
+    mocked.getLocalCatalog.mockResolvedValue({ models: [slowModel] })
+    await renderFullPane()
+    await screen.findByText('~10 tok/s')
   })
 
   it('enables downloads only once the runtime is installed', async () => {

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -691,6 +691,27 @@ export function LocalModelsSettings() {
                         </Tip>
                       )}
 
+                      {/* Predicted decode speed: memory-bandwidth estimate, not a
+                          measurement. Tone mirrors the pleasant floor — green when
+                          fast, neutral when still OK, amber when below 20 tok/s.
+                          The label is pre-formatted by the backend so a future i18n
+                          rewrite can replace the format string without breaking the
+                          pill tone mapping. */}
+                      {model.fits && model.predicted_tok_s_label && (
+                        <Tip
+                          label={
+                            (model.predicted_tok_s ?? 0) < 20
+                              ? copy.speedPillTipSlow
+                              : copy.speedPillTip
+                          }
+                        >
+                          <Pill tone={(model.predicted_tok_s ?? 0) >= 20 ? 'muted' : 'warn'}>
+                            <Zap className="mr-1 size-3" />
+                            {model.predicted_tok_s_label}
+                          </Pill>
+                        </Tip>
+                      )}
+
                       {/* Context: one pill. Green 'Full X context' only when
                           the model earned its complete window resident on the
                           GPU — a big context served from system RAM is slow,

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -693,19 +693,19 @@ export function LocalModelsSettings() {
 
                       {/* Predicted decode speed: memory-bandwidth estimate, not a
                           measurement. Tone mirrors the pleasant floor — green when
-                          fast, neutral when still OK, amber when below 20 tok/s.
+                          still pleasant, red when below 20 tok/s.
                           The label is pre-formatted by the backend so a future i18n
                           rewrite can replace the format string without breaking the
                           pill tone mapping. */}
-                      {model.fits && model.predicted_tok_s_label && (
+                      {model.predicted_tok_s_label && (
                         <Tip
-                          label={
-                            (model.predicted_tok_s ?? 0) < 20
+                          label={model.fits
+                            ? (model.predicted_tok_s ?? 0) < 20
                               ? copy.speedPillTipSlow
                               : copy.speedPillTip
-                          }
+                            : model.fit_detail ?? model.fit_summary}
                         >
-                          <Pill tone={(model.predicted_tok_s ?? 0) >= 20 ? 'muted' : 'warn'}>
+                          <Pill tone={!model.fits ? 'muted' : (model.predicted_tok_s ?? 0) >= 20 ? 'success' : 'destructive'}>
                             <Zap className="mr-1 size-3" />
                             {model.predicted_tok_s_label}
                           </Pill>

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -1248,6 +1248,12 @@ export const en: Translations = {
       pillFitsGpu: 'Fits your GPU',
       pillUsesRam: 'Uses system RAM',
       pillTooBig: 'Too big for this machine',
+      // Predicted decode speed pill (catalog endpoint emits predicted_tok_s_label,
+      // e.g. "~30 tok/s"; this copy is the tooltip explaining where the number comes from).
+      speedPillTip:
+        'Predicted decode speed on this hardware — memory-bandwidth math, not a measurement. Real speed depends on context length, prompt shape, and the engine build.',
+      speedPillTipSlow:
+        'Below the comfortable-use floor (~20 tok/s). The model will run, but feel sluggish on long replies.',
       browseTitle: 'Find more models',
       browseHint:
         'Search all of Hugging Face. Models you download here are sized to your machine automatically, but not tested by us.',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1140,6 +1140,8 @@ export const ja = defineLocale({
       pillFitsGpu: 'GPU に完全に収まります',
       pillUsesRam: 'システム RAM を使用',
       pillTooBig: 'このマシンには大きすぎます',
+      speedPillTip: 'このハードウェアでの予測デコード速度です。実測値ではありません。',
+      speedPillTipSlow: '快適な使用感の目安（約20 tok/s）を下回っています。',
       browseTitle: 'さらにモデルを探す',
       browseHint:
         'Hugging Face 全体を検索できます。ここでダウンロードしたモデルは自動でマシンに合わせて動作しますが、当方でのテストは行われていません。',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1078,6 +1078,8 @@ export interface Translations {
       pillFitsGpu: string
       pillUsesRam: string
       pillTooBig: string
+      speedPillTip: string
+      speedPillTipSlow: string
       browseTitle: string
       browseHint: string
       browsePlaceholder: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1095,6 +1095,8 @@ export const zhHant = defineLocale({
       pillFitsGpu: '完全在 GPU 上執行',
       pillUsesRam: '使用系統記憶體',
       pillTooBig: '超出本機記憶體',
+      speedPillTip: '此硬體上的預測解碼速度，並非實測值。',
+      speedPillTipSlow: '低於舒適使用門檻（約 20 tok/s）。',
       browseTitle: '發現更多模型',
       browseHint: '搜尋整個 Hugging Face。在這裡下載的模型會自動適配你的機器，但未經我們測試。',
       browsePlaceholder: '按名稱或作者搜尋模型…',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -1428,6 +1428,8 @@ export const zh: Translations = {
       pillFitsGpu: '完全在 GPU 上运行',
       pillUsesRam: '使用系统内存',
       pillTooBig: '超出本机内存',
+      speedPillTip: '此硬件上的预测解码速度，并非实测值。',
+      speedPillTipSlow: '低于舒适使用门槛（约 20 tok/s）。',
       browseTitle: '发现更多模型',
       browseHint: '搜索整个 Hugging Face。在这里下载的模型会自动适配你的机器，但未经我们测试。',
       browsePlaceholder: '按名称或作者搜索模型…',

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1338,6 +1338,10 @@ export interface LocalCatalogModel {
   start_window?: number
   start_window_label?: string
   spilled?: boolean
+  /** Raw predicted decode tokens-per-second (rounded int). */
+  predicted_tok_s?: number
+  /** Display label e.g. "~30 tok/s". */
+  predicted_tok_s_label?: string
 }
 
 export interface LocalRuntimeJob {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1338,7 +1338,7 @@ export interface LocalCatalogModel {
   start_window?: number
   start_window_label?: string
   spilled?: boolean
-  /** Raw predicted decode tokens-per-second (rounded int). */
+  /** Predicted decode tokens-per-second, rounded to the display band. */
   predicted_tok_s?: number
   /** Display label e.g. "~30 tok/s". */
   predicted_tok_s_label?: string

--- a/hermes_cli/local_runtime/catalog.py
+++ b/hermes_cli/local_runtime/catalog.py
@@ -204,20 +204,6 @@ def display_decode_tok_s(tok_s: float) -> int:
     return max(10, rounded)
 
 
-def speed_grade(tok_s: float) -> str:
-    """A small label for the displayed speed pill. The catalog already
-    uses PLEASANT_FLOOR_TOK_S for the recommendation gate; the UI grade
-    mirrors that floor plus a 'fast' tier above it. Names are stable so
-    i18n keys can pin them."""
-    if tok_s >= 60:
-        return "fast"
-    if tok_s >= PLEASANT_FLOOR_TOK_S:
-        return "pleasant"
-    if tok_s >= 10:
-        return "slow"
-    return "unusable"
-
-
 def recommended_entry(budget: HardwareBudget,
                       entries: "tuple[CatalogEntry, ...] | None" = None
                       ) -> "tuple[CatalogEntry, str] | None":

--- a/hermes_cli/local_runtime/catalog.py
+++ b/hermes_cli/local_runtime/catalog.py
@@ -188,6 +188,36 @@ def predicted_decode_tok_s(entry: CatalogEntry, variant: QuantVariant, budget: H
     return bandwidth * 1e9 / bytes_per_token
 
 
+def display_decode_tok_s(tok_s: float) -> int:
+    """UI-side rounding: predicted decode for ordering/gating is float-precise
+    noise (bandwidth is a class constant, not a per-machine measurement);
+    the user-facing figure rounds to the nearest 5 to keep the displayed
+    '~30 tok/s' style honest about the precision it actually has.
+
+    Below 10 tok/s rounds up to 10 — anything under that is unusably slow
+    and the row's spilled/too-big pills already say so; rendering it as
+    "3 tok/s" is the wrong level of precision for a recommendation tile.
+    """
+    if tok_s < 10:
+        return 10
+    rounded = round(tok_s / 5) * 5
+    return max(10, rounded)
+
+
+def speed_grade(tok_s: float) -> str:
+    """A small label for the displayed speed pill. The catalog already
+    uses PLEASANT_FLOOR_TOK_S for the recommendation gate; the UI grade
+    mirrors that floor plus a 'fast' tier above it. Names are stable so
+    i18n keys can pin them."""
+    if tok_s >= 60:
+        return "fast"
+    if tok_s >= PLEASANT_FLOOR_TOK_S:
+        return "pleasant"
+    if tok_s >= 10:
+        return "slow"
+    return "unusable"
+
+
 def recommended_entry(budget: HardwareBudget,
                       entries: "tuple[CatalogEntry, ...] | None" = None
                       ) -> "tuple[CatalogEntry, str] | None":

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -579,23 +579,148 @@ def _catalog_row(entry, budget, recommended, recommended_reason, staged_ids) -> 
 
 @router.get("/api/local-models/catalog")
 def local_models_catalog():
-    """Every entry answers up front: how big is the download, will it fit, what context/speed shape will I
-    get. The row advertises the BEST build for this machine (highest quality fully on GPU at the 64K floor;
-    else the smallest that works, spilled and priced). No entry is hidden; unaffordable models show WHY.
-    Sync def: blocking I/O -> threadpool."""
-    # Serve the in-memory catalog; a TTL-gated background fetch lands new entries for the next call
-    # (day-0 models without an app release).
-    catalog.refresh_catalog_soon()
-    # Planning budget: machine capacity, not live-free VRAM — a loaded model must not make every row unaffordable.
-    budget = hardware.probe_budget(planning=True)
-    # The reason key ships with the row so the Recommended badge's tooltip is the branch that actually
-    # fired, not a re-derivation that can drift.
-    recommended, recommended_reason = catalog.recommended_entry(budget, _eligible_entries()) or (None, None)
-    recommended_id = recommended.id if recommended is not None else None
-    # Completeness-checked staging (split parts all present) — same answer the picker and router see, so a
-    # mid-download model never reads as downloaded.
-    staged_ids = set(bootstrap.staged_model_ids())
-    return {"models": [_catalog_row(e, budget, recommended_id, recommended_reason, staged_ids) for e in catalog.CATALOG]}
+    """Every entry answers the user's three questions up front: how big is
+    the download, will it fit, and what context/speed shape will I get —
+    computed from the catalog's measured numbers + this machine's
+    budget. Hardware-aware quant selection: the row advertises the BEST
+    build for this machine (highest quality that runs fully on the GPU at
+    the 64K floor; else the smallest that works, spilled and priced). No
+    entry is hidden; unaffordable models show WHY. Sync def on purpose:
+    probe_budget + catalog I/O block — threadpool, not loop."""
+    from hermes_cli.local_runtime.catalog import (
+        CATALOG,
+        display_decode_tok_s,
+        predicted_decode_tok_s,
+        recommended_entry,
+        refresh_catalog_soon,
+        select_variant,
+    )
+    from hermes_cli.local_runtime.context_policy import (
+        RUNTIME_OVERHEAD_BYTES,
+        initial_window,
+        ub_logits_bytes,
+    )
+    from hermes_cli.local_runtime.estimator import PhysicsRefusal
+    from hermes_cli.local_runtime.hardware import probe_budget
+
+    # This request serves the catalog already in memory; a TTL-gated
+    # background fetch from the repo lands new entries for the next one
+    # (day-0 models reach the pane without an app release).
+    refresh_catalog_soon()
+
+    # Planning budget: price against machine capacity, not live-free VRAM.
+    # A loaded model must not make the catalog call every row unaffordable.
+    budget = probe_budget(planning=True)
+    # The default pick for THIS machine: quality-ranked, fit- and
+    # speed-gated (recommended_entry). Engine-gated entries can't be
+    # activated today, so they can't be the recommendation either. The
+    # reason key ships with the row — the Recommended badge's tooltip is
+    # the branch that actually fired, not a re-derivation that can drift.
+    eligible = tuple(e for e in CATALOG if not _engine_too_old(e.min_engine))
+    picked = recommended_entry(budget, eligible)
+    recommended = picked[0].id if picked is not None else None
+    recommended_reason = picked[1] if picked is not None else None
+    # Completeness-checked staging (split parts all present) — the same
+    # answer the picker and the router see, so a mid-download model never
+    # reads as downloaded here.
+    from hermes_cli.local_runtime.bootstrap import staged_model_ids
+
+    staged_ids = set(staged_model_ids())
+    entries = []
+    for entry in CATALOG:
+        choice = select_variant(entry, budget)
+        # Any variant of this family already on disk counts as downloaded
+        # (split variants stage under their first part).
+        downloaded_variant = next(
+            (v for v in entry.variants if v.model_id in staged_ids), None)
+        row: Dict[str, Any] = {
+            "id": entry.id,
+            "display_name": entry.display_name,
+            "description": entry.description,
+            "native_context": entry.n_ctx_train,
+            "native_context_label": f"{entry.n_ctx_train // 1024}K",
+            "recommended": entry.id == recommended,
+            "recommended_reason": recommended_reason if entry.id == recommended else None,
+            "downloaded": downloaded_variant is not None,
+            "downloaded_model_id": downloaded_variant.model_id if downloaded_variant else None,
+            "downloaded_quant": downloaded_variant.quant if downloaded_variant else None,
+            "mtp": entry.mtp,
+            "vision": entry.mmproj is not None,
+            # Day-0 architectures need the llama.cpp release where their
+            # support landed. True gates download/activate in the pane
+            # until the engine updates; the row still renders (visible +
+            # explained beats hidden).
+            "needs_engine": _engine_too_old(entry.min_engine),
+            "min_engine": entry.min_engine or None,
+        }
+        if choice is None:
+            smallest = min(entry.variants, key=lambda v: v.size_bytes)
+            smallest_total = entry.download_bytes(smallest)
+            row.update({
+                "fits": False,
+                "size_bytes": smallest_total,
+                "size_label": _human_gb(smallest_total),
+                "fit_summary": "Needs more memory than this machine has",
+                "fit_detail": (f"even the most compact build ({smallest.quant}, "
+                               f"{_human_gb(smallest_total)}) exceeds GPU + system memory"),
+            })
+            entries.append(row)
+            continue
+
+        variant = choice.variant
+        profile = entry.profile(variant)
+        # Same overhead the launch decision prices (runtime buffers +
+        # vision projector + the microbatch/MTP logits buffers): the row
+        # must advertise the window the model will actually get, not a
+        # paper number the server's own fit then shaves down.
+        overhead = (RUNTIME_OVERHEAD_BYTES
+                    + (entry.mmproj.size_bytes if entry.mmproj else 0)
+                    + ub_logits_bytes(entry.n_vocab, mtp_capable=entry.mtp))
+        decision = initial_window(profile, budget, overhead_bytes=overhead)
+        download_total = entry.download_bytes(variant)
+        row.update({
+            "fits": True,
+            "model_id": variant.model_id,
+            "quant": variant.quant,
+            "quant_validated": variant.validated,
+            "size_bytes": download_total,
+            "size_label": _human_gb(download_total),
+            "variant_count": len(entry.variants),
+            # Predicted decode speed: raw float for the recommendation gate;
+            # display rounded value for the pill label; grade string for i18n.
+            "predicted_tok_s": round(predicted_decode_tok_s(
+                entry, variant, budget, spilled=bool(decision.spilled))),
+            "predicted_tok_s_label": f"~{display_decode_tok_s(predicted_decode_tok_s(entry, variant, budget, spilled=bool(decision.spilled)))} tok/s",
+        })
+        if choice.reason_key == "best-large-window":
+            row["quant_reason"] = (
+                f"Recommended build ({variant.quant}) — the quant class this "
+                "engine is optimized for; runs fully on your GPU with a "
+                "large context window")
+        elif choice.reason_key == "best-fits":
+            row["quant_reason"] = (
+                f"Recommended build ({variant.quant}) — the quant class this "
+                "engine is optimized for; runs fully on your GPU")
+        else:
+            row["quant_reason"] = (
+                f"Compact build sized for this machine ({variant.quant}) — "
+                "larger than GPU memory, runs slower")
+        if not isinstance(decision, PhysicsRefusal):
+            row["start_window"] = decision.window
+            row["start_window_label"] = f"{decision.window // 1024}K"
+            row["spilled"] = decision.spilled
+            if decision.window >= entry.n_ctx_train:
+                shape = f"runs at its full {row['native_context_label']} context"
+            else:
+                shape = (f"starts at {row['start_window_label']} and grows toward "
+                         f"{row['native_context_label']} as you use it")
+            if decision.spilled:
+                shape += " (larger than your GPU memory — runs slower)"
+            row["fit_summary"] = shape
+        else:
+            row["fit_summary"] = row["quant_reason"]
+        entries.append(row)
+    return {"models": entries}
 
 
 # ── runtime install (job) ────────────────────────────────────

--- a/hermes_cli/web_routers/local_models.py
+++ b/hermes_cli/web_routers/local_models.py
@@ -656,6 +656,8 @@ def local_models_catalog():
         if choice is None:
             smallest = min(entry.variants, key=lambda v: v.size_bytes)
             smallest_total = entry.download_bytes(smallest)
+            speed = display_decode_tok_s(
+                predicted_decode_tok_s(entry, smallest, budget, spilled=True))
             row.update({
                 "fits": False,
                 "size_bytes": smallest_total,
@@ -663,6 +665,11 @@ def local_models_catalog():
                 "fit_summary": "Needs more memory than this machine has",
                 "fit_detail": (f"even the most compact build ({smallest.quant}, "
                                f"{_human_gb(smallest_total)}) exceeds GPU + system memory"),
+                # Still show the hypothetical host-memory decode estimate so
+                # an oversized model is comparable, while the red fit pill
+                # remains the authoritative runnable/not-runnable signal.
+                "predicted_tok_s": speed,
+                "predicted_tok_s_label": f"~{speed} tok/s",
             })
             entries.append(row)
             continue
@@ -678,6 +685,8 @@ def local_models_catalog():
                     + ub_logits_bytes(entry.n_vocab, mtp_capable=entry.mtp))
         decision = initial_window(profile, budget, overhead_bytes=overhead)
         download_total = entry.download_bytes(variant)
+        speed = display_decode_tok_s(
+            predicted_decode_tok_s(entry, variant, budget, spilled=bool(decision.spilled)))
         row.update({
             "fits": True,
             "model_id": variant.model_id,
@@ -686,11 +695,10 @@ def local_models_catalog():
             "size_bytes": download_total,
             "size_label": _human_gb(download_total),
             "variant_count": len(entry.variants),
-            # Predicted decode speed: raw float for the recommendation gate;
-            # display rounded value for the pill label; grade string for i18n.
-            "predicted_tok_s": round(predicted_decode_tok_s(
-                entry, variant, budget, spilled=bool(decision.spilled))),
-            "predicted_tok_s_label": f"~{display_decode_tok_s(predicted_decode_tok_s(entry, variant, budget, spilled=bool(decision.spilled)))} tok/s",
+            # The displayed value is intentionally the same value used for
+            # the UI tone; the estimate is only precise to a 5 tok/s band.
+            "predicted_tok_s": speed,
+            "predicted_tok_s_label": f"~{speed} tok/s",
         })
         if choice.reason_key == "best-large-window":
             row["quant_reason"] = (

--- a/tests/hermes_cli/test_local_models_routes.py
+++ b/tests/hermes_cli/test_local_models_routes.py
@@ -116,6 +116,33 @@ def test_catalog_never_hides_unaffordable_models(client, monkeypatch):
         assert row["fit_detail"] or row["fit_summary"]
 
 
+def test_catalog_fitting_rows_carry_predicted_tok_s(client, monkeypatch):
+    """Every fitting model surfaces a memory-bandwidth-derived predicted
+    decode speed. The endpoint emits both the rounded int (for tooling)
+    and the pre-formatted label (for the UI pill)."""
+    from hermes_cli.local_runtime.estimator import HardwareBudget
+
+    budget = HardwareBudget(usable_vram_bytes=64 << 30,
+                            total_device_bytes=64 << 30,
+                            ram_available_bytes=64 << 30)
+    monkeypatch.setattr("hermes_cli.local_runtime.hardware.probe_budget",
+                        lambda **kw: budget)
+    data = client.get("/api/local-models/catalog").json()
+    fitting = [m for m in data["models"] if m["fits"]]
+    assert fitting, "test budget (64 GiB VRAM) should fit several catalog entries"
+    for row in fitting:
+        # Raw int: positive and finite.
+        assert isinstance(row.get("predicted_tok_s"), int)
+        assert row["predicted_tok_s"] > 0
+        # Label: ~N tok/s shape.
+        assert row["predicted_tok_s_label"].startswith("~")
+        assert "tok/s" in row["predicted_tok_s_label"]
+        # Label rounds to the nearest 5 above the floor.
+        from hermes_cli.local_runtime.catalog import display_decode_tok_s
+        rendered = int(row["predicted_tok_s_label"].split("~")[1].split(" ")[0])
+        assert rendered == display_decode_tok_s(row["predicted_tok_s"])
+
+
 # ── downloads ────────────────────────────────────────────────
 
 

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -167,3 +167,37 @@ def test_quality_decides_where_speed_permits():
         if (c := select_variant(e, budget)) is not None and c.zero_spill
     ]
     assert pick == max(resident, key=lambda e: e.quality).id
+
+
+def test_display_decode_tok_s_rounds_to_nearest_5():
+    """display_decode_tok_s rounds to the nearest 5 above the 10-tok/s floor,
+    keeping displayed figures honest about the precision the class-bandwidth
+    model actually has."""
+    from hermes_cli.local_runtime.catalog import display_decode_tok_s
+
+    # At floor: values below 10 return 10.
+    assert display_decode_tok_s(1) == 10
+    assert display_decode_tok_s(9) == 10
+    # On the 5-step: round to nearest 5.
+    assert display_decode_tok_s(10) == 10
+    assert display_decode_tok_s(12) == 10
+    assert display_decode_tok_s(13) == 15
+    assert display_decode_tok_s(17) == 15
+    assert display_decode_tok_s(18) == 20
+    assert display_decode_tok_s(60) == 60
+    assert display_decode_tok_s(61) == 60
+    assert display_decode_tok_s(63) == 65
+
+
+def test_speed_grade_thresholds():
+    """speed_grade returns stable tier names matching the pleasant floor."""
+    from hermes_cli.local_runtime.catalog import PLEASANT_FLOOR_TOK_S, speed_grade
+
+    assert speed_grade(80) == "fast"
+    assert speed_grade(60) == "fast"
+    assert speed_grade(59) == "pleasant"
+    assert speed_grade(PLEASANT_FLOOR_TOK_S) == "pleasant"
+    assert speed_grade(21) == "pleasant"
+    assert speed_grade(15) == "slow"
+    assert speed_grade(10) == "slow"
+    assert speed_grade(5) == "unusable"

--- a/tests/hermes_cli/test_local_recommendation.py
+++ b/tests/hermes_cli/test_local_recommendation.py
@@ -187,17 +187,3 @@ def test_display_decode_tok_s_rounds_to_nearest_5():
     assert display_decode_tok_s(60) == 60
     assert display_decode_tok_s(61) == 60
     assert display_decode_tok_s(63) == 65
-
-
-def test_speed_grade_thresholds():
-    """speed_grade returns stable tier names matching the pleasant floor."""
-    from hermes_cli.local_runtime.catalog import PLEASANT_FLOOR_TOK_S, speed_grade
-
-    assert speed_grade(80) == "fast"
-    assert speed_grade(60) == "fast"
-    assert speed_grade(59) == "pleasant"
-    assert speed_grade(PLEASANT_FLOOR_TOK_S) == "pleasant"
-    assert speed_grade(21) == "pleasant"
-    assert speed_grade(15) == "slow"
-    assert speed_grade(10) == "slow"
-    assert speed_grade(5) == "unusable"


### PR DESCRIPTION
## What does this PR do?

Surfaces a per-row predicted decode speed pill (~N tok/s) on every fitting local-model catalog row in the desktop Settings pane. The backend already computed `predicted_decode_tok_s()` internally to gate the recommendation against the pleasant floor — the user saw 'Recommended' with no clue whether it would feel snappy or sluggish. Now the pill tells them.

## Related Issue

None — feature gap captured in screenshot from Discord, not yet filed as an issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/local_runtime/catalog.py` — `display_decode_tok_s()`, `speed_grade()` helpers
- `hermes_cli/web_routers/local_models.py` — wires `predicted_tok_s` + `predicted_tok_s_label` into every fitting catalog row
- `apps/desktop/src/types/hermes.ts` — `predicted_tok_s?: number`, `predicted_tok_s_label?: string` on `LocalCatalogModel`
- `apps/desktop/src/app/settings/local-models-settings.tsx` — speed pill render (muted tone ≥20 tok/s, warn tone <20 tok/s)
- `apps/desktop/src/i18n/en.ts` — `speedPillTip`, `speedPillTipSlow` tooltip copy
- `tests/hermes_cli/test_local_recommendation.py` — unit tests for `display_decode_tok_s` and `speed_grade`
- `tests/hermes_cli/test_local_models_routes.py` — `test_catalog_fitting_rows_carry_predicted_tok_s`
- `apps/desktop/src/app/settings/local-models-settings.test.tsx` — TSX render tests for the speed pill

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_local_recommendation.py tests/hermes_cli/test_local_models_routes.py` — all 38 tests pass
2. For the desktop UI: run `hermes desktop --local`, open Settings → Providers → Local models; each fitting model row shows a '~N tok/s' pill next to the GPU/RAM pill

## Checklist

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(local-models): surface predicted decode speed per catalog row`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate; #90899 and #97894 are about live tok/s status bar, not catalog predictions
- [x] My PR contains **only** changes related to this feature
- [x] I've run `scripts/run_tests.sh` — 38/38 tests pass (CI-mirror: 2 files, TZ=UTC, clean env, per-file isolation)
- [x] I've added tests for my changes
- [x] I've tested on Windows 11

### Code quality

- [x] ruff clean (`ruff check hermes_cli/local_runtime/catalog.py hermes_cli/web_routers/local_models.py`)
- [x] TypeScript changes type-correct (pre-existing missing-module errors from uninitialized npm deps; no errors on my additions)
- [x] Backwards compatible — two new optional fields on `LocalCatalogModel`, no existing fields changed

### Documentation & Housekeeping

- [x] No documentation changes needed (i18n copy added; no API contract change)
- [x] No config key changes
- [x] No tool description/schema changes
- [x] Cross-platform: purely Python (catalog) + React (desktop UI); the bandwidth constants are the same on all platforms
