### PR TITLE
fix(gateway): release guard-matched session lock before clearing stateless turn caches

### DIFF
--- a/contributors/emails/bepleecanton@gmail.com
+++ b/contributors/emails/bepleecanton@gmail.com
@@ -1,0 +1,2 @@
+beplee
+# PR #102409 salvage (session guard)

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3239,6 +3239,12 @@ class BasePlatformAdapter(ABC):
     # set this to False to stay correct-by-default.
     supports_async_delivery: bool = True
 
+    # Explicit lifecycle contract for transports whose conversations end with
+    # each request. Such adapters opt in once at the class level; contractor
+    # events also enforce this boundary independently so a plugin cannot
+    # accidentally retain adapter-owned session state by omitting the flag.
+    close_after_turn: bool = False
+
     # Whether this adapter's ``send()`` splits long content into multiple
     # messages via ``truncate_message()``.  When True, the delivery router
     # (gateway/delivery.py) skips gateway-level truncation and lets the
@@ -6180,6 +6186,20 @@ class BasePlatformAdapter(ABC):
         if state is not None and state.task is not None and not state.task.done():
             state.task.cancel()
 
+    def clear_session(self, session_key: str) -> None:
+        """Clear adapter-owned state for one completed stateless turn.
+
+        The persistent conversation store is owned by ``GatewayRunner`` and is
+        intentionally not touched here. This method removes every transient
+        adapter cache keyed by ``session_key`` so all platform subclasses share
+        the same close-after-turn behavior without bespoke cleanup hooks.
+        """
+        self._active_sessions.pop(session_key, None)
+        self._pending_messages.pop(session_key, None)
+        self._session_tasks.pop(session_key, None)
+        self._post_delivery_callbacks.pop(session_key, None)
+        self._discard_text_debounce(session_key)
+
     # ------------------------------------------------------------------
     # Session task + guard ownership helpers
     # ------------------------------------------------------------------
@@ -7438,7 +7458,13 @@ class BasePlatformAdapter(ABC):
                 # same session.
                 current_task = asyncio.current_task()
                 if current_task is not None and self._session_tasks.get(session_key) is current_task:
-                    self._cleanup_finished_session_task(session_key, interrupt_event)
+                    if (
+                        getattr(self, "close_after_turn", False) is True
+                        or getattr(event, "contractor_context", None) is not None
+                    ):
+                        self.clear_session(session_key)
+                    else:
+                        self._cleanup_finished_session_task(session_key, interrupt_event)
     
     def _cleanup_finished_session_task(
         self, session_key: str, interrupt_event: Optional[asyncio.Event]

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -7462,7 +7462,18 @@ class BasePlatformAdapter(ABC):
                         getattr(self, "close_after_turn", False) is True
                         or getattr(event, "contractor_context", None) is not None
                     ):
-                        self.clear_session(session_key)
+                        # Release the guard via the guard-matched path first so a
+                        # command-scoped guard swapped in by /stop /new /reset is
+                        # not cleared while it is still owned by a concurrent
+                        # path. Only clear the rest of the per-session adapter
+                        # caches once the guard was actually released for this
+                        # task.
+                        self._cleanup_finished_session_task(session_key, interrupt_event)
+                        if session_key not in self._active_sessions:
+                            self._pending_messages.pop(session_key, None)
+                            self._session_tasks.pop(session_key, None)
+                            self._post_delivery_callbacks.pop(session_key, None)
+                            self._discard_text_debounce(session_key)
                     else:
                         self._cleanup_finished_session_task(session_key, interrupt_event)
     

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2510,6 +2510,60 @@ class ProcessingOutcome(Enum):
     CANCELLED = "cancelled"
 
 
+@dataclass(frozen=True)
+class ContractorTurnContext:
+    """Registry-authorized policy for one ephemeral contractor turn.
+
+    This is an internal gateway contract, not a caller-extensible options
+    mapping.  The Bloodbank adapter owns registry resolution and constructs
+    this value only after it has pinned the profile and project root.  Hermes
+    validates the invariants again before it creates an agent.
+    """
+
+    contractor_id: str
+    contractor_version: int
+    memory_policy: str
+    continuity: bool
+    required_skills: tuple[str, ...]
+    profile_name: str
+    project_root: str
+
+    def __post_init__(self) -> None:
+        contractor_id = str(self.contractor_id or "")
+        if not contractor_id or contractor_id != contractor_id.strip():
+            raise ValueError("contractor_id must be a non-empty canonical string")
+        if type(self.contractor_version) is not int or self.contractor_version < 1:
+            raise ValueError("contractor_version must be a positive integer")
+        if self.memory_policy != "none":
+            raise ValueError("memory_policy must be exactly 'none'")
+        if self.continuity is not False:
+            raise ValueError("continuity must be exactly false")
+        if not isinstance(self.required_skills, tuple) or not self.required_skills:
+            raise ValueError("required_skills must be a non-empty ordered tuple")
+        normalized_skills: list[str] = []
+        for skill in self.required_skills:
+            if not isinstance(skill, str) or not skill.strip() or skill != skill.strip():
+                raise ValueError(
+                    "required_skills entries must be non-empty canonical strings"
+                )
+            normalized_skills.append(skill)
+        if len(set(normalized_skills)) != len(normalized_skills):
+            raise ValueError("required_skills must not contain duplicates")
+        profile_name = str(self.profile_name or "")
+        if not profile_name or profile_name != profile_name.strip():
+            raise ValueError("profile_name must be a non-empty canonical string")
+        root = Path(str(self.project_root or "")).expanduser()
+        if not root.is_absolute():
+            raise ValueError("project_root must be an absolute path")
+        try:
+            resolved_root = root.resolve(strict=True)
+        except (OSError, RuntimeError) as exc:
+            raise ValueError("project_root must resolve to an existing directory") from exc
+        if not resolved_root.is_dir():
+            raise ValueError("project_root must resolve to an existing directory")
+        object.__setattr__(self, "project_root", str(resolved_root))
+
+
 @dataclass
 class MessageEvent:
     """
@@ -2600,10 +2654,15 @@ class MessageEvent:
     timestamp: datetime = field(default_factory=datetime.now)
 
     # Whether this event may resolve gateway commands or pending control
-    # prompts. Kept last to preserve positional construction compatibility.
+    # prompts.
     # Proactive plugin events set this to False so untrusted payload text
     # remains conversational input.
     allow_gateway_control: bool = True
+
+    # Typed, registry-resolved policy for a one-shot contractor invocation.
+    # Kept last to preserve positional construction compatibility. Ordinary
+    # chat adapters leave it unset and retain the existing session path.
+    contractor_context: Optional[ContractorTurnContext] = None
     
     def is_command(self) -> bool:
         """Check if this is a command message (e.g., /new, /reset)."""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -18895,7 +18895,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # agents can observe or mutate it. The dedicated path revalidates that
         # the event is internal and pinned to its authorized profile/root.
         contractor_context = getattr(event, "contractor_context", None)
-        if contractor_context is not None:
+        if isinstance(contractor_context, ContractorTurnContext):
             return await self._handle_contractor_turn(
                 event, source, contractor_context
             )
@@ -21649,7 +21649,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
         contractor_context = getattr(event, "contractor_context", None)
-        if contractor_context is not None:
+        if isinstance(contractor_context, ContractorTurnContext):
             return await self._handle_contractor_turn(
                 event, source, contractor_context
             )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2467,6 +2467,10 @@ class ContractorTurnRejected(RuntimeError):
     """A contractor policy invariant failed before safe model execution."""
 
 
+class ContractorTurnCleanupFailed(ContractorTurnRejected):
+    """A contractor completed its work but could not close cleanly."""
+
+
 class HygieneTurnHoldExceeded(Exception):
     """The hygiene-compression turn-hold budget elapsed while the summary
     model was still streaming progress.
@@ -9053,7 +9057,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         user_message: str,
         model: str,
         runtime_kwargs: dict,
-        service_tier: Optional[str] = None,
+        service_tier: Any = _SERVICE_TIER_UNSET,
     ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
@@ -9070,7 +9074,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         ``service_tier`` may be supplied explicitly for callers (such as
         stateless contractor turns) that must not write shared runner state.
-        When omitted, the runner's own session-bound value is used.
+        Explicit ``None`` means normal tier; only omission falls back to the
+        runner's session-bound value.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -9106,7 +9111,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # dropped by the runtime whitelist above, so a custom provider's
         # configured extra_body (chat_template_kwargs, etc.) never reached the
         # model on the gateway path -- only /fast service-tier overrides did.
-        if service_tier is None:
+        if service_tier is _SERVICE_TIER_UNSET:
             service_tier = getattr(self, "_service_tier", None)
         if service_tier != "priority":
             # None (normal) or auto/cold — the bounded window is applied per
@@ -21280,27 +21285,33 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             raise ContractorTurnRejected("contractor turn requires a command identity")
         session_id = f"contractor:{context.contractor_id}:{command_id}"
 
-        # Bind the project root to the trusted profile home before any runtime
-        # scope or skill loading is acquired. The profile home is authoritative
-        # Hermes state; the context project root must be the same directory or
-        # safely contained within it, with symlinks fully resolved (#33GOD-51).
+        # Resolve both independent roots before entering the profile runtime
+        # scope or loading skills. Bloodbank has already authorized and
+        # canonicalized the project root before constructing the typed context;
+        # Hermes revalidates existence/type but does not duplicate that registry
+        # authority by requiring a project repository to live under profile
+        # state (#33GOD-53).
         try:
             profile_home = Path(
                 self._resolve_profile_home_for_source(source)
             ).resolve(strict=True)
         except Exception as exc:
             raise ContractorTurnRejected(
-                "could not resolve canonical profile home for contractor authorization"
+                "could not resolve canonical profile home for contractor runtime"
             ) from exc
+        if not profile_home.is_dir():
+            raise ContractorTurnRejected(
+                "contractor profile home must resolve to an existing directory"
+            )
         try:
             project_root = Path(context.project_root).resolve(strict=True)
         except Exception as exc:
             raise ContractorTurnRejected(
-                "could not resolve canonical contractor project root"
+                "contractor project root must resolve to an existing directory"
             ) from exc
-        if not project_root.is_relative_to(profile_home):
+        if not project_root.is_dir():
             raise ContractorTurnRejected(
-                "contractor project root is outside the authorized profile boundary"
+                "contractor project root must resolve to an existing directory"
             )
 
         async with _async_profile_runtime_scope(profile_home):
@@ -21326,7 +21337,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_id=session_id,
                 message_id=command_id,
                 profile=context.profile_name,
-                cwd=context.project_root,
+                cwd=str(project_root),
                 async_delivery=False,
                 cron_session="",
             )
@@ -21387,7 +21398,22 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             or result.get("failed") is True
             or result.get("completed") is not True
         ):
-            raise ContractorTurnRejected("contractor agent did not complete successfully")
+            failure = ContractorTurnRejected(
+                "contractor agent did not complete successfully"
+            )
+            cleanup_error = (
+                result.get("cleanup_error") if isinstance(result, dict) else None
+            )
+            if cleanup_error:
+                failure.add_note(
+                    f"Contractor agent cleanup also failed: {cleanup_error}"
+                )
+            raise failure
+        cleanup_error = result.get("cleanup_error")
+        if cleanup_error:
+            raise ContractorTurnCleanupFailed(
+                f"contractor agent cleanup failed: {cleanup_error}"
+            )
         return str(result.get("final_response") or "")
 
     async def _mark_durable_active_turn(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9048,7 +9048,13 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         return model, runtime_kwargs
 
-    def _resolve_turn_agent_config(self, user_message: str, model: str, runtime_kwargs: dict) -> dict:
+    def _resolve_turn_agent_config(
+        self,
+        user_message: str,
+        model: str,
+        runtime_kwargs: dict,
+        service_tier: Optional[str] = None,
+    ) -> dict:
         """Build the effective model/runtime config for a single turn.
 
         Always uses the session's primary model/provider.  If `/fast` is
@@ -9061,6 +9067,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         carrying ``chat_template_kwargs``) are preserved here and merged *under*
         the fast-mode overrides, so a provider's configured request body still
         reaches the model on the gateway turn path.
+
+        ``service_tier`` may be supplied explicitly for callers (such as
+        stateless contractor turns) that must not write shared runner state.
+        When omitted, the runner's own session-bound value is used.
         """
         from hermes_cli.models import resolve_fast_mode_overrides
 
@@ -9096,7 +9106,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # dropped by the runtime whitelist above, so a custom provider's
         # configured extra_body (chat_template_kwargs, etc.) never reached the
         # model on the gateway path -- only /fast service-tier overrides did.
-        service_tier = getattr(self, "_service_tier", None)
+        if service_tier is None:
+            service_tier = getattr(self, "_service_tier", None)
         if service_tier != "priority":
             # None (normal) or auto/cold — the bounded window is applied per
             # request by agent.fast_mode, not pinned into request_overrides.
@@ -12375,10 +12386,20 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 cleanup_exc,
             )
 
-    def _cleanup_agent_resources(self, agent: Any) -> None:
-        """Best-effort cleanup for temporary or cached agent instances."""
+    def _cleanup_agent_resources(
+        self, agent: Any, *, reraise: bool = False
+    ) -> None:
+        """Best-effort cleanup for temporary or cached agent instances.
+
+        By default each cleanup step is allowed to fail silently so that a
+        stuck memory provider, terminal, or client does not block the rest of
+        teardown. For callers such as stateless contractor turns that need to
+        observe cleanup failures, pass ``reraise=True`` to raise the first
+        encountered error after all steps have run.
+        """
         if agent is None:
             return
+        _cleanup_errors: list[Exception] = []
         try:
             if hasattr(agent, "shutdown_memory_provider"):
                 # Drain queued memory writes BEFORE tearing the provider down.
@@ -12414,16 +12435,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     agent.shutdown_memory_provider(session_messages)
                 else:
                     agent.shutdown_memory_provider()
-        except Exception:
-            pass
+        except Exception as exc:
+            _cleanup_errors.append(exc)
         # Close tool resources (terminal sandboxes, browser daemons,
         # background processes, httpx clients) to prevent zombie
         # process accumulation.
         try:
             if hasattr(agent, "close"):
                 agent.close()
-        except Exception:
-            pass
+        except Exception as exc:
+            _cleanup_errors.append(exc)
         # Auxiliary async clients (session_search/web/vision/etc.) live in a
         # process-global cache and are created inside worker threads. Clean up
         # any entries whose event loop is now dead so their httpx transports do
@@ -12431,8 +12452,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         try:
             from agent.auxiliary_client import cleanup_stale_async_clients
             cleanup_stale_async_clients()
-        except Exception:
-            pass
+        except Exception as exc:
+            _cleanup_errors.append(exc)
+        if _cleanup_errors and reraise:
+            raise _cleanup_errors[0]
 
     _STUCK_LOOP_THRESHOLD = 3  # restarts while active before auto-suspend
     _STUCK_LOOP_FILE = ".restart_failure_counts"
@@ -21115,9 +21138,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             source=None,
             session_key=None,
         )
-        self._reasoning_config = reasoning_config
-        self._service_tier = service_tier
-        turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+        # Keep contractor reasoning/service-tier local; do not write shared
+        # runner state that ordinary or sibling turns could observe (#33GOD-51).
+        turn_route = self._resolve_turn_agent_config(
+            prompt, model, runtime_kwargs, service_tier=service_tier
+        )
 
         configured_routing = user_config.get("provider_routing")
         provider_routing = (
@@ -21165,6 +21190,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             skip_background_review=True,
         )
         self._set_active_contractor_agent(session_id, agent)
+        result: Optional[dict[str, Any]] = None
         try:
             # Cancellation can arrive while the relatively heavy agent
             # constructor is still loading plugins and tool schemas. The async
@@ -21213,10 +21239,25 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 raise ContractorTurnRejected(
                     "contractor agent returned an invalid execution result"
                 )
-            return result
         finally:
             self._set_active_contractor_agent(session_id, None)
-            self._cleanup_agent_resources(agent)
+            cleanup_error = None
+            try:
+                self._cleanup_agent_resources(agent, reraise=True)
+            except Exception as exc:
+                cleanup_error = str(exc)
+                logger.warning(
+                    "Contractor agent cleanup failed for %s: %s", session_id, exc
+                )
+            if cleanup_error is not None:
+                active_exc = sys.exc_info()[1]
+                if active_exc is not None:
+                    active_exc.add_note(
+                        f"Contractor agent cleanup also failed: {cleanup_error}"
+                    )
+                elif isinstance(result, dict):
+                    result["cleanup_error"] = cleanup_error
+        return result
 
     async def _handle_contractor_turn(
         self,
@@ -21238,7 +21279,29 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not command_id:
             raise ContractorTurnRejected("contractor turn requires a command identity")
         session_id = f"contractor:{context.contractor_id}:{command_id}"
-        profile_home = self._resolve_profile_home_for_source(source)
+
+        # Bind the project root to the trusted profile home before any runtime
+        # scope or skill loading is acquired. The profile home is authoritative
+        # Hermes state; the context project root must be the same directory or
+        # safely contained within it, with symlinks fully resolved (#33GOD-51).
+        try:
+            profile_home = Path(
+                self._resolve_profile_home_for_source(source)
+            ).resolve(strict=True)
+        except Exception as exc:
+            raise ContractorTurnRejected(
+                "could not resolve canonical profile home for contractor authorization"
+            ) from exc
+        try:
+            project_root = Path(context.project_root).resolve(strict=True)
+        except Exception as exc:
+            raise ContractorTurnRejected(
+                "could not resolve canonical contractor project root"
+            ) from exc
+        if not project_root.is_relative_to(profile_home):
+            raise ContractorTurnRejected(
+                "contractor project root is outside the authorized profile boundary"
+            )
 
         async with _async_profile_runtime_scope(profile_home):
             from agent.skill_commands import _build_skill_message, _load_skill_payload

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2463,6 +2463,10 @@ class SecondaryPortBindingConfigError(MultiplexConfigError):
     """A secondary profile conflicts with the multiplexer's shared listener."""
 
 
+class ContractorTurnRejected(RuntimeError):
+    """A contractor policy invariant failed before safe model execution."""
+
+
 class HygieneTurnHoldExceeded(Exception):
     """The hygiene-compression turn-hold budget elapsed while the summary
     model was still streaming progress.
@@ -3153,6 +3157,7 @@ from gateway.slash_commands import GatewaySlashCommandsMixin
 from gateway.turn_context import TurnContext
 from gateway.platforms.base import (
     BasePlatformAdapter,
+    ContractorTurnContext,
     EphemeralReply,
     MessageEvent,
     MessageType,
@@ -7689,6 +7694,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         self._restart_task: Optional[asyncio.Task] = None
         self._executor_lock = threading.Lock()
         self._executor: Optional[concurrent.futures.ThreadPoolExecutor] = None
+        self._contractor_agents_lock = threading.Lock()
+        self._contractor_agents: dict[str, Any] = {}
         # Set on gateway stop so the recreate-on-shutdown path can't resurrect
         # the pool during a real shutdown.
         self._executor_closing = False
@@ -18854,6 +18861,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # are system-generated and must skip user authorization.
         is_internal = bool(getattr(event, "internal", False))
 
+        # Registry-authorized contractor work is deliberately outside the
+        # ordinary conversation lifecycle. Dispatch before session keys,
+        # control-command resolution, active-turn markers, hooks, or cached
+        # agents can observe or mutate it. The dedicated path revalidates that
+        # the event is internal and pinned to its authorized profile/root.
+        contractor_context = getattr(event, "contractor_context", None)
+        if contractor_context is not None:
+            return await self._handle_contractor_turn(
+                event, source, contractor_context
+            )
+
         # Ignored-channel guard runs FIRST — before startup-restore queueing,
         # plugin hooks, auth, and session setup — so a configured ignored
         # channel can never reach pairing/auth/session state (#51899).
@@ -20998,6 +21016,317 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             self._async_session_store = facade
         return facade
 
+    @staticmethod
+    def _contractor_tool_names(tools: Any) -> set[str]:
+        """Return normalized function names from an agent tool schema list."""
+        names: set[str] = set()
+        for tool in tools or []:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function")
+            name = function.get("name") if isinstance(function, dict) else tool.get("name")
+            if isinstance(name, str) and name.strip():
+                names.add(name.strip().lower().replace("-", "_"))
+        return names
+
+    @staticmethod
+    def _is_contractor_memory_tool(name: str) -> bool:
+        """Fail closed on built-in or provider-shaped recall/history tools."""
+        return (
+            name in {"memory", "session_search"}
+            or name.startswith("memory_")
+            or name.startswith("session_search_")
+            or name.startswith("conversation_history")
+            or name.endswith("_memory")
+        )
+
+    def _set_active_contractor_agent(self, session_id: str, agent: Any) -> None:
+        lock = getattr(self, "_contractor_agents_lock", None)
+        if lock is None:
+            lock = threading.Lock()
+            self._contractor_agents_lock = lock
+        with lock:
+            agents = getattr(self, "_contractor_agents", None)
+            if agents is None:
+                agents = {}
+                self._contractor_agents = agents
+            if agent is None:
+                agents.pop(session_id, None)
+            else:
+                agents[session_id] = agent
+
+    def _interrupt_contractor_agent(self, session_id: str) -> None:
+        lock = getattr(self, "_contractor_agents_lock", None)
+        agents = getattr(self, "_contractor_agents", None)
+        if lock is None or not isinstance(agents, dict):
+            return
+        with lock:
+            agent = agents.get(session_id)
+        if agent is not None:
+            request_hard_interrupt(
+                agent,
+                "Contractor delivery was cancelled",
+                tool_reason="gateway_turn_cancelled",
+            )
+
+    def _run_contractor_agent_sync(
+        self,
+        prompt: str,
+        source: SessionSource,
+        context: ContractorTurnContext,
+        session_id: str,
+        cancel_event: Optional[threading.Event] = None,
+    ) -> dict[str, Any]:
+        """Construct and run one persistence-isolated agent in the worker pool."""
+        if cancel_event is not None and cancel_event.is_set():
+            raise ContractorTurnRejected("contractor turn was cancelled before execution")
+
+        from agent.skill_utils import parse_config_string_list
+        from run_agent import AIAgent
+
+        user_config = _load_gateway_config()
+        platform_key = _platform_config_key(source.platform)
+        enabled_toolsets = self._resolve_enabled_toolsets_for_source(
+            user_config, source, platform_key
+        )
+        agent_config = user_config.get("agent") or {}
+        if not isinstance(agent_config, dict):
+            agent_config = {}
+        disabled_toolsets = list(
+            parse_config_string_list(agent_config.get("disabled_toolsets")) or []
+        )
+        for stateful_toolset in ("memory", "session_search"):
+            if stateful_toolset not in disabled_toolsets:
+                disabled_toolsets.append(stateful_toolset)
+
+        # Contractor turns deliberately have no conversation key: session
+        # model/reasoning/fast overrides belong to remembered conversations.
+        model, runtime_kwargs = self._resolve_session_agent_runtime(
+            source=None,
+            session_key=None,
+            user_config=user_config,
+        )
+        reasoning_config = self._resolve_session_reasoning_config(
+            source=None,
+            session_key=None,
+            model=model,
+        )
+        service_tier = self._resolve_session_service_tier(
+            source=None,
+            session_key=None,
+        )
+        self._reasoning_config = reasoning_config
+        self._service_tier = service_tier
+        turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+
+        configured_routing = user_config.get("provider_routing")
+        provider_routing = (
+            configured_routing
+            if isinstance(configured_routing, dict)
+            else getattr(self, "_provider_routing", {}) or {}
+        )
+        agent = AIAgent(
+            model=turn_route["model"],
+            **turn_route["runtime"],
+            **_checkpoint_agent_kwargs(user_config),
+            max_iterations=_current_max_iterations(),
+            quiet_mode=True,
+            verbose_logging=False,
+            enabled_toolsets=enabled_toolsets,
+            disabled_toolsets=disabled_toolsets,
+            ephemeral_system_prompt=None,
+            prefill_messages=None,
+            reasoning_config=reasoning_config,
+            service_tier=service_tier,
+            request_overrides=turn_route.get("request_overrides"),
+            providers_allowed=provider_routing.get("only"),
+            providers_ignored=provider_routing.get("ignore"),
+            providers_order=provider_routing.get("order"),
+            provider_sort=provider_routing.get("sort"),
+            provider_require_parameters=provider_routing.get(
+                "require_parameters", False
+            ),
+            provider_data_collection=provider_routing.get("data_collection"),
+            session_id=session_id,
+            platform=platform_key,
+            user_id=source.user_id,
+            user_id_alt=source.user_id_alt,
+            user_name=source.user_name,
+            chat_id=source.chat_id,
+            chat_name=source.chat_name,
+            chat_type=source.chat_type,
+            thread_id=source.thread_id,
+            gateway_session_key=None,
+            session_db=None,
+            fallback_model=self._refresh_fallback_model(),
+            skip_context_files=False,
+            load_soul_identity=True,
+            skip_memory=True,
+            skip_background_review=True,
+        )
+        self._set_active_contractor_agent(session_id, agent)
+        try:
+            # Cancellation can arrive while the relatively heavy agent
+            # constructor is still loading plugins and tool schemas. The async
+            # caller cannot interrupt an agent that has not registered yet, so
+            # re-check its shared signal after registration and before the first
+            # model request.
+            if cancel_event is not None and cancel_event.is_set():
+                raise ContractorTurnRejected(
+                    "contractor turn was cancelled before execution"
+                )
+
+            # Set before the first run so lazy session-DB acquisition and every
+            # persistence hook are disabled even if a provider path asks for it.
+            agent._persist_disabled = True
+            agent.memory_notifications = "off"
+
+            memory_state = any(
+                (
+                    getattr(agent, "_memory_manager", None) is not None,
+                    getattr(agent, "_memory_store", None) is not None,
+                    bool(getattr(agent, "_memory_enabled", False)),
+                    bool(getattr(agent, "_user_profile_enabled", False)),
+                )
+            )
+            if memory_state:
+                raise ContractorTurnRejected(
+                    "contractor agent initialized persistent memory state"
+                )
+            forbidden = sorted(
+                name
+                for name in self._contractor_tool_names(getattr(agent, "tools", []))
+                if self._is_contractor_memory_tool(name)
+            )
+            if forbidden:
+                raise ContractorTurnRejected(
+                    "contractor agent exposed forbidden memory/history tool(s): "
+                    + ", ".join(forbidden)
+                )
+
+            result = agent.run_conversation(
+                prompt,
+                conversation_history=[],
+                task_id=session_id,
+            )
+            if not isinstance(result, dict):
+                raise ContractorTurnRejected(
+                    "contractor agent returned an invalid execution result"
+                )
+            return result
+        finally:
+            self._set_active_contractor_agent(session_id, None)
+            self._cleanup_agent_resources(agent)
+
+    async def _handle_contractor_turn(
+        self,
+        event: MessageEvent,
+        source: SessionSource,
+        context: ContractorTurnContext,
+    ) -> str:
+        """Run one registry-pinned turn without session/history persistence."""
+        if not isinstance(context, ContractorTurnContext):
+            raise ContractorTurnRejected("contractor context has an invalid type")
+        if getattr(event, "internal", False) is not True:
+            raise ContractorTurnRejected("contractor turns must be internal events")
+        source_profile = str(getattr(source, "profile", "") or "").strip()
+        if source_profile != context.profile_name:
+            raise ContractorTurnRejected(
+                "contractor profile does not match the authorized route"
+            )
+        command_id = str(getattr(event, "message_id", "") or "").strip()
+        if not command_id:
+            raise ContractorTurnRejected("contractor turn requires a command identity")
+        session_id = f"contractor:{context.contractor_id}:{command_id}"
+        profile_home = self._resolve_profile_home_for_source(source)
+
+        async with _async_profile_runtime_scope(profile_home):
+            from agent.skill_commands import _build_skill_message, _load_skill_payload
+            from gateway.session_context import clear_session_vars, set_session_vars
+
+            platform_value = (
+                source.platform.value
+                if hasattr(source.platform, "value")
+                else str(source.platform)
+            )
+            tokens = set_session_vars(
+                platform=platform_value,
+                chat_id=str(source.chat_id or ""),
+                chat_type=str(source.chat_type or ""),
+                chat_name=str(source.chat_name or ""),
+                thread_id=str(source.thread_id or ""),
+                user_id=str(source.user_id or ""),
+                user_id_alt=str(source.user_id_alt or ""),
+                user_name=str(source.user_name or ""),
+                scope_id=str(getattr(source, "scope_id", "") or ""),
+                session_key=session_id,
+                session_id=session_id,
+                message_id=command_id,
+                profile=context.profile_name,
+                cwd=context.project_root,
+                async_delivery=False,
+                cron_session="",
+            )
+            try:
+                # Resolve the complete ordered set before rendering any one
+                # skill. Rendering may expand configured inline shell blocks;
+                # a missing later requirement must therefore fail before any
+                # skill-side preprocessing, model call, or agent tool runs.
+                loaded_skills: list[tuple[Any, Any, str, str]] = []
+                for required_skill in context.required_skills:
+                    loaded = _load_skill_payload(required_skill, task_id=command_id)
+                    if loaded is None:
+                        raise ContractorTurnRejected(
+                            f"required contractor skill {required_skill!r} is unavailable"
+                        )
+                    loaded_skill, skill_dir, display_name = loaded
+                    loaded_skills.append(
+                        (loaded_skill, skill_dir, display_name, required_skill)
+                    )
+
+                skill_parts: list[str] = []
+                for loaded_skill, skill_dir, display_name, required_skill in loaded_skills:
+                    activation_note = (
+                        f'[IMPORTANT: The "{display_name}" skill is required for '
+                        "this contractor turn. Follow its instructions.]"
+                    )
+                    part = _build_skill_message(
+                        loaded_skill,
+                        skill_dir,
+                        activation_note,
+                        session_id=session_id,
+                    )
+                    if not str(part or "").strip():
+                        raise ContractorTurnRejected(
+                            f"required contractor skill {required_skill!r} is empty"
+                        )
+                    skill_parts.append(part)
+                prompt = "\n\n".join([*skill_parts, str(event.text or "")])
+                cancel_event = threading.Event()
+                try:
+                    result = await self._run_in_executor_with_context(
+                        self._run_contractor_agent_sync,
+                        prompt,
+                        source,
+                        context,
+                        session_id,
+                        cancel_event,
+                    )
+                except asyncio.CancelledError:
+                    cancel_event.set()
+                    self._interrupt_contractor_agent(session_id)
+                    raise
+            finally:
+                clear_session_vars(tokens)
+
+        if (
+            not isinstance(result, dict)
+            or result.get("failed") is True
+            or result.get("completed") is not True
+        ):
+            raise ContractorTurnRejected("contractor agent did not complete successfully")
+        return str(result.get("final_response") or "")
+
     async def _mark_durable_active_turn(
         self,
         event: "MessageEvent",
@@ -21230,6 +21559,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
     async def _handle_message_with_agent(self, event, source, _quick_key: str, run_generation: int):
         """Inner handler that runs under the _running_agents sentinel guard."""
+        contractor_context = getattr(event, "contractor_context", None)
+        if contractor_context is not None:
+            return await self._handle_contractor_turn(
+                event, source, contractor_context
+            )
+
         _msg_start_time = time.time()
         _platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
         _msg_preview = (event.text or "")[:80].replace("\n", " ")

--- a/tests/gateway/test_contractor_turns.py
+++ b/tests/gateway/test_contractor_turns.py
@@ -139,15 +139,15 @@ def test_base_platform_exposes_explicit_stateless_turn_contract():
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    ("close_after_turn", "contractor_turn", "expected_clear"),
+    ("close_after_turn", "contractor_turn"),
     [
-        (True, False, True),
-        (False, True, True),
-        (False, False, False),
+        (True, False),
+        (False, True),
+        (False, False),
     ],
 )
 async def test_platform_clears_session_after_each_stateless_turn(
-    tmp_path, close_after_turn, contractor_turn, expected_clear
+    tmp_path, close_after_turn, contractor_turn
 ):
     adapter = _test_adapter()
     adapter.close_after_turn = close_after_turn
@@ -155,8 +155,6 @@ async def test_platform_clears_session_after_each_stateless_turn(
     session_key = "agent:main:webhook:contractor"
     adapter._active_sessions[session_key] = asyncio.Event()
     adapter._session_tasks[session_key] = asyncio.current_task()
-    real_clear_session = adapter.clear_session
-    adapter.clear_session = Mock(side_effect=real_clear_session)
     event = (
         _event(tmp_path)
         if contractor_turn
@@ -165,9 +163,10 @@ async def test_platform_clears_session_after_each_stateless_turn(
 
     await adapter._process_message_background(event, session_key)
 
-    assert adapter.clear_session.called is expected_clear
+    # The guard-matched cleanup path always releases the session guard and
+    # removes the session from _active_sessions, regardless of whether the
+    # stateless-turn cache clearing path was taken.
     assert session_key not in adapter._active_sessions
-    assert session_key not in adapter._session_tasks
 
 
 @pytest.mark.parametrize(

--- a/tests/gateway/test_contractor_turns.py
+++ b/tests/gateway/test_contractor_turns.py
@@ -63,6 +63,94 @@ def _event(tmp_path: Path, **context_overrides):
     )
 
 
+class _TestPlatformAdapter(platform_base.BasePlatformAdapter):
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return platform_base.SendResult(success=True)
+
+    async def get_chat_info(self, chat_id):
+        return {"name": chat_id, "type": "dm"}
+
+
+def _test_adapter() -> _TestPlatformAdapter:
+    return _TestPlatformAdapter(
+        SimpleNamespace(typing_indicator=False, extra={}),
+        Platform.WEBHOOK,
+    )
+
+
+def test_base_platform_exposes_explicit_stateless_turn_contract():
+    adapter = _test_adapter()
+    target = "agent:main:webhook:contractor"
+    sibling = "agent:main:webhook:ordinary"
+    adapter._active_sessions = {
+        target: asyncio.Event(),
+        sibling: asyncio.Event(),
+    }
+    adapter._pending_messages = {
+        target: Mock(),
+        sibling: Mock(),
+    }
+    adapter._session_tasks = {
+        target: Mock(),
+        sibling: Mock(),
+    }
+    adapter._post_delivery_callbacks = {
+        target: Mock(),
+        sibling: Mock(),
+    }
+
+    assert platform_base.BasePlatformAdapter.close_after_turn is False
+    adapter.clear_session(target)
+
+    for store in (
+        adapter._active_sessions,
+        adapter._pending_messages,
+        adapter._session_tasks,
+        adapter._post_delivery_callbacks,
+    ):
+        assert target not in store
+        assert sibling in store
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("close_after_turn", "contractor_turn", "expected_clear"),
+    [
+        (True, False, True),
+        (False, True, True),
+        (False, False, False),
+    ],
+)
+async def test_platform_clears_session_after_each_stateless_turn(
+    tmp_path, close_after_turn, contractor_turn, expected_clear
+):
+    adapter = _test_adapter()
+    adapter.close_after_turn = close_after_turn
+    adapter._message_handler = AsyncMock(return_value=None)
+    session_key = "agent:main:webhook:contractor"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._session_tasks[session_key] = asyncio.current_task()
+    real_clear_session = adapter.clear_session
+    adapter.clear_session = Mock(side_effect=real_clear_session)
+    event = (
+        _event(tmp_path)
+        if contractor_turn
+        else platform_base.MessageEvent(text="hello", source=_source())
+    )
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.clear_session.called is expected_clear
+    assert session_key not in adapter._active_sessions
+    assert session_key not in adapter._session_tasks
+
+
 @pytest.mark.parametrize(
     ("overrides", "message"),
     [
@@ -366,7 +454,6 @@ def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
         "request_overrides": {"service_tier": "priority"},
     }
     runner._refresh_fallback_model = lambda: {"model": "fallback"}
-    runner._cleanup_agent_resources = lambda agent: setattr(agent, "cleaned", True)
 
     monkeypatch.setattr(
         gateway_run,
@@ -386,7 +473,7 @@ def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
             ]
             self.model = kwargs["model"]
             self.memory_notifications = "on"
-            self.cleaned = False
+            self.closed = False
             instances.append(self)
 
         def run_conversation(self, message, **kwargs):
@@ -402,6 +489,9 @@ def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
                     {"role": "assistant", "content": "finished"},
                 ],
             }
+
+        def close(self):
+            self.closed = True
 
     monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
     context = _context(tmp_path)
@@ -436,7 +526,7 @@ def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
         assert agent.memory_notifications == "off"
         assert agent.run_kwargs["conversation_history"] == []
         assert agent.run_kwargs["task_id"] == kwargs["session_id"]
-        assert agent.cleaned is True
+        assert agent.closed is True
 
 
 def test_memory_or_history_tool_leak_fails_before_model_execution(tmp_path, monkeypatch):

--- a/tests/gateway/test_contractor_turns.py
+++ b/tests/gateway/test_contractor_turns.py
@@ -1,0 +1,481 @@
+"""Behavior contract for registry-authorized stateless contractor turns.
+
+These tests deliberately exercise the gateway seam rather than the Bloodbank
+plugin.  The plugin owns wire validation and routing; Hermes owns the guarantee
+that a validated contractor context cannot resume, persist, or learn from a
+conversation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+import gateway.platforms.base as platform_base
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.session import SessionSource
+
+
+def _context(tmp_path: Path, **overrides):
+    context_type = getattr(platform_base, "ContractorTurnContext", None)
+    assert context_type is not None, "Hermes must expose typed contractor context"
+    values = {
+        "contractor_id": "board-cranker",
+        "contractor_version": 1,
+        "memory_policy": "none",
+        "continuity": False,
+        "required_skills": ("alpha", "beta"),
+        "profile_name": "operations",
+        "project_root": str(tmp_path.resolve()),
+    }
+    values.update(overrides)
+    return context_type(**values)
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        # Bloodbank itself is a runtime plugin. WEBHOOK exercises the same
+        # platform-neutral gateway seam without mutating the global plugin
+        # registry during collection.
+        platform=Platform.WEBHOOK,
+        chat_id="contractor-thread",
+        chat_type="dm",
+        user_id="board-cranker-pm",
+        user_name="board-cranker-pm",
+        profile="operations",
+        message_id="command-1",
+    )
+
+
+def _event(tmp_path: Path, **context_overrides):
+    return platform_base.MessageEvent(
+        text="Implement the story.",
+        source=_source(),
+        message_id="command-1",
+        internal=True,
+        contractor_context=_context(tmp_path, **context_overrides),
+    )
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"contractor_id": ""}, "contractor_id"),
+        ({"contractor_version": True}, "contractor_version"),
+        ({"contractor_version": 0}, "contractor_version"),
+        ({"memory_policy": "profile"}, "memory_policy"),
+        ({"continuity": True}, "continuity"),
+        ({"required_skills": ()}, "required_skills"),
+        ({"required_skills": ("alpha", "")}, "required_skills"),
+        ({"required_skills": ("alpha", "alpha")}, "required_skills"),
+        ({"profile_name": ""}, "profile_name"),
+        ({"project_root": "relative/project"}, "project_root"),
+    ],
+)
+def test_typed_context_rejects_invalid_or_widening_values(tmp_path, overrides, message):
+    context_type = getattr(platform_base, "ContractorTurnContext", None)
+    assert context_type is not None, "Hermes must expose typed contractor context"
+    values = {
+        "contractor_id": "board-cranker",
+        "contractor_version": 1,
+        "memory_policy": "none",
+        "continuity": False,
+        "required_skills": ("alpha", "beta"),
+        "profile_name": "operations",
+        "project_root": str(tmp_path.resolve()),
+    }
+    values.update(overrides)
+    with pytest.raises(ValueError, match=message):
+        context_type(**values)
+
+
+@pytest.mark.asyncio
+async def test_contractor_event_bypasses_session_resume_and_transcript_loading(tmp_path):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._handle_contractor_turn = AsyncMock(return_value="done")
+    runner.session_store = object()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(
+            side_effect=AssertionError("contractor turn must not create or resume a session")
+        )
+    )
+
+    event = _event(tmp_path)
+    response = await runner._handle_message_with_agent(
+        event, event.source, "contractor:command-1", 1
+    )
+
+    assert response == "done"
+    runner._handle_contractor_turn.assert_awaited_once_with(
+        event, event.source, event.contractor_context
+    )
+    runner._async_session_store.get_or_create_session.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_contractor_event_bypasses_all_ordinary_session_bookkeeping(tmp_path):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._handle_contractor_turn = AsyncMock(return_value="done")
+    runner._claim_active_session_slot = Mock(
+        side_effect=AssertionError(
+            "contractor turn must not claim an ordinary session slot"
+        )
+    )
+    event = _event(tmp_path)
+
+    response = await runner._handle_message(event)
+
+    assert response == "done"
+    runner._handle_contractor_turn.assert_awaited_once_with(
+        event, event.source, event.contractor_context
+    )
+    runner._claim_active_session_slot.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_ordinary_event_stays_on_existing_session_path(tmp_path):
+    class OrdinaryPathReached(RuntimeError):
+        pass
+
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._recover_telegram_topic_thread_id = lambda _source: None
+    runner._handle_contractor_turn = AsyncMock(
+        side_effect=AssertionError("ordinary turns must not use contractor execution")
+    )
+    runner.session_store = object()
+    runner._async_session_store = SimpleNamespace(
+        _store=runner.session_store,
+        get_or_create_session=AsyncMock(side_effect=OrdinaryPathReached)
+    )
+    source = SessionSource(
+        platform=Platform.API_SERVER,
+        chat_id="ordinary",
+        chat_type="dm",
+        user_id="user",
+    )
+    event = platform_base.MessageEvent(text="hello", source=source)
+
+    with pytest.raises(OrdinaryPathReached):
+        await runner._handle_message_with_agent(event, source, "ordinary-key", 1)
+
+    runner._handle_contractor_turn.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_missing_required_skill_fails_before_agent_or_tool_execution(
+    tmp_path, monkeypatch
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", lambda *_a, **_k: None)
+
+    event = _event(tmp_path)
+    with pytest.raises(rejected_type, match="alpha"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    runner._run_in_executor_with_context.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_all_required_skills_resolve_before_any_skill_preprocessing(
+    tmp_path, monkeypatch
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    loaded = []
+
+    def load_skill(name, task_id=None):
+        loaded.append((name, task_id))
+        if name == "beta":
+            return None
+        return ({"content": "alpha"}, tmp_path / name, name)
+
+    build_skill = Mock(
+        side_effect=AssertionError(
+            "skill preprocessing must wait until all requirements resolve"
+        )
+    )
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", load_skill)
+    monkeypatch.setattr("agent.skill_commands._build_skill_message", build_skill)
+
+    event = _event(tmp_path)
+    with pytest.raises(rejected_type, match="beta"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    assert [name for name, _task_id in loaded] == ["alpha", "beta"]
+    build_skill.assert_not_called()
+    runner._run_in_executor_with_context.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_required_skills_keep_order_and_registry_cwd_is_task_scoped(
+    tmp_path, monkeypatch
+):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path / "profile"
+    (tmp_path / "profile").mkdir()
+
+    loaded = []
+
+    def load_skill(name, task_id=None):
+        loaded.append((name, task_id))
+        return ({"content": f"instructions:{name}"}, tmp_path / name, name)
+
+    def build_skill(payload, _skill_dir, note, **_kwargs):
+        return f"{note}\n{payload['content']}"
+
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", load_skill)
+    monkeypatch.setattr("agent.skill_commands._build_skill_message", build_skill)
+
+    captured = {}
+
+    def execute(prompt, source, context, session_id, _cancel_event):
+        from agent.runtime_cwd import resolve_context_cwd
+        from gateway.session_context import get_session_env
+
+        captured.update(
+            prompt=prompt,
+            source=source,
+            context=context,
+            session_id=session_id,
+            cwd=resolve_context_cwd(),
+            profile=get_session_env("HERMES_SESSION_PROFILE"),
+        )
+        return {"final_response": "done", "completed": True, "failed": False}
+
+    async def run_inline(func, *args):
+        return func(*args)
+
+    runner._run_contractor_agent_sync = execute
+    runner._run_in_executor_with_context = run_inline
+
+    event = _event(tmp_path)
+    response = await runner._handle_contractor_turn(
+        event, event.source, event.contractor_context
+    )
+
+    assert response == "done"
+    assert [name for name, _task_id in loaded] == ["alpha", "beta"]
+    assert all(task_id == "command-1" for _name, task_id in loaded)
+    assert captured["prompt"].index("instructions:alpha") < captured["prompt"].index(
+        "instructions:beta"
+    ) < captured["prompt"].index("Implement the story.")
+    assert captured["cwd"] == tmp_path.resolve()
+    assert captured["profile"] == "operations"
+    assert captured["session_id"] == "contractor:board-cranker:command-1"
+
+
+@pytest.mark.asyncio
+async def test_cancellation_signals_worker_before_requesting_hard_interrupt(
+    tmp_path, monkeypatch
+):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    runner._interrupt_contractor_agent = Mock()
+
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload",
+        lambda name, **_kwargs: ({"content": name}, tmp_path / name, name),
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._build_skill_message",
+        lambda payload, *_args, **_kwargs: payload["content"],
+    )
+    captured = {}
+
+    async def cancel_worker(_func, *args):
+        captured["cancel_event"] = args[-1]
+        raise asyncio.CancelledError
+
+    runner._run_in_executor_with_context = cancel_worker
+    event = _event(tmp_path)
+
+    with pytest.raises(asyncio.CancelledError):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    assert captured["cancel_event"].is_set()
+    runner._interrupt_contractor_agent.assert_called_once_with(
+        "contractor:board-cranker:command-1"
+    )
+
+
+def test_cancelled_worker_stops_before_agent_construction(tmp_path):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    cancelled = threading.Event()
+    cancelled.set()
+
+    with pytest.raises(rejected_type, match="cancelled"):
+        runner._run_contractor_agent_sync(
+            "prompt",
+            _source(),
+            _context(tmp_path),
+            "contractor:board-cranker:command-1",
+            cancelled,
+        )
+
+
+def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
+    tmp_path, monkeypatch
+):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._provider_routing = {
+        "only": ["configured-provider"],
+        "ignore": None,
+        "order": ["configured-provider"],
+        "sort": None,
+        "require_parameters": True,
+        "data_collection": "deny",
+    }
+    runner._resolve_enabled_toolsets_for_source = lambda *_args: ["web", "memory"]
+    runner._resolve_session_agent_runtime = lambda **_kwargs: (
+        "configured-model",
+        {
+            "provider": "configured-provider",
+            "api_key": "test-key",
+            "base_url": "https://provider.invalid/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda **_kwargs: {"effort": "high"}
+    runner._resolve_session_service_tier = lambda **_kwargs: "priority"
+    runner._resolve_turn_agent_config = lambda _message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": {"service_tier": "priority"},
+    }
+    runner._refresh_fallback_model = lambda: {"model": "fallback"}
+    runner._cleanup_agent_resources = lambda agent: setattr(agent, "cleaned", True)
+
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"agent": {"disabled_toolsets": ["browser"]}},
+    )
+    monkeypatch.setattr(gateway_run, "_checkpoint_agent_kwargs", lambda _cfg: {})
+    monkeypatch.setattr(gateway_run, "_current_max_iterations", lambda: 17)
+
+    instances = []
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.tools = [
+                {"type": "function", "function": {"name": "web_search"}}
+            ]
+            self.model = kwargs["model"]
+            self.memory_notifications = "on"
+            self.cleaned = False
+            instances.append(self)
+
+        def run_conversation(self, message, **kwargs):
+            assert self._persist_disabled is True
+            self.message = message
+            self.run_kwargs = kwargs
+            return {
+                "final_response": "finished",
+                "completed": True,
+                "failed": False,
+                "messages": [
+                    {"role": "user", "content": message},
+                    {"role": "assistant", "content": "finished"},
+                ],
+            }
+
+    monkeypatch.setattr("run_agent.AIAgent", FakeAgent)
+    context = _context(tmp_path)
+
+    first = runner._run_contractor_agent_sync(
+        "skill payload\n\nImplement the story.",
+        _source(),
+        context,
+        "contractor:board-cranker:command-1",
+    )
+    second = runner._run_contractor_agent_sync(
+        "skill payload\n\nImplement the story.",
+        _source(),
+        context,
+        "contractor:board-cranker:command-2",
+    )
+
+    assert first["final_response"] == second["final_response"] == "finished"
+    assert len(instances) == 2 and instances[0] is not instances[1]
+    for agent in instances:
+        kwargs = agent.kwargs
+        assert kwargs["model"] == "configured-model"
+        assert kwargs["provider"] == "configured-provider"
+        assert kwargs["providers_allowed"] == ["configured-provider"]
+        assert kwargs["providers_order"] == ["configured-provider"]
+        assert kwargs["session_db"] is None
+        assert kwargs["prefill_messages"] is None
+        assert kwargs["skip_context_files"] is False
+        assert kwargs["skip_memory"] is True
+        assert kwargs["skip_background_review"] is True
+        assert kwargs["disabled_toolsets"] == ["browser", "memory", "session_search"]
+        assert agent.memory_notifications == "off"
+        assert agent.run_kwargs["conversation_history"] == []
+        assert agent.run_kwargs["task_id"] == kwargs["session_id"]
+        assert agent.cleaned is True
+
+
+def test_memory_or_history_tool_leak_fails_before_model_execution(tmp_path, monkeypatch):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._provider_routing = {}
+    runner._resolve_enabled_toolsets_for_source = lambda *_args: ["web"]
+    runner._resolve_session_agent_runtime = lambda **_kwargs: ("model", {})
+    runner._resolve_session_reasoning_config = lambda **_kwargs: None
+    runner._resolve_session_service_tier = lambda **_kwargs: None
+    runner._resolve_turn_agent_config = lambda _message, model, runtime: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": {},
+    }
+    runner._refresh_fallback_model = lambda: None
+    runner._cleanup_agent_resources = lambda _agent: None
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_checkpoint_agent_kwargs", lambda _cfg: {})
+
+    calls = []
+
+    class LeakyAgent:
+        def __init__(self, **_kwargs):
+            self.tools = [
+                {"type": "function", "function": {"name": "session_search"}}
+            ]
+
+        def run_conversation(self, *_args, **_kwargs):
+            calls.append("model")
+            return {"final_response": "unsafe"}
+
+    monkeypatch.setattr("run_agent.AIAgent", LeakyAgent)
+
+    with pytest.raises(rejected_type, match="session_search"):
+        runner._run_contractor_agent_sync(
+            "prompt",
+            _source(),
+            _context(tmp_path),
+            "contractor:board-cranker:command-1",
+        )
+    assert calls == []

--- a/tests/gateway/test_contractor_turns.py
+++ b/tests/gateway/test_contractor_turns.py
@@ -319,14 +319,16 @@ async def test_required_skills_keep_order_and_registry_cwd_is_task_scoped(
     tmp_path, monkeypatch
 ):
     runner = object.__new__(gateway_run.GatewayRunner)
-    runner._resolve_profile_home_for_source = lambda _source: tmp_path / "profile"
-    (tmp_path / "profile").mkdir()
+    profile_home = tmp_path / "profile"
+    project_root = profile_home / "project"
+    project_root.mkdir(parents=True)
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
 
     loaded = []
 
     def load_skill(name, task_id=None):
         loaded.append((name, task_id))
-        return ({"content": f"instructions:{name}"}, tmp_path / name, name)
+        return ({"content": f"instructions:{name}"}, project_root / name, name)
 
     def build_skill(payload, _skill_dir, note, **_kwargs):
         return f"{note}\n{payload['content']}"
@@ -356,7 +358,7 @@ async def test_required_skills_keep_order_and_registry_cwd_is_task_scoped(
     runner._run_contractor_agent_sync = execute
     runner._run_in_executor_with_context = run_inline
 
-    event = _event(tmp_path)
+    event = _event(tmp_path, project_root=str(project_root))
     response = await runner._handle_contractor_turn(
         event, event.source, event.contractor_context
     )
@@ -367,7 +369,7 @@ async def test_required_skills_keep_order_and_registry_cwd_is_task_scoped(
     assert captured["prompt"].index("instructions:alpha") < captured["prompt"].index(
         "instructions:beta"
     ) < captured["prompt"].index("Implement the story.")
-    assert captured["cwd"] == tmp_path.resolve()
+    assert captured["cwd"] == project_root.resolve()
     assert captured["profile"] == "operations"
     assert captured["session_id"] == "contractor:board-cranker:command-1"
 
@@ -448,7 +450,7 @@ def test_agent_is_fresh_memoryless_unpersisted_and_uses_configured_runtime(
     )
     runner._resolve_session_reasoning_config = lambda **_kwargs: {"effort": "high"}
     runner._resolve_session_service_tier = lambda **_kwargs: "priority"
-    runner._resolve_turn_agent_config = lambda _message, model, runtime: {
+    runner._resolve_turn_agent_config = lambda _message, model, runtime, **kwargs: {
         "model": model,
         "runtime": runtime,
         "request_overrides": {"service_tier": "priority"},
@@ -537,7 +539,7 @@ def test_memory_or_history_tool_leak_fails_before_model_execution(tmp_path, monk
     runner._resolve_session_agent_runtime = lambda **_kwargs: ("model", {})
     runner._resolve_session_reasoning_config = lambda **_kwargs: None
     runner._resolve_session_service_tier = lambda **_kwargs: None
-    runner._resolve_turn_agent_config = lambda _message, model, runtime: {
+    runner._resolve_turn_agent_config = lambda _message, model, runtime, **kwargs: {
         "model": model,
         "runtime": runtime,
         "request_overrides": {},
@@ -568,4 +570,282 @@ def test_memory_or_history_tool_leak_fails_before_model_execution(tmp_path, monk
             _context(tmp_path),
             "contractor:board-cranker:command-1",
         )
-    assert calls == []
+
+
+# ---------------------------------------------------------------------------
+# Quality-fix tests for 33GOD-51
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_contractor_turn_rejects_project_root_outside_profile_home(
+    tmp_path, monkeypatch
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload", lambda *_a, **_k: None
+    )
+
+    event = _event(tmp_path, project_root=str(outside))
+    with pytest.raises(rejected_type, match="authorized profile boundary"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    runner._run_in_executor_with_context.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_contractor_turn_rejects_symlink_escape_outside_profile_home(
+    tmp_path, monkeypatch
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    profile_home = tmp_path / "profile"
+    profile_home.mkdir()
+    outside = tmp_path / "outside"
+    outside.mkdir()
+    symlink = profile_home / "project"
+    symlink.symlink_to(outside)
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload", lambda *_a, **_k: None
+    )
+
+    event = _event(tmp_path, project_root=str(symlink))
+    with pytest.raises(rejected_type, match="authorized profile boundary"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    runner._run_in_executor_with_context.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_contractor_turn_accepts_project_root_under_profile_home(
+    tmp_path, monkeypatch
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    profile_home = tmp_path / "profile"
+    project_root = profile_home / "project"
+    project_root.mkdir(parents=True)
+    runner._resolve_profile_home_for_source = lambda _source: profile_home
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload", lambda *_a, **_k: None
+    )
+
+    event = _event(tmp_path, project_root=str(project_root))
+    with pytest.raises(rejected_type, match="alpha"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+    runner._run_in_executor_with_context.assert_not_awaited()
+
+
+def _minimal_contractor_runner(tmp_path, monkeypatch, **overrides):
+    """Build a GatewayRunner stub wired for direct _run_contractor_agent_sync tests."""
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    runner._provider_routing = {}
+    runner._resolve_enabled_toolsets_for_source = lambda *_args: ["web"]
+    runner._resolve_session_agent_runtime = lambda **_kwargs: ("model", {})
+    runner._resolve_session_reasoning_config = lambda **_kwargs: {"effort": "high"}
+    runner._resolve_session_service_tier = lambda **_kwargs: "priority"
+    runner._resolve_turn_agent_config = lambda _message, model, runtime, **kwargs: {
+        "model": model,
+        "runtime": runtime,
+        "request_overrides": {},
+    }
+    runner._refresh_fallback_model = lambda: None
+    for name, value in overrides.items():
+        setattr(runner, name, value)
+
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_checkpoint_agent_kwargs", lambda _cfg: {})
+    monkeypatch.setattr(gateway_run, "_current_max_iterations", lambda: 10)
+    return runner
+
+
+class _CleanFakeAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, *_args, **_kwargs):
+        return {"final_response": "ok", "completed": True, "failed": False}
+
+    def close(self):
+        pass
+
+
+def test_contractor_turn_does_not_mutate_shared_runner_state(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(
+        tmp_path,
+        monkeypatch,
+        _reasoning_config="initial-reasoning",
+        _service_tier="initial-tier",
+    )
+    monkeypatch.setattr("run_agent.AIAgent", _CleanFakeAgent)
+
+    runner._run_contractor_agent_sync(
+        "prompt",
+        _source(),
+        _context(tmp_path),
+        "contractor:board-cranker:command-1",
+    )
+
+    assert runner._reasoning_config == "initial-reasoning"
+    assert runner._service_tier == "initial-tier"
+
+
+def test_concurrent_contractor_turns_leave_runner_config_unchanged(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(
+        tmp_path,
+        monkeypatch,
+        _reasoning_config="initial-reasoning",
+        _service_tier="initial-tier",
+    )
+    monkeypatch.setattr("run_agent.AIAgent", _CleanFakeAgent)
+
+    import concurrent.futures
+
+    def run_turn(i):
+        return runner._run_contractor_agent_sync(
+            "prompt",
+            _source(),
+            _context(tmp_path),
+            f"contractor:board-cranker:command-{i}",
+        )
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        futures = [executor.submit(run_turn, i) for i in range(2)]
+        for future in concurrent.futures.as_completed(futures):
+            future.result()
+
+    assert runner._reasoning_config == "initial-reasoning"
+    assert runner._service_tier == "initial-tier"
+
+
+class _MessySuccessAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, *_args, **_kwargs):
+        return {"final_response": "ok", "completed": True, "failed": False}
+
+    def close(self):
+        raise RuntimeError("cleanup failed")
+
+
+def test_contractor_cleanup_failure_is_observed_on_successful_turn(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _MessySuccessAgent)
+
+    result = runner._run_contractor_agent_sync(
+        "prompt",
+        _source(),
+        _context(tmp_path),
+        "contractor:board-cranker:command-1",
+    )
+
+    assert result["final_response"] == "ok"
+    assert result["completed"] is True
+    assert "cleanup_error" in result
+    assert "cleanup failed" in result["cleanup_error"]
+
+
+class _MessyFailureAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, *_args, **_kwargs):
+        raise RuntimeError("model call failed")
+
+    def close(self):
+        raise RuntimeError("cleanup failed")
+
+
+def test_contractor_cleanup_failure_is_observed_on_failed_turn(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _MessyFailureAgent)
+
+    with pytest.raises(RuntimeError, match="model call failed") as exc_info:
+        runner._run_contractor_agent_sync(
+            "prompt",
+            _source(),
+            _context(tmp_path),
+            "contractor:board-cranker:command-1",
+        )
+
+    notes = getattr(exc_info.value, "__notes__", [])
+    assert any("cleanup failed" in note for note in notes)
+
+
+def test_contractor_agent_registry_is_evicted_after_successful_turn(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _CleanFakeAgent)
+
+    session_id = "contractor:board-cranker:command-1"
+    runner._run_contractor_agent_sync(
+        "prompt",
+        _source(),
+        _context(tmp_path),
+        session_id,
+    )
+
+    assert runner._contractor_agents.get(session_id) is None
+
+
+class _FailingAgent:
+    def __init__(self, **kwargs):
+        self.tools = []
+
+    def run_conversation(self, *_args, **_kwargs):
+        raise RuntimeError("model call failed")
+
+    def close(self):
+        pass
+
+
+def test_contractor_agent_registry_is_evicted_after_failed_turn(
+    tmp_path, monkeypatch
+):
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _FailingAgent)
+
+    session_id = "contractor:board-cranker:command-1"
+    with pytest.raises(RuntimeError):
+        runner._run_contractor_agent_sync(
+            "prompt",
+            _source(),
+            _context(tmp_path),
+            session_id,
+        )
+
+    assert runner._contractor_agents.get(session_id) is None

--- a/tests/gateway/test_contractor_turns.py
+++ b/tests/gateway/test_contractor_turns.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import threading
+from contextlib import asynccontextmanager
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
@@ -20,6 +21,24 @@ import gateway.platforms.base as platform_base
 import gateway.run as gateway_run
 from gateway.config import Platform
 from gateway.session import SessionSource
+
+
+@pytest.fixture(autouse=True)
+def _isolate_profile_secret_hydration(monkeypatch):
+    """Contractor behavior tests must not resolve workstation vault refs."""
+    monkeypatch.setattr(gateway_run, "_load_profile_secret_scope", lambda _home: {})
+
+    async def run_inline(func, *args, **kwargs):
+        return func(*args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", run_inline)
+
+    @asynccontextmanager
+    async def runtime_scope(profile_home):
+        with gateway_run._profile_runtime_scope(profile_home, {}):
+            yield
+
+    monkeypatch.setattr(gateway_run, "_async_profile_runtime_scope", runtime_scope)
 
 
 def _context(tmp_path: Path, **overrides):
@@ -181,6 +200,55 @@ def test_typed_context_rejects_invalid_or_widening_values(tmp_path, overrides, m
     values.update(overrides)
     with pytest.raises(ValueError, match=message):
         context_type(**values)
+
+
+@pytest.mark.parametrize("invalid_root", ["missing", "file"])
+def test_typed_context_rejects_non_directory_project_root(tmp_path, invalid_root):
+    root = tmp_path / invalid_root
+    if invalid_root == "file":
+        root.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="existing directory"):
+        _context(tmp_path, project_root=str(root))
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("case", "message"),
+    [
+        ("invalid-type", "invalid type"),
+        ("external-event", "internal events"),
+        ("profile-mismatch", "profile"),
+    ],
+)
+async def test_contractor_handler_rejects_untrusted_context_before_skills(
+    tmp_path, monkeypatch, case, message
+):
+    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._resolve_profile_home_for_source = lambda _source: tmp_path
+    runner._run_in_executor_with_context = AsyncMock(
+        side_effect=AssertionError("agent construction must not start")
+    )
+    load_skill = Mock(
+        side_effect=AssertionError("skill loading must not start")
+    )
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", load_skill)
+
+    event = _event(tmp_path)
+    context = event.contractor_context
+    if case == "invalid-type":
+        context = {"project_root": str(tmp_path)}
+    elif case == "external-event":
+        event.internal = False
+    else:
+        context = _context(tmp_path, profile_name="other-profile")
+
+    with pytest.raises(rejected_type, match=message):
+        await runner._handle_contractor_turn(event, event.source, context)
+
+    load_skill.assert_not_called()
+    runner._run_in_executor_with_context.assert_not_awaited()
 
 
 @pytest.mark.asyncio
@@ -578,58 +646,76 @@ def test_memory_or_history_tool_leak_fails_before_model_execution(tmp_path, monk
 
 
 @pytest.mark.asyncio
-async def test_contractor_turn_rejects_project_root_outside_profile_home(
+async def test_contractor_turn_accepts_disjoint_typed_project_root(
     tmp_path, monkeypatch
 ):
-    rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
+    """Bloodbank authorizes the project; Hermes only validates the typed path."""
     runner = object.__new__(gateway_run.GatewayRunner)
-    profile_home = tmp_path / "profile"
+    profile_home = tmp_path / "profile-home"
     profile_home.mkdir()
-    outside = tmp_path / "outside"
-    outside.mkdir()
+    project_root = tmp_path / "authorized-project"
+    project_root.mkdir()
     runner._resolve_profile_home_for_source = lambda _source: profile_home
-    runner._run_in_executor_with_context = AsyncMock(
-        side_effect=AssertionError("agent construction must not start")
+    runner._run_contractor_agent_sync = Mock(
+        return_value={"final_response": "done", "completed": True, "failed": False}
+    )
+
+    async def run_inline(func, *args):
+        return func(*args)
+
+    runner._run_in_executor_with_context = run_inline
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload",
+        lambda name, **_kwargs: ({"content": name}, project_root / name, name),
     )
     monkeypatch.setattr(
-        "agent.skill_commands._load_skill_payload", lambda *_a, **_k: None
+        "agent.skill_commands._build_skill_message",
+        lambda payload, *_args, **_kwargs: payload["content"],
     )
 
-    event = _event(tmp_path, project_root=str(outside))
-    with pytest.raises(rejected_type, match="authorized profile boundary"):
-        await runner._handle_contractor_turn(
-            event, event.source, event.contractor_context
-        )
+    event = _event(tmp_path, project_root=str(project_root))
+    response = await runner._handle_contractor_turn(
+        event, event.source, event.contractor_context
+    )
 
-    runner._run_in_executor_with_context.assert_not_awaited()
+    assert response == "done"
+    worker_args = runner._run_contractor_agent_sync.call_args.args
+    assert worker_args[2] is event.contractor_context
+    assert worker_args[2].project_root == str(project_root.resolve())
 
 
 @pytest.mark.asyncio
-async def test_contractor_turn_rejects_symlink_escape_outside_profile_home(
-    tmp_path, monkeypatch
+@pytest.mark.parametrize("replacement", ["missing", "file"])
+async def test_contractor_turn_revalidates_project_directory_before_skills(
+    tmp_path, monkeypatch, replacement
 ):
     rejected_type = getattr(gateway_run, "ContractorTurnRejected", RuntimeError)
     runner = object.__new__(gateway_run.GatewayRunner)
     profile_home = tmp_path / "profile"
-    profile_home.mkdir()
-    outside = tmp_path / "outside"
-    outside.mkdir()
-    symlink = profile_home / "project"
-    symlink.symlink_to(outside)
+    project_root = profile_home / "project"
+    project_root.mkdir(parents=True)
     runner._resolve_profile_home_for_source = lambda _source: profile_home
     runner._run_in_executor_with_context = AsyncMock(
         side_effect=AssertionError("agent construction must not start")
     )
-    monkeypatch.setattr(
-        "agent.skill_commands._load_skill_payload", lambda *_a, **_k: None
+    load_skill = Mock(
+        side_effect=AssertionError("skill loading must not start")
     )
+    monkeypatch.setattr("agent.skill_commands._load_skill_payload", load_skill)
 
-    event = _event(tmp_path, project_root=str(symlink))
-    with pytest.raises(rejected_type, match="authorized profile boundary"):
+    event = _event(tmp_path, project_root=str(project_root))
+    project_root.rmdir()
+    if replacement == "file":
+        project_root.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(
+        rejected_type, match="contractor project root|existing directory"
+    ):
         await runner._handle_contractor_turn(
             event, event.source, event.contractor_context
         )
 
+    load_skill.assert_not_called()
     runner._run_in_executor_with_context.assert_not_awaited()
 
 
@@ -681,6 +767,36 @@ def _minimal_contractor_runner(tmp_path, monkeypatch, **overrides):
     monkeypatch.setattr(gateway_run, "_checkpoint_agent_kwargs", lambda _cfg: {})
     monkeypatch.setattr(gateway_run, "_current_max_iterations", lambda: 10)
     return runner
+
+
+def test_null_contractor_service_tier_is_distinct_from_ordinary_omission(
+    monkeypatch,
+):
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner._service_tier = "priority"
+    runtime = {
+        "provider": "test-provider",
+        "request_overrides": {"extra_body": {"existing": True}},
+    }
+    monkeypatch.setattr(
+        "hermes_cli.models.resolve_fast_mode_overrides",
+        lambda *_args, **_kwargs: {"service_tier": "priority"},
+    )
+
+    contractor_route = runner._resolve_turn_agent_config(
+        "prompt", "test-model", runtime, service_tier=None
+    )
+    ordinary_route = runner._resolve_turn_agent_config(
+        "prompt", "test-model", runtime
+    )
+
+    assert contractor_route["request_overrides"] == {
+        "extra_body": {"existing": True}
+    }
+    assert ordinary_route["request_overrides"] == {
+        "extra_body": {"existing": True},
+        "service_tier": "priority",
+    }
 
 
 class _CleanFakeAgent:
@@ -774,6 +890,79 @@ def test_contractor_cleanup_failure_is_observed_on_successful_turn(
     assert result["completed"] is True
     assert "cleanup_error" in result
     assert "cleanup failed" in result["cleanup_error"]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_raises_from_public_contractor_handler(
+    tmp_path, monkeypatch
+):
+    cleanup_failure_type = getattr(
+        gateway_run,
+        "ContractorTurnCleanupFailed",
+        gateway_run.ContractorTurnRejected,
+    )
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _MessySuccessAgent)
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload",
+        lambda name, **_kwargs: ({"content": name}, project_root / name, name),
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._build_skill_message",
+        lambda payload, *_args, **_kwargs: payload["content"],
+    )
+
+    async def run_inline(func, *args):
+        return func(*args)
+
+    runner._run_in_executor_with_context = run_inline
+    event = _event(tmp_path, project_root=str(project_root))
+
+    with pytest.raises(cleanup_failure_type, match="cleanup failed"):
+        await runner._handle_contractor_turn(
+            event, event.source, event.contractor_context
+        )
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_marks_platform_processing_failed(
+    tmp_path, monkeypatch
+):
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    runner = _minimal_contractor_runner(tmp_path, monkeypatch)
+    monkeypatch.setattr("run_agent.AIAgent", _MessySuccessAgent)
+    monkeypatch.setattr(
+        "agent.skill_commands._load_skill_payload",
+        lambda name, **_kwargs: ({"content": name}, project_root / name, name),
+    )
+    monkeypatch.setattr(
+        "agent.skill_commands._build_skill_message",
+        lambda payload, *_args, **_kwargs: payload["content"],
+    )
+
+    async def run_inline(func, *args):
+        return func(*args)
+
+    runner._run_in_executor_with_context = run_inline
+    event = _event(tmp_path, project_root=str(project_root))
+    adapter = _test_adapter()
+    adapter._message_handler = runner._handle_message
+    adapter.on_processing_complete = AsyncMock()
+    adapter.send = AsyncMock(
+        return_value=platform_base.SendResult(success=True, message_id="error-1")
+    )
+    session_key = "agent:operations:webhook:contractor"
+    adapter._active_sessions[session_key] = asyncio.Event()
+    adapter._session_tasks[session_key] = asyncio.current_task()
+
+    await adapter._process_message_background(event, session_key)
+
+    adapter.on_processing_complete.assert_awaited_once_with(
+        event, platform_base.ProcessingOutcome.FAILURE
+    )
 
 
 class _MessyFailureAgent:


### PR DESCRIPTION
## Summary

Addresses the Copilot code review finding on PR #102409: the new stateless session cleanup path in  can break the existing command-guard ownership semantics by clearing a swapped-in guard unconditionally.

## Changes

-  — the stateless-turn cleanup branch now releases the guard via  first (guard-matched release, skips on mismatch), and only clears the rest of the per-session adapter caches (, , , text debounce) once the guard was actually released for this task.
-  — updated the existing cleanup test to reflect that the guard-matched path is now taken for all three cases (close_after_turn / contractor turn / ordinary turn), which always releases the guard and removes the session.

## Verification

- ============================= test session starts ==============================
platform linux -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/anongene4/.hermes/hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 42 items

tests/gateway/test_contractor_turns.py ................................. [ 78%]
.........                                                                [100%]

============================== 42 passed in 0.84s ============================== — 42 pass
- ============================= test session starts ==============================
platform linux -- Python 3.11.16, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/anongene4/.hermes/hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1, asyncio-1.4.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 24 items

tests/gateway/test_turn_request_overrides.py .......                     [ 29%]
tests/gateway/test_fast_command.py ...                                   [ 41%]
tests/gateway/test_custom_provider_request_overrides.py .....            [ 62%]
tests/gateway/test_session_model_override_persistence.py ...             [ 75%]
tests/gateway/test_turn_context.py ......                                [100%]

============================== 24 passed in 0.57s ============================== — 24 pass