### PR TITLE
fix(desktop): guard state db update backups

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -360,6 +360,7 @@ import { ensureLoginShellPath } from './shell-path'
 import { createBootstrapCoordinator, sshConfigFingerprint } from './ssh-bootstrap-coordinator'
 import { collectSshConfigHosts, parseSshGOutput } from './ssh-config'
 import { createSshProbeConnection, pickLocalPort, redactSecrets, SshConnection } from './ssh-connection'
+import { preflightStateDb } from './state-db-preflight'
 import { createStreamThrottle } from './stream-throttle'
 import { registerTerminalIpc } from './terminal-ipc'
 import { nativeOverlayWidth as computeNativeOverlayWidth, macTitleBarOverlayHeight } from './titlebar-overlay-width'
@@ -4337,92 +4338,6 @@ function runningAppBundle() {
   } // -> .../X.app
 
   return dir.endsWith('.app') ? dir : null
-}
-
-// ── Pre-flight state.db integrity guard (#68474) ─────────────────────
-// Take an emergency snapshot of state.db and verify the live copy is
-// intact before any update process mutates the install.  Runs in the
-// desktop Electron process itself, before the backend is killed and
-// before the updater is spawned — a separate safety net from the
-// Python-level pre-update snapshot inside `hermes update`.
-function preflightStateDb(hermesHome, rememberLog) {
-  const stateDbPath = path.join(hermesHome, 'state.db')
-
-  if (!fileExists(stateDbPath)) {
-    rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
-
-    return
-  }
-
-  try {
-    const stat = fs.statSync(stateDbPath)
-
-    if (stat.size > 100) {
-      const fd = fs.openSync(stateDbPath, 'r')
-      const header = Buffer.alloc(16)
-
-      fs.readSync(fd, header, 0, 16, 0)
-      fs.closeSync(fd)
-
-      const expectedHeader = Buffer.from('SQLite format 3\0')
-      const headerOk = header.equals(expectedHeader)
-
-      rememberLog(
-        `[updates] state.db pre-flight: size=${stat.size}, ` +
-          `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
-      )
-
-      if (!headerOk) {
-        rememberLog(
-          '[updates] state.db header is INVALID before update — ' +
-            'this indicates pre-existing corruption or a concurrent write issue'
-        )
-      }
-
-      // Emergency timestamped backup, separate from the Python-level snapshot.
-      const ts = new Date().toISOString().replace(/[:.]/g, '-')
-
-      const emergencyPath = path.join(hermesHome, `state.db.pre-update-emergency-${ts}.bak`)
-
-      try {
-        fs.copyFileSync(stateDbPath, emergencyPath)
-        const emergStat = fs.statSync(emergencyPath)
-
-        rememberLog(`[updates] emergency state.db backup: ${emergencyPath} ` + `(${emergStat.size} bytes)`)
-
-        // Prune to the 2 most recent emergency backups.
-        try {
-          const homeDir = fs.readdirSync(hermesHome)
-
-          const backups = homeDir
-            .filter(
-              f =>
-                f.startsWith('state.db.pre-update-emergency-') &&
-                f.endsWith('.bak') &&
-                f !== path.basename(emergencyPath)
-            )
-            .sort()
-            .reverse()
-
-          for (const old of backups.slice(2)) {
-            try {
-              fs.unlinkSync(path.join(hermesHome, old))
-            } catch {
-              void 0
-            }
-          }
-        } catch {
-          void 0
-        }
-      } catch (copyErr) {
-        rememberLog(`[updates] emergency state.db backup failed: ${copyErr.message}`)
-      }
-    } else {
-      rememberLog(`[updates] state.db too small (${stat.size} bytes) for a valid SQLite database`)
-    }
-  } catch (statErr) {
-    rememberLog(`[updates] could not stat state.db before update: ${statErr.message}`)
-  }
 }
 
 // macOS/Linux update hand-off: spawn the repo-owned posix orchestrator

--- a/apps/desktop/electron/state-db-preflight.test.ts
+++ b/apps/desktop/electron/state-db-preflight.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import { afterEach, test } from 'vitest'
+
+import { preflightStateDb, STATE_DB_BACKUP_FREE_RESERVE_BYTES } from './state-db-preflight'
+
+const roots: string[] = []
+const SQLITE_HEADER = Buffer.concat([Buffer.from('SQLite format 3\0'), Buffer.alloc(128)])
+
+function fixture() {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-state-db-preflight-'))
+  roots.push(root)
+  fs.writeFileSync(path.join(root, 'state.db'), SQLITE_HEADER)
+
+  return root
+}
+
+function backup(root: string, stamp: string, body = 'prior') {
+  const file = path.join(root, `state.db.pre-update-emergency-${stamp}.bak`)
+  fs.writeFileSync(file, body)
+
+  return file
+}
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    fs.rmSync(root, { force: true, recursive: true })
+  }
+})
+
+test('prunes stale emergency copies before allocating a clone backup', () => {
+  const root = fixture()
+  const oldest = backup(root, '2026-08-01T00-00-00-000Z')
+  const middle = backup(root, '2026-08-02T00-00-00-000Z')
+  const newest = backup(root, '2026-08-03T00-00-00-000Z')
+  const order: string[] = []
+
+  const result = preflightStateDb(root, () => {}, {
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => ({
+      bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+      bsize: 1
+    }),
+    unlinkSync: file => {
+      order.push(`unlink:${path.basename(file)}`)
+      fs.unlinkSync(file)
+    },
+    cloneFile: (source, destination) => {
+      order.push('clone')
+      fs.copyFileSync(source, destination)
+    }
+  })
+
+  assert.equal(result.status, 'created')
+  assert.equal(result.method, process.platform === 'darwin' ? 'clone-or-physical' : 'clone')
+  assert.equal(fs.existsSync(oldest), false)
+  assert.equal(fs.existsSync(middle), false)
+  assert.equal(fs.existsSync(newest), true)
+  assert.equal(fs.existsSync(result.path), true)
+  assert.deepEqual(order.slice(0, 2), [
+    'unlink:state.db.pre-update-emergency-2026-08-02T00-00-00-000Z.bak',
+    'unlink:state.db.pre-update-emergency-2026-08-01T00-00-00-000Z.bak'
+  ])
+  assert.equal(order[2], 'clone')
+})
+
+test('low disk refuses physical fallback and removes a partial reflink destination', () => {
+  const root = fixture()
+  const newest = backup(root, '2026-08-03T00-00-00-000Z')
+  let physicalCopies = 0
+  let spaceChecks = 0
+
+  const result = preflightStateDb(root, () => {}, {
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => {
+      spaceChecks += 1
+
+      return {
+        bavail:
+          SQLITE_HEADER.length +
+          STATE_DB_BACKUP_FREE_RESERVE_BYTES -
+          (process.platform === 'darwin' && spaceChecks === 1 ? 0 : 1),
+        bsize: 1
+      }
+    },
+    cloneFile: (_source, destination) => {
+      fs.writeFileSync(destination, 'partial')
+      throw new Error('clone unsupported')
+    },
+    copyFileSync: (source, destination) => {
+      physicalCopies += 1
+      fs.copyFileSync(source, destination)
+    }
+  })
+
+  assert.equal(result.status, 'skipped-insufficient-space')
+  assert.equal(physicalCopies, 0)
+  assert.equal(fs.existsSync(newest), true)
+  assert.equal(fs.existsSync(result.path), false)
+})
+
+test.runIf(process.platform === 'darwin')(
+  'low disk refuses the macOS clone path before cp can fall back to a physical copy',
+  () => {
+    const root = fixture()
+    let cloneAttempts = 0
+
+    const result = preflightStateDb(root, () => {}, {
+      now: () => new Date('2026-09-03T20:00:00.000Z'),
+      statfsSync: () => ({
+        bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES - 1,
+        bsize: 1
+      }),
+      cloneFile: () => {
+        cloneAttempts += 1
+      }
+    })
+
+    assert.equal(result.status, 'skipped-insufficient-space')
+    assert.equal(cloneAttempts, 0)
+    assert.equal(fs.existsSync(result.path), false)
+  }
+)
+
+test.runIf(process.platform === 'darwin')(
+  'unverified headroom refuses the macOS clone path before cp can fall back to a physical copy',
+  () => {
+    const root = fixture()
+    let cloneAttempts = 0
+
+    const result = preflightStateDb(root, () => {}, {
+      now: () => new Date('2026-09-03T20:00:00.000Z'),
+      statfsSync: () => {
+        throw new Error('statfs unavailable')
+      },
+      cloneFile: () => {
+        cloneAttempts += 1
+      }
+    })
+
+    assert.equal(result.status, 'skipped-unverified-space')
+    assert.equal(cloneAttempts, 0)
+    assert.equal(fs.existsSync(result.path), false)
+  }
+)
+
+test('falls back to a physical copy only when verified headroom remains', () => {
+  const root = fixture()
+  let physicalCopies = 0
+
+  const result = preflightStateDb(root, () => {}, {
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => ({
+      bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+      bsize: 1
+    }),
+    cloneFile: () => {
+      throw new Error('clone unsupported')
+    },
+    copyFileSync: (source, destination) => {
+      physicalCopies += 1
+      fs.copyFileSync(source, destination)
+    }
+  })
+
+  assert.equal(result.status, 'created')
+  assert.equal(result.method, 'physical')
+  assert.equal(physicalCopies, 1)
+  assert.deepEqual(fs.readFileSync(result.path), SQLITE_HEADER)
+})
+
+test('refreshes a growing source size before allocating a physical backup', () => {
+  const root = fixture()
+  const source = path.join(root, 'state.db')
+  let physicalCopies = 0
+
+  const result = preflightStateDb(root, () => {}, {
+    cloneFile: null,
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => {
+      fs.appendFileSync(source, 'growth')
+
+      return {
+        bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+        bsize: 1
+      }
+    },
+    copyFileSync: (from, destination) => {
+      physicalCopies += 1
+      fs.copyFileSync(from, destination)
+    }
+  })
+
+  assert.equal(result.status, 'skipped-insufficient-space')
+  assert.equal(physicalCopies, 0)
+  assert.equal(fs.existsSync(result.path), false)
+})
+
+test('accepts a completed valid snapshot when the source grows during copying', () => {
+  const root = fixture()
+  const source = path.join(root, 'state.db')
+
+  const result = preflightStateDb(root, () => {}, {
+    cloneFile: null,
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => ({
+      bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES + 1024,
+      bsize: 1
+    }),
+    copyFileSync: (from, destination) => {
+      fs.appendFileSync(source, 'growth')
+      fs.copyFileSync(from, destination)
+    }
+  })
+
+  assert.equal(result.status, 'created')
+  assert.equal(result.method, 'physical')
+  assert.deepEqual(fs.readFileSync(result.path), Buffer.concat([SQLITE_HEADER, Buffer.from('growth')]))
+})
+
+test('rejects a same-size snapshot without a SQLite header', () => {
+  const root = fixture()
+
+  const result = preflightStateDb(root, () => {}, {
+    cloneFile: (_source, destination) => {
+      fs.writeFileSync(destination, Buffer.alloc(SQLITE_HEADER.length))
+    },
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => ({
+      bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+      bsize: 1
+    }),
+    copyFileSync: (_source, destination) => {
+      fs.writeFileSync(destination, Buffer.alloc(SQLITE_HEADER.length))
+    }
+  })
+
+  assert.equal(result.status, 'failed')
+  assert.equal(fs.existsSync(result.path), false)
+})
+
+test('removes a partial physical backup when fallback copying fails', () => {
+  const root = fixture()
+
+  const result = preflightStateDb(root, () => {}, {
+    cloneFile: null,
+    statfsSync: () => ({
+      bavail: SQLITE_HEADER.length + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+      bsize: 1
+    }),
+    copyFileSync: (_source, destination) => {
+      fs.writeFileSync(destination, 'partial')
+      throw new Error('ENOSPC')
+    },
+    now: () => new Date('2026-09-03T20:00:00.000Z')
+  })
+
+  assert.equal(result.status, 'failed')
+  assert.equal(fs.existsSync(result.path), false)
+})
+
+test.runIf(process.platform === 'darwin')('creates a guarded cp -c backup for a large sparse database', () => {
+  const root = fixture()
+  const source = path.join(root, 'state.db')
+
+  fs.truncateSync(source, 64 * 1024 * 1024)
+
+  const result = preflightStateDb(root, () => {}, {
+    now: () => new Date('2026-09-03T20:00:00.000Z'),
+    statfsSync: () => ({
+      bavail: fs.statSync(source).size + STATE_DB_BACKUP_FREE_RESERVE_BYTES,
+      bsize: 1
+    })
+  })
+
+  assert.equal(result.status, 'created')
+  assert.equal(result.method, 'clone-or-physical')
+  assert.equal(fs.statSync(result.path).size, fs.statSync(source).size)
+})

--- a/apps/desktop/electron/state-db-preflight.ts
+++ b/apps/desktop/electron/state-db-preflight.ts
@@ -1,0 +1,284 @@
+import { execFileSync } from 'node:child_process'
+import fs from 'node:fs'
+import path from 'node:path'
+
+export const STATE_DB_EMERGENCY_BACKUP_LIMIT = 2
+// A physical copy must not leave the updater itself starved for working space.
+// macOS `cp -c` can silently make one when cloning is unavailable, so it is
+// guarded too; forced reflinks on other platforms remain safe to try first.
+export const STATE_DB_BACKUP_FREE_RESERVE_BYTES = 10 * 1024 * 1024 * 1024
+
+const BACKUP_PREFIX = 'state.db.pre-update-emergency-'
+const BACKUP_SUFFIX = '.bak'
+const MIN_SQLITE_DB_BYTES = 100
+const SQLITE_HEADER = Buffer.from('SQLite format 3\0')
+
+type Log = (message: string) => void
+
+type StateDbPreflightDeps = {
+  closeSync?: (fd: number) => void
+  cloneFile?: ((source: string, destination: string) => void) | null
+  copyFileSync?: (source: string, destination: string) => void
+  existsSync?: (file: string) => boolean
+  now?: () => Date
+  openSync?: (file: string, flags: string) => number
+  readSync?: (fd: number, buffer: Buffer, offset: number, length: number, position: number) => number
+  readdirSync?: (directory: string) => string[]
+  statfsSync?: (directory: string) => { bavail: bigint | number; bsize: bigint | number }
+  statSync?: (file: string) => { size: number }
+  unlinkSync?: (file: string) => void
+}
+
+type StateDbPreflightResult =
+  | { status: 'not-found' | 'too-small'; path: string }
+  | { status: 'created'; path: string; method: 'clone' | 'clone-or-physical' | 'physical' }
+  | { status: 'failed' | 'skipped-insufficient-space' | 'skipped-unverified-space'; path: string }
+
+function defaultCloneFile() {
+  if (process.platform === 'darwin') {
+    return (source: string, destination: string) => {
+      execFileSync('/bin/cp', ['-c', source, destination], {
+        stdio: 'ignore',
+        timeout: 30_000
+      })
+    }
+  }
+
+  if (process.platform === 'win32') {
+    return null
+  }
+
+  return (source: string, destination: string) => {
+    fs.copyFileSync(source, destination, fs.constants.COPYFILE_FICLONE_FORCE)
+  }
+}
+
+function defaultDeps(): Required<StateDbPreflightDeps> {
+  return {
+    closeSync: fs.closeSync,
+    cloneFile: defaultCloneFile(),
+    copyFileSync: fs.copyFileSync,
+    existsSync: fs.existsSync,
+    now: () => new Date(),
+    openSync: fs.openSync,
+    readSync: fs.readSync,
+    readdirSync: directory => fs.readdirSync(directory, { encoding: 'utf8' }),
+    statfsSync: fs.statfsSync,
+    statSync: fs.statSync,
+    unlinkSync: fs.unlinkSync
+  }
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function availableBytes(stat: { bavail: bigint | number; bsize: bigint | number }) {
+  const value = BigInt(stat.bavail) * BigInt(stat.bsize)
+
+  return value > BigInt(Number.MAX_SAFE_INTEGER) ? Number.MAX_SAFE_INTEGER : Number(value)
+}
+
+function removeIfPresent(file: string, io: Required<StateDbPreflightDeps>, rememberLog: Log) {
+  if (!io.existsSync(file)) {
+    return
+  }
+
+  try {
+    io.unlinkSync(file)
+  } catch (error) {
+    rememberLog(`[updates] could not remove partial emergency state.db backup: ${errorMessage(error)}`)
+  }
+}
+
+function validateCompletedSnapshot(file: string, io: Required<StateDbPreflightDeps>) {
+  const size = io.statSync(file).size
+
+  if (size <= MIN_SQLITE_DB_BYTES) {
+    throw new Error(`snapshot too small: ${size} bytes`)
+  }
+
+  const fd = io.openSync(file, 'r')
+  const header = Buffer.alloc(SQLITE_HEADER.length)
+
+  try {
+    io.readSync(fd, header, 0, header.length, 0)
+  } finally {
+    io.closeSync(fd)
+  }
+
+  if (!header.equals(SQLITE_HEADER)) {
+    throw new Error(`snapshot has invalid SQLite header: ${header.toString('hex')}`)
+  }
+
+  return size
+}
+
+function guardPhysicalAllocation(
+  hermesHome: string,
+  stateDbPath: string,
+  emergencyPath: string,
+  io: Required<StateDbPreflightDeps>,
+  rememberLog: Log
+): StateDbPreflightResult | null {
+  let freeBytes: number
+
+  try {
+    freeBytes = availableBytes(io.statfsSync(hermesHome))
+  } catch (error) {
+    rememberLog(
+      `[updates] emergency state.db physical backup skipped: free space could not be verified (${errorMessage(error)})`
+    )
+
+    return { status: 'skipped-unverified-space', path: emergencyPath }
+  }
+
+  let sourceSize: number
+
+  try {
+    sourceSize = io.statSync(stateDbPath).size
+  } catch (error) {
+    rememberLog(`[updates] could not refresh state.db size before physical backup: ${errorMessage(error)}`)
+
+    return { status: 'failed', path: emergencyPath }
+  }
+
+  const requiredBytes = sourceSize + STATE_DB_BACKUP_FREE_RESERVE_BYTES
+
+  if (freeBytes < requiredBytes) {
+    rememberLog(
+      `[updates] emergency state.db physical backup skipped: ` +
+        `free=${freeBytes}, required=${requiredBytes}, reserve=${STATE_DB_BACKUP_FREE_RESERVE_BYTES}`
+    )
+
+    return { status: 'skipped-insufficient-space', path: emergencyPath }
+  }
+
+  return null
+}
+
+function pruneBeforeBackup(hermesHome: string, io: Required<StateDbPreflightDeps>, rememberLog: Log) {
+  try {
+    const backups = io
+      .readdirSync(hermesHome)
+      .filter(file => file.startsWith(BACKUP_PREFIX) && file.endsWith(BACKUP_SUFFIX))
+      .sort()
+      .reverse()
+
+    for (const old of backups.slice(STATE_DB_EMERGENCY_BACKUP_LIMIT - 1)) {
+      try {
+        io.unlinkSync(path.join(hermesHome, old))
+      } catch (error) {
+        rememberLog(`[updates] could not prune stale emergency state.db backup: ${errorMessage(error)}`)
+      }
+    }
+  } catch (error) {
+    rememberLog(`[updates] could not list emergency state.db backups: ${errorMessage(error)}`)
+  }
+}
+
+export function preflightStateDb(
+  hermesHome: string,
+  rememberLog: Log,
+  overrides: StateDbPreflightDeps = {}
+): StateDbPreflightResult {
+  const io = { ...defaultDeps(), ...overrides }
+  const stateDbPath = path.join(hermesHome, 'state.db')
+
+  if (!io.existsSync(stateDbPath)) {
+    rememberLog('[updates] state.db pre-flight: not found (fresh install?)')
+
+    return { status: 'not-found', path: stateDbPath }
+  }
+
+  let sourceSize: number
+
+  try {
+    sourceSize = io.statSync(stateDbPath).size
+  } catch (error) {
+    rememberLog(`[updates] could not stat state.db before update: ${errorMessage(error)}`)
+
+    return { status: 'failed', path: stateDbPath }
+  }
+
+  if (sourceSize <= MIN_SQLITE_DB_BYTES) {
+    rememberLog(`[updates] state.db too small (${sourceSize} bytes) for a valid SQLite database`)
+
+    return { status: 'too-small', path: stateDbPath }
+  }
+
+  try {
+    const fd = io.openSync(stateDbPath, 'r')
+    const header = Buffer.alloc(SQLITE_HEADER.length)
+
+    try {
+      io.readSync(fd, header, 0, header.length, 0)
+    } finally {
+      io.closeSync(fd)
+    }
+
+    const headerOk = header.equals(SQLITE_HEADER)
+
+    rememberLog(
+      `[updates] state.db pre-flight: size=${sourceSize}, ` +
+        `headerOk=${headerOk}, headerHex=${header.toString('hex')}`
+    )
+
+    if (!headerOk) {
+      rememberLog(
+        '[updates] state.db header is INVALID before update — ' +
+          'this indicates pre-existing corruption or a concurrent write issue'
+      )
+    }
+  } catch (error) {
+    rememberLog(`[updates] could not read state.db before update: ${errorMessage(error)}`)
+  }
+
+  const ts = io.now().toISOString().replace(/[:.]/g, '-')
+  const emergencyPath = path.join(hermesHome, `${BACKUP_PREFIX}${ts}${BACKUP_SUFFIX}`)
+
+  pruneBeforeBackup(hermesHome, io, rememberLog)
+
+  if (io.cloneFile !== null) {
+    if (process.platform === 'darwin') {
+      const guardResult = guardPhysicalAllocation(hermesHome, stateDbPath, emergencyPath, io, rememberLog)
+
+      if (guardResult !== null) {
+        return guardResult
+      }
+    }
+
+    try {
+      io.cloneFile(stateDbPath, emergencyPath)
+      const backupSize = validateCompletedSnapshot(emergencyPath, io)
+      const method = process.platform === 'darwin' ? 'clone-or-physical' : 'clone'
+
+      rememberLog(`[updates] emergency state.db backup: ${emergencyPath} (${backupSize} bytes, ${method})`)
+
+      return { status: 'created', path: emergencyPath, method }
+    } catch (error) {
+      removeIfPresent(emergencyPath, io, rememberLog)
+      rememberLog(`[updates] emergency state.db clone unavailable: ${errorMessage(error)}`)
+    }
+  }
+
+  const guardResult = guardPhysicalAllocation(hermesHome, stateDbPath, emergencyPath, io, rememberLog)
+
+  if (guardResult !== null) {
+    return guardResult
+  }
+
+  try {
+    io.copyFileSync(stateDbPath, emergencyPath)
+    const backupSize = validateCompletedSnapshot(emergencyPath, io)
+
+    rememberLog(`[updates] emergency state.db backup: ${emergencyPath} (${backupSize} bytes, physical)`)
+
+    return { status: 'created', path: emergencyPath, method: 'physical' }
+  } catch (error) {
+    removeIfPresent(emergencyPath, io, rememberLog)
+    rememberLog(`[updates] emergency state.db backup failed: ${errorMessage(error)}`)
+
+    return { status: 'failed', path: emergencyPath }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Prevents Hermes Desktop's emergency pre-update `state.db` backup from recreating disk exhaustion.

The preflight now:

- keeps at most two emergency backups;
- requires `state.db` size plus a 10 GiB reserve before any operation that may physically copy data;
- treats macOS `cp -c` conservatively because it may silently fall back from clone to physical copy;
- uses forced reflink semantics where available on non-Windows platforms, then a guarded physical fallback;
- validates the completed backup as SQLite while tolerating live database growth;
- removes incomplete/invalid backup artifacts;
- runs at both existing update handoff call sites.

## How was this tested?

- Focused Electron updater/preflight tests: 51 passed.
- ESLint: passed.
- Prettier: passed.
- Electron TypeScript typecheck: passed.
- Desktop build: passed.
- Changed-file gitleaks scan: passed.
- Full Electron platform suite: 2,114 passed, 2 failed. Both failures reproduce unchanged outside this patch (`managed-ssh-update` status 127 and `remote-lifecycle` `ps` race).
- Two independent exact-tree reviews: PASS.

## Notes

This intentionally gives up the low-free-space macOS clone optimization. `cp -c` is not clone-only, so the safe behavior is to reserve enough space before invoking it.
