### PR TITLE
fix(gateway): preserve automatic expiry reasons

### DIFF
--- a/docs/session-lifecycle.md
+++ b/docs/session-lifecycle.md
@@ -542,19 +542,19 @@ The `_session_expiry_watcher` task runs in the gateway event loop every 300 seco
 
 ### Responsibilities
 
-1. **Finalize expired sessions** — For each entry where `_is_session_expired()` returns
-   True and `expiry_finalized` is False:
+1. **Finalize expired sessions** — For each entry where `_session_expiry_reason()` returns
+   `idle` or `daily` and `expiry_finalized` is False:
    - Invoke `on_session_finalize` plugin hooks (cleanup, notifications).
    - Clean up cached AIAgent resources (close tool resources, shut down memory provider).
    - Evict the cached agent entry.
    - Clear per-session overrides (`_session_model_overrides`, reasoning overrides, etc.).
    - Mark `expiry_finalized=True` and persist (sessions.json + state.db).
-   - Promote the state.db session row to `end_reason='session_reset'` via
-     `promote_to_session_reset()` — conditional: only live rows or rows ended with a
-     recoverable accidental reason (`agent_close`, `ws_orphan_reap`) are promoted, so
-     explicit boundaries (`compression`, `session_switch`, …) are never overwritten. This
-     durably records the reset so stale-route recovery cannot resurrect the expired
-     session with its full history (#61220, #61993, #63539).
+   - Promote the state.db session row with the exact automatic expiry reason (`idle` or
+     `daily`) via `promote_to_session_reset()`. This is conditional: only live rows or
+     rows ended with a recoverable accidental reason (`agent_close`, `ws_orphan_reap`)
+     are promoted, so explicit boundaries (`compression`, `session_switch`, …) are never
+     overwritten. This durably records the reset so stale-route recovery cannot resurrect
+     the expired session with its full history (#61220, #61993, #63539).
 
 2. **Sweep idle cached agents** — Calls `_sweep_idle_cached_agents()` to evict agents that
    have been idle beyond the idle TTL (3600s / 1h by default), regardless of session

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15487,15 +15487,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 for key, entry in list(self.session_store._entries.items()):
                     if entry.expiry_finalized:
                         continue
-                    if not await self.async_session_store._is_session_expired(entry):
+                    expiry_reason = await self.async_session_store._session_expiry_reason(entry)
+                    if not expiry_reason:
                         continue
-                    _expired_entries.append((key, entry))
+                    _expired_entries.append((key, entry, expiry_reason))
 
                 if _expired_entries:
                     # Extract platform names from session keys for a compact summary.
                     # Keys look like "agent:main:telegram:dm:12345" — platform is field [2].
                     _platforms: dict[str, int] = {}
-                    for _k, _e in _expired_entries:
+                    for _k, _e, _reason in _expired_entries:
                         _parts = _k.split(":")
                         _plat = _parts[2] if len(_parts) > 2 else "unknown"
                         _platforms[_plat] = _platforms.get(_plat, 0) + 1
@@ -15507,7 +15508,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         len(_expired_entries), _plat_summary,
                     )
 
-                for key, entry in _expired_entries:
+                for key, entry, expiry_reason in _expired_entries:
                     try:
                         try:
                             _parts = key.split(":")
@@ -15562,7 +15563,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         # state.db (single write-path, #9006) — also drops
                         # the persisted /model override, since finalization
                         # is a conversation boundary.
-                        await self.async_session_store.set_expiry_finalized(entry)
+                        await self.async_session_store.set_expiry_finalized(
+                            entry, end_reason=expiry_reason
+                        )
                         logger.debug(
                             "Session expiry finalized for %s",
                             entry.session_id,
@@ -15578,7 +15581,9 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                                 failures, entry.session_id, e,
                             )
                             await self.async_session_store.set_expiry_finalized(
-                                entry, clear_model_override=False
+                                entry,
+                                clear_model_override=False,
+                                end_reason=expiry_reason,
                             )
                             _finalize_failures.pop(entry.session_id, None)
                         else:
@@ -15589,7 +15594,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
                 if _expired_entries:
                     _done = sum(
-                        1 for _, e in _expired_entries if e.expiry_finalized
+                        1 for _, e, _ in _expired_entries if e.expiry_finalized
                     )
                     _failed = len(_expired_entries) - _done
                     if _failed:

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -2581,7 +2581,11 @@ class SessionStore:
             logger.debug("Gateway session peer record failed for %s: %s", session_key, exc)
 
     def set_expiry_finalized(
-        self, entry: SessionEntry, *, clear_model_override: bool = True
+        self,
+        entry: SessionEntry,
+        *,
+        clear_model_override: bool = True,
+        end_reason: str = "session_reset",
     ) -> None:
         """Mark a session entry expiry-finalized in memory, sessions.json, AND state.db.
 
@@ -2590,7 +2594,9 @@ class SessionStore:
         survives sessions.json pruning/loss.
 
         ``clear_model_override=False`` preserves the give-up path's original
-        behavior (flag only, no override drop).
+        behavior (flag only, no override drop). ``end_reason`` preserves the
+        policy cause so lifecycle consumers can distinguish automatic expiry
+        from an explicit user reset.
         """
         with self._lock:
             entry.expiry_finalized = True
@@ -2624,26 +2630,25 @@ class SessionStore:
                 # live rows or rows ended with ``agent_close``.  Explicit
                 # boundaries (compression, session_reset, new_command, etc.)
                 # are preserved — the first writer wins.
-                _db.promote_to_session_reset(entry.session_id)
+                _db.promote_to_session_reset(entry.session_id, end_reason)
             except Exception as exc:
                 logger.debug(
                     "Session DB promote_to_session_reset failed for %s: %s",
                     entry.session_id, exc,
                 )
     
-    def _is_session_expired(self, entry: SessionEntry) -> bool:
-        """Check if a session has expired based on its reset policy.
-        
-        Works from the entry alone — no SessionSource needed.
-        Used by the background expiry watcher to proactively flush memories.
-        Sessions with active background processes are never considered expired.
+    def _session_expiry_reason(self, entry: SessionEntry) -> Optional[str]:
+        """Return the policy reason when a session has expired, else ``None``.
+
+        Works from the entry alone — no SessionSource needed. Sessions with
+        active background processes are never considered expired.
         """
         if self._has_active_processes_safe(entry.session_key, context="expiry"):
             logger.debug(
                 "Session %s not expired — active background processes",
                 entry.session_key,
             )
-            return False
+            return None
 
         policy = self.config.get_reset_policy(
             platform=entry.platform,
@@ -2651,14 +2656,14 @@ class SessionStore:
         )
 
         if policy.mode == "none":
-            return False
+            return None
 
         now = _now()
 
         if policy.mode in {"idle", "both"}:
             idle_deadline = entry.updated_at + timedelta(minutes=policy.idle_minutes)
             if now > idle_deadline:
-                return True
+                return "idle"
 
         if policy.mode in {"daily", "both"}:
             today_reset = now.replace(
@@ -2668,9 +2673,13 @@ class SessionStore:
             if now.hour < policy.at_hour:
                 today_reset -= timedelta(days=1)
             if entry.updated_at < today_reset:
-                return True
+                return "daily"
 
-        return False
+        return None
+
+    def _is_session_expired(self, entry: SessionEntry) -> bool:
+        """Backward-compatible boolean wrapper around expiry classification."""
+        return self._session_expiry_reason(entry) is not None
 
     def is_session_finalizable(self, entry: SessionEntry) -> bool:
         """Return True if the expiry watcher will *ever* finalize this session.

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -110,7 +110,7 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
     runner.session_store = MagicMock()
     runner.session_store._ensure_loaded = MagicMock()
     runner.session_store._entries = {session_key: expired_entry}
-    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._session_expiry_reason = MagicMock(return_value="idle")
     runner.session_store._lock = MagicMock()
     runner.session_store._lock.__enter__ = MagicMock(return_value=None)
     runner.session_store._lock.__exit__ = MagicMock(return_value=None)
@@ -147,6 +147,9 @@ async def test_idle_expiry_fires_finalize_hook(mock_invoke_hook):
     assert "sess-expired" in session_ids, (
         f"on_session_finalize was not fired during idle expiry; "
         f"got session_ids={session_ids} (regression of #14981)"
+    )
+    runner.session_store.set_expiry_finalized.assert_called_once_with(
+        expired_entry, end_reason="idle"
     )
 
 
@@ -188,7 +191,7 @@ async def test_idle_expiry_clears_last_resolved_model(mock_invoke_hook):
     runner.session_store = MagicMock()
     runner.session_store._ensure_loaded = MagicMock()
     runner.session_store._entries = {session_key: expired_entry}
-    runner.session_store._is_session_expired = MagicMock(return_value=True)
+    runner.session_store._session_expiry_reason = MagicMock(return_value="idle")
     runner.session_store._lock = MagicMock()
     runner.session_store._lock.__enter__ = MagicMock(return_value=None)
     runner.session_store._lock.__exit__ = MagicMock(return_value=None)
@@ -225,4 +228,7 @@ async def test_idle_expiry_clears_last_resolved_model(mock_invoke_hook):
     assert runner._last_resolved_model["agent:main:telegram:dm:other"] == "keep-me", (
         "session-expiry finalization must only clear the expired session's "
         "own key, not unrelated sessions' cached entries"
+    )
+    runner.session_store.set_expiry_finalized.assert_called_once_with(
+        expired_entry, end_reason="idle"
     )

--- a/tests/gateway/test_session_reset_notify.py
+++ b/tests/gateway/test_session_reset_notify.py
@@ -329,3 +329,57 @@ class TestResumePendingExpiredAutoReset:
         db.promote_to_session_reset.assert_called_once()
         _, ended_reason = db.promote_to_session_reset.call_args.args
         assert ended_reason == "idle"
+
+
+class TestBackgroundExpiryReason:
+    """The background watcher must preserve the same policy reason as lazy reset."""
+
+    def test_idle_policy_reason_is_preserved(self, tmp_path):
+        store = _make_store(
+            SessionResetPolicy(mode="idle", idle_minutes=1),
+            tmp_path,
+        )
+        entry = SessionEntry(
+            session_key="test",
+            session_id="sid-idle",
+            created_at=datetime.now() - timedelta(minutes=10),
+            updated_at=datetime.now() - timedelta(minutes=5),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+
+        assert store._session_expiry_reason(entry) == "idle"
+        assert store._is_session_expired(entry) is True
+
+    def test_daily_policy_reason_is_preserved(self, tmp_path):
+        now = datetime.now()
+        reset_hour = (now.hour - 1) % 24
+        store = _make_store(
+            SessionResetPolicy(mode="daily", at_hour=reset_hour),
+            tmp_path,
+        )
+        entry = SessionEntry(
+            session_key="test",
+            session_id="sid-daily",
+            created_at=now - timedelta(days=2),
+            updated_at=now - timedelta(days=1),
+            platform=Platform.TELEGRAM,
+            chat_type="dm",
+        )
+
+        assert store._session_expiry_reason(entry) == "daily"
+
+    def test_expiry_finalization_forwards_reason_to_state_db(self, tmp_path):
+        db = _make_db_mock()
+        store = _make_store_with_db(tmp_path, db)
+        entry = SessionEntry(
+            session_key="test",
+            session_id="sid-finalized",
+            created_at=datetime.now(),
+            updated_at=datetime.now(),
+        )
+        store._entries[entry.session_key] = entry
+
+        store.set_expiry_finalized(entry, end_reason="idle")
+
+        db.promote_to_session_reset.assert_called_once_with("sid-finalized", "idle")

--- a/tests/gateway/test_session_store_expiry_finalized.py
+++ b/tests/gateway/test_session_store_expiry_finalized.py
@@ -1,10 +1,11 @@
-"""Session expiry finalization closes sessions as session_reset.
+"""Session expiry finalization persists a durable reset boundary.
 
 Regression coverage for #61220: the expiry watcher marks a session expired,
 then agent cleanup can close it as ``agent_close``. Stale routing recovery treats
 ``agent_close`` as recoverable, so expired sessions were reopened with full
-history unless expiry finalization also persisted the real conversation boundary
-as ``end_reason='session_reset'``.
+history unless expiry finalization also persisted the real conversation boundary.
+The backward-compatible direct-call default remains ``session_reset``; the
+background watcher forwards the exact automatic reason, ``idle`` or ``daily``.
 
 These tests use a real ``SessionDB`` (in-memory) to verify the actual recovery
 contract in ``find_latest_gateway_session_for_peer`` — not just call counts on

--- a/tests/gateway/test_session_store_expiry_finalized.py
+++ b/tests/gateway/test_session_store_expiry_finalized.py
@@ -13,11 +13,14 @@ a MagicMock.
 
 from __future__ import annotations
 
-import time
+from datetime import datetime, timezone
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
+from gateway.config import GatewayConfig, SessionResetPolicy
+from gateway.session import SessionEntry, SessionStore
 from hermes_state import SessionDB
 
 
@@ -93,5 +96,62 @@ class TestPromotionBlocksRecovery:
         )
         assert recovered is not None
         assert recovered["id"] == "sid-pre"
+
+
+class TestSessionStoreAutomaticExpiryReasons:
+    """Background-style finalization preserves its durable policy reason."""
+
+    @pytest.mark.parametrize("reason", ["idle", "daily"])
+    def test_persists_reason_and_blocks_recovery(
+        self,
+        db: SessionDB,
+        tmp_path: Path,
+        reason: str,
+    ) -> None:
+        session_id = f"sid-{reason}"
+        db.create_session(
+            session_id,
+            _SOURCE,
+            user_id=_USER_ID,
+            session_key=_SESSION_KEY,
+            chat_id=_USER_ID,
+            chat_type="dm",
+        )
+        db.append_message(session_id, "user", "hello")
+
+        config = GatewayConfig(
+            default_reset_policy=SessionResetPolicy(mode="none")
+        )
+        with patch("gateway.session.SessionStore._ensure_loaded"):
+            store = SessionStore(sessions_dir=tmp_path, config=config)
+        store._db = db
+        store._loaded = True
+        entry = SessionEntry(
+            session_key=_SESSION_KEY,
+            session_id=session_id,
+            created_at=datetime.now(timezone.utc),
+            updated_at=datetime.now(timezone.utc),
+        )
+        store._entries[_SESSION_KEY] = entry
+
+        store.set_expiry_finalized(
+            entry,
+            clear_model_override=False,
+            end_reason=reason,
+        )
+
+        row = db.get_session(session_id)
+        assert row["end_reason"] == reason
+        assert row["ended_at"] is not None
+        assert (
+            db.find_latest_gateway_session_for_peer(
+                source=_SOURCE,
+                session_key=_SESSION_KEY,
+                user_id=_USER_ID,
+                chat_id=_USER_ID,
+                chat_type="dm",
+            )
+            is None
+        )
 
 


### PR DESCRIPTION
## Summary

- preserve the policy-specific `idle` / `daily` end reason when the background expiry watcher finalizes a session
- forward that reason through `SessionStore.set_expiry_finalized()` to the existing durable session-state promotion API
- keep `_is_session_expired()` as a compatibility wrapper for existing callers

## Problem

The lazy inbound expiry path already records whether an automatic reset was caused by the idle timeout or the daily boundary. The background watcher only retained a boolean and finalized the same rows as `session_reset`.

That makes equivalent automatic expiry paths produce different durable lifecycle state. It also causes downstream consumers to mistake background policy expiry for an explicit user reset boundary.

## Root cause

`_session_expiry_watcher()` called `_is_session_expired()`, which discarded the matching policy reason, and `set_expiry_finalized()` always used the default `session_reset` reason even though the underlying state API already accepts a specific end reason.

## Scope

This change does not alter expiry timing, session keys, explicit reset behavior, delivery routing, or recovery policy. It only preserves the reason for an automatic expiry that was already going to be finalized.

## Tests

- Final regression set is red on unmodified `63279301` (`7 failed, 14 passed`) and green on the candidate (`21 passed`).
- Added coverage for idle and daily reason classification, watcher forwarding, and durable persistence through a real `SessionDB`.
- `289 passed, 1 deselected`: adjacent session and async-delegation tests; the deselected upstream order-sensitive test passes independently on both the candidate and clean `main`.
- Ruff 0.15.10, `py_compile`, `git diff --check`, and the Windows footgun checker all pass for the changed files.
