### PR TITLE
fix(model_metadata): parse vLLM max_model_len=max_total_tokens output-cap rejection

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1786,6 +1786,10 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords
     patterns = [
+        # vLLM max_tokens rejection names the limit with an intervening
+        # descriptor: "max_model_len=max_total_tokens=262144" — the generic
+        # max_model_len pattern below cannot cross "=max_total_tokens=".
+        r'max_model_len\s*=\s*max_total_tokens\s*=\s*(\d{4,})',
         r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
@@ -1882,6 +1886,16 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
+    ) or (
+        # vLLM enforces input + max_tokens <= max_model_len and rejects an
+        # oversized output cap by naming the total window, e.g.
+        #   "max_tokens=393216 cannot be greater than
+        #    max_model_len=max_total_tokens=262144. Please request fewer
+        #    output tokens. (parameter=max_tokens, value=393216)"
+        # The rejection is on the max_tokens PARAMETER, so the input itself
+        # fits — reduce max_tokens and retry; do NOT compress.
+        "cannot be greater than" in error_lower
+        and "max_model_len" in error_lower
     )
     if not is_output_cap_error:
         return None
@@ -1985,6 +1999,22 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         if _available >= 1:
             return _available
 
+    # vLLM total-window form: "max_tokens=393216 cannot be greater than
+    # max_model_len=max_total_tokens=262144".  The message names the total
+    # window (input + output combined) but not the input size, so return the
+    # window itself as the upper bound — the caller clamps it against its own
+    # input estimate (conversation_loop keeps
+    # min(available_out, old_ctx - request_input_estimate) - 64), which yields
+    # exactly window - input - margin: the cap vLLM's
+    # input + max_tokens <= max_model_len rule demands.
+    _m_vllm_total = re.search(
+        r'max_model_len\s*=\s*max_total_tokens\s*=\s*(\d+)', error_lower
+    )
+    if _m_vllm_total:
+        _window = int(_m_vllm_total.group(1))
+        if _window >= 1:
+            return _window
+
     return None
 
 
@@ -2035,6 +2065,8 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "must be" in error_lower
         or ("exceeds model" in error_lower
             and "maximum output tokens" in error_lower)
+        or ("cannot be greater than" in error_lower         # vLLM: "max_tokens=N cannot
+            and "max_model_len" in error_lower)             # be greater than max_model_len=..."
     )
     if not output_cap_signal:
         return False

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1458,6 +1458,18 @@ class TestParseContextLimitFromError:
         fell through to None."""
         assert parse_context_limit_from_error(msg) == expected
 
+    def test_vllm_total_window_cap_format(self):
+        """vLLM's max_tokens rejection embeds the limit behind a descriptor —
+        "max_model_len=max_total_tokens=262144" — and the intervening
+        "=max_total_tokens=" is not in the delimiter set, so the parser
+        returned None (#102494)."""
+        msg = (
+            "max_tokens=393216 cannot be greater than "
+            "max_model_len=max_total_tokens=262144. Please request fewer "
+            "output tokens. (parameter=max_tokens, value=393216)"
+        )
+        assert parse_context_limit_from_error(msg) == 262144
+
     @pytest.mark.parametrize("msg,expected", [
         # Google Gemini/Gemma overflow phrasing (#57275): the limit follows
         # "supports up to"; the larger input count before it must NOT win.

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,41 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+class TestParseVllmTotalWindowOutputCap:
+    """vLLM rejects an oversized max_tokens by naming the total window.
+
+    Until this format was parsed, the 400 was misrouted to the compression
+    path (the classifier matches the bare "max_tokens"/"max_model_len"
+    words), every retry kept the same oversized cap, and the session
+    death-looped into "Cannot compress further" even though the input
+    (~76K) was far below the window (#102494)."""
+
+    # Verbatim 400 from a self-hosted vLLM server (max_model_len=262144)
+    # after /model switched the session to a provider whose configured
+    # max_tokens (393216) exceeded the window.
+    _VLLM_MSG = (
+        "max_tokens=393216 cannot be greater than "
+        "max_model_len=max_total_tokens=262144. Please request fewer output "
+        "tokens. (parameter=max_tokens, value=393216)"
+    )
+
+    def test_vllm_total_window_format(self):
+        # The message reports the total window but not the input size, so the
+        # window itself is the available-output upper bound; the caller
+        # clamps it against its own input estimate and safety margin.
+        assert parse_available_output_tokens_from_error(self._VLLM_MSG) == 262144
+
+    def test_vllm_total_window_is_output_cap(self):
+        assert is_output_cap_error(self._VLLM_MSG) is True
+
+    def test_vllm_prompt_overflow_stays_context_path(self):
+        # The input-overflow phrasing must keep routing to compression, not
+        # be mistaken for an output-cap rejection just because it mentions
+        # max_model_len.
+        assert is_output_cap_error(
+            "The decoder prompt (length 40000) is longer than the maximum "
+            "model length of 32768. Make sure that max_model_len is no "
+            "smaller than the model's context length (32768)."
+        ) is False
+


### PR DESCRIPTION
## What does this PR do?

vLLM rejects an oversized `max_tokens` with a 400 like:

```
max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144. Please request fewer output tokens. (parameter=max_tokens, value=393216)
```

None of the five known output-cap phrasings in `parse_available_output_tokens_from_error` matched it, and the broader `is_output_cap_error` gate missed it too, so the 400 was misrouted down the prompt-too-long path: Hermes compressed history, retried with the **same** `max_tokens`, got the identical 400 back, and the session death-looped into "Context length exceeded … Cannot compress further" + auto-reset — even though the input (~76K) fit the window easily (#102494).

This PR teaches the parsers the phrasing:

- the output-cap gate now recognizes `"cannot be greater than"` + `"max_model_len"` as an output-cap rejection;
- the extractor returns the reported total window (`max_model_len=max_total_tokens=N`) as the available-output upper bound — safe because the caller (`conversation_loop.py`) already clamps it to `min(available_out, old_ctx − request_input_estimate) − 64`, which is exactly the cap vLLM's `input + max_tokens ≤ max_model_len` rule demands;
- `is_output_cap_error` learns the same signal so the yes/no gate stops routing these 400s into compression;
- `parse_context_limit_from_error` gets the `max_model_len=max_total_tokens=N` form, whose intervening `=max_total_tokens=` descriptor is not in the existing delimiter set (covers the sibling case where the *input* alone exceeds `max_model_len`).

The input-overflow phrasings ("longer than the maximum model length of N", "prompt length N exceeds …") are unchanged and still route to compression — a regression test pins that.

## Related Issue

Fixes #102494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/model_metadata.py` — `parse_available_output_tokens_from_error`: new vLLM gate branch + total-window extraction (pure additions; existing phrasings untouched)
- `agent/model_metadata.py` — `is_output_cap_error`: matching signal branch so the broader gate classifies the phrasing correctly
- `agent/model_metadata.py` — `parse_context_limit_from_error`: new `max_model_len\s*=\s*max_total_tokens\s*=\s*(\d{4,})` pattern ahead of the generic vLLM pattern
- `tests/test_output_cap_parsing.py` — new `TestParseVllmTotalWindowOutputCap` (verbatim 400 message, gate classification, and input-overflow negative case)
- `tests/agent/test_model_metadata.py` — `test_vllm_total_window_cap_format` for the context-limit parser

## How to Test

1. `python -c "from agent.model_metadata import parse_available_output_tokens_from_error as p; print(p('max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144. Please request fewer output tokens. (parameter=max_tokens, value=393216)'))"`
   - Before: `None` (misrouted to compression)
   - After: `262144` (output-cap recovery clamps `max_tokens` and retries)
2. `pytest tests/test_output_cap_parsing.py -q` — Observed result: **20 passed** (17 pre-existing + 3 new)
3. `pytest "tests/agent/test_model_metadata.py::TestParseContextLimitFromError" -q` — Observed result: **14 passed** (13 pre-existing + 1 new)
4. `pytest tests/agent/test_model_metadata.py tests/test_ctx_halving_fix.py -q` — Observed result: **136 passed**, no regressions in the neighboring vLLM/SGLang/llama.cpp phrasing paths

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — #58832 covers vLLM's *input-side* "maximum model length of N" wording, #89504 covers llama.cpp, #83558 covers SGLang; the `max_model_len=max_total_tokens` output-cap rejection here is a distinct phrasing and a distinct hunk
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — targeted suites: `tests/test_output_cap_parsing.py`, `tests/agent/test_model_metadata.py`, `tests/test_ctx_halving_fix.py` all pass; `ruff check` clean
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (behavior documented in code comments)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure string parsing, no platform surface)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Repro of the parsers on the verbatim 400 from #102494 (before → after):

```
parse_available_output_tokens_from_error: None  → 262144
is_output_cap_error:                     False → True
parse_context_limit_from_error:          None  → 262144
# negative: vLLM input-overflow wording still is_output_cap_error=False, parse=None
# unchanged: vLLM token-based phrasing still parses to 32768
```
