### PR TITLE
fix(local-runtime): find nvidia-smi in WSL driver path

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -161,8 +161,8 @@ _smi_path_cache: "tuple[str | None] | None" = None
 
 def _nvidia_smi_path() -> str | None:
     """Absolute path to nvidia-smi, or None. PATH first (respects user
-    overrides), then the driver's known install locations on Windows;
-    on Linux/WSL the PATH lookup is the whole ladder."""
+    overrides), then the driver's known install locations on Windows and
+    WSL."""
     global _smi_path_cache
     if _smi_path_cache is not None:
         return _smi_path_cache[0]
@@ -179,6 +179,12 @@ def _nvidia_smi_path() -> str | None:
             if candidate.exists():
                 found = str(candidate)
                 break
+    elif found is None and sys.platform.startswith("linux"):
+        # The Windows display driver exposes nvidia-smi here inside WSL,
+        # but does not guarantee that the directory is present on PATH.
+        candidate = Path("/usr/lib/wsl/lib/nvidia-smi")
+        if candidate.exists():
+            found = str(candidate)
     _smi_path_cache = (found,)
     return found
 

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -14,6 +14,10 @@ any discrete card."""
 
 from __future__ import annotations
 
+from pathlib import Path
+
+import pytest
+
 import hermes_cli.local_runtime.hardware as hw
 
 GIB = 1 << 30
@@ -183,6 +187,18 @@ def test_smi_resolver_caches_and_survives_empty_path(monkeypatch):
     assert hw._nvidia_smi_path() == "/usr/bin/nvidia-smi"
     assert hw._nvidia_smi_path() == "/usr/bin/nvidia-smi"
     assert len(calls) == 1
+
+
+@pytest.mark.linux_only
+def test_smi_resolver_uses_wsl_driver_path_when_path_is_empty(monkeypatch):
+    """WSL exposes nvidia-smi through the Windows driver directory even
+    when a service PATH cannot resolve it."""
+    wsl_smi = Path("/usr/lib/wsl/lib/nvidia-smi")
+    monkeypatch.setattr(hw, "_smi_path_cache", None)
+    monkeypatch.setattr(hw.shutil, "which", lambda name: None)
+    monkeypatch.setattr(hw.Path, "exists", lambda candidate: candidate == wsl_smi)
+
+    assert hw._nvidia_smi_path() == str(wsl_smi)
 
 
 # ── probe cache ──────────────────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Hermes now finds the NVIDIA driver-provided `nvidia-smi` executable at its standard WSL path when a service environment cannot resolve it through `PATH`.

Without that fallback, the local-model hardware probe treated a discrete NVIDIA GPU as unified memory and displayed the WSL system-RAM total as GPU memory. This keeps normal `PATH` precedence and adds only the documented WSL driver location as the next resolver candidate.

## Related Issue

No GitHub issue.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [ ] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `hermes_cli/local_runtime/hardware.py` - fall back to `/usr/lib/wsl/lib/nvidia-smi` when Linux/WSL cannot resolve `nvidia-smi` through `PATH`.
- `tests/hermes_cli/test_unified_pool_quirk.py` - verify the WSL driver path is selected from an empty service `PATH`.

## How to Test

1. On WSL2 with an NVIDIA GPU, confirm `/usr/lib/wsl/lib/nvidia-smi` exists while `nvidia-smi` is absent from the service `PATH`.
2. Open Desktop against that backend and load the Local models hardware section.
3. Verify Hermes reports the discrete GPU and its VRAM separately from WSL system RAM, without the Unified memory label.

Focused automated coverage was added but not run locally under the workstation test policy. GitHub CI is expected to run it.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: WSL2 with an NVIDIA GPU

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - N/A; the resolver docstring now describes the WSL fallback.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

A WSL2 backend with a discrete NVIDIA GPU was reported as Unified memory, with identical GPU-memory and system-RAM totals. The failing path is deterministic when the service `PATH` omits WSL's driver directory.