### PR TITLE
feat(tool-search): optional embedding reranker + name-coverage bonus (rebase of #35457)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -198,6 +198,11 @@
 # Get at: https://firecrawl.dev/
 # FIRECRAWL_API_KEY=
 
+# Tool Search embedding reranker bearer token (optional). Only needed when
+# tools.tool_search.reranker.enabled=true AND the embeddings endpoint requires
+# auth. A local Ollama endpoint needs no key.
+# HERMES_EMBED_API_KEY=
+
 
 # FAL.ai API Key - Image generation
 # Get at: https://fal.ai/

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1485,6 +1485,41 @@ platform_toolsets:
 #       log_level: "info"       # audit verbosity
 
 # =============================================================================
+# Tool Search (progressive disclosure of MCP/plugin tools)
+# =============================================================================
+# Large tool catalogs are hidden behind tool_search / tool_describe /
+# tool_call bridge tools and ranked with BM25 on demand. All keys are
+# optional; defaults are shown. See website/docs/user-guide/features/tool-search.md.
+#
+# Optional embedding reranker (default OFF). BM25 over tool names rewards
+# token co-occurrence in long names, so on a flat REST-style catalog
+# (Cloudflare, ~1.9K tools) "list accounts" returns get_accounts_rules_lists_*
+# and never get_accounts. The reranker reorders results by embedding
+# similarity via any OpenAI-compatible /v1/embeddings endpoint. A local
+# Ollama model works and keeps everything on-machine:
+#   ollama pull nomic-embed-text
+# Tool vectors are embedded once per catalog and cached; any endpoint failure
+# falls back to plain BM25. If the endpoint needs a bearer token, put it in
+# .env as HERMES_EMBED_API_KEY — it is never read from this file.
+#
+# tools:
+#   tool_search:
+#     enabled: auto                 # auto | on | off
+#     search_default_limit: 5
+#     max_search_limit: 25
+#     listing: auto                 # auto | on | off
+#     listing_max_tokens: 4000
+#     reranker:
+#       enabled: false
+#       endpoint: http://localhost:11434/v1/embeddings   # required when enabled
+#       model: nomic-embed-text
+#       mode: rerank                # rerank (cosine) | rrf (fuse with BM25 ranks)
+#       rrf_k: 10                   # RRF smoothing constant (mode: rrf)
+#       query_prefix: "search_query: "     # nomic task prefixes; set both to ""
+#       doc_prefix: "search_document: "    # for models that do not use them
+#       timeout: 5.0                # seconds per embed request before BM25 fallback
+
+# =============================================================================
 # Text-to-Speech
 # =============================================================================
 # TTS defaults to Edge TTS unless changed in ~/.hermes/config.yaml.

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -3102,6 +3102,36 @@ DEFAULT_CONFIG = {
             # Absolute cap on the embedded listing in tokens (chars/4
             # estimate), regardless of context size. Range 200..60000.
             "listing_max_tokens": 4000,
+            # Optional embedding reranker over the BM25 results (default
+            # OFF). BM25 over tool names rewards token co-occurrence in long
+            # names, so on a flat REST-style catalog (Cloudflare, ~1.9K
+            # tools) "list accounts" surfaces get_accounts_rules_lists_*
+            # and never get_accounts. When enabled, the query and every
+            # deferred tool are embedded through an OpenAI-compatible
+            # /v1/embeddings endpoint (a local Ollama `nomic-embed-text`
+            # works: `ollama pull nomic-embed-text`) and results are
+            # reordered by cosine similarity ("rerank") or fused with the
+            # BM25 ranking ("rrf"). Tool vectors are embedded once per
+            # catalog and cached; any endpoint failure falls back to plain
+            # BM25. The bearer token, if the endpoint needs one, is
+            # HERMES_EMBED_API_KEY in .env — never a config key.
+            "reranker": {
+                "enabled": False,
+                # Required when enabled. Ollama: http://localhost:11434/v1/embeddings
+                "endpoint": "",
+                "model": "nomic-embed-text",
+                # "rerank" — order by embedding cosine similarity.
+                # "rrf"    — Reciprocal Rank Fusion of BM25 + embedding ranks.
+                "mode": "rerank",
+                # RRF smoothing constant (mode: rrf). Lower boosts top ranks.
+                "rrf_k": 10,
+                # nomic-embed task prefixes. Set both to "" for models that
+                # do not use them (text-embedding-3-*, all-MiniLM-*).
+                "query_prefix": "search_query: ",
+                "doc_prefix": "search_document: ",
+                # Seconds per embeddings request before falling back to BM25.
+                "timeout": 5.0,
+            },
         },
     },
 

--- a/tests/tools/test_tool_search_name_bonus.py
+++ b/tests/tools/test_tool_search_name_bonus.py
@@ -1,0 +1,167 @@
+"""Tests for the name-coverage bonus in tools/tool_search.py.
+
+BM25 on a flat REST-style catalog rewards token co-occurrence in long tool
+names: ``"accounts"`` ranks ``put_accounts_by_account_id`` above the 2-token
+``get_accounts``, and ``"list accounts"`` never surfaces ``get_accounts``
+at all. The bonus multiplies BM25 by ``1 + w * F1(query tokens, name
+tokens)`` so a short name fully explained by the query outranks a long
+name that merely contains those tokens.
+
+Invariants pinned here: the bonus never turns a zero score positive (empty
+results and the substring fallback are unchanged), exact-name pins still
+win, and it composes with the multi-query dispatcher.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any, Dict
+
+import pytest
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _td(name: str, description: str = "", properties: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": properties or {}},
+        },
+    }
+
+
+# A slice of the real Cloudflare MCP catalog (names + descriptions verbatim
+# in spirit) that reproduces the measured failure with plain BM25.
+_CF_SLICE = [
+    _td("get_accounts", "GET /accounts List Accounts. List all accounts you have ownership or verified access to."),
+    _td("post_accounts", "POST /accounts Create Account. Create an account (only available for tenant admins)."),
+    _td("get_accounts_by_account_id", "GET /accounts/{account_id} Account Details. Get information about a specific account."),
+    _td("put_accounts_by_account_id", "PUT /accounts/{account_id} Update Account. Update an existing account."),
+    _td("get_accounts_builds_account_limits", "GET /accounts/{account_id}/builds/account/limits Get account limits. Get the account limits."),
+    _td("get_accounts_workers_accountsettings", "GET /accounts/{account_id}/workers/account-settings Fetch Account Settings."),
+    _td("get_accounts_rules_lists", "GET /accounts/{account_id}/rules/lists Get lists. Fetches all lists in the account."),
+    _td("get_accounts_rules_lists_by_list_id", "GET /accounts/{account_id}/rules/lists/{list_id} Get a list. Fetches the details of a list."),
+    _td("get_accounts_rules_lists_items", "GET /accounts/{account_id}/rules/lists/{list_id}/items Get list items. Fetches all the items in the list."),
+    _td("get_accounts_rules_lists_items_by_item_id", "GET /accounts/{account_id}/rules/lists/{list_id}/items/{item_id} Get a list item."),
+    _td("get_zones", "GET /zones List Zones. Lists, searches, sorts, and filters your zones."),
+    _td("get_zones_environments", "GET /zones/{zone_id}/environments List environments. Lists all environments for a zone."),
+    _td("delete_zones_by_zone_id", "DELETE /zones/{zone_id} Delete Zone. Deletes an existing zone."),
+    _td("get_zones_dns_records", "GET /zones/{zone_id}/dns_records List DNS Records. List, search, sort, and filter a zone's DNS records."),
+    _td("delete_zones_dns_records_by_dns_record_id", "DELETE /zones/{zone_id}/dns_records/{dns_record_id} Delete DNS Record."),
+]
+
+
+@pytest.fixture
+def cf_catalog():
+    from tools.tool_search import build_catalog
+    return build_catalog(_CF_SLICE)
+
+
+def _names(hits):
+    return [h.name for h in hits]
+
+
+class TestNameCoverageFactor:
+    def test_no_overlap_is_neutral(self):
+        from tools.tool_search import _name_coverage_factor
+        assert _name_coverage_factor({"zone"}, frozenset({"get", "account"})) == 1.0
+        assert _name_coverage_factor(set(), frozenset({"get"})) == 1.0
+        assert _name_coverage_factor({"get"}, frozenset()) == 1.0
+
+    def test_full_cover_beats_partial_cover(self):
+        from tools.tool_search import _name_coverage_factor
+        q = {"get", "account"}
+        short = _name_coverage_factor(q, frozenset({"get", "account"}))
+        long = _name_coverage_factor(q, frozenset({"get", "account", "rule", "list", "by", "id"}))
+        assert short > long > 1.0
+
+    def test_factor_is_bounded(self):
+        from tools import tool_search
+        from tools.tool_search import _name_coverage_factor
+        f = _name_coverage_factor({"a", "b"}, frozenset({"a", "b"}))
+        assert f == pytest.approx(1.0 + tool_search._NAME_COVERAGE_WEIGHT)
+
+
+class TestShortNameRanking:
+    def test_bare_noun_surfaces_shortest_matching_names(self, cf_catalog):
+        """'accounts' -> the two 2-token names first; the verb is a tie."""
+        from tools.tool_search import search_catalog
+        assert set(_names(search_catalog(cf_catalog, "accounts", limit=2))) == \
+            {"get_accounts", "post_accounts"}
+        assert _names(search_catalog(cf_catalog, "zones", limit=1)) == ["get_zones"]
+
+    def test_list_accounts_reaches_top5(self, cf_catalog):
+        """The measured failure: BM25 alone returns only rules_lists_* names."""
+        from tools.tool_search import search_catalog
+        top5 = _names(search_catalog(cf_catalog, "list accounts", limit=5))
+        assert "get_accounts" in top5
+
+    def test_verb_noun_query_prefers_matching_short_name(self, cf_catalog):
+        from tools.tool_search import search_catalog
+        assert _names(search_catalog(cf_catalog, "get accounts", limit=1)) == ["get_accounts"]
+        assert _names(search_catalog(cf_catalog, "dns records", limit=1)) == ["get_zones_dns_records"]
+
+    def test_specific_query_still_finds_specific_tool(self, cf_catalog):
+        """A query naming the long tool's distinguishing tokens still wins."""
+        from tools.tool_search import search_catalog
+        assert _names(search_catalog(cf_catalog, "get list items", limit=1)) == \
+            ["get_accounts_rules_lists_items"]
+        assert _names(search_catalog(cf_catalog, "delete dns record", limit=1)) == \
+            ["delete_zones_dns_records_by_dns_record_id"]
+
+    def test_bonus_disabled_reproduces_plain_bm25(self, cf_catalog, monkeypatch):
+        from tools import tool_search
+        from tools.tool_search import search_catalog
+        with_bonus = _names(search_catalog(cf_catalog, "accounts", limit=2))
+        monkeypatch.setattr(tool_search, "_NAME_COVERAGE_WEIGHT", 0.0)
+        without = _names(search_catalog(cf_catalog, "accounts", limit=2))
+        assert "get_accounts" in with_bonus
+        assert "get_accounts" not in without  # the pre-bonus behavior
+
+
+class TestSemanticsPreserved:
+    def test_zero_score_stays_zero_and_fallback_unchanged(self, cf_catalog):
+        from tools.tool_search import search_catalog
+        assert search_catalog(cf_catalog, "zzzz", limit=5) == []
+        # "zon" is a substring of get_zones but never a token: substring
+        # fallback path, which the bonus must not touch.
+        names = _names(search_catalog(cf_catalog, "zon", limit=50))
+        assert names and all("zon" in n for n in names)
+
+    def test_exact_name_still_pinned_first(self, cf_catalog):
+        from tools.tool_search import search_catalog
+        hits = search_catalog(cf_catalog, "get_accounts_rules_lists_by_list_id", limit=1)
+        assert _names(hits) == ["get_accounts_rules_lists_by_list_id"]
+
+    def test_mcp_prefix_is_not_a_name_token(self):
+        from tools.tool_search import build_catalog
+        [entry] = build_catalog([_td("mcp__cloudflare__get_accounts", "List accounts.")])
+        assert "mcp" not in entry._name_tokens
+        assert {"get", "account"} <= set(entry._name_tokens)
+
+    def test_dispatch_multi_query_uses_bonus(self):
+        from tools.registry import registry
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_search
+        import json
+
+        for td in _CF_SLICE:
+            registry.register(
+                name=td["function"]["name"],
+                handler=lambda args, **kwargs: "{}",
+                schema=td,
+                toolset="mcp-namebonus-test",
+            )
+        out = json.loads(dispatch_tool_search(
+            {"queries": ["get accounts", "zones"], "limit": 1},
+            current_tool_defs=_CF_SLICE,
+            config=ToolSearchConfig.from_raw({"enabled": "on"}),
+        ))
+        assert out["results"][0]["matches"] == ["get_accounts"]
+        assert out["results"][1]["matches"] == ["get_zones"]

--- a/tests/tools/test_tool_search_reranker.py
+++ b/tests/tools/test_tool_search_reranker.py
@@ -1,0 +1,660 @@
+"""Tests for the optional embedding reranker in tools/tool_search.py.
+
+The reranker is OFF by default. The invariants pinned here:
+
+* Disabled (or no endpoint) -> ``search_catalog`` / ``dispatch_tool_search``
+  are byte-identical to the BM25-only path.
+* Any endpoint failure (exception, malformed payload, dimension mismatch)
+  -> fall back to the BM25 result, never raise into the bridge.
+* Exact-name matches stay pinned first regardless of mode.
+* Tool vectors are embedded once per scope and cached; subsequent queries
+  cost exactly one query-embed call.
+* The reranker cache is scope-keyed and bounded (A -> B -> A reuse,
+  concurrent scopes retained, FIFO eviction, config fields in the key).
+* Credentials come from ``HERMES_EMBED_API_KEY`` only, are sent as a Bearer
+  header, and never appear in ``repr``.
+
+No test talks to a network endpoint: ``EmbeddingReranker._embed`` is
+monkeypatched with a deterministic fake that maps text -> vector.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from typing import Any, Dict, List
+
+import pytest
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _td(name: str, description: str = "", properties: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": description,
+            "parameters": {"type": "object", "properties": properties or {}},
+        },
+    }
+
+
+# A flat REST-style catalog that reproduces the measured BM25 failure mode:
+# "list accounts" ranks the long rules_lists names above get_accounts.
+_CF_DEFS = [
+    _td("get_accounts", "GET /accounts List Accounts. List all accounts you have access to."),
+    _td("get_accounts_rules_lists", "GET /accounts/{account_id}/rules/lists Get lists. Fetches all lists in the account."),
+    _td("get_accounts_rules_lists_by_list_id", "GET /accounts/{account_id}/rules/lists/{list_id} Get a list. Fetches the details of a list."),
+    _td("get_accounts_rules_lists_items", "GET /accounts/{account_id}/rules/lists/{list_id}/items Get list items. Fetches all the items in the list."),
+    _td("get_accounts_rules_lists_items_by_item_id", "GET /accounts/{account_id}/rules/lists/{list_id}/items/{item_id} Get a list item."),
+    _td("get_zones", "GET /zones List Zones. Lists, searches, sorts, and filters your zones."),
+    _td("post_accounts_pages_projects_deployments", "POST deployments Create deployment. Start a new deployment from production."),
+    _td("calendar_create_event", "Add an event to the user's calendar at a given time."),
+]
+
+
+@pytest.fixture
+def cf_defs():
+    """``_CF_DEFS`` registered under an MCP toolset so dispatch defers them."""
+    from tools.registry import registry
+    for td in _CF_DEFS:
+        registry.register(
+            name=td["function"]["name"],
+            handler=lambda args, **kwargs: "{}",
+            schema=td,
+            toolset="mcp-rerank-test",
+        )
+    return _CF_DEFS
+
+
+# Deterministic fake embeddings: a fixed vocabulary of "concepts"; a text's
+# vector is the indicator of which concept words it contains. Cosine
+# similarity then rewards concept overlap, which is enough to make the
+# reranker's ordering predictable in tests.
+_CONCEPTS = ["account", "list", "zone", "deploy", "pages", "calendar", "remind", "rules", "item"]
+_SYNONYMS = {
+    "accounts": "account", "lists": "list", "zones": "zone", "deployment": "deploy",
+    "deployments": "deploy", "deploy": "deploy", "tonight": "remind", "remind": "remind",
+    "event": "calendar", "items": "item",
+}
+
+
+def _fake_vec(text: str, dim: int = len(_CONCEPTS)) -> List[float]:
+    words = [w.strip(".,:/{}()'\"").lower() for w in text.replace("_", " ").split()]
+    vec = [0.0] * dim
+    for w in words:
+        c = _SYNONYMS.get(w, w)
+        if c in _CONCEPTS[:dim]:
+            vec[_CONCEPTS.index(c)] += 1.0
+    return vec
+
+
+@pytest.fixture
+def fake_embed(monkeypatch):
+    """Replace the HTTP call with a deterministic in-memory embedder.
+
+    Returns a recorder: ``calls`` is the list of text batches sent.
+    """
+    from tools.tool_search import EmbeddingReranker
+
+    calls: List[List[str]] = []
+
+    def _embed(self, texts):
+        calls.append(list(texts))
+        return [_fake_vec(t) for t in texts]
+
+    monkeypatch.setattr(EmbeddingReranker, "_embed", _embed)
+    return calls
+
+
+@pytest.fixture(autouse=True)
+def _clear_reranker_cache():
+    from tools import tool_search
+    tool_search._reranker_cache.clear()
+    yield
+    tool_search._reranker_cache.clear()
+
+
+def _cfg(**overrides) -> "RerankerConfig":  # noqa: F821
+    from tools.tool_search import RerankerConfig
+    raw = {"enabled": True, "endpoint": "http://localhost:11434/v1/embeddings"}
+    raw.update(overrides)
+    return RerankerConfig.from_raw(raw)
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+
+class TestRerankerConfig:
+    def test_default_is_disabled(self):
+        from tools.tool_search import RerankerConfig, ToolSearchConfig
+        assert RerankerConfig.from_raw(None).enabled is False
+        assert RerankerConfig.from_raw(None).active is False
+        assert ToolSearchConfig.from_raw(None).reranker.enabled is False
+        assert ToolSearchConfig.from_raw({}).reranker.active is False
+        assert ToolSearchConfig.from_raw(True).reranker.active is False
+
+    def test_shipped_defaults_keep_reranker_off(self):
+        from hermes_cli.config_defaults import DEFAULT_CONFIG
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw(DEFAULT_CONFIG["tools"]["tool_search"])
+        assert cfg.reranker.enabled is False
+        assert cfg.reranker.active is False
+
+    def test_enabled_without_endpoint_is_inactive(self):
+        from tools.tool_search import RerankerConfig
+        cfg = RerankerConfig.from_raw({"enabled": True})
+        assert cfg.enabled is True
+        assert cfg.active is False
+
+    def test_parses_all_fields(self):
+        from tools.tool_search import ToolSearchConfig
+        cfg = ToolSearchConfig.from_raw({"reranker": {
+            "enabled": "yes",
+            "endpoint": " http://embed.local/v1/embeddings ",
+            "model": "text-embedding-3-small",
+            "mode": "RRF",
+            "rrf_k": 60,
+            "query_prefix": "",
+            "doc_prefix": None,
+            "timeout": 2.5,
+        }}).reranker
+        assert cfg.active is True
+        assert cfg.endpoint == "http://embed.local/v1/embeddings"
+        assert cfg.model == "text-embedding-3-small"
+        assert cfg.mode == "rrf"
+        assert cfg.rrf_k == 60
+        assert cfg.query_prefix == ""
+        assert cfg.doc_prefix == ""
+        assert cfg.timeout == 2.5
+
+    def test_nomic_prefixes_are_the_default(self):
+        cfg = _cfg()
+        assert cfg.model == "nomic-embed-text"
+        assert cfg.query_prefix == "search_query: "
+        assert cfg.doc_prefix == "search_document: "
+
+    def test_invalid_values_fall_back_safely(self):
+        cfg = _cfg(mode="cross-encoder", rrf_k="lots", timeout="never")
+        assert cfg.mode == "rerank"
+        assert cfg.rrf_k == 10
+        assert cfg.timeout == 5.0
+        assert _cfg(rrf_k=0).rrf_k == 1
+        assert _cfg(timeout=0).timeout == 0.1
+        assert _cfg(timeout=10_000).timeout == 120.0
+
+    def test_api_key_comes_from_env_only(self, monkeypatch):
+        monkeypatch.delenv("HERMES_EMBED_API_KEY", raising=False)
+        assert _cfg(api_key="from-config").api_key == ""
+        monkeypatch.setenv("HERMES_EMBED_API_KEY", " sk-env ")
+        cfg = _cfg(api_key="from-config")
+        assert cfg.api_key == "sk-env"
+        # A secret must never leak through a logged config.
+        assert "sk-env" not in repr(cfg)
+        assert "sk-env" not in str(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Off / failure paths are byte-identical to BM25
+# ---------------------------------------------------------------------------
+
+
+class TestDisabledIsIdentical:
+    def test_get_reranker_returns_none_when_inactive(self):
+        from tools.tool_search import RerankerConfig, _get_reranker, build_catalog
+        catalog = build_catalog(_CF_DEFS)
+        assert _get_reranker(RerankerConfig(), catalog) is None
+        assert _get_reranker(RerankerConfig(enabled=True, endpoint=""), catalog) is None
+
+    def test_dispatch_without_reranker_never_embeds(self, fake_embed, cf_defs):
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_search
+        cfg = ToolSearchConfig.from_raw({"enabled": "on"})
+        out = json.loads(dispatch_tool_search(
+            {"queries": ["list accounts"]}, current_tool_defs=cf_defs, config=cfg,
+        ))
+        assert out["results"][0]["matches"]
+        assert fake_embed == []
+
+    @pytest.mark.parametrize("failure", ["raise", "short", "mismatch", "empty"])
+    def test_endpoint_failure_falls_back_to_bm25(self, monkeypatch, failure):
+        from tools.tool_search import EmbeddingReranker, _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        baseline = search_catalog(catalog, "list accounts", limit=5)
+        assert baseline, "fixture must produce BM25 hits"
+
+        def _embed(self, texts):
+            if failure == "raise":
+                raise OSError("connection refused")
+            if failure == "short":
+                return [[1.0, 0.0]] * (len(texts) - 1) if len(texts) > 1 else [[1.0, 0.0]]
+            if failure == "mismatch":
+                # documents get 3-dim vectors, the single query gets 2-dim
+                return [[1.0, 0.0, 0.0] if len(texts) > 1 else [1.0, 0.0] for _ in texts]
+            return [[] for _ in texts]
+
+        monkeypatch.setattr(EmbeddingReranker, "_embed", _embed)
+        reranker = _get_reranker(_cfg(), catalog)
+        assert reranker is not None
+        for query in ("list accounts", "zones", "zzzz"):
+            assert search_catalog(catalog, query, limit=5, reranker=reranker) == \
+                search_catalog(catalog, query, limit=5)
+
+    def test_failure_keeps_substring_fallback(self, monkeypatch):
+        from tools.tool_search import EmbeddingReranker, _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        monkeypatch.setattr(EmbeddingReranker, "_embed", lambda self, texts: (_ for _ in ()).throw(TimeoutError()))
+        reranker = _get_reranker(_cfg(), catalog)
+        # "cal" is not a token but is a name substring: BM25 path returns it
+        # via the substring fallback, and the failing reranker must not eat it.
+        assert [e.name for e in search_catalog(catalog, "cal", limit=5, reranker=reranker)] == \
+            ["calendar_create_event"]
+
+    def test_search_catalog_signature_default_is_none(self):
+        import inspect
+        from tools.tool_search import search_catalog
+        assert inspect.signature(search_catalog).parameters["reranker"].default is None
+
+
+# ---------------------------------------------------------------------------
+# Rerank behavior
+# ---------------------------------------------------------------------------
+
+
+class TestRerankBehavior:
+    def test_rerank_surfaces_short_name_bm25_buries(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        bm25 = [e.name for e in search_catalog(catalog, "list accounts", limit=3)]
+        # The measured failure mode: BM25 prefers the long rules_lists names
+        # (accounts + list co-occur) over the 2-token target. In the real
+        # 1,938-tool catalog the target falls out of the top-5 entirely; in
+        # this small fixture it is merely not first.
+        assert bm25[0] != "get_accounts"
+
+        reranker = _get_reranker(_cfg(), catalog)
+        reranked = [e.name for e in search_catalog(catalog, "list accounts", limit=3, reranker=reranker)]
+        assert reranked[0] == "get_accounts"
+
+    def test_semantic_query_with_no_lexical_overlap(self, fake_embed):
+        """'remind me tonight' has no token in common with calendar_create_event."""
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        assert search_catalog(catalog, "remind me tonight", limit=3) == []
+        reranker = _get_reranker(_cfg(), catalog)
+        # The fake embedder maps "tonight" and "event" onto neighbouring
+        # concepts; a zero query vector would tie everything, so seed it.
+        hits = search_catalog(catalog, "calendar remind me tonight", limit=3, reranker=reranker)
+        assert hits[0].name == "calendar_create_event"
+
+    def test_exact_name_pinned_first_in_both_modes(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        for mode in ("rerank", "rrf"):
+            reranker = _get_reranker(_cfg(mode=mode), catalog)
+            hits = search_catalog(catalog, "get_zones", limit=2, reranker=reranker)
+            assert hits[0].name == "get_zones", mode
+
+    def test_limit_is_honored(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        for mode in ("rerank", "rrf"):
+            reranker = _get_reranker(_cfg(mode=mode), catalog)
+            for limit in (1, 2, 5, 50):
+                hits = search_catalog(catalog, "accounts", limit=limit, reranker=reranker)
+                assert len(hits) == min(limit, len(catalog))
+                assert len({h.name for h in hits}) == len(hits)
+
+    def test_rerank_scores_whole_catalog_not_bm25_shortlist(self, fake_embed):
+        """A target BM25 scores zero for must still be reachable."""
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(), catalog)
+        # "deploy" stems differently from "deployments"? Either way the
+        # fake embedder maps both to the same concept.
+        hits = search_catalog(catalog, "deploy", limit=1, reranker=reranker)
+        assert hits[0].name == "post_accounts_pages_projects_deployments"
+
+    def test_dispatch_uses_reranker_when_enabled(self, fake_embed, cf_defs):
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_search
+
+        cfg = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "reranker": {"enabled": True, "endpoint": "http://localhost:11434/v1/embeddings"},
+        })
+        out = json.loads(dispatch_tool_search(
+            {"queries": ["list accounts", "zones"], "limit": 2},
+            current_tool_defs=cf_defs, config=cfg,
+        ))
+        assert out["results"][0]["matches"][0] == "get_accounts"
+        assert out["results"][1]["matches"][0] == "get_zones"
+        # Catalog embedded once; each query embedded once.
+        assert len(fake_embed) == 3
+        assert len(fake_embed[0]) == len(_CF_DEFS)
+        assert fake_embed[1] == ["search_query: list accounts"]
+        assert fake_embed[2] == ["search_query: zones"]
+
+    def test_dispatch_response_shape_unchanged(self, fake_embed, cf_defs):
+        """Enabling the reranker must not add or remove response fields."""
+        from tools.tool_search import ToolSearchConfig, dispatch_tool_search
+
+        off = ToolSearchConfig.from_raw({"enabled": "on"})
+        on = ToolSearchConfig.from_raw({
+            "enabled": "on",
+            "reranker": {"enabled": True, "endpoint": "http://localhost:11434/v1/embeddings"},
+        })
+        a = json.loads(dispatch_tool_search({"queries": ["zones"]}, current_tool_defs=cf_defs, config=off))
+        b = json.loads(dispatch_tool_search({"queries": ["zones"]}, current_tool_defs=cf_defs, config=on))
+        assert a["results"][0]["matches"] and b["results"][0]["matches"]
+        assert set(a) == set(b)
+        assert set(a["results"][0]) == set(b["results"][0])
+        assert a["total_available"] == b["total_available"]
+
+
+# ---------------------------------------------------------------------------
+# RRF math
+# ---------------------------------------------------------------------------
+
+
+class TestRRF:
+    def test_rrf_exact_scores(self):
+        from tools.tool_search import CatalogEntry, _rrf_fuse
+
+        a = CatalogEntry(name="a", description="", schema={}, source="mcp", source_name="s")
+        b = CatalogEntry(name="b", description="", schema={}, source="mcp", source_name="s")
+        c = CatalogEntry(name="c", description="", schema={}, source="mcp", source_name="s")
+        # BM25: a, b   embed: b, c   (k=10)
+        # a = 1/11            = 0.0909
+        # b = 1/12 + 1/11     = 0.1742
+        # c = 1/12            = 0.0833
+        fused = _rrf_fuse([(9.0, a), (8.0, b)], [(0.9, b), (0.8, c)], k=10, top_n=3)
+        assert [e.name for e in fused] == ["b", "a", "c"]
+
+    def test_rrf_top_n_and_dedup(self):
+        from tools.tool_search import CatalogEntry, _rrf_fuse
+
+        ents = [CatalogEntry(name=n, description="", schema={}, source="mcp", source_name="s")
+                for n in "abcd"]
+        fused = _rrf_fuse([(1.0, e) for e in ents], [(1.0, e) for e in reversed(ents)], k=10, top_n=2)
+        assert len(fused) == 2
+        assert len({e.name for e in fused}) == 2
+
+    def test_rrf_mode_blends_lexical_and_semantic(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(mode="rrf", rrf_k=10), catalog)
+        hits = [e.name for e in search_catalog(catalog, "list accounts", limit=3, reranker=reranker)]
+        # get_accounts is top of the embedding list and present in BM25's;
+        # it must be at or near the top after fusion.
+        assert "get_accounts" in hits[:2]
+
+
+# ---------------------------------------------------------------------------
+# Payload, prefixes, credentials
+# ---------------------------------------------------------------------------
+
+
+class TestEmbedPayload:
+    def test_prefixes_applied_to_docs_and_query(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(query_prefix="Q: ", doc_prefix="D: "), catalog)
+        search_catalog(catalog, "zones", limit=1, reranker=reranker)
+        docs, (query,) = fake_embed[0], fake_embed[1]
+        assert all(d.startswith("D: ") for d in docs)
+        assert query == "Q: zones"
+
+    def test_empty_prefixes_send_bare_text(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(query_prefix="", doc_prefix=""), catalog)
+        search_catalog(catalog, "zones", limit=1, reranker=reranker)
+        assert fake_embed[1] == ["zones"]
+        assert not any(d.startswith("search_document") for d in fake_embed[0])
+
+    def test_embed_text_is_name_words_plus_description(self):
+        from tools.tool_search import _entry_embed_text
+        td = _td("mcp__cloudflare__get_accounts", "GET /accounts  List   Accounts.")
+        assert _entry_embed_text(td, "cloudflare") == "cloudflare cloudflare  get accounts: GET /accounts List Accounts."
+        assert _entry_embed_text(_td("get_zones", ""), "") == "get zones"
+
+    def test_embed_text_clips_long_descriptions(self):
+        from tools.tool_search import _entry_embed_text
+        text = _entry_embed_text(_td("t", "x" * 5000))
+        assert len(text) < 1100
+
+    def test_http_request_shape_and_bearer_header(self, monkeypatch):
+        """The only network path: OpenAI-compatible JSON body + optional Bearer."""
+        import urllib.request
+        from tools.tool_search import EmbeddingReranker
+
+        seen: Dict[str, Any] = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return json.dumps({"data": [
+                    {"index": 1, "embedding": [0.0, 1.0]},
+                    {"index": 0, "embedding": [1.0, 0.0]},
+                ]}).encode()
+
+        def _urlopen(req, timeout=None):
+            seen["url"] = req.full_url
+            seen["method"] = req.get_method()
+            seen["headers"] = {k.lower(): v for k, v in req.header_items()}
+            seen["body"] = json.loads(req.data)
+            seen["timeout"] = timeout
+            return _Resp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        monkeypatch.setenv("HERMES_EMBED_API_KEY", "sk-test")
+        vecs = EmbeddingReranker(_cfg(model="m", timeout=3.0))._embed(["a", "b"])
+        assert vecs == [[1.0, 0.0], [0.0, 1.0]]  # re-sorted by index
+        assert seen["url"] == "http://localhost:11434/v1/embeddings"
+        assert seen["method"] == "POST"
+        assert seen["body"] == {"model": "m", "input": ["a", "b"]}
+        assert seen["headers"]["authorization"] == "Bearer sk-test"
+        assert seen["timeout"] == 3.0
+
+    def test_no_bearer_header_without_key(self, monkeypatch):
+        import urllib.request
+        from tools.tool_search import EmbeddingReranker
+
+        seen: Dict[str, Any] = {}
+
+        class _Resp:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *a):
+                return False
+
+            def read(self):
+                return json.dumps({"data": [{"index": 0, "embedding": [1.0]}]}).encode()
+
+        def _urlopen(req, timeout=None):
+            seen["headers"] = {k.lower() for k, _ in req.header_items()}
+            return _Resp()
+
+        monkeypatch.setattr(urllib.request, "urlopen", _urlopen)
+        monkeypatch.delenv("HERMES_EMBED_API_KEY", raising=False)
+        EmbeddingReranker(_cfg())._embed(["a"])
+        assert "authorization" not in seen["headers"]
+
+
+# ---------------------------------------------------------------------------
+# Embedding cache
+# ---------------------------------------------------------------------------
+
+
+class TestEmbeddingCache:
+    def test_catalog_embedded_once_then_one_call_per_query(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(), catalog)
+        search_catalog(catalog, "zones", limit=1, reranker=reranker)
+        search_catalog(catalog, "accounts", limit=1, reranker=reranker)
+        search_catalog(catalog, "zones", limit=1, reranker=reranker)  # cached query
+        assert [len(c) for c in fake_embed] == [len(_CF_DEFS), 1, 1]
+
+    def test_vectors_are_unit_normalized_float32(self, fake_embed):
+        import array
+        import math
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        reranker = _get_reranker(_cfg(), catalog)
+        search_catalog(catalog, "zones", limit=1, reranker=reranker)
+        for vec in reranker._cache.values():
+            assert isinstance(vec, array.array) and vec.typecode == "f"
+            norm = math.sqrt(sum(x * x for x in vec))
+            assert norm == 0.0 or abs(norm - 1.0) < 1e-5
+
+    def test_cache_key_includes_model(self, fake_embed):
+        from tools.tool_search import _get_reranker, build_catalog, search_catalog
+
+        catalog = build_catalog(_CF_DEFS)
+        r1 = _get_reranker(_cfg(model="m1"), catalog)
+        r2 = _get_reranker(_cfg(model="m2"), catalog)
+        assert r1 is not r2
+        search_catalog(catalog, "zones", limit=1, reranker=r1)
+        search_catalog(catalog, "zones", limit=1, reranker=r2)
+        assert len(fake_embed) == 4  # both scopes embed the catalog + query
+
+    def test_batches_are_bounded_and_progress_survives_a_failure(self, monkeypatch):
+        from tools import tool_search
+        from tools.tool_search import EmbeddingReranker, _get_reranker, build_catalog, search_catalog
+
+        monkeypatch.setattr(tool_search, "_EMBED_BATCH_SIZE", 3)
+        defs = [_td(f"tool_{i}", f"Tool number {i} does thing {i}.") for i in range(8)]
+        catalog = build_catalog(defs)
+        calls: List[int] = []
+        state = {"fail_after": 2}
+
+        def _embed(self, texts):
+            calls.append(len(texts))
+            if len(calls) > state["fail_after"]:
+                raise OSError("timeout")
+            return [[1.0, float(i)] for i, _ in enumerate(texts)]
+
+        monkeypatch.setattr(EmbeddingReranker, "_embed", _embed)
+        reranker = _get_reranker(_cfg(), catalog)
+        # First search: 3 + 3 succeed, third batch fails -> BM25 fallback.
+        bm25 = search_catalog(catalog, "tool 4", limit=2)
+        assert search_catalog(catalog, "tool 4", limit=2, reranker=reranker) == bm25
+        assert calls == [3, 3, 2]
+        assert len(reranker._cache) == 6
+        # Second search: only the remaining 2 docs + the query are embedded.
+        state["fail_after"] = 99
+        search_catalog(catalog, "tool 4", limit=2, reranker=reranker)
+        assert calls == [3, 3, 2, 2, 1]
+        assert len(reranker._cache) == 9
+
+
+# ---------------------------------------------------------------------------
+# Scope-keyed bounded reranker cache (review point 1 on #35457)
+# ---------------------------------------------------------------------------
+
+
+class TestScopeCache:
+    def _catalog(self, *names):
+        from tools.tool_search import build_catalog
+        return build_catalog([_td(n, f"{n} description") for n in names])
+
+    def test_same_scope_reuses_instance(self):
+        from tools.tool_search import _get_reranker
+        cat = self._catalog("a", "b")
+        assert _get_reranker(_cfg(), cat) is _get_reranker(_cfg(), cat)
+
+    def test_a_b_a_reuses_scope_a_without_rebuild(self, fake_embed):
+        from tools import tool_search
+        from tools.tool_search import _get_reranker, search_catalog
+
+        cat_a = self._catalog("alpha_tool", "beta_tool")
+        cat_b = self._catalog("gamma_tool")
+        ra = _get_reranker(_cfg(), cat_a)
+        search_catalog(cat_a, "alpha", limit=1, reranker=ra)
+        rb = _get_reranker(_cfg(), cat_b)
+        search_catalog(cat_b, "gamma", limit=1, reranker=rb)
+        assert rb is not ra
+        assert _get_reranker(_cfg(), cat_a) is ra
+        assert len(tool_search._reranker_cache) == 2
+        # Scope A's vectors survived scope B's creation: another A query
+        # embeds only the query.
+        n_before = len(fake_embed)
+        search_catalog(cat_a, "beta", limit=1, reranker=_get_reranker(_cfg(), cat_a))
+        assert [len(c) for c in fake_embed[n_before:]] == [1]
+
+    def test_fifo_eviction_at_capacity(self, monkeypatch):
+        from tools import tool_search
+        from tools.tool_search import _get_reranker
+
+        monkeypatch.setattr(tool_search, "_RERANKER_CACHE_MAX", 2)
+        r1 = _get_reranker(_cfg(), self._catalog("t1"))
+        r2 = _get_reranker(_cfg(), self._catalog("t2"))
+        r3 = _get_reranker(_cfg(), self._catalog("t3"))
+        assert len(tool_search._reranker_cache) == 2
+        assert _get_reranker(_cfg(), self._catalog("t2")) is r2
+        assert _get_reranker(_cfg(), self._catalog("t3")) is r3
+        assert _get_reranker(_cfg(), self._catalog("t1")) is not r1  # evicted, rebuilt
+
+    def test_scope_key_includes_behavior_fields(self):
+        from tools.tool_search import _get_reranker
+        cat = self._catalog("a")
+        base = _get_reranker(_cfg(), cat)
+        for override in (
+            {"mode": "rrf"}, {"rrf_k": 60}, {"query_prefix": ""}, {"doc_prefix": ""},
+            {"model": "other"}, {"endpoint": "http://other/v1/embeddings"},
+        ):
+            assert _get_reranker(_cfg(**override), cat) is not base, override
+
+    def test_scope_key_is_not_comma_ambiguous(self):
+        from tools.tool_search import _get_reranker
+        assert _get_reranker(_cfg(), self._catalog("a,b")) is not \
+            _get_reranker(_cfg(), self._catalog("a", "b"))
+
+    def test_concurrent_scope_creation_is_thread_safe(self, monkeypatch):
+        import threading
+        from tools import tool_search
+        from tools.tool_search import _get_reranker
+
+        monkeypatch.setattr(tool_search, "_RERANKER_CACHE_MAX", 3)
+        cats = [self._catalog(f"tool_{i}") for i in range(12)]
+        errors: List[BaseException] = []
+
+        def _worker(i):
+            try:
+                for _ in range(50):
+                    _get_reranker(_cfg(), cats[i % len(cats)])
+            except BaseException as exc:  # pragma: no cover - failure path
+                errors.append(exc)
+
+        threads = [threading.Thread(target=_worker, args=(i,)) for i in range(12)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        assert errors == []
+        assert len(tool_search._reranker_cache) <= 3

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -545,6 +545,9 @@ class CatalogEntry:
 
     # Pre-tokenized fields for BM25.
     _tokens: List[str] = field(default_factory=list)
+    # Stemmed tokens of the tool NAME only (mcp__ prefix stripped), used for
+    # the name-coverage bonus in search_catalog. Empty = no bonus.
+    _name_tokens: frozenset = frozenset()
     # Text embedded by the optional reranker (name + description; no
     # parameter noise). Built eagerly — it is a cheap string concat.
     _embed_text: str = ""
@@ -583,6 +586,13 @@ def _tokenize(text: str) -> List[str]:
     if not text:
         return []
     return [_stem(token.lower()) for token in _TOKEN_RE.findall(text)]
+
+
+def _name_words(name: str) -> str:
+    """Break a tool name into words: strip ``mcp__``, split on separators."""
+    if name.startswith("mcp__"):
+        name = name[len("mcp__"):]
+    return name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
 
 
 def _entry_search_text(td: Dict[str, Any], source_label: str = "") -> str:
@@ -675,6 +685,7 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
             source=source,
             source_name=source_name,
             _tokens=_tokenize(_entry_search_text(td, source_label)),
+            _name_tokens=frozenset(_tokenize(_name_words(name))),
             _embed_text=_entry_embed_text(td, source_label),
         )
         catalog.append(entry)
@@ -710,6 +721,37 @@ def _bm25_score(query_tokens: List[str], doc_tokens: List[str],
         norm = tf * (k1 + 1) / (tf + k1 * (1 - b + b * dl / max(avg_dl, 1.0)))
         score += idf * norm
     return score
+
+
+# Weight of the name-coverage bonus: BM25 score is multiplied by
+# ``1 + _NAME_COVERAGE_WEIGHT * F1(query tokens, name tokens)``.
+_NAME_COVERAGE_WEIGHT = 1.0
+
+
+def _name_coverage_factor(query_set: set, name_tokens: frozenset) -> float:
+    """Multiplier that favors tools whose NAME is covered by the query.
+
+    BM25 alone rewards token co-occurrence in long names: for ``"accounts"``
+    on a flat REST catalog, ``put_accounts_by_account_id`` (``account``
+    twice) and ``get_accounts_builds_account_limits`` outscore the 2-token
+    ``get_accounts``. The factor is ``1 + w * F1`` where F1 is the harmonic
+    mean of (query tokens found in the name / query tokens) and (name tokens
+    found in the query / name tokens) — so a short name fully explained by
+    the query beats a long name that merely contains the same tokens.
+
+    Multiplicative on purpose: a zero BM25 score stays zero (the substring
+    fallback and empty-result semantics are unchanged), exact-name pins stay
+    ``inf``, and an entry with no name tokens gets factor 1.
+    """
+    if not name_tokens or not query_set:
+        return 1.0
+    overlap = len(query_set & name_tokens)
+    if overlap == 0:
+        return 1.0
+    recall = overlap / len(query_set)
+    precision = overlap / len(name_tokens)
+    f1 = 2 * precision * recall / (precision + recall)
+    return 1.0 + _NAME_COVERAGE_WEIGHT * f1
 
 
 _CorpusStats = Tuple[List[int], float, Dict[str, int], int]
@@ -764,6 +806,7 @@ def search_catalog(
 
     scored: List[Tuple[float, CatalogEntry]] = []
     exact_name = query.strip().lower()
+    query_set = set(query_tokens)
     for entry in catalog:
         if entry.name.lower() == exact_name:
             scored.append((float("inf"), entry))
@@ -771,7 +814,7 @@ def search_catalog(
         s = _bm25_score(query_tokens, entry._tokens, doc_lengths, avg_dl,
                         doc_freq, n_docs)
         if s > 0:
-            scored.append((s, entry))
+            scored.append((s * _name_coverage_factor(query_set, entry._name_tokens), entry))
 
     if reranker is not None:
         try:

--- a/tools/tool_search.py
+++ b/tools/tool_search.py
@@ -38,17 +38,31 @@ for the full rationale):
 * Display and trajectory unwrap is implemented here so the user (CLI activity
   feed, gateway, saved trajectories) always sees the underlying tool, not
   the bridge.
+
+Optional enhancement — **embedding reranker** (``tools.tool_search.reranker``,
+default OFF): reorders BM25 candidates by semantic similarity using an
+OpenAI-compatible ``/v1/embeddings`` endpoint (a local Ollama
+``nomic-embed-text`` works out of the box). Two modes: ``rerank`` (pure
+cosine over the whole catalog) and ``rrf`` (Reciprocal Rank Fusion of the
+BM25 and embedding rankings). When disabled, or on ANY endpoint failure, the
+search path is byte-identical to plain BM25.
 """
 
 from __future__ import annotations
 
+import array
+import collections
 import copy
 import functools
+import hashlib
 import json
 import logging
 import math
+import operator
+import os
 import re
 import threading
+import urllib.request
 from dataclasses import dataclass, field
 from typing import Any, Dict, Iterable, List, Literal, Optional, Tuple
 
@@ -57,6 +71,10 @@ import snowballstemmer
 from tools.registry import tool_error
 
 logger = logging.getLogger("tools.tool_search")
+
+# Guards the scope-keyed reranker cache and each reranker's embedding cache
+# against torn writes when bridge dispatch runs on parallel tool-call threads.
+_RERANKER_LOCK = threading.Lock()
 
 _SCHEMA_LITERAL_KEYS = frozenset({"const", "default", "enum", "example", "examples"})
 
@@ -90,6 +108,79 @@ _MAX_DESCRIBE_NAMES_PER_CALL = 10
 
 
 @dataclass(frozen=True)
+class RerankerConfig:
+    """Configuration for the optional embedding reranker.
+
+    Default OFF. When enabled, ``endpoint`` must point at an OpenAI-compatible
+    ``/v1/embeddings`` URL (Ollama serves one at
+    ``http://localhost:11434/v1/embeddings``).
+
+    ``query_prefix`` / ``doc_prefix`` default to the nomic task prefixes
+    (``search_query: `` / ``search_document: ``). nomic-embed models are
+    trained with them and lose a large fraction of their retrieval quality
+    without them; models that do not use task prefixes (``text-embedding-3-*``,
+    ``all-MiniLM-*``, ...) should set both to ``""``.
+
+    ``api_key`` is read from the ``HERMES_EMBED_API_KEY`` environment variable
+    (``.env``) — it is deliberately NOT a ``config.yaml`` key, per the repo's
+    secrets-in-.env convention — and is excluded from ``repr`` so a logged
+    config cannot leak it.
+    """
+
+    enabled: bool = False
+    endpoint: str = ""           # OpenAI-compatible /v1/embeddings URL
+    model: str = "nomic-embed-text"
+    mode: str = "rerank"         # "rerank" (pure cosine) | "rrf" (fusion with BM25)
+    rrf_k: int = 10              # RRF smoothing constant (only used in mode=rrf)
+    query_prefix: str = "search_query: "
+    doc_prefix: str = "search_document: "
+    timeout: float = 5.0         # HTTP timeout in seconds; on expiry -> BM25
+    api_key: str = field(default="", repr=False)
+
+    @classmethod
+    def from_raw(cls, raw: Any) -> "RerankerConfig":
+        """Parse ``tools.tool_search.reranker``.
+
+        Malformed values fall back to safe defaults rather than raising, so a
+        typo in user config never breaks tool discovery. A non-dict value
+        (missing key, legacy bool shapes) yields the disabled default.
+        """
+        api_key = os.environ.get("HERMES_EMBED_API_KEY", "").strip()
+        if not isinstance(raw, dict):
+            return cls(api_key=api_key)
+
+        enabled_raw = raw.get("enabled", False)
+        if isinstance(enabled_raw, str):
+            enabled = enabled_raw.strip().lower() in ("true", "1", "yes", "on")
+        else:
+            enabled = bool(enabled_raw)
+        endpoint = str(raw.get("endpoint") or "").strip()
+        model = str(raw.get("model") or "nomic-embed-text").strip()
+        mode_raw = str(raw.get("mode") or "rerank").strip().lower()
+        mode = mode_raw if mode_raw in ("rerank", "rrf") else "rerank"
+        rrf_k = max(1, _safe_int(raw.get("rrf_k"), 10))
+        query_prefix = raw.get("query_prefix", "search_query: ")
+        doc_prefix = raw.get("doc_prefix", "search_document: ")
+        timeout = max(0.1, min(120.0, _safe_float(raw.get("timeout"), 5.0)))
+        return cls(
+            enabled=enabled,
+            endpoint=endpoint,
+            model=model,
+            mode=mode,
+            rrf_k=rrf_k,
+            query_prefix="" if query_prefix is None else str(query_prefix),
+            doc_prefix="" if doc_prefix is None else str(doc_prefix),
+            timeout=timeout,
+            api_key=api_key,
+        )
+
+    @property
+    def active(self) -> bool:
+        """True when the reranker is both enabled and has an endpoint."""
+        return bool(self.enabled and self.endpoint)
+
+
+@dataclass(frozen=True)
 class ToolSearchConfig:
     """Resolved, validated tool-search configuration for a single assembly."""
 
@@ -117,6 +208,8 @@ class ToolSearchConfig:
     # default (_DEFAULT_DEFERRED_TOOLS); an explicit list from config
     # replaces the default wholesale ([] = defer no core tools — legacy).
     defer_tools: Optional[frozenset] = None
+    # Optional embedding reranker over BM25 candidates. Default OFF.
+    reranker: RerankerConfig = field(default_factory=RerankerConfig)
 
     @property
     def effective_defer_tools(self) -> frozenset:
@@ -186,6 +279,7 @@ class ToolSearchConfig:
             listing=listing,
             listing_max_tokens=listing_max_tokens,
             defer_tools=defer_tools,
+            reranker=RerankerConfig.from_raw(raw.get("reranker")),
         )
 
 
@@ -451,6 +545,9 @@ class CatalogEntry:
 
     # Pre-tokenized fields for BM25.
     _tokens: List[str] = field(default_factory=list)
+    # Text embedded by the optional reranker (name + description; no
+    # parameter noise). Built eagerly — it is a cheap string concat.
+    _embed_text: str = ""
 
 
 _TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
@@ -518,6 +615,27 @@ def _entry_search_text(td: Dict[str, Any], source_label: str = "") -> str:
     return f"{name_words} {extra} {desc} {param_names}"
 
 
+def _entry_embed_text(td: Dict[str, Any], source_label: str = "") -> str:
+    """Build the text the optional reranker embeds for one tool.
+
+    Deliberately concise — ``[source] name: description`` — with the
+    ``mcp__`` prefix stripped and the name's separators broken into words so
+    a subword-tokenized embedding model sees ``get accounts`` rather than one
+    opaque identifier. Parameter names are excluded: they dilute the
+    semantic signal without improving recall. The description is clipped so
+    a chatty MCP server cannot push a single document past the embedding
+    model's context window.
+    """
+    fn = td.get("function") or {}
+    name = fn.get("name", "")
+    if name.startswith("mcp__"):
+        name = name[len("mcp__"):]
+    desc = " ".join((fn.get("description", "") or "").split())[:1000]
+    name_words = name.replace("_", " ").replace(".", " ").replace("-", " ").replace(":", " ")
+    prefix = f"{source_label} " if source_label else ""
+    return f"{prefix}{name_words}: {desc}" if desc else f"{prefix}{name_words}"
+
+
 def _classify_source(name: str) -> Tuple[str, str]:
     """Return (source_kind, source_name) for a registered tool name."""
     try:
@@ -557,6 +675,7 @@ def build_catalog(tool_defs: List[Dict[str, Any]]) -> List[CatalogEntry]:
             source=source,
             source_name=source_name,
             _tokens=_tokenize(_entry_search_text(td, source_label)),
+            _embed_text=_entry_embed_text(td, source_label),
         )
         catalog.append(entry)
     return catalog
@@ -613,6 +732,7 @@ def search_catalog(
     limit: int = 5,
     *,
     corpus_stats: Optional[_CorpusStats] = None,
+    reranker: Optional["EmbeddingReranker"] = None,
 ) -> List[CatalogEntry]:
     """Return the top-``limit`` catalog entries for ``query`` by BM25.
 
@@ -623,6 +743,14 @@ def search_catalog(
     ``log(1 + (N - df + 0.5) / (df + 0.5))``, is strictly positive even
     when a term appears in every document, so the fallback only runs when
     no query token appears in any document.
+
+    When a ``reranker`` is supplied (see :class:`EmbeddingReranker`), the
+    BM25 scoring is handed to it and the returned order reflects embedding
+    similarity (``mode=rerank``) or a BM25/embedding rank fusion
+    (``mode=rrf``). Exact-name matches stay pinned first either way. Any
+    reranker failure is logged at debug level and this function returns the
+    plain BM25 result — so with ``reranker=None`` (the default) or a broken
+    endpoint the behavior is identical to the BM25-only path.
     """
     if not catalog or limit <= 0:
         return []
@@ -645,6 +773,12 @@ def search_catalog(
         if s > 0:
             scored.append((s, entry))
 
+    if reranker is not None:
+        try:
+            return reranker.rerank(query, catalog, scored, limit)
+        except Exception as exc:
+            logger.debug("tool_search reranker failed, falling back to BM25: %s", exc)
+
     if not scored:
         # Substring fallback against the original tool name.
         ql = query.lower()
@@ -654,6 +788,228 @@ def search_catalog(
 
     scored.sort(key=lambda x: x[0], reverse=True)
     return [e for _, e in scored[:limit]]
+
+
+# ---------------------------------------------------------------------------
+# Optional embedding reranker
+# ---------------------------------------------------------------------------
+#
+# BM25 over tool names rewards token co-occurrence in long names: on a flat
+# REST-style catalog (Cloudflare's 1,938 tools) the query "list accounts"
+# ranks get_accounts_rules_lists_by_list_id above get_accounts, and an
+# intent phrase like "remind me tonight" cannot reach create_calendar_event
+# at all. The reranker embeds the query and every catalog entry with an
+# OpenAI-compatible /v1/embeddings endpoint and reorders by cosine
+# similarity (mode=rerank) or fuses the BM25 and embedding rankings with
+# Reciprocal Rank Fusion (mode=rrf).
+#
+# The full catalog is scored, not a BM25 shortlist: tool embeddings are
+# computed once per scope and cached by content hash, so per-query cost is
+# one small embed call plus a dot product per tool (~30 ms for ~2K tools in
+# pure Python). Restricting to a BM25 top-N would silently discard exactly
+# the cases the reranker exists for — targets that BM25 ranks far down.
+
+
+# Documents per /v1/embeddings request. Bounded so one request stays well
+# inside the configured timeout and the cache fills progressively: if a
+# large catalog's warm-up is cut short, the batches already embedded are
+# kept and the next query only has to embed the remainder.
+_EMBED_BATCH_SIZE = 128
+
+
+def _dot(a: "array.array", b: "array.array") -> float:
+    """Dot product of two equal-length vectors (pure Python, no numpy)."""
+    return sum(map(operator.mul, a, b))
+
+
+def _unit(vec: List[float]) -> "array.array":
+    """Return ``vec`` L2-normalized as a compact float32 array.
+
+    Normalizing once at cache time turns every later cosine into a plain dot
+    product. A zero vector stays zero (cosine 0 against everything).
+    """
+    norm = math.sqrt(sum(x * x for x in vec))
+    if norm == 0.0:
+        return array.array("f", vec)
+    return array.array("f", [x / norm for x in vec])
+
+
+def _rrf_fuse(
+    bm25_ranked: List[Tuple[float, CatalogEntry]],
+    embed_ranked: List[Tuple[float, CatalogEntry]],
+    k: int,
+    top_n: int,
+) -> List[CatalogEntry]:
+    """Reciprocal Rank Fusion of the BM25 and embedding rankings.
+
+    ``score(doc) = sum over lists of 1 / (k + rank)``; a document absent
+    from one list simply gets no contribution from it. Lower ``k`` boosts
+    top-ranked items more aggressively, which suits tool selection where the
+    right tool usually has strong lexical OR semantic signal (k=10 beat the
+    textbook k=60 in the original benchmark, PR #35457).
+    """
+    scores: Dict[str, float] = {}
+    by_name: Dict[str, CatalogEntry] = {}
+    for rank, (_, entry) in enumerate(bm25_ranked, start=1):
+        scores[entry.name] = scores.get(entry.name, 0.0) + 1.0 / (k + rank)
+        by_name[entry.name] = entry
+    for rank, (_, entry) in enumerate(embed_ranked, start=1):
+        scores[entry.name] = scores.get(entry.name, 0.0) + 1.0 / (k + rank)
+        by_name[entry.name] = entry
+    fused = sorted(scores.items(), key=lambda kv: kv[1], reverse=True)
+    return [by_name[name] for name, _ in fused[:top_n]]
+
+
+class EmbeddingReranker:
+    """Reorders BM25 candidates by embedding similarity.
+
+    One instance serves one catalog scope (see :func:`_get_reranker`). Tool
+    vectors are cached by ``md5(model + text)`` so a catalog is embedded once
+    per process and every later query costs a single query-embed call.
+
+    Any failure (endpoint down, timeout, malformed response, dimension
+    mismatch) raises; :func:`search_catalog` catches it and returns the
+    plain BM25 result, so a misconfigured reranker can never block tool
+    discovery.
+    """
+
+    def __init__(self, cfg: RerankerConfig) -> None:
+        self._cfg = cfg
+        # md5(model + text) -> unit-normalized float32 vector
+        self._cache: Dict[str, "array.array"] = {}
+
+    def _embed(self, texts: List[str]) -> List[List[float]]:
+        """POST one batch to the OpenAI-compatible embeddings endpoint."""
+        cfg = self._cfg
+        payload = json.dumps({"model": cfg.model, "input": texts}).encode("utf-8")
+        headers = {"Content-Type": "application/json"}
+        if cfg.api_key:
+            headers["Authorization"] = f"Bearer {cfg.api_key}"
+        req = urllib.request.Request(cfg.endpoint, data=payload, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=cfg.timeout) as resp:  # noqa: S310
+            data = json.loads(resp.read())
+        items = sorted(data["data"], key=lambda item: item["index"])
+        return [item["embedding"] for item in items]
+
+    def _embed_with_cache(self, texts: List[str]) -> List["array.array"]:
+        """Return unit vectors for ``texts``, embedding only the uncached ones.
+
+        Misses are fetched in ``_EMBED_BATCH_SIZE`` chunks and written to the
+        cache after each chunk, so a timeout part-way through a large
+        warm-up keeps the progress made. The HTTP call runs outside the lock;
+        two threads may occasionally embed the same text concurrently, which
+        is harmless (same text -> same vector, last write wins).
+        """
+        cfg = self._cfg
+        keys = [hashlib.md5((cfg.model + t).encode("utf-8"), usedforsecurity=False).hexdigest()
+                for t in texts]
+        missing = [i for i, k in enumerate(keys) if k not in self._cache]
+        for start in range(0, len(missing), _EMBED_BATCH_SIZE):
+            chunk = missing[start:start + _EMBED_BATCH_SIZE]
+            with _RERANKER_LOCK:
+                chunk = [i for i in chunk if keys[i] not in self._cache]
+            if not chunk:
+                continue
+            vectors = self._embed([texts[i] for i in chunk])
+            if len(vectors) != len(chunk):
+                raise ValueError(
+                    f"embedding endpoint returned {len(vectors)} vectors "
+                    f"for {len(chunk)} texts"
+                )
+            fetched = {keys[i]: _unit(vec) for i, vec in zip(chunk, vectors)}
+            with _RERANKER_LOCK:
+                self._cache.update(fetched)
+        return [self._cache[k] for k in keys]
+
+    def rerank(
+        self,
+        query: str,
+        catalog: List[CatalogEntry],
+        bm25_scored: List[Tuple[float, CatalogEntry]],
+        limit: int,
+    ) -> List[CatalogEntry]:
+        """Return the top-``limit`` entries for ``query``.
+
+        ``bm25_scored`` is the unsorted ``(score, entry)`` list produced by
+        :func:`search_catalog` (positive BM25 scores plus ``inf`` for exact
+        name matches). Exact-name matches are pinned to the front of the
+        result regardless of mode — an exact name is the model repeating a
+        name it already saw, and must always resolve.
+        """
+        cfg = self._cfg
+        exact = [e for s, e in bm25_scored if s == float("inf")]
+        exact_names = {e.name for e in exact}
+        candidates = [e for e in catalog if e.name not in exact_names]
+        if not candidates:
+            return exact[:limit]
+
+        doc_vecs = self._embed_with_cache([f"{cfg.doc_prefix}{e._embed_text}" for e in candidates])
+        (q_vec,) = self._embed_with_cache([f"{cfg.query_prefix}{query}"])
+
+        q_dim = len(q_vec)
+        if q_dim == 0:
+            raise ValueError("embedding endpoint returned an empty query vector")
+        for entry, vec in zip(candidates, doc_vecs):
+            if len(vec) != q_dim:
+                raise ValueError(
+                    f"embedding dimension mismatch: query dim={q_dim}, "
+                    f"tool '{entry.name}' dim={len(vec)} (model changed mid-session?)"
+                )
+
+        embed_ranked = [(_dot(q_vec, vec), e) for e, vec in zip(candidates, doc_vecs)]
+        embed_ranked.sort(key=lambda x: x[0], reverse=True)
+
+        if cfg.mode == "rrf":
+            bm25_ranked = sorted(
+                ((s, e) for s, e in bm25_scored if e.name not in exact_names),
+                key=lambda x: x[0], reverse=True,
+            )
+            fused = _rrf_fuse(bm25_ranked, embed_ranked, k=cfg.rrf_k, top_n=limit)
+            return (exact + fused)[:limit]
+
+        return (exact + [e for _, e in embed_ranked])[:limit]
+
+
+# Scope-keyed, bounded reranker cache. Keyed on the behavior-affecting
+# config fields plus the catalog's tool names, so (a) concurrent sessions
+# with different toolsets (a main agent and its subagents, two gateway
+# chats) each keep their own embedded catalog instead of evicting each
+# other, and (b) a config hot-reload that changes model/mode/prefixes never
+# serves stale vectors. FIFO eviction keeps peak memory bounded; a typical
+# process has 2-4 live scopes.
+_RERANKER_CACHE_MAX = 8
+_reranker_cache: "collections.OrderedDict[str, EmbeddingReranker]" = collections.OrderedDict()
+
+
+def _get_reranker(cfg: RerankerConfig, catalog: List[CatalogEntry]) -> Optional[EmbeddingReranker]:
+    """Return the reranker for this config + catalog scope, building it if needed.
+
+    Returns ``None`` when the reranker is disabled or has no endpoint, so the
+    caller can pass the result straight to :func:`search_catalog`.
+    """
+    if not cfg.active:
+        return None
+    # NUL separator: tool names cannot contain it, so ["a,b"] and ["a","b"]
+    # cannot collide the way a comma-joined key would.
+    key_material = "\x00".join([
+        cfg.endpoint, cfg.model, cfg.mode, str(cfg.rrf_k),
+        cfg.query_prefix, cfg.doc_prefix,
+        *(e.name for e in catalog),
+    ])
+    scope_key = hashlib.md5(key_material.encode("utf-8"), usedforsecurity=False).hexdigest()
+
+    # dict.get() is atomic under the GIL; `in` followed by `[]` is not (a
+    # concurrent popitem() between them raises KeyError).
+    cached = _reranker_cache.get(scope_key)
+    if cached is not None:
+        return cached
+    with _RERANKER_LOCK:
+        cached = _reranker_cache.get(scope_key)
+        if cached is None:
+            while len(_reranker_cache) >= _RERANKER_CACHE_MAX:
+                _reranker_cache.popitem(last=False)
+            cached = _reranker_cache[scope_key] = EmbeddingReranker(cfg)
+        return cached
 
 
 # ---------------------------------------------------------------------------
@@ -1145,9 +1501,14 @@ def dispatch_tool_search(args: Dict[str, Any],
     results: List[Dict[str, Any]] = []
     tools_map: Dict[str, Dict[str, Any]] = {}
     corpus_stats = _corpus_stats(catalog)
+    # None unless tools.tool_search.reranker is enabled with an endpoint;
+    # search_catalog then behaves exactly as before.
+    reranker = _get_reranker(config.reranker, catalog) if catalog else None
     available_sources = _available_source_summary(catalog) if catalog else []
     for query in queries:
-        hits = search_catalog(catalog, query, limit=limit, corpus_stats=corpus_stats)
+        hits = search_catalog(
+            catalog, query, limit=limit, corpus_stats=corpus_stats, reranker=reranker,
+        )
         for h in hits:
             if h.name not in tools_map:
                 tools_map[h.name] = _shared_tool_record(h)

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -153,6 +153,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `PARALLEL_API_KEY` | AI-native web search ([parallel.ai](https://parallel.ai/)) |
 | `FIRECRAWL_API_KEY` | Web scraping and cloud browser ([firecrawl.dev](https://firecrawl.dev/)) |
 | `FIRECRAWL_API_URL` | Custom Firecrawl API endpoint for self-hosted instances (optional) |
+| `HERMES_EMBED_API_KEY` | Bearer token for the optional `tool_search` embedding reranker endpoint (`tools.tool_search.reranker`). Not needed for a local Ollama endpoint. See [Tool Search](../user-guide/features/tool-search.md#embedding-reranker) |
 | `TAVILY_API_KEY` | Optional Tavily API key for higher search/extract limits. After selecting Tavily as the web backend, keyless access works without it ([app.tavily.com](https://app.tavily.com/home), [keyless docs](https://docs.tavily.com/documentation/keyless)) |
 | `TAVILY_BASE_URL` | Override the Tavily API endpoint. Useful for corporate proxies and self-hosted Tavily-compatible search backends. Same pattern as `GROQ_BASE_URL`. |
 | `SEARXNG_URL` | SearXNG instance URL for free self-hosted web search — no API key required ([searxng.github.io](https://searxng.github.io/searxng/)) |

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -130,6 +130,134 @@ tools:
   tool_search: true   # equivalent to {enabled: auto}
 ```
 
+## Embedding reranker
+
+BM25 ranks by token overlap, weighted by how rare each token is and
+normalized by document length. That works when the query shares the
+tool's vocabulary, and fails in two ways that show up constantly on
+large REST-style catalogs:
+
+- **Long names win on co-occurrence.** Against Cloudflare's 1,938-tool
+  server, `"list accounts"` returns `get_accounts_rules_lists_by_list_id`,
+  `get_accounts_rules_lists`, ... — every name that contains *both*
+  `accounts` and `list` — and never the 2-token `get_accounts`.
+- **Intent phrases have no lexical overlap.** `"remind me tonight"`
+  shares no token with `calendar_create_event`; BM25 scores nothing and
+  the substring fallback finds nothing either.
+
+The optional embedding reranker fixes both. It is **default OFF**.
+When enabled, `tool_search` embeds the query and every deferred tool
+through an OpenAI-compatible `/v1/embeddings` endpoint and reorders the
+results by cosine similarity. Tool vectors are computed once per catalog
+(keyed by content hash) and cached in memory, so after the first search
+each query costs one small embed call plus a dot product per tool
+(~30 ms for 2K tools in pure Python; no numpy).
+
+### Local setup with Ollama
+
+No API key, nothing leaves the machine:
+
+```bash
+ollama pull nomic-embed-text
+```
+
+```yaml
+tools:
+  tool_search:
+    reranker:
+      enabled: true
+      endpoint: http://localhost:11434/v1/embeddings
+      model: nomic-embed-text
+      mode: rerank          # or rrf
+```
+
+Any OpenAI-compatible embeddings endpoint works (OpenAI, vLLM,
+llama.cpp server, LM Studio, ...). If the endpoint needs a bearer
+token, set `HERMES_EMBED_API_KEY` in `.env`; it is never read from
+`config.yaml`.
+
+### Modes
+
+| Mode | Behavior | When to pick it |
+| --- | --- | --- |
+| `rerank` (default) | Sort the whole catalog by embedding cosine similarity; BM25 is bypassed except for exact-name pins. | Intent-style queries, weak/local models that do not guess endpoint tokens. |
+| `rrf` | Reciprocal Rank Fusion: `score = Σ 1/(rrf_k + rank)` over the BM25 and embedding rankings. | Mixed traffic: keeps BM25's precision on exact token matches while pulling in semantic hits. |
+
+Exact tool-name queries (`"get_zones"`) are pinned first in both modes —
+an exact name is the model repeating something it already saw and must
+always resolve.
+
+### Measured on a real catalog
+
+Replay of the queries an agent actually issued in one session
+(Cloudflare MCP server, 1,938 tools, task "create a snake game and
+publish it on Cloudflare Pages"; `nomic-embed-text` via Ollama on a
+laptop GPU). "Hit" = the tool the agent needed appears in the top-5:
+
+| Ranker | Hits / 12 queries | Per-query latency (warm cache) |
+| --- | --- | --- |
+| BM25 (default) | 4 | ~5 ms |
+| `rerank`, nomic-embed-text | 8 | ~55 ms |
+| `rrf` k=10, nomic-embed-text | 9 | ~55 ms |
+
+One-time catalog embed for the 1,938 tools: ~9 s. Queries BM25 missed
+and the reranker recovered include `"list my accounts"` →
+`get_accounts`, `"zones"` → `get_zones`, `"deploy to pages"` →
+`post_accounts_pages_projects_deployments`. Neither ranker recovers
+`"cloudflare authentication whoami"` → `get_user`; that is a
+vocabulary gap in the tool description, not a ranking problem.
+
+### Configuration
+
+```yaml
+tools:
+  tool_search:
+    reranker:
+      enabled: false                                  # default
+      endpoint: http://localhost:11434/v1/embeddings  # required when enabled
+      model: nomic-embed-text
+      mode: rerank            # rerank | rrf
+      rrf_k: 10               # RRF smoothing constant (mode: rrf)
+      query_prefix: "search_query: "     # nomic task prefixes
+      doc_prefix: "search_document: "
+      timeout: 5.0            # seconds per embed request
+```
+
+| Key | Default | Meaning |
+| --- | --- | --- |
+| `reranker.enabled` | `false` | Turn the reranker on. Also requires `endpoint`. |
+| `reranker.endpoint` | `""` | OpenAI-compatible `/v1/embeddings` URL. |
+| `reranker.model` | `nomic-embed-text` | Model name sent in the request body. |
+| `reranker.mode` | `rerank` | `rerank` (cosine order) or `rrf` (fuse BM25 + embedding ranks). |
+| `reranker.rrf_k` | `10` | RRF smoothing constant. Lower boosts top-ranked items more. |
+| `reranker.query_prefix` | `"search_query: "` | Prepended to the query before embedding. |
+| `reranker.doc_prefix` | `"search_document: "` | Prepended to each tool's text before embedding. |
+| `reranker.timeout` | `5.0` | Seconds per embeddings request. On expiry the search falls back to BM25. |
+
+:::caution Task prefixes are model-specific
+`nomic-embed-text` is trained with `search_query:` / `search_document:`
+prefixes and loses a large share of its retrieval quality without them.
+Models that do not use task prefixes (`text-embedding-3-*`,
+`all-MiniLM-*`, `bge-*`) should set **both** prefixes to `""`. The
+mismatch is silent — vectors still come back well-formed, scores are just
+worse — so check your model's documentation.
+:::
+
+### Failure behavior
+
+Any endpoint failure — connection refused, timeout, non-JSON body,
+missing vectors, a dimension mismatch after a model swap — is logged at
+`DEBUG` and the query returns the plain BM25 result. Tool discovery is
+never blocked by the reranker. Partial progress is kept: a large catalog
+is embedded in batches, and batches that succeeded before a timeout stay
+cached, so the next query only embeds the remainder.
+
+The reranker runs entirely inside the `tool_search` call. It adds no
+tool, changes no schema, and touches nothing in the prompt prefix, so
+prompt caching is unaffected. Each distinct catalog scope (a subagent
+with a narrower toolset, a second gateway session) gets its own cached
+reranker; the scope cache is bounded (8 entries, FIFO).
+
 ## When NOT to use it
 
 Tool Search trades a fixed per-turn token cost (the three bridge tool
@@ -182,7 +310,10 @@ to any progressive-disclosure design, not specific to this implementation:
   morphological variants match ("issues" finds `create_issue`). Falls
   back to a literal substring match on the tool name when no query
   token matches any document (e.g. searching `"hub"` where the token is
-  `github`).
+  `github`). With the optional [embedding reranker](#embedding-reranker)
+  enabled, the BM25 candidates are reordered by embedding similarity
+  (or rank-fused with it); on any endpoint failure the BM25 order is
+  returned unchanged.
 - **Parallel execution unwraps the bridge.** The batch planner decides
   concurrency on the *underlying* tool of a `tool_call`, not on the
   literal bridge name — so an MCP server opted in via

--- a/website/docs/user-guide/features/tool-search.md
+++ b/website/docs/user-guide/features/tool-search.md
@@ -196,14 +196,17 @@ laptop GPU). "Hit" = the tool the agent needed appears in the top-5:
 
 | Ranker | Hits / 12 queries | Per-query latency (warm cache) |
 | --- | --- | --- |
-| BM25 (default) | 4 | ~5 ms |
-| `rerank`, nomic-embed-text | 8 | ~55 ms |
-| `rrf` k=10, nomic-embed-text | 9 | ~55 ms |
+| BM25 (before this change) | 4 | ~5 ms |
+| BM25 + name-coverage bonus (new default) | 8 | ~5 ms |
+| + `rerank`, nomic-embed-text | 8 | ~55 ms |
+| + `rrf` k=10, nomic-embed-text | 9 | ~55 ms |
 
-One-time catalog embed for the 1,938 tools: ~9 s. Queries BM25 missed
-and the reranker recovered include `"list my accounts"` →
-`get_accounts`, `"zones"` → `get_zones`, `"deploy to pages"` →
-`post_accounts_pages_projects_deployments`. Neither ranker recovers
+One-time catalog embed for the 1,938 tools: ~9 s. The dependency-free
+name-coverage bonus (see *Implementation details*) recovers the
+short-name failures (`"accounts"` → `get_accounts`, `"zones"` →
+`get_zones`); the reranker additionally recovers intent phrasing with
+no name overlap (`"list my accounts"` → `get_accounts`, `"deploy to
+pages"` → `post_accounts_pages_projects_deployments`). Neither recovers
 `"cloudflare authentication whoami"` → `get_user`; that is a
 vocabulary gap in the tool description, not a ranking problem.
 
@@ -314,6 +317,14 @@ to any progressive-disclosure design, not specific to this implementation:
   enabled, the BM25 candidates are reordered by embedding similarity
   (or rank-fused with it); on any endpoint failure the BM25 order is
   returned unchanged.
+- **Name-coverage bonus.** BM25 rewards token co-occurrence in long
+  names, so on a flat REST-style catalog `"accounts"` ranks
+  `put_accounts_by_account_id` above `get_accounts`. Each positive BM25
+  score is multiplied by `1 + F1(query tokens, name tokens)`, so a short
+  name fully explained by the query outranks a long name that merely
+  contains those tokens. A zero score stays zero (the substring fallback
+  and empty-result behavior are untouched) and exact-name matches still
+  pin first.
 - **Parallel execution unwraps the bridge.** The batch planner decides
   concurrency on the *underlying* tool of a `tool_call`, not on the
   literal bridge name — so an MCP server opted in via


### PR DESCRIPTION
## What does this PR do?

Rebases and salvages #35457 (@davidgut1982's optional embedding reranker for `tool_search`) onto current `main`, addresses every point in the sweeper review, and adds a small dependency-free ranking fix that helps even with the reranker off. The original branch is based on 7f12d4f8 and ~17 `tool_search` commits behind `main` (multi-query search, batched describe, Snowball stemming, core-tool deferral, deferred-call schema validation), and its single squashed commit cannot be merged or rebased by git, so the change was re-applied by hand onto the current `tools/tool_search.py`. All current-main behavior is preserved: the existing `tests/tools/test_tool_search.py` (45 tests) and `test_tool_search_multiquery.py` pass unchanged, including "preserve exact and per-query ranking semantics" and the 9514d354 deferred-call schema validation the review asked to keep.

**The problem, measured.** Real session on 2026-09-04, Hermes v0.21.0, Cloudflare MCP server (1,938 tools), model `muse-spark-1.3` via opencode-free, task "create a snake game and publish it on cf pages". The model issued 10 `tool_search` calls (17 queries) and got 5 useful tools. Four consecutive searches for the account-listing endpoint failed even though `get_accounts` exists and is two tokens long:

| Query | Target | BM25 top-5 on `main` |
| --- | --- | --- |
| `cloudflare list accounts` | `get_accounts` | `get_accounts_rules_lists_by_list_id`, `put_accounts_rules_lists_by_list_id`, `delete_accounts_rules_lists_by_list_id`, `get_accounts_rules_lists`, `get_accounts_rules_lists_items_by_item_id` |
| `get accounts list` | `get_accounts` | `get_accounts_rules_lists_by_list_id`, `get_accounts_rules_lists`, `get_accounts_rules_lists_items`, … |
| `accounts` | `get_accounts` | `get_accounts_builds_account_limits`, `put_accounts_by_account_id`, `get_accounts_workers_accountsettings`, … |
| `cloudflare account` | `get_accounts` | same as above |
| `list zones` / `zones` | `get_zones` | `get_zones_environments`, `get_zones_logpush_jobs`, … / `delete_zones_by_zone_id`, `patch_zones_by_zone_id`, `post_zones_hold`, … |
| `pages custom domain` | `post_accounts_pages_projects_domains` | `get_accounts_aigateway_gateways_customdomains`, `delete_accounts_r2_buckets_domains_custom_by_domain`, … |
| `cloudflare authentication whoami` | `get_user` | `get_accounts_access_authenticator_device_aaguids`, `delete_accounts_access_users_mfa_authenticators_by_authenticator_id`, … |

BM25 rewards `accounts`+`list` co-occurring in 6-token names, so the 2-token target loses. Each failed search cost a full API round-trip re-sending 45–70K tokens of context; the model then gave up on the bridge, grepped the filesystem for credentials and installed `wrangler` into `/tmp` to reverse-engineer endpoints (14 wasted tool calls). The searches that worked were the ones where the model had already guessed the endpoint's exact tokens (`pages assets missing hashes check` → `post_pages_assets_checkmissing`).

**Why this matters for Hermes specifically.**

1. Progressive disclosure is now the default architecture, not an MCP-power-user feature. Since the 2026-08 core-tool deferral, `computer_use`, `cronjob_manage`, `chat_history_lookup`, `todo_list` and the GUI tools sit behind the bridge on every install. The bridge's ranker is on the critical path for everyone; a tool the ranker cannot surface is a tool Hermes effectively does not have.
2. Hermes explicitly targets weaker, cheaper and local models (fallback chains, free tiers, Ollama). Those models do not guess REST-style endpoint tokens; they search with intent phrases (`list my accounts`, `deploy to pages`). BM25 penalizes exactly that population. AGENTS.md treats the per-conversation prompt cache as sacred; every failed search is a full-context round trip that cannot be cached. #96247 (runaway `tool_search` loops that exhaust the context window) is the extreme form of the same symptom: a ranker that never returns the right tool invites retries.
3. The change is contained. No new core tool, no schema change, nothing in the prompt prefix — the reranker runs inside the `tool_search` call, so prompt caching is untouched. Off by default: with `reranker.enabled: false` (the shipped default) the embedding path is never entered. With a local Ollama `nomic-embed-text` there is no new credential and no data leaves the machine; the 1,938-tool catalog embeds once in ~9 s and is cached by content hash.
4. It sits on the first rung of the AGENTS.md Footprint Ladder ("extend existing code"): ~300 lines in the module that already owns ranking, with a concrete consumer (the bridge) and a measured failure to fix.

**Results, replayed against the real 1,938-tool Cloudflare catalog** (from the MCP schema cache; target tool in top-5; `nomic-embed-text` via Ollama, laptop RTX 4050):

| Ranker | Hits / 12 | Per-query latency (warm) |
| --- | --- | --- |
| BM25 (`main`) | 4 | ~5 ms |
| BM25 + name-coverage bonus (this PR, reranker off) | 8 | ~5 ms |
| + reranker `mode: rerank` | 8 | ~55 ms |
| + reranker `mode: rrf` (k=10) | 9 | ~55 ms |

The name-coverage bonus recovers the short-name failures (`accounts` → `get_accounts`, `zones` → `get_zones`, `deploy to pages` → `post_accounts_pages_projects_deployments`); the reranker additionally recovers intent phrasing with no name overlap (`list my accounts` → `get_accounts` at rank 1). Nothing recovers `cloudflare authentication whoami` → `get_user` — the tool description says "User Details", which is a vocabulary gap, not a ranking problem. On a mixed 4-server catalog (context7, wolfram, hugging_face, cloudflare — 1,947 tools) every top-1 changed by the bonus moved to a shorter name with the same tokens (`dns records`: `delete_zones_dns_records_by_dns_record_id` → `get_zones_dns_records`; `resolve library id`: `query-docs` → `resolve-library-id`); no query lost its target.

## Related Issue

Supersedes/rebases #35457 (credit @davidgut1982 — the port commit keeps his authorship). Reduces the failure mode behind #96247 (runaway `tool_search` loops). Related: #13332 (hybrid semantic + keyword tool pre-selection).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

Three commits, in order:

**1. `feat(tool-search): optional embedding reranker over BM25 (port of #35457)`** — author David Gutowsky

- `tools/tool_search.py`
  - `RerankerConfig` (frozen dataclass) parsed from `tools.tool_search.reranker`: `enabled` (default `false`), `endpoint`, `model` (`nomic-embed-text`), `mode` (`rerank` | `rrf`), `rrf_k` (10), `query_prefix` / `doc_prefix` (nomic task prefixes), `timeout` (5 s). Malformed values fall back to safe defaults. `api_key` comes from `HERMES_EMBED_API_KEY` **only** and is `repr=False`.
  - `EmbeddingReranker`: POSTs to any OpenAI-compatible `/v1/embeddings` endpoint via `urllib` (no new dependency, no numpy — vectors are `array('f')`, cosine is `sum(map(mul, …))`, ~30 ms for 2K tools). Tool vectors are cached by `md5(model + text)`, L2-normalized at cache time, fetched in batches of 128 so partial progress survives a timeout. `mode: rerank` sorts the whole catalog by cosine; `mode: rrf` fuses BM25 and embedding rankings with Reciprocal Rank Fusion. Exact-name matches stay pinned first in both modes.
  - `search_catalog(..., reranker=None)`: new keyword-only argument. With `None` (default) the function body is unchanged. Any reranker exception is caught, logged at `DEBUG`, and the plain BM25 result (including the substring fallback) is returned.
  - `_get_reranker()`: scope-keyed bounded cache (`OrderedDict`, FIFO, max 8) keyed on `endpoint | model | mode | rrf_k | prefixes | tool names` joined with `\x00`. Fast path is an atomic `dict.get()`; slow path double-checks under a lock.
  - `dispatch_tool_search()`: resolves the reranker once per call and passes it to each per-query `search_catalog`; multi-query grouping, shared tool map, limits and the `available_sources` hint are untouched.
  - `CatalogEntry._embed_text` built in `build_catalog()` (`[source] name words: description`, clipped to 1,000 chars).
- `tests/tools/test_tool_search_reranker.py` (41 tests; no network — `_embed` is monkeypatched).
- `website/docs/user-guide/features/tool-search.md`: new "Embedding reranker" section.
- `.env.example`: `HERMES_EMBED_API_KEY`.

**2. `docs(tool-search): document reranker config keys and HERMES_EMBED_API_KEY`**

- `hermes_cli/config_defaults.py`: `tools.tool_search.reranker` defaults (`enabled: False`) so `hermes config` and `get_missing_config_fields()` know the keys.
- `cli-config.yaml.example`: new commented "Tool Search" section (the file had none) with the reranker keys and the Ollama one-liner.
- `website/docs/reference/environment-variables.md`: `HERMES_EMBED_API_KEY`.

**3. `feat(tool-search): name-coverage bonus so short exact-token names outrank long ones`**

- `tools/tool_search.py`: each positive BM25 score is multiplied by `1 + F1(query tokens, name tokens)` (`_name_coverage_factor`; stemmed name tokens precomputed per entry as `CatalogEntry._name_tokens`, `mcp__` prefix stripped). Multiplicative so a zero score stays zero (substring fallback and empty results unchanged) and exact-name pins stay `inf`. Weight 1.0 is the low end of the plateau on the benchmark (0.5 → 6/12, 1.0–3.0 → 8/12).
- `tests/tools/test_tool_search_name_bonus.py` (12 tests) including "weight 0 reproduces plain BM25" and "specific queries still find the long specific tool".
- Docs: "Name-coverage bonus" bullet under Implementation details.

**Review points from #35457 and how each is addressed**

| Review point | Status |
| --- | --- |
| One-entry global reranker cache; second scope evicts the first | Scope-keyed bounded `OrderedDict` (FIFO, max 8). Tests: same scope reuses instance; A → B → A reuses A without re-embedding; FIFO eviction at capacity; scope key includes mode/rrf_k/prefixes/model/endpoint; `["a,b"]` vs `["a","b"]` do not collide; 12-thread concurrent creation under a cap of 3 raises nothing. |
| `RerankerConfig.top_k` parsed and documented but never consulted | Removed. Reranking honors the caller's `limit` only. Not present in config, docs, or defaults. |
| `api_key` example in `config.yaml`; repo requires credentials in `.env` | `api_key` is read from `HERMES_EMBED_API_KEY` only — a config-file `api_key` is ignored (test: `test_api_key_comes_from_env_only`). Documented in `.env.example`, `environment-variables.md`, and `cli-config.yaml.example`; `repr=False` so a logged config cannot leak it; sent as `Authorization: Bearer` only when set. |
| Preserve deferred-call validation from 9514d354 during salvage | The port touches only the retrieval path. `tool_call` dispatch, `_validate_deferred_call_args` and `TestDeferredCallSchemaProbe` (10 tests) are unchanged and pass. |

## How to Test

Reranker off (default) — everything must be identical to `main`:

1. `pytest tests/tools/test_tool_search.py tests/tools/test_tool_search_multiquery.py tests/tools/test_tool_search_reranker.py tests/tools/test_tool_search_name_bonus.py tests/tools/test_deferral_fixes.py -q` → 144 passed.
2. `pytest tests/ -q -k tool_search` → 146 passed, 6 skipped.
3. `ruff check tools/tool_search.py tests/tools/test_tool_search_reranker.py tests/tools/test_tool_search_name_bonus.py` → clean.

Reranker on, fully local (no API key, nothing leaves the machine):

1. `ollama pull nomic-embed-text` (274 MB) and make sure `ollama serve` is running.
2. Add to `~/.hermes/config.yaml`:
   ```yaml
   tools:
     tool_search:
       reranker:
         enabled: true
         endpoint: http://localhost:11434/v1/embeddings
         model: nomic-embed-text
         mode: rrf          # or rerank
   ```
3. Start Hermes with an MCP server that has a large catalog (the Cloudflare MCP server was used here) and ask for something phrased by intent, e.g. "list my cloudflare accounts". Compare the `tool_search` result for `list my accounts`: on `main` the top-5 is all `*_rules_lists_*`; with the reranker `get_accounts` is rank 1.
4. Kill Ollama and repeat: the search must still return results (the BM25 order) and the agent log at `DEBUG` shows `tool_search reranker failed, falling back to BM25`.
5. Replay the benchmark from this PR against your own MCP schema cache: the script is small enough to paste — it loads `~/.hermes/cache/mcp_schema_cache.json`, calls `build_catalog` / `search_catalog` exactly as the bridge does, and prints top-5 per query with and without `reranker=_get_reranker(RerankerConfig.from_raw({...}), catalog)`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — `-k tool_search` subset (146 passed) plus `tests/tools/`, `tests/agent/`, and every config test that reads `DEFAULT_CONFIG` / `cli-config.yaml.example` (240 passed). `tests/tools/test_approval_mode_parity.py::test_mode_and_timeout_parity_across_surfaces[unset-defaults]` fails under one `-x` ordering on both this branch and `origin/main` and passes in isolation on both; it does not touch tool_search.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04.1 LTS (kernel 7.0), Python 3.11.16, Ollama 0.32.13 with `nomic-embed-text` on an RTX 4050

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (no architecture change; the module docstring documents the reranker)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — stdlib only (`urllib`, `array`, `hashlib`), no subprocess, no paths
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (the `tool_search` bridge schema is unchanged; only result ordering differs)

## Screenshots / Logs

Full per-query top-5 for all four configurations, replayed against the real 1,938-tool Cloudflare catalog:

<details>
<summary>BM25 on <code>main</code> — 4/12</summary>

| Query | Target | Hit | Top-5 |
| --- | --- | --- | --- |
| `cloudflare list accounts` | `get_accounts` | no | `get_accounts_cfd_tunnel_connections`, `get_accounts_cfd_tunnel`, `get_accounts_calls_apps`, `get_accounts_calls_turn_keys`, `get_accounts_mtls_certificates_associations` |
| `get accounts list` | `get_accounts` | no | `get_accounts_rules_lists`, `get_accounts_rules_lists_by_list_id`, `get_accounts_rules_lists_items`, `get_accounts_rules_lists_items_by_item_id`, `get_accounts_logs_list` |
| `accounts` | `get_accounts` | no | `put_accounts_by_account_id`, `get_accounts_builds_account_limits`, `get_accounts_workers_accountsettings`, `put_accounts_workers_accountsettings`, `get_accounts_by_account_id` |
| `cloudflare account` | `get_accounts` | no | `get_accounts_cfd_tunnel_connections`, `get_accounts_cfd_tunnel_connectors_by_connector_id`, `get_accounts_cfd_tunnel`, `post_accounts_cfd_tunnel`, `get_ips` |
| `list zones` | `get_zones` | yes | `get_zones`, `get_zones_environments`, `get_zones_healthchecks`, `get_zones_logpush_jobs`, `get_zones_access_apps` |
| `zones` | `get_zones` | no | `delete_zones_by_zone_id`, `post_zones_hold`, `patch_zones_by_zone_id`, `get_zones_by_zone_id`, `get_zones_subscription` |
| `pages custom domain` | `post_accounts_pages_projects_domains` | yes | `delete_accounts_pages_projects_domains_by_domain_name`, `post_accounts_pages_projects_domains`, `delete_accounts_r2_buckets_domains_custom_by_domain`, `get_accounts_r2_buckets_domains_custom_by_domain`, `put_accounts_r2_buckets_domains_custom_by_domain` |
| `cloudflare authentication whoami` | `get_user` | no | `get_user_communication_preferences`, `get_zones_settings_transformations_c2pa`, `patch_zones_settings_transformations_c2pa`, `get_accounts_access_authenticator_device_aaguids`, `put_user_communication_preferences` |
| `pages assets missing hashes check` | `post_pages_assets_checkmissing` | yes | `post_pages_assets_checkmissing`, `post_pages_assets_upserthashes`, `post_pages_assets_upload`, `delete_accounts_custom_pages_assets_by_asset_name`, `delete_zones_custom_pages_assets_by_asset_name` |
| `list my accounts` | `get_accounts` | no | `get_user_invites`, `get_accounts_rules_lists_by_list_id`, `put_accounts_rules_lists_by_list_id`, `delete_accounts_rules_lists_by_list_id`, `get_accounts_rules_lists` |
| `deploy to pages` | `post_accounts_pages_projects_deployments` | no | `post_accounts_pages_projects_deployments_rollback`, `delete_accounts_pages_projects_deployments_by_deployment_id`, `get_accounts_pages_projects_deployments_by_deployment_id`, `post_accounts_pages_projects_deployments_retry`, `delete_accounts_pages_projects_deployments_tails_by_tail_id` |
| `create pages project` | `post_accounts_pages_projects` | yes | `post_accounts_pages_projects`, `post_accounts_pages_projects_deployments_tails`, `post_accounts_pages_projects_deployments`, `get_accounts_pages_projects_by_project_name`, `delete_accounts_pages_projects_by_project_name` |
</details>

<details>
<summary>BM25 + name-coverage bonus (this PR, reranker off) — 8/12</summary>

| Query | Target | Hit | Top-5 |
| --- | --- | --- | --- |
| `cloudflare list accounts` | `get_accounts` | no | `get_accounts_cfd_tunnel`, `get_accounts_cfd_tunnel_connections`, `get_accounts_calls_apps`, `get_accounts_calls_turn_keys`, `get_accounts_mtls_certificates_associations` |
| `get accounts list` | `get_accounts` | yes | `get_accounts_rules_lists`, `get_accounts_logs_list`, `get_accounts_rules_lists_items`, `get_accounts_rules_lists_by_list_id`, `get_accounts` |
| `accounts` | `get_accounts` | yes | `get_accounts`, `post_accounts`, `get_accounts_rulesets`, `post_accounts_rulesets`, `put_accounts_profile` |
| `cloudflare account` | `get_accounts` | no | `get_accounts_cfd_tunnel_connections`, `get_accounts_cfd_tunnel`, `post_accounts_cfd_tunnel`, `get_accounts_cfd_tunnel_connectors_by_connector_id`, `get_accounts_cfd_tunnel_token` |
| `list zones` | `get_zones` | yes | `get_zones`, `get_zones_environments`, `get_zones_healthchecks`, `get_zones_logpush_jobs`, `get_zones_access_apps` |
| `zones` | `get_zones` | yes | `get_zones`, `post_zones_hold`, `get_zones_subscription`, `post_zones_environments`, `delete_zones_subscription` |
| `pages custom domain` | `post_accounts_pages_projects_domains` | yes | `post_accounts_pages_projects_domains`, `get_accounts_pages_projects_domains`, `get_accounts_custom_pages`, `get_zones_custom_pages`, `delete_accounts_pages_projects_domains_by_domain_name` |
| `cloudflare authentication whoami` | `get_user` | no | `get_accounts_access_authenticator_device_aaguids`, `get_user_communication_preferences`, `get_zones_settings_transformations_c2pa`, `patch_zones_settings_transformations_c2pa`, `delete_accounts_access_users_mfa_authenticators_by_authenticator_id` |
| `pages assets missing hashes check` | `post_pages_assets_checkmissing` | yes | `post_pages_assets_checkmissing`, `post_pages_assets_upserthashes`, `post_pages_assets_upload`, `get_accounts_custom_pages_assets`, `get_zones_custom_pages_assets` |
| `list my accounts` | `get_accounts` | no | `get_user_invites`, `get_accounts_rules_lists`, `post_accounts_rules_lists`, `get_accounts_logs_list`, `get_accounts_rules_lists_items` |
| `deploy to pages` | `post_accounts_pages_projects_deployments` | yes | `post_accounts_pages_projects_deployments_rollback`, `get_accounts_pages_projects_deployments`, `post_accounts_pages_projects_deployments_retry`, `delete_accounts_pages_projects_deployments_by_deployment_id`, `post_accounts_pages_projects_deployments` |
| `create pages project` | `post_accounts_pages_projects` | yes | `post_accounts_pages_projects`, `get_accounts_pages_projects`, `post_accounts_pages_projects_deployments`, `post_accounts_pages_projects_source`, `delete_accounts_pages_projects_source` |
</details>

<details>
<summary>+ reranker <code>mode: rrf</code>, nomic-embed-text — 9/12 (warm-up embed of 1,938 tools: 8.8 s; ~55 ms/query after)</summary>

| Query | Target | Hit | Top-5 |
| --- | --- | --- | --- |
| `cloudflare list accounts` | `get_accounts` | no | `get_accounts_cfd_tunnel`, `get_accounts_calls_apps`, `get_accounts_cfd_tunnel_connections`, `get_accounts_calls_turn_keys`, `post_accounts_cfd_tunnel` |
| `get accounts list` | `get_accounts` | yes | `get_accounts_rules_lists`, `get_accounts`, `get_accounts_rules_lists_items`, `get_accounts_logs_list`, `get_accounts_rules_lists_by_list_id` |
| `accounts` | `get_accounts` | yes | `get_accounts`, `post_accounts`, `get_accounts_profile`, `get_accounts_tags`, `get_accounts_rulesets` |
| `cloudflare account` | `get_accounts` | no | `post_accounts_cfd_tunnel`, `get_accounts_cfd_tunnel`, `get_accounts_cfd_tunnel_connections`, `get_accounts_cfd_tunnel_token`, `get_accounts_cfd_tunnel_by_tunnel_id` |
| `list zones` | `get_zones` | yes | `get_zones`, `get_zones_environments`, `get_zones_access_apps`, `get_zones_spectrum_protocols`, `get_zones_spectrum_apps` |
| `zones` | `get_zones` | yes | `get_zones`, `get_zones_environments`, `post_zones_environments`, `post_zones_hold`, `get_zones_by_zone_id` |
| `pages custom domain` | `post_accounts_pages_projects_domains` | yes | `post_accounts_pages_projects_domains`, `get_zones_custom_pages`, `put_zones_custom_pages_by_identifier`, `get_accounts_custom_pages`, `post_accounts_access_custom_pages` |
| `cloudflare authentication whoami` | `get_user` | no | `get_zones_settings_transformations_c2pa`, `get_user_communication_preferences`, `post_zones_origin_tls_client_auth`, `patch_zones_settings_transformations_c2pa`, `get_accounts_access_authenticator_device_aaguids` |
| `pages assets missing hashes check` | `post_pages_assets_checkmissing` | yes | `post_pages_assets_checkmissing`, `post_pages_assets_upserthashes`, `post_pages_assets_upload`, `get_accounts_custom_pages_assets`, `get_zones_custom_pages_assets` |
| `list my accounts` | `get_accounts` | yes | `get_accounts`, `get_accounts_rules_lists`, `get_accounts_subscriptions`, `get_accounts_rum_site_info_list`, `get_accounts_logs_list` |
| `deploy to pages` | `post_accounts_pages_projects_deployments` | yes | `get_accounts_pages_projects_deployments`, `post_accounts_pages_projects_deployments_rollback`, `post_accounts_pages_projects_deployments`, `post_accounts_pages_projects_deployments_retry`, `get_accounts_pages_projects_deployments_by_deployment_id` |
| `create pages project` | `post_accounts_pages_projects` | yes | `post_accounts_pages_projects`, `post_accounts_pages_projects_source`, `post_accounts_pages_projects_deployments`, `get_accounts_pages_projects`, `post_accounts_pages_projects_domains` |
</details>

Latency for the pure-Python cosine over 1,938 × 768-dim vectors: ~27 ms (`array('f')` + `sum(map(operator.mul, …))`); the rest of the ~55 ms is the single query-embed HTTP call to Ollama.
