### PR TITLE
fix(desktop): persist profile selection when primary has registered connection id

### DIFF
--- a/apps/desktop/src/store/profile-select-source.test.ts
+++ b/apps/desktop/src/store/profile-select-source.test.ts
@@ -14,6 +14,7 @@ const ensureGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const ensureGatewayForAgent = vi.fn(async (_connectionId: null | string, _profile: string) => true)
 const openGatewayForProfile = vi.fn(async (_profile: string) => undefined)
 const activeGatewayConnectionId = vi.fn<() => null | string>(() => null)
+const isActivePrimary = vi.fn<() => boolean>(() => false)
 const $gateway = atom<unknown>({ id: 'live-socket' })
 const resetStarmapGraph = vi.fn()
 
@@ -22,6 +23,7 @@ vi.mock('@/store/gateway', () => ({
   activeGatewayConnectionId,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
+  isActivePrimary,
   openGatewayForProfile
 }))
 vi.mock('@/hermes', () => ({
@@ -38,6 +40,8 @@ beforeEach(() => {
   ensureGatewayForAgent.mockClear()
   activeGatewayConnectionId.mockReset()
   activeGatewayConnectionId.mockReturnValue(null)
+  isActivePrimary.mockReset()
+  isActivePrimary.mockReturnValue(true)
   $gateway.set({ id: 'live-socket' })
   $activeGatewayProfile.set('default')
   // resolveConnectionForAgent is best-effort; without a bridge it resolves
@@ -162,6 +166,7 @@ describe('selectProfile startup preference (#79886)', () => {
 
   it('does not replace the startup preference for a registry-source pick', async () => {
     activeGatewayConnectionId.mockReturnValue('mini')
+    isActivePrimary.mockReturnValue(false)
 
     selectProfile('researcher')
 
@@ -223,5 +228,19 @@ describe('selectProfile startup preference (#79886)', () => {
     await new Promise(resolve => setTimeout(resolve, 0))
 
     expect(rememberProfile).not.toHaveBeenCalled()
+  })
+
+  // Regression: the prior onPrimary gate (`activeGatewayConnectionId() == null`)
+  // silently skipped persistence when the desktop's primary backend had a
+  // registered registry connection id (e.g. "local"). The structural
+  // activeKey === primaryProfile check is what actually identifies the
+  // window primary, regardless of the primary's connectionId.
+  it('remembers the selection when the primary has a registered connection id', async () => {
+    activeGatewayConnectionId.mockReturnValue('local')
+
+    selectProfile('tilly')
+
+    await vi.waitFor(() => expect(rememberProfile).toHaveBeenCalledWith('tilly'))
+    expect(ensureGatewayForProfile).toHaveBeenCalledWith('tilly')
   })
 })

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -18,6 +18,7 @@ import { invalidateCronModelImpactScopeState } from '@/store/cron-model-impact-s
 import {
   $gateway,
   activeGatewayConnectionId,
+  isActivePrimary,
   ensureGatewayForAgent,
   ensureGatewayForProfile,
   openGatewayForAgent,
@@ -815,8 +816,11 @@ export function selectProfile(name: string): void {
   // the selection for the next Desktop launch through the persistence-only
   // IPC instead (#79886). Registry-source picks name ANOTHER source's
   // profiles, so only a primary-backend activation updates the startup
-  // preference.
-  const onPrimary = activeGatewayConnectionId() == null
+  // preference. The active-key/primary-profile comparison is what actually
+  // identifies the window primary — activeGatewayConnectionId's null return
+  // is incidental and breaks when the primary has registered a registry
+  // connection id (e.g. "local").
+  const onPrimary = isActivePrimary()
 
   const shouldRememberStartupProfile = onPrimary ? isLocalDesktopProfile(target) : Promise.resolve(false)
 


### PR DESCRIPTION
## What does this PR do?

The Desktop profile rail's `selectProfile` persistence path uses an `onPrimary` gate to decide whether to record the pick into `active-profile.json` for the next launch. The gate was:

```ts
const onPrimary = activeGatewayConnectionId() == null
```

That only returns true when the desktop's primary backend has no registered registry connection id. On installs where the primary backend has registered a HermesConnection id (e.g. `'local'`), the gate returns false and the persistence-only `hermes:profile:remember` IPC is silently skipped. The user's profile-rail click lands in the right backend for the current session, but `active-profile.json` is never rewritten — and the next launch re-loads whichever value was last written by some other path.

Switch to `isActivePrimary()` (the same structural check used inside `activeGatewayConnectionId` itself), which identifies the window primary by `g.activeKey === g.primaryProfile` rather than by the primary's connectionId being null.

## Reproduction (before this PR)

1. Start Desktop with a primary backend whose `primaryConnectionId` is non-null (e.g. `'local'`).
2. Click any named profile in the rail.
3. `active-profile.json` is unchanged.
4. Quit + reopen Desktop → Desktop returns to the prior startup profile.

The test fixtures in `profile-select-source.test.ts` only covered the `activeGatewayConnectionId() === null` case, which masked the production case.

## Related Issue

Refs #79886 (the original issue that #79888 salvaged; the salvage used the broken `onPrimary` gate).

## Lineage

- #79888 (Tilly-YL, closed) introduced the persist path via the broken gate.
- #95087 (merged) salvaged #79888 into the class-7/8 consolidation that landed on `main`.
- This PR keeps the persistence semantics #79886 wanted but uses a gate that actually matches the primary-backend intent expressed in the surrounding comment ("only a primary-backend activation updates the startup preference").

cc @Tilly-YL — author of the original persist path; flagging in case you want to weigh in on the structural test surface.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/profile.ts`: import `isActivePrimary`; replace the `activeGatewayConnectionId() == null` gate with `isActivePrimary()`; tighten the surrounding comment to explain the structural check and the failure mode.
- `apps/desktop/src/store/profile-select-source.test.ts`: add `isActivePrimary` to the gateway mock; reset it in `beforeEach`; explicitly mock `false` for the registry-source pick test; add a regression test exercising `activeGatewayConnectionId() === 'local'`.

## How to Test

1. `cd apps/desktop && node_modules/.bin/vitest run src/store/profile-select-source.test.ts` — 14/14 pass.
2. `cd apps/desktop && node_modules/.bin/tsc -p tsconfig.json --noEmit` — no new errors.
3. Manual: with a primary whose `primaryConnectionId === 'local'`, click a named profile in the rail, quit + reopen, confirm `~/Library/Application Support/Hermes/active-profile.json` now reflects the chosen profile.

## Checklist

### Code
- [x] I have read the Contributing Guide.
- [x] My commit message follows Conventional Commits.
- [x] I searched open and closed issues and pull requests for duplicates.
- [x] This PR contains only changes related to this bug.
- [ ] I ran pytest tests/ -q. Not run because this patch changes only Desktop TypeScript and the scoped Vitest suite is listed above.
- [x] I added regression tests for the changed behavior.
- [ ] I completed a patched-binary restart test. Local repro and source checks pass; a restart of the Electron-built app on the same install is not part of CI and is intentionally not claimed here.

### Documentation & Housekeeping
- [x] Documentation update: N/A. No user-facing option or configuration key was added.
- [x] cli-config.yaml.example update: N/A.
- [x] CONTRIBUTING.md or AGENTS.md update: N/A.
- [x] Cross-platform impact considered. The change is renderer-side; the existing primary-backend resolution path is unchanged.
- [x] Tool descriptions and schemas: N/A.