### PR TITLE
fix(process): negotiate the systemd properties a transient scope accepts

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -2441,6 +2441,123 @@ class TestSystemdCgroupIsolation:
         assert pr._systemd_run_user_scope_available() is True
         assert len(probe_calls) == 2
 
+    def test_probe_negotiates_away_a_rejected_scope_property(self, monkeypatch):
+        """A property this systemd cannot parse costs that property only.
+
+        ``OOMPolicy=`` is valid on *scope* units only from systemd v253, so
+        managers like Ubuntu 22.04's 249 answer the probe with
+        ``Unknown assignment: OOMPolicy=kill``.  Reading that as "the scope
+        backend is unavailable" fails every restart-safe dispatch (#102486).
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_IS_LINUX", True)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROPERTIES", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_LAST_ERROR", None)
+        probe_argvs = []
+
+        def fake_run(argv, **kwargs):
+            probe_argvs.append(list(argv))
+            if any(value.startswith("OOMPolicy=") for value in argv):
+                return subprocess.CompletedProcess(
+                    args=argv,
+                    returncode=1,
+                    stderr=b"Unknown assignment: OOMPolicy=kill\n",
+                )
+            return subprocess.CompletedProcess(args=argv, returncode=0)
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is True
+        assert len(probe_argvs) == 2, "the probe must retry without the property"
+        assert pr._SYSTEMD_SCOPE_PROPERTIES == ("MemoryAccounting", "MemoryMax")
+
+        retry = probe_argvs[1]
+        assert not any(value.startswith("OOMPolicy=") for value in retry)
+        assert "MemoryAccounting=yes" in retry, retry
+        assert any(value.startswith("MemoryMax=") for value in retry), retry
+        first_unit = probe_argvs[0][probe_argvs[0].index("--unit") + 1]
+        retry_unit = retry[retry.index("--unit") + 1]
+        assert first_unit != retry_unit, "each attempt needs its own unit name"
+
+    def test_probe_does_not_negotiate_a_missing_user_bus(self, monkeypatch):
+        """Only unparseable properties are retried away.
+
+        A missing user D-Bus session is genuine unavailability: retrying with
+        a smaller property set would spin without ever succeeding.
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_IS_LINUX", True)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROPERTIES", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_LAST_ERROR", None)
+        probe_calls = []
+
+        def fake_run(argv, **kwargs):
+            probe_calls.append(list(argv))
+            return subprocess.CompletedProcess(
+                args=argv,
+                returncode=1,
+                stderr=b"Failed to connect to bus: No such file or directory\n",
+            )
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is False
+        assert len(probe_calls) == 1
+        assert pr._SYSTEMD_SCOPE_PROPERTIES is None
+        assert "Failed to connect to bus" in (pr._SYSTEMD_SCOPE_LAST_ERROR or "")
+
+    def test_scope_argv_uses_the_negotiated_property_set(self, monkeypatch):
+        """The worker scope is built from what the probe proved, not a guess.
+
+        Probing without OOMPolicy and then spawning with it would fail every
+        worker at exec time exactly as the probe did.
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr(
+            pr, "_SYSTEMD_SCOPE_PROPERTIES", ("MemoryAccounting", "MemoryMax")
+        )
+
+        argv = pr._build_systemd_scope_argv(["/bin/true"], unit_suffix="abc")
+
+        properties = [
+            argv[index + 1]
+            for index, value in enumerate(argv[:-1])
+            if value == "--property"
+        ]
+        assert not any(value.startswith("OOMPolicy=") for value in properties)
+        assert "MemoryAccounting=yes" in properties
+        assert any(value.startswith("MemoryMax=") for value in properties)
+
+    def test_fail_closed_error_reports_why_the_probe_failed(self, monkeypatch):
+        """The refusal names the systemd error instead of only its verdict.
+
+        The opaque "systemd-run --user --scope is unavailable" text is what
+        turned a single rejected property into a blind cron outage.
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_IS_LINUX", True)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 1_000_000.0)
+        monkeypatch.setattr(
+            pr,
+            "_SYSTEMD_SCOPE_LAST_ERROR",
+            "Failed to connect to bus: No such file or directory",
+        )
+        monkeypatch.setattr(pr, "_is_supervised_gateway_process", lambda: True)
+        monkeypatch.setenv("INVOCATION_ID", "deadbeef")
+
+        with pytest.raises(RuntimeError, match="Failed to connect to bus"):
+            pr.restart_safe_gateway_child_argv(["/bin/true"], unit_suffix="job")
+
     def test_stop_systemd_unit_treats_absent_unit_as_clean(self, monkeypatch):
         import tools.process_registry as pr
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -50,7 +50,7 @@ _IS_LINUX = platform.system() == "Linux"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
 from hermes_cli._subprocess_compat import windows_hide_flags
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from hermes_cli.config import get_hermes_home
 
@@ -114,6 +114,25 @@ _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
 _SYSTEMD_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
+# Properties requested for every transient worker scope, in argv order.
+# ``OOMPolicy=`` only became valid on *scope* units in systemd v253; older
+# managers (Ubuntu 22.04's 249, Debian 12 / RHEL 9's 252) reject the whole
+# invocation with ``Unknown assignment: OOMPolicy=kill``, which made the probe
+# below report a perfectly working scope backend as unavailable (#102486).
+# The probe therefore negotiates the set this manager accepts, and the scope
+# builder reuses exactly that set.
+_SCOPE_PROPERTY_NAMES: Tuple[str, ...] = (
+    "MemoryAccounting",
+    "MemoryMax",
+    "OOMPolicy",
+)
+_SYSTEMD_SCOPE_PROPERTIES: Optional[Tuple[str, ...]] = None
+_SYSTEMD_SCOPE_LAST_ERROR: Optional[str] = None
+_UNSUPPORTED_PROPERTY_MARKERS = (
+    "unknown assignment",
+    "unknown property",
+    "cannot set property",
+)
 _MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
 _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
 _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
@@ -181,6 +200,38 @@ def _worker_memory_max_bytes() -> int:
     return min(override_bound, safe_bound) if override_bound else safe_bound
 
 
+def _scope_property_argv(names: Sequence[str]) -> List[str]:
+    """Return ``--property NAME=VALUE`` pairs for *names*, in the given order."""
+    constants = {"MemoryAccounting": "yes", "OOMPolicy": "kill"}
+    argv: List[str] = []
+    for name in names:
+        # The bound is only read when the property survived negotiation.
+        value = (
+            str(_worker_memory_max_bytes())
+            if name == "MemoryMax"
+            else constants[name]
+        )
+        argv.extend(("--property", f"{name}={value}"))
+    return argv
+
+
+def _rejected_scope_properties(
+    stderr: str, candidates: Sequence[str]
+) -> Tuple[str, ...]:
+    """Return the *candidates* this systemd says it does not understand.
+
+    ``systemd-run`` refuses an unsupported property before creating anything
+    (``Unknown assignment: OOMPolicy=kill``); the manager reports the
+    server-side variant (``Cannot set property ..., or unknown property``).
+    Any other failure -- a missing user bus above all -- is a real
+    unavailability and must not be retried away.
+    """
+    lowered = stderr.lower()
+    if not any(marker in lowered for marker in _UNSUPPORTED_PROPERTY_MARKERS):
+        return ()
+    return tuple(name for name in candidates if name.lower() in lowered)
+
+
 def _systemd_run_user_scope_available() -> bool:
     """Return True if ``systemd-run --user --scope`` can create a cgroup.
 
@@ -193,6 +244,7 @@ def _systemd_run_user_scope_available() -> bool:
     outcome.
     """
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
+    global _SYSTEMD_SCOPE_PROPERTIES, _SYSTEMD_SCOPE_LAST_ERROR
     cached = _SYSTEMD_SCOPE_AVAILABLE
     now = time.monotonic()
     if cached is True:
@@ -219,43 +271,76 @@ def _systemd_run_user_scope_available() -> bool:
             return False
 
         available = False
+        supported: Tuple[str, ...] = _SCOPE_PROPERTY_NAMES
+        last_error: Optional[str] = None
         if _IS_LINUX:
             try:
                 import shutil
 
                 binary = shutil.which("systemd-run")
                 if binary:
-                    # Probe: create a transient scope that immediately exits.
-                    # A unique unit avoids collisions; timeout bounds D-Bus.
-                    probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
-                    result = subprocess.run(
-                        [
-                            binary, "--user", "--scope", "--quiet",
-                            "--unit", probe_unit,
-                            "--collect",
-                            "--property", "MemoryAccounting=yes",
-                            "--property", f"MemoryMax={_worker_memory_max_bytes()}",
-                            "--property", "OOMPolicy=kill",
-                            "--",
-                            "/bin/true",
-                        ],
-                        capture_output=True,
-                        timeout=3,
-                    )
-                    available = result.returncode == 0
-                    if not available:
-                        logger.debug(
-                            "systemd-run --user --scope probe failed (rc=%s): %s",
-                            result.returncode,
-                            (result.stderr or b"").decode(
-                                "utf-8", "replace"
-                            ).strip(),
+                    candidates = list(_SCOPE_PROPERTY_NAMES)
+                    while True:
+                        # Probe: create a transient scope that immediately
+                        # exits.  A unique unit avoids collisions; timeout
+                        # bounds D-Bus.
+                        probe_unit = (
+                            f"hermes-probe-scope-{os.getpid()}"
+                            f"-{uuid.uuid4().hex[:8]}"
+                        )
+                        result = subprocess.run(
+                            [
+                                binary, "--user", "--scope", "--quiet",
+                                "--unit", probe_unit,
+                                "--collect",
+                                *_scope_property_argv(candidates),
+                                "--",
+                                "/bin/true",
+                            ],
+                            capture_output=True,
+                            timeout=3,
+                        )
+                        if result.returncode == 0:
+                            available = True
+                            supported = tuple(candidates)
+                            break
+                        last_error = (result.stderr or b"").decode(
+                            "utf-8", "replace"
+                        ).strip()
+                        rejected = _rejected_scope_properties(
+                            last_error, candidates
+                        )
+                        if not rejected:
+                            logger.debug(
+                                "systemd-run --user --scope probe failed "
+                                "(rc=%s): %s",
+                                result.returncode,
+                                last_error,
+                            )
+                            break
+                        # This manager is too old for one of the hardening
+                        # properties.  Drop it and re-probe: an unsupported
+                        # knob must cost that knob, not the whole restart-safe
+                        # scope backend every worker dispatch depends on.
+                        candidates = [
+                            name for name in candidates if name not in rejected
+                        ]
+                        logger.warning(
+                            "systemd rejected transient-scope propert%s %s; "
+                            "worker isolation continues without %s (%s)",
+                            "y" if len(rejected) == 1 else "ies",
+                            ", ".join(rejected),
+                            "it" if len(rejected) == 1 else "them",
+                            last_error,
                         )
             except Exception as exc:
+                last_error = str(exc)
                 logger.debug("systemd-run --user --scope probe error: %s", exc)
 
         _SYSTEMD_SCOPE_AVAILABLE = available
         _SYSTEMD_SCOPE_PROBED_AT = time.monotonic()
+        _SYSTEMD_SCOPE_PROPERTIES = supported if available else None
+        _SYSTEMD_SCOPE_LAST_ERROR = None if available else last_error
         return available
 
 
@@ -303,7 +388,14 @@ def _build_systemd_scope_argv(
         # guard anyway so we never pass None into Popen.
         return shell_argv
     unit_name = f"hermes-worker-{unit_suffix}"
-    memory_max = _worker_memory_max_bytes()
+    # Exactly the properties the probe proved this systemd accepts.  When the
+    # probe has not run, ask for the full set: identical to the behaviour
+    # before the negotiation existed.
+    properties = (
+        _SCOPE_PROPERTY_NAMES
+        if _SYSTEMD_SCOPE_PROPERTIES is None
+        else _SYSTEMD_SCOPE_PROPERTIES
+    )
     return [
         binary,
         "--user",
@@ -312,12 +404,7 @@ def _build_systemd_scope_argv(
         "--unit",
         unit_name,
         "--collect",
-        "--property",
-        "MemoryAccounting=yes",
-        "--property",
-        f"MemoryMax={memory_max}",
-        "--property",
-        "OOMPolicy=kill",
+        *_scope_property_argv(properties),
         "--",
         *shell_argv,
     ]
@@ -339,9 +426,11 @@ def restart_safe_gateway_child_argv(
     if not _is_supervised_gateway_process() or not os.environ.get("INVOCATION_ID"):
         return command
     if not _systemd_run_user_scope_available():
+        reason = _SYSTEMD_SCOPE_LAST_ERROR
         raise RuntimeError(
             "cannot create restart-safe systemd scope for gateway child: "
             "systemd-run --user --scope is unavailable"
+            + (f" ({reason})" if reason else "")
         )
     scoped = _build_systemd_scope_argv(command, unit_suffix=unit_suffix)
     if scoped == command:


### PR DESCRIPTION
## Problem

On every systemd older than v253, each restart-safe worker dispatch fails:

```
Restart-safe cron worker dispatch failed: cannot create restart-safe systemd scope
for gateway child: systemd-run --user --scope is unavailable
```

`_systemd_run_user_scope_available()` probes the backend with the same property set
the worker spawn will use, and reads any non-zero exit as "no scope backend". One of
those properties, `OOMPolicy=`, became valid on **scope** units only in systemd
**v253** ("Scope units now support `OOMPolicy=`", systemd v253 NEWS). Ubuntu 22.04
ships 249; Debian 12 and RHEL 9 ship 252. All of them answer the probe with
`Unknown assignment: OOMPolicy=kill` and exit 1 *before creating anything*.

The verdict is then cached, and `restart_safe_gateway_child_argv()` fails closed on
every dispatch that goes through it — `cron/scheduler.py::_launch_external_cron_worker`
and `hermes_cli/kanban_db.py::_restart_safe_worker_argv`. A hardening knob nobody
asked about becomes a total worker outage, and the operator sees only the verdict,
never the `Unknown assignment` line that caused it.

## Root cause

The probe asserts a **hardcoded** property set, so one property this manager cannot
parse is indistinguishable from a missing user bus. The same list is then written a
second time in `_build_systemd_scope_argv()`, so the spawn can ask for something the
probe never proved.

## Fix

Probe the desired set; when systemd names a property it cannot parse, drop that
property and probe again. The surviving set is cached and the scope builder spawns
with exactly it.

| Host | Before | After |
|---|---|---|
| systemd 249 / 252 (Ubuntu 22.04, Debian 12, RHEL 9) | every dispatch fails closed | scope created with `MemoryAccounting` + `MemoryMax`; `OOMPolicy` dropped, once, with a warning |
| systemd >= 253 (Ubuntu 24.04, Fedora 38+) | works | unchanged — `OOMPolicy=kill` kept |
| no user D-Bus session | fails closed | fails closed, now quoting the systemd error |

An unsupported knob costs that knob, not the isolation every dispatch depends on.
Failures that are **not** a property rejection are deliberately left alone: a missing
user bus is real unavailability, and retrying with a smaller set would only spin. That
path still fails closed, preserving the #101940 restart-durability contract untouched.

```mermaid
%%{init: {'theme': 'dark', 'themeVariables': { 'primaryColor': '#8b0000', 'mainBkg': '#0a0204', 'primaryTextColor': '#ffccd5', 'primaryBorderColor': '#ff0038', 'lineColor': '#ff0038'}}}%%
graph TD
    A[Cron / Kanban Dispatch] --> B[Scope Availability Probe]
    B --> C{systemd-run exit code}
    C -->|0| D[Cache Accepted Property Set]
    C -->|Unknown assignment: PROP| E[Drop Rejected Property]
    C -->|Other failure e.g. no user bus| F[Fail Closed + Quote systemd Error]
    E --> B
    D --> G[Build Scope With The Proven Set]
    G --> H[Restart-Safe Worker Running]
```

## Relationship to open work

**Supersedes #102357.** That PR found the same rejected property on a live host — the
diagnosis is theirs and it is correct. It removes `OOMPolicy=kill` statically from both
argv sites, which also removes the OOM-kill semantics on every host where the property
*is* valid (systemd >= 253), leaves the next added property free to repeat the same
outage, and is currently red on `Python tests / Run tests` because
`tests/tools/test_process_registry.py:1960` still pins `OOMPolicy=kill`. Its own review
thread asks for exactly this shape: *"If per-worker OOM kill matters, consider re-adding
it conditionally behind a support probe later."* This PR is that probe. If maintainers
prefer the one-line removal, #102357 should land instead of this.

**Not this PR's layer:**
- **#102431** owns the fail-closed *policy* (degrade vs. raise when the scope genuinely
  cannot be created). Untouched here — this PR only stops the probe from producing a
  false "unavailable", which is the precondition that PR's reviewer flagged as needing
  to land first.
- **#97739** owns backend selection (falling back to a same-UID system scope).
- **#101911** owns Kanban worker re-adoption across restarts.
- **#70716** introduced the isolation; `5f93083221` added the memory bound.

## Test plan

`tests/tools/test_process_registry.py` (4 new, in the existing POSIX-only class):

- `test_probe_negotiates_away_a_rejected_scope_property` — `Unknown assignment:
  OOMPolicy=kill` on the first probe, success on the retry; asserts the cached set is
  `("MemoryAccounting", "MemoryMax")`, that the retry carries a fresh unit name, and
  that the memory bound survived.
- `test_probe_does_not_negotiate_a_missing_user_bus` — `Failed to connect to bus` probes
  exactly once and stays unavailable.
- `test_scope_argv_uses_the_negotiated_property_set` — the builder emits the negotiated
  set, not the wish list.
- `test_fail_closed_error_reports_why_the_probe_failed` — the refusal names the systemd
  error.

Existing coverage is unchanged: `test_wraps_in_systemd_scope_when_supervisor_and_available`
still passes because the builder asks for the full set when no probe has run.

Local run (Windows dev box, so the POSIX-only class is skipped there — the four new
tests were executed against the same module through an identical standalone mirror,
6 passed): `pytest tests/tools/test_process_registry.py tests/cron/test_restart_safe_worker.py`
→ 88 passed, 6 failed, and those same 6 fail identically on unmodified `main`
(Windows-only baseline noise: `TestTerminateHostPidPosix`, PTY, stdin-EOF).
`ruff check` clean on both files.

Closes #102486
