### PR TITLE
fix(mcp): request offline token_access_type for Dropbox OAuth

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -797,6 +797,31 @@ def _make_callback_handler() -> tuple[type, dict]:
 # ---------------------------------------------------------------------------
 
 
+def _augment_authorization_url(authorization_url: str) -> str:
+    """Add provider-specific authorization query params.
+
+    Dropbox only issues a refresh_token when the authorize request carries
+    ``token_access_type=offline``. The MCP SDK builds a generic OAuth URL with
+    no way to inject provider extras, so without this the token response is a
+    4-hour access token with no refresh_token — every gateway restart after
+    expiry looks like a dead server (#dropbox-short-lived-token).
+    """
+    try:
+        from urllib.parse import urlsplit, parse_qs, urlencode, urlunsplit
+
+        parts = urlsplit(authorization_url)
+        if parts.netloc.endswith("dropbox.com") and "/oauth2/authorize" in parts.path:
+            query = parse_qs(parts.query, keep_blank_values=True)
+            if "token_access_type" not in query:
+                query["token_access_type"] = ["offline"]
+                authorization_url = urlunsplit(
+                    parts._replace(query=urlencode(query, doseq=True))
+                )
+    except Exception:  # never break the flow over URL augmentation
+        pass
+    return authorization_url
+
+
 def _make_redirect_handler(port: int, redirect_uri: str | None = None):
     """Return a redirect handler closure that closes over the given port.
 
@@ -815,6 +840,7 @@ def _make_redirect_handler(port: int, redirect_uri: str | None = None):
         Opens the browser automatically when possible; always prints the URL
         as a fallback for headless/SSH/gateway environments.
         """
+        authorization_url = _augment_authorization_url(authorization_url)
         from tools.mcp_dashboard_oauth import get_dashboard_oauth_flow
 
         dashboard_flow = get_dashboard_oauth_flow()


### PR DESCRIPTION
## Symptom
Dropbox MCP server authenticates fine, then silently dies ~4 hours later. `hermes mcp test dropbox` reports the server needs re-authorization; the token file at `~/.hermes/mcp-tokens/dropbox.json` contains only an access_token (`expires_in: 14400`) and **no refresh_token**, so nothing can renew it.

## Root cause
Dropbox's OAuth implementation only issues a refresh_token when the authorize request carries `token_access_type=offline` ([Dropbox OAuth guide](https://developers.dropbox.com/oauth-guide)). The MCP SDK builds a generic authorization URL with no way to inject provider-specific query params, so every Dropbox authorization yields a short-lived, non-renewable token.

## Fix
Augment the authorization URL in `_redirect_handler` (covers both the dashboard flow and the CLI/browser flow) with `token_access_type=offline`, scoped strictly to `dropbox.com` `/oauth2/authorize` URLs. Other providers are untouched; failures in augmentation fall back to the original URL.

## Verification
Reproduced on current main: authorizing `https://mcp.dropbox.com/mcp` without the param yields a token file without refresh_token; expired 4h later with `expired_access_token`. After this patch, the same flow stores a refresh_token and the connection survives token expiry (verified with `hermes mcp test dropbox` after re-auth: Connected, 25 tools).