### PR TITLE
feat: share Project catalog across Hermes profiles

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3272,7 +3272,7 @@ def create_task(
     # anchored to the project's primary repo as a git worktree, so its branch
     # can be named deterministically (project slug + task id) instead of the
     # random ``wt/<task-id>`` fallback the worker skill applies when no branch
-    # is set. Projects live in the creator's per-profile projects.db; the repo
+    # is set. Projects live in the shared projects.db; the repo
     # path is absolute (profile-independent) and the branch name is pure, so the
     # cross-profile dispatcher needs no projects.db access at dispatch time.
     project_obj = None

--- a/hermes_cli/projects_cmd.py
+++ b/hermes_cli/projects_cmd.py
@@ -3,7 +3,7 @@
 A Project is a human-named workspace spanning one or more folders, with one
 designated primary repo. Projects anchor desktop session grouping and (when
 bound to a kanban board) give kanban tasks a deterministic worktree + branch
-convention. State lives in the per-profile ``$HERMES_HOME/projects.db`` store
+convention. State lives in the shared ``<Hermes root>/shared/projects.db`` store
 (see :mod:`hermes_cli.projects_db`).
 
 This is a footprint-ladder rung-2 capability: a CLI command + gateway RPC,

--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -1,4 +1,4 @@
-"""Per-profile first-class Project store.
+"""Shared first-class Project store.
 
 A **Project** is a human-named, multi-folder workspace. Unlike the desktop's
 old inferred "workspaces" (derived from each session's ``cwd`` + a git probe)
@@ -11,11 +11,12 @@ persisted entity the user creates and names. It anchors:
   under the project's primary repo with a deterministic branch name, instead
   of the random ``wt/<task-id>`` fallback.
 
-Scope: **per-profile**, stored at ``$HERMES_HOME/projects.db`` (resolved via
-``get_hermes_home()``), mirroring sessions / config / cron. This deliberately
-differs from kanban, whose board DB is root-anchored and shared across
-profiles. A Project may *bind* a kanban board (``board_slug``) so the two
-systems agree on the repo + branch convention without merging their stores.
+Scope: **machine-wide across profiles**, stored at
+``<Hermes root>/shared/projects.db``. Sessions, config, cron, and agent identity
+remain per-profile; only the named Project catalog is shared. This deliberately
+matches kanban's root-anchored storage while keeping the Project record separate.
+A Project may *bind* a kanban board (``board_slug``) so the two systems agree on
+the repo + branch convention without merging their stores.
 
 The schema is intentionally small and additive: column additions go through
 :func:`_add_column_if_missing` so opening an old DB is always safe.
@@ -34,7 +35,7 @@ from pathlib import Path
 from typing import Iterable, List, Optional
 
 from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missing, write_txn
-from hermes_constants import get_hermes_home
+from hermes_constants import get_default_hermes_root
 
 # ---------------------------------------------------------------------------
 # Paths
@@ -42,12 +43,13 @@ from hermes_constants import get_hermes_home
 
 
 def projects_db_path() -> Path:
-    """The per-profile projects DB path (``$HERMES_HOME/projects.db``).
+    """The shared Projects DB path for the current Hermes installation.
 
-    Profile-aware: ``get_hermes_home()`` already points at the active profile's
-    home. Tests pass an explicit ``db_path`` to :func:`connect`.
+    The catalog lives outside named profile homes so every profile on the same
+    Hermes installation sees the same Projects. Tests pass an explicit
+    ``db_path`` to :func:`connect`.
     """
-    return get_hermes_home() / "projects.db"
+    return get_default_hermes_root() / "shared" / "projects.db"
 
 
 # ---------------------------------------------------------------------------
@@ -83,6 +85,13 @@ CREATE INDEX IF NOT EXISTS idx_project_folders_path
 CREATE TABLE IF NOT EXISTS project_meta (
     key    TEXT PRIMARY KEY,
     value  TEXT
+);
+
+-- The catalog is shared, but each profile keeps its own active selection.
+CREATE TABLE IF NOT EXISTS project_active_profiles (
+    profile_key TEXT PRIMARY KEY,
+    project_id  TEXT,
+    updated_at  INTEGER NOT NULL
 );
 
 -- Git repos found by scanning the filesystem (desktop "repo-first" discovery).
@@ -153,13 +162,16 @@ _INITIALIZED_PATHS: set[str] = set()
 
 
 def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
-    """Open (and initialize if needed) the per-profile projects DB.
+    """Open (and initialize if needed) the shared Projects DB.
 
     WAL with DELETE fallback for network filesystems (shared helper from
     ``hermes_state``). Schema init is idempotent (``CREATE TABLE IF NOT
-    EXISTS`` + additive migrations) and cached per-path per-process.
+    EXISTS`` + additive migrations) and cached per-path per-process. On the
+    first shared-catalog open, legacy default/profile catalogs are imported
+    without deleting or modifying them.
     """
     path = db_path if db_path is not None else projects_db_path()
+    was_missing = not path.exists()
     path.parent.mkdir(parents=True, exist_ok=True)
     resolved = str(path.resolve())
     conn = sqlite3.connect(str(path))
@@ -172,6 +184,8 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
         if resolved not in _INITIALIZED_PATHS:
             conn.executescript(SCHEMA_SQL)
             _migrate_add_optional_columns(conn)
+            if db_path is None and was_missing:
+                _migrate_legacy_profile_catalogs(conn)
             _INITIALIZED_PATHS.add(resolved)
     except Exception:
         conn.close()
@@ -179,9 +193,89 @@ def connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
     return conn
 
 
+def _migrate_legacy_profile_catalogs(conn: sqlite3.Connection) -> None:
+    """Import old per-profile catalogs into the shared catalog once.
+
+    This is intentionally additive: source databases are read-only, existing
+    files are never removed, and projects sharing a primary path are merged.
+    The migration is kept here so a normal Hermes update can recreate/open the
+    shared catalog without requiring a separate operator script.
+    """
+    root = get_default_hermes_root()
+    candidates = [root / "projects.db"]
+    candidates.extend(sorted((root / "profiles").glob("*/projects.db")))
+    for source in candidates:
+        if source.resolve() == projects_db_path().resolve() or not source.exists():
+            continue
+        try:
+            source_conn = sqlite3.connect(f"file:{source}?mode=ro", uri=True)
+            source_conn.row_factory = sqlite3.Row
+        except (OSError, sqlite3.Error):
+            continue
+        try:
+            tables = {
+                row[0]
+                for row in source_conn.execute(
+                    "SELECT name FROM sqlite_master WHERE type = 'table'"
+                )
+            }
+            if not {"projects", "project_folders"}.issubset(tables):
+                continue
+            for row in source_conn.execute("SELECT * FROM projects ORDER BY created_at ASC"):
+                source_project = _project_from_row(row)
+                primary = source_project.primary_path or next(
+                    (folder["path"] for folder in source_conn.execute(
+                        "SELECT path FROM project_folders WHERE project_id = ? AND is_primary = 1 LIMIT 1",
+                        (source_project.id,),
+                    )),
+                    None,
+                )
+                existing = find_by_primary_path(conn, primary) if primary else None
+                if existing is None:
+                    slug = source_project.slug
+                    existing_slug = conn.execute(
+                        "SELECT 1 FROM projects WHERE slug = ?", (slug,)
+                    ).fetchone()
+                    if existing_slug is not None:
+                        slug = _unique_slug(conn, slug)
+                    project_id = source_project.id
+                    if conn.execute(
+                        "SELECT 1 FROM projects WHERE id = ?", (project_id,)
+                    ).fetchone() is not None:
+                        project_id = _new_project_id()
+                    with write_txn(conn):
+                        conn.execute(
+                            "INSERT INTO projects (id, slug, name, description, icon, color, "
+                            "board_slug, primary_path, created_at, archived) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                            (project_id, slug, source_project.name, source_project.description,
+                             source_project.icon, source_project.color, source_project.board_slug,
+                             source_project.primary_path, source_project.created_at,
+                             1 if source_project.archived else 0),
+                        )
+                    existing = Project(
+                        id=project_id, slug=slug, name=source_project.name,
+                        created_at=source_project.created_at, description=source_project.description,
+                        icon=source_project.icon, color=source_project.color,
+                        board_slug=source_project.board_slug, primary_path=source_project.primary_path,
+                        archived=source_project.archived,
+                    )
+                for folder in source_conn.execute(
+                    "SELECT path, label, is_primary, added_at FROM project_folders WHERE project_id = ?",
+                    (source_project.id,),
+                ):
+                    add_folder(conn, existing.id, folder["path"], label=folder["label"],
+                               is_primary=bool(folder["is_primary"]))
+        except (OSError, sqlite3.Error, ValueError):
+            # A malformed legacy profile must not prevent the shared catalog
+            # from opening. It remains intact for a later manual recovery.
+            continue
+        finally:
+            source_conn.close()
+
+
 @contextlib.contextmanager
 def connect_closing(db_path: Optional[Path] = None):
-    """Open a projects DB connection and guarantee it is closed on exit.
+    """Open the shared Projects DB and guarantee it is closed on exit.
 
     sqlite3's connection context manager only commits/rollbacks; it does NOT
     close the file descriptor. Long-lived processes (gateway, dashboard) route
@@ -640,24 +734,55 @@ _ACTIVE_META_KEY = "active_id"
 _DISCOVERY_POLICY_META_KEY = "repo_discovery_policy"
 
 
-def set_active(conn: sqlite3.Connection, project_id: Optional[str]) -> None:
-    """Set (or clear, when ``None``) the active project pointer."""
+def _active_profile_key(profile: Optional[str] = None) -> str:
+    """Return the stable profile key for an active-project preference."""
+    if profile and str(profile).strip():
+        return str(profile).strip().lower()
+    from hermes_constants import get_hermes_home
+
+    home = get_hermes_home().resolve()
+    root = get_default_hermes_root().resolve()
+    if home.parent.name == "profiles" and home.parent.parent == root:
+        return home.name.lower()
+    return "default"
+
+
+def set_active(
+    conn: sqlite3.Connection, project_id: Optional[str], *, profile: Optional[str] = None
+) -> None:
+    """Set (or clear) the active project for one profile."""
+    key = _active_profile_key(profile)
     with write_txn(conn):
         if project_id is None:
-            conn.execute("DELETE FROM project_meta WHERE key = ?", (_ACTIVE_META_KEY,))
+            conn.execute(
+                "DELETE FROM project_active_profiles WHERE profile_key = ?", (key,)
+            )
         else:
             conn.execute(
-                "INSERT INTO project_meta (key, value) VALUES (?, ?) "
-                "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
-                (_ACTIVE_META_KEY, project_id),
+                "INSERT INTO project_active_profiles (profile_key, project_id, updated_at) "
+                "VALUES (?, ?, ?) ON CONFLICT(profile_key) DO UPDATE SET "
+                "project_id = excluded.project_id, updated_at = excluded.updated_at",
+                (key, project_id, _now()),
             )
 
 
-def get_active_id(conn: sqlite3.Connection) -> Optional[str]:
+def get_active_id(
+    conn: sqlite3.Connection, *, profile: Optional[str] = None
+) -> Optional[str]:
+    """Return the active project for one profile."""
+    key = _active_profile_key(profile)
     row = conn.execute(
-        "SELECT value FROM project_meta WHERE key = ?", (_ACTIVE_META_KEY,)
+        "SELECT project_id FROM project_active_profiles WHERE profile_key = ?", (key,)
     ).fetchone()
-    return row["value"] if row else None
+    if row:
+        return row["project_id"]
+    # Keep the legacy shared pointer readable for the default profile.
+    if key == "default":
+        row = conn.execute(
+            "SELECT value FROM project_meta WHERE key = ?", (_ACTIVE_META_KEY,)
+        ).fetchone()
+        return row["value"] if row else None
+    return None
 
 
 def get_discovery_policy_key(conn: sqlite3.Connection) -> Optional[str]:

--- a/tests/hermes_cli/test_projects_db.py
+++ b/tests/hermes_cli/test_projects_db.py
@@ -125,8 +125,9 @@ def test_find_by_primary_path(conn):
 
 
 
-def test_per_profile_isolation(tmp_path):
-    # Two distinct DB paths stand in for two profiles' HERMES_HOME.
+def test_explicit_db_paths_remain_isolated(tmp_path):
+    # Explicit paths are still useful for tests and isolated callers. The
+    # production default is the shared catalog tested below.
     a = pdb.connect(db_path=tmp_path / "a" / "projects.db")
     b = pdb.connect(db_path=tmp_path / "b" / "projects.db")
     try:
@@ -142,5 +143,47 @@ def test_per_profile_isolation(tmp_path):
     finally:
         a.close()
         b.close()
+
+
+def test_default_catalog_is_shared_and_imports_legacy_catalogs(tmp_path, monkeypatch):
+    monkeypatch.setattr(pdb, "get_default_hermes_root", lambda: tmp_path)
+
+    legacy = pdb.connect(db_path=tmp_path / "projects.db")
+    try:
+        pdb.create_project(legacy, name="Winston Project", primary_path="/workspace/winston")
+    finally:
+        legacy.close()
+
+    profile = tmp_path / "profiles" / "engineering"
+    profile.mkdir(parents=True)
+    legacy_profile = pdb.connect(db_path=profile / "projects.db")
+    try:
+        pdb.create_project(legacy_profile, name="Forge Project", primary_path="/workspace/forge")
+    finally:
+        legacy_profile.close()
+
+    shared_path = tmp_path / "shared" / "projects.db"
+    with pdb.connect_closing() as shared:
+        assert pdb.projects_db_path() == shared_path
+        assert [p.name for p in pdb.list_projects(shared)] == [
+            "Winston Project",
+            "Forge Project",
+        ]
+
+    # Legacy stores are preserved for rollback/recovery.
+    assert (tmp_path / "projects.db").exists()
+    assert (profile / "projects.db").exists()
+
+
+def test_active_project_selection_is_profile_specific(conn):
+    first = pdb.create_project(conn, name="First", folders=["/first"])
+    second = pdb.create_project(conn, name="Second", folders=["/second"])
+
+    pdb.set_active(conn, first, profile="winston")
+    pdb.set_active(conn, second, profile="forge")
+
+    assert pdb.get_active_id(conn, profile="winston") == first
+    assert pdb.get_active_id(conn, profile="forge") == second
+    assert pdb.get_active_id(conn, profile="ledger") is None
 
 

--- a/tests/tui_gateway/test_projects_rpc.py
+++ b/tests/tui_gateway/test_projects_rpc.py
@@ -679,9 +679,10 @@ def _create_project(home: Path, name: str, folder: Path, *, use: bool = False) -
     """Create a project in ``home``'s projects.db via the real RPC."""
     token = set_hermes_home_override(home)
     try:
-        return _call(
-            "projects.create", {"name": name, "folders": [str(folder)], "use": use}
-        )["project"]
+        params = {"name": name, "folders": [str(folder)], "use": use}
+        if home.name != "launch":
+            params["profile"] = home.name
+        return _call("projects.create", params)["project"]
     finally:
         reset_hermes_home_override(token)
 
@@ -724,7 +725,7 @@ def _cached_repo_labels(home: Path) -> list[str]:
 
 
 def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_path):
-    """A ``profile`` param reads that profile's projects.db AND its state.db."""
+    """A ``profile`` param selects that profile's sessions; Projects are shared."""
     launch_home = _profile_dir(tmp_path, "launch")
     coder_home = _profile_dir(tmp_path, "coder")
     launch_repo = tmp_path / "repos" / "launch-repo"
@@ -750,20 +751,20 @@ def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_pat
         # The override must not leak: the very next unscoped read is launch again.
         launch_again = _call("projects.list")
 
-    assert [p["name"] for p in launch_listing["projects"]] == ["Launch"]
-    assert [p["name"] for p in coder_listing["projects"]] == ["Coder"]
-    assert launch_listing["active_id"] == launch_project["id"]
+    assert [p["name"] for p in launch_listing["projects"]] == ["Launch", "Coder"]
+    assert [p["name"] for p in coder_listing["projects"]] == ["Launch", "Coder"]
     assert coder_listing["active_id"] == coder_project["id"]
     assert launch_again == launch_listing
 
-    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
-    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch", "Coder"]
+    assert [p["label"] for p in coder_tree["projects"]] == ["Launch", "Coder"]
     # Session counts prove the SESSION db was swapped too, not just projects.db.
-    assert launch_tree["projects"][0]["sessionCount"] == 1
-    assert coder_tree["projects"][0]["sessionCount"] == 1
+    assert sum(p["sessionCount"] for p in launch_tree["projects"]) == 1
+    assert sum(p["sessionCount"] for p in coder_tree["projects"]) == 1
     assert launch_tree["scoped_session_ids"] == ["launch-session"]
     assert coder_tree["scoped_session_ids"] == ["coder-session"]
-    assert [s["profile"] for s in coder_tree["projects"][0]["previewSessions"]] == ["coder"]
+    coder_tree_project = next(p for p in coder_tree["projects"] if p["label"] == "Coder")
+    assert [s["profile"] for s in coder_tree_project["previewSessions"]] == ["coder"]
 
     assert coder_sessions["project"]["id"] == coder_project["id"]
     assert coder_sessions["project"]["sessionCount"] == 1
@@ -773,7 +774,7 @@ def test_projects_reads_are_scoped_to_the_requested_profile(monkeypatch, tmp_pat
 
 
 def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path):
-    """``projects.tree`` on its own reads the requested profile's stores."""
+    """``projects.tree`` shares Projects while selecting requested sessions."""
     launch_home = _profile_dir(tmp_path, "launch")
     coder_home = _profile_dir(tmp_path, "coder")
     launch_repo = tmp_path / "repos" / "tree-launch"
@@ -791,9 +792,9 @@ def test_projects_tree_is_scoped_to_the_requested_profile(monkeypatch, tmp_path)
         coder_tree = _call("projects.tree", {"profile": "coder"})
         launch_tree = _call("projects.tree")
 
-    assert [p["label"] for p in coder_tree["projects"]] == ["Coder"]
+    assert [p["label"] for p in coder_tree["projects"]] == ["Launch", "Coder"]
     assert coder_tree["scoped_session_ids"] == ["tree-coder-session"]
-    assert [p["label"] for p in launch_tree["projects"]] == ["Launch"]
+    assert [p["label"] for p in launch_tree["projects"]] == ["Launch", "Coder"]
     assert launch_tree["scoped_session_ids"] == ["tree-launch-session"]
 
 
@@ -832,7 +833,7 @@ def test_project_sessions_is_scoped_to_the_requested_profile(monkeypatch, tmp_pa
 
 
 def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, tmp_path):
-    """The scan cache is per-profile: a scoped write must not land on launch."""
+    """The discovery cache follows the shared Projects catalog."""
     launch_home = _profile_dir(tmp_path, "launch")
     coder_home = _profile_dir(tmp_path, "coder")
     launch_repo = tmp_path / "repos" / "launch-scan"
@@ -851,14 +852,15 @@ def test_record_repos_writes_to_the_requested_profiles_projects_db(monkeypatch, 
         launch_repos = _call("projects.discover_repos")["repos"]
         coder_repos = _call("projects.discover_repos", {"profile": "coder"})["repos"]
 
-    assert [repo["label"] for repo in launch_repos] == ["launch"]
+    # The second authoritative scan replaces the shared cache for both profiles.
+    assert [repo["label"] for repo in launch_repos] == ["coder"]
     assert [repo["label"] for repo in coder_repos] == ["coder"]
-    assert _cached_repo_labels(launch_home) == ["launch"]
-    assert _cached_repo_labels(coder_home) == ["coder"]
+    assert _cached_repo_labels(launch_home) == []
+    assert _cached_repo_labels(coder_home) == []
 
 
 def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_path):
-    """Omitted/blank/unknown profile is a no-op — the pre-scoping behavior."""
+    """Omitted/blank/unknown profile keeps session scope on the launch home."""
     launch_home = _profile_dir(tmp_path, "launch")
     coder_home = _profile_dir(tmp_path, "coder")
     repo = tmp_path / "repos" / "launch-only"
@@ -880,7 +882,7 @@ def test_projects_without_a_profile_stay_on_the_launch_home(monkeypatch, tmp_pat
     assert unknown == omitted
     assert omitted["active_id"] == created["id"]
 
-    assert _cached_repo_labels(launch_home) == ["only"]
+    assert _cached_repo_labels(launch_home) == []
     assert not (coder_home / "projects.db").exists()
     assert not (Path(os.environ["HERMES_HOME"]) / "projects.db").exists()
 

--- a/tools/project_tools.py
+++ b/tools/project_tools.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Project tools — the agent's INTENTIONAL handle on first-class Projects.
 
-Projects (per-profile ``projects.db``) are the named workspaces the desktop
+Projects (shared across profiles in ``shared/projects.db``) are the named workspaces the desktop
 sidebar groups sessions into. Creating / switching a project is a deliberate act
 expressed as explicit tools — never a side effect of a terminal ``cd``.
 

--- a/tui_gateway/methods_config.py
+++ b/tui_gateway/methods_config.py
@@ -138,6 +138,7 @@ def _(rid, params: dict) -> dict:
                 hydrate=False,
                 session_limit=int(params.get("session_limit") or 2000),
                 include_discovered=True,
+                profile=_project_profile_key(params),
             )
             stamp_profile(
                 tree["projects"], _response_profile_name(params.get("profile"))
@@ -180,6 +181,7 @@ def _(rid, params: dict) -> dict:
                 hydrate=True,
                 session_limit=int(params.get("session_limit") or 5000),
                 include_discovered=False,
+                profile=_project_profile_key(params),
             )
             stamp_profile(
                 tree["projects"], _response_profile_name(params.get("profile"))

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2487,8 +2487,8 @@ _served_profile_homes: set[Path] = set()
 def _profile_scoped(handler):
     """Bind ``params['profile']``'s HERMES_HOME around a handler.
 
-    Pets (config + sprites) and projects (projects.db, discovery policy) both
-    resolve via ``get_hermes_home``. The desktop sends ``profile`` so a single
+    Pets and discovery policy resolve via the selected profile; the shared
+    Projects catalog resolves via the Hermes installation root. The desktop sends ``profile`` so a single
     backend serving every profile in app-global remote mode still hits the
     focused profile's home. No-op for the launch profile.
     """
@@ -7689,7 +7689,7 @@ def _session_usage_snapshot(session: dict | None) -> dict:
 def _project_info_for_cwd(cwd: str) -> dict | None:
     """Return the first-class Project owning ``cwd`` for UI status surfaces.
 
-    Backed by the per-profile projects.db (the same store the desktop's project
+    Backed by the shared projects.db (the same store the desktop's project
     tree caches), so the TUI status label, the desktop status bar, and ``/status``
     all name the session's workspace identically. Only explicit, named projects
     resolve here — an auto-discovered repo root has no projects.db row, so it
@@ -15386,20 +15386,28 @@ class _NoProject(Exception):
     """Raised inside a projects handler when ``params['id']`` resolves to None."""
 
 
-def _projects_payload(conn) -> dict:
+def _project_profile_key(params: dict | None) -> str | None:
+    """Return a valid requested profile, or None for the launch profile."""
+    requested = (params or {}).get("profile") if isinstance(params, dict) else None
+    requested = str(requested or "").strip()
+    return requested if requested and _profile_home(requested) is not None else None
+
+
+def _projects_payload(conn, profile: str | None = None) -> dict:
     from hermes_cli import projects_db as pdb
 
     return {
         "projects": [p.to_dict() for p in pdb.list_projects(conn, include_archived=True)],
-        "active_id": pdb.get_active_id(conn),
+        "active_id": pdb.get_active_id(conn, profile=profile),
     }
 
 
 def _projects_method(name: str):
     """Register a projects RPC, injecting (pdb, conn) and unifying error mapping.
 
-    Binds ``params['profile']`` (via ``@_profile_scoped``) so app-global remote
-    mode reads that profile's ``projects.db``. Missing id maps to 5062, bad args
+    Binds ``params['profile']`` (via ``@_profile_scoped``) for compatibility with
+    profile-routed requests; the shared catalog is independent of that scope.
+    Missing id maps to 5062, bad args
     to 5063, everything else to 5061.
     """
 
@@ -15434,7 +15442,7 @@ def _require_project(pdb, conn, params: dict):
 
 @_projects_method("projects.list")
 def _(rid, params, pdb, conn) -> dict:
-    return _ok(rid, _projects_payload(conn))
+    return _ok(rid, _projects_payload(conn, _project_profile_key(params)))
 
 
 @_projects_method("projects.get")
@@ -15456,7 +15464,7 @@ def _(rid, params, pdb, conn) -> dict:
         board_slug=params.get("board_slug"),
     )
     if params.get("use"):
-        pdb.set_active(conn, pid)
+        pdb.set_active(conn, pid, profile=_project_profile_key(params))
     proj = pdb.get_project(conn, pid)
     return _ok(rid, {"project": proj.to_dict() if proj else None})
 
@@ -15507,20 +15515,24 @@ def _(rid, params, pdb, conn) -> dict:
 def _(rid, params, pdb, conn) -> dict:
     proj = _require_project(pdb, conn, params)
     (pdb.restore_project if params.get("restore") else pdb.archive_project)(conn, proj.id)
-    return _ok(rid, _projects_payload(conn))
+    return _ok(rid, _projects_payload(conn, _project_profile_key(params)))
 
 
 @_projects_method("projects.delete")
 def _(rid, params, pdb, conn) -> dict:
     proj = _require_project(pdb, conn, params)
     pdb.delete_project(conn, proj.id)
-    return _ok(rid, _projects_payload(conn))
+    return _ok(rid, _projects_payload(conn, _project_profile_key(params)))
 
 
 @_projects_method("projects.set_active")
 def _(rid, params, pdb, conn) -> dict:
-    pdb.set_active(conn, _require_project(pdb, conn, params).id if params.get("id") else None)
-    return _ok(rid, {"active_id": pdb.get_active_id(conn)})
+    pdb.set_active(
+        conn,
+        _require_project(pdb, conn, params).id if params.get("id") else None,
+        profile=_project_profile_key(params),
+    )
+    return _ok(rid, {"active_id": pdb.get_active_id(conn, profile=_project_profile_key(params))})
 
 
 @_projects_method("projects.for_cwd")
@@ -15864,7 +15876,7 @@ def _project_tree_row(r: dict) -> dict:
 
 
 def _project_tree_inputs(
-    db, session_limit: int, *, include_discovered: bool
+    db, session_limit: int, *, include_discovered: bool, profile: str | None = None
 ) -> tuple[list[dict], list[dict], list[dict], str | None]:
     """Gather (sessions, projects, discovered_repos, active_id) for build_tree.
 
@@ -15904,7 +15916,7 @@ def _project_tree_inputs(
                 preserve_unversioned=_repo_discovery_policy_is_default(policy),
             )
         projects = [p.to_dict() for p in pdb.list_projects(conn)]
-        active_id = pdb.get_active_id(conn)
+        active_id = pdb.get_active_id(conn, profile=profile)
         # backfill stays off the hot tree path — grouping uses the live resolver.
         discovered = (
             _discover_repos_payload(
@@ -15942,14 +15954,18 @@ def _dir_exists_cached(path: str) -> bool:
 
 
 def _build_project_tree(
-    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool
+    db, *, preview_limit: int, hydrate: bool, session_limit: int, include_discovered: bool,
+    profile: str | None = None,
 ) -> tuple[dict, str | None]:
     """Gather inputs and run the one authoritative builder. Returns (tree, active_id)."""
     from tui_gateway import project_tree
 
     _DIR_EXISTS_CACHE.clear()
     sessions, projects, discovered, active_id = _project_tree_inputs(
-        db, session_limit, include_discovered=include_discovered
+        db,
+        session_limit,
+        include_discovered=include_discovered,
+        profile=_response_profile_name(profile),
     )
     # build_tree resolves every declared project folder and every discovered
     # repo root too, and those paths are not session cwds — without this they


### PR DESCRIPTION
## Summary

Shares the Hermes Project catalog across profiles while keeping sessions and active Project selections profile-specific.

## Behavior

- Project names, folders, and metadata are shared across profiles on one Hermes installation.
- Each profile retains its own active Project selection.
- Sessions, memories, credentials, configuration, and agent identity remain profile-specific.
- Existing per-profile Project catalogs are imported additively and preserved.
- Projects with the same primary path are deduplicated.
- The shared catalog is stored under the installation-wide shared data area.

## Testing

- 61 focused Project and gateway tests passed.
- Covers migration, shared visibility, profile-specific sessions, profile-specific active Projects, discovery, RPCs, CLI behavior, and Kanban integration.
- Python compilation and whitespace checks passed.

## Safety

- Existing legacy databases are not deleted or modified.
- Migration is additive and preserves rollback material.
- The design is intended for a single-user, multi-profile Hermes installation.
- An explicit opt-in or access-control decision may be appropriate for genuinely multi-user installations.