### PR TITLE
fix(desktop): stop profile switches from spawning every backend

### DIFF
--- a/apps/desktop/electron/connection-config.test.ts
+++ b/apps/desktop/electron/connection-config.test.ts
@@ -406,6 +406,30 @@ const ROUTES = [
     expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
   },
   {
+    name: 'a read-only local session request reuses the primary backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET',
+      requestPath: '/api/sessions/session-1/messages?limit=20'
+    },
+    expected: { backend: 'primary', descriptorProfile: 'coder', scopePath: true }
+  },
+  {
+    name: 'a local session write keeps its pooled backend',
+    profile: 'coder',
+    opts: {
+      primaryProfile: 'default',
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'PATCH',
+      requestPath: '/api/sessions/session-1'
+    },
+    expected: { backend: 'pool', descriptorProfile: null, scopePath: false }
+  },
+  {
     name: 'a profile-management request uses the primary without a query scope',
     profile: 'coder',
     opts: {
@@ -692,6 +716,20 @@ test('resolveProfileApiRequest keeps eligible local REST on the primary backend'
     {
       backendProfile: null,
       requestPath: '/api/config?view=desktop&profile=iris'
+    }
+  )
+})
+
+test('resolveProfileApiRequest scopes read-only session probes without spawning a profile backend', () => {
+  assert.deepEqual(
+    resolveProfileApiRequest('iris', '/api/sessions/stored-session?include_compacted=true', {
+      globalRemote: false,
+      profileRemoteOverride: false,
+      requestMethod: 'GET'
+    }),
+    {
+      backendProfile: null,
+      requestPath: '/api/sessions/stored-session?include_compacted=true&profile=iris'
     }
   )
 })

--- a/apps/desktop/electron/connection-config.ts
+++ b/apps/desktop/electron/connection-config.ts
@@ -636,6 +636,14 @@ function localPrimaryRequestScope(opts: ProfileRouteOptions): boolean | null {
     return true
   }
 
+  // Session reads already accept `profile` and open that profile's state.db
+  // read-only. Keep ownership probes and transcript reads on the shared primary
+  // instead of spawning one local backend per profile. Writes remain pooled so
+  // their process-level profile scope and side effects are unchanged.
+  if (method === 'GET' && (pathname === '/api/sessions' || pathname.startsWith('/api/sessions/'))) {
+    return true
+  }
+
   // Every current /api/tools handler accepts `profile`; every /api/profiles
   // handler either aggregates profiles or names its target in the path/body.
   // These are the only whole families safe to route through the primary.


### PR DESCRIPTION
## What does this PR do?

Profile switches can probe a selected session across every configured local profile. Those read-only probes were routed to per-profile backend processes, so installations with many profiles could exhaust the local backend slots and leave subsequent switches waiting for spawn timeouts. This change routes only `GET /api/sessions` requests through the existing primary backend with an explicit `profile` query while preserving pooled routing for session writes.

### Symptom

Switching profiles while a session is selected can start one local Python backend per configured profile as Desktop searches for the session owner.

### Impact

Users with many local profiles can exhaust all backend spawn slots, queue the remaining probes, and experience profile-switch hangs or 30-second request failures.

### Bug Cause

**Trigger:** `apps/desktop/electron/connection-config.ts:608` / `localPrimaryRequestScope()` does not classify the read-only sessions route family as safe for the shared local primary.

**Causal chain:**
1. Session ownership resolution sends `GET /api/sessions/{id}` once per candidate profile.
2. The Electron resolver falls through to `backend: 'pool'` for each request because the sessions GET family is absent from the primary-scoped route policy.
3. `ensureBackend(profile)` starts a separate Python server for every candidate until the local spawn coordinator is saturated.

**Why it is wrong:** The Python sessions GET handlers already accept `profile` and open that profile's session database read-only, so these probes do not require a profile-owned server process.

**Working sibling / contrast:** Existing profile-aware reads such as `GET /api/config` reuse the primary backend and append `?profile=` through the same resolver.

**Ruled out:** The renderer's session-owner scan is not itself sufficient to cause the process storm; the storm occurs because Electron classifies each otherwise cheap read as requiring a pooled backend. Session writes remain excluded because they retain profile-process side effects.

### Fix

Treat `GET /api/sessions` and its subpaths as a profile-scoped local-primary route. Add resolver coverage for both backend selection and the final scoped request path, plus a negative assertion that PATCH requests remain pooled.

## Related Issue

Closes #102498

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/connection-config.ts` - route the read-only sessions family through the primary backend with profile scope.
- `apps/desktop/electron/connection-config.test.ts` - cover session GET routing, final URL scoping, and write-route isolation.

## How to Test

1. Run the Electron routing unit test.
2. Confirm session GET requests resolve to `backendProfile: null` and append the requested profile.
3. Confirm session PATCH requests continue resolving to the per-profile pool.

```bash
cd apps/desktop
npx vitest run --project electron electron/connection-config.test.ts
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the relevant Electron routing tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is not required; this is an internal routing correction
- [x] Config example update is not applicable; no config keys changed
- [x] Architecture guide update is not applicable; the existing routing contract is preserved
- [x] I've considered cross-platform impact; the resolver is platform-independent TypeScript
- [x] Tool description/schema updates are not applicable

## Screenshots / Logs

Not applicable; the regression is covered at the Electron request-routing boundary.
