### PR TITLE
fix(delegation): keep late background results from reopening accepted work

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5150,6 +5150,18 @@ class _VoiceInputMessage:
         return self.text
 
 
+class _AsyncDelegationInputMessage:
+    """Typed pending-input wrapper for a delegation completion timeline row."""
+
+    __slots__ = ("text",)
+
+    def __init__(self, text: str):
+        self.text = text
+
+    def __str__(self) -> str:
+        return self.text
+
+
 class _SeededQueryMessage:
     """Sentinel wrapper for a ``-q/--query`` prompt seeded into an
     interactive session.
@@ -13601,10 +13613,15 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
         session identity when draining so another window cannot claim and mark
         delivered a completion that belongs to this one.
         """
-        from tools.process_registry import process_registry
+        from tools.process_registry import (
+            format_process_notification,
+            process_registry,
+        )
         from tools.async_delegation import (
+            annotate_generation_disposition,
             claim_event_delivery,
             complete_event_delivery,
+            get_async_turn_generation,
         )
 
         session_key = getattr(self, "session_id", "") or ""
@@ -13612,10 +13629,34 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             session_key=session_key,
             owns_event=self._owns_process_notification,
         ):
+            if event.get("type") == "async_delegation":
+                generation_root = session_key
+                try:
+                    session_db = getattr(self, "_session_db", None)
+                    if session_db is not None:
+                        generation_root = (
+                            session_db.get_conversation_root(session_key)
+                            or session_key
+                        )
+                    if annotate_generation_disposition(
+                        event, get_async_turn_generation(generation_root)
+                    ):
+                        synthetic_message = (
+                            format_process_notification(event) or synthetic_message
+                        )
+                except Exception:
+                    logger.debug(
+                        "Could not classify CLI async delegation generation",
+                        exc_info=True,
+                    )
             claim = claim_event_delivery(event, consumer)
             if claim is None:
                 continue
-            self._pending_input.put(synthetic_message)
+            self._pending_input.put(
+                _AsyncDelegationInputMessage(synthetic_message)
+                if event.get("type") == "async_delegation"
+                else synthetic_message
+            )
             complete_event_delivery(event, claim)
 
     def _drain_interrupt_queue_to_pending_input(self) -> None:
@@ -16951,7 +16992,13 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             except Exception:
                 pass
 
-    def chat(self, message, images: list = None, voice_input: bool = False) -> Optional[str]:
+    def chat(
+        self,
+        message,
+        images: list = None,
+        voice_input: bool = False,
+        display_kind: Optional[str] = None,
+    ) -> Optional[str]:
         """
         Send a message to the agent and get a response.
         
@@ -16968,6 +17015,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             images: Optional list of Path objects for attached images
             voice_input: True when the message came from voice transcription
                 (gates the concise voice-response prefix, #65827)
+            display_kind: Optional durable timeline-row classification.
             
         Returns:
             The agent's response, or None on error
@@ -17122,6 +17170,8 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
             staged_user_message = stamp_message_timestamp(
                 {"role": "user", "content": message}
             )
+            if display_kind:
+                staged_user_message["display_kind"] = display_kind
             agent._pending_cli_user_message = staged_user_message
             self.conversation_history.append(staged_user_message)
 
@@ -17312,6 +17362,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         stream_callback=stream_callback,
                         task_id=self.session_id,
                         persist_user_message=_persist_clean_user_message,
+                        persist_user_display_kind=display_kind,
                         moa_config=_moa_cfg,
                     )
                     if getattr(self, "_pending_moa_disable_after_turn", False):
@@ -21071,6 +21122,12 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                                 pass
                         continue
 
+                    is_async_delegation_input = isinstance(
+                        user_input, _AsyncDelegationInputMessage
+                    )
+                    if is_async_delegation_input:
+                        user_input = user_input.text
+
                     # Voice-transcribed messages arrive wrapped in a sentinel
                     # so only genuine STT output gets the voice prefix (#65827).
                     is_voice_input = isinstance(user_input, _VoiceInputMessage)
@@ -21215,7 +21272,16 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                     app.invalidate()  # Refresh status line
 
                     try:
-                        self.chat(user_input, images=submit_images or None, voice_input=is_voice_input)
+                        self.chat(
+                            user_input,
+                            images=submit_images or None,
+                            voice_input=is_voice_input,
+                            display_kind=(
+                                "async_delegation_complete"
+                                if is_async_delegation_input
+                                else None
+                            ),
+                        )
                     finally:
                         self._agent_running = False
                         self._spinner_text = ""

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -28482,6 +28482,37 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             return "retry"
         return "deliver"
 
+    async def _annotate_async_delegation_generation(self, evt: dict) -> bool:
+        """Qualify a late delegation result against its current conversation."""
+        if evt.get("type") != "async_delegation" or not evt.get(
+            "origin_turn_generation"
+        ):
+            return False
+        parent_session_id = str(evt.get("parent_session_id") or "").strip()
+        session_db = getattr(self, "_session_db", None)
+        if not parent_session_id or session_db is None:
+            return False
+        try:
+            generation_root = (
+                await session_db.get_conversation_root(parent_session_id)
+                or parent_session_id
+            )
+            from tools.async_delegation import (
+                annotate_generation_disposition,
+                get_async_turn_generation,
+            )
+
+            current = await asyncio.to_thread(
+                get_async_turn_generation, generation_root
+            )
+            return annotate_generation_disposition(evt, current)
+        except Exception:
+            logger.debug(
+                "Could not classify async delegation turn generation",
+                exc_info=True,
+            )
+            return False
+
     async def _deliver_completion_notification(
         self, synth_text: str, evt: dict,
     ) -> Optional[bool]:
@@ -28493,6 +28524,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         event or the event has no gateway route. No cross-process exactly-once
         guarantee is claimed.
         """
+        if await self._annotate_async_delegation_generation(evt):
+            synth_text = _format_gateway_process_notification(evt) or synth_text
         identity = self._completion_delivery_identity(evt)
         durable_claim_id = ""
         durable_delegation_id = ""
@@ -28905,6 +28938,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
 
         deliverable: list[tuple[dict, str]] = []
         for evt in group:
+            await self._annotate_async_delegation_generation(evt)
             synth_text = _format_gateway_process_notification(evt)
             if not synth_text:
                 continue

--- a/gateway/wake.py
+++ b/gateway/wake.py
@@ -133,6 +133,14 @@ def _delegation_display_metadata(evt: dict) -> dict:
     duration = evt.get("total_duration_seconds") or evt.get("duration_seconds")
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
+    if evt.get("generation_disposition") == "stale_advisory":
+        metadata.update(
+            {
+                "generation_disposition": "stale_advisory",
+                "origin_turn_generation": evt.get("origin_turn_generation"),
+                "current_turn_generation": evt.get("current_turn_generation"),
+            }
+        )
     return metadata
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9814,6 +9814,24 @@ class AIAgent:
                             durable_turn_timer_handles.append(
                                 durable_turn_liveness_watchdog.schedule()
                             )
+                    # Async delegation generations begin lazily when a child is
+                    # dispatched. Advance only on later real user turns; typed
+                    # timeline rows (including delegation completions) preserve
+                    # the generation whose evidence they are advising on.
+                    if not persist_user_display_kind:
+                        try:
+                            from tools.async_delegation import (
+                                advance_async_turn_generation,
+                            )
+
+                            advance_async_turn_generation(
+                                self._conversation_root_id()
+                            )
+                        except Exception:
+                            logger.debug(
+                                "Could not advance async delegation turn generation",
+                                exc_info=True,
+                            )
                     result = run_conversation(
                         self,
                         user_message,

--- a/tests/cli/test_cli_async_delegation_delivery.py
+++ b/tests/cli/test_cli_async_delegation_delivery.py
@@ -42,7 +42,9 @@ def test_cli_completion_drain_uses_visible_session_identity(monkeypatch):
     cli._drain_process_notifications("cli-idle")
 
     assert calls == [("visible-session", True)]
-    assert cli._pending_input.get_nowait() == "completion payload"
+    pending = cli._pending_input.get_nowait()
+    assert type(pending).__name__ == "_AsyncDelegationInputMessage"
+    assert str(pending) == "completion payload"
     assert claimed == [(event, "cli-idle")]
     assert completed == [(event, "claim-token")]
 

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -739,6 +739,7 @@ def test_delegate_task_background_uses_live_tui_agent_session_id(monkeypatch):
     assert evt["type"] == "async_delegation"
     assert evt["session_key"] == "post-compress-tip"
     assert evt["origin_ui_session_id"] == "origin-tab"
+    assert evt["origin_turn_generation"] == 1
 
 
 def test_concurrent_dispatch_respects_capacity():
@@ -771,6 +772,76 @@ def test_concurrent_dispatch_respects_capacity():
     statuses = sorted(r["status"] for r in results)
     assert statuses == ["dispatched", "rejected"]
     gate.set()
+
+
+def test_async_turn_generation_advances_only_after_tracking_starts(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    assert ad.advance_async_turn_generation("session-root") is None
+    assert ad.ensure_async_turn_generation("session-root") == 1
+    assert ad.get_async_turn_generation("session-root") == 1
+    assert ad.advance_async_turn_generation("session-root") == 2
+    assert ad.get_async_turn_generation("session-root") == 2
+
+
+def test_completion_event_preserves_origin_turn_generation():
+    res = ad.dispatch_async_delegation(
+        goal="generation-aware task",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="m",
+        session_key="session-root",
+        parent_session_id="session-root",
+        origin_turn_generation=7,
+        runner=lambda: {"status": "completed", "summary": "done"},
+    )
+
+    evt = _drain_for(res["delegation_id"])
+
+    assert evt is not None
+    assert evt["origin_turn_generation"] == 7
+    durable = ad.get_durable_delegation(res["delegation_id"])
+    assert durable is not None
+    assert durable["origin_turn_generation"] == 7
+    restored_queue = queue.Queue()
+    assert ad.restore_undelivered_completions(restored_queue) == 1
+    assert restored_queue.get_nowait()["origin_turn_generation"] == 7
+
+
+def test_generation_disposition_marks_only_cross_generation_results():
+    same = {"origin_turn_generation": 3}
+    stale = {"origin_turn_generation": 3}
+
+    assert ad.annotate_generation_disposition(same, 3) is False
+    assert "generation_disposition" not in same
+
+    assert ad.annotate_generation_disposition(stale, 4) is True
+    assert stale["generation_disposition"] == "stale_advisory"
+    assert stale["current_turn_generation"] == 4
+
+
+@pytest.mark.asyncio
+async def test_gateway_compares_completion_with_current_generation(monkeypatch):
+    from unittest.mock import AsyncMock, MagicMock
+
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._session_db = MagicMock()
+    runner._session_db.get_conversation_root = AsyncMock(return_value="root")
+    monkeypatch.setattr(ad, "get_async_turn_generation", lambda _root: 8)
+    evt = {
+        "type": "async_delegation",
+        "parent_session_id": "compressed-tip",
+        "origin_turn_generation": 7,
+    }
+
+    changed = await runner._annotate_async_delegation_generation(evt)
+
+    assert changed is True
+    assert evt["generation_disposition"] == "stale_advisory"
+    assert evt["current_turn_generation"] == 8
 
 
 # ---------------------------------------------------------------------------
@@ -806,6 +877,23 @@ def test_gateway_formatter_renders_async_block():
     assert "ASYNC DELEGATION COMPLETE" in txt
     assert "Found the bug in test_foo" in txt
     assert "Investigate flaky test" in txt
+
+
+def test_gateway_formatter_makes_stale_generation_advisory_explicit():
+    from gateway.run import _format_gateway_process_notification
+
+    evt = _make_async_evt(
+        origin_turn_generation=4,
+        current_turn_generation=5,
+        generation_disposition="stale_advisory",
+    )
+    txt = _format_gateway_process_notification(evt)
+
+    assert txt is not None
+    assert "STALE ASYNC DELEGATION RESULT" in txt
+    assert "generation 4" in txt
+    assert "generation 5" in txt
+    assert "advisory" in txt.lower()
 
 
 def test_gateway_cli_origin_event_left_unrouted():

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -171,7 +171,14 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
             task_json TEXT,
             delivery_claim TEXT,
             delivery_claimed_at REAL,
-            origin_session_id TEXT NOT NULL DEFAULT ''
+            origin_session_id TEXT NOT NULL DEFAULT '',
+            origin_turn_generation INTEGER
+        )"""
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS async_delegation_generations (
+            session_root_id TEXT PRIMARY KEY,
+            generation INTEGER NOT NULL
         )"""
     )
     columns = {row[1] for row in conn.execute("PRAGMA table_info(async_delegations)")}
@@ -186,6 +193,7 @@ def _initialize_schema(conn: sqlite3.Connection) -> None:
         # completions recovered after a process restart are unroutable on
         # api_server (the in-memory record that carried it is gone).
         ("origin_session_id", "TEXT"),
+        ("origin_turn_generation", "INTEGER"),
     ):
         if name not in columns:
             conn.execute(f"ALTER TABLE async_delegations ADD COLUMN {name} {sql_type}")
@@ -265,13 +273,15 @@ def _persist_dispatch(record: Dict[str, Any]) -> None:
                (delegation_id, origin_session, origin_ui_session_id,
                 parent_session_id, state, dispatched_at, updated_at,
                 delivery_state, delivery_attempts, owner_pid,
-                owner_started_at, task_json, origin_session_id)
-               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?)""",
+                owner_started_at, task_json, origin_session_id,
+                origin_turn_generation)
+               VALUES (?, ?, ?, ?, 'running', ?, ?, 'pending', 0, ?, ?, ?, ?, ?)""",
             (record["delegation_id"], record.get("session_key", ""),
              record.get("origin_ui_session_id", ""), record.get("parent_session_id"),
              record["dispatched_at"], now, __import__("os").getpid(),
              owner_started_at, json.dumps(task_payload),
-             record.get("origin_session_id", "")),
+             record.get("origin_session_id", ""),
+             record.get("origin_turn_generation")),
         )
     _prune_durable_records()
 
@@ -340,6 +350,79 @@ def _note_delivery_attempt(delegation_id: str) -> None:
         )
 
 
+def ensure_async_turn_generation(session_root_id: str) -> Optional[int]:
+    """Start or read generation tracking for a conversation with async work."""
+    key = str(session_root_id or "").strip()
+    if not key:
+        return None
+    with _DB_LOCK, _transaction() as conn:
+        conn.execute(
+            """INSERT INTO async_delegation_generations
+               (session_root_id, generation) VALUES (?, 1)
+               ON CONFLICT(session_root_id) DO NOTHING""",
+            (key,),
+        )
+        row = conn.execute(
+            "SELECT generation FROM async_delegation_generations WHERE session_root_id=?",
+            (key,),
+        ).fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def advance_async_turn_generation(session_root_id: str) -> Optional[int]:
+    """Advance a tracked conversation for a new real user turn."""
+    key = str(session_root_id or "").strip()
+    if not key:
+        return None
+    with _DB_LOCK, _transaction() as conn:
+        cur = conn.execute(
+            """UPDATE async_delegation_generations
+               SET generation=generation+1 WHERE session_root_id=?""",
+            (key,),
+        )
+        if cur.rowcount != 1:
+            return None
+        row = conn.execute(
+            "SELECT generation FROM async_delegation_generations WHERE session_root_id=?",
+            (key,),
+        ).fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def get_async_turn_generation(session_root_id: str) -> Optional[int]:
+    """Return the tracked generation, or ``None`` for a legacy conversation."""
+    key = str(session_root_id or "").strip()
+    if not key:
+        return None
+    with _DB_LOCK, _transaction() as conn:
+        row = conn.execute(
+            "SELECT generation FROM async_delegation_generations WHERE session_root_id=?",
+            (key,),
+        ).fetchone()
+    return int(row[0]) if row is not None else None
+
+
+def annotate_generation_disposition(
+    evt: Dict[str, Any], current_generation: Optional[int]
+) -> bool:
+    """Mark a cross-generation result advisory while preserving its payload."""
+    try:
+        origin = int(evt.get("origin_turn_generation"))
+        current = int(current_generation) if current_generation is not None else None
+    except (TypeError, ValueError):
+        return False
+    if current is None or current <= origin:
+        return False
+    if (
+        evt.get("generation_disposition") == "stale_advisory"
+        and evt.get("current_turn_generation") == current
+    ):
+        return False
+    evt["generation_disposition"] = "stale_advisory"
+    evt["current_turn_generation"] = current
+    return True
+
+
 def recover_abandoned_delegations() -> int:
     """Classify records whose owning process disappeared as outcome unknown."""
     try:
@@ -352,12 +435,14 @@ def recover_abandoned_delegations() -> int:
         rows = conn.execute(
             """SELECT delegation_id, origin_session, origin_ui_session_id,
                       parent_session_id, dispatched_at, owner_pid,
-                      owner_started_at, task_json, origin_session_id
+                      owner_started_at, task_json, origin_session_id,
+                      origin_turn_generation
                FROM async_delegations WHERE state IN ('running','finalizing')"""
         ).fetchall()
         for row in rows:
             (delegation_id, session_key, origin_ui, parent_id, dispatched_at,
-             pid, started, task_json, origin_session_id) = row
+             pid, started, task_json, origin_session_id,
+             origin_turn_generation) = row
             live = False
             if pid:
                 live = _pid_exists(int(pid))
@@ -372,6 +457,7 @@ def recover_abandoned_delegations() -> int:
                 # Restore the durable wake target so completions recovered
                 # after a restart remain routable to api_server sessions.
                 "origin_session_id": origin_session_id or "",
+                "origin_turn_generation": origin_turn_generation,
                 "parent_session_id": parent_id, "goal": task.get("goal", ""),
                 "goals": task.get("goals"), "context": task.get("context"),
                 "toolsets": task.get("toolsets"), "role": task.get("role"),
@@ -583,7 +669,7 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         row = conn.execute(
             """SELECT origin_session, state, dispatched_at, completed_at,
                       result_json, delivery_state, delivery_attempts,
-                      origin_session_id
+                      origin_session_id, origin_turn_generation
                FROM async_delegations WHERE delegation_id=?""", (delegation_id,),
         ).fetchone()
     if row is None:
@@ -594,6 +680,7 @@ def get_durable_delegation(delegation_id: str) -> Optional[Dict[str, Any]]:
         "result": json.loads(row[4]) if row[4] else None,
         "delivery_state": row[5], "delivery_attempts": row[6],
         "origin_session_id": row[7] or "",
+        "origin_turn_generation": row[8],
     }
 
 
@@ -770,6 +857,7 @@ def dispatch_async_delegation(
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     origin_session_id: str = "",
+    origin_turn_generation: Optional[int] = None,
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
@@ -829,6 +917,7 @@ def dispatch_async_delegation(
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
+        "origin_turn_generation": origin_turn_generation,
         **_capture_routing_origin(),
         "status": "running",
         "dispatched_at": dispatched_at,
@@ -977,6 +1066,7 @@ def _push_completion_event(
         "origin_ui_session_id": record.get("origin_ui_session_id", ""),
         "origin_session_id": record.get("origin_session_id", ""),
         "parent_session_id": record.get("parent_session_id"),
+        "origin_turn_generation": record.get("origin_turn_generation"),
         "goal": record.get("goal", ""),
         "context": record.get("context"),
         "toolsets": record.get("toolsets"),
@@ -1032,6 +1122,7 @@ def dispatch_async_delegation_batch(
     runner: Callable[[], Dict[str, Any]],
     origin_ui_session_id: str = "",
     origin_session_id: str = "",
+    origin_turn_generation: Optional[int] = None,
     interrupt_fn: Optional[Callable[[], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     delegation_id: Optional[str] = None,
@@ -1076,6 +1167,7 @@ def dispatch_async_delegation_batch(
         "origin_ui_session_id": origin_ui_session_id,
         "origin_session_id": origin_session_id,
         "parent_session_id": parent_session_id,
+        "origin_turn_generation": origin_turn_generation,
         **_capture_routing_origin(),
         "status": "running",
         "dispatched_at": dispatched_at,
@@ -1189,6 +1281,7 @@ def _push_batch_completion_event(
         "origin_ui_session_id": event_record.get("origin_ui_session_id", ""),
         "origin_session_id": event_record.get("origin_session_id", ""),
         "parent_session_id": event_record.get("parent_session_id"),
+        "origin_turn_generation": event_record.get("origin_turn_generation"),
         "goal": event_record.get("goal", ""),
         "goals": event_record.get("goals"),
         "context": event_record.get("context"),

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4542,6 +4542,23 @@ def delegate_task(
             if _agent_session_id:
                 _session_key = _agent_session_id
         _parent_session_id = getattr(parent_agent, "session_id", None)
+        _origin_turn_generation = None
+        try:
+            from tools.async_delegation import ensure_async_turn_generation
+
+            _generation_root = (
+                parent_agent._conversation_root_id()
+                if callable(getattr(parent_agent, "_conversation_root_id", None))
+                else _parent_session_id
+            )
+            _origin_turn_generation = ensure_async_turn_generation(
+                str(_generation_root or _parent_session_id or "")
+            )
+        except Exception:
+            logger.debug(
+                "delegate_task: could not stamp origin turn generation",
+                exc_info=True,
+            )
         _child_agents = [c for (_, _, c) in children]
 
         # Detach every child from the parent's interrupt-propagation list — the
@@ -4618,6 +4635,7 @@ def delegate_task(
             origin_ui_session_id=_origin_ui_session_id,
             origin_session_id=_wake_sid,
             parent_session_id=_parent_session_id,
+            origin_turn_generation=_origin_turn_generation,
             runner=_batch_runner,
             interrupt_fn=_batch_interrupt,
             max_async_children=_get_max_async_children(),

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -3193,6 +3193,17 @@ def _format_async_delegation(evt: dict) -> str:
     truncated = evt.get("truncated") or evt.get("exit_reason") == "max_iterations"
     dispatched_at = evt.get("dispatched_at")
     completed_at = evt.get("completed_at") or _time.time()
+    stale_lines = []
+    if evt.get("generation_disposition") == "stale_advisory":
+        origin_generation = evt.get("origin_turn_generation", "?")
+        current_generation = evt.get("current_turn_generation", "?")
+        stale_lines = [
+            "[STALE ASYNC DELEGATION RESULT — ADVISORY ONLY]",
+            f"This result was commissioned in generation {origin_generation}, "
+            f"but the conversation is now at generation {current_generation}. "
+            "Preserve it as historical evidence; do not treat it as a current "
+            "user request or reopen accepted work without explicit revalidation.",
+        ]
 
     # ----- Batch (fan-out) completion: consolidated multi-task block -----
     # A whole delegate_task fan-out dispatched as one background unit finishes
@@ -3210,6 +3221,7 @@ def _format_async_delegation(evt: dict) -> str:
             "has finished. All ran in parallel and waited on each other; their "
             "consolidated results are below. You may have moved on since "
             "dispatching — act on these or re-dispatch if things have changed.",
+            *stale_lines,
             "",
         ]
         if isinstance(dispatched_at, (int, float)):
@@ -3288,6 +3300,7 @@ def _format_async_delegation(evt: dict) -> str:
         "A background subagent you dispatched earlier has finished. You may "
         "have moved on since dispatching it; the full task source is below so "
         "you can act on the result or re-dispatch if things have changed.",
+        *stale_lines,
         "",
     ]
     if isinstance(dispatched_at, (int, float)):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -12606,6 +12606,32 @@ def _collect_kanban_notifications(session: dict) -> list:
     return texts
 
 
+def _annotate_async_delegation_generation(session: dict, evt: dict) -> None:
+    """Mark a completion advisory when this TUI conversation has advanced."""
+    if evt.get("type") != "async_delegation":
+        return
+    try:
+        from tools.async_delegation import (
+            annotate_generation_disposition,
+            get_async_turn_generation,
+        )
+
+        agent = session.get("agent")
+        generation_root = (
+            agent._conversation_root_id()
+            if callable(getattr(agent, "_conversation_root_id", None))
+            else str(evt.get("parent_session_id") or "")
+        )
+        annotate_generation_disposition(
+            evt, get_async_turn_generation(generation_root)
+        )
+    except Exception:
+        logger.debug(
+            "Could not classify TUI async delegation generation",
+            exc_info=True,
+        )
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -12724,6 +12750,7 @@ def _notification_poller_loop(
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
 
+        _annotate_async_delegation_generation(session, evt)
         text = format_process_notification(evt)
         if not text:
             continue
@@ -12814,6 +12841,7 @@ def _notification_poller_loop(
         _evt_sid = evt.get("session_id", "")
         if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
             continue
+        _annotate_async_delegation_generation(session, evt)
         text = format_process_notification(evt)
         if not text:
             continue
@@ -12889,6 +12917,14 @@ def _async_delegation_display_metadata(evt: dict) -> dict:
     duration = evt.get("total_duration_seconds") or evt.get("duration_seconds")
     if isinstance(duration, (int, float)):
         metadata["duration_seconds"] = duration
+    if evt.get("generation_disposition") == "stale_advisory":
+        metadata.update(
+            {
+                "generation_disposition": "stale_advisory",
+                "origin_turn_generation": evt.get("origin_turn_generation"),
+                "current_turn_generation": evt.get("current_turn_generation"),
+            }
+        )
     return metadata
 
 


### PR DESCRIPTION
## What does this PR do?

Late background delegation results can currently re-enter an advanced conversation as if they were fresh user input, which can cause accepted work to be reopened against obsolete evidence. This change stamps async delegations with a durable originating turn generation, advances that generation only on later real user turns, and marks cross-generation results as stale advisory evidence without dropping them. Same-generation delivery, durable claims, batching, restart recovery, and session routing remain unchanged.

### Symptom

A background subagent dispatched in generation N can finish after the parent conversation advances to generation N+1. Its completion previously arrived with the same presentation as a current completion, without a machine-readable stale disposition.

### Impact

Long-lived sessions can act on obsolete review or research output after the underlying candidate has already changed or been accepted, causing unnecessary patches, tests, or deployments.

### Bug Cause

**Trigger:** `tools/async_delegation.py` completion event construction and `gateway/run.py::_deliver_completion_notification`

**Causal chain:**
1. A parent turn dispatches a background delegation and the durable record captures only session ownership.
2. The parent conversation advances before the child finishes, but delivery has no originating turn generation to compare.
3. The old result is injected as an unqualified synthetic user turn and can be mistaken for current evidence.

**Why it is wrong:** Session identity proves where a result belongs, but not whether the evidence generation that commissioned it is still current.

**Working sibling / contrast:** A child that completes before another real user turn remains in the same generation and follows the existing delivery path unchanged.

**Ruled out:** This is not the ended-session routing failure. Existing parent-session and compression-lineage checks can pass while the live parent conversation has still advanced to newer evidence.

### Fix

Track a monotonic generation lazily for conversations that dispatch async work, persist each delegation's origin generation, and compare it at CLI, TUI, gateway, and stateless delivery boundaries. Cross-generation events retain their full result but gain `generation_disposition=stale_advisory`, generation metadata, and an explicit advisory-only instruction. CLI completion turns are also persisted with a typed display kind instead of masquerading as ordinary user rows.

## Related Issue

N/A
## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/async_delegation.py` - persist generation state and origin generation across completion and restart recovery.
- `tools/delegate_tool.py` and `run_agent.py` - stamp dispatches and advance tracked generations on later real user turns.
- `gateway/run.py`, `gateway/wake.py`, `tui_gateway/server.py`, and `cli.py` - classify late results and preserve stale disposition metadata across delivery surfaces.
- `tools/process_registry.py` - render stale results as advisory evidence, not current requests.
- `tests/tools/test_async_delegation.py` and `tests/cli/test_cli_async_delegation_delivery.py` - cover same-generation controls, N to N+1 staleness, durable recovery, rendering, and typed CLI delivery.

## How to Test

1. Dispatch a background delegation in generation N and verify a completion before another real user turn follows the existing path.
2. Advance the same conversation to generation N+1, complete the generation-N child, and verify the full result is retained with `stale_advisory` metadata and advisory-only text.
3. Run the focused suites:

```bash
scripts/run_tests.sh tests/tools/test_async_delegation.py tests/cli/test_cli_async_delegation_delivery.py tests/gateway/test_async_delegation_session_binding.py tests/gateway/test_completion_delivery.py tests/gateway/test_completion_session_boundary.py tests/agent/test_synthetic_turn_display_kind.py -q
scripts/run_tests.sh tests/tools/test_async_delegation_fd_leak.py tests/gateway/test_async_delivery_capability.py tests/gateway/test_background_process_notifications.py tests/gateway/test_wake_delivery.py tests/tui_gateway/test_cross_process_orphan_ownership.py tests/cli/test_cli_async_delegation_delivery.py -q
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation or docstrings are updated, or N/A
- [x] `cli-config.yaml.example` is updated, or N/A - no config changes
- [x] `CONTRIBUTING.md` or `AGENTS.md` is updated, or N/A - no workflow changes
- [x] Cross-platform impact has been considered
- [x] Tool descriptions or schemas are updated, or N/A - no model-tool schema changes

## Screenshots / Logs

N/A - behavior is covered by deterministic generation and delivery tests.
