### PR TITLE
fix(agent): honor Retry-After and body reset fields in 402 classification

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -1299,7 +1299,7 @@ def _classify_by_status(
         )
 
     if status_code == 402:
-        return _classify_402(error_msg, result_fn)
+        return _classify_402(error_msg, body, response_headers, result_fn)
 
     if status_code == 404:
         # Nous API currently surfaces HA/NAS credit depletion as a paid model
@@ -1575,18 +1575,25 @@ def _has_usage_limit_transient_signal(
     return False
 
 
-def _classify_402(error_msg: str, result_fn) -> ClassifiedError:
+def _classify_402(
+    error_msg: str,
+    body: dict,
+    response_headers,
+    result_fn,
+) -> ClassifiedError:
     """Disambiguate 402: billing exhaustion vs transient usage limit.
 
     The key insight from OpenClaw: some 402s are transient rate limits
     disguised as payment errors.  "Usage limit, try again in 5 minutes"
     is NOT a billing problem — it's a periodic quota that resets.
     """
-    # Check for transient usage-limit signals first
-    has_usage_limit = any(p in error_msg for p in _USAGE_LIMIT_PATTERNS)
-    has_transient_signal = any(p in error_msg for p in _USAGE_LIMIT_TRANSIENT_SIGNALS)
-
-    if has_usage_limit and has_transient_signal:
+    # A transient signal is authoritative on its own — a 402 carrying
+    # Retry-After (OpenRouter's in-flight concurrency-budget throttle does
+    # this while the message mentions only "available credits", matching
+    # neither _USAGE_LIMIT_PATTERNS nor _BILLING_PATTERNS) is a temporary
+    # refusal, not terminal exhaustion.  Structured evidence (body reset
+    # fields, response headers) is checked here exactly like the 429 path.
+    if _has_usage_limit_transient_signal(error_msg, body, response_headers):
         # Transient quota — treat as rate limit, not billing
         return result_fn(
             FailoverReason.rate_limit,

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -165,6 +165,8 @@ class TestClassify402:
         """Plain 402 = billing."""
         result = _classify_402(
             "payment required",
+            {},
+            {},
             lambda reason, **kw: ClassifiedError(reason=reason, **kw),
         )
         assert result.reason == FailoverReason.billing
@@ -175,9 +177,37 @@ class TestClassify402:
         """402 with 'quota' + 'retry' = rate limit."""
         result = _classify_402(
             "quota exceeded, please retry after the window resets",
+            {},
+            {},
             lambda reason, **kw: ClassifiedError(reason=reason, **kw),
         )
         assert result.reason == FailoverReason.rate_limit
+
+    def test_retry_after_header_alone_is_rate_limit(self):
+        """A 402 whose message carries no transient wording but whose
+        response carries Retry-After is a temporary refusal — e.g.
+        OpenRouter's in-flight concurrency-budget throttle."""
+        result = _classify_402(
+            "in-flight request budget exceeded, credits still owed",
+            {},
+            {"Retry-After": "120"},
+            lambda reason, **kw: ClassifiedError(reason=reason, **kw),
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
+
+    def test_body_retry_after_field_alone_is_rate_limit(self):
+        """A structured retry_after field in the error body carries the
+        same authority as the header — providers that mirror response
+        headers into the body still get a retryable verdict."""
+        result = _classify_402(
+            "in-flight request budget exceeded, credits still owed",
+            {"error": {"retry_after": 120}},
+            {},
+            lambda reason, **kw: ClassifiedError(reason=reason, **kw),
+        )
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
 
 
 
@@ -217,8 +247,36 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.billing
         assert result.retryable is False
 
+    def test_402_in_flight_budget_with_retry_after_is_rate_limit(self):
+        """Regression (#102517): OpenRouter refuses a request with 402 when
+        the estimated cost of in-flight requests exceeds the concurrency
+        budget, and answers with Retry-After.  The message mentions only
+        "available credits" (no usage-limit pattern), so without the
+        structured signal the classifier terminally aborted unattended
+        runs on a throttle that clears itself in two minutes."""
+        e = MockAPIError(
+            "This request would exceed your available credits given your "
+            "current in-flight requests. Retry after in-flight requests "
+            "settle, or add credits.",
+            status_code=402,
+            headers={"Retry-After": "120"},
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.rate_limit
+        assert result.retryable is True
 
-
+    def test_402_credits_message_without_transient_signal_still_billing(self):
+        """Guard: a 402 about credits with no retry hint — no Retry-After
+        header, no structured reset field, no transient wording — remains
+        terminal billing exhaustion."""
+        e = MockAPIError(
+            "This request would exceed your available credits. Add credits "
+            "to continue.",
+            status_code=402,
+        )
+        result = classify_api_error(e, provider="openrouter")
+        assert result.reason == FailoverReason.billing
+        assert result.retryable is False
 
     def test_404_free_tier_model_block_is_billing(self):
         e = MockAPIError(


### PR DESCRIPTION
## What does this PR do?

A 402 that carries an explicit transient signal was still classified as terminal billing exhaustion unless the message *also* matched `_USAGE_LIMIT_PATTERNS`. OpenRouter's in-flight concurrency-budget throttle answers 402 with `Retry-After: 120` and a message that only mentions "available credits" (matching neither the usage-limit nor the billing patterns), so unattended cron runs aborted with "Non-retryable client error (HTTP 402)" on a throttle that clears itself in two minutes (#102517).

`_classify_402` previously received only `error_msg` and fell back to substring matching, so it was structurally unable to see the header. It now receives `body` and `response_headers` and consults the same helper the 429 path already uses (`_has_usage_limit_transient_signal`): a Retry-After header, a body `retry_after`/`resets_*` field, or transient wording alone routes to retryable `rate_limit` — matching the semantics the 429 path already applies (`not has_transient_signal` is what demotes to billing there).

The old `has_usage_limit and has_transient_signal` conjunction becomes redundant (any transient signal now short-circuits), so it is removed rather than left as dead code.

## Related Issue

Fixes #102517

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/error_classifier.py`: pass `body`/`response_headers` into `_classify_402` at the status-code dispatch site; make `_has_usage_limit_transient_signal(error_msg, body, response_headers)` the authoritative first check inside `_classify_402`, returning retryable `rate_limit` on any transient signal; drop the now-unreachable substring conjunction.
- `tests/agent/test_error_classifier.py`: update the two direct `_classify_402` unit calls to the new signature; add unit tests for the two structured channels (Retry-After header alone, body `retry_after` field alone, both with transient-free wording); add an end-to-end regression test reproducing the OpenRouter in-flight-budget 402 verbatim plus a guard that a credit-exhaustion 402 with no transient signal stays non-retryable billing.

## How to Test

1. `pytest tests/agent/test_error_classifier.py -q` — Observed result: **127 passed** (including the four new tests and every pre-existing 402/billing case unchanged: plain "Payment Required" and DeepSeek "余额不足" still classify as non-retryable billing).
2. Unit-level proof of the structured channels: `pytest tests/agent/test_error_classifier.py::TestClassify402 -q` — the header-only and body-field-only cases classify as `rate_limit`/`retryable=True` while their messages contain no transient wording.
3. End-to-end reproduction from the issue: `MockAPIError` with the exact OpenRouter message and `Retry-After: 120` header now yields `reason=rate_limit, retryable=True` (previously `billing, retryable=False`, which aborted the run).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6 (arm64)

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-availability) — pure string/dict/header logic, no platform-specific behavior
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

```
$ pytest tests/agent/test_error_classifier.py -q
127 passed, 6 warnings in 6.67s
```