### PR TITLE
feat(desktop): surface voice field for command-type TTS providers

### DIFF
--- a/apps/desktop/src/app/settings/constants.ts
+++ b/apps/desktop/src/app/settings/constants.ts
@@ -323,6 +323,8 @@ export const ENUM_OPTIONS: Record<string, string[]> = {
   ],
   'tts.kittentts.voice': ['Jasper'],
   'tts.piper.voice': ['en_US-lessac-medium', 'en_US-amy-medium', 'en_US-ryan-high', 'en_GB-alan-medium'],
+  // User-defined command-provider voices (see tts.providers.<name>.voice).
+  'tts.providers.breeze.voice': ['jo', 'narrator-female', 'news-male', 'assistant', 'upbeat'],
   'tts.neutts.model': ['neuphonic/neutts-air-q4-gguf', 'neuphonic/neutts-air-q8-gguf', 'neuphonic/neutts-air'],
   // Text-to-speech backends — kept in sync with the built-in source of truth
   // (agent/tts_registry.py::_BUILTIN_NAMES / tools/tts_tool.py::
@@ -732,6 +734,7 @@ export const SECTIONS: DesktopConfigSection[] = [
       'tts.kittentts.model',
       'tts.kittentts.voice',
       'tts.piper.voice',
+      'tts.providers.breeze.voice',
       'tts.deepinfra.model',
       'tts.deepinfra.voice',
       'stt.local.model',

--- a/apps/desktop/src/app/settings/helpers.ts
+++ b/apps/desktop/src/app/settings/helpers.ts
@@ -162,7 +162,10 @@ export function clearsEnabledToolsets(prev: HermesConfigRecord, next: HermesConf
 // Voice renders only fields for the selected TTS/STT provider. Search and the
 // page share this rule so every indexed field can actually mount when opened.
 export function voiceFieldVisible(key: string, config: HermesConfigRecord): boolean {
-  const match = /^(tts|stt)\.([^.]+)\./.exec(key)
+  // Built-in providers use the flat ``tts.<provider>.*`` path; user-defined
+  // command providers live at ``tts.providers.<name>.*``, so consume the
+  // optional ``providers.`` segment before capturing the provider name.
+  const match = /^(tts|stt)\.(?:providers\.)?([^.]+)\./.exec(key)
 
   if (!match) {
     return true

--- a/apps/desktop/src/app/settings/voice-field-visible.test.ts
+++ b/apps/desktop/src/app/settings/voice-field-visible.test.ts
@@ -45,4 +45,10 @@ describe('voiceFieldVisible', () => {
     expect(voiceFieldVisible('tts.openai.voice', cfg({ tts: { provider: 'openai', openai: {} } }))).toBe(true)
     expect(voiceFieldVisible('tts.edge.voice', cfg({ tts: { provider: 'openai', openai: {} } }))).toBe(false)
   })
+
+  it('resolves user-defined command-provider sub-fields via the nested path', () => {
+    const config = cfg({ tts: { provider: 'breeze', providers: { breeze: { voice: 'jo' } } } })
+    expect(voiceFieldVisible('tts.providers.breeze.voice', config)).toBe(true)
+    expect(voiceFieldVisible('tts.providers.other.voice', config)).toBe(false)
+  })
 })

--- a/apps/desktop/src/app/settings/voice-provider-fields.test.ts
+++ b/apps/desktop/src/app/settings/voice-provider-fields.test.ts
@@ -12,6 +12,10 @@ describe('voiceProviderKeys', () => {
     expect(voiceProviderKeys('tts', 'edge')).toEqual(['tts.edge.voice'])
   })
 
+  it('resolves user-defined command providers via their nested path', () => {
+    expect(voiceProviderKeys('tts', 'breeze')).toEqual(['tts.providers.breeze.voice'])
+  })
+
   it('covers every built-in TTS provider the Capabilities picker offers', () => {
     // Every provider key the backend TOOL_CATEGORIES["tts"] rows can carry
     // (tts_provider values) must resolve to at least one config field, so the

--- a/apps/desktop/src/app/settings/voice-provider-fields.tsx
+++ b/apps/desktop/src/app/settings/voice-provider-fields.tsx
@@ -18,9 +18,14 @@ import { enumOptionsFor, getNested, inferFieldSchema, setNested } from './helper
 const VOICE_KEYS = SECTIONS.find(s => s.id === 'voice')?.keys ?? []
 
 export function voiceProviderKeys(section: 'tts' | 'stt', providerKey: string): string[] {
-  const prefix = `${section}.${providerKey}.`
+  // Built-in TTS/STT providers live at the flat ``tts.<provider>.*`` path.
+  // User-defined command providers (``tts.providers.<name>.*``) are resolved via
+  // their canonical nested path too, so a custom provider's ``voice``/``model``
+  // fields surface in Settings → Voice and the Capabilities TTS panel.
+  const flatPrefix = `${section}.${providerKey}.`
+  const canonicalPrefix = `${section}.providers.${providerKey}.`
 
-  return VOICE_KEYS.filter(key => key.startsWith(prefix))
+  return VOICE_KEYS.filter(key => key.startsWith(flatPrefix) || key.startsWith(canonicalPrefix))
 }
 
 /**


### PR DESCRIPTION
## What
Custom command TTS/STT providers are declared under `tts.providers.<name>.*`, but the desktop app's voice-field plumbing (Settings -> Voice + the Capabilities TTS panel) only matched the flat built-in `tts.<provider>.*` path. As a result a command-type provider -- e.g. a locally installed Breeze TTS 2 -- never surfaced a voice selector, even though the runtime resolves a `{voice}` from `tts.providers.<name>.voice`.

## Changes
- `voiceProviderKeys()`: also resolve the canonical nested path `tts.providers.<name>.*` alongside the flat path.
- `voiceFieldVisible()`: consume the optional `providers.` segment so the selected command provider's voice field passes the visibility gate.
- Register a working voice enum (`tts.providers.breeze.voice`) so the field renders and offers its voices.
- Unit tests for both helpers.

## Validation
- `npx vitest run src/app/settings/voice-provider-fields.test.ts src/app/settings/voice-field-visible.test.ts src/app/settings/helpers.test.ts` -> 55 passed.
- End-to-end: `tts_tool.text_to_speech_tool(..., provider='breeze')` returns success + audio, with the `{voice}` placeholder routed from config.

## Notes
- The `constants.ts` voice enum is a concrete example (breeze). Other command providers can register their own voice options the same way; happy to generalize it to read a config-specified `voices` list if maintainers prefer.