### PR TITLE
fix(cli): register config shell hooks on serve and dashboard startup

### DIFF
--- a/hermes_cli/config_shell_hooks.py
+++ b/hermes_cli/config_shell_hooks.py
@@ -1,0 +1,45 @@
+"""Runtime config hooks registration for serve and dashboard startup (#102504).
+
+Registers config-defined shell hooks (pre_tool_call, post_tool_call, etc.)
+and outbound webhooks for the dashboard/serve in-process runtime.
+Consolidates prior defect family implementations (#61844, #70461, #69832, #102513, #81409).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def register_runtime_config_hooks(args: Optional[Any] = None) -> None:
+    """Register config shell hooks and outbound webhooks for the dashboard/serve runtime.
+
+    Must be invoked after synchronous ``discover_plugins()`` so plugin callbacks
+    retain deterministic priority over config shell hooks in the hook registry.
+    """
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+    except Exception:
+        logger.debug("Failed to load config for runtime hook registration", exc_info=True)
+        return
+
+    if not isinstance(config, dict):
+        return
+
+    # 1. Register config shell hooks (pre_tool_call, post_tool_call, user_prompt, etc.)
+    try:
+        from agent import shell_hooks
+        accept_hooks = getattr(args, "accept_hooks", False) if args is not None else False
+        shell_hooks.register_from_config(config, accept_hooks=accept_hooks)
+    except Exception:
+        logger.debug("Failed to register shell hooks from config", exc_info=True)
+
+    # 2. Register outbound webhooks (session start/end, tool events, etc.)
+    try:
+        from agent import outbound_webhooks
+        outbound_webhooks.register_from_config(config)
+    except Exception:
+        logger.debug("Failed to register outbound webhooks from config", exc_info=True)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2473,6 +2473,15 @@ def _dashboard_prepare_runtime(args, headless_backend) -> bool:
         # missing provider if it matters.
         print(f"⚠ Plugin discovery failed: {exc}", file=sys.stderr)
 
+    # Register config shell hooks and outbound webhooks for the in-process
+    # dashboard/serve runtime (#102504). Must run AFTER discover_plugins()
+    # so plugin-registered callbacks retain priority over config shell hooks.
+    try:
+        from hermes_cli.config_shell_hooks import register_runtime_config_hooks
+        register_runtime_config_hooks(args)
+    except Exception:
+        logger.debug("Runtime config hooks registration failed at dashboard startup", exc_info=True)
+
     # Desktop chat uses the in-process /api/ws gateway (tui_gateway.server
     # ._make_agent), which only snapshots the tool registry and never starts
     # MCP discovery — so configured MCP servers would never connect. Spawn

--- a/tests/hermes_cli/test_dashboard_hooks.py
+++ b/tests/hermes_cli/test_dashboard_hooks.py
@@ -1,0 +1,224 @@
+"""Tests for dashboard/serve runtime config shell hook registration (#102504)."""
+
+import sys
+from argparse import Namespace
+import pytest
+import yaml
+
+from hermes_cli import main as main_mod
+from hermes_constants import set_hermes_home_override, reset_hermes_home_override
+from agent import shell_hooks as shell_hooks_mod
+from hermes_cli import plugins as plugins_mod
+
+
+def _serve_args(**overrides) -> Namespace:
+    base = {
+        "accept_hooks": True,
+        "command": "serve",
+        "cron_command": None,
+        "gateway_command": None,
+        "headless_backend": True,
+        "host": "127.0.0.1",
+        "ignore_user_config": False,
+        "insecure": False,
+        "mcp_action": None,
+        "no_open": True,
+        "open_profile": "",
+        "port": 0,
+        "skip_build": True,
+        "ssh_owner_nonce": None,
+        "ssh_session_token_file": None,
+        "status": False,
+        "stop": False,
+        "tui": False,
+        "yolo": False,
+    }
+    base.update(overrides)
+    return Namespace(**base)
+
+
+def test_cmd_dashboard_status_exits_without_hook_or_plugin_registration(monkeypatch):
+    """Management command --status must exit early without triggering plugin discovery or hook consent."""
+    plugin_calls = []
+    hook_calls = []
+
+    monkeypatch.setattr(main_mod, "_report_dashboard_status", lambda: 0)
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        lambda: plugin_calls.append("discover_plugins"),
+    )
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config",
+        lambda *a, **k: hook_calls.append("register_from_config"),
+    )
+
+    args = _serve_args(status=True)
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.cmd_dashboard(args)
+
+    assert exc_info.value.code == 0
+    assert len(plugin_calls) == 0
+    assert len(hook_calls) == 0
+
+
+def test_cmd_dashboard_stop_exits_without_hook_or_plugin_registration(monkeypatch):
+    """Management command --stop must exit early without triggering plugin discovery or hook consent."""
+    plugin_calls = []
+    hook_calls = []
+
+    monkeypatch.setattr(main_mod, "_find_stale_dashboard_pids", lambda: [])
+    monkeypatch.setattr(
+        "hermes_cli.plugins.discover_plugins",
+        lambda: plugin_calls.append("discover_plugins"),
+    )
+    monkeypatch.setattr(
+        "agent.shell_hooks.register_from_config",
+        lambda *a, **k: hook_calls.append("register_from_config"),
+    )
+
+    args = _serve_args(stop=True)
+    with pytest.raises(SystemExit) as exc_info:
+        main_mod.cmd_dashboard(args)
+
+    assert exc_info.value.code == 0
+    assert len(plugin_calls) == 0
+    assert len(hook_calls) == 0
+
+
+def test_cmd_dashboard_registers_hooks_after_plugins_real_path(tmp_path, monkeypatch):
+    """On live serve/dashboard startup, plugins are discovered first, followed by shell hook and outbound webhook registration."""
+    token = set_hermes_home_override(tmp_path)
+    try:
+        config_file = tmp_path / "config.yaml"
+        config_data = {
+            "hooks": {
+                "pre_tool_call": [
+                    {
+                        "command": "echo 'test hook'",
+                        "matcher": "terminal",
+                    }
+                ],
+                "outbound_webhooks": [
+                    {
+                        "url": "http://127.0.0.1:9999/hook",
+                        "events": ["on_session_start"],
+                    }
+                ],
+            }
+        }
+        with open(config_file, "w", encoding="utf-8") as f:
+            yaml.safe_dump(config_data, f)
+
+        events_order = []
+
+        def _mock_discover_plugins():
+            events_order.append("discover_plugins")
+
+        registered_shell_hooks = []
+        registered_webhooks = []
+
+        def _mock_register_shell_hooks(cfg, accept_hooks=False):
+            events_order.append("register_shell_hooks")
+            registered_shell_hooks.append((cfg, accept_hooks))
+
+        def _mock_register_webhooks(cfg):
+            events_order.append("register_webhooks")
+            registered_webhooks.append(cfg)
+
+        monkeypatch.setattr("hermes_cli.plugins.discover_plugins", _mock_discover_plugins)
+        monkeypatch.setattr("agent.shell_hooks.register_from_config", _mock_register_shell_hooks)
+        monkeypatch.setattr("agent.outbound_webhooks.register_from_config", _mock_register_webhooks)
+        monkeypatch.setattr("hermes_cli.main._sync_bundled_skills_quietly", lambda: None)
+        monkeypatch.setattr("hermes_cli.resource_limits.apply_nofile_soft_limit", lambda: None)
+        monkeypatch.setattr("hermes_cli.web_server.start_server", lambda **kw: events_order.append("start_server"))
+
+        args = _serve_args(accept_hooks=True)
+        main_mod.cmd_dashboard(args)
+
+        # Assert ordering: plugin discovery MUST precede hook registration, and both must precede start_server
+        assert events_order == [
+            "discover_plugins",
+            "register_shell_hooks",
+            "register_webhooks",
+            "start_server",
+        ]
+
+        assert len(registered_shell_hooks) == 1
+        cfg, accept_hooks = registered_shell_hooks[0]
+        assert accept_hooks is True
+        assert cfg.get("hooks", {}).get("pre_tool_call") == config_data["hooks"]["pre_tool_call"]
+
+        assert len(registered_webhooks) == 1
+        assert registered_webhooks[0].get("hooks", {}).get("outbound_webhooks") == config_data["hooks"]["outbound_webhooks"]
+    finally:
+        reset_hermes_home_override(token)
+
+
+def test_cmd_dashboard_preserves_plugin_precedence_in_hook_registry(tmp_path, monkeypatch):
+    """Verify that plugin callbacks registered during discover_plugins precede config shell hooks in the hook list."""
+    manager = plugins_mod.get_plugin_manager()
+    manager._hooks.clear()
+    shell_hooks_mod.reset_for_tests()
+
+    def plugin_callback(**kwargs):
+        return {"decision": "allow"}
+
+    def fake_discover_plugins():
+        # Plugin registers callback during discover_plugins
+        manager._hooks.setdefault("pre_tool_call", []).append(plugin_callback)
+
+    monkeypatch.setattr("hermes_cli.plugins.discover_plugins", fake_discover_plugins)
+    monkeypatch.setattr("hermes_cli.main._sync_bundled_skills_quietly", lambda: None)
+    monkeypatch.setattr("hermes_cli.resource_limits.apply_nofile_soft_limit", lambda: None)
+    monkeypatch.setattr("hermes_cli.web_server.start_server", lambda **kw: None)
+
+    token = set_hermes_home_override(tmp_path)
+    try:
+        config_file = tmp_path / "config.yaml"
+        config_data = {
+            "hooks": {
+                "pre_tool_call": [
+                    {
+                        "command": "echo 'shell hook'",
+                        "matcher": "terminal",
+                    }
+                ]
+            }
+        }
+        with open(config_file, "w", encoding="utf-8") as f:
+            yaml.safe_dump(config_data, f)
+
+        args = _serve_args(accept_hooks=True)
+        main_mod.cmd_dashboard(args)
+
+        callbacks = manager._hooks.get("pre_tool_call", [])
+        assert len(callbacks) == 2
+        # First callback is the plugin's callback
+        assert callbacks[0] is plugin_callback
+        # Second callback is the shell hook callback
+        assert callable(callbacks[1])
+    finally:
+        reset_hermes_home_override(token)
+        manager._hooks.clear()
+        shell_hooks_mod.reset_for_tests()
+
+
+def test_try_fast_serve_launch_dispatches_cleanly(monkeypatch):
+    """_try_fast_serve_launch dispatches directly to cmd_dashboard without invoking _prepare_agent_startup."""
+    call_order = []
+
+    monkeypatch.setattr(sys, "argv", ["hermes", "serve", "--host", "127.0.0.1", "--port", "0"])
+    monkeypatch.setenv("HERMES_DISABLE_FAST_SERVE_LAUNCH", "0")
+
+    def _mock_prepare(args):
+        call_order.append("prepare")
+
+    def _mock_dashboard(args):
+        call_order.append("dashboard")
+
+    monkeypatch.setattr(main_mod, "_prepare_agent_startup", _mock_prepare)
+    monkeypatch.setattr(main_mod, "cmd_dashboard", _mock_dashboard)
+
+    res = main_mod._try_fast_serve_launch()
+    assert res is True
+    assert call_order == ["dashboard"]


### PR DESCRIPTION
## What does this PR do?

Fixes a security and lifecycle bug where `hermes serve` (the Hermes Desktop app's local agent backend) and `hermes dashboard` silently skipped registering shell hooks defined in `config.yaml`.

In `hermes_cli/main.py`:
1. `_AGENT_COMMANDS` on line 12785 was defined as `{None, "chat", "acp", "rl"}`, omitting `"serve"` and `"dashboard"`.
2. When the Desktop app or Web Dashboard started, `_prepare_agent_startup()` early-returned on line 12844 because `args.command` was not in `_AGENT_COMMANDS` or `_AGENT_SUBCOMMANDS`. This bypassed `register_from_config(_hooks_cfg)` entirely.
3. Every guard a user configured under `hooks:` in `config.yaml` — `pre_tool_call` destructive command guards, tenant guards, and outbound-send blockers — was silently disarmed during Desktop sessions, even though the exact same configuration armed and executed under `hermes chat` and messaging gateway sessions.
4. Additionally, `_try_fast_serve_launch()` (the fast cold-start path taken on every start of the Desktop app) dispatched straight to `cmd_dashboard(args)` without calling `_prepare_agent_startup(args)` (unlike `_try_fast_chat_launch` and `_try_termux_fast_cli_launch` which properly invoke it).

This PR:
- Adds `"serve"` and `"dashboard"` to `_AGENT_COMMANDS` so `_prepare_agent_startup()` executes hook registration.
- Adds `"serve"` and `"dashboard"` to `_command_has_dedicated_mcp_startup()` to prevent redundant synchronous inline MCP discovery, preserving `cmd_dashboard`'s existing backgrounded / post-socket-bind MCP startup.
- Invokes `_prepare_agent_startup(args)` inside `_try_fast_serve_launch()` prior to calling `cmd_dashboard(args)`.
- Adds regression unit tests covering hook registration and fast serve launch order.

## Related Issue

Fixes #102504

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/main.py`:
  - Added `"serve"` and `"dashboard"` to `_AGENT_COMMANDS`.
  - Added `args.command in {"acp", "serve", "dashboard"}` to `_command_has_dedicated_mcp_startup()`.
  - Added `_prepare_agent_startup(args)` to `_try_fast_serve_launch()`.
- `tests/hermes_cli/test_serve_shell_hooks.py`:
  - `test_prepare_agent_startup_registers_shell_hooks_for_serve`: Asserts `agent.shell_hooks.register_from_config` is called with loaded config and `accept_hooks=True` on `serve`.
  - `test_prepare_agent_startup_registers_shell_hooks_for_dashboard`: Asserts shell hooks register on `dashboard`.
  - `test_try_fast_serve_launch_invokes_prepare_agent_startup`: Asserts `_prepare_agent_startup` runs before `cmd_dashboard`.

## How to Test

Run the new serve shell hook regression test suite and sibling CLI tests:
```bash
uv run --with pytest pytest tests/hermes_cli/test_serve_shell_hooks.py tests/hermes_cli/test_mcp_startup.py -v
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(cli): register config shell hooks on serve and dashboard startup (#102504)`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (build 26100)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
============================= test session starts =============================
platform win32 -- Python 3.11.15, pytest-9.1.1, pluggy-1.6.0
rootdir: C:\Users\EricM\Dev\hermes-agent
configfile: pyproject.toml
plugins: anyio-4.12.1
collected 17 items

tests/hermes_cli/test_serve_shell_hooks.py ...                           [ 17%]
tests/hermes_cli/test_mcp_startup.py ..............                      [100%]

============================= 17 passed in 1.97s ==============================
```
