### PR TITLE
fix(codex): use live Sol context without aliases

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -171,7 +171,6 @@ from agent.credential_pool import load_pool
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
-    strip_codex_context_variant_suffix as _strip_codex_ctx_variant,
 )
 from hermes_cli.config import get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
@@ -903,19 +902,11 @@ def _is_codex_gpt54_or_gpt55(model: Optional[str], provider: Optional[str] = Non
     ``compression.codex_gpt55_autoraise`` config key.) The exact
     ``gpt-daybreak-blue-latest`` Codex slug is also a verified Sol-family
     alias and receives the same autoraise.
-
-    ``-900k`` large-context picker variants are explicitly EXCLUDED: the
-    85% autoraise exists to stop wasting a small 272K window, and a 900K
-    window doesn't have that problem — those sessions keep the user's
-    global ``compression.threshold`` (default 50%, ~450K).
     """
     prov = (provider or "").strip().lower()
     if prov != "openai-codex":
         return False
     bare = (model or "").strip().lower().rsplit("/", 1)[-1]
-    from agent.model_metadata import is_codex_context_variant
-    if is_codex_context_variant(bare):
-        return False
     return (
         bare == "gpt-5.4"
         or bare.startswith("gpt-5.4-")
@@ -1784,10 +1775,7 @@ class _CodexCompletionsAdapter:
         )
 
         resp_kwargs: Dict[str, Any] = {
-            # Strip the Hermes-side ``-900k`` large-context picker suffix —
-            # the Codex backend only knows the base slug (mirrors the main
-            # transport in agent/transports/codex.py::build_kwargs).
-            "model": _strip_codex_ctx_variant(model),
+            "model": model,
             "instructions": instructions,
             "input": input_items or [{"role": "user", "content": ""}],
             "store": False,

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -2640,162 +2640,30 @@ _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
     "gpt-5": 272_000,
 }
 
-# Codex OAuth advertises 272K via /backend-api/codex/models for these
-# families, but the backend actually ACCEPTS far more. OpenAI enabled the
-# large-context window for ChatGPT-subscription Codex accounts on
-# Aug 16 2026 (announced by @thsottiaux; previously API-key-only).
-# Verified live against chatgpt.com/backend-api/codex/responses the same
-# day: 911,276 input tokens completed OK on gpt-5.6-sol; ~925K+ rejected
-# with ``context_length_exceeded`` (the 1.05M window minus reserved output
-# headroom). gpt-5.6-terra, gpt-5.6-luna, and gpt-5.4 all completed 900,026
-# tokens OK. gpt-5.5 and gpt-5.4-mini still rejected >272K, so their
-# advertisement is real enforcement and they are NOT listed. 900K keeps
-# ≥11K margin under the observed ceiling and matches the compaction point
-# Codex's own client config documents for the 1M window.
+# Hermes trusts the Codex-advertised context windows verbatim, with one
+# provider-declared exception below. The Aug 2026 experiment of overriding
+# the advertisement through synthesized ``-900k`` picker aliases was
+# reverted — pseudo-model IDs are not a Hermes product surface; a model id
+# is the provider's id.
 #
-# OPT-IN ONLY (Aug 2026 policy, Teknium): the large window is exposed via
-# explicit ``-900k`` picker variants (e.g. ``gpt-5.6-sol-900k``) — the base
-# slugs keep the advertised 272K so the cheaper limit is the default. A
-# week of the 900K default burned through subscription usage for people
-# who never asked for it. The variant suffix is a Hermes-side alias: it is
-# stripped before the model id hits the wire (see
-# ``strip_codex_context_variant_suffix`` callers in agent/transports/codex.py
-# and agent/auxiliary_client.py).
-#
-# The bump is applied ONLY when the resolved value (live probe or fallback
-# table) is exactly the known-stale 272,000 advertisement — if OpenAI moves
-# the advertised number in either direction (the gpt-5.6 family shifted
-# 272K → 372K → 272K during July 2026), the catalog is trusted again and
-# this table is inert. ``gpt-5.6`` is a FAMILY PREFIX (sol/terra/luna and
-# dated snapshots; ``-pro`` slugs are not routable on Codex OAuth — the
-# backend 400s them — so over-matching there is moot). ``gpt-5.4`` is EXACT:
-# gpt-5.4-mini was probed and genuinely enforces 272K (rejected 500K), so
-# prefix-matching the 5.4 family would over-report for mini.
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES: Dict[str, int] = {
-    "gpt-5.6": 900_000,   # sol / terra / luna — all three verified live at 900K
-}
-_CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT: Dict[str, int] = {
-    "gpt-5.4": 900_000,   # verified live at 900K; gpt-5.4-mini rejected 500K — excluded
-    "gpt-daybreak-blue-latest": 900_000,  # exact Daybreak/Sol alias verified at 911,276
-}
-
-# The advertised value the verified-above table is allowed to override.
-_CODEX_OAUTH_STALE_ADVERTISED_CTX = 272_000
-
-# Hermes-side picker suffix that opts a Codex slug into the live-verified
-# large window. Never sent on the wire.
-CODEX_CONTEXT_VARIANT_SUFFIX = "-900k"
-
-# The ONLY base slugs eligible for a ``-900k`` variant: routable,
-# live-verified models. gpt-5.6 family-prefix matching is deliberately NOT
-# used here — it would synthesize dead variants for ``-pro`` slugs (the
-# Codex backend 400s them) and accept arbitrary future descendants that
-# were never probed. Dated snapshots of the routable 5.6 bases are allowed
-# via _CODEX_900K_SNAPSHOT_RE.
-_CODEX_900K_ELIGIBLE_BASES = frozenset({
-    "gpt-5.6-sol",
-    "gpt-5.6-terra",
-    "gpt-5.6-luna",
-    "gpt-5.4",                    # exact; gpt-5.4-mini enforces 272K
-    "gpt-daybreak-blue-latest",   # verified Sol alias
-})
-_CODEX_900K_SNAPSHOT_BASES = ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna")
-_CODEX_900K_SNAPSHOT_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-
-
-def _bare_codex_slug(model: Optional[str]) -> str:
-    """Lowercased slug with any ``vendor/`` namespace removed.
-
-    Display/auxiliary callers pass ids like ``openai/gpt-5.6-sol-900k``;
-    the main-agent path normalizes the namespace away earlier, but this
-    resolver must accept both shapes (#92797 review).
-    """
-    return (model or "").strip().lower().rsplit("/", 1)[-1]
-
-
-def is_codex_900k_base(model: Optional[str]) -> bool:
-    """True when *model* (a BASE slug, no suffix) may carry a ``-900k`` variant.
-
-    Single source of truth for the eligibility check — used by picker
-    synthesis, context resolution, `/model` validation, and wire stripping
-    so the four sites can never drift apart.
-    """
-    slug = _bare_codex_slug(model)
-    if not slug or slug.endswith(CODEX_CONTEXT_VARIANT_SUFFIX):
-        return False
-    if slug in _CODEX_900K_ELIGIBLE_BASES:
-        return True
-    # Dated snapshots of the routable 5.6 bases (gpt-5.6-sol-2026-07-09).
-    for base in _CODEX_900K_SNAPSHOT_BASES:
-        if slug.startswith(base + "-") and _CODEX_900K_SNAPSHOT_RE.match(
-            slug[len(base) + 1:]
-        ):
-            return True
-    return False
-
-
-def is_codex_context_variant(model: Optional[str]) -> bool:
-    """True when the model id is a VALID ``-900k`` opt-in variant.
-
-    Requires both the suffix and an eligible base — ``gpt-5.5-900k`` is not
-    a variant, it's an invalid alias.
-    """
-    slug = _bare_codex_slug(model)
-    if not slug.endswith(CODEX_CONTEXT_VARIANT_SUFFIX):
-        return False
-    return is_codex_900k_base(slug[: -len(CODEX_CONTEXT_VARIANT_SUFFIX)])
-
-
-def strip_codex_context_variant_suffix(model: Optional[str]) -> str:
-    """Return the wire-safe slug with a VALID ``-900k`` suffix removed.
-
-    The suffix is a Hermes picker alias (``gpt-5.6-sol-900k``); the Codex
-    backend only knows the base slug. Stripping is conditional on base
-    eligibility: an ineligible alias like ``gpt-5.5-900k`` is returned
-    unchanged so it fails honestly at the API instead of silently running
-    as a different model. Case-insensitive; preserves any ``vendor/``
-    namespace prefix.
-    """
-    raw = (model or "").strip()
-    if not raw.lower().endswith(CODEX_CONTEXT_VARIANT_SUFFIX):
-        return raw
-    base = raw[: -len(CODEX_CONTEXT_VARIANT_SUFFIX)]
-    if is_codex_900k_base(base):
-        return base
-    return raw
-
-
-def has_codex_context_variant(model_bare: str) -> bool:
-    """True when a Codex BASE slug should get a synthetic ``-900k`` entry.
-
-    Thin alias over :func:`is_codex_900k_base` kept for the picker call
-    sites' readability.
-    """
-    return is_codex_900k_base(model_bare)
-
-
-def _verified_codex_ctx_for_slug(model_bare: str) -> Optional[int]:
-    """Return the live-verified Codex cap for an OPTED-IN slug, or ``None``.
-
-    The large window is opt-in: only VALID ``-900k`` picker variants
-    (e.g. ``gpt-5.6-sol-900k``) resolve to the verified cap. Base slugs
-    keep the advertised 272K so the cheaper default limit applies unless
-    the user explicitly selects the large-context variant; ineligible
-    aliases (``gpt-5.5-900k``) never resolve here.
-    """
-    slug = _bare_codex_slug(model_bare)
-    if not slug.endswith(CODEX_CONTEXT_VARIANT_SUFFIX):
-        return None
-    base = slug[: -len(CODEX_CONTEXT_VARIANT_SUFFIX)]
-    if not is_codex_900k_base(base):
-        return None
-    exact = _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_EXACT.get(base)
-    if exact is not None:
-        return exact
-    for key, ctx in _CODEX_OAUTH_VERIFIED_ABOVE_ADVERTISED_PREFIXES.items():
-        if base == key or base.startswith(key + "-") or base.startswith(key + "."):
-            return ctx
-    return None
+# Extended-window slugs: the authenticated catalog reports a conservative
+# default ``context_window`` for these models alongside a server-released
+# ``max_context_window``. For these slugs Hermes resolves the provider's
+# ``max_context_window`` directly — derived live from each catalog
+# response, never a hardcoded Hermes number, so the window tracks the
+# provider in both directions. No client-side scaling is applied to the
+# provider's value: the safety margin under the ceiling lives in Hermes's
+# generic compaction/headroom machinery, not in this resolver. Evidence
+# chain for gpt-5.6-sol: OpenAI's own Codex client documents requesting a
+# 1M window against Sol's 1.05M direct-API maximum (@thsottiaux); the
+# ChatGPT OAuth route stayed gated lower (openai/codex#40258) until the
+# server released an 872K ``max_context_window`` (2026-09-02); the
+# 2026-09-03 authenticated catalog reports ``context_window=272000``,
+# ``max_context_window=872000`` → 872,000 today. The direct OpenAI API
+# route is untouched — it resolves through models.dev /
+# DEFAULT_CONTEXT_LENGTHS (1.05M tier). Every other Codex slug keeps its
+# advertised ``context_window`` verbatim.
+_CODEX_OAUTH_EXTENDED_WINDOW_SLUGS = frozenset({"gpt-5.6-sol"})
 
 
 _codex_oauth_context_cache: Dict[str, Tuple[Dict[str, int], float]] = {}
@@ -2833,6 +2701,29 @@ def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:
         return acct_id if isinstance(acct_id, str) and acct_id else None
     except Exception:
         return None
+
+
+def _codex_oauth_extended_window(
+    slug: str, item: Dict[str, Any], default_ctx: int
+) -> int:
+    """Resolve one Codex catalog entry's context window.
+
+    Extended-window slugs (``_CODEX_OAUTH_EXTENDED_WINDOW_SLUGS``) resolve
+    to the catalog's server-released ``max_context_window`` directly, but
+    only when it is a genuine integer at least as large as the advertised
+    default ``context_window`` — anything absent, malformed, boolean,
+    non-positive, or smaller keeps the advertised default. No client-side
+    scaling is applied to the provider's value. Every other slug resolves
+    verbatim.
+    """
+    if slug not in _CODEX_OAUTH_EXTENDED_WINDOW_SLUGS:
+        return default_ctx
+    max_ctx = item.get("max_context_window")
+    if isinstance(max_ctx, bool) or not isinstance(max_ctx, int):
+        return default_ctx
+    if max_ctx <= 0 or max_ctx < default_ctx:
+        return default_ctx
+    return max_ctx
 
 
 def _fetch_codex_oauth_context_lengths_with_source(
@@ -2887,7 +2778,9 @@ def _fetch_codex_oauth_context_lengths_with_source(
         slug = item.get("slug")
         ctx = item.get("context_window")
         if isinstance(slug, str) and isinstance(ctx, int) and ctx > 0:
-            result[slug.strip()] = ctx
+            result[slug.strip()] = _codex_oauth_extended_window(
+                slug.strip(), item, ctx
+            )
 
     if result:
         _codex_oauth_context_cache[cache_key] = (result, now)
@@ -2924,49 +2817,24 @@ def _resolve_codex_oauth_context_length_with_source(
     if not model_bare:
         return None, ""
 
-    def _apply_verified_bump(ctx: int, source: str) -> Tuple[int, str]:
-        """Lift a known-stale 272K advertisement to the live-verified cap.
-
-        Only fires for explicit ``-900k`` picker variants (opt-in), and only
-        when the resolved value is EXACTLY the stale 272,000 advertisement
-        for a slug we have probed above it (see
-        ``_verified_codex_ctx_for_slug``). Any other advertised value —
-        higher or lower — is trusted as a real server-side change.
-        """
-        bumped = _verified_codex_ctx_for_slug(model_bare)
-        if bumped is not None and ctx == _CODEX_OAUTH_STALE_ADVERTISED_CTX:
-            logger.debug(
-                "Codex OAuth context for %s: advertised %d raised to "
-                "live-verified %d", model_bare, ctx, bumped,
-            )
-            return bumped, source
-        return ctx, source
-
-    # ``-900k`` variants are Hermes picker aliases — the Codex catalog only
-    # knows the base slug, so resolve against the stripped id. Also drop any
-    # ``vendor/`` namespace (``openai/gpt-5.6-sol-900k``): the main-agent
-    # path normalizes it away before reaching here, but display/auxiliary
-    # callers pass it through (#92797 review).
-    lookup_bare = _bare_codex_slug(strip_codex_context_variant_suffix(model_bare))
-
     if access_token:
         live, fresh_probe = _fetch_codex_oauth_context_lengths_with_source(access_token)
         live_source = "live" if fresh_probe else "memory"
-        if lookup_bare in live:
-            return _apply_verified_bump(live[lookup_bare], live_source)
+        if model_bare in live:
+            return live[model_bare], live_source
         # Case-insensitive match in case casing drifts
-        model_lower = lookup_bare.lower()
+        model_lower = model_bare.lower()
         for slug, ctx in live.items():
             if slug.lower() == model_lower:
-                return _apply_verified_bump(ctx, live_source)
+                return ctx, live_source
 
     # Fallback: longest-key-first substring match over hardcoded defaults.
-    model_lower = lookup_bare.lower()
+    model_lower = model_bare.lower()
     for slug, ctx in sorted(
         _CODEX_OAUTH_CONTEXT_FALLBACK.items(), key=lambda x: len(x[0]), reverse=True
     ):
         if slug in model_lower:
-            return _apply_verified_bump(ctx, "fallback")
+            return ctx, "fallback"
 
     return None, ""
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -720,17 +720,8 @@ class ResponsesApiTransport(ProviderTransport):
         # request is issued (openai==2.24.0).  Reported for the
         # ``openai-codex`` / ``gpt-5.5`` combo on chatgpt.com/backend-api/codex
         # (#32892) when the agent runs without external tools registered.
-        # Function-level import: agent.model_metadata is imported lazily
-        # because provider plugins import this transport during
-        # model_metadata's own module init (circular otherwise).
-        from agent.model_metadata import (
-            strip_codex_context_variant_suffix as _strip_ctx_variant,
-        )
         kwargs = {
-            # ``-900k`` large-context picker variants are Hermes-side aliases
-            # (gpt-5.6-sol-900k etc.) — the Codex/OpenAI backend only knows
-            # the base slug, so strip the suffix before it hits the wire.
-            "model": _strip_ctx_variant(model),
+            "model": model,
             "instructions": instructions,
             "input": _chat_messages_to_responses_input(
                 payload_messages,

--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -1011,14 +1011,9 @@ _OFFICIAL_DOCS_PRICING: Dict[tuple[str, str], PricingEntry] = {
 
 # GPT-5.6 "-pro" high-effort variants bill at the same per-token rates as
 # their base tiers (more tokens per task, not a higher rate). Alias them
-# onto the base entries so the snapshot stays single-source. The Hermes-side
-# "-900k" large-context Codex picker variants are the same underlying model
-# (the suffix is stripped on the wire), so they alias identically.
+# onto the base entries so the snapshot stays single-source.
 for _base_56 in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna"):
     _OFFICIAL_DOCS_PRICING[("openai", f"{_base_56}-pro")] = _OFFICIAL_DOCS_PRICING[
-        ("openai", _base_56)
-    ]
-    _OFFICIAL_DOCS_PRICING[("openai", f"{_base_56}-900k")] = _OFFICIAL_DOCS_PRICING[
         ("openai", _base_56)
     ]
 del _base_56

--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -89,36 +89,9 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
     return ordered
 
 
-def _add_context_variants(model_ids: List[str]) -> List[str]:
-    """Insert ``-900k`` large-context picker variants after eligible base slugs.
-
-    The ChatGPT Codex backend advertises 272K for the gpt-5.4 / gpt-5.6
-    families but accepts ~911K (live-verified Aug 2026). The base slugs keep
-    the cheaper advertised 272K limit by default; each verified slug gets an
-    explicit ``<slug>-900k`` picker entry that opts into the large window.
-    The suffix is Hermes-side only — it is stripped before the model id hits
-    the wire (agent/transports/codex.py, agent/auxiliary_client.py).
-    """
-    from agent.model_metadata import (
-        CODEX_CONTEXT_VARIANT_SUFFIX,
-        has_codex_context_variant,
-    )
-
-    out: List[str] = []
-    present = set(model_ids)
-    for model_id in model_ids:
-        out.append(model_id)
-        variant = model_id + CODEX_CONTEXT_VARIANT_SUFFIX
-        if variant in present or variant in out:
-            continue
-        if has_codex_context_variant(model_id):
-            out.append(variant)
-    return out
-
-
 def _finalize_codex_models(model_ids: List[str]) -> List[str]:
-    """Forward-compat synthesis + large-context variant synthesis."""
-    return _add_context_variants(_add_forward_compat_models(model_ids))
+    """Forward-compat synthesis for the Codex picker catalog."""
+    return _add_forward_compat_models(model_ids)
 
 
 def _extract_chatgpt_account_id(access_token: str) -> Optional[str]:

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -7344,45 +7344,6 @@ def validate_requested_model(
             catalog_models = provider_model_ids(normalized)
         except Exception:
             catalog_models = []
-        # Ineligible ``-900k`` aliases (e.g. `gpt-5.5-900k`) must be rejected
-        # BEFORE the hidden-slug soft-accept below: the suffix is a Hermes
-        # picker convention, so an unknown `*-900k` name can never be a real
-        # hidden provider slug — soft-accepting one silently runs at 272K on
-        # a different model than the user thinks (#92797 review).
-        if normalized == "openai-codex":
-            from agent.model_metadata import (
-                CODEX_CONTEXT_VARIANT_SUFFIX,
-                is_codex_context_variant,
-            )
-            _req_lower = requested_for_lookup.strip().lower()
-            if (
-                _req_lower.endswith(CODEX_CONTEXT_VARIANT_SUFFIX)
-                and requested_for_lookup not in set(catalog_models)
-            ):
-                if is_codex_context_variant(requested_for_lookup):
-                    # Valid variant that a stale catalog hasn't synthesized
-                    # yet. Accept it directly — falling through would let the
-                    # typo auto-corrector "fix" it to the base slug and
-                    # silently drop the large-context opt-in.
-                    return {
-                        "accepted": True,
-                        "persist": True,
-                        "recognized": True,
-                        "message": None,
-                    }
-                _base_guess = requested_for_lookup[: -len(CODEX_CONTEXT_VARIANT_SUFFIX)]
-                return {
-                    "accepted": False,
-                    "persist": False,
-                    "recognized": False,
-                    "message": (
-                        f"`{requested}` is not a valid large-context variant — "
-                        f"`{_base_guess}` enforces the standard 272K window on "
-                        f"Codex, so no `-900k` option exists for it. Pick the "
-                        f"base model, or a verified variant from the `/model` "
-                        f"picker (e.g. `gpt-5.6-sol-900k`)."
-                    ),
-                }
         if catalog_models:
             if requested_for_lookup in set(catalog_models):
                 return {

--- a/tests/agent/test_arcee_trinity_overrides.py
+++ b/tests/agent/test_arcee_trinity_overrides.py
@@ -94,31 +94,9 @@ def test_compression_threshold_for_codex_gpt55() -> None:
     assert _compression_threshold_for_model("openai/gpt-5.5", "openai-codex") == 0.85
     assert _is_codex_gpt54_or_gpt55("gpt-daybreak-blue-latest", "openai-codex") is True
     assert _compression_threshold_for_model("gpt-daybreak-blue-latest", "openai-codex") == 0.85
-
-
-@pytest.mark.parametrize(
-    "model",
-    [
-        "gpt-5.6-sol-900k",
-        "gpt-5.6-terra-900k",
-        "gpt-5.6-luna-900k",
-        "gpt-5.4-900k",
-        "gpt-daybreak-blue-latest-900k",
-        "openai/gpt-5.6-sol-900k",
-    ],
-)
-def test_900k_variants_keep_global_threshold(model) -> None:
-    """The 85% autoraise compensates for the small 272K window; ``-900k``
-    opt-in variants run at ~900K, so they keep the user's global
-    ``compression.threshold`` (default 50%) — no override returned."""
-    assert _is_codex_gpt54_or_gpt55(model, "openai-codex") is False
-    assert _compression_threshold_for_model(model, "openai-codex") is None
-
-
-def test_base_slugs_still_autoraised_alongside_900k_variants() -> None:
-    """Sanity pair: the base slug autoraises while its variant does not."""
     assert _compression_threshold_for_model("gpt-5.6-sol", "openai-codex") == 0.85
-    assert _compression_threshold_for_model("gpt-5.6-sol-900k", "openai-codex") is None
+    assert _compression_threshold_for_model("gpt-5.6-terra", "openai-codex") == 0.85
+    assert _compression_threshold_for_model("gpt-5.6-luna", "openai-codex") == 0.85
 
 
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -531,47 +531,15 @@ class TestCodexOAuthContextLength:
             "gpt-5.6-sol",
             "gpt-5.6-terra",
             "gpt-5.6-luna",
-            "gpt-5.6-sol-2026-07-09",  # dated snapshot via gpt-5.6 family prefix
-            "gpt-5.4",
-            "gpt-daybreak-blue-latest",  # Sol alias; exact verified slug
-        ],
-    )
-    def test_900k_variant_slug_bumped_to_live_verified_900k(self, slug):
-        """The backend accepts ~911K for these slugs (verified live Aug 2026),
-        but the large window is OPT-IN: only the explicit ``-900k`` picker
-        variant resolves to 900K. The catalog only knows the base slug, so
-        the resolver strips the suffix for the lookup, then applies the bump."""
-        from agent.model_metadata import get_model_context_length
-
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.json.return_value = {
-            "models": [{"slug": slug, "context_window": 272_000}]
-        }
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.save_context_length"):
-            ctx = get_model_context_length(
-                model=slug + "-900k",
-                base_url="https://chatgpt.com/backend-api/codex",
-                api_key="fake-token",
-                provider="openai-codex",
-            )
-        assert ctx == 900_000
-
-    @pytest.mark.parametrize(
-        "slug",
-        [
-            "gpt-5.6-sol",
-            "gpt-5.6-terra",
-            "gpt-5.6-luna",
             "gpt-5.4",
             "gpt-daybreak-blue-latest",
         ],
     )
     def test_base_slug_keeps_advertised_272k(self, slug):
-        """Base slugs (no ``-900k`` suffix) keep the advertised 272K — the
-        cheaper default limit. The verified-above bump is opt-in only."""
+        """Catalog entries without extended-window fields resolve verbatim.
+        Base Sol's live derivation from ``max_context_window`` is covered
+        by the dedicated tests below — it requires that field, which these
+        entries lack."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -591,37 +559,12 @@ class TestCodexOAuthContextLength:
                 provider="openai-codex",
             )
         assert ctx == 272_000
-
-    def test_non_272k_advertisement_is_trusted_verbatim(self):
-        """Any advertised value other than the known-stale 272,000 — higher or
-        lower — is a real server-side change and must NOT be overridden, even
-        for an explicit ``-900k`` opt-in variant."""
-        from agent.model_metadata import get_model_context_length
-
-        for advertised in (372_000, 200_000, 1_050_000):
-            fake_response = MagicMock()
-            fake_response.status_code = 200
-            fake_response.json.return_value = {
-                "models": [{"slug": "gpt-5.6-sol", "context_window": advertised}]
-            }
-            import agent.model_metadata as mm
-            mm._codex_oauth_context_cache = {}
-            with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-                 patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-                 patch("agent.model_metadata.save_context_length"):
-                ctx = get_model_context_length(
-                    model="gpt-5.6-sol-900k",
-                    base_url="https://chatgpt.com/backend-api/codex",
-                    api_key="fake-token",
-                    provider="openai-codex",
-                )
-            assert ctx == advertised, f"advertised {advertised} must be trusted"
 
     @pytest.mark.parametrize("slug", ["gpt-5.5", "gpt-5.4-mini"])
     def test_slugs_that_enforce_272k_keep_advertised_value(self, slug):
-        """gpt-5.5 and gpt-5.4-mini both rejected large inputs in the live probe (360K and 500K respectively) —
-        their 272K advertisement is real enforcement, so no bump applies
-        (gpt-5.4 is an exact-match entry precisely to exclude -mini)."""
+        """gpt-5.5 and gpt-5.4-mini both rejected large inputs in the live
+        probe (360K and 500K respectively) — their 272K advertisement is
+        real enforcement and resolves verbatim."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -629,116 +572,221 @@ class TestCodexOAuthContextLength:
         fake_response.json.return_value = {
             "models": [{"slug": slug, "context_window": 272_000}]
         }
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.save_context_length"):
-            ctx = get_model_context_length(
-                model=slug,
-                base_url="https://chatgpt.com/backend-api/codex",
-                api_key="fake-token",
-                provider="openai-codex",
-            )
-        assert ctx == 272_000
-
-    @pytest.mark.parametrize("slug", ["gpt-5.6-sol-900k", "gpt-daybreak-blue-latest-900k"])
-    def test_fallback_table_resolution_also_bumped(self, slug):
-        """When the live probe fails, the 272K fallback-table value for an
-        opted-in ``-900k`` variant is bumped the same way (same enforcement
-        applies — the fallback lookup strips the suffix first)."""
-        from agent.model_metadata import get_model_context_length
-
-        fake_response = MagicMock()
-        fake_response.status_code = 401
-        fake_response.json.return_value = {}
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.save_context_length"):
-            ctx = get_model_context_length(
-                model=slug,
-                base_url="https://chatgpt.com/backend-api/codex",
-                api_key="expired-token",
-                provider="openai-codex",
-            )
-        assert ctx == 900_000
-
-    @pytest.mark.parametrize("slug", ["gpt-5.6-sol", "gpt-daybreak-blue-latest"])
-    def test_fallback_table_base_slug_stays_272k(self, slug):
-        """Fallback-table resolution for BASE slugs stays at the advertised
-        272K — the opt-in rule applies on the offline path too."""
-        from agent.model_metadata import get_model_context_length
-
-        fake_response = MagicMock()
-        fake_response.status_code = 401
-        fake_response.json.return_value = {}
-        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
-             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
-             patch("agent.model_metadata.save_context_length"):
-            ctx = get_model_context_length(
-                model=slug,
-                base_url="https://chatgpt.com/backend-api/codex",
-                api_key="expired-token",
-                provider="openai-codex",
-            )
-        assert ctx == 272_000
-
-    # Table-driven eligibility contract (#92797 review): one predicate
-    # (is_codex_900k_base) drives picker synthesis, context resolution,
-    # validation, and wire stripping — this table pins all of them.
-    # (model_id, is_valid_variant, expected_ctx, expected_wire_model)
-    _900K_TABLE = [
-        ("gpt-5.6-sol-900k",              True,  900_000, "gpt-5.6-sol"),
-        ("gpt-5.6-terra-900k",            True,  900_000, "gpt-5.6-terra"),
-        ("gpt-5.6-luna-900k",             True,  900_000, "gpt-5.6-luna"),
-        ("gpt-5.4-900k",                  True,  900_000, "gpt-5.4"),
-        ("gpt-daybreak-blue-latest-900k", True,  900_000, "gpt-daybreak-blue-latest"),
-        # dated snapshot of a routable 5.6 base
-        ("gpt-5.6-sol-2026-07-09-900k",   True,  900_000, "gpt-5.6-sol-2026-07-09"),
-        # vendor-namespaced variant (display/aux callers) resolves too
-        ("openai/gpt-5.6-sol-900k",       True,  900_000, "openai/gpt-5.6-sol"),
-        # -pro slugs are not routable on Codex OAuth: never a valid variant,
-        # never stripped (fails honestly at the API instead)
-        ("gpt-5.6-sol-pro-900k",          False, 272_000, "gpt-5.6-sol-pro-900k"),
-        # genuine 272K enforcers get no variant
-        ("gpt-5.5-900k",                  False, 272_000, "gpt-5.5-900k"),
-        ("gpt-5.4-mini-900k",             False, 272_000, "gpt-5.4-mini-900k"),
-        # arbitrary future family descendants are not auto-eligible
-        ("gpt-5.6-nova-900k",             False, 272_000, "gpt-5.6-nova-900k"),
-    ]
-
-    @pytest.mark.parametrize("model_id,valid,expected_ctx,wire", _900K_TABLE)
-    def test_900k_eligibility_table(self, model_id, valid, expected_ctx, wire):
-        from agent.model_metadata import (
-            get_model_context_length,
-            is_codex_context_variant,
-            strip_codex_context_variant_suffix,
-        )
-
-        assert is_codex_context_variant(model_id) is valid
-        assert strip_codex_context_variant_suffix(model_id) == wire
-
-        bare = model_id.rsplit("/", 1)[-1]
-        catalog_slug = strip_codex_context_variant_suffix(bare)
-        if catalog_slug.endswith("-900k"):
-            # invalid alias — catalog advertises the underlying family slug
-            catalog_slug = catalog_slug[: -len("-900k")]
-        fake_response = MagicMock()
-        fake_response.status_code = 200
-        fake_response.json.return_value = {
-            "models": [{"slug": catalog_slug, "context_window": 272_000}]
-        }
         import agent.model_metadata as mm
         mm._codex_oauth_context_cache = {}
         with patch("agent.model_metadata.requests.get", return_value=fake_response), \
              patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
             ctx = get_model_context_length(
-                model=model_id,
+                model=slug,
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx == expected_ctx
+        assert ctx == 272_000
 
+    @pytest.mark.parametrize("slug", ["gpt-5.6-sol", "gpt-daybreak-blue-latest"])
+    def test_fallback_table_base_slug_stays_272k(self, slug):
+        """Fallback-table resolution for base slugs returns the advertised
+        272K verbatim on the offline path too."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 401
+        fake_response.json.return_value = {}
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model=slug,
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="expired-token",
+                provider="openai-codex",
+            )
+        assert ctx == 272_000
+
+    # -- Extended-window derivation for base gpt-5.6-sol (live fields) --
+
+    def test_sol_resolves_provider_max_window_directly(self):
+        """Base Sol on the OAuth route resolves the catalog's server-released
+        ``max_context_window`` directly — the 2026-09-03 authenticated catalog
+        shape (``context_window=272000``, ``max_context_window=872000``, no
+        other window field) resolves 872,000, persisted like any live value."""
+        from agent.model_metadata import get_model_context_length
+
+        base_url = "https://chatgpt.com/backend-api/codex"
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": "gpt-5.6-sol",
+                "context_window": 272_000,
+                "max_context_window": 872_000,
+            }]
+        }
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url=base_url,
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 872_000
+        mock_save.assert_called_once_with("gpt-5.6-sol", base_url, 872_000)
+
+    @pytest.mark.parametrize(
+        "max_ctx,expected",
+        [
+            (872_000, 872_000),      # 2026-09-03 catalog values
+            (1_050_000, 1_050_000),  # a future full-window release
+            (400_000, 400_000),      # tracks the provider downward too
+            (272_000, 272_000),      # boundary: max equal to advertised
+        ],
+    )
+    def test_sol_window_tracks_live_catalog_fields(self, max_ctx, expected):
+        """The resolved window is the live ``max_context_window`` verbatim
+        on every probe — changing the catalog changes the answer, so the
+        value is provider-derived, not a Hermes magic number."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": "gpt-5.6-sol",
+                "context_window": 272_000,
+                "max_context_window": max_ctx,
+            }]
+        }
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == expected
+
+    def test_sol_max_window_is_used_directly_never_scaled(self):
+        """The resolver returns the integer ``max_context_window`` verbatim.
+        A stray percent-shaped catalog value must not scale it — headroom is
+        Hermes's generic compaction machinery, not resolver arithmetic."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": "gpt-5.6-sol",
+                "context_window": 272_000,
+                "max_context_window": 872_000,
+                "effective_context_window_percent": 1,
+            }]
+        }
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 872_000
+
+    @pytest.mark.parametrize(
+        "entry",
+        [
+            # max_context_window absent entirely
+            {"slug": "gpt-5.6-sol", "context_window": 272_000},
+            # max absent; a percent-shaped value alone is never a substitute
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "effective_context_window_percent": 95},
+            # malformed: non-integer shapes
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": "872000"},
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": 872000.5},
+            # boolean
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": True},
+            # non-positive
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": 0},
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": -1},
+            # below the advertised default
+            {"slug": "gpt-5.6-sol", "context_window": 272_000,
+             "max_context_window": 200_000},
+        ],
+    )
+    def test_sol_extended_window_requires_valid_catalog_fields(self, entry):
+        """Absent, malformed, boolean, non-positive, or below-advertised
+        ``max_context_window`` values degrade to the advertised default
+        window — the derivation never invents a value."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {"models": [entry]}
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 272_000
+
+    @pytest.mark.parametrize("slug", ["gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.5", "gpt-5.4"])
+    def test_other_codex_slugs_ignore_extended_window_fields(self, slug):
+        """Only base Sol derives from the extended field. Other Codex
+        slugs keep the advertised ``context_window`` verbatim even when
+        the catalog carries a larger ``max_context_window`` for them."""
+        from agent.model_metadata import get_model_context_length
+
+        fake_response = MagicMock()
+        fake_response.status_code = 200
+        fake_response.json.return_value = {
+            "models": [{
+                "slug": slug,
+                "context_window": 272_000,
+                "max_context_window": 872_000,
+            }]
+        }
+        with patch("agent.model_metadata.requests.get", return_value=fake_response), \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model=slug,
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="fake-token",
+                provider="openai-codex",
+            )
+        assert ctx == 272_000
+
+    def test_direct_api_sol_window_not_driven_by_oauth_catalog(self):
+        """The OAuth derivation is scoped to provider=openai-codex. The
+        direct OpenAI API route keeps Sol's documented 1.05M-tier window
+        (models.dev / static table) — the requested-1M client setting from
+        OpenAI's own Codex config lives on that route, not this one."""
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.models_dev.lookup_models_dev_context", return_value=None), \
+             patch("agent.model_metadata.requests.get") as mock_get, \
+             patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            ctx = get_model_context_length(
+                model="gpt-5.6-sol", provider="openai", api_key="sk-test",
+            )
+        assert ctx == 1_050_000
+        mock_get.assert_not_called()
 
 
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -39,17 +39,6 @@ class TestCodexTransportBasic:
 
 class TestCodexBuildKwargs:
 
-    def test_900k_context_variant_suffix_stripped_on_wire(self, transport):
-        """``-900k`` large-context picker variants are Hermes-side aliases —
-        the Codex backend only knows the base slug, so build_kwargs must
-        strip the suffix from the wire model id."""
-        messages = [{"role": "user", "content": "Hi"}]
-        kw = transport.build_kwargs(
-            model="gpt-5.6-sol-900k", messages=messages, tools=[],
-            params={"is_codex_backend": True},
-        )
-        assert kw["model"] == "gpt-5.6-sol"
-
     def test_base_slug_model_id_unchanged_on_wire(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -35,33 +35,23 @@ def test_curated_codex_fallback_excludes_chatgpt_rejected_pro_slugs(monkeypatch)
     assert CHATGPT_REJECTED_CODEX_PRO_SLUGS.isdisjoint(model_ids)
 
 
-def test_picker_synthesizes_900k_variants_for_verified_slugs():
-    """Every live-verified large-context slug gets an explicit ``-900k``
-    picker variant directly after its base entry; slugs that genuinely
-    enforce 272K (gpt-5.5, gpt-5.4-mini) never get one. Base slugs stay
-    in the list as the cheaper 272K default."""
+def test_picker_lists_each_base_slug_once_and_never_synthesizes_900k_variants():
+    """Regression guard: the picker shows each base Codex slug exactly once
+    and never synthesizes ``-900k`` pseudo-model aliases. That experiment
+    was removed at source — a model id is the provider's id, not a
+    Hermes-invented one."""
     model_ids = get_codex_model_ids()  # offline curated path
 
     for base in ("gpt-5.6-sol", "gpt-5.6-terra", "gpt-5.6-luna", "gpt-5.4"):
-        assert base in model_ids
-        assert f"{base}-900k" in model_ids
-        assert model_ids.index(f"{base}-900k") == model_ids.index(base) + 1
+        assert model_ids.count(base) == 1
+    assert not [m for m in model_ids if m.endswith("-900k")]
 
-    assert "gpt-5.5-900k" not in model_ids
-    assert "gpt-5.4-mini-900k" not in model_ids
-    assert "gpt-5.3-codex-900k" not in model_ids
-
-
-def test_picker_never_synthesizes_900k_for_pro_or_unknown_slugs():
-    """Eligibility is an exact predicate, not a family-prefix match:
-    ``-pro`` slugs are not routable on Codex OAuth (backend 400s them) and
-    unknown future descendants were never probed — neither may gain a
-    synthetic ``-900k`` entry (#92797 review)."""
+    # The forward-compat finalize seam behaves the same: ids pass through
+    # without ever gaining synthetic context variants.
     from hermes_cli.codex_models import _finalize_codex_models
 
     out = _finalize_codex_models(["gpt-5.6-sol-pro", "gpt-5.6-nova"])
-    assert "gpt-5.6-sol-pro-900k" not in out
-    assert "gpt-5.6-nova-900k" not in out
+    assert not [m for m in out if m.endswith("-900k")]
 
 
 

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -506,35 +506,6 @@ class TestValidateCodexAutoCorrection:
         assert result["message"] is None
 
 
-class TestValidateCodex900kVariants:
-    """`-900k` is a Hermes picker convention: valid variants come from the
-    catalog; ineligible aliases are hard-rejected BEFORE the hidden-slug
-    soft-accept (#92797 review)."""
-
-    _CATALOG = ["gpt-5.6-sol", "gpt-5.6-sol-900k", "gpt-5.5", "gpt-5.4-mini"]
-
-    def test_catalog_listed_variant_accepted(self):
-        with patch("hermes_cli.models.provider_model_ids", return_value=self._CATALOG):
-            result = validate_requested_model("gpt-5.6-sol-900k", "openai-codex")
-        assert result["accepted"] is True
-        assert result["recognized"] is True
-
-    @pytest.mark.parametrize("alias", ["gpt-5.5-900k", "gpt-5.4-mini-900k", "gpt-5.6-sol-pro-900k"])
-    def test_ineligible_900k_alias_rejected_not_soft_accepted(self, alias):
-        with patch("hermes_cli.models.provider_model_ids", return_value=self._CATALOG):
-            result = validate_requested_model(alias, "openai-codex")
-        assert result["accepted"] is False
-        assert result["persist"] is False
-        assert "272K" in result["message"]
-
-    def test_valid_variant_missing_from_catalog_still_accepted(self):
-        """A verified variant not yet in the (possibly stale) catalog is
-        accepted via the eligibility predicate, not the soft-accept."""
-        with patch("hermes_cli.models.provider_model_ids", return_value=["gpt-5.6-sol"]):
-            result = validate_requested_model("gpt-5.6-sol-900k", "openai-codex")
-        assert result["accepted"] is True
-
-
 # -- probe_api_models — Cloudflare UA mitigation --------------------------------
 
 class TestProbeApiModelsUserAgent:

--- a/website/docs/developer-guide/context-compression-and-caching.md
+++ b/website/docs/developer-guide/context-compression-and-caching.md
@@ -207,26 +207,33 @@ To keep the 85% autoraise but hide only the one-time notice:
 hermes config set compression.codex_gpt55_autoraise_notice false
 ```
 
-### Codex large-context `-900k` picker variants (opt-in)
+### Codex OAuth extended window for `gpt-5.6-sol`
 
-The ChatGPT Codex backend *advertises* a 272K window for the gpt-5.4 and
-gpt-5.6 (Sol/Terra/Luna) families, but actually accepts ~911K input tokens
-for ChatGPT-subscription accounts (live-verified Aug 2026). Hermes keeps the
-**advertised 272K as the default** for the base slugs — a bigger window means
-more tokens per request and much faster subscription-usage burn, so the large
-window is strictly opt-in.
+Two different windows circulate for `gpt-5.6-sol`, and Hermes keeps them
+distinct:
 
-To use the large window, pick the explicit `-900k` variant in `/model` (e.g.
-`gpt-5.6-sol-900k`, `gpt-5.6-terra-900k`, `gpt-5.6-luna-900k`,
-`gpt-5.4-900k`). These are Hermes-side aliases: the suffix is stripped before
-the model id is sent to the backend, and pricing/usage accounting treats them
-as the base model. Slugs that genuinely enforce 272K (gpt-5.5, gpt-5.4-mini)
-have no `-900k` variant.
+- **Direct OpenAI API (untouched).** Sol's documented maximum there is
+  1.05M; OpenAI's own Codex client configures a requested 1M window
+  (`model_context_window = 1000000`) against it. Hermes resolves the direct
+  route through models.dev / its static table and does not clamp it.
+- **OAuth catalog maximum (872K today).** The authenticated
+  `/backend-api/codex/models` catalog advertises a conservative default
+  `context_window` (272K) alongside the server-released `max_context_window`
+  — 872,000 as of the 2026-09-03 catalog, after openai/codex#40258 closed
+  the originator-gated history on 2026-09-02. On `openai-codex`, base
+  `gpt-5.6-sol` resolves that live `max_context_window` directly — 872,000
+  today — derived from every authenticated probe, never a hardcoded Hermes
+  number, so the window tracks the provider in both directions.
 
-Compaction thresholds follow the window: base slugs (272K) get the **85%
-autoraise** described above, while `-900k` variants keep your global
-`compression.threshold` (default 50%, ~450K) — the autoraise exists to stop
-wasting a small window, which a 900K window doesn't need.
+There are no `-900k`-style aliases: the picker lists exactly one real
+`gpt-5.6-sol`, and the model id on the wire is the provider's id.
+Compaction thresholds derive from the resolved window as usual (the Codex
+gpt-5.x autoraise to 85% applies on the OAuth route), and probed values
+persist through the normal context-length cache. When the catalog lacks a
+usable `max_context_window` (older endpoint, unauthenticated fallback), Sol
+keeps the advertised 272K default. The safety margin under the ceiling is
+Hermes's generic compaction/headroom machinery — no Sol-specific scaling is
+applied to the resolved window.
 
 ### Codex app-server thread compaction
 


### PR DESCRIPTION
## Behavior

- Defines exactly one real `gpt-5.6-sol` model and removes all `-900k` aliases.
- For `openai-codex`, Sol uses a valid provider `max_context_window` directly, currently `872000`.
- Missing or unsafe provider maximums fall back to the advertised `272000` context window.
- Other Codex model slugs are unchanged.
- Direct API context remains `1050000`.
- Generic compaction and headroom behavior are unchanged.

## Tests

- Focused suite: 304 passed.
- Broader suite: 534 passed.