### PR TITLE
fix(kanban): refuse schedule/block on running task while worker is alive (#102423)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -6261,7 +6261,9 @@ def block_task(
     reason: Optional[str] = None,
     kind: Optional[str] = None,
     expected_run_id: Optional[int] = None,
-) -> bool:
+    force: bool = False,
+    with_reason: bool = False,
+) -> "bool | tuple[bool, Optional[str]]":
     """Transition ``running``/``ready`` → ``blocked`` (or route elsewhere).
 
     ``kind`` (one of :data:`VALID_BLOCK_KINDS`, or ``None`` for a legacy
@@ -6288,7 +6290,19 @@ def block_task(
 
     Returns True on any successful transition (to ``blocked``, ``todo``, or
     ``triage``), False when the task wasn't in a blockable state.
+
+    When a live worker holds the card (status='running' with a non-null
+    ``worker_pid`` and ``_pid_alive(worker_pid)``), the function refuses by
+    default to prevent a silent double-spawn (#102423). Operators that know
+    what they're doing can pass ``force=True`` to override.
+
+    By default returns ``bool`` (matches historical contract). With
+    ``with_reason=True`` returns ``(ok, reason)`` mirroring
+    :func:`schedule_task`/``request_review``/``request_changes``.
     """
+    def _ret(ok: bool, reason: Optional[str] = None):
+        return (ok, reason) if with_reason else ok
+
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(
             f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None"
@@ -6296,11 +6310,31 @@ def block_task(
     recurrences = 0
     with write_txn(conn):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?",
+            "SELECT status, block_kind, block_recurrences, worker_pid "
+            "FROM tasks WHERE id = ?",
             (task_id,),
         ).fetchone()
         if cur_row is None:
-            return False
+            return _ret(False, f"task {task_id} not found")
+        # Refuse to clear a live worker's claim without proof of ownership
+        # (expected_run_id) or an explicit operator override (force=True).
+        # Without this guard, #102423 fires: block -> unblock -> ready ->
+        # dispatcher spawns a second worker for the same card while the
+        # original is still running.
+        if (
+            expected_run_id is None
+            and not force
+            and cur_row["status"] == "running"
+            and cur_row["worker_pid"] is not None
+            and _pid_alive(cur_row["worker_pid"])
+        ):
+            return _ret(
+                False,
+                "task is running under a live worker (pid "
+                f"{cur_row['worker_pid']}); pass expected_run_id (worker "
+                "ownership) or force=True (explicit operator override) "
+                "instead of clearing the live run's claim",
+            )
         source_status = (
             _retry_status_for_run(conn, task_id)
             if cur_row["status"] == "running"
@@ -6334,7 +6368,7 @@ def block_task(
                 else (kind, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
-                return False
+                return _ret(False, "dependency block UPDATE did not match")
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6362,7 +6396,7 @@ def block_task(
                 run_id=run_id,
                 reason=reason,
             )
-            return True
+            return _ret(True)
 
         # Truly-blocked kinds. Increment the unblock-loop counter when this is a
         # re-block for the SAME reason after a prior unblock. block_task only
@@ -6392,7 +6426,7 @@ def block_task(
                 else (kind, recurrences, task_id, int(expected_run_id)),
             )
             if cur.rowcount != 1:
-                return False
+                return _ret(False, "triage route UPDATE did not match")
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6446,7 +6480,7 @@ def block_task(
                     (kind, recurrences, task_id, int(expected_run_id)),
                 )
             if cur.rowcount != 1:
-                return False
+                return _ret(False, "block UPDATE did not match")
             run_id = _end_run(
                 conn, task_id,
                 outcome="blocked", status="blocked",
@@ -6479,7 +6513,7 @@ def block_task(
         run_id=run_id,
         reason=reason,
     )
-    return True
+    return _ret(True)
 
 
 
@@ -7929,14 +7963,61 @@ def schedule_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
-) -> bool:
+    force: bool = False,
+    with_reason: bool = False,
+) -> "bool | tuple[bool, Optional[str]]":
     """Park a task in ``scheduled`` so it is waiting on time, not human input.
 
     ``scheduled`` tasks are intentionally not dispatchable; an external cron,
     human action, or automation can later call ``unblock_task`` to re-gate them
     to ``ready`` (or ``todo`` if parents are still incomplete).
+
+    When a live worker holds the card (status='running' with a non-null
+    ``worker_pid`` and ``_pid_alive(worker_pid)``), the function refuses by
+    default to prevent a silent double-spawn (#102423): clearing the claim
+    while the live worker is still alive lets the next dispatcher tick spawn a
+    duplicate worker for the same card.
+
+    Callers that know what they're doing (e.g. operators reclaiming a stuck
+    card after a host crash that the DB hasn't noticed yet) can pass
+    ``force=True`` to override. The transition is then performed, the worker
+    PID is cleared, and a ``scheduled`` audit event is emitted with
+    ``force=True`` and ``orphaned_pid`` so an operator can find the live
+    process without ``pgrep``.
+
+    By default returns ``bool`` (matches historical contract). With
+    ``with_reason=True`` returns ``(ok, reason)`` mirroring
+    :func:`block_task`/``request_review``/``request_changes`` —
+    ``reason`` is a diagnostic string on failure, ``None`` on success.
     """
+    def _ret(ok: bool, reason: Optional[str] = None):
+        return (ok, reason) if with_reason else ok
+
     with write_txn(conn):
+        trow = conn.execute(
+            "SELECT status, worker_pid FROM tasks WHERE id = ?", (task_id,),
+        ).fetchone()
+        if trow is None:
+            return _ret(False, f"task {task_id} not found")
+        # Refuse to clear a live worker's claim without proof of ownership
+        # (expected_run_id) or an explicit operator override (force=True).
+        # Without this guard, #102423 fires: schedule -> unblock -> ready ->
+        # dispatcher spawns a second worker for the same card while the
+        # original is still running.
+        if (
+            expected_run_id is None
+            and not force
+            and trow["status"] == "running"
+            and trow["worker_pid"] is not None
+            and _pid_alive(trow["worker_pid"])
+        ):
+            return _ret(
+                False,
+                "task is running under a live worker (pid "
+                f"{trow['worker_pid']}); pass expected_run_id (worker "
+                "ownership) or force=True (explicit operator override) "
+                "instead of clearing the live run's claim",
+            )
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -7952,7 +8033,11 @@ def schedule_task(
             params.append(int(expected_run_id))
         cur = conn.execute(sql, params)
         if cur.rowcount != 1:
-            return False
+            return _ret(
+                False,
+                "task is not in todo/ready/running/blocked (or "
+                "expected_run_id did not match the current run)",
+            )
         run_id = _end_run(
             conn, task_id,
             outcome="scheduled", status="scheduled",
@@ -7964,8 +8049,18 @@ def schedule_task(
                 outcome="scheduled",
                 summary=reason,
             )
-        _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
-        return True
+        # Audit-trail payload records the orphaned PID so operators can
+        # locate the live worker process without `pgrep`. Recorded whenever
+        # the worker PID is non-null at transition time (covers force=True
+        # override AND the rare case where _pid_alive misses a transient
+        # process — the operator still gets the breadcrumb).
+        payload: dict[str, Any] = {"reason": reason}
+        if trow["worker_pid"] is not None:
+            payload["orphaned_pid"] = int(trow["worker_pid"])
+        if force:
+            payload["force"] = True
+        _append_event(conn, task_id, "scheduled", payload, run_id=run_id)
+        return _ret(True)
 
 
 # Dispatcher (one-shot pass)

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -200,6 +200,172 @@ def test_schedule_task_parks_time_delay_without_dispatching(kanban_home):
         assert any(e.kind == "scheduled" and e.payload == {"reason": "run next week"} for e in events)
 
 
+# ---------------------------------------------------------------------------
+# Live-worker guard for schedule_task / block_task on a `running` task (#102423)
+# ---------------------------------------------------------------------------
+
+
+def _make_running_task_with_alive_worker(conn, title: str = "live worker") -> tuple[str, int]:
+    """Create a task, mark it ``running`` with a known-alive worker PID.
+
+    Uses the test process's own PID (always alive on this host) so we don't
+    need to spawn a child. Returns ``(task_id, worker_pid)``.
+    """
+    t = kb.create_task(conn, title=title, assignee="ops")
+    # Bring the task to ``ready`` then claim it so claim_lock / worker_pid
+    # populate the way the dispatcher would. We bypass the dispatcher's
+    # per-tick atomicity on purpose — the bug fires regardless of how the
+    # card got to ``running`` (operator-initiated transition or
+    # dispatcher-claimed).
+    kb.recompute_ready(conn)
+    host = kb._claimer_id().split(":", 1)[0]
+    kb.claim_task(conn, t, claimer=f"{host}:worker")
+    worker_pid = os.getpid()
+    kb._set_worker_pid(conn, t, worker_pid)
+    task = kb.get_task(conn, t)
+    assert task.status == "running", task.status
+    assert task.worker_pid == worker_pid
+    return t, worker_pid
+
+
+def test_schedule_task_refuses_when_worker_alive_on_running_task(kanban_home):
+    """Reproduces #102423 L1.
+
+    ``schedule_task`` on a ``running`` task with a live worker must NOT
+    silently drop the claim and leave the worker orphaned — the next
+    dispatcher tick would spawn a duplicate. Refuse with a clear reason.
+    """
+    with kb.connect() as conn:
+        t, worker_pid = _make_running_task_with_alive_worker(conn)
+        # Sanity: the worker is alive on this host.
+        assert kb._pid_alive(worker_pid)
+
+        ok, reason = kb.schedule_task(conn, t, reason="oops", with_reason=True)
+
+        assert ok is False, "schedule must refuse when live worker holds the card"
+        assert isinstance(reason, str) and reason, "refusal must include a reason string"
+        assert "running" in reason.lower() or str(worker_pid) in reason or "live" in reason.lower()
+
+        task = kb.get_task(conn, t)
+        assert task.status == "running", "status must NOT have changed"
+        assert task.worker_pid == worker_pid, "worker_pid must NOT have been cleared"
+        assert task.claim_lock is not None, "claim_lock must NOT have been cleared"
+
+
+def test_block_task_refuses_when_worker_alive_on_running_task(kanban_home):
+    """Reproduces #102423 L2.
+
+    ``block_task`` on a ``running`` task with a live worker must refuse,
+    for the same reason — clearing the claim would let a later
+    ``unblock_task`` → ``ready`` chain spawn a duplicate worker.
+    """
+    with kb.connect() as conn:
+        t, worker_pid = _make_running_task_with_alive_worker(conn)
+
+        ok, reason = kb.block_task(conn, t, reason="oops", with_reason=True)
+
+        assert ok is False, "block must refuse when live worker holds the card"
+        assert isinstance(reason, str) and reason, "refusal must include a reason string"
+
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.worker_pid == worker_pid
+        assert task.claim_lock is not None
+
+
+def test_schedule_task_force_allows_with_orphan_event(kanban_home):
+    """Reproduces #102423 L3 + L4.
+
+    ``schedule_task(force=True)`` on a ``running`` task with a live worker
+    must (a) perform the transition, (b) clear the worker PID, AND
+    (c) emit an audit event that records the orphaned PID so an operator
+    can find the live worker process without `pgrep`.
+    """
+    with kb.connect() as conn:
+        t, worker_pid = _make_running_task_with_alive_worker(conn)
+
+        ok, reason = kb.schedule_task(conn, t, reason="manual override", force=True, with_reason=True)
+
+        assert ok is True, f"force=True must permit the transition (got reason={reason!r})"
+        task = kb.get_task(conn, t)
+        assert task.status == "scheduled"
+        assert task.worker_pid is None
+        assert task.claim_lock is None
+
+        events = kb.list_events(conn, t)
+        override_events = [
+            e for e in events
+            if e.kind == "scheduled" and isinstance(e.payload, dict)
+            and e.payload.get("force") is True
+        ]
+        assert override_events, f"expected a force-scheduled event with orphan pid, got {events!r}"
+        payload = override_events[-1].payload
+        assert payload.get("orphaned_pid") == worker_pid, (
+            f"orphaned_pid={payload.get('orphaned_pid')} != worker_pid={worker_pid}"
+        )
+        assert payload.get("reason") == "manual override"
+
+
+def test_schedule_task_proceeds_when_worker_pid_dead(kanban_home):
+    """GREEN path: card stuck in 'running' with a dead worker must still be
+    recoverable without ``force``. The dispatcher / operator may have
+    legitimately failed to clear the row after a host crash.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="stuck dead worker", assignee="ops")
+        kb.recompute_ready(conn)
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        # PID 1 is init on POSIX and always present, but we want a PID we
+        # can guarantee the host considers gone. Use a very high PID that
+        # cannot be allocated by the kernel in normal operation.
+        kb._set_worker_pid(conn, t, 2_000_000_000)
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert kb._pid_alive(2_000_000_000) is False, "test premise: high PID must be dead"
+
+        ok, reason = kb.schedule_task(conn, t, reason="clean up dead worker", with_reason=True)
+
+        assert ok is True, f"schedule must proceed when worker is gone (reason={reason!r})"
+        task = kb.get_task(conn, t)
+        assert task.status == "scheduled"
+        assert task.worker_pid is None
+
+
+def test_schedule_task_proceeds_when_worker_pid_none(kanban_home):
+    """GREEN path: a running task without a recorded worker_pid (e.g. legacy
+    row, dispatcher crash mid-claim) must still be schedulable.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="running no pid", assignee="ops")
+        kb.recompute_ready(conn)
+        host = kb._claimer_id().split(":", 1)[0]
+        kb.claim_task(conn, t, claimer=f"{host}:worker")
+        # Don't call _set_worker_pid. The row is ``running`` but PID is NULL.
+        task = kb.get_task(conn, t)
+        assert task.status == "running"
+        assert task.worker_pid is None
+
+        ok, reason = kb.schedule_task(conn, t, reason="legacy row cleanup", with_reason=True)
+
+        assert ok is True, f"schedule must proceed when no PID recorded (reason={reason!r})"
+        task = kb.get_task(conn, t)
+        assert task.status == "scheduled"
+
+
+def test_schedule_task_legacy_single_arg_returns_bool_still_works(kanban_home):
+    """Backwards-compat: callers that pass only ``task_id`` and ``reason``
+    (no ``force``/``with_reason``) must still get the legacy ``bool`` return
+    contract on the workerless path. The bug only manifests when a live
+    worker holds the card.
+    """
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="normal delay", assignee="ops")
+        # Worker-less path — must be a truthy scalar (legacy contract).
+        result = kb.schedule_task(conn, t, reason="run next week")
+        assert result is True
+
+
 
 
 


### PR DESCRIPTION
Issue #102423: `hermes kanban schedule` (and `block_task` with the same shape) silently cleared the live worker's claim when `status='running'` and no `expected_run_id` was supplied. The next dispatcher tick claimed the (now scheduled → unblock → ready) card and spawned a second worker — two concurrent workers on the same card.

## Fix

Mirrors the live-claim guard already used in `request_review`:
- When `status='running'` AND `worker_pid` is alive AND `expected_run_id` is None → refuse unless `force=True`
- `with_reason=True` returns `(ok, reason)` for diagnostic callers; default return stays `bool` for back-compat
- Force path emits an audit event with `orphaned_pid` so the live process is locatable without `pgrep`
- Dead-PID and NULL-PID GREEN paths preserve host-crash recovery (`release_stale_claims` still wins on dead PIDs)

## Verification

- 6/6 new tests pass (`tests/hermes_cli/test_kanban_db.py`)
- RED proof: 5/6 fail on `upstream/main` (reverted `kanmes_db.py` to HEAD~1, only legacy back-compat test passes); restored → all 6 pass
- Full file: 37 passed, 1 skipped
- 0 1 ahead of `upstream/main`

Auto-published by Moonsong via Path B automated pipeline.