### PR TITLE
Enforce required terminal-tool turns at the gateway boundary

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2036,7 +2036,7 @@ def run_conversation(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
-    gateway_turn: bool = False,
+    gateway_turn: Any = None,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -2065,8 +2065,8 @@ def run_conversation(
             Discord/Telegram message id) to store as metadata on that
             persisted user message, so restart drain-window recovery can
             dedup an interrupted turn against the transcript.
-        gateway_turn: Trusted marker set only by the gateway's natural-turn
-            runner. Direct CLI, TUI, desktop, and API calls leave it false.
+        gateway_turn: Opaque marker minted only by the gateway's natural-turn
+            runner. Direct CLI, TUI, desktop, and API calls leave it unset.
                 or queuing follow-up prefetch work.
 
     Returns:
@@ -2296,7 +2296,9 @@ def run_conversation(
     agent._required_terminal_turn_active = False
     try:
         required_terminal_policy = load_required_terminal_policy(
-            agent, gateway_turn=gateway_turn
+            agent,
+            gateway_turn=gateway_turn,
+            platform_message_id=persist_user_platform_id,
         )
         if required_terminal_policy is not None:
             required_terminal_failure = required_terminal_policy.failure_response
@@ -3698,9 +3700,18 @@ def run_conversation(
                         )
                     from agent import relay_llm
 
+                    def _dispatch_physical_provider(final_api_kwargs):
+                        if required_terminal_policy is not None:
+                            final_api_kwargs = apply_required_terminal_request(
+                                final_api_kwargs,
+                                policy=required_terminal_policy,
+                                provider=agent.provider,
+                            )
+                        return agent._interruptible_api_call(final_api_kwargs)
+
                     return relay_llm.execute(
                         next_api_kwargs,
-                        agent._interruptible_api_call,
+                        _dispatch_physical_provider,
                         session_id=str(agent.session_id or ""),
                         name=str(agent.provider or "provider"),
                         model_name=str(agent.model or ""),
@@ -8304,6 +8315,11 @@ def run_conversation(
                         persisted = False
                     if persisted is False:
                         final_response = required_terminal_failure
+                        messages.pop()
+                        append_message(
+                            messages,
+                            {"role": "assistant", "content": final_response},
+                        )
                         failed = True
                         _turn_exit_reason = (
                             "required_terminal_tool_failure(final_persistence)"

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -2036,6 +2036,7 @@ def run_conversation(
     persist_user_display_metadata: Optional[Dict[str, Any]] = None,
     persist_user_platform_id: Optional[str] = None,
     moa_config: Optional[dict[str, Any]] = None,
+    gateway_turn: bool = False,
 ) -> Dict[str, Any]:
     """
     Run a complete conversation with tool calling until completion.
@@ -2064,6 +2065,8 @@ def run_conversation(
             Discord/Telegram message id) to store as metadata on that
             persisted user message, so restart drain-window recovery can
             dedup an interrupted turn against the transcript.
+        gateway_turn: Trusted marker set only by the gateway's natural-turn
+            runner. Direct CLI, TUI, desktop, and API calls leave it false.
                 or queuing follow-up prefetch work.
 
     Returns:
@@ -2272,12 +2275,56 @@ def run_conversation(
     # stale prior turn's usage.
     agent._last_turn_usage = None
 
+    # Resolve the profile-owned terminal policy once per natural gateway turn.
+    # Keep all state turn-local on the cached agent and reset it before any
+    # provider or tool work so receipts cannot leak across queued messages.
+    from agent.required_terminal_turn import (
+        DEFAULT_FAILURE_RESPONSE,
+        RequiredTerminalTurnError,
+        apply_required_terminal_request,
+        load_required_terminal_policy,
+        validate_required_terminal_call,
+        validate_required_terminal_policy,
+    )
+
+    required_terminal_policy = None
+    required_terminal_policy_error = None
+    required_terminal_failure = DEFAULT_FAILURE_RESPONSE
+    agent._required_terminal_policy = None
+    agent._required_terminal_result = None
+    agent._required_terminal_request_id = None
+    agent._required_terminal_turn_active = False
+    try:
+        required_terminal_policy = load_required_terminal_policy(
+            agent, gateway_turn=gateway_turn
+        )
+        if required_terminal_policy is not None:
+            required_terminal_failure = required_terminal_policy.failure_response
+            validate_required_terminal_policy(agent, required_terminal_policy)
+            platform_message_id = str(persist_user_platform_id or "").strip()
+            session_id = str(getattr(agent, "session_id", "") or "").strip()
+            if not platform_message_id or not session_id:
+                raise RequiredTerminalTurnError(
+                    "required terminal turn lacks durable inbound identity"
+                )
+            agent._required_terminal_policy = required_terminal_policy
+            agent._required_terminal_request_id = (
+                f"{session_id}:{platform_message_id}"
+            )
+            agent._required_terminal_turn_active = True
+    except RequiredTerminalTurnError as exc:
+        required_terminal_policy_error = str(exc)
+        agent._required_terminal_turn_active = True
+
     # Optional opt-in runtime: if api_mode == codex_app_server, hand the
     # turn to the codex app-server subprocess (terminal/file ops/patching
     # all run inside Codex). Default Hermes path is bypassed entirely.
     # See agent/transports/codex_app_server_session.py for the adapter
     # and references/codex-app-server-runtime.md for the rationale.
-    if agent.api_mode == "codex_app_server":
+    if (
+        agent.api_mode == "codex_app_server"
+        and not agent._required_terminal_turn_active
+    ):
         return agent._run_codex_app_server_turn(
             user_message=user_message,
             original_user_message=original_user_message,
@@ -2287,6 +2334,11 @@ def run_conversation(
         )
 
     while (api_call_count < agent.max_iterations and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+        if required_terminal_policy_error is not None:
+            final_response = required_terminal_failure
+            failed = True
+            _turn_exit_reason = "required_terminal_tool_failure(preflight)"
+            break
         _redirect_text = agent._drain_pending_redirect()
         if _redirect_text:
             _apply_active_turn_redirect(agent, messages, _redirect_text)
@@ -3634,6 +3686,12 @@ def run_conversation(
                             is_github_responses=agent._is_copilot_url(),
                             sanitize_harmony_tokens=agent._is_codex_backend(),
                         )
+                    if required_terminal_policy is not None:
+                        next_api_kwargs = apply_required_terminal_request(
+                            next_api_kwargs,
+                            policy=required_terminal_policy,
+                            provider=agent.provider,
+                        )
                     if _use_streaming:
                         return agent._interruptible_streaming_api_call(
                             next_api_kwargs, on_first_delta=_stop_spinner
@@ -3816,6 +3874,13 @@ def run_conversation(
                             error_details.append("response.choices is empty")
 
                 if response_invalid:
+                    if required_terminal_policy is not None:
+                        final_response = required_terminal_failure
+                        failed = True
+                        _turn_exit_reason = (
+                            "required_terminal_tool_failure(invalid_response)"
+                        )
+                        break
                     agent._invoke_api_request_error_hook(
                         task_id=effective_task_id,
                         turn_id=turn_id,
@@ -4042,6 +4107,17 @@ def run_conversation(
                             force=True,
                         )
                         finish_reason = "length"
+
+                if (
+                    required_terminal_policy is not None
+                    and finish_reason != "stop"
+                ):
+                    final_response = required_terminal_failure
+                    failed = True
+                    _turn_exit_reason = (
+                        "required_terminal_tool_failure(provider_finish)"
+                    )
+                    break
 
                 # ── Content-policy refusal (HTTP 200) ──────────────────
                 # The model — or the provider's safety system — returned a
@@ -4969,6 +5045,13 @@ def run_conversation(
                 break  # Success, exit retry loop
 
             except InterruptedError:
+                if required_terminal_policy is not None:
+                    final_response = required_terminal_failure
+                    failed = True
+                    _turn_exit_reason = (
+                        "required_terminal_tool_failure(interrupted)"
+                    )
+                    break
                 if thinking_spinner:
                     thinking_spinner.stop("")
                     thinking_spinner = None
@@ -5003,6 +5086,17 @@ def run_conversation(
                 break
 
             except Exception as api_error:
+                if required_terminal_policy is not None:
+                    logger.warning(
+                        "Required terminal provider request failed closed: %s",
+                        api_error,
+                    )
+                    final_response = required_terminal_failure
+                    failed = True
+                    _turn_exit_reason = (
+                        "required_terminal_tool_failure(provider_request)"
+                    )
+                    break
                 # Stop spinner silently — retry status is buffered and
                 # only flushed when every retry+fallback is exhausted.
                 if thinking_spinner:
@@ -7417,6 +7511,8 @@ def run_conversation(
         # (e.g. repeated context-length errors that exhausted retry_count),
         # the `response` variable is still None. Break out cleanly.
         if response is None:
+            if required_terminal_policy is not None and failed:
+                break
             _turn_exit_reason = "all_retries_exhausted_no_response"
             print(f"{agent.log_prefix}❌ All API retries exhausted with no successful response.")
             agent._persist_session(messages, conversation_history)
@@ -7430,6 +7526,19 @@ def run_conversation(
             normalized = _transport.normalize_response(response, **_normalize_kwargs)
             assistant_message = normalized
             finish_reason = normalized.finish_reason
+
+            if required_terminal_policy is not None:
+                try:
+                    validate_required_terminal_call(
+                        assistant_message, required_terminal_policy
+                    )
+                except RequiredTerminalTurnError:
+                    final_response = required_terminal_failure
+                    failed = True
+                    _turn_exit_reason = (
+                        "required_terminal_tool_failure(provider_response)"
+                    )
+                    break
             
             # Normalize content to string — some OpenAI-compatible servers
             # (llama-server, etc.) return content as a dict or list instead
@@ -7646,7 +7755,8 @@ def run_conversation(
                                     last_msg[_key] = interim_msg[_key]
                     else:
                         append_message(messages, interim_msg)
-                        agent._emit_interim_assistant_message(interim_msg)
+                        if required_terminal_policy is None:
+                            agent._emit_interim_assistant_message(interim_msg)
 
                 if agent._codex_incomplete_retries < 3:
                     # When the interim message has nothing the Responses
@@ -8141,7 +8251,8 @@ def run_conversation(
                 # still only an ephemeral in-memory projection. Emit interim
                 # commentary only after the canonical SessionDB append above.
                 if not duplicate_previous_interim:
-                    agent._emit_interim_assistant_message(assistant_msg)
+                    if required_terminal_policy is None:
+                        agent._emit_interim_assistant_message(assistant_msg)
 
                 # Close any open streaming display (response box, reasoning
                 # box) before tool execution begins.  Intermediate turns may
@@ -8149,7 +8260,10 @@ def run_conversation(
                 # flushing here prevents it from wrapping tool feed lines.
                 # Only signal the display callback — TTS (_stream_callback)
                 # should NOT receive None (it uses None as end-of-stream).
-                if agent.stream_delta_callback:
+                if (
+                    agent.stream_delta_callback
+                    and required_terminal_policy is None
+                ):
                     try:
                         agent.stream_delta_callback(None)
                     except Exception:
@@ -8164,6 +8278,38 @@ def run_conversation(
                     _turn_exit_reason = "session_persistence_failed"
                     final_response = ""
                     failed = True
+                    break
+
+                if required_terminal_policy is not None:
+                    terminal_result = getattr(
+                        agent, "_required_terminal_result", None
+                    )
+                    if terminal_result is None:
+                        final_response = required_terminal_failure
+                        failed = True
+                        _turn_exit_reason = (
+                            "required_terminal_tool_failure(tool_result)"
+                        )
+                        break
+                    final_response = terminal_result.response_text
+                    append_message(
+                        messages,
+                        {"role": "assistant", "content": final_response},
+                    )
+                    try:
+                        persisted = agent._flush_messages_to_session_db(
+                            messages, conversation_history
+                        )
+                    except Exception:
+                        persisted = False
+                    if persisted is False:
+                        final_response = required_terminal_failure
+                        failed = True
+                        _turn_exit_reason = (
+                            "required_terminal_tool_failure(final_persistence)"
+                        )
+                        break
+                    _turn_exit_reason = "required_terminal_tool_success"
                     break
 
                 if agent._tool_guardrail_halt_decision is not None:
@@ -9145,6 +9291,15 @@ def run_conversation(
                 break
             
         except Exception as e:
+            if required_terminal_policy is not None:
+                logger.warning(
+                    "Required terminal-tool turn failed closed: %s", e,
+                    exc_info=True,
+                )
+                final_response = required_terminal_failure
+                failed = True
+                _turn_exit_reason = "required_terminal_tool_failure(exception)"
+                break
             # Count every escaped exception against the per-turn bound before
             # classification — permanent failures must terminate even when the
             # turn budget is unlimited (#92450).

--- a/agent/required_terminal_turn.py
+++ b/agent/required_terminal_turn.py
@@ -1,0 +1,186 @@
+"""Host-owned contract for a required terminal tool on gateway turns.
+
+The helper owns validation only. Provider calls, tool dispatch, transcript
+persistence, and final delivery remain in Hermes' existing agent loop.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+from tools.registry import TerminalToolResult
+
+DEFAULT_FAILURE_RESPONSE = (
+    "I couldn't safely complete this turn. Please send your message again."
+)
+
+
+class RequiredTerminalTurnError(RuntimeError):
+    """The configured terminal-turn contract cannot be satisfied safely."""
+
+
+@dataclass(frozen=True)
+class RequiredTerminalPolicy:
+    name: str
+    failure_response: str = DEFAULT_FAILURE_RESPONSE
+
+
+def load_required_terminal_policy(
+    agent: Any, *, gateway_turn: bool
+) -> RequiredTerminalPolicy | None:
+    """Read the profile-owned policy only at the trusted gateway boundary."""
+
+    if not gateway_turn:
+        return None
+
+    from hermes_cli.config import load_config_readonly
+
+    config = load_config_readonly() or {}
+    agent_config = config.get("agent") or {}
+    if not isinstance(agent_config, dict):
+        raise RequiredTerminalTurnError("agent config must be a mapping")
+    raw = agent_config.get("required_terminal_tool")
+    if raw in (None, False, ""):
+        return None
+    if not isinstance(raw, dict):
+        raise RequiredTerminalTurnError(
+            "agent.required_terminal_tool must be a mapping"
+        )
+    if str(raw.get("surface") or "gateway").strip().lower() != "gateway":
+        raise RequiredTerminalTurnError(
+            "required terminal tool surface must be 'gateway'"
+        )
+
+    name = str(raw.get("name") or "").strip()
+    if not name:
+        raise RequiredTerminalTurnError("required terminal tool name is missing")
+    failure_response = str(
+        raw.get("failure_response") or DEFAULT_FAILURE_RESPONSE
+    ).strip()
+    if not failure_response:
+        failure_response = DEFAULT_FAILURE_RESPONSE
+    return RequiredTerminalPolicy(name=name, failure_response=failure_response)
+
+
+def validate_required_terminal_policy(
+    agent: Any, policy: RequiredTerminalPolicy
+) -> None:
+    """Fail before provider access when the declared terminal tool is unusable."""
+
+    from tools.registry import registry
+
+    if getattr(agent, "api_mode", None) != "codex_responses":
+        raise RequiredTerminalTurnError(
+            "required terminal tools need codex_responses mode"
+        )
+    if getattr(agent, "provider", None) != "openai-codex":
+        raise RequiredTerminalTurnError(
+            "required terminal tools need the openai-codex provider"
+        )
+
+    entry = registry.get_entry(policy.name)
+    if entry is None or not getattr(entry, "terminal", False):
+        raise RequiredTerminalTurnError(
+            f"required terminal tool {policy.name!r} is unavailable or non-terminal"
+        )
+
+    names = {
+        str((tool.get("function") or {}).get("name") or "")
+        for tool in (getattr(agent, "tools", None) or [])
+        if isinstance(tool, dict)
+    }
+    if policy.name not in names:
+        raise RequiredTerminalTurnError(
+            f"required terminal tool {policy.name!r} is absent from this turn"
+        )
+
+
+def apply_required_terminal_request(
+    request: dict[str, Any],
+    *,
+    policy: RequiredTerminalPolicy,
+    provider: str,
+) -> dict[str, Any]:
+    """Apply the host-owned provider request constraint after all middleware."""
+
+    if provider != "openai-codex":
+        raise RequiredTerminalTurnError(
+            f"required terminal tools are unsupported for provider {provider!r}"
+        )
+    names: set[str] = set()
+    for tool in request.get("tools") or []:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if isinstance(function, dict):
+            names.add(str(function.get("name") or ""))
+        names.add(str(tool.get("name") or ""))
+    if policy.name not in names:
+        raise RequiredTerminalTurnError(
+            f"middleware removed required terminal tool {policy.name!r}"
+        )
+    updated = dict(request)
+    updated["tool_choice"] = {"type": "function", "name": policy.name}
+    updated["parallel_tool_calls"] = False
+    return updated
+
+
+def validate_required_terminal_call(
+    assistant_message: Any, policy: RequiredTerminalPolicy
+) -> Any:
+    """Accept exactly one pure call to the configured tool, before execution."""
+
+    content = str(getattr(assistant_message, "content", "") or "")
+    calls = list(getattr(assistant_message, "tool_calls", None) or [])
+    if content.strip():
+        raise RequiredTerminalTurnError("provider mixed prose with terminal call")
+    if len(calls) != 1:
+        raise RequiredTerminalTurnError("provider must emit exactly one terminal call")
+
+    call = calls[0]
+    function = getattr(call, "function", None)
+    if str(getattr(function, "name", "") or "") != policy.name:
+        raise RequiredTerminalTurnError("provider emitted the wrong terminal tool")
+    if not str(getattr(call, "id", "") or "").strip():
+        raise RequiredTerminalTurnError("terminal tool call ID is missing")
+    try:
+        arguments = json.loads(str(getattr(function, "arguments", "") or "{}"))
+    except (TypeError, ValueError) as exc:
+        raise RequiredTerminalTurnError(
+            "terminal tool arguments are invalid JSON"
+        ) from exc
+    if not isinstance(arguments, dict):
+        raise RequiredTerminalTurnError("terminal tool arguments must be an object")
+    return call
+
+
+def validate_terminal_result(
+    result: Any,
+    *,
+    turn_id: str,
+    tool_call_id: str,
+    request_id: str,
+) -> TerminalToolResult:
+    """Bind a trusted terminal receipt to this exact host turn and tool call."""
+
+    if not isinstance(result, TerminalToolResult):
+        raise RequiredTerminalTurnError("terminal tool returned no terminal receipt")
+    if result.turn_id != turn_id:
+        raise RequiredTerminalTurnError("terminal receipt turn ID mismatch")
+    if result.tool_call_id != tool_call_id:
+        raise RequiredTerminalTurnError("terminal receipt tool-call ID mismatch")
+    if result.request_id != request_id:
+        raise RequiredTerminalTurnError("terminal receipt request ID mismatch")
+    if not isinstance(result.response_text, str) or not result.response_text.strip():
+        raise RequiredTerminalTurnError("terminal receipt response is empty")
+    if not isinstance(result.receipt, dict):
+        raise RequiredTerminalTurnError("terminal receipt payload is invalid")
+    try:
+        json.dumps(result.receipt)
+    except (TypeError, ValueError) as exc:
+        raise RequiredTerminalTurnError(
+            "terminal receipt payload is not JSON-serializable"
+        ) from exc
+    return result

--- a/agent/required_terminal_turn.py
+++ b/agent/required_terminal_turn.py
@@ -27,13 +27,50 @@ class RequiredTerminalPolicy:
     failure_response: str = DEFAULT_FAILURE_RESPONSE
 
 
+_NATURAL_GATEWAY_TURN_SEAL = object()
+
+
+@dataclass(frozen=True, slots=True)
+class _NaturalGatewayTurn:
+    platform_message_id: str
+    seal: object
+
+
+def _mint_natural_gateway_turn(
+    platform_message_id: Any, *, internal: bool
+) -> _NaturalGatewayTurn | None:
+    """Mint the private marker used by the natural inbound gateway runner."""
+
+    if internal:
+        return None
+    message_id = str(platform_message_id or "").strip()
+    if not message_id:
+        return None
+    return _NaturalGatewayTurn(message_id, _NATURAL_GATEWAY_TURN_SEAL)
+
+
+def _natural_gateway_message_id(gateway_turn: Any) -> str | None:
+    if (
+        isinstance(gateway_turn, _NaturalGatewayTurn)
+        and gateway_turn.seal is _NATURAL_GATEWAY_TURN_SEAL
+    ):
+        return gateway_turn.platform_message_id
+    return None
+
+
 def load_required_terminal_policy(
-    agent: Any, *, gateway_turn: bool
+    agent: Any, *, gateway_turn: Any, platform_message_id: Any
 ) -> RequiredTerminalPolicy | None:
     """Read the profile-owned policy only at the trusted gateway boundary."""
 
-    if not gateway_turn:
+    capability_message_id = _natural_gateway_message_id(gateway_turn)
+    if capability_message_id is None:
         return None
+    durable_message_id = str(platform_message_id or "").strip()
+    if not durable_message_id or durable_message_id != capability_message_id:
+        raise RequiredTerminalTurnError(
+            "natural gateway capability does not match durable inbound identity"
+        )
 
     from hermes_cli.config import load_config_readonly
 

--- a/agent/tool_executor.py
+++ b/agent/tool_executor.py
@@ -2530,8 +2530,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
-                            api_request_id=getattr(agent, "_current_api_request_id", "")
-                            or "",
+                            request_id=getattr(
+                                agent, "_required_terminal_request_id", None
+                            ),
+                            api_request_id=getattr(
+                                agent, "_current_api_request_id", ""
+                            ) or "",
                             enabled_tools=(
                                 list(agent.valid_tool_names)
                                 if agent.valid_tool_names
@@ -2612,8 +2616,12 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                             tool_call_id=tool_call_id,
                             session_id=agent.session_id or "",
                             turn_id=getattr(agent, "_current_turn_id", "") or "",
-                            api_request_id=getattr(agent, "_current_api_request_id", "")
-                            or "",
+                            request_id=getattr(
+                                agent, "_required_terminal_request_id", None
+                            ),
+                            api_request_id=getattr(
+                                agent, "_current_api_request_id", ""
+                            ) or "",
                             enabled_tools=(
                                 list(agent.valid_tool_names)
                                 if agent.valid_tool_names
@@ -2672,6 +2680,36 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
                 function_result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("handle_function_call raised for %s: %s", function_name, tool_error, exc_info=True)
             tool_duration = time.time() - tool_start_time
+
+        terminal_result = None
+        from agent.required_terminal_turn import (
+            RequiredTerminalTurnError,
+            validate_terminal_result,
+        )
+        from tools.registry import TerminalToolResult
+
+        if isinstance(function_result, TerminalToolResult):
+            try:
+                policy = getattr(agent, "_required_terminal_policy", None)
+                if policy is None or function_name != policy.name:
+                    raise RequiredTerminalTurnError(
+                        "terminal receipt came from an unrequested tool"
+                    )
+                terminal_result = validate_terminal_result(
+                    function_result,
+                    turn_id=str(getattr(agent, "_current_turn_id", "") or ""),
+                    tool_call_id=tool_call_id,
+                    request_id=str(
+                        getattr(agent, "_required_terminal_request_id", "") or ""
+                    ),
+                )
+                function_result = terminal_result.tool_content()
+            except RequiredTerminalTurnError as exc:
+                terminal_result = None
+                function_result = json.dumps(
+                    {"error": str(exc), "error_type": "terminal_tool_contract"},
+                    sort_keys=True,
+                )
 
         _execution_timed_out = isinstance(
             function_result, (_ToolTimeoutResult, _ToolCancelledResult)
@@ -2783,6 +2821,8 @@ def execute_tool_calls_sequential(agent, assistant_message, messages: list, effe
             stage=f"tool result {function_name}",
         ):
             return
+        if terminal_result is not None:
+            agent._required_terminal_result = terminal_result
 
         # UI completion/progress events are projections of the canonical tool
         # row, never a competing in-memory authority.

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -617,7 +617,13 @@ def finalize_turn(
     # Fired once per turn after the tool-calling loop completes.
     # Plugins can transform the LLM's output text before it's returned.
     # First hook to return a string wins; None/empty return leaves text unchanged.
-    if final_response and not interrupted:
+    # A required terminal turn has already persisted its exact host-owned
+    # projection; no fail-open plugin hook may rewrite that value.
+    if (
+        final_response
+        and not interrupted
+        and not getattr(agent, "_required_terminal_turn_active", False)
+    ):
         try:
             from hermes_cli.lifecycle import invoke_hook as _invoke_hook
             _transform_results = _invoke_hook(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7099,7 +7099,7 @@ class TurnRunner:
             _conversation_kwargs = {
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
-                "gateway_turn": ctx.inbound_message_id is not None,
+                "gateway_turn": ctx.gateway_turn,
             }
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override
@@ -23186,6 +23186,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # session_entry.session_id while the old run is still unwinding.
             _run_start_session_id = session_entry.session_id
             _turn_started_monotonic = time.monotonic()
+            from agent.required_terminal_turn import _mint_natural_gateway_turn
+
+            _gateway_turn = _mint_natural_gateway_turn(
+                event.message_id,
+                internal=bool(getattr(event, "internal", False)),
+            )
             agent_result = await self._run_agent(
                 message=message_text,
                 context_prompt=context_prompt,
@@ -23198,6 +23204,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 inbound_message_id=(
                     str(event.message_id) if event.message_id else None
                 ),
+                gateway_turn=_gateway_turn,
                 channel_prompt=event.channel_prompt,
                 moa_config=getattr(event, "_moa_config", None),
                 persist_user_message=persist_user_message,
@@ -31145,6 +31152,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         inbound_message_id: Optional[str] = None,
+        gateway_turn: Any = None,
         channel_prompt: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
@@ -31167,6 +31175,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
                 inbound_message_id=inbound_message_id,
+                gateway_turn=gateway_turn,
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -31181,6 +31190,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 session_key=session_key, run_generation=run_generation,
                 _interrupt_depth=_interrupt_depth, event_message_id=event_message_id,
                 inbound_message_id=inbound_message_id,
+                gateway_turn=gateway_turn,
                 channel_prompt=channel_prompt, moa_config=moa_config,
                 persist_user_message=persist_user_message,
                 persist_user_timestamp=persist_user_timestamp,
@@ -31324,6 +31334,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         _interrupt_depth: int = 0,
         event_message_id: Optional[str] = None,
         inbound_message_id: Optional[str] = None,
+        gateway_turn: Any = None,
         channel_prompt: Optional[str] = None,
         moa_config: Optional[dict] = None,
         persist_user_message: Optional[Any] = None,
@@ -31636,6 +31647,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _interrupt_depth=_interrupt_depth,
             event_message_id=event_message_id,
             inbound_message_id=inbound_message_id,
+            gateway_turn=gateway_turn,
             moa_config=moa_config,
             persist_user_message=persist_user_message,
             persist_user_timestamp=persist_user_timestamp,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7099,6 +7099,7 @@ class TurnRunner:
             _conversation_kwargs = {
                 "conversation_history": agent_history,
                 "task_id": ctx.session_id,
+                "gateway_turn": ctx.inbound_message_id is not None,
             }
             if _persist_user_message_override is not None:
                 _conversation_kwargs["persist_user_message"] = _persist_user_message_override

--- a/gateway/turn_context.py
+++ b/gateway/turn_context.py
@@ -93,6 +93,10 @@ class TurnContext:
     # be the replied-to message on Slack/Mattermost/Buzz or None for Telegram
     # topics. Used to stamp platform_message_id on the persisted user turn.
     inbound_message_id: Optional[str] = None
+    # Opaque marker minted only from a non-internal MessageEvent with the same
+    # inbound_message_id. Direct agent callers cannot activate gateway policy
+    # with a boolean or platform label.
+    gateway_turn: Any = None
     moa_config: Optional[dict] = None
     persist_user_message: Optional[Any] = None
     persist_user_timestamp: Optional[float] = None

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -66,6 +66,9 @@ DEFAULT_CONFIG = {
         # inline lease waiter also delays unrelated topics. Non-positive values
         # fall back to the five-second safety default.
         "gateway_turn_lease_timeout": 5,
+        # Optional fail-closed gateway turn policy for a plugin tool registered
+        # with terminal=True. The mapping is deliberately absent by default.
+        "required_terminal_tool": None,
         # Per-session AIAgent cache in the gateway. Each cached agent keeps a
         # warm prompt prefix AND the session's full transcript, so the cache
         # trades memory for cost: too small and every turn re-pays an uncached

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -1787,6 +1787,7 @@ class PluginContext:
         description: str = "",
         emoji: str = "",
         override: bool = False,
+        terminal: bool = False,
     ) -> Optional[PluginRegistration]:
         """Register a tool in the global registry **and** track it as plugin-provided.
 
@@ -1794,6 +1795,10 @@ class PluginContext:
         same name (e.g. swap the default ``browser_navigate`` for a custom
         CDP-backed implementation). Without it, attempting to register a name
         already claimed by a different toolset is rejected.
+
+        ``terminal=True`` declares that the handler may return a
+        ``TerminalToolResult``. It has no effect unless the profile also opts
+        into ``agent.required_terminal_tool`` for natural gateway turns.
 
         ``override=True`` against a built-in tool requires the operator to
         opt in via ``plugins.entries.<plugin_id>.allow_tool_override: true``
@@ -1834,6 +1839,7 @@ class PluginContext:
             is_async=is_async,
             description=description,
             emoji=emoji,
+            terminal=terminal,
             override=override,
             scope=scope,
         )

--- a/model_tools.py
+++ b/model_tools.py
@@ -1255,6 +1255,7 @@ def handle_function_call(
     tool_call_id: Optional[str] = None,
     session_id: Optional[str] = None,
     turn_id: Optional[str] = None,
+    request_id: Optional[str] = None,
     api_request_id: Optional[str] = None,
     user_task: Optional[str] = None,
     enabled_tools: Optional[List[str]] = None,
@@ -1264,7 +1265,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
-) -> str:
+) -> Any:
     """
     Main function call dispatcher that routes calls to the tool registry.
 
@@ -1556,6 +1557,15 @@ def handle_function_call(
         except Exception:
             reset_current_observability_context = None
         try:
+            terminal_context = (
+                {
+                    "request_id": request_id,
+                    "turn_id": turn_id,
+                    "tool_call_id": tool_call_id,
+                }
+                if request_id
+                else {}
+            )
             if function_name == "execute_code":
                 # Prefer the caller-provided list so subagents can't overwrite
                 # the parent's tool set via the process-global.
@@ -1566,6 +1576,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         enabled_tools=sandbox_enabled,
+                        **terminal_context,
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
@@ -1574,6 +1585,7 @@ def handle_function_call(
                         task_id=task_id,
                         session_id=session_id,
                         user_task=user_task,
+                        **terminal_context,
                     )
             if skip_tool_execution_middleware:
                 result = _dispatch(function_args)

--- a/run_agent.py
+++ b/run_agent.py
@@ -9278,7 +9278,7 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
-        gateway_turn: bool = False,
+        gateway_turn: Any = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache

--- a/run_agent.py
+++ b/run_agent.py
@@ -7499,6 +7499,8 @@ class AIAgent:
             logger.debug("on_stream_start plugin hook enqueue failed", exc_info=True)
 
     def _emit_stream_end(self, *, final_text: str, finished: bool, error: str | None) -> None:
+        if getattr(self, "_required_terminal_turn_active", False):
+            return
         try:
             from agent.plugin_stream_hooks import enqueue_plugin_stream_hook
 
@@ -7514,6 +7516,8 @@ class AIAgent:
 
     def _fire_stream_delta(self, text: str) -> None:
         """Fire all registered stream delta callbacks (display + TTS)."""
+        if getattr(self, "_required_terminal_turn_active", False):
+            return
         # Single-writer guard (#65991): a superseded stream must not interleave
         # its tokens into the turn alongside the retry that replaced it.
         if self._stream_writer_superseded():
@@ -7586,6 +7590,8 @@ class AIAgent:
 
     def _fire_reasoning_delta(self, text: str) -> None:
         """Fire reasoning callback if registered."""
+        if getattr(self, "_required_terminal_turn_active", False):
+            return
         # Single-writer guard (#65991): fence out a superseded stream's
         # reasoning deltas the same way as content deltas.
         if self._stream_writer_superseded():
@@ -7648,6 +7654,8 @@ class AIAgent:
 
     def _try_activate_fallback(self, reason: "FailoverReason | None" = None) -> bool:
         """Forwarder — see ``agent.chat_completion_helpers.try_activate_fallback``."""
+        if getattr(self, "_required_terminal_turn_active", False):
+            return False
         from agent.chat_completion_helpers import try_activate_fallback
         return try_activate_fallback(self, reason)
 
@@ -7659,6 +7667,8 @@ class AIAgent:
         fallback chain configured).  Mirrors the early-return guard in
         ``try_activate_fallback`` (#35314, #17446).
         """
+        if getattr(self, "_required_terminal_turn_active", False):
+            return False
         chain = getattr(self, "_fallback_chain", None) or []
         index = getattr(self, "_fallback_index", 0)
         return index < len(chain)
@@ -9268,6 +9278,7 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        gateway_turn: bool = False,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -9827,6 +9838,7 @@ class AIAgent:
                         persist_user_display_metadata=persist_user_display_metadata,
                         persist_user_platform_id=persist_user_platform_id,
                         moa_config=moa_config,
+                        gateway_turn=gateway_turn,
                     )
                 finally:
                     # The lease remains held through relay/task finalization, but

--- a/tests/agent/test_required_terminal_turn.py
+++ b/tests/agent/test_required_terminal_turn.py
@@ -11,6 +11,7 @@ import pytest
 from agent.required_terminal_turn import (
     DEFAULT_FAILURE_RESPONSE,
     TerminalToolResult,
+    _mint_natural_gateway_turn,
 )
 from agent.transports.types import NormalizedResponse, ToolCall
 from hermes_cli.middleware import (
@@ -40,6 +41,7 @@ DOMAIN = {
     "calls": 0,
     "receipts": {},
 }
+_AUTO_GATEWAY_TURN = object()
 
 
 def _domain_handler(args, **kwargs):
@@ -282,7 +284,7 @@ def _make_agent(
     if fail_flush_role is not None:
         real_flush = agent._flush_messages_to_session_db
 
-        def guarded_flush(_self, messages, history):
+        def guarded_flush(_self, messages, history=None):
             if messages and messages[-1].get("role") == fail_flush_role:
                 if fail_flush_role != "assistant" or (
                     len(messages) >= 2 and messages[-2].get("role") == "tool"
@@ -308,8 +310,13 @@ def _run_case(
     api_mode="codex_responses",
     platform="telegram",
     tamper_execution=False,
-    gateway_turn=True,
+    relay_rewrite=None,
+    gateway_turn=_AUTO_GATEWAY_TURN,
 ):
+    if gateway_turn is _AUTO_GATEWAY_TURN:
+        gateway_turn = _mint_natural_gateway_turn(
+            platform_message_id, internal=False
+        )
     agent, session_db, requests, streamed, transforms = _make_agent(
         monkeypatch,
         tmp_path,
@@ -322,6 +329,15 @@ def _run_case(
         platform=platform,
         tamper_execution=tamper_execution,
     )
+    if relay_rewrite is not None:
+        from agent import relay_llm
+
+        setattr(agent, "_disable_streaming", True)
+
+        def relay_execute(request, callback, **_kwargs):
+            return callback(relay_rewrite(dict(request)))
+
+        monkeypatch.setattr(relay_llm, "execute", relay_execute)
     try:
         result = agent.run_conversation(
             "learner input",
@@ -362,6 +378,50 @@ def test_real_loop_success_is_terminal_and_persisted(monkeypatch, tmp_path):
     roles = [row["role"] for row in persisted]
     assert roles[-4:] == ["user", "assistant", "tool", "assistant"]
     assert persisted[-1]["content"] == expected
+
+
+def test_relay_final_request_cannot_relax_terminal_constraint(
+    monkeypatch, tmp_path
+):
+    response = NormalizedResponse(None, [_tool_call()], "stop")
+
+    result, _persisted, requests, _streamed, _transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "relay-relaxes-constraint",
+        response,
+        relay_rewrite=lambda request: {
+            **request,
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        },
+    )
+    assert result["completed"] is True
+    assert requests[0]["tool_choice"] == {
+        "type": "function",
+        "name": TOOL_NAME,
+    }
+    assert requests[0]["parallel_tool_calls"] is False
+
+
+def test_relay_final_request_cannot_remove_terminal_tool(monkeypatch, tmp_path):
+    response = NormalizedResponse(None, [_tool_call()], "stop")
+    DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+    result, _persisted, requests, _streamed, _transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "relay-removes-tool",
+        response,
+        relay_rewrite=lambda request: {
+            **request,
+            "tools": [],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        },
+    )
+    assert result["final_response"] == DEFAULT_FAILURE_RESPONSE
+    assert requests == []
+    assert DOMAIN["calls"] == 0
 
 
 def test_wrong_missing_multiple_and_mixed_prose_fail_before_execution(
@@ -434,6 +494,14 @@ def test_bad_results_and_persistence_fail_closed(monkeypatch, tmp_path):
     assert result["completed"] is False
     assert streamed == [] and transforms == []
     assert "UNTRUSTED" not in json.dumps(persisted)
+    assistant_rows = [
+        row for row in result["messages"] if row.get("role") == "assistant"
+    ]
+    assert assistant_rows[-1]["content"] == DEFAULT_FAILURE_RESPONSE
+    assert not any(
+        str(row.get("content") or "").startswith("committed:")
+        for row in assistant_rows
+    )
 
 
 def test_cached_agent_resets_receipt_and_domain_replays_idempotently(
@@ -457,25 +525,25 @@ def test_cached_agent_resets_receipt_and_domain_replays_idempotently(
             "first",
             conversation_history=[],
             persist_user_platform_id="same",
-            gateway_turn=True,
+            gateway_turn=_mint_natural_gateway_turn("same", internal=False),
         )
         second = agent.run_conversation(
             "retry",
             conversation_history=[],
             persist_user_platform_id="same",
-            gateway_turn=True,
+            gateway_turn=_mint_natural_gateway_turn("same", internal=False),
         )
         conflict_result = agent.run_conversation(
             "conflict",
             conversation_history=[],
             persist_user_platform_id="same",
-            gateway_turn=True,
+            gateway_turn=_mint_natural_gateway_turn("same", internal=False),
         )
         third = agent.run_conversation(
             "new",
             conversation_history=[],
             persist_user_platform_id="new",
-            gateway_turn=True,
+            gateway_turn=_mint_natural_gateway_turn("new", internal=False),
         )
         assert first["final_response"] == second["final_response"]
         assert DOMAIN["mutations"] == 1 and DOMAIN["calls"] == 3
@@ -540,6 +608,48 @@ def test_policy_is_opt_in_and_unsupported_boundaries_fail_preflight(
         assert requests[0]["tool_choice"] == "auto"
         assert streamed == ["UNTRUSTED STREAM"]
         assert transforms == ["transform_llm_output"]
+
+    internal_marker = _mint_natural_gateway_turn(
+        "internal-message", internal=True
+    )
+    assert internal_marker is None
+    internal, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "internal-gateway-event",
+        ordinary,
+        platform_message_id="internal-message",
+        gateway_turn=internal_marker,
+    )
+    assert internal["final_response"] == "UNTRUSTED TRANSFORM"
+    assert requests[0]["tool_choice"] == "auto"
+    assert streamed == ["UNTRUSTED STREAM"]
+    assert transforms == ["transform_llm_output"]
+
+    forged, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "forged-gateway-bool",
+        ordinary,
+        gateway_turn=True,
+    )
+    assert forged["final_response"] == "UNTRUSTED TRANSFORM"
+    assert requests[0]["tool_choice"] == "auto"
+    assert streamed == ["UNTRUSTED STREAM"]
+    assert transforms == ["transform_llm_output"]
+
+    mismatched, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "mismatched-gateway-capability",
+        ordinary,
+        platform_message_id="message-1",
+        gateway_turn=_mint_natural_gateway_turn(
+            "different-message", internal=False
+        ),
+    )
+    assert mismatched["final_response"] == DEFAULT_FAILURE_RESPONSE
+    assert requests == [] and streamed == [] and transforms == []
 
     unsupported, _persisted, requests, streamed, transforms, _agent = _run_case(
         monkeypatch,

--- a/tests/agent/test_required_terminal_turn.py
+++ b/tests/agent/test_required_terminal_turn.py
@@ -1,0 +1,592 @@
+"""Required terminal-tool integration tests for the real agent loop."""
+
+from __future__ import annotations
+
+import json
+from types import MethodType, SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from agent.required_terminal_turn import (
+    DEFAULT_FAILURE_RESPONSE,
+    TerminalToolResult,
+)
+from agent.transports.types import NormalizedResponse, ToolCall
+from hermes_cli.middleware import (
+    run_llm_execution_middleware as ORIGINAL_LLM_EXECUTION_MIDDLEWARE,
+)
+from hermes_state import SessionDB
+from run_agent import AIAgent
+from tools.registry import registry
+
+TOOL_NAME = "test_terminal_turn"
+TOOL_SCHEMA = {
+    "type": "function",
+    "function": {
+        "name": TOOL_NAME,
+        "description": "Resolve one terminal test turn.",
+        "parameters": {
+            "type": "object",
+            "properties": {"intent": {"type": "string"}},
+            "required": ["intent"],
+        },
+    },
+}
+
+DOMAIN = {
+    "mode": "success",
+    "mutations": 0,
+    "calls": 0,
+    "receipts": {},
+}
+
+
+def _domain_handler(args, **kwargs):
+    DOMAIN["calls"] += 1
+    mode = DOMAIN["mode"]
+    if mode == "error":
+        raise RuntimeError("domain handler failed")
+    if mode == "nonterminal":
+        return json.dumps({"status": "ok"})
+
+    request_id = str(kwargs.get("request_id") or "")
+    intent = str(args["intent"])
+    prior = DOMAIN["receipts"].get(request_id)
+    if prior is None:
+        DOMAIN["mutations"] += 1
+        prior = {
+            "intent": intent,
+            "response_text": f"committed:{request_id}:{intent}",
+            "receipt": {"request_id": request_id, "mutation": DOMAIN["mutations"]},
+        }
+        DOMAIN["receipts"][request_id] = prior
+    elif prior["intent"] != intent:
+        raise RuntimeError("request id reused with a different intent")
+
+    turn_id = str(kwargs.get("turn_id") or "")
+    tool_call_id = str(kwargs.get("tool_call_id") or "")
+    if mode == "wrong_turn":
+        turn_id = "wrong-turn"
+    elif mode == "wrong_call":
+        tool_call_id = "wrong-call"
+
+    receipt = {"invalid": {"set"}} if mode == "invalid_receipt" else prior["receipt"]
+
+    return TerminalToolResult(
+        turn_id=turn_id,
+        tool_call_id=tool_call_id,
+        request_id="wrong-request" if mode == "wrong_request" else request_id,
+        response_text=prior["response_text"],
+        receipt=receipt,
+    )
+
+
+@pytest.fixture(autouse=True)
+def registered_terminal_tool():
+    previous = registry.get_entry(TOOL_NAME)
+    DOMAIN.update(mode="success", mutations=0, calls=0, receipts={})
+    registry.register(
+        name=TOOL_NAME,
+        toolset="test-terminal",
+        schema=TOOL_SCHEMA["function"],
+        handler=_domain_handler,
+        check_fn=lambda: True,
+        terminal=True,
+    )
+    current = registry.get_entry(TOOL_NAME)
+    try:
+        yield
+    finally:
+        if current is not None:
+            registry.restore_registration(TOOL_NAME, current, previous)
+
+
+class FakeCodexTransport:
+    def preflight_kwargs(self, kwargs, **_ignored):
+        return dict(kwargs)
+
+    def validate_response(self, response):
+        return bool(response and response.output)
+
+    def normalize_response(self, response, **_ignored):
+        return response.normalized
+
+    def normalize_usage(self, _response):
+        return None
+
+
+def _raw_response(normalized):
+    return SimpleNamespace(
+        id="response-test",
+        model="gpt-5.6-luna",
+        status="completed",
+        incomplete_details=None,
+        output=[{"type": "function_call"}],
+        usage=None,
+        normalized=normalized,
+    )
+
+
+def _tool_call(name=TOOL_NAME, call_id="call-test", *, intent="reply"):
+    return ToolCall(
+        id=call_id,
+        name=name,
+        arguments=json.dumps({"intent": intent}),
+        provider_data={"call_id": call_id, "response_item_id": f"fc-{call_id}"},
+    )
+
+
+def _make_agent(
+    monkeypatch,
+    tmp_path,
+    case_name,
+    responses,
+    *,
+    fail_flush_role=None,
+    required_tool=TOOL_NAME,
+    provider="openai-codex",
+    api_mode="codex_responses",
+    platform="telegram",
+    tamper_execution=False,
+):
+    from hermes_cli import config as config_module
+    from hermes_cli import lifecycle
+    from hermes_cli import middleware as middleware_module
+
+    monkeypatch.setattr(
+        config_module,
+        "load_config_readonly",
+        lambda: (
+            {}
+            if required_tool is None
+            else {
+                "agent": {
+                    "required_terminal_tool": {
+                        "name": required_tool,
+                        "surface": "gateway",
+                        "failure_response": DEFAULT_FAILURE_RESPONSE,
+                    }
+                }
+            }
+        ),
+    )
+
+    # Prove the host policy runs after public middleware: this deliberately
+    # weakens the request, and the provider capture must still see the exact
+    # required choice with parallel calls disabled.
+    monkeypatch.setattr(
+        middleware_module,
+        "apply_llm_request_middleware",
+        lambda payload, **_kwargs: SimpleNamespace(
+            payload={
+                **payload,
+                "tool_choice": "auto",
+                "parallel_tool_calls": True,
+            },
+            original_payload=dict(payload),
+            trace=["tampered-by-test"],
+        ),
+    )
+    execution_middleware = ORIGINAL_LLM_EXECUTION_MIDDLEWARE
+    if tamper_execution:
+        def execution_middleware(request, next_call, **_kwargs):
+            return next_call(
+                {
+                    **request,
+                    "tool_choice": "auto",
+                    "parallel_tool_calls": True,
+                }
+            )
+
+    monkeypatch.setattr(
+        middleware_module,
+        "run_llm_execution_middleware",
+        execution_middleware,
+    )
+
+    db_path = tmp_path / f"{case_name}.sqlite3"
+    session_db = SessionDB(db_path)
+    agent = AIAgent(
+        api_key="sentinel-not-a-secret",
+        base_url="http://127.0.0.1:9/v1",
+        model="test-model",
+        provider="custom",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+        session_db=session_db,
+        platform=platform,
+    )
+    session_id = f"session-{case_name}"
+    session_db.ensure_session(session_id, source="test")
+    agent.session_id = session_id
+    agent.provider = provider
+    agent.api_mode = api_mode
+    agent.model = "gpt-5.6-luna"
+    agent.client = Mock()
+    agent.tools = [TOOL_SCHEMA]
+    agent.valid_tool_names = {TOOL_NAME}
+    agent.max_iterations = 4
+    agent._api_max_retries = 1
+
+    transport = FakeCodexTransport()
+    agent._get_transport = MethodType(lambda _self: transport, agent)
+    agent._build_api_kwargs = MethodType(
+        lambda _self, api_messages, tools_for_api=None: {
+            "model": agent.model,
+            "input": api_messages,
+            "tools": [TOOL_SCHEMA],
+            "tool_choice": "auto",
+            "parallel_tool_calls": True,
+        },
+        agent,
+    )
+
+    requests = []
+    responses = list(responses)
+
+    def provider_call(_self, kwargs):
+        requests.append(dict(kwargs))
+        if not responses:
+            raise AssertionError("unexpected second provider request")
+        return _raw_response(responses.pop(0))
+
+    agent._interruptible_api_call = MethodType(provider_call, agent)
+
+    streamed = []
+
+    def streaming_call(_self, kwargs, *, on_first_delta=None):
+        if on_first_delta:
+            on_first_delta()
+        agent._fire_stream_delta("UNTRUSTED STREAM")
+        return provider_call(agent, kwargs)
+
+    agent._interruptible_streaming_api_call = MethodType(streaming_call, agent)
+
+    transforms = []
+    monkeypatch.setattr(
+        lifecycle,
+        "has_hook",
+        lambda hook_name: hook_name == "transform_llm_output",
+    )
+
+    def invoke_hook(hook_name, **_kwargs):
+        if hook_name == "transform_llm_output":
+            transforms.append(hook_name)
+            return ["UNTRUSTED TRANSFORM"]
+        return []
+
+    monkeypatch.setattr(lifecycle, "invoke_hook", invoke_hook)
+
+    if fail_flush_role is not None:
+        real_flush = agent._flush_messages_to_session_db
+
+        def guarded_flush(_self, messages, history):
+            if messages and messages[-1].get("role") == fail_flush_role:
+                if fail_flush_role != "assistant" or (
+                    len(messages) >= 2 and messages[-2].get("role") == "tool"
+                ):
+                    return False
+            return real_flush(messages, history)
+
+        agent._flush_messages_to_session_db = MethodType(guarded_flush, agent)
+
+    return agent, session_db, requests, streamed, transforms
+
+
+def _run_case(
+    monkeypatch,
+    tmp_path,
+    case_name,
+    response,
+    *,
+    platform_message_id="message-1",
+    fail_flush_role=None,
+    required_tool=TOOL_NAME,
+    provider="openai-codex",
+    api_mode="codex_responses",
+    platform="telegram",
+    tamper_execution=False,
+    gateway_turn=True,
+):
+    agent, session_db, requests, streamed, transforms = _make_agent(
+        monkeypatch,
+        tmp_path,
+        case_name,
+        [response],
+        fail_flush_role=fail_flush_role,
+        required_tool=required_tool,
+        provider=provider,
+        api_mode=api_mode,
+        platform=platform,
+        tamper_execution=tamper_execution,
+    )
+    try:
+        result = agent.run_conversation(
+            "learner input",
+            conversation_history=[],
+            persist_user_platform_id=platform_message_id,
+            stream_callback=streamed.append,
+            gateway_turn=gateway_turn,
+        )
+        persisted = session_db.get_messages(agent.session_id)
+        return result, persisted, requests, streamed, transforms, agent
+    finally:
+        agent.close()
+
+
+def test_real_loop_success_is_terminal_and_persisted(monkeypatch, tmp_path):
+    DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+    response = NormalizedResponse(
+        content=None,
+        tool_calls=[_tool_call()],
+        finish_reason="stop",
+    )
+    result, persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "success", response, tamper_execution=True
+    )
+    expected = "committed:session-success:message-1:reply"
+    assert result["final_response"] == expected, result
+    assert len(requests) == 1
+    assert requests[0]["tool_choice"] == {
+        "type": "function",
+        "name": TOOL_NAME,
+    }
+    assert requests[0]["parallel_tool_calls"] is False
+    assert streamed == []
+    assert transforms == []
+    assert DOMAIN["calls"] == 1 and DOMAIN["mutations"] == 1
+    roles = [row["role"] for row in persisted]
+    assert roles[-4:] == ["user", "assistant", "tool", "assistant"]
+    assert persisted[-1]["content"] == expected
+
+
+def test_wrong_missing_multiple_and_mixed_prose_fail_before_execution(
+    monkeypatch, tmp_path
+):
+    cases = {
+        "missing": NormalizedResponse("UNTRUSTED", None, "stop"),
+        "wrong": NormalizedResponse(None, [_tool_call("wrong_tool")], "stop"),
+        "invalid_args": NormalizedResponse(
+            None,
+            [ToolCall(id="call-invalid", name=TOOL_NAME, arguments="{")],
+            "stop",
+        ),
+        "multiple": NormalizedResponse(
+            None, [_tool_call(call_id="one"), _tool_call(call_id="two")], "stop"
+        ),
+        "mixed": NormalizedResponse("UNTRUSTED", [_tool_call()], "stop"),
+    }
+    for name, response in cases.items():
+        DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+        result, persisted, requests, streamed, transforms, _agent = _run_case(
+            monkeypatch,
+            tmp_path,
+            name, response
+        )
+        assert result["final_response"] == DEFAULT_FAILURE_RESPONSE
+        assert len(requests) == 1
+        assert DOMAIN["calls"] == 0 and DOMAIN["mutations"] == 0
+        assert streamed == [] and transforms == []
+        assert "UNTRUSTED" not in json.dumps(persisted)
+
+
+def test_bad_results_and_persistence_fail_closed(monkeypatch, tmp_path):
+    response = NormalizedResponse(None, [_tool_call()], "stop")
+    for mode in (
+        "error",
+        "nonterminal",
+        "wrong_turn",
+        "wrong_call",
+        "wrong_request",
+        "invalid_receipt",
+    ):
+        DOMAIN.update(mode=mode, calls=0, mutations=0, receipts={})
+        result, persisted, _requests, streamed, transforms, _agent = _run_case(
+            monkeypatch,
+            tmp_path,
+            f"bad-{mode}", response
+        )
+        assert result["final_response"] == DEFAULT_FAILURE_RESPONSE
+        assert streamed == [] and transforms == []
+        assert "UNTRUSTED" not in json.dumps(persisted)
+
+    DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+    result, persisted, _requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "fail-tool-persist", response, fail_flush_role="tool"
+    )
+    assert not result["final_response"].startswith("committed:")
+    assert streamed == [] and transforms == []
+    assert "UNTRUSTED" not in json.dumps(persisted)
+
+    DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+    result, persisted, _requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "fail-final-persist", response, fail_flush_role="assistant"
+    )
+    assert not result["final_response"].startswith("committed:")
+    assert result["completed"] is False
+    assert streamed == [] and transforms == []
+    assert "UNTRUSTED" not in json.dumps(persisted)
+
+
+def test_cached_agent_resets_receipt_and_domain_replays_idempotently(
+    monkeypatch, tmp_path
+):
+    DOMAIN.update(mode="success", calls=0, mutations=0, receipts={})
+    success = NormalizedResponse(None, [_tool_call()], "stop")
+    conflict = NormalizedResponse(
+        None,
+        [_tool_call(intent="different")],
+        "stop",
+    )
+    missing = NormalizedResponse("UNTRUSTED", None, "stop")
+    agent, session_db, requests, streamed, transforms = _make_agent(
+        monkeypatch,
+        tmp_path,
+        "consecutive", [success, success, conflict, missing]
+    )
+    try:
+        first = agent.run_conversation(
+            "first",
+            conversation_history=[],
+            persist_user_platform_id="same",
+            gateway_turn=True,
+        )
+        second = agent.run_conversation(
+            "retry",
+            conversation_history=[],
+            persist_user_platform_id="same",
+            gateway_turn=True,
+        )
+        conflict_result = agent.run_conversation(
+            "conflict",
+            conversation_history=[],
+            persist_user_platform_id="same",
+            gateway_turn=True,
+        )
+        third = agent.run_conversation(
+            "new",
+            conversation_history=[],
+            persist_user_platform_id="new",
+            gateway_turn=True,
+        )
+        assert first["final_response"] == second["final_response"]
+        assert DOMAIN["mutations"] == 1 and DOMAIN["calls"] == 3
+        assert conflict_result["final_response"] == DEFAULT_FAILURE_RESPONSE
+        assert third["final_response"] == DEFAULT_FAILURE_RESPONSE
+        assert len(requests) == 4 and streamed == [] and transforms == []
+    finally:
+        agent.close()
+
+
+def test_plugin_register_tool_exposes_terminal_metadata(tmp_path):
+    from hermes_cli.plugins import PluginContext, PluginManager, PluginManifest
+
+    manager = PluginManager(scope_key=str(tmp_path / "plugin-scope"))
+    context = PluginContext(
+        PluginManifest(name="terminal-test", key="terminal-test"), manager
+    )
+    context.register_tool(
+        name="plugin_terminal_turn",
+        toolset="test-terminal",
+        schema={"name": "plugin_terminal_turn"},
+        handler=lambda _args, **_kwargs: "unused",
+        terminal=True,
+    )
+    try:
+        entry = registry.get_entry("plugin_terminal_turn", scope=manager.scope_key)
+        assert entry is not None and entry.terminal is True
+    finally:
+        registry.deregister("plugin_terminal_turn", scope=manager.scope_key)
+
+
+def test_policy_is_opt_in_and_unsupported_boundaries_fail_preflight(
+    monkeypatch, tmp_path
+):
+    ordinary = NormalizedResponse(
+        content="ordinary provider text",
+        tool_calls=None,
+        finish_reason="stop",
+    )
+
+    normal, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "opt-in-off", ordinary, required_tool=None
+    )
+    assert normal["final_response"] == "UNTRUSTED TRANSFORM"
+    assert len(requests) == 1
+    assert requests[0]["tool_choice"] == "auto"
+    assert streamed == ["UNTRUSTED STREAM"]
+    assert transforms == ["transform_llm_output"]
+
+    for surface in ("tui", "desktop"):
+        direct, _persisted, requests, streamed, transforms, _agent = _run_case(
+            monkeypatch,
+            tmp_path,
+            f"direct-{surface}",
+            ordinary,
+            platform=surface,
+            gateway_turn=False,
+        )
+        assert direct["final_response"] == "UNTRUSTED TRANSFORM"
+        assert requests[0]["tool_choice"] == "auto"
+        assert streamed == ["UNTRUSTED STREAM"]
+        assert transforms == ["transform_llm_output"]
+
+    unsupported, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "unsupported-provider",
+        ordinary,
+        provider="custom",
+    )
+    assert unsupported["final_response"] == DEFAULT_FAILURE_RESPONSE
+    assert requests == [] and streamed == [] and transforms == []
+
+    unsupported_mode, _persisted, requests, streamed, transforms, _agent = (
+        _run_case(
+            monkeypatch,
+            tmp_path,
+            "unsupported-mode",
+            ordinary,
+            api_mode="chat_completions",
+        )
+    )
+    assert unsupported_mode["final_response"] == DEFAULT_FAILURE_RESPONSE
+    assert requests == [] and streamed == [] and transforms == []
+
+    fallback_agent, fallback_db, *_ = _make_agent(
+        monkeypatch,
+        tmp_path,
+        "fallback-blocked", [ordinary]
+    )
+    try:
+        setattr(fallback_agent, "_required_terminal_turn_active", True)
+        setattr(
+            fallback_agent,
+            "_fallback_config",
+            [{"provider": "other", "model": "other"}],
+        )
+        setattr(fallback_agent, "_fallback_index", 0)
+        assert fallback_agent._try_activate_fallback() is False
+        assert getattr(fallback_agent, "_fallback_index") == 0
+    finally:
+        fallback_db.close()
+
+    missing, _persisted, requests, streamed, transforms, _agent = _run_case(
+        monkeypatch,
+        tmp_path,
+        "missing-tool",
+        ordinary,
+        required_tool="absent_terminal_tool",
+    )
+    assert missing["final_response"] == DEFAULT_FAILURE_RESPONSE
+    assert requests == [] and streamed == [] and transforms == []

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -22,8 +22,9 @@ import logging
 import sys
 import threading
 import time
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Callable, Dict, List, Optional, Set
+from typing import Any, Callable, Dict, List, Optional, Set
 
 from hermes_constants import hermes_home_key
 
@@ -34,6 +35,29 @@ _MAX_TOOL_ERROR_CHARS = 2048
 _TOOL_ERROR_TRUNCATION_MARKER = "… [truncated]"
 # Logs keep more of the body than the model sees, but still a bounded amount.
 _MAX_LOGGED_ERROR_CHARS = 8192
+
+
+@dataclass(frozen=True)
+class TerminalToolResult:
+    """Trusted tool result that owns the exact user-visible projection."""
+
+    turn_id: str
+    tool_call_id: str
+    request_id: str
+    response_text: str
+    receipt: dict[str, Any]
+
+    def tool_content(self) -> str:
+        return json.dumps(
+            {
+                "status": "ok",
+                "request_id": self.request_id,
+                "response_text": self.response_text,
+                "receipt": self.receipt,
+            },
+            ensure_ascii=False,
+            sort_keys=True,
+        )
 
 
 def _bound_error_text(text: str) -> str:
@@ -207,12 +231,13 @@ class ToolEntry:
     __slots__ = (
         "name", "toolset", "schema", "handler", "check_fn",
         "requires_env", "is_async", "description", "emoji",
-        "max_result_size_chars", "dynamic_schema_overrides",
+        "max_result_size_chars", "dynamic_schema_overrides", "terminal",
     )
 
     def __init__(self, name, toolset, schema, handler, check_fn,
                  requires_env, is_async, description, emoji,
-                 max_result_size_chars=None, dynamic_schema_overrides=None):
+                 max_result_size_chars=None, dynamic_schema_overrides=None,
+                 terminal: bool = False):
         self.name = name
         self.toolset = toolset
         self.schema = schema
@@ -231,6 +256,9 @@ class ToolEntry:
         # on every get_definitions() call; results are merged shallow on top
         # of the base schema before the {"type": "function", ...} wrap.
         self.dynamic_schema_overrides = dynamic_schema_overrides
+        # Declarative metadata for the host-owned terminal-turn policy.
+        # Ordinary tool dispatch remains unchanged until a profile opts in.
+        self.terminal = bool(terminal)
 
 
 class _PluginOverridePolicy:
@@ -800,6 +828,7 @@ class ToolRegistry:
         dynamic_schema_overrides: Callable = None,
         override: bool = False,
         scope: Optional[str] = None,
+        terminal: bool = False,
     ):
         """Register a tool.  Called at module-import time by each tool file.
 
@@ -895,6 +924,7 @@ class ToolRegistry:
                 emoji=emoji,
                 max_result_size_chars=max_result_size_chars,
                 dynamic_schema_overrides=dynamic_schema_overrides,
+                terminal=terminal,
             )
             # Availability is now derived per-tool (_toolset_has_exposable_tools),
             # so this map no longer gates a toolset. It is still consumed by
@@ -1142,6 +1172,11 @@ class ToolRegistry:
         """
         if isinstance(result, str):
             return _bound_json_error_result(result)
+        # A terminal result is consumed by the host-owned agent loop after the
+        # normal tool pipeline persists its canonical tool row. Keep the typed
+        # value intact until that boundary; it never returns to the model.
+        if isinstance(result, TerminalToolResult):
+            return result
         if (
             isinstance(result, dict)
             and result.get("_multimodal") is True
@@ -1169,7 +1204,7 @@ class ToolRegistry:
         *,
         scope: Optional[str] = None,
         **kwargs,
-    ) -> str | dict:
+    ) -> Any:
         """Execute a tool handler by name.
 
         * Async handlers are bridged automatically via ``_run_async()``.

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -110,6 +110,7 @@ def handle_turn(params, *, request_id, turn_id, tool_call_id, **kwargs):
         request_id=request_id,
         turn_id=turn_id,
         tool_call_id=tool_call_id,
+        receipt={"request_id": request_id},
     )
 
 
@@ -133,9 +134,9 @@ agent:
     failure_response: "The request could not be committed safely. Please retry."
 ```
 
-The policy currently supports natural gateway turns through the `openai-codex` Responses transport. Hermes forces exactly one call to the named tool after middleware and transport preflight, suppresses provider prose and streaming, persists the tool call/result and exact terminal response, then stops without a second model call or fallback. Missing or inconsistent configuration, the wrong number of calls, mixed prose, handler failure, an invalid receipt, or transcript-persistence failure all fail closed.
+The policy currently supports natural gateway turns carrying a durable platform message ID through the `openai-codex` Responses transport. Hermes forces exactly one call to the named tool after middleware and transport preflight, suppresses provider prose and streaming, persists the tool call/result and exact terminal response, then stops without a second model call or fallback. Missing or inconsistent configuration, the wrong number of calls, mixed prose, handler failure, an invalid receipt, or transcript-persistence failure all fail closed.
 
-`request_id` is host-owned and stable for the same gateway session and inbound platform message. A mutating handler must enforce durable idempotency itself: same request ID and same intent replays the stored response; the same request ID with a different intent must not mutate.
+`receipt` is required and must be JSON-serializable. `request_id` is host-owned and stable for the same gateway session and inbound platform message. A mutating handler must enforce durable idempotency itself: same request ID and same intent replays the stored response; the same request ID with a different intent must not mutate.
 
 ## What plugins can do
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -92,6 +92,51 @@ The model-facing tool description belongs in `schema["description"]`. The option
 
 Project-local plugins under `./.hermes/plugins/` are disabled by default. Enable them only for trusted repositories by setting `HERMES_ENABLE_PROJECT_PLUGINS=true` before starting Hermes.
 
+### Fail-closed terminal tools
+
+A gateway profile can require one plugin tool to own the complete visible result of every natural inbound turn. This is intended for stateful applications where ordinary model prose must never be mistaken for a committed transition.
+
+Register the tool as terminal and return a receipt bound to the identifiers Hermes passes to the handler:
+
+```python
+from tools.registry import TerminalToolResult
+
+
+def handle_turn(params, *, request_id, turn_id, tool_call_id, **kwargs):
+    # Commit or replay the application transition under request_id first.
+    response_text = apply_or_replay(params, request_id=request_id)
+    return TerminalToolResult(
+        response_text=response_text,
+        request_id=request_id,
+        turn_id=turn_id,
+        tool_call_id=tool_call_id,
+    )
+
+
+def register(ctx):
+    ctx.register_tool(
+        name="application_turn",
+        toolset="application",
+        schema={...},
+        handler=handle_turn,
+        terminal=True,
+    )
+```
+
+Enable the requirement explicitly in that profile's `config.yaml`:
+
+```yaml
+agent:
+  required_terminal_tool:
+    name: application_turn
+    surface: gateway
+    failure_response: "The request could not be committed safely. Please retry."
+```
+
+The policy currently supports natural gateway turns through the `openai-codex` Responses transport. Hermes forces exactly one call to the named tool after middleware and transport preflight, suppresses provider prose and streaming, persists the tool call/result and exact terminal response, then stops without a second model call or fallback. Missing or inconsistent configuration, the wrong number of calls, mixed prose, handler failure, an invalid receipt, or transcript-persistence failure all fail closed.
+
+`request_id` is host-owned and stable for the same gateway session and inbound platform message. A mutating handler must enforce durable idempotency itself: same request ID and same intent replays the stored response; the same request ID with a different intent must not mutate.
+
 ## What plugins can do
 
 Every `ctx.*` API below is available inside a plugin's `register(ctx)` function.


### PR DESCRIPTION
## What does this PR do?

Adds an opt-in plugin contract for stateful turns whose visible response must be backed by one verified terminal tool result.

Today, `tool_choice` can require a function name, but it does not by itself guarantee the call's receipt, persistence, or the absence of later model prose. A stateful plugin can therefore ask for a mutation without Hermes being able to prove that the delivered response corresponds to that exact committed transition.

With this change, a gateway profile may require one tool registered with `terminal=True` for natural inbound messages carrying a durable platform message ID:

```text
natural gateway message
  -> exact terminal tool call
  -> typed receipt bound to the host request
  -> transcript and final response persisted
  -> delivery and immediate stop
```

The request constraint is reapplied after middleware, transport preflight, and Relay rewriting. Missing, wrong, multiple, malformed, mixed-prose, timed-out, failed, or unpersisted results fail closed to the profile's static response. There is no second provider call, fallback, stream, or output transform on the terminal path.

Activation is absent by default. Ordinary CLI, TUI, Desktop, API, internal/synthetic gateway events, and ordinary tools keep their existing behavior.

## Related Issue

N/A — no upstream issue exists for this proposal.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add the required-terminal-turn policy, natural gateway provenance marker, host request identity, and receipt validation;
- let plugins declare `ctx.register_tool(..., terminal=True)` and return a typed `TerminalToolResult`;
- enforce the exact tool request at the final provider boundary, including the Relay callback;
- persist the tool transcript and final assistant projection before delivery, then stop the turn;
- fail closed without provider prose when configuration, execution, receipt, or persistence is inconsistent;
- document the opt-in plugin contract, required JSON-serializable receipt, and application-owned idempotency boundary;
- add real conversation-loop regression tests, including direct-entry isolation, Relay rewrites, receipt binding, failures, persistence order, and cached-session isolation.

This PR contains no application-specific business logic, SQLite schema, delivery worker, Telegram-specific behavior, provider fallback, migration, or live activation.

## How to Test

```bash
pytest -q \
  tests/agent/test_required_terminal_turn.py \
  tests/agent/test_tool_executor_checkpoint_paths.py \
  tests/run_agent/test_tool_executor_contextvar_propagation.py \
  tests/agent/test_turn_finalizer_*.py \
  tests/agent/test_relay_llm.py \
  -k 'not test_stream_uses_rewritten_request_and_post_intercept_chunks'

pytest -q tests/hermes_cli/test_plugins.py tests/hermes_cli/test_agent_plugins.py
pytest -q tests/hermes_cli/test_config.py
```

Local results on Ubuntu 24.04 / Python 3.11:

- agent-loop and adjacent paths: `77 passed, 1 deselected`;
- plugin suites: `115 passed`;
- configuration suite: `120 passed, 4 skipped`;
- compile and `git diff --check`: pass;
- focused independent rerun: `8 passed`.

The deselected Relay tracing test expects a `traceparent` header unavailable in this environment and fails identically on the untouched base commit.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu 24.04 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] `cli-config.yaml.example` update is N/A; the profile option is documented in the plugin guide and remains absent by default
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A; the public plugin contract is documented in the plugin guide
- [x] I've considered cross-platform impact; the new path uses existing gateway, provider, registry, and persistence abstractions without OS-specific behavior
- [x] I've updated the tool registration and result contract

## Review and publication identity

An independent review found four material gaps in the initial candidate: a post-enforcement Relay rewrite, a forgeable public gateway boolean, a stale in-memory success projection after final persistence failure, and an incomplete documentation example. All four were corrected, and a targeted counter-review returned **PASS** with no directly caused regression.

The reviewed source candidate was `79842781a85c6c178a3ab6bfe78ae1cbcba45b2b`. The published App-authored head is `ce8745a9a98d13a6368a46ad47dbb4ab9c814248`; only commit author/committer metadata and the resulting commit IDs changed. Both have:

- base `63279301bcbdc185c1b07b98a9312eb0c862f26d`;
- final tree `003e60e4a2383ee6f3a60cd687da9bb88ce06c42`;
- cumulative binary-diff SHA-256 `7293204f32a2831d8daf76035a6ea89edbcd138d6b3ceb701fb4e4800195cda9`.

## Risk and rollback

The feature is opt-in and absent by default. Application handlers remain responsible for atomic durable mutation and idempotent replay for the same host request ID and intent.

Rollback is removal of the profile option or reverting the two commits. No persisted Hermes migration is introduced.
