### PR TITLE
fix(model_metadata): parse vLLM max_tokens greater than max_model_len error

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1786,7 +1786,7 @@ def parse_context_limit_from_error(error_msg: str) -> Optional[int]:
     error_lower = error_msg.lower()
     # Pattern: look for numbers near context-related keywords
     patterns = [
-        r'max_model_len\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", ": 32768", "(32768)", "is 32768"
+        r'(?:max_model_len(?:\s*=\s*max_total_tokens)?|max_total_tokens)\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM: "max_model_len 32768", "=32768", "=max_total_tokens=262144", ": 32768", "(32768)", "is 32768"
         r'maximum model length\s*(?:is\s*)?[:=(]?\s*(\d{4,})',  # vLLM alt: "maximum model length 131072", "... is 131072"
         r'(?:max(?:imum)?|limit)\s*(?:context\s*)?(?:length|size|window)?\s*(?:is|of|:)?\s*(\d{4,})',
         r'context\s*(?:length|size|window)\s*(?:is|of|:)?\s*(\d{4,})',
@@ -1882,6 +1882,12 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
         # This is independent of the input context window.
         "exceeds model" in error_lower
         and "maximum output tokens" in error_lower
+    ) or (
+        # vLLM phrasing:
+        #   "max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144.
+        #    Please request fewer output tokens."
+        ("cannot be greater than" in error_lower or "request fewer output tokens" in error_lower or "fewer output tokens" in error_lower)
+        and ("max_tokens" in error_lower or "max_model_len" in error_lower or "max_total_tokens" in error_lower)
     )
     if not is_output_cap_error:
         return None
@@ -1905,6 +1911,21 @@ def parse_available_output_tokens_from_error(error_msg: str) -> Optional[int]:
     )
     if _m_range:
         _cap = int(_m_range.group(1))
+        if _cap >= 1:
+            return _cap
+
+    # vLLM total-window output-cap form:
+    #   "max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144. Please request fewer output tokens."
+    # The error gives the model's total max_model_len / max_total_tokens window.
+    # Returning this cap is safe: conversation_loop.py computes
+    #   safe_out = max(1, min(available_out, old_ctx - request_input_estimate) - 64)
+    # which yields exactly window - input - margin.
+    _m_vllm_total = re.search(
+        r'(?:max_model_len(?:\s*=\s*max_total_tokens)?|max_total_tokens)\s*[:=]\s*(\d+)',
+        error_lower,
+    )
+    if _m_vllm_total:
+        _cap = int(_m_vllm_total.group(1))
         if _cap >= 1:
             return _cap
 
@@ -2035,6 +2056,9 @@ def is_output_cap_error(error_msg: str) -> bool:
         or "must be" in error_lower
         or ("exceeds model" in error_lower
             and "maximum output tokens" in error_lower)
+        or "cannot be greater than" in error_lower          # vLLM: "max_tokens=X cannot be greater than max_model_len=..."
+        or "request fewer output tokens" in error_lower     # vLLM: "Please request fewer output tokens."
+        or "fewer output tokens" in error_lower
     )
     if not output_cap_signal:
         return False

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1450,6 +1450,9 @@ class TestParseContextLimitFromError:
         ("maximum model length 131072", 131072),
         ("maximum model length is 131072", 131072),
         ("maximum model length: 131072", 131072),
+        ("max_model_len=max_total_tokens=262144", 262144),
+        ("max_total_tokens=262144", 262144),
+        ("max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144. Please request fewer output tokens.", 262144),
     ])
     def test_vllm_delimiter_variants(self, msg, expected):
         """vLLM emits the limit with various delimiters (space/colon/equals/

--- a/tests/test_output_cap_parsing.py
+++ b/tests/test_output_cap_parsing.py
@@ -191,3 +191,36 @@ class TestParseVllmTokenBasedOutputCap:
             cap = available
         assert real_input + cap <= window, f"did not converge: cap={cap}"
 
+
+class TestParseVllmMaxModelLenOutputCap:
+    """vLLM rejects max_tokens > max_model_len with:
+    'max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144.
+    Please request fewer output tokens.'
+    """
+
+    _VLLM_OUTPUT_CAP_MSG = (
+        "400: max_tokens=393216 cannot be greater than "
+        "max_model_len=max_total_tokens=262144. Please request fewer output tokens. "
+        "(parameter=max_tokens, value=393216)"
+    )
+
+    def test_vllm_max_model_len_extracted(self):
+        assert parse_available_output_tokens_from_error(self._VLLM_OUTPUT_CAP_MSG) == 262144
+
+    def test_vllm_max_model_len_without_total_tokens_extracted(self):
+        msg = "max_tokens=100000 cannot be greater than max_model_len=65536. Please request fewer output tokens."
+        assert parse_available_output_tokens_from_error(msg) == 65536
+
+    def test_vllm_max_total_tokens_alone_extracted(self):
+        msg = "max_tokens=100000 cannot be greater than max_total_tokens=65536. Please request fewer output tokens."
+        assert parse_available_output_tokens_from_error(msg) == 65536
+
+    def test_vllm_is_output_cap_error(self):
+        assert is_output_cap_error(self._VLLM_OUTPUT_CAP_MSG) is True
+
+    def test_vllm_request_fewer_output_tokens_is_output_cap(self):
+        assert is_output_cap_error(
+            "Please request fewer output tokens: max_tokens=100000 cannot be greater than 65536."
+        ) is True
+
+


### PR DESCRIPTION
## What does this PR do?

Resolves **#102494** where vLLM's `max_tokens > max_model_len` 400 rejection:
```
400: max_tokens=393216 cannot be greater than max_model_len=max_total_tokens=262144. Please request fewer output tokens. (parameter=max_tokens, value=393216)
```
was misparsed as a *prompt-too-long* error rather than an *output-cap* error.

When users switched to a custom self-hosted vLLM model with global `max_tokens` configured higher than the vLLM instance's `max_model_len`:
1. `agent/model_metadata.py:parse_available_output_tokens_from_error()` failed to match any known phrasing pattern because the error uses `cannot be greater than` and `request fewer output tokens` with `max_model_len=max_total_tokens=`.
2. Returning `None` routed the error into the prompt compression recovery path (`agent/conversation_loop.py:6392`).
3. Compression re-sent the identical `max_tokens` payload, hit the identical 400 error, and looped until exhausting `compression_attempts`, causing the session to auto-reset with *"Cannot compress further"*.
4. In addition, `parse_context_limit_from_error()` failed to extract the context length due to the `=max_total_tokens=` delimiter.

This PR extends:
- `is_output_cap_error()` to recognize `cannot be greater than`, `request fewer output tokens`, and `fewer output tokens` as unambiguous output-cap signals so calls never enter compression death-loops.
- `parse_available_output_tokens_from_error()` to parse `max_model_len` / `max_total_tokens` bounds directly from vLLM's error message.
- `parse_context_limit_from_error()` to handle `=max_total_tokens=` and `max_total_tokens` tokens.

## Related Issue

Fixes #102494

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/model_metadata.py`:
  - Extended regex in `parse_context_limit_from_error` to recognize `max_model_len=max_total_tokens=` and `max_total_tokens` delimiters.
  - Added vLLM output-cap phrasing to `is_output_cap_error` and `parse_available_output_tokens_from_error`.
  - Added extraction of the model limit from `(max_model_len(=max_total_tokens)?|max_total_tokens)[=:](\d+)`.
- `tests/agent/test_model_metadata.py`:
  - Added parameterized test cases for `max_model_len=max_total_tokens=262144`, `max_total_tokens=262144`, and verbatim vLLM 400 strings.
- `tests/test_output_cap_parsing.py`:
  - Added `TestParseVllmMaxModelLenOutputCap` suite covering value extraction and output-cap classification for vLLM variants.

## How to Test

1. Run unit test suites:
```bash
uv run --with pytest pytest tests/test_output_cap_parsing.py tests/agent/test_model_metadata.py -k "vllm or OutputCap" -v
```
All 32 tests pass.
2. Verify full test suites:
```bash
uv run --with pytest pytest tests/test_output_cap_parsing.py tests/agent/test_model_metadata.py
```
All 146 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
