### PR TITLE
feat(review): add dedicated child timeout

### DIFF
--- a/agent/review_engine.py
+++ b/agent/review_engine.py
@@ -234,6 +234,28 @@ def _load_review_credentials_cfg() -> Optional[Dict[str, Any]]:
     }
 
 
+def _load_review_timeout_override() -> tuple[Any, Optional[str]]:
+    """Return the dedicated reviewer timeout and its config path when set.
+
+    ``None`` means the key is unset and the delegation-wide timeout should be
+    inherited. An explicit zero is preserved because it disables the cap.
+    """
+    try:
+        from hermes_cli.config import load_config_readonly
+
+        full = load_config_readonly()
+        aux = full.get("auxiliary") or {}
+        review = aux.get("review") or {}
+        if not isinstance(review, dict):
+            return None, None
+        value = review.get("child_timeout_seconds")
+    except Exception:
+        return None, None
+    if value is None:
+        return None, None
+    return value, "auxiliary.review.child_timeout_seconds"
+
+
 def start_review(
     parent_agent,
     messages: List[Dict[str, Any]],
@@ -258,15 +280,23 @@ def start_review(
     loaded_skills = collect_parent_loaded_skills(parent_agent, messages)
     goal, context = build_review_task(snapshot, user_prompt, loaded_skills)
     credentials_cfg = _load_review_credentials_cfg()
+    timeout_value, timeout_source = _load_review_timeout_override()
 
     from tools.delegate_tool import delegate_task
 
+    delegate_kwargs: Dict[str, Any] = {}
+    if timeout_source is not None:
+        delegate_kwargs.update(
+            _child_timeout_seconds=timeout_value,
+            _child_timeout_source=timeout_source,
+        )
     raw = delegate_task(
         goal=goal,
         context=context,
         background=True,
         parent_agent=parent_agent,
         credentials_cfg=credentials_cfg,
+        **delegate_kwargs,
     )
     try:
         result = json.loads(raw)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1257,6 +1257,7 @@ DEFAULT_CONFIG = {
             "base_url": "",        # direct OpenAI-compatible endpoint (takes precedence over provider)
             "api_key": "",         # API key for base_url / provider override
             "api_mode": "",        # force transport: chat_completions | anthropic_messages | codex_responses
+            "child_timeout_seconds": None,  # unset = inherit delegation.child_timeout_seconds; 0 = no cap
         },
         "mcp": {
             "provider": "auto",

--- a/tests/agent/test_review_engine.py
+++ b/tests/agent/test_review_engine.py
@@ -146,6 +146,64 @@ def test_load_review_credentials_cfg_missing_section(monkeypatch):
     assert re_mod._load_review_credentials_cfg() is None
 
 
+@pytest.mark.parametrize(
+    ("review_config", "expected"),
+    [
+        ({"child_timeout_seconds": 1200}, (1200, "auxiliary.review.child_timeout_seconds")),
+        ({"child_timeout_seconds": 0}, (0, "auxiliary.review.child_timeout_seconds")),
+        ({}, (None, None)),
+    ],
+)
+def test_load_review_timeout_override(monkeypatch, review_config, expected):
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: {"auxiliary": {"review": review_config}},
+    )
+    assert re_mod._load_review_timeout_override() == expected
+
+
+def test_start_review_passes_dedicated_timeout_to_delegate_task(monkeypatch):
+    import tools.delegate_tool as dt
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"status": "dispatched", "delegation_id": "review-1"})
+
+    monkeypatch.setattr(dt, "delegate_task", fake_delegate_task)
+    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(
+        re_mod,
+        "_load_review_timeout_override",
+        lambda: (1200, "auxiliary.review.child_timeout_seconds"),
+    )
+
+    start_review(_fake_parent(), [{"role": "user", "content": "review this"}])
+
+    assert captured["_child_timeout_seconds"] == 1200
+    assert captured["_child_timeout_source"] == "auxiliary.review.child_timeout_seconds"
+
+
+def test_start_review_omits_timeout_override_when_unset(monkeypatch):
+    import tools.delegate_tool as dt
+
+    captured = {}
+
+    def fake_delegate_task(**kwargs):
+        captured.update(kwargs)
+        return json.dumps({"status": "dispatched", "delegation_id": "review-1"})
+
+    monkeypatch.setattr(dt, "delegate_task", fake_delegate_task)
+    monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(re_mod, "_load_review_timeout_override", lambda: (None, None))
+
+    start_review(_fake_parent(), [{"role": "user", "content": "review this"}])
+
+    assert "_child_timeout_seconds" not in captured
+    assert "_child_timeout_source" not in captured
+
+
 # ---------------------------------------------------------------------------
 # delegate_task credentials_cfg override (the internal /review routing hook)
 # ---------------------------------------------------------------------------
@@ -210,6 +268,8 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
 
     def fake_run_single_child(task_index, goal, child=None, parent_agent=None, **kw):
         captured["goal"] = goal
+        captured["timeout_seconds"] = kw.get("_child_timeout_seconds")
+        captured["timeout_source"] = kw.get("_child_timeout_source")
         return {
             "task_index": 0, "status": "completed",
             "summary": "REVIEW: looks good", "api_calls": 2,
@@ -232,6 +292,11 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
     monkeypatch.setattr(dt, "_run_single_child", fake_run_single_child)
     monkeypatch.setattr(dt, "_resolve_delegation_credentials", lambda *a, **k: creds)
     monkeypatch.setattr(re_mod, "_load_review_credentials_cfg", lambda: None)
+    monkeypatch.setattr(
+        re_mod,
+        "_load_review_timeout_override",
+        lambda: (1, "auxiliary.review.child_timeout_seconds"),
+    )
 
     msgs = [
         {"role": "user", "content": "open a PR for the fix"},
@@ -256,6 +321,8 @@ def test_start_review_dispatches_background_and_completes(monkeypatch):
             continue
     assert evt is not None and evt["type"] == "async_delegation"
     assert evt["results"][0]["summary"] == "REVIEW: looks good"
+    assert captured["timeout_seconds"] == 30.0
+    assert captured["timeout_source"] == "auxiliary.review.child_timeout_seconds"
 
 
 def test_start_review_rejects_empty_conversation():

--- a/tests/tools/test_delegate_subagent_timeout_diagnostic.py
+++ b/tests/tools/test_delegate_subagent_timeout_diagnostic.py
@@ -201,6 +201,7 @@ class TestRunSingleChildTimeoutDump:
 
         assert result["status"] == "timeout"
         assert result["api_calls"] == 0
+        assert result["timeout_source"] == "delegation.child_timeout_seconds"
         assert result["diagnostic_path"] is not None
         dump_path = Path(result["diagnostic_path"])
         assert dump_path.is_file()
@@ -236,5 +237,45 @@ class TestRunSingleChildTimeoutDump:
 
         assert result["status"] == "error"
         assert result["timeout_seconds"] is None
+        assert result["timeout_source"] is None
         assert result["timed_out_after_seconds"] is None
         assert result["timeout_phase"] is None
+
+    def test_internal_timeout_override_reports_config_source(self, hermes_home, monkeypatch):
+        """Role-specific callers can override the cap and expose its source."""
+        from tools import delegate_tool
+
+        monkeypatch.setattr(delegate_tool, "_get_child_timeout", lambda: 30.0)
+        child = _StubChild(api_call_count=0, hang_seconds=10.0)
+        parent = MagicMock()
+        parent._touch_activity = MagicMock()
+        parent._current_task_id = None
+
+        result = delegate_tool._run_single_child(
+            task_index=0,
+            goal="review test goal",
+            child=child,
+            parent_agent=parent,
+            _child_timeout_seconds=0.3,
+            _child_timeout_source="auxiliary.review.child_timeout_seconds",
+        )
+
+        assert result["status"] == "timeout"
+        assert result["timeout_seconds"] == 0.3
+        assert result["timeout_source"] == "auxiliary.review.child_timeout_seconds"
+        assert "configured by auxiliary.review.child_timeout_seconds" in result["error"]
+        dump = Path(result["diagnostic_path"]).read_text(encoding="utf-8")
+        assert "configured_by:      auxiliary.review.child_timeout_seconds" in dump
+
+    @pytest.mark.parametrize(
+        ("configured", "expected"),
+        [(0, None), (-1, None), (1, 30.0), (1200, 1200.0)],
+    )
+    def test_internal_timeout_override_uses_global_timeout_semantics(
+        self, configured, expected
+    ):
+        from tools.delegate_tool import _normalize_child_timeout_override
+
+        assert _normalize_child_timeout_override(
+            configured, "auxiliary.review.child_timeout_seconds"
+        ) == expected

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -956,6 +956,7 @@ def _get_worktree_isolation() -> bool:
 
 
 _LEGACY_MAX_ASYNC_WARNED = False
+_CHILD_TIMEOUT_UNSET = object()
 
 
 def _get_max_async_children() -> int:
@@ -1025,6 +1026,23 @@ def _get_child_timeout() -> Optional[float]:
         else:
             return None if parsed <= 0 else max(30.0, parsed)
     return DEFAULT_CHILD_TIMEOUT
+
+
+def _normalize_child_timeout_override(value: Any, source: str) -> Any:
+    """Normalize an internal role-specific timeout or request inheritance."""
+    if value is _CHILD_TIMEOUT_UNSET:
+        return _CHILD_TIMEOUT_UNSET
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        logger.warning(
+            "%s=%r is not a valid number; falling back to "
+            "delegation.child_timeout_seconds",
+            source,
+            value,
+        )
+        return _CHILD_TIMEOUT_UNSET
+    return None if parsed <= 0 else max(30.0, parsed)
 
 
 def _get_max_spawn_depth() -> int:
@@ -2265,6 +2283,7 @@ def _dump_subagent_timeout_diagnostic(
     duration_seconds: float,
     worker_thread: Optional[threading.Thread],
     goal: str,
+    timeout_source: Optional[str] = None,
 ) -> Optional[str]:
     """Write a structured diagnostic dump for a subagent that timed out
     before making any API call.
@@ -2306,6 +2325,7 @@ def _dump_subagent_timeout_diagnostic(
         _w(f"  task_index:        {task_index}")
         _w(f"  subagent_id:       {subagent_id}")
         _w(f"  configured_timeout: {timeout_seconds}s")
+        _w(f"  configured_by:      {timeout_source or 'delegation.child_timeout_seconds'}")
         _w(f"  actual_duration:   {duration_seconds:.2f}s")
         _w("")
 
@@ -2622,6 +2642,8 @@ def _run_single_child(
     owner_session_id: Optional[str] = None,
     owner_transport: Any = None,
     owner_session_record: Any = None,
+    _child_timeout_seconds: Any = _CHILD_TIMEOUT_UNSET,
+    _child_timeout_source: Optional[str] = None,
     **_kwargs,
 ) -> Dict[str, Any]:
     """
@@ -2971,7 +2993,12 @@ def _run_single_child(
         # Run child with an optional hard timeout (off by default —
         # result(timeout=None) blocks until the child finishes). Stuck-child
         # protection comes from the heartbeat staleness monitor instead.
-        child_timeout = _get_child_timeout()
+        if _child_timeout_seconds is _CHILD_TIMEOUT_UNSET:
+            child_timeout = _get_child_timeout()
+            timeout_source = "delegation.child_timeout_seconds"
+        else:
+            child_timeout = _child_timeout_seconds
+            timeout_source = _child_timeout_source or "internal child timeout override"
         # Daemon worker (tools.daemon_pool): a timed-out child is abandoned
         # below; a stdlib non-daemon worker would then block interpreter
         # exit at atexit-join time if the child never unwinds.
@@ -3062,6 +3089,7 @@ def _run_single_child(
                     duration_seconds=float(duration),
                     worker_thread=_worker_thread_holder.get("t"),
                     goal=goal,
+                    timeout_source=timeout_source,
                 )
                 if diagnostic_path:
                     logger.warning(
@@ -3089,7 +3117,8 @@ def _run_single_child(
             if is_timeout:
                 if child_api_calls == 0:
                     _err = (
-                        f"Subagent timed out after {child_timeout}s without "
+                        f"Subagent timed out after {child_timeout}s "
+                        f"(configured by {timeout_source}) without "
                         f"making any API call — the child never reached its "
                         f"first LLM request (prompt construction, credential "
                         f"resolution, or transport may be stuck)."
@@ -3098,7 +3127,8 @@ def _run_single_child(
                         _err += f" Diagnostic: {diagnostic_path}"
                 else:
                     _err = (
-                        f"Subagent timed out after {child_timeout}s with "
+                        f"Subagent timed out after {child_timeout}s "
+                        f"(configured by {timeout_source}) with "
                         f"{child_api_calls} API call(s) completed — likely "
                         f"stuck on a slow API call, tool call, or unresponsive "
                         f"network request."
@@ -3117,6 +3147,7 @@ def _run_single_child(
                 "api_calls": child_api_calls,
                 "duration_seconds": duration,
                 "timeout_seconds": child_timeout if is_timeout else None,
+                "timeout_source": timeout_source if is_timeout else None,
                 "timed_out_after_seconds": duration if is_timeout else None,
                 "timeout_phase": (
                     "before_first_llm_call" if is_timeout and child_api_calls == 0
@@ -3933,6 +3964,8 @@ def delegate_task(
     message: Optional[str] = None,
     parent_agent=None,
     credentials_cfg: Optional[Dict[str, Any]] = None,
+    _child_timeout_seconds: Any = _CHILD_TIMEOUT_UNSET,
+    _child_timeout_source: Optional[str] = None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks, or control
@@ -4005,8 +4038,18 @@ def delegate_task(
             f"multiplies API cost)."
         )
 
-    # Load config
+    # Load config. Role-specific callers may supply an internal timeout
+    # override; invalid values deliberately fall back to the global setting.
     cfg = _load_config()
+    effective_child_timeout = _normalize_child_timeout_override(
+        _child_timeout_seconds,
+        _child_timeout_source or "internal child timeout override",
+    )
+    effective_child_timeout_source = (
+        None
+        if effective_child_timeout is _CHILD_TIMEOUT_UNSET
+        else (_child_timeout_source or "internal child timeout override")
+    )
     default_max_iter = cfg.get("max_iterations", DEFAULT_MAX_ITERATIONS)
     # Model-supplied max_iterations is ignored — the config value is authoritative
     # so users get predictable budgets. The kwarg is retained for internal callers
@@ -4262,6 +4305,8 @@ def delegate_task(
                 owner_session_id=_origin_ui_session_id or None,
                 owner_transport=_origin_owner_transport,
                 owner_session_record=_origin_owner_session_record,
+                _child_timeout_seconds=effective_child_timeout,
+                _child_timeout_source=effective_child_timeout_source,
             )
             results.append(result)
         else:
@@ -4287,6 +4332,8 @@ def delegate_task(
                         owner_session_id=_origin_ui_session_id or None,
                         owner_transport=_origin_owner_transport,
                         owner_session_record=_origin_owner_session_record,
+                        _child_timeout_seconds=effective_child_timeout,
+                        _child_timeout_source=effective_child_timeout_source,
                     )
                     futures[future] = i
 

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -219,9 +219,12 @@ auxiliary:
   review:
     provider: openrouter               # or nous, anthropic, a direct base_url, ...
     model: anthropic/claude-opus-4.6   # a strong reviewer model
+    child_timeout_seconds: 1200        # optional /review-only wall-clock cap
 ```
 
 Credentials resolve exactly like a `delegation.provider` pin (full runtime-provider bundle: base_url, api key, api_mode). `provider: auto` with an empty `model` means "inherit the main agent's model" — the default.
+
+`child_timeout_seconds` controls only the reviewer subagent. When omitted, `/review` inherits `delegation.child_timeout_seconds`; `0` or a negative value disables the reviewer cap, and positive values use the same 30-second minimum as ordinary delegation. Timeout results identify the effective config key in `timeout_source` and in the human-readable error and zero-call diagnostic.
 
 `/review` is deliberately separate from `/refine`: `/refine` reviews the conversation to update memory and skills, `/review` reviews the *work product* the conversation created.
 


### PR DESCRIPTION
## Summary

- add `auxiliary.review.child_timeout_seconds` as an optional `/review`-only wall-clock cap
- inherit `delegation.child_timeout_seconds` when the reviewer setting is unset, while preserving `0`/negative disable semantics and the 30-second floor
- report the effective timeout config path in structured timeout metadata, errors, and zero-call diagnostics

## Testing

- `scripts/run_tests.sh tests/agent/test_review_engine.py tests/tools/test_delegate_subagent_timeout_diagnostic.py tests/gateway/test_review_command.py tests/run_agent/test_background_review.py tests/tools/test_delegate_timeout_cleanup.py tests/tools/test_94248_timeout_transport_drain.py -q` (64 passed)
- `C:/workspace/hermes-agent/.venv/Scripts/python.exe -m py_compile agent/review_engine.py tools/delegate_tool.py hermes_cli/config_defaults.py tests/agent/test_review_engine.py tests/tools/test_delegate_subagent_timeout_diagnostic.py`
- `git diff --check`

## Risk

Low. The override is internal to the `/review` dispatch path; model-facing `delegate_task` arguments and ordinary delegation timeout resolution are unchanged.

Closes #102514
