### PR TITLE
fix(cron): keep direct runs alive after CLI timeout

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -45,7 +45,10 @@ from typing import Any, Callable, List, Optional, Protocol
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    windows_detach_popen_kwargs,
+    windows_hide_flags,
+)
 from hermes_cli.config import (
     _expand_env_vars,
     cron_model_drift_axes,
@@ -8133,13 +8136,19 @@ def _wait_for_external_cron_worker(
                 pass
 
 
-def _launch_external_cron_worker(job: dict) -> bool:
-    """Launch *job* outside a managed gateway cgroup when required.
+def _launch_external_cron_worker(
+    job: dict,
+    *,
+    detach: bool = False,
+    allow_unscoped: bool = False,
+    extra_prompt: Optional[str] = None,
+) -> bool:
+    """Launch *job* in a process that survives its dispatching caller.
 
-    Returns ``False`` when the caller is not a managed systemd gateway and the
-    existing in-process path should be used.  In managed topology, failure to
-    establish the transient scope raises: falling back would recreate the
-    restart interruption this handoff exists to prevent.
+    Managed gateways use a transient systemd scope and wait for the worker's
+    terminal ledger state. Direct CLI runs pass ``allow_unscoped`` and
+    ``detach``: they return after ownership acknowledgement with a durable
+    execution receipt. Other unscoped callers keep the in-process path.
     """
     execution_id = str(job["execution_id"])
     job_id = str(job["id"])
@@ -8165,7 +8174,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
         command,
         unit_suffix=f"cron-{job_id}-exec-{execution_id}",
     )
-    if scoped_command == command:
+    if scoped_command == command and not allow_unscoped:
         return False
 
     if mark_execution_handoff_pending(execution_id) is None:
@@ -8186,6 +8195,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
                     "job": job,
                     "profile_home": str(_get_hermes_home().resolve()),
                     "multiplex_active": multiplex_active,
+                    "extra_prompt": extra_prompt,
                 },
                 payload_file,
             )
@@ -8208,8 +8218,7 @@ def _launch_external_cron_worker(job: dict) -> bool:
             stdin=subprocess.DEVNULL,
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
-            start_new_session=True,
-            creationflags=windows_hide_flags(),
+            **windows_detach_popen_kwargs(),
         )
     except BaseException:
         payload_path.unlink(missing_ok=True)
@@ -8258,6 +8267,8 @@ def _launch_external_cron_worker(job: dict) -> bool:
                 acknowledgement.get("pid"),
                 execution_id,
             )
+            if detach:
+                return True
             return _wait_for_external_cron_worker(
                 process,
                 execution_id=execution_id,
@@ -8358,7 +8369,13 @@ def _run_external_worker_payload(payload_path: Path, ack_path: Path) -> bool:
             old_external_execution = os.environ.get("_HERMES_CRON_EXTERNAL_WORKER")
             os.environ["_HERMES_CRON_EXTERNAL_WORKER"] = execution_id
             try:
-                return run_one_job(job, adapters=None, loop=None, verbose=False)
+                return run_one_job(
+                    job,
+                    adapters=None,
+                    loop=None,
+                    verbose=False,
+                    extra_prompt=payload.get("extra_prompt"),
+                )
             finally:
                 if old_external_execution is None:
                     os.environ.pop("_HERMES_CRON_EXTERNAL_WORKER", None)

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -931,7 +931,11 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         except Exception:
             _stateless_reset = None
     try:
-        result = _cron_api(action=action, job_id=job_id)
+        result = _cron_api(
+            action=action,
+            job_id=job_id,
+            **({"detach_run": True} if action == "run" else {}),
+        )
     finally:
         if _stateless_reset is not None:
             _stateless_reset()
@@ -953,7 +957,13 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         # success/failure verdict would be a lie (#83340). Report the
         # background dispatch instead of claiming the run failed.
         delegation_id = job.get("delegation_id")
-        if job.get("execution_mode") == "background" or delegation_id:
+        execution_id = job.get("execution_id")
+        if job.get("execution_mode") == "detached":
+            if execution_id:
+                print(f"  Running in detached worker (execution {execution_id}).")
+            else:
+                print("  Running in detached worker.")
+        elif job.get("execution_mode") == "background" or delegation_id:
             if delegation_id:
                 print(f"  Running in background (delegation {delegation_id}).")
             else:

--- a/tests/cron/test_cron_relay_run_forward.py
+++ b/tests/cron/test_cron_relay_run_forward.py
@@ -148,6 +148,31 @@ class TestForwardRelayFrontedRun:
             cronjob_tools._forward_relay_fronted_run({"id": "j1"})
         assert sent["json"] == {}
 
+    def test_detached_direct_run_forwards_instead_of_launching_worker(self):
+        job = {"id": "j1", "name": "relay run", "deliver": "discord"}
+        with patch.object(
+            cronjob_tools, "resolve_job_ref", return_value=job
+        ), patch.object(
+            cronjob_tools,
+            "_relay_fronted_delivery_platforms",
+            return_value={"discord"},
+        ), patch("httpx.post", return_value=_Resp(200)) as post, patch.object(
+            cronjob_tools, "_try_dispatch_detached_run"
+        ) as detached:
+            out = json.loads(
+                cronjob_tools.cronjob(
+                    action="run",
+                    job_id="j1",
+                    prompt="one fire only",
+                    detach_run=True,
+                )
+            )
+
+        assert out["success"] is True
+        assert out["forwarded_to_gateway"] is True
+        assert post.call_args.kwargs["json"] == {"prompt": "one fire only"}
+        detached.assert_not_called()
+
 
 class TestManualRunPromptConsumption:
     """The stamped transient prompt reaches the fire that consumes the

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -230,6 +230,10 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     handoff = Mock(return_value={"id": "exec-1", "handoff_pending": 1})
     monkeypatch.setattr(scheduler, "mark_execution_handoff_pending", handoff)
     monkeypatch.setattr(scheduler.subprocess, "Popen", popen)
+    monkeypatch.setattr(
+        scheduler, "windows_detach_popen_kwargs",
+        lambda: {"start_new_session": True},
+    )
     observed_statuses = iter(
         [
             {"id": "exec-1", "status": "running"},
@@ -255,6 +259,56 @@ def test_launch_external_worker_uses_restart_safe_scope_and_acknowledges(
     assert payloads[0]["multiplex_active"] is True
     # Once the attempt is terminal the parent reaps its own handoff artifacts.
     assert not (tmp_path / "cron/external-workers/exec-1.json").exists()
+
+
+def test_direct_cli_worker_detaches_without_waiting_for_terminal_state(
+    tmp_path, monkeypatch
+):
+    import cron.scheduler as scheduler
+
+    job = {"id": "job-direct", "execution_id": "exec-direct", "prompt": "work"}
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tools.process_registry.restart_safe_gateway_child_argv",
+        lambda command, **_kwargs: command,
+    )
+    monkeypatch.setattr(
+        scheduler, "mark_execution_handoff_pending",
+        Mock(return_value={"id": "exec-direct", "handoff_pending": 1}),
+    )
+    monkeypatch.setattr(
+        scheduler, "windows_detach_popen_kwargs",
+        lambda: {"start_new_session": True},
+    )
+
+    process = Mock()
+    process.poll.return_value = None
+    process.wait.side_effect = AssertionError("detached launch waited for completion")
+
+    def popen(command, **_kwargs):
+        ack = Path(command[command.index("--ack-file") + 1])
+        ack.write_text(
+            json.dumps({"pid": 4321, "execution_id": "exec-direct"}),
+            encoding="utf-8",
+        )
+        return process
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", popen)
+
+    assert scheduler._launch_external_cron_worker(
+        job,
+        detach=True,
+        allow_unscoped=True,
+        extra_prompt="one fire only",
+    ) is True
+
+    process.wait.assert_not_called()
+    payload = json.loads(
+        (tmp_path / "cron/external-workers/exec-direct.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert payload["extra_prompt"] == "one fire only"
 
 
 def test_external_worker_exit_rechecks_exact_execution_before_failure(monkeypatch):

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -443,6 +443,33 @@ class TestCronRunBackgroundDispatch:
         rc = cron_command(Namespace(cron_command="run", job_id="job-1"))
         return rc, capsys.readouterr().out
 
+    def test_direct_cli_requests_detached_run_and_prints_execution_receipt(
+        self, monkeypatch, capsys
+    ):
+        observed = {}
+
+        def fake_cron_api(**kwargs):
+            observed.update(kwargs)
+            return {
+                "success": True,
+                "job": {
+                    "id": "job-1",
+                    "name": "Watchdog",
+                    "executed": True,
+                    "execution_mode": "detached",
+                    "execution_id": "exec-123",
+                },
+            }
+
+        monkeypatch.setattr(cron_cli, "_cron_api", fake_cron_api)
+
+        rc, out = self._run_cmd(capsys)
+
+        assert rc == 0
+        assert observed["detach_run"] is True
+        assert "Running in detached worker (execution exec-123)." in out
+        assert "Ran now" not in out
+
     def test_background_dispatch_with_delegation_id_does_not_report_failed(
         self, monkeypatch, capsys
     ):

--- a/tests/tools/test_cronjob_run_background.py
+++ b/tests/tools/test_cronjob_run_background.py
@@ -17,6 +17,7 @@ import threading
 from unittest.mock import patch
 
 from tools.cronjob_tools import (
+    _try_dispatch_detached_run,
     _try_dispatch_background_run,
     cronjob,
 )
@@ -195,6 +196,46 @@ class TestSyncFallbacks:
         m_run.assert_called_once()   # ran inline on this thread
 
 
+class TestDetachedCliDispatch:
+    def test_claims_creates_receipt_and_hands_ownership_to_worker(self):
+        claimed = {
+            **_job("job-direct-helper"),
+            "fire_claim": {"by": "direct-owner"},
+        }
+        launch_observed = {}
+
+        def launch(job, **kwargs):
+            launch_observed["job"] = job
+            launch_observed["kwargs"] = kwargs
+            return True
+
+        with patch(
+            "tools.cronjob_tools.claim_job_for_fire", return_value=claimed
+        ) as claim, patch(
+            "cron.executions.create_execution",
+            return_value={"id": "exec-direct-helper"},
+        ) as create, patch(
+            "cron.scheduler._launch_external_cron_worker", side_effect=launch
+        ):
+            result = _try_dispatch_detached_run(
+                _job("job-direct-helper"), extra_prompt="one fire"
+            )
+
+        assert result == {
+            "claimed": True,
+            "dispatched": True,
+            "execution_id": "exec-direct-helper",
+        }
+        claim.assert_called_once_with("job-direct-helper", return_job=True)
+        create.assert_called_once_with("job-direct-helper", source="direct")
+        assert launch_observed["job"]["execution_id"] == "exec-direct-helper"
+        assert launch_observed["kwargs"] == {
+            "detach": True,
+            "allow_unscoped": True,
+            "extra_prompt": "one fire",
+        }
+
+
 class TestInFlightDedupe:
     """Manual runs must not double-fire a job that is already mid-run
     (salvaged from #53395 by @izumi0uu): the fire claim's 300s TTL is
@@ -296,6 +337,30 @@ class TestInFlightDedupe:
 
 
 class TestCronjobRunToolIntegration:
+    def test_direct_cli_detach_returns_durable_execution_receipt(self):
+        detached = {
+            "claimed": True,
+            "dispatched": True,
+            "execution_id": "exec-direct-1",
+        }
+        with patch("tools.cronjob_tools.resolve_job_ref", return_value=_job("job-direct-1")), \
+             patch("tools.cronjob_tools._try_dispatch_detached_run", return_value=detached) as dispatch, \
+             patch("tools.cronjob_tools._try_dispatch_background_run") as background, \
+             patch("tools.cronjob_tools._execute_job_now") as inline, \
+             patch("tools.cronjob_tools.get_job", return_value={
+                 "id": "job-direct-1", "name": "direct run",
+             }):
+            out = json.loads(cronjob(
+                action="run", job_id="job-direct-1", detach_run=True
+            ))
+
+        assert out["success"] is True
+        assert out["job"]["execution_mode"] == "detached"
+        assert out["job"]["execution_id"] == "exec-direct-1"
+        dispatch.assert_called_once()
+        background.assert_not_called()
+        inline.assert_not_called()
+
     def test_run_action_returns_background_note(self):
         """cronjob(action='run') surfaces the handle + do-not-wait note."""
         with _bound_session_key():

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -992,6 +992,96 @@ def _execute_job_now(
     return _run_claimed_job(claimed_job, extra_prompt=extra_prompt)
 
 
+def _try_dispatch_detached_run(
+    job: Dict[str, Any], extra_prompt: Optional[str] = None
+) -> Dict[str, Any]:
+    """Claim a direct CLI run and hand it to a durable child process.
+
+    Unlike the async-delegation path, this worker owns its execution ledger
+    row and does not depend on the foreground CLI process remaining alive.
+    The acknowledgement is published before agent or script side effects
+    begin, so returning the execution id is a durable receipt rather than a
+    terminal outcome claim.
+    """
+    job_id = job["id"]
+    try:
+        from cron.scheduler import get_running_job_ids
+
+        if job_id in get_running_job_ids():
+            return {
+                "claimed": False,
+                "dispatched": False,
+                "error": (
+                    "Job is already running (a scheduler tick or another "
+                    "manual run is executing it); not started again."
+                ),
+            }
+    except Exception:
+        pass
+
+    try:
+        claimed_job = claim_job_for_fire(job_id, return_job=True)
+        if not isinstance(claimed_job, dict):
+            refreshed = get_job(job_id)
+            if refreshed is None:
+                reason = "Job no longer exists; nothing to run."
+            elif not is_job_runnable(refreshed):
+                reason = "Job is paused/disabled; resume it before running."
+            else:
+                reason = "Job is already being fired by the scheduler; not run again."
+            return {
+                "claimed": False,
+                "dispatched": False,
+                "error": reason,
+            }
+
+        from cron.executions import create_execution, finish_execution
+        from cron.scheduler import _launch_external_cron_worker
+
+        execution = create_execution(job_id, source="direct")
+        execution_id = str(execution["id"])
+        claimed_job["execution_id"] = execution_id
+        if not _launch_external_cron_worker(
+            claimed_job, detach=True, allow_unscoped=True,
+            extra_prompt=extra_prompt,
+        ):
+            raise RuntimeError("detached cron worker was not launched")
+        return {
+            "claimed": True,
+            "dispatched": True,
+            "execution_id": execution_id,
+        }
+    except Exception as exc:
+        logger.error("Failed to dispatch cron job %s durably: %s", job_id, exc)
+        execution_id = locals().get("execution_id")
+        if execution_id:
+            try:
+                terminal = finish_execution(
+                    execution_id, success=False, error=str(exc)
+                )
+            except Exception:
+                terminal = None
+            if terminal is None:
+                # Ownership may already have transferred. Its ledger row is the
+                # authority; never clear the fire claim and risk a duplicate.
+                return {
+                    "claimed": True,
+                    "dispatched": True,
+                    "execution_id": execution_id,
+                    "warning": str(exc),
+                }
+        try:
+            mark_job_run(job_id, False, str(exc))
+        except Exception:
+            pass
+        return {
+            "claimed": True,
+            "dispatched": False,
+            "success": False,
+            "error": str(exc),
+        }
+
+
 def _run_claimed_job(
     job: Dict[str, Any], extra_prompt: Optional[str] = None
 ) -> Dict[str, Any]:
@@ -1533,6 +1623,7 @@ def cronjob(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
+    detach_run: bool = False,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1787,20 +1878,30 @@ def cronjob(
             # batches of manual runs (#80xxx — the "stuck Telegram session"
             # incident). Falls back to inline execution when the session
             # runtime can't receive detached completions.
-            bg = _try_dispatch_background_run(
-                job, session_id=session_id, extra_prompt=extra_prompt
-            )
+            if detach_run:
+                bg = _try_dispatch_detached_run(job, extra_prompt=extra_prompt)
+            else:
+                bg = _try_dispatch_background_run(
+                    job, session_id=session_id, extra_prompt=extra_prompt
+                )
             if bg is not None and bg.get("dispatched"):
                 _notify_provider_jobs_changed_safe()
                 result = _format_job(get_job(job_id) or {"id": job_id})
                 result["executed"] = True
-                result["execution_mode"] = "background"
-                result["delegation_id"] = bg.get("delegation_id")
+                if detach_run:
+                    result["execution_mode"] = "detached"
+                    result["execution_id"] = bg.get("execution_id")
+                else:
+                    result["execution_mode"] = "background"
+                    result["delegation_id"] = bg.get("delegation_id")
                 return json.dumps(
                     {
                         "success": True,
                         "job": result,
                         "note": (
+                            "The job is running in a detached worker. Track its "
+                            "durable execution receipt with `hermes cron runs`."
+                            if detach_run else
                             "The job is running in the background. You and the "
                             "user can keep working; its outcome re-enters the "
                             "conversation as a new message when it finishes. "

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1879,6 +1879,14 @@ def cronjob(
             # incident). Falls back to inline execution when the session
             # runtime can't receive detached completions.
             if detach_run:
+                # Relay-fronted platforms can only deliver through the live
+                # gateway adapter. Preserve that transport before choosing a
+                # standalone worker, which intentionally has no adapters.
+                forwarded = _forward_relay_fronted_run(
+                    job, extra_prompt=extra_prompt
+                )
+                if forwarded is not None:
+                    return forwarded
                 bg = _try_dispatch_detached_run(job, extra_prompt=extra_prompt)
             else:
                 bg = _try_dispatch_background_run(


### PR DESCRIPTION
## What does this PR do?

`hermes cron run <job_id>` now transfers a direct manual run to a detached worker and returns its durable execution ID before long agent work begins. Killing or timing out the foreground CLI therefore no longer kills the execution owner and turns an otherwise healthy run into an unknown outcome.

### Symptom

A long agent-backed direct run remains owned by the foreground CLI process. If that caller times out, the next scheduler recovery marks the execution `unknown` even though side effects may already have occurred.

### Impact

Operators cannot safely retry an `unknown` attempt because the agent may already have written files or delivered messages. The execution also loses an authoritative terminal outcome solely because the invoking shell stopped waiting.

### Bug Cause

**Trigger:** `hermes_cli/cron.py:_job_action` forced direct runs through the synchronous fallback in `tools/cronjob_tools.py`.

**Causal chain:**
1. `hermes cron run` disabled async delivery and called `_execute_job_now` inline.
2. `run_one_job` created a ledger row owned by the foreground CLI PID and performed the full agent run in that process.
3. A caller timeout terminated that owner before `finish_execution`, so dead-owner recovery could only record `unknown`.

**Why it is wrong:** A potentially hours-long autonomous execution must not inherit the lifetime of the shell waiting for the command response.

**Working sibling / contrast:** Managed gateway runs already transfer execution ownership to an external worker before side effects begin. This change reuses that fenced handoff for direct CLI runs without requiring a systemd scope.

**Ruled out:** The execution ledger's dead-owner recovery is not the defect; `unknown` is the correct result after a genuine worker crash. The defect was assigning the foreground caller as the long-lived worker owner.

### Fix

- Add a direct-CLI dispatch path that claims the job, creates the execution row, transfers ownership to a detached worker, and returns after the worker acknowledges adoption.
- Return and print the durable execution ID so `hermes cron runs` can track the attempt.
- Preserve transient per-run prompt context across the worker handoff.
- Use the existing cross-platform detached subprocess policy so the worker survives terminal closure on macOS, Linux, and Windows.

## Related Issue

Closes #102511

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/cron.py` - request detached execution for direct CLI runs and print the execution receipt.
- `tools/cronjob_tools.py` - claim and dispatch direct runs without binding them to the CLI lifetime.
- `cron/scheduler.py` - support acknowledged, unscoped detached worker handoff and preserve transient prompts.
- `tests/cron/test_restart_safe_worker.py` - verify detached handoff returns before terminal completion.
- `tests/hermes_cli/test_cron.py` - verify CLI dispatch and receipt output.
- `tests/tools/test_cronjob_run_background.py` - verify claim, execution creation, ownership handoff, and result shape.

## How to Test

1. Create an agent-backed cron job whose work lasts longer than the invoking shell's timeout.
2. Run `hermes cron run <job_id>` and confirm it immediately prints an execution ID.
3. Terminate the invoking shell, then use `hermes cron runs <job_id>` to confirm the detached attempt reaches its authoritative terminal state.
4. Run the automated regression suite:

```bash
scripts/run_tests.sh tests/cron/test_restart_safe_worker.py tests/tools/test_cronjob_run_background.py tests/hermes_cli/test_cron.py -q
```

Result: 61 passed, 2 platform-marked tests skipped on Windows.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test wrapper on the relevant tests and all targeted tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the CLI output and implementation docstrings describe the new receipt behavior
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no contributor workflow changed
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] Tool schema update is N/A; the model-facing `cronjob` behavior is unchanged

## Screenshots / Logs

N/A; automated tests cover the execution handoff and CLI receipt.
