### PR TITLE
fix(desktop): preserve spaces in MEDIA file paths

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -835,8 +835,8 @@ def hud_surface_note(valid_tool_names: "set[str] | None" = None) -> str:
 DEVELOPER_ROLE_MODELS = ("gpt-5", "codex")
 
 _MEDIA_NATIVE = (
-    "You can send files natively: write MEDIA:/absolute/path/to/file in "
-    "your response. "
+    "You can send files natively: put each MEDIA:/absolute/path/to/file "
+    "directive on its own line, with no prose after the path. "
 )
 
 _LOCAL_CRON_DELIVERY_NOTE = (
@@ -962,7 +962,8 @@ PLATFORM_HINTS = {
         "You are chatting inside the Hermes desktop app, a graphical chat "
         "surface. Markdown renders with full GitHub flavor (tables, "
         "syntax-highlighted code, math via $...$, task lists, callouts). "
-        "Deliver files by writing MEDIA:/absolute/path/to/file — any file "
+        "Deliver files by putting each MEDIA:/absolute/path/to/file directive "
+        "on its own line with no prose after the path — any file "
         "type: images/audio/video render inline, everything else becomes a "
         "card with Download and preview buttons. Remote image URLs render "
         "via ![alt](url); local files ONLY via MEDIA: (local markdown "

--- a/apps/desktop/e2e/media-path-preview.spec.ts
+++ b/apps/desktop/e2e/media-path-preview.spec.ts
@@ -1,0 +1,77 @@
+import * as fs from 'node:fs'
+import * as os from 'node:os'
+import * as path from 'node:path'
+
+import { type MockBackendFixture, setupMockBackend, waitForAppReady } from './fixtures'
+import { expect, test } from './test'
+
+const EXPECTED_HEADING = 'Monark I13+ Time Thesis Deep Research Plan'
+const PROMPT = 'Return the configured MEDIA attachment.'
+
+let fixture: MockBackendFixture | null = null
+let generatedRoot: string | null = null
+let targetPath = ''
+
+test.beforeAll(async () => {
+  const requested = process.env.HERMES_MEDIA_E2E_PATH?.trim()
+
+  if (requested) {
+    if (!path.isAbsolute(requested) || !fs.statSync(requested).isFile()) {
+      throw new Error(`HERMES_MEDIA_E2E_PATH must name an existing absolute file: ${requested}`)
+    }
+
+    targetPath = requested
+  } else {
+    generatedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'Hermes Projects-media-preview-'))
+    targetPath = path.join(
+      generatedRoot,
+      'Monark-Inc',
+      'Bank-Charter',
+      '.hermes',
+      'plans',
+      '2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md'
+    )
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true })
+    fs.writeFileSync(targetPath, `# ${EXPECTED_HEADING}\n\nExact-path E2E fixture.\n`, 'utf8')
+  }
+
+  fixture = await setupMockBackend({ mockServer: { reply: `MEDIA:${targetPath}` } })
+  await waitForAppReady(fixture)
+})
+
+test.afterAll(async () => {
+  await fixture?.cleanup()
+  fixture = null
+
+  if (generatedRoot) {
+    fs.rmSync(generatedRoot, { force: true, recursive: true })
+    generatedRoot = null
+  }
+})
+
+test('streams a spaced MEDIA path into the file card and opens the markdown preview', async () => {
+  const page = fixture!.page
+  const composer = page.locator('[contenteditable="true"]').first()
+
+  await composer.waitFor({ state: 'visible', timeout: 15_000 })
+  await composer.click()
+  await composer.fill(PROMPT)
+  await page.keyboard.press('Enter')
+
+  const filename = path.basename(targetPath)
+  const fileCardName = page.getByText(filename, { exact: true }).first()
+
+  await fileCardName.waitFor({ state: 'visible', timeout: 60_000 })
+  await expect(page.getByRole('button', { name: 'Download' }).last()).toBeVisible()
+
+  const openPreview = page.getByRole('button', { name: 'Open preview' }).last()
+
+  await expect(openPreview).toBeVisible()
+  await openPreview.click()
+
+  const rightRail = page.getByRole('complementary').last()
+
+  await expect(rightRail).toBeVisible()
+  await expect(rightRail.getByText(EXPECTED_HEADING, { exact: true })).toBeVisible({ timeout: 30_000 })
+  await expect(page.getByRole('button', { name: 'Hide' }).last()).toBeVisible()
+})

--- a/apps/desktop/e2e/mock-server.ts
+++ b/apps/desktop/e2e/mock-server.ts
@@ -24,6 +24,8 @@ import nodePath from 'node:path'
 export const MOCK_REPLY = 'Hello from the mock inference server! The full boot chain is working.'
 
 export interface MockServerOptions {
+  /** Override the ordinary final reply for a focused renderer E2E scenario. */
+  reply?: string
   /** Pause the matching stream after its first token for session-switch E2E coverage. */
   holdFirstStreamForPrompt?: string
 /** Pause the first completion whose request JSON contains this text. */
@@ -396,6 +398,7 @@ function includesBlockingClarifyTrigger(value: unknown): boolean {
  */
 export function startMockServer(options: MockServerOptions = {}): Promise<MockServer> {
   return new Promise((resolve, reject) => {
+    const reply = options.reply ?? MOCK_REPLY
     const receivedPrompts: string[] = []
     let resolveHeldStreamStarted: (() => void) | null = null
     let releaseHeldStream: (() => void) | null = null
@@ -620,7 +623,7 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
               options.holdFirstStreamForPrompt && typeof lastUserMessage?.content === 'string' &&
                 lastUserMessage.content.includes(options.holdFirstStreamForPrompt),
             )
-            streamTextResponse(res, model, MOCK_REPLY, holdThisStream || holdThisCompletion ? () => {
+            streamTextResponse(res, model, reply, holdThisStream || holdThisCompletion ? () => {
               if (holdThisCompletion) {
                 heldCompletionCount++
               }
@@ -631,9 +634,9 @@ export function startMockServer(options: MockServerOptions = {}): Promise<MockSe
             if (holdThisCompletion) {
               heldCompletionCount++
               resolveHeldStreamStarted?.()
-              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, MOCK_REPLY))
+              void heldStreamReleased.then(() => nonStreamingTextResponse(res, model, reply))
             } else {
-              nonStreamingTextResponse(res, model, MOCK_REPLY)
+              nonStreamingTextResponse(res, model, reply)
             }
           }
         })

--- a/apps/desktop/electron/hardening.test.ts
+++ b/apps/desktop/electron/hardening.test.ts
@@ -728,6 +728,26 @@ test('resolveRequestedPathForIpc expands ~ to the home directory', () => {
   )
 })
 
+test.skipIf(process.platform !== 'win32')(
+  'resolveRequestedPathForIpc round-trips the spaced Windows file URL emitted by MEDIA links',
+  () => {
+    const nativePath = 'C:\\Users\\ADMIN\\OneDrive\\Priv - Hermes Projects\\exports\\final report.pdf'
+    const rendererUrl = 'file:///C:/Users/ADMIN/OneDrive/Priv%20-%20Hermes%20Projects/exports/final%20report.pdf'
+
+    assert.equal(resolveRequestedPathForIpc(rendererUrl, { purpose: 'Open external file' }), nativePath)
+  }
+)
+
+test.skipIf(process.platform !== 'win32')(
+  'resolveRequestedPathForIpc round-trips a spaced UNC file URL emitted by MEDIA links',
+  () => {
+    assert.equal(
+      resolveRequestedPathForIpc('file://server/Shared%20Files/report.pdf', { purpose: 'Open external file' }),
+      '\\\\server\\Shared Files\\report.pdf'
+    )
+  }
+)
+
 test('resolveReadableFileForIpc validates existence type size and sensitivity', async () => {
   const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'hermes-desktop-hardening-'))
 

--- a/apps/desktop/src/app/artifacts/artifact-utils.ts
+++ b/apps/desktop/src/app/artifacts/artifact-utils.ts
@@ -1,3 +1,4 @@
+import { mediaPathsFromText } from '@/lib/chat-messages'
 import { mediaExternalUrl, resolveMediaDisplaySrc } from '@/lib/media'
 import type { SessionInfo, SessionMessage } from '@/types/hermes'
 
@@ -28,7 +29,6 @@ export interface ArtifactLoadResult {
 
 const MARKDOWN_IMAGE_RE = /!\[([^\]]*)\]\(([^)\s]+)\)/g
 const MARKDOWN_LINK_RE = /\[([^\]]+)\]\(([^)\s]+)\)/g
-const MEDIA_RE = /[`"']?MEDIA:\s*(`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 const URL_RE = /https?:\/\/[^\s<>"')]+/g
 const PATH_RE = /(^|[\s("'`])((?:\/|~\/|\.\.?\/)[^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
 const WINDOWS_PATH_RE = /(^|[\s("'`])([A-Za-z]:[\\/][^\s"'`<>]+(?:\.[a-z0-9]{1,8})?)/gi
@@ -71,10 +71,12 @@ function unquoteMediaValue(value: string): string {
   return trimmed
 }
 
+function mediaValuesFromText(text: string): string[] {
+  return mediaPathsFromText(text).map(unquoteMediaValue)
+}
+
 function collectMediaValues(text: string, pushValue: (value: string) => void): void {
-  for (const match of text.matchAll(MEDIA_RE)) {
-    pushValue(unquoteMediaValue(match[1] || ''))
-  }
+  mediaValuesFromText(text).forEach(pushValue)
 }
 
 function parseMaybeJson(value: string): unknown {
@@ -268,17 +270,50 @@ function collectStringValues(
   }
 }
 
-function collectArtifactsFromText(text: string, pushValue: (value: string) => void): void {
-  collectMediaValues(text, pushValue)
+function maskMediaValueOccurrences(text: string, mediaValues: string[]): string {
+  // Keep source offsets stable for the generic scanners below, but mutate one
+  // code-unit array instead of rebuilding the entire string for every MEDIA
+  // value. The old repeated slice/concatenate loop was quadratic on histories
+  // containing many attachments.
+  const masked = text.split('')
+  let cursor = 0
 
-  for (const match of text.matchAll(MARKDOWN_IMAGE_RE)) {
+  for (const value of mediaValues) {
+    const marker = text.indexOf('MEDIA:', cursor)
+
+    if (marker < 0) {
+      break
+    }
+
+    const start = text.indexOf(value, marker + 'MEDIA:'.length)
+
+    if (start < 0) {
+      cursor = marker + 'MEDIA:'.length
+
+      continue
+    }
+
+    masked.fill(' ', start, start + value.length)
+    cursor = start + value.length
+  }
+
+  return masked.join('')
+}
+
+function collectArtifactsFromText(text: string, pushValue: (value: string) => void): void {
+  const mediaValues = mediaValuesFromText(text)
+  const genericText = maskMediaValueOccurrences(text, mediaValues)
+
+  mediaValues.forEach(pushValue)
+
+  for (const match of genericText.matchAll(MARKDOWN_IMAGE_RE)) {
     pushValue(match[2] || '')
   }
 
-  for (const match of text.matchAll(MARKDOWN_LINK_RE)) {
+  for (const match of genericText.matchAll(MARKDOWN_LINK_RE)) {
     const start = match.index ?? 0
 
-    if (start > 0 && text[start - 1] === '!') {
+    if (start > 0 && genericText[start - 1] === '!') {
       continue
     }
 
@@ -289,7 +324,7 @@ function collectArtifactsFromText(text: string, pushValue: (value: string) => vo
     }
   }
 
-  for (const match of text.matchAll(URL_RE)) {
+  for (const match of genericText.matchAll(URL_RE)) {
     const value = match[0] || ''
 
     if (looksLikeArtifact(value)) {
@@ -297,11 +332,11 @@ function collectArtifactsFromText(text: string, pushValue: (value: string) => vo
     }
   }
 
-  for (const match of text.matchAll(PATH_RE)) {
+  for (const match of genericText.matchAll(PATH_RE)) {
     pushValue(match[2] || '')
   }
 
-  for (const match of text.matchAll(WINDOWS_PATH_RE)) {
+  for (const match of genericText.matchAll(WINDOWS_PATH_RE)) {
     pushValue(match[2] || '')
   }
 }

--- a/apps/desktop/src/app/artifacts/index.test.ts
+++ b/apps/desktop/src/app/artifacts/index.test.ts
@@ -251,6 +251,101 @@ ${payload}
     ])
   })
 
+  it.each([
+    ['MEDIA: /tmp/foo.txt bar.pdf', '/tmp/foo.txt bar.pdf'],
+    ['MEDIA: "/tmp/foo.txt bar.pdf"', '/tmp/foo.txt bar.pdf'],
+    ['MEDIA: C:\\Shared Files\\report.pdf', 'C:\\Shared Files\\report.pdf'],
+    ['MEDIA: \\\\server\\Shared Files\\report.pdf', '\\\\server\\Shared Files\\report.pdf']
+  ])('does not index a contained partial path beside a recognized MEDIA path: %s', (content, path) => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      { content, role: 'assistant', timestamp: 1_781_774_000 }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([path])
+  })
+
+  it('keeps a shorter path when it is mentioned separately from the MEDIA value', () => {
+    const mediaPath = '/tmp/foo.txt bar.pdf'
+    const separatePath = '/tmp/foo.txt'
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: `MEDIA: ${mediaPath}\nAlso keep ${separatePath}`,
+        role: 'assistant',
+        timestamp: 1_781_774_000
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([mediaPath, separatePath])
+  })
+
+  it('keeps both prose-prefixed consecutive MEDIA paths intact', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: 'Files: MEDIA:/tmp/a one.png MEDIA:/tmp/b two.png',
+        role: 'assistant',
+        timestamp: 1_781_774_000
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual(['/tmp/a one.png', '/tmp/b two.png'])
+  })
+
+  it('keeps a standalone streamed-style MEDIA path with spaces as one artifact', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: `ready\nMEDIA:${path}`,
+        role: 'assistant',
+        timestamp: 1_781_774_004
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([path])
+  })
+
+  it('indexes the complete Hermes Projects markdown path once without a truncated prefix', () => {
+    const path =
+      '/Users/test/Documents/Hermes Projects/Monark-Inc/Bank-Charter/.hermes/plans/2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md'
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: `MEDIA:${path}`,
+        role: 'assistant',
+        timestamp: 1_781_774_004
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([path])
+  })
+
+  it('keeps prose outside a quote around a delivered MEDIA directive', () => {
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: '"MEDIA:/tmp/generated/final report.pdf" is ready',
+        role: 'assistant',
+        timestamp: 1_781_774_005
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual(['/tmp/generated/final report.pdf'])
+  })
+
+  it('keeps spaces in a standalone unquoted MEDIA file URL', () => {
+    const path = 'file:///C:/Program Files/final report.pdf'
+
+    const artifacts = collectArtifactsForSession(makeSession(), [
+      {
+        content: `MEDIA:${path}`,
+        role: 'assistant',
+        timestamp: 1_781_774_006
+      }
+    ])
+
+    expect(artifacts.map(artifact => artifact.value)).toEqual([path])
+  })
+
   it('normalizes epoch-second message timestamps', () => {
     const artifacts = collectArtifactsForSession(makeSession(), [
       {

--- a/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.media.test.tsx
@@ -1,7 +1,9 @@
-import { cleanup, render, screen, waitFor } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
-import { $connection } from '@/store/session'
+import { renderMediaTags } from '@/lib/chat-messages'
+import { $previewTarget, closeRightRail } from '@/store/preview'
+import { $connection, $currentCwd } from '@/store/session'
 
 import { MarkdownImage, MarkdownTextContent } from './markdown-text'
 
@@ -77,5 +79,62 @@ describe('MarkdownImage media routing', () => {
 
     expect(container.querySelector('video')).toBeNull()
     expect(container.querySelector('audio')).toBeNull()
+  })
+})
+
+describe('MarkdownTextContent local files', () => {
+  const normalizePreviewTarget = vi.fn(async (target: string) => ({
+    kind: 'file' as const,
+    label: target.split(/[\\/]/).pop() || target,
+    language: 'markdown',
+    path: target,
+    previewKind: 'text' as const,
+    source: target,
+    url: `file://${target.split('/').map(encodeURIComponent).join('/')}`
+  }))
+
+  let originalDesktop: typeof window.hermesDesktop
+
+  beforeEach(() => {
+    normalizePreviewTarget.mockClear()
+    originalDesktop = window.hermesDesktop
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: { normalizePreviewTarget }
+    })
+    $connection.set({ mode: 'local', profile: 'default' } as never)
+    $currentCwd.set('/Users/test/Documents/Hermes Projects/Monark-Inc/Bank-Charter')
+    closeRightRail()
+  })
+
+  afterEach(() => {
+    cleanup()
+    closeRightRail()
+    $connection.set(null)
+    $currentCwd.set('')
+    Object.defineProperty(window, 'hermesDesktop', {
+      configurable: true,
+      value: originalDesktop
+    })
+  })
+
+  it('opens the complete unquoted Markdown MEDIA path in PreviewAttachment when it contains spaces', async () => {
+    const path =
+      '/Users/test/Documents/Hermes Projects/Monark-Inc/Bank-Charter/.hermes/plans/2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md'
+
+    render(<MarkdownTextContent isRunning={false} text={renderMediaTags(`MEDIA:${path}`)} />)
+
+    expect(await screen.findByText('2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md')).toBeTruthy()
+    expect(screen.getByRole('button', { name: 'Download' })).toBeTruthy()
+    const openPreview = screen.getByRole('button', { name: 'Open preview' })
+
+    expect(normalizePreviewTarget).not.toHaveBeenCalled()
+    fireEvent.click(openPreview)
+    await waitFor(() => expect($previewTarget.get()?.path).toBe(path))
+    expect(normalizePreviewTarget).toHaveBeenCalledOnce()
+    expect(normalizePreviewTarget).toHaveBeenCalledWith(
+      path,
+      '/Users/test/Documents/Hermes Projects/Monark-Inc/Bank-Charter'
+    )
   })
 })

--- a/apps/desktop/src/lib/chat-messages.test.ts
+++ b/apps/desktop/src/lib/chat-messages.test.ts
@@ -9,6 +9,7 @@ import {
   chatMessageText,
   collectUnspokenTurnSpeech,
   completeOpenTimelineParts,
+  mediaPathsFromText,
   mergeFinalAssistantText,
   preserveLocalAssistantErrors,
   reasoningPart,
@@ -471,11 +472,359 @@ describe('renderMediaTags', () => {
     expect(renderMediaTags('MEDIA:/tmp/demo.mp4')).toBe('[Video: demo.mp4](#media:%2Ftmp%2Fdemo.mp4)')
   })
 
+  it('keeps spaces in a standalone unquoted Windows MEDIA path', () => {
+    const path =
+      'C:\\Users\\ADMIN\\OneDrive\\Priv - Hermes Projects\\Person-researcher\\exports\\dos-20260724-olle-bergstedt.pdf'
+
+    expect(renderMediaTags(`MEDIA:${path}`)).toBe(
+      `[File: dos-20260724-olle-bergstedt.pdf](#media:${encodeURIComponent(path)})`
+    )
+  })
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n']
+  ])('keeps spaces in consecutive standalone MEDIA paths with %s line endings', (_label, newline) => {
+    const firstPath = 'C:\\Users\\ADMIN\\My Files\\first report.pdf'
+    const secondPath = '\\\\server\\Shared Files\\second report.pdf'
+
+    expect(renderMediaTags(`MEDIA:${firstPath}${newline}MEDIA:${secondPath}`)).toBe(
+      `[File: first report.pdf](#media:${encodeURIComponent(firstPath)})${newline}` +
+        `[File: second report.pdf](#media:${encodeURIComponent(secondPath)})`
+    )
+  })
+
+  it.each([
+    ['LF', '\n'],
+    ['CRLF', '\r\n']
+  ])('does not consume the following line when a MEDIA path is blank with %s', (_label, newline) => {
+    expect(renderMediaTags(`before${newline}MEDIA:   ${newline}not-a-path`)).toBe(
+      `before${newline}MEDIA:${newline}not-a-path`
+    )
+  })
+
+  it('leaves ordinary standalone MEDIA prose unchanged', () => {
+    expect(renderMediaTags('before\nMEDIA: the report is ready\nafter')).toBe(
+      'before\nMEDIA: the report is ready\nafter'
+    )
+  })
+
+  it.each(['MEDIA: note', 'MEDIA: /tmp is the default directory', 'This paragraph says MEDIA: coverage matters'])(
+    'leaves pathless MEDIA prose unchanged: %s',
+    source => {
+      expect(renderMediaTags(source)).toBe(source)
+      expect(mediaPathsFromText(source)).toEqual([])
+    }
+  )
+
+  it('keeps a line-leading inline MEDIA tag separate from trailing prose', () => {
+    expect(renderMediaTags('MEDIA:/tmp/voice.mp3 done')).toBe('[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3) done')
+  })
+
+  it('keeps a spaced standalone path separate from trailing prose', () => {
+    expect(renderMediaTags('MEDIA:/tmp/final report.pdf is ready')).toBe(
+      '[File: final report.pdf](#media:%2Ftmp%2Ffinal%20report.pdf) is ready'
+    )
+  })
+
+  it('keeps a quoted standalone path separate from trailing prose through final reconciliation', () => {
+    const source = 'MEDIA:"/tmp/final report.pdf" is ready'
+    const expected = '[File: final report.pdf](#media:%2Ftmp%2Ffinal%20report.pdf) is ready'
+    const streamed = appendAssistantTextPart([], source, 1)
+
+    expect(renderMediaTags(source)).toBe(expected)
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: streamed })).toBe(expected)
+
+    const settled = mergeFinalAssistantText(streamed, source, 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: settled })).toBe(expected)
+  })
+
+  it('keeps an extensionless inline MEDIA URL separate from trailing prose', () => {
+    expect(renderMediaTags('MEDIA:https://example.com/download done')).toBe(
+      '[File: download](#media:https%3A%2F%2Fexample.com%2Fdownload) done'
+    )
+  })
+
+  it('keeps spaces in a standalone unquoted file URL', () => {
+    const path = 'file:///C:/Program Files/final report.pdf'
+    const source = `MEDIA:${path}`
+    const expected = `[File: final report.pdf](#media:${encodeURIComponent(path)})`
+    const streamed = appendAssistantTextPart([], source, 1)
+
+    expect(renderMediaTags(source)).toBe(expected)
+    expect(mediaPathsFromText(source)).toEqual([path])
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: streamed })).toBe(expected)
+  })
+
+  it('renders consecutive inline MEDIA tags at the start of a line independently', () => {
+    expect(renderMediaTags('MEDIA:/tmp/a.png MEDIA:/tmp/b.png')).toBe(
+      '[Image: a.png](#media:%2Ftmp%2Fa.png) [Image: b.png](#media:%2Ftmp%2Fb.png)'
+    )
+  })
+
+  it('keeps spaces in consecutive standalone MEDIA paths', () => {
+    const source = 'MEDIA:/tmp/a one.png MEDIA:/tmp/b two.png'
+
+    expect(renderMediaTags(source)).toBe(
+      '[Image: a one.png](#media:%2Ftmp%2Fa%20one.png) [Image: b two.png](#media:%2Ftmp%2Fb%20two.png)'
+    )
+    expect(mediaPathsFromText(source)).toEqual(['/tmp/a one.png', '/tmp/b two.png'])
+  })
+
+  it('keeps spaces in prose-prefixed consecutive MEDIA paths across every split point', () => {
+    const source = 'Files: MEDIA:/tmp/a one.png MEDIA:/tmp/b two.png'
+
+    const expected =
+      'Files: [Image: a one.png](#media:%2Ftmp%2Fa%20one.png) [Image: b two.png](#media:%2Ftmp%2Fb%20two.png)\n'
+
+    expect(renderMediaTags(`${source}\n`)).toBe(expected)
+    expect(mediaPathsFromText(`${source}\n`)).toEqual(['/tmp/a one.png', '/tmp/b two.png'])
+
+    for (let split = 1; split < source.length; split += 1) {
+      let parts = appendAssistantTextPart([], source.slice(0, split), 1)
+
+      parts = appendAssistantTextPart(parts, `${source.slice(split)}\n`, 2)
+      expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(expected)
+    }
+  })
+
+  it.each(['', 'files: '])('keeps the final consecutive MEDIA path provisional while streaming: %s', prefix => {
+    let parts = appendAssistantTextPart([], `${prefix}MEDIA:/tmp/a.png MEDIA:/tmp/b`, 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, '.png\n', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      `${prefix}[Image: a.png](#media:%2Ftmp%2Fa.png) [Image: b.png](#media:%2Ftmp%2Fb.png)\n`
+    )
+  })
+
+  it('keeps a consecutive sequence provisional when a chunk ends immediately after the next marker', () => {
+    let parts = appendAssistantTextPart([], 'MEDIA:/tmp/a one.png MEDIA:', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource', 'MEDIA:/tmp/a one.png MEDIA:')
+    parts = appendAssistantTextPart(parts, '/tmp/b two.png\n', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[Image: a one.png](#media:%2Ftmp%2Fa%20one.png) [Image: b two.png](#media:%2Ftmp%2Fb%20two.png)\n'
+    )
+  })
+
+  it.each(['MEDIA:/tmp/a one.png MEDIA:\n', 'MEDIA:/tmp/a one.png MEDIA: coverage matters\n'])(
+    'leaves an ambiguous consecutive MEDIA sequence unchanged: %s',
+    source => {
+      expect(renderMediaTags(source)).toBe(source)
+      expect(mediaPathsFromText(source)).toEqual([])
+    }
+  )
+
+  it('handles a long malformed consecutive MEDIA line without quadratic reparsing', () => {
+    const source = `${Array.from({ length: 4_000 }, (_, index) => `MEDIA:/tmp/${index}.png`).join(' ')} MEDIA: coverage`
+    const startedAt = performance.now()
+
+    expect(renderMediaTags(source)).toBe(source)
+    expect(performance.now() - startedAt).toBeLessThan(750)
+  })
+
+  it('rejects a long whitespace-only MEDIA line without quadratic backtracking', () => {
+    const source = `MEDIA:${' '.repeat(32_000)}`
+    const startedAt = performance.now()
+
+    expect(renderMediaTags(source)).toBe(source)
+    expect(performance.now() - startedAt).toBeLessThan(250)
+  })
+
+  it.each([
+    ['/tmp/foo.txt bar.pdf', 'foo.txt bar.pdf'],
+    ['/Users/me/v1.0 Final/report.md', 'report.md']
+  ])('does not truncate an unquoted path after an extension-like component: %s', (path, label) => {
+    expect(renderMediaTags(`MEDIA:${path}`)).toBe(`[File: ${label}](#media:${encodeURIComponent(path)})`)
+  })
+
+  it('does not finalize an extension-like directory while the path is streaming', () => {
+    let parts = appendAssistantTextPart([], 'MEDIA:/Users/me/v1.0 Final/re', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource', 'MEDIA:/Users/me/v1.0 Final/re')
+    parts = appendAssistantTextPart(parts, 'port.md', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: report.md](#media:%2FUsers%2Fme%2Fv1.0%20Final%2Freport.md)'
+    )
+  })
+
+  it.each(['`', '"', "'"])('keeps spaces in a standalone path quoted with %s', quote => {
+    const path = 'reports/the final report.pdf'
+
+    expect(renderMediaTags(`MEDIA:${quote}${path}${quote}`)).toBe(
+      `[File: the final report.pdf](#media:${encodeURIComponent(path)})`
+    )
+  })
+
   it('renders streamed assistant media once the tag is complete', () => {
     const parts = appendAssistantTextPart(appendAssistantTextPart([], 'ok\nMEDIA:'), '/tmp/voice.mp3')
     const text = chatMessageText({ id: 'a', role: 'assistant', parts })
 
     expect(text).toBe('ok\n[Audio: voice.mp3](#media:%2Ftmp%2Fvoice.mp3)')
+  })
+
+  it('does not freeze a streamed path before later space-separated chunks arrive', () => {
+    const path = '/Users/zora/Documents/ZORA/hermes/operations/B17-B Value Extraction and Retirement Receipt.md'
+    let parts = appendAssistantTextPart([], 'ready\nMEDIA:/Users/zora/Documents/ZORA/hermes/operations/B17-B', 10.125)
+
+    parts = appendAssistantTextPart(parts, ' Value Ex', 10.5)
+    parts = appendAssistantTextPart(parts, 'traction and Retirement Receipt.md\n', 11)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      `ready\n[File: B17-B Value Extraction and Retirement Receipt.md](#media:${encodeURIComponent(path)})\n`
+    )
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ timestamp: 10.125, type: 'text' })
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+  })
+
+  it('preserves the complete Hermes Projects markdown path across every streaming split point', () => {
+    const path =
+      '/Users/test/Documents/Hermes Projects/Monark-Inc/Bank-Charter/.hermes/plans/2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md'
+
+    const source = `MEDIA:${path}`
+    const expected = `[File: 2026-09-03_204030-monark-i13-plus-time-thesis-deep-research.md](#media:${encodeURIComponent(path)})\n`
+
+    expect(renderMediaTags(source)).toBe(expected.trimEnd())
+    expect(mediaPathsFromText(source)).toEqual([path])
+
+    for (let split = 1; split < source.length; split += 1) {
+      let parts = appendAssistantTextPart([], source.slice(0, split), 1)
+
+      parts = appendAssistantTextPart(parts, `${source.slice(split)}\n`, 2)
+      expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(expected)
+      expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    }
+  })
+
+  it('does not reinterpret a legitimate trailing media link when more text streams in', () => {
+    const link = '[File: report.md](#media:%2Ftmp%2Freport.md)'
+    let parts = appendAssistantTextPart([], link, 1)
+
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(`${link} continued`)
+    expect(parts).toHaveLength(1)
+    expect(parts[0]).toMatchObject({ timestamp: 1, type: 'text' })
+  })
+
+  it('treats a closing quote as the end of a streamed standalone MEDIA path', () => {
+    let parts = appendAssistantTextPart([], 'MEDIA:"/tmp/the report.pdf"', 1)
+
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) continued'
+    )
+  })
+
+  it('treats a quote around the whole streamed MEDIA directive as closed', () => {
+    let parts = appendAssistantTextPart([], '"MEDIA:/tmp/the report.pdf"', 1)
+
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, ' continued', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) continued'
+    )
+  })
+
+  it('keeps prose outside a quote around the whole MEDIA directive', () => {
+    const source = '"MEDIA:/tmp/the report.pdf" is ready'
+    const expected = '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) is ready'
+    const streamed = appendAssistantTextPart([], source, 1)
+
+    expect(renderMediaTags(source)).toBe(expected)
+    expect(mediaPathsFromText(source)).toEqual(['/tmp/the report.pdf'])
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: streamed })).toBe(expected)
+
+    const settled = mergeFinalAssistantText(streamed, source, 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts: settled })).toBe(expected)
+  })
+
+  it('preserves the separator when prose streams after a whole-directive quote', () => {
+    let parts = appendAssistantTextPart([], '"MEDIA:/tmp/the report.pdf" ', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    parts = appendAssistantTextPart(parts, 'is ready\n', 2)
+
+    expect(chatMessageText({ id: 'a', role: 'assistant', parts })).toBe(
+      '[File: the report.pdf](#media:%2Ftmp%2Fthe%20report.pdf) is ready\n'
+    )
+  })
+
+  it('does not carry provisional MEDIA state across a reasoning boundary', () => {
+    let parts: ChatMessagePart[] = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource', 'MEDIA:/tmp/partial')
+    parts = appendReasoningPart(parts, 'thinking', 2)
+    parts = appendAssistantTextPart(parts, ' filename.pdf', 3)
+
+    expect(parts.map(part => part.type)).toEqual(['text', 'reasoning', 'text'])
+    expect(parts.map(part => part.timestamp)).toEqual([1, 2, 3])
+    expect(parts.map(part => part.completedAt)).toEqual([2, 3, undefined])
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    expect((parts[0] as { text: string }).text).toBe('[File: partial](#media:%2Ftmp%2Fpartial)')
+    expect((parts[2] as { text: string }).text).toBe(' filename.pdf')
+  })
+
+  it('clears provisional MEDIA state when the timeline part completes', () => {
+    const parts = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    const completed = completeOpenTimelineParts(parts, 2)
+
+    expect(completed[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(completed[0]).toMatchObject({ completedAt: 2, timestamp: 1, type: 'text' })
+  })
+
+  it('clears provisional MEDIA state when a tool call closes the text segment', () => {
+    let parts = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    parts = upsertToolPart(parts, { name: 'read_file', tool_id: 'tc-media' }, 'running', 2)
+
+    expect(parts[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(parts[0]).toMatchObject({ completedAt: 2, timestamp: 1, type: 'text' })
+    expect(parts[1]).toMatchObject({ toolCallId: 'tc-media', type: 'tool-call' })
+  })
+
+  it('clears provisional MEDIA state during final-response reconciliation', () => {
+    const parts = appendAssistantTextPart([], 'MEDIA:/tmp/partial', 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    const settled = mergeFinalAssistantText(parts, 'MEDIA:/tmp/partial', 2)
+
+    expect(settled).toHaveLength(1)
+    expect(settled[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(settled[0]).toMatchObject({
+      text: '[File: partial](#media:%2Ftmp%2Fpartial)',
+      timestamp: 1,
+      type: 'text'
+    })
+  })
+
+  it('settles provisional MEDIA state before preserving a blank final completion', () => {
+    const path = '/tmp/final report.md'
+    const parts = appendAssistantTextPart([], `MEDIA:${path}`, 1)
+
+    expect(parts[0]).toHaveProperty('provisionalMediaSource')
+    const settled = mergeFinalAssistantText(parts, '', 2)
+
+    expect(settled).toHaveLength(1)
+    expect(settled[0]).not.toHaveProperty('provisionalMediaSource')
+    expect(settled[0]).toMatchObject({
+      text: `[File: final report.md](#media:${encodeURIComponent(path)})`,
+      timestamp: 1,
+      type: 'text'
+    })
   })
 })
 

--- a/apps/desktop/src/lib/chat-messages/index.ts
+++ b/apps/desktop/src/lib/chat-messages/index.ts
@@ -7,6 +7,7 @@ export {
   collectUnspokenTurnSpeech,
   completeOpenTimelineParts,
   dedupeRepeatedTextInParts,
+  mediaPathsFromText,
   mergeFinalAssistantText,
   reasoningPart,
   renderMediaTags,

--- a/apps/desktop/src/lib/chat-messages/parts.ts
+++ b/apps/desktop/src/lib/chat-messages/parts.ts
@@ -10,9 +10,10 @@ export function reasoningPart(text: string, timestamp?: number): ChatMessagePart
   return { type: 'reasoning', text, ...(timestamp !== undefined ? { timestamp } : {}) }
 }
 
-const MEDIA_LINE_RE = /(^|\n)[\t ]*[`"']?MEDIA:\s*(?<line>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?[\t ]*(\n|$)/g
+const MEDIA_LINE_RE =
+  /(^|\n)[\t ]*[`"']?MEDIA:(?![\t ]*(?:\r?\n|$))[\t ]*(?<line>`[^`\r\n]+`|"[^"\r\n]+"|'[^'\r\n]+'|[^\r\n]*?\S)[`"']?[\t ]*(?=\r?\n|$)/g
 
-const MEDIA_TAG_RE = /[`"']?MEDIA:\s*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
+const MEDIA_TAG_RE = /[`"']?MEDIA:[\t ]*(?<inline>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|\S+)[`"']?/g
 
 function unquoteMediaPath(value: string): string {
   const trimmed = value.trim()
@@ -21,21 +22,416 @@ function unquoteMediaPath(value: string): string {
   return quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote) ? trimmed.slice(1, -1) : trimmed
 }
 
-function mediaLink(value: string): string {
+function mediaLink(value: string, onPath?: (path: string) => void): string {
   const path = unquoteMediaPath(value)
+
+  onPath?.(path)
 
   return `[${mediaDisplayLabel(path)}](${mediaMarkdownHref(path)})`
 }
 
+function isExplicitlyQuotedMediaPath(value: string): boolean {
+  const trimmed = value.trim()
+  const quote = trimmed[0]
+
+  return Boolean(quote && quote === trimmed.at(-1) && ['"', "'", '`'].includes(quote))
+}
+
+function isClosedQuotedMediaDirective(match: string, lead: string): boolean {
+  return isExplicitlyQuotedMediaPath(match.slice(lead.length))
+}
+
+function wholeDirectiveOpeningQuote(match: string, lead: string): string | undefined {
+  const directive = match.slice(lead.length).trimStart()
+  const quote = directive[0]
+
+  return quote && ['"', "'", '`'].includes(quote) && directive.slice(1).startsWith('MEDIA:') ? quote : undefined
+}
+
+function isPathShapedMediaValue(value: string): boolean {
+  return (
+    /^(?:file:|https?:|data:|\/|~[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|\\\\)/i.test(value) ||
+    /\.[a-z0-9]{1,16}(?:[?#].*)?$/i.test(value)
+  )
+}
+
+type StandaloneMediaIntent = 'inline' | 'path' | 'prose'
+
+type StandaloneMediaValue = { intent: 'inline' | 'prose' } | { intent: 'path'; path: string; tail: string }
+
+const MEDIA_EXTENSION_RE = /\.[a-z0-9]{1,16}(?:[?#].*)?$/i
+
+/**
+ * Classify a line-leading MEDIA value before replacing it. A quoted value or
+ * `/tmp/the final report.pdf` is one path; `the report is ready` is prose;
+ * `/tmp/report.pdf is ready` splits at the extension so the suffix remains
+ * prose instead of becoming part of the filename.
+ */
+function parseStandaloneMediaValue(value: string): StandaloneMediaValue {
+  const trimmed = value.trim()
+
+  if (!trimmed) {
+    return { intent: 'prose' }
+  }
+
+  const quote = trimmed[0]
+
+  if (['"', "'", '`'].includes(quote)) {
+    const closingQuote = trimmed.indexOf(quote, 1)
+
+    if (closingQuote > 0) {
+      return {
+        intent: 'path',
+        path: trimmed.slice(0, closingQuote + 1),
+        tail: trimmed.slice(closingQuote + 1)
+      }
+    }
+  }
+
+  if (!/\s/.test(trimmed)) {
+    return isPathShapedMediaValue(trimmed) ? { intent: 'path', path: trimmed, tail: '' } : { intent: 'prose' }
+  }
+
+  if (/\bMEDIA:/.test(trimmed)) {
+    return { intent: 'inline' }
+  }
+
+  const firstToken = trimmed.match(/^\S+/)?.[0]
+
+  if (firstToken && /^(?:https?:|data:)/i.test(firstToken)) {
+    return { intent: 'path', path: firstToken, tail: trimmed.slice(firstToken.length) }
+  }
+
+  if (MEDIA_EXTENSION_RE.test(trimmed)) {
+    return { intent: 'path', path: trimmed, tail: '' }
+  }
+
+  if (isPathShapedMediaValue(trimmed)) {
+    const tokens = [...trimmed.matchAll(/\S+/g)]
+
+    for (let index = tokens.length - 1; index >= 0; index -= 1) {
+      const token = tokens[index]
+
+      if (!MEDIA_EXTENSION_RE.test(token[0])) {
+        continue
+      }
+
+      const end = (token.index ?? 0) + token[0].length
+
+      return { intent: 'path', path: trimmed.slice(0, end), tail: trimmed.slice(end) }
+    }
+
+    return /^(?:file:|~[\\/]|\.{1,2}[\\/]|[a-z]:[\\/]|\\\\|\/[^/\s]+[\\/])/i.test(trimmed)
+      ? { intent: 'path', path: trimmed, tail: '' }
+      : { intent: 'prose' }
+  }
+
+  if (firstToken && MEDIA_EXTENSION_RE.test(firstToken)) {
+    return { intent: 'path', path: firstToken, tail: trimmed.slice(firstToken.length) }
+  }
+
+  return { intent: 'prose' }
+}
+
+function standaloneMediaIntent(value: string): StandaloneMediaIntent {
+  return parseStandaloneMediaValue(value).intent
+}
+
+interface ConsecutiveMediaMarker {
+  end: number
+  index: number
+  mediaIndex: number
+}
+
+function isHorizontalWhitespace(value: string | undefined): boolean {
+  return value === ' ' || value === '\t'
+}
+
+function trimHorizontalWhitespaceBeforeNewlines(value: string): string {
+  let rendered = ''
+  let lineStart = 0
+
+  while (lineStart < value.length) {
+    const newline = value.indexOf('\n', lineStart)
+
+    if (newline < 0) {
+      rendered += value.slice(lineStart)
+
+      break
+    }
+
+    const carriageReturn = newline > lineStart && value[newline - 1] === '\r'
+    let contentEnd = carriageReturn ? newline - 1 : newline
+
+    while (contentEnd > lineStart && isHorizontalWhitespace(value[contentEnd - 1])) {
+      contentEnd -= 1
+    }
+
+    rendered += `${value.slice(lineStart, contentEnd)}${carriageReturn ? '\r' : ''}\n`
+    lineStart = newline + 1
+  }
+
+  return rendered
+}
+
+function consecutiveMediaMarkers(value: string): ConsecutiveMediaMarker[] {
+  const markers: ConsecutiveMediaMarker[] = []
+  let searchFrom = 0
+
+  while (searchFrom < value.length) {
+    const mediaIndex = value.indexOf('MEDIA:', searchFrom)
+
+    if (mediaIndex < 0) {
+      break
+    }
+
+    const quoted = ['`', '"', "'"].includes(value[mediaIndex - 1] || '')
+    const prefixEnd = quoted ? mediaIndex - 1 : mediaIndex
+
+    if (!isHorizontalWhitespace(value[prefixEnd - 1])) {
+      searchFrom = mediaIndex + 'MEDIA:'.length
+
+      continue
+    }
+
+    let index = prefixEnd - 1
+
+    while (index > 0 && isHorizontalWhitespace(value[index - 1])) {
+      index -= 1
+    }
+
+    let end = mediaIndex + 'MEDIA:'.length
+
+    while (end < value.length && isHorizontalWhitespace(value[end])) {
+      end += 1
+    }
+
+    markers.push({ end, index, mediaIndex })
+    searchFrom = end
+  }
+
+  return markers
+}
+
+function isOpenConsecutiveMediaMarker(value: string, markers: ConsecutiveMediaMarker[]): boolean {
+  const marker = markers.at(-1)
+
+  return marker ? /^[\t ]*$/.test(value.slice(marker.mediaIndex + 'MEDIA:'.length)) : false
+}
+
+function renderConsecutiveMediaValues(
+  value: string,
+  onPath: (path: string) => void,
+  markers = consecutiveMediaMarkers(value)
+): string | undefined {
+  if (!markers.length) {
+    return undefined
+  }
+
+  const values: string[] = []
+  let start = 0
+
+  for (const marker of markers) {
+    values.push(value.slice(start, marker.index).trim())
+    start = marker.end
+  }
+
+  values.push(value.slice(start).trim())
+  const parsed = values.map(parseStandaloneMediaValue)
+
+  if (parsed.some(entry => entry.intent !== 'path')) {
+    return undefined
+  }
+
+  return parsed
+    .map(entry => {
+      if (entry.intent !== 'path') {
+        return ''
+      }
+
+      return `${mediaLink(entry.path, onPath)}${entry.tail}`
+    })
+    .join(' ')
+}
+
+function renderMediaSequencesInText(text: string, onPath: (path: string) => void, onOpenSequence: () => void): string {
+  let rendered = ''
+  let lineStart = 0
+
+  while (lineStart < text.length) {
+    const newline = text.indexOf('\n', lineStart)
+    const lineEnd = newline === -1 ? text.length : newline
+    const contentEnd = lineEnd > lineStart && text[lineEnd - 1] === '\r' ? lineEnd - 1 : lineEnd
+    const line = text.slice(lineStart, contentEnd)
+    const marker = line.indexOf('MEDIA:')
+    let content = line
+
+    if (marker >= 0) {
+      const value = line.slice(marker + 'MEDIA:'.length)
+      const markers = consecutiveMediaMarkers(value)
+      const sequence = renderConsecutiveMediaValues(value, onPath, markers)
+
+      if (sequence !== undefined) {
+        content = `${line.slice(0, marker)}${sequence}`
+
+        if (newline === -1) {
+          onOpenSequence()
+        }
+      } else if (newline === -1 && isOpenConsecutiveMediaMarker(value, markers)) {
+        onOpenSequence()
+      }
+    }
+
+    rendered += content
+
+    if (newline === -1) {
+      break
+    }
+
+    rendered += text.slice(contentEnd, newline + 1)
+    lineStart = newline + 1
+  }
+
+  return rendered
+}
+
+function mediaSequenceIntentsByLine(source: string): Map<number, StandaloneMediaIntent> {
+  const intents = new Map<number, StandaloneMediaIntent>()
+  let lineStart = 0
+
+  while (lineStart <= source.length) {
+    const lineEnd = source.indexOf('\n', lineStart)
+    const line = source.slice(lineStart, lineEnd === -1 ? source.length : lineEnd)
+    const marker = line.indexOf('MEDIA:')
+
+    if (marker >= 0) {
+      const value = line.slice(marker + 'MEDIA:'.length)
+      const markers = consecutiveMediaMarkers(value)
+
+      if (markers.length) {
+        const intent = renderConsecutiveMediaValues(value, () => {}, markers) === undefined ? 'prose' : 'path'
+
+        intents.set(lineStart, intent)
+      }
+    }
+
+    if (lineEnd === -1) {
+      break
+    }
+
+    lineStart = lineEnd + 1
+  }
+
+  return intents
+}
+
+function lineLeadingMediaIntent(source: string, offset: number): StandaloneMediaIntent | undefined {
+  const lineStart = source.lastIndexOf('\n', Math.max(0, offset - 1)) + 1
+
+  if (!/^[\t ]*$/.test(source.slice(lineStart, offset))) {
+    return undefined
+  }
+
+  const lineEnd = source.indexOf('\n', offset)
+  const line = source.slice(offset, lineEnd === -1 ? source.length : lineEnd)
+  const marker = line.indexOf('MEDIA:')
+
+  return marker === -1 ? undefined : standaloneMediaIntent(line.slice(marker + 'MEDIA:'.length))
+}
+
+function renderMediaText(text: string): { paths: string[]; provisional: boolean; text: string } {
+  const paths: string[] = []
+  let provisional = false
+
+  let rendered = text.replace(MEDIA_LINE_RE, (match, lead: string, value: string, offset: number, source: string) => {
+    if (/[\t ]+[`"']?MEDIA:[\t ]*$/.test(value) && offset + match.length === source.length) {
+      provisional = true
+
+      return match
+    }
+
+    const sequence = renderConsecutiveMediaValues(value, path => paths.push(path))
+
+    if (sequence !== undefined) {
+      provisional ||= offset + match.length === source.length
+
+      return `${lead}${sequence}`
+    }
+
+    const wholeDirectiveQuote = wholeDirectiveOpeningQuote(match, lead)
+    const closingWholeDirectiveQuote = wholeDirectiveQuote ? value.indexOf(wholeDirectiveQuote) : -1
+    let parsed = parseStandaloneMediaValue(value)
+    let wholeDirectiveClosed = isClosedQuotedMediaDirective(match, lead)
+    const trailingWhitespace = /[\t ]+$/.test(match)
+
+    if (closingWholeDirectiveQuote >= 0) {
+      parsed = {
+        intent: 'path',
+        path: value.slice(0, closingWholeDirectiveQuote),
+        tail: value.slice(closingWholeDirectiveQuote + 1)
+      }
+      wholeDirectiveClosed = true
+    }
+
+    if (parsed.intent !== 'path') {
+      return match
+    }
+
+    provisional ||=
+      !isExplicitlyQuotedMediaPath(parsed.path) &&
+      (!wholeDirectiveClosed || trailingWhitespace) &&
+      offset + match.length === source.length
+
+    return `${lead}${mediaLink(parsed.path, path => paths.push(path))}${parsed.tail}`
+  })
+
+  rendered = renderMediaSequencesInText(
+    rendered,
+    path => paths.push(path),
+    () => {
+      provisional = true
+    }
+  )
+
+  const sequenceIntents = mediaSequenceIntentsByLine(rendered)
+  let inlineLineStart = 0
+  let inlineLineEnd = rendered.indexOf('\n')
+
+  rendered = rendered.replace(MEDIA_TAG_RE, (match, value: string, offset: number, source: string) => {
+    while (inlineLineEnd >= 0 && offset > inlineLineEnd) {
+      inlineLineStart = inlineLineEnd + 1
+      inlineLineEnd = rendered.indexOf('\n', inlineLineStart)
+    }
+
+    const sequenceIntent = sequenceIntents.get(inlineLineStart)
+
+    if (sequenceIntent === 'prose') {
+      return match
+    }
+
+    const lineIntent = lineLeadingMediaIntent(source, offset)
+    const pathShaped = isExplicitlyQuotedMediaPath(value) || isPathShapedMediaValue(unquoteMediaPath(value))
+
+    if (lineIntent === 'prose' || (lineIntent === undefined && !pathShaped)) {
+      return match
+    }
+
+    provisional ||= !isExplicitlyQuotedMediaPath(value) && source.indexOf('\n', offset) === -1
+
+    return mediaLink(value, path => paths.push(path))
+  })
+
+  rendered = trimHorizontalWhitespaceBeforeNewlines(rendered).replace(/\n{3,}/g, '\n\n')
+
+  return { paths, provisional, text: rendered }
+}
+
 export function renderMediaTags(text: string): string {
-  return text
-    .replace(
-      MEDIA_LINE_RE,
-      (_match, lead: string, value: string, trailer: string) => `${lead}${mediaLink(value)}${trailer}`
-    )
-    .replace(MEDIA_TAG_RE, (_match, value: string) => mediaLink(value))
-    .replace(/[ \t]+\n/g, '\n')
-    .replace(/\n{3,}/g, '\n\n')
+  return renderMediaText(text).text
+}
+
+export function mediaPathsFromText(text: string): string[] {
+  return renderMediaText(text).paths
 }
 
 export function assistantTextPart(text: string, timestamp?: number): ChatMessagePart {
@@ -155,8 +551,11 @@ export function mergeFinalAssistantText(
   finalText: string,
   fallbackTimestamp?: number
 ): ChatMessagePart[] {
+  parts = clearProvisionalMediaSources(parts)
+
   // Empty / whitespace-only completion is not authoritative — keep streamed
-  // text, reasoning, and tool parts (#95514).
+  // text, reasoning, and tool parts (#95514). Provisional MEDIA metadata is
+  // still settled first so it cannot leak past the turn boundary.
   if (!finalText.trim()) {
     return parts
   }
@@ -214,11 +613,53 @@ export function mergeFinalAssistantText(
 
 /** Seal every still-open visible activity when the assistant turn stops. */
 export function completeOpenTimelineParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
-  return parts.map(part =>
-    part.timestamp !== undefined && part.completedAt === undefined
-      ? ({ ...part, completedAt } as ChatMessagePart)
-      : part
-  )
+  return parts.map(part => {
+    const settled = clearProvisionalMediaSource(part)
+
+    return settled.timestamp !== undefined && settled.completedAt === undefined
+      ? ({ ...settled, completedAt } as ChatMessagePart)
+      : settled
+  })
+}
+
+function clearProvisionalMediaSource(part: ChatMessagePart): ChatMessagePart {
+  if (part.provisionalMediaSource === undefined) {
+    return part
+  }
+
+  const { provisionalMediaSource: _source, ...settled } = part
+
+  return settled as ChatMessagePart
+}
+
+function clearProvisionalMediaSources(parts: ChatMessagePart[]): ChatMessagePart[] {
+  let changed = false
+
+  const settled = parts.map(part => {
+    const next = clearProvisionalMediaSource(part)
+
+    changed ||= next !== part
+
+    return next
+  })
+
+  return changed ? settled : parts
+}
+
+function restoreOpenProvisionalMediaSource(parts: ChatMessagePart[]): ChatMessagePart[] {
+  const tailIndex = parts.length - 1
+  const tail = parts[tailIndex]
+
+  if (tail?.type !== 'text' || tail.completedAt !== undefined || tail.provisionalMediaSource === undefined) {
+    return parts
+  }
+
+  const next = [...parts]
+  const settled = clearProvisionalMediaSource(tail)
+
+  next[tailIndex] = { ...settled, text: tail.provisionalMediaSource } as ChatMessagePart
+
+  return next
 }
 
 // Coalesce only adjacent deltas of the same channel. Switching between text
@@ -241,12 +682,13 @@ function appendStreamPart(
     return { index: tailIndex, parts: next }
   }
 
-  if (
-    timestamp !== undefined &&
-    (tail?.type === 'text' || tail?.type === 'reasoning') &&
-    tail.completedAt === undefined
-  ) {
-    next[tailIndex] = { ...tail, completedAt: timestamp } as ChatMessagePart
+  if ((tail?.type === 'text' || tail?.type === 'reasoning') && tail.completedAt === undefined) {
+    const settled = clearProvisionalMediaSource(tail)
+
+    next[tailIndex] = {
+      ...settled,
+      ...(timestamp !== undefined ? { completedAt: timestamp } : {})
+    } as ChatMessagePart
   }
 
   const STREAM_PART: Record<'reasoning' | 'text', (text: string, timestamp?: number) => ChatMessagePart> = {
@@ -268,7 +710,7 @@ export function appendAssistantTextPart(
   delta: string,
   timestamp?: number
 ): ChatMessagePart[] {
-  const { index, parts: next } = appendStreamPart(parts, 'text', delta, timestamp)
+  const { index, parts: next } = appendStreamPart(restoreOpenProvisionalMediaSource(parts), 'text', delta, timestamp)
   const part = next[index]
 
   if (part?.type !== 'text') {
@@ -279,10 +721,16 @@ export function appendAssistantTextPart(
     delta.includes('MEDIA:') || delta.includes('DIA:') || delta.includes('EDIA:') || delta.includes('IA:')
 
   if (mayContainMedia || part.text.includes('MEDIA:')) {
-    const rendered = renderMediaTags(part.text)
+    const rendered = renderMediaText(part.text)
 
-    if (rendered !== part.text) {
-      next[index] = { ...part, text: rendered }
+    if (rendered.text !== part.text || rendered.provisional) {
+      const settled = clearProvisionalMediaSource(part)
+
+      next[index] = {
+        ...settled,
+        text: rendered.text,
+        ...(rendered.provisional ? { provisionalMediaSource: part.text } : {})
+      } as ChatMessagePart
     }
   }
 

--- a/apps/desktop/src/lib/chat-messages/tool-parts.ts
+++ b/apps/desktop/src/lib/chat-messages/tool-parts.ts
@@ -279,11 +279,16 @@ function toolResult(
 }
 
 function completeOpenStreamParts(parts: ChatMessagePart[], completedAt: number): ChatMessagePart[] {
-  return parts.map(part =>
-    (part.type === 'text' || part.type === 'reasoning') && part.completedAt === undefined
-      ? ({ ...part, completedAt } as ChatMessagePart)
-      : part
-  )
+  return parts.map(part => {
+    const settled =
+      part.provisionalMediaSource === undefined
+        ? part
+        : (({ provisionalMediaSource: _source, ...rest }) => rest as ChatMessagePart)(part)
+
+    return (settled.type === 'text' || settled.type === 'reasoning') && settled.completedAt === undefined
+      ? ({ ...settled, completedAt } as ChatMessagePart)
+      : settled
+  })
 }
 
 export function upsertToolPart(

--- a/apps/desktop/src/lib/chat-messages/types.ts
+++ b/apps/desktop/src/lib/chat-messages/types.ts
@@ -10,6 +10,9 @@ export interface TimelinePartMetadata {
   timestamp?: number
   /** Unix seconds when this segment stopped or handed off to the next one. */
   completedAt?: number
+  /** Undecorated source for a trailing MEDIA directive that may receive more
+   * streamed path characters. Live-only and removed when the segment closes. */
+  provisionalMediaSource?: string
 }
 
 export type ChatMessagePart = Exclude<ThreadMessageLike['content'], string>[number] & TimelinePartMetadata

--- a/apps/desktop/src/lib/local-preview.test.ts
+++ b/apps/desktop/src/lib/local-preview.test.ts
@@ -133,6 +133,27 @@ describe('remote HTML previews', () => {
     expect(localPreviewTarget('//srv/share/report #1?.html')?.url).toBe('file:////srv/share/report%20%231%3F.html')
   })
 
+  it('does not join native Windows drive and UNC paths to the session cwd', () => {
+    expect(localPreviewTarget('C:\\Users\\demo\\Hermes Projects\\report.md', 'C:\\workspace')).toMatchObject({
+      path: 'C:\\Users\\demo\\Hermes Projects\\report.md',
+      url: 'file:///C:/Users/demo/Hermes%20Projects/report.md'
+    })
+    expect(localPreviewTarget('\\\\server\\Hermes Projects\\report.md', 'C:\\workspace')).toMatchObject({
+      path: '\\\\server\\Hermes Projects\\report.md',
+      url: 'file://server/Hermes%20Projects/report.md'
+    })
+  })
+
+  it('decodes Windows drive and UNC file URLs for remote preview reads', () => {
+    expect(localPreviewTarget('file:///C:/Users/demo/Hermes%20Projects/report.md')).toMatchObject({
+      path: 'C:/Users/demo/Hermes Projects/report.md'
+    })
+    expect(localPreviewTarget('file://server/Hermes%20Projects/report.md')).toMatchObject({
+      path: '\\\\server\\Hermes Projects\\report.md',
+      url: 'file://server/Hermes%20Projects/report.md'
+    })
+  })
+
   it('opens ordinary targets without staging them', async () => {
     const openPreviewInBrowser = vi.fn(async () => undefined)
     const saveImageBuffer = vi.fn()

--- a/apps/desktop/src/lib/local-preview.ts
+++ b/apps/desktop/src/lib/local-preview.ts
@@ -1,6 +1,7 @@
 import DOMPurify from 'dompurify'
 
 import { isDesktopFsRemoteMode, readDesktopFileDataUrl, readDesktopFileText } from '@/lib/desktop-fs'
+import { filePathFromMediaPath } from '@/lib/media'
 import type { PreviewTarget } from '@/store/preview'
 
 const HTML_EXTENSIONS = new Set(['.htm', '.html'])
@@ -70,7 +71,7 @@ function pathToFileUrl(path: string) {
 
   const encoded = normalized
     .split('/')
-    .map(part => encodeURIComponent(part))
+    .map(part => (/^[A-Za-z]:$/.test(part) ? part : encodeURIComponent(part)))
     .join('/')
 
   if (isWindowsUnc) {
@@ -189,15 +190,10 @@ export function localPreviewTarget(rawTarget: string, cwd?: string | null): Prev
     return { kind: 'url', label: basename(raw), source: raw, url: raw }
   }
 
-  let path = raw
+  let path = filePathFromMediaPath(raw)
+  const absoluteWindowsPath = /^[A-Za-z]:[\\/]/.test(path) || path.startsWith('\\\\')
 
-  if (/^file:\/\//i.test(raw)) {
-    try {
-      path = decodeURIComponent(new URL(raw).pathname)
-    } catch {
-      path = raw.replace(/^file:\/\//i, '')
-    }
-  } else if (!raw.startsWith('/') && cwd) {
+  if (!path.startsWith('/') && !absoluteWindowsPath && cwd) {
     path = joinPath(cwd, raw)
   }
 

--- a/apps/desktop/src/lib/media.remote.test.ts
+++ b/apps/desktop/src/lib/media.remote.test.ts
@@ -10,6 +10,7 @@ import {
   isRemoteGateway,
   mediaExternalUrl,
   mediaGatewayStreamUrl,
+  mediaName,
   resolveMediaDisplaySrc,
   resolveMediaPlaybackSrc
 } from './media'
@@ -43,6 +44,28 @@ describe('filePathFromMediaPath', () => {
   it('decodes a file:// URL with encoded characters', () => {
     expect(filePathFromMediaPath('file:///tmp/a%20b.png')).toBe('/tmp/a b.png')
   })
+
+  it('decodes Windows drive and UNC file URLs without losing their roots', () => {
+    expect(filePathFromMediaPath('file:///C:/Users/demo/Hermes%20Projects/report.md')).toBe(
+      'C:/Users/demo/Hermes Projects/report.md'
+    )
+    expect(filePathFromMediaPath('file://server/Hermes%20Projects/report.md')).toBe(
+      '\\\\server\\Hermes Projects\\report.md'
+    )
+  })
+
+  it('normalizes an already-decoded WHATWG Windows drive pathname', () => {
+    expect(filePathFromMediaPath('/C:/Users/demo/Hermes Projects/report.md')).toBe(
+      'C:/Users/demo/Hermes Projects/report.md'
+    )
+  })
+})
+
+describe('mediaName', () => {
+  it('extracts the basename from Windows drive and UNC paths', () => {
+    expect(mediaName('C:\\Users\\ADMIN\\My Files\\report.pdf')).toBe('report.pdf')
+    expect(mediaName('\\\\server\\Shared Files\\report.pdf')).toBe('report.pdf')
+  })
 })
 
 describe('mediaExternalUrl', () => {
@@ -59,6 +82,14 @@ describe('mediaExternalUrl', () => {
     $connection.set({ mode: 'local' } as never)
     expect(mediaExternalUrl('/tmp/a.png')).toBe('file:///tmp/a.png')
     expect(mediaExternalUrl('file:///tmp/a.png')).toBe('file:///tmp/a.png')
+  })
+
+  it('creates standards-compliant Windows drive and UNC file URLs', () => {
+    $connection.set({ mode: 'local' } as never)
+    expect(mediaExternalUrl('C:\\Program Files\\final report.pdf')).toBe(
+      'file:///C:/Program%20Files/final%20report.pdf'
+    )
+    expect(mediaExternalUrl('\\\\server\\Shared Files\\report.pdf')).toBe('file://server/Shared%20Files/report.pdf')
   })
 
   it('rewrites gateway-local paths to an authenticated download URL', () => {

--- a/apps/desktop/src/lib/media.ts
+++ b/apps/desktop/src/lib/media.ts
@@ -56,10 +56,15 @@ export function mediaMime(path: string): string {
 }
 
 export function mediaName(path: string): string {
+  if (/^(?:[a-z]:[\\/]|\\\\)/i.test(path)) {
+    return path.split(/[\\/]/).filter(Boolean).pop() || path
+  }
+
   try {
     const url = new URL(path)
+    const name = url.pathname.split('/').filter(Boolean).pop()
 
-    return url.pathname.split('/').filter(Boolean).pop() || path
+    return name ? decodeURIComponent(name) : path
   } catch {
     return path.split(/[\\/]/).filter(Boolean).pop() || path
   }
@@ -112,6 +117,31 @@ export async function resolveMediaPlaybackSrc(path: string): Promise<string> {
 // Resolve a media path to a URL the shell can open. Remote mode rewrites
 // gateway-local paths to an authenticated /api/files/download URL (the file
 // lives on the gateway, not this disk); local mode keeps the file:// form.
+function localMediaFileUrl(path: string): string {
+  if (/^file:/i.test(path)) {
+    try {
+      return new URL(path).toString()
+    } catch {
+      return path
+    }
+  }
+
+  const normalized = path.replace(/\\/g, '/')
+
+  if (normalized.startsWith('//')) {
+    const [host, ...segments] = normalized.slice(2).split('/')
+
+    return `file://${host}/${segments.map(encodeURIComponent).join('/')}`
+  }
+
+  const encoded = normalized
+    .split('/')
+    .map(segment => (/^[a-z]:$/i.test(segment) ? segment : encodeURIComponent(segment)))
+    .join('/')
+
+  return normalized.startsWith('/') ? `file://${encoded}` : `file:///${encoded}`
+}
+
 export function mediaExternalUrl(path: string): string {
   if (/^https?:/i.test(path)) {
     return path
@@ -127,7 +157,7 @@ export function mediaExternalUrl(path: string): string {
     }
   }
 
-  return /^file:/i.test(path) ? path : `file://${path}`
+  return localMediaFileUrl(path)
 }
 
 // Remote gateway audio/video is proxied by the Electron main process. OAuth
@@ -172,15 +202,33 @@ export function mediaPathFromMarkdownHref(href?: string): string | null {
   }
 }
 
+// WHATWG URL.pathname represents file:///C:/... as /C:/.... That leading
+// slash is not a Windows drive path and makes a remote Windows gateway join
+// the value to its cwd. Normalize it at the shared media-path boundary.
+const WHATWG_WINDOWS_DRIVE_PATHNAME = /^\/([A-Za-z]:)(\/.*)?$/
+
+export function stripWhatwgWindowsDrivePrefix(pathname: string): string {
+  const match = pathname.match(WHATWG_WINDOWS_DRIVE_PATHNAME)
+
+  return match ? `${match[1]}${match[2] || '/'}` : pathname
+}
+
 export function filePathFromMediaPath(path: string): string {
   if (!path.startsWith('file:')) {
-    return path
+    return stripWhatwgWindowsDrivePrefix(path)
   }
 
   try {
-    return decodeURIComponent(new URL(path).pathname)
+    const url = new URL(path)
+    const pathname = decodeURIComponent(url.pathname)
+
+    if (url.hostname && url.hostname !== 'localhost') {
+      return `\\\\${url.hostname}${pathname.replace(/\//g, '\\')}`
+    }
+
+    return stripWhatwgWindowsDrivePrefix(pathname)
   } catch {
-    return path.replace(/^file:\/\//, '')
+    return stripWhatwgWindowsDrivePrefix(path.replace(/^file:\/\//, ''))
   }
 }
 

--- a/apps/desktop/src/lib/preview-targets.test.ts
+++ b/apps/desktop/src/lib/preview-targets.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from 'vitest'
 
-import { extractPreviewTargets, previewTargetFromMarkdownHref, stripPreviewTargets } from './preview-targets'
+import {
+  extractPreviewTargets,
+  previewName,
+  previewTargetFromMarkdownHref,
+  stripPreviewTargets
+} from './preview-targets'
 
 describe('preview target detection', () => {
   it('does not infer preview targets from raw paths or URLs', () => {
@@ -23,5 +28,10 @@ describe('preview target detection', () => {
       'ready\n/tmp/mycelium-bunnies.html\nopen it'
     )
     expect(stripPreviewTargets('[Preview: demo.html](#preview:%2Ftmp%2Fdemo.html)\nopen it')).toBe('open it')
+  })
+
+  it('extracts native Windows drive and UNC basenames before URL parsing', () => {
+    expect(previewName('C:\\Users\\ADMIN\\Hermes Projects\\final report.md')).toBe('final report.md')
+    expect(previewName('\\\\server\\Hermes Projects\\final report.md')).toBe('final report.md')
   })
 })

--- a/apps/desktop/src/lib/preview-targets.ts
+++ b/apps/desktop/src/lib/preview-targets.ts
@@ -41,6 +41,13 @@ export function previewTargetFromMarkdownHref(href?: string): string | null {
 }
 
 export function previewName(target: string): string {
+  // WHATWG treats a native Windows drive path as a URL with a one-letter
+  // protocol. Resolve drive and UNC basenames before URL parsing so preview
+  // cards do not display the entire backslash path.
+  if (/^[A-Za-z]:[\\/]/.test(target) || target.startsWith('\\\\')) {
+    return target.split(/[\\/]/).filter(Boolean).pop() || target
+  }
+
   try {
     const url = new URL(target)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -720,9 +720,17 @@ class TestPromptBuilderConstants:
         ), "CLI hint should explicitly discourage MEDIA: tags."
         # Messaging hints should still advertise MEDIA: positively (sanity
         # check that this test is calibrated correctly).
-        # Dieted (#95681): messaging hints now share the _MEDIA_NATIVE
-        # spine ("write MEDIA:/absolute/path..."), not per-hint prose.
+        # Dieted (#95681): messaging hints share the _MEDIA_NATIVE spine.
         assert "MEDIA:/absolute/path" in PLATFORM_HINTS["telegram"]
+        assert "own line" in PLATFORM_HINTS["telegram"]
+        assert "no prose after the path" in PLATFORM_HINTS["telegram"]
+
+    def test_desktop_media_hint_requires_one_unambiguous_directive_per_line(self):
+        hint = PLATFORM_HINTS["desktop"]
+
+        assert "MEDIA:/absolute/path" in hint
+        assert "own line" in hint
+        assert "no prose after the path" in hint
 
 
 


### PR DESCRIPTION
## Summary

This is the current-main merge-forward and completion of #70801. It preserves Rickard Robin as commit author and hashtag1974 as co-author, while reconciling the implementation with the Desktop changes that landed after the original PR.

It fixes the Desktop renderer truncating unquoted `MEDIA:` paths at the first space, which produced a card for a nonexistent prefix and left the rest of the path as visible prose.

Fixes #96657.

## Provenance

- Original PR: #70801
- Original commit: `d089c1af397d8c6ef65dd767875d01f594a1ad57`
- Original author preserved: Rickard Robin
- Original co-author preserved: hashtag1974
- Merge-forward base: `63279301bcbdc185c1b07b98a9312eb0c862f26d`

This PR should be treated as a salvage/merge-forward of #70801, not independent reimplementation. If this lands, maintainers can close the conflicting original PR and its partial duplicates.

## What changed

### Complete and streamed path parsing

- Preserve complete standalone paths containing spaces across LF and CRLF.
- Keep ordinary `MEDIA:` prose unchanged.
- Keep quoted values, inline values and consecutive directives separate.
- Treat a trailing unquoted path as provisional while streaming.
- Restore its undecorated source before each later text delta so a partial path cannot freeze permanently.
- Remove live-only provisional state at reasoning, tool, timeline-completion and final-response boundaries.
- Preserve #95514 blank/whitespace-final behavior by settling provisional state before the early return.

### One Desktop extraction authority

- Reuse the same `mediaPathsFromText()` authority for transcript rendering and the Artifacts view.
- Prevent a recognized spaced `MEDIA:` path from also being indexed as a shorter generic path.
- Replace repeated whole-string Artifact masking with a monotonic, linear code-unit mask.

### Current PreviewAttachment integration

- Adapt the old `openExternal` regression to the current #97812/#97816 Download plus Open preview card.
- Verify the complete path reaches `normalizePreviewTarget()` and opens the Preview rail.
- Correct native Windows drive and UNC card labels before WHATWG URL parsing.

### Cross-platform path handling

- Emit valid encoded Windows drive and UNC file URLs.
- Preserve drive and UNC roots when decoding `file:` URLs.
- Prevent absolute Windows paths from being joined to the session cwd in renderer fallback mode.
- Normalize the WHATWG `/C:/...` pathname shape before remote Windows reads.

### Output contract and E2E

- Tell agents to place each `MEDIA:` directive on its own line with no trailing prose.
- Add an isolated Desktop E2E that streams a `.md` path containing `Hermes Projects`, renders the complete file card, clicks Open preview and verifies the rendered Markdown heading.

## Verification

All checks were run from the merge-forward commit before publication:

- Full Desktop renderer suite: **718 files, 7,227 tests passed, 0 failed**
- Focused MEDIA/Preview suite: **10 files, 231 tests passed, 0 failed**
- Electron hardening: **45 passed, 2 Windows-only skipped on macOS, 0 failed**
- Prompt-builder suite: **76 passed, 1 skipped, 0 failed**
- Renderer, Electron and E2E TypeScript checks: **passed**
- Ruff on changed Python files: **passed**
- ESLint on changed TypeScript files: **0 errors**
- Prettier and `git diff --check`: **passed**
- Production Desktop build: **passed**
- Signed packaged-app smoke test against a real Markdown path containing spaces: **passed**
- Live installed macOS test after restart: complete card and Markdown Preview **passed**

The exact `Hermes Projects` path was also split after every character in a regression test. Every streamed result converged to the same complete target as the one-shot parse.

## Scope boundary

This fixes intact raw `MEDIA:` directives, including those loaded from existing session history. It does not rewrite historical message rows that were already persisted in the old malformed `[File: prefix](#media:...) remainder` form. Mutating stored conversation history is intentionally excluded from this renderer fix.
