### PR TITLE
fix(tools): clearer memory tool error when action is omitted (#100927)

### DIFF
--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -297,6 +297,30 @@ class TestMemoryToolDispatcher:
         assert "not available" in result["error"]
 
 
+    def test_missing_action_returns_clear_error(self, store):
+        # Some providers emit the call without the 'action' field; the error
+        # must explain the field is required instead of "Unknown action ''".
+        result = json.loads(memory_tool(content="fact", store=store))
+        assert result["success"] is False
+        assert "action" in result["error"]
+        assert "add" in result["error"] and "replace" in result["error"] and "remove" in result["error"]
+        assert "Unknown action" not in result["error"]
+
+    def test_null_action_returns_same_clear_error(self, store):
+        # action=None (explicit null) is the same omission as a missing field.
+        result = json.loads(memory_tool(action=None, content="fact", store=store))
+        assert result["success"] is False
+        assert "Missing required field 'action'" in result["error"]
+        assert "Unknown action" not in result["error"]
+
+    def test_unknown_action_keeps_existing_error(self, store):
+        # A real but unsupported action keeps the original message.
+        result = json.loads(memory_tool(action="get", store=store))
+        assert result["success"] is False
+        assert "Unknown action 'get'" in result["error"]
+        assert "Use: add, replace, remove" in result["error"]
+
+
     def test_replace_missing_content_still_distinct_error(self, store):
         # When old_text IS present but content is missing, keep the original
         # content-specific error (don't route through the old_text recovery path).

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -1139,6 +1139,17 @@ def memory_tool(
     # --- Single-op path ---------------------------------------------------
     # Validate required params BEFORE the gate so an invalid write is rejected
     # immediately instead of being staged and only failing at approve time.
+    # An action-less single-op call means the model omitted the required
+    # 'action' field (some providers emit calls with it missing or null).
+    # Explain that the field is required and list the valid values instead of
+    # reporting "Unknown action 'None'". (issue #100927)
+    if not action:
+        return tool_error(
+            "Missing required field 'action'. Use: add, replace, remove "
+            "(single-op shape) or pass an 'operations' list to apply several "
+            "changes at once.",
+            success=False,
+        )
     if action == "add" and not content:
         return tool_error("Content is required for 'add' action.", success=False)
     if action == "replace" and (not old_text or not content):


### PR DESCRIPTION
Closes #100927

When a provider emits a memory tool call with the `action` field missing or null (DeepSeek does this), `memory_tool()` previously fell through to the final branch and reported `Unknown action 'None'. Use: add, replace, remove` — which names the omitted value as if it were a real (invalid) action and gives no hint that the field itself is required.

This adds an early guard on the single-op path: when `action` is missing or null (and no `operations` list was passed), the tool now returns a clear error stating that `action` is a required field and listing the valid values (`add`, `replace`, `remove`), with a pointer to the batch `operations` shape. Genuinely unknown actions (e.g. `get`) keep the existing `Unknown action ...` message unchanged.

Tests:
- `PYTHONPATH=$PWD /usr/local/lib/hermes-agent/venv/bin/python3 -m pytest -q tests/tools/test_memory_tool.py -x` → 44 passed
- `PYTHONPATH=$PWD /usr/local/lib/hermes-agent/venv/bin/python3 -m pytest -q tests/tools/test_memory_tool_schema.py tests/tools/test_write_approval.py tests/agent/test_builtin_memory_disabled_surface.py tests/agent/test_skip_memory_store_65429.py -x` → 39 passed