### PR TITLE
fix(desktop): pin launch SessionDB handle to the launch home (#102526)

### DIFF
--- a/tests/tui_gateway/test_launch_db_home_override_race.py
+++ b/tests/tui_gateway/test_launch_db_home_override_race.py
@@ -1,0 +1,52 @@
+"""Regression for #102526.
+
+The launch backend's lazy ``_get_db()`` handle must bind to the import-time
+launch home, not whatever ``get_hermes_home()`` resolves to at first-touch
+time. The desktop multiplex cron ticker installs per-profile override windows
+at startup; if the first ``session.*`` RPC races into a foreign window, the
+backend permanently serves the wrong profile's state.db.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+from tui_gateway import server
+
+
+@pytest.fixture()
+def launch_db_env(monkeypatch, tmp_path):
+    launch_home = tmp_path / "launch"
+    foreign_home = tmp_path / "foreign"
+    launch_home.mkdir()
+    foreign_home.mkdir()
+
+    monkeypatch.setenv("HERMES_HOME", str(launch_home))
+    monkeypatch.setattr(server, "_hermes_home", str(launch_home))
+    monkeypatch.setattr(server, "_db", None)
+    monkeypatch.setattr(server, "_db_error", None)
+
+    captured: list[Path | None] = []
+
+    def _factory(db_path=None, **_kwargs):
+        captured.append(Path(db_path) if db_path is not None else None)
+        return SimpleNamespace(db_path=db_path)
+
+    monkeypatch.setattr("hermes_state.get_shared_session_db", _factory)
+    return launch_home, foreign_home, captured
+
+
+def test_get_db_first_touch_under_foreign_override_uses_launch_path(launch_db_env):
+    launch_home, foreign_home, captured = launch_db_env
+    token = set_hermes_home_override(str(foreign_home))
+    try:
+        db = server._get_db()
+        assert db is not None
+        assert captured == [launch_home / "state.db"]
+        assert server._get_db() is db
+    finally:
+        reset_hermes_home_override(token)

--- a/tests/tui_gateway/test_session_resume_db_ownership.py
+++ b/tests/tui_gateway/test_session_resume_db_ownership.py
@@ -116,20 +116,20 @@ def _resume(**params):
     )
 
 
-def test_resume_closes_profile_db_when_session_not_found(profile_dbs):
+def test_resume_closes_profile_db_when_session_not_found(profile_dbs, tmp_path):
     """The 'session not found' early return must not leak the handle.
 
     The stranded-session adoption fallback (#93296 follow-up) may lazily
     construct the SHARED launch handle via ``_get_db()`` while probing the
-    default store for a donor row; that handle carries ``db_path=None`` and
-    is never closed by design (see module docstring). Only the dedicated
-    profile-scoped open (``db_path=<profile>/state.db``) is the caller's to
-    close, so the leak assertion filters to path-scoped opens.
+    default store for a donor row; that handle is never closed by design (see
+    module docstring). Only the dedicated profile-scoped open is the caller's
+    to close, so the leak assertion filters to the profile store path.
     """
+    profile_store = tmp_path / "work" / "state.db"
     resp = _resume(session_id="missing", profile="work")
 
     assert resp["error"]["code"] == 4007
-    scoped = [db for db in profile_dbs if db.db_path is not None]
+    scoped = [db for db in profile_dbs if db.db_path == profile_store]
     assert len(scoped) == 1
     assert scoped[0].closed == 1
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2311,7 +2311,12 @@ def _get_db():
         from hermes_state import get_shared_session_db
 
         try:
-            _db = get_shared_session_db()
+            # Pin to import-time launch home (#102526). A bare
+            # get_shared_session_db() follows get_hermes_home(), which the
+            # desktop multiplex cron ticker temporarily overrides per profile at
+            # startup — first touch inside a foreign window permanently binds
+            # this process-wide handle to the wrong state.db.
+            _db = get_shared_session_db(Path(_hermes_home) / "state.db")
             _db_error = None
         except Exception as exc:
             _db_error = str(exc)


### PR DESCRIPTION
## Summary

- Pin `tui_gateway/server.py::_get_db()` to the import-time launch home (`Path(_hermes_home) / "state.db"`) instead of resolving through override-aware `get_hermes_home()` at first touch.
- Fixes [#102526](https://github.com/NousResearch/hermes-agent/issues/102526): the desktop multiplex cron ticker temporarily overrides `HERMES_HOME` per profile at startup, so the lazy launch SessionDB singleton could permanently bind to another profile's `state.db` — the default bot row then opened and wrote into the wrong profile's Bot Chat.
- Add a regression test for first-touch under a foreign override window, and adjust resume ownership leak filtering now that the shared launch handle carries an explicit path.

## Test plan

- [x] `scripts/run_tests.sh tests/tui_gateway/test_launch_db_home_override_race.py tests/tui_gateway/test_session_resume_db_ownership.py -q` (11 passed)
- [ ] Cold-start Hermes Desktop with multiple profiles; click the default Hermes bot first — Bot Chat should belong to the default profile, not another profile's session
- [ ] Confirm default backend holds its own `state.db` RW via `lsof`; replay `session.list {profile: "default", title: "Bot Chat"}` on the default backend WS and verify the default row is returned