### PR TITLE
feat(meta): fall back to local muse login when no API key is configured

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -809,6 +809,21 @@ def _resolve_api_key_provider_secret(
     except Exception:
         pass
 
+    # Last resort for the Meta family only: reuse the local `muse login`
+    # session (subscription billing) when no explicit API key is configured.
+    # Explicit env/pool credentials above keep priority, mirroring
+    # `muse login --help` ("META_API_KEY always takes priority over the
+    # account login").  See hermes_cli/muse_auth.py.
+    try:
+        from hermes_cli import muse_auth
+
+        if provider_id in muse_auth.MUSE_LOGIN_PROVIDER_IDS:
+            key, source = muse_auth.read_muse_login_key()
+            if key:
+                return key, source
+    except Exception:
+        pass
+
     return "", ""
 
 

--- a/hermes_cli/muse_auth.py
+++ b/hermes_cli/muse_auth.py
@@ -1,0 +1,161 @@
+"""Muse CLI login reuse for the Meta Model API provider family.
+
+Background
+----------
+Hermes' ``meta-ai`` provider (``plugins/model-providers/meta-ai``) only knows
+API-key auth (``MODEL_API_KEY`` / ``META_API_KEY`` / ``META_MODEL_API_KEY``),
+i.e. pay-as-you-go billing.  The official ``muse`` CLI, however, supports a
+second billing path: ``muse login`` (Meta-account OAuth device-code flow)
+provisions a subscription-bound credential and ``META_API_KEY`` takes
+priority over it (``muse login --help``).  Users on the Power Usage
+subscription therefore pay per-token in Hermes while the same model
+(``muse-spark-1.3-contributor``) bills to their subscription in ``muse``.
+
+What ``muse login`` stores
+--------------------------
+On macOS the login session lives in the login keychain as a generic-password
+item, service ``ai.meta.dev.credentials``, account ``meta``, holding JSON::
+
+    {"secret_schema_version": 1, "api_key": "LLM|...", "access_token": "dca..."}
+
+``api_key`` (``LLM|...``, login-provisioned — note the ``|``, distinct from
+dev-console pay-as-you-go ``LLM_...`` keys) authenticates to
+``https://api.meta.ai/v1`` as a Bearer token exactly like ``MODEL_API_KEY``
+(verified: ``GET /v1/models`` returns the same 7-model catalog with both).
+``access_token`` (``dca...``) is NOT an inference credential (401 on
+``/v1/models``) and is ignored here.  The provisioned key is stable — the
+payload carries no expiry/refresh material — so a read-through fallback with
+a short TTL cache is sufficient; no refresh flow is needed.
+
+Resolution order (enforced by the caller in ``hermes_cli.auth``)
+---------------------------------------------------------------
+Explicit configuration always beats implicit cross-app reuse, mirroring
+``muse``' own priority rule:
+
+1. env (``MODEL_API_KEY`` → ``META_API_KEY`` → ``META_MODEL_API_KEY``),
+2. Hermes credential pool (``hermes auth add`` entries),
+3. this module (local ``muse login`` session) — last resort only.
+
+Only the last-resort branch calls into this module, so machines without a
+Muse login never spawn a subprocess (cf. #60800), and setting any explicit
+Meta key disables the keychain read entirely.
+
+Platform notes
+--------------
+macOS reads via the ``security`` CLI.  The non-macOS ``muse`` credential
+fallback-file location is undocumented, so other platforms currently resolve
+to "no login found"; that gap is a deliberate follow-up, not silent
+misbehavior.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+import sys
+import time
+
+logger = logging.getLogger(__name__)
+
+# Keychain identity used by `muse login` (macOS login keychain).
+MUSE_KEYCHAIN_SERVICE = "ai.meta.dev.credentials"
+MUSE_KEYCHAIN_ACCOUNT = "meta"
+
+# Provider ids served by the bundled meta-ai plugin (name + aliases).
+MUSE_LOGIN_PROVIDER_IDS = frozenset({
+    "meta-ai",
+    "meta",
+    "muse",
+    "muse-spark",
+    "model-api",
+    "msl",
+})
+
+# Source label reported alongside the resolved key (mirrors the
+# "env:VAR" / "credential_pool:<id>" labels used by _resolve_api_key_provider_secret).
+MUSE_LOGIN_SOURCE = "muse-login:keychain"
+
+# TTL for the in-process login lookup cache (seconds).  Caches both hits and
+# misses: a miss must not re-spawn `security` on every resolution, and a hit
+# re-reads periodically so a `muse login` rotation is picked up.
+_LOGIN_CACHE_TTL_SECONDS = 300.0
+
+_cache_checked_at = 0.0
+_cache_key = ""
+_cache_source = ""
+
+
+def _reset_login_cache() -> None:
+    """Clear the in-process lookup cache (tests only)."""
+    global _cache_checked_at, _cache_key, _cache_source
+    _cache_checked_at = 0.0
+    _cache_key = ""
+    _cache_source = ""
+
+
+def _read_keychain_payload(timeout_seconds: float = 10.0) -> dict | None:
+    """Return the parsed `muse login` keychain payload, or None.
+
+    macOS only.  Never logs secret material.
+    """
+    if sys.platform != "darwin":
+        return None
+    if shutil.which("security") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            [
+                "security",
+                "find-generic-password",
+                "-s",
+                MUSE_KEYCHAIN_SERVICE,
+                "-a",
+                MUSE_KEYCHAIN_ACCOUNT,
+                "-w",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=max(1.0, float(timeout_seconds)),
+        )
+    except Exception as exc:
+        logger.debug("muse login keychain read failed: %s", type(exc).__name__)
+        return None
+    if proc.returncode != 0:
+        return None
+    try:
+        payload = json.loads((proc.stdout or "").strip())
+    except Exception:
+        logger.debug("muse login keychain payload is not JSON")
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def read_muse_login_key() -> tuple[str, str]:
+    """Return ``(api_key, source)`` from the local `muse login` session.
+
+    Returns ``("", "")`` when there is no usable login (wrong platform, no
+    `security` helper, no keychain item, unparseable payload, or empty key).
+    Results are cached in-process for ``_LOGIN_CACHE_TTL_SECONDS``.
+    """
+    global _cache_checked_at, _cache_key, _cache_source
+    now = time.monotonic()
+    if now - _cache_checked_at < _LOGIN_CACHE_TTL_SECONDS:
+        return _cache_key, _cache_source
+
+    key, source = "", ""
+    try:
+        from hermes_cli.auth import has_usable_secret
+
+        payload = _read_keychain_payload()
+        candidate = (payload or {}).get("api_key")
+        if has_usable_secret(candidate):
+            key, source = str(candidate).strip(), MUSE_LOGIN_SOURCE
+    except Exception as exc:
+        logger.debug("muse login resolution failed: %s", type(exc).__name__)
+        key, source = "", ""
+
+    _cache_checked_at = now
+    _cache_key, _cache_source = key, source
+    return key, source

--- a/tests/hermes_cli/test_muse_auth.py
+++ b/tests/hermes_cli/test_muse_auth.py
@@ -1,0 +1,291 @@
+"""Tests for `muse login` session reuse (hermes_cli.muse_auth + resolver hook).
+
+Hermes' meta-ai provider family previously resolved credentials from explicit
+API-key env vars and the credential pool only, i.e. pay-as-you-go billing
+even for users with a Muse Code Power Usage subscription (`muse login`).
+The last-resort fallback in `_resolve_api_key_provider_secret` now reuses the
+local `muse login` provisioned key (macOS keychain) when nothing explicit is
+configured.
+
+Rules under test (see hermes_cli/muse_auth.py):
+- explicit env beats pool beats muse-login; muse-login never fires for
+  non-Meta providers and never fires when explicit config exists (no stray
+  `security` subprocess, cf. #60800);
+- the login `access_token` is ignored (401s on /v1/models); only the stable
+  provisioned `api_key` is used;
+- secret material is never logged;
+- stdlib + pytest + unittest.mock only; no live network/keychain access.
+
+The `LLM|...` fixtures below are synthetic values in the documented shape,
+never real credentials.
+"""
+
+import json
+import logging
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+LOGIN_KEY = "LLM|1403246500870000|synthetic-test-key-material"
+PAYG_KEY = "LLM_2272589396850547 synthetic-test-payg-material"
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    for key in ("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    return home
+
+
+@pytest.fixture(autouse=True)
+def _fresh_login_cache():
+    from hermes_cli import muse_auth
+
+    muse_auth._reset_login_cache()
+    yield
+    muse_auth._reset_login_cache()
+
+
+def _write_env_file(home: Path, **kwargs) -> None:
+    lines = [f"{k}={v}" for k, v in kwargs.items()]
+    (home / ".env").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _mock_pool(*entries):
+    pool = MagicMock()
+    pool.has_credentials.return_value = bool(entries)
+    pool.peek.return_value = entries[0] if entries else None
+    pool.entries.return_value = list(entries)
+    return pool
+
+
+def _pool_entry(token):
+    e = MagicMock()
+    e.access_token = token
+    e.runtime_api_key = ""
+    return e
+
+
+def _meta_pconfig():
+    from hermes_cli.auth import ProviderConfig
+
+    return ProviderConfig(
+        id="meta-ai",
+        name="Meta Model API",
+        auth_type="api_key",
+        api_key_env_vars=("MODEL_API_KEY", "META_API_KEY", "META_MODEL_API_KEY"),
+    )
+
+
+def _keychain_payload(**overrides):
+    payload = {
+        "secret_schema_version": 1,
+        "api_key": LOGIN_KEY,
+        "access_token": "dca-synthetic",
+    }
+    payload.update(overrides)
+    return payload
+
+
+class TestReadMuseLoginKey:
+    def test_valid_payload_returns_key_and_source(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(_keychain_payload()),
+            stderr="",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed) as run:
+            key, source = muse_auth.read_muse_login_key()
+        assert key == LOGIN_KEY
+        assert source == muse_auth.MUSE_LOGIN_SOURCE
+        run.assert_called_once()
+
+    def test_missing_api_key_returns_empty(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        payload = _keychain_payload()
+        del payload["api_key"]
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(payload),
+            stderr="",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed):
+            assert muse_auth.read_muse_login_key() == ("", "")
+
+    def test_non_json_payload_returns_empty(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="not-json",
+            stderr="",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed):
+            assert muse_auth.read_muse_login_key() == ("", "")
+
+    def test_keychain_miss_returns_empty(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=44,
+            stdout="",
+            stderr="not found",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed):
+            assert muse_auth.read_muse_login_key() == ("", "")
+
+    def test_non_darwin_never_spawns_subprocess(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "linux")
+        with patch.object(muse_auth.subprocess, "run") as run:
+            assert muse_auth.read_muse_login_key() == ("", "")
+        run.assert_not_called()
+
+    def test_missing_security_helper_returns_empty(self, monkeypatch):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: None)
+        with patch.object(muse_auth.subprocess, "run") as run:
+            assert muse_auth.read_muse_login_key() == ("", "")
+        run.assert_not_called()
+
+    def test_miss_is_cached(self, monkeypatch):
+        """A keychain miss must not re-spawn `security` on every resolve."""
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=44,
+            stdout="",
+            stderr="not found",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed) as run:
+            assert muse_auth.read_muse_login_key() == ("", "")
+            assert muse_auth.read_muse_login_key() == ("", "")
+        run.assert_called_once()
+
+    def test_secret_never_logged(self, monkeypatch, caplog):
+        from hermes_cli import muse_auth
+
+        monkeypatch.setattr("sys.platform", "darwin")
+        monkeypatch.setattr("shutil.which", lambda _name: "/usr/bin/security")
+        completed = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=json.dumps(_keychain_payload()),
+            stderr="",
+        )
+        with patch.object(muse_auth.subprocess, "run", return_value=completed):
+            with caplog.at_level(logging.DEBUG):
+                muse_auth.read_muse_login_key()
+        for record in caplog.records:
+            assert LOGIN_KEY not in record.getMessage()
+
+
+class TestResolverFallbackOrder:
+    def _resolve(self, provider_id="meta-ai", pconfig=None, pool=None):
+        from hermes_cli.auth import _resolve_api_key_provider_secret
+
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            return _resolve_api_key_provider_secret(
+                provider_id=provider_id,
+                pconfig=pconfig or _meta_pconfig(),
+            )
+
+    def test_env_beats_muse_login(self, isolated_hermes_home):
+        _write_env_file(isolated_hermes_home, MODEL_API_KEY=PAYG_KEY)
+        with patch(
+            "hermes_cli.muse_auth.read_muse_login_key",
+            return_value=(LOGIN_KEY, "muse-login:keychain"),
+        ) as login:
+            key, source = self._resolve(pool=_mock_pool())
+        assert key == PAYG_KEY
+        assert source == "MODEL_API_KEY"
+        login.assert_not_called()
+
+    def test_pool_beats_muse_login(self, isolated_hermes_home):
+        (isolated_hermes_home / ".env").write_text("", encoding="utf-8")
+        with patch(
+            "hermes_cli.muse_auth.read_muse_login_key",
+            return_value=(LOGIN_KEY, "muse-login:keychain"),
+        ) as login:
+            key, source = self._resolve(pool=_mock_pool(_pool_entry("pool-key")))
+        assert key == "pool-key"
+        assert source == "credential_pool:meta-ai"
+        login.assert_not_called()
+
+    def test_muse_login_is_last_resort(self, isolated_hermes_home):
+        (isolated_hermes_home / ".env").write_text("", encoding="utf-8")
+        with patch(
+            "hermes_cli.muse_auth.read_muse_login_key",
+            return_value=(LOGIN_KEY, "muse-login:keychain"),
+        ):
+            key, source = self._resolve(pool=_mock_pool())
+        assert key == LOGIN_KEY
+        assert source == "muse-login:keychain"
+
+    def test_muse_login_failure_returns_empty(self, isolated_hermes_home):
+        (isolated_hermes_home / ".env").write_text("", encoding="utf-8")
+        with patch("hermes_cli.muse_auth.read_muse_login_key", return_value=("", "")):
+            assert self._resolve(pool=_mock_pool()) == ("", "")
+
+    def test_non_meta_provider_never_consults_login(self, isolated_hermes_home):
+        from hermes_cli.auth import ProviderConfig
+
+        (isolated_hermes_home / ".env").write_text("", encoding="utf-8")
+        with patch(
+            "hermes_cli.muse_auth.read_muse_login_key",
+            return_value=(LOGIN_KEY, "muse-login:keychain"),
+        ) as login:
+            key, source = self._resolve(
+                provider_id="openrouter",
+                pconfig=ProviderConfig(
+                    id="openrouter",
+                    name="OpenRouter",
+                    auth_type="api_key",
+                    api_key_env_vars=("OPENROUTER_API_KEY",),
+                ),
+                pool=_mock_pool(),
+            )
+        assert (key, source) == ("", "")
+        login.assert_not_called()
+
+    def test_login_key_passes_prefix_check(self):
+        """The meta family declares no key prefix (fail-open): the `LLM|`-shaped
+        login key must not be rejected as malformed."""
+        from hermes_cli.auth import _secret_matches_declared_prefix
+
+        for provider_id in (
+            "meta-ai",
+            "meta",
+            "muse",
+            "muse-spark",
+            "model-api",
+            "msl",
+        ):
+            assert _secret_matches_declared_prefix(provider_id, LOGIN_KEY) is True


### PR DESCRIPTION
## What does this PR do?

Gives the `meta-ai` provider family (`meta-ai`/`meta`/`muse`/`muse-spark`/`model-api`/`msl`) a last-resort credential source: the local `muse login` session (subscription billing). Today the family resolves only explicit API-key env vars + credential-pool entries, so subscription users burn pay-as-you-go tokens in Hermes while the same model bills to their subscription in `muse`.

`muse login` provisions a stable subscription-bound key (`LLM|...`, distinct from dev-console payg `LLM_...` keys) in the macOS keychain (service `ai.meta.dev.credentials`, account `meta`). Verified it authenticates to `https://api.meta.ai/v1` as Bearer identically to `MODEL_API_KEY` (same 7-model catalog on `GET /v1/models`); the co-stored `dca...` access token 401s and is ignored. No refresh flow needed (no expiry material in the payload).

Resolution order is **env -> pool -> muse-login**, so explicit configuration keeps priority, mirroring `muse login --help` (`META_API_KEY always takes priority over the account login`).

## Related Issue

Fixes #102535

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/muse_auth.py` (new): keychain read + TTL-cached (hit+miss, 300s) `read_muse_login_key()`; macOS-only, silent miss on other platforms (non-macOS `muse` fallback-file location is undocumented — deliberate follow-up). Never logs secret material.
- `hermes_cli/auth.py`: 15-line hook at the end of `_resolve_api_key_provider_secret` (same shape as the copilot special-case above it); lazy import, Meta family only.
- `tests/hermes_cli/test_muse_auth.py` (new, 14 tests): payload parsing, miss/non-darwin/no-helper paths, cache behavior, no-secret-in-logs, resolver order (env > pool > login), non-Meta isolation, prefix fail-open.

## How to Test

1. On a Mac with `muse login` active and no Meta env keys: `hermes auth status meta-ai` resolves via `muse-login:keychain`.
2. Set `MODEL_API_KEY`: env key wins, keychain never read.
3. `pytest tests/hermes_cli/test_muse_auth.py` — 14 passed; neighboring suites (`test_auth_key_prefix_skip`, `test_api_key_providers`, `test_copilot_auth`, `test_meta_ai_profile`) — 140 passed, no regressions.
4. `ruff check` on touched files — clean.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Commit message follows Conventional Commits (`feat(meta): ...`)
- [x] Searched existing PRs/issues — no duplicate (meta-ai PRs cover catalog/context-window only; #80591 was the api_key provider itself)
- [x] PR contains only this feature (3 files, +467)
- [x] Tests added; neighboring suites pass (full `scripts/run_tests.sh` not run — no venv with pytest on this machine; used repo venv + isolated pytest per CONTRIBUTING's module set)
- [x] No live network calls in tests (stdlib + pytest + unittest.mock only)

### Notes for review

- Non-macOS returns empty today; happy to extend once the `muse` fallback-file path is known.
- Billing attribution itself isn't API-observable; the subscription-vs-payg distinction rests on `muse`' documented login/key priority rule plus the distinct `LLM|` vs `LLM_` key shapes.