### PR TITLE
feat(desktop): recover from empty sidebar filter intersections

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
+++ b/apps/desktop/src/app/chat/sidebar/filter-menu.tsx
@@ -1,6 +1,7 @@
 import { useStore } from '@nanostores/react'
 
 import { sessionDotClassName } from '@/app/chat/session-status-dot'
+import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import {
@@ -20,8 +21,10 @@ import {
 } from '@/components/ui/dropdown-menu'
 import { useI18n } from '@/i18n'
 import { desktopGit } from '@/lib/desktop-git'
+import { compactNumber } from '@/lib/format'
 import { cn } from '@/lib/utils'
 import {
+  $sidebarActiveFilterCount,
   $sidebarCardRows,
   $sidebarFiltersActive,
   $sidebarGrouping,
@@ -164,6 +167,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
   const prFilter = useStore($sidebarPrFilter)
   const showArchived = useStore($sidebarShowArchived)
   const filtersActive = useStore($sidebarFiltersActive)
+  const activeFilterCount = useStore($sidebarActiveFilterCount)
   const viewCustomized = useStore($sidebarViewCustomized)
   const nodeOpen = useStore($sidebarWorkspaceNodeOpen)
   const listGroupIds = useStore($sidebarListGroupIds)
@@ -217,7 +221,7 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
         <Button
-          aria-label="Filters"
+          aria-label={t.sidebar.filtersAria(activeFilterCount)}
           className={cn(
             className,
             'data-[state=open]:bg-(--ui-control-active-background) data-[state=open]:text-foreground data-[state=open]:opacity-100',
@@ -230,7 +234,16 @@ export function SidebarFilterMenu({ className }: { className?: string }) {
           type="button"
           variant="ghost"
         >
-          <Codicon name="list-filter" size="0.75rem" />
+          <span className="relative inline-flex">
+            <Codicon name="list-filter" size="0.75rem" />
+            {activeFilterCount > 0 ? (
+              <span className="pointer-events-none absolute -top-2.5 -right-1.5 z-1">
+                <Badge aria-hidden size="overlay" variant="solid">
+                  {compactNumber(activeFilterCount)}
+                </Badge>
+              </span>
+            ) : null}
+          </span>
         </Button>
       </DropdownMenuTrigger>
 

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -171,7 +171,12 @@ import {
   useRepoWorktreeMap
 } from './projects'
 import { WorktreeDialog } from './projects/worktree-dialog'
-import { SidebarBlankState, SidebarPinnedEmptyState, SidebarSessionSkeletons } from './section-states'
+import {
+  SidebarBlankState,
+  SidebarFilterEmptyState,
+  SidebarPinnedEmptyState,
+  SidebarSessionSkeletons
+} from './section-states'
 import { buildSessionByAnyId, resolvePinnedSessions } from './session-index'
 import { SidebarSessionsSection, VIRTUALIZE_THRESHOLD } from './sessions-section'
 import { CONTEXT_SPLIT_KIT, SplitSubmenu } from './split-submenu'
@@ -1688,15 +1693,11 @@ export function ChatSidebar({
                 emptyState={
                   showSessionSkeletons ? (
                     <SidebarSessionSkeletons />
+                  ) : filtersActive && !inProject ? (
+                    <SidebarFilterEmptyState />
                   ) : (
                     <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
-                      {inProject
-                        ? s.projectEmpty
-                        : filtersActive
-                          ? s.noFilterMatches
-                          : pinnedSessions.length > 0
-                            ? s.allPinned
-                            : s.noSessions}
+                      {inProject ? s.projectEmpty : pinnedSessions.length > 0 ? s.allPinned : s.noSessions}
                     </div>
                   )
                 }

--- a/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.test.tsx
@@ -1,0 +1,60 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+
+import { I18nProvider } from '@/i18n'
+import {
+  $sidebarFiltersActive,
+  $sidebarProjectFilter,
+  $sidebarStatusFilter,
+  clearSidebarFilters,
+  resetSidebarView,
+  toggleSidebarProjectFilter,
+  toggleSidebarStatusFilter
+} from '@/store/layout'
+import { $showAllProfiles } from '@/store/profile'
+
+import { SidebarFilterEmptyState } from './section-states'
+
+afterEach(cleanup)
+
+beforeEach(() => {
+  $showAllProfiles.set(false)
+  resetSidebarView()
+})
+
+function renderEmpty() {
+  return render(
+    <I18nProvider configClient={null} initialLocale="en">
+      <SidebarFilterEmptyState />
+    </I18nProvider>
+  )
+}
+
+describe('SidebarFilterEmptyState', () => {
+  it('names the active filters and clears only those when clicked', () => {
+    toggleSidebarStatusFilter('working')
+    toggleSidebarProjectFilter('ceo-system')
+
+    expect($sidebarFiltersActive.get()).toBe(true)
+
+    renderEmpty()
+
+    expect(screen.getByText('No sessions match the active filters.')).toBeTruthy()
+    expect(screen.getByText('Active: Status · Project')).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: 'Clear filters' }))
+
+    expect($sidebarStatusFilter.get()).toEqual([])
+    expect($sidebarProjectFilter.get()).toEqual([])
+    expect($sidebarFiltersActive.get()).toBe(false)
+  })
+
+  it('uses the exported clear action, not a full view reset', () => {
+    toggleSidebarStatusFilter('idle')
+    const before = $sidebarStatusFilter.get()
+
+    expect(before).toEqual(['idle'])
+    clearSidebarFilters()
+    expect($sidebarStatusFilter.get()).toEqual([])
+  })
+})

--- a/apps/desktop/src/app/chat/sidebar/section-states.tsx
+++ b/apps/desktop/src/app/chat/sidebar/section-states.tsx
@@ -1,8 +1,11 @@
+import { useStore } from '@nanostores/react'
+
 import { Button } from '@/components/ui/button'
 import { Codicon } from '@/components/ui/codicon'
 import { Skeleton } from '@/components/ui/skeleton'
 import { useI18n } from '@/i18n'
 import { cn } from '@/lib/utils'
+import { $sidebarActiveFilterKinds, clearSidebarFilters } from '@/store/layout'
 
 import { SidebarRowCluster, SidebarRowShell, SidebarRowStack } from './chrome'
 
@@ -35,6 +38,25 @@ export function SidebarBlankState({ onNewProject }: { onNewProject: () => void }
         <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={onNewProject} size="sm" variant="ghost">
           <Codicon name="add" size="0.75rem" />
           {s.projects.newButton}
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export function SidebarFilterEmptyState() {
+  const { t } = useI18n()
+  const s = t.sidebar
+  const kinds = useStore($sidebarActiveFilterKinds)
+  const labels = kinds.map(kind => s.filterKinds[kind]).join(' · ')
+
+  return (
+    <div className="grid min-h-16 place-items-center rounded-lg px-2 text-center text-xs text-(--ui-text-tertiary)">
+      <div className="flex flex-col items-center gap-1.5">
+        <p>{s.noFilterMatches}</p>
+        {labels ? <p className="text-(--ui-text-quaternary)">{s.activeFilters(labels)}</p> : null}
+        <Button className="mt-0.5 text-(--ui-text-secondary)" onClick={clearSidebarFilters} size="sm" variant="ghost">
+          {s.clearFilters}
         </Button>
       </div>
     </div>

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1717,7 +1717,17 @@ export const ar = defineLocale({
     noWorkspace: 'بدون مساحة عمل',
     projectEmpty: 'لا توجد جلسات بعد',
     noSessions: 'لا توجد جلسات بعد',
-    noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية هذه',
+    noFilterMatches: 'لا توجد جلسات تطابق عوامل التصفية النشطة.',
+    clearFilters: 'مسح عوامل التصفية',
+    activeFilters: labels => `نشط: ${labels}`,
+    filtersAria: count => (count > 0 ? `عوامل التصفية، ${count} نشطة` : 'عوامل التصفية'),
+    filterKinds: {
+      archived: 'مؤرشف',
+      pr: 'طلب سحب',
+      profile: 'الملف الشخصي',
+      project: 'المشروع',
+      status: 'الحالة'
+    },
     projects: {
       sectionLabel: 'المشاريع',
       home: 'الرئيسية',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2342,7 +2342,17 @@ export const en: Translations = {
     noWorkspace: 'No workspace',
     projectEmpty: 'No sessions yet',
     noSessions: 'No sessions yet',
-    noFilterMatches: 'No sessions match these filters',
+    noFilterMatches: 'No sessions match the active filters.',
+    clearFilters: 'Clear filters',
+    activeFilters: labels => `Active: ${labels}`,
+    filtersAria: count => (count > 0 ? `Filters, ${count} active` : 'Filters'),
+    filterKinds: {
+      archived: 'Archived',
+      pr: 'Pull request',
+      profile: 'Profile',
+      project: 'Project',
+      status: 'Status'
+    },
     projects: {
       sectionLabel: 'Projects',
       home: 'Home',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2017,7 +2017,17 @@ export const ja = defineLocale({
     noWorkspace: 'ワークスペースなし',
     projectEmpty: 'セッションはまだありません',
     noSessions: 'セッションはまだありません',
-    noFilterMatches: 'このフィルターに一致するセッションはありません',
+    noFilterMatches: '有効なフィルターに一致するセッションはありません。',
+    clearFilters: 'フィルターをクリア',
+    activeFilters: labels => `有効: ${labels}`,
+    filtersAria: count => (count > 0 ? `フィルター、${count} 件有効` : 'フィルター'),
+    filterKinds: {
+      archived: 'アーカイブ',
+      pr: 'プルリクエスト',
+      profile: 'プロファイル',
+      project: 'プロジェクト',
+      status: 'ステータス'
+    },
     projects: {
       sectionLabel: 'プロジェクト',
       home: 'ホーム',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2378,7 +2378,17 @@ export const ru = defineLocale({
     noWorkspace: 'Без рабочего пространства',
     projectEmpty: 'Сеансов пока нет',
     noSessions: 'Сеансов пока нет',
-    noFilterMatches: 'Нет сеансов по этим фильтрам',
+    noFilterMatches: 'Нет сеансов по активным фильтрам.',
+    clearFilters: 'Сбросить фильтры',
+    activeFilters: labels => `Активны: ${labels}`,
+    filtersAria: count => (count > 0 ? `Фильтры, активно ${count}` : 'Фильтры'),
+    filterKinds: {
+      archived: 'В архиве',
+      pr: 'Запрос на слияние',
+      profile: 'Профиль',
+      project: 'Проект',
+      status: 'Статус'
+    },
     projects: {
       sectionLabel: 'Проекты',
       home: 'Главная',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1991,6 +1991,16 @@ export interface Translations {
     projectEmpty: string
     noSessions: string
     noFilterMatches: string
+    clearFilters: string
+    activeFilters: (labels: string) => string
+    filtersAria: (count: number) => string
+    filterKinds: {
+      archived: string
+      pr: string
+      profile: string
+      project: string
+      status: string
+    }
     projects: {
       sectionLabel: string
       home: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1942,7 +1942,17 @@ export const zhHant = defineLocale({
     noWorkspace: '無工作區',
     projectEmpty: '尚無工作階段',
     noSessions: '尚無工作階段',
-    noFilterMatches: '沒有工作階段符合這些篩選條件',
+    noFilterMatches: '沒有工作階段符合目前的篩選條件。',
+    clearFilters: '清除篩選',
+    activeFilters: labels => `目前篩選：${labels}`,
+    filtersAria: count => (count > 0 ? `篩選，${count} 項已啟用` : '篩選'),
+    filterKinds: {
+      archived: '已封存',
+      pr: '拉取請求',
+      profile: '設定檔',
+      project: '專案',
+      status: '狀態'
+    },
     projects: {
       sectionLabel: '專案',
       home: '主頁',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2509,7 +2509,17 @@ export const zh: Translations = {
     noWorkspace: '无工作区',
     projectEmpty: '暂无会话',
     noSessions: '暂无会话',
-    noFilterMatches: '没有会话符合这些筛选条件',
+    noFilterMatches: '没有会话符合当前筛选条件。',
+    clearFilters: '清除筛选',
+    activeFilters: labels => `当前筛选：${labels}`,
+    filtersAria: count => (count > 0 ? `筛选，${count} 项已启用` : '筛选'),
+    filterKinds: {
+      archived: '已归档',
+      pr: '拉取请求',
+      profile: '配置',
+      project: '项目',
+      status: '状态'
+    },
     projects: {
       sectionLabel: '项目',
       home: '主页',

--- a/apps/desktop/src/store/layout-sidebar-filters.test.ts
+++ b/apps/desktop/src/store/layout-sidebar-filters.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import {
+  $sidebarActiveFilterCount,
+  $sidebarActiveFilterKinds,
+  $sidebarCardRows,
+  $sidebarFiltersActive,
+  $sidebarGrouping,
+  $sidebarOrdering,
+  $sidebarPrFilter,
+  $sidebarProfileFilter,
+  $sidebarProjectFilter,
+  $sidebarRowMeta,
+  $sidebarShowArchived,
+  $sidebarStatusFilter,
+  $sidebarViewCustomized,
+  clearSidebarFilters,
+  resetSidebarView,
+  setSidebarCardRows,
+  setSidebarGrouping,
+  setSidebarOrdering,
+  sidebarActiveFilterCount,
+  sidebarActiveFilterKinds,
+  toggleSidebarPrFilter,
+  toggleSidebarProfileFilter,
+  toggleSidebarProjectFilter,
+  toggleSidebarRowMeta,
+  toggleSidebarStatusFilter
+} from './layout'
+import { $showAllProfiles } from './profile'
+
+beforeEach(() => {
+  $showAllProfiles.set(false)
+  resetSidebarView()
+})
+
+describe('sidebarActiveFilterKinds / count', () => {
+  it('names only the dimensions that are on, and counts each selected value', () => {
+    expect(sidebarActiveFilterKinds([], [], [], [], false)).toEqual([])
+    expect(sidebarActiveFilterCount([], [], [], [], false)).toBe(0)
+
+    expect(sidebarActiveFilterKinds(['working', 'idle'], ['proj'], [], ['open'], true)).toEqual([
+      'status',
+      'project',
+      'pr',
+      'archived'
+    ])
+    expect(sidebarActiveFilterCount(['working', 'idle'], ['proj'], [], ['open'], true)).toBe(5)
+  })
+})
+
+describe('clearSidebarFilters', () => {
+  it('clears status, project, profile, pull request, and archived', () => {
+    toggleSidebarStatusFilter('working')
+    toggleSidebarProjectFilter('ceo-system')
+    toggleSidebarProfileFilter('coder')
+    toggleSidebarPrFilter('open')
+    $sidebarShowArchived.set(true)
+
+    expect($sidebarFiltersActive.get()).toBe(true)
+    expect($sidebarActiveFilterCount.get()).toBe(5)
+    expect($sidebarActiveFilterKinds.get()).toEqual(['status', 'project', 'profile', 'pr', 'archived'])
+
+    clearSidebarFilters()
+
+    expect($sidebarStatusFilter.get()).toEqual([])
+    expect($sidebarProjectFilter.get()).toEqual([])
+    expect($sidebarProfileFilter.get()).toEqual([])
+    expect($sidebarPrFilter.get()).toEqual([])
+    expect($sidebarShowArchived.get()).toBe(false)
+    expect($sidebarFiltersActive.get()).toBe(false)
+    expect($sidebarActiveFilterCount.get()).toBe(0)
+    expect($sidebarActiveFilterKinds.get()).toEqual([])
+  })
+
+  it('leaves grouping, ordering, row metadata, and inbox style alone', () => {
+    setSidebarGrouping('status')
+    setSidebarOrdering('tokens')
+    toggleSidebarRowMeta('tokens')
+    setSidebarCardRows(true)
+    toggleSidebarStatusFilter('unread')
+
+    const grouping = $sidebarGrouping.get()
+    const ordering = $sidebarOrdering.get()
+    const rowMeta = $sidebarRowMeta.get()
+    const cardRows = $sidebarCardRows.get()
+
+    clearSidebarFilters()
+
+    expect($sidebarGrouping.get()).toBe(grouping)
+    expect($sidebarOrdering.get()).toBe(ordering)
+    expect($sidebarRowMeta.get()).toEqual(rowMeta)
+    expect($sidebarCardRows.get()).toBe(cardRows)
+    expect($sidebarViewCustomized.get()).toBe(true)
+    expect($sidebarFiltersActive.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/layout.ts
+++ b/apps/desktop/src/store/layout.ts
@@ -374,10 +374,66 @@ export const $sidebarOrdering: ReadableAtom<SidebarOrdering> = computed(
   (manual, key) => (manual ? 'manual' : key)
 )
 
+export type SidebarFilterKind = 'archived' | 'pr' | 'profile' | 'project' | 'status'
+
+/** Which filter dimensions currently hide rows — empty-state copy names these. */
+export function sidebarActiveFilterKinds(
+  statuses: readonly unknown[],
+  projects: readonly unknown[],
+  profiles: readonly unknown[],
+  prs: readonly unknown[],
+  archived: boolean
+): SidebarFilterKind[] {
+  const kinds: SidebarFilterKind[] = []
+
+  if (statuses.length > 0) {
+    kinds.push('status')
+  }
+
+  if (projects.length > 0) {
+    kinds.push('project')
+  }
+
+  if (profiles.length > 0) {
+    kinds.push('profile')
+  }
+
+  if (prs.length > 0) {
+    kinds.push('pr')
+  }
+
+  if (archived) {
+    kinds.push('archived')
+  }
+
+  return kinds
+}
+
+/** Selected values across every filter dimension (archived counts as one). */
+export function sidebarActiveFilterCount(
+  statuses: readonly unknown[],
+  projects: readonly unknown[],
+  profiles: readonly unknown[],
+  prs: readonly unknown[],
+  archived: boolean
+): number {
+  return statuses.length + projects.length + profiles.length + prs.length + (archived ? 1 : 0)
+}
+
 export const $sidebarFiltersActive: ReadableAtom<boolean> = computed(
   [$sidebarStatusFilter, $sidebarProjectFilter, $sidebarProfileFilter, $sidebarPrFilter, $sidebarShowArchived],
   (statuses, projects, profiles, prs, archived) =>
-    statuses.length > 0 || projects.length > 0 || profiles.length > 0 || prs.length > 0 || archived
+    sidebarActiveFilterCount(statuses, projects, profiles, prs, archived) > 0
+)
+
+export const $sidebarActiveFilterKinds: ReadableAtom<SidebarFilterKind[]> = computed(
+  [$sidebarStatusFilter, $sidebarProjectFilter, $sidebarProfileFilter, $sidebarPrFilter, $sidebarShowArchived],
+  sidebarActiveFilterKinds
+)
+
+export const $sidebarActiveFilterCount: ReadableAtom<number> = computed(
+  [$sidebarStatusFilter, $sidebarProjectFilter, $sidebarProfileFilter, $sidebarPrFilter, $sidebarShowArchived],
+  sidebarActiveFilterCount
 )
 
 /** Anything at all moved off the shipped view — what makes a reset worth
@@ -669,7 +725,9 @@ export function toggleSidebarPrFilter(bucket: PullRequestBucket) {
   toggleIn($sidebarPrFilter, bucket)
 }
 
-function clearSidebarFilters() {
+/** Drop only what hides rows. Grouping, ordering, row metadata, and inbox
+ *  style stay put — those are view preferences, not filters. */
+export function clearSidebarFilters() {
   $sidebarStatusFilter.set([])
   $sidebarProjectFilter.set([])
   $sidebarProfileFilter.set([])


### PR DESCRIPTION
## What does this PR do?

The desktop session sidebar can stack status, project, profile, pull request, and archived filters. When their intersection is empty, the list only said sessions did not match “these filters,” with no way to recover except **Reset to defaults**, which also wipes grouping, ordering, row metadata, and inbox style.

When `$sidebarFiltersActive` is on and the recents list is empty, the empty state now says **No sessions match the active filters.**, lists the active filter dimensions, and offers **Clear filters**. That action calls the existing `clearSidebarFilters()` helper (now exported) so only filter state is dropped.

The filter button also shows the active-filter count so a persisted intersection is visible before the list goes empty.

## Related Issue

Fixes #101070

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/store/layout.ts` — export `clearSidebarFilters()`; add `sidebarActiveFilterKinds` / `sidebarActiveFilterCount` and matching atoms
- `apps/desktop/src/app/chat/sidebar/section-states.tsx` — `SidebarFilterEmptyState` with copy, active-filter list, and Clear filters
- `apps/desktop/src/app/chat/sidebar/index.tsx` — render that empty state when filters are active and the recents list is empty
- `apps/desktop/src/app/chat/sidebar/filter-menu.tsx` — count badge on the filter trigger
- `apps/desktop/src/i18n/{en,zh,zh-hant,ja,ar,ru,types}.ts` — empty-state and filter-kind strings
- `apps/desktop/src/store/layout-sidebar-filters.test.ts` — clear vs preserve-view contract
- `apps/desktop/src/app/chat/sidebar/section-states.test.tsx` — empty-state copy and Clear filters click

## How to Test

1. Open Hermes Desktop with sessions assigned to a project.
2. Enable a status filter that excludes those sessions, then select **Project → that project**.
3. Confirm the sidebar shows **No sessions match the active filters.**, lists the active dimensions (Status · Project), and that the filter button shows a count.
4. Click **Clear filters**. The sessions return. Grouping, ordering, row metadata, and inbox style stay as they were.
5. From `apps/desktop`: `npx vitest run src/store/layout-sidebar-filters.test.ts src/app/chat/sidebar/section-states.test.tsx src/store/layout-sidebar-view.test.ts`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (Ubuntu), desktop vitest

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
Test Files  3 passed (3)
     Tests  11 passed (11)
```
