### PR TITLE
fix(cron): detach CLI/tool cron run so a dead caller cannot leave unknown

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -782,6 +782,23 @@ _running_fire_owners: dict[str, dict[object, tuple[Optional[str], Path]]] = {}
 # process sweep cannot reach the worker's transient scope.
 _restart_safe_waiter_job_ids: set[str] = set()
 _running_lock = threading.Lock()
+_allow_unscoped_worker: contextvars.ContextVar[bool] = contextvars.ContextVar(
+    "cron_allow_unscoped_worker", default=False
+)
+
+
+@contextlib.contextmanager
+def allow_unscoped_cron_worker():
+    """Permit a detached cron worker outside a managed systemd gateway.
+
+    Used by immediate ``hermes cron run`` / ``cronjob(action='run')`` so the
+    one-shot caller is only a waiter. Ticker fires must not use this.
+    """
+    token = _allow_unscoped_worker.set(True)
+    try:
+        yield
+    finally:
+        _allow_unscoped_worker.reset(token)
 
 # Wall-clock (time.time()) instant each in-flight job id was claimed by
 # ``_submit_with_guard``, plus the future that owns its release (a pending
@@ -8134,15 +8151,24 @@ def _wait_for_external_cron_worker(
 
 
 def _launch_external_cron_worker(job: dict) -> bool:
-    """Launch *job* outside a managed gateway cgroup when required.
+    """Launch *job* in a detached worker that owns the durable execution.
 
-    Returns ``False`` when the caller is not a managed systemd gateway and the
-    existing in-process path should be used.  In managed topology, failure to
-    establish the transient scope raises: falling back would recreate the
-    restart interruption this handoff exists to prevent.
+    Managed systemd gateway: the child is wrapped in a transient user scope
+    so a gateway restart cannot kill it with the service cgroup.  Failure to
+    establish that scope raises — falling back would recreate the restart
+    interruption this handoff exists to prevent.
+
+    Immediate ``hermes cron run`` / ``cronjob(action='run')`` (the
+    ``_hermes_allow_unscoped_worker`` flag): launch the same worker without
+    systemd-run.  The child starts a new session so a caller timeout/SIGTERM
+    of the one-shot CLI process cannot take the execution owner with it.
+    Ticker fires stay in-process outside managed topology (return False).
     """
     execution_id = str(job["execution_id"])
     job_id = str(job["id"])
+    allow_unscoped = bool(
+        job.get("_hermes_allow_unscoped_worker") or _allow_unscoped_worker.get()
+    )
     handoff_dir = _get_hermes_home() / "cron" / "external-workers"
     payload_path = handoff_dir / f"{execution_id}.json"
     ack_path = handoff_dir / f"{execution_id}.ready"
@@ -8166,7 +8192,9 @@ def _launch_external_cron_worker(job: dict) -> bool:
         unit_suffix=f"cron-{job_id}-exec-{execution_id}",
     )
     if scoped_command == command:
-        return False
+        if not allow_unscoped:
+            return False
+        scoped_command = command
 
     if mark_execution_handoff_pending(execution_id) is None:
         raise RuntimeError(
@@ -8181,9 +8209,14 @@ def _launch_external_cron_worker(job: dict) -> bool:
     fd = os.open(payload_path, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
     try:
         with os.fdopen(fd, "w", encoding="utf-8") as payload_file:
+            payload_job = {
+                key: value
+                for key, value in job.items()
+                if key != "_hermes_allow_unscoped_worker"
+            }
             json.dump(
                 {
-                    "job": job,
+                    "job": payload_job,
                     "profile_home": str(_get_hermes_home().resolve()),
                     "multiplex_active": multiplex_active,
                 },

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -961,6 +961,8 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
         elif job.get("executed"):
             outcome = "succeeded" if job.get("execution_success") else "failed"
             print(f"  Ran now: {outcome}.")
+            if job.get("execution_id"):
+                print(f"  Execution: {job['execution_id']}")
         elif job.get("execution_skipped"):
             print(f"  {job['execution_skipped']}")
         else:

--- a/tests/cron/test_direct_run_caller_timeout.py
+++ b/tests/cron/test_direct_run_caller_timeout.py
@@ -1,0 +1,150 @@
+"""Direct `hermes cron run` must survive caller timeout.
+
+A one-shot CLI process used to own the durable execution in-process. When
+the caller was SIGTERM/SIGKILL'd mid-run, recover_interrupted_executions()
+proved the owner dead and marked the attempt unknown, with no output.
+Immediate runs now hand off to a start_new_session worker so the waiter
+can die without taking the owner or the artifact with it.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+
+def _env(home: Path, repo: Path) -> dict:
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(home)
+    env["PYTHONPATH"] = str(repo)
+    return env
+
+
+def _py(repo: Path, env: dict, snippet: str, **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, "-c", snippet],
+        cwd=repo,
+        env=env,
+        text=True,
+        capture_output=True,
+        **kwargs,
+    )
+
+
+def test_direct_run_caller_kill_leaves_worker_to_terminalize(tmp_path):
+    home = tmp_path / "home"
+    (home / "scripts").mkdir(parents=True)
+    (home / "cron").mkdir()
+    workdir = home / "workdir"
+    workdir.mkdir()
+    artifact = workdir / "report.md"
+    started = home / "started.flag"
+    (home / "scripts" / "slow.py").write_text(
+        "import time, pathlib\n"
+        f"pathlib.Path({str(started)!r}).write_text('started')\n"
+        "time.sleep(4)\n"
+        f"pathlib.Path({str(artifact)!r}).write_text('report complete')\n"
+        "print('done')\n",
+        encoding="utf-8",
+    )
+    repo = Path(__file__).resolve().parents[2]
+    env = _env(home, repo)
+
+    created = _py(
+        repo,
+        env,
+        "from cron.jobs import create_job; "
+        "j=create_job(prompt=None, schedule='every 1h', name='timeout-repro', "
+        "script='slow.py', no_agent=True, deliver='local', "
+        f"workdir={str(workdir)!r}); print(j['id'])",
+        check=True,
+    )
+    job_id = created.stdout.strip().splitlines()[-1]
+    assert job_id
+
+    runner = subprocess.Popen(
+        [
+            sys.executable,
+            "-c",
+            "import os, threading, time\n"
+            "from pathlib import Path\n"
+            "from cron.jobs import get_job\n"
+            "from tools.cronjob_tools import _execute_job_now\n"
+            f"started = Path({str(started)!r})\n"
+            "def abandon_caller():\n"
+            "    deadline = time.monotonic() + 8\n"
+            "    while time.monotonic() < deadline and not started.exists():\n"
+            "        time.sleep(0.05)\n"
+            "    time.sleep(0.2)\n"
+            "    os._exit(9)\n"
+            "threading.Thread(target=abandon_caller, daemon=True).start()\n"
+            f"job=get_job({job_id!r})\n"
+            "print(_execute_job_now(job), flush=True)\n",
+        ],
+        cwd=repo,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    try:
+        out, err = runner.communicate(timeout=12)
+    except subprocess.TimeoutExpired:
+        runner.terminate()
+        out, err = runner.communicate(timeout=5)
+        raise AssertionError(
+            f"caller never abandoned; rc={runner.returncode}\nstdout={out}\nstderr={err}"
+        )
+    assert runner.returncode == 9, (
+        f"caller should abandon with os._exit(9); rc={runner.returncode}\n"
+        f"stdout={out}\nstderr={err}"
+    )
+    assert started.exists(), "job script never started"
+
+    mid = _py(
+        repo,
+        env,
+        "import json; "
+        "from cron.executions import list_executions, recover_interrupted_executions; "
+        f"print(recover_interrupted_executions()); "
+        f"print(json.dumps(list_executions(job_id={job_id!r})))",
+        check=True,
+    )
+    lines = [ln for ln in mid.stdout.splitlines() if ln.strip()]
+    recovered = int(lines[0])
+    records = json.loads(lines[1])
+    assert recovered == 0, (
+        f"live detached worker must not be marked unknown; records={records}"
+    )
+    assert records, "direct run must have created an execution row"
+    assert records[0]["source"] == "direct"
+    assert records[0]["status"] in {"claimed", "running"}
+    worker_pid = int(records[0]["pid"])
+    assert worker_pid != runner.pid
+
+    finish_deadline = time.monotonic() + 20
+    while time.monotonic() < finish_deadline:
+        if artifact.exists():
+            break
+        time.sleep(0.1)
+    assert artifact.exists(), "detached worker should have written the job artifact"
+    assert artifact.read_text(encoding="utf-8") == "report complete"
+
+    final = _py(
+        repo,
+        env,
+        "import json; "
+        "from cron.executions import list_executions, recover_interrupted_executions; "
+        "print(recover_interrupted_executions()); "
+        f"print(json.dumps(list_executions(job_id={job_id!r})))",
+        check=True,
+    )
+    final_lines = [ln for ln in final.stdout.splitlines() if ln.strip()]
+    assert final_lines[0] == "0"
+    final_records = json.loads(final_lines[1])
+    assert final_records[0]["status"] == "completed"
+    assert final_records[0]["error"] is None

--- a/tests/cron/test_restart_safe_worker.py
+++ b/tests/cron/test_restart_safe_worker.py
@@ -328,6 +328,65 @@ def test_launch_external_worker_stays_in_process_outside_managed_gateway(
     popen.assert_not_called()
 
 
+def test_launch_external_worker_unscoped_when_cli_direct_run_asks(
+    monkeypatch, tmp_path
+):
+    """Immediate hermes cron run must detach even outside a managed gateway."""
+    import cron.scheduler as scheduler
+
+    monkeypatch.setattr(scheduler, "_get_hermes_home", lambda: tmp_path)
+    monkeypatch.setattr(
+        "tools.process_registry.restart_safe_gateway_child_argv",
+        lambda command, *, unit_suffix: command,
+    )
+    monkeypatch.setattr(
+        scheduler, "mark_execution_handoff_pending",
+        Mock(return_value={"id": "exec-cli"}),
+    )
+
+    class FakeProcess:
+        returncode = None
+
+        def poll(self):
+            return self.returncode
+
+        def wait(self, timeout=None):
+            if self.returncode is None:
+                raise subprocess.TimeoutExpired(cmd="worker", timeout=timeout)
+            return self.returncode
+
+    spawned = []
+
+    def popen(command, **kwargs):
+        spawned.append((command, kwargs))
+        ack_index = command.index("--ack-file") + 1
+        Path(command[ack_index]).write_text(
+            json.dumps({"pid": 7777, "execution_id": "exec-cli"}),
+            encoding="utf-8",
+        )
+        return FakeProcess()
+
+    monkeypatch.setattr(scheduler.subprocess, "Popen", popen)
+    statuses = iter(
+        [
+            {"id": "exec-cli", "status": "running"},
+            {"id": "exec-cli", "status": "completed"},
+        ]
+    )
+    monkeypatch.setattr(
+        scheduler, "get_execution",
+        Mock(side_effect=lambda _execution_id: next(statuses)),
+    )
+
+    with scheduler.allow_unscoped_cron_worker():
+        assert scheduler._launch_external_cron_worker(
+            {"id": "job-cli", "execution_id": "exec-cli"}
+        ) is True
+    assert spawned
+    assert spawned[0][1]["start_new_session"] is True
+    assert spawned[0][0][0:2] == [sys.executable, "-m"]
+
+
 def test_shared_run_path_hands_gateway_fire_to_external_worker(monkeypatch):
     import cron.scheduler as scheduler
 

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1009,6 +1009,7 @@ def _run_claimed_job(
     fire_owner = None
     try:
         from cron.scheduler import (
+            allow_unscoped_cron_worker,
             release_running_job,
             run_one_job,
             try_register_running_job,
@@ -1111,12 +1112,18 @@ def _run_claimed_job(
         adapters = getattr(runner, "adapters", None) if runner is not None else None
         gateway_loop = getattr(runner, "_gateway_loop", None) if runner is not None else None
 
+        # Immediate CLI / tool runs used to own the execution in THIS
+        # process. A caller timeout then proved the owner dead and
+        # recover_interrupted_executions() marked the attempt unknown.
+        # allow_unscoped_cron_worker() hands the durable owner to a
+        # start_new_session child so the waiter can die independently.
         try:
             try:
-                processed = run_one_job(
-                    job, adapters=adapters, loop=gateway_loop,
-                    extra_prompt=extra_prompt,
-                )
+                with allow_unscoped_cron_worker():
+                    processed = run_one_job(
+                        job, adapters=adapters, loop=gateway_loop,
+                        extra_prompt=extra_prompt,
+                    )
             finally:
                 _heartbeat_stop.set()
                 if _heartbeat_thread is not None:
@@ -1152,6 +1159,7 @@ def _run_claimed_job(
             "claimed": True,
             "success": bool(processed and ok),
             "error": run_error,
+            "execution_id": execution_id,
         }
 
     except Exception as e:
@@ -1832,6 +1840,8 @@ def cronjob(
             result = _format_job(get_job(job_id) or {"id": job_id})
             result["executed"] = exec_result.get("claimed", False)
             result["execution_success"] = exec_result.get("success", False)
+            if exec_result.get("execution_id"):
+                result["execution_id"] = exec_result["execution_id"]
             if not exec_result.get("claimed", False):
                 result["execution_skipped"] = exec_result.get("error") or (
                     "Already being fired by the scheduler; not run again."


### PR DESCRIPTION
## What does this PR do?

`hermes cron run` (and `cronjob(action="run")`) used to keep the one-shot caller process as the durable execution owner outside a managed gateway. If that caller timed out or was killed mid-run, `recover_interrupted_executions()` proved the owner dead and marked the attempt `unknown`, with no output artifact.

Immediate runs now reuse the existing restart-safe worker (`start_new_session`) so the waiter can die without taking the owner or the artifact with it. Scheduler ticker fires stay in-process unless a managed systemd argv rewrite applies. Successful CLI run-now output includes the durable execution id.

## Related Issue

Fixes #102511

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `cron/scheduler.py` — `allow_unscoped_cron_worker()` ContextVar; `_launch_external_cron_worker` launches the same worker when that flag is set even if `restart_safe_gateway_child_argv` is a no-op; payload strips `_hermes_allow_unscoped_worker` so the child cannot re-handoff
- `tools/cronjob_tools.py` — `_run_claimed_job` wraps `run_one_job` in that context and returns `execution_id`
- `hermes_cli/cron.py` — print `Execution: <id>` after a successful run-now
- `tests/cron/test_restart_safe_worker.py` — opt-in detach vs ticker-stays-in-process
- `tests/cron/test_direct_run_caller_timeout.py` — caller `os._exit` mid-run; recover stays 0 while the worker lives; artifact written; status `completed`

## How to Test

1. Create a `--no-agent` job whose script sleeps a few seconds and writes a workdir artifact, then run it through `_execute_job_now` / `hermes cron run`.
2. Kill the waiter after the script starts (`os._exit` or SIGKILL of the CLI process). Confirm `recover_interrupted_executions()` returns 0 and the ledger row is still `claimed`/`running` under a different pid.
3. Wait for the artifact, then confirm the execution is `completed` with `error` unset — not `unknown`.
4. Targeted suite: `scripts/run_tests.sh tests/cron/test_restart_safe_worker.py tests/cron/test_direct_run_caller_timeout.py tests/cron/test_execution_ledger.py tests/cron/test_run_one_job.py tests/cron/test_cron_run_stale_claim_reap_86721.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
test_direct_run_caller_kill_leaves_worker_to_terminalize PASSED
test_launch_external_worker_unscoped_when_cli_direct_run_asks PASSED
test_launch_external_worker_stays_in_process_outside_managed_gateway PASSED
```
