### PR TITLE
fix(auth): key get_nous_auth_status() cache on content digest, not mtime

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7509,25 +7509,46 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
 # subscription-feature checks) call it many times per render — `hermes tools` → "All Platforms"
 # was firing the refresh ~31× during one menu paint, racking up >13s of HTTP and burning
 # single-use refresh tokens. Cache the snapshot for a few seconds, keyed on the auth.json
-# path + mtime so that profile switches do not share a process memo and
+# path + content digest so that profile switches do not share a process memo and
 # `hermes auth login/logout/add/remove` invalidate naturally on the next call.
+#
+# Content-digest-keyed, not mtime-keyed: this cache stores the live Nous
+# access_token (see _compute_nous_auth_status below), so it guards credential
+# identity, not just a parse. A (path, mtime) signature is the right idiom for
+# a config cache, but an external metadata-preserving copy of auth.json
+# (dotfile sync, backup/restore, `rsync -a`) can replace the file's bytes
+# while restoring its original mtime — a stat-only key would never detect
+# that and would keep serving a stale (or entirely different) access_token
+# for the life of the TTL window. Same class of bug already fixed for the
+# Vertex SA credential cache (agent/vertex_adapter.py's _read_sa_file) and
+# for this file's own _load_global_auth_store()/_oauth_heal_clean_marks
+# caches; hashing the content closes the same gap here.
 _NOUS_AUTH_STATUS_CACHE_TTL = 15.0  # seconds
-_nous_auth_status_cache: Optional[Tuple[float, str, Optional[float], Dict[str, Any]]] = None
+_nous_auth_status_cache: Optional[Tuple[float, str, Optional[str], Dict[str, Any]]] = None
 
-# mtime-keyed memo for _load_global_auth_store(): (path, mtime_ns, store).
+# content-digest-keyed memo for _load_global_auth_store(): (path, sha256, store).
 # Same invalidation contract as _nous_auth_status_cache — the global auth
 # file changes only when a global-scope auth write touches it.
 _global_auth_store_cache: Optional[Tuple[str, int, Dict[str, Any]]] = None
 
 
-def _auth_file_cache_key() -> Tuple[str, Optional[float]]:
+def _auth_file_cache_key() -> Tuple[str, Optional[str]]:
+    """(resolved auth.json path, sha256-of-content) cache key.
+
+    Fingerprints the file's CONTENT, not stat metadata — see the module
+    comment above _nous_auth_status_cache for why a credential cache can't
+    use a stat-only key. The file is a few KB of JSON; one read + sha256 per
+    cache PROBE is noise next to the OAuth refresh POST this cache exists to
+    avoid.
+    """
     auth_file = _auth_file_path()
     try:
         auth_file_key = str(auth_file.resolve(strict=False))
     except Exception:
         auth_file_key = str(auth_file)
     try:
-        return auth_file_key, auth_file.stat().st_mtime
+        digest = hashlib.sha256(auth_file.read_bytes()).hexdigest()
+        return auth_file_key, digest
     except FileNotFoundError:
         return auth_file_key, None
     except Exception:
@@ -7555,27 +7576,27 @@ def get_nous_auth_status() -> Dict[str, Any]:
     as a healthy login. If provider state is absent, fall back to the credential
     pool for the just-logged-in / not-yet-promoted case.
 
-    The returned snapshot is memoised for ~15s keyed on the auth.json mtime,
-    so menu/status surfaces that ask repeatedly don't trigger one refresh POST
-    per call. Login/logout flows write to auth.json and therefore invalidate
-    the cache automatically; tests can also call
+    The returned snapshot is memoised for ~15s keyed on the auth.json content
+    digest, so menu/status surfaces that ask repeatedly don't trigger one
+    refresh POST per call. Login/logout flows write to auth.json and
+    therefore invalidate the cache automatically; tests can also call
     ``invalidate_nous_auth_status_cache()`` explicitly.
     """
     global _nous_auth_status_cache
     now = time.monotonic()
-    auth_file_key, mtime = _auth_file_cache_key()
+    auth_file_key, digest = _auth_file_cache_key()
     cached = _nous_auth_status_cache
     if cached is not None:
-        cached_at, cached_auth_file_key, cached_mtime, cached_status = cached
+        cached_at, cached_auth_file_key, cached_digest, cached_status = cached
         if (
             cached_auth_file_key == auth_file_key
-            and cached_mtime == mtime
+            and cached_digest == digest
             and (now - cached_at) < _NOUS_AUTH_STATUS_CACHE_TTL
         ):
             return dict(cached_status)
 
     status = _compute_nous_auth_status()
-    _nous_auth_status_cache = (now, auth_file_key, mtime, dict(status))
+    _nous_auth_status_cache = (now, auth_file_key, digest, dict(status))
     return status
 
 

--- a/tests/hermes_cli/test_nous_auth_status_cache.py
+++ b/tests/hermes_cli/test_nous_auth_status_cache.py
@@ -3,9 +3,12 @@
 The cache avoids re-validating Nous credentials on every menu paint —
 `hermes tools` → "All Platforms" used to fire ~31 OAuth refresh POSTs
 against portal.nousresearch.com during one render. The cache is keyed
-on auth.json path + mtime so profile switches stay isolated while
-login/logout flows invalidate naturally; tests and other writers can
-also call invalidate_nous_auth_status_cache().
+on auth.json path + content digest (not mtime — this cache stores the
+live access_token, so it guards credential identity, same class of bug
+already fixed for the Vertex SA credential cache and this file's own
+_load_global_auth_store()/_oauth_heal_clean_marks caches) so profile
+switches stay isolated while login/logout flows invalidate naturally;
+tests and other writers can also call invalidate_nous_auth_status_cache().
 """
 
 from __future__ import annotations
@@ -85,5 +88,62 @@ def test_get_nous_auth_status_caches_failure_path(tmp_path, monkeypatch):
     assert call_count["n"] == 1, (
         f"Logged-out snapshots must cache; got {call_count['n']} computes for 10 calls."
     )
+
+    auth_mod.invalidate_nous_auth_status_cache()
+
+
+def test_metadata_preserving_replace_is_not_served_stale(tmp_path, monkeypatch):
+    """A stat-only cache key would miss a content change that preserves mtime.
+
+    This is the direct regression test for the credential-cache anti-pattern
+    already fixed elsewhere in this codebase (Vertex SA credential cache,
+    agent/vertex_adapter.py's _read_sa_file; and this file's own
+    _load_global_auth_store()/_oauth_heal_clean_marks caches): a tool that
+    replaces a file's bytes while preserving its mtime — dotfile sync,
+    backup/restore, `rsync -a` — must not leave get_nous_auth_status()
+    serving a stale (here, a *different account's*) access_token for the
+    rest of the TTL window.
+
+    Bumping mtime alone would NOT discriminate old vs. new code (content
+    changes normally bump mtime too), so the file's exact original
+    st_mtime_ns is restored via os.utime after the content swap.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    auth_file = _seed_auth_file(tmp_path)
+
+    from hermes_cli import auth as auth_mod
+
+    auth_mod.invalidate_nous_auth_status_cache()
+
+    call_n = [0]
+
+    def fake_compute():
+        call_n[0] += 1
+        return {"logged_in": True, "source": "auth_store", "access_token": f"token-{call_n[0]}"}
+
+    with patch.object(auth_mod, "_compute_nous_auth_status", side_effect=fake_compute):
+        first = auth_mod.get_nous_auth_status()
+        assert first["access_token"] == "token-1"
+
+        original_stat = auth_file.stat()
+
+        # External metadata-preserving replace: the file's bytes change (a
+        # different account's credentials, or a stale backup, lands in
+        # auth.json) but its mtime is restored to the exact value the cache
+        # observed on the first call.
+        auth_file.write_text(
+            json.dumps({"providers": {}, "marker": "replaced"}), encoding="utf-8"
+        )
+        os.utime(auth_file, ns=(original_stat.st_atime_ns, original_stat.st_mtime_ns))
+        assert auth_file.stat().st_mtime_ns == original_stat.st_mtime_ns  # sanity
+
+        second = auth_mod.get_nous_auth_status()
+
+    assert call_n[0] == 2, (
+        "Content changed (bytes differ) even though mtime did not — the "
+        "digest-keyed cache must detect it and recompute, not keep serving "
+        "the stale cached access_token."
+    )
+    assert second["access_token"] == "token-2"
 
     auth_mod.invalidate_nous_auth_status_cache()


### PR DESCRIPTION
## Summary

`get_nous_auth_status()`'s process-level memo (`_nous_auth_status_cache`) stores the live Nous `access_token` for up to 15s, keyed via `_auth_file_cache_key()` on `(auth.json path, mtime)`. A `(path, mtime)` signature is the right idiom for a config cache, but this one guards credential identity: an external tool that preserves mtime while replacing the file's bytes (dotfile sync, backup/restore, `rsync -a`) can swap in a different account's credentials, and the stat-only key never notices — the cache keeps serving the stale `access_token` for the rest of the TTL window.

Same class of bug already fixed twice in this codebase:
- The Vertex SA credential cache (`agent/vertex_adapter.py`'s `_read_sa_file`, #97701, merged) — "stat idiom is right for config caches... wrong for a credential cache."
- This file's own `_load_global_auth_store()`/`_oauth_heal_clean_marks` caches (#97847, open) — same digest-key fix, different function in the same file. That PR's diff does not touch `get_nous_auth_status()` or `_auth_file_cache_key()`.

## Fix

Rekey `_auth_file_cache_key()` on `sha256(auth.json content)` instead of `mtime`, mirroring `_read_sa_file()`'s exact pattern. The file is a few KB of JSON, so one read+hash per cache probe is noise next to the OAuth refresh POST this cache exists to avoid (see the file's own comment: `hermes tools` → "All Platforms" was firing ~31 refreshes per render before this cache was introduced).

## Verification

Added `test_metadata_preserving_replace_is_not_served_stale`: replaces `auth.json`'s content while restoring its exact original `st_mtime_ns` via `os.utime`, and asserts the second `get_nous_auth_status()` call recomputes rather than serving the stale cached token. A test that only bumps mtime would not be discriminating (normal content changes bump mtime too) — this test isolates the actual bug.

Mutation-verified: reverting just the `hermes_cli/auth.py` change makes this new test fail (`assert 1 == 2`, the stale token is served); restoring the fix makes it pass. All 3 tests in `tests/hermes_cli/test_nous_auth_status_cache.py` pass.

## Competitor check

Open PR #35525 ("add threading lock to `get_nous_auth_status()` cache") touches the same function but for a different, orthogonal concern (concurrent-caller lock) — its diff is against a stale pre-refactor base (uses `_auth_file_mtime()` / a 3-tuple cache; current code already has `_auth_file_cache_key()` / a 4-tuple with a path key), so it doesn't overlap with this fix. No open or closed PR touches the mtime-vs-digest key itself.
