### PR TITLE
fix(tools): decode browser subprocess output with utf-8 and errors='replace'

### DIFF
--- a/tests/tools/test_browser_subprocess_encoding.py
+++ b/tests/tools/test_browser_subprocess_encoding.py
@@ -1,0 +1,209 @@
+"""Regression tests for UTF-8 subprocess decoding across browser tools (issue #102500).
+
+On Windows with a non-UTF-8 code page (e.g. cp1252), subprocess.run(..., text=True)
+without explicit encoding decodes child stdout using the locale ANSI code page.
+When browser-use, agent-browser, or lightpanda output UTF-8 non-ASCII characters
+(emojis, accents, symbols), the reader thread crashes with UnicodeDecodeError,
+causing subprocess.run to silently return stdout=None.
+Adding encoding="utf-8", errors="replace" ensures robust decoding and prevents
+silent null output.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from unittest.mock import MagicMock, mock_open, patch
+
+import pytest
+
+import hermes_cli.browser_connect as bc
+import tools.browser_lightpanda as lp
+import tools.browser_tool as bt
+import tools.browser_use_cli as bu_cli
+
+
+class TestBrowserExecEncoding:
+    def test_browser_exec_passes_utf8_and_replace_to_subprocess(self, monkeypatch):
+        """browser_exec must explicitly set encoding='utf-8' and errors='replace'."""
+        captured_kwargs = {}
+
+        def _mock_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else kwargs.get("args"),
+                returncode=0,
+                stdout="PAGE_OUTPUT \U0001F434 \u00b7 caf\u00e9\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: ["browser-use"])
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", lambda *a, **kw: None)
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+
+        res_str = bu_cli.browser_exec("print(1)")
+        result = json.loads(res_str)
+
+        assert captured_kwargs.get("text") is True
+        assert captured_kwargs.get("encoding") == "utf-8"
+        assert captured_kwargs.get("errors") == "replace"
+        assert result["success"] is True
+        assert "\U0001F434" in result["output"]
+        assert "caf\u00e9" in result["output"]
+
+    def test_browser_exec_real_subprocess_non_ascii_roundtrip(self, monkeypatch):
+        """End-to-end execution of a child process emitting UTF-8 non-ASCII output."""
+        payload = "TITLE \U0001F434 \u00b7 caf\u00e9"
+        child_cmd = [
+            sys.executable,
+            "-c",
+            "import sys, io; sys.stdout=io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8'); print("
+            + repr(payload)
+            + ")",
+        ]
+
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: child_cmd)
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", lambda *a, **kw: None)
+
+        res_str = bu_cli.browser_exec("ignored_by_mock_child")
+        result = json.loads(res_str)
+
+        assert result["success"] is True
+        assert result["exit_code"] == 0
+        assert result["output"] is not None
+        assert "TITLE \U0001F434 \u00b7 caf\u00e9" in result["output"]
+
+    def test_browser_exec_real_subprocess_invalid_bytes_replaced(self, monkeypatch):
+        """Invalid UTF-8 bytes are cleanly replaced with replacement character without crashing."""
+        child_cmd = [
+            sys.executable,
+            "-c",
+            "import sys; sys.stdout.buffer.write(b'HELLO \\xff\\xfe WORLD\\n'); sys.stdout.buffer.flush()",
+        ]
+
+        monkeypatch.setattr(bu_cli, "_find_cli", lambda: child_cmd)
+        monkeypatch.setattr(bu_cli, "_resolve_backend_cdp", lambda *a, **kw: None)
+
+        res_str = bu_cli.browser_exec("ignored")
+        result = json.loads(res_str)
+
+        assert result["success"] is True
+        assert result["output"] is not None
+        assert "HELLO" in result["output"]
+        assert "WORLD" in result["output"]
+        assert "\ufffd" in result["output"]
+
+
+class TestBrowserToolEncoding:
+    def test_agent_browser_get_cdp_passes_utf8_and_replace(self, monkeypatch):
+        captured_kwargs = {}
+
+        def _mock_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else kwargs.get("args"),
+                returncode=0,
+                stdout="ws://127.0.0.1:9222/devtools/browser/abc \U0001F434\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(bt, "_agent_browser_argv", lambda cmd: [cmd])
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+
+        url = bt._agent_browser_get_cdp("sess1")
+        assert url == "http://127.0.0.1:9222"
+        assert captured_kwargs.get("text") is True
+        assert captured_kwargs.get("encoding") == "utf-8"
+        assert captured_kwargs.get("errors") == "replace"
+
+    def test_agent_browser_close_session_passes_utf8_and_replace(self, monkeypatch):
+        captured_kwargs = {}
+
+        def _mock_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else kwargs.get("args"),
+                returncode=0,
+                stdout="closed\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(bt, "_agent_browser_argv", lambda cmd: [cmd])
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+
+        bt._agent_browser_close_session("sess1")
+        assert captured_kwargs.get("text") is True
+        assert captured_kwargs.get("encoding") == "utf-8"
+        assert captured_kwargs.get("errors") == "replace"
+
+    def test_real_profile_cdp_launch_passes_utf8_and_replace(self, monkeypatch):
+        captured_kwargs = {}
+
+        def _mock_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else kwargs.get("args"),
+                returncode=0,
+                stdout="ok \U0001F434\n",
+                stderr="",
+            )
+
+        monkeypatch.setattr(bt, "_use_real_profile", lambda: True)
+        monkeypatch.setattr(bt, "_using_lightpanda_engine", lambda: False)
+        cdp_calls = []
+        def _mock_get_cdp(sess):
+            if not cdp_calls:
+                cdp_calls.append(1)
+                return None
+            return "http://127.0.0.1:9222"
+        monkeypatch.setattr(bt, "_agent_browser_get_cdp", _mock_get_cdp)
+        monkeypatch.setattr(bt, "_cdp_http_ready", lambda cdp: True)
+        monkeypatch.setattr(bt, "_find_agent_browser", lambda: "agent-browser")
+        monkeypatch.setattr(bt, "_agent_browser_argv", lambda cmd: [cmd])
+        monkeypatch.setattr(bt, "_build_browser_env", lambda: {})
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+
+        monkeypatch.setattr(bc, "detect_default_chromium", lambda: "chrome")
+        monkeypatch.setattr(bc, "real_profile_copy_dir", lambda b: "/tmp/hermes-profile")
+        monkeypatch.setattr(bc, "snapshot_real_profile", lambda b: ("/tmp/hermes-profile", None))
+        monkeypatch.setattr(bc, "chromium_executable", lambda b: "/bin/chrome")
+
+        fake_popen = MagicMock()
+        fake_popen.poll.return_value = None
+        monkeypatch.setattr(subprocess, "Popen", lambda *a, **kw: fake_popen)
+
+        with patch("builtins.open", mock_open(read_data="9222\nws://127.0.0.1:9222/devtools/browser\n")):
+            cdp_url, err = bt._real_profile_cdp()
+
+        assert err is None
+        assert captured_kwargs.get("text") is True
+        assert captured_kwargs.get("encoding") == "utf-8"
+        assert captured_kwargs.get("errors") == "replace"
+
+
+class TestBrowserLightpandaEncoding:
+    def test_binary_supports_http_cache_passes_utf8_and_replace(self, monkeypatch):
+        captured_kwargs = {}
+
+        def _mock_run(*args, **kwargs):
+            captured_kwargs.update(kwargs)
+            return subprocess.CompletedProcess(
+                args=args[0] if args else kwargs.get("args"),
+                returncode=0,
+                stdout="lightpanda 0.3.0 --http-cache-dir \U0001F434\n",
+                stderr="",
+            )
+
+        lp._binary_supports_http_cache.cache_clear()
+        monkeypatch.setattr(subprocess, "run", _mock_run)
+
+        supported = lp._binary_supports_http_cache("/usr/local/bin/lightpanda")
+        assert supported is True
+        assert captured_kwargs.get("text") is True
+        assert captured_kwargs.get("encoding") == "utf-8"
+        assert captured_kwargs.get("errors") == "replace"

--- a/tools/browser_lightpanda.py
+++ b/tools/browser_lightpanda.py
@@ -144,7 +144,11 @@ def _binary_supports_http_cache(binary: str) -> bool:
     try:
         proc = subprocess.run(
             [binary, "help"],
-            capture_output=True, text=True, timeout=3.0,
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=3.0,
             stdin=subprocess.DEVNULL,
         )
         return _HTTP_CACHE_FLAG in ((proc.stdout or "") + (proc.stderr or ""))

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1594,7 +1594,12 @@ def _agent_browser_get_cdp(session_name: str) -> Optional[str]:
     try:
         proc = subprocess.run(
             [*_agent_browser_argv(browser_cmd), "--session", session_name, "get", "cdp-url"],
-            capture_output=True, text=True, timeout=15, env=_build_browser_env(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            env=_build_browser_env(),
         )
     except (subprocess.SubprocessError, OSError) as e:
         logger.debug("real-profile get cdp-url failed: %s", e)
@@ -1634,7 +1639,12 @@ def _agent_browser_close_session(session_name: str) -> None:
     try:
         subprocess.run(
             [*_agent_browser_argv(browser_cmd), "--session", session_name, "close"],
-            capture_output=True, text=True, timeout=15, env=_build_browser_env(),
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=15,
+            env=_build_browser_env(),
         )
     except (subprocess.SubprocessError, OSError) as e:
         logger.debug("real-profile session close failed: %s", e)
@@ -1877,7 +1887,11 @@ def _real_profile_cdp() -> tuple:
         ]
         try:
             proc = subprocess.run(
-                argv, capture_output=True, text=True,
+                argv,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
                 timeout=_get_open_command_timeout(first_open=True),
                 env=_build_browser_env(),
             )

--- a/tools/browser_use_cli.py
+++ b/tools/browser_use_cli.py
@@ -831,6 +831,8 @@ def browser_exec(
             input=code,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=timeout,
             env=env,
             **popen_extra,


### PR DESCRIPTION
## What does this PR do?

On Windows systems running single-byte code pages (such as Windows-1252 / `cp1252`), invoking `subprocess.run(..., text=True)` without an explicit `encoding` parameter defaults to `locale.getpreferredencoding(False)`. When child browser tools (`browser-use`, `agent-browser`, or `lightpanda`) output UTF-8 non-ASCII characters—such as emojis (`🐴`), accented characters (`café`), non-Latin scripts, or page symbols in titles and logs—Python's internal subprocess reader thread raises an unhandled `UnicodeDecodeError` and dies silently.

Because this exception occurs in the reader thread, `subprocess.run` completes with `returncode == 0` and sets `stdout = None`. In `tools/browser_use_cli.py::browser_exec`, this causes the tool to return:
```json
{"success": true, "exit_code": 0, "output": null}
```
silently swallowing all page content.

This PR fixes the issue across all child browser execution paths by explicitly setting `encoding="utf-8"` and `errors="replace"`, ensuring consistent UTF-8 text decoding across all platforms and substituting any invalid byte sequences with standard Unicode replacement characters (`\ufffd`) rather than crashing reader threads or returning `null`.

## Related Issue

Fixes #102500

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [`tools/browser_use_cli.py`](file:///tools/browser_use_cli.py): Added `encoding="utf-8"` and `errors="replace"` to `subprocess.run` in `browser_exec`.
- [`tools/browser_tool.py`](file:///tools/browser_tool.py): Added `encoding="utf-8"` and `errors="replace"` to `_agent_browser_get_cdp`, `_agent_browser_close_session`, and `_real_profile_cdp` subprocess invocations.
- [`tools/browser_lightpanda.py`](file:///tools/browser_lightpanda.py): Added `encoding="utf-8"` and `errors="replace"` to `_binary_supports_http_cache` subprocess invocation.
- [`tests/tools/test_browser_subprocess_encoding.py`](file:///tests/tools/test_browser_subprocess_encoding.py): Added test suite testing argument propagation, real subprocess roundtrip of UTF-8 emojis/accents, and invalid byte resilience.

## How to Test

1. Run the new regression test suite:
   ```bash
   uv run --with pytest pytest tests/tools/test_browser_subprocess_encoding.py -v
   ```
2. Verify all 7 tests pass cleanly, including end-to-end child subprocess emission of emojis and UTF-8 multibyte characters.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 (x64), Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
