### PR TITLE
fix(matrix): scope MATRIX_REACTIONS to the active profile under multiplexing

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -1327,9 +1327,13 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_PROCESS_NOTICES", "false"
         ).lower() in ("true", "1", "yes")
 
-        # Reactions: configurable via MATRIX_REACTIONS (default: true).
-        self._reactions_enabled: bool = os.getenv(
-            "MATRIX_REACTIONS", "true"
+        # Reactions: configurable via MATRIX_REACTIONS (default: true). No
+        # config.yaml counterpart (env-only knob, like MATRIX_ALLOW_ROOM_MENTIONS/
+        # MATRIX_DM_AUTO_THREAD) -- scope the read itself so a secondary
+        # multiplex profile's own .env value wins over the shared process env
+        # instead of silently inheriting the default profile's toggle.
+        self._reactions_enabled: bool = _startup_env_secret(
+            "MATRIX_REACTIONS"
         ).lower() not in {"false", "0", "no"}
         self._pending_reactions: dict[tuple[str, str], str] = {}
         # Delay before redacting reactions so Matrix homeservers have time to

--- a/tests/agent/test_secret_scope_tier1_migration.py
+++ b/tests/agent/test_secret_scope_tier1_migration.py
@@ -152,6 +152,32 @@ class TestMatrixStartupSecret:
         ss.set_multiplex_active(True)
         assert helper("MATRIX_PASSWORD") == "own-env-pass"
 
+    # MATRIX_REACTIONS (#102097 sibling gap): this env-only toggle was still
+    # read via raw os.getenv in MatrixAdapter.__init__ while its neighbors
+    # (MATRIX_ACCESS_TOKEN, MATRIX_PASSWORD, MATRIX_HOMESERVER) were already
+    # routed through this same scoped helper -- a secondary multiplex profile
+    # silently inherited the default profile's MATRIX_REACTIONS toggle.
+
+    def test_scoped_value_wins_reactions(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        ss.set_multiplex_active(True)
+        with _Scope({"MATRIX_REACTIONS": "true"}):
+            assert helper("MATRIX_REACTIONS") == "true"
+
+    def test_scoped_miss_no_borrow_reactions(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")  # another profile's bridge
+        ss.set_multiplex_active(True)
+        with _Scope({"UNRELATED": "x"}):
+            assert helper("MATRIX_REACTIONS") == ""
+
+    def test_unscoped_multiplex_falls_back_reactions(self, monkeypatch):
+        helper = self._helper()
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        ss.set_multiplex_active(True)
+        assert helper("MATRIX_REACTIONS") == "false"
+
 
 # ── Cluster C: managed tool gateway token override ─────────────────────────
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -3342,3 +3342,75 @@ class TestCryptoPickleKeyMigration:
         # start still sees a legacy-key account and retries the migration.
         store.put_account.assert_not_awaited()
         assert "retried on the next start" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Multiplex secondary-profile scope: MATRIX_REACTIONS
+# ---------------------------------------------------------------------------
+#
+# MATRIX_REACTIONS has no config.yaml counterpart (env-only knob, like
+# MATRIX_ALLOW_ROOM_MENTIONS/MATRIX_DM_AUTO_THREAD) and __init__ previously
+# read it via raw os.getenv while its neighbors (MATRIX_ACCESS_TOKEN,
+# MATRIX_PASSWORD, MATRIX_HOMESERVER) were already routed through the
+# scope-aware ``_startup_env_secret`` helper. Under gateway.multiplex_profiles,
+# os.environ holds the DEFAULT profile's bridged value, so a secondary
+# profile would silently inherit the default profile's reactions toggle for
+# the adapter's entire runtime lifetime. Mirrors the established Matrix
+# startup-secret pattern (#59739 / test_matrix_recovery_key_scope.py).
+
+
+class TestMatrixReactionsMultiplexScope:
+    @pytest.fixture(autouse=True)
+    def _reset_multiplex(self):
+        from agent import secret_scope as ss
+
+        ss.set_multiplex_active(False)
+        yield
+        ss.set_multiplex_active(False)
+
+    def test_secondary_profile_scope_wins_over_default_profile_env(self, monkeypatch):
+        """The secondary profile's own scoped value is authoritative, not the
+        default profile's MATRIX_REACTIONS bridged into os.environ."""
+        from agent import secret_scope as ss
+
+        # Simulates the default profile's YAML-to-env bridge output sitting
+        # in the shared process env.
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"MATRIX_REACTIONS": "true"})
+        try:
+            adapter = _make_adapter()
+        finally:
+            ss.reset_secret_scope(token)
+        assert adapter._reactions_enabled is True
+
+    def test_secondary_profile_scope_miss_defaults_true_not_env(self, monkeypatch):
+        """A scope without MATRIX_REACTIONS must default to enabled (true),
+        not silently borrow the default profile's disabled toggle."""
+        from agent import secret_scope as ss
+
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        ss.set_multiplex_active(True)
+        token = ss.set_secret_scope({"UNRELATED": "x"})
+        try:
+            adapter = _make_adapter()
+        finally:
+            ss.reset_secret_scope(token)
+        assert adapter._reactions_enabled is True
+
+    def test_unscoped_multiplex_startup_falls_back_to_env(self, monkeypatch):
+        """Default-profile startup loop under multiplex (no scope installed
+        yet): falls back to os.environ, which is that profile's own value."""
+        from agent import secret_scope as ss
+
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        ss.set_multiplex_active(True)
+        # No secret scope installed -> get_secret raises UnscopedSecretError.
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled is False
+
+    def test_single_profile_legacy_env(self, monkeypatch):
+        """Non-multiplex deployment: reads os.environ transparently."""
+        monkeypatch.setenv("MATRIX_REACTIONS", "false")
+        adapter = _make_adapter()
+        assert adapter._reactions_enabled is False


### PR DESCRIPTION
## Problem

`MatrixAdapter.__init__` reads `MATRIX_REACTIONS` (the lifecycle-reaction toggle: eyes reaction on start, checkmark/cross on completion) via raw `os.getenv("MATRIX_REACTIONS", "true")`, with no `config.extra` check and no profile-scope awareness at all:

```python
# Reactions: configurable via MATRIX_REACTIONS (default: true).
self._reactions_enabled: bool = os.getenv(
    "MATRIX_REACTIONS", "true"
).lower() not in {"false", "0", "no"}
```

Under `gateway.multiplex_profiles`, `os.environ` holds the **default profile's** YAML-to-env bridge output. A secondary profile's `MatrixAdapter` would silently inherit the default profile's reactions toggle for the adapter's entire runtime lifetime, rather than resolving its own profile's setting.

This is a sibling gap left behind by #102097, which scoped `require_mention`/`process_notices`/`session_scope`/`auto_thread`/`dm_mention_threads`/`max_message_length` in this same `__init__` but did not touch `_reactions_enabled` — a bot review comment on that PR flagged this exact line as possibly orphaned from the sweep, which is what prompted this follow-up.

`MATRIX_REACTIONS` has no `config.yaml` counterpart (an env-only knob, like `MATRIX_ALLOW_ROOM_MENTIONS`/`MATRIX_DM_AUTO_THREAD`, both of which #102097 already wrapped in the scope-aware `_startup_env_secret()` helper), and this file's own `_startup_env_secret()` is already used for exactly this pattern on `MATRIX_ACCESS_TOKEN`/`MATRIX_PASSWORD`/`MATRIX_HOMESERVER`.

## Fix

```python
self._reactions_enabled: bool = _startup_env_secret(
    "MATRIX_REACTIONS"
).lower() not in {"false", "0", "no"}
```

`_startup_env_secret()` (Slack pattern, #59739): a scoped read honors the installed profile's secret-scope verdict (scoped miss ⇒ empty string, which correctly resolves to the `true` default here since `""` is not in the falsy set — no borrowing the process env); only an *unscoped* read under multiplex (the default-profile startup loop) falls back to `os.environ`, which is that profile's own value.

## Testing

- Extended `TestMatrixStartupSecret` in `tests/agent/test_secret_scope_tier1_migration.py` with `MATRIX_REACTIONS` cases (scoped value wins, scoped miss doesn't borrow, unscoped-under-multiplex falls back to env) — this is the repo's established generic test class for `_startup_env_secret()`, already covering `MATRIX_ACCESS_TOKEN`/`MATRIX_PASSWORD`.
- Added `TestMatrixReactionsMultiplexScope` in `tests/gateway/test_matrix.py`: an integration-level test that constructs a real `MatrixAdapter` under multiplex + a secondary-profile scope and asserts `_reactions_enabled` reflects the scoped value, not the leaked default-profile env value (plus the scope-miss-defaults-true and single-profile-legacy-env cases).
- **Mutation-verified**: reverted just the `adapter.py` change and confirmed the two new integration tests fail (`assert False is True`) without the fix, then restored it and confirmed all 147 tests in the affected files pass (`tests/gateway/test_matrix.py`, `tests/agent/test_secret_scope_tier1_migration.py`, `tests/gateway/test_matrix_recovery_key_scope.py`, `tests/gateway/test_matrix_crypto_store_per_profile.py`).

## Scope note

I also checked the Matrix E2EE crypto-store scoping (`_resolve_store_dir()` / `_get_hermes_dir`) — it uses a separate, already-correct mechanism (pinning the crypto-store directory to the active profile's `HERMES_HOME` context), unrelated to this env-var-scoping idiom, and needed no changes.

I also found `_homeserver`/`_user_id`/`_device_id` (a few lines above the fixed field) use an `config.extra.get(...) or os.getenv(...)` pattern where the fallback is still raw/unscoped — a similar but distinct residual gap. That's out of scope here since it wasn't part of #102097's sweep or this bot comment, and touching it would broaden this PR's blast radius; flagging it for a possible follow-up.

**Competitor check**: #96302 ("make per-message read receipts and lifecycle reactions configurable") is an open feature PR that also rewrites this same `_reactions_enabled` block, adding `config.yaml` `matrix.reactions` support via a new `_parse_reactions_enabled()` static method. It is complementary, not a duplicate: its env fallback is `env_val = _coerce(os.getenv("MATRIX_REACTIONS"))` — still a raw, unscoped read, so the multiplex leak this PR fixes would persist there too. If #96302 lands first, this PR will need a rebase, and #96302's `os.getenv` fallback in `_parse_reactions_enabled()` should get the same `_startup_env_secret()` treatment.

Closes the sibling gap flagged in review on #102097.