### PR TITLE
fix(desktop): isolate hidden composer selection

### DIFF
--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.test.tsx
@@ -9,6 +9,7 @@ import { $connection } from '@/store/session'
 import { useComposerActions } from '../../hooks/use-composer-actions'
 import type { QueueEditState } from '../composer-utils'
 import { type ComposerTarget, getActiveComposer, markActiveComposer } from '../focus'
+import { composerPlainText } from '../rich-editor'
 import { type ComposerScope, ComposerScopeProvider, MAIN_COMPOSER_SCOPE } from '../scope'
 
 import { useComposerDraft } from './use-composer-draft'
@@ -349,5 +350,102 @@ describe('useComposerDraft — a hidden keep-alive tab never auto-focuses its co
     renderScopedHidden('tile:vis', false)
 
     expect(getActiveComposer()).toBe('tile:vis')
+  })
+
+  function renderHiddenDraftHarness() {
+    let hiddenDraft!: ReturnType<typeof useComposerDraft>
+
+    function HiddenDraftHarness() {
+      hiddenDraft = useComposerDraft({
+        activeQueueSessionKey: 'session-hidden',
+        focusKey: null,
+        inputDisabled: false,
+        queueEditRef: { current: null as QueueEditState | null },
+        sessionId: 'session-hidden'
+      })
+
+      return <div contentEditable data-slot="composer-rich-input" ref={hiddenDraft.editorRef} />
+    }
+
+    render(
+      <PaneVisibleContext.Provider value={false}>
+        <ComposerScopeProvider value={{ ...MAIN_COMPOSER_SCOPE, target: 'tile:hidden' }}>
+          <HiddenDraftHarness />
+        </ComposerScopeProvider>
+      </PaneVisibleContext.Provider>
+    )
+
+    return () => hiddenDraft
+  }
+
+  function createForegroundSelection() {
+    const visibleEditor = globalThis.document.createElement('div')
+    const visibleText = globalThis.document.createTextNode('foreground draft')
+    visibleEditor.contentEditable = 'true'
+    visibleEditor.tabIndex = 0
+    visibleEditor.appendChild(visibleText)
+    globalThis.document.body.appendChild(visibleEditor)
+    visibleEditor.focus()
+    expect(globalThis.document.activeElement).toBe(visibleEditor)
+
+    const range = globalThis.document.createRange()
+    range.setStart(visibleText, visibleText.textContent?.length ?? 0)
+    range.collapse(true)
+    window.getSelection()?.removeAllRanges()
+    window.getSelection()?.addRange(range)
+
+    return {
+      editor: visibleEditor,
+      startContainer: range.startContainer,
+      startOffset: range.startOffset,
+      endContainer: range.endContainer,
+      endOffset: range.endOffset
+    }
+  }
+
+  function expectForegroundSelectionPreserved(foreground: ReturnType<typeof createForegroundSelection>) {
+    const selection = window.getSelection()
+    expect(globalThis.document.activeElement).toBe(foreground.editor)
+    expect(selection?.rangeCount).toBe(1)
+
+    const range = selection!.getRangeAt(0)
+    expect(range.startContainer).toBe(foreground.startContainer)
+    expect(range.startOffset).toBe(foreground.startOffset)
+    expect(range.endContainer).toBe(foreground.endContainer)
+    expect(range.endOffset).toBe(foreground.endOffset)
+  }
+
+  it('does not move the document selection when a hidden composer reloads its draft', () => {
+    const getHiddenDraft = renderHiddenDraftHarness()
+    const foreground = createForegroundSelection()
+
+    act(() => getHiddenDraft().loadIntoComposer('background update', []))
+
+    expect(composerPlainText(getHiddenDraft().editorRef.current!)).toBe('background update')
+    expectForegroundSelectionPreserved(foreground)
+    foreground.editor.remove()
+  })
+
+  it('does not move the document selection when a hidden composer clears its draft', () => {
+    const getHiddenDraft = renderHiddenDraftHarness()
+    act(() => getHiddenDraft().loadIntoComposer('clear me', []))
+    const foreground = createForegroundSelection()
+
+    act(() => getHiddenDraft().clearDraft())
+
+    expect(getHiddenDraft().editorRef.current?.textContent).toBe('')
+    expectForegroundSelectionPreserved(foreground)
+    foreground.editor.remove()
+  })
+
+  it('does not move the document selection when hidden composer refs are requested', () => {
+    const getHiddenDraft = renderHiddenDraftHarness()
+    const foreground = createForegroundSelection()
+
+    act(() => getHiddenDraft().insertInlineRefs(['@file:`src/background.ts`']))
+
+    expect(composerPlainText(getHiddenDraft().editorRef.current!)).toContain('@file:`src/background.ts`')
+    expectForegroundSelectionPreserved(foreground)
+    foreground.editor.remove()
   })
 })

--- a/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
+++ b/apps/desktop/src/app/chat/composer/hooks/use-composer-draft.ts
@@ -147,14 +147,22 @@ export function useComposerDraft({
 
       if (editor) {
         renderComposerContents(editor, next, { trailingCommitted: true })
-        placeCaretEnd(editor)
+
+        // Selection is document-global: a keep-alive composer in a hidden tab
+        // may repaint when its background session updates, but moving its caret
+        // here steals the selection from the visible composer without changing
+        // document.activeElement. The foreground then still looks focused while
+        // printable keydowns produce no input.
+        if (paneVisible) {
+          placeCaretEnd(editor)
+        }
       }
 
       if (focus) {
         requestMainFocus()
       }
     },
-    [requestMainFocus, setComposerText]
+    [paneVisible, requestMainFocus, setComposerText]
   )
 
   const appendExternalText = useCallback(
@@ -263,9 +271,12 @@ export function useComposerDraft({
 
     if (editorRef.current) {
       renderComposerContents(editorRef.current, '')
-      placeCaretEnd(editorRef.current)
+
+      if (paneVisible) {
+        placeCaretEnd(editorRef.current)
+      }
     }
-  }, [setComposerText])
+  }, [paneVisible, setComposerText])
 
   // Read the editor's current plain text into draftRef + composer state. This
   // closes the "queued rAF flush hasn't run yet" window so scope-swap/pagehide
@@ -364,7 +375,7 @@ export function useComposerDraft({
       return false
     }
 
-    const nextDraft = insertInlineRefsIntoEditor(editor, refs)
+    const nextDraft = insertInlineRefsIntoEditor(editor, refs, { interactive: paneVisible })
 
     if (nextDraft === null) {
       return false
@@ -372,7 +383,10 @@ export function useComposerDraft({
 
     draftRef.current = nextDraft
     setComposerText(nextDraft)
-    requestMainFocus()
+
+    if (paneVisible) {
+      requestMainFocus()
+    }
 
     return true
   }

--- a/apps/desktop/src/app/chat/composer/inline-refs.ts
+++ b/apps/desktop/src/app/chat/composer/inline-refs.ts
@@ -134,7 +134,11 @@ function buildRefFragment(
   return fragment
 }
 
-export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonly InlineRefInput[]) {
+export function insertInlineRefsIntoEditor(
+  editor: HTMLDivElement,
+  refs: readonly InlineRefInput[],
+  { interactive = true }: { interactive?: boolean } = {}
+) {
   const parsed = refs.map(parseInlineRef).filter((ref): ref is NonNullable<typeof ref> => ref !== null)
   const hasEmptySentinel = editor.childNodes.length === 1 && editor.firstChild?.nodeName === 'BR'
 
@@ -146,9 +150,11 @@ export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonl
     editor.replaceChildren()
   }
 
-  editor.focus({ preventScroll: true })
+  if (interactive) {
+    editor.focus({ preventScroll: true })
+  }
 
-  const selection = window.getSelection()
+  const selection = interactive ? window.getSelection() : null
 
   const range =
     !hasEmptySentinel && selection?.rangeCount && editor.contains(selection.getRangeAt(0).commonAncestorContainer)
@@ -177,7 +183,10 @@ export function insertInlineRefsIntoEditor(editor: HTMLDivElement, refs: readonl
         needsBeforeSpace: current.length > 0 && !/\s$/.test(current)
       })
     )
-    placeCaretEnd(editor)
+
+    if (interactive) {
+      placeCaretEnd(editor)
+    }
   }
 
   normalizeComposerEditorDom(editor)


### PR DESCRIPTION
## Summary

A background keep-alive composer could take Chromium's document-global selection from the visible composer while the visible editor remained focused. The foreground composer then looked active, but printable keydowns produced no input until it was clicked again.

This change lets hidden composers continue synchronizing their DOM and draft state without calling focus or selection APIs. Visible composers keep the existing interactive behavior.

Addresses #88621.

## Changes

- Gate `placeCaretEnd` during draft load and clear by pane visibility.
- Add an `interactive` option to inline-reference insertion; it defaults to `true` for existing callers.
- Prevent hidden inline-reference updates from focusing the editor, replacing native selection, placing the caret, or requesting main-composer focus.
- Add regressions for hidden draft load, draft clear, and inline-reference insertion. Each test keeps a visible editor focused and asserts that its native selection remains there.

## Evidence

A live privacy-safe trace found multiple composer elements mounted by the keep-alive layout. At the failure boundary, the visible composer remained `document.activeElement` and stayed editable, while native selection moved into a hidden composer. No prompt text or character values were recorded.

This is separate from the reconnect path fixed by #99357 and the active empty-caret-node normalizer case addressed by #100333.

## Test plan

```text
npm test -- --run src/app/chat/composer/hooks/use-composer-draft.test.tsx src/app/chat/composer/rich-editor.test.ts
34/34 passed

npm run typecheck
passed

npm run lint
0 errors (124 existing warnings)

npm run test:ui
7,170/7,170 passed

git diff --check
passed
```

I tested this from `main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d` on Windows 11 with Hermes Desktop 0.17.0 and Electron 40.10.2.

## Risk

Low. The new inline-reference option defaults to the old interactive behavior. The changed behavior applies only when `PaneVisibleContext` reports a hidden composer: draft/DOM state still updates, but document focus and native selection are left alone.
