### PR TITLE
fix(kanban): sanitize invalid dot forms in task branches

### DIFF
--- a/hermes_cli/projects_db.py
+++ b/hermes_cli/projects_db.py
@@ -817,7 +817,14 @@ def branch_name_for(project: Project, task_id: str, *, title: str = "") -> str:
     base = f"{slug}/{task_id}"
     if title:
         tslug = _BRANCH_SAFE_RE.sub("-", str(title).strip().lower()).strip("-")
-        tslug = tslug[:40].strip("-")
+        # Git rejects refs containing ``..``, ending in ``.``, or whose final
+        # path component ends in ``.lock``. Normalize only those dot forms so
+        # useful single dots (for example, version numbers) remain intact.
+        tslug = re.sub(r"\.{2,}", "-", tslug)
+        tslug = tslug[:40].strip("-.")
+        if tslug.endswith(".lock"):
+            stem = tslug[:-5].rstrip("-.")
+            tslug = f"{stem}-lock" if stem else "lock"
         if tslug:
             base = f"{base}-{tslug}"
     return base

--- a/tests/hermes_cli/test_kanban_project_link.py
+++ b/tests/hermes_cli/test_kanban_project_link.py
@@ -4,6 +4,7 @@ worktree path + branch instead of the random ``wt/<task-id>`` fallback."""
 from __future__ import annotations
 
 import os
+import subprocess
 
 import pytest
 
@@ -26,6 +27,15 @@ def _make_project(name="Web App", repo="/tmp/webapp"):
         return pdb.get_project(pc, pid)
 
 
+def _assert_valid_git_branch(branch: str) -> None:
+    result = subprocess.run(
+        ["git", "check-ref-format", "--branch", branch],
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr
+
+
 def test_project_linked_task_gets_deterministic_worktree_and_branch(kanban_conn):
     proj = _make_project()
     tid = kb.create_task(kanban_conn, title="Add login", project_id=proj.slug)
@@ -38,6 +48,48 @@ def test_project_linked_task_gets_deterministic_worktree_and_branch(kanban_conn)
     # Deterministic branch: <slug>/<task-id>-<title-slug>. NOT a random wt/...
     assert task.branch_name == f"{proj.slug}/{tid}-add-login"
     assert not task.branch_name.startswith("wt/")
+
+
+def test_project_linked_task_branch_survives_dot_at_title_truncation(kanban_conn):
+    proj = _make_project(name="Reefmind Project")
+    title = "3291 Integrate merge and prove Gemini 3.1 support"
+
+    tid = kb.create_task(kanban_conn, title=title, project_id=proj.slug)
+    branch = kb.get_task(kanban_conn, tid).branch_name
+
+    # Regression: the 40-character title truncation used to produce
+    # ``.../t_<id>-3291-integrate-merge-and-prove-gemini-3.``, which Git
+    # rejects because a ref cannot end in a dot.
+    assert branch == (
+        f"reefmind-project/{tid}-3291-integrate-merge-and-prove-gemini-3"
+    )
+    _assert_valid_git_branch(branch)
+
+
+@pytest.mark.parametrize(
+    ("title", "suffix"),
+    [
+        ("release.", "release"),
+        ("gemini..support", "gemini-support"),
+        ("release.lock", "release-lock"),
+    ],
+)
+def test_deterministic_project_branch_sanitizes_invalid_dot_forms(title, suffix):
+    proj = _make_project()
+
+    branch = pdb.branch_name_for(proj, "t_deadbeef", title=title)
+
+    assert branch == f"web-app/t_deadbeef-{suffix}"
+    _assert_valid_git_branch(branch)
+
+
+def test_deterministic_project_branch_preserves_valid_single_dots():
+    proj = _make_project()
+
+    branch = pdb.branch_name_for(proj, "t_deadbeef", title="Gemini 3.1 support")
+
+    assert branch == "web-app/t_deadbeef-gemini-3.1-support"
+    _assert_valid_git_branch(branch)
 
 
 def test_explicit_branch_overrides_project_default(kanban_conn):
@@ -62,5 +114,3 @@ def test_unlinked_task_unchanged(kanban_conn):
     # No branch is persisted — the worker still owns the wt/<id> fallback for
     # genuinely ad-hoc worktree tasks, but unlinked scratch tasks have none.
     assert task.branch_name is None
-
-


### PR DESCRIPTION
## Summary
- prevent generated Kanban worktree branches from ending in `.`
- normalize consecutive dots and terminal `.lock` while preserving valid version dots
- add a regression for the exact trailing-period spawn failure

## Verification
- `python -m pytest -q tests/hermes_cli/test_kanban_project_link.py tests/hermes_cli/test_projects_db.py tests/hermes_cli/test_projects_cli.py tests/hermes_cli/test_kanban_board_project.py`
- 21 passed
- independent Codex review: PASS