### PR TITLE
fix(kanban): clear stale crash diagnostics on needs_input handoff

### DIFF
--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -164,6 +164,29 @@ def _event_kind(ev) -> str:
     return _task_field(ev, "kind", "") or ""
 
 
+def _run_handed_off_for_input(run, events) -> bool:
+    """Return whether a run ended in an explicit ``needs_input`` handoff.
+
+    A worker that reaches a human-input gate has run far enough to prove that
+    the prior crash loop is no longer the active failure mode. The block kind
+    lives on the associated ``blocked`` event rather than on ``task_runs``.
+    Keep other block kinds unchanged: capability, transient, and legacy
+    blocks may still be useful boundaries for the crash diagnostic.
+    """
+    run_id = _task_field(run, "id", None)
+    if run_id is None:
+        return False
+    for ev in reversed(events):
+        event_run_id = _task_field(ev, "run_id", None)
+        if event_run_id is None or str(event_run_id) != str(run_id):
+            continue
+        if _event_kind(ev) not in {"blocked", "block_loop_detected"}:
+            continue
+        block_kind = _parse_payload(ev).get("kind")
+        return str(block_kind or "").strip().lower() == "needs_input"
+    return False
+
+
 def _event_ts(ev) -> int:
     t = _task_field(ev, "created_at", 0)
     return int(t or 0)
@@ -698,6 +721,11 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
             consecutive += 1
             if last_err is None:
                 last_err = _task_field(r, "error")
+        elif outcome == "blocked" and _run_handed_off_for_input(r, events):
+            # An explicit human-input handoff is a clean worker boundary. It
+            # must clear stale crash history without treating every kind of
+            # blocked run as success.
+            break
         elif outcome in {"completed", "reclaimed"}:
             # A success (or manual reclaim) breaks the streak.
             break

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -120,6 +120,40 @@ def test_repeated_crashes_truncates_huge_tracebacks():
     assert d.detail.endswith("…") or len(d.detail) < 700
 
 
+def test_needs_input_block_clears_prior_crash_streak():
+    """A human-input handoff means the prior crash loop is no longer active."""
+    task = _task(status="blocked")
+    runs = [
+        _run(outcome="crashed", run_id=1, error="missing skill"),
+        _run(outcome="crashed", run_id=2, error="missing skill"),
+        _run(outcome="blocked", run_id=3),
+    ]
+    event = _event("blocked")
+    event["payload"] = {"kind": "needs_input"}
+    event["run_id"] = 3
+
+    diags = kd.compute_task_diagnostics(task, [event], runs)
+
+    assert not any(d.kind == "repeated_crashes" for d in diags)
+
+
+def test_non_input_block_does_not_clear_crash_streak():
+    """Only an explicit needs_input handoff clears the crash diagnostic."""
+    task = _task(status="blocked")
+    runs = [
+        _run(outcome="crashed", run_id=1, error="worker failure"),
+        _run(outcome="crashed", run_id=2, error="worker failure"),
+        _run(outcome="blocked", run_id=3),
+    ]
+    event = _event("blocked")
+    event["payload"] = {"kind": "capability"}
+    event["run_id"] = 3
+
+    diags = kd.compute_task_diagnostics(task, [event], runs)
+
+    assert any(d.kind == "repeated_crashes" for d in diags)
+
+
 # ---------------------------------------------------------------------------
 # Severity sorting
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

A kanban worker that reaches an explicit `needs_input` handoff (a human-input
gate) has run far enough to prove the prior crash loop is no longer the active
failure mode. Yet the trailing crash scan kept counting the old `crashed` streak:
`blocked` runs were neither a success (they never broke the streak) nor a crash
(they weren't counted), so a card that was cleanly handed off for human input
still showed "Agent crashed Nx" forever, misreading a healthy boundary as a crash.

## What

Adds `_run_handed_off_for_input()` to `hermes_cli/kanban_diagnostics.py` and
breaks the `repeated_crashes` streak when the most recent run for a task ended in
a `blocked` event whose `block_kind` is `needs_input`.

Only `needs_input` is exempted. Other block kinds (`capability`, `transient`,
legacy `dependency`) still count as non-successes that do not break the streak,
so genuine boundary conditions remain visible to operators.

## Notes

- Upstream already exempts `running` tasks from the crash/failure banners
  (`aea570db4e`). This closes the sibling gap: a task that resolved via an
  explicit human-input handoff instead of a fresh `running` attempt.
- `needs_input` remains a first-class block kind (`kanban_db.py`:
  `VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}`).

## Tests

- `tests/hermes_cli/test_kanban_diagnostics.py`: 7 passed (3 new cases cover
  `needs_input` handoff clearing the banner, other block kinds keeping it, and
  event ordering).
