### PR TITLE
feat(agent): configurable rate-limit retry policy for 429s

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -2142,6 +2142,17 @@ def init_agent(
         _api_retries = 3
     agent._api_max_retries = _api_retries
 
+    # Rate-limit retry policy (agent.rate_limit_retry in config.yaml).
+    # Overrides 429 handling when present: hold the primary provider with
+    # long exponential backoff instead of eagerly failing over (useful when
+    # every fallback rides the same throttled upstream). Disabled by
+    # default — absent/malformed config must preserve legacy behavior
+    # byte-for-byte. See agent/rate_limit_policy.py for the shape.
+    from agent.rate_limit_policy import resolve_rate_limit_retry_policy
+    agent._rate_limit_retry_policy = resolve_rate_limit_retry_policy(
+        _agent_section.get("rate_limit_retry")
+    )
+
     # Initialize context compressor for automatic context management
     # Compresses conversation when approaching model's context limit
     # Configuration via config.yaml (compression section)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -1310,6 +1310,32 @@ def recover_with_credential_pool(
                 or "usage limit reached" in context_message
                 or "usage limit has been reached" in context_message
             )
+        # rate_limit_retry policy: when the policy owns plain 429 handling,
+        # hold the current credential with the turn loop's long backoff
+        # instead of marking the pool entry exhausted. With a single-
+        # credential pool, the 1h exhaustion cooldown starves every OTHER
+        # process (cron jobs, new sessions) while this loop keeps using the
+        # same key anyway. With a second usable credential, standard
+        # rotation below is still the better move. Real quota walls
+        # (usage_limit_reached) still exhaust below.
+        _rl_policy = getattr(agent, "_rate_limit_retry_policy", None)
+        if (
+            _rl_policy is not None
+            and _rl_policy.enabled
+            and not usage_limit_reached
+        ):
+            _rl_alternates = [
+                e for e in pool.entries()
+                if (current_entry is None or e.id != current_entry.id)
+                and e.last_status != STATUS_EXHAUSTED
+            ]
+            if not _rl_alternates:
+                if getattr(current_entry, "last_status", None) == STATUS_EXHAUSTED:
+                    # Stale exhaustion flag (e.g. a pre-policy turn tripped
+                    # during a 429 storm): clear it so other processes can
+                    # resolve credentials again.
+                    pool.reset_statuses()
+                return False, True
         if not has_retried_429 and not usage_limit_reached:
             return False, True
         rotate_status = status_code if status_code is not None else 429

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -93,6 +93,7 @@ from agent.prompt_caching import (
     strip_anthropic_tool_cache_control,
 )
 from agent.provider_projection import splice_provider_projection
+from agent.rate_limit_policy import policy_backoff_wait
 from agent.retry_utils import (
     adaptive_rate_limit_backoff,
     is_zai_coding_overload_error,
@@ -6033,10 +6034,37 @@ def run_conversation(
                 )
                 if _is_zai_coding_overload:
                     max_retries = max(max_retries, zai_coding_overload_retry_ceiling())
-                _should_fallback = (
-                    (is_rate_limited and _wrapped_output_cap_budget is None)
-                    or (_is_transport_failure and retry_count >= 2)
+                # rate_limit_retry policy: hold the primary provider on long
+                # backoff instead of eager failover. Billing is exempt —
+                # backoff cannot recover an empty account. Unlimited (-1)
+                # keeps raising the loop ceiling so neither the ``while``
+                # condition nor the give-up check below can fire while the
+                # policy is live; finite N raises the ceiling once to N+1 so
+                # the budget is actually reachable (api_max_retries may be
+                # smaller).
+                _rate_limit_policy = getattr(agent, "_rate_limit_retry_policy", None)
+                _policy_active = bool(
+                    _rate_limit_policy is not None
+                    and _rate_limit_policy.enabled
+                    and classified.reason == FailoverReason.rate_limit
                 )
+                _policy_budget_left = False
+                if _policy_active:
+                    _policy_budget_left = (
+                        _rate_limit_policy.max_retries < 0
+                        or _retry.rate_limit_policy_retries < _rate_limit_policy.max_retries
+                    )
+                    if _rate_limit_policy.max_retries < 0:
+                        max_retries = max(max_retries, retry_count + 2)
+                    else:
+                        max_retries = max(max_retries, _rate_limit_policy.max_retries + 1)
+                if _policy_active and _policy_budget_left:
+                    _should_fallback = False
+                else:
+                    _should_fallback = (
+                        (is_rate_limited and _wrapped_output_cap_budget is None)
+                        or (_is_transport_failure and retry_count >= 2)
+                    )
                 if _should_fallback and agent._fallback_index < len(agent._fallback_chain):
                     # Don't eagerly fallback if credential pool rotation may
                     # still recover.  See _pool_may_recover_from_rate_limit
@@ -7266,13 +7294,34 @@ def run_conversation(
                         error=api_error,
                         default_wait=wait_time,
                     )
+                # rate_limit_retry policy backoff: never wait less than the
+                # policy schedule says (a provider-supplied short Retry-After
+                # would otherwise re-hammer a still-throttled upstream), but
+                # still honor a LONGER provider window. Counting this retry
+                # against the policy here keeps the eager-fallback gate above
+                # accurate: once the budget is spent, failover proceeds.
+                if _policy_active and _policy_budget_left:
+                    _policy_wait = policy_backoff_wait(
+                        _rate_limit_policy,
+                        _retry.rate_limit_policy_retries + 1,
+                    )
+                    wait_time = max(wait_time, _policy_wait)
+                    _backoff_policy = "rate_limit_retry_policy"
+                    _retry.rate_limit_policy_retries += 1
                 if is_rate_limited or _is_zai_coding_overload:
                     _policy_note = ""
                     if _backoff_policy == "zai_coding_overload_long":
                         _policy_note = " (Z.AI Coding overload adaptive long backoff)"
                     elif _backoff_policy == "zai_coding_overload_short":
                         _policy_note = " (Z.AI Coding overload short retry)"
-                    _wait_reason = "Provider overloaded" if _is_zai_coding_overload and not is_rate_limited else "Rate limited"
+                    elif _backoff_policy == "rate_limit_retry_policy":
+                        _budget = (
+                            "unlimited"
+                            if _rate_limit_policy.max_retries < 0
+                            else f"{_retry.rate_limit_policy_retries}/{_rate_limit_policy.max_retries}"
+                        )
+                        _policy_note = f" (rate-limit retry policy, {_budget})"
+                    _wait_reason = "Provider overloaded" if (_is_zai_coding_overload and not is_rate_limited) else "Rate limited"
                     _rate_limit_status = f"⏱️ {_wait_reason}. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries}){_policy_note}..."
                     # Normal retries are buffered to avoid noisy transient chatter. Long
                     # Z.AI Coding waits are different: they can last minutes, so surface

--- a/agent/rate_limit_policy.py
+++ b/agent/rate_limit_policy.py
@@ -1,0 +1,102 @@
+"""Rate-limit retry policy — config-gated 429 handling for the turn loop.
+
+Config shape (all keys optional):
+
+    agent:
+      rate_limit_retry:
+        max_retries: -1    # -1 = unlimited, 0 = off (default), N = N policy retries
+        backoff_base: 10   # seconds, first wait
+        backoff_max: 600   # seconds, ceiling
+
+When enabled (``max_retries != 0``), the conversation loop holds the primary
+provider on long exponential backoff for rate-limit 429s instead of eagerly
+failing over to the fallback chain — the right posture when every fallback
+rides the same throttled upstream (z.ai, single-tenant aggregators). Billing
+429s are exempt: backoff cannot recover an empty account.
+
+Disabled by default. An absent, malformed, or empty section must produce the
+same result as legacy behavior (``None`` → loop code takes the legacy path).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+@dataclass(frozen=True)
+class RateLimitRetryPolicy:
+    """Resolved ``agent.rate_limit_retry`` config values.
+
+    ``max_retries`` semantics: 0 = disabled, -1 = unlimited,
+    positive N = at most N policy retries per API-call block.
+    """
+
+    max_retries: int = 0
+    backoff_base: float = 10.0
+    backoff_max: float = 600.0
+
+    @property
+    def enabled(self) -> bool:
+        """Return True when the policy is active (max_retries != 0)."""
+        return self.max_retries != 0
+
+
+def resolve_rate_limit_retry_policy(raw: Any) -> Optional[RateLimitRetryPolicy]:
+    """Resolve the raw ``agent.rate_limit_retry`` config value.
+
+    Returns None for anything disabled or malformed so callers can use a
+    simple ``if policy and policy.enabled`` gate. Never raises — a bad config
+    entry must not break agent startup.
+    """
+    if not isinstance(raw, dict):
+        return None
+
+    def _int(key: str, default: int, lo: int, hi: int) -> int:
+        try:
+            val = int(raw.get(key, default))
+        except (TypeError, ValueError):
+            return default
+        return max(lo, min(hi, val))
+
+    def _float(key: str, default: float, lo: float, hi: float) -> float:
+        try:
+            val = float(raw.get(key, default))
+        except (TypeError, ValueError):
+            return default
+        return max(lo, min(hi, val))
+
+    policy = RateLimitRetryPolicy(
+        max_retries=_int("max_retries", 0, -1, 100000),
+        backoff_base=_float("backoff_base", 10.0, 0.1, 3600.0),
+        backoff_max=_float("backoff_max", 600.0, 1.0, 86400.0),
+    )
+    if not policy.enabled:
+        return None
+    # backoff_max below backoff_base is a config error; clamp so the
+    # schedule is monotonically capped rather than shrinking.
+    if policy.backoff_max < policy.backoff_base:
+        policy = RateLimitRetryPolicy(
+            max_retries=policy.max_retries,
+            backoff_base=policy.backoff_base,
+            backoff_max=policy.backoff_base,
+        )
+    return policy
+
+
+def policy_backoff_wait(
+    policy: RateLimitRetryPolicy,
+    retry_index: int,
+) -> float:
+    """Exponential backoff wait for policy retry ``retry_index`` (1-based).
+
+    Adds light uniform jitter (±10%) to decorrelate concurrent sessions
+    without making status messages unreadable. The result never exceeds
+    ``policy.backoff_max``.
+    """
+    import random
+
+    exponent = max(0, retry_index - 1)
+    delay = min(policy.backoff_base * (2 ** min(exponent, 20)), policy.backoff_max)
+    jitter = random.uniform(0.9, 1.1)
+    return min(delay * jitter, policy.backoff_max)

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1160,6 +1160,15 @@ agent:
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
 
+  # Rate-limit retry policy: when present, hold the primary provider on long
+  # exponential backoff for 429s instead of eagerly failing over. Useful when
+  # every fallback rides the same throttled upstream (single-tenant
+  # aggregators, z.ai). Disabled by default (max_retries: 0 or absent section).
+  # rate_limit_retry:
+  #   max_retries: -1    # -1=unlimited, 0=off, N=finite budget
+  #   backoff_base: 10   # seconds, first wait (default: 10)
+  #   backoff_max: 600   # seconds, ceiling (default: 600)
+
   # After the agent edits code without fresh passing verification, nudge it to
   # verify before finishing. The default "auto" enables it on interactive
   # coding surfaces (CLI, TUI, desktop) and programmatic callers, and disables

--- a/contributors/emails/ben@hodgens.net
+++ b/contributors/emails/ben@hodgens.net
@@ -1,0 +1,1 @@
+bhodgens

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -135,6 +135,13 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Rate-limit retry policy: when present, hold the primary provider
+        # on long exponential backoff for 429s instead of eagerly failing
+        # over. Useful when every fallback rides the same throttled upstream
+        # (single-tenant aggregators, z.ai). Disabled by default (max_retries:
+        # 0 or absent section). See website/docs/user-guide/configuration.md
+        # for the full shape.
+        "rate_limit_retry": {},
         # Empty-response retry guard (NS-503).  The empty-retry loop
         # re-sends the full conversation input at full price on every
         # attempt; these settings stop it from re-billing *deterministic*

--- a/tests/run_agent/test_rate_limit_pool_hold.py
+++ b/tests/run_agent/test_rate_limit_pool_hold.py
@@ -1,0 +1,142 @@
+"""Tests for the rate_limit_retry policy's credential-pool interaction.
+
+The policy holds the primary provider on long backoff during 429 storms.
+That turn-loop behavior must also change how the credential pool is
+updated: with a single-credential pool, marking the entry exhausted on a
+transient concurrency 429 triggers a 1h cooldown that starves every OTHER
+process (cron jobs, new sessions) even though the chat loop keeps using
+the same key anyway.
+
+Behavior under test (agent/agent_runtime_helpers.py::_recover_with_credential_pool,
+FailoverReason.rate_limit branch):
+
+1. Policy active + single pool entry → no mark_exhausted_and_rotate call.
+2. Policy active + a second available entry → rotation proceeds (a real
+   alternate exists, failover is the better move).
+3. Policy active + real quota wall (usage_limit_reached) → exhaustion
+   proceeds (backoff cannot recover a dead quota).
+4. Policy disabled/absent → legacy behavior byte-identical (exhaustion on
+   second 429).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import agent.agent_runtime_helpers as helpers
+from agent.rate_limit_policy import RateLimitRetryPolicy
+
+
+ACTIVE_POLICY = RateLimitRetryPolicy(max_retries=-1, backoff_base=10.0, backoff_max=300.0)
+
+
+def _make_pool(n_entries=1, current_status=None):
+    pool = MagicMock()
+    pool.provider = "zai"
+    entries = []
+    for i in range(n_entries):
+        e = MagicMock()
+        e.id = f"zai-entry-{i}"
+        e.runtime_api_key = f"key-{i}"
+        e.last_status = current_status if (i == 0 and current_status) else None
+        entries.append(e)
+    pool.entries.return_value = entries
+    current = entries[0] if entries else None
+    pool.current.return_value = current
+    pool.mark_exhausted_and_rotate.return_value = current if n_entries > 1 else None
+    pool.reset_statuses.return_value = 1
+    return pool
+
+
+def _make_agent(policy, pool):
+    agent = MagicMock()
+    agent.provider = "zai"
+    agent.model = "glm-5.3-flash"
+    agent._rate_limit_retry_policy = policy
+    agent._credential_pool = pool
+    agent._fallback_activated = False
+    return agent
+
+
+def _run_recovery(agent, *, has_retried_429=True, status_code=429, error_context=None):
+    """Invoke the real recover_with_credential_pool rate-limit branch."""
+    # The helper module resolves dependencies through _ra(); patch the
+    # pieces the rate-limit branch touches so no real I/O happens.
+    with patch.object(helpers, "_ra") as ra:
+        ra.return_value.logger = MagicMock()
+        result = helpers.recover_with_credential_pool(
+            agent,
+            status_code=status_code,
+            has_retried_429=has_retried_429,
+            error_context=error_context,
+        )
+    return result
+
+
+class TestPolicyHoldsPoolEntry:
+    def test_policy_single_entry_no_exhaustion(self):
+        """Policy active + one entry → hold the key, don't poison the pool."""
+        pool = _make_pool(n_entries=1)
+        agent = _make_agent(ACTIVE_POLICY, pool)
+
+        result = _run_recovery(agent, has_retried_429=True)
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        assert result == (False, True)
+
+    def test_policy_second_entry_still_rotates(self):
+        """Policy active but a real alternate exists → standard rotation."""
+        pool = _make_pool(n_entries=2)
+        agent = _make_agent(ACTIVE_POLICY, pool)
+
+        result = _run_recovery(agent, has_retried_429=True)
+
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        agent._swap_credential.assert_called_once()
+
+    def test_policy_quota_wall_still_exhausts(self):
+        """usage_limit_reached is a real quota wall — backoff can't fix it."""
+        pool = _make_pool(n_entries=1)
+        pool.mark_exhausted_and_rotate.return_value = None
+        agent = _make_agent(ACTIVE_POLICY, pool)
+
+        result = _run_recovery(
+            agent,
+            has_retried_429=True,
+            error_context={"reason": "usage_limit_reached"},
+        )
+
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        assert result == (False, True)
+
+    def test_no_policy_legacy_exhaustion(self):
+        """Policy disabled → legacy exhaustion path is byte-identical."""
+        pool = _make_pool(n_entries=1)
+        agent = _make_agent(None, pool)
+
+        result = _run_recovery(agent, has_retried_429=True)
+
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        assert result == (False, True)
+
+    def test_policy_first_429_still_defers(self):
+        """has_retried_429=False → both legacy and policy defer the rotation
+        decision (return False, True) without touching the pool."""
+        pool = _make_pool(n_entries=1)
+        agent = _make_agent(ACTIVE_POLICY, pool)
+
+        result = _run_recovery(agent, has_retried_429=False)
+
+        pool.mark_exhausted_and_rotate.assert_not_called()
+        assert result == (False, True)
+
+    def test_policy_clears_stale_exhaustion_flag(self):
+        """Pre-policy turns may have left the only entry exhausted; the
+        upstream early-return handles this before the policy branch."""
+        pool = _make_pool(n_entries=1, current_status="exhausted")
+        agent = _make_agent(ACTIVE_POLICY, pool)
+
+        result = _run_recovery(agent, has_retried_429=True)
+
+        # Legacy path: marks exhausted and rotates (returns False, True)
+        pool.mark_exhausted_and_rotate.assert_called_once()
+        assert result == (False, True)

--- a/tests/run_agent/test_rate_limit_retry_policy.py
+++ b/tests/run_agent/test_rate_limit_retry_policy.py
@@ -1,0 +1,161 @@
+"""Tests for agent.rate_limit_retry policy surface.
+
+Covers: config resolution (agent_init wiring), the RateLimitRetryPolicy
+dataclass semantics, and the policy backoff schedule used by the turn loop
+to hold the primary provider on long exponential backoff for rate-limit
+429s instead of eagerly failing over.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from agent.rate_limit_policy import (
+    RateLimitRetryPolicy,
+    policy_backoff_wait,
+    resolve_rate_limit_retry_policy,
+)
+
+
+# ── resolve_rate_limit_retry_policy ─────────────────────────────────────
+
+
+class TestResolvePolicy:
+    def test_absent_section_returns_none(self):
+        """No agent.rate_limit_retry → policy disabled (legacy behavior)."""
+        assert resolve_rate_limit_retry_policy(None) is None
+
+    def test_malformed_section_returns_none(self):
+        assert resolve_rate_limit_retry_policy("yes") is None
+        assert resolve_rate_limit_retry_policy([1, 2]) is None
+
+    def test_zero_max_retries_returns_none(self):
+        """max_retries: 0 is the explicit off switch."""
+        assert resolve_rate_limit_retry_policy({"max_retries": 0}) is None
+
+    def test_empty_section_returns_none(self):
+        """Present but empty → default max_retries 0 → disabled."""
+        assert resolve_rate_limit_retry_policy({}) is None
+
+    def test_negative_enables_unlimited(self):
+        policy = resolve_rate_limit_retry_policy({"max_retries": -1})
+        assert policy is not None
+        assert policy.max_retries == -1
+        assert policy.enabled
+
+    def test_finite_budget_enabled(self):
+        policy = resolve_rate_limit_retry_policy({"max_retries": 20})
+        assert policy is not None
+        assert policy.max_retries == 20
+
+    def test_default_backoff_values(self):
+        policy = resolve_rate_limit_retry_policy({"max_retries": 5})
+        assert policy.backoff_base == 10.0
+        assert policy.backoff_max == 600.0
+
+    def test_custom_backoff_values(self):
+        policy = resolve_rate_limit_retry_policy(
+            {"max_retries": -1, "backoff_base": 15, "backoff_max": 300}
+        )
+        assert policy.backoff_base == 15.0
+        assert policy.backoff_max == 300.0
+
+    def test_garbage_max_retries_disables_policy(self):
+        """Unparseable max_retries → default 0 → disabled (legacy path).
+
+        Malformed values never crash init and never enable aggressive
+        retrying by accident.
+        """
+        policy = resolve_rate_limit_retry_policy(
+            {"max_retries": "forever", "backoff_base": "lots", "backoff_max": None}
+        )
+        assert policy is None
+
+    def test_garbage_backoff_falls_back_to_defaults(self):
+        policy = resolve_rate_limit_retry_policy(
+            {"max_retries": 5, "backoff_base": "lots", "backoff_max": None}
+        )
+        assert policy is not None
+        assert policy.backoff_base == 10.0
+        assert policy.backoff_max == 600.0
+
+    def test_backoff_max_clamped_to_base(self):
+        """max < base would shrink the schedule; clamp to base."""
+        policy = resolve_rate_limit_retry_policy(
+            {"max_retries": 3, "backoff_base": 60, "backoff_max": 30}
+        )
+        assert policy.backoff_max == 60.0
+
+    def test_extreme_values_clamped_to_sane_bounds(self):
+        policy = resolve_rate_limit_retry_policy(
+            {"max_retries": 10**9, "backoff_base": 10**6, "backoff_max": 10**7}
+        )
+        assert policy.max_retries == 100000
+        assert policy.backoff_base == 3600.0
+        assert policy.backoff_max == 86400.0
+
+
+# ── policy_backoff_wait ──────────────────────────────────────────────────
+
+
+class TestPolicyBackoffWait:
+    def test_first_wait_near_base(self):
+        policy = RateLimitRetryPolicy(max_retries=-1, backoff_base=10.0, backoff_max=600.0)
+        wait = policy_backoff_wait(policy, 1)
+        assert 9.0 <= wait <= 11.0  # ±10% jitter
+
+    def test_exponential_growth(self):
+        policy = RateLimitRetryPolicy(max_retries=-1, backoff_base=10.0, backoff_max=100000.0)
+        wait_1 = policy_backoff_wait(policy, 1)
+        wait_2 = policy_backoff_wait(policy, 2)
+        wait_3 = policy_backoff_wait(policy, 3)
+        # Jitter is ±10%; growth is 2x per step, far outside the band.
+        assert wait_2 > wait_1 * 1.6
+        assert wait_3 > wait_2 * 1.6
+
+    def test_caps_at_backoff_max(self):
+        policy = RateLimitRetryPolicy(max_retries=-1, backoff_base=10.0, backoff_max=300.0)
+        for index in (6, 7, 20, 50):
+            assert policy_backoff_wait(policy, index) <= 300.0
+
+    def test_long_plateau_sits_at_cap(self):
+        """After enough doublings, every wait is at (or a hair under) the cap."""
+        policy = RateLimitRetryPolicy(max_retries=-1, backoff_base=10.0, backoff_max=600.0)
+        for index in (10, 11, 12):
+            assert policy_backoff_wait(policy, index) > 540.0
+
+
+# ── agent_init wiring ────────────────────────────────────────────────────
+
+
+def _make_agent(agent_section):
+    from run_agent import AIAgent
+
+    cfg = {"agent": dict(agent_section)}
+    with patch("run_agent.OpenAI"), \
+         patch("hermes_cli.config.load_config_readonly", return_value=cfg), \
+         patch("hermes_cli.config.load_config", return_value=cfg):
+        return AIAgent(
+            api_key="test-key",
+            base_url="https://api.z.ai/api/paas/v4",
+            model="glm-5.3-flash",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+
+
+class TestAgentInitWiring:
+    def test_no_policy_by_default(self):
+        agent = _make_agent({})
+        assert agent._rate_limit_retry_policy is None
+
+    def test_policy_from_config(self):
+        agent = _make_agent({"rate_limit_retry": {"max_retries": -1, "backoff_base": 15}})
+        policy = agent._rate_limit_retry_policy
+        assert policy is not None
+        assert policy.max_retries == -1
+        assert policy.backoff_base == 15.0
+
+    def test_malformed_policy_does_not_break_init(self):
+        agent = _make_agent({"rate_limit_retry": "unlimited please"})
+        assert agent._rate_limit_retry_policy is None

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1094,6 +1094,26 @@ agent:
 
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
+### Rate-limit retry policy (`agent.rate_limit_retry`)
+
+When your primary provider returns HTTP 429 (rate limited), Hermes normally falls back to your next provider immediately. Use `agent.rate_limit_retry` to hold the primary provider on long exponential backoff instead — useful when every fallback rides the same throttled upstream (single-tenant aggregators, z.ai).
+
+```yaml
+agent:
+  rate_limit_retry:
+    max_retries: -1    # -1 = unlimited retries, 0 = off (default), N = finite budget
+    backoff_base: 10   # seconds, first wait (default: 10)
+    backoff_max: 600   # seconds, ceiling (default: 600)
+```
+
+- `max_retries: -1` keeps retrying indefinitely until the provider recovers
+- `max_retries: N` (positive) retries at most N times before falling back
+- `max_retries: 0` or absent section disables the policy (legacy behavior)
+- Billing errors (402) are always exempt — backoff cannot recover an empty account
+- A provider-supplied `Retry-After` header longer than the policy schedule still wins
+
+The policy holds the credential pool entry instead of marking it exhausted, preventing a single-entry pool from starving other processes (cron jobs, new sessions) during a 429 storm.
+
 ## Wall-Clock Run Budget
 
 Separate from the iteration budget, you can give each conversation run an optional **wall-clock** budget. This is designed for one-shot and eval-harness invocations that run under a hard external ceiling (e.g. a 900-second per-task limit): without it, a run can time out with the work essentially done — one generation short of emitting the final answer, or stuck in a single hung provider call.


### PR DESCRIPTION
## What does this PR do?

Add a config-gated rate-limit retry policy that holds the primary provider on long exponential backoff instead of eagerly failing over on 429 errors. Useful when every fallback rides the same throttled upstream — single-tenant aggregators, z.ai, and others. 

It's often the case that providers use 429 to (correctly) limit throughput due to load-induced performance degradation. This PR adheres to 429 HTTP specification allowing for a graceful exponential backoff. 

## Related Issue

Closes #49031

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

Changes are inagent/rate_limit_policy.py, agent/agent_init.py, agent/conversation_loop.py, agent/agent_runtime_helpers.py, agent/turn_retry_state.py, hermes_cli/config.py, and the docs plus tests.
-

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. Configure agent.rate_limit_retry with max_retries: -1 in your config.yaml,
2. trigger a 429 on your primary provider
3. and watch Hermes wait with the configured backoff instead of immediately falling back.


## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [X] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->
