### PR TITLE
error_classifier, conversation_loop: handle Cloudflare 524 origin timeout

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -3846,16 +3846,36 @@ def run_conversation(
                     # Eager fallback: empty/malformed responses are a common
                     # rate-limit symptom.  Switch to fallback immediately
                     # rather than retrying with extended backoff.
+                    # Cloudflare 524 (origin timeout) also triggers eager fallback
+                    # since retries won't fix an infrastructure timeout.
+                    _resp_error_code = None
+                    if response and hasattr(response, 'error') and response.error:
+                        _code_raw = getattr(response.error, 'code', None)
+                        if _code_raw is None and isinstance(response.error, dict):
+                            _code_raw = response.error.get('code')
+                        if _code_raw is not None:
+                            try:
+                                _resp_error_code = int(_code_raw)
+                            except (TypeError, ValueError):
+                                pass
+
+                    is_cloudflare_524 = (_resp_error_code == 524)
+                    is_empty_malformed = not is_cloudflare_524  # original check
+
                     if agent._fallback_index < len(agent._fallback_chain):
-                        agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
-                    if agent._try_activate_fallback():
-                        active_system_prompt = _sync_failover_system_message(
-                            agent, api_messages, active_system_prompt)
-                        retry_count = 0
-                        compression_attempts = 0
-                        _retry.primary_recovery_attempted = False
-                        _retry.restart_with_rebuilt_messages = True
-                        break
+                        if is_empty_malformed:
+                            agent._buffer_status("⚠️ Empty/malformed response — switching to fallback...")
+                        elif is_cloudflare_524:
+                            agent._buffer_status("⚠️ Cloudflare 524 (origin timeout) — switching to fallback...")
+                    if is_empty_malformed or is_cloudflare_524:
+                        if agent._try_activate_fallback():
+                            active_system_prompt = _sync_failover_system_message(
+                                agent, api_messages, active_system_prompt)
+                            retry_count = 0
+                            compression_attempts = 0
+                            _retry.primary_recovery_attempted = False
+                            _retry.restart_with_rebuilt_messages = True
+                            break
 
                     # Check for error field in response (some providers include this)
                     error_msg = "Unknown"
@@ -3901,8 +3921,8 @@ def run_conversation(
                         _failure_hint = "rate limited by upstream provider (429)"
                     elif _resp_error_code in {500, 502}:
                         _failure_hint = f"upstream server error ({_resp_error_code}, {api_duration:.0f}s)"
-                    elif _resp_error_code in {503, 529}:
-                        _failure_hint = f"upstream provider overloaded ({_resp_error_code})"
+                    elif _resp_error_code in {503, 524, 529}:
+                        _failure_hint = f"upstream provider overloaded or timed out ({_resp_error_code})"
                     elif _resp_error_code is not None:
                         _failure_hint = f"upstream error (code {_resp_error_code}, {api_duration:.0f}s)"
                     elif api_duration < 10:

--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -671,6 +671,10 @@ _TIMEOUT_MESSAGE_PATTERNS = [
     "deadline exceeded",
     "operation timed out",
     "upstream timed out",
+    # Cloudflare 524: origin didn't respond within proxy read timeout (120s)
+    "error 524",
+    "proxy read timeout",
+    "origin web server did not return a complete response",
 ]
 
 # Connection-establishment / DNS failure message patterns.  These surface
@@ -1490,11 +1494,12 @@ def _classify_by_status(
             )
         return result_fn(FailoverReason.server_error, retryable=True)
 
-    if status_code in {503, 529}:
+    if status_code in {503, 524, 529}:
         # Same overflow-as-5xx variant (server busy / model-load OOM, or a
-        # Cloudflare/Tailscale hop relabeling the status). Route explicit
-        # overflow bodies into compression; otherwise treat as transient
-        # overload and retry.
+        # Cloudflare/Tailscale hop relabeling the status). 524 is a Cloudflare-
+        # specific "A timeout occurred" (origin didn't respond within 120s proxy
+        # read timeout). Route explicit overflow bodies into compression;
+        # otherwise treat as transient overload and retry.
         if any(p in error_msg for p in _EMPTY_PROVIDER_RESPONSE_PATTERNS):
             return result_fn(
                 FailoverReason.server_error,


### PR DESCRIPTION
Fixes Deepseek Flash v4 flash 0731 hitting Cloudflare 524 (120s proxy read
timeout). The error is an infrastructure timeout that retries won't fix.

Changes:
1. error_classifier: Add 524 to overloaded status codes; add Cloudflare 524
   message patterns to timeout detection
2. conversation_loop: Detect 524 in invalid responses and trigger eager
   fallback immediately instead of exhausting retries

Without this, 3 retries with backoff (5-120s each) waste time before fallback.