### PR TITLE
fix(update): size the blunt systemctl restart timeout to the drain budget

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10320,6 +10320,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         # the restart idempotent.  Mirrors the recovery
                         # path in `hermes gateway restart`
                         # (`systemd_restart()`) as of PR #20949.
+                        _blunt_restart_timeout = _blunt_restart_subprocess_timeout(
+                            _drain_budget
+                        )
                         subprocess.run(
                             _manage_cmd + ["reset-failed", svc_name],
                             capture_output=True,
@@ -10330,7 +10333,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                             _manage_cmd + ["restart", svc_name],
                             capture_output=True,
                             text=True, encoding="utf-8", errors="replace",
-                            timeout=15,
+                            timeout=_blunt_restart_timeout,
                         )
                         if restart.returncode == 0:
                             # Verify the service actually survived the
@@ -10362,7 +10365,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
                                     _manage_cmd + ["restart", svc_name],
                                     capture_output=True,
                                     text=True, encoding="utf-8", errors="replace",
-                                    timeout=15,
+                                    timeout=_blunt_restart_timeout,
                                 )
                                 if _wait_for_service_active(
                                     scope_cmd,
@@ -11171,6 +11174,38 @@ def _print_items(items, label, key, fallback_key=None):
     extra = len(items) - len(shown)
     if extra > 0:
         print(f"      … and {extra} more")
+
+def _blunt_restart_subprocess_timeout(drain_budget: float) -> float:
+    """Timeout for the blunt ``systemctl restart`` subprocess call itself.
+
+    ``systemctl restart`` blocks until the stop+start transaction
+    completes. The unit's ``TimeoutStopSec`` is pinned to
+    ``agent.restart_drain_timeout`` plus slack (see
+    ``55-drain-timeout.conf``) so a gateway draining an in-flight turn
+    can legitimately take that long to stop. A subprocess timeout
+    shorter than the drain budget kills the ``systemctl`` CLI client
+    (not the transaction already queued with the systemd manager, which
+    keeps running) and makes the caller wrongly report a unit that was
+    still draining as "not restarted".
+    """
+    return max(15.0, drain_budget + 30.0)
+
+
+def _blunt_restart_subprocess_timeout(drain_budget: float) -> float:
+    """Timeout for the blunt ``systemctl restart`` subprocess call itself.
+
+    ``systemctl restart`` blocks until the stop+start transaction
+    completes. The unit's ``TimeoutStopSec`` is pinned to
+    ``agent.restart_drain_timeout`` plus slack (see
+    ``55-drain-timeout.conf``) so a gateway draining an in-flight turn
+    can legitimately take that long to stop. A subprocess timeout
+    shorter than the drain budget kills the ``systemctl`` CLI client
+    (not the transaction already queued with the systemd manager, which
+    keeps running) and makes the caller wrongly report a unit that was
+    still draining as "not restarted".
+    """
+    return max(15.0, drain_budget + 30.0)
+
 
 def _wait_for_service_active(
     scope_cmd_: list,

--- a/tests/hermes_cli/test_update_blunt_restart_timeout.py
+++ b/tests/hermes_cli/test_update_blunt_restart_timeout.py
@@ -1,0 +1,31 @@
+"""Regression: the blunt ``systemctl restart`` fallback must not time out
+before a unit's configured drain window has a chance to complete.
+
+``hermes-gateway*`` units pin ``TimeoutStopSec`` to
+``agent.restart_drain_timeout`` plus slack (see ``55-drain-timeout.conf``,
+600s by default). ``systemctl restart`` blocks until the stop+start
+transaction finishes, so a subprocess timeout shorter than the drain budget
+kills the ``systemctl`` CLI client — not the transaction already queued with
+the systemd manager, which keeps running — and made ``hermes update`` report
+a unit that was still gracefully draining as "not restarted" even though it
+came back on its own moments later.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.update_cmd import _blunt_restart_subprocess_timeout
+
+
+class TestBluntRestartSubprocessTimeout:
+    def test_covers_a_long_configured_drain_budget(self):
+        # agent.restart_drain_timeout default (600s) plus the
+        # restart_after_turn_timeout headroom _get_restart_exit_wait_budget
+        # already folds in.
+        assert _blunt_restart_subprocess_timeout(600.0) == 630.0
+
+    def test_never_drops_below_the_original_flat_timeout(self):
+        assert _blunt_restart_subprocess_timeout(-30.0) == 15.0
+        assert _blunt_restart_subprocess_timeout(-100.0) == 15.0
+
+    def test_scales_with_the_drain_budget(self):
+        assert _blunt_restart_subprocess_timeout(45.0) == 75.0


### PR DESCRIPTION
## Summary
- `hermes-gateway*` units pin `TimeoutStopSec` to `agent.restart_drain_timeout` plus slack (600s by default), so a gateway draining an in-flight turn can legitimately take that long to stop.
- The blunt `systemctl restart` fallback path in `hermes update` used a flat 15s subprocess timeout for the `systemctl restart` call itself. `systemctl restart` blocks until the stop+start transaction completes, so a timeout shorter than the drain budget kills the `systemctl` CLI client (not the transaction already queued with the systemd manager, which keeps running) — and `hermes update` reports a unit that is still gracefully draining as "not restarted," even though it comes back up on its own moments later.
- Extracts `_blunt_restart_subprocess_timeout()` and sizes both the initial and retry `systemctl restart` calls off the same drain budget the graceful SIGUSR1 restart path already uses.

## Test plan
- [x] `pytest tests/hermes_cli/test_update_blunt_restart_timeout.py tests/hermes_cli/test_update_fleet_restart_timeout.py tests/hermes_cli/test_update_gateway_restart_aborted.py` — 22 passed
- [x] Reproduced on a live fleet: `hermes-gateway-littleram` took 66s to gracefully stop under load (SIGTERM at 00:23:39, `Stopped` at 00:24:45), exceeding the old 15s timeout; `hermes update` reported it as an incomplete restart even though the unit came back up and started serving current code four seconds later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)