### PR TITLE
fix(kanban): gate stop-nudge & budget bridge on dispatcher-task ownership

### DIFF
--- a/agent/kanban_stop.py
+++ b/agent/kanban_stop.py
@@ -25,14 +25,32 @@ _DEFAULT_MAX_ATTEMPTS = 2
 def kanban_stop_nudge_enabled() -> bool:
     """Return whether the kanban stop-guard is active for this process.
 
-    On when ``HERMES_KANBAN_TASK`` is set (dispatcher-spawned worker), unless
-    ``HERMES_KANBAN_STOP_NUDGE`` explicitly disables it.
+    On when ``HERMES_KANBAN_TASK`` is set AND this execution actually owns
+    that dispatcher task, unless ``HERMES_KANBAN_STOP_NUDGE`` explicitly
+    disables it.
+
+    The ownership check matters for executions that see a dispatcher
+    worker's ``HERMES_KANBAN_*`` vars without being that worker: a cron
+    job fired in-process from a worker (``cron.scheduler.run_job`` enters
+    ``non_dispatcher_owned_context``) and a ``hermes cron run`` subprocess
+    that inherited the worker's env. Gating on the canonical
+    ``is_dispatcher_owned_worker_context`` predicate keeps the guard
+    synced with every other ``HERMES_KANBAN_*`` identity gate (kanban
+    toolset, worker protocol, ``kanban_complete`` default) instead of
+    misreading an unrelated cron agent as the worker and nudging it to
+    close a task it does not own.
     """
     env = os.environ.get("HERMES_KANBAN_STOP_NUDGE")
     if env is not None and env.strip().lower() in {"0", "false", "no", "off"}:
         return False
     task = (os.environ.get("HERMES_KANBAN_TASK") or "").strip()
-    return bool(task)
+    if not task:
+        return False
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+    except Exception:
+        return True
+    return is_dispatcher_owned_worker_context()
 
 
 def _tool_call_name(tc: Any) -> str:

--- a/agent/turn_finalizer.py
+++ b/agent/turn_finalizer.py
@@ -32,6 +32,26 @@ from agent.message_metadata import append_message, stamp_message_timestamp
 from agent.message_sanitization import _sanitize_surrogates
 
 
+def _is_dispatcher_owned_kanban_worker() -> bool:
+    """True only when this execution owns the dispatcher's kanban task.
+
+    ``HERMES_KANBAN_TASK`` in ``os.environ`` says a dispatcher worker's
+    identity is *visible*, not that this execution *is* that worker: cron
+    jobs fired in-process from a worker (``cron.scheduler.run_job`` enters
+    ``non_dispatcher_owned_context``) and ``hermes cron run`` subprocesses
+    that inherited the worker's env both see the vars without owning the
+    task. Delegates to the canonical predicate every other
+    ``HERMES_KANBAN_*`` identity gate uses; fail-open on import failure so
+    exotic runtimes never lose the dispatcher's failure-circuit signal.
+    """
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        return is_dispatcher_owned_worker_context()
+    except Exception:
+        return True
+
+
 def _assistant_row_missing_visible_text(msg: dict) -> bool:
     """True when an assistant row has no visible text (blank final or tool-only)."""
     if not isinstance(msg, dict) or msg.get("role") != "assistant":
@@ -220,8 +240,15 @@ def finalize_turn(
         # We route through ``_record_task_failure(outcome="timed_out")``
         # rather than ``kanban_block`` so this counts toward the dispatcher's
         # consecutive-failure circuit breaker (#29747 gap 2).
+        #
+        # ``HERMES_KANBAN_TASK`` in ``os.environ`` is not ownership: a cron
+        # job fired in-process from a worker (or a ``hermes cron run``
+        # subprocess that inherited the worker's env) sees the variable
+        # without owning that task, and recording a failure here would close
+        # the worker's run behind its back. Same canonical predicate the
+        # kanban toolset / worker-protocol gates use.
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
+        if _kanban_task and _is_dispatcher_owned_kanban_worker():
             _record_kanban_budget_exhausted(
                 _kanban_task, api_call_count, agent.max_iterations, logger,
             )
@@ -234,8 +261,9 @@ def finalize_turn(
         # ``_record_task_failure`` (compare-and-swap receipt path) which
         # is a no-op if another path closed it — the CAS invariant in
         # ``_end_run`` (``WHERE ended_at IS NULL``) guarantees idempotence.
+        # Ownership-gated for the same reason as the branch above.
         _kanban_task = os.environ.get("HERMES_KANBAN_TASK")
-        if _kanban_task:
+        if _kanban_task and _is_dispatcher_owned_kanban_worker():
             _record_kanban_budget_exhausted(
                 _kanban_task, api_call_count, agent.max_iterations, logger,
             )

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -8,6 +8,7 @@ pause/resume/run/remove, status, and tick.
 import json
 import re
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional
 
@@ -47,6 +48,34 @@ def _cron_api(**kwargs):
     from tools.cronjob_tools import cronjob as cronjob_tool
 
     return json.loads(cronjob_tool(**kwargs))
+
+
+@contextmanager
+def _non_dispatcher_owned_cron_cli_scope():
+    """Mark a standalone ``hermes cron run`` / ``cron tick`` CLI process as
+    not owning any dispatcher kanban task.
+
+    When a kanban worker fires a cron job *in-process* (``cronjob`` tool),
+    ``cron.scheduler.run_job()`` enters ``non_dispatcher_owned_context`` so
+    the cron agent is not misread as the worker. A ``hermes cron run``
+    subprocess spawned from a worker inherits the worker's
+    ``HERMES_KANBAN_*`` env, but a ContextVar cannot cross the process
+    boundary — so without this marker the freshly spawned CLI process
+    defaults to "owns the dispatcher's task" and its cron agent inherits
+    the worker's kanban identity (stop-nudge, budget-exhausted task
+    failure records, force-added kanban toolset).
+
+    Scoped to the command only and best-effort: if the delegation-context
+    import fails, run exactly as before.
+    """
+    try:
+        from agent.delegation_context import non_dispatcher_owned_context
+    except Exception:
+        # Degrade to historical behavior rather than block the command.
+        yield
+        return
+    with non_dispatcher_owned_context():
+        yield
 
 
 def _active_cron_provider_name() -> str:
@@ -1071,7 +1100,8 @@ def cron_command(args):
         return cron_doctor()
 
     if subcmd == "tick":
-        return cron_tick()
+        with _non_dispatcher_owned_cron_cli_scope():
+            return cron_tick()
 
     if subcmd in {"runs", "history"}:
         cron_runs(getattr(args, "job_id", None), getattr(args, "limit", 20))
@@ -1096,7 +1126,8 @@ def cron_command(args):
         return cron_resume(args)
 
     if subcmd == "run":
-        return _job_action("run", args.job_id, "Triggered")
+        with _non_dispatcher_owned_cron_cli_scope():
+            return _job_action("run", args.job_id, "Triggered")
 
     if subcmd in {"remove", "rm", "delete"}:
         return _job_action("remove", args.job_id, "Removed")

--- a/tests/agent/test_kanban_stop.py
+++ b/tests/agent/test_kanban_stop.py
@@ -74,6 +74,42 @@ def test_no_nudge_after_kanban_complete(clear_kanban_env):
     assert build_kanban_stop_nudge(messages=messages) is None
 
 
+# ── Ownership gate (regression: worker's cron subprocess got nudged) ──
+
+
+def test_no_nudge_in_non_dispatcher_owned_context(clear_kanban_env):
+    """A cron agent fired from a kanban worker — in-process via
+    ``cronjob(action="run")`` or as a ``hermes cron run`` subprocess that
+    inherited the worker's env — sees ``HERMES_KANBAN_TASK`` without
+    owning it. The stop-guard must stay off, otherwise the cron agent is
+    nudged into calling ``kanban_complete`` on the worker's task
+    (t_f1e15318: nudge issued in session cron_b7412e9c6d20_20260903_094436).
+    """
+    from agent.delegation_context import non_dispatcher_owned_context
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_worker_real_task")
+    with non_dispatcher_owned_context():
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+    # Outside the scope the worker identity is owned again.
+    assert kanban_stop_nudge_enabled() is True
+
+
+def test_no_nudge_in_delegated_child_context(clear_kanban_env):
+    """delegate_task children run in the parent's env via ContextVar; the
+    stop-guard must not treat them as the dispatcher worker either."""
+    import agent.delegation_context as dc
+
+    clear_kanban_env.setenv("HERMES_KANBAN_TASK", "t_worker_real_task")
+    token = dc._DELEGATED_CHILD_CONTEXT.set(True)
+    try:
+        assert kanban_stop_nudge_enabled() is False
+        assert build_kanban_stop_nudge(messages=[]) is None
+    finally:
+        dc._DELEGATED_CHILD_CONTEXT.reset(token)
+    assert kanban_stop_nudge_enabled() is True
+
+
 
 
 

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import ast
 import os
 import threading
+from types import SimpleNamespace
 
 import pytest
 
@@ -372,6 +373,100 @@ class TestRunJobKanbanIsolation:
             k: v for k, v in os.environ.items() if k.startswith("HERMES_KANBAN_")
         }
         assert after == before, "worker identity must survive concurrent cron jobs"
+
+
+# ---------------------------------------------------------------------------
+# Standalone CLI surfaces (`hermes cron run` / `hermes cron tick`)
+# ---------------------------------------------------------------------------
+
+class TestCronCliNonDispatcherScope:
+    """A standalone ``hermes cron run`` / ``cron tick`` process executes
+    jobs in-process, but unlike ``run_job()`` it has no ContextVar marking:
+    when the CLI was spawned by a kanban worker it inherits the worker's
+    ``HERMES_KANBAN_*`` env, and a ContextVar cannot cross the process
+    boundary (t_f1e15318). The CLI command handlers must therefore enter
+    the non-dispatcher scope themselves.
+    """
+
+    def test_scope_sets_and_restores(self):
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+        from hermes_cli.cron import _non_dispatcher_owned_cron_cli_scope
+
+        assert is_dispatcher_owned_worker_context() is True
+        with _non_dispatcher_owned_cron_cli_scope():
+            assert is_dispatcher_owned_worker_context() is False
+        assert is_dispatcher_owned_worker_context() is True
+
+    def test_cron_run_command_wraps_job_action(self, worker_env, monkeypatch):
+        import hermes_cli.cron as cron_cli
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        observed: dict = {}
+
+        def fake_job_action(action, job_id, verb):
+            observed["inside"] = is_dispatcher_owned_worker_context()
+            return 0
+
+        monkeypatch.setattr(cron_cli, "_job_action", fake_job_action)
+
+        args = SimpleNamespace(cron_command="run", job_id="t_iso_cli")
+        rc = cron_cli.cron_command(args)
+
+        assert rc == 0
+        assert observed["inside"] is False, (
+            "cron run inside a worker-spawned subprocess must not be "
+            "treated as the dispatcher-owned worker"
+        )
+        assert is_dispatcher_owned_worker_context() is True, (
+            "the scope must be restored after the command"
+        )
+
+    def test_cron_tick_command_wraps_tick(self, worker_env, monkeypatch):
+        import hermes_cli.cron as cron_cli
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        observed: dict = {}
+
+        def fake_tick():
+            observed["inside"] = is_dispatcher_owned_worker_context()
+            return 0
+
+        monkeypatch.setattr(cron_cli, "cron_tick", fake_tick)
+
+        args = SimpleNamespace(cron_command="tick")
+        rc = cron_cli.cron_command(args)
+
+        assert rc == 0
+        assert observed["inside"] is False
+        assert is_dispatcher_owned_worker_context() is True
+
+    def test_scope_degrades_without_delegation_context(self, worker_env, monkeypatch):
+        """If agent.delegation_context cannot be imported the command must
+        still work (historical behavior), not crash."""
+        import builtins
+
+        import hermes_cli.cron as cron_cli
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        real_import = builtins.__import__
+
+        def broken_import(name, *a, **kw):
+            if name == "agent.delegation_context":
+                raise ImportError("simulated missing module")
+            return real_import(name, *a, **kw)
+
+        monkeypatch.setattr(builtins, "__import__", broken_import)
+
+        def fake_job_action(action, job_id, verb):
+            return 0
+
+        monkeypatch.setattr(cron_cli, "_job_action", fake_job_action)
+
+        args = SimpleNamespace(cron_command="run", job_id="t_iso_degrade")
+        rc = cron_cli.cron_command(args)
+
+        assert rc == 0
+        assert is_dispatcher_owned_worker_context() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4706,6 +4706,92 @@ class TestRunConversation:
             "_record_task_failure should not be called outside kanban mode"
         )
 
+    def test_no_kanban_budget_record_in_non_dispatcher_context(
+        self, agent, monkeypatch
+    ):
+        """Regression (t_f1e15318): a cron agent fired from a kanban worker —
+        in-process via the ``cronjob`` tool or as a ``hermes cron run``
+        subprocess that inherited the worker's env — sees
+        ``HERMES_KANBAN_TASK`` without owning that task. Its budget
+        exhaustion must NOT close the worker's run on the board."""
+        from agent.delegation_context import non_dispatcher_owned_context
+
+        self._setup_agent(agent)
+        agent.max_iterations = 2
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker_real_task")
+
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tool_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[tc],
+        )
+        summary_resp = _mock_response(
+            content="Summary.", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_resp, tool_resp, summary_resp,
+        ]
+
+        mock_record_failure = MagicMock(return_value=False)
+
+        with non_dispatcher_owned_context():
+            with (
+                patch("run_agent.handle_function_call", return_value="ok"),
+                patch("hermes_cli.kanban_db._record_task_failure",
+                      mock_record_failure),
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                agent.run_conversation("run the scheduled job")
+
+        assert mock_record_failure.call_count == 0, (
+            "cron agent must not record a task failure for a worker task "
+            "it does not own"
+        )
+
+    def test_no_kanban_budget_record_in_delegated_child_context(
+        self, agent, monkeypatch
+    ):
+        """delegate_task children inherit the parent worker's env view; the
+        budget-exhausted bridge must not fire for them either."""
+        import agent.delegation_context as dc
+
+        self._setup_agent(agent)
+        agent.max_iterations = 2
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker_real_task")
+
+        tc = _mock_tool_call(name="web_search", arguments="{}", call_id="c1")
+        tool_resp = _mock_response(
+            content="", finish_reason="tool_calls", tool_calls=[tc],
+        )
+        summary_resp = _mock_response(
+            content="Summary.", finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            tool_resp, tool_resp, summary_resp,
+        ]
+
+        mock_record_failure = MagicMock(return_value=False)
+
+        token = dc._DELEGATED_CHILD_CONTEXT.set(True)
+        try:
+            with (
+                patch("run_agent.handle_function_call", return_value="ok"),
+                patch("hermes_cli.kanban_db._record_task_failure",
+                      mock_record_failure),
+                patch.object(agent, "_persist_session"),
+                patch.object(agent, "_save_trajectory"),
+                patch.object(agent, "_cleanup_task_resources"),
+            ):
+                agent.run_conversation("delegate child work")
+        finally:
+            dc._DELEGATED_CHILD_CONTEXT.reset(token)
+
+        assert mock_record_failure.call_count == 0, (
+            "delegate_task child must not record a task failure for the "
+            "worker's task"
+        )
+
     # ── Output-cap retry: safe_out uses provider available_out + request estimate ──
 
     def test_output_cap_retry_uses_provider_available_out(self, agent):


### PR DESCRIPTION
## Root cause

A `hermes cron run` subprocess spawned from a Kanban worker inherits the worker's `HERMES_KANBAN_*` environment. `cron.scheduler.run_job()` already calls `enter_non_dispatcher_owned_context()` for in-process runs (scheduler.py:6212-6230), but a ContextVar cannot cross a process boundary — so the fresh CLI process defaulted to *owning* the dispatcher's task. Two surfaces still read `os.environ` directly without the canonical ownership predicate:

1. **Stop-nudge** (`agent/kanban_stop.py:25-35`) — the cron agent received `kanban stop-loop nudge issued ... task=<worker task>` and was nudged into calling `kanban_complete` on a task it does not own. Evidence: `profiles/vida/logs/agent.log`, session `cron_b7412e9c6d20_20260903_094436`, line 17817.
2. **Budget-exhausted bridge** (`agent/turn_finalizer.py`) — when the subprocess hit its iteration budget, both branches recorded a task failure against the worker's run it does not own.

## Fix (6 files, +301/−7)

- `agent/kanban_stop.py` — `kanban_stop_nudge_enabled()` now requires `is_dispatcher_owned_worker_context()` (the same predicate already used by the kanban toolset, skill env and the `kanban_complete` default); fails open on import error.
- `agent/turn_finalizer.py` — both budget-exhausted branches only record a task failure when the execution actually owns the task.
- `hermes_cli/cron.py` — `cron run` and `cron tick` handlers enter `non_dispatcher_owned_context()` (best-effort; degrades gracefully if the module is unavailable). In-process cron was already covered by `cron.scheduler.run_job()`.
- Regression tests: stop-guard (non-dispatcher scope + delegated child), budget bridge (same two scopes), CLI scope (set/restore/degrade-without-import).

Worker heartbeat (`run_agent._touch_activity`) is untouched; no global env is cleared in-process.

## Validation

- 356 tests green: `test_kanban_stop` 27/27 (2 new ownership-gate tests), cron env isolation 27/27 (4 new), `test_run_agent.py` 285/285 (2 new budget-bridge tests), turn-finalizer 22/22, telegram gating 25/25, desktop ticker scope 3/3.
- Controlled E2E: a test cron job fired via `hermes cron run` with the worker's env inherited → execution `completed`, session `end_reason=cron_complete`, **zero** stop-nudge lines, **zero** kanban toolset exposed, worker's task untouched.
- One pre-existing failure (`test_scheduler_cron_session_isolation.py::test_run_job_cron_execute_code_deny…`, approval-guard related) reproduces on clean `main` @ `561b053f79` and is unrelated to this change.
