### PR TITLE
fix(doctor): explain workspace npm advisories in plain language

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -2730,7 +2730,7 @@ def run_doctor(args):
                     else:
                         vuln_detail = (
                             f"{critical} critical, {high} high, {moderate} moderate — "
-                            "build-tool advisory; clears via lockfile bump"
+                            "in dev tooling only, no action needed"
                         )
                     check_warn(
                         f"{label} deps",
@@ -2743,9 +2743,11 @@ def run_doctor(args):
                         # arborist crash (edgesOut / isDescendantOf) on this monorepo
                         # tree — in that case it is an npm bug, not a Hermes one.
                         check_info(
-                            "  ^ build-time tooling (not runtime); if manual npm remediation "
-                            "errors with an arborist crash it's a known npm bug — clears "
-                            "via a lockfile bump"
+                            "  ^ Only affects the build process, not the app you run "
+                            "— nothing you need to do. (If you try to fix it "
+                            "yourself, `npm audit fix` may fail here with an "
+                            "unrelated npm error; that's a known npm bug, not "
+                            "something wrong with your setup.)"
                         )
                     issues.append(
                         f"{label} has {total} npm "

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -1737,3 +1737,48 @@ def test_run_doctor_warns_when_lightpanda_binary_missing(monkeypatch, tmp_path):
     monkeypatch.setattr("tools.browser_lightpanda.find_lightpanda_binary", lambda: None)
     out = helper._run_doctor_and_capture(monkeypatch, tmp_path)
     assert "Lightpanda selected but binary not found" in out
+
+
+def test_run_doctor_npm_workspace_advisory_message_is_plain_language(monkeypatch, tmp_path):
+    """#102555: the workspace-scoped npm audit note used jargon ("arborist
+    crash", "clears via a lockfile bump") that a non-technical user can't act
+    on. It must instead say plainly that no user action is needed."""
+    helper = TestDoctorMemoryProviderSection()
+    project = tmp_path / "project"
+    (project / "node_modules").mkdir(parents=True, exist_ok=True)
+
+    real_which = doctor_mod.shutil.which
+
+    def fake_which(cmd):
+        # Node absent so the browser-tools section (agent-browser/npx
+        # resolution) is skipped entirely — this test only cares about the
+        # npm-audit block below, which is gated on npm alone.
+        if cmd == "node":
+            return None
+        if cmd == "npm":
+            return "/usr/bin/npm"
+        return real_which(cmd)
+
+    monkeypatch.setattr(doctor_mod.shutil, "which", fake_which)
+
+    import json as _json
+
+    real_run = doctor_mod.subprocess.run
+
+    def fake_run(cmd, **kwargs):
+        if isinstance(cmd, list) and "audit" in cmd:
+            high = 1 if "web" in cmd else 0
+            payload = {"metadata": {"vulnerabilities": {"critical": 0, "high": high, "moderate": 0}}}
+            return SimpleNamespace(stdout=_json.dumps(payload), stderr="", returncode=0)
+        return real_run(cmd, **kwargs)
+
+    monkeypatch.setattr(doctor_mod.subprocess, "run", fake_run)
+
+    out = helper._run_doctor_and_capture(monkeypatch, tmp_path, provider="")
+
+    assert "in dev tooling only, no action needed" in out
+    assert "Only affects the build process, not the app you run" in out
+    assert "nothing you need to do" in out
+    assert "arborist" not in out
+    assert "clears via a lockfile bump" not in out
+    assert "build-tool advisory" not in out


### PR DESCRIPTION
Fixes #102555

## Problem

`hermes doctor`'s "External Tools" section reports web/ui-tui workspace npm
advisories with internal jargon that a non-technical user can't act on:

```
⚠ web workspace deps (0 critical, 1 high, 1 moderate — build-tool advisory; clears via lockfile bump)
  →   ^ build-time tooling (not runtime); if manual npm remediation errors with an arborist crash it's a known npm bug — clears via a lockfile bump
```

The issue reporter singled this out directly: "On what planet is a message
like `if manual npm remediation errors with an arborist crash it's a known
npm bug` helpful?"

## Fix

Reworded both the summary line and the follow-up note in
`hermes_cli/doctor.py`'s `run_doctor()` to say plainly, in the same two
spots, that this only affects build tooling and needs no user action —
without "arborist", "build-tool advisory", or "lockfile bump":

```
⚠ web workspace deps (0 critical, 1 high, 1 moderate — in dev tooling only, no action needed)
  →   ^ Only affects the build process, not the app you run — nothing you need to do. (If you try to fix it yourself, `npm audit fix` may fail here with an unrelated npm error; that's a known npm bug, not something wrong with your setup.)
```

No behavior change beyond message text — the vulnerability counting, the
`--workspace` fix-command suppression (still `None`, since `npm audit fix
--workspace <name>` genuinely crashes here), and the `issues` list entry are
untouched.

## Test plan

Added `test_run_doctor_npm_workspace_advisory_message_is_plain_language` in
`tests/hermes_cli/test_doctor.py`, mocking `npm audit --workspace web` to
report a high-severity advisory and asserting the new plain-language text
appears while none of the old jargon (`arborist`, `clears via a lockfile
bump`, `build-tool advisory`) does.

Confirmed the test fails without the fix and passes with it:

```
$ git checkout HEAD~1 -- hermes_cli/doctor.py   # (source reverted, test kept)
$ python -m pytest tests/hermes_cli/test_doctor.py -k npm_workspace_advisory_message_is_plain_language -v
FAILED ... AssertionError: assert 'in dev tooling only, no action needed' in "..."
$ git checkout HEAD -- hermes_cli/doctor.py
$ python -m pytest tests/hermes_cli/test_doctor.py -k npm_workspace_advisory_message_is_plain_language -v
1 passed
```

Full `tests/hermes_cli/test_doctor.py` suite (ran 3x to check for flakes):

```
71 passed in ~13.5s
```

`ruff check hermes_cli/doctor.py tests/hermes_cli/test_doctor.py`: all checks passed.

## Disclosure

This change was prepared with AI assistance (an autonomous coding agent),
with the diff reviewed and verified by running the test suite before
pushing.
