### PR TITLE
fix(local): budget AMD BIOS-carve APUs from the sysfs VRAM bar

### DIFF
--- a/hermes_cli/local_runtime/hardware.py
+++ b/hermes_cli/local_runtime/hardware.py
@@ -16,6 +16,14 @@ matter what any other number says. Only when the driver API is
 unreachable does the engine's --list-devices view apply, and then only
 behind two independent conditions no discrete card can meet.
 
+AMD (Linux): amdgpu publishes the device's memory bar via sysfs
+(mem_info_vram_*), which reads like a discrete device query — honest
+for discrete cards and for APUs with a large BIOS-dedicated carve
+(Strix Halo), misleading for small-carve APUs whose real pool is
+system RAM. The RAM-sized-carve gate (the NVIDIA quirk's
+_POOL_RAM_FRACTION) picks the former; everything else keeps the
+RAM-as-UMA budget below.
+
 Every probe here must work under a stripped PATH — gateway and service
 sessions don't inherit the interactive environment. nvcuda/libcuda load
 through the system loader (PATH plays no part), so classification never
@@ -238,6 +246,33 @@ def _cuda_driver_pool() -> "tuple[int, bool | None] | None":
         return None
 
 
+def _amd_sysfs_vram() -> tuple[int, int] | None:
+    """(total, free) bytes for an AMD GPU via Linux sysfs, or None.
+
+    amdgpu exposes the device's memory bar as mem_info_vram_total/used
+    under /sys/class/drm/card*/device. On APUs with a large BIOS carve
+    (Strix Halo and friends) that bar IS the dedicated pool: the kernel
+    removed it from system RAM, the OS cannot reclaim it, and placement
+    inside it runs at full bandwidth — the honest equivalent of a
+    discrete card's device query. Only the amdgpu bind point carries
+    these files, so a vendor check is redundant but cheap insurance.
+    """
+    if sys.platform != "linux":
+        return None
+    best: tuple[int, int] | None = None
+    for device in Path("/sys/class/drm").glob("card*/device"):
+        try:
+            if (device / "vendor").read_text().strip().lower() != "0x1002":
+                continue
+            total = int((device / "mem_info_vram_total").read_text())
+            used = int((device / "mem_info_vram_used").read_text())
+        except (OSError, ValueError):
+            continue
+        if total > 0 and (best is None or total > best[0]):
+            best = (total, max(0, total - used))
+    return best
+
+
 def _engine_device_pool() -> "tuple[int, bool | None] | None":
     """(engine_total_bytes, None) from the installed runtime's own
     --list-devices, or None. The fallback truth source when the driver
@@ -327,6 +362,18 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
     """
     ram_total, ram_avail = _ram_bytes()
     vram = _nvidia_vram()
+    if vram is None:
+        # AMD (Linux): amdgpu's sysfs bar answers like a discrete device
+        # query. Trust it only when the carve is RAM-sized — the
+        # signature of a BIOS-dedicated pool (Strix Halo, framed APUs).
+        # A small-carve APU (0.5-4 GiB of a shared pool) fails the gate
+        # and keeps today's RAM-as-UMA budget; a real discrete card
+        # passes because its bar is a large fraction of any box it
+        # ships in. Mirrors the NVIDIA quirk's _POOL_RAM_FRACTION gate.
+        amd = _amd_sysfs_vram()
+        if (amd is not None and ram_total > 0
+                and amd[0] >= int(ram_total * _POOL_RAM_FRACTION)):
+            vram = amd
 
     # Unified-memory NVIDIA: the CUDA allocator pool is the real
     # capacity. Classification comes from the driver API/engine — it
@@ -362,8 +409,9 @@ def probe_budget(*, planning: bool = False) -> HardwareBudget:
 
     if vram is None:
         # No NVIDIA device visible: Metal/Vulkan/CPU paths budget from RAM
-        # as UMA (Apple Silicon) — conservative for discrete AMD until a
-        # vendor probe lands (E3 hardware).
+        # as UMA (Apple Silicon), and small-carve AMD APUs stay here too —
+        # conservative for those pools, whose device queries have been
+        # observed off by 3x.
         base = ram_total if planning else ram_avail
         usable = max(0, int(base * (1 - _UMA_HEADROOM_FRACTION)))
         return HardwareBudget(usable_vram_bytes=usable,

--- a/tests/hermes_cli/test_amd_sysfs_budget.py
+++ b/tests/hermes_cli/test_amd_sysfs_budget.py
@@ -1,0 +1,151 @@
+"""The AMD sysfs probe must never misclassify a small-carve APU.
+
+On APUs with a large BIOS-dedicated carve (Strix Halo and friends),
+amdgpu's mem_info_vram_total bar IS the real pool: the kernel removed
+it from system RAM, the OS cannot reclaim it, and placement inside it
+runs at full bandwidth. Budgeting those machines from OS RAM (the
+UMA fallback) sees a fraction of the truth and prices every model
+wrong.
+
+The other direction is the regression this file guards: a small-carve
+APU (0.5-4 GiB bar of a shared RAM pool) must keep today's
+RAM-as-UMA budget — trusting its bar would budget 2 GiB against a
+machine with 64 GiB. The RAM-sized-carve gate (_POOL_RAM_FRACTION,
+shared with the NVIDIA quirk) separates the two shapes."""
+
+from __future__ import annotations
+
+import hermes_cli.local_runtime.hardware as hw
+
+GIB = 1 << 30
+
+# Representative Strix Halo shape: 96 GiB BIOS carve, 32 GiB OS RAM.
+STRIX_CARVE = 96 * GIB
+STRIX_CARVE_USED = 2 * GIB
+STRIX_RAM = 32 * GIB
+
+# Representative small-carve APU: 512 MiB bar, 64 GiB shared pool.
+SMALL_CARVE = 512 << 20
+SMALL_CARVE_USED = 128 << 20
+SMALL_RAM = 64 * GIB
+
+
+def _machine(monkeypatch, *, nvidia=None, amd=None, ram=(0, 0)):
+    monkeypatch.setattr(hw, "_nvidia_vram", lambda: nvidia)
+    monkeypatch.setattr(hw, "_amd_sysfs_vram", lambda: amd)
+    monkeypatch.setattr(hw, "_ram_bytes", lambda: ram)
+
+
+# ── the gate in probe_budget ─────────────────────────────────
+
+
+def test_strix_halo_budgets_from_the_carve(monkeypatch):
+    """Large BIOS carve passes the RAM-sized gate: the budget becomes the
+    dedicated-pool shape (discrete math, RAM kept as spill room), not
+    the 32 GiB RAM-as-UMA budget that started this."""
+    _machine(monkeypatch, amd=(STRIX_CARVE, STRIX_CARVE - STRIX_CARVE_USED),
+             ram=(STRIX_RAM, 16 * GIB))
+    b = hw.probe_budget(planning=True)
+    assert b.uma is False
+    assert b.total_device_bytes == STRIX_CARVE
+    margin = max(hw._MARGIN_FLOOR, int(STRIX_CARVE * hw._MARGIN_FRACTION))
+    assert b.usable_vram_bytes == STRIX_CARVE - margin
+    # Planning budgets report ram_total as the spill room (by design).
+    assert b.ram_available_bytes == STRIX_RAM
+    # The whole point: the budget must dwarf the OS-visible RAM.
+    assert b.usable_vram_bytes > STRIX_RAM
+
+
+def test_strix_halo_live_budget_uses_carve_free(monkeypatch):
+    _machine(monkeypatch, amd=(STRIX_CARVE, STRIX_CARVE - STRIX_CARVE_USED),
+             ram=(STRIX_RAM, 16 * GIB))
+    b = hw.probe_budget(planning=False)
+    assert b.uma is False
+    assert b.usable_vram_bytes == (STRIX_CARVE - STRIX_CARVE_USED) - max(
+        hw._MARGIN_FLOOR, int(STRIX_CARVE * hw._MARGIN_FRACTION))
+
+
+def test_small_carve_apu_keeps_uma_budget(monkeypatch):
+    """512 MiB bar in a 64 GiB box fails the gate — exactly today's
+    RAM-as-UMA behavior, bit for bit."""
+    _machine(monkeypatch, amd=(SMALL_CARVE, SMALL_CARVE - SMALL_CARVE_USED),
+             ram=(SMALL_RAM, 48 * GIB))
+    b = hw.probe_budget(planning=True)
+    assert b.uma is True
+    assert b.total_device_bytes == SMALL_RAM
+    assert b.usable_vram_bytes == int(
+        SMALL_RAM * (1 - hw._UMA_HEADROOM_FRACTION))
+    assert b.ram_available_bytes == 0
+
+
+def test_no_amd_device_keeps_uma_budget(monkeypatch):
+    """Probe miss (non-AMD Linux box) -> exactly today's behavior."""
+    _machine(monkeypatch, amd=None, ram=(STRIX_RAM, 16 * GIB))
+    b = hw.probe_budget(planning=True)
+    assert b.uma is True
+    assert b.total_device_bytes == STRIX_RAM
+
+
+def test_zero_ram_stays_uma_conservative(monkeypatch):
+    """RAM unreadable: the gate has no denominator, so it must not fire —
+    an unclassified carve claim alone never flips the verdict."""
+    _machine(monkeypatch, amd=(STRIX_CARVE, STRIX_CARVE), ram=(0, 0))
+    b = hw.probe_budget(planning=True)
+    assert b.uma is True
+    assert b.total_device_bytes == 0
+
+
+def test_nvidia_device_takes_precedence(monkeypatch):
+    """An NVIDIA device answering means the AMD probe never runs: the
+    discrete-NVIDIA path is untouched."""
+    seen = []
+    monkeypatch.setattr(hw, "_amd_sysfs_vram",
+                        lambda: seen.append(1) or (STRIX_CARVE, STRIX_CARVE))
+    _machine(monkeypatch, nvidia=(24 * GIB, 23 * GIB),
+             ram=(64 * GIB, 48 * GIB))
+    b = hw.probe_budget(planning=True)
+    assert b.uma is False
+    assert b.total_device_bytes == 24 * GIB
+    assert not seen
+
+
+# ── _amd_sysfs_vram parsing ──────────────────────────────────
+
+
+def test_probe_reads_amdgpu_sysfs(tmp_path, monkeypatch):
+    """The probe reads vendor + mem_info_* from the amdgpu bind point and
+    picks the largest card (multi-GPU boxes)."""
+    drm = tmp_path / "drm"
+    for name, vendor, total, used in (
+        ("card0", "0x8086", 0, 0),               # Intel iGPU: no mem_info
+        ("card1", "0x1002", STRIX_CARVE, STRIX_CARVE_USED),
+        ("card2", "0x1002", 24 * GIB, 1 * GIB),
+    ):
+        dev = drm / name / "device"
+        dev.mkdir(parents=True)
+        (dev / "vendor").write_text(vendor + "\n")
+        if total:
+            (dev / "mem_info_vram_total").write_text(f"{total}\n")
+            (dev / "mem_info_vram_used").write_text(f"{used}\n")
+    monkeypatch.setattr(hw.Path, "glob",
+                        lambda self, pat: (drm / "card1" / "device",
+                                           drm / "card2" / "device"))
+    monkeypatch.setattr(hw.sys, "platform", "linux")
+    assert hw._amd_sysfs_vram() == (STRIX_CARVE, STRIX_CARVE - STRIX_CARVE_USED)
+
+
+def test_probe_skips_unreadable_or_broken_entries(tmp_path, monkeypatch):
+    drm = tmp_path / "drm"
+    dev = drm / "card1" / "device"
+    dev.mkdir(parents=True)
+    (dev / "vendor").write_text("0x1002\n")
+    (dev / "mem_info_vram_total").write_text("not a number\n")
+    monkeypatch.setattr(hw.Path, "glob", lambda self, pat: (dev,))
+    monkeypatch.setattr(hw.sys, "platform", "linux")
+    assert hw._amd_sysfs_vram() is None
+
+
+def test_probe_other_platforms_return_none(monkeypatch):
+    for platform in ("darwin", "win32"):
+        monkeypatch.setattr(hw.sys, "platform", platform)
+        assert hw._amd_sysfs_vram() is None

--- a/tests/hermes_cli/test_unified_pool_quirk.py
+++ b/tests/hermes_cli/test_unified_pool_quirk.py
@@ -89,6 +89,9 @@ def test_no_probe_available_stays_discrete(monkeypatch):
 
 def _uma_machine(monkeypatch, *, view):
     _no_cache(monkeypatch)
+    # The AMD sysfs probe must not answer from the real machine: these
+    # tests pin a synthetic NVIDIA shape and must stay machine-independent.
+    monkeypatch.setattr(hw, "_amd_sysfs_vram", lambda: None)
     monkeypatch.setattr(hw, "_nvidia_vram",
                         lambda: (UMA_SMI_TOTAL, 14848 << 20))
     monkeypatch.setattr(hw, "_ram_bytes",
@@ -129,6 +132,7 @@ def test_budget_unified_no_smi_still_classifies(monkeypatch):
     (system loader, PATH-independent) still classifies unified, planning
     still budgets the full pool, and live falls back to OS-available."""
     _no_cache(monkeypatch)
+    monkeypatch.setattr(hw, "_amd_sysfs_vram", lambda: None)
     monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
     monkeypatch.setattr(hw, "_ram_bytes", lambda: (UMA_RAM, 32 * GIB))
     monkeypatch.setattr(hw, "_device_pool_view", lambda: (UMA_POOL, True))
@@ -165,6 +169,7 @@ def test_engine_fallback_without_smi_stays_conservative(monkeypatch):
     off and budgeting falls to the conservative RAM-as-UMA path — an
     attribute-less pool claim alone must never flip the verdict."""
     _no_cache(monkeypatch)
+    monkeypatch.setattr(hw, "_amd_sysfs_vram", lambda: None)
     monkeypatch.setattr(hw, "_nvidia_vram", lambda: None)
     monkeypatch.setattr(hw, "_ram_bytes", lambda: (UMA_RAM, 32 * GIB))
     monkeypatch.setattr(hw, "_device_pool_view", lambda: (UMA_POOL, None))


### PR DESCRIPTION
## Summary

On APUs with a large BIOS-dedicated memory carve (Strix Halo and friends), amdgpu's `mem_info_vram_total` sysfs bar **is** the real pool: the kernel removed it from system RAM, the OS cannot reclaim it, and placement inside it runs at full bandwidth. `probe_budget` had no AMD probe at all (its docstring deferred one to "E3 hardware"), so those machines fell to the RAM-as-UMA path and budgeted only the OS-visible remainder — a 96G-carve / 32G-RAM box read as a **~25 GiB machine**, pricing every mid-size model "larger than your GPU memory".

## The fix (minimal, reuses existing patterns)

- `_amd_sysfs_vram()` — vendor-checked read of `/sys/class/drm/card*/device/mem_info_vram_{total,used}` (largest card wins; unreadable entries skipped; Linux-only).
- Wired into `probe_budget` behind the **RAM-sized-carve gate** — the same `_POOL_RAM_FRACTION` constant the NVIDIA WDDM carve-out quirk already uses:
  - Large BIOS carve (>= 75% of OS RAM) -> budget with the existing **discrete** math, RAM kept as `ram_available_bytes` spill room.
  - Small-carve APU (0.5-4 GiB bar of a shared pool) -> fails the gate -> today's RAM-as-UMA budget **bit-for-bit unchanged**.
  - NVIDIA devices answer first and never reach the AMD probe; non-AMD / non-Linux boxes are untouched.
- Docstrings updated (the stale "until a vendor probe lands" note is now true).

## Test plan

- [x] New `tests/hermes_cli/test_amd_sysfs_budget.py`: Strix Halo shape budgets from the carve; small-carve APU, no-AMD, zero-RAM, multi-GPU, and broken-sysfs stay on today's path; neighbor `test_unified_pool_quirk.py` helpers stubbed machine-independent (they previously leaked the real host's sysfs into synthetic-NVIDIA tests).
- [x] 60 passed across test_amd_sysfs_budget, test_unified_pool_quirk, test_budget_source, test_local_recommendation, test_catalog_variants; ruff clean.
- [x] E2E on real hardware (Strix Halo, 96G carve / 32G RAM): planning usable 24.9 -> **87.4 GiB**, live 4.8 -> **85.1 GiB**; a ~50 GiB model refused by `physics_check` under the old budget **fits** under the new one.

Fixes #102593
