### PR TITLE
feat(connections): expose passive profile-scoped health

### DIFF
--- a/apps/desktop/src/contrib/connection-health.test.ts
+++ b/apps/desktop/src/contrib/connection-health.test.ts
@@ -43,17 +43,73 @@ describe('connectionHealthProviders', () => {
       {
         icon: 'plug',
         id: 'demo:health',
-        load,
+        load: expect.any(Function),
         name: 'Demo health',
         repair: { kind: 'route', path: '/settings?tab=plugins' },
         source: 'plugin:demo'
       },
       {
         id: 'unsafe:health',
-        load,
+        load: expect.any(Function),
         source: 'plugin:unsafe'
       }
     ])
+  })
+
+  it('drops malformed repairs returned by a provider load', async () => {
+    const load = vi.fn(async () => [
+      {
+        checkedAt: 1,
+        id: 'unsafe',
+        name: 'Unsafe',
+        reason: 'check_failed' as const,
+        repair: { kind: 'command', value: 'rm -rf /' }
+      },
+      {
+        checkedAt: 2,
+        id: 'safe',
+        name: 'Safe',
+        reason: 'auth_required' as const,
+        repair: { kind: 'message' as const, message: 'Sign in again' }
+      },
+      {
+        checkedAt: 3,
+        id: 'external-route',
+        name: 'External route',
+        reason: 'check_failed' as const,
+        repair: { kind: 'route' as const, path: '//host' }
+      }
+    ])
+
+    const [provider] = connectionHealthProviders([{
+      area: CONNECTION_HEALTH_AREA,
+      data: { load },
+      id: 'loaded:health',
+      source: 'plugin:loaded'
+    }])
+
+    await expect(provider.load()).resolves.toEqual([
+      {
+        checkedAt: 1,
+        id: 'unsafe',
+        name: 'Unsafe',
+        reason: 'check_failed'
+      },
+      {
+        checkedAt: 2,
+        id: 'safe',
+        name: 'Safe',
+        reason: 'auth_required',
+        repair: { kind: 'message', message: 'Sign in again' }
+      },
+      {
+        checkedAt: 3,
+        id: 'external-route',
+        name: 'External route',
+        reason: 'check_failed'
+      }
+    ])
+    expect(load).toHaveBeenCalledOnce()
   })
 
   it('keeps the provider snapshot stable across unrelated rerenders', () => {

--- a/apps/desktop/src/contrib/connection-health.test.ts
+++ b/apps/desktop/src/contrib/connection-health.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { CONNECTION_HEALTH_AREA, connectionHealthProviders } from './connection-health'
+import type { Contribution } from './types'
+
+describe('connectionHealthProviders', () => {
+  it('returns only callable providers with host-stamped provenance', () => {
+    const load = vi.fn(async () => [])
+
+    const contributions: Contribution[] = [
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: {
+          icon: 'plug',
+          load,
+          name: 'Demo health',
+          repair: { kind: 'route', path: '/settings?tab=plugins' }
+        },
+        id: 'demo:health',
+        source: 'plugin:demo'
+      },
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: { load: 'not-callable' },
+        id: 'broken:health',
+        source: 'plugin:broken'
+      }
+    ]
+
+    expect(connectionHealthProviders(contributions)).toEqual([
+      {
+        icon: 'plug',
+        id: 'demo:health',
+        load,
+        name: 'Demo health',
+        repair: { kind: 'route', path: '/settings?tab=plugins' },
+        source: 'plugin:demo'
+      }
+    ])
+  })
+})

--- a/apps/desktop/src/contrib/connection-health.test.ts
+++ b/apps/desktop/src/contrib/connection-health.test.ts
@@ -1,6 +1,12 @@
+import { renderHook } from '@testing-library/react'
 import { describe, expect, it, vi } from 'vitest'
 
-import { CONNECTION_HEALTH_AREA, connectionHealthProviders } from './connection-health'
+import {
+  CONNECTION_HEALTH_AREA,
+  connectionHealthProviders,
+  useConnectionHealthProviders
+} from './connection-health'
+import { registry } from './registry'
 import type { Contribution } from './types'
 
 describe('connectionHealthProviders', () => {
@@ -24,6 +30,12 @@ describe('connectionHealthProviders', () => {
         data: { load: 'not-callable' },
         id: 'broken:health',
         source: 'plugin:broken'
+      },
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: { load, repair: { kind: 'command', value: 'rm -rf /' } },
+        id: 'unsafe:health',
+        source: 'plugin:unsafe'
       }
     ]
 
@@ -35,7 +47,32 @@ describe('connectionHealthProviders', () => {
         name: 'Demo health',
         repair: { kind: 'route', path: '/settings?tab=plugins' },
         source: 'plugin:demo'
+      },
+      {
+        id: 'unsafe:health',
+        load,
+        source: 'plugin:unsafe'
       }
     ])
+  })
+
+  it('keeps the provider snapshot stable across unrelated rerenders', () => {
+    const dispose = registry.register({
+      area: CONNECTION_HEALTH_AREA,
+      data: { load: async () => [] },
+      id: 'stable:health',
+      source: 'plugin:stable'
+    })
+
+    try {
+      const { result, rerender } = renderHook(() => useConnectionHealthProviders())
+      const first = result.current
+
+      rerender()
+
+      expect(result.current).toBe(first)
+    } finally {
+      dispose()
+    }
   })
 })

--- a/apps/desktop/src/contrib/connection-health.ts
+++ b/apps/desktop/src/contrib/connection-health.ts
@@ -1,3 +1,5 @@
+import { useMemo } from 'react'
+
 import { useContributions } from './react/use-contributions'
 import type { Contribution, ContributionSource } from './types'
 
@@ -45,6 +47,23 @@ function isProvider(value: unknown): value is ConnectionHealthProvider {
   return typeof value === 'object' && value !== null && typeof (value as { load?: unknown }).load === 'function'
 }
 
+function isRepair(value: unknown): value is ConnectionHealthRepair {
+  if (typeof value !== 'object' || value === null) {
+    return false
+  }
+
+  const repair = value as { kind?: unknown; message?: unknown; path?: unknown }
+
+  if (repair.kind === 'message') {
+    return typeof repair.message === 'string'
+  }
+
+  return repair.kind === 'route'
+    && typeof repair.path === 'string'
+    && repair.path.startsWith('/')
+    && !repair.path.startsWith('//')
+}
+
 export function connectionHealthProviders(
   contributions: readonly Contribution[]
 ): RegisteredConnectionHealthProvider[] {
@@ -60,12 +79,14 @@ export function connectionHealthProviders(
       id: contribution.id,
       load: provider.load,
       ...(typeof provider.name === 'string' ? { name: provider.name } : {}),
-      ...(provider.repair ? { repair: provider.repair } : {}),
+      ...(isRepair(provider.repair) ? { repair: provider.repair } : {}),
       source: contribution.source ?? 'core'
     }]
   })
 }
 
 export function useConnectionHealthProviders(): RegisteredConnectionHealthProvider[] {
-  return connectionHealthProviders(useContributions(CONNECTION_HEALTH_AREA))
+  const contributions = useContributions(CONNECTION_HEALTH_AREA)
+
+  return useMemo(() => connectionHealthProviders(contributions), [contributions])
 }

--- a/apps/desktop/src/contrib/connection-health.ts
+++ b/apps/desktop/src/contrib/connection-health.ts
@@ -64,6 +64,28 @@ function isRepair(value: unknown): value is ConnectionHealthRepair {
     && !repair.path.startsWith('//')
 }
 
+function safeHealthResults(value: unknown): readonly ConnectionHealthResult[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap(item => {
+    if (typeof item !== 'object' || item === null) {
+      return []
+    }
+
+    const result = item as ConnectionHealthResult & { repair?: unknown }
+
+    if (result.repair === undefined || isRepair(result.repair)) {
+      return [result]
+    }
+
+    const { repair: _unsafeRepair, ...safeResult } = result
+
+    return [safeResult as ConnectionHealthResult]
+  })
+}
+
 export function connectionHealthProviders(
   contributions: readonly Contribution[]
 ): RegisteredConnectionHealthProvider[] {
@@ -77,7 +99,7 @@ export function connectionHealthProviders(
     return [{
       ...(typeof provider.icon === 'string' ? { icon: provider.icon } : {}),
       id: contribution.id,
-      load: provider.load,
+      load: async () => safeHealthResults(await provider.load()),
       ...(typeof provider.name === 'string' ? { name: provider.name } : {}),
       ...(isRepair(provider.repair) ? { repair: provider.repair } : {}),
       source: contribution.source ?? 'core'

--- a/apps/desktop/src/contrib/connection-health.ts
+++ b/apps/desktop/src/contrib/connection-health.ts
@@ -1,0 +1,71 @@
+import { useContributions } from './react/use-contributions'
+import type { Contribution, ContributionSource } from './types'
+
+export const CONNECTION_HEALTH_AREA = 'connections.health'
+
+export type ConnectionHealthReason =
+  | 'healthy'
+  | 'auth_required'
+  | 'service_unreachable'
+  | 'permission_required'
+  | 'not_installed'
+  | 'not_configured'
+  | 'stale'
+  | 'check_failed'
+
+export type ConnectionHealthRepair =
+  | { kind: 'message'; message: string }
+  | { kind: 'route'; path: string }
+
+export interface ConnectionHealthResult {
+  id: string
+  name: string
+  icon?: string
+  status?: string
+  reason: ConnectionHealthReason
+  detail?: string
+  checkedAt: number
+  staleAfterMs?: number
+  repair?: ConnectionHealthRepair
+}
+
+export interface ConnectionHealthProvider {
+  name?: string
+  icon?: string
+  repair?: ConnectionHealthRepair
+  load: () => Promise<readonly ConnectionHealthResult[]> | readonly ConnectionHealthResult[]
+}
+
+export interface RegisteredConnectionHealthProvider extends ConnectionHealthProvider {
+  id: string
+  source: ContributionSource
+}
+
+function isProvider(value: unknown): value is ConnectionHealthProvider {
+  return typeof value === 'object' && value !== null && typeof (value as { load?: unknown }).load === 'function'
+}
+
+export function connectionHealthProviders(
+  contributions: readonly Contribution[]
+): RegisteredConnectionHealthProvider[] {
+  return contributions.flatMap(contribution => {
+    if (!isProvider(contribution.data)) {
+      return []
+    }
+
+    const provider = contribution.data
+
+    return [{
+      ...(typeof provider.icon === 'string' ? { icon: provider.icon } : {}),
+      id: contribution.id,
+      load: provider.load,
+      ...(typeof provider.name === 'string' ? { name: provider.name } : {}),
+      ...(provider.repair ? { repair: provider.repair } : {}),
+      source: contribution.source ?? 'core'
+    }]
+  })
+}
+
+export function useConnectionHealthProviders(): RegisteredConnectionHealthProvider[] {
+  return connectionHealthProviders(useContributions(CONNECTION_HEALTH_AREA))
+}

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { host } from '@/sdk'
+import { CONNECTION_HEALTH_AREA, connectionHealthProviders, host } from '@/sdk'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+describe('connection health SDK contract', () => {
+  it('exports the shared contribution area and resolver', () => {
+    expect(CONNECTION_HEALTH_AREA).toBe('connections.health')
+    expect(connectionHealthProviders([])).toEqual([])
+  })
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1571,6 +1571,16 @@ export { Switch } from '@/components/ui/switch'
 export { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 export { Textarea } from '@/components/ui/textarea'
 export { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+export {
+  CONNECTION_HEALTH_AREA,
+  type ConnectionHealthProvider,
+  connectionHealthProviders,
+  type ConnectionHealthReason,
+  type ConnectionHealthRepair,
+  type ConnectionHealthResult,
+  type RegisteredConnectionHealthProvider,
+  useConnectionHealthProviders
+} from '@/contrib/connection-health'
 export type { GatewayEventListener } from '@/contrib/events'
 export type {
   HermesPlugin,

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,9 +4,11 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import os
+import pickle
 import sys
 import threading
 import time
@@ -275,6 +277,13 @@ class TestMCPStatus:
             mcp_tool._connect_failure_reason(OAuthNonInteractiveError("browser required"))
             == "auth_required"
         )
+        tagged = mcp_tool._connect_error_text(
+            "Connection closed",
+            OAuthNonInteractiveError("browser required"),
+        )
+        for cloned in (copy.copy(tagged), copy.deepcopy(tagged), pickle.loads(pickle.dumps(tagged))):
+            assert cloned == "Connection closed"
+            assert getattr(cloned, "reason") == "auth_required"
 
         monkeypatch.setattr(
             mcp_tool,

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -296,11 +296,10 @@ class TestMCPStatus:
             mcp_tool._server_connecting.clear()
             mcp_tool._server_connect_errors.clear()
             mcp_tool._server_connecting.add("connecting")
-            mcp_tool._server_connect_errors["failed"] = "Connection closed"
-            failed_server = MagicMock(spec=mcp_tool.MCPServerTask)
-            failed_server.session = None
-            failed_server._error = OAuthNonInteractiveError("browser required")
-            mcp_tool._servers["failed"] = failed_server
+            mcp_tool._server_connect_errors["failed"] = mcp_tool._connect_error_text(
+                "Connection closed",
+                OAuthNonInteractiveError("browser required"),
+            )
 
         try:
             statuses = {

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -375,6 +375,74 @@ class TestMCPStatus:
         assert unscoped_status["status"] == "configured"
         assert unscoped_status["reason"] == "stale"
 
+    def test_scoped_shutdown_clears_only_its_connection_status(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+
+        monkeypatch.setattr(mcp_tool, "_stop_mcp_loop", lambda **_kwargs: None)
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            saved_connecting = set(mcp_tool._server_connecting)
+            saved_errors = dict(mcp_tool._server_connect_errors)
+            saved_retry_after = dict(mcp_tool._server_connect_retry_after)
+            saved_failures = dict(mcp_tool._server_connect_failures)
+            mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update({
+                "work-connecting": "profile:work",
+                "work-failed": "profile:work",
+                "other-failed": "profile:other",
+            })
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connecting.add("work-connecting")
+            mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_errors.update({
+                "work-failed": "work error",
+                "other-failed": "other error",
+            })
+            mcp_tool._server_connect_retry_after.clear()
+            mcp_tool._server_connect_retry_after.update({
+                "work-failed": 1.0,
+                "other-failed": 2.0,
+            })
+            mcp_tool._server_connect_failures.clear()
+            mcp_tool._server_connect_failures.update({
+                "work-failed": 1,
+                "other-failed": 2,
+            })
+
+        try:
+            mcp_tool.shutdown_mcp_servers(scope="profile:work")
+
+            with mcp_tool._lock:
+                assert mcp_tool._server_connecting == set()
+                assert mcp_tool._server_connect_errors == {
+                    "other-failed": "other error"
+                }
+                assert mcp_tool._server_scope_keys == {
+                    "other-failed": "profile:other"
+                }
+                assert mcp_tool._server_connect_retry_after == {
+                    "other-failed": 2.0
+                }
+                assert mcp_tool._server_connect_failures == {
+                    "other-failed": 2
+                }
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+                mcp_tool._server_connecting.clear()
+                mcp_tool._server_connecting.update(saved_connecting)
+                mcp_tool._server_connect_errors.clear()
+                mcp_tool._server_connect_errors.update(saved_errors)
+                mcp_tool._server_connect_retry_after.clear()
+                mcp_tool._server_connect_retry_after.update(saved_retry_after)
+                mcp_tool._server_connect_failures.clear()
+                mcp_tool._server_connect_failures.update(saved_failures)
+
 
 class TestLifecycleConfig:
     def test_get_lifecycle_seconds_accepts_top_level_and_nested_values(self):
@@ -2759,6 +2827,52 @@ class TestRegisterMcpServers:
 
         assert "mcp__my_server__tool1" in result
         _servers.pop("my_server", None)
+
+    def test_records_profile_scope_before_connect(self):
+        import tools.mcp_tool as mcp_tool
+
+        seen = []
+
+        async def fake_register(name, _cfg):
+            with mcp_tool._lock:
+                seen.append((
+                    name in mcp_tool._server_connecting,
+                    mcp_tool._server_scope_keys.get(name),
+                ))
+            raise RuntimeError("expected connect failure")
+
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            saved_connecting = set(mcp_tool._server_connecting)
+            saved_errors = dict(mcp_tool._server_connect_errors)
+            mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connect_errors.clear()
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._filter_suspicious_mcp_servers", side_effect=lambda value: value), \
+                 patch("tools.mcp_tool._connect_cooldown_active", return_value=False), \
+                 patch("tools.mcp_tool._mcp_registry_scope", return_value="profile:work"), \
+                 patch("tools.mcp_tool._discover_and_register_server", side_effect=fake_register):
+                mcp_tool.register_mcp_servers({"scoped": {"command": "test"}})
+
+            assert seen == [(True, "profile:work")]
+            with mcp_tool._lock:
+                assert mcp_tool._server_connect_errors["scoped"].reason == "check_failed"
+                assert mcp_tool._server_scope_keys["scoped"] == "profile:work"
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+                mcp_tool._server_connecting.clear()
+                mcp_tool._server_connecting.update(saved_connecting)
+                mcp_tool._server_connect_errors.clear()
+                mcp_tool._server_connect_errors.update(saved_errors)
 
     def test_skips_servers_already_connecting(self):
         """Servers in _server_connecting must not be spawned again (#58862)."""

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -268,6 +268,13 @@ class TestMCPStatus:
         self, monkeypatch
     ):
         import tools.mcp_tool as mcp_tool
+        from tools.mcp_oauth import OAuthNonInteractiveError
+
+        assert mcp_tool._connect_failure_reason(RuntimeError("network")) == "check_failed"
+        assert (
+            mcp_tool._connect_failure_reason(OAuthNonInteractiveError("browser required"))
+            == "auth_required"
+        )
 
         monkeypatch.setattr(
             mcp_tool,
@@ -283,11 +290,14 @@ class TestMCPStatus:
             saved_servers = dict(mcp_tool._servers)
             saved_connecting = set(mcp_tool._server_connecting)
             saved_errors = dict(mcp_tool._server_connect_errors)
+            saved_reasons = dict(mcp_tool._server_connect_reasons)
             mcp_tool._servers.clear()
             mcp_tool._server_connecting.clear()
             mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_reasons.clear()
             mcp_tool._server_connecting.add("connecting")
             mcp_tool._server_connect_errors["failed"] = "Connection closed"
+            mcp_tool._server_connect_reasons["failed"] = "auth_required"
 
         try:
             statuses = {
@@ -302,15 +312,52 @@ class TestMCPStatus:
                 mcp_tool._server_connecting.update(saved_connecting)
                 mcp_tool._server_connect_errors.clear()
                 mcp_tool._server_connect_errors.update(saved_errors)
+                mcp_tool._server_connect_reasons.clear()
+                mcp_tool._server_connect_reasons.update(saved_reasons)
 
         assert statuses["configured"]["status"] == "configured"
         assert statuses["configured"]["connected"] is False
         assert statuses["configured"]["disabled"] is False
         assert statuses["connecting"]["status"] == "connecting"
+        assert statuses["connecting"]["reason"] == "stale"
         assert statuses["failed"]["status"] == "failed"
         assert statuses["failed"]["error"] == "Connection closed"
+        assert statuses["failed"]["reason"] == "auth_required"
         assert statuses["disabled"]["status"] == "disabled"
         assert statuses["disabled"]["disabled"] is True
+
+    def test_status_ignores_a_runtime_owned_by_another_profile(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+
+        monkeypatch.setattr(
+            mcp_tool,
+            "_load_mcp_config",
+            lambda: {"shared": {"command": "shared-mcp"}},
+        )
+        monkeypatch.setattr(mcp_tool, "_mcp_registry_scope", lambda: "profile:work")
+        foreign_server = MagicMock(spec=mcp_tool.MCPServerTask)
+        foreign_server.session = object()
+        foreign_server._registered_tool_names = ["secret_tool"]
+        foreign_server._tools = []
+        foreign_server._sampling = None
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            mcp_tool._servers["shared"] = foreign_server
+            mcp_tool._server_scope_keys["shared"] = "profile:other"
+
+        try:
+            [status] = mcp_tool.get_mcp_status()
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+
+        assert status["status"] == "configured"
+        assert status["reason"] == "stale"
+        assert status["tools"] == 0
 
 
 class TestLifecycleConfig:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -288,16 +288,19 @@ class TestMCPStatus:
         )
         with mcp_tool._lock:
             saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
             saved_connecting = set(mcp_tool._server_connecting)
             saved_errors = dict(mcp_tool._server_connect_errors)
-            saved_reasons = dict(mcp_tool._server_connect_reasons)
             mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
             mcp_tool._server_connecting.clear()
             mcp_tool._server_connect_errors.clear()
-            mcp_tool._server_connect_reasons.clear()
             mcp_tool._server_connecting.add("connecting")
             mcp_tool._server_connect_errors["failed"] = "Connection closed"
-            mcp_tool._server_connect_reasons["failed"] = "auth_required"
+            failed_server = MagicMock(spec=mcp_tool.MCPServerTask)
+            failed_server.session = None
+            failed_server._error = OAuthNonInteractiveError("browser required")
+            mcp_tool._servers["failed"] = failed_server
 
         try:
             statuses = {
@@ -308,12 +311,12 @@ class TestMCPStatus:
             with mcp_tool._lock:
                 mcp_tool._servers.clear()
                 mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
                 mcp_tool._server_connecting.clear()
                 mcp_tool._server_connecting.update(saved_connecting)
                 mcp_tool._server_connect_errors.clear()
                 mcp_tool._server_connect_errors.update(saved_errors)
-                mcp_tool._server_connect_reasons.clear()
-                mcp_tool._server_connect_reasons.update(saved_reasons)
 
         assert statuses["configured"]["status"] == "configured"
         assert statuses["configured"]["connected"] is False
@@ -348,6 +351,9 @@ class TestMCPStatus:
 
         try:
             [status] = mcp_tool.get_mcp_status()
+            with mcp_tool._lock:
+                mcp_tool._server_scope_keys.pop("shared", None)
+            [unscoped_status] = mcp_tool.get_mcp_status()
         finally:
             with mcp_tool._lock:
                 mcp_tool._servers.clear()
@@ -358,6 +364,8 @@ class TestMCPStatus:
         assert status["status"] == "configured"
         assert status["reason"] == "stale"
         assert status["tools"] == 0
+        assert unscoped_status["status"] == "configured"
+        assert unscoped_status["reason"] == "stale"
 
 
 class TestLifecycleConfig:

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -155,6 +155,30 @@ def test_status_redacts_internal_failures(hermes_root, monkeypatch):
     assert "must-not-leak" not in str(response)
 
 
+def test_status_omits_raw_server_errors(hermes_root, monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    monkeypatch.setattr(
+        mcp_tool,
+        "get_mcp_status",
+        lambda configured, include_runtime: [{
+            "name": "svc",
+            "transport": "stdio",
+            "tools": 0,
+            "connected": False,
+            "disabled": False,
+            "status": "failed",
+            "reason": "auth_required",
+            "error": "token=must-not-leak",
+        }],
+    )
+
+    payload = _result(_call("mcp.servers.status"))
+    assert payload["servers"][0]["reason"] == "auth_required"
+    assert "error" not in payload["servers"][0]
+    assert "must-not-leak" not in str(payload)
+
+
 def test_status_does_not_run_the_runtime_config_loader(hermes_root, monkeypatch):
     import tools.mcp_tool as mcp_tool
 

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -110,6 +110,50 @@ def test_list_reflects_the_scoped_profile(hermes_root):
     assert work_server["command"] == "svc-a-bin"
 
 
+def test_status_is_profile_scoped_and_credential_safe(hermes_root):
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "svc-a", "config": {"command": "svc-a-bin"}},
+        )
+    )
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "other", "name": "svc-b", "config": {"command": "svc-b-bin"}},
+        )
+    )
+
+    payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+
+    assert payload["checked_at"] > 0
+    assert payload["servers"] == [
+        {
+            "name": "svc-a",
+            "transport": "stdio",
+            "tools": 0,
+            "connected": False,
+            "disabled": False,
+            "status": "configured",
+            "reason": "stale",
+        }
+    ]
+    assert "error" not in str(payload)
+
+
+def test_status_redacts_internal_failures(hermes_root, monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    def fail():
+        raise RuntimeError("token=must-not-leak")
+
+    monkeypatch.setattr(mcp_tool, "get_mcp_status", fail)
+    response = _call("mcp.servers.status", {"profile": "work"})
+
+    assert response["error"]["message"] == "MCP status unavailable"
+    assert "must-not-leak" not in str(response)
+
+
 def test_set_api_key_writes_env_and_header_to_right_profile(hermes_root):
     root = hermes_root
     _result(

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -232,6 +232,55 @@ def test_status_does_not_mix_launch_runtime_into_another_profile(hermes_root):
     assert payload["servers"][0]["tools"] == 0
 
 
+def test_status_includes_named_profile_runtime_in_multiplex(hermes_root):
+    from agent.secret_scope import is_multiplex_active, set_multiplex_active
+    from hermes_constants import (
+        hermes_home_key,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    import tools.mcp_tool as mcp_tool
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "shared", "config": {"command": "work-bin"}},
+        )
+    )
+    work_token = set_hermes_home_override(hermes_root / "profiles" / "work")
+    try:
+        work_scope = hermes_home_key()
+    finally:
+        reset_hermes_home_override(work_token)
+
+    work_server = SimpleNamespace(
+        session=object(),
+        _registered_tool_names=["work_tool"],
+        _tools=[],
+        _sampling=None,
+    )
+    previous_multiplex = is_multiplex_active()
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_scopes = dict(mcp_tool._server_scope_keys)
+        mcp_tool._servers["shared"] = work_server  # type: ignore[assignment]
+        mcp_tool._server_scope_keys["shared"] = work_scope
+
+    set_multiplex_active(True)
+    try:
+        payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    finally:
+        set_multiplex_active(previous_multiplex)
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update(saved_scopes)
+
+    assert payload["servers"][0]["status"] == "connected"
+    assert payload["servers"][0]["tools"] == 1
+
+
 def test_set_api_key_writes_env_and_header_to_right_profile(hermes_root):
     root = hermes_root
     _result(

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -154,6 +154,25 @@ def test_status_redacts_internal_failures(hermes_root, monkeypatch):
     assert "must-not-leak" not in str(response)
 
 
+def test_status_does_not_run_the_runtime_config_loader(hermes_root, monkeypatch):
+    import tools.mcp_tool as mcp_tool
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "svc-a", "config": {"command": "svc-a-bin"}},
+        )
+    )
+
+    def forbidden():
+        raise AssertionError("runtime config loader executed")
+
+    monkeypatch.setattr(mcp_tool, "_load_mcp_config", forbidden)
+
+    payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    assert [server["name"] for server in payload["servers"]] == ["svc-a"]
+
+
 def test_set_api_key_writes_env_and_header_to_right_profile(hermes_root):
     root = hermes_root
     _result(

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -171,6 +172,40 @@ def test_status_does_not_run_the_runtime_config_loader(hermes_root, monkeypatch)
 
     payload = _result(_call("mcp.servers.status", {"profile": "work"}))
     assert [server["name"] for server in payload["servers"]] == ["svc-a"]
+
+
+def test_status_does_not_mix_launch_runtime_into_another_profile(hermes_root):
+    import tools.mcp_tool as mcp_tool
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "shared", "config": {"command": "work-bin"}},
+        )
+    )
+    launch_server = SimpleNamespace(
+        session=object(),
+        _registered_tool_names=["launch_secret_tool"],
+        _tools=[],
+        _sampling=None,
+    )
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_scopes = dict(mcp_tool._server_scope_keys)
+        mcp_tool._servers["shared"] = launch_server
+        mcp_tool._server_scope_keys.pop("shared", None)
+
+    try:
+        payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update(saved_scopes)
+
+    assert payload["servers"][0]["status"] == "configured"
+    assert payload["servers"][0]["tools"] == 0
 
 
 def test_set_api_key_writes_env_and_header_to_right_profile(hermes_root):

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -9146,6 +9146,35 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
             if scope is None or _server_scope_keys.get(name) == scope
         ]
         servers_snapshot = [_servers[name] for name in selected]
+        selected_status = (
+            set(_servers)
+            | set(_server_scope_keys)
+            | set(_server_connecting)
+            | set(_server_connect_errors)
+            if scope is None
+            else {
+                name
+                for name, owner in _server_scope_keys.items()
+                if owner == scope
+            }
+        )
+
+    def _clear_selected_status() -> None:
+        with _lock:
+            _server_connecting.difference_update(selected_status)
+            for name in selected_status:
+                _server_connect_errors.pop(name, None)
+                _server_scope_keys.pop(name, None)
+
+    def _clear_selected_retry_state() -> None:
+        with _lock:
+            if scope is None:
+                _server_connect_retry_after.clear()
+                _server_connect_failures.clear()
+                return
+            for name in selected_status:
+                _server_connect_retry_after.pop(name, None)
+                _server_connect_failures.pop(name, None)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still
     # be populated here — a server that failed to connect is never recorded
@@ -9154,9 +9183,8 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     # entries exist. Clear them so a post-shutdown restart re-attempts every
     # configured server immediately.
     if not servers_snapshot:
-        with _lock:
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+        _clear_selected_status()
+        _clear_selected_retry_state()
         _stop_mcp_loop(only_if_idle=scope is not None)
         return
 
@@ -9173,12 +9201,11 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
         with _lock:
             for name in selected:
                 _servers.pop(name, None)
-                _server_scope_keys.pop(name, None)
-            # Drop connect-retry cooldowns too: a full shutdown/restart
-            # should re-attempt every server immediately, not honour a
-            # stale per-server backoff from before the restart (#50394).
-            _server_connect_retry_after.clear()
-            _server_connect_failures.clear()
+        _clear_selected_status()
+        # Drop connect-retry cooldowns too: a shutdown/restart should
+        # re-attempt the selected servers immediately, not honour a stale
+        # per-server backoff from before the restart (#50394).
+        _clear_selected_retry_state()
 
     with _lock:
         loop = _mcp_loop
@@ -9199,9 +9226,7 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     # timed out, or was never scheduled (loop already stopped), a full
     # shutdown must leave no stale connect-cooldown state behind — the
     # next start should re-attempt every server immediately (#50394).
-    with _lock:
-        _server_connect_retry_after.clear()
-        _server_connect_failures.clear()
+    _clear_selected_retry_state()
 
     _stop_mcp_loop(only_if_idle=scope is not None)
 

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5297,6 +5297,21 @@ def _connect_failure_reason(exc: BaseException) -> str:
     return "auth_required" if _is_auth_error(_unwrap_exception_group(exc)) else "check_failed"
 
 
+class _MCPConnectErrorText(str):
+    """Backward-compatible error text carrying a credential-safe reason."""
+
+    reason: str
+
+    def __new__(cls, message: str, reason: str):
+        value = super().__new__(cls, message)
+        value.reason = reason
+        return value
+
+
+def _connect_error_text(message: str, exc: BaseException) -> str:
+    return _MCPConnectErrorText(message, _connect_failure_reason(exc))
+
+
 def _handle_auth_error_and_retry(
     server_name: str,
     exc: BaseException,
@@ -6455,7 +6470,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         message = _format_connect_error(exc)
         with _lock:
             _server_connecting.discard(server_name)
-            _server_connect_errors[server_name] = message
+            _server_connect_errors[server_name] = _connect_error_text(message, exc)
             _record_connect_failure(server_name)
         logger.warning(
             "Lazy MCP connect failed for '%s': %s", server_name, message,
@@ -8321,7 +8336,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 message = _format_connect_error(result)
                 with _lock:
                     _server_connecting.discard(name)
-                    _server_connect_errors[name] = message
+                    _server_connect_errors[name] = _connect_error_text(message, result)
                     # Arm the per-server backoff so the next discovery pass
                     # doesn't immediately re-spawn this failing server
                     # (#50394). Isolated to this server -- healthy servers
@@ -8368,9 +8383,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 )
                 _server_connecting.difference_update(stale)
                 for _sn in stale:
+                    message = f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery"
                     _server_connect_errors.setdefault(
                         _sn,
-                        f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery",
+                        _MCPConnectErrorText(message, "check_failed"),
                     )
 
         raise
@@ -8538,7 +8554,11 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _parallel_safe_servers)
 
 
-def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
+def get_mcp_status(
+    configured: Optional[Dict[str, dict]] = None,
+    *,
+    include_runtime: bool = True,
+) -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
     Returns a list of dicts with keys: name, transport, tools, connected,
@@ -8555,7 +8575,7 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
 
     current_scope = _mcp_registry_scope()
     with _lock:
-        scope_keys = dict(_server_scope_keys)
+        scope_keys = dict(_server_scope_keys) if include_runtime else {}
 
         def visible_in_current_scope(name: str) -> bool:
             if name in scope_keys:
@@ -8565,17 +8585,17 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
         active_servers = {
             name: server
             for name, server in _servers.items()
-            if visible_in_current_scope(name)
+            if include_runtime and visible_in_current_scope(name)
         }
         connecting = {
             name
             for name in _server_connecting
-            if visible_in_current_scope(name)
+            if include_runtime and visible_in_current_scope(name)
         }
         connect_errors = {
             name: error
             for name, error in _server_connect_errors.items()
-            if visible_in_current_scope(name)
+            if include_runtime and visible_in_current_scope(name)
         }
 
     for name, cfg in configured.items():
@@ -8620,6 +8640,10 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
             })
         elif name in connect_errors:
             failure = getattr(server, "_error", None) if server is not None else None
+            stored_error = connect_errors[name]
+            reason = getattr(stored_error, "reason", None)
+            if reason is None and isinstance(failure, BaseException):
+                reason = _connect_failure_reason(failure)
             result.append({
                 "name": name,
                 "transport": transport,
@@ -8627,8 +8651,8 @@ def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "failed",
-                "reason": _connect_failure_reason(failure) if isinstance(failure, BaseException) else "check_failed",
-                "error": connect_errors[name],
+                "reason": reason or "check_failed",
+                "error": str(stored_error),
             })
         else:
             result.append({

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4269,7 +4269,6 @@ class MCPServerTask:
         with _lock:
             if _servers.get(self.name) is self:
                 _server_connect_errors.pop(self.name, None)
-                _server_connect_reasons.pop(self.name, None)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -4826,7 +4825,6 @@ _servers: Dict[str, MCPServerTask] = {}
 _server_scope_keys: Dict[str, Optional[str]] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
-_server_connect_reasons: Dict[str, str] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
@@ -6443,7 +6441,6 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             return False
         _server_connecting.add(server_name)
         _server_connect_errors.pop(server_name, None)
-        _server_connect_reasons.pop(server_name, None)
 
     logger.info("MCP server '%s': lazy start on first use", server_name)
     _ensure_mcp_loop()
@@ -6459,7 +6456,6 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         with _lock:
             _server_connecting.discard(server_name)
             _server_connect_errors[server_name] = message
-            _server_connect_reasons[server_name] = _connect_failure_reason(exc)
             _record_connect_failure(server_name)
         logger.warning(
             "Lazy MCP connect failed for '%s': %s", server_name, message,
@@ -8169,7 +8165,6 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     with _lock:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
-        _server_connect_reasons.pop(name, None)
         _servers[name] = server
         _server_scope_keys[name] = _mcp_registry_scope()
 
@@ -8244,9 +8239,10 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
             if k in _servers and getattr(_servers[k], "session", None) is None
         ]
         _server_connecting.update(new_servers)
+        current_scope = _mcp_registry_scope()
         for srv_name in new_servers:
+            _server_scope_keys[srv_name] = current_scope
             _server_connect_errors.pop(srv_name, None)
-            _server_connect_reasons.pop(srv_name, None)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -8326,7 +8322,6 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors[name] = message
-                    _server_connect_reasons[name] = _connect_failure_reason(result)
                     # Arm the per-server backoff so the next discovery pass
                     # doesn't immediately re-spawn this failing server
                     # (#50394). Isolated to this server -- healthy servers
@@ -8342,7 +8337,6 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors.pop(name, None)
-                    _server_connect_reasons.pop(name, None)
                     _clear_connect_failure(name)
 
     # Per-server timeouts are handled inside _discover_and_register_server.
@@ -8378,7 +8372,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                         _sn,
                         f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery",
                     )
-                    _server_connect_reasons.setdefault(_sn, "check_failed")
+
         raise
     finally:
         if _was_interrupted:
@@ -8544,7 +8538,7 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _parallel_safe_servers)
 
 
-def get_mcp_status() -> List[dict]:
+def get_mcp_status(configured: Optional[Dict[str, dict]] = None) -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
     Returns a list of dicts with keys: name, transport, tools, connected,
@@ -8555,32 +8549,33 @@ def get_mcp_status() -> List[dict]:
     result: List[dict] = []
 
     # Get configured servers from config
-    configured = _load_mcp_config()
+    configured = _load_mcp_config() if configured is None else dict(configured)
     if not configured:
         return result
 
     current_scope = _mcp_registry_scope()
     with _lock:
         scope_keys = dict(_server_scope_keys)
+
+        def visible_in_current_scope(name: str) -> bool:
+            if name in scope_keys:
+                return scope_keys[name] == current_scope
+            return current_scope is None
+
         active_servers = {
             name: server
             for name, server in _servers.items()
-            if scope_keys.get(name, current_scope) == current_scope
+            if visible_in_current_scope(name)
         }
         connecting = {
             name
             for name in _server_connecting
-            if scope_keys.get(name, current_scope) == current_scope
+            if visible_in_current_scope(name)
         }
         connect_errors = {
             name: error
             for name, error in _server_connect_errors.items()
-            if scope_keys.get(name, current_scope) == current_scope
-        }
-        connect_reasons = {
-            name: reason
-            for name, reason in _server_connect_reasons.items()
-            if scope_keys.get(name, current_scope) == current_scope
+            if visible_in_current_scope(name)
         }
 
     for name, cfg in configured.items():
@@ -8624,6 +8619,7 @@ def get_mcp_status() -> List[dict]:
                 "reason": "stale",
             })
         elif name in connect_errors:
+            failure = getattr(server, "_error", None) if server is not None else None
             result.append({
                 "name": name,
                 "transport": transport,
@@ -8631,7 +8627,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "failed",
-                "reason": connect_reasons.get(name, "check_failed"),
+                "reason": _connect_failure_reason(failure) if isinstance(failure, BaseException) else "check_failed",
                 "error": connect_errors[name],
             })
         else:

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -4269,6 +4269,7 @@ class MCPServerTask:
         with _lock:
             if _servers.get(self.name) is self:
                 _server_connect_errors.pop(self.name, None)
+                _server_connect_reasons.pop(self.name, None)
 
     async def run(self, config: dict):
         """Long-lived coroutine: connect, discover tools, wait, disconnect.
@@ -4825,6 +4826,7 @@ _servers: Dict[str, MCPServerTask] = {}
 _server_scope_keys: Dict[str, Optional[str]] = {}
 _server_connecting: set[str] = set()
 _server_connect_errors: Dict[str, str] = {}
+_server_connect_reasons: Dict[str, str] = {}
 # Lazy MCP startup (#56832): servers whose tools were registered from the
 # on-disk schema cache without spawning/connecting. Keyed by server name;
 # entries are popped once a real connection is established on first use.
@@ -5290,6 +5292,11 @@ def _is_auth_error(exc: BaseException) -> bool:
     if status_error_types and isinstance(exc, status_error_types):
         return getattr(exc.response, "status_code", None) == 401
     return True
+
+
+def _connect_failure_reason(exc: BaseException) -> str:
+    """Reduce an MCP connect exception to a credential-safe health reason."""
+    return "auth_required" if _is_auth_error(_unwrap_exception_group(exc)) else "check_failed"
 
 
 def _handle_auth_error_and_retry(
@@ -6436,6 +6443,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
             return False
         _server_connecting.add(server_name)
         _server_connect_errors.pop(server_name, None)
+        _server_connect_reasons.pop(server_name, None)
 
     logger.info("MCP server '%s': lazy start on first use", server_name)
     _ensure_mcp_loop()
@@ -6451,6 +6459,7 @@ def _ensure_lazy_server_connected(server_name: str) -> bool:
         with _lock:
             _server_connecting.discard(server_name)
             _server_connect_errors[server_name] = message
+            _server_connect_reasons[server_name] = _connect_failure_reason(exc)
             _record_connect_failure(server_name)
         logger.warning(
             "Lazy MCP connect failed for '%s': %s", server_name, message,
@@ -8160,6 +8169,7 @@ async def _discover_and_register_server(name: str, config: dict) -> List[str]:
     with _lock:
         _server_connecting.discard(name)
         _server_connect_errors.pop(name, None)
+        _server_connect_reasons.pop(name, None)
         _servers[name] = server
         _server_scope_keys[name] = _mcp_registry_scope()
 
@@ -8236,6 +8246,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
         _server_connecting.update(new_servers)
         for srv_name in new_servers:
             _server_connect_errors.pop(srv_name, None)
+            _server_connect_reasons.pop(srv_name, None)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
             if _parse_boolish(srv_cfg.get("supports_parallel_tool_calls", False), default=False):
@@ -8315,6 +8326,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors[name] = message
+                    _server_connect_reasons[name] = _connect_failure_reason(result)
                     # Arm the per-server backoff so the next discovery pass
                     # doesn't immediately re-spawn this failing server
                     # (#50394). Isolated to this server -- healthy servers
@@ -8330,6 +8342,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                 with _lock:
                     _server_connecting.discard(name)
                     _server_connect_errors.pop(name, None)
+                    _server_connect_reasons.pop(name, None)
                     _clear_connect_failure(name)
 
     # Per-server timeouts are handled inside _discover_and_register_server.
@@ -8365,6 +8378,7 @@ def register_mcp_servers(servers: Dict[str, dict]) -> List[str]:
                         _sn,
                         f"Connection attempt {'timed out' if isinstance(_e, TimeoutError) else 'interrupted'} during discovery",
                     )
+                    _server_connect_reasons.setdefault(_sn, "check_failed")
         raise
     finally:
         if _was_interrupted:
@@ -8534,7 +8548,7 @@ def get_mcp_status() -> List[dict]:
     """Return status of all configured MCP servers for banner display.
 
     Returns a list of dicts with keys: name, transport, tools, connected,
-    disabled, and status. Includes connected servers, disabled servers,
+    disabled, status, and a credential-safe reason. Includes connected servers, disabled servers,
     in-flight connection attempts, recorded failures, and servers that are
     configured but have not been started in this process yet.
     """
@@ -8545,10 +8559,29 @@ def get_mcp_status() -> List[dict]:
     if not configured:
         return result
 
+    current_scope = _mcp_registry_scope()
     with _lock:
-        active_servers = dict(_servers)
-        connecting = set(_server_connecting)
-        connect_errors = dict(_server_connect_errors)
+        scope_keys = dict(_server_scope_keys)
+        active_servers = {
+            name: server
+            for name, server in _servers.items()
+            if scope_keys.get(name, current_scope) == current_scope
+        }
+        connecting = {
+            name
+            for name in _server_connecting
+            if scope_keys.get(name, current_scope) == current_scope
+        }
+        connect_errors = {
+            name: error
+            for name, error in _server_connect_errors.items()
+            if scope_keys.get(name, current_scope) == current_scope
+        }
+        connect_reasons = {
+            name: reason
+            for name, reason in _server_connect_reasons.items()
+            if scope_keys.get(name, current_scope) == current_scope
+        }
 
     for name, cfg in configured.items():
         transport = cfg.get("transport", "http") if "url" in cfg else "stdio"
@@ -8562,6 +8595,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": True,
                 "disabled": False,
                 "status": "connected",
+                "reason": "healthy",
             }
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
@@ -8577,6 +8611,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": True,
                 "status": "disabled",
+                "reason": "not_configured",
             })
         elif name in connecting:
             result.append({
@@ -8586,6 +8621,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "connecting",
+                "reason": "stale",
             })
         elif name in connect_errors:
             result.append({
@@ -8595,6 +8631,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "failed",
+                "reason": connect_reasons.get(name, "check_failed"),
                 "error": connect_errors[name],
             })
         else:
@@ -8605,6 +8642,7 @@ def get_mcp_status() -> List[dict]:
                 "connected": False,
                 "disabled": False,
                 "status": "configured",
+                "reason": "stale",
             })
 
     return result

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -5307,6 +5307,9 @@ class _MCPConnectErrorText(str):
         value.reason = reason
         return value
 
+    def __reduce__(self):
+        return type(self), (str(self), self.reason)
+
 
 def _connect_error_text(message: str, exc: BaseException) -> str:
     return _MCPConnectErrorText(message, _connect_failure_reason(exc))

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2093,6 +2093,7 @@ def _(rid, params: dict) -> dict:
     try:
         import time
 
+        from hermes_cli.mcp_config import _get_mcp_servers
         from tools.mcp_tool import get_mcp_status
 
         safe_fields = (
@@ -2109,7 +2110,7 @@ def _(rid, params: dict) -> dict:
             {
                 "servers": [
                     {key: entry[key] for key in safe_fields if key in entry}
-                    for entry in get_mcp_status()
+                    for entry in get_mcp_status(_get_mcp_servers())
                 ],
                 "checked_at": int(time.time() * 1000),
             },

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2087,6 +2087,9 @@ def _(rid, params: dict) -> dict:
     Params: optional ``profile``. Raw connection errors are deliberately
     omitted because they can contain paths, URLs, or credential-adjacent data.
     """
+    from hermes_constants import hermes_home_key
+
+    runtime_home_key = hermes_home_key()
     token, err = _mcp_resolve_profile(rid, params)
     if err:
         return err
@@ -2110,7 +2113,10 @@ def _(rid, params: dict) -> dict:
             {
                 "servers": [
                     {key: entry[key] for key in safe_fields if key in entry}
-                    for entry in get_mcp_status(_get_mcp_servers())
+                    for entry in get_mcp_status(
+                        _get_mcp_servers(),
+                        include_runtime=hermes_home_key() == runtime_home_key,
+                    )
                 ],
                 "checked_at": int(time.time() * 1000),
             },

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2080,6 +2080,46 @@ def _(rid, params: dict) -> dict:
         _mcp_reset_profile(token)
 
 
+@method("mcp.servers.status")
+def _(rid, params: dict) -> dict:
+    """Return cached MCP runtime state without connecting to any server.
+
+    Params: optional ``profile``. Raw connection errors are deliberately
+    omitted because they can contain paths, URLs, or credential-adjacent data.
+    """
+    token, err = _mcp_resolve_profile(rid, params)
+    if err:
+        return err
+    try:
+        import time
+
+        from tools.mcp_tool import get_mcp_status
+
+        safe_fields = (
+            "name",
+            "transport",
+            "tools",
+            "connected",
+            "disabled",
+            "status",
+            "reason",
+        )
+        return _ok(
+            rid,
+            {
+                "servers": [
+                    {key: entry[key] for key in safe_fields if key in entry}
+                    for entry in get_mcp_status()
+                ],
+                "checked_at": int(time.time() * 1000),
+            },
+        )
+    except Exception:
+        return _err(rid, 5024, "MCP status unavailable")
+    finally:
+        _mcp_reset_profile(token)
+
+
 @method("mcp.servers.add")
 def _(rid, params: dict) -> dict:
     """Add/save an MCP server to a profile's config.yaml.

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -2087,6 +2087,7 @@ def _(rid, params: dict) -> dict:
     Params: optional ``profile``. Raw connection errors are deliberately
     omitted because they can contain paths, URLs, or credential-adjacent data.
     """
+    from agent.secret_scope import is_multiplex_active
     from hermes_constants import hermes_home_key
 
     runtime_home_key = hermes_home_key()
@@ -2115,7 +2116,10 @@ def _(rid, params: dict) -> dict:
                     {key: entry[key] for key in safe_fields if key in entry}
                     for entry in get_mcp_status(
                         _get_mcp_servers(),
-                        include_runtime=hermes_home_key() == runtime_home_key,
+                        include_runtime=(
+                            is_multiplex_active()
+                            or hermes_home_key() == runtime_home_key
+                        ),
                     )
                 ],
                 "checked_at": int(time.time() * 1000),


### PR DESCRIPTION
> **Historical status:** Closed unmerged. This foundation-only version was withdrawn so the backend/SDK work could be reconsidered with the complete Connections product. The scope decision later changed: its cleaned-up core successor #102612 again submits only the generic foundation, while the product plugin remains outside that PR.

## What does this PR do?

Adds a passive, profile-scoped MCP status RPC and a validated `connections.health` contribution contract for Desktop plugins.

Hermes already stores configured MCP servers and cached runtime state, but Desktop plugins had no passive, credential-safe way to consume that state. The existing MCP test path can connect, probe, or start authentication flows, which is unsuitable for a status surface. This change projects only cached state and validates provider-supplied health and repair metadata at the Desktop host boundary.

This historical version intentionally contains no Connections product UI and no Computer Use changes.

## Related Issue

N/A — no issue covered this exact passive RPC plus Desktop contribution contract. It was closed to reconsider the foundation with the finished Connections product; the later decision was to submit the generic core separately as #102612 and keep the product plugin outside that PR.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool.py`
  - project cached runtime state into a credential-safe shape;
  - isolate runtime, connecting, failure, retry, and shutdown observations by profile;
  - preserve safe authentication reasons without exposing raw errors.
- `tui_gateway/methods_tools.py`
  - add the passive `mcp.servers.status` RPC without connecting, probing, starting OAuth, or invoking plugin discovery.
- `apps/desktop/src/contrib/connection-health.ts` and SDK exports
  - add the `connections.health` provider contract;
  - reject unsafe repair metadata both at registration and after provider loading.
- Add focused MCP/profile RPC and Desktop SDK regression tests.

## How to Test

1. Run the affected MCP/profile Python suites and verify configured servers plus cached state are returned without starting a server or OAuth flow.
2. Run the targeted Desktop contribution/SDK tests and verify malformed repair metadata plus external or protocol-relative routes are rejected. Provider-authored display strings remain provider responsibility rather than being content-scanned by the SDK.
3. Run Desktop typecheck, lint, UI tests, and production build.
4. Verify named profiles cannot observe another profile's connecting, failed, retry, or shutdown state.

Verified on the final historical head `e74244fbcb3ceda927e975ebc72744d56d998e02`:

- 678 broad MCP-related Python tests passed across 61 files.
- 145 focused MCP/profile tests passed across 6 files.
- 15 targeted Desktop tests passed across 2 files.
- 7,171 Desktop UI tests passed across 719 files.
- TypeScript typecheck and production build passed.
- Ruff passed on all changed Python files.
- ESLint completed with 0 errors and 124 pre-existing warnings outside this diff.
- Independent standards and specification reviews found no merge blocker.

Packaging/codesigning and a live packaged-Desktop smoke test were not run. The pre-existing global MCP runtime maps are keyed by server name, so simultaneous same-named runtimes across multiplex profiles were not fully supported; this passive path failed closed rather than exposing foreign state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for overlapping MCP status, profile, OAuth-probe, and Desktop plugin work
- [x] My PR contains **only** the passive core/SDK foundation and its tests; no standalone Connections UI or Computer Use changes
- [ ] I've run `pytest tests/ -q` and all tests pass — only the documented broad and focused affected suites are claimed green
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon / arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A in this historical version; the successor #102612 adds the provider-contract documentation
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — no shell commands, process control, or platform-specific filesystem behavior were added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed; the RPC and SDK contract are covered by typed interfaces and tests

## Screenshots / Logs

N/A — this closed foundation PR did not include the Connections UI. Test evidence and the unverified packaging boundary are recorded above.
