### PR TITLE
fix(desktop): refresh window state on connection republish

### DIFF
--- a/apps/desktop/electron/connection-window-state.test.ts
+++ b/apps/desktop/electron/connection-window-state.test.ts
@@ -1,0 +1,39 @@
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+import { describe, expect, it } from 'vitest'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const mainSource = fs.readFileSync(path.join(here, 'main.ts'), 'utf8').replace(/\r\n/g, '\n')
+
+function ipcHandlerSource(channel: string, nextRegistration: string): string {
+  const start = mainSource.indexOf(`ipcMain.handle('${channel}', `)
+  const end = mainSource.indexOf(nextRegistration, start)
+
+  expect(start).toBeGreaterThan(-1)
+  expect(end).toBeGreaterThan(start)
+
+  return mainSource.slice(start, end)
+}
+
+describe('connection IPC window state', () => {
+  it('overlays cached primary connection chrome with the sender window live state', () => {
+    const handler = ipcHandlerSource('hermes:connection', "ipcMain.handle('hermes:connection:for', ")
+
+    expect(handler).toContain(
+      'const windowState = getWindowState(BrowserWindow.fromWebContents(event.sender) || mainWindow)'
+    )
+    expect(handler).toContain('{ ...connection, ...windowState, connectionId }')
+    expect(handler).toContain('{ ...connection, ...windowState }')
+  })
+
+  it('overlays cached registry connection chrome with the sender window live state', () => {
+    const handler = ipcHandlerSource('hermes:connection:for', 'const windowConnectionRoutes')
+
+    expect(handler).toContain(
+      'const windowState = getWindowState(BrowserWindow.fromWebContents(event.sender) || mainWindow)'
+    )
+    expect(handler).toContain('{ ...connection, ...windowState, connectionId: id, registryScoped: true }')
+  })
+})

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14803,7 +14803,7 @@ function createWindow() {
   })
 }
 
-ipcMain.handle('hermes:connection', async (_event, profile, extra) => {
+ipcMain.handle('hermes:connection', async (event, profile, extra) => {
   // Coalesce concurrent renderer dials for one profile scope (#90812): the
   // renderer-side reconnect lock is per-window, so two windows waking at once
   // both land here. The claim key mirrors ensureBackend()'s own profile
@@ -14825,15 +14825,21 @@ ipcMain.handle('hermes:connection', async (_event, profile, extra) => {
   }
 
   const connectionId = resolvedConnectionId(readDesktopConnectionsRegistry(), connection)
+  // Republished connections reach a window that may have moved, resized or changed
+  // display since it first dialled, so re-read the state of the calling window here
+  // instead of letting the renderer keep the values from its original connect.
+  const windowState = getWindowState(BrowserWindow.fromWebContents(event.sender) || mainWindow)
 
-  return connectionId ? { ...connection, connectionId } : connection
+  return connectionId
+    ? { ...connection, ...windowState, connectionId }
+    : { ...connection, ...windowState }
 })
 // Registry-scoped variant: resolve a backend for (connectionId, profile).
 // connectionId '' / 'local' / the registry primary all behave sensibly; the
 // local kind delegates to ensureBackend when the v1 route is local, and
 // forces a genuinely-local child when the v1 global mode is remote (the
 // registry 'local' entry always means this machine).
-ipcMain.handle('hermes:connection:for', async (_event, payload) => {
+ipcMain.handle('hermes:connection:for', async (event, payload) => {
   const { connectionId, profile, priority } = payload && typeof payload === 'object' ? (payload as any) : ({} as any)
   const registry = readDesktopConnectionsRegistry()
   const id = String(connectionId || '').trim() || registry.primary
@@ -14853,7 +14859,9 @@ ipcMain.handle('hermes:connection:for', async (_event, payload) => {
     clearSpawnPriority()
   }
 
-  return { ...connection, connectionId: id, registryScoped: true }
+  const windowState = getWindowState(BrowserWindow.fromWebContents(event.sender) || mainWindow)
+
+  return { ...connection, ...windowState, connectionId: id, registryScoped: true }
 })
 
 const windowConnectionRoutes = new WindowConnectionRouteRegistry()


### PR DESCRIPTION
## Summary

Desktop connection republishes could overwrite live fullscreen chrome state with the stale snapshot cached when the backend started. This made the macOS titlebar controls jump back to the traffic-light offset after reconnects or gateway/profile switches.

## Changes

- Resolve the BrowserWindow that requested each connection descriptor.
- Overlay fresh `getWindowState()` values after cached connection fields in both connection IPC handlers.
- Add regression coverage for the primary and registry-scoped response paths.

The separate secondary-window fullscreen event-routing issue is intentionally left out of scope.

## Validation

- Passed TypeScript syntax checks for the changed implementation and test.
- Passed a targeted connection IPC regression probe and `git diff --check`.
- The Vitest regression, typecheck, lint, and formatter could not run locally because this worktree has no Node dependencies installed.

Fixes #102451
