### PR TITLE
fix(desktop): keep macOS HUD visible when inactive

### DIFF
--- a/apps/desktop/electron/hud-overlay.test.ts
+++ b/apps/desktop/electron/hud-overlay.test.ts
@@ -4,7 +4,7 @@ import { test } from 'vitest'
 
 import { applyHudElectronOverlay } from './hud-overlay'
 
-test('macOS uses the floating panel level and all-spaces visibility', () => {
+test('macOS uses the floating window level and all-spaces visibility', () => {
   const calls: string[] = []
 
   const win = {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -14005,13 +14005,12 @@ function spawnHudWindow(sessionId, profile) {
     minimizable: false,
     maximizable: false,
     fullscreenable: false,
-    // Same rationale as the pet overlay: on Windows/Linux keep the helper out
-    // of the taskbar/alt-tab list; on macOS use an NSPanel so the frameless
-    // window never becomes the app's cmd-tab anchor.
+    // Keep the interactive macOS HUD as an ordinary NSWindow. NSPanel defaults
+    // hidesOnDeactivate to true, which removes the HUD while the user works in
+    // another app; the floating/all-spaces setup below supplies overlay behavior.
     skipTaskbar: !IS_MAC,
     hasShadow: false,
     alwaysOnTop: true,
-    type: IS_MAC ? 'panel' : undefined,
     // Clips the vibrancy layer to the HUD's silhouette rather than a hard
     // rectangle — the frost stops where the window's corners do.
     roundedCorners: true,


### PR DESCRIPTION
## What does this PR do?

Keeps the macOS Desktop HUD visible when Hermes loses application focus.

The full HUD was created with Electron's `type: 'panel'`, which maps to an AppKit `NSPanel`. AppKit panels hide when their application deactivates by default. That conflicts with the HUD's intended behavior of remaining visible while the user works in another app.

This removes the panel type from the full interactive HUD so it uses a normal `NSWindow`. The existing floating window level and all-spaces behavior still provide the overlay behavior. Pet and Quick Entry panels are unchanged.

## Related Issue

Discord support report; no GitHub issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Remove the macOS `panel` window type from the full HUD in `apps/desktop/electron/main.ts`.
- Keep the existing floating level, always-on-top, and all-spaces overlay behavior.
- Update the existing HUD overlay test description to reflect that the HUD is a floating window rather than a panel.

## How to Test

1. On macOS, open Desktop and enter HUD mode from the title bar or with `Cmd+Shift+H`.
2. Activate another application.
3. Verify the HUD remains visible and interactive, then exit HUD mode and verify the main Desktop window returns normally.

Focused checks run from `apps/desktop`:

```text
..\..\node_modules\.bin\vitest.cmd run electron/hud-overlay.test.ts --project electron
..\..\node_modules\.bin\tsc.cmd -p tsconfig.electron.json --noEmit
..\..\node_modules\.bin\eslint.cmd electron/main.ts electron/hud-overlay.test.ts
```

All passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 focused Vitest, TypeScript, and ESLint checks. Native macOS window behavior still needs manual validation.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

The support report shows the HUD briefly rendering and then disappearing while the Desktop process remains alive. Native macOS verification is requested because the fix changes the AppKit window class selected by Electron.
