### PR TITLE
fix(tests): two Windows test failures - WSL bash launcher and git autocrlf

### DIFF
--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -77,6 +77,46 @@ class TestWalk:
 # 2. Bash output
 # ---------------------------------------------------------------------------
 
+def _usable_bash_for_syntax_check() -> str | None:
+    """A `bash` that can actually run `bash -n` here, or None.
+
+    Windows ships a `bash.exe` in System32 that is the WSL launcher: it
+    boots a Linux VM on first use, which can take a minute or more, and a
+    syntax check against it either times out or comes back with VM-boot
+    noise — neither validates the generated script. Probe with a short
+    timeout and fall back to a real bash (Git for Windows) when the PATH
+    one is unusable; skip when no usable bash exists at all.
+
+    Must be called at test time, not module import: a subprocess probe in
+    a decorator argument would run during collection on every platform.
+    """
+    import shutil as _shutil
+
+    candidates = []
+    on_path = _shutil.which("bash")
+    if on_path:
+        candidates.append(on_path)
+    git_exe = _shutil.which("git")
+    if git_exe:
+        candidates.append(
+            os.path.join(os.path.dirname(os.path.dirname(git_exe)), "bin", "bash.exe")
+        )
+    seen = set()
+    for bash in candidates:
+        if not bash or bash in seen or not os.path.exists(bash):
+            continue
+        seen.add(bash)
+        try:
+            probe = subprocess.run(
+                [bash, "--version"], capture_output=True, timeout=10
+            )
+        except (OSError, subprocess.SubprocessError):
+            continue
+        if probe.returncode == 0:
+            return bash
+    return None
+
+
 class TestGenerateBash:
     def test_contains_completion_function_and_register(self):
         out = generate_bash(_make_parser())
@@ -86,13 +126,24 @@ class TestGenerateBash:
 
     def test_valid_bash_syntax(self):
         """Script must pass `bash -n` syntax check."""
+        bash = _usable_bash_for_syntax_check()
+        if bash is None:
+            pytest.skip("no usable bash for syntax check (WSL launcher or none)")
         out = generate_bash(_make_parser())
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".bash", delete=False) as f:
+        # Explicit UTF-8 + LF: the platform-default text mode can write
+        # UTF-16 / CRLF on Windows, and `bash -n` chokes on both — a
+        # file-encoding artifact, not a real syntax failure of the
+        # generated script.
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".bash", delete=False, encoding="utf-8", newline="\n"
+        ) as f:
             f.write(out)
             path = f.name
         try:
-            result = subprocess.run(["bash", "-n", path], capture_output=True)
-            assert result.returncode == 0, result.stderr.decode()
+            result = subprocess.run(
+                [bash, "-n", path], capture_output=True, timeout=60
+            )
+            assert result.returncode == 0, result.stderr.decode(errors="replace")
         finally:
             os.unlink(path)
 

--- a/tests/hermes_cli/test_diff_command.py
+++ b/tests/hermes_cli/test_diff_command.py
@@ -60,7 +60,7 @@ def _run(stub, command):
 
 
 def _git(repo, *args):
-    subprocess.run(["git", *args], cwd=repo, check=True, capture_output=True,
+    subprocess.run(["git", "-c", "core.autocrlf=false", *args], cwd=repo, check=True, capture_output=True,
                    env={"GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
                         "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
                         "HOME": str(repo),


### PR DESCRIPTION
## Summary

Two tests fail on native Windows for environment reasons, not because the code under test is wrong.

## 1. `test_completion.py::test_valid_bash_syntax`

The test shells out to bare `bash -n`. On Windows, PATH resolves `bash` to `C:\Windows\System32\bash.exe` - the **WSL launcher**. With no WSL distro installed it returns rc=1 with UTF-16LE stderr:

```
returncode=1, stdout=b'...\x00R\x00E\x00G\x00D\x00B\x00_\x00E\x00_\x00C\x00L\x00A\x00S\x00S\x00N\x00O\x00T\x00R\x00E\x00G\x00...'
```

That is VM-launcher noise; it says nothing about the generated completion script. Where a distro *is* installed, the launcher boots a VM and the check takes 60s+.

**Fix:** `_usable_bash_for_syntax_check()` probes candidates (PATH bash, then Git-for-Windows `bash.exe`) with a 10s `--version` timeout and returns the first that answers rc=0; the test skips when none does. The temp script is now written with explicit `encoding="utf-8", newline="\n"` - `NamedTemporaryFile`'s default text mode can emit the locale codec and CRLF, both of which bash rejects.

Resolution happens **at test time**, not in a decorator argument, so no subprocess runs during collection on any platform.

## 2. `test_diff_command.py::test_diff_clean_repo_reports_no_changes`

The `_git` fixture helper inherits the host's `core.autocrlf`. On a Windows checkout with `autocrlf=true`, the committed blob is stored LF-normalized while the worktree file keeps CRLF, so a genuinely clean repo diffs as:

```
main.py | 2 +-
 1 file changed, 1 insertion(+), 1 deletion(-)
-print('hello')
+print('hello')
```

Two identical-looking lines - the delta is invisible CR bytes - and the `"No changes"` assertion fails.

**Fix:** run the fixture's git as `git -c core.autocrlf=false ...`. Scoped to the test helper; no global git config touched.

## Verification

Native Windows, Python 3.12:

```
tests/hermes_cli/test_completion.py + test_diff_command.py
before: 2 failed
after:  10 passed, 1 skipped   (the pre-existing zsh-not-installed skip)
```

Test-only; no production code changed. POSIX behavior is unchanged - the bash probe hits `/usr/bin/bash` on the first candidate and autocrlf is already false there.

One commit on current `main`.