### PR TITLE
fix(mcp): stop npx cache fast-path from picking an ambiguous generation

### DIFF
--- a/tests/tools/test_mcp_npx_cached_bin.py
+++ b/tests/tools/test_mcp_npx_cached_bin.py
@@ -93,6 +93,46 @@ def test_ambiguous_bin_map_is_left_to_npx(tmp_path):
     assert _npx_cached_bin(["-y", "multi"]) is None
 
 
+@pytest.mark.parametrize(
+    "entry_order",
+    [
+        pytest.param(("old-cache", "new-cache"), id="old-first"),
+        pytest.param(("new-cache", "old-cache"), id="new-first"),
+    ],
+)
+def test_unpinned_package_with_multiple_cached_versions_falls_back_to_npx(
+    tmp_path, monkeypatch, entry_order
+):
+    _cache(
+        tmp_path,
+        package="mcp-linear",
+        deps={"mcp-linear": "1.0.0"},
+        bin_field={"mcp-linear": "dist/index.js"},
+        entry="old-cache",
+    )
+    _cache(
+        tmp_path,
+        package="mcp-linear",
+        deps={"mcp-linear": "2.0.0"},
+        bin_field={"mcp-linear": "dist/index.js"},
+        entry="new-cache",
+    )
+    npx_root = os.fspath(tmp_path / ".npm" / "_npx")
+    real_listdir = os.listdir
+
+    def ordered_listdir(path):
+        if os.fspath(path) == npx_root:
+            return list(entry_order)
+        return real_listdir(path)
+
+    monkeypatch.setattr(os, "listdir", ordered_listdir)
+
+    # Which cache generation npm would actually resolve is not decidable
+    # from directory order alone, so both enumeration orders must defer to
+    # npx rather than picking whichever entry happens to sort first.
+    assert _npx_cached_bin(["-y", "mcp-linear"]) is None
+
+
 def test_missing_or_non_executable_binary_falls_back(tmp_path):
     _cache(
         tmp_path,

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1110,7 +1110,10 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
 
     Deliberately conservative — returns None for anything unusual:
     a version-pinned spec (``pkg@1.2.3``), extra npx flags, a package whose
-    manifest declares no single obvious bin, or any unreadable cache entry.
+    manifest declares no single obvious bin, any unreadable cache entry, or
+    more than one cache generation containing the package (directory
+    enumeration order is not npm's resolution order, so which generation is
+    current cannot be determined without it).
 
     Returns ``(binary_path, remaining_args)`` or None.
     """
@@ -1150,6 +1153,7 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
     except OSError:
         return None
 
+    matching_entries = []
     for entry in entries:
         manifest = os.path.join(npx_root, entry, "package.json")
         try:
@@ -1157,29 +1161,37 @@ def _npx_cached_bin(args: list) -> Optional[tuple]:
                 deps = (json.load(fh) or {}).get("dependencies") or {}
         except (OSError, ValueError, TypeError):
             continue
-        if spec not in deps:
-            continue
+        if spec in deps:
+            matching_entries.append(entry)
 
-        pkg_json = os.path.join(npx_root, entry, "node_modules", spec, "package.json")
-        try:
-            with open(pkg_json, "r", encoding="utf-8") as fh:
-                bin_field = (json.load(fh) or {}).get("bin")
-        except (OSError, ValueError, TypeError):
-            continue
+    # Directory enumeration order is not npm's resolution order. With one
+    # matching generation there is nothing to disambiguate; with more than
+    # one, which version/tag npm would currently resolve to is unknowable
+    # from the filesystem alone, so let npx decide instead of guessing.
+    if len(matching_entries) != 1:
+        return None
+    entry = matching_entries[0]
 
-        if isinstance(bin_field, str):
-            names = [os.path.basename(spec)]
-        elif isinstance(bin_field, dict) and len(bin_field) == 1:
-            names = list(bin_field.keys())
-        else:
-            # Zero or several bins: which one npx would pick is not ours to
-            # guess. Let npx decide.
-            continue
+    pkg_json = os.path.join(npx_root, entry, "node_modules", spec, "package.json")
+    try:
+        with open(pkg_json, "r", encoding="utf-8") as fh:
+            bin_field = (json.load(fh) or {}).get("bin")
+    except (OSError, ValueError, TypeError):
+        return None
 
-        bin_dir = os.path.join(npx_root, entry, "node_modules", ".bin")
-        for candidate in _npx_bin_candidates(bin_dir, names[0]):
-            if os.path.exists(candidate) and os.access(candidate, os.X_OK):
-                return candidate, rest[1:]
+    if isinstance(bin_field, str):
+        names = [os.path.basename(spec)]
+    elif isinstance(bin_field, dict) and len(bin_field) == 1:
+        names = list(bin_field.keys())
+    else:
+        # Zero or several bins: which one npx would pick is not ours to
+        # guess. Let npx decide.
+        return None
+
+    bin_dir = os.path.join(npx_root, entry, "node_modules", ".bin")
+    for candidate in _npx_bin_candidates(bin_dir, names[0]):
+        if os.path.exists(candidate) and os.access(candidate, os.X_OK):
+            return candidate, rest[1:]
 
     return None
 


### PR DESCRIPTION
## What does this PR do?

For unpinned `npx -y <package>` invocations, `_npx_cached_bin()` (`tools/mcp_tool.py`)
scans `~/.npm/_npx` with `os.listdir()` and returns the *first* cache entry whose
manifest lists the requested package, then spawns that binary directly instead of
going through `npx`. Directory enumeration order is not npm's version/tag/range
resolution order, so with more than one cache generation for the same unpinned
package, the executable Hermes launches depends on filesystem enumeration order
rather than which version npm would actually resolve.

This PR makes the ambiguity explicit: the resolver now scans every cache entry for
a manifest match before deciding anything. If exactly one generation matches, it is
resolved and executed as before. If zero or more than one match, `_npx_cached_bin`
returns `None` and the caller falls back to plain `npx`, which performs correct
resolution.

The OSV malware preflight and version-pin/ambiguous-bin/flag-ordering guards are
unchanged — this only tightens the "which cache entry" decision.

## Related Issue

Fixes #102576

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `tools/mcp_tool.py`: `_npx_cached_bin()` first collects every cache entry whose
  `package.json` dependencies contain the requested spec; only proceeds to bin
  resolution when exactly one such entry exists, otherwise returns `None`
  (falls back to `npx`). Docstring updated to document the new fallback case.
- `tests/tools/test_mcp_npx_cached_bin.py`: added
  `test_unpinned_package_with_multiple_cached_versions_falls_back_to_npx`,
  parametrized over both directory-enumeration orders, per the regression test
  proposed in the issue.

## How to Test

1. `git checkout HEAD~1 -- tools/mcp_tool.py` (revert only the fix, keep the new test)
2. `python -m pytest -q tests/tools/test_mcp_npx_cached_bin.py -k multiple_cached_versions`
   → both parametrized cases fail:
   ```
   FAILED ...[old-first] - AssertionError: assert ('.../.npm/_npx/old-cache/node_modules/.bin/mcp-linear', []) is None
   FAILED ...[new-first] - AssertionError: assert ('.../.npm/_npx/new-cache/node_modules/.bin/mcp-linear', []) is None
   ```
3. `git checkout HEAD -- tools/mcp_tool.py` (restore the fix)
4. `python -m pytest -q tests/tools/test_mcp_npx_cached_bin.py` → all pass:
   ```
   .....................                                                    [100%]
   21 passed in 1.29s
   ```
5. Full related suite also passes:
   ```
   python -m pytest -q tests/tools/test_mcp_tool.py tests/tools/test_mcp_tool_session_expired.py \
     tests/tools/test_mcp_tool_issue_948.py tests/tools/test_mcp_death_supervisor.py \
     tests/tools/test_mcp_tool_401_handling.py tests/hermes_cli/test_mcp_tools_config.py \
     tests/tools/test_browser_npx_warmup.py
   # 174 passed
   ```
6. `ruff check tools/mcp_tool.py tests/tools/test_mcp_npx_cached_bin.py` → all checks passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run `pytest tests/ -q` (targeted to the affected files above; full suite not run) and all pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux (CI container)

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool schemas changed

## AI assistance disclosure

This PR was authored with the assistance of an AI coding agent (Claude), which
implemented the fix and test per the issue's own proposed regression test and
suggested minimal direction, then verified the failing/passing behavior before
opening this PR.
