### PR TITLE
fix(prompt): cap concurrent stuck context-file reader threads

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -80,16 +80,33 @@ def _get_context_file_read_timeout() -> float:
     return _CONTEXT_FILE_READ_TIMEOUT_SECS
 
 
+# Upper bound on daemon reader threads that may be blocked in a permanently
+# stuck ``read_text()`` call at once (a network filesystem that never faults
+# a file back in). Python cannot cancel a blocked thread, so once this many
+# slots are occupied by stuck reads, further reads fail closed (return None)
+# instead of spawning another thread that would never be reclaimed.
+_MAX_CONCURRENT_CONTEXT_READS = 4
+_context_read_admission = threading.Semaphore(_MAX_CONCURRENT_CONTEXT_READS)
+
+
 def _read_text_with_timeout(path: Path, timeout: Optional[float] = None) -> Optional[str]:
     """``path.read_text()`` on a daemon thread so a slow file can't stall startup.
 
     Returns the text, or ``None`` after *timeout* seconds (logged at WARNING;
-    the orphaned reader thread finishes on its own). Read errors propagate to
-    the caller exactly as a direct ``read_text`` would, so existing
-    ``try/except`` handling at each site is unchanged.
+    the orphaned reader thread finishes on its own) or if
+    ``_MAX_CONCURRENT_CONTEXT_READS`` reads are already in flight. Read errors
+    propagate to the caller exactly as a direct ``read_text`` would, so
+    existing ``try/except`` handling at each site is unchanged.
     """
     if timeout is None:
         timeout = _get_context_file_read_timeout()
+    if not _context_read_admission.acquire(blocking=False):
+        logger.warning(
+            "Context file %s read skipped: %d context-read threads already in flight",
+            path,
+            _MAX_CONCURRENT_CONTEXT_READS,
+        )
+        return None
     result: "queue.Queue[tuple[bool, object]]" = queue.Queue(maxsize=1)
 
     def _reader() -> None:
@@ -97,6 +114,8 @@ def _read_text_with_timeout(path: Path, timeout: Optional[float] = None) -> Opti
             result.put((True, path.read_text(encoding="utf-8")))
         except Exception as exc:  # re-raised on the caller thread
             result.put((False, exc))
+        finally:
+            _context_read_admission.release()
 
     threading.Thread(target=_reader, daemon=True, name=f"context-read:{path.name}").start()
     try:

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -1191,3 +1191,42 @@ class TestContextFileReadTimeout:
 
         with pytest.raises(FileNotFoundError):
             _read_text_with_timeout(tmp_path / "missing.md", timeout=1.0)
+
+    def test_repeated_stuck_context_reads_do_not_leak_unbounded_threads(self):
+        # A permanently blocked read_text() can never be cancelled, so this
+        # runs in a subprocess: the leaked daemon threads it deliberately
+        # creates must not contaminate the rest of the pytest run.
+        import subprocess
+        import sys as _sys
+        import textwrap
+
+        probe = textwrap.dedent(
+            """
+            import threading
+            from agent.prompt_builder import _read_text_with_timeout, _MAX_CONCURRENT_CONTEXT_READS
+            never = threading.Event()
+
+            class PermanentlyStuckPath:
+                name = "AGENTS.md"
+                def read_text(self, *args, **kwargs):
+                    never.wait()
+                def __str__(self):
+                    return "PermanentlyStuckPath(AGENTS.md)"
+
+            before = sum(t.name.startswith("context-read:") for t in threading.enumerate())
+            for _ in range(12):
+                assert _read_text_with_timeout(PermanentlyStuckPath(), timeout=0.002) is None
+            after = sum(t.name.startswith("context-read:") for t in threading.enumerate())
+            leaked = after - before
+            print(f"stuck_context_reader_threads={leaked}")
+            raise SystemExit(0 if leaked <= _MAX_CONCURRENT_CONTEXT_READS else 23)
+            """
+        )
+        completed = subprocess.run(
+            [_sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+        assert completed.returncode == 0, completed.stdout + completed.stderr


### PR DESCRIPTION
## What does this PR do?

`_read_text_with_timeout()` in `agent/prompt_builder.py` starts a fresh
`threading.Thread(daemon=True)` for every context-file read (SOUL.md,
AGENTS.md, .cursorrules, ...). When `Path.read_text()` blocks permanently —
one of the exact cases the timeout exists to protect against, e.g. a network
filesystem that never faults an evicted file back in — the caller returns
`None` after the timeout, but the reader thread cannot be cancelled and stays
alive forever. Repeated agent/session creation therefore grows the process by
one orphaned thread per stuck read, with no bound.

This adds a fixed-size admission semaphore (`_MAX_CONCURRENT_CONTEXT_READS =
4`) around thread creation in `_read_text_with_timeout()`. The semaphore slot
acquired for a read is released in the reader thread's `finally`, so it is
only held for the lifetime of the underlying `read_text()` call — a normal
fast read releases it almost immediately, but a permanently stuck read holds
it forever. Once all 4 slots are occupied by stuck reads, further reads fail
closed immediately (return `None`, log a warning) instead of spawning another
thread that could never be reclaimed. This is the "admission cap" direction
the issue itself suggests, since Python cannot safely kill a blocked
filesystem thread.

Because the cap is a semaphore around plain daemon threads (not a
`concurrent.futures.ThreadPoolExecutor`), process exit is never blocked
waiting for a permanently stuck reader — `ThreadPoolExecutor` workers are
non-daemon and register with `atexit`, which would hang shutdown on a
genuinely stuck read.

## Related Issue

Fixes #102575

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py`: add `_MAX_CONCURRENT_CONTEXT_READS` /
  `_context_read_admission` semaphore; `_read_text_with_timeout()` now
  acquires a slot before spawning a reader thread and fails closed
  (`return None`) if none are free; the reader releases its slot in
  `finally` once the underlying `read_text()` call actually returns.
- `tests/agent/test_prompt_builder.py`: add
  `test_repeated_stuck_context_reads_do_not_leak_unbounded_threads`, adapted
  from the issue's proposed regression test. It runs in a subprocess (per the
  issue's own reasoning) so the deliberately-stuck daemon threads it creates
  can't contaminate the rest of the pytest run.

## How to Test

1. `python -m pytest -q tests/agent/test_prompt_builder.py -k
   ContextFileReadTimeout` — the new test drives 12 calls against a path
   whose `read_text()` blocks forever and asserts the number of live
   `context-read:*` threads never exceeds `_MAX_CONCURRENT_CONTEXT_READS`.
2. Proof the test fails without the fix: `git checkout HEAD~1 --
   agent/prompt_builder.py`, rerun the same test — it fails immediately
   with `ImportError: cannot import name '_MAX_CONCURRENT_CONTEXT_READS'`
   (and, functionally, the old code leaks all 12 threads uncapped). Restore
   with `git checkout HEAD -- agent/prompt_builder.py`.

### Real output

Before the fix (source reverted to parent commit, test kept):
```
$ python -m pytest -q tests/agent/test_prompt_builder.py -k test_repeated_stuck_context_reads_do_not_leak_unbounded_threads
FAILED ... AssertionError: Traceback (most recent call last):
    File "<string>", line 3, in <module>
  ImportError: cannot import name '_MAX_CONCURRENT_CONTEXT_READS' from 'agent.prompt_builder'
1 failed, 76 deselected in 0.31s
```

After the fix:
```
$ python -m pytest -q tests/agent/test_prompt_builder.py -k ContextFileReadTimeout
...                                                                      [100%]
3 passed, 74 deselected in 0.35s

$ python -m pytest -q tests/agent/test_prompt_builder.py
77 passed in 0.81s

$ python -m pytest -q tests/agent/test_subdirectory_hints.py   # other caller of _read_text_with_timeout
57 passed in 0.49s

$ ruff check agent/prompt_builder.py tests/agent/test_prompt_builder.py
All checks passed!
```

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've run the relevant tests and all pass
- [x] I've added a test for the change (regression test proven to fail
      pre-fix, pass post-fix)
- [ ] I've tested on my platform — tested only in Linux CI-style container;
      no macOS/Windows access

## Disclosure

This change was written with AI assistance (Claude Code / Claude Sonnet 5),
reviewed and verified by the human/automation submitting this PR before
being pushed.
