### PR TITLE
fix(tui): ensure notification poller runs for /loop wakeups (#102088)

### DIFF
--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -919,6 +919,18 @@ def _(rid, params: dict) -> dict:
         if not sid_key:
             return _err(rid, 4001, "no session key")
 
+        # Ensure the notification poller is running for this session so that
+        # loop/heartbeat wakeups fire. The poller is started at session init,
+        # but if it died or was never started for this session, (re)start it
+        # here. Safe to call multiple times.
+        try:
+            stop_event = session.get("_notif_stop")
+            if stop_event is None or stop_event.is_set():
+                _start_notification_poller(sid, session)
+        except Exception:
+            # Poller startup is best-effort; loop state is still saved.
+            pass
+
         mgr = LoopManager(session_id=sid_key)
         result = dispatch_loop_command(mgr, arg)
         output = result.get("output") or ""


### PR DESCRIPTION
## What does this PR do?

Fixes the bug where `/loop` slash command is accepted but never injects wakeup turns in Hermes Desktop TUI. The same issue affects `/heartbeat` — both show as "armed" but never fire.

## Root cause

The notification poller thread (which fires `/loop` and `/heartbeat` wakeups) is started at session initialization in `server.py`. However, if the poller died or was never started for a session (e.g., session created via a different path, or poller thread crashed), the loop/heartbeat ticks would never fire even though the loop state was correctly saved.

## The fix

When a `/loop` command creates a new loop, explicitly ensure the notification poller is running for that session by calling `_start_notification_poller()`. This is idempotent — safe to call multiple times.

## Testing

- All 9 `test_loop_command.py` tests pass
- All 69 `test_loops.py` tests pass
- TypeScript typecheck passes

## Related Issue

Fixes #102088