### PR TITLE
fix(desktop): migrate to Electron WebContentsConsoleMessageEventParams (#102420)

### DIFF
--- a/apps/desktop/electron/renderer-log.test.ts
+++ b/apps/desktop/electron/renderer-log.test.ts
@@ -3,37 +3,38 @@ import { describe, expect, it, vi } from 'vitest'
 import { attachRendererConsoleCapture, formatRendererBoundaryReport, formatRendererConsoleLine } from './renderer-log'
 
 describe('formatRendererConsoleLine', () => {
-  it('formats the canonical Electron 36+ details shape at error level', () => {
+  it('formats an error-level Electron console-message event', () => {
     const line = formatRendererConsoleLine('hud', {
-      level: 3,
+      level: 'error',
       message: 'Minified React error #310',
-      sourceUrl: 'file:///app/index.js',
+      sourceId: 'file:///app/index.js',
       lineNumber: 13
     })
 
     expect(line).toBe('[renderer console:hud] Minified React error #310 (file:///app/index.js:13)')
   })
 
-  it('formats the deprecated positional shape at error level', () => {
-    const line = formatRendererConsoleLine('main', 3, 'boom', 7, 'file:///app/vendor.js')
-
-    expect(line).toBe('[renderer console:main] boom (file:///app/vendor.js:7)')
-  })
-
-  it('drops non-error levels in both shapes', () => {
-    expect(formatRendererConsoleLine('main', { level: 1, message: 'x', sourceUrl: 's', lineNumber: 1 })).toBeNull()
-    expect(formatRendererConsoleLine('main', 2, 'warn', 1, 's')).toBeNull()
+  it('drops non-error levels', () => {
+    expect(
+      formatRendererConsoleLine('main', { level: 'debug', message: 'x', sourceId: 's', lineNumber: 1 })
+    ).toBeNull()
+    expect(
+      formatRendererConsoleLine('main', { level: 'info', message: 'x', sourceId: 's', lineNumber: 1 })
+    ).toBeNull()
+    expect(
+      formatRendererConsoleLine('main', { level: 'warning', message: 'warn', sourceId: 's', lineNumber: 1 })
+    ).toBeNull()
   })
 })
 
 describe('attachRendererConsoleCapture', () => {
   it('logs error-level messages and skips the rest', () => {
     const log = vi.fn()
-    let handler: ((...args: unknown[]) => void) | undefined
+    let handler: ((...args: any[]) => void) | undefined
 
     const win = {
       webContents: {
-        on: (_event: string, listener: (...args: unknown[]) => void) => {
+        on: (_event: string, listener: (...args: any[]) => void) => {
           handler = listener
         }
       }
@@ -41,8 +42,8 @@ describe('attachRendererConsoleCapture', () => {
 
     attachRendererConsoleCapture(win, 'quick-entry', log)
 
-    handler?.({}, { level: 3, message: 'crash', sourceUrl: 'src', lineNumber: 2 })
-    handler?.({}, { level: 0, message: 'debug', sourceUrl: 'src', lineNumber: 3 })
+    handler?.({ level: 'error', message: 'crash', sourceId: 'src', lineNumber: 2 })
+    handler?.({ level: 'debug', message: 'debug message', sourceId: 'src', lineNumber: 3 })
 
     expect(log).toHaveBeenCalledTimes(1)
     expect(log).toHaveBeenCalledWith('[renderer console:quick-entry] crash (src:2)')

--- a/apps/desktop/electron/renderer-log.ts
+++ b/apps/desktop/electron/renderer-log.ts
@@ -15,53 +15,44 @@
  * tokens or PII we never want on disk.
  */
 
-interface ConsoleMessageDetails {
-  level: number
+/** Shape of the `Event<WebContentsConsoleMessageEventParams>` Electron
+ *  delivers as the first argument of the `webContents` `console-message`
+ *  event. Electron still appends the legacy positional arguments
+ *  `(level, message, line, sourceId)` after the event object, but any
+ *  listener that declares them triggers Electron's runtime deprecation
+ *  warning, so handlers must read from the event object only. */
+interface RendererConsoleMessage {
+  /** Severity. Chromium's `ConsoleMessageLevel` arrives stringified:
+   *  verbose → `debug`, then `info`, `warning`, `error`. */
+  level: 'debug' | 'info' | 'warning' | 'error'
   message: string
-  sourceUrl: string
   lineNumber: number
+  sourceId: string
 }
 
 interface WebContentsLike {
-  on(event: 'console-message', listener: (...args: unknown[]) => void): unknown
+  on(event: 'console-message', listener: (event: RendererConsoleMessage) => void): unknown
 }
 
 interface WindowLike {
   webContents: WebContentsLike
 }
 
-/** Normalize Electron's two `console-message` signatures into one line, or
- *  null for non-error levels. Canonical (Electron 36+): `(event, details)`;
- *  deprecated positional: `(event, level, message, line, sourceId)`.
- *  `level` is numeric 0..3, where 3 === error. */
-export function formatRendererConsoleLine(
-  label: string,
-  detailsOrLevel: unknown,
-  message?: unknown,
-  line?: unknown,
-  sourceId?: unknown
-): string | null {
-  const details =
-    detailsOrLevel && typeof detailsOrLevel === 'object' ? (detailsOrLevel as ConsoleMessageDetails) : null
-
-  const level = details ? details.level : detailsOrLevel
-
-  if (level !== 3) {
+/** Format a renderer console-message event into one desktop.log line, or
+ *  null for non-error levels. */
+export function formatRendererConsoleLine(label: string, event: RendererConsoleMessage): string | null {
+  if (event.level !== 'error') {
     return null
   }
 
-  const text = details ? details.message : message
-  const src = details ? details.sourceUrl : sourceId
-  const lineNo = details ? details.lineNumber : line
-
-  return `[renderer console:${label}] ${String(text)} (${String(src)}:${String(lineNo)})`
+  return `[renderer console:${label}] ${event.message} (${event.sourceId}:${event.lineNumber})`
 }
 
 /** Attach the error-level console hook to a renderer window. `log` is the
  *  desktop.log sink (rememberLog in main.ts). */
 export function attachRendererConsoleCapture(win: WindowLike, label: string, log: (line: string) => void): void {
-  win.webContents.on('console-message', (_event, detailsOrLevel, message, line, sourceId) => {
-    const formatted = formatRendererConsoleLine(label, detailsOrLevel, message, line, sourceId)
+  win.webContents.on('console-message', (event) => {
+    const formatted = formatRendererConsoleLine(label, event)
 
     if (formatted !== null) {
       log(formatted)


### PR DESCRIPTION
Closes #102420

Electron logs a deprecation warning on every boot and on every console message from a `<webview>` preview pane: the legacy positional `console-message` arguments are deprecated and will be removed in a future Electron major.

This migrates `renderer-log.ts` to the canonical `Event<WebContentsConsoleMessageEventParams>` signature:

- Handlers read `event.level` (string: `error | warning | info | debug`), `event.message`, `event.lineNumber` and `event.sourceId` from the event object instead of the deprecated positional args.
- `formatRendererConsoleLine` normalized to a single event-object path (legacy dual-signature handling removed).
- Test fake updated to the new listener shape, still covering the error-only logging behavior.

Validation:
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean
- `vitest run electron/renderer-log.test.ts` — 6/6 passed
