### PR TITLE
fix(process): resolve true binary via PATH in systemd scope probe

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -145,6 +145,21 @@ def _systemd_scope_cached() -> Optional[bool]:
     return None if _SYSTEMD_SCOPE_AVAILABLE is None or stale else False
 
 
+def _portable_true_binary() -> str:
+    """Resolve a usable ``true`` binary, tolerant of NixOS (no /bin/true)."""
+    import shutil as _shutil
+    for candidate in (
+        _shutil.which("true"),
+        "/run/current-system/sw/bin/true",
+        "/usr/bin/true",
+        "/bin/true",
+    ):
+        if candidate and os.path.exists(candidate):
+            return candidate
+    return "/bin/true"  # fallback — will fail on NixOS but at least won't crash import
+
+
+
 def _systemd_run_user_scope_available() -> bool:
     """True if ``systemd-run --user --scope`` can create a cgroup.
     ``shutil.which`` alone is insufficient: system services and containers may lack
@@ -170,7 +185,8 @@ def _systemd_run_user_scope_available() -> bool:
                     # Unique unit avoids collisions; the timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
                     result = subprocess.run(
-                        _systemd_scope_argv(binary, probe_unit, "/bin/true"), capture_output=True, timeout=3,
+                        _systemd_scope_argv(binary, probe_unit, _portable_true_binary()),
+                        capture_output=True, timeout=3,
                     )
                     available = result.returncode == 0
                     if not available:


### PR DESCRIPTION
## Summary
The `systemd-run --user --scope` availability probe in `tools/process_registry.py` hardcoded `/bin/true`. NixOS has no `/bin/true` (only `/run/current-system/sw/bin/true`), so the probe failed and cron worker dispatch raised `RuntimeError` on every run — 24 documented hourly failures over Sep 3–4. Nasty part: the gateway itself stayed up and answered Telegram normally the whole time, so the only symptom was missed scheduled check-ins.

## Change
Resolve the binary portably instead of hardcoding it: try `shutil.which("true")` first, then fall back to known locations checked by existence (`/run/current-system/sw/bin/true`, `/usr/bin/true`, `/bin/true`). The existence cascade matters — learned the hard way that the gateway systemd service PATH lacks the NixOS store paths, so `which()` alone returns None right where the bug bites (first version of this PR had a plain `/bin/true` fallback and kept failing in production). (`shutil`/`os` were already imported at the probe site.) FHS behavior is unchanged — `which()` finds `/usr/bin/true` there and the fallback never triggers.

## Test plan
- [x] Existence cascade resolves to `/run/current-system/sw/bin/true` on NixOS; probe via real `systemd-run --scope` returns rc=0
- [x] Live gateway proof: restarted 09:11 ET Sep 4, first hourly dispatch (10:15 ET) succeeded — mesh hub shows hermes-nixos checked in fresh, 5/5 nodes online, zero dispatch errors