### PR TITLE
feat(desktop): show still-booting splash until backend is ready (#102419)

### DIFF
--- a/apps/desktop/electron/boot-splash-html.test.ts
+++ b/apps/desktop/electron/boot-splash-html.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+
+import { BOOT_SPLASH_SHOW_AFTER_MS, buildBootSplashHtml, bootSplashStatusScript } from './boot-splash-html'
+
+describe('buildBootSplashHtml', () => {
+  const meta = { version: '1.2.3', stampLabel: 'abc123def456 (main)' }
+
+  it('renders the still-booting title and the version', () => {
+    const html = buildBootSplashHtml(meta)
+    expect(html).toContain('Still booting — please wait')
+    expect(html).toContain('Hermes Desktop v1.2.3')
+  })
+
+  it('shows the install-stamp label when present and hides it when absent', () => {
+    const stamped = buildBootSplashHtml(meta)
+    expect(stamped).toContain('abc123def456 (main)')
+
+    const bare = buildBootSplashHtml({ version: '1.2.3', stampLabel: null })
+    expect(bare).toContain('Hermes Desktop v1.2.3')
+    expect(bare).not.toContain('abc123def456')
+  })
+
+  it('escapes HTML in version and stamp label', () => {
+    const html = buildBootSplashHtml({ version: '1.2.3', stampLabel: '<img src=x onerror=1> (main)' })
+    expect(html).toContain('&lt;img src=x onerror=1&gt;')
+    expect(html).not.toContain('<img src=x onerror=1>')
+  })
+
+  it('exposes the live status updater hook', () => {
+    const html = buildBootSplashHtml(meta)
+    expect(html).toContain('window.__hermesBootStatus')
+    expect(html).toContain('id="boot-status"')
+  })
+})
+
+describe('bootSplashStatusScript', () => {
+  it('calls the updater with a JSON-encoded message', () => {
+    expect(bootSplashStatusScript('hi')).toBe('window.__hermesBootStatus && window.__hermesBootStatus("hi")')
+  })
+
+  it('keeps quotes and backslashes safe inside the generated source', () => {
+    const script = bootSplashStatusScript('backend "spoke" \\ fast')
+    expect(script).toContain('window.__hermesBootStatus("backend \\"spoke\\" \\\\ fast")')
+  })
+})
+
+describe('splash timing constants', () => {
+  it('waits long enough to never flash on a normal launch, and polls cheaply', () => {
+    expect(BOOT_SPLASH_SHOW_AFTER_MS).toBeGreaterThanOrEqual(4000)
+  })
+})

--- a/apps/desktop/electron/boot-splash-html.ts
+++ b/apps/desktop/electron/boot-splash-html.ts
@@ -1,0 +1,147 @@
+// Pre-renderer boot splash markup (#102419).
+//
+// The macOS first-launch stall this addresses happens BEFORE the main
+// renderer paints (Chromium's trust_store_mac walks the entire system
+// keychain on Electron boot; on keychains Apple seeded with a duplicate
+// com.apple.kerberos.kdc cert the walk blocks the first paint for minutes).
+// The main window stays `show: false` until its first themed paint, so the
+// user only sees the Dock's frozen "Opening…" with no feedback at all.
+//
+// This module builds the tiny splash document the MAIN process shows while
+// that window is still unpainted. It is intentionally plain HTML/CSS/JS (no
+// preload, no app bundle): a data: URL page that paints its own frame long
+// before the heavy renderer load, exactly like the update/launch splash
+// windows Linear and VS Code ship. The main process rewrites the one-line
+// status via executeJavaScript as real boot-progress phases land.
+//
+// Pure (no Electron import) so the markup is unit-testable under vitest.
+
+export const BOOT_SPLASH_SHOW_AFTER_MS = 5_000
+export const BOOT_SPLASH_WATCH_MS = 250
+
+export interface BootSplashMeta {
+  version: string
+  // Short install-stamp label (e.g. "abc1234 (main)"). Null in dev checkouts
+  // that never ran a build — the footer then shows the version only.
+  stampLabel: string | null
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;')
+}
+
+/**
+ * Full standalone splash document. The initial status line is overwritten by
+ * the main process as soon as the page paints and boot progress advances.
+ */
+export function buildBootSplashHtml(meta: BootSplashMeta): string {
+  const stamp = meta.stampLabel ? ` · ${escapeHtml(meta.stampLabel)}` : ''
+
+  return `<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Hermes</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  html, body { height: 100%; }
+  body {
+    background: #0e1116;
+    color: #e8eaed;
+    font-family: system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    user-select: none;
+    -webkit-user-select: none;
+    cursor: default;
+  }
+  .splash { width: 100%; padding: 26px 30px; }
+  .line { display: flex; align-items: center; gap: 16px; }
+  .spinner {
+    flex: none;
+    width: 24px;
+    height: 24px;
+    border-radius: 50%;
+    border: 3px solid rgba(232, 234, 237, 0.16);
+    border-top-color: #4ade80;
+    animation: boot-spin 1.1s linear infinite;
+  }
+  .title { font-size: 15px; font-weight: 600; letter-spacing: 0.01em; }
+  #boot-status {
+    margin-top: 5px;
+    font-size: 12.5px;
+    color: #9aa3b2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 400px;
+  }
+  .meta {
+    display: flex;
+    justify-content: space-between;
+    gap: 12px;
+    margin-top: 18px;
+    font-size: 11px;
+    color: #6f7885;
+    white-space: nowrap;
+  }
+  @keyframes boot-spin { to { transform: rotate(360deg); } }
+  @media (prefers-reduced-motion: reduce) {
+    .spinner { animation: none; border-top-color: #4ade80; }
+  }
+</style>
+</head>
+<body>
+  <div class="splash">
+    <div class="line">
+      <div class="spinner" aria-hidden="true"></div>
+      <div>
+        <div class="title">Still booting — please wait</div>
+        <div id="boot-status">Starting Hermes Desktop…</div>
+      </div>
+    </div>
+    <div class="meta">
+      <span id="boot-meta">Hermes Desktop v${escapeHtml(meta.version)}${stamp}</span>
+      <span id="boot-elapsed" aria-hidden="true"></span>
+    </div>
+  </div>
+  <script>
+    (function () {
+      var startedAt = Date.now()
+      var statusEl = document.getElementById('boot-status')
+      var elapsedEl = document.getElementById('boot-elapsed')
+      // Called from the main process (executeJavaScript) whenever boot
+      // progress advances, so the one-liner stays live during a long stall.
+      window.__hermesBootStatus = function (message) {
+        statusEl.textContent = message
+      }
+      function pad(n) { return n < 10 ? '0' + n : String(n) }
+      function renderElapsed() {
+        var s = Math.floor((Date.now() - startedAt) / 1000)
+        var h = Math.floor(s / 3600)
+        var m = Math.floor((s % 3600) / 60)
+        var sec = s % 60
+        elapsedEl.textContent = 'elapsed ' + (h > 0 ? h + ':' + pad(m) + ':' + pad(sec) : m + ':' + pad(sec))
+      }
+      renderElapsed()
+      setInterval(renderElapsed, 1000)
+    })()
+  </script>
+</body>
+</html>`
+}
+
+/**
+ * JS snippet that rewrites the splash status line. `message` is our own boot
+ * progress text; JSON.stringify keeps quotes/backslashes safe inside the
+ * executeJavaScript source regardless of content.
+ */
+export function bootSplashStatusScript(message: string): string {
+  return `window.__hermesBootStatus && window.__hermesBootStatus(${JSON.stringify(message)})`
+}

--- a/apps/desktop/electron/boot-splash-window.ts
+++ b/apps/desktop/electron/boot-splash-window.ts
@@ -1,0 +1,164 @@
+// Pre-renderer boot splash window (#102419).
+//
+// The main window is created `show: false` and only appears once its renderer
+// has painted its first themed frame (wireWindowReveal). On macOS first
+// launch Chromium's system-keychain walk can delay that first paint by
+// minutes, so the user would otherwise stare at the Dock's frozen "Opening…"
+// with no feedback. See boot-splash-html.ts for the full rationale.
+//
+// This module owns the tiny frameless splash BrowserWindow:
+//
+//  1. createBootSplashWindow() opens a HIDDEN splash before the main window
+//     even starts its renderer load, so its own frame paints first and is
+//     ready to show instantly later.
+//  2. gateBootSplash() waits BOOT_SPLASH_SHOW_AFTER_MS: if the main window is
+//     visible by then (a normal launch) the splash closes silently — no flash;
+//     otherwise the splash takes over the screen and its status line is fed
+//     live from the existing boot-progress state until the main window
+//     finally shows, then it closes for good.
+//
+// Skipped under Playwright (TEST_WORKER_INDEX) in main.ts because the reveal
+// is forced there and an extra window would confuse the suite.
+
+import { BrowserWindow } from 'electron'
+
+import {
+  BOOT_SPLASH_SHOW_AFTER_MS,
+  BOOT_SPLASH_WATCH_MS,
+  bootSplashStatusScript,
+  buildBootSplashHtml,
+  type BootSplashMeta
+} from './boot-splash-html'
+
+function splashDataUrl(meta: BootSplashMeta): string {
+  return `data:text/html;charset=utf-8,${encodeURIComponent(buildBootSplashHtml(meta))}`
+}
+
+export function createBootSplashWindow(meta: BootSplashMeta): BrowserWindow {
+  const splash = new BrowserWindow({
+    width: 470,
+    height: 210,
+    show: false,
+    frame: false,
+    resizable: false,
+    minimizable: false,
+    maximizable: false,
+    fullscreenable: false,
+    skipTaskbar: true,
+    alwaysOnTop: true,
+    center: true,
+    title: 'Hermes',
+    backgroundColor: '#0e1116',
+    // Deliberately no preload and no node integration: this page is static
+    // HTML updated only by the main process via executeJavaScript.
+    webPreferences: {
+      contextIsolation: true,
+      nodeIntegration: false,
+      sandbox: true,
+      devTools: false,
+      spellcheck: false
+    }
+  })
+
+  splash.loadURL(splashDataUrl(meta)).catch(() => {
+    // A data: URL load failing is essentially impossible; if it ever does,
+    // the splash stays hidden and startup proceeds exactly as before.
+  })
+
+  return splash
+}
+
+export interface BootSplashGateOptions {
+  splash: BrowserWindow
+  getMainWindow: () => BrowserWindow | null
+  getStatusMessage: () => string
+}
+
+/**
+ * Reveal gate described above. Timers are the only moving parts; they are
+ * cancelled on dispose so a closed splash never leaks a tick.
+ */
+export function gateBootSplash({ splash, getMainWindow, getStatusMessage }: BootSplashGateOptions): () => void {
+  let disposed = false
+  let shown = false
+  let lastStatus: string | null = null
+
+  const dispose = () => {
+    if (disposed) {
+      return
+    }
+
+    disposed = true
+    clearTimeout(showTimer)
+    clearInterval(watchTimer)
+  }
+
+  const splashClosed = () => {
+    // Covers manual close (e.g. Cmd+W on macOS) and app quit.
+    dispose()
+  }
+
+  const pushStatus = () => {
+    if (disposed || shown === false || splash.isDestroyed() || splash.webContents.isLoadingMainFrame()) {
+      return
+    }
+
+    const message = getStatusMessage()
+
+    if (message !== lastStatus) {
+      lastStatus = message
+      void splash.webContents
+        .executeJavaScript(bootSplashStatusScript(message))
+        .catch(() => {
+          // The page can be torn down between the isDestroyed check and the
+          // eval landing; the next watch tick catches up or gives up.
+        })
+    }
+  }
+
+  const showTimer = setTimeout(() => {
+    if (disposed) {
+      return
+    }
+
+    const mainWindow = getMainWindow()
+
+    // Normal launch won the race — the splash was never needed.
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()) {
+      dispose()
+      splash.close()
+      return
+    }
+
+    if (splash.isDestroyed()) {
+      dispose()
+      return
+    }
+
+    shown = true
+    splash.show()
+    pushStatus()
+  }, BOOT_SPLASH_SHOW_AFTER_MS)
+
+  const watchTimer = setInterval(() => {
+    if (disposed) {
+      return
+    }
+
+    const mainWindow = getMainWindow()
+
+    // The main window appeared (or was destroyed, e.g. crash-relaunch) —
+    // hand over to its own boot UI and get out of the way.
+    if (mainWindow && !mainWindow.isDestroyed() && mainWindow.isVisible()) {
+      dispose()
+      splash.close()
+      return
+    }
+
+    pushStatus()
+  }, BOOT_SPLASH_WATCH_MS)
+
+  splash.once('closed', splashClosed)
+
+  return dispose
+}

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -410,6 +410,7 @@ import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from 
 import { registrySshScopeForWindowRoute, WindowConnectionRouteRegistry } from './window-connection-route'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
+import { createBootSplashWindow, gateBootSplash } from './boot-splash-window'
 import {
   bindGeometryPersistence,
   computeWindowOptions,
@@ -14420,6 +14421,31 @@ function createWindow() {
 
   const createdMainWindow = mainWindow
 
+  // #102419: pre-renderer boot splash. The primary window starts hidden and
+  // only shows after its first themed paint; on macOS first launch the
+  // Chromium system-keychain walk can delay that paint for minutes, leaving
+  // only a frozen Dock icon. A tiny hidden splash (its own frame paints long
+  // before the heavy renderer load) takes over if the main window still has
+  // not appeared shortly after startup, reports the live boot phase from
+  // bootProgressState, and closes itself when the main window finally shows.
+  // Skipped under Playwright, where the reveal is forced immediately below.
+  let disposeBootSplash = null
+
+  if (process.env.TEST_WORKER_INDEX === undefined) {
+    const splash = createBootSplashWindow({
+      version: app.getVersion(),
+      stampLabel: INSTALL_STAMP
+        ? `${INSTALL_STAMP.commit.slice(0, 12)}${INSTALL_STAMP.branch ? ` (${INSTALL_STAMP.branch})` : ''}`
+        : null
+    })
+
+    disposeBootSplash = gateBootSplash({
+      splash,
+      getMainWindow: () => mainWindow,
+      getStatusMessage: () => bootProgressState.message || 'Starting Hermes…'
+    })
+  }
+
   // Chat-surface registration: see applyWindowTranslucency.
   translucencyBackedWindows.add(mainWindow)
 
@@ -14500,6 +14526,14 @@ function createWindow() {
   mainWindow.on('closed', () => {
     closePetOverlay()
     wakeIndicatorController.close()
+
+    // #102419: the splash outlives nothing. If the main window is gone
+    // before the reveal (crash-relaunch, quit race), stop its timers and
+    // close it so no orphan splash window lingers.
+    if (disposeBootSplash) {
+      disposeBootSplash()
+      disposeBootSplash = null
+    }
 
     if (mainWindow === createdMainWindow) {
       mainWindow = null


### PR DESCRIPTION
Closes #102419

On first launch the Desktop main window is created hidden and only shows after its first themed paint. On macOS that first paint can be delayed for minutes (Chromium's system-keychain walk), leaving the user staring at a frozen Dock icon with no feedback at all.

This adds a tiny pre-renderer boot splash owned by the main process:

- `createBootSplashWindow()` opens a **hidden** splash before the main window's heavy renderer load starts, so its own frame paints first and can appear instantly.
- `gateBootSplash()` waits 5s; if the main window is visible by then (a normal launch) the splash closes silently — no flash on fast boots. If the main window is still hidden, the splash takes over and its one-line status is fed live from the existing `bootProgressState` until the main window finally appears, then it closes for good.
- The splash page is a plain data: URL document (no preload, no node integration, sandboxed) updated by the main process via `executeJavaScript`; it shows the app version and install-stamp label.
- Skipped under Playwright (`TEST_WORKER_INDEX`), where the window reveal is forced immediately.

Validation:
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean
- `vitest run electron/boot-splash-html.test.ts` — 7/7 passed
