### PR TITLE
feat(cli): expose per-slot reasoning effort in `hermes moa configure`

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -49,6 +49,28 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
+def _slot_reasoning_effort(
+    provider: dict[str, Any], model: str, current_effort: str
+) -> str | None:
+    """Prompt for a per-slot reasoning effort when the picked model supports one.
+
+    Reuses the primary-model setup prompt. "none" (disable) and a picked level
+    are returned as-is; skipping keeps whatever the slot already carries so
+    re-running configure on a preset never silently drops an existing effort.
+    """
+    caps = provider.get("capabilities")
+    entry = caps.get(model) if isinstance(caps, dict) else None
+    if not isinstance(entry, dict) or not entry.get("reasoning"):
+        return None
+    from hermes_constants import VALID_REASONING_EFFORTS
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    selected = _prompt_reasoning_effort_selection(
+        list(VALID_REASONING_EFFORTS), current_effort=current_effort
+    )
+    return selected or (current_effort or None)
+
+
 def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
     providers = _model_options()
     if not providers:
@@ -66,7 +88,13 @@ def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
     current_model = (current or {}).get("model", "")
     model_default = models.index(current_model) if current_model in models else 0
     model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
-    return {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    slot: dict[str, str] = {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    effort = _slot_reasoning_effort(
+        provider, str(model), str((current or {}).get("reasoning_effort") or "")
+    )
+    if effort:
+        slot["reasoning_effort"] = effort
+    return slot
 
 
 def _format_slot(slot: dict[str, Any]) -> str:

--- a/tests/hermes_cli/test_moa_slot_reasoning_effort.py
+++ b/tests/hermes_cli/test_moa_slot_reasoning_effort.py
@@ -1,0 +1,87 @@
+"""Regression tests for per-slot reasoning effort in ``hermes moa configure``.
+
+Issue #102582: ``moa.presets.<name>.reference_models[].reasoning_effort`` and
+``.aggregator.reasoning_effort`` are first-class config fields that
+``hermes moa list`` displays, but ``_pick_slot`` never offered them — the only
+way to set one was hand-editing the config JSON. The slot picker must now reuse
+the primary-model effort prompt whenever the picked model's capability map says
+it supports reasoning.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.moa_cmd import _pick_slot
+
+PROVIDER = {
+    "slug": "z-ai",
+    "name": "Z AI",
+    "models": ["glm-5.3", "glm-5.3-air"],
+    "capabilities": {
+        "glm-5.3": {"fast": False, "reasoning": True},
+        "glm-5.3-air": {"fast": True, "reasoning": False},
+    },
+}
+
+
+def _run_pick_slot(*, model_idx: int = 0, current: dict | None = None):
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, model_idx]
+    ) as choice:
+        slot = _pick_slot(current)
+    return slot, choice
+
+
+def _run_with_selection(selection, *, model_idx: int = 0, current: dict | None = None):
+    with patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value=selection) as prompt:
+        slot, choice = _run_pick_slot(model_idx=model_idx, current=current)
+    return slot, choice, prompt
+
+
+class TestPickSlotReasoningEffort:
+    def test_capable_model_prompts_and_persists_effort(self):
+        slot, _, prompt = _run_with_selection("high")
+        assert slot == {
+            "provider": "z-ai",
+            "model": "glm-5.3",
+            "reasoning_effort": "high",
+        }
+        prompt.assert_called_once()
+        args, kwargs = prompt.call_args
+        assert args[0] == [
+            "minimal", "low", "medium", "high", "xhigh", "max", "ultra",
+        ]
+        assert kwargs.get("current_effort") == ""
+
+    def test_disable_reasoning_persists_none(self):
+        slot, _, _ = _run_with_selection("none")
+        assert slot["reasoning_effort"] == "none"
+
+    def test_skip_on_new_slot_omits_key(self):
+        slot, _, prompt = _run_with_selection(None)
+        assert slot == {"provider": "z-ai", "model": "glm-5.3"}
+        prompt.assert_called_once()
+
+    def test_skip_keeps_existing_effort(self):
+        slot, _, prompt = _run_with_selection(
+            None, current={"provider": "z-ai", "model": "glm-5.3", "reasoning_effort": "low"}
+        )
+        assert slot["reasoning_effort"] == "low"
+        assert prompt.call_args.kwargs.get("current_effort") == "low"
+
+    def test_non_reasoning_model_not_prompted(self):
+        slot, _, prompt = _run_with_selection("high", model_idx=1)
+        assert slot == {"provider": "z-ai", "model": "glm-5.3-air"}
+        prompt.assert_not_called()
+
+    def test_missing_capability_entry_not_prompted(self):
+        provider = dict(PROVIDER, models=["glm-5.3-flash"], capabilities={"glm-5.3": {"reasoning": True}})
+        with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+            "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+        ), patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
+        ) as prompt:
+            slot = _pick_slot(None)
+        assert slot == {"provider": "z-ai", "model": "glm-5.3-flash"}
+        prompt.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

`hermes moa configure` now offers a per-slot reasoning-effort level right after a model is picked in `_pick_slot()`. `reasoning_effort` was already a first-class field on MoA reference models and the aggregator (`hermes_cli/moa_config.py`, displayed by `hermes moa list` via `_format_slot`), but the interactive setup flow never set it — the only path was hand-editing the config JSON.

When the picker's capability map (already built with `capabilities=True` in `_model_options()`) says the picked model supports reasoning, the slot picker reuses the exact prompt the primary-model setup uses (`_prompt_reasoning_effort_selection`), offering the standard levels plus disable/skip. This applies to every reference model and the aggregator independently, so cheap low-effort advisors can feed a high-effort aggregator. Models the catalog flags as non-reasoning skip the prompt entirely.

Skipping keeps whatever the slot already carried, so re-running `hermes moa configure` on a preset never silently drops an existing effort.

## Related Issue

Fixes #102582

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/moa_cmd.py`: new `_slot_reasoning_effort()` helper — gates on the picked model's `capabilities[model]["reasoning"]` entry, then delegates to the existing `_prompt_reasoning_effort_selection()` with `VALID_REASONING_EFFORTS`; returns the picked level, `"none"`, or falls back to the slot's current effort when skipped.
- `hermes_cli/moa_cmd.py`: `_pick_slot()` persists the returned effort as the slot's `reasoning_effort` (key omitted when unset).
- `tests/hermes_cli/test_moa_slot_reasoning_effort.py`: regression tests covering prompt gating, persistence of a picked level, `"none"`, skip-on-new-slot, skip-keeps-existing-effort, and no-prompt for non-reasoning / uncatalogued models.

## How to Test

1. Run `pytest tests/hermes_cli/test_moa_slot_reasoning_effort.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py tests/hermes_cli/test_reasoning_effort_menu.py -q` — should pass: 6 passed + 8 passed (observed locally).
2. Run `hermes moa configure`, pick a reasoning-capable model (e.g. a GLM/Claude entry) for a reference slot — a "Select reasoning effort" prompt appears; picking `high` then running `hermes moa list` should show the slot as `provider:model [reasoning=high]`.
3. Pick a non-reasoning model — no effort prompt appears.
4. Re-run `hermes moa configure` on the same preset and skip the effort prompt — the previously saved effort is retained.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
