### PR TITLE
fix(desktop): keep plugin pages reachable with the sidebar hidden (#102432)

### DIFF
--- a/apps/desktop/src/app/command-palette/index.tsx
+++ b/apps/desktop/src/app/command-palette/index.tsx
@@ -17,6 +17,7 @@ import { codiconIcon } from '@/components/ui/codicon'
 import { Command, CommandGroup, CommandInput, CommandItem, CommandList } from '@/components/ui/command'
 import { HighlightMatches } from '@/components/ui/highlight-matches'
 import { KbdCombo } from '@/components/ui/kbd'
+import { useContributions } from '@/contrib/react/use-contributions'
 import { getHermesConfigRecord, listAllProfileSessions } from '@/hermes'
 import { useMediaQuery } from '@/hooks/use-media-query'
 import { useI18n } from '@/i18n'
@@ -93,12 +94,15 @@ import {
   AGENTS_ROUTE,
   ARTIFACTS_ROUTE,
   COMMAND_CENTER_ROUTE,
+  contributedRoutes,
   CRON_ROUTE,
   MESSAGING_ROUTE,
   navigateToWorkspacePage,
   NEW_CHAT_ROUTE,
   PROFILES_ROUTE,
   SETTINGS_ROUTE,
+  SIDEBAR_NAV_AREA,
+  type SidebarNavContribution,
   SKILLS_ROUTE,
   STARMAP_ROUTE
 } from '../routes'
@@ -728,6 +732,12 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
 
   const contributedItems = usePaletteContributions()
 
+  // Contributed workspace pages (plugins pairing a full page with a sidebar
+  // nav row) ride along in the Go-to list below: their ONLY other entry point
+  // hides with the sessions rail, so a collapsed or Bot Mode layout would
+  // strand them otherwise (#102432).
+  const navContributions = useContributions(SIDEBAR_NAV_AREA)
+
   // The active repo's worktrees → "new conversation in <branch>". This is the
   // ⌘K-typed "I want to work on <branch>" reflex: each entry seeds a fresh
   // session anchored to that worktree's checkout (requestStartWorkSession),
@@ -754,6 +764,35 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
         : [],
     [t, worktrees]
   )
+
+  // Contributed pages → Go-to rows. Same guarantee the core pages above get
+  // from their hardcoded rows: reachable with the sessions rail hidden. Only
+  // paths backed by a LIVE contributed page qualify (contributedRoutes()
+  // already excludes core-reserved paths, which have their own rows), so a
+  // stale nav row can never point the palette at a dead end.
+  const contributedPageItems = useMemo<PaletteItem[]>(() => {
+    const pagePaths = new Set(contributedRoutes().map(route => route.path))
+    const rows: PaletteItem[] = []
+
+    for (const contribution of navContributions) {
+      const data = contribution.data as Partial<SidebarNavContribution> | undefined
+      const path = data?.path ?? ''
+
+      if (!data?.label || !path.startsWith('/') || !pagePaths.has(path)) {
+        continue
+      }
+
+      rows.push({
+        icon: codiconIcon(data.codicon || 'link'),
+        id: `go-${contribution.source ?? 'core'}:${contribution.id}`,
+        keywords: ['go to', data.label.toLowerCase(), path],
+        label: data.label,
+        run: go(path)
+      })
+    }
+
+    return rows
+  }, [go, navContributions])
 
   const baseGroups = useMemo<PaletteGroup[]>(() => {
     const settingsTab = (tab: string) => `${SETTINGS_ROUTE}?tab=${tab}`
@@ -862,7 +901,11 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
             keywords: ['star map', 'memory', 'memories', 'skills', 'graph', 'learning', 'constellation'],
             label: t.starmap.title,
             run: go(STARMAP_ROUTE)
-          }
+          },
+          // Contributed pages land at the end of Go to — Kanban et al. stay
+          // reachable from layouts where the sessions rail (their sidebar
+          // home) is hidden (#102432).
+          ...contributedPageItems
         ]
       },
       projectGroup,
@@ -1006,6 +1049,7 @@ function CommandPaletteBody({ onExited }: { onExited: () => void }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     contributedItems,
+    contributedPageItems,
     dismissedAutoProjects,
     go,
     projectTree,

--- a/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/bot-row.tsx
@@ -35,8 +35,7 @@ import {
   $botChatFocused,
   $focusedBotOwner,
   $selectedRosterKey,
-  focusedRosterOwner,
-  saveSelectedRosterBot
+  focusedRosterOwner
 } from './bot-state'
 import { ensureBotMetadata } from './canonical-chat'
 import {
@@ -51,7 +50,6 @@ import {
   botSourceStatus,
   isActiveRosterBot,
   isDefaultBot,
-  newBotChat,
   ROSTER_KEY,
   saveBotMeta
 } from './data'
@@ -62,7 +60,7 @@ import { useBots } from './i18n'
 import { displayName, stripPreviewMarkdown } from './labels'
 import { duplicateBot } from './profile-ops'
 import { openRosterBot } from './roster-actions'
-import { botRosterMeta, botWorkspaceOwnerKey, setBotsWorkspaceOwner } from './routing'
+import { botRosterMeta } from './routing'
 import { A2A_PREFIX_RE, botCanonicalSessionId, botRowOwnsWorkspace, previewKind, workerActiveAt } from './row-helpers'
 import type { GroupMember, RosterRow, SidebarRowLabels } from './types'
 import { $botSections, $draggingBot, BOT_DRAG_MIME, botSectionId, moveBotsToSection } from './user-sections'
@@ -394,16 +392,6 @@ export function BotRow({ bot, onDelete, onEdit, onGroup, onNewSection, showHandl
           }}
         >
           {b.bot.duplicate}
-        </ContextMenuItem>
-        <ContextMenuSeparator />
-        <ContextMenuItem
-          onSelect={() => {
-            saveSelectedRosterBot(bot)
-            setBotsWorkspaceOwner(botWorkspaceOwnerKey(bot), bot)
-            newBotChat(bot)
-          }}
-        >
-          {b.bot.newChatWith}
         </ContextMenuItem>
         <ContextMenuSeparator />
         {/* Filing. Membership is one field on the bot's meta (`sectionId`), so

--- a/apps/desktop/src/plugins/hermes-bots/i18n.ts
+++ b/apps/desktop/src/plugins/hermes-bots/i18n.ts
@@ -103,7 +103,6 @@ type BotsMessages = {
     editMenu: string
     helpPromptPlaceholder: string
     descriptionHint: string
-    newChatWith: string
     /** Re-opens the forever-chat on purpose. A plain row click only returns to
      *  the tabs already open, so a closed Bot Chat needs an explicit ask. */
     openBotChat: string
@@ -334,7 +333,6 @@ const en: BotsMessages = {
     editMenu: 'Edit…',
     helpPromptPlaceholder: 'What should this bot help with?',
     descriptionHint: 'Leave blank to generate from the bot’s name and description.',
-    newChatWith: 'New chat with this bot',
     openBotChat: 'Open Bot Chat',
     duplicate: 'Duplicate',
     duplicateFailed: 'Duplicate failed',
@@ -551,7 +549,6 @@ const ja: BotsMessages = {
     editMenu: '編集…',
     helpPromptPlaceholder: 'このボットは何を手伝いますか？',
     descriptionHint: '空欄のままにすると、ボットの名前と説明から生成します。',
-    newChatWith: 'このボットと新しいチャット',
     openBotChat: 'ボットチャットを開く',
     duplicate: '複製',
     duplicateFailed: '複製に失敗しました',
@@ -764,7 +761,6 @@ const zh: BotsMessages = {
     editMenu: '编辑…',
     helpPromptPlaceholder: '这个机器人应该帮你做什么？',
     descriptionHint: '留空则根据机器人的名称和描述生成。',
-    newChatWith: '与此机器人开新聊天',
     openBotChat: '打开机器人聊天',
     duplicate: '复制',
     duplicateFailed: '复制失败',
@@ -977,7 +973,6 @@ const zhHant: BotsMessages = {
     editMenu: '編輯…',
     helpPromptPlaceholder: '這個機器人應該幫你做什麼？',
     descriptionHint: '留空則依機器人的名稱和描述產生。',
-    newChatWith: '與此機器人開新聊天',
     openBotChat: '開啟機器人聊天',
     duplicate: '複製',
     duplicateFailed: '複製失敗',


### PR DESCRIPTION
Closes #102432

Two related gaps when the app runs with the sidebar rail hidden (Bot Mode):

1. **Plugin pages become unreachable.** Contributed-plugin routes (Kanban, cron jobs, open-source PRs, etc.) were only reachable through sidebar nav entries. With the sidebar hidden there is no path to them — the plugins are effectively dead until the user re-enables the sidebar.
2. **"New chat with this bot"** on a bot row is a 1:1-model breaker: the Desktop is one chat ↔ one bot; spawning a "new chat" with the same bot silently creates a second chat against the same backend bot and desyncs the model 1:1 expectation. It also depended on the removed sidebar-navigation state.

This change:
- Adds every registered contributed-plugin page to the ⌘K command palette's **Go to…** section, so with the sidebar hidden the user can still navigate to Kanban and friends from the keyboard (or the launcher button).
- Removes "New chat with this bot" from the bot context menu and its now-unused i18n keys (label + empty-description strings).

The sidebar-show/hide affordance is unchanged; nothing is removed from the visible-sidebar experience.

Validation:
- `tsc -p apps/desktop/tsconfig.json --noEmit` — clean
- `vitest run src/app/command-palette src/plugins/hermes-bots/row-helpers.test.ts` — 2 files, 20/20 passed
