### PR TITLE
fix(cron): route lifecycle guard script reads through the sqlite live-connection registry

### DIFF
--- a/cron/lifecycle_guard.py
+++ b/cron/lifecycle_guard.py
@@ -1023,6 +1023,15 @@ def _read_referenced_script(
     evicted placeholder's ``open()`` can hang preflight indefinitely
     (#88052). The lexical check covers direct cloud paths; the resolved
     check covers local launchers that are symlinks into a cloud subtree.
+
+    The same choke point also refuses a path with a live SQLite connection
+    in this process (e.g. the gateway's own ``state.db``, merely mentioned
+    in the terminal command being checked): ``close()`` on a bare
+    ``os.open()`` descriptor cancels every POSIX advisory lock this process
+    holds on that file, for every other fd, dropping the gateway's WAL
+    protection out from under it (#102589). ``sqlite_safe_read`` already
+    tracks which paths have a live connection; consult its registry instead
+    of reading blind.
     """
     byte_limit = _capped_read_limit(max_bytes)
     if _is_cloud_placeholder_path(path):
@@ -1035,6 +1044,10 @@ def _read_referenced_script(
         # guarded path must never crash the guard (#76762).
         resolved = path
     if _is_cloud_placeholder_path(resolved):
+        return None, True
+    from hermes_cli.sqlite_safe_read import has_live_connection
+
+    if has_live_connection(path) or has_live_connection(resolved):
         return None, True
     flags = os.O_RDONLY | getattr(os, "O_NONBLOCK", 0)
     try:

--- a/tests/cron/test_lifecycle_guard_live_db.py
+++ b/tests/cron/test_lifecycle_guard_live_db.py
@@ -1,0 +1,45 @@
+"""``_read_referenced_script`` must never raw-open a path with a live
+SQLite connection in this process (#102589).
+
+A bare ``os.open()``/``os.close()`` on such a path cancels every POSIX
+advisory lock this process holds on that file, for every fd, even though
+the caller never touched the tracked connection. That drops the gateway's
+WAL protection out from under it the moment a terminal command merely
+*mentions* ``state.db``'s path.
+"""
+
+from __future__ import annotations
+
+import cron.lifecycle_guard as lifecycle_guard
+from hermes_cli import sqlite_safe_read
+
+
+def test_read_referenced_script_fails_closed_on_live_connection(tmp_path, monkeypatch):
+    db = tmp_path / "state.db"
+    db.write_bytes(b"not a real sqlite file, presence is enough")
+
+    def _must_not_open(*_args, **_kwargs):
+        raise AssertionError(
+            "must not raw os.open() a path with a live SQLite connection"
+        )
+
+    monkeypatch.setattr(lifecycle_guard.os, "open", _must_not_open)
+
+    sqlite_safe_read.track_connection(db)
+    try:
+        text, unsafe = lifecycle_guard._read_referenced_script(db)
+    finally:
+        sqlite_safe_read.untrack_connection(db)
+
+    assert text is None
+    assert unsafe is True
+
+
+def test_read_referenced_script_reads_normally_without_live_connection(tmp_path):
+    script = tmp_path / "s.sh"
+    script.write_text("echo ok\n", encoding="utf-8")
+
+    text, unsafe = lifecycle_guard._read_referenced_script(script)
+
+    assert text == "echo ok\n"
+    assert unsafe is False


### PR DESCRIPTION
Fixes #102589.

## Bug

`cron/lifecycle_guard.py::_read_referenced_script()` opens **any path-like
token** found in a terminal command with a raw `os.open()` / `os.close()`
inside the gateway process. When that token happens to be the gateway's own
`~/.hermes/state.db` (a command merely *mentioning* the path is enough — the
file doesn't need to be executed), the close cancels **every POSIX advisory
lock the gateway process holds on that file**, because POSIX locks are
per-process and are dropped when *any* fd for the file is closed — even one
opened and closed by unrelated code in the same process.

From that point the gateway's `SessionDB` handles no longer protect the WAL:
the next unrelated process that closes a connection (a cron child, an ad-hoc
`sqlite3` CLI session, a backup script) sees itself as the "last connection,"
checkpoints, and unlinks `state.db-wal` / `state.db-shm` while the gateway
still has the old inodes mapped — a WAL split-brain that only a restart
recovers from.

The repo already has the fix for this class of bug in
`hermes_cli/sqlite_safe_read.py`: it tracks which database paths have a live
connection in this process and refuses raw byte-level reads of them
(`read_header_bytes_preopen`, `offline_file_access`) for precisely this
reason — quoting the module's own docstring:

> `close()` would cancel its POSIX locks

`_read_referenced_script` is the one script-reading choke point in the guard
that bypasses this protection.

## Fix

Consult the same live-connection registry in `_read_referenced_script`,
right where the existing cloud-placeholder check already refuses to open a
path outright, and fail closed (skip the read, mark `unsafe=True`) instead
of raw-opening a path this process holds a live SQLite connection to. This
is suggested fix #1 from the issue (the smallest of the three proposed).

```python
from hermes_cli.sqlite_safe_read import has_live_connection

if has_live_connection(path) or has_live_connection(resolved):
    return None, True
```

## Test

Added `tests/cron/test_lifecycle_guard_live_db.py`:

- `test_read_referenced_script_fails_closed_on_live_connection` — registers
  a live connection for a path via `sqlite_safe_read.track_connection`,
  monkeypatches `os.open` to raise if called, and asserts
  `_read_referenced_script` returns `(None, True)` without ever calling
  `os.open`.
- `test_read_referenced_script_reads_normally_without_live_connection` —
  confirms ordinary script reads are unaffected.

Verified the first test fails without the fix (reverted `cron/lifecycle_guard.py`
to the pre-fix version, kept the test):

```
cron/lifecycle_guard.py:1041: in _read_referenced_script
    descriptor = os.open(path, flags)
E   AssertionError: must not raw os.open() a path with a live SQLite connection
1 failed, 1 passed in 0.33s
```

With the fix restored, both tests pass:

```
tests/cron/test_lifecycle_guard_live_db.py::test_read_referenced_script_fails_closed_on_live_connection PASSED
tests/cron/test_lifecycle_guard_live_db.py::test_read_referenced_script_reads_normally_without_live_connection PASSED
2 passed in 0.29s
```

Full existing suite for this module also green via the canonical runner:

```
scripts/run_tests.sh tests/cron/test_lifecycle_guard_live_db.py tests/cron/test_lifecycle_guard_budget.py -v
=== Summary: 2 files, 18 tests passed, 0 failed (100% complete) in 2.7s (8 workers) ===
```

`ruff check` on both changed files: `All checks passed!`.

(Also ran the full `tests/cron/` directory: 1199 passed, 1 pre-existing
unrelated failure — `test_cron_multiplex_shared_route_delivery.py`'s Discord
delivery test, which fails only when the whole directory runs under plain
`pytest` due to cross-test env leakage, not under the canonical per-file
isolated runner, and is unaffected by this change — reproduced identically
on the pre-fix version of the file.)

## Scope

This addresses suggested fix #1 only (route through the existing registry).
Fix #2 (scope the guard's script-reading to files that are plausibly shell
scripts) is the subject of open PR #76797 and is a larger, separate change;
fix #3 (defence-in-depth anchor connection) is optional hardening on top of
either. This PR closes the reported hole on its own.

---

AI-assistance disclosure: this patch was written with the assistance of an
AI coding agent (Claude), under human supervision, including reproducing the
bug, writing the fix and test, and running the test/lint suite as shown
above.
