### PR TITLE
fix(ntfy): route cron deliveries to addressed topic via publish_topic bridge

### DIFF
--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -562,14 +562,7 @@ class DeliveryRouter:
                     send_metadata["user_id"] = home.user_id
                 if home.scope_id:
                     send_metadata["scope_id"] = home.scope_id
-        # ntfy has no native per-conversation identity: chat_id IS the target
-        # topic. The adapter's send() honors metadata.publish_topic first
-        # (subscribe-in/publish-out split deployments), then falls back to the
-        # fixed publish topic — so without this bridge, cron deliveries to
-        # `ntfy:<topic>` (or a non-home NTFY_HOME_CHANNEL) are pinned to the
-        # adapter's configured publish topic instead of reaching the addressed
-        # topic. Mirror what tools/send_message_tool._send_via_adapter does for
-        # ntfy so cron delivery and the send tool route identically.
+        # ntfy: chat_id is the target topic (mirror send_message_tool).
         if target.platform.value == "ntfy" and target.chat_id:
             send_metadata["publish_topic"] = target.chat_id
         is_named_telegram_private_topic = False

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -562,7 +562,6 @@ class DeliveryRouter:
                     send_metadata["user_id"] = home.user_id
                 if home.scope_id:
                     send_metadata["scope_id"] = home.scope_id
-        # ntfy: chat_id is the target topic (mirror send_message_tool).
         if target.platform.value == "ntfy" and target.chat_id:
             send_metadata["publish_topic"] = target.chat_id
         is_named_telegram_private_topic = False

--- a/gateway/delivery.py
+++ b/gateway/delivery.py
@@ -562,6 +562,16 @@ class DeliveryRouter:
                     send_metadata["user_id"] = home.user_id
                 if home.scope_id:
                     send_metadata["scope_id"] = home.scope_id
+        # ntfy has no native per-conversation identity: chat_id IS the target
+        # topic. The adapter's send() honors metadata.publish_topic first
+        # (subscribe-in/publish-out split deployments), then falls back to the
+        # fixed publish topic — so without this bridge, cron deliveries to
+        # `ntfy:<topic>` (or a non-home NTFY_HOME_CHANNEL) are pinned to the
+        # adapter's configured publish topic instead of reaching the addressed
+        # topic. Mirror what tools/send_message_tool._send_via_adapter does for
+        # ntfy so cron delivery and the send tool route identically.
+        if target.platform.value == "ntfy" and target.chat_id:
+            send_metadata["publish_topic"] = target.chat_id
         is_named_telegram_private_topic = False
         named_telegram_private_topic_name: Optional[str] = None
         if target.thread_id:

--- a/tests/gateway/test_delivery.py
+++ b/tests/gateway/test_delivery.py
@@ -398,7 +398,59 @@ def test_local_delivery_writes_non_ascii_on_windows_codepage(tmp_path, monkeypat
     result = router._deliver_local(
         "完了 ✅ café", job_id="job1", job_name="日次レポート", metadata=None
     )
-
     written = Path(result["path"]).read_text(encoding="utf-8")
     assert "完了 ✅ café" in written
     assert "日次レポート" in written
+
+
+# ---------------------------------------------------------------------------
+# ntfy cron delivery routing (issue: cron ntfy:<topic> was pinned to the
+# adapter's fixed publish topic; must carry publish_topic = chat_id, the same
+# bridge send_message_tool._send_via_adapter already applies)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_ntfy_cron_delivery_carries_publish_topic_for_target_topic(tmp_path, monkeypatch):
+    """A cron job delivered to `ntfy:<topic>` must reach that exact topic.
+
+    ntfy's adapter send() honors metadata.publish_topic before falling back
+    to the fixed configured publish topic, and the DeliveryRouter is the cron
+    live-adapter path — so the router must bridge chat_id -> publish_topic
+    exactly like send_message_tool does, or the delivery is silently pinned
+    to the configured home topic.
+    """
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    ntfy_platform = Platform("ntfy")
+    router = DeliveryRouter(GatewayConfig(), adapters={ntfy_platform: adapter})
+
+    await router._deliver_to_platform(
+        DeliveryTarget(platform=ntfy_platform, chat_id="alerts-channel"),
+        "disk 90%",
+        metadata={"job_id": "cron-ops"},
+    )
+
+    assert len(adapter.calls) == 1
+    call = adapter.calls[0]
+    assert call["chat_id"] == "alerts-channel"
+    assert call["metadata"]["publish_topic"] == "alerts-channel"
+    assert call["metadata"]["job_id"] == "cron-ops"
+
+
+@pytest.mark.asyncio
+async def test_non_ntfy_delivery_untouched_by_publish_topic_bridge(tmp_path, monkeypatch):
+    """The ntfy publish_topic bridge must not leak metadata into other platforms."""
+    monkeypatch.setattr("gateway.delivery.get_hermes_home", lambda: tmp_path)
+    adapter = RecordingAdapter()
+    router = DeliveryRouter(GatewayConfig(), adapters={Platform.SLACK: adapter})
+
+    await router._deliver_to_platform(
+        DeliveryTarget(platform=Platform.SLACK, chat_id="C123"),
+        "hello",
+        metadata={"job_id": "cron-1"},
+    )
+
+    assert len(adapter.calls) == 1
+    call = adapter.calls[0]
+    assert "publish_topic" not in call["metadata"]
+    assert call["metadata"]["job_id"] == "cron-1"

--- a/tests/gateway/test_ntfy_plugin.py
+++ b/tests/gateway/test_ntfy_plugin.py
@@ -223,6 +223,29 @@ class TestSend:
         posted_url = mock_client.post.call_args[0][0]
         assert posted_url.endswith("/hermes-out")
 
+    def test_send_honors_metadata_publish_topic_over_configured(self):
+        """An explicit metadata publish_topic (used by the send tool for
+        ntfy:<topic> targets) must reach that topic even when the adapter
+        also has a fixed publish topic configured."""
+        adapter = self._make_adapter(topic="hermes-in", publish_topic="hermes-out")
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"id": "xyz789"}
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_resp)
+        adapter._http_client = mock_client
+
+        result = _run(adapter.send(
+            "ignored-chat", "Disk at 90%",
+            metadata={"publish_topic": "alerts-channel"},
+        ))
+        assert result.success is True
+
+        posted_url = mock_client.post.call_args[0][0]
+        assert posted_url.endswith("/alerts-channel")
+
     def test_send_falls_back_to_subscribe_topic(self):
         adapter = self._make_adapter(topic="hermes-in")
 


### PR DESCRIPTION
## Summary

Cron jobs delivered to `ntfy:<topic>` are silently pinned to the adapter's fixed publish topic (`NTFY_HOME_CHANNEL` / `NTFY_PUBLISH_TOPIC`) whenever the gateway is running. They only reach the addressed topic when cron runs out-of-process (via `_standalone_send`, which is chat_id-first).

## Root cause

The DeliveryRouter's live-adapter path (`gateway/delivery.py::_deliver_to_platform`) calls `adapter.send(chat_id, ..., metadata=send_metadata)` but does **not** bridge the target topic into metadata the way `tools/send_message_tool._send_via_adapter` already does for ntfy:

```python
# send_message_tool.py (existing)
if platform_name == "ntfy" and chat_id:
    metadata["publish_topic"] = chat_id
```

ntfy's `chat_id` **is** the target topic, and `NtfyAdapter.send()` resolves:
`metadata.publish_topic or self._publish_topic or chat_id`

So without the metadata bridge, cron deliveries to `ntfy:<topic>` (or a non-home `NTFY_HOME_CHANNEL`) always hit the fixed publish topic. This contradicts the documented behavior ("target a specific topic explicitly via the cron job's deliver field", `hermes send ntfy:alerts-channel`).

## Fix

Mirror the send-tool bridge in `DeliveryRouter._deliver_to_platform`: when the delivery target's platform is `ntfy` and a chat_id is present, copy it into `send_metadata["publish_topic"]`. Non-ntfy platforms are untouched (verified by a regression test).

## Tests

- `tests/gateway/test_delivery.py`: new tests asserting the ntfy bridge sets `publish_topic=chat_id` and that other platforms receive no `publish_topic` metadata.
- `tests/gateway/test_ntfy_plugin.py`: new test asserting `metadata.publish_topic` outranks the adapter's configured publish topic (the mechanism the bridge relies on).
- Full run: `48 passed` (`test_delivery.py` + `test_ntfy_plugin.py`).
