### PR TITLE
fix(moa): let users retune slots without re-picking models

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5333,7 +5333,7 @@ def _set_reasoning_effort(config, effort: str) -> None:
     agent_cfg["reasoning_effort"] = effort
 
 
-def _prompt_reasoning_effort_selection(efforts, current_effort=""):
+def _prompt_reasoning_effort_selection(efforts, current_effort="", *, allow_disable=True):
     """Prompt for a reasoning effort. Returns effort, 'none', or None to keep current."""
     deduped = list(
         dict.fromkeys(
@@ -5354,7 +5354,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
     disable_label = "Disable reasoning"
     skip_label = "Skip (keep current)"
 
-    if current_effort == "none":
+    if current_effort == "none" and allow_disable:
         default_idx = len(ordered)
     elif current_effort in ordered:
         default_idx = ordered.index(current_effort)
@@ -5367,7 +5367,8 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         from hermes_cli.curses_ui import curses_radiolist
 
         choices = [_label(effort) for effort in ordered]
-        choices.append(disable_label)
+        if allow_disable:
+            choices.append(disable_label)
         choices.append(skip_label)
         idx = curses_radiolist(
             "Select reasoning effort:",
@@ -5380,7 +5381,7 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
         print()
         if idx < len(ordered):
             return ordered[idx]
-        if idx == len(ordered):
+        if allow_disable and idx == len(ordered):
             return "none"
         return None
     except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
@@ -5390,23 +5391,25 @@ def _prompt_reasoning_effort_selection(efforts, current_effort=""):
     for i, effort in enumerate(ordered, 1):
         print(f"  {i}. {_label(effort)}")
     n = len(ordered)
-    print(f"  {n + 1}. {disable_label}")
-    print(f"  {n + 2}. {skip_label}")
+    if allow_disable:
+        print(f"  {n + 1}. {disable_label}")
+    skip_idx = n + 2 if allow_disable else n + 1
+    print(f"  {skip_idx}. {skip_label}")
     print()
 
     while True:
         try:
-            choice = input(f"Choice [1-{n + 2}] (default: keep current): ").strip()
+            choice = input(f"Choice [1-{skip_idx}] (default: keep current): ").strip()
             if not choice:
                 return None
             idx = int(choice)
             if 1 <= idx <= n:
                 return ordered[idx - 1]
-            if idx == n + 1:
+            if allow_disable and idx == n + 1:
                 return "none"
-            if idx == n + 2:
+            if idx == skip_idx:
                 return None
-            print(f"Please enter 1-{n + 2}")
+            print(f"Please enter 1-{skip_idx}")
         except ValueError:
             print("Please enter a number")
         except (KeyboardInterrupt, EOFError):

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -55,7 +55,7 @@ def _prompt_positive_int(title: str, current: int | None = None) -> int | None:
     while True:
         try:
             raw = input(f"{title}{suffix}: ").strip()
-        except (KeyboardInterrupt, EOFError):
+        except EOFError:
             return current
         if not raw:
             return current
@@ -129,6 +129,11 @@ def _edit_slot_parameters(
         model = str(slot.get("model") or "")
         reasoning_support = _model_supports_reasoning(provider, model)
         if reasoning_support is False:
+            if "reasoning_effort" in slot:
+                print(
+                    f"Note: {slot.get('provider')}:{model} does not support reasoning; "
+                    "dropping the existing reasoning_effort override."
+                )
             slot.pop("reasoning_effort", None)
         elif reasoning_support is True:
             effort_action = _prompt_choice(

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -83,6 +83,14 @@ def _model_supports_reasoning(provider: dict[str, Any], model: str) -> bool | No
     return bool(model_capabilities["reasoning"])
 
 
+def _model_can_disable_reasoning(provider: dict[str, Any], model: str) -> bool | None:
+    capabilities = provider.get("capabilities")
+    model_capabilities = capabilities.get(model) if isinstance(capabilities, dict) else None
+    if not isinstance(model_capabilities, dict) or "can_disable_reasoning" not in model_capabilities:
+        return None
+    return bool(model_capabilities["can_disable_reasoning"])
+
+
 def _slot_reasoning_effort(
     provider: dict[str, Any], model: str, current_effort: str = ""
 ) -> str | None:
@@ -91,8 +99,13 @@ def _slot_reasoning_effort(
 
     from hermes_cli.main import _prompt_reasoning_effort_selection
 
+    allow_disable = _model_can_disable_reasoning(provider, model) is not False
+    if not allow_disable and current_effort == "none":
+        current_effort = ""
     selected = _prompt_reasoning_effort_selection(
-        list(VALID_REASONING_EFFORTS), current_effort=current_effort
+        list(VALID_REASONING_EFFORTS),
+        current_effort=current_effort,
+        allow_disable=allow_disable,
     )
     return selected or (current_effort or None)
 
@@ -136,6 +149,15 @@ def _edit_slot_parameters(
                 )
             slot.pop("reasoning_effort", None)
         elif reasoning_support is True:
+            if (
+                _model_can_disable_reasoning(provider, model) is False
+                and current_effort == "none"
+            ):
+                print(
+                    f"Note: {slot.get('provider')}:{model} requires reasoning; "
+                    "dropping the existing disabled-reasoning override."
+                )
+                slot.pop("reasoning_effort", None)
             effort_action = _prompt_choice(
                 "Reasoning effort",
                 [
@@ -197,6 +219,12 @@ def _pick_slot(
         if same_model
         else ""
     )
+    reasoning_support = _model_supports_reasoning(provider, str(model))
+    if current and "reasoning_effort" in current and reasoning_support is False:
+        print(
+            f"Note: {slot['provider']}:{slot['model']} does not support reasoning; "
+            "dropping the existing reasoning_effort override."
+        )
     effort = _slot_reasoning_effort(provider, str(model), current_effort)
     if effort:
         slot["reasoning_effort"] = effort

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -225,6 +225,15 @@ def _pick_slot(
             f"Note: {slot['provider']}:{slot['model']} does not support reasoning; "
             "dropping the existing reasoning_effort override."
         )
+    elif (
+        same_model
+        and current_effort == "none"
+        and _model_can_disable_reasoning(provider, str(model)) is False
+    ):
+        print(
+            f"Note: {slot['provider']}:{slot['model']} requires reasoning; "
+            "dropping the existing disabled-reasoning override."
+        )
     effort = _slot_reasoning_effort(provider, str(model), current_effort)
     if effort:
         slot["reasoning_effort"] = effort

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -50,9 +50,6 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
-_REASONING_EFFORTS = ("none", *VALID_REASONING_EFFORTS)
-
-
 def _prompt_positive_int(title: str, current: int | None = None) -> int | None:
     suffix = f" [{current}]" if current is not None else ""
     while True:
@@ -71,56 +68,91 @@ def _prompt_positive_int(title: str, current: int | None = None) -> int | None:
         print("Please enter a positive integer, or leave blank to keep the current value.")
 
 
-def _edit_slot_parameters(current: dict[str, Any]) -> dict[str, Any]:
-    slot = dict(current)
-    current_max_tokens = slot.get("max_tokens")
-    max_tokens_label = current_max_tokens if isinstance(current_max_tokens, int) else "preset default"
-    max_tokens_action = _prompt_choice(
-        "Max tokens",
-        [
-            f"Keep current ({max_tokens_label})",
-            "Use preset default (unset override)",
-            "Set custom limit",
-        ],
+def _provider_for_slot(
+    providers: list[dict[str, Any]], slot: dict[str, Any]
+) -> dict[str, Any] | None:
+    provider_slug = str(slot.get("provider") or "")
+    return next((provider for provider in providers if provider.get("slug") == provider_slug), None)
+
+
+def _model_supports_reasoning(provider: dict[str, Any], model: str) -> bool:
+    capabilities = provider.get("capabilities")
+    model_capabilities = capabilities.get(model) if isinstance(capabilities, dict) else None
+    return isinstance(model_capabilities, dict) and bool(model_capabilities.get("reasoning"))
+
+
+def _slot_reasoning_effort(
+    provider: dict[str, Any], model: str, current_effort: str = ""
+) -> str | None:
+    if not _model_supports_reasoning(provider, model):
+        return None
+
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    selected = _prompt_reasoning_effort_selection(
+        list(VALID_REASONING_EFFORTS), current_effort=current_effort
     )
-    if max_tokens_action == 1:
-        slot.pop("max_tokens", None)
-    elif max_tokens_action == 2:
-        value = _prompt_positive_int(
+    return selected or (current_effort or None)
+
+
+def _edit_slot_parameters(
+    current: dict[str, Any], provider: dict[str, Any] | None, *, role: str
+) -> dict[str, Any]:
+    slot = dict(current)
+    if role == "reference":
+        current_max_tokens = slot.get("max_tokens")
+        max_tokens_label = current_max_tokens if isinstance(current_max_tokens, int) else "preset default"
+        max_tokens_action = _prompt_choice(
             "Max tokens",
-            current_max_tokens if isinstance(current_max_tokens, int) else None,
+            [
+                f"Keep current ({max_tokens_label})",
+                "Use preset default (unset override)",
+                "Set custom limit",
+            ],
         )
-        if value is not None:
-            slot["max_tokens"] = value
+        if max_tokens_action == 1:
+            slot.pop("max_tokens", None)
+        elif max_tokens_action == 2:
+            value = _prompt_positive_int(
+                "Max tokens",
+                current_max_tokens if isinstance(current_max_tokens, int) else None,
+            )
+            if value is not None:
+                slot["max_tokens"] = value
+    else:
+        slot.pop("max_tokens", None)
 
     current_effort = str(slot.get("reasoning_effort") or "").strip().lower()
-    effort_label = current_effort or "provider default"
-    effort_action = _prompt_choice(
-        "Reasoning effort",
-        [
-            f"Keep current ({effort_label})",
-            "Use provider default (unset override)",
-            *_REASONING_EFFORTS,
-        ],
-    )
-    if effort_action == 1:
-        slot.pop("reasoning_effort", None)
-    elif effort_action >= 2:
-        slot["reasoning_effort"] = _REASONING_EFFORTS[effort_action - 2]
+    if provider is not None:
+        effort = _slot_reasoning_effort(
+            provider, str(slot.get("model") or ""), current_effort
+        )
+        if effort:
+            slot["reasoning_effort"] = effort
     return slot
 
 
-def _pick_slot(current: dict[str, Any] | None = None) -> dict[str, Any]:
+def _pick_slot(
+    current: dict[str, Any] | None = None, *, role: str = "reference"
+) -> dict[str, Any]:
     if current:
+        parameter_label = (
+            "reasoning_effort"
+            if role == "aggregator"
+            else "max_tokens / reasoning_effort"
+        )
         action = _prompt_choice(
             "Edit existing slot",
             [
-                "Keep provider/model; edit max_tokens / reasoning_effort",
+                f"Keep provider/model; edit {parameter_label}",
                 "Change provider/model",
             ],
         )
         if action == 0:
-            return _edit_slot_parameters(current)
+            providers = _model_options()
+            return _edit_slot_parameters(
+                current, _provider_for_slot(providers, current), role=role
+            )
 
     providers = _model_options()
     if not providers:
@@ -138,7 +170,11 @@ def _pick_slot(current: dict[str, Any] | None = None) -> dict[str, Any]:
     current_model = (current or {}).get("model", "")
     model_default = models.index(current_model) if current_model in models else 0
     model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
-    return {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    slot = {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    effort = _slot_reasoning_effort(provider, str(model))
+    if effort:
+        slot["reasoning_effort"] = effort
+    return slot
 
 
 def _format_slot(slot: dict[str, Any]) -> str:
@@ -183,7 +219,7 @@ def cmd_moa(args) -> None:
         idx = 0
         while True:
             base = existing[idx] if idx < len(existing) else None
-            picked = _pick_slot(base)
+            picked = _pick_slot(base, role="reference")
             picked["enabled"] = bool((base or {}).get("enabled", True))
             refs.append(picked)
             idx += 1
@@ -193,7 +229,7 @@ def cmd_moa(args) -> None:
         print("Configure aggregator model.")
         current = dict(current)
         current["reference_models"] = refs
-        current["aggregator"] = _pick_slot(current.get("aggregator"))
+        current["aggregator"] = _pick_slot(current.get("aggregator"), role="aggregator")
         moa["presets"][preset_name] = current
         moa.setdefault("default_preset", preset_name)
         cfg["moa"] = normalize_moa_config(moa)

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -75,16 +75,18 @@ def _provider_for_slot(
     return next((provider for provider in providers if provider.get("slug") == provider_slug), None)
 
 
-def _model_supports_reasoning(provider: dict[str, Any], model: str) -> bool:
+def _model_supports_reasoning(provider: dict[str, Any], model: str) -> bool | None:
     capabilities = provider.get("capabilities")
     model_capabilities = capabilities.get(model) if isinstance(capabilities, dict) else None
-    return isinstance(model_capabilities, dict) and bool(model_capabilities.get("reasoning"))
+    if not isinstance(model_capabilities, dict) or "reasoning" not in model_capabilities:
+        return None
+    return bool(model_capabilities["reasoning"])
 
 
 def _slot_reasoning_effort(
     provider: dict[str, Any], model: str, current_effort: str = ""
 ) -> str | None:
-    if not _model_supports_reasoning(provider, model):
+    if _model_supports_reasoning(provider, model) is not True:
         return None
 
     from hermes_cli.main import _prompt_reasoning_effort_selection
@@ -124,11 +126,24 @@ def _edit_slot_parameters(
 
     current_effort = str(slot.get("reasoning_effort") or "").strip().lower()
     if provider is not None:
-        effort = _slot_reasoning_effort(
-            provider, str(slot.get("model") or ""), current_effort
-        )
-        if effort:
-            slot["reasoning_effort"] = effort
+        model = str(slot.get("model") or "")
+        reasoning_support = _model_supports_reasoning(provider, model)
+        if reasoning_support is False:
+            slot.pop("reasoning_effort", None)
+        elif reasoning_support is True:
+            effort_action = _prompt_choice(
+                "Reasoning effort",
+                [
+                    "Keep or change reasoning effort",
+                    "Use provider default (unset override)",
+                ],
+            )
+            if effort_action == 1:
+                slot.pop("reasoning_effort", None)
+            else:
+                effort = _slot_reasoning_effort(provider, model, current_effort)
+                if effort:
+                    slot["reasoning_effort"] = effort
     return slot
 
 
@@ -171,7 +186,13 @@ def _pick_slot(
     model_default = models.index(current_model) if current_model in models else 0
     model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
     slot = {"provider": str(provider.get("slug") or ""), "model": str(model)}
-    effort = _slot_reasoning_effort(provider, str(model))
+    same_model = slot["provider"] == current_provider and slot["model"] == current_model
+    current_effort = (
+        str((current or {}).get("reasoning_effort") or "").strip().lower()
+        if same_model
+        else ""
+    )
+    effort = _slot_reasoning_effort(provider, str(model), current_effort)
     if effort:
         slot["reasoning_effort"] = effort
     return slot

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+from hermes_constants import VALID_REASONING_EFFORTS
 from hermes_cli.config import load_config, save_config
 from hermes_cli.inventory import build_models_payload, load_picker_context
 from hermes_cli.moa_config import DEFAULT_MOA_PRESET_NAME, normalize_moa_config
@@ -49,7 +50,78 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
-def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
+_REASONING_EFFORTS = ("none", *VALID_REASONING_EFFORTS)
+
+
+def _prompt_positive_int(title: str, current: int | None = None) -> int | None:
+    suffix = f" [{current}]" if current is not None else ""
+    while True:
+        try:
+            raw = input(f"{title}{suffix}: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            return current
+        if not raw:
+            return current
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+        print("Please enter a positive integer, or leave blank to keep the current value.")
+
+
+def _edit_slot_parameters(current: dict[str, Any]) -> dict[str, Any]:
+    slot = dict(current)
+    current_max_tokens = slot.get("max_tokens")
+    max_tokens_label = current_max_tokens if isinstance(current_max_tokens, int) else "preset default"
+    max_tokens_action = _prompt_choice(
+        "Max tokens",
+        [
+            f"Keep current ({max_tokens_label})",
+            "Use preset default (unset override)",
+            "Set custom limit",
+        ],
+    )
+    if max_tokens_action == 1:
+        slot.pop("max_tokens", None)
+    elif max_tokens_action == 2:
+        value = _prompt_positive_int(
+            "Max tokens",
+            current_max_tokens if isinstance(current_max_tokens, int) else None,
+        )
+        if value is not None:
+            slot["max_tokens"] = value
+
+    current_effort = str(slot.get("reasoning_effort") or "").strip().lower()
+    effort_label = current_effort or "provider default"
+    effort_action = _prompt_choice(
+        "Reasoning effort",
+        [
+            f"Keep current ({effort_label})",
+            "Use provider default (unset override)",
+            *_REASONING_EFFORTS,
+        ],
+    )
+    if effort_action == 1:
+        slot.pop("reasoning_effort", None)
+    elif effort_action >= 2:
+        slot["reasoning_effort"] = _REASONING_EFFORTS[effort_action - 2]
+    return slot
+
+
+def _pick_slot(current: dict[str, Any] | None = None) -> dict[str, Any]:
+    if current:
+        action = _prompt_choice(
+            "Edit existing slot",
+            [
+                "Keep provider/model; edit max_tokens / reasoning_effort",
+                "Change provider/model",
+            ],
+        )
+        if action == 0:
+            return _edit_slot_parameters(current)
+
     providers = _model_options()
     if not providers:
         raise RuntimeError("No configured model providers found. Run `hermes model` first.")

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -127,6 +127,27 @@ def test_replacing_with_changed_model_does_not_carry_effort_when_selection_is_sk
     assert slot == {"provider": "openai-codex", "model": "gpt-5.6-sol"}
 
 
+def test_replacing_with_non_reasoning_model_reports_dropped_override(capsys):
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[1, 0, 1]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {"provider": "openrouter", "model": "openai/gpt-4.1"}
+    prompt.assert_not_called()
+    assert "does not support reasoning" in capsys.readouterr().out
+
+
+def test_replacing_non_reasoning_model_without_override_prints_no_notice(capsys):
+    current = {key: value for key, value in CURRENT.items() if key != "reasoning_effort"}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[1, 0, 1]
+    ):
+        _pick_slot(current)
+
+    assert capsys.readouterr().out == ""
+
+
 def test_custom_max_tokens_reprompts_until_positive_integer(capsys):
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
         "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2, 0]
@@ -176,6 +197,42 @@ def test_unknown_reasoning_capability_preserves_existing_override():
 
     assert slot == CURRENT
     prompt.assert_not_called()
+
+
+@pytest.mark.parametrize("can_disable", [True, None])
+def test_reasoning_prompt_allows_disable_when_not_explicitly_forbidden(can_disable):
+    capability = {"reasoning": True}
+    if can_disable is not None:
+        capability["can_disable_reasoning"] = can_disable
+    provider = {**PROVIDER, "capabilities": {CURRENT["model"]: capability}}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 0]
+    ), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+    ) as prompt:
+        _pick_slot(CURRENT)
+
+    assert prompt.call_args.kwargs["allow_disable"] is True
+
+
+def test_mandatory_reasoning_model_hides_disable_and_drops_stale_disabled_override(capsys):
+    provider = {
+        **PROVIDER,
+        "capabilities": {
+            CURRENT["model"]: {"reasoning": True, "can_disable_reasoning": False}
+        },
+    }
+    current = {**CURRENT, "reasoning_effort": "none"}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 0]
+    ), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+    ) as prompt:
+        slot = _pick_slot(current)
+
+    assert "reasoning_effort" not in slot
+    assert prompt.call_args.kwargs == {"current_effort": "", "allow_disable": False}
+    assert "requires reasoning" in capsys.readouterr().out
 
 
 def test_existing_slot_parameter_editor_can_unset_reasoning_effort():

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -235,6 +235,26 @@ def test_mandatory_reasoning_model_hides_disable_and_drops_stale_disabled_overri
     assert "requires reasoning" in capsys.readouterr().out
 
 
+def test_same_mandatory_model_replacement_reports_dropped_disabled_override(capsys):
+    provider = {
+        **PROVIDER,
+        "capabilities": {
+            CURRENT["model"]: {"reasoning": True, "can_disable_reasoning": False}
+        },
+    }
+    current = {**CURRENT, "reasoning_effort": "none"}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[1, 0, 0]
+    ), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+    ) as prompt:
+        slot = _pick_slot(current)
+
+    assert "reasoning_effort" not in slot
+    assert prompt.call_args.kwargs == {"current_effort": "", "allow_disable": False}
+    assert "requires reasoning" in capsys.readouterr().out
+
+
 def test_existing_slot_parameter_editor_can_unset_reasoning_effort():
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
         "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 1]

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.moa_cmd import _pick_slot, cmd_moa
+import pytest
+
+from hermes_cli.moa_cmd import _pick_slot, _prompt_positive_int, cmd_moa
 
 
 CURRENT = {
@@ -137,7 +139,20 @@ def test_custom_max_tokens_reprompts_until_positive_integer(capsys):
     assert capsys.readouterr().out.count("positive integer") == 2
 
 
-def test_non_reasoning_slot_does_not_offer_reasoning_control():
+def test_custom_max_tokens_keyboard_interrupt_aborts_edit():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2]
+    ), patch("builtins.input", side_effect=KeyboardInterrupt):
+        with pytest.raises(KeyboardInterrupt):
+            _pick_slot(CURRENT)
+
+
+def test_custom_max_tokens_eof_keeps_current_value():
+    with patch("builtins.input", side_effect=EOFError):
+        assert _prompt_positive_int("Max tokens", 600) == 600
+
+
+def test_non_reasoning_slot_does_not_offer_reasoning_control(capsys):
     current = {**CURRENT, "model": "openai/gpt-4.1"}
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
         "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
@@ -146,6 +161,10 @@ def test_non_reasoning_slot_does_not_offer_reasoning_control():
 
     assert slot == {key: value for key, value in current.items() if key != "reasoning_effort"}
     prompt.assert_not_called()
+    assert (
+        "Note: openrouter:openai/gpt-4.1 does not support reasoning; "
+        "dropping the existing reasoning_effort override."
+    ) in capsys.readouterr().out
 
 
 def test_unknown_reasoning_capability_preserves_existing_override():

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -29,7 +29,7 @@ PROVIDER = {
 
 def test_existing_slot_parameters_can_be_edited_without_model_picker():
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
-        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2]
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2, 0]
     ) as choice, patch("builtins.input", return_value="1200") as prompt, patch(
         "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
     ):
@@ -46,12 +46,13 @@ def test_existing_slot_parameters_can_be_edited_without_model_picker():
     assert [call.args[0] for call in choice.call_args_list] == [
         "Edit existing slot",
         "Max tokens",
+        "Reasoning effort",
     ]
 
 
 def test_existing_slot_parameter_editor_can_keep_current_values():
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
-        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 0]
     ), patch("builtins.input", side_effect=AssertionError("value prompt must not run")), patch(
         "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
     ):
@@ -60,7 +61,7 @@ def test_existing_slot_parameter_editor_can_keep_current_values():
 
 def test_existing_slot_parameter_editor_can_clear_max_tokens_override():
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
-        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 1]
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 1, 0]
     ), patch("builtins.input", side_effect=AssertionError("value prompt must not run")), patch(
         "hermes_cli.main._prompt_reasoning_effort_selection", return_value="none"
     ):
@@ -96,9 +97,37 @@ def test_existing_slot_can_still_change_provider_and_model():
     }
 
 
+def test_replacing_with_same_model_preserves_effort_when_selection_is_skipped():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[1, 0, 0]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value=None):
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4.8",
+        "reasoning_effort": "low",
+    }
+
+
+def test_replacing_with_changed_model_does_not_carry_effort_when_selection_is_skipped():
+    provider = {
+        "slug": "openai-codex",
+        "name": "OpenAI Codex",
+        "models": ["gpt-5.6-sol"],
+        "capabilities": {"gpt-5.6-sol": {"reasoning": True}},
+    }
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[1, 0, 0]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value=None):
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {"provider": "openai-codex", "model": "gpt-5.6-sol"}
+
+
 def test_custom_max_tokens_reprompts_until_positive_integer(capsys):
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
-        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2]
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2, 0]
     ), patch("builtins.input", side_effect=["invalid", "0", "2048"]), patch(
         "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
     ):
@@ -115,21 +144,45 @@ def test_non_reasoning_slot_does_not_offer_reasoning_control():
     ), patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
         slot = _pick_slot(current)
 
-    assert slot == current
+    assert slot == {key: value for key, value in current.items() if key != "reasoning_effort"}
+    prompt.assert_not_called()
+
+
+def test_unknown_reasoning_capability_preserves_existing_override():
+    provider = {**PROVIDER, "capabilities": {}}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[provider]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
+        slot = _pick_slot(CURRENT)
+
+    assert slot == CURRENT
+    prompt.assert_not_called()
+
+
+def test_existing_slot_parameter_editor_can_unset_reasoning_effort():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 1]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {key: value for key, value in CURRENT.items() if key != "reasoning_effort"}
     prompt.assert_not_called()
 
 
 def test_aggregator_editor_does_not_offer_or_persist_max_tokens():
     with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
-        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0]
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
     ) as choice, patch(
         "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
     ):
         slot = _pick_slot(CURRENT, role="aggregator")
 
     assert "max_tokens" not in slot
-    assert choice.call_count == 1
-    assert choice.call_args.args[1][0] == "Keep provider/model; edit reasoning_effort"
+    assert [call.args[0] for call in choice.call_args_list] == [
+        "Edit existing slot",
+        "Reasoning effort",
+    ]
+    assert choice.call_args_list[0].args[1][0] == "Keep provider/model; edit reasoning_effort"
 
 
 def test_configure_marks_reference_and_aggregator_slot_roles():

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -2,9 +2,10 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from unittest.mock import patch
 
-from hermes_cli.moa_cmd import _pick_slot
+from hermes_cli.moa_cmd import _pick_slot, cmd_moa
 
 
 CURRENT = {
@@ -15,14 +16,22 @@ CURRENT = {
     "reasoning_effort": "low",
 }
 
+PROVIDER = {
+    "slug": "openrouter",
+    "name": "OpenRouter",
+    "models": ["anthropic/claude-opus-4.8", "openai/gpt-4.1"],
+    "capabilities": {
+        "anthropic/claude-opus-4.8": {"reasoning": True},
+        "openai/gpt-4.1": {"reasoning": False},
+    },
+}
+
 
 def test_existing_slot_parameters_can_be_edited_without_model_picker():
-    with patch(
-        "hermes_cli.moa_cmd._prompt_choice",
-        side_effect=[0, 2, 6],  # edit, set max_tokens, high effort
-    ), patch("builtins.input", return_value="1200") as prompt, patch(
-        "hermes_cli.moa_cmd._model_options",
-        side_effect=AssertionError("provider/model picker must not run"),
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2]
+    ) as choice, patch("builtins.input", return_value="1200") as prompt, patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
     ):
         slot = _pick_slot(CURRENT)
 
@@ -34,18 +43,26 @@ def test_existing_slot_parameters_can_be_edited_without_model_picker():
         "reasoning_effort": "high",
     }
     prompt.assert_called_once()
+    assert [call.args[0] for call in choice.call_args_list] == [
+        "Edit existing slot",
+        "Max tokens",
+    ]
 
 
 def test_existing_slot_parameter_editor_can_keep_current_values():
-    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 0]), patch(
-        "builtins.input", side_effect=AssertionError("value prompt must not run")
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+    ), patch("builtins.input", side_effect=AssertionError("value prompt must not run")), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
     ):
         assert _pick_slot(CURRENT) == CURRENT
 
 
-def test_existing_slot_parameter_editor_can_clear_overrides():
-    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 1, 1]), patch(
-        "builtins.input", side_effect=AssertionError("value prompt must not run")
+def test_existing_slot_parameter_editor_can_clear_max_tokens_override():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 1]
+    ), patch("builtins.input", side_effect=AssertionError("value prompt must not run")), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value="none"
     ):
         slot = _pick_slot(CURRENT)
 
@@ -53,25 +70,87 @@ def test_existing_slot_parameter_editor_can_clear_overrides():
         "provider": "openrouter",
         "model": "anthropic/claude-opus-4.8",
         "enabled": False,
+        "reasoning_effort": "none",
     }
 
 
 def test_existing_slot_can_still_change_provider_and_model():
-    providers = [{"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.6-sol"]}]
+    providers = [
+        {
+            "slug": "openai-codex",
+            "name": "OpenAI Codex",
+            "models": ["gpt-5.6-sol"],
+            "capabilities": {"gpt-5.6-sol": {"reasoning": True}},
+        }
+    ]
     with patch("hermes_cli.moa_cmd._model_options", return_value=providers), patch(
         "hermes_cli.moa_cmd._prompt_choice",
         side_effect=[1, 0, 0],  # change model, provider, model
-    ):
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value="medium"):
         slot = _pick_slot(CURRENT)
 
-    assert slot == {"provider": "openai-codex", "model": "gpt-5.6-sol"}
+    assert slot == {
+        "provider": "openai-codex",
+        "model": "gpt-5.6-sol",
+        "reasoning_effort": "medium",
+    }
 
 
 def test_custom_max_tokens_reprompts_until_positive_integer(capsys):
-    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2, 0]), patch(
-        "builtins.input", side_effect=["invalid", "0", "2048"]
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2]
+    ), patch("builtins.input", side_effect=["invalid", "0", "2048"]), patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
     ):
         slot = _pick_slot(CURRENT)
 
     assert slot["max_tokens"] == 2048
     assert capsys.readouterr().out.count("positive integer") == 2
+
+
+def test_non_reasoning_slot_does_not_offer_reasoning_control():
+    current = {**CURRENT, "model": "openai/gpt-4.1"}
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+    ), patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
+        slot = _pick_slot(current)
+
+    assert slot == current
+    prompt.assert_not_called()
+
+
+def test_aggregator_editor_does_not_offer_or_persist_max_tokens():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0]
+    ) as choice, patch(
+        "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
+    ):
+        slot = _pick_slot(CURRENT, role="aggregator")
+
+    assert "max_tokens" not in slot
+    assert choice.call_count == 1
+    assert choice.call_args.args[1][0] == "Keep provider/model; edit reasoning_effort"
+
+
+def test_configure_marks_reference_and_aggregator_slot_roles():
+    config = {
+        "moa": {
+            "default_preset": "default",
+            "presets": {
+                "default": {
+                    "reference_models": [CURRENT],
+                    "aggregator": CURRENT,
+                }
+            },
+        }
+    }
+    with patch("hermes_cli.moa_cmd.load_config", return_value=config), patch(
+        "hermes_cli.moa_cmd._pick_slot",
+        side_effect=[dict(CURRENT), dict(CURRENT)],
+    ) as pick_slot, patch("hermes_cli.moa_cmd._prompt_choice", return_value=1), patch(
+        "hermes_cli.moa_cmd.save_config"
+    ), patch("hermes_cli.moa_cmd._print_config"):
+        cmd_moa(SimpleNamespace(moa_command="configure", name="default"))
+
+    assert pick_slot.call_args_list[0].kwargs == {"role": "reference"}
+    assert pick_slot.call_args_list[1].kwargs == {"role": "aggregator"}

--- a/tests/hermes_cli/test_moa_edit_slot_parameters.py
+++ b/tests/hermes_cli/test_moa_edit_slot_parameters.py
@@ -1,0 +1,77 @@
+"""Regression tests for editing existing MoA slot parameters in place."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from hermes_cli.moa_cmd import _pick_slot
+
+
+CURRENT = {
+    "provider": "openrouter",
+    "model": "anthropic/claude-opus-4.8",
+    "enabled": False,
+    "max_tokens": 600,
+    "reasoning_effort": "low",
+}
+
+
+def test_existing_slot_parameters_can_be_edited_without_model_picker():
+    with patch(
+        "hermes_cli.moa_cmd._prompt_choice",
+        side_effect=[0, 2, 6],  # edit, set max_tokens, high effort
+    ), patch("builtins.input", return_value="1200") as prompt, patch(
+        "hermes_cli.moa_cmd._model_options",
+        side_effect=AssertionError("provider/model picker must not run"),
+    ):
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4.8",
+        "enabled": False,
+        "max_tokens": 1200,
+        "reasoning_effort": "high",
+    }
+    prompt.assert_called_once()
+
+
+def test_existing_slot_parameter_editor_can_keep_current_values():
+    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0, 0]), patch(
+        "builtins.input", side_effect=AssertionError("value prompt must not run")
+    ):
+        assert _pick_slot(CURRENT) == CURRENT
+
+
+def test_existing_slot_parameter_editor_can_clear_overrides():
+    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 1, 1]), patch(
+        "builtins.input", side_effect=AssertionError("value prompt must not run")
+    ):
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "anthropic/claude-opus-4.8",
+        "enabled": False,
+    }
+
+
+def test_existing_slot_can_still_change_provider_and_model():
+    providers = [{"slug": "openai-codex", "name": "OpenAI Codex", "models": ["gpt-5.6-sol"]}]
+    with patch("hermes_cli.moa_cmd._model_options", return_value=providers), patch(
+        "hermes_cli.moa_cmd._prompt_choice",
+        side_effect=[1, 0, 0],  # change model, provider, model
+    ):
+        slot = _pick_slot(CURRENT)
+
+    assert slot == {"provider": "openai-codex", "model": "gpt-5.6-sol"}
+
+
+def test_custom_max_tokens_reprompts_until_positive_integer(capsys):
+    with patch("hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 2, 0]), patch(
+        "builtins.input", side_effect=["invalid", "0", "2048"]
+    ):
+        slot = _pick_slot(CURRENT)
+
+    assert slot["max_tokens"] == 2048
+    assert capsys.readouterr().out.count("positive integer") == 2

--- a/tests/hermes_cli/test_reasoning_effort_menu.py
+++ b/tests/hermes_cli/test_reasoning_effort_menu.py
@@ -23,3 +23,18 @@ def test_reasoning_menu_orders_minimal_before_low(monkeypatch):
         "medium  ← currently in use",
         "high",
     ]
+
+
+def test_reasoning_menu_can_hide_disable_for_mandatory_models(monkeypatch):
+    captured = {}
+
+    def _fake_radiolist(title, items, *, selected=0, cancel_returns=None, description=None):
+        captured["items"] = items
+        return len(items) - 1
+
+    monkeypatch.setattr("hermes_cli.curses_ui.curses_radiolist", _fake_radiolist)
+
+    assert _prompt_reasoning_effort_selection(
+        ["low", "medium", "high"], allow_disable=False
+    ) is None
+    assert captured["items"] == ["low", "medium", "high", "Skip (keep current)"]


### PR DESCRIPTION
## What does this PR do?

Users can now retune an existing MoA slot's output cap or reasoning effort without walking through provider and model selection again. The configure flow preserves the selected provider/model and other slot state while still retaining the full replacement path.

### Symptom

`hermes moa configure` always opens the provider and model pickers for an existing slot, even when the user only wants to adjust `max_tokens` or `reasoning_effort`.

### Impact

Repeated tuning is slower and exposes an already-correct provider/model pairing to accidental replacement.

### Bug Cause

**Trigger:** `hermes_cli/moa_cmd.py:53` / `_pick_slot(current)`

**Causal chain:**
1. The configure flow passes an existing slot into `_pick_slot`.
2. `_pick_slot` uses the existing provider/model only as picker defaults and immediately opens both selection menus.
3. It reconstructs the slot from only the selected provider/model, so parameter-only tuning still requires model selection and drops existing slot overrides.

**Why it is wrong:** Existing slots and new slots were forced through the same all-or-nothing selection path even though only new slots require provider/model discovery.

**Working sibling / contrast:** New slots still use the complete provider/model flow because they have no identity or inference parameters to preserve.

**Ruled out:** Provider inventory behavior is not the cause; the unnecessary selection occurs before any distinction between parameter editing and model replacement exists.

### Fix

Existing slots now offer a first menu with two explicit paths. The lightweight path edits `max_tokens` and `reasoning_effort` in place, including keep and unset choices, without loading provider/model inventory. The replacement path retains the existing full picker behavior. Positive integer validation prevents invalid custom token caps from being saved.

## Related Issue

Closes #102585

## Type of Change

- [x] Bug fix

## Changes Made

- `hermes_cli/moa_cmd.py` - add an in-place editor for existing slot inference parameters and retain the full model replacement path.
- `tests/hermes_cli/test_moa_edit_slot_parameters.py` - cover edit, keep, clear, replacement, validation, and no-inventory behavior.

## How to Test

1. Run the targeted MoA CLI tests:

```bash
scripts/run_tests.sh tests/cli/test_moa_command.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_moa_edit_slot_parameters.py tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py -q
```

2. Verify all 19 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry point on the relevant tests and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; the existing command remains self-explanatory
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] Cross-platform impact was considered; the implementation uses existing curses/input abstractions
- [x] Tool descriptions and schemas are N/A; no model tool changed
