### PR TITLE
fix(kanban): terminate live worker on schedule_task and block_task transitions (#102423)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2913,12 +2913,16 @@ def block_task(
     so a forever-flaky task escalates. True on any transition."""
     if kind is not None and kind not in VALID_BLOCK_KINDS:
         raise ValueError(f"block kind must be one of {sorted(VALID_BLOCK_KINDS)} or None")
-    with write_txn(conn):
+    caller_owns_txn = bool(getattr(conn, "in_transaction", False))
+    termination: Optional[tuple[Optional[int], Optional[str]]] = None
+    with write_txn(conn, allow_nested=True):
         cur_row = conn.execute(
-            "SELECT status, block_kind, block_recurrences FROM tasks WHERE id = ?", (task_id,),
+            "SELECT status, block_kind, block_recurrences, worker_pid, claim_lock FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
         if cur_row is None:
             return False
+        if cur_row["status"] == "running":
+            termination = (cur_row["worker_pid"], cur_row["claim_lock"])
         source_status = _retry_status_for_run(conn, task_id) if cur_row["status"] == "running" else "ready"
         new_status, event_kind, set_sql, params, payload = _route_block(
             kind, reason, source_status, prev_kind=_row_get(cur_row, "block_kind"),
@@ -2948,7 +2952,11 @@ def block_task(
         if kind == "dependency":
             # Historical ordering: the dependency lane fires inside the txn.
             _fire_task_hook("kanban_task_blocked", blocked_task, task_id, run_id, reason=reason)
+            if termination and not caller_owns_txn:
+                _terminate_reclaimed_worker(termination[0], termination[1])
             return True
+    if termination and not caller_owns_txn:
+        _terminate_reclaimed_worker(termination[0], termination[1])
     _fire_task_hook("kanban_task_blocked", blocked_task, task_id, run_id, reason=reason)
     return True
 
@@ -3690,7 +3698,15 @@ def schedule_task(
 ) -> bool:
     """Park in ``scheduled`` (waiting on time, not a human; not dispatchable)
     until ``unblock_task`` re-gates it."""
-    with write_txn(conn):
+    caller_owns_txn = bool(getattr(conn, "in_transaction", False))
+    termination: Optional[tuple[Optional[int], Optional[str]]] = None
+    with write_txn(conn, allow_nested=True):
+        cur_row = conn.execute(
+            "SELECT status, worker_pid, claim_lock FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if cur_row is not None and cur_row["status"] == "running":
+            termination = (cur_row["worker_pid"], cur_row["claim_lock"])
         params: list[Any] = [task_id]
         sql = """
             UPDATE tasks
@@ -3710,7 +3726,9 @@ def schedule_task(
             conn, task_id, outcome="scheduled", status="scheduled", summary=reason, synthesize=bool(reason),
         )
         _append_event(conn, task_id, "scheduled", {"reason": reason}, run_id=run_id)
-        return True
+    if termination and not caller_owns_txn:
+        _terminate_reclaimed_worker(termination[0], termination[1])
+    return True
 
 
 # --- Worker context builder (what a spawned worker sees) ---

--- a/tests/hermes_cli/test_kanban_worker_termination.py
+++ b/tests/hermes_cli/test_kanban_worker_termination.py
@@ -1,0 +1,120 @@
+"""Tests for worker termination on schedule_task and block_task transitions."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_db_connect as kbc
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kbc.init_db()
+    return home
+
+
+def test_schedule_running_task_terminates_worker(kanban_home, monkeypatch):
+    """Scheduling a running task terminates its worker process post-commit."""
+    mock_terminate = MagicMock(return_value={"terminated": True, "prev_pid": 12345})
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", mock_terminate)
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="Active task")
+        # Simulate worker claim and running state
+        conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'running',
+                   claim_lock = 'host1:uuid1',
+                   worker_pid = 12345
+             WHERE id = ?
+            """,
+            (task_id,),
+        )
+        conn.commit()
+
+        success = kb.schedule_task(conn, task_id, reason="Hold for later")
+        assert success is True
+
+        # Verify task state in database
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        assert row["status"] == "scheduled"
+        assert row["claim_lock"] is None
+        assert row["worker_pid"] is None
+
+        # Verify worker termination was invoked
+        mock_terminate.assert_called_once_with(12345, "host1:uuid1")
+
+
+def test_schedule_ready_task_does_not_terminate_worker(kanban_home, monkeypatch):
+    """Scheduling a ready (non-running) task does not attempt worker termination."""
+    mock_terminate = MagicMock()
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", mock_terminate)
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="Ready task")
+        success = kb.schedule_task(conn, task_id, reason="Hold for later")
+        assert success is True
+
+        mock_terminate.assert_not_called()
+
+
+def test_block_running_task_terminates_worker(kanban_home, monkeypatch):
+    """Blocking a running task terminates its worker process post-commit."""
+    mock_terminate = MagicMock(return_value={"terminated": True, "prev_pid": 54321})
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", mock_terminate)
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="Active task to block")
+        conn.execute(
+            """
+            UPDATE tasks
+               SET status = 'running',
+                   claim_lock = 'host2:uuid2',
+                   worker_pid = 54321
+             WHERE id = ?
+            """,
+            (task_id,),
+        )
+        conn.commit()
+
+        success = kb.block_task(conn, task_id, reason="Missing API token", kind="needs_input")
+        assert success is True
+
+        # Verify task state in database
+        row = conn.execute(
+            "SELECT status, claim_lock, worker_pid, block_kind FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        assert row["status"] == "blocked"
+        assert row["claim_lock"] is None
+        assert row["worker_pid"] is None
+        assert row["block_kind"] == "needs_input"
+
+        # Verify worker termination was invoked
+        mock_terminate.assert_called_once_with(54321, "host2:uuid2")
+
+
+def test_block_ready_task_does_not_terminate_worker(kanban_home, monkeypatch):
+    """Blocking a ready (non-running) task does not attempt worker termination."""
+    mock_terminate = MagicMock()
+    monkeypatch.setattr(kb, "_terminate_reclaimed_worker", mock_terminate)
+
+    with kbc.connect() as conn:
+        task_id = kb.create_task(conn, title="Ready task to block")
+        success = kb.block_task(conn, task_id, reason="Needs info", kind="needs_input")
+        assert success is True
+
+        mock_terminate.assert_not_called()


### PR DESCRIPTION
## What does this PR do?

When an operator or automation transitions a running Kanban card via `schedule_task` or `block_task` (e.g. `hermes kanban schedule` or `hermes kanban block`), the database transaction cleared `claim_lock`, `claim_expires`, and `worker_pid` and force-ended the run without terminating or checking the live worker process. When the card was later unblocked or rescheduled to ready, the dispatcher claimed it and spawned a second concurrent worker on the exact same card and workspace.

This change ensures that transitioning a `running` task via `schedule_task` or `block_task` terminates the host-local worker process post-commit via `_terminate_reclaimed_worker(worker_pid, claim_lock)`, mirroring the established pattern in `invalidate_descendant_tasks`.

## Related Issue

Fixes #102423

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [`hermes_cli/kanban_db.py`](file:///hermes_cli/kanban_db.py):
  - In `schedule_task`: inspect target task before update, capture `(worker_pid, claim_lock)` if status is `running`, and invoke `_terminate_reclaimed_worker` post-commit.
  - In `block_task`: inspect target task before update, capture `(worker_pid, claim_lock)` if status is `running`, and invoke `_terminate_reclaimed_worker` post-commit.
- [`tests/hermes_cli/test_kanban_worker_termination.py`](file:///tests/hermes_cli/test_kanban_worker_termination.py):
  - Added unit tests verifying `schedule_task` and `block_task` terminate running workers post-commit, while non-running tasks do not trigger termination.

## How to Test

1. Run unit test suite:
   ```bash
   pytest tests/hermes_cli/test_kanban_worker_termination.py -v
   ```
2. Verify all 4 tests pass.
3. Run related Kanban lifecycle test suites:
   ```bash
   pytest tests/hermes_cli/test_kanban_worker_lifecycle_hooks.py tests/hermes_cli/test_kanban_parent_reopen_invalidation.py tests/hermes_cli/test_kanban_write_guard.py -v
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (docstrings)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
