### PR TITLE
fix(moa): let configure set per-reference max token caps

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -52,7 +52,10 @@ def _model_options() -> list[dict[str, Any]]:
 def _prompt_max_tokens_override() -> int | None:
     """Return a per-reference token cap, or None to inherit the preset default."""
     while True:
-        raw = input("Max tokens override (blank to inherit preset default): ").strip()
+        try:
+            raw = input("Max tokens override (blank to inherit preset default): ").strip()
+        except (EOFError, KeyboardInterrupt):
+            raise SystemExit("\nMoA configuration cancelled.") from None
         if not raw:
             return None
         try:

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -49,7 +49,24 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
-def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
+def _prompt_max_tokens_override() -> int | None:
+    """Return a per-reference token cap, or None to inherit the preset default."""
+    while True:
+        raw = input("Max tokens override (blank to inherit preset default): ").strip()
+        if not raw:
+            return None
+        try:
+            value = int(raw)
+        except ValueError:
+            value = 0
+        if value > 0:
+            return value
+        print("Enter a positive integer, or leave blank to inherit the preset default.")
+
+
+def _pick_slot(
+    current: dict[str, Any] | None = None, *, configure_max_tokens: bool = True
+) -> dict[str, Any]:
     providers = _model_options()
     if not providers:
         raise RuntimeError("No configured model providers found. Run `hermes model` first.")
@@ -66,13 +83,27 @@ def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
     current_model = (current or {}).get("model", "")
     model_default = models.index(current_model) if current_model in models else 0
     model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
-    return {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    slot: dict[str, Any] = {
+        "provider": str(provider.get("slug") or ""),
+        "model": str(model),
+    }
+    if configure_max_tokens:
+        max_tokens = _prompt_max_tokens_override()
+        if max_tokens is not None:
+            slot["max_tokens"] = max_tokens
+    return slot
 
 
 def _format_slot(slot: dict[str, Any]) -> str:
     label = f"{slot['provider']}:{slot['model']}"
+    details: list[str] = []
     effort = str(slot.get("reasoning_effort") or "").strip()
-    return f"{label} [reasoning={effort}]" if effort else label
+    if effort:
+        details.append(f"reasoning={effort}")
+    max_tokens = slot.get("max_tokens")
+    if max_tokens is not None:
+        details.append(f"max_tokens={max_tokens}")
+    return f"{label} [{', '.join(details)}]" if details else label
 
 
 def _print_config(config: dict[str, Any]) -> None:
@@ -106,7 +137,7 @@ def cmd_moa(args) -> None:
         current = moa["presets"].get(preset_name, moa["presets"][moa["default_preset"]])
         print(f"Configure MoA preset: {preset_name}")
         print("Pick at least one reference model; choose Done when finished.")
-        refs: list[dict[str, str]] = []
+        refs: list[dict[str, Any]] = []
         existing = list(current.get("reference_models") or [])
         idx = 0
         while True:
@@ -121,7 +152,9 @@ def cmd_moa(args) -> None:
         print("Configure aggregator model.")
         current = dict(current)
         current["reference_models"] = refs
-        current["aggregator"] = _pick_slot(current.get("aggregator"))
+        current["aggregator"] = _pick_slot(
+            current.get("aggregator"), configure_max_tokens=False
+        )
         moa["presets"][preset_name] = current
         moa.setdefault("default_preset", preset_name)
         cfg["moa"] = normalize_moa_config(moa)

--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -94,14 +94,14 @@ def _pick_slot(
     return slot
 
 
-def _format_slot(slot: dict[str, Any]) -> str:
+def _format_slot(slot: dict[str, Any], *, include_max_tokens: bool = True) -> str:
     label = f"{slot['provider']}:{slot['model']}"
     details: list[str] = []
     effort = str(slot.get("reasoning_effort") or "").strip()
     if effort:
         details.append(f"reasoning={effort}")
     max_tokens = slot.get("max_tokens")
-    if max_tokens is not None:
+    if include_max_tokens and max_tokens is not None:
         details.append(f"max_tokens={max_tokens}")
     return f"{label} [{', '.join(details)}]" if details else label
 
@@ -119,7 +119,7 @@ def _print_config(config: dict[str, Any]) -> None:
         for idx, slot in enumerate(preset["reference_models"], start=1):
             print(f"    {idx}. {_format_slot(slot)}")
         agg = preset["aggregator"]
-        print(f"  Aggregator: {_format_slot(agg)}")
+        print(f"  Aggregator: {_format_slot(agg, include_max_tokens=False)}")
 
 
 def cmd_moa(args) -> None:

--- a/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
+++ b/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.moa_cmd import (
     _format_slot,
     _pick_slot,
@@ -50,6 +52,14 @@ def test_invalid_max_tokens_override_reprompts(capsys):
         assert _prompt_max_tokens_override() == 800
 
     assert capsys.readouterr().out.count("Enter a positive integer") == 2
+
+
+@pytest.mark.parametrize("interruption", [EOFError(), KeyboardInterrupt()])
+def test_max_tokens_override_interruptions_cancel_cleanly(interruption):
+    with patch("builtins.input", side_effect=interruption), pytest.raises(
+        SystemExit, match="MoA configuration cancelled"
+    ):
+        _prompt_max_tokens_override()
 
 
 def test_aggregator_slot_does_not_offer_reference_override():

--- a/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
+++ b/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
@@ -1,0 +1,75 @@
+"""CLI coverage for per-reference max_tokens overrides."""
+
+from unittest.mock import patch
+
+from hermes_cli.moa_cmd import (
+    _format_slot,
+    _pick_slot,
+    _prompt_max_tokens_override,
+)
+
+
+PROVIDER = {
+    "slug": "openrouter",
+    "name": "OpenRouter",
+    "models": ["deepseek/deepseek-v4-pro"],
+}
+
+
+def test_format_slot_shows_max_tokens_override():
+    assert _format_slot(
+        {
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-pro",
+            "max_tokens": 600,
+        }
+    ) == "openrouter:deepseek/deepseek-v4-pro [max_tokens=600]"
+
+
+def test_pick_reference_slot_prompts_for_max_tokens_override():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+    ), patch("builtins.input", return_value="600"):
+        slot = _pick_slot()
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "deepseek/deepseek-v4-pro",
+        "max_tokens": 600,
+    }
+
+
+def test_blank_max_tokens_override_inherits_preset_default():
+    with patch("builtins.input", return_value=""):
+        assert _prompt_max_tokens_override() is None
+
+
+def test_invalid_max_tokens_override_reprompts(capsys):
+    with patch("builtins.input", side_effect=["0", "many", "800"]):
+        assert _prompt_max_tokens_override() == 800
+
+    assert capsys.readouterr().out.count("Enter a positive integer") == 2
+
+
+def test_aggregator_slot_does_not_offer_reference_override():
+    with patch("hermes_cli.moa_cmd._model_options", return_value=[PROVIDER]), patch(
+        "hermes_cli.moa_cmd._prompt_choice", side_effect=[0, 0]
+    ), patch("builtins.input") as prompt:
+        slot = _pick_slot(configure_max_tokens=False)
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "deepseek/deepseek-v4-pro",
+    }
+    prompt.assert_not_called()
+
+
+def test_format_slot_shows_reasoning_and_max_tokens_overrides():
+    assert _format_slot(
+        {
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-pro",
+            "reasoning_effort": "low",
+            "max_tokens": 600,
+        }
+    ) == "openrouter:deepseek/deepseek-v4-pro [reasoning=low, max_tokens=600]"

--- a/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
+++ b/tests/hermes_cli/test_moa_slot_max_tokens_cli.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 from hermes_cli.moa_cmd import (
     _format_slot,
     _pick_slot,
+    _print_config,
     _prompt_max_tokens_override,
 )
 
@@ -62,6 +63,38 @@ def test_aggregator_slot_does_not_offer_reference_override():
         "model": "deepseek/deepseek-v4-pro",
     }
     prompt.assert_not_called()
+
+
+def test_print_config_hides_reference_only_override_on_aggregator(capsys):
+    _print_config(
+        {
+            "moa": {
+                "presets": {
+                    "custom": {
+                        "reference_models": [
+                            {
+                                "provider": "openrouter",
+                                "model": "reference",
+                                "max_tokens": 600,
+                            }
+                        ],
+                        "aggregator": {
+                            "provider": "openrouter",
+                            "model": "aggregator",
+                            "reasoning_effort": "high",
+                            "max_tokens": 777,
+                        },
+                    }
+                },
+                "default_preset": "custom",
+            }
+        }
+    )
+
+    output = capsys.readouterr().out
+    assert "openrouter:reference [max_tokens=600]" in output
+    assert "Aggregator: openrouter:aggregator [reasoning=high]" in output
+    assert "max_tokens=777" not in output
 
 
 def test_format_slot_shows_reasoning_and_max_tokens_overrides():


### PR DESCRIPTION
## What does this PR do?

`hermes moa configure` now lets users set an optional output-token cap for each reference model, so per-advisor cost and latency controls no longer require hand-editing config data. Leaving the prompt blank inherits the preset-level `reference_max_tokens`, and `hermes moa list` displays explicit slot overrides.

### Symptom

The interactive MoA configurator only selected a provider and model for each reference slot. Although the runtime and config normalizer already supported `reference_models[].max_tokens`, users could neither set that field through the CLI nor see it in list output.

### Impact

Users who need different output caps for verbose and terse advisors must know the internal config shape and edit it manually. The interactive CLI hides a supported cost and latency control.

### Bug Cause

**Trigger:** `hermes_cli/moa_cmd.py:_pick_slot` and `hermes_cli/moa_cmd.py:_format_slot`

**Causal chain:**
1. A user runs `hermes moa configure` and selects a reference provider and model.
2. `_pick_slot()` returns only `provider` and `model`, while `_format_slot()` only renders `reasoning_effort` metadata.
3. No CLI path persists or displays the slot's supported `max_tokens` override.

**Why it is wrong:** The interactive write and display paths omit a field already preserved by `_clean_slot()` and consumed by the reference-model runtime.

**Working sibling / contrast:** Hand-edited `reference_models[].max_tokens` values survive normalization and override the preset-level cap during reference calls.

**Ruled out:** The runtime and schema are not missing support; existing MoA tests confirm slot-level caps reach reference requests. The gap is confined to interactive configuration and display.

### Fix

Prompt for a positive integer after each reference-model selection, with blank input meaning preset inheritance. Keep the aggregator on its existing preset-level `max_tokens`, render all configured slot details together, and cover persistence, inheritance, validation, aggregator behavior, and list formatting.

## Related Issue

Closes #102584

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/moa_cmd.py` - collect optional per-reference `max_tokens` values and display configured overrides.
- `tests/hermes_cli/test_moa_slot_max_tokens_cli.py` - cover prompt validation, preset inheritance, aggregator exclusion, and list formatting.

## How to Test

1. Run `hermes moa configure`, select a reference model, and enter `600` at the max-tokens prompt.
2. Run `hermes moa list` and confirm that reference shows `[max_tokens=600]`.
3. Run the automated coverage:

```bash
scripts/run_tests.sh tests/hermes_cli/test_moa_slot_max_tokens_cli.py -q
scripts/run_tests.sh tests/hermes_cli/test_moa_config.py -q
scripts/run_tests.sh tests/agent/test_moa_slot_max_tokens.py -q
```

Observed locally: 15 tests passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation changes are N/A; the prompt and list output describe the behavior
- [x] `cli-config.yaml.example` changes are N/A; this exposes an existing config field
- [x] `CONTRIBUTING.md` and `AGENTS.md` changes are N/A; no architecture or workflow changed
- [x] Cross-platform impact considered; the implementation uses portable Python input and formatting
- [x] Tool description/schema changes are N/A; no model tool changed

## Screenshots / Logs

N/A; automated CLI behavior coverage is included.
