### PR TITLE
fix(sanitizer): recursively sanitize surrogates and non-ASCII in multipart and structured message content

### DIFF
--- a/agent/message_sanitization.py
+++ b/agent/message_sanitization.py
@@ -90,16 +90,13 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
         if not isinstance(msg, dict):
             continue
         content = msg.get("content")
-        if isinstance(content, str) and _SURROGATE_RE.search(content):
-            msg["content"] = _SURROGATE_RE.sub('\ufffd', content)
-            found = True
-        elif isinstance(content, list):
-            for part in content:
-                if isinstance(part, dict):
-                    text = part.get("text")
-                    if isinstance(text, str) and _SURROGATE_RE.search(text):
-                        part["text"] = _SURROGATE_RE.sub('\ufffd', text)
-                        found = True
+        if isinstance(content, str):
+            if _SURROGATE_RE.search(content):
+                msg["content"] = _SURROGATE_RE.sub('\ufffd', content)
+                found = True
+        elif isinstance(content, (dict, list)):
+            if _sanitize_structure_surrogates(content):
+                found = True
         name = msg.get("name")
         if isinstance(name, str) and _SURROGATE_RE.search(name):
             msg["name"] = _SURROGATE_RE.sub('\ufffd', name)
@@ -107,21 +104,8 @@ def _sanitize_messages_surrogates(messages: list) -> bool:
         tool_calls = msg.get("tool_calls")
         if isinstance(tool_calls, list):
             for tc in tool_calls:
-                if not isinstance(tc, dict):
-                    continue
-                tc_id = tc.get("id")
-                if isinstance(tc_id, str) and _SURROGATE_RE.search(tc_id):
-                    tc["id"] = _SURROGATE_RE.sub('\ufffd', tc_id)
-                    found = True
-                fn = tc.get("function")
-                if isinstance(fn, dict):
-                    fn_name = fn.get("name")
-                    if isinstance(fn_name, str) and _SURROGATE_RE.search(fn_name):
-                        fn["name"] = _SURROGATE_RE.sub('\ufffd', fn_name)
-                        found = True
-                    fn_args = fn.get("arguments")
-                    if isinstance(fn_args, str) and _SURROGATE_RE.search(fn_args):
-                        fn["arguments"] = _SURROGATE_RE.sub('\ufffd', fn_args)
+                if isinstance(tc, dict):
+                    if _sanitize_structure_surrogates(tc):
                         found = True
         # Walk any additional string / nested fields (reasoning,
         # reasoning_content, reasoning_details, etc.) — surrogates from
@@ -347,22 +331,16 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
     for msg in messages:
         if not isinstance(msg, dict):
             continue
-        # Sanitize content (string)
+        # Sanitize content (string or nested structures)
         content = msg.get("content")
         if isinstance(content, str):
             sanitized = _strip_non_ascii(content)
             if sanitized != content:
                 msg["content"] = sanitized
                 found = True
-        elif isinstance(content, list):
-            for part in content:
-                if isinstance(part, dict):
-                    text = part.get("text")
-                    if isinstance(text, str):
-                        sanitized = _strip_non_ascii(text)
-                        if sanitized != text:
-                            part["text"] = sanitized
-                            found = True
+        elif isinstance(content, (dict, list)):
+            if _sanitize_structure_non_ascii(content):
+                found = True
         # Sanitize name field (can contain non-ASCII in tool results)
         name = msg.get("name")
         if isinstance(name, str):
@@ -375,14 +353,8 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
         if isinstance(tool_calls, list):
             for tc in tool_calls:
                 if isinstance(tc, dict):
-                    fn = tc.get("function", {})
-                    if isinstance(fn, dict):
-                        fn_args = fn.get("arguments")
-                        if isinstance(fn_args, str):
-                            sanitized = _strip_non_ascii(fn_args)
-                            if sanitized != fn_args:
-                                fn["arguments"] = sanitized
-                                found = True
+                    if _sanitize_structure_non_ascii(tc):
+                        found = True
         # Sanitize any additional top-level string fields (e.g. reasoning_content)
         for key, value in msg.items():
             if key in {"content", "name", "tool_calls", "role"}:
@@ -391,6 +363,9 @@ def _sanitize_messages_non_ascii(messages: list) -> bool:
                 sanitized = _strip_non_ascii(value)
                 if sanitized != value:
                     msg[key] = sanitized
+                    found = True
+            elif isinstance(value, (dict, list)):
+                if _sanitize_structure_non_ascii(value):
                     found = True
     return found
 

--- a/tests/run_agent/test_unicode_ascii_codec.py
+++ b/tests/run_agent/test_unicode_ascii_codec.py
@@ -88,6 +88,61 @@ class TestSurrogateVsAsciiSanitization:
         messages = [{"role": "user", "content": "hello ⚕ world"}]
         assert _sanitize_messages_surrogates(messages) is False
 
+    def test_surrogates_in_multipart_string_list_sanitized(self):
+        """Multipart list of plain strings containing surrogates must be sanitized."""
+        messages = [{
+            "role": "user",
+            "content": ["First part clean", "Second part with surrogate \ud800 here"],
+        }]
+        assert _sanitize_messages_surrogates(messages) is True
+        assert "\ud800" not in messages[0]["content"][1]
+        assert "\ufffd" in messages[0]["content"][1]
+
+    def test_surrogates_in_multipart_thinking_and_tool_result_sanitized(self):
+        """Multipart structured parts (thinking blocks, tool results, citations) with surrogates are sanitized."""
+        messages = [{
+            "role": "assistant",
+            "content": [
+                {"type": "thinking", "thinking": "Internal thought with \ud800 surrogate"},
+                {"type": "tool_result", "content": "Tool output with \ud900 surrogate"},
+                {"type": "text", "text": "Clean visible text", "citations": [{"text": "cite \uda00"}]},
+            ],
+        }]
+        assert _sanitize_messages_surrogates(messages) is True
+        assert "\ud800" not in messages[0]["content"][0]["thinking"]
+        assert "\ufffd" in messages[0]["content"][0]["thinking"]
+        assert "\ud900" not in messages[0]["content"][1]["content"]
+        assert "\ufffd" in messages[0]["content"][1]["content"]
+        assert "\uda00" not in messages[0]["content"][2]["citations"][0]["text"]
+        assert "\ufffd" in messages[0]["content"][2]["citations"][0]["text"]
+
+    def test_surrogates_in_dict_content_sanitized(self):
+        """Dictionary content payload (Responses API format) with surrogates is sanitized."""
+        messages = [{
+            "role": "user",
+            "content": {"type": "input_text", "text": "Input prompt with \ud800 surrogate"},
+        }]
+        assert _sanitize_messages_surrogates(messages) is True
+        assert "\ud800" not in messages[0]["content"]["text"]
+        assert "\ufffd" in messages[0]["content"]["text"]
+
+    def test_non_ascii_in_multipart_and_dict_content_sanitized(self):
+        """Non-ASCII in multipart lists, structured parts, and dict content are stripped."""
+        messages = [
+            {
+                "role": "user",
+                "content": ["Part 1: 🤖", {"type": "text", "text": "Part 2: 你好"}],
+            },
+            {
+                "role": "assistant",
+                "content": {"type": "output_text", "text": "Output: ⚕"},
+            },
+        ]
+        assert _sanitize_messages_non_ascii(messages) is True
+        assert messages[0]["content"][0] == "Part 1: "
+        assert messages[0]["content"][1]["text"] == "Part 2: "
+        assert messages[1]["content"]["text"] == "Output: "
+
 
 class TestApiKeyNonAsciiSanitization:
     """Tests for API key sanitization in the UnicodeEncodeError recovery.


### PR DESCRIPTION
## What does this PR do?

When an upstream LLM API request encounters a `UnicodeEncodeError` (e.g., from un-paired UTF-16 surrogates or encoding mismatches), `run_agent.py` attempts message sanitization via `_sanitize_messages_surrogates()` and `_sanitize_messages_non_ascii()`.

Previously, these sanitizers only inspected scalar string `msg["content"]` and the `text` field of dictionary parts in `content: list[dict]`. They did not sanitize:
1. Multipart list messages containing plain strings (`content: list[str]`).
2. Structured content parts with non-text keys (such as `thinking`, `thought`, `citations`, or `tool_result` content dictionaries).
3. Dict-shaped `content` structures (used by OpenAI Responses / Codex formats).
4. Nested dictionary/list fields within `tool_calls` arguments.

This change ensures `_sanitize_messages_surrogates()` and `_sanitize_messages_non_ascii()` recursively sanitize nested strings across arbitrary structured/multipart content blocks and dict payloads using `_sanitize_structure_surrogates()` and `_sanitize_structure_non_ascii()`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- [`run_agent.py`](file:///run_agent.py):
  - Updated `_sanitize_messages_surrogates()` to use `_sanitize_structure_surrogates()` on list and dict `content` structures and tool calls.
  - Updated `_sanitize_messages_non_ascii()` to recursively clean nested dicts/lists in `content` and tool calls using `_sanitize_structure_non_ascii()`.
- [`tests/run_agent/test_unicode_ascii_codec.py`](file:///tests/run_agent/test_unicode_ascii_codec.py):
  - Added unit tests covering surrogates and non-ASCII sanitization across multipart string lists, thinking blocks, tool result parts, and dictionary content shapes.

## How to Test

```bash
pytest tests/run_agent/test_unicode_ascii_codec.py -v
```

All 21 tests pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/` and relevant tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11
