### PR TITLE
fix(cron): reject unsupported inherited models

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6475,6 +6475,23 @@ def run_job(
             or configured_provider_for_drift
             or None
         )
+
+        # Validate before provider resolution whenever config identifies a
+        # closed-catalog provider. That keeps target_model/api_mode atomic: the
+        # runtime resolver never derives transport settings from a stale slug.
+        from hermes_cli.models import validate_strict_provider_model
+
+        _pre_model_verdict, _pre_validated_model = validate_strict_provider_model(
+            str(primary_provider_for_drift or ""), str(model)
+        )
+        if _pre_model_verdict is False and not _pre_validated_model:
+            raise RuntimeError(
+                f"Unsupported model {model!r} for provider "
+                f"{primary_provider_for_drift!r}; no safe default is available"
+            )
+        if _pre_model_verdict is not None:
+            model = _pre_validated_model
+
         try:
             # Do not inject HERMES_INFERENCE_PROVIDER here. resolve_runtime_provider()
             # already prefers persisted config over stale shell/env overrides when
@@ -6560,6 +6577,44 @@ def run_job(
                     logger.debug("Job '%s': fallback %s failed: %s", job_id, fb_provider, fb_exc)
             if runtime is None:
                 raise RuntimeError(format_runtime_provider_error(resolve_exc)) from resolve_exc
+
+        # A persisted model can outlive a closed provider catalog. Reject the
+        # stale ID before AIAgent is constructed and fall back within the SAME
+        # provider; never turn a bad slug into cross-provider routing or a 400.
+        # Open/dynamic/custom catalogs return ``None`` and remain untouched.
+        from hermes_cli.models import validate_strict_provider_model
+
+        _runtime_provider_for_model = str(
+            runtime.get("provider") or primary_provider_for_drift or ""
+        ).strip().lower()
+        _model_verdict, _validated_model = validate_strict_provider_model(
+            _runtime_provider_for_model, str(model)
+        )
+        if _model_verdict is False and not _validated_model:
+            raise RuntimeError(
+                f"Unsupported model {model!r} for provider "
+                f"{_runtime_provider_for_model!r}; no safe default is available"
+            )
+        if _model_verdict is not None and _validated_model != str(model):
+            # Provider may only become known after credential resolution. When
+            # that reveals a stale or noncanonical slug, re-resolve atomically
+            # so provider-specific api_mode/base_url match the corrected model.
+            _corrected_kwargs = {
+                "requested": _runtime_provider_for_model,
+                "target_model": _validated_model,
+            }
+            if job.get("base_url"):
+                _corrected_kwargs["explicit_base_url"] = job.get("base_url")
+            runtime = resolve_runtime_provider(**_corrected_kwargs)
+            logger.warning(
+                "Job '%s': %s model %r for provider %r; using %r",
+                job_id,
+                "normalized" if _model_verdict is True else "rejected unsupported",
+                model,
+                _runtime_provider_for_model,
+                _validated_model,
+            )
+            model = _validated_model
 
         reasoning_config = _resolve_job_reasoning_config(
             job, _cfg if isinstance(_cfg, dict) else {}, str(model)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -32,7 +32,7 @@ import time
 import unicodedata
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Any, Optional, List, Tuple, Set
+from typing import Dict, Any, Optional, List, Tuple, Set, cast
 
 from hermes_cli.route_identity import normalize_route_base_url
 from hermes_cli.secret_prompt import masked_secret_prompt
@@ -2528,6 +2528,40 @@ def validate_config_structure(config: Optional[Dict[str, Any]] = None) -> List["
             "    base_url: https://...",
         ))
 
+    # Closed-catalog providers can reject impossible model IDs without a
+    # network call. Open/dynamic/custom providers are intentionally skipped:
+    # an ID absent from Hermes' snapshot may still be a valid deployment.
+    provider_id = ""
+    model_id = ""
+    if isinstance(model_cfg, dict):
+        provider_id = str(model_cfg.get("provider") or "").strip().lower()
+        model_id = str(
+            model_cfg.get("default") or model_cfg.get("model") or ""
+        ).strip()
+    elif isinstance(model_cfg, str):
+        model_id = model_cfg.strip()
+    if model_id:
+        try:
+            from hermes_cli.models import validate_strict_provider_model
+
+            verdict, fallback = validate_strict_provider_model(
+                provider_id, model_id
+            )
+        except Exception:
+            verdict, fallback = None, model_id
+        if verdict is False:
+            provider_note = f" for provider '{provider_id}'" if provider_id else ""
+            hint = (
+                f"Use a supported model such as '{fallback}', or run 'hermes model' to choose one"
+                if fallback
+                else "Configure model.provider and choose a supported model with 'hermes model'"
+            )
+            issues.append(ConfigIssue(
+                "error",
+                f"model '{model_id}' is not supported{provider_note}",
+                hint,
+            ))
+
     # ── Root-level keys that look misplaced ──────────────────────────────
     # Only provider-like fields (base_url, api_key, …) are flagged. Arbitrary
     # unknown top-level keys are deliberately NOT warned about: top-level
@@ -4200,7 +4234,7 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                     return copy.deepcopy(lkg_copy) if want_deepcopy else lkg_copy
 
         normalized = _normalize_root_model_keys(_normalize_max_turns_config(config))
-        expanded = _expand_env_vars(normalized)
+        expanded = cast(Dict[str, Any], _expand_env_vars(normalized))
         # Managed scope wins at the leaf. Applied AFTER user expansion so a user
         # ${VAR} cannot shadow a managed literal: managed values are expanded only
         # against the process environment, never against user-config-defined refs.
@@ -4221,6 +4255,69 @@ def _load_config_impl(*, want_deepcopy: bool) -> Dict[str, Any]:
                 managed_normalized["model"] = {"default": managed_normalized["model"]}
             managed_expanded = _expand_env_vars(managed_normalized)
             expanded = _deep_merge(expanded, managed_expanded)
+
+        # Reject impossible IDs for closed-catalog providers at the canonical
+        # load boundary. Keep config.yaml byte-for-byte intact so the operator
+        # can inspect/repair the bad value; only the effective in-memory config
+        # falls back. This prevents unattended reads from sending a known-bad
+        # slug while avoiding false rejection for custom/dynamic catalogs.
+        _effective_model_cfg = expanded.get("model")
+        _effective_provider = ""
+        _effective_model = ""
+        _legacy_scalar = isinstance(_effective_model_cfg, str)
+        if isinstance(_effective_model_cfg, dict):
+            _effective_provider = str(
+                _effective_model_cfg.get("provider") or ""
+            ).strip().lower()
+            _effective_model = str(
+                _effective_model_cfg.get("default") or ""
+            ).strip()
+        elif _legacy_scalar:
+            _effective_model = str(_effective_model_cfg).strip()
+
+        if _effective_model:
+            from hermes_cli.models import validate_strict_provider_model
+
+            _model_verdict, _validated_model = validate_strict_provider_model(
+                _effective_provider, _effective_model
+            )
+            # Legacy scalar configs do not name a provider. Only universally
+            # invalid sentinel values return False without one; resolve those
+            # against Hermes' default provider so unattended jobs can recover.
+            if _legacy_scalar and _model_verdict is False:
+                _default_model_cfg = DEFAULT_CONFIG.get("model", {})
+                if isinstance(_default_model_cfg, dict):
+                    _effective_provider = str(
+                        _default_model_cfg.get("provider") or ""
+                    ).strip().lower()
+                _model_verdict, _validated_model = validate_strict_provider_model(
+                    _effective_provider, _effective_model
+                )
+            if _model_verdict is False and not _validated_model:
+                raise InvalidUserConfigError(
+                    f"Unsupported model.default {_effective_model!r} for "
+                    f"provider {_effective_provider!r}; no safe provider "
+                    "default is available"
+                )
+            if _model_verdict is not None and _validated_model != _effective_model:
+                expanded = copy.deepcopy(expanded)
+                expanded["model"] = dict(_effective_model_cfg) if isinstance(
+                    _effective_model_cfg, dict
+                ) else {}
+                expanded["model"]["default"] = _validated_model
+                if _effective_provider:
+                    expanded["model"]["provider"] = _effective_provider
+                action = (
+                    "normalized" if _model_verdict is True else "rejected unsupported"
+                )
+                logger.warning(
+                    "%s model.default %r for provider %r; using %r for "
+                    "this process (config.yaml was not modified)",
+                    action.capitalize(),
+                    _effective_model,
+                    _effective_provider,
+                    _validated_model,
+                )
         _LAST_EXPANDED_CONFIG_BY_PATH[path_key] = copy.deepcopy(expanded)
         if cache_sig is not None:
             # Cache stores a separate deepcopy so subsequent ``load_config()``

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -1677,6 +1677,19 @@ def pick_silent_default_model(model_ids: list[str], provider: str = "openrouter"
 # ``partition_nous_models_by_tier`` — which can hit the Portal.
 _SILENT_DEFAULT_PROVIDERS: frozenset[str] = frozenset({"nous", "openrouter"})
 
+# Providers in this set expose a closed, Hermes-controlled model namespace.
+# Their model IDs are safe to validate offline against ``_PROVIDER_MODELS``.
+# Do not add aggregators, custom endpoints, deployment-name providers, or any
+# provider whose users can legitimately supply IDs absent from our snapshot.
+_STRICT_MODEL_CATALOG_PROVIDERS: frozenset[str] = frozenset({"openai-codex"})
+
+# Sentinel values are never meaningful built-in model IDs. Catch them even when
+# a legacy scalar config omits the provider; this is the exact shape that once
+# took every unpinned cron job offline.
+_OBVIOUSLY_INVALID_MODEL_IDS: frozenset[str] = frozenset(
+    {"test", "placeholder", "dummy", "example", "todo", "none", "null"}
+)
+
 
 def get_default_model_for_provider(provider: str) -> str:
     """Return a cost-safe default model for a provider, or "" if unknown.
@@ -1702,6 +1715,46 @@ def get_default_model_for_provider(provider: str) -> str:
         if preferred and (preferred in models or not models):
             return preferred
     return models[0] if models else ""
+
+
+def validate_strict_provider_model(
+    provider: str,
+    model: str,
+) -> tuple[Optional[bool], str]:
+    """Validate a model only when its provider has a closed local catalog.
+
+    Returns ``(True, model)`` for a known model, ``(False, fallback)`` for an
+    impossible model, and ``(None, model)`` when local validation would be
+    unsafe (open/dynamic/custom providers). The fallback is deliberately the
+    provider's normal non-interactive default, so callers never invent a model
+    or silently route the stale ID through a different provider.
+    """
+    provider_id = str(provider or "").strip().lower()
+    model_id = str(model or "").strip()
+    if not model_id or provider_id.startswith("custom:"):
+        return None, model_id
+    provider_prefix = f"{provider_id}/"
+    if provider_id in _STRICT_MODEL_CATALOG_PROVIDERS and model_id.lower().startswith(
+        provider_prefix
+    ):
+        model_id = model_id[len(provider_prefix):]
+    if model_id.lower() in _OBVIOUSLY_INVALID_MODEL_IDS:
+        fallback = (
+            get_default_model_for_provider(provider_id)
+            if provider_id in _STRICT_MODEL_CATALOG_PROVIDERS
+            else ""
+        )
+        return False, fallback
+    if provider_id not in _STRICT_MODEL_CATALOG_PROVIDERS:
+        return None, model_id
+
+    known = _PROVIDER_MODELS.get(provider_id, [])
+    for candidate in known:
+        if model_id.lower() == candidate.lower():
+            # Return the catalog spelling. Provider model IDs can be
+            # case-sensitive even though user-facing config matching is not.
+            return True, candidate
+    return False, get_default_model_for_provider(provider_id)
 
 
 def _openrouter_model_is_free(pricing: Any) -> bool:

--- a/tests/cron/test_preflight_config.py
+++ b/tests/cron/test_preflight_config.py
@@ -191,6 +191,51 @@ class TestMissingProviderKeyBlocks:
         assert error is None
 
 
+class TestInvalidClosedCatalogModelFallback:
+    def test_unpinned_job_never_constructs_agent_with_invalid_codex_model(self, tmp_path):
+        """Regression: weekly-review inherited ``test`` and sent it to Codex."""
+        (tmp_path / "config.yaml").write_text(
+            "model:\n  provider: openai-codex\n  default: test\n",
+            encoding="utf-8",
+        )
+        job = _job()
+        fake_db = MagicMock()
+        runtime = dict(_RUNTIME, provider="openai-codex", api_mode="codex_responses")
+        resolve_mock = MagicMock(return_value=runtime)
+
+        patches = [
+            patch("cron.scheduler._hermes_home", tmp_path),
+            patch("cron.scheduler._resolve_origin", return_value=None),
+            patch("hermes_cli.env_loader.load_hermes_dotenv"),
+            patch("hermes_cli.env_loader.reset_secret_source_cache"),
+            patch("hermes_state.get_shared_session_db", return_value=fake_db),
+            patch("tools.mcp_tool.discover_mcp_tools", return_value=[]),
+            patch(
+                "hermes_cli.runtime_provider.resolve_runtime_provider",
+                new=resolve_mock,
+            ),
+        ]
+
+        from contextlib import ExitStack
+
+        with cron_jobs.use_cron_store(tmp_path), patch("run_agent.AIAgent") as agent_cls:
+            agent_cls.return_value.run_conversation.return_value = {
+                "final_response": "ok"
+            }
+            with ExitStack() as stack:
+                for p in patches:
+                    stack.enter_context(p)
+                success, _output, _final_response, error = run_job(job)
+
+        assert success is True
+        assert error is None
+        resolved_model = resolve_mock.call_args.kwargs["target_model"]
+        assert resolved_model.startswith("gpt-")
+        assert resolved_model != "test"
+        selected_model = agent_cls.call_args.kwargs["model"]
+        assert selected_model == resolved_model
+
+
 class TestHealthyJobUnaffected:
     def test_healthy_job_runs_normally(self, tmp_path):
         job = _job()

--- a/tests/hermes_cli/test_config_loader_e2e.py
+++ b/tests/hermes_cli/test_config_loader_e2e.py
@@ -158,3 +158,59 @@ def test_writeback_roundtrip_byte_identical_when_unchanged(tmp_path):
     out = _run_py(code, {"HERMES_HOME": str(home)}, tmp_path)
     assert out["identical"] is True
     assert out["parsed"]["custom_prompt"] == "keep ${NOT_SET_VAR}"
+
+
+def test_legacy_scalar_placeholder_is_rejected_at_load_time(tmp_path: Path):
+    """The historical ``model: test`` outage fails before provider use."""
+    home = tmp_path / "home"
+    home.mkdir()
+    original = "model: test\n"
+    (home / "config.yaml").write_text(original, encoding="utf-8")
+    code = """
+import json
+import os
+from pathlib import Path
+from hermes_cli.config import InvalidUserConfigError, load_config
+try:
+    load_config()
+except InvalidUserConfigError as exc:
+    result = {"rejected": True, "message": str(exc)}
+else:
+    result = {"rejected": False}
+Path(os.environ["E2E_OUT_FILE"]).write_text(json.dumps(result), encoding="utf-8")
+"""
+    out = _run_py(code, {"HERMES_HOME": str(home)}, tmp_path)
+    assert out["rejected"] is True
+    assert "test" in out["message"]
+    assert (home / "config.yaml").read_text(encoding="utf-8") == original
+
+
+def test_invalid_codex_model_falls_back_during_load_without_rewriting_file(tmp_path):
+    """A stale/impossible Codex slug must never reach an unattended API call."""
+    home = tmp_path / "hermes_home"
+    home.mkdir()
+    original = "model:\n  provider: openai-codex\n  default: test\n"
+    (home / "config.yaml").write_text(original, encoding="utf-8")
+
+    code = textwrap.dedent(
+        """
+        import json
+        import os
+        from pathlib import Path
+        from hermes_cli.config import load_config
+
+        home = Path(os.environ["HERMES_HOME"])
+        cfg = load_config()
+        Path(os.environ["E2E_OUT_FILE"]).write_text(json.dumps({
+            "effective_model": cfg["model"]["default"],
+            "provider": cfg["model"]["provider"],
+            "saved": (home / "config.yaml").read_text(encoding="utf-8"),
+        }), encoding="utf-8")
+        """
+    )
+    out = _run_py(code, {"HERMES_HOME": str(home)}, tmp_path)
+
+    assert out["effective_model"].startswith("gpt-")
+    assert out["effective_model"] != "test"
+    assert out["provider"] == "openai-codex"
+    assert out["saved"] == original

--- a/tests/hermes_cli/test_config_validation.py
+++ b/tests/hermes_cli/test_config_validation.py
@@ -111,6 +111,54 @@ class TestVoiceSubmitModeValidation:
         )
 
 
+class TestStrictProviderModelValidation:
+    """Closed-catalog providers reject impossible persisted model ids early."""
+
+    def test_invalid_codex_model_is_an_error_with_fallback_hint(self):
+        issues = validate_config_structure({
+            "model": {"provider": "openai-codex", "default": "test"},
+        })
+
+        assert any(
+            issue.severity == "error"
+            and "model 'test'" in issue.message
+            and "openai-codex" in issue.message
+            and "gpt-" in issue.hint
+            for issue in issues
+        )
+
+    def test_legacy_scalar_placeholder_model_is_rejected(self):
+        issues = validate_config_structure({"model": "test"})
+
+        assert any(
+            issue.severity == "error"
+            and "model 'test'" in issue.message
+            and "model.provider" in issue.hint
+            for issue in issues
+        )
+
+    def test_valid_codex_model_is_accepted(self):
+        issues = validate_config_structure({
+            "model": {"provider": "openai-codex", "default": "gpt-5.4"},
+        })
+        assert not any("not supported" in issue.message for issue in issues)
+
+    def test_provider_qualified_codex_model_is_normalized_and_accepted(self):
+        issues = validate_config_structure({
+            "model": {
+                "provider": "openai-codex",
+                "default": "openai-codex/gpt-5.4",
+            },
+        })
+        assert not any("not supported" in issue.message for issue in issues)
+
+    def test_open_catalog_provider_is_not_rejected_locally(self):
+        issues = validate_config_structure({
+            "model": {"provider": "custom:private", "default": "test"},
+        })
+        assert not any("not supported" in issue.message for issue in issues)
+
+
 class TestUnknownTopLevelKeys:
     """Arbitrary top-level keys must NOT warn — they are bridged to os.environ.
 


### PR DESCRIPTION
## Summary
- reject providerless placeholder models such as the historical `model: test` at config load
- validate offline only for closed provider catalogs while preserving custom/dynamic IDs
- make cron correct stale inherited models to the same-provider default before provider/API-mode resolution and before AIAgent construction
- preserve config.yaml byte-for-byte and emit an explicit warning when an in-memory fallback is used

## Root cause
All 29 live cron jobs are unpinned. A prior scalar `model: test` in `~/.hermes/config.yaml` therefore propagated to every job and Codex rejected it with HTTP 400. The existing scheduler trusted inherited model IDs and had no validation/fallback boundary.

## Test plan
- [x] `uv run --python 3.11 pytest -q tests/hermes_cli/test_config_validation.py tests/hermes_cli/test_config_loader_e2e.py tests/cron/test_preflight_config.py` (31 passed)
- [x] `uv run --python 3.11 ruff check ...`
- [x] `git diff --check`
- [x] full `tests/cron`: 1195 passed, 21 skipped; 2 unrelated failures (missing DISCORD_BOT_TOKEN fixture isolation and timing-sensitive heartbeat assertion)
- [x] broad `tests/hermes_cli -x`: 940 passed, 7 skipped before unrelated update/TCC supervision failure

## Operational safety
No live cron job or production configuration was modified. Current live config is already `openai-codex` / `gpt-5.6-sol`, weekly-review latest status is `ok`, and the fleet audit found zero explicit/placeholder job-level models.

## Rollback
Revert commit `90231c4ec5` (or the eventual squash commit). No data/config migration is required.