### PR TITLE
test(desktop): lock #79231 steer insert when streamId is null

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/rewind.test.ts
@@ -78,6 +78,31 @@ describe('appendMidTurnUserMessage', () => {
     expect(next.interimBoundaryPending).toBe(false)
   })
 
+  // #79231: streamId is often still null while the live turn is thinking / in
+  // a tool, so the old last-assistant fallback spliced the steer above the
+  // current prompt. Null stream id must append at the tail.
+  it('never inserts a steer above the current turn prompt when streamId is null (#79231)', () => {
+    const state: MidTurnState = {
+      interimBoundaryPending: false,
+      streamId: null,
+      messages: [
+        row('user-1', 'user', 'original prompt'),
+        row('assistant-1', 'assistant', 'reply'),
+        row('user-2', 'user', 'current prompt')
+      ]
+    }
+
+    const next = appendMidTurnUserMessage(state, row('user-steer', 'user', 'correction'))
+
+    expect(next.messages.map(message => message.id)).toEqual([
+      'user-1',
+      'assistant-1',
+      'user-2',
+      'user-steer'
+    ])
+    expect(next.streamId).toBeNull()
+  })
+
   it('drops an empty pending stream placeholder instead of sealing it', () => {
     const state: MidTurnState = {
       interimBoundaryPending: false,


### PR DESCRIPTION
## Bug Description

Steering mid-turn used to splice the correction **above** the current prompt when `streamId` was null (thinking / tool, no assistant bubble yet).

`appendMidTurnUserMessage` already appends at the tail (see #73793 / #83151). This PR only adds the exact #79231 fixture so that splice cannot return unnoticed.

Fixes #79231

## Root Cause

Historical: `lastIndexOf('assistant')` across the whole transcript when `streamId` missed. That helper is gone; the remaining gap was no test for `[user, assistant, user]` + `streamId = null`.

## Fix

Regression test only. No production change.

## How to Verify

`npx vitest run src/app/session/hooks/use-prompt-actions/rewind.test.ts`

## Test Plan

- [x] `never inserts a steer above the current turn prompt when streamId is null (#79231)`
- [x] Sabotage: prepending the steer fails that test (and the sibling appendMidTurn cases)
- [x] Full rewind.test.ts: 36 passed

## Risk Assessment

None — test-only.
