### PR TITLE
feat(cli): expose per-slot reasoning_effort/max_tokens in hermes moa configure

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -4,9 +4,16 @@ from __future__ import annotations
 
 from typing import Any
 
+from hermes_cli.cli_output import line_input
 from hermes_cli.config import load_config, save_config
 from hermes_cli.inventory import build_models_payload, load_picker_context
 from hermes_cli.moa_config import DEFAULT_MOA_PRESET_NAME, normalize_moa_config
+
+# Fixed canonical scale rather than a per-model "supported efforts" list: the
+# latter under-reports (see _apply_capabilities in inventory.py — a route can
+# serve a level its catalog doesn't advertise), so the picker always offers
+# the full scale on any model whose capabilities mark it reasoning-capable.
+_REASONING_EFFORT_SCALE = ("low", "medium", "high")
 
 
 def _prompt_choice(title: str, rows: list[str], default: int = 0) -> int:
@@ -49,7 +56,65 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
-def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
+def _model_supports_reasoning(provider: dict[str, Any], model: str) -> bool:
+    entry = (provider.get("capabilities") or {}).get(model) or {}
+    return bool(entry.get("reasoning", True))
+
+
+def _prompt_slot_tuning(
+    provider_slug: str,
+    model: str,
+    current: dict[str, Any] | None,
+    *,
+    supports_reasoning: bool,
+) -> dict[str, Any]:
+    """Prompt for the optional per-slot ``reasoning_effort`` / ``max_tokens`` overrides."""
+    current = current or {}
+    tuning: dict[str, Any] = {}
+
+    if supports_reasoning:
+        from hermes_cli.main import _prompt_reasoning_effort_selection
+
+        current_effort = str(current.get("reasoning_effort") or "")
+        selected = _prompt_reasoning_effort_selection(_REASONING_EFFORT_SCALE, current_effort=current_effort)
+        effort = current_effort if selected is None else selected
+        if effort:
+            tuning["reasoning_effort"] = effort
+
+    current_tokens = current.get("max_tokens")
+    default = str(current_tokens) if current_tokens else ""
+    raw = line_input(
+        f"Max tokens for {provider_slug}:{model} (blank = no per-slot cap) [{default}]: "
+    ).strip()
+    tokens = raw or default
+    if tokens:
+        tuning["max_tokens"] = tokens
+
+    return tuning
+
+
+def _pick_slot(current: dict[str, Any] | None = None) -> dict[str, Any]:
+    if current and current.get("provider") and current.get("model"):
+        choice = _prompt_choice(
+            "Edit slot",
+            [
+                "Keep provider/model — edit max_tokens / reasoning effort only",
+                "Change provider/model",
+            ],
+            0,
+        )
+        if choice == 0:
+            providers = _model_options()
+            provider = next((p for p in providers if p.get("slug") == current.get("provider")), {})
+            supports_reasoning = _model_supports_reasoning(provider, current["model"])
+            slot: dict[str, Any] = {"provider": current["provider"], "model": current["model"]}
+            slot.update(
+                _prompt_slot_tuning(
+                    current["provider"], current["model"], current, supports_reasoning=supports_reasoning
+                )
+            )
+            return slot
+
     providers = _model_options()
     if not providers:
         raise RuntimeError("No configured model providers found. Run `hermes model` first.")
@@ -66,13 +131,22 @@ def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
     current_model = (current or {}).get("model", "")
     model_default = models.index(current_model) if current_model in models else 0
     model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
-    return {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    supports_reasoning = _model_supports_reasoning(provider, model)
+    slot: dict[str, Any] = {"provider": str(provider.get("slug") or ""), "model": str(model)}
+    slot.update(_prompt_slot_tuning(provider.get("slug") or "", model, current, supports_reasoning=supports_reasoning))
+    return slot
 
 
 def _format_slot(slot: dict[str, Any]) -> str:
     label = f"{slot['provider']}:{slot['model']}"
+    extras = []
     effort = str(slot.get("reasoning_effort") or "").strip()
-    return f"{label} [reasoning={effort}]" if effort else label
+    if effort:
+        extras.append(f"reasoning={effort}")
+    max_tokens = slot.get("max_tokens")
+    if max_tokens:
+        extras.append(f"max_tokens={max_tokens}")
+    return f"{label} [{', '.join(extras)}]" if extras else label
 
 
 def _print_config(config: dict[str, Any]) -> None:

--- a/tests/hermes_cli/test_moa_cmd.py
+++ b/tests/hermes_cli/test_moa_cmd.py
@@ -1,0 +1,124 @@
+"""Tests for the per-slot reasoning_effort / max_tokens knobs in `hermes moa configure`.
+
+Issues #102582 (reasoning_effort), #102584 (max_tokens), #102585 (edit an
+existing slot's knobs without re-picking provider/model) — tracked by #102586.
+"""
+
+from __future__ import annotations
+
+from hermes_cli import moa_cmd
+
+
+def _provider(slug="openrouter", models=("model-a",), reasoning=True):
+    return {
+        "slug": slug,
+        "name": slug,
+        "models": list(models),
+        "capabilities": {m: {"reasoning": reasoning} for m in models},
+    }
+
+
+def test_format_slot_shows_reasoning_and_max_tokens():
+    slot = {"provider": "openrouter", "model": "model-a", "reasoning_effort": "high", "max_tokens": 512}
+    assert moa_cmd._format_slot(slot) == "openrouter:model-a [reasoning=high, max_tokens=512]"
+
+
+def test_format_slot_bare_when_no_tuning():
+    slot = {"provider": "openrouter", "model": "model-a"}
+    assert moa_cmd._format_slot(slot) == "openrouter:model-a"
+
+
+def test_pick_new_slot_prompts_for_reasoning_effort_and_max_tokens(monkeypatch):
+    """A fresh slot on a reasoning-capable model prompts for both knobs."""
+    provider = _provider(reasoning=True)
+    monkeypatch.setattr(moa_cmd, "_model_options", lambda: [provider])
+    monkeypatch.setattr(moa_cmd, "_prompt_choice", lambda title, rows, default=0: 0)
+    monkeypatch.setattr(moa_cmd, "line_input", lambda prompt_text: "512")
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_reasoning_effort_selection",
+        lambda efforts, current_effort="": "high",
+    )
+
+    slot = moa_cmd._pick_slot(None)
+
+    assert slot == {
+        "provider": "openrouter",
+        "model": "model-a",
+        "reasoning_effort": "high",
+        "max_tokens": "512",
+    }
+
+
+def test_pick_new_slot_skips_reasoning_prompt_when_unsupported(monkeypatch):
+    """A model whose capabilities mark reasoning=False never sees the effort menu."""
+    provider = _provider(reasoning=False)
+    monkeypatch.setattr(moa_cmd, "_model_options", lambda: [provider])
+    monkeypatch.setattr(moa_cmd, "_prompt_choice", lambda title, rows, default=0: 0)
+    monkeypatch.setattr(moa_cmd, "line_input", lambda prompt_text: "")
+
+    def _fail(*args, **kwargs):
+        raise AssertionError("reasoning effort menu must not be shown for a non-reasoning model")
+
+    monkeypatch.setattr("hermes_cli.main._prompt_reasoning_effort_selection", _fail)
+
+    slot = moa_cmd._pick_slot(None)
+
+    assert slot == {"provider": "openrouter", "model": "model-a"}
+
+
+def test_pick_existing_slot_offers_edit_in_place(monkeypatch):
+    """#102585: editing an already-picked slot must not re-walk provider/model."""
+    provider = _provider(reasoning=True)
+    monkeypatch.setattr(moa_cmd, "_model_options", lambda: [provider])
+
+    seen_titles = []
+
+    def fake_prompt_choice(title, rows, default=0):
+        seen_titles.append(title)
+        if title == "Edit slot":
+            return 0  # keep provider/model
+        raise AssertionError(f"unexpected prompt during edit-in-place: {title}")
+
+    monkeypatch.setattr(moa_cmd, "_prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr(moa_cmd, "line_input", lambda prompt_text: "256")
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_reasoning_effort_selection",
+        lambda efforts, current_effort="": "medium",
+    )
+
+    current = {"provider": "openrouter", "model": "model-a"}
+    slot = moa_cmd._pick_slot(current)
+
+    assert seen_titles == ["Edit slot"]
+    assert slot == {
+        "provider": "openrouter",
+        "model": "model-a",
+        "reasoning_effort": "medium",
+        "max_tokens": "256",
+    }
+
+
+def test_pick_existing_slot_can_still_change_provider_model(monkeypatch):
+    """Choosing 'Change provider/model' falls through to the full picker."""
+    provider = _provider(reasoning=True)
+    monkeypatch.setattr(moa_cmd, "_model_options", lambda: [provider])
+
+    def fake_prompt_choice(title, rows, default=0):
+        if title == "Edit slot":
+            return 1  # change provider/model
+        return 0
+
+    monkeypatch.setattr(moa_cmd, "_prompt_choice", fake_prompt_choice)
+    monkeypatch.setattr(moa_cmd, "line_input", lambda prompt_text: "")
+    monkeypatch.setattr(
+        "hermes_cli.main._prompt_reasoning_effort_selection",
+        lambda efforts, current_effort="": None,
+    )
+
+    current = {"provider": "openrouter", "model": "model-a", "reasoning_effort": "low"}
+    slot = moa_cmd._pick_slot(current)
+
+    assert slot["provider"] == "openrouter"
+    assert slot["model"] == "model-a"
+    # No new selection made and no blank input given: prior effort is kept.
+    assert slot["reasoning_effort"] == "low"


### PR DESCRIPTION
## What does this PR do?

`hermes moa configure` -> `_pick_slot()` (`hermes_cli/moa_cmd.py`) only ever
prompted for provider + model, even though `hermes_cli/moa_config.py`
(`_clean_slot`) already accepts a per-slot `reasoning_effort` and
`max_tokens` on both reference models and the aggregator, and `_format_slot`
was already prepared to display `reasoning_effort`. The only way to set
either knob was hand-editing `config.yaml`.

This adds the missing UI, reusing the existing pieces the schema already
anticipated:

- After a model is picked, if the picker's own capabilities map says the
  model supports reasoning (`_model_options()`'s per-model `capabilities`
  entry), prompt for a reasoning effort via the same
  `_prompt_reasoning_effort_selection` helper the primary-model Copilot setup
  flow already uses. A fixed `low/medium/high` scale is offered rather than a
  provider's advertised "supported efforts" list, matching the documented
  reason `_apply_capabilities` already gives for not filtering by that list
  (some routes serve levels their catalog doesn't advertise).
- Always prompt for an optional per-slot `max_tokens` override (blank keeps
  the preset-level default — the existing "None = no cap" contract in
  `_clean_slot`).
- `_format_slot` now also renders `max_tokens` when set, alongside the
  existing `reasoning_effort` display.
- Re-configuring an already-picked slot (`_pick_slot(current=...)`) now
  offers a lighter "keep provider/model, edit max_tokens/reasoning effort
  only" choice before falling into the full provider/model re-selection, so
  retuning cost/latency knobs doesn't force navigating both pickers again.

## Related Issue

Fixes #102582
Fixes #102584
Fixes #102585
Fixes #102586

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `hermes_cli/moa_cmd.py`: add `_model_supports_reasoning`, add
  `_prompt_slot_tuning` (the reasoning-effort + max_tokens prompts), teach
  `_pick_slot` an edit-in-place path for slots that already have a
  provider/model, and extend `_format_slot` to also show `max_tokens`.
- `tests/hermes_cli/test_moa_cmd.py`: new test file covering the tuning
  prompts, the reasoning-capability gate, the edit-in-place menu, and the
  fall-through "change provider/model" path.

## How to Test

1. `hermes moa configure` on a preset with an existing reference model whose
   provider/model supports reasoning controls.
2. Pick "Keep provider/model — edit max_tokens / reasoning effort only" when
   re-visiting that slot; set an effort and a max_tokens value.
3. `hermes moa list` — the slot now shows
   `provider:model [reasoning=<effort>, max_tokens=<n>]`.

Automated:

```
$ python -m pytest tests/hermes_cli/test_moa_cmd.py tests/hermes_cli/test_moa_config.py tests/hermes_cli/test_reasoning_effort_menu.py -v
...
tests/hermes_cli/test_moa_cmd.py::test_format_slot_shows_reasoning_and_max_tokens PASSED
tests/hermes_cli/test_moa_cmd.py::test_format_slot_bare_when_no_tuning PASSED
tests/hermes_cli/test_moa_cmd.py::test_pick_new_slot_prompts_for_reasoning_effort_and_max_tokens PASSED
tests/hermes_cli/test_moa_cmd.py::test_pick_new_slot_skips_reasoning_prompt_when_unsupported PASSED
tests/hermes_cli/test_moa_cmd.py::test_pick_existing_slot_offers_edit_in_place PASSED
tests/hermes_cli/test_moa_cmd.py::test_pick_existing_slot_can_still_change_provider_model PASSED
tests/hermes_cli/test_moa_config.py ... (6 passed)
tests/hermes_cli/test_reasoning_effort_menu.py::test_reasoning_menu_orders_minimal_before_low PASSED
14 passed in 3.53s
```

Confirmed the new tests fail without the fix (`git checkout HEAD~1 --
hermes_cli/moa_cmd.py`, keeping the new test file): 5 of 6 new tests fail —
one with `AttributeError: <module 'hermes_cli.moa_cmd' ...> has no attribute
'line_input'` (the tuning prompts don't exist yet), one with an assertion
mismatch on the `max_tokens` display.

`scripts/run_tests.sh tests/hermes_cli/` also run before and after this
change: the same 3 pre-existing failures appear on unmodified `main`
(`test_local_quickstart.py::test_quickstart_runs_all_three_legs` /
`test_quickstart_skips_satisfied_legs`, both a `409` from state leaking
across that test file's fixtures, and
`test_kanban_review_surfaces.py::test_review_tools_are_gated_and_visible_to_kanban_workers`,
`ModuleNotFoundError: No module named 'acp'`) — unrelated to this change and
not introduced by it.

`ruff check hermes_cli/moa_cmd.py tests/hermes_cli/test_moa_cmd.py` passes.
`ty check hermes_cli/moa_cmd.py` reports the same pre-existing
`curses_radiolist` argument-type diagnostic that exists on unmodified `main`
(unrelated to this change, in `_prompt_choice`, which this PR doesn't touch)
— and this change actually removes one pre-existing `ty` diagnostic on the
line `picked["enabled"] = ...` by widening `_pick_slot`'s return type from
`dict[str, str]` to `dict[str, Any]`, which is what it always actually
returned once `enabled` (a bool) was assigned into it.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature
- [x] I've run `pytest tests/ -q` and all tests pass (see pre-existing
  failures noted above, reproduced on unmodified `main`)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — CI container (Linux), no interactive TTY
  available to exercise the curses UI path manually; verified via the
  `input()`/`line_input` fallback path exercised by the new tests.

### Documentation & Housekeeping

- [x] N/A — no new config keys (existing `reasoning_effort`/`max_tokens`
  schema in `moa_config.py` already supported these)
- [x] N/A — no tool schema changes

## Notes

This PR was prepared by an autonomous coding agent (Claude Code) exercising
the existing `moa_config.py` schema and the existing
`_prompt_reasoning_effort_selection` helper; all code and tests were reviewed
against the codebase before submission.
