### PR TITLE
feat(connections): add profile-safe connection health foundation

### DIFF
--- a/apps/desktop/src/contrib/connection-health.test.ts
+++ b/apps/desktop/src/contrib/connection-health.test.ts
@@ -1,0 +1,169 @@
+import { renderHook } from '@testing-library/react'
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  CONNECTION_HEALTH_AREA,
+  connectionHealthProviders,
+  useConnectionHealthProviders
+} from './connection-health'
+import { registry } from './registry'
+import type { Contribution } from './types'
+
+describe('connectionHealthProviders', () => {
+  it('returns only callable providers with host-stamped provenance', () => {
+    const load = vi.fn(async () => [])
+
+    const contributions: Contribution[] = [
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: {
+          icon: 'plug',
+          load,
+          name: 'Demo health',
+          repair: { kind: 'route', path: '/settings?tab=plugins', run: 'not allowed' }
+        },
+        id: 'demo:health',
+        source: 'plugin:demo'
+      },
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: { load: 'not-callable' },
+        id: 'broken:health',
+        source: 'plugin:broken'
+      },
+      {
+        area: CONNECTION_HEALTH_AREA,
+        data: { load, repair: { kind: 'command', value: 'rm -rf /' } },
+        id: 'unsafe:health',
+        source: 'plugin:unsafe'
+      }
+    ]
+
+    expect(connectionHealthProviders(contributions)).toEqual([
+      {
+        icon: 'plug',
+        id: 'demo:health',
+        load: expect.any(Function),
+        name: 'Demo health',
+        repair: { kind: 'route', path: '/settings?tab=plugins' },
+        source: 'plugin:demo'
+      },
+      {
+        id: 'unsafe:health',
+        load: expect.any(Function),
+        source: 'plugin:unsafe'
+      }
+    ])
+  })
+
+  it('drops malformed repairs returned by a provider load', async () => {
+    const load = vi.fn(async () => [
+      {
+        checkedAt: 1,
+        id: 'unsafe',
+        name: 'Unsafe',
+        reason: 'check_failed' as const,
+        repair: { kind: 'command', value: 'rm -rf /' }
+      },
+      {
+        checkedAt: 2,
+        id: 'safe',
+        name: 'Safe',
+        reason: 'auth_required' as const,
+        repair: { kind: 'message' as const, message: 'Sign in again', run: 'not allowed' }
+      },
+      {
+        checkedAt: 3,
+        id: 'external-route',
+        name: 'External route',
+        reason: 'check_failed' as const,
+        repair: { kind: 'route' as const, path: '//host' }
+      }
+    ])
+
+    const [provider] = connectionHealthProviders([{
+      area: CONNECTION_HEALTH_AREA,
+      data: { load },
+      id: 'loaded:health',
+      source: 'plugin:loaded'
+    }])
+
+    await expect(provider.load()).resolves.toEqual([
+      {
+        checkedAt: 1,
+        id: 'unsafe',
+        name: 'Unsafe',
+        reason: 'check_failed'
+      },
+      {
+        checkedAt: 2,
+        id: 'safe',
+        name: 'Safe',
+        reason: 'auth_required',
+        repair: { kind: 'message', message: 'Sign in again' }
+      },
+      {
+        checkedAt: 3,
+        id: 'external-route',
+        name: 'External route',
+        reason: 'check_failed'
+      }
+    ])
+    expect(load).toHaveBeenCalledOnce()
+  })
+
+  it('returns only well-formed, whitelisted health results', async () => {
+    const load = vi.fn(async () => [
+      null,
+      { checkedAt: 1, id: 'missing-name', reason: 'healthy' },
+      { checkedAt: 1, id: 'unknown-reason', name: 'Unknown', reason: 'made_up' },
+      { checkedAt: Number.NaN, id: 'bad-time', name: 'Bad time', reason: 'healthy' },
+      {
+        checkedAt: 4,
+        detail: 123,
+        extra: 'not part of the contract',
+        icon: false,
+        id: 'valid',
+        name: 'Valid',
+        reason: 'healthy',
+        staleAfterMs: -1,
+        status: 'Connected'
+      }
+    ])
+
+    const [provider] = connectionHealthProviders([{
+      area: CONNECTION_HEALTH_AREA,
+      data: { load },
+      id: 'loaded:health',
+      source: 'plugin:loaded'
+    }])
+
+    await expect(provider.load()).resolves.toEqual([{
+      checkedAt: 4,
+      id: 'valid',
+      name: 'Valid',
+      reason: 'healthy',
+      status: 'Connected'
+    }])
+  })
+
+  it('keeps the provider snapshot stable across unrelated rerenders', () => {
+    const dispose = registry.register({
+      area: CONNECTION_HEALTH_AREA,
+      data: { load: async () => [] },
+      id: 'stable:health',
+      source: 'plugin:stable'
+    })
+
+    try {
+      const { result, rerender } = renderHook(() => useConnectionHealthProviders())
+      const first = result.current
+
+      rerender()
+
+      expect(result.current).toBe(first)
+    } finally {
+      dispose()
+    }
+  })
+})

--- a/apps/desktop/src/contrib/connection-health.ts
+++ b/apps/desktop/src/contrib/connection-health.ts
@@ -1,0 +1,159 @@
+import { useMemo } from 'react'
+
+import { useContributions } from './react/use-contributions'
+import type { Contribution, ContributionSource } from './types'
+
+export const CONNECTION_HEALTH_AREA = 'connections.health'
+
+const CONNECTION_HEALTH_REASONS = [
+  'healthy',
+  'auth_required',
+  'service_unreachable',
+  'permission_required',
+  'not_installed',
+  'not_configured',
+  'stale',
+  'check_failed'
+] as const
+
+export type ConnectionHealthReason = (typeof CONNECTION_HEALTH_REASONS)[number]
+
+const CONNECTION_HEALTH_REASON_SET: ReadonlySet<string> = new Set(CONNECTION_HEALTH_REASONS)
+
+export type ConnectionHealthRepair =
+  | { kind: 'message'; message: string }
+  | { kind: 'route'; path: string }
+
+export interface ConnectionHealthResult {
+  id: string
+  name: string
+  icon?: string
+  status?: string
+  reason: ConnectionHealthReason
+  detail?: string
+  checkedAt: number
+  staleAfterMs?: number
+  repair?: ConnectionHealthRepair
+}
+
+export interface ConnectionHealthProvider {
+  name?: string
+  icon?: string
+  repair?: ConnectionHealthRepair
+  load: () => Promise<readonly ConnectionHealthResult[]> | readonly ConnectionHealthResult[]
+}
+
+export interface RegisteredConnectionHealthProvider extends ConnectionHealthProvider {
+  id: string
+  source: ContributionSource
+}
+
+function isProvider(value: unknown): value is ConnectionHealthProvider {
+  return typeof value === 'object' && value !== null && typeof (value as { load?: unknown }).load === 'function'
+}
+
+function safeRepair(value: unknown): ConnectionHealthRepair | undefined {
+  if (typeof value !== 'object' || value === null) {
+    return undefined
+  }
+
+  const repair = value as { kind?: unknown; message?: unknown; path?: unknown }
+
+  if (repair.kind === 'message' && typeof repair.message === 'string') {
+    return { kind: 'message', message: repair.message }
+  }
+
+  if (
+    repair.kind === 'route'
+    && typeof repair.path === 'string'
+    && repair.path.startsWith('/')
+    && !repair.path.startsWith('//')
+  ) {
+    return { kind: 'route', path: repair.path }
+  }
+
+  return undefined
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim().length > 0
+}
+
+function isReason(value: unknown): value is ConnectionHealthReason {
+  return typeof value === 'string' && CONNECTION_HEALTH_REASON_SET.has(value)
+}
+
+function isTimestamp(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0
+}
+
+function isPositiveDuration(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+}
+
+function safeHealthResults(value: unknown): readonly ConnectionHealthResult[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  return value.flatMap(item => {
+    if (typeof item !== 'object' || item === null) {
+      return []
+    }
+
+    const result = item as Record<string, unknown>
+
+    if (
+      !isNonEmptyString(result.id)
+      || !isNonEmptyString(result.name)
+      || !isReason(result.reason)
+      || !isTimestamp(result.checkedAt)
+    ) {
+      return []
+    }
+
+    const repair = safeRepair(result.repair)
+
+    const safeResult: ConnectionHealthResult = {
+      checkedAt: result.checkedAt,
+      id: result.id,
+      name: result.name,
+      reason: result.reason,
+      ...(typeof result.icon === 'string' ? { icon: result.icon } : {}),
+      ...(typeof result.status === 'string' ? { status: result.status } : {}),
+      ...(typeof result.detail === 'string' ? { detail: result.detail } : {}),
+      ...(isPositiveDuration(result.staleAfterMs) ? { staleAfterMs: result.staleAfterMs } : {}),
+      ...(repair ? { repair } : {})
+    }
+
+    return [safeResult]
+  })
+}
+
+export function connectionHealthProviders(
+  contributions: readonly Contribution[]
+): RegisteredConnectionHealthProvider[] {
+  return contributions.flatMap(contribution => {
+    if (!isProvider(contribution.data)) {
+      return []
+    }
+
+    const provider = contribution.data
+    const repair = safeRepair(provider.repair)
+
+    return [{
+      ...(typeof provider.icon === 'string' ? { icon: provider.icon } : {}),
+      id: contribution.id,
+      load: async () => safeHealthResults(await provider.load()),
+      ...(typeof provider.name === 'string' ? { name: provider.name } : {}),
+      ...(repair ? { repair } : {}),
+      source: contribution.source ?? 'core'
+    }]
+  })
+}
+
+export function useConnectionHealthProviders(): RegisteredConnectionHealthProvider[] {
+  const contributions = useContributions(CONNECTION_HEALTH_AREA)
+
+  return useMemo(() => connectionHealthProviders(contributions), [contributions])
+}

--- a/apps/desktop/src/sdk/index.test.ts
+++ b/apps/desktop/src/sdk/index.test.ts
@@ -1,9 +1,16 @@
 import { afterEach, describe, expect, it } from 'vitest'
 
 import { createClientSessionState } from '@/lib/chat-runtime'
-import { host } from '@/sdk'
+import { CONNECTION_HEALTH_AREA, connectionHealthProviders, host } from '@/sdk'
 import { setActiveSessionId, setAwaitingResponse, setBusy } from '@/store/session'
 import { clearAllSessionStates, publishSessionState } from '@/store/session-states'
+
+describe('connection health SDK contract', () => {
+  it('exports the shared contribution area and resolver', () => {
+    expect(CONNECTION_HEALTH_AREA).toBe('connections.health')
+    expect(connectionHealthProviders([])).toEqual([])
+  })
+})
 
 describe('host.state turn flags', () => {
   afterEach(() => {

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1571,6 +1571,16 @@ export { Switch } from '@/components/ui/switch'
 export { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 export { Textarea } from '@/components/ui/textarea'
 export { Tip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+export {
+  CONNECTION_HEALTH_AREA,
+  type ConnectionHealthProvider,
+  connectionHealthProviders,
+  type ConnectionHealthReason,
+  type ConnectionHealthRepair,
+  type ConnectionHealthResult,
+  type RegisteredConnectionHealthProvider,
+  useConnectionHealthProviders
+} from '@/contrib/connection-health'
 export type { GatewayEventListener } from '@/contrib/events'
 export type {
   HermesPlugin,

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -4,9 +4,11 @@ All tests use mocks -- no real MCP servers or subprocesses are started.
 """
 
 import asyncio
+import copy
 import json
 import logging
 import os
+import pickle
 import sys
 import threading
 import time
@@ -272,6 +274,19 @@ class TestMCPStatus:
         import tools.mcp_tool as mcp_tool
         from tools import mcp_tool_config as _mcp_config
         from tools import mcp_tool_discovery as _mcp_discovery
+        from tools import mcp_tool_errors as _mcp_errors
+        from tools.mcp_oauth import OAuthNonInteractiveError
+
+        assert _mcp_errors._connect_failure_reason(RuntimeError("network")) == "check_failed"
+        assert _mcp_errors._connect_failure_reason(
+            OAuthNonInteractiveError("browser required")
+        ) == "auth_required"
+        tagged = _mcp_errors._connect_error_text(
+            "Connection closed", OAuthNonInteractiveError("browser required")
+        )
+        for cloned in (copy.copy(tagged), copy.deepcopy(tagged), pickle.loads(pickle.dumps(tagged))):
+            assert cloned == "Connection closed"
+            assert getattr(cloned, "reason") == "auth_required"
 
         monkeypatch.setattr(
             _mcp_config, "_load_mcp_config",
@@ -284,13 +299,17 @@ class TestMCPStatus:
         )
         with mcp_tool._lock:
             saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
             saved_connecting = set(mcp_tool._server_connecting)
             saved_errors = dict(mcp_tool._server_connect_errors)
             mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
             mcp_tool._server_connecting.clear()
             mcp_tool._server_connect_errors.clear()
             mcp_tool._server_connecting.add("connecting")
-            mcp_tool._server_connect_errors["failed"] = "Connection closed"
+            mcp_tool._server_connect_errors["failed"] = _mcp_errors._connect_error_text(
+                "Connection closed", OAuthNonInteractiveError("browser required")
+            )
 
         try:
             statuses = {
@@ -301,6 +320,8 @@ class TestMCPStatus:
             with mcp_tool._lock:
                 mcp_tool._servers.clear()
                 mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
                 mcp_tool._server_connecting.clear()
                 mcp_tool._server_connecting.update(saved_connecting)
                 mcp_tool._server_connect_errors.clear()
@@ -310,10 +331,121 @@ class TestMCPStatus:
         assert statuses["configured"]["connected"] is False
         assert statuses["configured"]["disabled"] is False
         assert statuses["connecting"]["status"] == "connecting"
+        assert statuses["connecting"]["reason"] == "stale"
         assert statuses["failed"]["status"] == "failed"
         assert statuses["failed"]["error"] == "Connection closed"
+        assert statuses["failed"]["reason"] == "auth_required"
         assert statuses["disabled"]["status"] == "disabled"
         assert statuses["disabled"]["disabled"] is True
+
+    def test_status_ignores_a_runtime_owned_by_another_profile(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from tools import mcp_tool_config as _mcp_config
+        from tools import mcp_tool_discovery as _mcp_discovery
+
+        monkeypatch.setattr(
+            _mcp_config, "_load_mcp_config",
+            lambda: {"shared": {"command": "shared-mcp"}},
+        )
+        monkeypatch.setattr(mcp_tool, "_mcp_registry_scope", lambda: "profile:work")
+        foreign_server = MagicMock(spec=mcp_tool.MCPServerTask)
+        foreign_server.session = object()
+        foreign_server._registered_tool_names = ["secret_tool"]
+        foreign_server._tools = []
+        foreign_server._sampling = None
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            mcp_tool._servers["shared"] = foreign_server
+            mcp_tool._server_scope_keys["shared"] = "profile:other"
+
+        try:
+            [status] = _mcp_discovery.get_mcp_status()
+            with mcp_tool._lock:
+                mcp_tool._server_scope_keys.pop("shared", None)
+            [unscoped_status] = _mcp_discovery.get_mcp_status()
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+
+        assert status["status"] == "configured"
+        assert status["reason"] == "stale"
+        assert status["tools"] == 0
+        assert unscoped_status["status"] == "configured"
+        assert unscoped_status["reason"] == "stale"
+
+
+    def test_scoped_shutdown_clears_only_its_connection_status(self, monkeypatch):
+        import tools.mcp_tool as mcp_tool
+        from tools import mcp_tool_lifecycle, mcp_tool_loop, mcp_tool_discovery
+
+        monkeypatch.setattr(mcp_tool_loop, "_stop_mcp_loop", lambda **_kwargs: None)
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            saved_connecting = set(mcp_tool._server_connecting)
+            saved_errors = dict(mcp_tool._server_connect_errors)
+            saved_retry_after = dict(mcp_tool._server_connect_retry_after)
+            saved_failures = dict(mcp_tool._server_connect_failures)
+            mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update({
+                "work-connecting": "profile:work",
+                "work-failed": "profile:work",
+                "other-failed": "profile:other",
+            })
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connecting.add("work-connecting")
+            mcp_tool._server_connect_errors.clear()
+            mcp_tool._server_connect_errors.update({
+                "work-failed": "work error",
+                "other-failed": "other error",
+            })
+            mcp_tool._server_connect_retry_after.clear()
+            mcp_tool._server_connect_retry_after.update({
+                "work-failed": 1.0,
+                "other-failed": 2.0,
+            })
+            mcp_tool._server_connect_failures.clear()
+            mcp_tool._server_connect_failures.update({
+                "work-failed": 1,
+                "other-failed": 2,
+            })
+
+        try:
+            mcp_tool_lifecycle.shutdown_mcp_servers(scope="profile:work")
+
+            with mcp_tool._lock:
+                assert mcp_tool._server_connecting == set()
+                assert mcp_tool._server_connect_errors == {
+                    "other-failed": "other error"
+                }
+                assert mcp_tool._server_scope_keys == {
+                    "other-failed": "profile:other"
+                }
+                assert mcp_tool._server_connect_retry_after == {
+                    "other-failed": 2.0
+                }
+                assert mcp_tool._server_connect_failures == {
+                    "other-failed": 2
+                }
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+                mcp_tool._server_connecting.clear()
+                mcp_tool._server_connecting.update(saved_connecting)
+                mcp_tool._server_connect_errors.clear()
+                mcp_tool._server_connect_errors.update(saved_errors)
+                mcp_tool._server_connect_retry_after.clear()
+                mcp_tool._server_connect_retry_after.update(saved_retry_after)
+                mcp_tool._server_connect_failures.clear()
+                mcp_tool._server_connect_failures.update(saved_failures)
 
 
 class TestLifecycleConfig:
@@ -2688,6 +2820,53 @@ class TestSanitizeMcpNameComponent:
 
 
 class TestRegisterMcpServers:
+    def test_records_profile_scope_before_connect(self):
+        import tools.mcp_tool as mcp_tool
+        from tools import mcp_tool_lifecycle, mcp_tool_loop, mcp_tool_discovery
+
+        seen = []
+
+        async def fake_register(name, _cfg):
+            with mcp_tool._lock:
+                seen.append((
+                    name in mcp_tool._server_connecting,
+                    mcp_tool._server_scope_keys.get(name),
+                ))
+            raise RuntimeError("expected connect failure")
+
+        with mcp_tool._lock:
+            saved_servers = dict(mcp_tool._servers)
+            saved_scopes = dict(mcp_tool._server_scope_keys)
+            saved_connecting = set(mcp_tool._server_connecting)
+            saved_errors = dict(mcp_tool._server_connect_errors)
+            mcp_tool._servers.clear()
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_connecting.clear()
+            mcp_tool._server_connect_errors.clear()
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool_config._filter_suspicious_mcp_servers", side_effect=lambda value: value), \
+                 patch("tools.mcp_tool_discovery._connect_cooldown_active", return_value=False), \
+                 patch("tools.mcp_tool._mcp_registry_scope", return_value="profile:work"), \
+                 patch("tools.mcp_tool_discovery._discover_and_register_server", side_effect=fake_register):
+                mcp_tool_discovery.register_mcp_servers({"scoped": {"command": "test"}})
+
+            assert seen == [(True, "profile:work")]
+            with mcp_tool._lock:
+                assert mcp_tool._server_connect_errors["scoped"].reason == "check_failed"
+                assert mcp_tool._server_scope_keys["scoped"] == "profile:work"
+        finally:
+            with mcp_tool._lock:
+                mcp_tool._servers.clear()
+                mcp_tool._servers.update(saved_servers)
+                mcp_tool._server_scope_keys.clear()
+                mcp_tool._server_scope_keys.update(saved_scopes)
+                mcp_tool._server_connecting.clear()
+                mcp_tool._server_connecting.update(saved_connecting)
+                mcp_tool._server_connect_errors.clear()
+                mcp_tool._server_connect_errors.update(saved_errors)
+
     """Verify the new register_mcp_servers() public API."""
 
     def test_mcp_not_available_returns_empty(self):

--- a/tests/tui_gateway/test_mcp_profile_rpcs.py
+++ b/tests/tui_gateway/test_mcp_profile_rpcs.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -108,6 +109,176 @@ def test_list_reflects_the_scoped_profile(hermes_root):
     work_server = _result(_call("mcp.servers.list", {"profile": "work"}))["servers"][0]
     assert work_server["transport"] == "stdio"
     assert work_server["command"] == "svc-a-bin"
+
+
+def test_status_is_profile_scoped_and_credential_safe(hermes_root):
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "svc-a", "config": {"command": "svc-a-bin"}},
+        )
+    )
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "other", "name": "svc-b", "config": {"command": "svc-b-bin"}},
+        )
+    )
+
+    payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+
+    assert payload["checked_at"] > 0
+    assert payload["servers"] == [
+        {
+            "name": "svc-a",
+            "transport": "stdio",
+            "tools": 0,
+            "connected": False,
+            "disabled": False,
+            "status": "configured",
+            "reason": "stale",
+        }
+    ]
+    assert "error" not in str(payload)
+
+
+def test_status_redacts_internal_failures(hermes_root, monkeypatch):
+    from tools import mcp_tool_discovery
+
+    def fail(*args, **kwargs):
+        raise RuntimeError("token=must-not-leak")
+
+    monkeypatch.setattr(mcp_tool_discovery, "get_mcp_status", fail)
+    response = _call("mcp.servers.status", {"profile": "work"})
+
+    assert response["error"]["message"] == "MCP status unavailable"
+    assert "must-not-leak" not in str(response)
+
+
+def test_status_omits_raw_server_errors(hermes_root, monkeypatch):
+    from tools import mcp_tool_discovery
+
+    monkeypatch.setattr(
+        mcp_tool_discovery,
+        "get_mcp_status",
+        lambda configured, include_runtime: [{
+            "name": "svc",
+            "transport": "stdio",
+            "tools": 0,
+            "connected": False,
+            "disabled": False,
+            "status": "failed",
+            "reason": "auth_required",
+            "error": "token=must-not-leak",
+        }],
+    )
+
+    payload = _result(_call("mcp.servers.status"))
+    assert payload["servers"][0]["reason"] == "auth_required"
+    assert "error" not in payload["servers"][0]
+    assert "must-not-leak" not in str(payload)
+
+
+def test_status_does_not_run_the_runtime_config_loader(hermes_root, monkeypatch):
+    from tools import mcp_tool_config
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "svc-a", "config": {"command": "svc-a-bin"}},
+        )
+    )
+
+    def forbidden():
+        raise AssertionError("runtime config loader executed")
+
+    monkeypatch.setattr(mcp_tool_config, "_load_mcp_config", forbidden)
+
+    payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    assert [server["name"] for server in payload["servers"]] == ["svc-a"]
+
+
+def test_status_does_not_mix_launch_runtime_into_another_profile(hermes_root):
+    import tools.mcp_tool as mcp_tool
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "shared", "config": {"command": "work-bin"}},
+        )
+    )
+    launch_server = SimpleNamespace(
+        session=object(),
+        _registered_tool_names=["launch_secret_tool"],
+        _tools=[],
+        _sampling=None,
+    )
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_scopes = dict(mcp_tool._server_scope_keys)
+        mcp_tool._servers["shared"] = launch_server
+        mcp_tool._server_scope_keys.pop("shared", None)
+
+    try:
+        payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    finally:
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update(saved_scopes)
+
+    assert payload["servers"][0]["status"] == "configured"
+    assert payload["servers"][0]["tools"] == 0
+
+
+def test_status_includes_named_profile_runtime_in_multiplex(hermes_root):
+    from agent.secret_scope import is_multiplex_active, set_multiplex_active
+    from hermes_constants import (
+        hermes_home_key,
+        reset_hermes_home_override,
+        set_hermes_home_override,
+    )
+    import tools.mcp_tool as mcp_tool
+
+    _result(
+        _call(
+            "mcp.servers.add",
+            {"profile": "work", "name": "shared", "config": {"command": "work-bin"}},
+        )
+    )
+    work_token = set_hermes_home_override(hermes_root / "profiles" / "work")
+    try:
+        work_scope = hermes_home_key()
+    finally:
+        reset_hermes_home_override(work_token)
+
+    work_server = SimpleNamespace(
+        session=object(),
+        _registered_tool_names=["work_tool"],
+        _tools=[],
+        _sampling=None,
+    )
+    previous_multiplex = is_multiplex_active()
+    with mcp_tool._lock:
+        saved_servers = dict(mcp_tool._servers)
+        saved_scopes = dict(mcp_tool._server_scope_keys)
+        mcp_tool._servers["shared"] = work_server  # type: ignore[assignment]
+        mcp_tool._server_scope_keys["shared"] = work_scope
+
+    set_multiplex_active(True)
+    try:
+        payload = _result(_call("mcp.servers.status", {"profile": "work"}))
+    finally:
+        set_multiplex_active(previous_multiplex)
+        with mcp_tool._lock:
+            mcp_tool._servers.clear()
+            mcp_tool._servers.update(saved_servers)
+            mcp_tool._server_scope_keys.clear()
+            mcp_tool._server_scope_keys.update(saved_scopes)
+
+    assert payload["servers"][0]["status"] == "connected"
+    assert payload["servers"][0]["tools"] == 1
 
 
 def test_set_api_key_writes_env_and_header_to_right_profile(hermes_root):

--- a/tools/mcp_tool_discovery.py
+++ b/tools/mcp_tool_discovery.py
@@ -112,7 +112,7 @@ def _note_connect_failure(name: str, exc: BaseException) -> str:
     message = _errors._format_connect_error(exc)
     with _core._lock:
         _core._server_connecting.discard(name)
-        _core._server_connect_errors[name] = message
+        _core._server_connect_errors[name] = _errors._connect_error_text(message, exc)
         _record_connect_failure(name)
     return message
 
@@ -245,7 +245,9 @@ def _select_new_servers(servers: Dict[str, dict]) -> Dict[str, dict]:
         stale_cached = [_core._servers[k] for k in servers
                         if k in _core._servers and getattr(_core._servers[k], "session", None) is None]
         _core._server_connecting.update(new_servers)
+        current_scope = _core._mcp_registry_scope()
         for srv_name in new_servers:
+            _core._server_scope_keys[srv_name] = current_scope
             _core._server_connect_errors.pop(srv_name, None)
         # Track which servers opt-in to parallel tool calls (idempotent).
         for srv_name, srv_cfg in servers.items():
@@ -327,7 +329,9 @@ def _run_discovery_pass(new_servers: Dict[str, dict]) -> None:
                                "connecting set: %s", how, len(stale), ", ".join(stale))
                 _core._server_connecting.difference_update(stale)
                 for _sn in stale:
-                    _core._server_connect_errors.setdefault(_sn, f"Connection attempt {how} during discovery")
+                    message = f"Connection attempt {how} during discovery"
+                    _core._server_connect_errors.setdefault(
+                        _sn, _errors._MCPConnectErrorText(message, "check_failed"))
         raise
     finally:
         if _was_interrupted:
@@ -453,16 +457,36 @@ def is_mcp_tool_parallel_safe(tool_name: str) -> bool:
         return bool(server_name and server_name in _core._parallel_safe_servers)
 
 
-def get_mcp_status() -> List[dict]:
-    """Per-server status dicts for banner/TUI: name, transport, tools, connected, disabled,
-    status (connected / disabled / connecting / failed / configured) and error for failed."""
-    configured = _config._load_mcp_config()
+def get_mcp_status(
+    configured: Optional[Dict[str, dict]] = None,
+    *,
+    include_runtime: bool = True,
+) -> List[dict]:
+    """Per-server cached status without initiating connections."""
+    configured = _config._load_mcp_config() if configured is None else dict(configured)
     if not configured:
         return []
+    current_scope = _core._mcp_registry_scope()
     with _core._lock:
-        active_servers = dict(_core._servers)
-        connecting = set(_core._server_connecting)
-        connect_errors = dict(_core._server_connect_errors)
+        scope_keys = dict(_core._server_scope_keys) if include_runtime else {}
+
+        def visible_in_current_scope(name: str) -> bool:
+            if name in scope_keys:
+                return scope_keys[name] == current_scope
+            return current_scope is None
+
+        active_servers = {
+            name: server for name, server in _core._servers.items()
+            if include_runtime and visible_in_current_scope(name)
+        }
+        connecting = {
+            name for name in _core._server_connecting
+            if include_runtime and visible_in_current_scope(name)
+        }
+        connect_errors = {
+            name: error for name, error in _core._server_connect_errors.items()
+            if include_runtime and visible_in_current_scope(name)
+        }
 
     result: List[dict] = []
     for name, cfg in configured.items():
@@ -471,8 +495,13 @@ def get_mcp_status() -> List[dict]:
         live = server is not None and server.session is not None
         status = ("connected" if live else "disabled" if not enabled else "connecting" if name in connecting
                   else "failed" if name in connect_errors else "configured")
+        reason = {
+            "connected": "healthy", "disabled": "not_configured",
+            "connecting": "stale", "configured": "stale",
+        }.get(status, "check_failed")
         entry = {"name": name, "transport": cfg.get("transport", "http") if "url" in cfg else "stdio",
-                 "tools": 0, "connected": False, "disabled": status == "disabled", "status": status}
+                 "tools": 0, "connected": False, "disabled": status == "disabled",
+                 "status": status, "reason": reason}
         if live:
             entry["connected"] = True
             entry["tools"] = (len(server._registered_tool_names) if hasattr(server, "_registered_tool_names")
@@ -480,7 +509,13 @@ def get_mcp_status() -> List[dict]:
             if server._sampling:
                 entry["sampling"] = dict(server._sampling.metrics)
         elif status == "failed":
-            entry["error"] = connect_errors[name]
+            stored_error = connect_errors[name]
+            failure = getattr(server, "_error", None) if server is not None else None
+            failure_reason = getattr(stored_error, "reason", None)
+            if failure_reason is None and isinstance(failure, BaseException):
+                failure_reason = _errors._connect_failure_reason(failure)
+            entry["reason"] = failure_reason or "check_failed"
+            entry["error"] = str(stored_error)
         result.append(entry)
     return result
 

--- a/tools/mcp_tool_errors.py
+++ b/tools/mcp_tool_errors.py
@@ -283,6 +283,29 @@ def _is_auth_error(exc: BaseException) -> bool:
     return getattr(exc.response, "status_code", None) == 401 if isinstance(exc, http_types) else True
 
 
+def _connect_failure_reason(exc: BaseException) -> str:
+    """Reduce an MCP connect exception to a credential-safe health reason."""
+    return "auth_required" if _is_auth_error(_unwrap_exception_group(exc)) else "check_failed"
+
+
+class _MCPConnectErrorText(str):
+    """Backward-compatible error text carrying a credential-safe reason."""
+
+    reason: str
+
+    def __new__(cls, message: str, reason: str):
+        value = super().__new__(cls, message)
+        value.reason = reason
+        return value
+
+    def __reduce__(self):
+        return type(self), (str(self), self.reason)
+
+
+def _connect_error_text(message: str, exc: BaseException) -> str:
+    return _MCPConnectErrorText(message, _connect_failure_reason(exc))
+
+
 # Lower-cased substrings meaning the transport session expired / was GC'd (OAuth token still valid).
 # Substrings (lower-cased match) that indicate the MCP server rejected the request because its server-side
 # transport session expired / was garbage-collected. See #13383.

--- a/tools/mcp_tool_lifecycle.py
+++ b/tools/mcp_tool_lifecycle.py
@@ -84,11 +84,16 @@ def _filter_mcp_children(pids: set) -> set:
     return kept
 
 
-def _clear_connect_cooldowns() -> None:
+def _clear_connect_cooldowns(names=None) -> None:
     """Drop connect-retry cooldowns: a restart must re-attempt every server immediately, not
     honour a stale per-server backoff. Caller holds ``_core._lock``."""
-    _core._server_connect_retry_after.clear()
-    _core._server_connect_failures.clear()
+    if names is None:
+        _core._server_connect_retry_after.clear()
+        _core._server_connect_failures.clear()
+    else:
+        for name in names:
+            _core._server_connect_retry_after.pop(name, None)
+            _core._server_connect_failures.pop(name, None)
 
 
 def shutdown_mcp_servers(*, scope: Optional[str] = None):
@@ -100,6 +105,19 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     with _core._lock:
         selected = [name for name in _core._servers if scope is None or _core._server_scope_keys.get(name) == scope]
         servers_snapshot = [_core._servers[name] for name in selected]
+        selected_status = (
+            set(_core._servers) | set(_core._server_scope_keys)
+            | set(_core._server_connecting) | set(_core._server_connect_errors)
+            if scope is None else {
+                name for name, owner in _core._server_scope_keys.items() if owner == scope
+            }
+        )
+
+    def clear_selected_status():
+        _core._server_connecting.difference_update(selected_status)
+        for name in selected_status:
+            _core._server_connect_errors.pop(name, None)
+            _core._server_scope_keys.pop(name, None)
 
     # Fast path: nothing to shut down. The connect-cooldown maps can still be populated here — a server that
     # failed to connect is never recorded in ``_servers`` (that is the very premise of the #50394 cooldown),
@@ -115,7 +133,8 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
                 for name in selected:
                     _core._servers.pop(name, None)
                     _core._server_scope_keys.pop(name, None)
-                _clear_connect_cooldowns()
+                clear_selected_status()
+                _clear_connect_cooldowns(None if scope is None else selected_status)
 
         with _core._lock:
             loop = _core._mcp_loop
@@ -132,7 +151,9 @@ def shutdown_mcp_servers(*, scope: Optional[str] = None):
     # (a server that failed to connect is never in ``_servers`` — the most likely state for
     # stale backoff entries), no connect-cooldown state may survive shutdown.
     with _core._lock:
-        _clear_connect_cooldowns()
+        if not servers_snapshot:
+            clear_selected_status()
+        _clear_connect_cooldowns(None if scope is None else selected_status)
     _loop._stop_mcp_loop(only_if_idle=scope is not None)
 
 

--- a/tui_gateway/methods_tools.py
+++ b/tui_gateway/methods_tools.py
@@ -1166,6 +1166,39 @@ def _(rid, params: dict) -> dict:
     return _ok(rid, {"servers": [_mcp_summarize_server(name, cfg) for name, cfg in sorted(servers.items())]})
 
 
+@method("mcp.servers.status")
+def _(rid, params: dict) -> dict:
+    """Return credential-safe cached MCP runtime state without connecting."""
+    hc = _tools_mod("hermes_constants")
+    runtime_home_key = hc.hermes_home_key()
+    token = None
+    try:
+        if profile := _str_arg(params, "profile"):
+            profile_dir = _tools_mod("hermes_cli.profiles").get_profile_dir(profile)
+            if not profile_dir or not profile_dir.is_dir():
+                return _err(rid, 4064, f"profile '{profile}' not found")
+            token = hc.set_hermes_home_override(str(profile_dir))
+
+        import time
+        from agent.secret_scope import is_multiplex_active
+
+        configured = _tools_mod("hermes_cli.mcp_config")._get_mcp_servers()
+        get_status = _tools_mod("tools.mcp_tool_discovery").get_mcp_status
+        safe_fields = ("name", "transport", "tools", "connected", "disabled", "status", "reason")
+        servers = get_status(
+            configured,
+            include_runtime=is_multiplex_active() or hc.hermes_home_key() == runtime_home_key,
+        )
+        return _ok(rid, {
+            "servers": [{key: entry[key] for key in safe_fields if key in entry} for entry in servers],
+            "checked_at": int(time.time() * 1000),
+        })
+    except Exception:
+        return _err(rid, 5024, "MCP status unavailable")
+    finally:
+        _mcp_reset_profile(token)
+
+
 @_mcp_rpc("add")
 def _(rid, params: dict) -> dict:
     """Add ``name`` from ``preset`` (catalog id) and/or ``config`` (url/command/args/env/headers/auth/

--- a/website/docs/developer-guide/desktop-plugin-sdk.md
+++ b/website/docs/developer-guide/desktop-plugin-sdk.md
@@ -206,6 +206,7 @@ Import the area constants from the SDK; each area has its own `data` payload.
 | Layout pane | `PANES_AREA` (`'panes'`) | `title` + `render` + `data: { placement, dock?, width?, height? }` |
 | Full page | `ROUTES_AREA` | `data: { path }` + `render` |
 | Sidebar nav | `SIDEBAR_NAV_AREA` | `data: { path, label, codicon }` |
+| Connection health | `CONNECTION_HEALTH_AREA` | `data: ConnectionHealthProvider` |
 | Status bar | `STATUSBAR_AREAS.left` / `.right` | `render` (or `data` as `StatusbarItem`) |
 | Title bar | `TITLEBAR_AREAS.left` / `.center` / `.right` | `data` as `TitlebarTool`, or a mount-scoped `<Contribute>` |
 | ⌘K palette | `PALETTE_AREA` | `data: PaletteContribution` |
@@ -278,6 +279,46 @@ ctx.registerMany([
 
 `codicon` is a [VS Code codicon](https://microsoft.github.io/vscode-codicons/dist/codicon.html)
 id. Navigate to a route from anywhere with `host.navigate('/my-page')`.
+
+### Connection health
+
+A plugin that owns an external integration can publish a passive health snapshot
+for a Connections-style overview. The provider reports cached or otherwise cheap
+state; registering it must not connect, authenticate, prompt, restart, or probe a
+remote service.
+
+```javascript
+import { CONNECTION_HEALTH_AREA } from '@hermes/plugin-sdk'
+
+ctx.register({
+  id: 'calendar-health',
+  area: CONNECTION_HEALTH_AREA,
+  data: {
+    name: 'Calendar',
+    load: () => [{
+      id: 'calendar',
+      name: 'Calendar',
+      status: 'Connected',
+      reason: 'healthy',
+      checkedAt: Date.now(),
+      staleAfterMs: 60_000,
+      repair: { kind: 'route', path: '/settings?tab=plugins' }
+    }]
+  }
+})
+```
+
+`reason` is one of `healthy`, `auth_required`, `service_unreachable`,
+`permission_required`, `not_installed`, `not_configured`, `stale`, or
+`check_failed`. Repairs are deliberately non-executable: use a plain `message`
+or an internal absolute `route`. The host drops malformed results, unknown
+fields, unsafe repairs, non-finite timestamps, and invalid stale durations.
+
+An overview plugin consumes the registered providers with
+`useConnectionHealthProviders()` and decides when to call `load()`. Provider
+failures should be caught and displayed per provider. Keep credentials and raw
+exception text out of health results; configuration, authentication, and active
+tests remain on the integration's owning surface.
 
 ### Status bar and title bar
 
@@ -895,12 +936,12 @@ not treat this pipeline as a trust boundary.
 |----------|---------|
 | Host | `host` (`.state.*`, `.notify`, `.notifyError`, `.navigate`, `.onEvent`, `.logs`, `.status`, `.restartGateway`, `.request`) |
 | Plugin contract | `HermesPlugin`, `PluginContext`, `PluginContribution`, `PluginStorage`, `PluginOs`, `PluginRestOptions`, `PluginNativeNotificationInput`, `PluginNotificationAction`, `HermesOpenTarget`, `Contribution` |
-| Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
-| Area payloads | `RouteContribution`, `SidebarNavContribution`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
+| Area constants | `PANES_AREA`, `ROUTES_AREA`, `SIDEBAR_NAV_AREA`, `CONNECTION_HEALTH_AREA`, `STATUSBAR_AREAS`, `TITLEBAR_AREAS`, `PALETTE_AREA`, `KEYBINDS_AREA`, `THEMES_AREA`, `COMPOSER_AREAS` |
+| Area payloads | `RouteContribution`, `SidebarNavContribution`, `ConnectionHealthProvider`, `ConnectionHealthResult`, `ConnectionHealthReason`, `ConnectionHealthRepair`, `RegisteredConnectionHealthProvider`, `StatusbarItem`, `TitlebarTool`, `PaletteContribution`, `KeybindContribution`, `ComposerMiddleware`, `ComposerAttachmentProvider` |
 | React / state | `useValue`, `atom`, `computed`, `useQuery`, `useMutation`, `useQueryClient`, `queryClient`, `Contribute` |
 | Theming | `useTheme`, `requestTheme`, `setAccentOverride`, `$accentOverride`, `retintTheme`, `themeHue`, `DesktopTheme`, `DesktopThemeColors`, plus OKLCH math (`hexToOklch`, `oklchToHex`, `oklchToSrgb255`, `mixOklab`, `maxChroma`, `hueDelta`, `contrastRatio`, `readableOn`, `normalizeHex`) |
 | UI kit | `Button`, `Input`, `Textarea`, `Select*`, `Switch`, `Checkbox`, `SegmentedControl`, `Tabs*`, `Dialog*`, `ConfirmDialog`, `DropdownMenu*`, `ContextMenu*`, `Popover*`, `Tip`/`Tooltip*`, `Badge`, `Kbd`/`KbdGroup`, `SearchField`, `ScrollArea`, `Separator`, `Skeleton`, `GlyphSpinner`, `Loader`, `EmptyState`, `ErrorState`, `CopyButton`, `StatusDot`, `LogView`, `Codicon`, `DecodeText` |
-| Helpers | `cn`, `icons`, `haptic`, `useI18n`, `profileColor`, `profileColorSoft`, `relativeTime`, `fmtDateTime`, `fmtDayTime`, `coarseElapsed`, `evaluateRuntimeReadiness` |
+| Helpers | `cn`, `icons`, `haptic`, `useI18n`, `profileColor`, `profileColorSoft`, `relativeTime`, `fmtDateTime`, `fmtDayTime`, `coarseElapsed`, `evaluateRuntimeReadiness`, `connectionHealthProviders`, `useConnectionHealthProviders` |
 
 The canonical, always-current export list is `apps/desktop/src/sdk/index.ts`.
 


### PR DESCRIPTION
## What does this PR do?

Adds the generic core foundation needed by a Connections-style Desktop plugin without adding that product UI or any product-specific integration to Hermes core.

Hermes already knows which messaging platforms and MCP servers are configured, but Desktop plugins had no passive way to consume truthful MCP runtime health. The existing MCP test path is active: it can connect, probe, or enter authentication flows. Connection-health consumers also need a narrow contribution contract so the host can enforce stable provider identity, a fixed result shape, and non-executable repair kinds/routes.

This PR therefore adds two small core surfaces:

1. `mcp.servers.status`, a profile-scoped gateway RPC that projects configured servers plus cached runtime state without connecting to or probing them. This projection uses a credential-safe field whitelist and fixed failure messages.
2. `connections.health`, a Desktop SDK contribution area whose provider identity, result shape, and repair intents are normalized and validated by the host. Provider-authored display strings remain provider responsibility; the SDK does not claim to inspect arbitrary text for embedded secrets.

The approach keeps existing Hermes registries and configuration as the source of truth. The actual Connections UI and local API checks remain a standalone plugin, which is also the real consumer used for manual verification.

This supersedes the closed foundation draft #102567. That PR was withdrawn while the backend/SDK work was being reconsidered with the finished plugin; after product review, the scope decision changed to submit the generic core separately in three clean commits while keeping the product plugin outside this PR.

## Related Issue

N/A — no issue describes this exact combination of a passive Desktop RPC and a generic connection-health contribution contract.

Related and historical work reviewed:

- #102567 is the closed predecessor; this PR supersedes it with a cleaned commit series, provider-contract documentation, and the clarified core-only scope above.
- #96977 exposes read-only MCP status through the authenticated HTTP API; this PR provides the profile-aware gateway JSON-RPC surface used by Desktop plugins.
- #80746 and #99923 address broader profile ownership and discovery lifecycle concerns; this PR does not replace those larger changes and limits its scope to safe status projection.
- #78604 suppresses interactive OAuth inside the existing active Desktop test endpoint; this PR avoids that test endpoint entirely for passive status reads.
- #100648 improves lazy-server status semantics; that status work is complementary to this consumer-facing RPC.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/mcp_tool_discovery.py`, `tools/mcp_tool_errors.py`, and `tools/mcp_tool_lifecycle.py`
  - project cached MCP runtime state into a credential-safe status shape;
  - preserve the machine-readable `auth_required` / `check_failed` reason across existing string, copy, and pickle consumers;
  - scope connecting and failed runtime observations to their owning profile.
- `tui_gateway/methods_tools.py`
  - add the passive `mcp.servers.status` RPC;
  - inject the already-resolved profile configuration instead of invoking plugin discovery, secret hydration, OAuth, or MCP connection paths;
  - whitelist response fields and replace unexpected exceptions with a fixed message.
- `apps/desktop/src/contrib/connection-health.ts` and SDK exports
  - add the `connections.health` provider contract;
  - attach host provenance and stable contribution IDs;
  - accept only callable loaders and the supported non-executable `message` or internal `/...` route repair forms;
  - normalize the returned structure while leaving provider-authored display-string content under the provider's responsibility;
  - keep the React hook referentially stable across unrelated renders.
- Add focused MCP, profile, RPC, SDK, validation, and reference-stability regression tests.
- Document the Desktop provider contract, including its passivity and provider-content responsibilities.

## How to Test

Run:

```bash
scripts/run_tests.sh tests/tools/test_mcp_tool.py tests/tools/test_mcp_lazy_start.py tests/tools/test_mcp_loop_profile_override.py tests/tui_gateway/test_mcp_profile_rpcs.py tests/gateway/test_multiplex_mcp_discovery.py tests/tools/test_mcp_bridge_single_failure.py
cd apps/desktop
npm run typecheck
npm run lint
npm run test:ui
npm run build
```

Verified after rebasing onto `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`, on head `986ca92e2213fb07eda11ab09c6fe178577880c6`:

- 145 affected Python tests passed, including real profile-config/RPC integration, multiplex runtime visibility and scoped shutdown cleanup. The scoped cleanup regression fails on the base.
- All 7,176 Desktop UI tests passed (719 files); the 16 contribution/SDK tests also passed separately.
- TypeScript typecheck and production Desktop build passed.
- ESLint passed with existing warnings and no errors; Ruff passed.
- `scripts/check_compat_pointers.py`, `scripts/check-windows-footguns.py --diff origin/main` and `git diff --check` passed.

The implementation follows the decomposed ownership: discovery/status in `tools/mcp_tool_discovery.py`, typed errors in `tools/mcp_tool_errors.py`, scoped cleanup in `tools/mcp_tool_lifecycle.py`. Tests import the owning modules directly. The passive RPC exposes named-profile runtime only when the multiplex runtime can scope it; it does not connect, probe, or hydrate credentials.

The standalone product plugin remains outside this PR. The repository-wide Python suite and native desktop platform suite were not rerun for this revision; no fresh native UI acceptance or GitHub Actions success is claimed.

## Current GitHub status

After the update GitHub reports `MERGEABLE` against `main` `5a0b1ba766956a1a16bc2f17dc3b83eb63633402`. [Exact-head CI run](https://github.com/NousResearch/hermes-agent/actions/runs/33911672238) is `action_required`; the external-fork workflows require maintainer approval. The PR remains `BLOCKED` pending repository gates, so conflict-free and locally tested does not yet mean CI-green or merge-ready.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched open and closed issues and PRs for overlapping MCP status, profile, OAuth-probe, and Desktop plugin work
- [x] My PR contains **only** changes related to this feature (no standalone Connections plugin or Computer Use changes)
- [ ] I've run `pytest tests/ -q` and all tests pass — the full repository suite is not claimed; current affected-suite evidence is listed above
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS 26.6.2 (Apple Silicon / arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`website/docs/developer-guide/desktop-plugin-sdk.md`)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A, no config keys changed
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A, the SDK contract is documented in the developer guide
- [x] I've considered cross-platform impact — no new platform APIs, paths, shell commands, or process-management behavior; the Windows footgun diff check passes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no model tool changed; the new RPC and SDK contract are documented and tested

## Screenshots / Logs

N/A — this PR adds framework surfaces and deliberately does not include the standalone Connections UI. The end-to-end consumer was verified locally and remains outside this core diff.

