### PR TITLE
fix(periodic_scheduler): dispatch periodic callbacks via bounded worker pool (#102574)

### DIFF
--- a/agent/periodic_scheduler.py
+++ b/agent/periodic_scheduler.py
@@ -1,17 +1,19 @@
-"""One process-wide timer thread for periodic maintenance callbacks.
+"""One process-wide timer thread + bounded worker pool for periodic maintenance callbacks.
 
 Replaces the per-child ``while not stop.wait(interval): body()`` daemon
 threads (delegate heartbeat, durable turn-lease refresher, turn-liveness
 watchdog).  With ~130 in-process subagents those added 2-3 sleeping OS
-threads per child; this module runs every periodic body on ONE daemon
-thread ordered by a heap of due times.
+threads per child; this module runs timer management on ONE daemon
+thread ordered by a heap of due times and dispatches executions to a
+bounded pool of worker threads.
 
 Semantics match the loop they replace: the first call happens ``interval``
 seconds after :func:`schedule`, and each following call ``interval`` seconds
 after the previous body *returned* (drift-free wrt. body duration was never
 a property of the old loops either).  A body that returns ``False`` stops
 itself; a body that raises is logged at debug and rescheduled — one bad
-callback must never kill the shared thread.
+or blocked callback must never stall sibling callbacks or kill the shared
+thread.
 """
 
 from __future__ import annotations
@@ -19,13 +21,16 @@ from __future__ import annotations
 import heapq
 import itertools
 import logging
+import queue
 import threading
 import time
-from typing import Callable, Optional
+from typing import Callable, Dict, Optional, Set
 
 logger = logging.getLogger(__name__)
 
 _THREAD_NAME = "hermes-periodic-scheduler"
+_WORKER_THREAD_NAME_PREFIX = "hermes-periodic-worker"
+_DEFAULT_MAX_WORKERS = 8
 
 
 class ScheduledHandle:
@@ -51,12 +56,33 @@ class ScheduledHandle:
 
 
 class PeriodicScheduler:
-    def __init__(self) -> None:
+    def __init__(self, max_workers: int = _DEFAULT_MAX_WORKERS) -> None:
         self._cond = threading.Condition()
         self._heap: list = []  # (due, seq, handle)
         self._seq = itertools.count()
         self._thread: Optional[threading.Thread] = None
-        self._running: Optional[ScheduledHandle] = None
+        self._max_workers = max(1, max_workers)
+        self._work_queue: queue.Queue[Optional[ScheduledHandle]] = queue.Queue()
+        self._workers: list[threading.Thread] = []
+        self._running_handles: Set[ScheduledHandle] = set()
+        self._handle_threads: Dict[ScheduledHandle, threading.Thread] = {}
+
+    @property
+    def _running(self) -> Optional[ScheduledHandle]:
+        """Backwards-compatibility accessor for tests checking in-flight execution."""
+        with self._cond:
+            return next(iter(self._running_handles), None) if self._running_handles else None
+
+    def _ensure_worker_under_lock(self) -> None:
+        if len(self._workers) < self._max_workers:
+            idx = len(self._workers) + 1
+            w = threading.Thread(
+                target=self._worker_loop,
+                name=f"{_WORKER_THREAD_NAME_PREFIX}-{idx}",
+                daemon=True,
+            )
+            self._workers.append(w)
+            w.start()
 
     def schedule(self, fn: Callable[[], object], interval: float) -> ScheduledHandle:
         handle = ScheduledHandle(self, fn, float(interval))
@@ -71,9 +97,47 @@ class PeriodicScheduler:
     def _cancel(self, handle: ScheduledHandle, wait: Optional[float]) -> None:
         with self._cond:
             handle._cancelled = True
-            self._cond.notify()
-            if wait and self._running is handle and threading.current_thread() is not self._thread:
-                self._cond.wait_for(lambda: self._running is not handle, timeout=wait)
+            self._cond.notify_all()
+            if wait and handle in self._running_handles:
+                current = threading.current_thread()
+                if (
+                    current is not self._thread
+                    and current is not self._handle_threads.get(handle)
+                ):
+                    self._cond.wait_for(
+                        lambda: handle not in self._running_handles, timeout=wait
+                    )
+
+    def _worker_loop(self) -> None:
+        while True:
+            handle = self._work_queue.get()
+            if handle is None:
+                break
+            try:
+                self._execute(handle)
+            finally:
+                self._work_queue.task_done()
+
+    def _execute(self, handle: ScheduledHandle) -> None:
+        with self._cond:
+            self._handle_threads[handle] = threading.current_thread()
+        stop = False
+        try:
+            if not handle._cancelled:
+                stop = handle._fn() is False
+        except Exception:
+            logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
+        with self._cond:
+            self._handle_threads.pop(handle, None)
+            self._running_handles.discard(handle)
+            if stop:
+                handle._cancelled = True
+            elif not handle._cancelled:
+                heapq.heappush(
+                    self._heap,
+                    (time.monotonic() + handle._interval, next(self._seq), handle),
+                )
+            self._cond.notify_all()
 
     def _run(self) -> None:
         while True:
@@ -91,23 +155,10 @@ class PeriodicScheduler:
                         self._cond.wait(delay)
                         continue
                     heapq.heappop(self._heap)
-                    self._running = handle
+                    self._running_handles.add(handle)
+                    self._ensure_worker_under_lock()
+                    self._work_queue.put(handle)
                     break
-            stop = False
-            try:
-                stop = handle._fn() is False
-            except Exception:
-                logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
-            with self._cond:
-                self._running = None
-                if stop:
-                    handle._cancelled = True
-                elif not handle._cancelled:
-                    heapq.heappush(
-                        self._heap,
-                        (time.monotonic() + handle._interval, next(self._seq), handle),
-                    )
-                self._cond.notify_all()
 
 
 _DEFAULT = PeriodicScheduler()

--- a/tests/agent/test_periodic_scheduler.py
+++ b/tests/agent/test_periodic_scheduler.py
@@ -1,4 +1,4 @@
-"""agent/periodic_scheduler: one shared thread runs every periodic timer."""
+"""agent/periodic_scheduler: shared timer thread + bounded workers for periodic timers."""
 
 import threading
 import time
@@ -24,7 +24,7 @@ def test_two_intervals_fire_proportionally_and_cancel_stops_one():
 
     assert _wait_until(lambda: len(slow) >= 3)
     assert len(fast) > len(slow)  # 5x interval ratio -> clearly more fast ticks
-    # Both ran on this scheduler's single thread, not on new threads.
+    # Both ran within this scheduler's bounded pool, not unconstrained new threads.
     before = threading.active_count()
     sched.schedule(lambda: None, 0.01).cancel()
     assert threading.active_count() == before
@@ -84,9 +84,78 @@ def test_module_level_schedule_uses_shared_default():
     h.cancel()
     thread = periodic_scheduler._DEFAULT._thread
     assert thread is not None and thread.name == "hermes-periodic-scheduler"
-    # Scheduling more timers on the shared default adds no OS threads.
+    # Scheduling more timers on the shared default adds no OS threads beyond bounded pool.
     before = threading.active_count()
     handles = [schedule(lambda: None, 0.01) for _ in range(20)]
     assert threading.active_count() == before
     for handle in handles:
         handle.cancel()
+
+
+def test_blocked_callback_does_not_stall_due_sibling(monkeypatch):
+    """Regression test for Issue #102574: one blocked callback must not stall sibling due timers."""
+    scheduler = PeriodicScheduler()
+    monkeypatch.setattr(periodic_scheduler, "_DEFAULT", scheduler)
+    blocker_entered = threading.Event()
+    release_blocker = threading.Event()
+    sibling_ran = threading.Event()
+
+    def blocker():
+        blocker_entered.set()
+        release_blocker.wait(2.0)
+        return False
+
+    def sibling():
+        sibling_ran.set()
+        return False
+
+    blocker_handle = schedule(blocker, 0.01)
+    assert blocker_entered.wait(1.0)
+    sibling_handle = schedule(sibling, 0.01)
+    try:
+        assert sibling_ran.wait(0.30), (
+            "a blocked periodic callback stalled an unrelated due callback"
+        )
+    finally:
+        release_blocker.set()
+        blocker_handle.cancel(wait=1.0)
+        sibling_handle.cancel(wait=1.0)
+
+
+def test_worker_pool_growth_bounded_with_many_handles():
+    """Verify thread growth remains strictly bounded under heavy handle load."""
+    max_workers = 4
+    sched = PeriodicScheduler(max_workers=max_workers)
+    events = [threading.Event() for _ in range(20)]
+    release_all = threading.Event()
+
+    def make_task(ev):
+        def task():
+            ev.set()
+            release_all.wait(0.5)
+            return False
+        return task
+
+    handles = [sched.schedule(make_task(ev), 0.005) for ev in events]
+    time.sleep(0.05)
+    # Total worker threads created for this scheduler must not exceed max_workers
+    assert len(sched._workers) <= max_workers
+    release_all.set()
+    for h in handles:
+        h.cancel(wait=1.0)
+
+
+def test_self_cancel_from_inside_callback_does_not_deadlock():
+    """Verify a callback calling cancel(wait=...) on its own handle does not deadlock."""
+    sched = PeriodicScheduler()
+    handle_box = []
+    completed = threading.Event()
+
+    def self_cancelling():
+        handle_box[0].cancel(wait=1.0)
+        completed.set()
+        return False
+
+    h = sched.schedule(self_cancelling, 0.01)
+    handle_box.append(h)
+    assert completed.wait(2.0), "self-cancellation deadlocked the worker"


### PR DESCRIPTION
## Summary

Fixes #102574.

`PeriodicScheduler` in `agent/periodic_scheduler.py` previously executed every periodic callback inline on its single timer thread (`hermes-periodic-scheduler`). When any callback blocked or encountered slow I/O (e.g. SQLite database lock contention, slow disk operations, network timeouts), all other scheduled callbacks—including turn-liveness watchdogs, durable turn lease refreshes, and delegated-child heartbeats—were stalled behind it, creating a process-wide liveness failure domain.

This change decouples timer ordering/scheduling from callback execution:
- **Dedicated Timer Thread**: The scheduler thread maintains the heap of due timestamps and dispatches ready callbacks to a bounded worker queue.
- **Bounded Worker Pool**: Callbacks execute across a bounded pool of worker threads (`max_workers=8`), bounding thread growth regardless of handle load.
- **Per-Handle In-Flight Isolation**: Tracks `_running_handles: set[ScheduledHandle]` and `_handle_threads` so `cancel(wait=timeout)` waits strictly for that handle's active execution without deadlocking on self-cancellation or stalling behind unrelated callbacks.
- **Preserved Semantics**: Rescheduling interval continues to compute from callback return time (`interval` seconds after completion); `False` returns stop/cancel the handle; unhandled exceptions are caught and logged at debug level and rescheduled.

## Tests Added / Updated

- `test_blocked_callback_does_not_stall_due_sibling` in `tests/agent/test_periodic_scheduler.py`: Verifies a blocking callback holding a lock does not stall unrelated due sibling callbacks from executing within their deadline.
- `test_worker_pool_growth_bounded_with_many_handles`: Asserts worker thread growth remains strictly bounded under heavy handle load (20+ handles).
- `test_self_cancel_from_inside_callback_does_not_deadlock`: Verifies a callback invoking `cancel(wait=...)` on its own handle does not deadlock.
- All existing periodic scheduler and turn liveness tests pass (17/17).
