### PR TITLE
fix: strip workspace context from session titles

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -131,6 +131,18 @@ _CONTROL_WRAPPERS = (
     ("<ide_selection>", "</ide_selection>"),
 )
 
+# The hosted workspace prepends machine-authored metadata as a self-closing
+# tag. Strip one leading tag while preserving the user's following request.
+_LEADING_WORKSPACE_CONTEXT_RE = re.compile(
+    r"^<workspace_context\b(?:[^>\"']|\"[^\"]*\"|'[^']*')*/>\s*",
+    re.IGNORECASE,
+)
+
+
+def _strip_leading_workspace_context(text: str) -> str:
+    """Remove one hosted-workspace metadata tag before classifying the turn."""
+    return _LEADING_WORKSPACE_CONTEXT_RE.sub("", text.strip(), count=1).strip()
+
 # Hermes' own machine-authored openers. A compaction handoff or a resumed
 # session must not be titled after the scaffolding that carried it. The legacy
 # summary prefix comes from the compressor rather than a fourth local copy —
@@ -194,7 +206,7 @@ def strip_control_wrappers(text: str) -> str:
     """
     if not text:
         return ""
-    current = text.strip()
+    current = _strip_leading_workspace_context(text)
     # Bounded: each pass must remove at least one wrapper or we stop.
     for _ in range(len(_CONTROL_WRAPPERS) * 2):
         stripped = current
@@ -230,14 +242,15 @@ def _summarize_user_message(user_message: str) -> str:
     """
     if not user_message:
         return ""
+    normalized = _strip_leading_workspace_context(user_message)
     described = None
     try:
         from agent.skill_commands import describe_skill_invocation
 
-        described = describe_skill_invocation(user_message)
+        described = describe_skill_invocation(normalized)
     except Exception:
         logger.debug("Skill-scaffolding summary failed; titling raw", exc_info=True)
-    text = described if described is not None else user_message
+    text = described if described is not None else normalized
     return strip_control_wrappers(text)
 
 
@@ -249,10 +262,11 @@ def is_titleable_user_message(user_message: str) -> bool:
     """
     if not isinstance(user_message, str) or not user_message.strip():
         return False
+    normalized = _strip_leading_workspace_context(user_message)
     for prefix in _MACHINE_PREFIXES:
-        if user_message.lstrip().startswith(prefix):
+        if normalized.startswith(prefix):
             return False
-    return bool(_summarize_user_message(user_message).strip())
+    return bool(_summarize_user_message(normalized).strip())
 
 
 def derive_title(user_message: str) -> Optional[str]:

--- a/tests/test_title_generator_workspace_context.py
+++ b/tests/test_title_generator_workspace_context.py
@@ -1,0 +1,76 @@
+from types import SimpleNamespace
+
+import agent.title_generator as title_generator
+
+
+def test_derive_title_strips_leading_workspace_context():
+    message = (
+        '<workspace_context cwd="/private/project" branch="secret" />\n'
+        "Fix login button on mobile"
+    )
+
+    assert title_generator.derive_title(message) == "Fix login button on mobile"
+
+
+def test_generate_title_sends_only_request_after_workspace_context(monkeypatch):
+    captured = {}
+
+    def fake_call_llm(**kwargs):
+        captured.update(kwargs)
+        return SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content='{"title": "Fix mobile login button"}'
+                    )
+                )
+            ]
+        )
+
+    monkeypatch.setattr(title_generator, "_auto_title_enabled", lambda: True)
+    monkeypatch.setattr(title_generator, "_title_language", lambda: "")
+    monkeypatch.setattr(title_generator, "call_llm", fake_call_llm)
+
+    message = (
+        '<workspace_context cwd="/private/project" branch="secret" />\n'
+        "Fix login button on mobile"
+    )
+
+    assert title_generator.generate_title(message) == "Fix mobile login button"
+    assert captured["messages"][1]["content"] == "Fix login button on mobile"
+    assert "workspace_context" not in captured["messages"][1]["content"]
+    assert "/private/project" not in captured["messages"][1]["content"]
+
+
+def test_workspace_context_is_removed_before_skill_summarization(monkeypatch):
+    from agent import skill_commands
+
+    seen = {}
+
+    def fake_describe(message):
+        seen["message"] = message
+        return "/work — fix the title leak"
+
+    monkeypatch.setattr(skill_commands, "describe_skill_invocation", fake_describe)
+    message = '<workspace_context cwd="/private/project" />\n/skill expanded scaffold'
+
+    assert title_generator.derive_title(message) == "/work — fix the title leak"
+    assert seen["message"] == "/skill expanded scaffold"
+
+
+def test_workspace_context_before_machine_marker_is_not_titleable():
+    message = (
+        '<workspace_context cwd="/private/project" />\n'
+        "[CONTEXT COMPACTION — REFERENCE ONLY] Earlier turns were compacted"
+    )
+
+    assert title_generator.is_titleable_user_message(message) is False
+
+
+def test_workspace_context_only_is_not_titleable():
+    assert (
+        title_generator.is_titleable_user_message(
+            '<workspace_context cwd="/private/project" />'
+        )
+        is False
+    )


### PR DESCRIPTION
Strip the hosted dashboard self-closing workspace_context metadata tag before skill invocation summarization and machine-prefix classification, so both deterministic and model-backed titles use the real user request. Includes regressions for normal requests, model input, prefixed skill scaffolding, machine-only markers, and metadata-only turns. Focused project test wrapper: 41 passed, 0 failed. Independently reviewed before publication.