### PR TITLE
fix(kanban): fail closed on missing worker handoff

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1470,8 +1470,75 @@ def _wait_for_oneshot_background_completions(cli) -> None:
         )
 
 
+def _ensure_kanban_worker_lifecycle(
+    task_id: str,
+    run_id: int,
+    *,
+    clean_exit: bool,
+    retry_delays: tuple[float, ...] = (0.0, 0.05, 0.2),
+) -> bool:
+    """Verify a clean Kanban worker exit has a durable terminal run record.
+
+    Returns ``True`` when the run was already finalized (including review
+    handoffs) or this is not a clean exit.  A missing handoff is durably
+    recorded as a protocol violation and returns ``False`` so the process
+    cannot report nominal success.  Transient DB failures are retried; every
+    successful write is read back through a fresh connection before success is
+    reported.
+    """
+    if not clean_exit:
+        return True
+
+    from hermes_cli import kanban_db as kb
+
+    delays = retry_delays or (0.0,)
+    for attempt, delay in enumerate(delays):
+        if delay:
+            time.sleep(delay)
+        try:
+            with kb.connect_closing() as conn:
+                disposition = kb.finalize_clean_worker_exit(conn, task_id, run_id)
+            with kb.connect_closing() as verify_conn:
+                run = kb.get_run(verify_conn, run_id)
+                durable = bool(
+                    run is not None
+                    and run.task_id == task_id
+                    and run.outcome is not None
+                    and run.ended_at is not None
+                )
+            if not durable:
+                raise RuntimeError(
+                    f"Kanban run {run_id} has no durable terminal lifecycle transition"
+                )
+            return disposition != "protocol_violation"
+        except Exception:
+            if attempt + 1 == len(delays):
+                logger.error(
+                    "Kanban worker lifecycle finalization failed for %s run %s",
+                    task_id,
+                    run_id,
+                    exc_info=True,
+                )
+            else:
+                logger.debug(
+                    "retrying Kanban worker lifecycle finalization for %s run %s",
+                    task_id,
+                    run_id,
+                    exc_info=True,
+                )
+    return False
+
+
 def _finalize_single_query(cli) -> None:
     """Close one-shot CLI resources before releasing the active session lease."""
+    active_exception = sys.exc_info()[1]
+    clean_exit = active_exception is None or (
+        isinstance(active_exception, SystemExit)
+        and active_exception.code in (None, 0)
+    )
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    raw_run_id = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    lifecycle_ok = True
     try:
         # Linger (bounded) for background processes the turn spawned with
         # notify_on_complete=true BEFORE any teardown. The one-shot parent
@@ -1492,9 +1559,37 @@ def _finalize_single_query(cli) -> None:
         except Exception:
             logger.debug("one-shot session store flush failed", exc_info=True)
         _notify_single_query_session_finalize(cli)
+        if task_id:
+            if not raw_run_id:
+                lifecycle_ok = False
+                logger.error(
+                    "missing HERMES_KANBAN_RUN_ID for worker %s",
+                    task_id,
+                )
+            else:
+                try:
+                    run_id = int(raw_run_id)
+                except ValueError:
+                    lifecycle_ok = False
+                    logger.error(
+                        "invalid HERMES_KANBAN_RUN_ID=%r for worker %s",
+                        raw_run_id,
+                        task_id,
+                    )
+                else:
+                    lifecycle_ok = _ensure_kanban_worker_lifecycle(
+                        task_id,
+                        run_id,
+                        clean_exit=clean_exit,
+                    )
+        # Lifecycle verification precedes cleanup because cleanup's watchdog may
+        # terminate a wedged process with os._exit(0). A Kanban worker must have
+        # durably closed its exact run before that fail-safe can report success.
         _run_cleanup(notify_session_finalize=False)
     finally:
         cli._release_active_session()
+    if not lifecycle_ok:
+        raise SystemExit(1)
 
 
 def _reset_terminal_input_modes_on_exit() -> None:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8380,6 +8380,100 @@ def _defer_reclaim_for_live_worker(
         _append_event(conn, task_id, "reclaim_deferred", payload, run_id=run_id)
 
 
+def finalize_clean_worker_exit(
+    conn: sqlite3.Connection,
+    task_id: str,
+    expected_run_id: int,
+) -> str:
+    """Fail closed when a worker returns normally without a terminal handoff.
+
+    The worker process calls this at its own clean-exit boundary, before the
+    dispatcher can lose the exit status to PID reaping.  A completed, blocked,
+    review-requested, or otherwise closed run is preserved verbatim.  An open
+    run still owned by this task is atomically closed as a protocol violation
+    and returned to its source lane for a bounded retry; it is never inferred
+    as completed, and the breaker is applied only after the existing violation
+    limit is exhausted.
+
+    Returns ``"already_finalized"``, ``"protocol_violation"``, or
+    ``"superseded"``.  Replayed calls are idempotent because only the exact
+    active run can take the transition.
+    """
+    error_text = (
+        "worker exited cleanly (rc=0) without a durable terminal lifecycle "
+        "transition — protocol violation. Verify prior work and call "
+        "kanban_complete, kanban_block, or kanban_request_review."
+    )
+    with write_txn(conn):
+        run = conn.execute(
+            "SELECT outcome, ended_at, metadata FROM task_runs "
+            "WHERE id = ? AND task_id = ?",
+            (int(expected_run_id), task_id),
+        ).fetchone()
+        if run is None:
+            return "superseded"
+        if run["outcome"] is not None or run["ended_at"] is not None:
+            try:
+                metadata = json.loads(run["metadata"]) if run["metadata"] else {}
+            except (TypeError, ValueError):
+                metadata = {}
+            if (
+                run["outcome"] == "crashed"
+                and isinstance(metadata, dict)
+                and metadata.get("protocol_violation") is True
+                and metadata.get("source") == "worker_exit_finalizer"
+            ):
+                return "protocol_violation"
+            return "already_finalized"
+
+        retry_status = _retry_status_for_run(conn, task_id, int(expected_run_id))
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL, "
+            "claim_expires = NULL, worker_pid = NULL, last_failure_error = ? "
+            "WHERE id = ? AND status = 'running' AND current_run_id = ?",
+            (retry_status, error_text[:500], task_id, int(expected_run_id)),
+        )
+        if cur.rowcount != 1:
+            # Ownership moved between the run read and the CAS.  Never mutate a
+            # successor run or infer completion from task-level status.
+            return "superseded"
+        payload = {
+            "exit_code": 0,
+            "protocol_violation": True,
+            "retry_status": retry_status,
+            "source": "worker_exit_finalizer",
+        }
+        run_id = _end_run(
+            conn,
+            task_id,
+            outcome="crashed",
+            status="crashed",
+            error=error_text,
+            metadata=payload,
+        )
+        if run_id != int(expected_run_id):
+            raise RuntimeError(
+                f"worker finalizer closed run {run_id}, expected {expected_run_id}"
+            )
+        _append_event(
+            conn,
+            task_id,
+            "protocol_violation",
+            payload,
+            run_id=run_id,
+        )
+        _account_protocol_violation(
+            conn,
+            task_id,
+            error_text,
+            event_payload_extra={
+                "protocol_violations": _protocol_violation_streak(conn, task_id),
+                "source": "worker_exit_finalizer",
+            },
+        )
+    return "protocol_violation"
+
+
 def heartbeat_worker(
     conn: sqlite3.Connection,
     task_id: str,
@@ -8860,6 +8954,47 @@ def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
     return streak
 
 
+def _account_protocol_violation(
+    conn: sqlite3.Connection,
+    task_id: str,
+    error_text: str,
+    *,
+    event_payload_extra: Optional[dict] = None,
+) -> bool:
+    """Apply the bounded clean-exit violation breaker exactly once."""
+    streak = _protocol_violation_streak(conn, task_id)
+    row = conn.execute(
+        "SELECT max_retries FROM tasks WHERE id = ?", (task_id,),
+    ).fetchone()
+    if row is None:
+        return False
+    task_override = row["max_retries"]
+    violation_limit = (
+        int(task_override)
+        if task_override is not None
+        else _PROTOCOL_VIOLATION_FAILURE_LIMIT
+    )
+    if streak < violation_limit:
+        return False
+    extra = dict(event_payload_extra or {})
+    extra.update({
+        "protocol_violations": streak,
+        "protocol_violation_limit": violation_limit,
+    })
+    return _record_task_failure(
+        conn,
+        task_id,
+        error=error_text,
+        outcome="crashed",
+        failure_limit=violation_limit,
+        force_trip=True,
+        release_claim=False,
+        end_run=False,
+        event_payload_extra=extra,
+        _allow_nested_txn=conn.in_transaction,
+    )
+
+
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -9077,47 +9212,11 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
         for tid, pid, claimer, protocol_violation, error_text in crash_details:
             if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
-                )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
-                tripped = _record_task_failure(
-                    conn, tid,
-                    error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
-                    force_trip=True,
-                    release_claim=False,
-                    end_run=False,
-                    event_payload_extra={
-                        "pid": pid,
-                        "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
-                    },
+                tripped = _account_protocol_violation(
+                    conn,
+                    tid,
+                    error_text,
+                    event_payload_extra={"pid": pid, "claimer": claimer},
                 )
                 if tripped:
                     auto_blocked.append(tid)
@@ -9171,6 +9270,7 @@ def _record_task_failure(
     release_claim: bool = False,
     end_run: bool = False,
     event_payload_extra: Optional[dict] = None,
+    _allow_nested_txn: bool = False,
 ) -> bool:
     """Record a non-success outcome (spawn_failed / crashed / timed_out)
     and maybe trip the circuit breaker.
@@ -9218,7 +9318,7 @@ def _record_task_failure(
     if failure_limit is None:
         failure_limit = DEFAULT_FAILURE_LIMIT
     blocked = False
-    with write_txn(conn):
+    with write_txn(conn, allow_nested=_allow_nested_txn):
         row = conn.execute(
             "SELECT consecutive_failures, status, max_retries, current_run_id "
             "FROM tasks WHERE id = ?", (task_id,),
@@ -9243,6 +9343,12 @@ def _record_task_failure(
         else:
             effective_limit = int(failure_limit)
             limit_source = "dispatcher"
+
+        # A caller that already exhausted a separate bounded-retry policy is
+        # tripping this breaker at that policy's threshold. Persist at least
+        # that threshold so recompute_ready cannot immediately undo the block.
+        if force_trip:
+            failures = max(failures, effective_limit)
 
         if force_trip or failures >= effective_limit:
             # Trip the breaker.

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -8897,6 +8897,33 @@ def _error_fingerprint(error_text: str) -> str:
 # precedence ``_record_task_failure`` documents for every other failure kind.
 _PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
 
+# Durable marker identifying a task that requires explicit product/human
+# sign-off (``PRODUCT_SIGNOFF`` in the title or body). Such tasks are exempt
+# from the clean-exit violation breaker below: the task body defines the
+# worker's job as reporting back for sign-off rather than driving to a
+# terminal transition, so repeated clean exits without one are a property of
+# the workflow, not a runaway worker — the breaker must never auto-block
+# them. The classification is durable (read from the task row at accounting
+# time, not from run metadata), so it survives retries, reclaims, and
+# dispatcher restarts.
+_PRODUCT_SIGNOFF_MARKER = "PRODUCT_SIGNOFF"
+
+
+def _is_product_signoff_task(
+    conn: sqlite3.Connection, task_id: str
+) -> bool:
+    """True when the task durably requires product sign-off."""
+    row = conn.execute(
+        "SELECT title, body FROM tasks WHERE id = ?", (task_id,)
+    ).fetchone()
+    if row is None:
+        return False
+    for column in ("title", "body"):
+        text = row[column]
+        if text and _PRODUCT_SIGNOFF_MARKER in text:
+            return True
+    return False
+
 # How far back to walk a task's closed runs when counting the violation
 # streak. The streak trips at a handful of violations, so anything beyond a
 # few dozen rows (violations interleaved with neutral rate-limited requeues)
@@ -8961,7 +8988,15 @@ def _account_protocol_violation(
     *,
     event_payload_extra: Optional[dict] = None,
 ) -> bool:
-    """Apply the bounded clean-exit violation breaker exactly once."""
+    """Apply the bounded clean-exit violation breaker exactly once.
+
+    Tasks that durably require product sign-off (``PRODUCT_SIGNOFF`` marker in
+    title/body, see ``_is_product_signoff_task``) are exempt: the violation is
+    still recorded and the task retried, but the breaker never auto-blocks
+    them regardless of how many times the limit is reached.
+    """
+    if _is_product_signoff_task(conn, task_id):
+        return False
     streak = _protocol_violation_streak(conn, task_id)
     row = conn.execute(
         "SELECT max_retries FROM tasks WHERE id = ?", (task_id,),

--- a/tests/hermes_cli/test_kanban_worker_finalization.py
+++ b/tests/hermes_cli/test_kanban_worker_finalization.py
@@ -115,11 +115,32 @@ def test_duplicate_finalization_is_idempotent(kanban_home):
         assert [e.id for e in kb.list_events(conn, task_id)] == event_ids
 
 
-def test_product_signoff_is_not_auto_blocked(kanban_home):
+def test_product_signoff_task_is_never_auto_blocked_across_violation_limit(
+    kanban_home,
+):
     with kb.connect() as conn:
-        task_id, run_id = _claimed(conn, body="PRODUCT_SIGNOFF required from owner")
+        task_id = kb.create_task(
+            conn,
+            title="ship release",
+            body="PRODUCT_SIGNOFF required from owner",
+            assignee="coder",
+        )
+        for _ in range(kb._PROTOCOL_VIOLATION_FAILURE_LIMIT + 1):
+            task = kb.claim_task(conn, task_id)
+            assert task is not None and task.current_run_id is not None
 
-        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "protocol_violation"
+            assert (
+                kb.finalize_clean_worker_exit(conn, task_id, task.current_run_id)
+                == "protocol_violation"
+            )
+
+            task = kb.get_task(conn, task_id)
+            assert task is not None and task.status == "ready"
+            assert not any(
+                e.kind == "gave_up" for e in kb.list_events(conn, task_id)
+            )
+
+        assert kb.recompute_ready(conn) == 0
         assert kb.get_task(conn, task_id).status == "ready"
 
 

--- a/tests/hermes_cli/test_kanban_worker_finalization.py
+++ b/tests/hermes_cli/test_kanban_worker_finalization.py
@@ -1,0 +1,232 @@
+"""Fail-closed finalization for dispatcher-spawned Kanban workers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+import cli
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _claimed(conn, *, assignee="coder", body=None):
+    task_id = kb.create_task(conn, title="work", body=body, assignee=assignee)
+    task = kb.claim_task(conn, task_id)
+    assert task is not None and task.current_run_id is not None
+    return task_id, task.current_run_id
+
+
+@pytest.mark.parametrize("assignee", ["coder", "qa"])
+def test_clean_worker_exit_without_lifecycle_is_durably_failed_closed(
+    kanban_home, assignee,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn, assignee=assignee)
+
+        result = kb.finalize_clean_worker_exit(conn, task_id, run_id)
+
+        assert result == "protocol_violation"
+        task = kb.get_task(conn, task_id)
+        run = kb.get_run(conn, run_id)
+        assert task.status == "ready"
+        assert task.current_run_id is None
+        assert run.outcome == "crashed"
+        assert run.ended_at is not None
+        assert run.metadata["protocol_violation"] is True
+        assert not any(e.kind == "gave_up" for e in kb.list_events(conn, task_id))
+
+
+@pytest.mark.parametrize(
+    ("transition", "expected"),
+    [
+        (lambda conn, tid, rid: kb.complete_task(conn, tid, summary="done", expected_run_id=rid), "completed"),
+        (lambda conn, tid, rid: kb.block_task(conn, tid, reason="dependency", expected_run_id=rid), "blocked"),
+        (lambda conn, tid, rid: kb.request_review(conn, tid, summary="review me", expected_run_id=rid), "review_requested"),
+    ],
+)
+def test_successful_lifecycle_transition_is_preserved(
+    kanban_home, transition, expected,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+        assert transition(conn, task_id, run_id)
+
+        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "already_finalized"
+        assert kb.get_run(conn, run_id).outcome == expected
+
+
+def test_transient_finalization_write_is_retried_and_verified(
+    kanban_home, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+
+    real_connect = kb.connect_closing
+    attempts = 0
+
+    def flaky_connect():
+        nonlocal attempts
+        attempts += 1
+        if attempts == 1:
+            raise OSError("temporary database failure")
+        return real_connect()
+
+    monkeypatch.setattr(kb, "connect_closing", flaky_connect)
+    assert cli._ensure_kanban_worker_lifecycle(
+        task_id, run_id, clean_exit=True, retry_delays=(0, 0)
+    ) is False
+    # One failed open + one successful write + one fresh verification read.
+    assert attempts == 3
+    with kb.connect() as conn:
+        assert kb.get_run(conn, run_id).ended_at is not None
+
+
+def test_process_crash_does_not_fabricate_a_lifecycle_transition(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+
+    assert cli._ensure_kanban_worker_lifecycle(
+        task_id, run_id, clean_exit=False, retry_delays=(0,)
+    ) is True
+    with kb.connect() as conn:
+        assert kb.get_task(conn, task_id).status == "running"
+        assert kb.get_run(conn, run_id).ended_at is None
+
+
+def test_duplicate_finalization_is_idempotent(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "protocol_violation"
+        event_ids = [e.id for e in kb.list_events(conn, task_id)]
+
+        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "protocol_violation"
+        assert [e.id for e in kb.list_events(conn, task_id)] == event_ids
+
+
+def test_product_signoff_is_not_auto_blocked(kanban_home):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn, body="PRODUCT_SIGNOFF required from owner")
+
+        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "protocol_violation"
+        assert kb.get_task(conn, task_id).status == "ready"
+
+
+def test_finalization_and_breaker_accounting_share_one_transaction(
+    kanban_home, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+        conn.execute("UPDATE tasks SET max_retries = 1 WHERE id = ?", (task_id,))
+        real_record_failure = kb._record_task_failure
+
+        def require_active_transaction(inner_conn, *args, **kwargs):
+            assert inner_conn.in_transaction
+            return real_record_failure(inner_conn, *args, **kwargs)
+
+        monkeypatch.setattr(kb, "_record_task_failure", require_active_transaction)
+
+        assert kb.finalize_clean_worker_exit(conn, task_id, run_id) == "protocol_violation"
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
+def test_breaker_accounting_failure_rolls_back_run_finalization(
+    kanban_home, monkeypatch,
+):
+    with kb.connect() as conn:
+        task_id, run_id = _claimed(conn)
+        conn.execute("UPDATE tasks SET max_retries = 1 WHERE id = ?", (task_id,))
+
+        def fail_accounting(*_args, **_kwargs):
+            raise OSError("accounting write failed")
+
+        monkeypatch.setattr(kb, "_record_task_failure", fail_accounting)
+
+        with pytest.raises(OSError, match="accounting write failed"):
+            kb.finalize_clean_worker_exit(conn, task_id, run_id)
+
+        assert kb.get_task(conn, task_id).status == "running"
+        assert kb.get_run(conn, run_id).ended_at is None
+        assert not any(
+            event.kind == "protocol_violation"
+            for event in kb.list_events(conn, task_id)
+        )
+
+
+def test_protocol_violation_limit_stays_blocked_after_recompute(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="repeated omission", assignee="qa")
+        for _ in range(kb._PROTOCOL_VIOLATION_FAILURE_LIMIT):
+            task = kb.claim_task(conn, task_id)
+            assert task is not None and task.current_run_id is not None
+            kb.finalize_clean_worker_exit(conn, task_id, task.current_run_id)
+
+        assert kb.get_task(conn, task_id).status == "blocked"
+        assert kb.recompute_ready(conn) == 0
+        assert kb.get_task(conn, task_id).status == "blocked"
+
+
+def test_single_query_finalizer_rejects_missing_run_identity(monkeypatch):
+    worker = SimpleNamespace(_release_active_session=lambda: None, agent=None, session_id=None)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    monkeypatch.delenv("HERMES_KANBAN_RUN_ID", raising=False)
+    monkeypatch.setattr(cli, "_wait_for_oneshot_background_completions", lambda _cli: None)
+    monkeypatch.setattr(cli, "_flush_one_shot_session_store", lambda _cli: None)
+    monkeypatch.setattr(cli, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **_kw: None)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._finalize_single_query(worker)
+
+    assert exc.value.code != 0
+
+
+def test_single_query_finalizes_worker_before_cleanup(monkeypatch):
+    order = []
+    worker = SimpleNamespace(
+        _release_active_session=lambda: order.append("release"),
+        agent=None,
+        session_id=None,
+    )
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setattr(cli, "_wait_for_oneshot_background_completions", lambda _cli: None)
+    monkeypatch.setattr(cli, "_flush_one_shot_session_store", lambda _cli: None)
+    monkeypatch.setattr(cli, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(
+        cli,
+        "_ensure_kanban_worker_lifecycle",
+        lambda *a, **k: order.append("lifecycle") or True,
+    )
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **_kw: order.append("cleanup"))
+
+    cli._finalize_single_query(worker)
+
+    assert order == ["lifecycle", "cleanup", "release"]
+
+
+def test_single_query_finalizer_forces_nonzero_exit_on_protocol_violation(monkeypatch):
+    worker = SimpleNamespace(_release_active_session=lambda: None, agent=None, session_id=None)
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_worker")
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "42")
+    monkeypatch.setattr(cli, "_wait_for_oneshot_background_completions", lambda _cli: None)
+    monkeypatch.setattr(cli, "_flush_one_shot_session_store", lambda _cli: None)
+    monkeypatch.setattr(cli, "_notify_single_query_session_finalize", lambda _cli: None)
+    monkeypatch.setattr(cli, "_run_cleanup", lambda **_kw: None)
+    monkeypatch.setattr(cli, "_ensure_kanban_worker_lifecycle", lambda *a, **k: False)
+
+    with pytest.raises(SystemExit) as exc:
+        cli._finalize_single_query(worker)
+
+    assert exc.value.code != 0


### PR DESCRIPTION
## Summary
- fail closed in one-shot Kanban workers when an rc=0 return lacks a durable complete, block, or review handoff
- fence finalization to the exact task run, retry transient database failures, and verify the terminal run via a fresh connection
- atomically record protocol violations with existing bounded circuit-breaker accounting while preserving completed, blocked, reviewed, crashed, and stale runs
- reject missing or malformed worker run identity and finalize before the cleanup watchdog can force a successful process exit

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_kanban*.py tests/plugins/test_kanban*.py tests/cli/test_single_query_session_finalize.py tests/cli/test_oneshot_resumed_session_persist.py tests/tools/test_oneshot_completion_linger.py -q` — 453 passed, 2 OS-specific skipped
- `ruff check cli.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worker_finalization.py` — passed
- `python -m compileall -q cli.py hermes_cli/kanban_db.py tests/hermes_cli/test_kanban_worker_finalization.py` — passed
- `git diff --cached --check` — passed
- independent staged-diff review — passed with no security concerns or logic errors

## Safety
- no Discord gateway was started
- no model/provider spend configuration was changed
- this PR must not be merged by the implementing agent
