### PR TITLE
feat(desktop): add per-zone background tints

### DIFF
--- a/apps/desktop/src/components/pane-shell/tree/model.ts
+++ b/apps/desktop/src/components/pane-shell/tree/model.ts
@@ -29,6 +29,14 @@ export type Orientation = 'row' | 'column'
  */
 export type TabStripMode = 'always' | 'never'
 
+/** Curated semantic hues for tinting a zone without storing arbitrary CSS. */
+export const ZONE_BACKGROUND_TINTS = ['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'purple'] as const
+export type ZoneBackgroundTint = (typeof ZONE_BACKGROUND_TINTS)[number]
+
+export function isZoneBackgroundTint(value: unknown): value is ZoneBackgroundTint {
+  return typeof value === 'string' && ZONE_BACKGROUND_TINTS.includes(value as ZoneBackgroundTint)
+}
+
 export interface SplitNode {
   type: 'split'
   id: string
@@ -51,6 +59,8 @@ export interface GroupNode {
    *  only by the zone menu and the toggle command. Minimize ignores it — a
    *  minimized group IS its strip. */
   tabStrip?: TabStripMode
+  /** Optional theme-aware background tint. Absent follows the active skin. */
+  backgroundTint?: ZoneBackgroundTint
 }
 
 export type LayoutNode = SplitNode | GroupNode
@@ -69,7 +79,8 @@ export const group = (panes: string[], options?: Partial<Omit<GroupNode, 'type' 
   panes,
   active: options?.active ?? panes[0] ?? '',
   minimized: options?.minimized,
-  tabStrip: options?.tabStrip
+  tabStrip: options?.tabStrip,
+  backgroundTint: options?.backgroundTint
 })
 
 export const split = (
@@ -547,6 +558,23 @@ export function setGroupTabStrip(root: LayoutNode, groupId: string, tabStrip: Ta
   return mapGroups(root, g => (g.id === groupId ? { ...g, tabStrip } : g))
 }
 
+/** Apply a curated tint to one zone; undefined returns it to the active skin. */
+export function setGroupBackgroundTint(
+  root: LayoutNode,
+  groupId: string,
+  backgroundTint: ZoneBackgroundTint | undefined
+): LayoutNode {
+  return mapGroups(root, group => {
+    if (group.id !== groupId) {
+      return group
+    }
+
+    const { backgroundTint: _current, ...untinted } = group
+
+    return backgroundTint ? { ...untinted, backgroundTint } : untinted
+  })
+}
+
 function replaceNode(node: LayoutNode, id: string, make: (g: GroupNode) => LayoutNode): LayoutNode {
   if (node.type === 'group') {
     return node.id === id ? make(node) : node
@@ -608,10 +636,24 @@ export function setSplitWeights(root: LayoutNode, splitId: string, weights: numb
  */
 export function migratePersistedTree(node: LayoutNode): LayoutNode {
   if (node.type === 'group') {
-    const { headerHidden, ...rest } = node as GroupNode & { headerHidden?: unknown }
+    const {
+      backgroundTint: rawBackgroundTint,
+      headerHidden,
+      ...rest
+    } = node as GroupNode & {
+      backgroundTint?: unknown
+      headerHidden?: unknown
+    }
+
     const tabStrip = rest.tabStrip === 'always' || rest.tabStrip === 'never' ? rest.tabStrip : undefined
 
-    return headerHidden === undefined && rest.tabStrip === tabStrip ? node : { ...rest, tabStrip }
+    const backgroundTint = isZoneBackgroundTint(rawBackgroundTint) ? rawBackgroundTint : undefined
+
+    if (headerHidden === undefined && rest.tabStrip === tabStrip && rawBackgroundTint === backgroundTint) {
+      return node
+    }
+
+    return { ...rest, tabStrip, ...(backgroundTint ? { backgroundTint } : {}) }
   }
 
   return { ...node, children: node.children.map(migratePersistedTree) }

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.test.tsx
@@ -1,9 +1,11 @@
+import { fireEvent, screen } from '@testing-library/react'
 import { act, type ReactNode } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import { registry } from '@/contrib/registry'
 
+import { $layoutEditMode } from '../../edit-mode'
 import type { GroupNode } from '../model'
 
 import { TreeGroup } from './tree-group'
@@ -52,6 +54,7 @@ afterEach(() => {
   root = null
   container = null
   disposePane = null
+  $layoutEditMode.set(false)
   vi.unstubAllGlobals()
 })
 
@@ -74,5 +77,84 @@ describe('TreeGroup', () => {
     render(<TreeGroup node={terminalGroup(true)} parentAxis="column" />)
 
     expect(toggle('Restore').querySelector('i')!.className).toContain('codicon-chevron-up')
+  })
+
+  it('scopes a semantic background tint to the selected zone', () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    render(<TreeGroup node={{ ...terminalGroup(false), backgroundTint: 'cyan' }} parentAxis="column" />)
+
+    const zone = globalThis.document.querySelector<HTMLElement>('[data-tree-group="terminal-zone"]')
+
+    expect(zone?.style.getPropertyValue('--ui-chat-surface-background')).toBe(
+      'color-mix(in srgb, var(--ui-cyan) 10%, var(--ui-zone-chat-surface-background))'
+    )
+    expect(zone?.style.getPropertyValue('--ui-editor-surface-background')).toBe(
+      'color-mix(in srgb, var(--ui-cyan) 10%, var(--ui-zone-editor-surface-background))'
+    )
+    expect(zone?.style.getPropertyValue('--ui-sidebar-surface-background')).toBe(
+      'color-mix(in srgb, var(--ui-cyan) 10%, var(--ui-zone-sidebar-surface-background))'
+    )
+  })
+
+  it('offers background tint controls from the existing zone context menu', async () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+
+    render(<TreeGroup node={terminalGroup(false)} parentAxis="column" />)
+    fireEvent.contextMenu(globalThis.document.querySelector('[data-zone-tabstrip="terminal-zone"]')!)
+
+    expect(await screen.findByText('Background tint')).toBeTruthy()
+  })
+
+  it('offers background tint controls from a headerless zone in layout edit mode', async () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    $layoutEditMode.set(true)
+
+    render(<TreeGroup node={{ ...terminalGroup(false), tabStrip: 'never' }} parentAxis="column" />)
+    fireEvent.contextMenu(globalThis.document.querySelector('[data-zone-edit-veil="terminal-zone"]')!)
+
+    expect(await screen.findByText('Background tint')).toBeTruthy()
+  })
+
+  it('provides keyboard-operable zone actions and native tint menu items in layout edit mode', async () => {
+    disposePane = registry.register({
+      area: 'panes',
+      data: { height: '12rem' },
+      id: 'terminal',
+      render: () => <div>Terminal</div>,
+      title: 'Terminal'
+    })
+    vi.stubGlobal('CSS', { escape: (value: string) => value })
+    $layoutEditMode.set(true)
+
+    render(<TreeGroup node={{ ...terminalGroup(false), tabStrip: 'never' }} parentAxis="column" />)
+    fireEvent.click(screen.getByRole('button', { name: 'Zone actions' }))
+    const tintTrigger = (await screen.findByText('Background tint')).closest('[role="menuitem"]')
+
+    fireEvent.click(tintTrigger!)
+
+    expect(await screen.findByRole('menuitemradio', { name: 'Red' })).toBeTruthy()
+    expect(screen.getByRole('menuitemradio', { name: 'Default background' })).toBeTruthy()
   })
 })

--- a/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
+++ b/apps/desktop/src/components/pane-shell/tree/renderer/tree-group.tsx
@@ -43,7 +43,13 @@ import {
   resolveRememberedActivePane,
   workspaceScopeKey
 } from '../../workspace-scope'
-import type { DropPosition, GroupNode } from '../model'
+import {
+  type DropPosition,
+  type GroupNode,
+  isZoneBackgroundTint,
+  ZONE_BACKGROUND_TINTS,
+  type ZoneBackgroundTint
+} from '../model'
 import {
   $dropHint,
   $hiddenTreePanes,
@@ -67,6 +73,7 @@ import {
   restoreTreePane,
   SESSION_TILE_DRAG,
   setStripTabHidden,
+  setTreeGroupBackgroundTint,
   setTreeGroupMinimized,
   setTreeGroupTabStrip,
   treeTabCloseTargets
@@ -85,12 +92,17 @@ import { tabStripVisibleForZone } from './strip-visibility'
 import { useActiveTabVisible } from './tab-strip-scroll'
 import { paneChrome } from './track-model'
 
+function swatchForTint(tint: ZoneBackgroundTint | undefined): null | string {
+  return tint ? `var(--ui-${tint})` : null
+}
+
 /** Right-click zone menu: the tab verbs (close this / others / to the right /
  *  all) plus the strip's own chrome toggles. Same items and icons as a session
  *  tab's menu, so every tab in a strip answers a right-click the same way —
  *  a pane with no domain menu of its own (the file tree, a terminal, the main
  *  tab on a fresh draft) falls through to this one. */
 function ZoneMenu({
+  backgroundTint,
   children,
   closable,
   minimizable = true,
@@ -100,6 +112,7 @@ function ZoneMenu({
   tabMenuPrefix,
   targetPane
 }: {
+  backgroundTint?: ZoneBackgroundTint
   children: ReactNode
   /** The pane the menu closes (the right-clicked chip / the active pane);
    *  undefined = not closable (the main zone). */
@@ -204,6 +217,47 @@ function ZoneMenu({
             label: minimized ? t.zones.restore : t.zones.minimize,
             onSelect: () => setTreeGroupMinimized(nodeId, !minimized)
           })}
+        <kit.Sub>
+          <kit.SubTrigger>
+            <Codicon name="symbol-color" size="0.875rem" />
+            <span>{t.zones.backgroundTint}</span>
+            {backgroundTint && (
+              <span
+                aria-hidden="true"
+                className="ml-auto size-2.5 rounded-full ring-1 ring-(--ui-stroke-primary)"
+                style={{ backgroundColor: swatchForTint(backgroundTint) ?? undefined }}
+              />
+            )}
+          </kit.SubTrigger>
+          <kit.SubContent aria-label={t.zones.backgroundTint} className="w-44">
+            {ZONE_BACKGROUND_TINTS.map(tint => (
+              <kit.Item
+                aria-checked={backgroundTint === tint}
+                key={tint}
+                onSelect={() => setTreeGroupBackgroundTint(nodeId, tint)}
+                role="menuitemradio"
+              >
+                <span
+                  aria-hidden="true"
+                  className="size-3.5 rounded-full ring-1 ring-(--ui-stroke-primary)"
+                  style={{ backgroundColor: swatchForTint(tint) ?? undefined }}
+                />
+                <span>{t.zones.backgroundTintOption(tint)}</span>
+                {backgroundTint === tint && <Codicon className="ml-auto" name="check" size="0.75rem" />}
+              </kit.Item>
+            ))}
+            <kit.Separator />
+            <kit.Item
+              aria-checked={!backgroundTint}
+              onSelect={() => setTreeGroupBackgroundTint(nodeId, undefined)}
+              role="menuitemradio"
+            >
+              <Codicon name="circle-slash" size="0.875rem" />
+              <span>{t.zones.defaultBackground}</span>
+              {!backgroundTint && <Codicon className="ml-auto" name="check" size="0.75rem" />}
+            </kit.Item>
+          </kit.SubContent>
+        </kit.Sub>
       </>
     )
   }
@@ -405,6 +459,7 @@ export function TreeGroup({
 
   // Same menu on the header strip and the edit veil — one prop bag.
   const zoneMenu = {
+    backgroundTint: node.backgroundTint,
     closable,
     minimizable,
     minimized: node.minimized,
@@ -413,6 +468,25 @@ export function TreeGroup({
     tabMenuPrefix: (kit: MenuKit) => paneChrome(paneFor(targetPane())).tabMenuPrefix?.(kit),
     targetPane
   }
+
+  const safeBackgroundTint = isZoneBackgroundTint(node.backgroundTint) ? node.backgroundTint : undefined
+
+  const tintedSurface = (base: string) =>
+    safeBackgroundTint ? `color-mix(in srgb, var(--ui-${safeBackgroundTint}) 10%, var(${base}))` : undefined
+
+  const zoneStyle =
+    wcOverlap || safeBackgroundTint
+      ? ({
+          ...(safeBackgroundTint
+            ? {
+                '--ui-chat-surface-background': tintedSurface('--ui-zone-chat-surface-background'),
+                '--ui-editor-surface-background': tintedSurface('--ui-zone-editor-surface-background'),
+                '--ui-sidebar-surface-background': tintedSurface('--ui-zone-sidebar-surface-background')
+              }
+            : {}),
+          ...(wcOverlap ? { paddingTop: wcOverlap.y + wcOverlap.height } : {})
+        } as CSSProperties)
+      : undefined
 
   return (
     <div
@@ -430,7 +504,7 @@ export function TreeGroup({
         setMenuPane((e.target as HTMLElement).closest('[data-tree-tab]')?.getAttribute('data-tree-tab') ?? undefined)
       }}
       ref={ref}
-      style={wcOverlap ? { paddingTop: wcOverlap.y + wcOverlap.height } : undefined}
+      style={zoneStyle}
     >
       {wcOverlap && (
         <div
@@ -732,6 +806,7 @@ export function TreeGroup({
             // barely-tinted wash; the light blur reads as "edit mode" the same
             // way the zone editor's backdrop does.
             className="absolute inset-x-0 bottom-0 z-50 flex cursor-grab items-center justify-center outline-1 -outline-offset-2 outline-dashed backdrop-blur-[2px]"
+            data-zone-edit-veil={node.id}
             onPointerDown={e => startPaneDrag(activeId, e, undefined, undefined, active?.title ?? activeId)}
             style={{
               top: headerVisible ? 28 : 0,
@@ -743,6 +818,30 @@ export function TreeGroup({
             <span className="flex max-w-[calc(100%-1rem)] items-center gap-1.5 rounded-md border border-(--ui-stroke-secondary) bg-popover px-2 py-1 text-[0.64rem] font-semibold uppercase tracking-[0.16em] text-(--ui-text-secondary)">
               <Codicon className="shrink-0" name="gripper" size="0.8125rem" />
               <span className="min-w-0 truncate">{active?.title ?? activeId}</span>
+              <button
+                aria-haspopup="menu"
+                aria-label={t.zones.zoneActions}
+                className="-mr-1 flex size-5 shrink-0 items-center justify-center rounded-sm text-(--ui-text-tertiary) hover:bg-(--ui-bg-hover) hover:text-(--ui-text-primary) focus-visible:outline-2 focus-visible:outline-(--ui-accent)"
+                onClick={event => {
+                  event.stopPropagation()
+                  const rect = event.currentTarget.getBoundingClientRect()
+
+                  event.currentTarget.dispatchEvent(
+                    new MouseEvent('contextmenu', {
+                      bubbles: true,
+                      button: 2,
+                      cancelable: true,
+                      clientX: rect.right,
+                      clientY: rect.bottom
+                    })
+                  )
+                }}
+                onPointerDown={event => event.stopPropagation()}
+                title={t.zones.zoneActions}
+                type="button"
+              >
+                <Codicon name="kebab-horizontal" size="0.8125rem" />
+              </button>
             </span>
           </div>
         </ZoneMenu>

--- a/apps/desktop/src/components/pane-shell/tree/store.ts
+++ b/apps/desktop/src/components/pane-shell/tree/store.ts
@@ -35,11 +35,13 @@ import {
   removePane,
   reorderPanesInGroup as reorderPanesInGroupOp,
   setActivePane as setActivePaneOp,
+  setGroupBackgroundTint as setGroupBackgroundTintOp,
   setGroupMinimized,
   setGroupTabStrip as setGroupTabStripOp,
   setSplitWeights as setSplitWeightsOp,
   type SplitNode,
-  type TabStripMode
+  type TabStripMode,
+  type ZoneBackgroundTint
 } from './model'
 import { FLOATING_PLACEMENT } from './renderer/floating-rect'
 import { tabStripVisibleForZone } from './renderer/strip-visibility'
@@ -1639,6 +1641,16 @@ export function setTreeGroupMinimized(groupId: string, minimized: boolean) {
 
   if (tree) {
     commit(setGroupMinimized(tree, groupId, minimized))
+  }
+}
+
+/** Tint one zone and persist it as a custom layout choice. */
+export function setTreeGroupBackgroundTint(groupId: string, backgroundTint: ZoneBackgroundTint | undefined) {
+  const tree = $layoutTree.get()
+
+  if (tree) {
+    commit(setGroupBackgroundTintOp(tree, groupId, backgroundTint))
+    markActivePreset('custom')
   }
 }
 

--- a/apps/desktop/src/components/pane-shell/tree/zone-background.test.ts
+++ b/apps/desktop/src/components/pane-shell/tree/zone-background.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { group, migratePersistedTree, setGroupBackgroundTint, split, ZONE_BACKGROUND_TINTS } from './model'
+import { $activePresetId, $layoutTree, setTreeGroupBackgroundTint } from './store'
+
+describe('zone background tint model', () => {
+  it('changes only the selected zone and can return it to the theme default', () => {
+    const tree = split('row', [group(['sessions'], { id: 'sidebar' }), group(['workspace'], { id: 'workspace' })])
+
+    const tinted = setGroupBackgroundTint(tree, 'workspace', 'blue')
+
+    expect(tinted.type).toBe('split')
+
+    if (tinted.type !== 'split') {
+      return
+    }
+
+    expect(tinted.children[0]).toHaveProperty('backgroundTint', undefined)
+    expect(tinted.children[1]).toHaveProperty('backgroundTint', 'blue')
+
+    const cleared = setGroupBackgroundTint(tinted, 'workspace', undefined)
+    expect(cleared.type === 'split' && cleared.children[1]).not.toHaveProperty('backgroundTint')
+  })
+
+  it('keeps allowed persisted tints and drops untrusted values recursively', () => {
+    const migrated = migratePersistedTree(
+      split('row', [
+        group(['sessions'], { backgroundTint: 'green', id: 'sidebar' }),
+        group(['workspace'], { backgroundTint: 'url(https://example.com/tracker)', id: 'workspace' } as never)
+      ])
+    )
+
+    expect(migrated.type).toBe('split')
+
+    if (migrated.type !== 'split') {
+      return
+    }
+
+    expect(migrated.children[0]).toHaveProperty('backgroundTint', 'green')
+    expect(migrated.children[1]).not.toHaveProperty('backgroundTint')
+    expect(ZONE_BACKGROUND_TINTS).toEqual(['red', 'orange', 'yellow', 'green', 'cyan', 'blue', 'purple'])
+  })
+})
+
+describe('zone background tint persistence', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $layoutTree.set(group(['workspace'], { id: 'workspace' }))
+    $activePresetId.set('default')
+  })
+
+  it('persists the tint with the layout and marks the arrangement custom', () => {
+    setTreeGroupBackgroundTint('workspace', 'purple')
+
+    expect($layoutTree.get()).toHaveProperty('backgroundTint', 'purple')
+    expect($activePresetId.get()).toBe('custom')
+    expect(JSON.parse(window.localStorage.getItem('hermes.desktop.layoutTree.v2') ?? '{}')).toHaveProperty(
+      'backgroundTint',
+      'purple'
+    )
+  })
+})

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -2445,6 +2445,19 @@ export const ar = defineLocale({
   zones: {
     showTabStrip: 'إظهار علامات التبويب',
     hideTabStrip: 'إخفاء علامات التبويب',
+    backgroundTint: 'صبغة الخلفية',
+    defaultBackground: 'الخلفية الافتراضية',
+    backgroundTintOption: tint =>
+      ({
+        red: 'أحمر',
+        orange: 'برتقالي',
+        yellow: 'أصفر',
+        green: 'أخضر',
+        cyan: 'سماوي',
+        blue: 'أزرق',
+        purple: 'أرجواني'
+      })[tint] ?? tint,
+    zoneActions: 'إجراءات المنطقة',
     showStripTab: title => `إظهار ${title}`,
     hideStripTab: title => `إخفاء ${title}`,
     lastTabKeptTitle: 'يبقى آخر تبويب',

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -3286,6 +3286,19 @@ export const en: Translations = {
   zones: {
     showTabStrip: 'Show tabs',
     hideTabStrip: 'Hide tabs',
+    backgroundTint: 'Background tint',
+    defaultBackground: 'Default background',
+    backgroundTintOption: tint =>
+      ({
+        red: 'Red',
+        orange: 'Orange',
+        yellow: 'Yellow',
+        green: 'Green',
+        cyan: 'Cyan',
+        blue: 'Blue',
+        purple: 'Purple'
+      })[tint] ?? tint,
+    zoneActions: 'Zone actions',
     showStripTab: title => `Show ${title}`,
     hideStripTab: title => `Hide ${title}`,
     lastTabKeptTitle: 'Last tab stays',

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -2889,6 +2889,19 @@ export const ja = defineLocale({
   zones: {
     showTabStrip: 'タブを表示',
     hideTabStrip: 'タブを隠す',
+    backgroundTint: '背景の色合い',
+    defaultBackground: 'デフォルトの背景',
+    backgroundTintOption: tint =>
+      ({
+        red: '赤',
+        orange: 'オレンジ',
+        yellow: '黄',
+        green: '緑',
+        cyan: 'シアン',
+        blue: '青',
+        purple: '紫'
+      })[tint] ?? tint,
+    zoneActions: 'ゾーン操作',
     showStripTab: title => `${title} を表示`,
     hideStripTab: title => `${title} を隠す`,
     lastTabKeptTitle: '最後のタブは残ります',

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -3290,6 +3290,19 @@ export const ru = defineLocale({
   zones: {
     showTabStrip: 'Показать вкладки',
     hideTabStrip: 'Скрыть вкладки',
+    backgroundTint: 'Оттенок фона',
+    defaultBackground: 'Фон по умолчанию',
+    backgroundTintOption: tint =>
+      ({
+        red: 'Красный',
+        orange: 'Оранжевый',
+        yellow: 'Жёлтый',
+        green: 'Зелёный',
+        cyan: 'Бирюзовый',
+        blue: 'Синий',
+        purple: 'Фиолетовый'
+      })[tint] ?? tint,
+    zoneActions: 'Действия зоны',
     showStripTab: title => `Показать ${title}`,
     hideStripTab: title => `Скрыть ${title}`,
     lastTabKeptTitle: 'Последняя вкладка остаётся',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -2828,6 +2828,10 @@ export interface Translations {
   zones: {
     showTabStrip: string
     hideTabStrip: string
+    backgroundTint: string
+    defaultBackground: string
+    backgroundTintOption: (tint: string) => string
+    zoneActions: string
     showStripTab: (title: string) => string
     hideStripTab: (title: string) => string
     lastTabKeptTitle: string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -2785,6 +2785,19 @@ export const zhHant = defineLocale({
   zones: {
     showTabStrip: '顯示分頁',
     hideTabStrip: '隱藏分頁',
+    backgroundTint: '背景色調',
+    defaultBackground: '預設背景',
+    backgroundTintOption: tint =>
+      ({
+        red: '紅色',
+        orange: '橙色',
+        yellow: '黃色',
+        green: '綠色',
+        cyan: '青色',
+        blue: '藍色',
+        purple: '紫色'
+      })[tint] ?? tint,
+    zoneActions: '區域操作',
     showStripTab: title => `顯示 ${title}`,
     hideStripTab: title => `隱藏 ${title}`,
     lastTabKeptTitle: '保留最後一個分頁',

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -3433,6 +3433,19 @@ export const zh: Translations = {
   zones: {
     showTabStrip: '显示标签',
     hideTabStrip: '隐藏标签',
+    backgroundTint: '背景色调',
+    defaultBackground: '默认背景',
+    backgroundTintOption: tint =>
+      ({
+        red: '红色',
+        orange: '橙色',
+        yellow: '黄色',
+        green: '绿色',
+        cyan: '青色',
+        blue: '蓝色',
+        purple: '紫色'
+      })[tint] ?? tint,
+    zoneActions: '区域操作',
     showStripTab: title => `显示 ${title}`,
     hideStripTab: title => `隐藏 ${title}`,
     lastTabKeptTitle: '保留最后一个标签',

--- a/apps/desktop/src/styles.css
+++ b/apps/desktop/src/styles.css
@@ -365,6 +365,9 @@
     --ui-sidebar-surface-background: var(--ui-bg-sidebar);
     --ui-chat-surface-background: var(--ui-bg-chrome);
     --ui-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-chat-surface-background: var(--ui-bg-chrome);
+    --ui-zone-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-sidebar-surface-background: var(--ui-bg-sidebar);
     /* The integrated terminal wears the transcript's background, not the
        editor's — it reads as part of the conversation surface. Its own token so
        the two can diverge without dragging the terminal along, and so a skin
@@ -610,6 +613,9 @@
     --ui-chat-surface-background: transparent;
     --ui-sidebar-surface-background: transparent;
     --ui-editor-surface-background: transparent;
+    --ui-zone-chat-surface-background: transparent;
+    --ui-zone-editor-surface-background: transparent;
+    --ui-zone-sidebar-surface-background: transparent;
     --ui-terminal-surface-background: var(--ui-bg-chrome);
   }
 
@@ -661,6 +667,9 @@
   :root[data-hermes-glass] [data-glass-opaque] {
     --ui-chat-surface-background: var(--ui-bg-chrome);
     --ui-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-chat-surface-background: var(--ui-bg-chrome);
+    --ui-zone-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-sidebar-surface-background: var(--ui-bg-sidebar);
     --ui-sidebar-surface-background: var(--ui-bg-sidebar);
   }
 
@@ -682,6 +691,9 @@
       transparent
     );
     --ui-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-chat-surface-background: var(--ui-bg-chrome);
+    --ui-zone-editor-surface-background: var(--ui-bg-chrome);
+    --ui-zone-sidebar-surface-background: var(--ui-bg-sidebar);
   }
 
   /* Clear mode (native window opacity) fades EVERYTHING in the window
@@ -2954,7 +2966,8 @@ button[data-slot='aui_msg-reactions'] svg {
    Widgets on the shared shell (components/chat/widget-shell.ts →
    `--ui-widget-surface-background`) and any chat-surface card are matched on
    their class, so new ones inherit this without touching the list. */
-[data-hud-shell] [data-slot='composer-bounds']
+[data-hud-shell]
+  [data-slot='composer-bounds']
   :is(
     [data-slot='clarify-inline'],
     [data-slot='tool-block'],


### PR DESCRIPTION
## Summary

- add seven curated, semantic background tints to Desktop layout zones
- persist tint selection with the layout tree so colors stay attached to zones when panes move
- expose the picker through the existing zone context menu and a keyboard-accessible Zone actions button in Layout Edit mode
- use localized native menu-radio choices with a Default reset
- scope tinting across chat, editor, and sidebar surfaces while preserving light, dark, clear, and glass behavior
- reject untrusted persisted CSS values and update all supported locales

## Verification

- `npm run test:ui` — 719 files, 7,174 tests passed
- `npm run typecheck` — passed
- `npm run build` — passed
- changed-file ESLint — passed
- `git diff --check` — passed
- isolated Electron QA — light and dark themes, headerless Layout Edit access, mouse and keyboard submenu interaction, persistence readback
- measured minimum text contrast: 13.43:1 light, 14.15:1 dark
