### PR TITLE
fix(desktop): retire superseded install errors in the Local Models pane

### DIFF
--- a/apps/desktop/src/app/settings/local-models-settings.test.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.test.tsx
@@ -349,6 +349,94 @@ describe('LocalModelsSettings', () => {
 
     expect(await screen.findByText(/integrity check/)).toBeTruthy()
   })
+
+  it('retires a runtime-install error superseded by a successful retry (#102616)', async () => {
+    mocked.getLocalModelsStatus.mockResolvedValue({
+      ...BASE_STATUS,
+      runtime_installed: true,
+      runtime_backend: 'metal'
+    })
+    // The failed first attempt (a transient verify miss whose captured
+    // output was empty) stays in the backend job registry forever, but a
+    // newer install job finished OK after it — the pane must not keep
+    // painting the old error next to the green up-to-date row.
+    $localRuntimeJobs.set([
+      {
+        job_id: 'ok-install',
+        kind: 'runtime-install',
+        target: 'b10679',
+        model_id: null,
+        status: 'done',
+        phase: 'done',
+        detail: '',
+        total_bytes: null,
+        done_bytes: 0,
+        error: null,
+        started_at: 2000
+      },
+      {
+        job_id: 'bad-install',
+        kind: 'runtime-install',
+        target: 'b10679',
+        model_id: null,
+        status: 'error',
+        phase: 'verifying',
+        detail: '',
+        total_bytes: null,
+        done_bytes: 0,
+        error:
+          'version check failed for /Users/x/.hermes/runtimes/llamacpp/b10679/metal/llama-b10679/llama-server: expected b10679, got:',
+        started_at: 1000
+      }
+    ])
+
+    await renderFullPane()
+
+    expect(await screen.findByText('Engine up to date')).toBeTruthy()
+    expect(screen.queryByText(/version check failed/)).toBeNull()
+  })
+
+  it('still surfaces an error that is newer than the last success of its kind', async () => {
+    mocked.getLocalModelsStatus.mockResolvedValue({
+      ...BASE_STATUS,
+      runtime_installed: true,
+      runtime_backend: 'cuda'
+    })
+    // Order flipped: the failure is the LATEST word for this kind — only
+    // a strictly newer done job may retire an error, never an older one.
+    $localRuntimeJobs.set([
+      {
+        job_id: 'bad-install',
+        kind: 'runtime-install',
+        target: 'b10679',
+        model_id: null,
+        status: 'error',
+        phase: 'verifying',
+        detail: '',
+        total_bytes: null,
+        done_bytes: 0,
+        error: 'download interrupted — try again',
+        started_at: 2000
+      },
+      {
+        job_id: 'ok-install',
+        kind: 'runtime-install',
+        target: 'b10679',
+        model_id: null,
+        status: 'done',
+        phase: 'done',
+        detail: '',
+        total_bytes: null,
+        done_bytes: 0,
+        error: null,
+        started_at: 1000
+      }
+    ])
+
+    await renderFullPane()
+
+    expect(await screen.findByText(/download interrupted/)).toBeTruthy()
+  })
 })
 
 describe('quickstart', () => {

--- a/apps/desktop/src/app/settings/local-models-settings.tsx
+++ b/apps/desktop/src/app/settings/local-models-settings.tsx
@@ -292,7 +292,20 @@ export function LocalModelsSettings() {
   }
 
   const rJob = runningRuntimeInstall(jobs)
-  const lastError = jobs.find(j => j.status === 'error')
+
+  // The latest error that is still current: an error superseded by a
+  // newer SUCCESSFUL job of the same kind (retry install after a
+  // transient verify failure, redownload after a broken file) is stale
+  // history — rendering it next to the green 'up to date' row reads as
+  // a live failure and never heals (#102616). A newer running job
+  // settles the question either way, so it does not clear the error yet.
+  const lastError = jobs.find(
+    j =>
+      j.status === 'error' &&
+      !jobs.some(
+        o => o.kind === j.kind && o.status === 'done' && (o.started_at ?? 0) > (j.started_at ?? 0)
+      )
+  )
 
   const sortedCatalog = [...catalog].sort((a, b) => fitRank(a) - fitRank(b))
 

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -1349,6 +1349,9 @@ export interface LocalRuntimeJob {
   done_bytes: number
   percent?: number
   error: string | null
+  // Epoch seconds, from the backend job registry (drives its ordering);
+  // optional so older gateways that omit it keep rendering.
+  started_at?: number
 }
 
 export interface ActionResponse {


### PR DESCRIPTION
## What does this PR do?

The Local Models pane rendered the newest **error** job from the backend job registry forever: once any install/download attempt failed, its error line stayed on screen even after a retry of the same kind succeeded. In #102616 this shows up as a red `version check failed for …: expected b10679, got:` line sitting right under the green `Engine up to date ✓` row — the failed attempt's error was never reconciled away by the successful retry, and nothing but a gateway restart clears it.

The pane now treats an error as current only while it is the **latest word for its kind**: an error job is suppressed once a strictly newer `done` job of the same kind exists (retry install after a transient verify miss, redownload after a broken file). A newer *running* job does not suppress it yet — it settles the question either way when it finishes. This covers all three surfaces that read `lastError` (runtime-install, model-download, quickstart).

`LocalRuntimeJob` gains the backend's `started_at` field (the registry already returns it and sorts by it) so "newer" is well-defined; it's optional so older gateways that omit it keep rendering unchanged (the comparison degrades to "never superseded", i.e. today's behavior).

## Related Issue

Fixes #102616

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/app/settings/local-models-settings.tsx` — `lastError` now skips error jobs superseded by a strictly newer `done` job of the same kind
- `apps/desktop/src/types/hermes.ts` — `LocalRuntimeJob.started_at?: number` (already returned by `/api/local-models/jobs`, which orders by it)
- `apps/desktop/src/app/settings/local-models-settings.test.tsx` — regression tests for both directions (superseded error retired; newer-than-last-success error still shown)

## How to Test

1. `cd apps/desktop && npx vitest run src/app/settings/local-models-settings.test.tsx --project ui` — 18 tests pass (16 pre-existing + 2 new).
2. New test `retires a runtime-install error superseded by a successful retry (#102616)` seeds the job store with an old `runtime-install` error (the exact `version check failed … got:` string from the issue) plus a newer `done` install and `runtime_installed: true`: Observed result — `Engine up to date` renders and the stale error does not.
3. New test `still surfaces an error that is newer than the last success of its kind` flips the timestamps: Observed result — the error still renders, so only a strictly newer success retires an error, never an older one.
4. `npx tsc -p . --noEmit` and `npx eslint` on the three touched files pass.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — N/A for this change (renderer-only); equivalent suite run: `vitest run --project ui` for the touched component and its dependents (29 tests across 3 files) plus renderer `tsc --noEmit` and eslint, all green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A (pure renderer logic; the job payload is platform-independent)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
