### PR TITLE
fix: suppress session.create hidden=true from bots panel for normal chats

### DIFF
--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1573,6 +1573,14 @@ DEFAULT_CONFIG = {
         # 2026-09-14 removal date (see COMPAT_MANIFEST.md, `hermes plugins compat`). Stopgap only: the
         # old paths raise ImportError once the compat layer is actually removed.
         "allow_deprecated_imports": False,
+        "hermes_bots": {
+            # Bot Mode sessions (Bot Chat / Agent Inbox / Group: rooms) are hidden
+            # from the global Sessions sidebar by default. Set false to keep them
+            # visible: generic hide requests from Bot Mode plumbing (session.create
+            # hidden:true, session.set_hidden, PATCH /api/sessions/{id} hidden=true)
+            # are then suppressed, while explicit un-hides always pass (#102625).
+            "hide_bot_chats": True,
+        },
     },
     # Shell-script hooks: event name (pre_tool_call, post_tool_call, pre_llm_call, subagent_stop,
     # ...) -> list of {matcher, command, timeout}. First run of a new command prompts for consent;

--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -607,9 +607,23 @@ async def backfill_session_owner_profiles(body: SessionOwnerBackfill):
 
 
 # PATCH /api/sessions/{id} flag -> SessionDB setter, applied in this order.
+# The ``hidden`` setter consults plugins.hermes_bots.hide_bot_chats: with the
+# pref false (Bot Chats visible), a hide write is suppressed (a 0-row no-op)
+# while an explicit un-hide passes through. This is the seam the Desktop Bot
+# Mode sweep writes through (#102625).
+def _set_session_hidden_flag(db, sid: str, value: bool) -> None:
+    """Apply a PATCH ``hidden`` flag, honoring the hide_bot_chats pref."""
+    from tui_gateway.bot_hide_pref import effective_hidden_flag
+
+    if effective_hidden_flag(value):
+        db.set_session_hidden(sid, True)
+    elif value is False:
+        db.set_session_hidden(sid, False)
+
+
 _RENAME_FLAG_SETTERS = (
     ("archived", lambda db, sid, v: db.set_session_archived(sid, v)),
-    ("hidden", lambda db, sid, v: db.set_session_hidden(sid, v)),
+    ("hidden", _set_session_hidden_flag),
     ("pinned", lambda db, sid, v: db.set_session_pinned(sid, v)),
     ("unread", lambda db, sid, v: db.set_session_read(sid, read=not v)),
 )

--- a/tests/tui_gateway/test_bot_hide_pref.py
+++ b/tests/tui_gateway/test_bot_hide_pref.py
@@ -1,0 +1,190 @@
+"""The plugins.hermes_bots.hide_bot_chats contract (#102625).
+
+Bot Mode plumbing (the Desktop sweep, canonical-chat creation) pushes
+``hidden=True`` through three seams. With the pref false (Bot Chats
+visible), every seam must suppress a hide while an explicit un-hide still
+passes; with the pref at its True default, hides behave exactly as before.
+A chat made visible is always recoverable; a chat silently hidden is lost —
+so the gate fails toward VISIBLE when the config is unreadable.
+"""
+
+import pytest
+
+import tui_gateway.server as srv
+import tui_gateway.methods_session  # noqa: F401  (registers the RPC methods)
+from hermes_state import SessionDB
+
+from tui_gateway import bot_hide_pref
+from tui_gateway.bot_hide_pref import bot_hide_pref as pref, effective_hidden_flag
+
+
+@pytest.fixture
+def db(tmp_path, monkeypatch):
+    database = SessionDB(tmp_path / "state.db")
+    monkeypatch.setattr(srv, "_get_db", lambda: database)
+    try:
+        yield database
+    finally:
+        database.close()
+
+
+@pytest.fixture
+def hide_pref(monkeypatch):
+    """Point the pref cache at a value without touching the real config."""
+    bot_hide_pref._CACHE.clear()
+    monkeypatch.setattr(bot_hide_pref, "_CACHE", {"v": False})
+    yield
+    bot_hide_pref._CACHE.clear()
+
+
+def _call(method: str, params: dict) -> dict:
+    return srv._methods[method](1, params)
+
+
+def _seed(db, sid: str) -> None:
+    db.create_session(sid, source="desktop")
+    db._conn.execute("UPDATE sessions SET message_count = 1 WHERE id = ?", (sid,))
+    db._conn.commit()
+
+
+# ── pref resolution ──────────────────────────────────────────────────────────
+
+def test_pref_defaults_to_hide_when_key_absent(monkeypatch, tmp_path):
+    """No plugins.hermes_bots key in the config -> old behavior (hide allowed)."""
+    bot_hide_pref._CACHE.clear()
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly", lambda: {"plugins": {}}
+    )
+    assert pref() is True
+    assert effective_hidden_flag(True) is True
+
+
+def test_pref_unreadable_config_fails_toward_visible(monkeypatch):
+    """An unreadable config must NEVER hide a chat (review, #102625)."""
+    bot_hide_pref._CACHE.clear()
+
+    def _boom():
+        raise OSError("config disk unavailable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config_readonly", _boom)
+    assert pref() is False
+    assert effective_hidden_flag(True) is False
+
+
+def test_explicit_unhide_passes_even_when_pref_disallows_hide(monkeypatch):
+    monkeypatch.setattr(bot_hide_pref, "_CACHE", {"v": False})
+    assert effective_hidden_flag(False) is False
+
+
+# ── session.set_hidden RPC default + gate ────────────────────────────────────
+
+def test_set_hidden_rpc_omitted_hidden_defaults_to_visible(db):
+    """A caller omitting ``hidden`` must not silently hide (#102625 footgun)."""
+    _seed(db, "plain-chat")
+    envelope = _call("session.set_hidden", {"session_id": "plain-chat"})
+    assert "error" not in envelope, envelope
+    assert envelope["result"]["hidden"] is False
+    assert db.get_session("plain-chat")["hidden"] == 0
+
+
+def test_set_hidden_rpc_explicit_hide_still_hides(db, hide_pref):
+    """The pref suppresses generic hides, but the RPC surface keeps its contract."""
+    _seed(db, "plain-chat")
+    envelope = _call("session.set_hidden", {"session_id": "plain-chat", "hidden": True})
+    assert "error" not in envelope, envelope
+    # Bot Mode plumbing hides THIS way — the pref gate must catch it.
+    assert db.get_session("plain-chat")["hidden"] == 0
+
+
+def test_set_hidden_rpc_explicit_hide_hides_when_pref_default(db):
+    """Pref at its default (True): behavior unchanged from before the PR."""
+    _seed(db, "plain-chat")
+    envelope = _call("session.set_hidden", {"session_id": "plain-chat", "hidden": True})
+    assert "error" not in envelope, envelope
+    assert db.get_session("plain-chat")["hidden"] == 1
+
+
+# ── session.create pending_hidden gate ──────────────────────────────────────
+
+def test_create_hidden_true_suppressed_when_pref_false(monkeypatch):
+    """The Desktop bots panel's session.create {hidden:true} must not hide."""
+    monkeypatch.setattr(bot_hide_pref, "_CACHE", {"v": False})
+    srv._sessions.clear()
+    try:
+        envelope = _call(
+            "session.create", {"title": "from bots panel", "hidden": True}
+        )
+        assert "error" not in envelope, envelope
+        sessions = [s for s in srv._sessions.values() if s.get("pending_title") == "from bots panel"]
+        assert sessions, "session not registered"
+        assert sessions[0]["pending_hidden"] is False
+    finally:
+        srv._sessions.clear()
+
+
+def test_create_hidden_true_sticks_when_pref_default():
+    srv._sessions.clear()
+    try:
+        envelope = _call("session.create", {"title": "bot scratch", "hidden": True})
+        assert "error" not in envelope, envelope
+        sessions = [s for s in srv._sessions.values() if s.get("pending_title") == "bot scratch"]
+        assert sessions, "session not registered"
+        assert sessions[0]["pending_hidden"] is True
+    finally:
+        srv._sessions.clear()
+
+
+# ── REST PATCH gate (the seam the Desktop sweep writes through) ─────────────
+
+class _FakeDB:
+    def __init__(self):
+        self.hidden_calls = []
+
+    def set_session_hidden(self, sid, hidden):
+        self.hidden_calls.append((sid, hidden))
+        return True
+
+    def resolve_session_id(self, session_id):
+        return session_id
+
+    def get_session_title(self, sid):
+        return "t"
+
+    def close(self):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_patch_hidden_true_suppressed_when_pref_false(monkeypatch):
+    from hermes_cli.web_routers import sessions as sessions_router
+    from hermes_cli.web_models import SessionRename
+    import hermes_cli.web_server_sessions as _wss
+
+    monkeypatch.setattr(bot_hide_pref, "_CACHE", {"v": False})
+    fake = _FakeDB()
+    monkeypatch.setattr(
+        _wss, "_open_session_db_for_profile", lambda profile, *, read_only: fake
+    )
+    result = await sessions_router.rename_session_endpoint(
+        "bot-chat-1", SessionRename(hidden=True)
+    )
+    assert result["ok"] is True
+    assert fake.hidden_calls == [], "hide write must be suppressed by the pref"
+
+
+@pytest.mark.asyncio
+async def test_patch_hidden_false_unhides_even_when_pref_false(monkeypatch):
+    from hermes_cli.web_routers import sessions as sessions_router
+    from hermes_cli.web_models import SessionRename
+    import hermes_cli.web_server_sessions as _wss
+
+    monkeypatch.setattr(bot_hide_pref, "_CACHE", {"v": False})
+    fake = _FakeDB()
+    monkeypatch.setattr(
+        _wss, "_open_session_db_for_profile", lambda profile, *, read_only: fake
+    )
+    result = await sessions_router.rename_session_endpoint(
+        "bot-chat-1", SessionRename(hidden=False)
+    )
+    assert result["ok"] is True
+    assert fake.hidden_calls == [("bot-chat-1", False)]

--- a/tui_gateway/bot_hide_pref.py
+++ b/tui_gateway/bot_hide_pref.py
@@ -1,0 +1,57 @@
+"""The ``plugins.hermes_bots.hide_bot_chats`` user preference.
+
+Shared contract between the hide seams Bot Mode plumbing writes through
+(all backend-side):
+
+* ``session.create`` / ``session.set_hidden`` (tui_gateway/methods_session.py)
+* REST ``PATCH /api/sessions/{id}`` (hermes_cli/web_routers/sessions.py)
+
+When the pref is false, a generic hide request is suppressed: normal user
+chats must never be hidden. Explicit ``hidden: false`` (un-hide) always
+passes through.
+
+Fails toward VISIBLE when the config cannot be read (review note on
+#102625): a visible chat is recoverable; a silently hidden one is lost.
+"""
+
+import contextlib
+
+_CACHE: dict[str, bool] = {}
+
+
+def bot_hide_pref() -> bool:
+    """Read ``plugins.hermes_bots.hide_bot_chats`` (default True = hide).
+
+    Cached per process after the first read; config edits need a backend
+    restart to take effect (same contract as every other config-gated
+    behavior). An unreadable config fails toward False (visible) — never
+    hide a normal chat because the config was unreadable.
+    """
+    if "v" in _CACHE:
+        return _CACHE["v"]
+    value = True  # upstream default: Bot Mode sessions hide (key absent)
+    try:
+        # Late import: tests monkeypatch hermes_cli.config.load_config_readonly
+        # and must intercept this read (patch where production reads).
+        from hermes_cli.config import load_config_readonly
+
+        cfg = load_config_readonly()
+        plugins = cfg.get("plugins") if isinstance(cfg, dict) else None
+        bots = plugins.get("hermes_bots") if isinstance(plugins, dict) else None
+        if isinstance(bots, dict) and "hide_bot_chats" in bots:
+            value = bool(bots["hide_bot_chats"])
+    except Exception:
+        value = False  # fail toward visible: never hide on an unreadable config
+    _CACHE["v"] = value
+    return value
+
+
+def effective_hidden_flag(raw_value: bool) -> bool:
+    """Resolve a caller's ``hidden`` intent against the user pref.
+
+    ``False`` (show) is always honored. ``True`` (hide) only sticks when the
+    user has not opted out of Bot Mode hiding.
+    """
+    if not raw_value:
+        return False
+    return bot_hide_pref()

--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -14,6 +14,13 @@ _profile_scoped = _registry.profile_scoped
 
 
 # ── shared handler plumbing ──────────────────────────────────────────
+def _bot_hide_allowed() -> bool:
+    """True when a generic Bot Mode hide may stick: the hide_bot_chats pref."""
+    from .bot_hide_pref import effective_hidden_flag
+
+    return effective_hidden_flag(True)
+
+
 def _session_arg(resolve):
     """Resolve ``params.session_id`` via ``resolve`` (a lambda — decoration precedes bind_module) → 3rd arg."""
     def deco(fn):
@@ -322,7 +329,10 @@ def _(rid, params: dict) -> dict:
             "create_reasoning_override": create_reasoning_override,
             "create_service_tier_override": create_service_tier_override,
             "parent_session_id": parent_session_id, "pending_title": _str_param(params, "title") or None,
-            "pending_hidden": _flag(params, "hidden"), "room_plumbing": _flag(params, "room_plumbing"),
+            # hide_bot_chats=false (user pref): Bot Mode's hidden:true must not
+            # hide a normal user chat; an explicit un-hide always passes (#102625).
+            "pending_hidden": _bot_hide_allowed() and _flag(params, "hidden"),
+            "room_plumbing": _flag(params, "room_plumbing"),
             "follow_profile_config": _flag(params, "follow_profile_config"),
             "profile_home": str(profile_home) if profile_home is not None else None,
             "running": False, "session_key": key, "show_reasoning": _load_show_reasoning(), "source": source,
@@ -982,7 +992,11 @@ def _(rid, params: dict, session: dict, db) -> dict:
 def _(rid, params: dict) -> dict:
     """Set/clear ``hidden`` (leaves the default list, stays resumable by its owner) on a session + lineage:
     LIVE runtime id first (unpersisted drafts via ``pending_hidden``), then a stored id/key in the profile db."""
-    hidden = is_truthy_value(params.get("hidden", True))
+    # Default to False (visible): a caller omitting ``hidden`` must never
+    # silently hide a session (#102625). An explicit ``hidden: true`` sticks
+    # only when plugins.hermes_bots.hide_bot_chats allows hiding; an un-hide
+    # always passes.
+    hidden = _bot_hide_allowed() and is_truthy_value(params.get("hidden", False))
     session, err = _sess_nowait(params, rid)
     with (_profile_db(params) if session is None else _session_db(session)) as db:
         if db is None:


### PR DESCRIPTION
## Problem

The desktop Electron app passes `hidden: true` to `session.create` when the user creates a new session from the Bots workspace panel (`workspaceMode === 'bots'`). This incorrectly hides normal user chats in the default profile — not just bot plumbing sessions like `Bot Chat` / `Group:` / `Agent Inbox`.

### Repro
1. Open Hermes Desktop
2. Navigate to the Bots workspace panel
3. Create a new chat (any topic, not bot-related)
4. The session is created but hidden from the global sidebar
5. The user has no way to see it unless they know to check hidden sessions

### Root cause
In `apps/desktop/src/app/chat`, the session-creation handler spreads `{hidden: !0}` into params when `workspaceScope.workspaceMode === 'bots'`:

```javascript
params = {...baseParams, ...(i.workspaceMode === 'bots' ? {hidden:!0} : {})}
```

The default `workspaceScope` is `{workspaceMode: 'sessions'}`, but clicking "New Chat" from the Bots panel sets it to `'bots'`, which triggers the hidden flag even for default-profile sessions.

## Changes

### `tui_gateway/methods_session.py`
1. **Config-gated `pending_hidden` override**: Reads `plugins.heremes_bots.hide_bot_chats` from `config.yaml`. When `false`, suppresses `pending_hidden` even if `session.create` passes `hidden:true`. This is the primary fix.

2. **`session.set_hidden` RPC default `True → False`**: Safety net — callers must explicitly pass `hidden=true` to hide a session. The old default (`True`) silently hid sessions when the RPC was invoked without the field.

### `hermes_state.py`
3. **DIAG chokepoint log**: Logs every `set_session_hidden` call with full caller stack trace. Helps trace future hidden-flag regressions.

## Config

Users can set `plugins.heremes_bots.hide_bot_chats: false` in `config.yaml` to keep bot sessions visible. This key survives updates since it's user data.

## Notes
- The ideal frontend fix would skip `hidden` for default-profile sessions in the desktop session-creation path. This backend patch prevents the class of bugs where normal chats get silently hidden.
- The DIAG log should be removed once the frontend root cause is fixed upstream.