### PR TITLE
fix(gateway): keep named custom providers routable in session.info

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -12161,6 +12161,61 @@ def test_session_info_includes_mcp_servers(monkeypatch):
     assert info["mcp_servers"] == fake_status
 
 
+def test_session_info_preserves_named_custom_provider(monkeypatch):
+    from hermes_cli import runtime_provider
+
+    config = {
+        "model": {"provider": "custom:named-endpoint"},
+        "providers": {
+            "named-endpoint": {"api": "https://named.invalid/v1"},
+            "model-endpoint": {
+                "api": "https://model.invalid/v1",
+                "models": {"colliding-model": {}},
+            },
+        },
+    }
+    monkeypatch.setattr(runtime_provider, "load_config", lambda: config)
+    monkeypatch.setattr(
+        runtime_provider, "_get_model_config", lambda: config["model"]
+    )
+
+    agent = types.SimpleNamespace(
+        tools=[],
+        model="example-model",
+        provider="custom",
+        requested_provider="custom",
+        base_url="https://named.invalid/v1",
+    )
+    assert server._session_info(agent)["provider"] == "custom:named-endpoint"
+
+    agent.base_url = ""
+    agent.requested_provider = "custom:named-endpoint"
+    config["model"]["provider"] = "openai"
+    session = {
+        "history": [],
+        "model_override": {"model": "colliding-model", "provider": "custom"},
+        "_metadata_mirror": {"model": "colliding-model", "provider": "custom"},
+    }
+    assert server._session_info(agent, session)["provider"] == "custom:named-endpoint"
+
+    agent.base_url = "https://adhoc.invalid/v1"
+    assert server._session_info(agent)["provider"] == "custom"
+
+    session["pending_model_switch"] = {
+        "display_model": "pending-model",
+        "display_provider": "custom",
+    }
+    agent.base_url = "https://named.invalid/v1"
+    assert server._session_info(agent, session)["provider"] == "custom:named-endpoint"
+
+    session["pending_model_switch"]["display_model"] = "colliding-model"
+    agent.base_url = "https://adhoc.invalid/v1"
+    assert server._session_info(agent, session)["provider"] == "custom"
+
+    agent.base_url = ""
+    assert server._session_info(agent, session)["provider"] == "custom"
+
+
 def test_session_info_includes_session_title(monkeypatch):
     class _FakeDB:
         def get_session_title(self, key):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -7766,6 +7766,52 @@ def _session_info(agent, session: dict | None = None) -> dict:
     pending_switch = (session or {}).get("pending_model_switch") or {}
     pending_model = str(pending_switch.get("display_model") or "").strip()
     pending_provider = str(pending_switch.get("display_provider") or "").strip()
+    display_model = pending_model or mirror.get(
+        "model", getattr(agent, "model", "")
+    )
+    display_provider = pending_provider or mirror.get(
+        "provider", getattr(agent, "provider", "")
+    )
+    if str(display_provider or "").strip().lower() == "custom":
+        override = (session or {}).get("model_override") or {}
+        override = override if isinstance(override, dict) else {}
+        requested_provider = str(override.get("provider") or "").strip()
+        if requested_provider.lower() in {"", "custom"}:
+            requested_provider = str(
+                getattr(agent, "requested_provider", "") or ""
+            ).strip()
+        if requested_provider.lower() == "custom":
+            requested_provider = ""
+        try:
+            from hermes_cli.runtime_provider import (
+                canonical_custom_identity,
+                find_custom_provider_identity,
+            )
+
+            base_url = str(
+                getattr(agent, "base_url", "")
+                or mirror.get("base_url")
+                or override.get("base_url")
+                or ""
+            ).strip()
+            if base_url:
+                recovered_provider = find_custom_provider_identity(base_url)
+            elif pending_provider:
+                recovered_provider = None
+            elif requested_provider:
+                recovered_provider = canonical_custom_identity(
+                    config_provider=requested_provider
+                )
+            else:
+                recovered_provider = canonical_custom_identity(
+                    model=display_model or None,
+                )
+            display_provider = recovered_provider or display_provider
+        except Exception:
+            logger.debug(
+                "custom provider identity recovery failed (session info)",
+                exc_info=True,
+            )
     # Epoch seconds the current turn started, or None when idle. Lets the
     # desktop preserve the turn-elapsed timer across session switches (cold
     # resume path) instead of resetting it to 0:00.
@@ -7777,9 +7823,8 @@ def _session_info(agent, session: dict | None = None) -> dict:
     )
 
     info: dict = {
-        "model": pending_model or mirror.get("model", getattr(agent, "model", "")),
-        "provider": pending_provider
-        or mirror.get("provider", getattr(agent, "provider", "")),
+        "model": display_model,
+        "provider": display_provider,
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",


### PR DESCRIPTION
## What does this PR do?

Named custom-provider entries resolve on the agent to the bare billing class `custom`. When `session.info` emits that class, Desktop can feed it back into a later `session.create`, losing the routable `custom:<key>` identity and falling through to a different/default provider.

This change recovers the durable identity at the `session.info` boundary using the strongest available evidence:

- exact endpoint ownership;
- the requested provider when no endpoint is available;
- model/config recovery for legacy or mirrored state.

An unmatched ad-hoc endpoint remains bare `custom`; it is never reclassified from model or global configuration. Pending bare-custom switches follow the switcher's current-endpoint reuse semantics.

## Related Issue

Related to #100250 and #100317. #100317 addresses the tooltip label by preferring `requested_provider`; this patch additionally protects the session round trip, endpoint-ownership boundary, pending switches, and mirrored state. Happy to consolidate if maintainers prefer.

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature
- [ ] Security fix
- [ ] Documentation update
- [x] Tests
- [ ] Refactor
- [ ] New skill

## Changes Made

- Canonicalize bare custom provider identities before emitting `session.info`.
- Preserve unmatched ad-hoc endpoints as bare `custom`.
- Add one regression test covering named endpoints, requested/model collisions, mirrored metadata, and pending switches.

## How to Test

```text
python -m pytest -q tests/test_tui_gateway_server.py
# 638 passed

python -m pytest -q tests/hermes_cli/test_canonical_custom_identity.py tests/tui_gateway/test_custom_provider_session_persistence.py
# 45 passed
```

A full `pytest tests/ -q` collection was also attempted, but the available environment did not include `pytest-asyncio` or `snowballstemmer`; GitHub CI provides the complete development environment.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit message follows Conventional Commits
- [x] I searched for existing PRs and described the overlap above
- [x] This PR contains only related changes
- [ ] I've run the complete `pytest tests/ -q` suite locally
- [x] I've added regression coverage
- [x] I've tested on macOS

### Documentation & Housekeeping

- [x] Documentation is not applicable; no public API or config key changed
- [x] `cli-config.yaml.example` is not affected
- [x] Architecture/workflow documentation is not affected
- [x] Cross-platform impact was considered; this is platform-neutral Python logic
- [x] Tool descriptions and schemas are not affected

## Screenshots / Logs

N/A; behavior is covered by unit tests.
