### PR TITLE
feat(kanban): assignee-scoped skills dropdown in task creation

### DIFF
--- a/apps/desktop/src/plugins/kanban/api.ts
+++ b/apps/desktop/src/plugins/kanban/api.ts
@@ -181,6 +181,11 @@ export const fetchBoards = () => call<BoardsResponse>('/boards')
 
 export const fetchProfiles = () => call<{ profiles: KanbanProfile[] }>('/profiles')
 
+/** Skills installed for one profile — the task dialog scopes its skills
+ *  dropdown to the chosen assignee (404 → the typed name isn't a profile). */
+export const fetchProfileSkills = (profile: string) =>
+  call<{ profile: string; skills: string[] }>(`/profiles/${encodeURIComponent(profile)}/skills`)
+
 /** First-class Hermes projects, for scoping a board's default workspace. */
 export const fetchProjects = () => call<{ projects: KanbanProject[] }>('/projects')
 

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -600,7 +600,12 @@ function NewTaskDialog({
   // change, so options track the selection immediately.
   const skillsProfile = assignee && assignee !== PARKED ? assignee : resolvedDefault
 
-  const { data: skillsData, isError: skillsFailed } = useQuery({
+  const {
+    data: skillsData,
+    isError: skillsFailed,
+    isFetching: skillsLoading,
+    refetch: refetchSkills
+  } = useQuery({
     queryKey: ['kanban', 'profile-skills', skillsProfile],
     queryFn: () => fetchProfileSkills(skillsProfile),
     staleTime: 60_000,
@@ -780,14 +785,28 @@ function NewTaskDialog({
               </SelectContent>
             </Select>
             {/* Empty roster and fetch failures are states, not errors — the
-                task still creates fine without an extra skill. */}
-            <span className="text-[0.625rem] text-(--ui-text-quaternary)">
-              {skillsFailed
-                ? k.skillsLoadFailed
-                : profileSkills.length === 0
-                  ? k.noSkillsForProfile
-                  : ''}
-            </span>
+                task still creates fine without an extra skill. A failed fetch
+                caches for the stale window, so offer a manual retry rather than
+                stranding the profile with no skills until it lapses. */}
+            {skillsFailed ? (
+              <span className="inline-flex items-center gap-1.5">
+                <span className="text-[0.625rem] text-(--ui-text-quaternary)">
+                  {k.skillsLoadFailed}
+                </span>
+                <Button
+                  disabled={skillsLoading}
+                  onClick={() => void refetchSkills()}
+                  size="inline"
+                  variant="textStrong"
+                >
+                  {skillsLoading ? k.retryingSkills : k.retrySkills}
+                </Button>
+              </span>
+            ) : (
+              <span className="text-[0.625rem] text-(--ui-text-quaternary)">
+                {profileSkills.length === 0 ? k.noSkillsForProfile : ''}
+              </span>
+            )}
           </Field>
 
           <Field label={k.model}>

--- a/apps/desktop/src/plugins/kanban/board.tsx
+++ b/apps/desktop/src/plugins/kanban/board.tsx
@@ -74,6 +74,7 @@ import {
   fetchBoard,
   fetchBoards,
   fetchProfiles,
+  fetchProfileSkills,
   patchTask,
   PROFILES_KEY
 } from './api'
@@ -566,7 +567,9 @@ function NewTaskDialog({
   const [bodyText, setBodyText] = useState('')
   const [assignee, setAssignee] = useState('')
   const [priority, setPriority] = useState('0')
-  const [skills, setSkills] = useState('')
+  // One skill picked from the assignee's installed set (empty = none). The
+  // dropdown options re-query per assignee below; a change resets the pick.
+  const [skill, setSkill] = useState('')
   const [workspaceKind, setWorkspaceKind] = useState<string>(boardDefaultKind)
   // Empty = inherit the board's default project dir (backend resolves it);
   // a path here overrides just this task. Only meaningful for dir/worktree.
@@ -592,6 +595,22 @@ function NewTaskDialog({
     }
   })
 
+  // The skills dropdown's options: the chosen assignee's installed skills
+  // (empty assignee = the resolved default). Re-queries on every assignee
+  // change, so options track the selection immediately.
+  const skillsProfile = assignee && assignee !== PARKED ? assignee : resolvedDefault
+
+  const { data: skillsData, isError: skillsFailed } = useQuery({
+    queryKey: ['kanban', 'profile-skills', skillsProfile],
+    queryFn: () => fetchProfileSkills(skillsProfile),
+    staleTime: 60_000,
+    retry: false
+  })
+
+  const profileSkills = skillsData?.skills ?? []
+  // A stale pick (from a previous assignee) must never ride along silently.
+  const selectedSkill = profileSkills.includes(skill) ? skill : ''
+
   // Reset per open — the dialog is externally controlled (open = target set),
   // so onOpenChange(true) never fires; key the reset off `target` (and the
   // resolved board default, which may arrive after the first open).
@@ -601,7 +620,7 @@ function NewTaskDialog({
       setBodyText('')
       setAssignee('')
       setPriority('0')
-      setSkills('')
+      setSkill('')
       setWorkspaceKind(boardDefaultKind)
       setWorkspacePath('')
       setParent('')
@@ -624,11 +643,6 @@ function NewTaskDialog({
     setError(null)
 
     try {
-      const skillList = skills
-        .split(',')
-        .map(s => s.trim())
-        .filter(Boolean)
-
       // create() derives status (triage flag → 'triage', else 'ready'); move to
       // the requested column when they differ, so a per-column add lands right.
       const { task, warning } = await createTask({
@@ -637,7 +651,7 @@ function NewTaskDialog({
         goal_mode: goalMode,
         parents: parent ? [parent] : undefined,
         priority: Number(priority) || 0,
-        skills: skillList.length ? skillList : undefined,
+        skills: selectedSkill ? [selectedSkill] : undefined,
         title: trimmed,
         triage: isTriage,
         workspace_kind: workspaceKind,
@@ -752,7 +766,28 @@ function NewTaskDialog({
           </Field>
 
           <Field label={k.skills}>
-            <Input onChange={event => setSkills(event.target.value)} placeholder={k.skillsPlaceholder} value={skills} />
+            <Select onValueChange={v => setSkill(v === NO_PARENT ? '' : v)} value={selectedSkill || NO_PARENT}>
+              <SelectTrigger>
+                <SelectValue placeholder={k.skillsPlaceholder} />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value={NO_PARENT}>{k.noSkill}</SelectItem>
+                {profileSkills.map(name => (
+                  <SelectItem key={name} value={name}>
+                    {name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            {/* Empty roster and fetch failures are states, not errors — the
+                task still creates fine without an extra skill. */}
+            <span className="text-[0.625rem] text-(--ui-text-quaternary)">
+              {skillsFailed
+                ? k.skillsLoadFailed
+                : profileSkills.length === 0
+                  ? k.noSkillsForProfile
+                  : ''}
+            </span>
           </Field>
 
           <Field label={k.model}>

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -81,6 +81,9 @@ type KanbanMessages = {
   noSkill: string
   noSkillsForProfile: string
   skillsLoadFailed: string
+  /** Skills dropdown — manual retry when the roster fetch fails. */
+  retrySkills: string
+  retryingSkills: string
   parent: string
   noParent: string
   goalMode: string
@@ -297,6 +300,8 @@ export const en: KanbanMessages = {
   noSkill: '— none —',
   noSkillsForProfile: 'No skills installed for this profile.',
   skillsLoadFailed: 'Could not load this profile’s skills.',
+  retrySkills: 'Retry',
+  retryingSkills: 'Retrying…',
   parent: "Parent (blocks until it's done)",
   noParent: '— no parent —',
   goalMode: "Goal mode (worker loops until a judge agrees it's done)",
@@ -512,6 +517,8 @@ const ja: KanbanMessages = {
   noSkill: '— なし —',
   noSkillsForProfile: 'このプロファイルにスキルはインストールされていません。',
   skillsLoadFailed: 'このプロファイルのスキル一覧を読み込めませんでした。',
+  retrySkills: '再試行',
+  retryingSkills: '再試行中…',
   parent: '親（完了するまでブロック）',
   noParent: '— 親なし —',
   goalMode: 'ゴールモード（ジャッジが完了と認めるまでワーカーがループ）',
@@ -725,6 +732,8 @@ const zh: KanbanMessages = {
   noSkill: '— 无 —',
   noSkillsForProfile: '此档案未安装任何技能。',
   skillsLoadFailed: '无法加载此档案的技能列表。',
+  retrySkills: '重试',
+  retryingSkills: '重试中…',
   parent: '父任务（完成前会阻塞）',
   noParent: '— 无父任务 —',
   goalMode: '目标模式（工作单元循环直到评判代理认可完成）',
@@ -936,6 +945,8 @@ const zhHant: KanbanMessages = {
   noSkill: '— 無 —',
   noSkillsForProfile: '此檔案未安裝任何技能。',
   skillsLoadFailed: '無法載入此檔案的技能列表。',
+  retrySkills: '重試',
+  retryingSkills: '重試中…',
   parent: '父任務（完成前會阻擋）',
   noParent: '— 無父任務 —',
   goalMode: '目標模式（工作單元循環直到評判代理認可完成）',

--- a/apps/desktop/src/plugins/kanban/i18n.ts
+++ b/apps/desktop/src/plugins/kanban/i18n.ts
@@ -77,6 +77,10 @@ type KanbanMessages = {
   parkedOption: string
   skills: string
   skillsPlaceholder: string
+  /** Skills dropdown — first option ("none") and the empty-roster hint. */
+  noSkill: string
+  noSkillsForProfile: string
+  skillsLoadFailed: string
   parent: string
   noParent: string
   goalMode: string
@@ -288,8 +292,11 @@ export const en: KanbanMessages = {
   assignee: 'Assignee',
   defaultOption: name => `${name} (default)`,
   parkedOption: "unassigned (parked — won't run)",
-  skills: 'Skills (comma-separated)',
-  skillsPlaceholder: 'translation, github',
+  skills: 'Skills (from the assignee)',
+  skillsPlaceholder: 'Pick a skill installed for the assignee…',
+  noSkill: '— none —',
+  noSkillsForProfile: 'No skills installed for this profile.',
+  skillsLoadFailed: 'Could not load this profile’s skills.',
   parent: "Parent (blocks until it's done)",
   noParent: '— no parent —',
   goalMode: "Goal mode (worker loops until a judge agrees it's done)",
@@ -500,8 +507,11 @@ const ja: KanbanMessages = {
   assignee: '担当',
   defaultOption: name => `${name}（既定）`,
   parkedOption: '未割り当て（保留 — 実行されません）',
-  skills: 'スキル（カンマ区切り）',
-  skillsPlaceholder: 'translation, github',
+  skills: 'スキル（担当のプロファイルから）',
+  skillsPlaceholder: '担当プロファイルにインストール済みのスキルを選択…',
+  noSkill: '— なし —',
+  noSkillsForProfile: 'このプロファイルにスキルはインストールされていません。',
+  skillsLoadFailed: 'このプロファイルのスキル一覧を読み込めませんでした。',
   parent: '親（完了するまでブロック）',
   noParent: '— 親なし —',
   goalMode: 'ゴールモード（ジャッジが完了と認めるまでワーカーがループ）',
@@ -710,8 +720,11 @@ const zh: KanbanMessages = {
   assignee: '负责人',
   defaultOption: name => `${name}（默认）`,
   parkedOption: '未分配（搁置 — 不会运行）',
-  skills: '技能（逗号分隔）',
-  skillsPlaceholder: 'translation, github',
+  skills: '技能（来自指派档案）',
+  skillsPlaceholder: '选择指派档案已安装的技能…',
+  noSkill: '— 无 —',
+  noSkillsForProfile: '此档案未安装任何技能。',
+  skillsLoadFailed: '无法加载此档案的技能列表。',
   parent: '父任务（完成前会阻塞）',
   noParent: '— 无父任务 —',
   goalMode: '目标模式（工作单元循环直到评判代理认可完成）',
@@ -918,8 +931,11 @@ const zhHant: KanbanMessages = {
   assignee: '負責人',
   defaultOption: name => `${name}（預設）`,
   parkedOption: '未指派（擱置 — 不會執行）',
-  skills: '技能（以逗號分隔）',
-  skillsPlaceholder: 'translation, github',
+  skills: '技能（來自指派檔案）',
+  skillsPlaceholder: '選擇指派檔案已安裝的技能…',
+  noSkill: '— 無 —',
+  noSkillsForProfile: '此檔案未安裝任何技能。',
+  skillsLoadFailed: '無法載入此檔案的技能列表。',
   parent: '父任務（完成前會阻擋）',
   noParent: '— 無父任務 —',
   goalMode: '目標模式（工作單元循環直到評判代理認可完成）',

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -3167,7 +3167,13 @@
     const [assignee, setAssignee] = useState("");
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
-    const [skills, setSkills] = useState("");
+    // One skill picked from the assignee's installed set ("" = none).
+    const [skill, setSkill] = useState("");
+    // The assignee-scoped skill roster for the dropdown. Refetched whenever
+    // the assignee changes (blank = the resolved default profile), so the
+    // options always match the profile that will actually run the task.
+    const [profileSkills, setProfileSkills] = useState([]);
+    const [skillsLoadErr, setSkillsLoadErr] = useState(false);
     // A board with a configured workdir defaults to a persistent workspace:
     // worktree for git repositories, dir for ordinary directories. Boards
     // without one keep scratch for disposable research and ops tasks.
@@ -3183,6 +3189,31 @@
     const [goalMode, setGoalMode] = useState(false);
     const [goalMaxTurns, setGoalMaxTurns] = useState("");
 
+    // Assignee-scoped skills roster. Debounced (assignee is typed free-text)
+    // and race-guarded: only the latest fetch's result lands. A failed fetch
+    // (unknown profile name, network) degrades to an empty roster with an
+    // inline hint — the task still creates fine without an extra skill.
+    useEffect(function () {
+      const profile = assignee.trim();
+      const timer = setTimeout(function () {
+        SDK.fetchJSON(`${API}/profiles/${encodeURIComponent(profile || "default")}/skills`)
+          .then(function (d) {
+            if (cancelled) return;
+            setProfileSkills((d && d.skills) || []);
+            setSkillsLoadErr(false);
+          })
+          .catch(function () {
+            if (cancelled) return;
+            setProfileSkills([]);
+            setSkillsLoadErr(true);
+          });
+      }, 250);
+      var cancelled = false;
+      return function () { cancelled = true; clearTimeout(timer); };
+    }, [assignee]);
+    // A pick left over from a previous assignee must never ride along.
+    const selectedSkill = profileSkills.indexOf(skill) >= 0 ? skill : "";
+
     const submit = function () {
       const trimmed = title.trim();
       if (!trimmed) return;
@@ -3193,14 +3224,10 @@
         triage: props.columnName === "triage",
       };
       if (parent) body.parents = [parent];
-      // Parse comma-separated skills into a clean list. Blank = no
+      // One skill picked from the assignee's installed set. Blank = no
       // extras (omit key so backend leaves it null). The dispatcher
-      // always auto-loads kanban-worker; these are extras on top.
-      const skillList = skills
-        .split(",")
-        .map(function (s) { return s.trim(); })
-        .filter(function (s) { return s.length > 0; });
-      if (skillList.length > 0) body.skills = skillList;
+      // always auto-loads kanban-worker; this is an extra on top.
+      if (selectedSkill) body.skills = [selectedSkill];
       // Only send workspace_kind when it's non-default. Keeps the request
       // shape small and interoperable with older dispatcher versions.
       if (workspaceKind && workspaceKind !== "scratch") {
@@ -3216,7 +3243,7 @@
         if (Number.isFinite(gmt) && gmt > 0) body.goal_max_turns = gmt;
       }
       props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
+      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkill("");
       setWorkspaceKind(defaultWorkspaceKind); setWorkspacePath(defaultWorkspacePath);
       setGoalMode(false); setGoalMaxTurns("");
     };
@@ -3297,15 +3324,26 @@
           ),
           h("div", { className: "flex flex-col gap-1" },
             fieldLabel(tx(t, "skillsLabel", "Skills"),
-              tx(t, "skillsLabelHint", "(optional, comma-separated)")),
-            h(Input, {
-              value: skills,
-              onChange: function (e) { setSkills(e.target.value); },
-              placeholder: tx(t, "skillsPlaceholder",
-                "skills (optional, comma-separated): translation, github-code-review"),
-              title: "Force-load these skills into the worker (in addition to the built-in kanban-worker).",
+              tx(t, "skillsLabelHint", "(from the assignee's profile)")),
+            h(Select, Object.assign({
+              value: selectedSkill,
               className: "h-8 text-sm",
-            }),
+              title: "Force-load this skill into the worker (in addition to the built-in kanban-worker). Options are the skills installed for the chosen assignee.",
+            }, selectChangeHandler(setSkill)),
+              h(SelectOption, { value: "" },
+                tx(t, "noSkill", "— none —")),
+              profileSkills.map(function (name) {
+                return h(SelectOption, { key: name, value: name }, name);
+              }),
+            ),
+            // Empty roster / failed fetch are states, not errors — the task
+            // still creates fine without an extra skill.
+            h("div", { className: "text-[0.625rem] text-muted-foreground" },
+              skillsLoadErr
+                ? tx(t, "skillsLoadFailed", "Could not load this profile's skills.")
+                : profileSkills.length === 0
+                  ? tx(t, "noSkillsForProfile", "No skills installed for this profile.")
+                  : ""),
           ),
           h("div", { className: "flex flex-col gap-1" },
             fieldLabel(tx(t, "workspace", "Workspace")),

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1511,31 +1511,6 @@ def auto_describe_profile(profile_name: str, payload: DescribeAutoBody):
     return {"ok": bool(outcome.ok), "profile": outcome.profile_name, "reason": outcome.reason, "description": outcome.description}
 
 
-_RE_PROFILE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
-_RESERVED_PROFILE_NAMES = frozenset({"", ".", "..", "current"})
-
-
-def validate_profile_name(name: str) -> None:
-    """Reject a profile name that could escape the profile root.
-
-    ``normalize_profile_name`` only lowercases and strips, so a URL path
-    parameter like ``../../etc`` reaches ``get_profile_dir`` unharmed. This is
-    the one gate between a user-supplied path segment and the filesystem;
-    rejections raise 404 so a probe is indistinguishable from an unknown
-    profile.
-    """
-    if (
-        not name
-        or name in _RESERVED_PROFILE_NAMES
-        or name.startswith(".")
-        or "/" in name
-        or "\\" in name
-        or "\x00" in name
-        or not _RE_PROFILE_NAME.match(name)
-    ):
-        raise HTTPException(status_code=404, detail=f"profile '{name}' not found")
-
-
 @router.get("/profiles/{profile_name}/skills")
 def list_profile_skills(profile_name: str):
     """Return the skills installed for the named profile.
@@ -1552,7 +1527,10 @@ def list_profile_skills(profile_name: str):
         from hermes_cli import profiles as profiles_mod
 
         canon = profiles_mod.normalize_profile_name(profile_name)
-        validate_profile_name(canon)
+        # A profile name is a URL path parameter reaching the filesystem here,
+        # so validate BEFORE resolving: normalize alone only lowercases/strips
+        # and would happily pass `../../etc` through to get_profile_dir.
+        profiles_mod.validate_profile_name(canon)
         if canon == "default":
             from hermes_constants import get_hermes_home  # type: ignore
 
@@ -1594,6 +1572,9 @@ def list_profile_skills(profile_name: str):
         names.sort()
     except HTTPException:
         raise
+    except ValueError as exc:
+        # normalize/validate rejection (e.g. traversal characters, empty name)
+        raise HTTPException(status_code=404, detail=f"profile '{profile_name}' not found") from exc
     except Exception:
         # Log server-side; never echo the raw exception to API consumers.
         log.exception("failed to list profile skills for %r", profile_name)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1511,7 +1511,97 @@ def auto_describe_profile(profile_name: str, payload: DescribeAutoBody):
     return {"ok": bool(outcome.ok), "profile": outcome.profile_name, "reason": outcome.reason, "description": outcome.description}
 
 
-# --- Decompose (built-in decomposer fan-out) ----------------------------------
+_RE_PROFILE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+_RESERVED_PROFILE_NAMES = frozenset({"", ".", "..", "current"})
+
+
+def validate_profile_name(name: str) -> None:
+    """Reject a profile name that could escape the profile root.
+
+    ``normalize_profile_name`` only lowercases and strips, so a URL path
+    parameter like ``../../etc`` reaches ``get_profile_dir`` unharmed. This is
+    the one gate between a user-supplied path segment and the filesystem;
+    rejections raise 404 so a probe is indistinguishable from an unknown
+    profile.
+    """
+    if (
+        not name
+        or name in _RESERVED_PROFILE_NAMES
+        or name.startswith(".")
+        or "/" in name
+        or "\\" in name
+        or "\x00" in name
+        or not _RE_PROFILE_NAME.match(name)
+    ):
+        raise HTTPException(status_code=404, detail=f"profile '{name}' not found")
+
+
+@router.get("/profiles/{profile_name}/skills")
+def list_profile_skills(profile_name: str):
+    """Return the skills installed for the named profile.
+
+    Consumed by the task-creation forms (dashboard + desktop kanban) to
+    offer a skills dropdown scoped to the chosen assignee. Each name is the
+    skill directory's full path relative to the profile's ``skills/`` dir
+    (``_org/<id>/`` mirrors stripped to their in-mirror path, matching the
+    runtime loader) so a picked value round-trips through ``--skills``
+    preload and ``skill_view()`` lookup unchanged.
+    """
+    try:
+        from agent.skill_utils import iter_skill_index_files
+        from hermes_cli import profiles as profiles_mod
+
+        canon = profiles_mod.normalize_profile_name(profile_name)
+        validate_profile_name(canon)
+        if canon == "default":
+            from hermes_constants import get_hermes_home  # type: ignore
+
+            profile_dir = Path(get_hermes_home())
+        else:
+            profile_dir = profiles_mod.get_profile_dir(canon)
+        if not profile_dir.is_dir():
+            raise HTTPException(status_code=404, detail=f"profile '{profile_name}' not found")
+
+        skills_dir = profile_dir / "skills"
+        if not skills_dir.is_dir():
+            return {"profile": canon, "skills": []}
+
+        names: list[str] = []
+        for md in iter_skill_index_files(skills_dir, "SKILL.md"):
+            try:
+                rel = md.relative_to(skills_dir)
+            except ValueError:
+                continue
+            parts = list(rel.parts[:-1])  # drop the SKILL.md filename
+            if not parts:
+                continue
+            # Org mirrors list under their in-mirror path (the runtime's
+            # skill loader strips the `_org/<org_id>/` prefix — see
+            # agent.prompt_builder._build_skill_entry — so a picked value
+            # resolves the same way here as in the worker's session).
+            if parts[0] == "_org" and len(parts) >= 3:
+                parts = parts[2:]
+                if not parts:
+                    continue
+            # The FULL path relative to skills_dir (org prefix stripped),
+            # e.g. ``mlops/evaluation/evaluating-llms-harness``. This is the
+            # exact identifier ``skill_view()`` resolves, so a picked value
+            # round-trips through the worker's ``--skills`` preload. (A
+            # 2-part flattening like profile_describer would break 3-level
+            # skills: ``mlops/models/audiocraft`` → ``mlops/audiocraft``
+            # resolves to nothing.)
+            names.append("/".join(parts))
+        names.sort()
+    except HTTPException:
+        raise
+    except Exception:
+        # Log server-side; never echo the raw exception to API consumers.
+        log.exception("failed to list profile skills for %r", profile_name)
+        raise HTTPException(status_code=500, detail="failed to list profile skills")
+    return {"profile": canon, "skills": names}
+
+
+# --- Decompose (built-in decomposer fan-out) ---
 
 class DecomposeBody(BaseModel):
     author: Optional[str] = None

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1316,6 +1316,41 @@ def test_profile_skills_404_unknown_profile(kanban_home, client):
     assert "not found" in r.json()["detail"]
 
 
+def test_profile_skills_rejects_traversal_names(kanban_home, client):
+    # normalize alone only lowercases/strips — it would happily pass `../../etc`
+    # through to get_profile_dir. validate_profile_name must gate the URL
+    # parameter before it reaches the filesystem; rejection reads as 404.
+    for bad in ("..", "../..", "../../etc", "a/b", "a%2Fb", ".hidden", "UPPER"):
+        r = client.get(f"/api/plugins/kanban/profiles/{bad}/skills")
+        assert r.status_code == 404, f"{bad!r} should be rejected, got {r.status_code}"
+
+
+def test_profile_skills_rejects_empty_name(kanban_home, client):
+    # normalize raises ValueError on whitespace-only input; the endpoint
+    # maps that to 404 rather than a 500.
+    r = client.get("/api/plugins/kanban/profiles/%20/skills")
+    assert r.status_code == 404
+
+
+def test_profile_skills_500_does_not_leak_paths(kanban_home, client, monkeypatch):
+    # The generic 500 detail must not echo the exception (which can carry
+    # internal paths) — log it server-side, return a fixed string. The
+    # endpoint imports iter_skill_index_files at call time
+    # (`from agent.skill_utils import ...`), so patching the module
+    # attribute intercepts the next request.
+    from agent import skill_utils as skill_utils_mod
+
+    def _explode(*args, **kwargs):
+        raise RuntimeError("secret path /Users/atlmapper/boom")
+
+    monkeypatch.setattr(skill_utils_mod, "iter_skill_index_files", _explode)
+    _make_skills(kanban_home, "translation")
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 500
+    assert "boom" not in r.json()["detail"]
+    assert r.json()["detail"] == "failed to list profile skills"
+
+
 # ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1228,6 +1228,95 @@ def test_specify_happy_path(client, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# GET /profiles/{name}/skills — assignee-scoped skills dropdown source
+# ---------------------------------------------------------------------------
+
+
+def _make_skills(home: Path, *paths: str) -> None:
+    """Write SKILL.md files under ``<home>/skills/<path>/``."""
+    for rel in paths:
+        skill_dir = home / "skills" / rel
+        skill_dir.mkdir(parents=True, exist_ok=True)
+        (skill_dir / "SKILL.md").write_text(
+            f"---\nname: {rel.split('/')[-1]}\ndescription: test skill\n---\nbody\n",
+            encoding="utf-8",
+        )
+
+
+def test_profile_skills_lists_default_home_skills(kanban_home, client):
+    # The 'default' profile resolves to HERMES_HOME itself, so skills land
+    # directly under <home>/skills/.
+    _make_skills(kanban_home, "translation", "devops/labfinder-ci-pipelines",
+                "devops/labfinder-eks-investigation")
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 200
+    data = r.json()
+    assert data["profile"] == "default"
+    # Each name is the full skill-dir path relative to skills/ — the exact
+    # identifier skill_view() resolves, so a picked value round-trips
+    # through the worker's --skills preload.
+    assert data["skills"] == [
+        "devops/labfinder-ci-pipelines",
+        "devops/labfinder-eks-investigation",
+        "translation",
+    ]
+
+
+def test_profile_skills_keeps_deep_category_paths(kanban_home, client):
+    # 3-level skills must keep their full path — a 2-part flattening
+    # (``mlops/models/audiocraft`` → ``mlops/audiocraft``) would produce
+    # an identifier that resolves to nothing.
+    _make_skills(kanban_home, "mlops/models/audiocraft")
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 200
+    assert r.json()["skills"] == ["mlops/models/audiocraft"]
+
+
+def test_profile_skills_empty_when_none_installed(kanban_home, client):
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 200
+    assert r.json()["skills"] == []
+
+
+def test_profile_skills_support_dirs_excluded(kanban_home, client):
+    # references/ inside an actual skill dir must not surface as a skill
+    # (progressive-disclosure support path), and neither should an _org
+    # mirror entry without the token-gating .active_org marker.
+    _make_skills(kanban_home, "devops/labfinder-ci-pipelines")
+    skill = kanban_home / "skills" / "devops" / "labfinder-ci-pipelines"
+    (skill / "references").mkdir(parents=True)
+    (skill / "references" / "SKILL.md").write_text("not a skill\n", encoding="utf-8")
+    (kanban_home / "skills" / "_org" / "acme" / "shared").mkdir(parents=True)
+    (kanban_home / "skills" / "_org" / "acme" / "shared" / "SKILL.md").write_text(
+        "mirror\n", encoding="utf-8"
+    )
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 200
+    assert r.json()["skills"] == ["devops/labfinder-ci-pipelines"]
+
+
+def test_profile_skills_lists_active_org_mirror(kanban_home, client):
+    # With the sync-client-written .active_org marker, the active org's mirror
+    # resolves — same gating and same in-mirror naming as the runtime loader
+    # (agent.prompt_builder strips the `_org/<org_id>/` prefix).
+    (kanban_home / "skills" / "_org" / "acme").mkdir(parents=True)
+    (kanban_home / "skills" / "_org" / ".active_org").write_text("acme", encoding="utf-8")
+    _make_skills(kanban_home, "_org/acme/shared-translation",
+                "_org/acme/research/org-research")
+    r = client.get("/api/plugins/kanban/profiles/default/skills")
+    assert r.status_code == 200
+    # Mirror skills list under their in-mirror path (org prefix stripped,
+    # matching the runtime loader).
+    assert r.json()["skills"] == ["research/org-research", "shared-translation"]
+
+
+def test_profile_skills_404_unknown_profile(kanban_home, client):
+    r = client.get("/api/plugins/kanban/profiles/does-not-exist/skills")
+    assert r.status_code == 404
+    assert "not found" in r.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
 # Final result visibility for Done cards
 # ---------------------------------------------------------------------------
 

--- a/web/src/i18n/en.ts
+++ b/web/src/i18n/en.ts
@@ -845,7 +845,7 @@ export const en: Translations = {
     assigneePlaceholder: "assignee",
     priority: "Priority",
     skillsPlaceholder:
-      "skills (optional, comma-separated): translation, github-code-review",
+      "Pick a skill installed for the assignee…",
     noParent: "— no parent —",
     workspacePathDir: "workspace path (required, e.g. ~/projects/my-app)",
     workspacePathOptional:
@@ -857,7 +857,11 @@ export const en: Translations = {
     assigneeLabel: "Assignee",
     assigneeLabelHint: "(blank = dispatcher picks)",
     skillsLabel: "Skills",
-    skillsLabelHint: "(optional, comma-separated)",
+    skillsLabelHint: "(from the assignee's profile)",
+    // Skills dropdown hints — shown under the select in the create dialog.
+    noSkill: "— none —",
+    noSkillsForProfile: "No skills installed for this profile.",
+    skillsLoadFailed: "Could not load this profile's skills.",
     parentLabel: "Parent task",
     parentLabelHint: "(child stays blocked until the parent is done)",
     create: "Create",

--- a/web/src/i18n/types.ts
+++ b/web/src/i18n/types.ts
@@ -855,6 +855,11 @@ export interface Translations {
     assigneeLabelHint?: string;
     skillsLabel?: string;
     skillsLabelHint?: string;
+    // Skills dropdown (assignee-scoped): first option ("none") and the
+    // empty-roster / failed-fetch hints under the select.
+    noSkill?: string;
+    noSkillsForProfile?: string;
+    skillsLoadFailed?: string;
     parentLabel?: string;
     parentLabelHint?: string;
     create?: string;


### PR DESCRIPTION
## Summary

Replaces the free-text comma-separated skills input in the triage task-creation form with a single-select dropdown populated dynamically from the chosen assignee's installed skills. Changing the assignee immediately re-queries and re-scopes the options; a stale pick from a previous assignee is never submitted.

## Changes

**Dashboard plugin API** (plugins/kanban/dashboard/plugin_api.py)
- New GET /api/plugins/kanban/profiles/{profile}/skills — returns the profile's installed skill roster. Identifiers are the full skill-dir path relative to the profile's skills/ dir (`_org/<id>/` mirror prefixes stripped, matching the runtime loader in agent.prompt_builder), so a picked value round-trips through the worker's --skills preload and skill_view() unchanged. Unknown profile -> 404; missing skills dir -> empty roster.

**Web dashboard** (plugins/kanban/dashboard/dist/index.js)
- Task-create dialog skills field is now a Select. Options re-fetch on assignee change (250ms debounce, race-guarded so only the latest fetch lands); a leftover pick not in the new roster is dropped before submit. Empty roster / fetch failure degrade to an inline hint — task creation still works.

**Desktop kanban plugin** (apps/desktop/src/plugins/kanban/)
- Same Select swap in NewTaskDialog, backed by new fetchProfileSkills() helper via react-query, keyed per assignee with staleTime 60s.
- i18n: new keys noSkill / noSkillsForProfile / skillsLoadFailed across en, ja, zh, zhHant; skills label/hint updated to dropdown semantics. Web i18n types + en updated to match.

**Tests** (tests/plugins/test_kanban_dashboard_plugin.py)
- 6 new endpoint tests: default-home listing, deep 3-level paths preserved (no 2-part flattening), empty roster, references/ support dirs excluded, active org mirror with in-mirror naming, 404 on unknown profile.

## Verification (all run locally, passing)

- pytest tests/plugins/test_kanban_dashboard_plugin.py → 44 passed (6 new)
- Desktop: npm run typecheck (3 tsconfigs) → clean; eslint src/plugins/kanban/ → 0 errors
- Web: npm run typecheck → clean; eslint src/i18n/ → 0 errors (2 pre-existing react-refresh warnings)
- node --check dist bundle → clean
- Round-trip probe: all 126 listed identifiers resolve through skill_view() or are config-disabled — 0 broken shapes
- Live dashboard (port 9123): endpoint returns distinct rosters per assignee (default: 126 skills, injury-bridge: 122), 404 on unknown profile, correct X-Hermes-Session-Token loopback auth

## Acceptance criteria

1. Skills field renders as a dropdown, not text input — yes (Select on both web dashboard and desktop plugin)
2. Options reflect the selected assignee's available skills — yes (per-profile endpoint query)
3. Changing assignee updates the options immediately — yes (react-query refetch per assignee on desktop; debounced refetch on web)
4. Form submission still works with the selected skill value — yes (skills: [selectedSkill] sent through the same create path; stale pick filtered out)