### PR TITLE
fix(models): retain current plugin provider catalog

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3718,8 +3718,24 @@ _PROVIDER_RETIRED_ALIASES: dict[str, tuple[str, ...]] = {
 
 
 def _provider_catalog_names(provider: str) -> tuple[str, ...]:
-    """Active picker models plus retired aliases recognized for detection."""
+    """Active picker models plus retired aliases recognized for detection.
+
+    Static catalogs remain authoritative for built-in providers.  A provider
+    plugin has no entry there, so use its public profile fallback only when the
+    static catalog is absent.  This lets the current plugin retain a model it
+    explicitly advertises without making plugins candidates for cross-provider
+    guessing.
+    """
     active = tuple(_PROVIDER_MODELS.get(provider, []))
+    if not active:
+        try:
+            from providers import get_provider_profile
+
+            profile = get_provider_profile(provider)
+            if profile is not None:
+                active = tuple(profile.fallback_models or ())
+        except Exception:
+            pass
     retired = _PROVIDER_RETIRED_ALIASES.get(provider, ())
     return active + retired
 

--- a/tests/hermes_cli/test_models.py
+++ b/tests/hermes_cli/test_models.py
@@ -8,6 +8,7 @@ from unittest.mock import patch, MagicMock
 from hermes_cli.nous_account import NousPortalAccountInfo
 from hermes_cli.models import (
     OPENROUTER_MODELS, fetch_openrouter_models, model_ids, detect_provider_for_model,
+    detect_static_provider_for_model,
     is_nous_free_tier, partition_nous_models_by_tier,
     check_nous_free_tier, _FREE_TIER_CACHE_TTL,
     union_with_portal_free_recommendations,
@@ -159,6 +160,34 @@ class TestDetectProviderForModel:
         detection must return None instead of switching to openai.
         """
         assert detect_provider_for_model("gpt-5.4", "custom:foo") is None
+
+    def test_current_plugin_catalog_wins_over_built_in_provider(self):
+        """A plugin can advertise a model that also belongs to a built-in."""
+        from providers import ProviderProfile, register_provider
+
+        model = _models_mod._PROVIDER_MODELS["openai-api"][0]
+        provider = "test-current-plugin-catalog"
+        register_provider(ProviderProfile(name=provider, fallback_models=(model,)))
+
+        assert detect_provider_for_model(model, provider) is None
+
+    def test_plugin_catalog_does_not_enable_cross_provider_guessing(self):
+        """Only the current plugin's profile participates in detection."""
+        from providers import ProviderProfile, register_provider
+
+        model = _models_mod._PROVIDER_MODELS["openai-api"][0]
+        provider = "test-unrelated-plugin-catalog"
+        register_provider(
+            ProviderProfile(name=provider, fallback_models=("plugin-only-model",))
+        )
+
+        assert detect_static_provider_for_model(model, provider) == ("openai-api", model)
+        assert detect_static_provider_for_model("plugin-only-model", "anthropic") is None
+
+    def test_explicit_built_in_provider_remains_authoritative(self):
+        model = _models_mod._PROVIDER_MODELS["openai-api"][0]
+
+        assert detect_provider_for_model(model, "openai-api") is None
 
 
 


### PR DESCRIPTION
## Summary
- Keep the current model-provider plugin selected when an exact model appears in its public `ProviderProfile.fallback_models` catalog.
- Preserve built-in static catalogs as authoritative and avoid adding plugin providers to cross-provider guessing.
- Cover conflicts with built-in model names, unrelated plugin catalogs, and explicit built-in provider selection.

## Test plan
- [x] Run `scripts/run_tests.sh tests/hermes_cli/test_models.py -q` (84 passed).
- [x] Run the same focused suite on the Tars maintenance backport (82 passed).
- [x] Run Ruff checks for the changed files.
- [ ] Let repository CI exercise the full platform matrix; an attempted local full suite reached 6,767 passing tests before interruption and exposed two unrelated compression timing failures.
