### PR TITLE
fix(codex): uniquify replayed call_ids that recur across turns

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -557,6 +557,16 @@ def _chat_messages_to_responses_input(
     # `function_call_output` wrapper) that no longer carries it (#90976).
     item_sources: List[Optional[Dict[str, Any]]] = []
     seen_item_ids: set = set()
+    # A stored tool call_id (e.g. a short-lived id like "terminal:0") can
+    # recur on a LATER, unrelated turn of the same session. Replayed
+    # verbatim, the second occurrence puts the same call_id on the wire
+    # twice; the Responses API rejects the whole request with 400
+    # "Duplicate function_call_output" and the session is permanently
+    # bricked (#102629). Every occurrence past the first gets a unique
+    # wire id; the queue lets the matching "tool" message below reuse the
+    # exact id its function_call was given, in call order.
+    call_id_occurrences: Dict[str, int] = {}
+    call_id_wire_queue: Dict[str, List[str]] = {}
 
     for msg in messages:
         if not isinstance(msg, dict):
@@ -751,9 +761,18 @@ def _chat_messages_to_responses_input(
                             arguments = str(arguments)
                         arguments = arguments.strip() or "{}"
 
+                        base_wire_id = _clamp_responses_call_id(call_id)
+                        occurrence = call_id_occurrences.get(base_wire_id, 0)
+                        call_id_occurrences[base_wire_id] = occurrence + 1
+                        wire_call_id = (
+                            base_wire_id if occurrence == 0
+                            else _clamp_responses_call_id(f"{base_wire_id}_dup{occurrence}")
+                        )
+                        call_id_wire_queue.setdefault(base_wire_id, []).append(wire_call_id)
+
                         items.append({
                             "type": "function_call",
-                            "call_id": _clamp_responses_call_id(call_id),
+                            "call_id": wire_call_id,
                             "name": _sanitize_replayed_fn_name(fn_name),
                             "arguments": arguments,
                         })
@@ -800,9 +819,19 @@ def _chat_messages_to_responses_input(
             else:
                 output_value = str(tool_content or "")
 
+            # Pair with the wire id its matching function_call was given
+            # above — if that call_id recurred on an earlier turn, the
+            # queue holds the de-duplicated id for THIS occurrence, in
+            # call order (#102629). No queued entry (malformed/partial
+            # history) falls back to the plain clamped id, unchanged
+            # from prior behavior.
+            base_wire_id = _clamp_responses_call_id(call_id)
+            queue = call_id_wire_queue.get(base_wire_id)
+            wire_call_id = queue.pop(0) if queue else base_wire_id
+
             items.append({
                 "type": "function_call_output",
-                "call_id": _clamp_responses_call_id(call_id),
+                "call_id": wire_call_id,
                 "output": output_value,
             })
             item_sources.append(msg)

--- a/tests/agent/test_codex_responses_adapter.py
+++ b/tests/agent/test_codex_responses_adapter.py
@@ -452,6 +452,62 @@ def test_chat_messages_to_responses_input_canonicalizes_fc_only_pair():
         assert len(call["call_id"]) <= 64
 
 
+def test_chat_messages_to_responses_input_uniquifies_call_id_reused_across_turns():
+    """A stored call_id (e.g. a short-lived id like "terminal:0") can recur
+    on a later, unrelated turn. Replayed verbatim, both function_call items
+    and both function_call_output items would carry the same call_id, and
+    the Responses API rejects the whole request with 400 "Duplicate
+    function_call_output" (#102629). Each occurrence must get a unique
+    call_id, still correctly paired with its own output."""
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0",
+                    "function": {"name": "terminal", "arguments": '{"command":"first"}'},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "terminal:0",
+            "content": "first result",
+        },
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0",
+                    "function": {"name": "terminal", "arguments": '{"command":"second"}'},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "terminal:0",
+            "content": "second result",
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    calls = [i for i in items if i.get("type") == "function_call"]
+    outputs = [i for i in items if i.get("type") == "function_call_output"]
+    assert len(calls) == 2
+    assert len(outputs) == 2
+
+    call_ids = [c["call_id"] for c in calls]
+    assert len(set(call_ids)) == 2, "duplicate call_ids would 400 the whole request"
+
+    assert calls[0]["call_id"] == outputs[0]["call_id"]
+    assert calls[1]["call_id"] == outputs[1]["call_id"]
+    assert outputs[0]["output"] == "first result"
+    assert outputs[1]["output"] == "second result"
+
+
 def test_preflight_codex_input_items_sanitizes_replayed_fn_name():
     """The preflight choke-point also coerces invalid replayed names
     (covers callers that build input items without the chat converter)."""


### PR DESCRIPTION
## What does this PR do?

Prevents `_chat_messages_to_responses_input` in `agent/codex_responses_adapter.py`
from replaying the same tool `call_id` twice on one Responses request when a
stored id (e.g. a short-lived id like `terminal:0`) recurs on a later,
unrelated turn of the same session. Replayed verbatim, both occurrences put
the same `call_id` on the wire (one `function_call`/`function_call_output`
pair each), and the provider rejects the whole request with a non-retryable
`400 Duplicate function_call_output`, permanently bricking the session.

## Related Issue

Fixes #102629

## Root Cause

The converter derives each replayed `function_call`/`function_call_output`
`call_id` from the stored tool id and appends it unchanged. Nothing enforced
per-request uniqueness when one stored id recurs across turns — only a
separate `seen_item_ids` set for reasoning-item replay existed, which does
not cover tool call ids at all.

## Fix

Track how many times each (clamped) `call_id` has been used to emit a
`function_call` item in this request. The first occurrence keeps its
original id; every later occurrence gets a deterministic, still-≤64-char
suffixed id (`_dup{n}`, reclamped via the existing SHA-256 clamp helper if
that pushes it over the limit). A FIFO queue keyed by the original call_id
lets the matching `tool`-role message reuse the exact same wire id for its
`function_call_output`, so pairing survives in call order — mirroring the
existing pairing invariant used by the oversized-id clamp path (#73492).

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Tests (adding or improving test coverage)

## Changes Made

- `agent/codex_responses_adapter.py`: de-duplicate replayed `call_id`s inside
  `_chat_messages_to_responses_input` (function_call + matching
  function_call_output).
- `tests/agent/test_codex_responses_adapter.py`: regression test with the
  same `call_id` on two separate turns — asserts both function_call items
  get distinct ids and each output still pairs with its own call.

## How to Test

```
python -m pytest tests/agent/test_codex_responses_adapter.py -q
```

Result: `27 passed`.

Verified the new test fails without the fix:

```
$ git checkout HEAD~1 -- agent/codex_responses_adapter.py
$ python -m pytest tests/agent/test_codex_responses_adapter.py -q -k uniquifies
...
E       AssertionError: duplicate call_ids would 400 the whole request
E       assert 1 == 2
E        +  where 1 = len({'terminal:0'})
1 failed, 26 deselected

$ git checkout HEAD -- agent/codex_responses_adapter.py
$ python -m pytest tests/agent/test_codex_responses_adapter.py -q
27 passed
```

Also ran the broader adjacent suites to check for regressions (all green):

```
tests/run_agent/test_native_compaction.py            74 passed
tests/agent/transports/test_codex_transport.py      108 passed
tests/agent/test_message_sanitization_policy.py      56 passed
tests/agent/test_estimator_parity_84371.py           13 passed
tests/run_agent/test_run_agent_codex_responses.py    63 passed
tests/agent/test_native_preflight_estimate.py         8 passed
tests/run_agent/test_native_compaction_nontext_retention.py  6 passed
tests/run_agent/test_native_compaction_summary_retention.py 24 passed
tests/agent/test_memory_provider.py                  71 passed
tests/run_agent/test_codex_multimodal_tool_result.py  5 passed
tests/run_agent/test_codex_xai_oauth_recovery.py     19 passed
tests/run_agent/test_provider_parity.py              54 passed
tests/run_agent/test_run_agent_multimodal_prologue.py 4 passed
```

`ruff check agent/codex_responses_adapter.py tests/agent/test_codex_responses_adapter.py`: passed.
`git diff --check`: passed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs/issues; #94708, #99941, #91779, #93416, #100978,
      and #91126 all touch adjacent duplicate-tool-call/call_id machinery but
      none cover this codepath — #100978 dedupes repeated `call_id`s **within
      a single incoming model response** (`_normalize_codex_response`), while
      this fixes duplicate ids on **replayed stored history across turns**
      (`_chat_messages_to_responses_input`), a different function and a
      different direction of the wire.
- [x] My PR contains only changes related to this fix
- [x] I've run the relevant test suites locally (see above)
- [x] I've added tests for my changes
- [x] I've tested on Linux with Python 3.12

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example`: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A
- [x] Cross-platform impact considered: provider-neutral Python logic and synthetic test
- [x] Tool descriptions/schemas: N/A

> **AI-assisted contribution:** The bug investigation, implementation, and
> tests were developed with AI assistance. I reviewed the scope and am
> submitting the code for normal maintainer review.
