### PR TITLE
fix(rooms): forbid a Discussion member writing another participant's line

### DIFF
--- a/gateway/hosted_room_discussion.py
+++ b/gateway/hosted_room_discussion.py
@@ -909,6 +909,9 @@ def _build_prompt(
         '- If you have nothing new to add, reply with exactly "(pass)".',
         "- Mention a teammate by handle to pull them into the next round; do not repeat points already made.",
         "- Never reveal content from private conversations. Your reply is published verbatim.",
+        "- Write only your own line. The \"@handle:\" prefixes above mark who "
+        "said what; they are not a format to copy. Never write a line for "
+        "another participant \u2014 every member gets its own turn.",
     ]
     fixed_bytes = len("\n".join([*opening, *rules]).encode("utf-8"))
     available = max(0, driver.MAX_PROMPT_BYTES - fixed_bytes - 1)


### PR DESCRIPTION
## What does this PR do?

Adds one rule to the Discussion room prompt forbidding a member from writing a line attributed to another participant.

Discussion renders the shared history to each member via `_format_message`, which formats every prior turn as `@handle: text`:

```python
def _format_message(event: _ValidatedEvent, room: DiscussionRoom) -> str:
    text = str(event.payload["text"])
    if event.kind == "message.user":
        return f"User (user): {text}"
    member = _member_by_id(room, event.payload["member_id"])
    return f"@{member.handle}: {text}"
```

That prefix is server-generated from the authoritative `member_id`, so attribution itself cannot be forged — `_validate_member_message` enforces that. The gap is that nothing tells a member the prefix is a *reading* convention rather than a *writing* one. `_build_prompt`'s rules list covers passing, mentions, repetition and privacy, but says nothing about speaking for others.

The result is that a member imitates the transcript format it was shown and emits a whole turn in another participant's voice. Because a Discussion member's turn is replayed into every other member's context, the fabricated turn then propagates as though that participant had actually said it — other members quote and rebut claims their supposed author never made, and the member being spoken for often passes, having "already answered."

This is a prompt-level gap, not an attribution or validation bug, so it is fixed at the prompt.

## Related Issue

No existing issue — I searched open and merged PRs and issues for `impersonate`, `impersonation`, `hosted_room_discussion`, and Discussion prompt/rules and found nothing covering this.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/hosted_room_discussion.py` — one rule appended to the `rules` list in `_build_prompt`:

  > `- Write only your own line. The "@handle:" prefixes above mark who said what; they are not a format to copy. Never write a line for another participant — every member gets its own turn.`

No other files. No signature, schema, event or config change. `fixed_bytes` already accounts for the rules block when computing the history budget, so the 226 added bytes reduce available history space by that amount and are handled by the existing truncation path rather than risking the `MAX_PROMPT_BYTES` guard.

## How to Test

Reproduced and verified on a live 5-member Discussion room (`chief-of-staff`, `coder`, `finance-desk`, `homelab`, `research`), same room and same profiles throughout, with only this rule changed between runs.

1. Create a Discussion room with several members, at least one of whose persona casts it as a generalist or coordinator that speaks on behalf of others.
2. Send: `@everyone one short line each on what you own. Your own line only.`
3. **Before:** the coordinator member replied with a turn written in another member's voice, prefixed `@homelab (one quick line): …`, describing that member's domain. It reproduced on every attempt. The impersonated member then produced no reply of its own that round. The other four members each replied correctly with only their own line.
4. **After:** the same member replied `Telegram front door + generalist — the profile Sriram talks to day-to-day; …` — its own line, its own voice, no `@handle:` prefix, first try.

Worth noting for reviewers: a persona-level instruction ("do not speak for other participants", added to that member's `SOUL.md`) was tried first and did **not** hold — the behaviour reproduced with it in place. The turn-time prompt is the layer where this sticks.

## Checklist

- [x] I've tested on my platform: macOS 26 (Darwin 27.0.0), Python 3.11.15
- [x] I've updated relevant documentation — N/A, no user-facing surface changed
- [x] I've updated `cli-config.yaml.example` — N/A, no config keys
- [x] I've updated `CONTRIBUTING.md` / `AGENTS.md` — N/A, no architecture change
- [x] I've considered cross-platform impact — N/A, a prompt string
- [x] I've updated tool descriptions/schemas — N/A

I was not able to run `tests/gateway/test_hosted_room_discussion.py` locally (the install I have is a runtime venv without the dev extras, and I did not want to mutate it). I read the suite instead: its prompt assertions are substring-presence checks and a `len(prompt) <= driver.MAX_PROMPT_BYTES` bound, both preserved. The `Earlier content omitted` case at the end of that file asserts truncation *does* occur, and a larger fixed block makes truncation more likely, not less — so the change moves that assertion in the safe direction. Happy to adjust if CI disagrees.
