### PR TITLE
feat(cli): hermes group — relay a user request into a hosted Group Chat from any session

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2312,7 +2312,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "chat", "model", "gateway", "setup", "whatsapp", "whatsapp-cloud", "login", "logout",
         "auth", "status", "cron", "doctor", "config", "pairing", "skills", "tools", "mcp",
         "sessions", "insights", "update", "uninstall", "profile", "dashboard", "serve",
-        "desktop", "gui", "honcho", "claw", "plugins", "security", "acp", "webhook", "peer",
+        "desktop", "gui", "honcho", "claw", "plugins", "security", "acp", "webhook", "peer", "group",
         "memory", "dump", "debug", "backup", "import", "completion", "logs",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
@@ -2598,7 +2598,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
-        "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
+        "group", "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
         "project", "proxy",
         "prompt-size",
         "resume",
@@ -3199,6 +3199,10 @@ def _build_cli_parser():
 
     from hermes_cli.subcommands.peer import build_peer_parser
     build_peer_parser(subparsers)
+
+    # group command — relay user messages into Group Chats from any session
+    from hermes_cli.subcommands.group import build_group_parser
+    build_group_parser(subparsers)
 
     from hermes_cli.portal_cli import add_parser as _add_portal_parser
     _add_portal_parser(subparsers)

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -17,12 +17,15 @@ driven headlessly by the gateway's hosted-room worker.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
 import sys
+import tempfile
 import time
 import uuid
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Protocol
 
@@ -96,6 +99,105 @@ class Transport(Protocol):
 
 
 _TRANSPORTS: list[Transport] = []
+
+# ── session → thread continuity ──────────────────────────────────────────────
+#
+# A relaying session (Discord thread, CLI chat) that sends twice into the same
+# room should land in the SAME room thread, while a different session starts a
+# new one. The agent cannot be trusted to remember a minted thread id across
+# turns, so the CLI binds (room, session) → thread on the first send and reuses
+# it. The session id comes from HERMES_SESSION_ID (set per turn by the agent
+# runtime for tools it spawns) or --session; --new-thread breaks the binding.
+
+_THREAD_BINDINGS_FILE = "thread-bindings.json"
+_THREAD_BINDINGS_MAX = 500
+
+
+def _bindings_path() -> Path:
+    # Machine root (profile-independent), beside state.db.
+    return hosted_rooms.default_db_path().parent / "group_relay" / _THREAD_BINDINGS_FILE
+
+
+def _read_bindings(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+@contextlib.contextmanager
+def _bindings_lock(path: Path) -> Iterator[None]:
+    """Serialize read-modify-write across relays. flock where available;
+    a no-op elsewhere (the write below is still atomic per file)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover — Windows
+        yield
+        return
+    with open(lock_path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _mutate_bindings(mutate: Callable[[dict[str, dict[str, Any]]], None]) -> None:
+    """Locked, atomic read-modify-write of the bindings file. Never raises."""
+    try:
+        path = _bindings_path()
+        with _bindings_lock(path):
+            data = _read_bindings(path)
+            mutate(data)
+            # Unique temp per writer: a shared name let two writers clobber
+            # each other's temp before os.replace.
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".bindings-", suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle)
+            os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _binding_key(ref: RoomRef, session_id: str) -> str:
+    return f"{ref.kind}:{ref.room_id}:{session_id}"
+
+
+def bound_thread(ref: RoomRef, session_id: str) -> str | None:
+    """The room thread this session already writes to, if any."""
+    entry = _read_bindings(_bindings_path()).get(_binding_key(ref, session_id))
+    thread = entry.get("thread") if isinstance(entry, dict) else None
+    return str(thread) if thread else None
+
+
+def bind_thread(ref: RoomRef, session_id: str, thread: str) -> None:
+    """Remember that ``session_id`` continues ``thread`` in ``ref``. Never raises."""
+    if not session_id or not thread:
+        return
+
+    def mutate(data: dict[str, dict[str, Any]]) -> None:
+        data[_binding_key(ref, session_id)] = {"thread": thread, "at": int(time.time())}
+        if len(data) > _THREAD_BINDINGS_MAX:
+            oldest = sorted(
+                data.items(),
+                key=lambda kv: kv[1].get("at", 0) if isinstance(kv[1], dict) else 0,
+            )
+            for key, _ in oldest[: len(data) - _THREAD_BINDINGS_MAX]:
+                data.pop(key, None)
+
+    _mutate_bindings(mutate)
+
+
+def forget_thread(ref: RoomRef, session_id: str) -> None:
+    _mutate_bindings(lambda data: data.pop(_binding_key(ref, session_id), None))
+
+
+def _session_id(args) -> str:
+    explicit = str(getattr(args, "session", None) or "").strip()
+    return explicit or (os.getenv("HERMES_SESSION_ID") or "").strip()
 
 
 def register_transport(transport: Transport) -> None:
@@ -449,13 +551,28 @@ def _cmd_send(args) -> int:
     ref = resolve_room(args.group, kind=getattr(args, "kind", None))
     transport = _transport_for(ref.kind)
     label = (args.as_label or f"{_profile()} relay").strip()
+    session = _session_id(args)
+    if args.thread:
+        thread = thread_id(args.thread)
+    elif session and not args.new_thread and bound_thread(ref, session):
+        thread = str(bound_thread(ref, session))
+    elif session:
+        # New thread for this session: a session-derived label, distinct
+        # from other sessions' threads. Transports that mint their thread on
+        # delivery bind it after --wait instead (see below).
+        thread = thread_id(f"s-{session}") if ref.kind == "hosted" else DEFAULT_THREAD
+        forget_thread(ref, session)
+    else:
+        thread = DEFAULT_THREAD
     sent = transport.send(
         ref,
         text=text,
-        thread=thread_id(args.thread),
+        thread=thread,
         label=label,
         event_key=args.event_id,
     )
+    if session and ref.kind == "hosted" and not args.thread:
+        bind_thread(ref, session, sent.thread)
     if not args.wait:
         if args.json:
             print(
@@ -481,6 +598,10 @@ def _cmd_send(args) -> int:
         poll_seconds=float(args.poll),
         on_reply=(lambda *_: None) if args.json else _print_reply,
     )
+    if session and summary.get("thread") and not args.thread:
+        # An explicit --thread is a one-off; it must not redirect the
+        # session's implicit continuity.
+        bind_thread(ref, session, str(summary["thread"]))
     if args.json:
         print(json.dumps({"kind": ref.kind, "room_id": ref.room_id, "name": ref.name, **summary}, indent=2))
     else:
@@ -543,11 +664,13 @@ def build_group_parser(subparsers) -> None:
             "agent session; its output carries the members' replies."
         ),
         epilog=(
-            "Threads: hosted rooms accept any --thread label (sanitized to "
-            "[A-Za-z0-9._:-]); omit it for the shared 'cli' thread. A room keeps "
-            "only the LATEST pending user message per thread, so concurrent relays "
-            "should use distinct --thread values. A new relaying session should "
-            "start a new thread rather than reuse another session's.\n"
+            "Threads follow the relaying SESSION: the first send from a session "
+            "starts a new room thread; later sends from the same session "
+            "($HERMES_SESSION_ID, or --session) continue it; a different session "
+            "gets its own thread. --new-thread starts over; --thread <id|label> "
+            "overrides for that send only (it does not change the session's "
+            "thread). Without any session id the shared 'cli' thread is used. "
+            "A room keeps only the LATEST pending user message per thread.\n"
             "\n"
             "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
             "(partial replies already printed), 4 superseded by a room stop. A "
@@ -577,7 +700,19 @@ def build_group_parser(subparsers) -> None:
     send = actions.add_parser("send", help="Relay a message into a group as the user")
     send.add_argument("group", help="Group name or room_id")
     send.add_argument("text", nargs="?", default=None, help="Message text (or stdin)")
-    send.add_argument("--thread", default=None, help="Thread label (see epilog)")
+    send.add_argument("--thread", default=None, help="Explicit thread (see epilog)")
+    send.add_argument(
+        "--session",
+        default=None,
+        metavar="ID",
+        help="Relaying session id for thread continuity (default: $HERMES_SESSION_ID)",
+    )
+    send.add_argument(
+        "--new-thread",
+        action="store_true",
+        default=False,
+        help="Start a new room thread even if this session already has one",
+    )
     send.add_argument(
         "--as",
         dest="as_label",

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -246,6 +246,8 @@ class HostedTransport:
         )
 
     def wait(self, sent, *, timeout, poll_seconds, on_reply):
+        if not (float(poll_seconds) > 0):
+            raise GroupCLIError("--poll must be a positive number of seconds")
         room_id, my_id, my_seq = sent.ref.room_id, sent.message_id, int(sent.seq or 0)
         handles = self._handles(sent.ref)
         cursor = my_seq
@@ -264,10 +266,19 @@ class HostedTransport:
                 if kind.startswith("turn.") or kind == "room.activity":
                     saw_driver_activity = True
                 if kind == "message.member":
-                    pending[str(event["event_id"])] = event
+                    # Only OUR discussion's replies: other relays/threads in the
+                    # same room interleave in the log and must not stream here.
+                    if (
+                        str(payload.get("discussion_event_id") or "") == my_id
+                        and str(payload.get("thread_id") or "") == sent.thread
+                    ):
+                        pending[str(event["event_id"])] = event
                 elif kind == "turn.settled":
                     committed = pending.pop(str(payload.get("message_event_id") or ""), None)
-                    if committed is not None:
+                    if (
+                        committed is not None
+                        and str(payload.get("discussion_event_id") or "") == my_id
+                    ):
                         member_id = str(committed["payload"].get("member_id") or "?")
                         text = str(committed["payload"].get("text") or "")
                         replies.append(
@@ -290,6 +301,12 @@ class HostedTransport:
                         "replies": replies,
                     }
                 elif kind == "room.stop_requested" and cursor > my_seq:
+                    # The stop fence is ROOM-WIDE by design: the policy's
+                    # stopped_through_seq supersedes every earlier user turn in
+                    # every thread (gateway/hosted_room_discussion.py
+                    # plan_next_task). A stop issued after our send therefore
+                    # cancels our discussion too, so exit 4 is the truth even
+                    # when the stop was aimed at another thread.
                     return EXIT_SUPERSEDED, {
                         "status": "stopped",
                         "reason": "room.stop_requested",
@@ -312,7 +329,7 @@ class HostedTransport:
                     flush=True,
                 )
                 warned = True
-            time.sleep(max(0.0, float(poll_seconds)))
+            time.sleep(float(poll_seconds))
 
     def log(self, ref, *, since):
         handles = self._handles(ref)
@@ -533,7 +550,9 @@ def build_group_parser(subparsers) -> None:
             "start a new thread rather than reuse another session's.\n"
             "\n"
             "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
-            "(partial replies already printed), 4 superseded by a room stop.\n"
+            "(partial replies already printed), 4 superseded by a room stop. A "
+            "room stop is room-wide: it cancels every pending user turn in every "
+            "thread, including this relay's.\n"
             "\n"
             "Examples:\n"
             "  hermes group list\n"

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -1,0 +1,585 @@
+"""``hermes group`` — relay user messages into Group Chats from any session.
+
+Acting-as-user: the caller (typically an agent in a Discord/CLI/Desktop
+session) writes into the room ON THE USER'S BEHALF. It is not a room member
+and needs no membership — the actor is a ``user`` whose ``profile`` and
+``display_name`` record who relayed. Turns run wherever the room's
+coordinator lives; ``send --wait`` follows the room until the discussion
+settles and streams member replies, so a background ``terminal`` call brings
+the deliberation back to the originating session as a completion
+notification (the same shape as ``hermes -p <agent> chat -q`` handoffs).
+
+Transports are pluggable via :func:`register_transport`. This module ships the
+gateway-hosted room transport (:mod:`gateway.hosted_rooms`), whose rooms are
+driven headlessly by the gateway's hosted-room worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, Protocol
+
+from gateway import hosted_rooms
+
+# ``thread_id`` grammar in gateway.hosted_room_discussion: [A-Za-z0-9][A-Za-z0-9._:-]*
+_THREAD_SAFE_RE = re.compile(r"[^A-Za-z0-9._:-]+")
+DEFAULT_THREAD = "cli"
+DEFAULT_WAIT_TIMEOUT_SECONDS = 1800.0
+_WORKER_WARN_AFTER_SECONDS = 30.0
+
+# Exit codes (documented in --help; the relaying agent branches on them).
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+EXIT_TIMEOUT = 3
+EXIT_SUPERSEDED = 4
+
+
+class GroupCLIError(Exception):
+    """User-facing failure; ``cmd_group`` prints it and exits 1."""
+
+
+@dataclass(frozen=True)
+class RoomRef:
+    kind: str
+    room_id: str
+    name: str
+    members: tuple[str, ...]
+    managed_here: bool
+    raw: dict = field(default_factory=dict, compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class SentMessage:
+    ref: RoomRef
+    message_id: str
+    seq: int | None
+    thread: str
+    raw: dict = field(default_factory=dict, compare=False, repr=False)
+
+
+OnReply = Callable[[str, str], None]
+
+
+class Transport(Protocol):
+    kind: str
+
+    def list_rooms(self) -> list[RoomRef]: ...
+
+    def send(
+        self,
+        ref: RoomRef,
+        *,
+        text: str,
+        thread: str,
+        label: str,
+        event_key: str | None,
+    ) -> SentMessage: ...
+
+    def wait(
+        self,
+        sent: SentMessage,
+        *,
+        timeout: float,
+        poll_seconds: float,
+        on_reply: OnReply,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    def log(self, ref: RoomRef, *, since: int) -> Iterator[dict[str, Any]]: ...
+
+
+_TRANSPORTS: list[Transport] = []
+
+
+def register_transport(transport: Transport) -> None:
+    if all(existing.kind != transport.kind for existing in _TRANSPORTS):
+        _TRANSPORTS.append(transport)
+
+
+def transports() -> list[Transport]:
+    return list(_TRANSPORTS)
+
+
+def _transport_for(kind: str) -> Transport:
+    for transport in _TRANSPORTS:
+        if transport.kind == kind:
+            return transport
+    raise GroupCLIError(f"no transport registered for group kind {kind!r}")
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _profile() -> str:
+    return (os.getenv("HERMES_PROFILE") or "default").strip() or "default"
+
+
+def thread_id(raw: str | None) -> str:
+    """Coerce a caller-supplied thread label into the room-log identifier grammar."""
+    text = _THREAD_SAFE_RE.sub("-", (raw or DEFAULT_THREAD).strip()).strip("-")
+    if not text:
+        return DEFAULT_THREAD
+    return text if text[0].isalnum() else f"t-{text}"
+
+
+def resolve_room(ref: str, *, kind: str | None = None) -> RoomRef:
+    """Exact name → case-insensitive unique name → room_id, across transports."""
+    want = (ref or "").strip()
+    if not want:
+        raise GroupCLIError("group name or room_id is required")
+    rooms = [
+        room
+        for transport in _TRANSPORTS
+        if kind in (None, transport.kind)
+        for room in transport.list_rooms()
+    ]
+    matchers: tuple[Callable[[RoomRef], bool], ...] = (
+        lambda room: room.name == want,
+        lambda room: room.name.lower() == want.lower(),
+        lambda room: room.room_id == want,
+    )
+    for matcher in matchers:
+        hits = [room for room in rooms if matcher(room)]
+        if len(hits) == 1:
+            return hits[0]
+        if len(hits) > 1:
+            listed = ", ".join(f"{room.kind}:{room.room_id}" for room in hits)
+            raise GroupCLIError(
+                f"Group {want!r} is ambiguous: {listed}. Pass the room_id, or --kind <kind>."
+            )
+    names = ", ".join(sorted({f"{room.name} ({room.kind})" for room in rooms})) or "(none)"
+    raise GroupCLIError(f"No group named {want!r}. Groups on this machine: {names}")
+
+
+# ── hosted transport ─────────────────────────────────────────────────────────
+
+
+class HostedTransport:
+    """Rooms in the gateway's ``state.db``, driven by the hosted-room worker."""
+
+    kind = "hosted"
+
+    @staticmethod
+    def _db():
+        return hosted_rooms.default_db_path()
+
+    def list_rooms(self) -> list[RoomRef]:
+        local = hosted_rooms.local_authority_gateway_id()
+        out: list[RoomRef] = []
+        for room in hosted_rooms.list_rooms(self._db()):
+            members_raw = room.get("members")
+            members: list[Any] = members_raw if isinstance(members_raw, list) else []
+            out.append(
+                RoomRef(
+                    kind=self.kind,
+                    room_id=str(room["room_id"]),
+                    name=str(room["name"]),
+                    members=tuple(
+                        str(m.get("handle") or m.get("profile") or m.get("member_id") or "?")
+                        for m in members
+                        if isinstance(m, dict)
+                    ),
+                    managed_here=str(room["authority_gateway_id"]) == local,
+                    raw=room,
+                )
+            )
+        return out
+
+    def send(self, ref, *, text, thread, label, event_key):
+        from gateway import hosted_room_discussion as discussion
+
+        if not ref.managed_here:
+            raise GroupCLIError(
+                f"Group {ref.name!r} is managed by another gateway "
+                f"({ref.raw.get('authority_gateway_id')}); send from that machine."
+            )
+        try:
+            payload = discussion.validate_user_payload({"text": text, "thread_id": thread})
+        except discussion.DiscussionValidationError as exc:
+            raise GroupCLIError(str(exc)) from exc
+        actor = {
+            "kind": "user",
+            "id": "cli",
+            "profile": _profile(),
+            "display_name": label,
+        }
+        event = hosted_rooms.append_event(
+            self._db(),
+            room_id=ref.room_id,
+            event_id=hosted_rooms.user_event_id(event_key or f"cli:{uuid.uuid4().hex}"),
+            kind="message.user",
+            actor=actor,
+            payload=payload,
+            authority_gateway_id=str(ref.raw["authority_gateway_id"]),
+            authority_epoch=int(ref.raw["authority_epoch"]),
+        )
+        return SentMessage(
+            ref=ref,
+            message_id=str(event["event_id"]),
+            seq=int(event["seq"]),
+            thread=str(payload["thread_id"]),
+            raw=event,
+        )
+
+    def _handles(self, ref: RoomRef) -> dict[str, str]:
+        members_raw = ref.raw.get("members")
+        members: list[Any] = members_raw if isinstance(members_raw, list) else []
+        return {
+            str(m.get("member_id")): str(m.get("handle") or m.get("member_id"))
+            for m in members
+            if isinstance(m, dict) and m.get("member_id") is not None
+        }
+
+    def _page(self, room_id: str, since_seq: int) -> dict[str, Any]:
+        return hosted_rooms.read_events(
+            self._db(),
+            room_id=room_id,
+            since_seq=since_seq,
+            limit=hosted_rooms.MAX_LOG_LIMIT,
+        )
+
+    def wait(self, sent, *, timeout, poll_seconds, on_reply):
+        room_id, my_id, my_seq = sent.ref.room_id, sent.message_id, int(sent.seq or 0)
+        handles = self._handles(sent.ref)
+        cursor = my_seq
+        started = time.monotonic()
+        deadline = started + max(0.0, float(timeout))
+        warned = False
+        saw_driver_activity = False
+        pending: dict[str, dict[str, Any]] = {}  # message.member awaiting turn.settled
+        replies: list[dict[str, Any]] = []
+        while True:
+            page = self._page(room_id, cursor)
+            for event in page.get("events", []):
+                cursor = int(event["seq"])
+                kind = str(event.get("kind") or "")
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                if kind.startswith("turn.") or kind == "room.activity":
+                    saw_driver_activity = True
+                if kind == "message.member":
+                    pending[str(event["event_id"])] = event
+                elif kind == "turn.settled":
+                    committed = pending.pop(str(payload.get("message_event_id") or ""), None)
+                    if committed is not None:
+                        member_id = str(committed["payload"].get("member_id") or "?")
+                        text = str(committed["payload"].get("text") or "")
+                        replies.append(
+                            {
+                                "member_id": member_id,
+                                "handle": handles.get(member_id, member_id),
+                                "text": text,
+                                "seq": int(committed["seq"]),
+                            }
+                        )
+                        on_reply(f"@{handles.get(member_id, member_id)}", text)
+                elif (
+                    kind == "room.activity"
+                    and str(payload.get("discussion_event_id") or "") == my_id
+                    and payload.get("status") in ("settled", "bounded")
+                ):
+                    return EXIT_OK, {
+                        "status": str(payload["status"]),
+                        "reason": str(payload.get("reason_code") or ""),
+                        "replies": replies,
+                    }
+                elif kind == "room.stop_requested" and cursor > my_seq:
+                    return EXIT_SUPERSEDED, {
+                        "status": "stopped",
+                        "reason": "room.stop_requested",
+                        "replies": replies,
+                    }
+            if page.get("has_more"):
+                continue
+            now = time.monotonic()
+            if now >= deadline:
+                return EXIT_TIMEOUT, {"status": "timeout", "reason": "timeout", "replies": replies}
+            if (
+                not warned
+                and not saw_driver_activity
+                and now - started >= _WORKER_WARN_AFTER_SECONDS
+            ):
+                print(
+                    "hermes group: no gateway worker has picked this up yet — is "
+                    "`hermes gateway` (or the Desktop backend) running?",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                warned = True
+            time.sleep(max(0.0, float(poll_seconds)))
+
+    def log(self, ref, *, since):
+        handles = self._handles(ref)
+        cursor = int(since)
+        pending: dict[str, dict[str, Any]] = {}
+        while True:
+            page = self._page(ref.room_id, cursor)
+            for event in page.get("events", []):
+                cursor = int(event["seq"])
+                kind = str(event.get("kind") or "")
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                if kind == "message.user":
+                    actor = event.get("actor") if isinstance(event.get("actor"), dict) else {}
+                    who = str(actor.get("display_name") or "user")
+                    yield {
+                        "seq": cursor,
+                        "speaker": f"User ({who})",
+                        "text": str(payload.get("text") or ""),
+                        "thread": str(payload.get("thread_id") or ""),
+                    }
+                elif kind == "message.member":
+                    pending[str(event["event_id"])] = event
+                elif kind == "turn.settled":
+                    committed = pending.pop(str(payload.get("message_event_id") or ""), None)
+                    if committed is not None:
+                        member_id = str(committed["payload"].get("member_id") or "?")
+                        yield {
+                            "seq": int(committed["seq"]),
+                            "speaker": f"@{handles.get(member_id, member_id)}",
+                            "text": str(committed["payload"].get("text") or ""),
+                            "thread": str(committed["payload"].get("thread_id") or ""),
+                        }
+            if not page.get("has_more"):
+                return
+
+
+register_transport(HostedTransport())
+
+
+# ── commands ─────────────────────────────────────────────────────────────────
+
+
+def _cmd_list(args) -> int:
+    rows = [room for transport in _TRANSPORTS for room in transport.list_rooms()]
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "kind": room.kind,
+                        "name": room.name,
+                        "room_id": room.room_id,
+                        "members": list(room.members),
+                        "managed_here": room.managed_here,
+                    }
+                    for room in rows
+                ],
+                indent=2,
+            )
+        )
+        return EXIT_OK
+    if not rows:
+        print("No groups found. Create a hosted one: hermes group create <name> --member a --member b")
+        return EXIT_OK
+    for room in rows:
+        tail = "" if room.managed_here else "  [managed elsewhere]"
+        print(f"{room.name}  [{room.kind}] ({room.room_id})  members: {', '.join(room.members)}{tail}")
+    return EXIT_OK
+
+
+def _local_profiles(root) -> tuple[str, ...]:
+    names = {"default"}
+    profiles_dir = root / "profiles"
+    if profiles_dir.is_dir():
+        names.update(p.name for p in profiles_dir.iterdir() if p.is_dir())
+    return tuple(sorted(names))
+
+
+def _cmd_create(args) -> int:
+    from gateway import hosted_room_discussion as discussion
+
+    def handle(profile: str) -> str:
+        return "hermes" if profile == "default" else profile
+
+    members = [
+        {"member_id": profile, "profile": profile, "handle": handle(profile)}
+        for profile in args.member
+    ]
+    db = hosted_rooms.default_db_path()
+    try:
+        discussion.validate_roster(members, local_profiles=_local_profiles(db.parent))
+    except discussion.DiscussionValidationError as exc:
+        raise GroupCLIError(str(exc)) from exc
+    room = hosted_rooms.create_room(
+        db,
+        room_id=f"grp-{uuid.uuid4().hex[:12]}",
+        name=args.name,
+        members=members,
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    if args.json:
+        print(json.dumps(room, indent=2))
+    else:
+        print(f"created {room['name']} ({room['room_id']}) members: {', '.join(args.member)}")
+    return EXIT_OK
+
+
+def _print_reply(speaker: str, text: str) -> None:
+    print(f"{speaker}: {text}\n", flush=True)
+
+
+def _cmd_send(args) -> int:
+    text = args.text if args.text is not None else sys.stdin.read()
+    text = (text or "").strip()
+    if not text:
+        raise GroupCLIError("message text is required (argument or stdin)")
+    ref = resolve_room(args.group, kind=getattr(args, "kind", None))
+    transport = _transport_for(ref.kind)
+    label = (args.as_label or f"{_profile()} relay").strip()
+    sent = transport.send(
+        ref,
+        text=text,
+        thread=thread_id(args.thread),
+        label=label,
+        event_key=args.event_id,
+    )
+    if not args.wait:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "kind": ref.kind,
+                        "room_id": ref.room_id,
+                        "name": ref.name,
+                        "message_id": sent.message_id,
+                        "seq": sent.seq,
+                        "thread": sent.thread,
+                        "raw": sent.raw,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"sent to {ref.name} [{ref.kind}] id={sent.message_id} thread={sent.thread}")
+        return EXIT_OK
+    rc, summary = transport.wait(
+        sent,
+        timeout=float(args.timeout),
+        poll_seconds=float(args.poll),
+        on_reply=(lambda *_: None) if args.json else _print_reply,
+    )
+    if args.json:
+        print(json.dumps({"kind": ref.kind, "room_id": ref.room_id, "name": ref.name, **summary}, indent=2))
+    else:
+        count = len(summary.get("replies") or [])
+        line = f"[group {ref.name}: {summary.get('status')} ({summary.get('reason')}), {count} replies]"
+        print(line, file=sys.stderr if rc else sys.stdout, flush=True)
+    return rc
+
+
+def _cmd_log(args) -> int:
+    ref = resolve_room(args.group, kind=getattr(args, "kind", None))
+    rows = list(_transport_for(ref.kind).log(ref, since=int(args.since)))
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return EXIT_OK
+    for row in rows:
+        print(f"{row['speaker']}: {row['text']}")
+    return EXIT_OK
+
+
+_ACTIONS = {
+    "list": _cmd_list,
+    "ls": _cmd_list,
+    "create": _cmd_create,
+    "send": _cmd_send,
+    "log": _cmd_log,
+}
+
+
+def cmd_group(args) -> int:
+    action = getattr(args, "group_action", None)
+    if action not in _ACTIONS:
+        print("usage: hermes group {list,create,send,log} ...", file=sys.stderr)
+        return EXIT_USAGE
+    try:
+        return _ACTIONS[action](args)
+    except (GroupCLIError, hosted_rooms.HostedRoomError) as exc:
+        print(f"hermes group: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+def build_args(argv: list[str]) -> argparse.Namespace:
+    """Test helper: parse ``argv`` exactly as the top-level CLI would."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers()
+    build_group_parser(subparsers)
+    return parser.parse_args(["group", *argv])
+
+
+def build_group_parser(subparsers) -> None:
+    """Attach the ``group`` subcommand to ``subparsers``."""
+    parser = subparsers.add_parser(
+        "group",
+        help="Relay user messages into Group Chats (from any session)",
+        description=(
+            "Write into a Group Chat AS THE USER and follow the deliberation. The "
+            "caller is a relay, not a member: the message lands attributed to the "
+            "user with your profile/label recorded as who relayed it. Run "
+            "'hermes group send <group> \"...\" --wait' in the background from any "
+            "agent session; its output carries the members' replies."
+        ),
+        epilog=(
+            "Threads: hosted rooms accept any --thread label (sanitized to "
+            "[A-Za-z0-9._:-]); omit it for the shared 'cli' thread. A room keeps "
+            "only the LATEST pending user message per thread, so concurrent relays "
+            "should use distinct --thread values. A new relaying session should "
+            "start a new thread rather than reuse another session's.\n"
+            "\n"
+            "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
+            "(partial replies already printed), 4 superseded by a room stop.\n"
+            "\n"
+            "Examples:\n"
+            "  hermes group list\n"
+            "  hermes group create DevTeam --member archie --member mason\n"
+            '  hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait\n'
+            "  hermes group log DevTeam --since 0\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    actions = parser.add_subparsers(dest="group_action")
+
+    ls = actions.add_parser("list", aliases=["ls"], help="List groups on this machine")
+    ls.add_argument("--json", action="store_true", default=False)
+
+    create = actions.add_parser("create", help="Create a gateway-hosted group (2-6 local profiles)")
+    create.add_argument("name")
+    create.add_argument(
+        "--member", action="append", required=True, metavar="PROFILE", help="Repeat per member"
+    )
+    create.add_argument("--json", action="store_true", default=False)
+
+    send = actions.add_parser("send", help="Relay a message into a group as the user")
+    send.add_argument("group", help="Group name or room_id")
+    send.add_argument("text", nargs="?", default=None, help="Message text (or stdin)")
+    send.add_argument("--thread", default=None, help="Thread label (see epilog)")
+    send.add_argument(
+        "--as",
+        dest="as_label",
+        default=None,
+        metavar="LABEL",
+        help="Who relayed, e.g. 'Pax via Discord' (default '<profile> relay')",
+    )
+    send.add_argument(
+        "--event-id",
+        default=None,
+        metavar="KEY",
+        help="Idempotent retry key; resending the same key+text is a no-op",
+    )
+    send.add_argument("--wait", action="store_true", default=False, help="Stream replies until settled")
+    send.add_argument("--timeout", type=float, default=DEFAULT_WAIT_TIMEOUT_SECONDS, metavar="SECONDS")
+    send.add_argument("--poll", type=float, default=1.0, help=argparse.SUPPRESS)
+    send.add_argument("--json", action="store_true", default=False)
+
+    log = actions.add_parser("log", help="Print the group's committed transcript")
+    log.add_argument("group", help="Group name or room_id")
+    log.add_argument("--since", type=int, default=0, metavar="SEQ")
+    log.add_argument("--json", action="store_true", default=False)
+
+    parser.set_defaults(func=cmd_group)

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -26,6 +26,7 @@ def home(tmp_path, monkeypatch):
         (root / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     return root
 
 
@@ -463,3 +464,90 @@ def test_transport_registry_dedupes_by_kind():
     before = len(g.transports())
     g.register_transport(g.HostedTransport())
     assert len(g.transports()) == before
+
+
+# ── session-bound thread continuity ──────────────────────────────────────────
+
+
+def test_hosted_thread_follows_session(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1200_abc")
+    assert _run(["send", "DevTeam", "first", "--json"]) == 0
+    t1 = _out_json(capsys)["thread"]
+    assert t1 == g.thread_id("s-20260903_1200_abc")
+    assert _run(["send", "DevTeam", "second", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == t1
+    # A different session gets its own thread.
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1300_xyz")
+    assert _run(["send", "DevTeam", "other", "--json"]) == 0
+    assert _out_json(capsys)["thread"] != t1
+    # --new-thread from the first session breaks its binding... to a fresh derived label
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1200_abc")
+    assert _run(["send", "DevTeam", "restart", "--new-thread", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == t1  # hosted label is session-derived, so same label is correct
+    # --session overrides the env; --thread overrides everything.
+    assert _run(["send", "DevTeam", "x", "--session", "S2", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == g.thread_id("s-S2")
+    assert _run(["send", "DevTeam", "x", "--thread", "explicit", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "explicit"
+
+
+def test_no_session_uses_shared_cli_thread(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    assert _run(["send", "DevTeam", "x", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "cli"
+
+
+def test_bindings_file_is_bounded_and_survives_corruption(home, monkeypatch):
+    mk_room()
+    ref = g.resolve_room("DevTeam")
+    monkeypatch.setattr(g, "_THREAD_BINDINGS_MAX", 3)
+    for i in range(5):
+        g.bind_thread(ref, f"s{i}", f"t{i}")
+    assert g.bound_thread(ref, "s0") is None and g.bound_thread(ref, "s4") == "t4"
+    g._bindings_path().write_text("{not json")
+    assert g.bound_thread(ref, "s4") is None
+    g.bind_thread(ref, "s9", "t9")  # rewrites cleanly
+    assert g.bound_thread(ref, "s9") == "t9"
+    g.forget_thread(ref, "s9")
+    assert g.bound_thread(ref, "s9") is None
+
+
+def test_bind_thread_is_safe_under_concurrent_writers(home):
+    """Many writers, each binding its own session: no binding may be lost."""
+    import multiprocessing as mp
+
+    mk_room()
+    ref = g.resolve_room("DevTeam")
+
+    def worker(i, home_path):
+        import os as _os
+
+        _os.environ["HERMES_HOME"] = home_path
+        from hermes_cli.subcommands import group as gg
+
+        gg.bind_thread(ref, f"sess-{i}", f"t{i}")
+
+    ctx = mp.get_context("fork")
+    procs = [ctx.Process(target=worker, args=(i, str(home))) for i in range(24)]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(10)
+    for i in range(24):
+        assert g.bound_thread(ref, f"sess-{i}") == f"t{i}", i
+    # No temp files left behind, lock file is harmless.
+    leftovers = [p.name for p in g._bindings_path().parent.iterdir() if p.name.startswith(".bindings-")]
+    assert leftovers == []
+
+
+def test_explicit_thread_does_not_rebind_session(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_SESSION_ID", "S")
+    assert _run(["send", "DevTeam", "a", "--json"]) == 0
+    own = _out_json(capsys)["thread"]
+    assert _run(["send", "DevTeam", "b", "--thread", "elsewhere", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "elsewhere"
+    assert _run(["send", "DevTeam", "c", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == own

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -1,0 +1,437 @@
+"""Behavior contract for ``hermes group`` (hosted-room transport).
+
+The CLI relays a message into a gateway-hosted Group Chat AS THE USER from
+any session, and ``send --wait`` follows the typed room log until the
+discussion settles. Tests drive the room log by hand (no worker), mirroring
+``tests/tui_gateway/test_hosted_room_service.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+
+import pytest
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_rooms
+from hermes_cli.subcommands import group as g
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    for profile in ("pax", "archie"):
+        (root / "profiles" / profile).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    return root
+
+
+def _db():
+    return hosted_rooms.default_db_path()
+
+
+def mk_room(room_id="room-1", name="DevTeam", authority=None):
+    return hosted_rooms.create_room(
+        _db(),
+        room_id=room_id,
+        name=name,
+        members=[
+            {"member_id": "pax", "profile": "pax", "handle": "pax"},
+            {"member_id": "archie", "profile": "archie", "handle": "archie"},
+        ],
+        authority_gateway_id=authority or hosted_rooms.local_authority_gateway_id(),
+    )
+
+
+def _run(argv):
+    return g.cmd_group(g.build_args(argv))
+
+
+def _out_json(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+# ── resolution + list ────────────────────────────────────────────────────────
+
+
+def test_resolve_exact_ci_id_and_missing(home):
+    mk_room()
+    assert g.resolve_room("DevTeam").room_id == "room-1"
+    assert g.resolve_room("devteam").room_id == "room-1"
+    assert g.resolve_room("room-1").room_id == "room-1"
+    assert g.resolve_room("DevTeam").kind == "hosted"
+    with pytest.raises(g.GroupCLIError, match="No group named"):
+        g.resolve_room("nope")
+    with pytest.raises(g.GroupCLIError, match="required"):
+        g.resolve_room("  ")
+
+
+def test_resolve_ambiguous_ci_fails_closed_but_exact_wins(home):
+    mk_room("room-1", "DevTeam")
+    mk_room("room-2", "devteam")
+    with pytest.raises(g.GroupCLIError, match="ambiguous"):
+        g.resolve_room("DEVTEAM")
+    assert g.resolve_room("DevTeam").room_id == "room-1"
+
+
+def test_list_json_and_plain(home, capsys):
+    mk_room()
+    mk_room("room-2", "Remote", authority="install:elsewhere")
+    assert _run(["list", "--json"]) == 0
+    rows = _out_json(capsys)
+    by_id = {r["room_id"]: r for r in rows}
+    assert by_id["room-1"] == {
+        "kind": "hosted",
+        "name": "DevTeam",
+        "room_id": "room-1",
+        "members": ["pax", "archie"],
+        "managed_here": True,
+    }
+    assert by_id["room-2"]["managed_here"] is False
+    assert _run(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "DevTeam  [hosted] (room-1)  members: pax, archie" in out
+    assert "[managed elsewhere]" in out
+
+
+def test_list_empty(home, capsys):
+    assert _run(["list"]) == 0
+    assert "No groups found" in capsys.readouterr().out
+
+
+# ── create ───────────────────────────────────────────────────────────────────
+
+
+def test_create_hosted(home, capsys):
+    rc = _run(["create", "DevTeam", "--member", "pax", "--member", "archie", "--json"])
+    assert rc == 0
+    out = _out_json(capsys)
+    assert out["name"] == "DevTeam"
+    assert out["room_id"].startswith("grp-")
+    assert out["authority_gateway_id"] == hosted_rooms.local_authority_gateway_id()
+    assert [m["handle"] for m in out["members"]] == ["pax", "archie"]
+    # The new room is now resolvable and driven here.
+    assert g.resolve_room("DevTeam").managed_here is True
+
+
+def test_create_default_profile_handle_is_hermes(home, capsys):
+    assert _run(["create", "X", "--member", "default", "--member", "pax", "--json"]) == 0
+    assert [m["handle"] for m in _out_json(capsys)["members"]] == ["hermes", "pax"]
+
+
+def test_create_rejects_bad_roster(home, capsys):
+    assert _run(["create", "X", "--member", "pax"]) == 1
+    assert "between 2 and 6" in capsys.readouterr().err
+    assert _run(["create", "X", "--member", "pax", "--member", "ghost"]) == 1
+    assert "ghost" in capsys.readouterr().err
+
+
+# ── send ─────────────────────────────────────────────────────────────────────
+
+
+def test_send_appends_user_event_with_relay_attribution(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_PROFILE", "pax")
+    rc = _run(["send", "DevTeam", "plan the release", "--as", "Pax via Discord", "--json"])
+    assert rc == 0
+    out = _out_json(capsys)
+    assert out["kind"] == "hosted" and out["room_id"] == "room-1"
+    assert out["message_id"].startswith("user:")
+    event = out["raw"]
+    assert event["kind"] == "message.user"
+    assert event["actor"] == {
+        "kind": "user",
+        "id": "cli",
+        "profile": "pax",
+        "display_name": "Pax via Discord",
+    }
+    assert event["payload"] == {"text": "plan the release", "thread_id": "cli"}
+    # Landed in the durable log with authority fencing intact.
+    logged = hosted_rooms.read_events(_db(), room_id="room-1", since_seq=0)["events"]
+    assert [e["kind"] for e in logged] == ["message.user"]
+    assert logged[0]["authority_epoch"] == 1
+
+
+def test_send_default_label_and_thread_sanitizing(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "hi", "--thread", "discord_2026_09_03 #x", "--json"]) == 0
+    out = _out_json(capsys)
+    assert out["thread"] == "discord_2026_09_03-x"
+    assert out["raw"]["actor"]["display_name"] == "default relay"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "cli"),
+        ("", "cli"),
+        ("__", "t-__"),
+        ("-abc-", "abc"),
+        (".hidden", "t-.hidden"),
+        ("a b/c", "a-b-c"),
+        ("ok.thread:1", "ok.thread:1"),
+    ],
+)
+def test_thread_id_grammar(raw, expected):
+    assert g.thread_id(raw) == expected
+    discussion.validate_user_payload({"text": "x", "thread_id": g.thread_id(raw)})
+
+
+def test_send_refuses_room_managed_elsewhere(home, capsys):
+    mk_room("r2", "Remote", authority="install:elsewhere")
+    assert _run(["send", "Remote", "hi"]) == 1
+    assert "another gateway" in capsys.readouterr().err
+    assert hosted_rooms.read_events(_db(), room_id="r2", since_seq=0)["events"] == []
+
+
+def test_send_stdin_and_empty(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setattr("sys.stdin", io.StringIO("from stdin"))
+    assert _run(["send", "DevTeam", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["payload"]["text"] == "from stdin"
+    monkeypatch.setattr("sys.stdin", io.StringIO("   "))
+    assert _run(["send", "DevTeam"]) == 1
+    assert "required" in capsys.readouterr().err
+
+
+def test_send_oversize_text_is_rejected_before_append(home, capsys):
+    mk_room()
+    big = "x" * (discussion.MAX_USER_TEXT_BYTES + 1)
+    assert _run(["send", "DevTeam", big]) == 1
+    assert "too large" in capsys.readouterr().err
+    assert hosted_rooms.read_events(_db(), room_id="room-1", since_seq=0)["events"] == []
+
+
+def test_send_event_id_is_idempotent(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "once", "--event-id", "k1", "--json"]) == 0
+    first = _out_json(capsys)
+    assert _run(["send", "DevTeam", "once", "--event-id", "k1", "--json"]) == 0
+    again = _out_json(capsys)
+    assert first["seq"] == again["seq"] == 1
+    assert _run(["send", "DevTeam", "different", "--event-id", "k1"]) == 1  # conflict fails closed
+
+
+def test_send_plain_output(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "hi"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("sent to DevTeam [hosted] id=user:") and "thread=cli" in out
+
+
+# ── send --wait / log ────────────────────────────────────────────────────────
+
+
+def _gateway(room):
+    return {"kind": "gateway", "id": str(room["authority_gateway_id"])}
+
+
+def _authority(room):
+    return {
+        "authority_gateway_id": str(room["authority_gateway_id"]),
+        "authority_epoch": int(room["authority_epoch"]),
+    }
+
+
+def _member_turn(room, *, discussion_id, member_id, text, thread="cli", n=1, passed=False):
+    """Append the committed shape: message.member then turn.settled(message_event_id)."""
+    coords = {
+        "discussion_event_id": discussion_id,
+        "member_id": member_id,
+        "member_index": 0,
+        "round_index": 0,
+        "task_id": f"task-{n}",
+        "thread_id": thread,
+        "turn_id": f"turn-{n}",
+    }
+    message = None
+    if not passed:
+        message = hosted_rooms.append_event(
+            _db(),
+            room_id=room["room_id"],
+            event_id=f"msg-{n}",
+            kind="message.member",
+            actor={"kind": "member", "id": member_id, "profile": member_id},
+            payload={**coords, "text": text},
+            **_authority(room),
+        )
+    hosted_rooms.append_event(
+        _db(),
+        room_id=room["room_id"],
+        event_id=f"settled-{n}",
+        kind="turn.settled",
+        actor=_gateway(room),
+        payload={
+            **coords,
+            "seen_through_seq": 1,
+            "message_event_id": message["event_id"] if message else None,
+            "passed": passed,
+        },
+        **_authority(room),
+    )
+    return message
+
+
+def _activity(room, *, discussion_id, status="settled", reason="consensus", thread="cli"):
+    return hosted_rooms.append_event(
+        _db(),
+        room_id=room["room_id"],
+        event_id=f"dactivity:{discussion_id}:{reason}",
+        kind="room.activity",
+        actor=_gateway(room),
+        payload={
+            "status": status,
+            "reason_code": reason,
+            "thread_id": thread,
+            "discussion_event_id": discussion_id,
+        },
+        **_authority(room),
+    )
+
+
+def _sent(room, text="go", key="k"):
+    ref = g.resolve_room(room["room_id"])
+    return g.HostedTransport().send(ref, text=text, thread="cli", label="Pax", event_key=key)
+
+
+def test_wait_streams_committed_replies_and_exits_on_settled(home, capsys):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="reply from archie", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="pax", text="", n=2, passed=True)
+    _activity(room, discussion_id=sent.message_id)
+    got = []
+    rc, summary = g.HostedTransport().wait(
+        sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append((s, t))
+    )
+    assert rc == 0
+    assert got == [("@archie", "reply from archie")]
+    assert summary["status"] == "settled" and summary["reason"] == "consensus"
+    assert [r["handle"] for r in summary["replies"]] == ["archie"]
+
+
+def test_wait_ignores_uncommitted_member_message(home):
+    room = mk_room()
+    sent = _sent(room)
+    hosted_rooms.append_event(
+        _db(),
+        room_id="room-1",
+        event_id="orphan",
+        kind="message.member",
+        actor={"kind": "member", "id": "archie", "profile": "archie"},
+        payload={
+            "discussion_event_id": sent.message_id,
+            "member_id": "archie",
+            "member_index": 0,
+            "round_index": 0,
+            "task_id": "t",
+            "thread_id": "cli",
+            "turn_id": "u",
+            "text": "never committed",
+        },
+        **_authority(room),
+    )
+    _activity(room, discussion_id=sent.message_id, status="bounded", reason="round-cap")
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: got.append(a))
+    assert rc == 0 and got == [] and summary["status"] == "bounded"
+
+
+def test_wait_only_settles_on_own_discussion(home):
+    room = mk_room()
+    sent = _sent(room)
+    _activity(room, discussion_id="user:someone-else", thread="other")
+    rc, summary = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 3 and summary["status"] == "timeout"
+
+
+def test_wait_times_out_with_partial_replies(home):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="partial", n=1)
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
+    assert rc == 3 and got == ["partial"] and len(summary["replies"]) == 1
+
+
+def test_wait_exit_4_when_room_stop_supersedes(home):
+    room = mk_room()
+    sent = _sent(room)
+    hosted_rooms.request_room_stop(
+        _db(),
+        room_id="room-1",
+        cancel_id="stop-1",
+        expected_gateway_id=str(room["authority_gateway_id"]),
+        expected_epoch=int(room["authority_epoch"]),
+    )
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 4 and summary["status"] == "stopped"
+
+
+def test_wait_warns_once_when_no_worker(home, capsys, monkeypatch):
+    room = mk_room()
+    sent = _sent(room)
+    monkeypatch.setattr(g, "_WORKER_WARN_AFTER_SECONDS", 0.0)
+    rc, _ = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 3
+    assert capsys.readouterr().err.count("no gateway worker") == 1
+
+
+def test_send_wait_cli_output_and_exit_codes(home, capsys):
+    room = mk_room()
+    key = "cli-wait"
+    # Pre-seed the log so the CLI's own send (same key → same event) sees a finished discussion.
+    sent = _sent(room, key=key)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="done deal", n=1)
+    _activity(room, discussion_id=sent.message_id)
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "@archie: done deal" in out
+    assert "[group DevTeam: settled (consensus), 1 replies]" in out
+
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5", "--json"])
+    assert rc == 0
+    summary = _out_json(capsys)
+    assert summary["status"] == "settled" and summary["replies"][0]["text"] == "done deal"
+
+    rc = _run(["send", "DevTeam", "again", "--thread", "t2", "--wait", "--poll", "0.01", "--timeout", "0.05"])
+    assert rc == 3
+    assert "timeout" in capsys.readouterr().err
+
+
+def test_log_renders_committed_transcript_with_relay_attribution(home, capsys):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="ack", n=1)
+    assert _run(["log", "DevTeam", "--json"]) == 0
+    rows = _out_json(capsys)
+    assert [(r["speaker"], r["text"]) for r in rows] == [("User (Pax)", "go"), ("@archie", "ack")]
+    assert _run(["log", "DevTeam", "--since", str(sent.seq)]) == 0
+    assert capsys.readouterr().out.strip() == "@archie: ack"
+
+
+# ── parser / dispatch ────────────────────────────────────────────────────────
+
+
+def test_parser_registers_and_dispatches():
+    parser = argparse.ArgumentParser(prog="hermes")
+    g.build_group_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(["group", "send", "DevTeam", "hi", "--as", "X", "--wait"])
+    assert args.func is g.cmd_group
+    assert args.group_action == "send" and args.as_label == "X" and args.wait is True
+    assert args.timeout == g.DEFAULT_WAIT_TIMEOUT_SECONDS
+
+
+def test_cmd_group_without_action_is_usage_error(capsys):
+    assert g.cmd_group(argparse.Namespace(group_action=None)) == 2
+    assert "usage" in capsys.readouterr().err
+
+
+def test_transport_registry_dedupes_by_kind():
+    before = len(g.transports())
+    g.register_transport(g.HostedTransport())
+    assert len(g.transports()) == before

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -340,6 +340,33 @@ def test_wait_ignores_uncommitted_member_message(home):
     assert rc == 0 and got == [] and summary["status"] == "bounded"
 
 
+def test_wait_does_not_stream_replies_from_other_discussions_or_threads(home):
+    room = mk_room()
+    sent = _sent(room)
+    other = g.HostedTransport().send(
+        g.resolve_room("room-1"), text="other relay", thread="t2", label="Other", event_key="k-other"
+    )
+    # A committed reply to the OTHER discussion (different discussion id AND thread).
+    _member_turn(room, discussion_id=other.message_id, member_id="archie", text="for t2", thread="t2", n=1)
+    # A committed reply whose thread matches ours but belongs to another discussion id.
+    _member_turn(room, discussion_id="user:stale", member_id="archie", text="stale", thread="cli", n=2)
+    # Ours.
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="for us", n=3)
+    _activity(room, discussion_id=sent.message_id)
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
+    assert rc == 0 and got == ["for us"]
+    assert [r["text"] for r in summary["replies"]] == ["for us"]
+
+
+def test_wait_rejects_non_positive_poll(home):
+    room = mk_room()
+    sent = _sent(room)
+    for bad in (0, -1):
+        with pytest.raises(g.GroupCLIError, match="--poll"):
+            g.HostedTransport().wait(sent, timeout=1, poll_seconds=bad, on_reply=lambda *a: None)
+
+
 def test_wait_only_settles_on_own_discussion(home):
     room = mk_room()
     sent = _sent(room)
@@ -358,6 +385,7 @@ def test_wait_times_out_with_partial_replies(home):
 
 
 def test_wait_exit_4_when_room_stop_supersedes(home):
+    """A stop fence is room-wide (policy stopped_through_seq), so exit 4 even for a stop aimed elsewhere."""
     room = mk_room()
     sent = _sent(room)
     hosted_rooms.request_room_stop(

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import multiprocessing
+import sys
 
 import pytest
 
@@ -514,6 +516,10 @@ def test_bindings_file_is_bounded_and_survives_corruption(home, monkeypatch):
     assert g.bound_thread(ref, "s9") is None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32" or "fork" not in multiprocessing.get_all_start_methods(),
+    reason="fork start method required; the flock is a no-op without fcntl anyway",
+)
 def test_bind_thread_is_safe_under_concurrent_writers(home):
     """Many writers, each binding its own session: no binding may be lost."""
     import multiprocessing as mp

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -523,7 +523,10 @@ concurrent relays should pass distinct `--thread` values, and a new relaying
 session should start its own thread rather than reuse another session's.
 
 Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
-received so far are already printed), `4` superseded by a room stop.
+received so far are already printed), `4` superseded by a room stop. A room
+stop is room-wide — it cancels every pending user turn in every thread,
+including a relay's — so `4` is correct even when the stop targeted another
+thread.
 
 ## `hermes secrets`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -54,6 +54,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes login` / `logout` | **Deprecated** — use `hermes auth` instead. |
 | `hermes send` | Send a one-shot message to a configured messaging platform (Telegram, Discord, Slack, Signal, SMS, …). Useful from shell scripts, cron jobs, CI hooks, and monitoring daemons — no agent loop, no LLM. |
 | `hermes peer` | Register peer Hermes gateways on other machines and DM their agents' canonical Bot Chats (`hermes peer dm <peer>[/<agent>] "…"`). The transport behind cross-machine bot-to-bot messaging. |
+| `hermes group` | Relay a user request into a gateway-hosted Group Chat from any session and stream the members' replies back (`hermes group send <group> "…" --wait`). |
 | `hermes secrets` | Manage external secret sources (currently Bitwarden Secrets Manager) for pulling API keys at process startup instead of from `~/.hermes/.env`. |
 | `hermes migrate` | Diagnose and (optionally) rewrite `config.yaml` to replace references to retired models or deprecated settings (e.g. `migrate xai`). |
 | `hermes status` | Show agent, auth, and platform status. |
@@ -483,6 +484,46 @@ cross-machine teammates without SOUL edits. See
 [Bot Mode](../user-guide/bot-mode.md).
 
 Exit codes: `0` on success, `1` on delivery/peer failure, `2` on usage errors.
+
+## `hermes group`
+
+```bash
+hermes group list [--json]
+hermes group create <name> --member <profile> --member <profile> [...] [--json]
+hermes group send <group> ["message"] [--thread ID] [--as LABEL] [--wait] [--timeout SECONDS] [--event-id KEY] [--json]
+hermes group log <group> [--since SEQ] [--json]
+```
+
+Relay a user's request into a **gateway-hosted Group Chat from any session**
+and bring the deliberation back. The caller acts *as the user* — it is a
+relay, not a room member, so no membership is needed: the message lands as a
+user message with the relaying profile and `--as` label recorded as who
+relayed it. Member turns run headlessly in the gateway's hosted-room worker
+(`hermes gateway` or the Desktop backend must be running).
+
+`send --wait` streams each committed member reply as `@handle: text` and
+exits when the room reports the discussion settled or bounded. Run it in the
+background from an agent session and the completion output carries the
+replies — the same handoff shape as `hermes -p <agent> chat -q`:
+
+```
+terminal(command='hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait',
+         background=True, notify=True)
+```
+
+| Subcommand | Description |
+|--------|-------------|
+| `list` | Hosted groups on this machine with members and whether this gateway manages them. |
+| `create <name> --member …` | Create a hosted group of 2–6 local profiles (`default` is addressed as `hermes`). |
+| `send <group> [message]` | Append a user message (argument or stdin). `--thread` picks the thread (default `cli`; sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
+| `log <group>` | Print the committed transcript (`User (<label>)` / `@handle` lines) from `--since`. |
+
+Threads: a room keeps only the **latest pending user message per thread**, so
+concurrent relays should pass distinct `--thread` values, and a new relaying
+session should start its own thread rather than reuse another session's.
+
+Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
+received so far are already printed), `4` superseded by a room stop.
 
 ## `hermes secrets`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -515,12 +515,15 @@ terminal(command='hermes group send DevTeam "Plan the release checklist" --as "P
 |--------|-------------|
 | `list` | Hosted groups on this machine with members and whether this gateway manages them. |
 | `create <name> --member …` | Create a hosted group of 2–6 local profiles (`default` is addressed as `hermes`). |
-| `send <group> [message]` | Append a user message (argument or stdin). `--thread` picks the thread (default `cli`; sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
+| `send <group> [message]` | Append a user message (argument or stdin). The thread follows the session (see below); `--thread` overrides (sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
 | `log <group>` | Print the committed transcript (`User (<label>)` / `@handle` lines) from `--since`. |
 
-Threads: a room keeps only the **latest pending user message per thread**, so
-concurrent relays should pass distinct `--thread` values, and a new relaying
-session should start its own thread rather than reuse another session's.
+Threads follow the **relaying session**: the first `send` from a session
+starts a new room thread, later sends from the same session
+(`$HERMES_SESSION_ID`, which Hermes sets for every tool an agent spawns, or
+`--session`) continue it, and a different session gets its own thread.
+`--new-thread` starts over; `--thread` overrides for that send only. A room
+keeps only the latest pending user message per thread.
 
 Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
 received so far are already printed), `4` superseded by a room stop. A room

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -101,6 +101,10 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 - **Not every Bot replies to every message.** Speaking is each member's own choice — a Bot replies only when it has something new to add and passes otherwise, and @-mentioning specific members scopes the round to them. Expect the members you addressed (or whoever has something to say) to speak, and the rest to stay quiet.
 - **Rooms can span machines.** The New Group Chat picker seats Bots from any registered connection; each member's turns run on its own machine, in its own `Group: <name>` session there. Cross-machine members carry a device badge (`dixie · Mac Mini`) in the room and in other members' transcripts, and the disambiguated `@name-device` handle works in room mentions — so same-named agents on two machines never blur together.
 
+### Relaying into a group from another session (`hermes group`)
+
+Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Pax via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. See [`hermes group`](../reference/cli-commands.md#hermes-group).
+
 ## Bot-to-bot messaging
 
 Bots message each other with attribution, and you can hand work off from any chat:


### PR DESCRIPTION
## What does this PR do?

**Lets a user drive a Group Chat from wherever they're already talking to their bot.**

Today a Group Chat can only be addressed from the Desktop's Bots pane. If you're on your phone in Discord (or Telegram, Slack, the CLI…) and want the room's take, you have to go open the app. After this PR:

> **You, in Discord:** "Run this by the DevTeam room — what's the one thing that would make us delay the release?"
> **Your bot:** "Sent to DevTeam — I'll report back when they settle."
> *(a minute later, same Discord thread)*
> **Your bot:** "DevTeam settled with 3 replies — **researcher:** the migration isn't reversible yet… **ops:** on-call coverage over the weekend… **planner:** …"

The bot relays the message into the room **as you** (the room log shows it as the user's message, with the bot recorded as who relayed it), the members deliberate in the hosted-room engine, and the deliberation comes back into the originating conversation. Follow-ups from the same conversation land in the same room thread; a different conversation starts its own. This is the messaging-gateway counterpart of "rooms follow your gateways, not one Desktop" in the Bot Mode docs.

Concretely: `hermes group {list,create,send,log}`, a CLI the bot runs from any session via its terminal tool with `--wait` in the background, so the completion notification carries the replies — the same shape as the existing `hermes -p <agent> chat -q` handoffs.

**Why a CLI and not a tool.** `message_agent` is bot-to-bot DM and only exists in canonical Bot Chat sessions; a Discord session never sees it. The hosted-room engine (`gateway/hosted_rooms.py`, `hosted_room_discussion.py`, `tui_gateway/hosted_room_service.py`; "run same-gateway Group Chats without Desktop", 93c7089f) already drives rooms headlessly but its only client-facing entry is the `groups.send` JSON-RPC the Desktop uses.

**Approach (Footprint Ladder rung 2 — CLI + skill, zero tool footprint).** The CLI acts **as the user**: it's a relay, not a member, so no membership is required and no new model tool is added. It appends a `message.user` event whose actor is `{"kind":"user","id":"cli","profile":<relaying profile>,"display_name":<--as label>}` — both optional actor fields are already accepted by `_validate_actor`, so no schema change. `send --wait` tails `read_events` and prints each **committed** member reply (a `message.member` counts only once its `turn.settled` carries `message_event_id`), then exits when the room's `room.activity{settled|bounded}` references our discussion. Run it in the background from an agent session and the completion notification carries the replies — the same shape as `hermes -p <agent> chat -q` handoffs:

```
terminal(command='hermes group send DevTeam "Plan the release checklist" --as "Ada via Discord" --wait', background=True, notify=True)
```

**Thread continuity follows the relaying session.** Found in real use: an agent relaying three follow-ups from one chat session put each in a new room thread, because asking the model to carry a thread id across turns doesn't work. The CLI owns it instead: the session id is `$HERMES_SESSION_ID` (set by the agent runtime for every tool it spawns) or `--session`. First send from a session → new room thread (a session-derived label); later sends from the same session → same thread; a different session → its own thread. `--new-thread` starts over; `--thread` overrides for that send only. Bindings live in `<root>/group_relay/thread-bindings.json` under an flock-serialized read-modify-write (no-op without `fcntl`), per-writer temp + atomic replace, bounded at 500, corruption-tolerant. No session id → the shared `cli` thread.

Transports are pluggable (`register_transport`) — a follow-up PR adds a Desktop-room transport for the interim before the Desktop client adopts hosted rooms; this PR stands alone without it.

## Related Issue

N/A — discussed as the natural CLI face of the hosted-room engine.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📝 Documentation update
- [x] ✅ Tests

## Changes Made

- `hermes_cli/subcommands/group.py` (new) — parser, `resolve_room` (exact name → ci-unique → room_id), `HostedTransport` (list/send/wait/log), transport registry, session→thread bindings (`--session`, `--new-thread`).
- `hermes_cli/main.py` — register `group` beside `peer`; add to the subcommand name sets.
- `website/docs/reference/cli-commands.md`, `website/docs/user-guide/bot-mode.md` — command reference + one paragraph in Bot Mode.
- `tests/hermes_cli/test_group_cli.py` (new, 39 tests) — the room log is driven by hand (no worker), covering session-bound continuity (incl. a 24-process concurrent-writer test for the bindings file that fails on an unlocked implementation), resolution, create roster validation, send attribution/idempotency/oversize, thread grammar, and every `--wait` exit path: settled/bounded, timeout with partial output, room stop fence (exit 4), uncommitted replies ignored, **replies from other discussions/threads in the same room are not streamed**, worker-absent warning.

Contract details worth reviewer attention:
- `--event-id` maps to `hosted_rooms.user_event_id` (the `user:` namespace); a retry with identical actor+payload is a no-op, different content fails closed — same as `append_event`.
- `room.stop_requested` is treated as superseding our discussion even when aimed at another thread: `plan_next_task`'s `stopped_through_seq` is room-wide by design. Documented in `--help` and the reference.
- Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout (replies so far already on stdout), 4 superseded.
- No new env vars, no RPC, no network; the CLI touches only `state.db` the same way the gateway does.

## How to Test

1. `hermes group create DevTeam --member <profileA> --member <profileB>` (profiles must exist locally)
2. With `hermes gateway` running: `hermes group send DevTeam "Name one risk in shipping this." --as "me via CLI" --wait` — expect `@handle: …` lines streaming, then `[group DevTeam: settled|bounded (…), N replies]`, exit 0.
3. Send again from the same shell (same `$HERMES_SESSION_ID`, or `--session X` both times) → same room thread; `--session Y` → a new thread.
4. `hermes group log DevTeam` — shows `User (me via CLI): …` and the replies.
5. `python -m pytest tests/hermes_cli/test_group_cli.py tests/gateway/test_hosted_rooms.py tests/gateway/test_hosted_room_discussion.py tests/tui_gateway/test_hosted_room_service.py -q` → all pass (167 on my machine).

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] Conventional Commits
- [x] No duplicate PR found
- [x] Only changes related to this feature
- [x] `pytest` passes (targeted suites above; full `tests/` run before opening)
- [x] Tests added
- [x] Tested on: macOS 15.7, Python 3.11

### Documentation & Housekeeping

- [x] Docs updated
- [x] `cli-config.yaml.example` — N/A (no config keys)
- [x] `AGENTS.md` — N/A
- [x] Cross-platform: stdlib only; paths via `pathlib`; no shell-outs
- [x] Tool schemas — N/A (no model tool added, by design)

## Screenshots / Logs

```
$ hermes group send DevTeam "…name one risk…" --as "Ada via CLI" --wait
@researcher: Group-scoped config conflicts: …
@ops: … an overly broad permission scope …
…
[group DevTeam: bounded (max_rounds), 6 replies]
```
