### PR TITLE
feat(bot-mode): hermes group send reaches Desktop-coordinated Group Chats (interim relay bridge)

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/group-chat.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-chat.ts
@@ -227,6 +227,11 @@ export function groupChatSyncSnapshot(
           ? {
               source: String(entry.from.source).slice(0, 128)
             }
+          : {}),
+        ...(entry?.from?.via
+          ? {
+              via: String(entry.from.via).slice(0, 128)
+            }
           : {})
       },
       text: String(entry?.text || '').slice(0, GROUP_CHAT_SYNC_TEXT_CHARS),

--- a/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
@@ -156,6 +156,35 @@ describe('handleGroupRelayEnvelope', () => {
     expect(minted.length).toBeGreaterThan(0)
   })
 
+  it('streams a reply that lands synchronously during the send, before the watcher exists', async () => {
+    const room = await loadRoom({ turn: () => '(pass)' })
+
+    // Simulate a member reply appended INSIDE the send's synchronous window
+    // (the first store notification fires before handleGroupRelayEnvelope
+    // has registered its watcher). A watcher seeded after the send would
+    // treat this entry as pre-existing and never stream it.
+    let injected = false
+
+    const unsub = room.chat.$groupChats.listen(rooms => {
+      const log = rooms.Launchpad?.log || []
+      const user = log.find(entry => entry.text === 'race')
+
+      if (user && !injected) {
+        injected = true
+        room.chat.appendGroupChatEntry('Launchpad', { kind: 'member', name: 'scout' }, 'raced you', String(user.thread))
+      }
+    })
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e9', room_id: 'rm-launch', text: 'race' })
+    unsub()
+    await drain(() => isRunning(room))
+    await room.relay.tickGroupRelayWatchers()
+
+    const lines = replyLines(room, 'e9')
+    expect(lines.filter(l => l.kind === 'reply').map(l => l.text)).toContain('raced you')
+    expect(lines.pop()).toMatchObject({ kind: 'done' })
+  })
+
   it('reports room_not_found and no_members without touching any room', async () => {
     const room = await loadRoom()
 

--- a/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
@@ -25,8 +25,8 @@ interface Room {
 }
 
 const MEMBERS: RosterRow[] = [
-  { name: 'archie', title: '' } as RosterRow,
-  { name: 'socrates', title: '' } as RosterRow
+  { name: 'scout', title: '' } as RosterRow,
+  { name: 'helper', title: '' } as RosterRow
 ]
 
 async function loadRoom(options: GatewayOptions = {}): Promise<Room> {
@@ -49,16 +49,16 @@ async function loadRoom(options: GatewayOptions = {}): Promise<Room> {
 
   shared.setPluginCtx(scriptedStorage(gateway.storage))
 
-  // Seat two local bots in "TraderChat": roster rows whose meta lists the
+  // Seat two local bots in "Launchpad": roster rows whose meta lists the
   // group, exactly what groupChatMemberBots reads.
   data.$lastRoster.set(MEMBERS)
   data.$botMeta.set({
-    archie: { groups: ['TraderChat'] },
-    socrates: { groups: ['TraderChat'] }
+    scout: { groups: ['Launchpad'] },
+    helper: { groups: ['Launchpad'] }
   } as never)
   void membership
-  chat.updateGroupChat('TraderChat', current => {
-    current.roomId = 'rm-trader'
+  chat.updateGroupChat('Launchpad', current => {
+    current.roomId = 'rm-launch'
 
     return current
   })
@@ -72,7 +72,7 @@ const replyLines = (room: Room, id: string) =>
     .filter(call => call.params.id === id)
     .map(call => call.params.line as Record<string, unknown>)
 
-const isRunning = (room: Room) => room.chat.$groupChats.get().TraderChat?.running === true
+const isRunning = (room: Room) => room.chat.$groupChats.get().Launchpad?.running === true
 
 beforeEach(() => {
   runTimersInline()
@@ -83,23 +83,23 @@ describe('resolveRelayRoom', () => {
     const room = await loadRoom()
     const rooms = room.chat.$groupChats.get()
 
-    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'rm-trader', room_name: 'Wrong' }, rooms)?.name).toBe('TraderChat')
-    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'TraderChat' }, rooms)?.name).toBe('TraderChat')
-    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'traderchat' }, rooms)).toBeNull()
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'rm-launch', room_name: 'Wrong' }, rooms)?.name).toBe('Launchpad')
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'Launchpad' }, rooms)?.name).toBe('Launchpad')
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'launchpad' }, rooms)).toBeNull()
   })
 })
 
 describe('handleGroupRelayEnvelope', () => {
   it('sends on the user\'s behalf with via provenance, streams replies in the new thread, then done', async () => {
     const room = await loadRoom({
-      turn: ({ profile }) => (profile === 'archie' ? 'archie says hi' : '(pass)')
+      turn: ({ profile }) => (profile === 'scout' ? 'scout says hi' : '(pass)')
     })
 
     const ok = await room.relay.handleGroupRelayEnvelope({
       id: 'e1',
-      label: 'Pax via Discord',
-      room_id: 'rm-trader',
-      room_name: 'TraderChat',
+      label: 'Ada via Discord',
+      room_id: 'rm-launch',
+      room_name: 'Launchpad',
       text: 'What is the plan?'
     })
 
@@ -107,15 +107,15 @@ describe('handleGroupRelayEnvelope', () => {
     await drain(() => isRunning(room))
     await room.relay.tickGroupRelayWatchers()
 
-    const log = room.chat.$groupChats.get().TraderChat.log
-    expect(log[0].from).toEqual({ kind: 'user', name: 'You', via: 'Pax via Discord' })
+    const log = room.chat.$groupChats.get().Launchpad.log
+    expect(log[0].from).toEqual({ kind: 'user', name: 'You', via: 'Ada via Discord' })
     expect(log[0].text).toBe('What is the plan?')
 
     const lines = replyLines(room, 'e1')
-    expect(lines[0]).toMatchObject({ kind: 'accepted', group: 'TraderChat' })
+    expect(lines[0]).toMatchObject({ kind: 'accepted', group: 'Launchpad' })
     expect(lines[0].thread).toBe(log[0].thread)
     expect(lines.filter(l => l.kind === 'reply')).toEqual([
-      expect.objectContaining({ member: 'archie', text: 'archie says hi', thread: log[0].thread })
+      expect.objectContaining({ member: 'scout', text: 'scout says hi', thread: log[0].thread })
     ])
     expect(lines[lines.length - 1]).toMatchObject({ kind: 'done', status: 'settled', replies: 1 })
     expect(room.relay.groupRelayWatcherIds()).toEqual([])
@@ -124,10 +124,10 @@ describe('handleGroupRelayEnvelope', () => {
   it('never re-streams entries that predate the relay and ignores other threads', async () => {
     const room = await loadRoom({ turn: () => 'reply' })
 
-    room.chat.appendGroupChatEntry('TraderChat', { kind: 'member', name: 'socrates' }, 'old news', 'tmtm-old')
-    room.chat.appendGroupChatEntry('TraderChat', { kind: 'member', name: 'archie' }, 'other thread', 'tmtm-other')
+    room.chat.appendGroupChatEntry('Launchpad', { kind: 'member', name: 'helper' }, 'old news', 'tmtm-old')
+    room.chat.appendGroupChatEntry('Launchpad', { kind: 'member', name: 'scout' }, 'other thread', 'tmtm-other')
 
-    await room.relay.handleGroupRelayEnvelope({ id: 'e2', room_id: 'rm-trader', text: 'go' })
+    await room.relay.handleGroupRelayEnvelope({ id: 'e2', room_id: 'rm-launch', text: 'go' })
     await drain(() => isRunning(room))
     await room.relay.tickGroupRelayWatchers()
 
@@ -143,13 +143,13 @@ describe('handleGroupRelayEnvelope', () => {
   it('continues an existing Desktop thread only when the id is known; otherwise starts a new one', async () => {
     const room = await loadRoom({ turn: () => '(pass)' })
 
-    room.chat.appendGroupChatEntry('TraderChat', { kind: 'user', name: 'You' }, 'earlier', 'tmtm-known')
+    room.chat.appendGroupChatEntry('Launchpad', { kind: 'user', name: 'You' }, 'earlier', 'tmtm-known')
 
-    await room.relay.handleGroupRelayEnvelope({ id: 'e3', room_id: 'rm-trader', text: 'follow-up', thread: 'tmtm-known' })
+    await room.relay.handleGroupRelayEnvelope({ id: 'e3', room_id: 'rm-launch', text: 'follow-up', thread: 'tmtm-known' })
     await drain(() => isRunning(room))
     expect(replyLines(room, 'e3')[0].thread).toBe('tmtm-known')
 
-    await room.relay.handleGroupRelayEnvelope({ id: 'e4', room_id: 'rm-trader', text: 'new topic', thread: 'discord-session-42' })
+    await room.relay.handleGroupRelayEnvelope({ id: 'e4', room_id: 'rm-launch', text: 'new topic', thread: 'discord-session-42' })
     await drain(() => isRunning(room))
     const minted = String(replyLines(room, 'e4')[0].thread)
     expect(minted).not.toBe('discord-session-42')
@@ -171,9 +171,9 @@ describe('handleGroupRelayEnvelope', () => {
   it('reports cancelled when a newer send supersedes the relay\'s round', async () => {
     const room = await loadRoom({ turn: () => '(pass)' })
 
-    await room.relay.handleGroupRelayEnvelope({ id: 'e7', room_id: 'rm-trader', text: 'first' })
+    await room.relay.handleGroupRelayEnvelope({ id: 'e7', room_id: 'rm-launch', text: 'first' })
     // Composer send bumps the epoch before the watcher has observed the end.
-    room.chat.updateGroupChat('TraderChat', current => {
+    room.chat.updateGroupChat('Launchpad', current => {
       current.epoch = (current.epoch || 0) + 1
 
       return current
@@ -187,9 +187,9 @@ describe('handleGroupRelayEnvelope', () => {
   it('times out a watcher whose round never ends', async () => {
     const room = await loadRoom({ turn: () => '(pass)' })
 
-    await room.relay.handleGroupRelayEnvelope({ id: 'e8', room_id: 'rm-trader', text: 'stuck' })
+    await room.relay.handleGroupRelayEnvelope({ id: 'e8', room_id: 'rm-launch', text: 'stuck' })
     // Hold the room "running" forever and jump the clock.
-    room.chat.updateGroupChat('TraderChat', current => {
+    room.chat.updateGroupChat('Launchpad', current => {
       current.running = true
 
       return current
@@ -214,7 +214,7 @@ describe('drainGroupRelayOutbox', () => {
 
         served = true
 
-        return { envelopes: [{ id: 'd1', room_id: 'rm-trader', text: 'via drain', label: 'CLI' }] }
+        return { envelopes: [{ id: 'd1', room_id: 'rm-launch', text: 'via drain', label: 'CLI' }] }
       }
 
       return base(method, params)
@@ -226,7 +226,7 @@ describe('drainGroupRelayOutbox', () => {
     await room.relay.tickGroupRelayWatchers()
     room.relay.stopGroupRelay()
 
-    const entry = room.chat.$groupChats.get().TraderChat.log.find(e => e.text === 'via drain')
+    const entry = room.chat.$groupChats.get().Launchpad.log.find(e => e.text === 'via drain')
     expect(entry).toMatchObject({ text: 'via drain', from: { kind: 'user', name: 'You', via: 'CLI' } })
     expect(replyLines(room, 'd1').pop()).toMatchObject({ kind: 'done' })
 

--- a/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-relay.test.ts
@@ -1,0 +1,243 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type * as groupChat from './group-chat'
+import type * as groupRelay from './group-relay'
+import { createGroupGateway, drain, runTimersInline, scriptedStorage } from './group-test-utils'
+import type { GatewayOptions, ScriptedGateway } from './group-test-utils'
+import type { RosterRow } from './types'
+
+// The Desktop half of `hermes group send` for Desktop-coordinated rooms: a
+// gateway envelope becomes a sendToGroupChat ON THE USER'S BEHALF, and the
+// round's progress streams back as group_relay.reply lines the CLI tails.
+
+const { host } = vi.hoisted(() => ({ host: {} as Record<string, unknown> }))
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { pluginSdkMock } = await import('./group-test-utils')
+
+  return pluginSdkMock(host)
+})
+
+interface Room {
+  chat: typeof groupChat
+  gateway: ScriptedGateway
+  relay: typeof groupRelay
+}
+
+const MEMBERS: RosterRow[] = [
+  { name: 'archie', title: '' } as RosterRow,
+  { name: 'socrates', title: '' } as RosterRow
+]
+
+async function loadRoom(options: GatewayOptions = {}): Promise<Room> {
+  vi.resetModules()
+  const gateway = createGroupGateway(options)
+
+  for (const key of Object.keys(host)) {
+    delete host[key]
+  }
+
+  Object.assign(host, gateway.host)
+
+  const [chat, relay, shared, data, membership] = await Promise.all([
+    import('./group-chat'),
+    import('./group-relay'),
+    import('./shared'),
+    import('./data'),
+    import('./group-membership')
+  ])
+
+  shared.setPluginCtx(scriptedStorage(gateway.storage))
+
+  // Seat two local bots in "TraderChat": roster rows whose meta lists the
+  // group, exactly what groupChatMemberBots reads.
+  data.$lastRoster.set(MEMBERS)
+  data.$botMeta.set({
+    archie: { groups: ['TraderChat'] },
+    socrates: { groups: ['TraderChat'] }
+  } as never)
+  void membership
+  chat.updateGroupChat('TraderChat', current => {
+    current.roomId = 'rm-trader'
+
+    return current
+  })
+
+  return { chat, gateway, relay }
+}
+
+const replyLines = (room: Room, id: string) =>
+  room.gateway
+    .rpcFor('group_relay.reply')
+    .filter(call => call.params.id === id)
+    .map(call => call.params.line as Record<string, unknown>)
+
+const isRunning = (room: Room) => room.chat.$groupChats.get().TraderChat?.running === true
+
+beforeEach(() => {
+  runTimersInline()
+})
+
+describe('resolveRelayRoom', () => {
+  it('prefers the durable roomId, falls back to the exact display name', async () => {
+    const room = await loadRoom()
+    const rooms = room.chat.$groupChats.get()
+
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'rm-trader', room_name: 'Wrong' }, rooms)?.name).toBe('TraderChat')
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'TraderChat' }, rooms)?.name).toBe('TraderChat')
+    expect(room.relay.resolveRelayRoom({ id: 'e', room_id: 'nope', room_name: 'traderchat' }, rooms)).toBeNull()
+  })
+})
+
+describe('handleGroupRelayEnvelope', () => {
+  it('sends on the user\'s behalf with via provenance, streams replies in the new thread, then done', async () => {
+    const room = await loadRoom({
+      turn: ({ profile }) => (profile === 'archie' ? 'archie says hi' : '(pass)')
+    })
+
+    const ok = await room.relay.handleGroupRelayEnvelope({
+      id: 'e1',
+      label: 'Pax via Discord',
+      room_id: 'rm-trader',
+      room_name: 'TraderChat',
+      text: 'What is the plan?'
+    })
+
+    expect(ok).toBe(true)
+    await drain(() => isRunning(room))
+    await room.relay.tickGroupRelayWatchers()
+
+    const log = room.chat.$groupChats.get().TraderChat.log
+    expect(log[0].from).toEqual({ kind: 'user', name: 'You', via: 'Pax via Discord' })
+    expect(log[0].text).toBe('What is the plan?')
+
+    const lines = replyLines(room, 'e1')
+    expect(lines[0]).toMatchObject({ kind: 'accepted', group: 'TraderChat' })
+    expect(lines[0].thread).toBe(log[0].thread)
+    expect(lines.filter(l => l.kind === 'reply')).toEqual([
+      expect.objectContaining({ member: 'archie', text: 'archie says hi', thread: log[0].thread })
+    ])
+    expect(lines[lines.length - 1]).toMatchObject({ kind: 'done', status: 'settled', replies: 1 })
+    expect(room.relay.groupRelayWatcherIds()).toEqual([])
+  })
+
+  it('never re-streams entries that predate the relay and ignores other threads', async () => {
+    const room = await loadRoom({ turn: () => 'reply' })
+
+    room.chat.appendGroupChatEntry('TraderChat', { kind: 'member', name: 'socrates' }, 'old news', 'tmtm-old')
+    room.chat.appendGroupChatEntry('TraderChat', { kind: 'member', name: 'archie' }, 'other thread', 'tmtm-other')
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e2', room_id: 'rm-trader', text: 'go' })
+    await drain(() => isRunning(room))
+    await room.relay.tickGroupRelayWatchers()
+
+    const texts = replyLines(room, 'e2')
+      .filter(l => l.kind === 'reply')
+      .map(l => l.text)
+
+    expect(texts).not.toContain('old news')
+    expect(texts).not.toContain('other thread')
+    expect(texts.length).toBeGreaterThan(0)
+  })
+
+  it('continues an existing Desktop thread only when the id is known; otherwise starts a new one', async () => {
+    const room = await loadRoom({ turn: () => '(pass)' })
+
+    room.chat.appendGroupChatEntry('TraderChat', { kind: 'user', name: 'You' }, 'earlier', 'tmtm-known')
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e3', room_id: 'rm-trader', text: 'follow-up', thread: 'tmtm-known' })
+    await drain(() => isRunning(room))
+    expect(replyLines(room, 'e3')[0].thread).toBe('tmtm-known')
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e4', room_id: 'rm-trader', text: 'new topic', thread: 'discord-session-42' })
+    await drain(() => isRunning(room))
+    const minted = String(replyLines(room, 'e4')[0].thread)
+    expect(minted).not.toBe('discord-session-42')
+    expect(minted.length).toBeGreaterThan(0)
+  })
+
+  it('reports room_not_found and no_members without touching any room', async () => {
+    const room = await loadRoom()
+
+    expect(await room.relay.handleGroupRelayEnvelope({ id: 'e5', room_id: 'missing', room_name: 'Nope', text: 'x' })).toBe(false)
+    expect(replyLines(room, 'e5')[0]).toMatchObject({ kind: 'error', reason: 'room_not_found' })
+
+    room.chat.updateGroupChat('Empty', current => current)
+    expect(await room.relay.handleGroupRelayEnvelope({ id: 'e6', room_name: 'Empty', text: 'x' })).toBe(false)
+    expect(replyLines(room, 'e6')[0]).toMatchObject({ kind: 'error', reason: 'no_members' })
+    expect(room.gateway.calls).toEqual([])
+  })
+
+  it('reports cancelled when a newer send supersedes the relay\'s round', async () => {
+    const room = await loadRoom({ turn: () => '(pass)' })
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e7', room_id: 'rm-trader', text: 'first' })
+    // Composer send bumps the epoch before the watcher has observed the end.
+    room.chat.updateGroupChat('TraderChat', current => {
+      current.epoch = (current.epoch || 0) + 1
+
+      return current
+    })
+    await room.relay.tickGroupRelayWatchers()
+
+    const last = replyLines(room, 'e7').pop()
+    expect(last).toMatchObject({ kind: 'done', status: 'cancelled' })
+  })
+
+  it('times out a watcher whose round never ends', async () => {
+    const room = await loadRoom({ turn: () => '(pass)' })
+
+    await room.relay.handleGroupRelayEnvelope({ id: 'e8', room_id: 'rm-trader', text: 'stuck' })
+    // Hold the room "running" forever and jump the clock.
+    room.chat.updateGroupChat('TraderChat', current => {
+      current.running = true
+
+      return current
+    })
+    await room.relay.tickGroupRelayWatchers(Date.now() + room.relay.GROUP_RELAY_WATCH_TIMEOUT_MS + 1)
+
+    expect(replyLines(room, 'e8').pop()).toMatchObject({ kind: 'done', status: 'timeout' })
+  })
+})
+
+describe('drainGroupRelayOutbox', () => {
+  it('claims envelopes from the gateway and acts on each; tolerates a gateway without the method', async () => {
+    const room = await loadRoom({ turn: () => 'ok' })
+    const base = host.request as (method: string, params?: Record<string, unknown>) => Promise<unknown>
+    let served = false
+
+    host.request = async (method: string, params: Record<string, unknown> = {}) => {
+      if (method === 'group_relay.outbox.drain') {
+        if (served) {
+          return { envelopes: [] }
+        }
+
+        served = true
+
+        return { envelopes: [{ id: 'd1', room_id: 'rm-trader', text: 'via drain', label: 'CLI' }] }
+      }
+
+      return base(method, params)
+    }
+
+    room.relay.startGroupRelay()
+    await room.relay.drainGroupRelayOutbox()
+    await drain(() => isRunning(room))
+    await room.relay.tickGroupRelayWatchers()
+    room.relay.stopGroupRelay()
+
+    const entry = room.chat.$groupChats.get().TraderChat.log.find(e => e.text === 'via drain')
+    expect(entry).toMatchObject({ text: 'via drain', from: { kind: 'user', name: 'You', via: 'CLI' } })
+    expect(replyLines(room, 'd1').pop()).toMatchObject({ kind: 'done' })
+
+    host.request = async (method: string) => {
+      if (method === 'group_relay.outbox.drain') {
+        throw new Error('unknown method')
+      }
+
+      return {}
+    }
+
+    await expect(room.relay.drainGroupRelayOutbox()).resolves.toBeUndefined()
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/group-relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-relay.ts
@@ -1,0 +1,407 @@
+// Group relay — the Desktop half of `hermes group send` for Desktop-
+// coordinated Group Chats.
+//
+// Those rooms live in this plugin's storage and only the renderer can start a
+// member round (sendToGroupChat → runGroupChatRounds). A CLI in another
+// session (a Discord thread, a terminal) cannot reach them directly, so it
+// queues an envelope on the gateway (tools/group_relay.py) and THIS module:
+//
+//   1. drains the outbox on a short interval (plus the gateway's
+//      `group_relay.outbox.pending` push signal),
+//   2. calls sendToGroupChat ON THE USER'S BEHALF — the entry renders as
+//      "You" with `via: <label>` recorded as provenance,
+//   3. watches the room and streams progress lines back through
+//      `group_relay.reply`: accepted → reply (per committed member message in
+//      the relay's thread) → done (settled | capped | cancelled | timeout).
+//
+// Deliberately a sibling of relay.ts (the cross-connection DM relay), not an
+// extension: that drain is gated on ≥2 connections and its envelopes carry a
+// different contract. This module only ever talks to the ACTIVE connection —
+// the gateway the CLI wrote its envelope on is the one this Desktop is
+// attached to. Remove this file + its two call sites and the feature is gone.
+
+import { host } from '@hermes/plugin-sdk'
+
+import { $botMeta, $lastRoster } from './data'
+import { $groupActivity } from './group-activity'
+import type { GroupActivityEntry } from './group-activity'
+import { $groupChats } from './group-chat'
+import { groupChatMemberBots } from './group-membership'
+import { sendToGroupChat } from './group-rounds'
+import type { GroupChat, GroupMember, GroupMessage } from './types'
+
+export const GROUP_RELAY_DRAIN_INTERVAL_MS = 5_000
+const GROUP_RELAY_PUSH_DEBOUNCE_MS = 150
+/** A relay whose round never ends (member stuck) still resolves the waiting CLI. */
+export const GROUP_RELAY_WATCH_TIMEOUT_MS = 45 * 60_000
+
+export interface GroupRelayEnvelope {
+  id: string
+  created_at?: number
+  from_profile?: string
+  label?: string
+  room_id?: string
+  room_name?: string
+  text?: string
+  thread?: null | string
+}
+
+export type GroupRelayLine =
+  | { kind: 'accepted'; thread: string; group: string }
+  | { kind: 'reply'; member: string; text: string; thread: string }
+  | { kind: 'done'; status: 'cancelled' | 'capped' | 'settled' | 'timeout'; replies: number }
+  | { error: string; kind: 'error'; reason?: string }
+
+interface Watcher {
+  envelopeId: string
+  epoch: number
+  group: string
+  replies: number
+  /** Log entry ids already streamed. */
+  seen: Set<string>
+  startedAt: number
+  thread: string
+  /** Set once the room has been observed running for this relay. */
+  wasRunning: boolean
+}
+
+interface RelayState {
+  disposed: boolean
+  drainBusy: boolean
+  drainRerun: boolean
+  drainTimer: null | ReturnType<typeof setInterval>
+  pushDebounceTimer: null | ReturnType<typeof setTimeout>
+  pushUnsub: null | (() => void)
+  storeUnsub: null | (() => void)
+  watchers: Map<string, Watcher>
+}
+
+const relay: RelayState = {
+  disposed: true,
+  drainBusy: false,
+  drainRerun: false,
+  drainTimer: null,
+  pushDebounceTimer: null,
+  pushUnsub: null,
+  storeUnsub: null,
+  watchers: new Map()
+}
+
+// ── room lookup ─────────────────────────────────────────────────────────────
+
+/** Resolve an envelope to a Desktop room: durable roomId first, then the
+ *  exact display name (rooms are keyed by name in `$groupChats`). */
+export function resolveRelayRoom(
+  envelope: GroupRelayEnvelope,
+  rooms: Record<string, GroupChat> = $groupChats.get()
+): null | { name: string; room: GroupChat } {
+  const wantId = String(envelope?.room_id || '').trim()
+
+  if (wantId) {
+    for (const [name, room] of Object.entries(rooms || {})) {
+      if (room && String(room.roomId || '') === wantId) {
+        return { name, room }
+      }
+    }
+  }
+
+  const wantName = String(envelope?.room_name || '').trim()
+
+  if (wantName && rooms?.[wantName]) {
+    return { name: wantName, room: rooms[wantName] }
+  }
+
+  return null
+}
+
+function relayMembers(group: string): GroupMember[] {
+  return groupChatMemberBots(group, $lastRoster.get(), $botMeta.get())
+}
+
+// ── reply plumbing ──────────────────────────────────────────────────────────
+
+async function postLine(envelopeId: string, line: GroupRelayLine) {
+  try {
+    await host.request('group_relay.reply', { id: envelopeId, line })
+  } catch {
+    // Gateway unreachable: the CLI's own --timeout resolves the wait.
+  }
+}
+
+// ── watchers: turn room-log deltas into streamed reply lines ───────────────
+
+function latestActivityFor(group: string, thread: string, epoch: number): GroupActivityEntry | null {
+  const events = $groupActivity.get()[group]?.events || []
+
+  for (let i = events.length - 1; i >= 0; i--) {
+    const event = events[i]
+
+    if (event.epoch === epoch && (event.thread || null) === thread) {
+      return event
+    }
+  }
+
+  return null
+}
+
+/** One pass over every watcher against the current room state. Exported for
+ *  tests; production runs it from the `$groupChats` / `$groupActivity`
+ *  subscriptions and the drain interval. */
+export async function tickGroupRelayWatchers(now = Date.now()) {
+  const rooms = $groupChats.get()
+
+  for (const watcher of [...relay.watchers.values()]) {
+    const room = rooms[watcher.group]
+
+    if (!room) {
+      relay.watchers.delete(watcher.envelopeId)
+      await postLine(watcher.envelopeId, { kind: 'error', reason: 'room_gone', error: `group '${watcher.group}' no longer exists` })
+
+      continue
+    }
+
+    // Stream newly committed member replies in the relay's thread.
+    for (const entry of room.log || []) {
+      const key = String(entry?.id || `${entry?.at}:${entry?.from?.name}`)
+
+      if (watcher.seen.has(key) || entry?.from?.kind !== 'member') {
+        continue
+      }
+
+      if (String(entry.thread || 'legacy') !== watcher.thread) {
+        continue
+      }
+
+      watcher.seen.add(key)
+      watcher.replies += 1
+      await postLine(watcher.envelopeId, {
+        kind: 'reply',
+        member: String(entry.from.name || 'bot'),
+        text: String(entry.text || ''),
+        thread: watcher.thread
+      })
+    }
+
+    // Terminal conditions, in priority order.
+    if ((room.epoch || 0) !== watcher.epoch) {
+      // A newer user send (composer or another relay) superseded this round.
+      relay.watchers.delete(watcher.envelopeId)
+      await postLine(watcher.envelopeId, { kind: 'done', status: 'cancelled', replies: watcher.replies })
+
+      continue
+    }
+
+    if (room.running === true) {
+      watcher.wasRunning = true
+    }
+
+    const activity = latestActivityFor(watcher.group, watcher.thread, watcher.epoch)
+    const ended = activity && (activity.kind === 'settled' || activity.kind === 'capped' || activity.kind === 'cancelled')
+
+    if (ended || (watcher.wasRunning && room.running !== true)) {
+      relay.watchers.delete(watcher.envelopeId)
+      const status = ended ? (activity!.kind as 'cancelled' | 'capped' | 'settled') : 'settled'
+      await postLine(watcher.envelopeId, { kind: 'done', status, replies: watcher.replies })
+
+      continue
+    }
+
+    if (now - watcher.startedAt > GROUP_RELAY_WATCH_TIMEOUT_MS) {
+      relay.watchers.delete(watcher.envelopeId)
+      await postLine(watcher.envelopeId, { kind: 'done', status: 'timeout', replies: watcher.replies })
+    }
+  }
+}
+
+let tickChain: Promise<void> = Promise.resolve()
+
+/** Serialize ticks: store notifications can burst, and two concurrent passes
+ *  would double-post the same log entry before `seen` is updated. */
+function scheduleTick() {
+  if (relay.disposed) {
+    return
+  }
+
+  tickChain = tickChain.then(() => tickGroupRelayWatchers()).catch(() => undefined)
+}
+
+// ── drain: envelopes → sendToGroupChat ─────────────────────────────────────
+
+/** Act on one claimed envelope. Exported for tests. */
+export async function handleGroupRelayEnvelope(envelope: GroupRelayEnvelope): Promise<boolean> {
+  const envelopeId = String(envelope?.id || '')
+
+  if (!envelopeId) {
+    return false
+  }
+
+  const resolved = resolveRelayRoom(envelope)
+
+  if (!resolved) {
+    await postLine(envelopeId, {
+      kind: 'error',
+      reason: 'room_not_found',
+      error: `no Desktop group matches ${envelope.room_name || envelope.room_id || '?'} on this Desktop`
+    })
+
+    return false
+  }
+
+  const members = relayMembers(resolved.name)
+
+  if (!members.length) {
+    await postLine(envelopeId, { kind: 'error', reason: 'no_members', error: `group '${resolved.name}' has no seated members` })
+
+    return false
+  }
+
+  const text = String(envelope.text || '').trim()
+  // An existing Desktop thread id continues that thread; anything else (or
+  // nothing) starts a new one — a relay from a fresh session is a new topic.
+  const requested = String(envelope.thread || '').trim()
+  const knownThread = requested && (resolved.room.log || []).some(entry => String(entry?.thread || '') === requested)
+
+  const thread = sendToGroupChat(resolved.name, members, text, knownThread ? requested : null, undefined, {
+    via: String(envelope.label || '').trim() || undefined
+  })
+
+  if (!thread) {
+    await postLine(envelopeId, { kind: 'error', reason: 'send_refused', error: 'the room refused the message (empty text or no members)' })
+
+    return false
+  }
+
+  const room = $groupChats.get()[resolved.name] || {}
+  relay.watchers.set(envelopeId, {
+    envelopeId,
+    epoch: room.epoch || 0,
+    group: resolved.name,
+    replies: 0,
+    seen: new Set(
+      // Everything already in the log predates this relay — never re-stream it.
+      (room.log || []).map((entry: GroupMessage) => String(entry?.id || `${entry?.at}:${entry?.from?.name}`))
+    ),
+    startedAt: Date.now(),
+    thread,
+    wasRunning: room.running === true
+  })
+  await postLine(envelopeId, { kind: 'accepted', thread, group: resolved.name })
+  scheduleTick()
+
+  return true
+}
+
+export async function drainGroupRelayOutbox() {
+  if (relay.disposed) {
+    return
+  }
+
+  if (relay.drainBusy) {
+    relay.drainRerun = true
+
+    return
+  }
+
+  relay.drainBusy = true
+
+  try {
+    let envelopes: GroupRelayEnvelope[] = []
+
+    try {
+      const res = await host.request<{ envelopes?: GroupRelayEnvelope[] }>('group_relay.outbox.drain', {})
+      envelopes = Array.isArray(res?.envelopes) ? res.envelopes : []
+    } catch {
+      // Older gateway without the method, or transport blip: try next tick.
+      envelopes = []
+    }
+
+    for (const envelope of envelopes) {
+      if (relay.disposed) {
+        return
+      }
+
+      await handleGroupRelayEnvelope(envelope)
+    }
+
+    // Watchers advance on store changes; the interval is the backstop for
+    // the timeout path and for rooms that end without a store notification.
+    await tickGroupRelayWatchers()
+  } finally {
+    relay.drainBusy = false
+
+    if (relay.drainRerun && !relay.disposed) {
+      relay.drainRerun = false
+      scheduleGroupRelayPushDrain()
+    }
+  }
+}
+
+function scheduleGroupRelayPushDrain() {
+  if (relay.disposed || typeof setTimeout !== 'function' || relay.pushDebounceTimer !== null) {
+    return
+  }
+
+  relay.pushDebounceTimer = setTimeout(() => {
+    relay.pushDebounceTimer = null
+    void drainGroupRelayOutbox()
+  }, GROUP_RELAY_PUSH_DEBOUNCE_MS)
+}
+
+// ── lifecycle ───────────────────────────────────────────────────────────────
+
+export function startGroupRelay() {
+  relay.disposed = false
+
+  if (typeof setInterval !== 'function' || typeof clearInterval !== 'function') {
+    return
+  }
+
+  if (relay.drainTimer === null) {
+    relay.drainTimer = setInterval(() => void drainGroupRelayOutbox(), GROUP_RELAY_DRAIN_INTERVAL_MS)
+  }
+
+  if (relay.storeUnsub === null) {
+    const unsubRooms = $groupChats.listen(() => scheduleTick())
+    const unsubActivity = $groupActivity.listen(() => scheduleTick())
+
+    relay.storeUnsub = () => {
+      unsubRooms()
+      unsubActivity()
+    }
+  }
+
+  if (relay.pushUnsub === null && typeof host.onEvent === 'function') {
+    relay.pushUnsub = host.onEvent('group_relay.outbox.pending', () => scheduleGroupRelayPushDrain())
+  }
+}
+
+export function stopGroupRelay() {
+  relay.disposed = true
+
+  if (relay.drainTimer !== null) {
+    clearInterval(relay.drainTimer)
+    relay.drainTimer = null
+  }
+
+  if (relay.pushDebounceTimer !== null) {
+    clearTimeout(relay.pushDebounceTimer)
+    relay.pushDebounceTimer = null
+  }
+
+  if (relay.storeUnsub !== null) {
+    relay.storeUnsub()
+    relay.storeUnsub = null
+  }
+
+  if (relay.pushUnsub !== null) {
+    relay.pushUnsub()
+    relay.pushUnsub = null
+  }
+
+  relay.watchers.clear()
+}
+
+/** Test hook: active watcher ids. */
+export function groupRelayWatcherIds() {
+  return [...relay.watchers.keys()]
+}

--- a/apps/desktop/src/plugins/hermes-bots/group-relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-relay.ts
@@ -114,6 +114,12 @@ export function resolveRelayRoom(
   return null
 }
 
+/** Stable identity for a log entry; ids are minted on append, the fallback
+ *  covers legacy entries hydrated without one. */
+function entryKey(entry: GroupMessage): string {
+  return String(entry?.id || `${entry?.at}:${entry?.from?.name}:${entry?.thread || ''}`)
+}
+
 function relayMembers(group: string): GroupMember[] {
   return groupChatMemberBots(group, $lastRoster.get(), $botMeta.get())
 }
@@ -162,7 +168,7 @@ export async function tickGroupRelayWatchers(now = Date.now()) {
 
     // Stream newly committed member replies in the relay's thread.
     for (const entry of room.log || []) {
-      const key = String(entry?.id || `${entry?.at}:${entry?.from?.name}`)
+      const key = entryKey(entry)
 
       if (watcher.seen.has(key) || entry?.from?.kind !== 'member') {
         continue
@@ -261,6 +267,13 @@ export async function handleGroupRelayEnvelope(envelope: GroupRelayEnvelope): Pr
   const requested = String(envelope.thread || '').trim()
   const knownThread = requested && (resolved.room.log || []).some(entry => String(entry?.thread || '') === requested)
 
+  // Snapshot the log BEFORE the send: only entries that predate the relay
+  // are pre-seen, so a member reply appended at any point after this line —
+  // even synchronously inside sendToGroupChat's round kick — is streamed.
+  // (A watcher seeded after the send could swallow such a reply.)
+  const before = $groupChats.get()[resolved.name] || {}
+  const seen = new Set((before.log || []).map(entryKey))
+
   const thread = sendToGroupChat(resolved.name, members, text, knownThread ? requested : null, undefined, {
     via: String(envelope.label || '').trim() || undefined
   })
@@ -277,10 +290,7 @@ export async function handleGroupRelayEnvelope(envelope: GroupRelayEnvelope): Pr
     epoch: room.epoch || 0,
     group: resolved.name,
     replies: 0,
-    seen: new Set(
-      // Everything already in the log predates this relay — never re-stream it.
-      (room.log || []).map((entry: GroupMessage) => String(entry?.id || `${entry?.at}:${entry?.from?.name}`))
-    ),
+    seen,
     startedAt: Date.now(),
     thread,
     wasRunning: room.running === true

--- a/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
+++ b/apps/desktop/src/plugins/hermes-bots/group-rounds.ts
@@ -959,12 +959,20 @@ async function harvestStrandedUntilSettled(group: string, members: GroupMember[]
  *  Appends, bumps the room epoch (supersedes any running loop at its next
  *  member boundary), and starts the turn drive for the target thread.
  *  Returns the thread id the message landed in. */
+/** Options for a send made ON THE USER'S BEHALF by a relay (`hermes group
+ *  send`): `via` is recorded on the user entry as provenance; the entry is
+ *  otherwise indistinguishable from one typed in the composer. */
+export interface SendToGroupChatOptions {
+  via?: string
+}
+
 export function sendToGroupChat(
   group: string,
   members: GroupMember[],
   text: string,
   thread?: null | string,
-  images?: Attachment[]
+  images?: Attachment[],
+  opts?: SendToGroupChatOptions
 ): null | string {
   const trimmed = String(text || '').trim()
   const attached = Array.isArray(images) ? images.filter((img: Attachment) => img && img.data) : []
@@ -987,11 +995,14 @@ export function sendToGroupChat(
     return room
   })
 
+  const via = String(opts?.via || '').trim()
+
   const sent = appendGroupChatEntry(
     group,
     {
       kind: 'user',
-      name: 'You'
+      name: 'You',
+      ...(via ? { via } : {})
     },
     trimmed,
     target,

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -55,6 +55,7 @@ import {
   updateGroupChat
 } from './group-chat'
 import { groupWorkspaceOwnerKey } from './group-membership'
+import { startGroupRelay, stopGroupRelay } from './group-relay'
 import { annotateOrphanedGroupChatMembers } from './hygiene'
 import { BOTS_LOCALES } from './i18n'
 import { displayName } from './labels'
@@ -105,6 +106,9 @@ export default {
     // The cross-connection relay rides every gateway socket this Desktop
     // holds: roster sync + envelope drain/deliver/reply loops.
     startBotRelay()
+    // `hermes group send` into Desktop-coordinated rooms: drain the gateway's
+    // group_relay outbox and act on the user's behalf (group-relay.ts).
+    startGroupRelay()
 
     // Disabling the plugin (or a hot reload) must actually stop the clock —
     // before this, the rAF loop + 1Hz document scan ran until app restart.
@@ -112,6 +116,7 @@ export default {
       ctx.onDispose(disposeLocales)
       ctx.onDispose(stopFaceClock)
       ctx.onDispose(stopBotRelay)
+      ctx.onDispose(stopGroupRelay)
     }
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -140,7 +140,7 @@ export interface GroupMessageAuthor {
   /** Connection label, present when the speaker lives on another machine. */
   source?: string
   /** Relay provenance for a user entry written on the user's behalf by an
-   *  agent in another session (`hermes group send --as "Pax via Discord"`).
+   *  agent in another session (`hermes group send --as "Ada via Discord"`).
    *  The pane still renders the speaker as "You"; logs/mobile surface it. */
   via?: string
 }

--- a/apps/desktop/src/plugins/hermes-bots/types.ts
+++ b/apps/desktop/src/plugins/hermes-bots/types.ts
@@ -139,6 +139,10 @@ export interface GroupMessageAuthor {
   name: string
   /** Connection label, present when the speaker lives on another machine. */
   source?: string
+  /** Relay provenance for a user entry written on the user's behalf by an
+   *  agent in another session (`hermes group send --as "Pax via Discord"`).
+   *  The pane still renders the speaker as "You"; logs/mobile surface it. */
+  via?: string
 }
 
 export interface GroupMessage {

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4396,13 +4396,14 @@ def _housekeeping_media_caches() -> None:
     from tools.environments.local import cleanup_terminal_temp_cache
     from tools.bot_mode_dm import cleanup_bot_dm_cache
     from tools.bot_relay import cleanup_bot_relay_artifacts
+    from tools.group_relay import cleanup_group_relay_artifacts
 
     for cache_name, cleanup_fn in (
         ("Image", cleanup_image_cache), ("Document", cleanup_document_cache),
         ("Audio", cleanup_audio_cache), ("Video", cleanup_video_cache),
         ("Screenshot", cleanup_screenshot_cache), ("Spillover", cleanup_spillover_cache),
         ("Terminal temp", cleanup_terminal_temp_cache), ("Bot DM", cleanup_bot_dm_cache),
-        ("Bot relay", cleanup_bot_relay_artifacts)):
+        ("Bot relay", cleanup_bot_relay_artifacts), ("Group relay", cleanup_group_relay_artifacts)):
         def _one(name=cache_name, fn=cleanup_fn):
             removed = fn(max_age_hours=24)
             if removed:

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2312,7 +2312,7 @@ def _coalesce_session_name_args(argv: list) -> list:
         "chat", "model", "gateway", "setup", "whatsapp", "whatsapp-cloud", "login", "logout",
         "auth", "status", "cron", "doctor", "config", "pairing", "skills", "tools", "mcp",
         "sessions", "insights", "update", "uninstall", "profile", "dashboard", "serve",
-        "desktop", "gui", "honcho", "claw", "plugins", "security", "acp", "webhook", "peer",
+        "desktop", "gui", "honcho", "claw", "plugins", "security", "acp", "webhook", "peer", "group",
         "memory", "dump", "debug", "backup", "import", "completion", "logs",
     }
     _SESSION_FLAGS = {"-c", "--continue", "-r", "--resume"}
@@ -2598,7 +2598,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "dump", "egress", "fallback", "gateway", "hooks", "import", "import-agent", "insights",
         "gui", "desktop", "kanban", "login", "logout", "logs", "lsp", "mcp", "memory", "migrate", "moa",
         "journey", "memory-graph", "learning",
-        "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
+        "group", "model", "monitoring", "pairing", "pause", "peer", "pets", "plugins", "portal", "profile",
         "project", "proxy",
         "prompt-size",
         "resume",
@@ -3199,6 +3199,10 @@ def _build_cli_parser():
 
     from hermes_cli.subcommands.peer import build_peer_parser
     build_peer_parser(subparsers)
+
+    # group command — relay user messages into Group Chats from any session
+    from hermes_cli.subcommands.group import build_group_parser
+    build_group_parser(subparsers)
 
     from hermes_cli.portal_cli import add_parser as _add_portal_parser
     _add_portal_parser(subparsers)

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -695,8 +695,8 @@ def build_group_parser(subparsers) -> None:
             "\n"
             "Examples:\n"
             "  hermes group list\n"
-            "  hermes group create DevTeam --member archie --member mason\n"
-            '  hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait\n'
+            "  hermes group create DevTeam --member researcher --member ops\n"
+            '  hermes group send DevTeam "Plan the release checklist" --as "Ada via Discord" --wait\n'
             "  hermes group log DevTeam --since 0\n"
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -734,7 +734,7 @@ def build_group_parser(subparsers) -> None:
         dest="as_label",
         default=None,
         metavar="LABEL",
-        help="Who relayed, e.g. 'Pax via Discord' (default '<profile> relay')",
+        help="Who relayed, e.g. 'Ada via Discord' (default '<profile> relay')",
     )
     send.add_argument(
         "--event-id",

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -17,12 +17,15 @@ driven headlessly by the gateway's hosted-room worker.
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
 import sys
+import tempfile
 import time
 import uuid
+from pathlib import Path
 from dataclasses import dataclass, field
 from typing import Any, Callable, Iterator, Protocol
 
@@ -96,6 +99,105 @@ class Transport(Protocol):
 
 
 _TRANSPORTS: list[Transport] = []
+
+# ── session → thread continuity ──────────────────────────────────────────────
+#
+# A relaying session (Discord thread, CLI chat) that sends twice into the same
+# room should land in the SAME room thread, while a different session starts a
+# new one. The agent cannot be trusted to remember a minted thread id across
+# turns, so the CLI binds (room, session) → thread on the first send and reuses
+# it. The session id comes from HERMES_SESSION_ID (set per turn by the agent
+# runtime for tools it spawns) or --session; --new-thread breaks the binding.
+
+_THREAD_BINDINGS_FILE = "thread-bindings.json"
+_THREAD_BINDINGS_MAX = 500
+
+
+def _bindings_path() -> Path:
+    # Machine root (profile-independent), beside state.db.
+    return hosted_rooms.default_db_path().parent / "group_relay" / _THREAD_BINDINGS_FILE
+
+
+def _read_bindings(path: Path) -> dict[str, dict[str, Any]]:
+    try:
+        data = json.loads(path.read_text(encoding="utf-8")) if path.is_file() else {}
+    except (OSError, ValueError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+@contextlib.contextmanager
+def _bindings_lock(path: Path) -> Iterator[None]:
+    """Serialize read-modify-write across relays. flock where available;
+    a no-op elsewhere (the write below is still atomic per file)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lock_path = path.with_name(path.name + ".lock")
+    try:
+        import fcntl
+    except ImportError:  # pragma: no cover — Windows
+        yield
+        return
+    with open(lock_path, "a+", encoding="utf-8") as handle:
+        fcntl.flock(handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(handle.fileno(), fcntl.LOCK_UN)
+
+
+def _mutate_bindings(mutate: Callable[[dict[str, dict[str, Any]]], None]) -> None:
+    """Locked, atomic read-modify-write of the bindings file. Never raises."""
+    try:
+        path = _bindings_path()
+        with _bindings_lock(path):
+            data = _read_bindings(path)
+            mutate(data)
+            # Unique temp per writer: a shared name let two writers clobber
+            # each other's temp before os.replace.
+            fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=".bindings-", suffix=".tmp")
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle)
+            os.replace(tmp, path)
+    except Exception:
+        pass
+
+
+def _binding_key(ref: RoomRef, session_id: str) -> str:
+    return f"{ref.kind}:{ref.room_id}:{session_id}"
+
+
+def bound_thread(ref: RoomRef, session_id: str) -> str | None:
+    """The room thread this session already writes to, if any."""
+    entry = _read_bindings(_bindings_path()).get(_binding_key(ref, session_id))
+    thread = entry.get("thread") if isinstance(entry, dict) else None
+    return str(thread) if thread else None
+
+
+def bind_thread(ref: RoomRef, session_id: str, thread: str) -> None:
+    """Remember that ``session_id`` continues ``thread`` in ``ref``. Never raises."""
+    if not session_id or not thread:
+        return
+
+    def mutate(data: dict[str, dict[str, Any]]) -> None:
+        data[_binding_key(ref, session_id)] = {"thread": thread, "at": int(time.time())}
+        if len(data) > _THREAD_BINDINGS_MAX:
+            oldest = sorted(
+                data.items(),
+                key=lambda kv: kv[1].get("at", 0) if isinstance(kv[1], dict) else 0,
+            )
+            for key, _ in oldest[: len(data) - _THREAD_BINDINGS_MAX]:
+                data.pop(key, None)
+
+    _mutate_bindings(mutate)
+
+
+def forget_thread(ref: RoomRef, session_id: str) -> None:
+    _mutate_bindings(lambda data: data.pop(_binding_key(ref, session_id), None))
+
+
+def _session_id(args) -> str:
+    explicit = str(getattr(args, "session", None) or "").strip()
+    return explicit or (os.getenv("HERMES_SESSION_ID") or "").strip()
 
 
 def register_transport(transport: Transport) -> None:
@@ -449,13 +551,28 @@ def _cmd_send(args) -> int:
     ref = resolve_room(args.group, kind=getattr(args, "kind", None))
     transport = _transport_for(ref.kind)
     label = (args.as_label or f"{_profile()} relay").strip()
+    session = _session_id(args)
+    if args.thread:
+        thread = thread_id(args.thread)
+    elif session and not args.new_thread and bound_thread(ref, session):
+        thread = str(bound_thread(ref, session))
+    elif session:
+        # New thread for this session: a session-derived label, distinct
+        # from other sessions' threads. Transports that mint their thread on
+        # delivery bind it after --wait instead (see below).
+        thread = thread_id(f"s-{session}") if ref.kind == "hosted" else DEFAULT_THREAD
+        forget_thread(ref, session)
+    else:
+        thread = DEFAULT_THREAD
     sent = transport.send(
         ref,
         text=text,
-        thread=thread_id(args.thread),
+        thread=thread,
         label=label,
         event_key=args.event_id,
     )
+    if session and ref.kind == "hosted" and not args.thread:
+        bind_thread(ref, session, sent.thread)
     if not args.wait:
         if args.json:
             print(
@@ -481,6 +598,10 @@ def _cmd_send(args) -> int:
         poll_seconds=float(args.poll),
         on_reply=(lambda *_: None) if args.json else _print_reply,
     )
+    if session and summary.get("thread") and not args.thread:
+        # An explicit --thread is a one-off; it must not redirect the
+        # session's implicit continuity.
+        bind_thread(ref, session, str(summary["thread"]))
     if args.json:
         print(json.dumps({"kind": ref.kind, "room_id": ref.room_id, "name": ref.name, **summary}, indent=2))
     else:
@@ -543,11 +664,13 @@ def build_group_parser(subparsers) -> None:
             "agent session; its output carries the members' replies."
         ),
         epilog=(
-            "Threads: hosted rooms accept any --thread label (sanitized to "
-            "[A-Za-z0-9._:-]); omit it for the shared 'cli' thread. A room keeps "
-            "only the LATEST pending user message per thread, so concurrent relays "
-            "should use distinct --thread values. A new relaying session should "
-            "start a new thread rather than reuse another session's.\n"
+            "Threads follow the relaying SESSION: the first send from a session "
+            "starts a new room thread; later sends from the same session "
+            "($HERMES_SESSION_ID, or --session) continue it; a different session "
+            "gets its own thread. --new-thread starts over; --thread <id|label> "
+            "overrides for that send only (it does not change the session's "
+            "thread). Without any session id the shared 'cli' thread is used. "
+            "A room keeps only the LATEST pending user message per thread.\n"
             "\n"
             "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
             "(partial replies already printed), 4 superseded by a room stop. A "
@@ -577,7 +700,19 @@ def build_group_parser(subparsers) -> None:
     send = actions.add_parser("send", help="Relay a message into a group as the user")
     send.add_argument("group", help="Group name or room_id")
     send.add_argument("text", nargs="?", default=None, help="Message text (or stdin)")
-    send.add_argument("--thread", default=None, help="Thread label (see epilog)")
+    send.add_argument("--thread", default=None, help="Explicit thread (see epilog)")
+    send.add_argument(
+        "--session",
+        default=None,
+        metavar="ID",
+        help="Relaying session id for thread continuity (default: $HERMES_SESSION_ID)",
+    )
+    send.add_argument(
+        "--new-thread",
+        action="store_true",
+        default=False,
+        help="Start a new room thread even if this session already has one",
+    )
     send.add_argument(
         "--as",
         dest="as_label",

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -114,8 +114,9 @@ _THREAD_BINDINGS_MAX = 500
 
 
 def _bindings_path() -> Path:
-    # Machine root (profile-independent), beside state.db.
-    return hosted_rooms.default_db_path().parent / "group_relay" / _THREAD_BINDINGS_FILE
+    from tools.group_relay import gateway_root, relay_root
+
+    return relay_root(gateway_root()) / _THREAD_BINDINGS_FILE
 
 
 def _read_bindings(path: Path) -> dict[str, dict[str, Any]]:
@@ -470,6 +471,13 @@ class HostedTransport:
 
 register_transport(HostedTransport())
 
+# Optional transports register themselves on import. Each is self-contained;
+# removing its module (and this import) removes the transport.
+try:
+    from . import group_desktop as _group_desktop  # noqa: F401
+except ImportError:  # pragma: no cover — transport module absent
+    pass
+
 
 # ── commands ─────────────────────────────────────────────────────────────────
 
@@ -651,6 +659,10 @@ def build_args(argv: list[str]) -> argparse.Namespace:
     return parser.parse_args(["group", *argv])
 
 
+def _kinds() -> list[str]:
+    return [transport.kind for transport in _TRANSPORTS]
+
+
 def build_group_parser(subparsers) -> None:
     """Attach the ``group`` subcommand to ``subparsers``."""
     parser = subparsers.add_parser(
@@ -669,8 +681,12 @@ def build_group_parser(subparsers) -> None:
             "($HERMES_SESSION_ID, or --session) continue it; a different session "
             "gets its own thread. --new-thread starts over; --thread <id|label> "
             "overrides for that send only (it does not change the session's "
-            "thread). Without any session id the shared 'cli' thread is used. "
-            "A room keeps only the LATEST pending user message per thread.\n"
+            "thread). Without any session id the shared 'cli' thread is used "
+            "(hosted) or a fresh thread is minted per send (desktop). Desktop "
+            "rooms mint the thread on delivery, so continuity there requires "
+            "--wait on the first send; a fire-and-forget first send is followed "
+            "by a new thread. A hosted room keeps only the LATEST pending user "
+            "message per thread.\n"
             "\n"
             "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
             "(partial replies already printed), 4 superseded by a room stop. A "
@@ -730,10 +746,12 @@ def build_group_parser(subparsers) -> None:
     send.add_argument("--timeout", type=float, default=DEFAULT_WAIT_TIMEOUT_SECONDS, metavar="SECONDS")
     send.add_argument("--poll", type=float, default=1.0, help=argparse.SUPPRESS)
     send.add_argument("--json", action="store_true", default=False)
+    send.add_argument("--kind", choices=_kinds(), default=None, help="Disambiguate same-named groups")
 
     log = actions.add_parser("log", help="Print the group's committed transcript")
     log.add_argument("group", help="Group name or room_id")
     log.add_argument("--since", type=int, default=0, metavar="SEQ")
     log.add_argument("--json", action="store_true", default=False)
+    log.add_argument("--kind", choices=_kinds(), default=None, help="Disambiguate same-named groups")
 
     parser.set_defaults(func=cmd_group)

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -246,6 +246,8 @@ class HostedTransport:
         )
 
     def wait(self, sent, *, timeout, poll_seconds, on_reply):
+        if not (float(poll_seconds) > 0):
+            raise GroupCLIError("--poll must be a positive number of seconds")
         room_id, my_id, my_seq = sent.ref.room_id, sent.message_id, int(sent.seq or 0)
         handles = self._handles(sent.ref)
         cursor = my_seq
@@ -264,10 +266,19 @@ class HostedTransport:
                 if kind.startswith("turn.") or kind == "room.activity":
                     saw_driver_activity = True
                 if kind == "message.member":
-                    pending[str(event["event_id"])] = event
+                    # Only OUR discussion's replies: other relays/threads in the
+                    # same room interleave in the log and must not stream here.
+                    if (
+                        str(payload.get("discussion_event_id") or "") == my_id
+                        and str(payload.get("thread_id") or "") == sent.thread
+                    ):
+                        pending[str(event["event_id"])] = event
                 elif kind == "turn.settled":
                     committed = pending.pop(str(payload.get("message_event_id") or ""), None)
-                    if committed is not None:
+                    if (
+                        committed is not None
+                        and str(payload.get("discussion_event_id") or "") == my_id
+                    ):
                         member_id = str(committed["payload"].get("member_id") or "?")
                         text = str(committed["payload"].get("text") or "")
                         replies.append(
@@ -290,6 +301,12 @@ class HostedTransport:
                         "replies": replies,
                     }
                 elif kind == "room.stop_requested" and cursor > my_seq:
+                    # The stop fence is ROOM-WIDE by design: the policy's
+                    # stopped_through_seq supersedes every earlier user turn in
+                    # every thread (gateway/hosted_room_discussion.py
+                    # plan_next_task). A stop issued after our send therefore
+                    # cancels our discussion too, so exit 4 is the truth even
+                    # when the stop was aimed at another thread.
                     return EXIT_SUPERSEDED, {
                         "status": "stopped",
                         "reason": "room.stop_requested",
@@ -312,7 +329,7 @@ class HostedTransport:
                     flush=True,
                 )
                 warned = True
-            time.sleep(max(0.0, float(poll_seconds)))
+            time.sleep(float(poll_seconds))
 
     def log(self, ref, *, since):
         handles = self._handles(ref)
@@ -533,7 +550,9 @@ def build_group_parser(subparsers) -> None:
             "start a new thread rather than reuse another session's.\n"
             "\n"
             "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
-            "(partial replies already printed), 4 superseded by a room stop.\n"
+            "(partial replies already printed), 4 superseded by a room stop. A "
+            "room stop is room-wide: it cancels every pending user turn in every "
+            "thread, including this relay's.\n"
             "\n"
             "Examples:\n"
             "  hermes group list\n"

--- a/hermes_cli/subcommands/group.py
+++ b/hermes_cli/subcommands/group.py
@@ -1,0 +1,585 @@
+"""``hermes group`` — relay user messages into Group Chats from any session.
+
+Acting-as-user: the caller (typically an agent in a Discord/CLI/Desktop
+session) writes into the room ON THE USER'S BEHALF. It is not a room member
+and needs no membership — the actor is a ``user`` whose ``profile`` and
+``display_name`` record who relayed. Turns run wherever the room's
+coordinator lives; ``send --wait`` follows the room until the discussion
+settles and streams member replies, so a background ``terminal`` call brings
+the deliberation back to the originating session as a completion
+notification (the same shape as ``hermes -p <agent> chat -q`` handoffs).
+
+Transports are pluggable via :func:`register_transport`. This module ships the
+gateway-hosted room transport (:mod:`gateway.hosted_rooms`), whose rooms are
+driven headlessly by the gateway's hosted-room worker.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import time
+import uuid
+from dataclasses import dataclass, field
+from typing import Any, Callable, Iterator, Protocol
+
+from gateway import hosted_rooms
+
+# ``thread_id`` grammar in gateway.hosted_room_discussion: [A-Za-z0-9][A-Za-z0-9._:-]*
+_THREAD_SAFE_RE = re.compile(r"[^A-Za-z0-9._:-]+")
+DEFAULT_THREAD = "cli"
+DEFAULT_WAIT_TIMEOUT_SECONDS = 1800.0
+_WORKER_WARN_AFTER_SECONDS = 30.0
+
+# Exit codes (documented in --help; the relaying agent branches on them).
+EXIT_OK = 0
+EXIT_ERROR = 1
+EXIT_USAGE = 2
+EXIT_TIMEOUT = 3
+EXIT_SUPERSEDED = 4
+
+
+class GroupCLIError(Exception):
+    """User-facing failure; ``cmd_group`` prints it and exits 1."""
+
+
+@dataclass(frozen=True)
+class RoomRef:
+    kind: str
+    room_id: str
+    name: str
+    members: tuple[str, ...]
+    managed_here: bool
+    raw: dict = field(default_factory=dict, compare=False, repr=False)
+
+
+@dataclass(frozen=True)
+class SentMessage:
+    ref: RoomRef
+    message_id: str
+    seq: int | None
+    thread: str
+    raw: dict = field(default_factory=dict, compare=False, repr=False)
+
+
+OnReply = Callable[[str, str], None]
+
+
+class Transport(Protocol):
+    kind: str
+
+    def list_rooms(self) -> list[RoomRef]: ...
+
+    def send(
+        self,
+        ref: RoomRef,
+        *,
+        text: str,
+        thread: str,
+        label: str,
+        event_key: str | None,
+    ) -> SentMessage: ...
+
+    def wait(
+        self,
+        sent: SentMessage,
+        *,
+        timeout: float,
+        poll_seconds: float,
+        on_reply: OnReply,
+    ) -> tuple[int, dict[str, Any]]: ...
+
+    def log(self, ref: RoomRef, *, since: int) -> Iterator[dict[str, Any]]: ...
+
+
+_TRANSPORTS: list[Transport] = []
+
+
+def register_transport(transport: Transport) -> None:
+    if all(existing.kind != transport.kind for existing in _TRANSPORTS):
+        _TRANSPORTS.append(transport)
+
+
+def transports() -> list[Transport]:
+    return list(_TRANSPORTS)
+
+
+def _transport_for(kind: str) -> Transport:
+    for transport in _TRANSPORTS:
+        if transport.kind == kind:
+            return transport
+    raise GroupCLIError(f"no transport registered for group kind {kind!r}")
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _profile() -> str:
+    return (os.getenv("HERMES_PROFILE") or "default").strip() or "default"
+
+
+def thread_id(raw: str | None) -> str:
+    """Coerce a caller-supplied thread label into the room-log identifier grammar."""
+    text = _THREAD_SAFE_RE.sub("-", (raw or DEFAULT_THREAD).strip()).strip("-")
+    if not text:
+        return DEFAULT_THREAD
+    return text if text[0].isalnum() else f"t-{text}"
+
+
+def resolve_room(ref: str, *, kind: str | None = None) -> RoomRef:
+    """Exact name → case-insensitive unique name → room_id, across transports."""
+    want = (ref or "").strip()
+    if not want:
+        raise GroupCLIError("group name or room_id is required")
+    rooms = [
+        room
+        for transport in _TRANSPORTS
+        if kind in (None, transport.kind)
+        for room in transport.list_rooms()
+    ]
+    matchers: tuple[Callable[[RoomRef], bool], ...] = (
+        lambda room: room.name == want,
+        lambda room: room.name.lower() == want.lower(),
+        lambda room: room.room_id == want,
+    )
+    for matcher in matchers:
+        hits = [room for room in rooms if matcher(room)]
+        if len(hits) == 1:
+            return hits[0]
+        if len(hits) > 1:
+            listed = ", ".join(f"{room.kind}:{room.room_id}" for room in hits)
+            raise GroupCLIError(
+                f"Group {want!r} is ambiguous: {listed}. Pass the room_id, or --kind <kind>."
+            )
+    names = ", ".join(sorted({f"{room.name} ({room.kind})" for room in rooms})) or "(none)"
+    raise GroupCLIError(f"No group named {want!r}. Groups on this machine: {names}")
+
+
+# ── hosted transport ─────────────────────────────────────────────────────────
+
+
+class HostedTransport:
+    """Rooms in the gateway's ``state.db``, driven by the hosted-room worker."""
+
+    kind = "hosted"
+
+    @staticmethod
+    def _db():
+        return hosted_rooms.default_db_path()
+
+    def list_rooms(self) -> list[RoomRef]:
+        local = hosted_rooms.local_authority_gateway_id()
+        out: list[RoomRef] = []
+        for room in hosted_rooms.list_rooms(self._db()):
+            members_raw = room.get("members")
+            members: list[Any] = members_raw if isinstance(members_raw, list) else []
+            out.append(
+                RoomRef(
+                    kind=self.kind,
+                    room_id=str(room["room_id"]),
+                    name=str(room["name"]),
+                    members=tuple(
+                        str(m.get("handle") or m.get("profile") or m.get("member_id") or "?")
+                        for m in members
+                        if isinstance(m, dict)
+                    ),
+                    managed_here=str(room["authority_gateway_id"]) == local,
+                    raw=room,
+                )
+            )
+        return out
+
+    def send(self, ref, *, text, thread, label, event_key):
+        from gateway import hosted_room_discussion as discussion
+
+        if not ref.managed_here:
+            raise GroupCLIError(
+                f"Group {ref.name!r} is managed by another gateway "
+                f"({ref.raw.get('authority_gateway_id')}); send from that machine."
+            )
+        try:
+            payload = discussion.validate_user_payload({"text": text, "thread_id": thread})
+        except discussion.DiscussionValidationError as exc:
+            raise GroupCLIError(str(exc)) from exc
+        actor = {
+            "kind": "user",
+            "id": "cli",
+            "profile": _profile(),
+            "display_name": label,
+        }
+        event = hosted_rooms.append_event(
+            self._db(),
+            room_id=ref.room_id,
+            event_id=hosted_rooms.user_event_id(event_key or f"cli:{uuid.uuid4().hex}"),
+            kind="message.user",
+            actor=actor,
+            payload=payload,
+            authority_gateway_id=str(ref.raw["authority_gateway_id"]),
+            authority_epoch=int(ref.raw["authority_epoch"]),
+        )
+        return SentMessage(
+            ref=ref,
+            message_id=str(event["event_id"]),
+            seq=int(event["seq"]),
+            thread=str(payload["thread_id"]),
+            raw=event,
+        )
+
+    def _handles(self, ref: RoomRef) -> dict[str, str]:
+        members_raw = ref.raw.get("members")
+        members: list[Any] = members_raw if isinstance(members_raw, list) else []
+        return {
+            str(m.get("member_id")): str(m.get("handle") or m.get("member_id"))
+            for m in members
+            if isinstance(m, dict) and m.get("member_id") is not None
+        }
+
+    def _page(self, room_id: str, since_seq: int) -> dict[str, Any]:
+        return hosted_rooms.read_events(
+            self._db(),
+            room_id=room_id,
+            since_seq=since_seq,
+            limit=hosted_rooms.MAX_LOG_LIMIT,
+        )
+
+    def wait(self, sent, *, timeout, poll_seconds, on_reply):
+        room_id, my_id, my_seq = sent.ref.room_id, sent.message_id, int(sent.seq or 0)
+        handles = self._handles(sent.ref)
+        cursor = my_seq
+        started = time.monotonic()
+        deadline = started + max(0.0, float(timeout))
+        warned = False
+        saw_driver_activity = False
+        pending: dict[str, dict[str, Any]] = {}  # message.member awaiting turn.settled
+        replies: list[dict[str, Any]] = []
+        while True:
+            page = self._page(room_id, cursor)
+            for event in page.get("events", []):
+                cursor = int(event["seq"])
+                kind = str(event.get("kind") or "")
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                if kind.startswith("turn.") or kind == "room.activity":
+                    saw_driver_activity = True
+                if kind == "message.member":
+                    pending[str(event["event_id"])] = event
+                elif kind == "turn.settled":
+                    committed = pending.pop(str(payload.get("message_event_id") or ""), None)
+                    if committed is not None:
+                        member_id = str(committed["payload"].get("member_id") or "?")
+                        text = str(committed["payload"].get("text") or "")
+                        replies.append(
+                            {
+                                "member_id": member_id,
+                                "handle": handles.get(member_id, member_id),
+                                "text": text,
+                                "seq": int(committed["seq"]),
+                            }
+                        )
+                        on_reply(f"@{handles.get(member_id, member_id)}", text)
+                elif (
+                    kind == "room.activity"
+                    and str(payload.get("discussion_event_id") or "") == my_id
+                    and payload.get("status") in ("settled", "bounded")
+                ):
+                    return EXIT_OK, {
+                        "status": str(payload["status"]),
+                        "reason": str(payload.get("reason_code") or ""),
+                        "replies": replies,
+                    }
+                elif kind == "room.stop_requested" and cursor > my_seq:
+                    return EXIT_SUPERSEDED, {
+                        "status": "stopped",
+                        "reason": "room.stop_requested",
+                        "replies": replies,
+                    }
+            if page.get("has_more"):
+                continue
+            now = time.monotonic()
+            if now >= deadline:
+                return EXIT_TIMEOUT, {"status": "timeout", "reason": "timeout", "replies": replies}
+            if (
+                not warned
+                and not saw_driver_activity
+                and now - started >= _WORKER_WARN_AFTER_SECONDS
+            ):
+                print(
+                    "hermes group: no gateway worker has picked this up yet — is "
+                    "`hermes gateway` (or the Desktop backend) running?",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                warned = True
+            time.sleep(max(0.0, float(poll_seconds)))
+
+    def log(self, ref, *, since):
+        handles = self._handles(ref)
+        cursor = int(since)
+        pending: dict[str, dict[str, Any]] = {}
+        while True:
+            page = self._page(ref.room_id, cursor)
+            for event in page.get("events", []):
+                cursor = int(event["seq"])
+                kind = str(event.get("kind") or "")
+                payload = event.get("payload") if isinstance(event.get("payload"), dict) else {}
+                if kind == "message.user":
+                    actor = event.get("actor") if isinstance(event.get("actor"), dict) else {}
+                    who = str(actor.get("display_name") or "user")
+                    yield {
+                        "seq": cursor,
+                        "speaker": f"User ({who})",
+                        "text": str(payload.get("text") or ""),
+                        "thread": str(payload.get("thread_id") or ""),
+                    }
+                elif kind == "message.member":
+                    pending[str(event["event_id"])] = event
+                elif kind == "turn.settled":
+                    committed = pending.pop(str(payload.get("message_event_id") or ""), None)
+                    if committed is not None:
+                        member_id = str(committed["payload"].get("member_id") or "?")
+                        yield {
+                            "seq": int(committed["seq"]),
+                            "speaker": f"@{handles.get(member_id, member_id)}",
+                            "text": str(committed["payload"].get("text") or ""),
+                            "thread": str(committed["payload"].get("thread_id") or ""),
+                        }
+            if not page.get("has_more"):
+                return
+
+
+register_transport(HostedTransport())
+
+
+# ── commands ─────────────────────────────────────────────────────────────────
+
+
+def _cmd_list(args) -> int:
+    rows = [room for transport in _TRANSPORTS for room in transport.list_rooms()]
+    if args.json:
+        print(
+            json.dumps(
+                [
+                    {
+                        "kind": room.kind,
+                        "name": room.name,
+                        "room_id": room.room_id,
+                        "members": list(room.members),
+                        "managed_here": room.managed_here,
+                    }
+                    for room in rows
+                ],
+                indent=2,
+            )
+        )
+        return EXIT_OK
+    if not rows:
+        print("No groups found. Create a hosted one: hermes group create <name> --member a --member b")
+        return EXIT_OK
+    for room in rows:
+        tail = "" if room.managed_here else "  [managed elsewhere]"
+        print(f"{room.name}  [{room.kind}] ({room.room_id})  members: {', '.join(room.members)}{tail}")
+    return EXIT_OK
+
+
+def _local_profiles(root) -> tuple[str, ...]:
+    names = {"default"}
+    profiles_dir = root / "profiles"
+    if profiles_dir.is_dir():
+        names.update(p.name for p in profiles_dir.iterdir() if p.is_dir())
+    return tuple(sorted(names))
+
+
+def _cmd_create(args) -> int:
+    from gateway import hosted_room_discussion as discussion
+
+    def handle(profile: str) -> str:
+        return "hermes" if profile == "default" else profile
+
+    members = [
+        {"member_id": profile, "profile": profile, "handle": handle(profile)}
+        for profile in args.member
+    ]
+    db = hosted_rooms.default_db_path()
+    try:
+        discussion.validate_roster(members, local_profiles=_local_profiles(db.parent))
+    except discussion.DiscussionValidationError as exc:
+        raise GroupCLIError(str(exc)) from exc
+    room = hosted_rooms.create_room(
+        db,
+        room_id=f"grp-{uuid.uuid4().hex[:12]}",
+        name=args.name,
+        members=members,
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id(),
+    )
+    if args.json:
+        print(json.dumps(room, indent=2))
+    else:
+        print(f"created {room['name']} ({room['room_id']}) members: {', '.join(args.member)}")
+    return EXIT_OK
+
+
+def _print_reply(speaker: str, text: str) -> None:
+    print(f"{speaker}: {text}\n", flush=True)
+
+
+def _cmd_send(args) -> int:
+    text = args.text if args.text is not None else sys.stdin.read()
+    text = (text or "").strip()
+    if not text:
+        raise GroupCLIError("message text is required (argument or stdin)")
+    ref = resolve_room(args.group, kind=getattr(args, "kind", None))
+    transport = _transport_for(ref.kind)
+    label = (args.as_label or f"{_profile()} relay").strip()
+    sent = transport.send(
+        ref,
+        text=text,
+        thread=thread_id(args.thread),
+        label=label,
+        event_key=args.event_id,
+    )
+    if not args.wait:
+        if args.json:
+            print(
+                json.dumps(
+                    {
+                        "kind": ref.kind,
+                        "room_id": ref.room_id,
+                        "name": ref.name,
+                        "message_id": sent.message_id,
+                        "seq": sent.seq,
+                        "thread": sent.thread,
+                        "raw": sent.raw,
+                    },
+                    indent=2,
+                )
+            )
+        else:
+            print(f"sent to {ref.name} [{ref.kind}] id={sent.message_id} thread={sent.thread}")
+        return EXIT_OK
+    rc, summary = transport.wait(
+        sent,
+        timeout=float(args.timeout),
+        poll_seconds=float(args.poll),
+        on_reply=(lambda *_: None) if args.json else _print_reply,
+    )
+    if args.json:
+        print(json.dumps({"kind": ref.kind, "room_id": ref.room_id, "name": ref.name, **summary}, indent=2))
+    else:
+        count = len(summary.get("replies") or [])
+        line = f"[group {ref.name}: {summary.get('status')} ({summary.get('reason')}), {count} replies]"
+        print(line, file=sys.stderr if rc else sys.stdout, flush=True)
+    return rc
+
+
+def _cmd_log(args) -> int:
+    ref = resolve_room(args.group, kind=getattr(args, "kind", None))
+    rows = list(_transport_for(ref.kind).log(ref, since=int(args.since)))
+    if args.json:
+        print(json.dumps(rows, indent=2))
+        return EXIT_OK
+    for row in rows:
+        print(f"{row['speaker']}: {row['text']}")
+    return EXIT_OK
+
+
+_ACTIONS = {
+    "list": _cmd_list,
+    "ls": _cmd_list,
+    "create": _cmd_create,
+    "send": _cmd_send,
+    "log": _cmd_log,
+}
+
+
+def cmd_group(args) -> int:
+    action = getattr(args, "group_action", None)
+    if action not in _ACTIONS:
+        print("usage: hermes group {list,create,send,log} ...", file=sys.stderr)
+        return EXIT_USAGE
+    try:
+        return _ACTIONS[action](args)
+    except (GroupCLIError, hosted_rooms.HostedRoomError) as exc:
+        print(f"hermes group: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+
+def build_args(argv: list[str]) -> argparse.Namespace:
+    """Test helper: parse ``argv`` exactly as the top-level CLI would."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    subparsers = parser.add_subparsers()
+    build_group_parser(subparsers)
+    return parser.parse_args(["group", *argv])
+
+
+def build_group_parser(subparsers) -> None:
+    """Attach the ``group`` subcommand to ``subparsers``."""
+    parser = subparsers.add_parser(
+        "group",
+        help="Relay user messages into Group Chats (from any session)",
+        description=(
+            "Write into a Group Chat AS THE USER and follow the deliberation. The "
+            "caller is a relay, not a member: the message lands attributed to the "
+            "user with your profile/label recorded as who relayed it. Run "
+            "'hermes group send <group> \"...\" --wait' in the background from any "
+            "agent session; its output carries the members' replies."
+        ),
+        epilog=(
+            "Threads: hosted rooms accept any --thread label (sanitized to "
+            "[A-Za-z0-9._:-]); omit it for the shared 'cli' thread. A room keeps "
+            "only the LATEST pending user message per thread, so concurrent relays "
+            "should use distinct --thread values. A new relaying session should "
+            "start a new thread rather than reuse another session's.\n"
+            "\n"
+            "Exit codes: 0 settled/bounded, 1 error, 2 usage, 3 timeout "
+            "(partial replies already printed), 4 superseded by a room stop.\n"
+            "\n"
+            "Examples:\n"
+            "  hermes group list\n"
+            "  hermes group create DevTeam --member archie --member mason\n"
+            '  hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait\n'
+            "  hermes group log DevTeam --since 0\n"
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    actions = parser.add_subparsers(dest="group_action")
+
+    ls = actions.add_parser("list", aliases=["ls"], help="List groups on this machine")
+    ls.add_argument("--json", action="store_true", default=False)
+
+    create = actions.add_parser("create", help="Create a gateway-hosted group (2-6 local profiles)")
+    create.add_argument("name")
+    create.add_argument(
+        "--member", action="append", required=True, metavar="PROFILE", help="Repeat per member"
+    )
+    create.add_argument("--json", action="store_true", default=False)
+
+    send = actions.add_parser("send", help="Relay a message into a group as the user")
+    send.add_argument("group", help="Group name or room_id")
+    send.add_argument("text", nargs="?", default=None, help="Message text (or stdin)")
+    send.add_argument("--thread", default=None, help="Thread label (see epilog)")
+    send.add_argument(
+        "--as",
+        dest="as_label",
+        default=None,
+        metavar="LABEL",
+        help="Who relayed, e.g. 'Pax via Discord' (default '<profile> relay')",
+    )
+    send.add_argument(
+        "--event-id",
+        default=None,
+        metavar="KEY",
+        help="Idempotent retry key; resending the same key+text is a no-op",
+    )
+    send.add_argument("--wait", action="store_true", default=False, help="Stream replies until settled")
+    send.add_argument("--timeout", type=float, default=DEFAULT_WAIT_TIMEOUT_SECONDS, metavar="SECONDS")
+    send.add_argument("--poll", type=float, default=1.0, help=argparse.SUPPRESS)
+    send.add_argument("--json", action="store_true", default=False)
+
+    log = actions.add_parser("log", help="Print the group's committed transcript")
+    log.add_argument("group", help="Group name or room_id")
+    log.add_argument("--since", type=int, default=0, metavar="SEQ")
+    log.add_argument("--json", action="store_true", default=False)
+
+    parser.set_defaults(func=cmd_group)

--- a/hermes_cli/subcommands/group_desktop.py
+++ b/hermes_cli/subcommands/group_desktop.py
@@ -1,0 +1,212 @@
+"""Desktop-room transport for ``hermes group`` — reaches Group Chats that the
+Hermes Desktop coordinates (plugin storage + renderer-driven rounds).
+
+Interim bridge until the Desktop client adopts gateway-hosted rooms: the CLI
+cannot start a Desktop round itself, so ``send`` queues an envelope in
+``<root>/group_relay/`` (``tools/group_relay.py``) and the open Desktop drains
+it, calls ``sendToGroupChat`` on the user's behalf, and streams progress
+lines back that ``--wait`` tails. Rooms are discovered from the compact
+projection the Desktop mirrors into the default profile's
+``ui_meta['hermes-bots-groups']`` (``<root>/profile.yaml``).
+
+Registered through :func:`hermes_cli.subcommands.group.register_transport`
+at import; deleting this module (and its one-line import in ``group.py``)
+removes the transport cleanly.
+"""
+
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+from typing import Any, Iterator
+
+from tools import group_relay
+
+from . import group as base
+
+GROUP_CHAT_SYNC_META_KEY = "hermes-bots-groups"
+_DESKTOP_WARN_AFTER_SECONDS = 30.0
+# Fail fast when the outbox is visibly not being drained (Desktop closed).
+_STALE_OUTBOX_MIN_AGE_SECONDS = 60.0
+_STALE_OUTBOX_MAX_PENDING = 20
+
+
+def _root() -> Path:
+    return group_relay.gateway_root()
+
+
+def read_projection(root: Path | None = None) -> dict[str, Any]:
+    """The Desktop's ``hermes-bots-groups`` mirror, or ``{}``. Never raises."""
+    path = (root or _root()) / "profile.yaml"
+    if not path.is_file():
+        return {}
+    try:
+        import yaml
+
+        with open(path, "r", encoding="utf-8") as handle:
+            data = yaml.safe_load(handle) or {}
+    except Exception:
+        return {}
+    ui_meta = data.get("ui_meta") if isinstance(data, dict) else None
+    snapshot = ui_meta.get(GROUP_CHAT_SYNC_META_KEY) if isinstance(ui_meta, dict) else None
+    return snapshot if isinstance(snapshot, dict) else {}
+
+
+def _entries(room: dict[str, Any]) -> list[dict[str, Any]]:
+    log = room.get("log")
+    return [e for e in log if isinstance(e, dict)] if isinstance(log, list) else []
+
+
+def _author(entry: dict[str, Any]) -> dict[str, Any]:
+    author = entry.get("from")
+    return author if isinstance(author, dict) else {}
+
+
+def _member_handles(room: dict[str, Any]) -> tuple[str, ...]:
+    members = room.get("members")
+    names: list[str] = []
+    if isinstance(members, list):
+        for member in members:
+            if isinstance(member, dict) and member.get("name"):
+                names.append(str(member["name"]))
+    if not names:
+        seen: dict[str, None] = {}
+        for entry in _entries(room):
+            author = _author(entry)
+            if author.get("kind") == "member" and author.get("name"):
+                seen.setdefault(str(author["name"]), None)
+        names = list(seen)
+    return tuple(names)
+
+
+class DesktopTransport:
+    """Desktop-coordinated rooms, reached through the group_relay outbox."""
+
+    kind = "desktop"
+
+    def list_rooms(self) -> list[base.RoomRef]:
+        rooms = read_projection().get("rooms")
+        out: list[base.RoomRef] = []
+        if not isinstance(rooms, dict):
+            return out
+        for key, room in rooms.items():
+            if not isinstance(room, dict):
+                continue
+            room_id = str(room.get("roomId") or (key[3:] if str(key).startswith("id:") else "") or "")
+            name = str(room.get("name") or (key[5:] if str(key).startswith("name:") else key) or "")
+            if not name:
+                continue
+            out.append(
+                base.RoomRef(
+                    kind=self.kind,
+                    room_id=room_id or name,
+                    name=name,
+                    members=_member_handles(room),
+                    managed_here=True,
+                    raw=room,
+                )
+            )
+        return out
+
+    def send(self, ref, *, text, thread, label, event_key):
+        del event_key  # relay envelopes are single-shot; the Desktop dedupes appends
+        stale = group_relay.pending_count(_root(), older_than_seconds=_STALE_OUTBOX_MIN_AGE_SECONDS)
+        if stale >= _STALE_OUTBOX_MAX_PENDING:
+            raise base.GroupCLIError(
+                f"{stale} relay envelopes have sat undrained for over "
+                f"{int(_STALE_OUTBOX_MIN_AGE_SECONDS)}s — the Hermes Desktop does not "
+                "appear to be open. Open it (Bots pane) and retry."
+            )
+        # 'cli' is the hosted default; for Desktop rooms it means "new thread".
+        requested = None if thread == base.DEFAULT_THREAD else thread
+        try:
+            envelope = group_relay.enqueue(
+                _root(),
+                room_id=ref.room_id if ref.room_id != ref.name else "",
+                room_name=ref.name,
+                text=text,
+                from_profile=base._profile(),
+                label=label,
+                thread=requested,
+            )
+        except group_relay.GroupRelayError as exc:
+            raise base.GroupCLIError(str(exc)) from exc
+        return base.SentMessage(
+            ref=ref,
+            message_id=str(envelope["id"]),
+            seq=None,
+            thread=requested or "(new thread — assigned by the Desktop)",
+            raw=envelope,
+        )
+
+    def wait(self, sent, *, timeout, poll_seconds, on_reply):
+        if not (float(poll_seconds) > 0):
+            raise base.GroupCLIError("--poll must be a positive number of seconds")
+        offset = 0
+        started = time.monotonic()
+        deadline = started + max(0.0, float(timeout))
+        accepted_thread: str | None = None
+        warned = False
+        replies: list[dict[str, Any]] = []
+        while True:
+            lines, offset = group_relay.read_reply_lines(_root(), sent.message_id, offset=offset)
+            for line in lines:
+                kind = str(line.get("kind") or "")
+                if kind == "accepted":
+                    accepted_thread = str(line.get("thread") or "")
+                elif kind == "reply":
+                    member = str(line.get("member") or "bot")
+                    text = str(line.get("text") or "")
+                    replies.append({"handle": member, "member_id": member, "text": text})
+                    on_reply(f"@{member}", text)
+                elif kind == "done":
+                    status = str(line.get("status") or "")
+                    summary = {"status": status, "reason": status, "thread": accepted_thread, "replies": replies}
+                    if status in ("settled", "capped"):
+                        return base.EXIT_OK, summary
+                    if status == "cancelled":
+                        return base.EXIT_SUPERSEDED, summary
+                    return base.EXIT_TIMEOUT, summary
+                elif kind == "error":
+                    raise base.GroupCLIError(
+                        f"{line.get('error') or 'relay failed'}"
+                        + (f" [reason: {line['reason']}]" if line.get("reason") else "")
+                    )
+            now = time.monotonic()
+            if now >= deadline:
+                return base.EXIT_TIMEOUT, {
+                    "status": "timeout",
+                    "reason": "timeout",
+                    "thread": accepted_thread,
+                    "replies": replies,
+                }
+            if not warned and accepted_thread is None and now - started >= _DESKTOP_WARN_AFTER_SECONDS:
+                print(
+                    "hermes group: the Desktop hasn't picked this up yet — is the Hermes "
+                    "app open with the Bots pane loaded?",
+                    file=sys.stderr,
+                    flush=True,
+                )
+                warned = True
+            time.sleep(float(poll_seconds))
+
+    def log(self, ref, *, since) -> Iterator[dict[str, Any]]:
+        for index, entry in enumerate(_entries(ref.raw)):
+            if index < int(since):
+                continue
+            author = _author(entry)
+            if author.get("kind") == "member":
+                speaker = f"@{author.get('name') or 'bot'}"
+            else:
+                via = str(author.get("via") or "").strip()
+                speaker = f"User ({via})" if via else "User (You)"
+            yield {
+                "seq": index,
+                "speaker": speaker,
+                "text": str(entry.get("text") or ""),
+                "thread": str(entry.get("thread") or ""),
+            }
+
+
+base.register_transport(DesktopTransport())

--- a/hermes_cli/subcommands/group_desktop.py
+++ b/hermes_cli/subcommands/group_desktop.py
@@ -117,7 +117,8 @@ class DesktopTransport:
                 f"{int(_STALE_OUTBOX_MIN_AGE_SECONDS)}s — the Hermes Desktop does not "
                 "appear to be open. Open it (Bots pane) and retry."
             )
-        # 'cli' is the hosted default; for Desktop rooms it means "new thread".
+        # The hosted default thread means "no explicit thread" here → the
+        # Desktop mints a new one; a bound/explicit Desktop thread id continues.
         requested = None if thread == base.DEFAULT_THREAD else thread
         try:
             envelope = group_relay.enqueue(

--- a/hermes_cli/subcommands/group_desktop.py
+++ b/hermes_cli/subcommands/group_desktop.py
@@ -110,7 +110,6 @@ class DesktopTransport:
         return out
 
     def send(self, ref, *, text, thread, label, event_key):
-        del event_key  # relay envelopes are single-shot; the Desktop dedupes appends
         stale = group_relay.pending_count(_root(), older_than_seconds=_STALE_OUTBOX_MIN_AGE_SECONDS)
         if stale >= _STALE_OUTBOX_MAX_PENDING:
             raise base.GroupCLIError(
@@ -129,6 +128,7 @@ class DesktopTransport:
                 from_profile=base._profile(),
                 label=label,
                 thread=requested,
+                event_key=event_key,
             )
         except group_relay.GroupRelayError as exc:
             raise base.GroupCLIError(str(exc)) from exc

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -24,7 +24,7 @@ from hermes_cli.subcommands import group as g
 @pytest.fixture
 def home(tmp_path, monkeypatch):
     root = tmp_path / ".hermes"
-    for profile in ("pax", "archie"):
+    for profile in ("researcher", "scout"):
         (root / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
@@ -42,8 +42,8 @@ def mk_room(room_id="room-1", name="DevTeam", authority=None):
         room_id=room_id,
         name=name,
         members=[
-            {"member_id": "pax", "profile": "pax", "handle": "pax"},
-            {"member_id": "archie", "profile": "archie", "handle": "archie"},
+            {"member_id": "researcher", "profile": "researcher", "handle": "researcher"},
+            {"member_id": "scout", "profile": "scout", "handle": "scout"},
         ],
         authority_gateway_id=authority or hosted_rooms.local_authority_gateway_id(),
     )
@@ -90,13 +90,13 @@ def test_list_json_and_plain(home, capsys):
         "kind": "hosted",
         "name": "DevTeam",
         "room_id": "room-1",
-        "members": ["pax", "archie"],
+        "members": ["researcher", "scout"],
         "managed_here": True,
     }
     assert by_id["room-2"]["managed_here"] is False
     assert _run(["list"]) == 0
     out = capsys.readouterr().out
-    assert "DevTeam  [hosted] (room-1)  members: pax, archie" in out
+    assert "DevTeam  [hosted] (room-1)  members: researcher, scout" in out
     assert "[managed elsewhere]" in out
 
 
@@ -109,26 +109,26 @@ def test_list_empty(home, capsys):
 
 
 def test_create_hosted(home, capsys):
-    rc = _run(["create", "DevTeam", "--member", "pax", "--member", "archie", "--json"])
+    rc = _run(["create", "DevTeam", "--member", "researcher", "--member", "scout", "--json"])
     assert rc == 0
     out = _out_json(capsys)
     assert out["name"] == "DevTeam"
     assert out["room_id"].startswith("grp-")
     assert out["authority_gateway_id"] == hosted_rooms.local_authority_gateway_id()
-    assert [m["handle"] for m in out["members"]] == ["pax", "archie"]
+    assert [m["handle"] for m in out["members"]] == ["researcher", "scout"]
     # The new room is now resolvable and driven here.
     assert g.resolve_room("DevTeam").managed_here is True
 
 
 def test_create_default_profile_handle_is_hermes(home, capsys):
-    assert _run(["create", "X", "--member", "default", "--member", "pax", "--json"]) == 0
-    assert [m["handle"] for m in _out_json(capsys)["members"]] == ["hermes", "pax"]
+    assert _run(["create", "X", "--member", "default", "--member", "researcher", "--json"]) == 0
+    assert [m["handle"] for m in _out_json(capsys)["members"]] == ["hermes", "researcher"]
 
 
 def test_create_rejects_bad_roster(home, capsys):
-    assert _run(["create", "X", "--member", "pax"]) == 1
+    assert _run(["create", "X", "--member", "researcher"]) == 1
     assert "between 2 and 6" in capsys.readouterr().err
-    assert _run(["create", "X", "--member", "pax", "--member", "ghost"]) == 1
+    assert _run(["create", "X", "--member", "researcher", "--member", "ghost"]) == 1
     assert "ghost" in capsys.readouterr().err
 
 
@@ -137,8 +137,8 @@ def test_create_rejects_bad_roster(home, capsys):
 
 def test_send_appends_user_event_with_relay_attribution(home, capsys, monkeypatch):
     mk_room()
-    monkeypatch.setenv("HERMES_PROFILE", "pax")
-    rc = _run(["send", "DevTeam", "plan the release", "--as", "Pax via Discord", "--json"])
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    rc = _run(["send", "DevTeam", "plan the release", "--as", "Ada via Discord", "--json"])
     assert rc == 0
     out = _out_json(capsys)
     assert out["kind"] == "hosted" and out["room_id"] == "room-1"
@@ -148,8 +148,8 @@ def test_send_appends_user_event_with_relay_attribution(home, capsys, monkeypatc
     assert event["actor"] == {
         "kind": "user",
         "id": "cli",
-        "profile": "pax",
-        "display_name": "Pax via Discord",
+        "profile": "researcher",
+        "display_name": "Ada via Discord",
     }
     assert event["payload"] == {"text": "plan the release", "thread_id": "cli"}
     # Landed in the durable log with authority fencing intact.
@@ -297,23 +297,23 @@ def _activity(room, *, discussion_id, status="settled", reason="consensus", thre
 
 def _sent(room, text="go", key="k"):
     ref = g.resolve_room(room["room_id"])
-    return g.HostedTransport().send(ref, text=text, thread="cli", label="Pax", event_key=key)
+    return g.HostedTransport().send(ref, text=text, thread="cli", label="Ada", event_key=key)
 
 
 def test_wait_streams_committed_replies_and_exits_on_settled(home, capsys):
     room = mk_room()
     sent = _sent(room)
-    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="reply from archie", n=1)
-    _member_turn(room, discussion_id=sent.message_id, member_id="pax", text="", n=2, passed=True)
+    _member_turn(room, discussion_id=sent.message_id, member_id="scout", text="reply from scout", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="researcher", text="", n=2, passed=True)
     _activity(room, discussion_id=sent.message_id)
     got = []
     rc, summary = g.HostedTransport().wait(
         sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append((s, t))
     )
     assert rc == 0
-    assert got == [("@archie", "reply from archie")]
+    assert got == [("@scout", "reply from scout")]
     assert summary["status"] == "settled" and summary["reason"] == "consensus"
-    assert [r["handle"] for r in summary["replies"]] == ["archie"]
+    assert [r["handle"] for r in summary["replies"]] == ["scout"]
 
 
 def test_wait_ignores_uncommitted_member_message(home):
@@ -324,10 +324,10 @@ def test_wait_ignores_uncommitted_member_message(home):
         room_id="room-1",
         event_id="orphan",
         kind="message.member",
-        actor={"kind": "member", "id": "archie", "profile": "archie"},
+        actor={"kind": "member", "id": "scout", "profile": "scout"},
         payload={
             "discussion_event_id": sent.message_id,
-            "member_id": "archie",
+            "member_id": "scout",
             "member_index": 0,
             "round_index": 0,
             "task_id": "t",
@@ -350,11 +350,11 @@ def test_wait_does_not_stream_replies_from_other_discussions_or_threads(home):
         g.resolve_room("room-1"), text="other relay", thread="t2", label="Other", event_key="k-other"
     )
     # A committed reply to the OTHER discussion (different discussion id AND thread).
-    _member_turn(room, discussion_id=other.message_id, member_id="archie", text="for t2", thread="t2", n=1)
+    _member_turn(room, discussion_id=other.message_id, member_id="scout", text="for t2", thread="t2", n=1)
     # A committed reply whose thread matches ours but belongs to another discussion id.
-    _member_turn(room, discussion_id="user:stale", member_id="archie", text="stale", thread="cli", n=2)
+    _member_turn(room, discussion_id="user:stale", member_id="scout", text="stale", thread="cli", n=2)
     # Ours.
-    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="for us", n=3)
+    _member_turn(room, discussion_id=sent.message_id, member_id="scout", text="for us", n=3)
     _activity(room, discussion_id=sent.message_id)
     got = []
     rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
@@ -381,7 +381,7 @@ def test_wait_only_settles_on_own_discussion(home):
 def test_wait_times_out_with_partial_replies(home):
     room = mk_room()
     sent = _sent(room)
-    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="partial", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="scout", text="partial", n=1)
     got = []
     rc, summary = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
     assert rc == 3 and got == ["partial"] and len(summary["replies"]) == 1
@@ -416,15 +416,15 @@ def test_send_wait_cli_output_and_exit_codes(home, capsys):
     key = "cli-wait"
     # Pre-seed the log so the CLI's own send (same key → same event) sees a finished discussion.
     sent = _sent(room, key=key)
-    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="done deal", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="scout", text="done deal", n=1)
     _activity(room, discussion_id=sent.message_id)
-    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5"])
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Ada", "--wait", "--poll", "0.01", "--timeout", "5"])
     assert rc == 0
     out = capsys.readouterr().out
-    assert "@archie: done deal" in out
+    assert "@scout: done deal" in out
     assert "[group DevTeam: settled (consensus), 1 replies]" in out
 
-    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5", "--json"])
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Ada", "--wait", "--poll", "0.01", "--timeout", "5", "--json"])
     assert rc == 0
     summary = _out_json(capsys)
     assert summary["status"] == "settled" and summary["replies"][0]["text"] == "done deal"
@@ -437,12 +437,12 @@ def test_send_wait_cli_output_and_exit_codes(home, capsys):
 def test_log_renders_committed_transcript_with_relay_attribution(home, capsys):
     room = mk_room()
     sent = _sent(room)
-    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="ack", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="scout", text="ack", n=1)
     assert _run(["log", "DevTeam", "--json"]) == 0
     rows = _out_json(capsys)
-    assert [(r["speaker"], r["text"]) for r in rows] == [("User (Pax)", "go"), ("@archie", "ack")]
+    assert [(r["speaker"], r["text"]) for r in rows] == [("User (Ada)", "go"), ("@scout", "ack")]
     assert _run(["log", "DevTeam", "--since", str(sent.seq)]) == 0
-    assert capsys.readouterr().out.strip() == "@archie: ack"
+    assert capsys.readouterr().out.strip() == "@scout: ack"
 
 
 # ── parser / dispatch ────────────────────────────────────────────────────────

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -26,6 +26,7 @@ def home(tmp_path, monkeypatch):
         (root / "profiles" / profile).mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     return root
 
 
@@ -463,3 +464,90 @@ def test_transport_registry_dedupes_by_kind():
     before = len(g.transports())
     g.register_transport(g.HostedTransport())
     assert len(g.transports()) == before
+
+
+# ── session-bound thread continuity ──────────────────────────────────────────
+
+
+def test_hosted_thread_follows_session(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1200_abc")
+    assert _run(["send", "DevTeam", "first", "--json"]) == 0
+    t1 = _out_json(capsys)["thread"]
+    assert t1 == g.thread_id("s-20260903_1200_abc")
+    assert _run(["send", "DevTeam", "second", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == t1
+    # A different session gets its own thread.
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1300_xyz")
+    assert _run(["send", "DevTeam", "other", "--json"]) == 0
+    assert _out_json(capsys)["thread"] != t1
+    # --new-thread from the first session breaks its binding... to a fresh derived label
+    monkeypatch.setenv("HERMES_SESSION_ID", "20260903_1200_abc")
+    assert _run(["send", "DevTeam", "restart", "--new-thread", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == t1  # hosted label is session-derived, so same label is correct
+    # --session overrides the env; --thread overrides everything.
+    assert _run(["send", "DevTeam", "x", "--session", "S2", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == g.thread_id("s-S2")
+    assert _run(["send", "DevTeam", "x", "--thread", "explicit", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "explicit"
+
+
+def test_no_session_uses_shared_cli_thread(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
+    assert _run(["send", "DevTeam", "x", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "cli"
+
+
+def test_bindings_file_is_bounded_and_survives_corruption(home, monkeypatch):
+    mk_room()
+    ref = g.resolve_room("DevTeam")
+    monkeypatch.setattr(g, "_THREAD_BINDINGS_MAX", 3)
+    for i in range(5):
+        g.bind_thread(ref, f"s{i}", f"t{i}")
+    assert g.bound_thread(ref, "s0") is None and g.bound_thread(ref, "s4") == "t4"
+    g._bindings_path().write_text("{not json")
+    assert g.bound_thread(ref, "s4") is None
+    g.bind_thread(ref, "s9", "t9")  # rewrites cleanly
+    assert g.bound_thread(ref, "s9") == "t9"
+    g.forget_thread(ref, "s9")
+    assert g.bound_thread(ref, "s9") is None
+
+
+def test_bind_thread_is_safe_under_concurrent_writers(home):
+    """Many writers, each binding its own session: no binding may be lost."""
+    import multiprocessing as mp
+
+    mk_room()
+    ref = g.resolve_room("DevTeam")
+
+    def worker(i, home_path):
+        import os as _os
+
+        _os.environ["HERMES_HOME"] = home_path
+        from hermes_cli.subcommands import group as gg
+
+        gg.bind_thread(ref, f"sess-{i}", f"t{i}")
+
+    ctx = mp.get_context("fork")
+    procs = [ctx.Process(target=worker, args=(i, str(home))) for i in range(24)]
+    for proc in procs:
+        proc.start()
+    for proc in procs:
+        proc.join(10)
+    for i in range(24):
+        assert g.bound_thread(ref, f"sess-{i}") == f"t{i}", i
+    # No temp files left behind, lock file is harmless.
+    leftovers = [p.name for p in g._bindings_path().parent.iterdir() if p.name.startswith(".bindings-")]
+    assert leftovers == []
+
+
+def test_explicit_thread_does_not_rebind_session(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_SESSION_ID", "S")
+    assert _run(["send", "DevTeam", "a", "--json"]) == 0
+    own = _out_json(capsys)["thread"]
+    assert _run(["send", "DevTeam", "b", "--thread", "elsewhere", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == "elsewhere"
+    assert _run(["send", "DevTeam", "c", "--json"]) == 0
+    assert _out_json(capsys)["thread"] == own

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -1,0 +1,437 @@
+"""Behavior contract for ``hermes group`` (hosted-room transport).
+
+The CLI relays a message into a gateway-hosted Group Chat AS THE USER from
+any session, and ``send --wait`` follows the typed room log until the
+discussion settles. Tests drive the room log by hand (no worker), mirroring
+``tests/tui_gateway/test_hosted_room_service.py``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import json
+
+import pytest
+
+from gateway import hosted_room_discussion as discussion
+from gateway import hosted_rooms
+from hermes_cli.subcommands import group as g
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    for profile in ("pax", "archie"):
+        (root / "profiles" / profile).mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    return root
+
+
+def _db():
+    return hosted_rooms.default_db_path()
+
+
+def mk_room(room_id="room-1", name="DevTeam", authority=None):
+    return hosted_rooms.create_room(
+        _db(),
+        room_id=room_id,
+        name=name,
+        members=[
+            {"member_id": "pax", "profile": "pax", "handle": "pax"},
+            {"member_id": "archie", "profile": "archie", "handle": "archie"},
+        ],
+        authority_gateway_id=authority or hosted_rooms.local_authority_gateway_id(),
+    )
+
+
+def _run(argv):
+    return g.cmd_group(g.build_args(argv))
+
+
+def _out_json(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+# ── resolution + list ────────────────────────────────────────────────────────
+
+
+def test_resolve_exact_ci_id_and_missing(home):
+    mk_room()
+    assert g.resolve_room("DevTeam").room_id == "room-1"
+    assert g.resolve_room("devteam").room_id == "room-1"
+    assert g.resolve_room("room-1").room_id == "room-1"
+    assert g.resolve_room("DevTeam").kind == "hosted"
+    with pytest.raises(g.GroupCLIError, match="No group named"):
+        g.resolve_room("nope")
+    with pytest.raises(g.GroupCLIError, match="required"):
+        g.resolve_room("  ")
+
+
+def test_resolve_ambiguous_ci_fails_closed_but_exact_wins(home):
+    mk_room("room-1", "DevTeam")
+    mk_room("room-2", "devteam")
+    with pytest.raises(g.GroupCLIError, match="ambiguous"):
+        g.resolve_room("DEVTEAM")
+    assert g.resolve_room("DevTeam").room_id == "room-1"
+
+
+def test_list_json_and_plain(home, capsys):
+    mk_room()
+    mk_room("room-2", "Remote", authority="install:elsewhere")
+    assert _run(["list", "--json"]) == 0
+    rows = _out_json(capsys)
+    by_id = {r["room_id"]: r for r in rows}
+    assert by_id["room-1"] == {
+        "kind": "hosted",
+        "name": "DevTeam",
+        "room_id": "room-1",
+        "members": ["pax", "archie"],
+        "managed_here": True,
+    }
+    assert by_id["room-2"]["managed_here"] is False
+    assert _run(["list"]) == 0
+    out = capsys.readouterr().out
+    assert "DevTeam  [hosted] (room-1)  members: pax, archie" in out
+    assert "[managed elsewhere]" in out
+
+
+def test_list_empty(home, capsys):
+    assert _run(["list"]) == 0
+    assert "No groups found" in capsys.readouterr().out
+
+
+# ── create ───────────────────────────────────────────────────────────────────
+
+
+def test_create_hosted(home, capsys):
+    rc = _run(["create", "DevTeam", "--member", "pax", "--member", "archie", "--json"])
+    assert rc == 0
+    out = _out_json(capsys)
+    assert out["name"] == "DevTeam"
+    assert out["room_id"].startswith("grp-")
+    assert out["authority_gateway_id"] == hosted_rooms.local_authority_gateway_id()
+    assert [m["handle"] for m in out["members"]] == ["pax", "archie"]
+    # The new room is now resolvable and driven here.
+    assert g.resolve_room("DevTeam").managed_here is True
+
+
+def test_create_default_profile_handle_is_hermes(home, capsys):
+    assert _run(["create", "X", "--member", "default", "--member", "pax", "--json"]) == 0
+    assert [m["handle"] for m in _out_json(capsys)["members"]] == ["hermes", "pax"]
+
+
+def test_create_rejects_bad_roster(home, capsys):
+    assert _run(["create", "X", "--member", "pax"]) == 1
+    assert "between 2 and 6" in capsys.readouterr().err
+    assert _run(["create", "X", "--member", "pax", "--member", "ghost"]) == 1
+    assert "ghost" in capsys.readouterr().err
+
+
+# ── send ─────────────────────────────────────────────────────────────────────
+
+
+def test_send_appends_user_event_with_relay_attribution(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setenv("HERMES_PROFILE", "pax")
+    rc = _run(["send", "DevTeam", "plan the release", "--as", "Pax via Discord", "--json"])
+    assert rc == 0
+    out = _out_json(capsys)
+    assert out["kind"] == "hosted" and out["room_id"] == "room-1"
+    assert out["message_id"].startswith("user:")
+    event = out["raw"]
+    assert event["kind"] == "message.user"
+    assert event["actor"] == {
+        "kind": "user",
+        "id": "cli",
+        "profile": "pax",
+        "display_name": "Pax via Discord",
+    }
+    assert event["payload"] == {"text": "plan the release", "thread_id": "cli"}
+    # Landed in the durable log with authority fencing intact.
+    logged = hosted_rooms.read_events(_db(), room_id="room-1", since_seq=0)["events"]
+    assert [e["kind"] for e in logged] == ["message.user"]
+    assert logged[0]["authority_epoch"] == 1
+
+
+def test_send_default_label_and_thread_sanitizing(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "hi", "--thread", "discord_2026_09_03 #x", "--json"]) == 0
+    out = _out_json(capsys)
+    assert out["thread"] == "discord_2026_09_03-x"
+    assert out["raw"]["actor"]["display_name"] == "default relay"
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        (None, "cli"),
+        ("", "cli"),
+        ("__", "t-__"),
+        ("-abc-", "abc"),
+        (".hidden", "t-.hidden"),
+        ("a b/c", "a-b-c"),
+        ("ok.thread:1", "ok.thread:1"),
+    ],
+)
+def test_thread_id_grammar(raw, expected):
+    assert g.thread_id(raw) == expected
+    discussion.validate_user_payload({"text": "x", "thread_id": g.thread_id(raw)})
+
+
+def test_send_refuses_room_managed_elsewhere(home, capsys):
+    mk_room("r2", "Remote", authority="install:elsewhere")
+    assert _run(["send", "Remote", "hi"]) == 1
+    assert "another gateway" in capsys.readouterr().err
+    assert hosted_rooms.read_events(_db(), room_id="r2", since_seq=0)["events"] == []
+
+
+def test_send_stdin_and_empty(home, capsys, monkeypatch):
+    mk_room()
+    monkeypatch.setattr("sys.stdin", io.StringIO("from stdin"))
+    assert _run(["send", "DevTeam", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["payload"]["text"] == "from stdin"
+    monkeypatch.setattr("sys.stdin", io.StringIO("   "))
+    assert _run(["send", "DevTeam"]) == 1
+    assert "required" in capsys.readouterr().err
+
+
+def test_send_oversize_text_is_rejected_before_append(home, capsys):
+    mk_room()
+    big = "x" * (discussion.MAX_USER_TEXT_BYTES + 1)
+    assert _run(["send", "DevTeam", big]) == 1
+    assert "too large" in capsys.readouterr().err
+    assert hosted_rooms.read_events(_db(), room_id="room-1", since_seq=0)["events"] == []
+
+
+def test_send_event_id_is_idempotent(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "once", "--event-id", "k1", "--json"]) == 0
+    first = _out_json(capsys)
+    assert _run(["send", "DevTeam", "once", "--event-id", "k1", "--json"]) == 0
+    again = _out_json(capsys)
+    assert first["seq"] == again["seq"] == 1
+    assert _run(["send", "DevTeam", "different", "--event-id", "k1"]) == 1  # conflict fails closed
+
+
+def test_send_plain_output(home, capsys):
+    mk_room()
+    assert _run(["send", "DevTeam", "hi"]) == 0
+    out = capsys.readouterr().out
+    assert out.startswith("sent to DevTeam [hosted] id=user:") and "thread=cli" in out
+
+
+# ── send --wait / log ────────────────────────────────────────────────────────
+
+
+def _gateway(room):
+    return {"kind": "gateway", "id": str(room["authority_gateway_id"])}
+
+
+def _authority(room):
+    return {
+        "authority_gateway_id": str(room["authority_gateway_id"]),
+        "authority_epoch": int(room["authority_epoch"]),
+    }
+
+
+def _member_turn(room, *, discussion_id, member_id, text, thread="cli", n=1, passed=False):
+    """Append the committed shape: message.member then turn.settled(message_event_id)."""
+    coords = {
+        "discussion_event_id": discussion_id,
+        "member_id": member_id,
+        "member_index": 0,
+        "round_index": 0,
+        "task_id": f"task-{n}",
+        "thread_id": thread,
+        "turn_id": f"turn-{n}",
+    }
+    message = None
+    if not passed:
+        message = hosted_rooms.append_event(
+            _db(),
+            room_id=room["room_id"],
+            event_id=f"msg-{n}",
+            kind="message.member",
+            actor={"kind": "member", "id": member_id, "profile": member_id},
+            payload={**coords, "text": text},
+            **_authority(room),
+        )
+    hosted_rooms.append_event(
+        _db(),
+        room_id=room["room_id"],
+        event_id=f"settled-{n}",
+        kind="turn.settled",
+        actor=_gateway(room),
+        payload={
+            **coords,
+            "seen_through_seq": 1,
+            "message_event_id": message["event_id"] if message else None,
+            "passed": passed,
+        },
+        **_authority(room),
+    )
+    return message
+
+
+def _activity(room, *, discussion_id, status="settled", reason="consensus", thread="cli"):
+    return hosted_rooms.append_event(
+        _db(),
+        room_id=room["room_id"],
+        event_id=f"dactivity:{discussion_id}:{reason}",
+        kind="room.activity",
+        actor=_gateway(room),
+        payload={
+            "status": status,
+            "reason_code": reason,
+            "thread_id": thread,
+            "discussion_event_id": discussion_id,
+        },
+        **_authority(room),
+    )
+
+
+def _sent(room, text="go", key="k"):
+    ref = g.resolve_room(room["room_id"])
+    return g.HostedTransport().send(ref, text=text, thread="cli", label="Pax", event_key=key)
+
+
+def test_wait_streams_committed_replies_and_exits_on_settled(home, capsys):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="reply from archie", n=1)
+    _member_turn(room, discussion_id=sent.message_id, member_id="pax", text="", n=2, passed=True)
+    _activity(room, discussion_id=sent.message_id)
+    got = []
+    rc, summary = g.HostedTransport().wait(
+        sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append((s, t))
+    )
+    assert rc == 0
+    assert got == [("@archie", "reply from archie")]
+    assert summary["status"] == "settled" and summary["reason"] == "consensus"
+    assert [r["handle"] for r in summary["replies"]] == ["archie"]
+
+
+def test_wait_ignores_uncommitted_member_message(home):
+    room = mk_room()
+    sent = _sent(room)
+    hosted_rooms.append_event(
+        _db(),
+        room_id="room-1",
+        event_id="orphan",
+        kind="message.member",
+        actor={"kind": "member", "id": "archie", "profile": "archie"},
+        payload={
+            "discussion_event_id": sent.message_id,
+            "member_id": "archie",
+            "member_index": 0,
+            "round_index": 0,
+            "task_id": "t",
+            "thread_id": "cli",
+            "turn_id": "u",
+            "text": "never committed",
+        },
+        **_authority(room),
+    )
+    _activity(room, discussion_id=sent.message_id, status="bounded", reason="round-cap")
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: got.append(a))
+    assert rc == 0 and got == [] and summary["status"] == "bounded"
+
+
+def test_wait_only_settles_on_own_discussion(home):
+    room = mk_room()
+    sent = _sent(room)
+    _activity(room, discussion_id="user:someone-else", thread="other")
+    rc, summary = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 3 and summary["status"] == "timeout"
+
+
+def test_wait_times_out_with_partial_replies(home):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="partial", n=1)
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
+    assert rc == 3 and got == ["partial"] and len(summary["replies"]) == 1
+
+
+def test_wait_exit_4_when_room_stop_supersedes(home):
+    room = mk_room()
+    sent = _sent(room)
+    hosted_rooms.request_room_stop(
+        _db(),
+        room_id="room-1",
+        cancel_id="stop-1",
+        expected_gateway_id=str(room["authority_gateway_id"]),
+        expected_epoch=int(room["authority_epoch"]),
+    )
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 4 and summary["status"] == "stopped"
+
+
+def test_wait_warns_once_when_no_worker(home, capsys, monkeypatch):
+    room = mk_room()
+    sent = _sent(room)
+    monkeypatch.setattr(g, "_WORKER_WARN_AFTER_SECONDS", 0.0)
+    rc, _ = g.HostedTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 3
+    assert capsys.readouterr().err.count("no gateway worker") == 1
+
+
+def test_send_wait_cli_output_and_exit_codes(home, capsys):
+    room = mk_room()
+    key = "cli-wait"
+    # Pre-seed the log so the CLI's own send (same key → same event) sees a finished discussion.
+    sent = _sent(room, key=key)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="done deal", n=1)
+    _activity(room, discussion_id=sent.message_id)
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "@archie: done deal" in out
+    assert "[group DevTeam: settled (consensus), 1 replies]" in out
+
+    rc = _run(["send", "DevTeam", "go", "--event-id", key, "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5", "--json"])
+    assert rc == 0
+    summary = _out_json(capsys)
+    assert summary["status"] == "settled" and summary["replies"][0]["text"] == "done deal"
+
+    rc = _run(["send", "DevTeam", "again", "--thread", "t2", "--wait", "--poll", "0.01", "--timeout", "0.05"])
+    assert rc == 3
+    assert "timeout" in capsys.readouterr().err
+
+
+def test_log_renders_committed_transcript_with_relay_attribution(home, capsys):
+    room = mk_room()
+    sent = _sent(room)
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="ack", n=1)
+    assert _run(["log", "DevTeam", "--json"]) == 0
+    rows = _out_json(capsys)
+    assert [(r["speaker"], r["text"]) for r in rows] == [("User (Pax)", "go"), ("@archie", "ack")]
+    assert _run(["log", "DevTeam", "--since", str(sent.seq)]) == 0
+    assert capsys.readouterr().out.strip() == "@archie: ack"
+
+
+# ── parser / dispatch ────────────────────────────────────────────────────────
+
+
+def test_parser_registers_and_dispatches():
+    parser = argparse.ArgumentParser(prog="hermes")
+    g.build_group_parser(parser.add_subparsers(dest="command"))
+    args = parser.parse_args(["group", "send", "DevTeam", "hi", "--as", "X", "--wait"])
+    assert args.func is g.cmd_group
+    assert args.group_action == "send" and args.as_label == "X" and args.wait is True
+    assert args.timeout == g.DEFAULT_WAIT_TIMEOUT_SECONDS
+
+
+def test_cmd_group_without_action_is_usage_error(capsys):
+    assert g.cmd_group(argparse.Namespace(group_action=None)) == 2
+    assert "usage" in capsys.readouterr().err
+
+
+def test_transport_registry_dedupes_by_kind():
+    before = len(g.transports())
+    g.register_transport(g.HostedTransport())
+    assert len(g.transports()) == before

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -340,6 +340,33 @@ def test_wait_ignores_uncommitted_member_message(home):
     assert rc == 0 and got == [] and summary["status"] == "bounded"
 
 
+def test_wait_does_not_stream_replies_from_other_discussions_or_threads(home):
+    room = mk_room()
+    sent = _sent(room)
+    other = g.HostedTransport().send(
+        g.resolve_room("room-1"), text="other relay", thread="t2", label="Other", event_key="k-other"
+    )
+    # A committed reply to the OTHER discussion (different discussion id AND thread).
+    _member_turn(room, discussion_id=other.message_id, member_id="archie", text="for t2", thread="t2", n=1)
+    # A committed reply whose thread matches ours but belongs to another discussion id.
+    _member_turn(room, discussion_id="user:stale", member_id="archie", text="stale", thread="cli", n=2)
+    # Ours.
+    _member_turn(room, discussion_id=sent.message_id, member_id="archie", text="for us", n=3)
+    _activity(room, discussion_id=sent.message_id)
+    got = []
+    rc, summary = g.HostedTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, t: got.append(t))
+    assert rc == 0 and got == ["for us"]
+    assert [r["text"] for r in summary["replies"]] == ["for us"]
+
+
+def test_wait_rejects_non_positive_poll(home):
+    room = mk_room()
+    sent = _sent(room)
+    for bad in (0, -1):
+        with pytest.raises(g.GroupCLIError, match="--poll"):
+            g.HostedTransport().wait(sent, timeout=1, poll_seconds=bad, on_reply=lambda *a: None)
+
+
 def test_wait_only_settles_on_own_discussion(home):
     room = mk_room()
     sent = _sent(room)
@@ -358,6 +385,7 @@ def test_wait_times_out_with_partial_replies(home):
 
 
 def test_wait_exit_4_when_room_stop_supersedes(home):
+    """A stop fence is room-wide (policy stopped_through_seq), so exit 4 even for a stop aimed elsewhere."""
     room = mk_room()
     sent = _sent(room)
     hosted_rooms.request_room_stop(

--- a/tests/hermes_cli/test_group_cli.py
+++ b/tests/hermes_cli/test_group_cli.py
@@ -11,6 +11,8 @@ from __future__ import annotations
 import argparse
 import io
 import json
+import multiprocessing
+import sys
 
 import pytest
 
@@ -514,6 +516,10 @@ def test_bindings_file_is_bounded_and_survives_corruption(home, monkeypatch):
     assert g.bound_thread(ref, "s9") is None
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32" or "fork" not in multiprocessing.get_all_start_methods(),
+    reason="fork start method required; the flock is a no-op without fcntl anyway",
+)
 def test_bind_thread_is_safe_under_concurrent_writers(home):
     """Many writers, each binding its own session: no binding may be lost."""
     import multiprocessing as mp

--- a/tests/hermes_cli/test_group_cli_desktop.py
+++ b/tests/hermes_cli/test_group_cli_desktop.py
@@ -19,34 +19,34 @@ PROJECTION = textwrap.dedent(
     """\
     ui_meta:
       hermes-bots:
-        title: Pax
+        title: Ada
       hermes-bots-groups:
         version: 3
         updatedAt: 1788476626302
         rooms:
-          id:rmtm1xrg6-f5ljm:
-            name: TraderChat
-            roomId: rmtm1xrg6-f5ljm
+          id:rm-8f2c1a:
+            name: Launchpad
+            roomId: rm-8f2c1a
             log:
               - id: a1
                 from: {kind: user, name: You}
-                text: Good clarification from HL founder
+                text: Kickoff — scope the release
                 at: 1788474195411
-                thread: tmtm3cx5e-h1wzb
+                thread: tmtm-a1
               - id: a2
-                from: {kind: member, name: socrates}
-                text: This is a genuine confirm limb
+                from: {kind: member, name: helper}
+                text: Scoped to two work items
                 at: 1788474200000
-                thread: tmtm3cx5e-h1wzb
+                thread: tmtm-a1
               - id: a3
-                from: {kind: user, name: You, via: Pax via Discord}
+                from: {kind: user, name: You, via: Ada via Discord}
                 text: relayed question
                 at: 1788474300000
                 thread: tmtm9
           name:Legacy Room:
             name: Legacy Room
             log:
-              - from: {kind: member, name: argus}
+              - from: {kind: member, name: ops}
                 text: hi
                 at: 1
     """
@@ -56,7 +56,7 @@ PROJECTION = textwrap.dedent(
 @pytest.fixture
 def home(tmp_path, monkeypatch):
     root = tmp_path / ".hermes"
-    (root / "profiles" / "pax").mkdir(parents=True)
+    (root / "profiles" / "researcher").mkdir(parents=True)
     (root / "profile.yaml").write_text(PROJECTION, encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
@@ -75,14 +75,14 @@ def test_transport_registered_and_lists_desktop_rooms(home, capsys):
     assert [t.kind for t in g.transports()] == ["hosted", "desktop"]
     assert _run(["list", "--json"]) == 0
     rows = {r["name"]: r for r in _out_json(capsys)}
-    assert rows["TraderChat"] == {
+    assert rows["Launchpad"] == {
         "kind": "desktop",
-        "name": "TraderChat",
-        "room_id": "rmtm1xrg6-f5ljm",
-        "members": ["socrates"],
+        "name": "Launchpad",
+        "room_id": "rm-8f2c1a",
+        "members": ["helper"],
         "managed_here": True,
     }
-    assert rows["Legacy Room"]["room_id"] == "Legacy Room" and rows["Legacy Room"]["members"] == ["argus"]
+    assert rows["Legacy Room"]["room_id"] == "Legacy Room" and rows["Legacy Room"]["members"] == ["ops"]
 
 
 def test_projection_missing_or_corrupt_is_empty(home):
@@ -95,30 +95,30 @@ def test_projection_missing_or_corrupt_is_empty(home):
 
 def test_name_collision_across_kinds_requires_kind(home, capsys):
     hosted_rooms.create_room(
-        hosted_rooms.default_db_path(), room_id="h1", name="TraderChat",
-        members=[{"member_id": "pax", "profile": "pax", "handle": "pax"},
+        hosted_rooms.default_db_path(), room_id="h1", name="Launchpad",
+        members=[{"member_id": "researcher", "profile": "researcher", "handle": "researcher"},
                  {"member_id": "default", "profile": "default", "handle": "hermes"}],
         authority_gateway_id=hosted_rooms.local_authority_gateway_id())
-    assert _run(["send", "TraderChat", "hi"]) == 1
+    assert _run(["send", "Launchpad", "hi"]) == 1
     assert "ambiguous" in capsys.readouterr().err
-    assert g.resolve_room("TraderChat", kind="desktop").kind == "desktop"
-    assert g.resolve_room("TraderChat", kind="hosted").kind == "hosted"
-    assert _run(["send", "TraderChat", "hi", "--kind", "desktop", "--json"]) == 0
+    assert g.resolve_room("Launchpad", kind="desktop").kind == "desktop"
+    assert g.resolve_room("Launchpad", kind="hosted").kind == "hosted"
+    assert _run(["send", "Launchpad", "hi", "--kind", "desktop", "--json"]) == 0
     assert _out_json(capsys)["kind"] == "desktop"
 
 
 def test_send_enqueues_envelope_new_thread_by_default(home, capsys, monkeypatch):
-    monkeypatch.setenv("HERMES_PROFILE", "pax")
-    assert _run(["send", "TraderChat", "what now?", "--as", "Pax via Discord", "--json"]) == 0
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    assert _run(["send", "Launchpad", "what now?", "--as", "Ada via Discord", "--json"]) == 0
     out = _out_json(capsys)
     assert out["kind"] == "desktop" and out["seq"] is None
     env = out["raw"]
-    assert env["room_id"] == "rmtm1xrg6-f5ljm" and env["room_name"] == "TraderChat"
-    assert env["text"] == "what now?" and env["label"] == "Pax via Discord" and env["from_profile"] == "pax"
+    assert env["room_id"] == "rm-8f2c1a" and env["room_name"] == "Launchpad"
+    assert env["text"] == "what now?" and env["label"] == "Ada via Discord" and env["from_profile"] == "researcher"
     assert env["thread"] is None  # default 'cli' → new Desktop thread
     assert gr.pending_count(home) == 1
-    assert _run(["send", "TraderChat", "cont", "--thread", "tmtm3cx5e-h1wzb", "--json"]) == 0
-    assert _out_json(capsys)["raw"]["thread"] == "tmtm3cx5e-h1wzb"
+    assert _run(["send", "Launchpad", "cont", "--thread", "tmtm-a1", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["thread"] == "tmtm-a1"
 
 
 def test_send_by_name_only_room_omits_room_id(home, capsys):
@@ -136,26 +136,26 @@ def test_send_fails_fast_when_outbox_is_visibly_undrained(home, capsys, monkeypa
         import os
 
         os.utime(path, (old, old))
-    assert _run(["send", "TraderChat", "hi"]) == 1
+    assert _run(["send", "Launchpad", "hi"]) == 1
     assert "Desktop does not appear to be open" in capsys.readouterr().err
 
 
 def _sent(home):
-    ref = g.resolve_room("TraderChat", kind="desktop")
-    return gd.DesktopTransport().send(ref, text="go", thread="cli", label="Pax", event_key=None)
+    ref = g.resolve_room("Launchpad", kind="desktop")
+    return gd.DesktopTransport().send(ref, text="go", thread="cli", label="Ada", event_key=None)
 
 
 def test_wait_streams_lines_and_maps_done_statuses(home):
     t = gd.DesktopTransport()
     for status, rc in (("settled", 0), ("capped", 0), ("cancelled", 4), ("timeout", 3)):
         sent = _sent(home)
-        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "tmtmNEW", "group": "TraderChat"})
-        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "socrates", "text": "one", "thread": "tmtmNEW"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "tmtmNEW", "group": "Launchpad"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "helper", "text": "one", "thread": "tmtmNEW"})
         gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": status, "replies": 1})
         got = []
         code, summary = t.wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, x: got.append((s, x)))
         assert code == rc, status
-        assert got == [("@socrates", "one")]
+        assert got == [("@helper", "one")]
         assert summary["status"] == status and summary["thread"] == "tmtmNEW"
         assert [r["text"] for r in summary["replies"]] == ["one"]
 
@@ -165,9 +165,9 @@ def test_wait_streams_incrementally_while_lines_arrive(home):
 
     def writer():
         time.sleep(0.05)
-        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "t", "group": "TraderChat"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "t", "group": "Launchpad"})
         time.sleep(0.05)
-        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "argus", "text": "late", "thread": "t"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "ops", "text": "late", "thread": "t"})
         gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": "settled", "replies": 1})
 
     threading.Thread(target=writer, daemon=True).start()
@@ -199,7 +199,7 @@ def test_send_wait_cli_end_to_end(home, capsys):
     result = {}
 
     def cli():
-        result["rc"] = _run(["send", "TraderChat", "go", "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5"])
+        result["rc"] = _run(["send", "Launchpad", "go", "--as", "Ada", "--wait", "--poll", "0.01", "--timeout", "5"])
 
     worker = threading.Thread(target=cli)
     worker.start()
@@ -211,25 +211,25 @@ def test_send_wait_cli_end_to_end(home, capsys):
             env = json.loads(pending[0].read_text())
         else:
             time.sleep(0.01)
-    assert env is not None and env["label"] == "Pax"
+    assert env is not None and env["label"] == "Ada"
     gr.claim_pending(home)
-    gr.append_reply_line(home, env["id"], {"kind": "accepted", "thread": "tmtmX", "group": "TraderChat"})
-    gr.append_reply_line(home, env["id"], {"kind": "reply", "member": "socrates", "text": "done deal", "thread": "tmtmX"})
+    gr.append_reply_line(home, env["id"], {"kind": "accepted", "thread": "tmtmX", "group": "Launchpad"})
+    gr.append_reply_line(home, env["id"], {"kind": "reply", "member": "helper", "text": "done deal", "thread": "tmtmX"})
     gr.append_reply_line(home, env["id"], {"kind": "done", "status": "settled", "replies": 1})
     worker.join(timeout=5)
     assert result["rc"] == 0
     out = capsys.readouterr().out
-    assert "@socrates: done deal" in out and "[group TraderChat: settled (settled), 1 replies]" in out
+    assert "@helper: done deal" in out and "[group Launchpad: settled (settled), 1 replies]" in out
 
 
 def test_log_renders_projection_with_via(home, capsys):
-    assert _run(["log", "TraderChat", "--json"]) == 0
+    assert _run(["log", "Launchpad", "--json"]) == 0
     rows = _out_json(capsys)
     assert [(r["speaker"], r["text"]) for r in rows] == [
-        ("User (You)", "Good clarification from HL founder"),
-        ("@socrates", "This is a genuine confirm limb"),
-        ("User (Pax via Discord)", "relayed question"),
+        ("User (You)", "Kickoff — scope the release"),
+        ("@helper", "Scoped to two work items"),
+        ("User (Ada via Discord)", "relayed question"),
     ]
     assert rows[2]["thread"] == "tmtm9"
-    assert _run(["log", "TraderChat", "--since", "2"]) == 0
-    assert capsys.readouterr().out.strip() == "User (Pax via Discord): relayed question"
+    assert _run(["log", "Launchpad", "--since", "2"]) == 0
+    assert capsys.readouterr().out.strip() == "User (Ada via Discord): relayed question"

--- a/tests/hermes_cli/test_group_cli_desktop.py
+++ b/tests/hermes_cli/test_group_cli_desktop.py
@@ -233,3 +233,15 @@ def test_log_renders_projection_with_via(home, capsys):
     assert rows[2]["thread"] == "tmtm9"
     assert _run(["log", "Launchpad", "--since", "2"]) == 0
     assert capsys.readouterr().out.strip() == "User (Ada via Discord): relayed question"
+
+
+def test_send_event_id_is_idempotent_for_desktop_rooms(home, capsys):
+    assert _run(["send", "Launchpad", "once", "--event-id", "k1", "--json"]) == 0
+    first = _out_json(capsys)
+    assert _run(["send", "Launchpad", "once", "--event-id", "k1", "--json"]) == 0
+    again = _out_json(capsys)
+    assert first["message_id"] == again["message_id"] == gr.envelope_id_for_key("k1")
+    assert gr.pending_count(home) == 1
+    assert _run(["send", "Launchpad", "different", "--event-id", "k1"]) == 1
+    assert "different content" in capsys.readouterr().err
+    assert gr.pending_count(home) == 1

--- a/tests/hermes_cli/test_group_cli_desktop.py
+++ b/tests/hermes_cli/test_group_cli_desktop.py
@@ -245,3 +245,15 @@ def test_send_event_id_is_idempotent_for_desktop_rooms(home, capsys):
     assert _run(["send", "Launchpad", "different", "--event-id", "k1"]) == 1
     assert "different content" in capsys.readouterr().err
     assert gr.pending_count(home) == 1
+
+
+def test_wait_with_event_id_skips_the_receipt_line(home):
+    ref = g.resolve_room("Launchpad", kind="desktop")
+    t = gd.DesktopTransport()
+    sent = t.send(ref, text="go", thread="cli", label="Ada", event_key="keyed")
+    gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "t", "group": "Launchpad"})
+    gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "helper", "text": "ok", "thread": "t"})
+    gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": "settled", "replies": 1})
+    got = []
+    rc, summary = t.wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, x: got.append(x))
+    assert rc == 0 and got == ["ok"] and summary["thread"] == "t"

--- a/tests/hermes_cli/test_group_cli_desktop.py
+++ b/tests/hermes_cli/test_group_cli_desktop.py
@@ -1,0 +1,235 @@
+"""Behavior contract for the Desktop-room transport of ``hermes group``
+(hermes_cli/subcommands/group_desktop.py) — envelope out, JSONL lines in."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+import threading
+import time
+
+import pytest
+
+from gateway import hosted_rooms
+from hermes_cli.subcommands import group as g
+from hermes_cli.subcommands import group_desktop as gd
+from tools import group_relay as gr
+
+PROJECTION = textwrap.dedent(
+    """\
+    ui_meta:
+      hermes-bots:
+        title: Pax
+      hermes-bots-groups:
+        version: 3
+        updatedAt: 1788476626302
+        rooms:
+          id:rmtm1xrg6-f5ljm:
+            name: TraderChat
+            roomId: rmtm1xrg6-f5ljm
+            log:
+              - id: a1
+                from: {kind: user, name: You}
+                text: Good clarification from HL founder
+                at: 1788474195411
+                thread: tmtm3cx5e-h1wzb
+              - id: a2
+                from: {kind: member, name: socrates}
+                text: This is a genuine confirm limb
+                at: 1788474200000
+                thread: tmtm3cx5e-h1wzb
+              - id: a3
+                from: {kind: user, name: You, via: Pax via Discord}
+                text: relayed question
+                at: 1788474300000
+                thread: tmtm9
+          name:Legacy Room:
+            name: Legacy Room
+            log:
+              - from: {kind: member, name: argus}
+                text: hi
+                at: 1
+    """
+)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    (root / "profiles" / "pax").mkdir(parents=True)
+    (root / "profile.yaml").write_text(PROJECTION, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    return root
+
+
+def _run(argv):
+    return g.cmd_group(g.build_args(argv))
+
+
+def _out_json(capsys):
+    return json.loads(capsys.readouterr().out)
+
+
+def test_transport_registered_and_lists_desktop_rooms(home, capsys):
+    assert [t.kind for t in g.transports()] == ["hosted", "desktop"]
+    assert _run(["list", "--json"]) == 0
+    rows = {r["name"]: r for r in _out_json(capsys)}
+    assert rows["TraderChat"] == {
+        "kind": "desktop",
+        "name": "TraderChat",
+        "room_id": "rmtm1xrg6-f5ljm",
+        "members": ["socrates"],
+        "managed_here": True,
+    }
+    assert rows["Legacy Room"]["room_id"] == "Legacy Room" and rows["Legacy Room"]["members"] == ["argus"]
+
+
+def test_projection_missing_or_corrupt_is_empty(home):
+    (home / "profile.yaml").write_text("ui_meta: [not, a, map]\n")
+    assert gd.read_projection(home) == {}
+    (home / "profile.yaml").unlink()
+    assert gd.read_projection(home) == {}
+    assert gd.DesktopTransport().list_rooms() == []
+
+
+def test_name_collision_across_kinds_requires_kind(home, capsys):
+    hosted_rooms.create_room(
+        hosted_rooms.default_db_path(), room_id="h1", name="TraderChat",
+        members=[{"member_id": "pax", "profile": "pax", "handle": "pax"},
+                 {"member_id": "default", "profile": "default", "handle": "hermes"}],
+        authority_gateway_id=hosted_rooms.local_authority_gateway_id())
+    assert _run(["send", "TraderChat", "hi"]) == 1
+    assert "ambiguous" in capsys.readouterr().err
+    assert g.resolve_room("TraderChat", kind="desktop").kind == "desktop"
+    assert g.resolve_room("TraderChat", kind="hosted").kind == "hosted"
+    assert _run(["send", "TraderChat", "hi", "--kind", "desktop", "--json"]) == 0
+    assert _out_json(capsys)["kind"] == "desktop"
+
+
+def test_send_enqueues_envelope_new_thread_by_default(home, capsys, monkeypatch):
+    monkeypatch.setenv("HERMES_PROFILE", "pax")
+    assert _run(["send", "TraderChat", "what now?", "--as", "Pax via Discord", "--json"]) == 0
+    out = _out_json(capsys)
+    assert out["kind"] == "desktop" and out["seq"] is None
+    env = out["raw"]
+    assert env["room_id"] == "rmtm1xrg6-f5ljm" and env["room_name"] == "TraderChat"
+    assert env["text"] == "what now?" and env["label"] == "Pax via Discord" and env["from_profile"] == "pax"
+    assert env["thread"] is None  # default 'cli' → new Desktop thread
+    assert gr.pending_count(home) == 1
+    assert _run(["send", "TraderChat", "cont", "--thread", "tmtm3cx5e-h1wzb", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["thread"] == "tmtm3cx5e-h1wzb"
+
+
+def test_send_by_name_only_room_omits_room_id(home, capsys):
+    assert _run(["send", "Legacy Room", "x", "--json"]) == 0
+    env = _out_json(capsys)["raw"]
+    assert env["room_id"] == "" and env["room_name"] == "Legacy Room"
+
+
+def test_send_fails_fast_when_outbox_is_visibly_undrained(home, capsys, monkeypatch):
+    monkeypatch.setattr(gd, "_STALE_OUTBOX_MAX_PENDING", 2)
+    for _ in range(2):
+        env = gr.enqueue(home, room_id="r", room_name="n", text="t", from_profile="p", label="l")
+        path = gr.relay_root(home) / gr.OUTBOX_DIR / f"{env['id']}.json"
+        old = time.time() - 600
+        import os
+
+        os.utime(path, (old, old))
+    assert _run(["send", "TraderChat", "hi"]) == 1
+    assert "Desktop does not appear to be open" in capsys.readouterr().err
+
+
+def _sent(home):
+    ref = g.resolve_room("TraderChat", kind="desktop")
+    return gd.DesktopTransport().send(ref, text="go", thread="cli", label="Pax", event_key=None)
+
+
+def test_wait_streams_lines_and_maps_done_statuses(home):
+    t = gd.DesktopTransport()
+    for status, rc in (("settled", 0), ("capped", 0), ("cancelled", 4), ("timeout", 3)):
+        sent = _sent(home)
+        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "tmtmNEW", "group": "TraderChat"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "socrates", "text": "one", "thread": "tmtmNEW"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": status, "replies": 1})
+        got = []
+        code, summary = t.wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, x: got.append((s, x)))
+        assert code == rc, status
+        assert got == [("@socrates", "one")]
+        assert summary["status"] == status and summary["thread"] == "tmtmNEW"
+        assert [r["text"] for r in summary["replies"]] == ["one"]
+
+
+def test_wait_streams_incrementally_while_lines_arrive(home):
+    sent = _sent(home)
+
+    def writer():
+        time.sleep(0.05)
+        gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "t", "group": "TraderChat"})
+        time.sleep(0.05)
+        gr.append_reply_line(home, sent.message_id, {"kind": "reply", "member": "argus", "text": "late", "thread": "t"})
+        gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": "settled", "replies": 1})
+
+    threading.Thread(target=writer, daemon=True).start()
+    got = []
+    code, _ = gd.DesktopTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, x: got.append(x))
+    assert code == 0 and got == ["late"]
+
+
+def test_wait_error_line_raises_clean_error(home):
+    sent = _sent(home)
+    gr.append_reply_line(home, sent.message_id, {"kind": "error", "reason": "room_not_found", "error": "no such room"})
+    with pytest.raises(g.GroupCLIError, match=r"no such room \[reason: room_not_found\]"):
+        gd.DesktopTransport().wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: None)
+
+
+def test_wait_timeout_and_warning(home, capsys, monkeypatch):
+    monkeypatch.setattr(gd, "_DESKTOP_WARN_AFTER_SECONDS", 0.0)
+    sent = _sent(home)
+    code, summary = gd.DesktopTransport().wait(sent, timeout=0.05, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert code == 3 and summary["status"] == "timeout"
+    assert capsys.readouterr().err.count("Desktop hasn't picked this up") == 1
+    with pytest.raises(g.GroupCLIError, match="--poll"):
+        gd.DesktopTransport().wait(sent, timeout=1, poll_seconds=0, on_reply=lambda *a: None)
+
+
+def test_send_wait_cli_end_to_end(home, capsys):
+    # Pre-stage the reply file is impossible before the id exists, so run
+    # the CLI in a thread and answer it from the outbox.
+    result = {}
+
+    def cli():
+        result["rc"] = _run(["send", "TraderChat", "go", "--as", "Pax", "--wait", "--poll", "0.01", "--timeout", "5"])
+
+    worker = threading.Thread(target=cli)
+    worker.start()
+    deadline = time.time() + 3
+    env = None
+    while time.time() < deadline and env is None:
+        pending = list((gr.relay_root(home) / gr.OUTBOX_DIR).glob("*.json"))
+        if pending:
+            env = json.loads(pending[0].read_text())
+        else:
+            time.sleep(0.01)
+    assert env is not None and env["label"] == "Pax"
+    gr.claim_pending(home)
+    gr.append_reply_line(home, env["id"], {"kind": "accepted", "thread": "tmtmX", "group": "TraderChat"})
+    gr.append_reply_line(home, env["id"], {"kind": "reply", "member": "socrates", "text": "done deal", "thread": "tmtmX"})
+    gr.append_reply_line(home, env["id"], {"kind": "done", "status": "settled", "replies": 1})
+    worker.join(timeout=5)
+    assert result["rc"] == 0
+    out = capsys.readouterr().out
+    assert "@socrates: done deal" in out and "[group TraderChat: settled (settled), 1 replies]" in out
+
+
+def test_log_renders_projection_with_via(home, capsys):
+    assert _run(["log", "TraderChat", "--json"]) == 0
+    rows = _out_json(capsys)
+    assert [(r["speaker"], r["text"]) for r in rows] == [
+        ("User (You)", "Good clarification from HL founder"),
+        ("@socrates", "This is a genuine confirm limb"),
+        ("User (Pax via Discord)", "relayed question"),
+    ]
+    assert rows[2]["thread"] == "tmtm9"
+    assert _run(["log", "TraderChat", "--since", "2"]) == 0
+    assert capsys.readouterr().out.strip() == "User (Pax via Discord): relayed question"

--- a/tests/hermes_cli/test_group_cli_desktop.py
+++ b/tests/hermes_cli/test_group_cli_desktop.py
@@ -60,6 +60,7 @@ def home(tmp_path, monkeypatch):
     (root / "profile.yaml").write_text(PROJECTION, encoding="utf-8")
     monkeypatch.setenv("HERMES_HOME", str(root))
     monkeypatch.delenv("HERMES_PROFILE", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_ID", raising=False)
     return root
 
 
@@ -257,3 +258,92 @@ def test_wait_with_event_id_skips_the_receipt_line(home):
     got = []
     rc, summary = t.wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda s, x: got.append(x))
     assert rc == 0 and got == ["ok"] and summary["thread"] == "t"
+
+
+def test_desktop_thread_binds_on_accept_and_continues_per_session(home, capsys, monkeypatch):
+    """First send from a session mints (thread None); --wait learns the minted id
+    from the accepted line and binds it; the next send from the same session
+    continues it; another session mints again; --new-thread mints again."""
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-A")
+    ref = g.resolve_room("Launchpad", kind="desktop")
+    t = gd.DesktopTransport()
+
+    # Drive the transport directly for the --wait leg (no capsys/thread mixing).
+    sent = t.send(ref, text="first", thread=g.DEFAULT_THREAD, label="Ada", event_key=None)
+    assert sent.raw["thread"] is None
+    gr.claim_pending(home)
+    gr.append_reply_line(home, sent.message_id, {"kind": "accepted", "thread": "tmtm-minted-1", "group": "Launchpad"})
+    gr.append_reply_line(home, sent.message_id, {"kind": "done", "status": "settled", "replies": 0})
+    rc, summary = t.wait(sent, timeout=5, poll_seconds=0.01, on_reply=lambda *a: None)
+    assert rc == 0 and summary["thread"] == "tmtm-minted-1"
+    g.bind_thread(ref, "sess-A", summary["thread"])  # what _cmd_send does after wait
+
+    # Same session: the CLI now requests the minted thread.
+    assert _run(["send", "Launchpad", "second", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["thread"] == "tmtm-minted-1"
+
+    # Different session: mints again.
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-B")
+    assert _run(["send", "Launchpad", "other", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["thread"] is None
+
+    # Back to A with --new-thread: binding dropped, mints again.
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-A")
+    assert _run(["send", "Launchpad", "restart", "--new-thread", "--json"]) == 0
+    assert _out_json(capsys)["raw"]["thread"] is None
+    assert g.bound_thread(ref, "sess-A") is None
+
+
+def test_desktop_cli_wait_binds_thread_end_to_end(home, capsys, monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_ID", "sess-E2E")
+    result = {}
+
+    def cli():
+        result["rc"] = _run(["send", "Launchpad", "first", "--wait", "--poll", "0.01", "--timeout", "5"])
+
+    w = threading.Thread(target=cli)
+    w.start()
+    deadline = time.time() + 3
+    env = None
+    while time.time() < deadline and env is None:
+        pending = list((gr.relay_root(home) / gr.OUTBOX_DIR).glob("*.json"))
+        if pending:
+            env = json.loads(pending[0].read_text())
+        else:
+            time.sleep(0.01)
+    assert env is not None and env["thread"] is None
+    gr.claim_pending(home)
+    gr.append_reply_line(home, env["id"], {"kind": "accepted", "thread": "tmtm-e2e", "group": "Launchpad"})
+    gr.append_reply_line(home, env["id"], {"kind": "done", "status": "settled", "replies": 0})
+    w.join(5)
+    assert result["rc"] == 0
+    capsys.readouterr()
+    assert g.bound_thread(g.resolve_room("Launchpad", kind="desktop"), "sess-E2E") == "tmtm-e2e"
+
+
+def test_desktop_explicit_thread_wait_does_not_rebind_session(home, monkeypatch):
+    monkeypatch.setenv("HERMES_SESSION_ID", "S")
+    ref = g.resolve_room("Launchpad", kind="desktop")
+    g.bind_thread(ref, "S", "tmtm-own")
+    result = {}
+
+    def cli():
+        result["rc"] = _run(["send", "Launchpad", "one-off", "--thread", "tmtm-a1", "--wait", "--poll", "0.01", "--timeout", "5"])
+
+    w = threading.Thread(target=cli)
+    w.start()
+    deadline = time.time() + 3
+    env = None
+    while time.time() < deadline and env is None:
+        pending = list((gr.relay_root(home) / gr.OUTBOX_DIR).glob("*.json"))
+        if pending:
+            env = json.loads(pending[0].read_text())
+        else:
+            time.sleep(0.01)
+    assert env["thread"] == "tmtm-a1"
+    gr.claim_pending(home)
+    gr.append_reply_line(home, env["id"], {"kind": "accepted", "thread": "tmtm-a1", "group": "Launchpad"})
+    gr.append_reply_line(home, env["id"], {"kind": "done", "status": "settled", "replies": 0})
+    w.join(5)
+    assert result["rc"] == 0
+    assert g.bound_thread(ref, "S") == "tmtm-own"

--- a/tests/tools/test_group_relay.py
+++ b/tests/tools/test_group_relay.py
@@ -180,3 +180,40 @@ def test_no_event_key_means_fresh_envelope_each_time(root):
     kw = dict(room_id="r", room_name="n", text="x", from_profile="p", label="l")
     a, b = gr.enqueue(root, **kw), gr.enqueue(root, **kw)
     assert a["id"] != b["id"] and "event_key" not in a and gr.pending_count(root) == 2
+
+
+def test_keyed_enqueue_recovers_from_crash_between_receipt_and_outbox(root, monkeypatch):
+    """Receipt written, outbox write never happened (crash): a retry must re-queue, same id."""
+    kw = dict(room_id="r", room_name="n", text="once", from_profile="p", label="l", event_key="k1")
+    real = gr._atomic_write_json
+
+    def crash(*args, **kwargs):
+        raise OSError("disk went away")
+
+    monkeypatch.setattr(gr, "_atomic_write_json", crash)
+    with pytest.raises(OSError):
+        gr.enqueue(root, **kw)
+    expected = gr.envelope_id_for_key("k1")
+    assert gr._receipt_from_replies(gr.relay_root(root), expected) is not None
+    assert gr.pending_count(root) == 0
+    monkeypatch.setattr(gr, "_atomic_write_json", real)
+    recovered = gr.enqueue(root, **kw)
+    assert recovered["id"] == expected and gr.pending_count(root) == 1
+    # Only one receipt line was written; the retry did not duplicate it.
+    lines, _ = gr.read_reply_lines(root, expected)
+    assert [l["kind"] for l in lines] == ["receipt"]
+    # And a conflicting retry in that same crashed state still fails closed.
+    (gr.relay_root(root) / gr.OUTBOX_DIR / f"{expected}.json").unlink()
+    with pytest.raises(gr.GroupRelayConflictError):
+        gr.enqueue(root, **{**kw, "text": "twice"})
+    assert gr.pending_count(root) == 0
+
+
+def test_keyed_enqueue_does_not_requeue_once_desktop_accepted(root):
+    kw = dict(room_id="r", room_name="n", text="once", from_profile="p", label="l", event_key="k2")
+    first = gr.enqueue(root, **kw)
+    gr.claim_pending(root)
+    (gr.relay_root(root) / gr.CLAIMED_DIR / f"{first['id']}.json").unlink()
+    gr.append_reply_line(root, first["id"], {"kind": "accepted", "thread": "t", "group": "n"})
+    assert gr.enqueue(root, **kw)["id"] == first["id"]
+    assert gr.pending_count(root) == 0

--- a/tests/tools/test_group_relay.py
+++ b/tests/tools/test_group_relay.py
@@ -149,11 +149,31 @@ def test_event_key_is_idempotent_and_conflict_checked(root):
     assert [e["id"] for e in gr.claim_pending(root)] == [first["id"]]
     assert gr.enqueue(root, **kw)["id"] == first["id"]
     assert gr.pending_count(root) == 0
-    # Same key after claimed/ was swept but the reply file exists: still no re-queue.
+    # Same key after claimed/ was swept: the receipt at the head of the reply
+    # file still answers — same content → same id, nothing re-queued.
     (gr.relay_root(root) / gr.CLAIMED_DIR / f"{first['id']}.json").unlink()
     gr.append_reply_line(root, first["id"], {"kind": "done", "status": "settled", "replies": 0})
     assert gr.enqueue(root, **kw)["id"] == first["id"]
     assert gr.pending_count(root) == 0
+
+
+@pytest.mark.parametrize("field,value", [("text", "twice"), ("room_id", "r2"), ("room_name", "n2"), ("thread", "other")])
+def test_event_key_conflict_survives_sweep_of_claimed_envelope(root, field, value):
+    kw = dict(room_id="r", room_name="n", text="once", from_profile="p", label="l", event_key="k1", thread=None)
+    first = gr.enqueue(root, **kw)
+    lines, _ = gr.read_reply_lines(root, first["id"])
+    assert lines[0] == {**lines[0], "kind": "receipt", "room_id": "r", "room_name": "n", "thread": None, "text": "once"}
+    gr.claim_pending(root)
+    (gr.relay_root(root) / gr.CLAIMED_DIR / f"{first['id']}.json").unlink()
+    gr.append_reply_line(root, first["id"], {"kind": "done", "status": "settled", "replies": 0})
+    with pytest.raises(gr.GroupRelayConflictError, match="different content"):
+        gr.enqueue(root, **{**kw, field: value})
+    assert gr.pending_count(root) == 0
+
+
+def test_receipt_is_ignored_by_readers_without_a_key(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="x", from_profile="p", label="l")
+    assert gr.read_reply_lines(root, env["id"]) == ([], 0)  # no receipt without a key
 
 
 def test_no_event_key_means_fresh_envelope_each_time(root):

--- a/tests/tools/test_group_relay.py
+++ b/tests/tools/test_group_relay.py
@@ -1,0 +1,135 @@
+"""Tests: tools/group_relay.py — the file store between `hermes group send`
+and the Desktop for Desktop-coordinated Group Chats."""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import pytest
+
+from tools import group_relay as gr
+
+
+@pytest.fixture
+def root(tmp_path):
+    return tmp_path / ".hermes"
+
+
+def test_enqueue_writes_envelope_atomically(root):
+    env = gr.enqueue(
+        root, room_id="rm-1", room_name="TraderChat", text="  hello  ",
+        from_profile="pax", label="Pax via Discord", thread=None,
+    )
+    assert len(env["id"]) == 32 and env["text"] == "hello" and env["thread"] is None
+    path = gr.relay_root(root) / gr.OUTBOX_DIR / f"{env['id']}.json"
+    assert json.loads(path.read_text()) == env
+    assert not list((gr.relay_root(root) / gr.OUTBOX_DIR).glob(".env-*"))  # no temp leftovers
+    assert gr.pending_count(root) == 1
+
+
+def test_enqueue_validation(root):
+    with pytest.raises(gr.GroupRelayError, match="text"):
+        gr.enqueue(root, room_id="r", room_name="n", text="  ", from_profile="p", label="l")
+    with pytest.raises(gr.GroupRelayError, match="room"):
+        gr.enqueue(root, room_id="", room_name="", text="x", from_profile="p", label="l")
+    with pytest.raises(gr.GroupRelayError, match="too long"):
+        gr.enqueue(root, room_id="r", room_name="n", text="x" * (gr.MAX_TEXT_CHARS + 1), from_profile="p", label="l")
+    with pytest.raises(gr.GroupRelayError, match="label"):
+        gr.enqueue(root, room_id="r", room_name="n", text="x", from_profile="p", label="l" * 201)
+
+
+def test_claim_pending_is_exactly_once_and_ordered(root):
+    a = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    b = gr.enqueue(root, room_id="r", room_name="n", text="b", from_profile="p", label="l")
+    first = gr.claim_pending(root)
+    assert sorted(e["id"] for e in first) == sorted([a["id"], b["id"]])
+    assert gr.claim_pending(root) == []
+    assert gr.pending_count(root) == 0
+    assert (gr.relay_root(root) / gr.CLAIMED_DIR / f"{a['id']}.json").exists()
+
+
+def test_claim_expires_stale_envelopes_with_error_line(root):
+    env = gr.enqueue(root, room_id="r", room_name="TraderChat", text="a", from_profile="p", label="l")
+    path = gr.relay_root(root) / gr.OUTBOX_DIR / f"{env['id']}.json"
+    stale = {**env, "created_at": int(time.time()) - 3600}
+    path.write_text(json.dumps(stale))
+    assert gr.claim_pending(root, ttl_seconds=60) == []
+    assert not path.exists()
+    lines, _ = gr.read_reply_lines(root, env["id"])
+    assert lines[0]["kind"] == "error" and lines[0]["reason"] == "queued_expired"
+    assert "TraderChat" in lines[0]["error"]
+
+
+def test_claim_ttl_zero_never_expires(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    path = gr.relay_root(root) / gr.OUTBOX_DIR / f"{env['id']}.json"
+    path.write_text(json.dumps({**env, "created_at": 1}))
+    assert [e["id"] for e in gr.claim_pending(root, ttl_seconds=0)] == [env["id"]]
+
+
+def test_reply_lines_append_and_incremental_read(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    gr.append_reply_line(root, env["id"], {"kind": "accepted", "thread": "tmtm1"})
+    lines, off = gr.read_reply_lines(root, env["id"])
+    assert [l["kind"] for l in lines] == ["accepted"] and lines[0]["thread"] == "tmtm1" and off > 0
+    gr.append_reply_line(root, env["id"], {"kind": "reply", "member": "socrates", "text": "hi"})
+    gr.append_reply_line(root, env["id"], {"kind": "done", "status": "settled", "replies": 1})
+    more, off2 = gr.read_reply_lines(root, env["id"], offset=off)
+    assert [l["kind"] for l in more] == ["reply", "done"] and off2 > off
+    assert gr.read_reply_lines(root, env["id"], offset=off2) == ([], off2)
+    assert all(l["id"] == env["id"] and isinstance(l["at"], int) for l in lines + more)
+
+
+def test_reply_lines_skip_partial_trailing_line(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    gr.append_reply_line(root, env["id"], {"kind": "accepted", "thread": "t"})
+    path = gr.relay_root(root) / gr.REPLIES_DIR / f"{env['id']}.jsonl"
+    with open(path, "ab") as fh:
+        fh.write(b'{"kind": "reply", "text": "half')  # no newline yet
+    lines, off = gr.read_reply_lines(root, env["id"])
+    assert [l["kind"] for l in lines] == ["accepted"]
+    with open(path, "ab") as fh:
+        fh.write(b'"}\n')
+    more, _ = gr.read_reply_lines(root, env["id"], offset=off)
+    assert more[0]["text"] == "half"
+
+
+def test_reply_line_validation(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    with pytest.raises(gr.GroupRelayError, match="kind"):
+        gr.append_reply_line(root, env["id"], {"kind": "nope"})
+    with pytest.raises(gr.GroupRelayError, match="status"):
+        gr.append_reply_line(root, env["id"], {"kind": "done", "status": "weird"})
+    with pytest.raises(gr.GroupRelayError, match="text"):
+        gr.append_reply_line(root, env["id"], {"kind": "reply", "member": "x", "text": " "})
+    with pytest.raises(gr.GroupRelayError, match="invalid group relay id"):
+        gr.append_reply_line(root, "../../etc/passwd", {"kind": "accepted"})
+    with pytest.raises(gr.GroupRelayError):
+        gr.read_reply_lines(root, "not-hex")
+    assert gr.read_reply_lines(root, "0" * 32) == ([], 0)
+
+
+def test_reply_file_mode_is_private(root):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    path = gr.append_reply_line(root, env["id"], {"kind": "accepted", "thread": "t"})
+    assert oct(path.stat().st_mode & 0o777) == "0o600"
+
+
+def test_sweep_and_cleanup_hook(root, monkeypatch):
+    env = gr.enqueue(root, room_id="r", room_name="n", text="a", from_profile="p", label="l")
+    gr.append_reply_line(root, env["id"], {"kind": "accepted", "thread": "t"})
+    old = time.time() - gr.STALE_AFTER_SECONDS - 10
+    for path in gr.relay_root(root).rglob("*.json*"):
+        os.utime(path, (old, old))
+    monkeypatch.setenv("HERMES_HOME", str(root))
+    assert gr.cleanup_group_relay_artifacts() == 2
+    assert gr.pending_count(root) == 0
+
+
+def test_gateway_root_resolves_profile_home_to_machine_root(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "pax"))
+    assert gr.gateway_root() == tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    assert gr.gateway_root() == tmp_path / ".hermes"

--- a/tests/tools/test_group_relay.py
+++ b/tests/tools/test_group_relay.py
@@ -133,3 +133,30 @@ def test_gateway_root_resolves_profile_home_to_machine_root(tmp_path, monkeypatc
     assert gr.gateway_root() == tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     assert gr.gateway_root() == tmp_path / ".hermes"
+
+
+def test_event_key_is_idempotent_and_conflict_checked(root):
+    kw = dict(room_id="r", room_name="n", text="once", from_profile="p", label="l", event_key="k1")
+    first = gr.enqueue(root, **kw)
+    assert first["id"] == gr.envelope_id_for_key("k1") and first["event_key"] == "k1"
+    assert gr.enqueue(root, **kw) == first
+    assert gr.pending_count(root) == 1  # no duplicate envelope
+    with pytest.raises(gr.GroupRelayConflictError, match="different content"):
+        gr.enqueue(root, **{**kw, "text": "twice"})
+    with pytest.raises(gr.GroupRelayConflictError):
+        gr.enqueue(root, **{**kw, "thread": "other"})
+    # Same key after the Desktop claimed it: still the same envelope, nothing re-queued.
+    assert [e["id"] for e in gr.claim_pending(root)] == [first["id"]]
+    assert gr.enqueue(root, **kw)["id"] == first["id"]
+    assert gr.pending_count(root) == 0
+    # Same key after claimed/ was swept but the reply file exists: still no re-queue.
+    (gr.relay_root(root) / gr.CLAIMED_DIR / f"{first['id']}.json").unlink()
+    gr.append_reply_line(root, first["id"], {"kind": "done", "status": "settled", "replies": 0})
+    assert gr.enqueue(root, **kw)["id"] == first["id"]
+    assert gr.pending_count(root) == 0
+
+
+def test_no_event_key_means_fresh_envelope_each_time(root):
+    kw = dict(room_id="r", room_name="n", text="x", from_profile="p", label="l")
+    a, b = gr.enqueue(root, **kw), gr.enqueue(root, **kw)
+    assert a["id"] != b["id"] and "event_key" not in a and gr.pending_count(root) == 2

--- a/tests/tools/test_group_relay.py
+++ b/tests/tools/test_group_relay.py
@@ -19,8 +19,8 @@ def root(tmp_path):
 
 def test_enqueue_writes_envelope_atomically(root):
     env = gr.enqueue(
-        root, room_id="rm-1", room_name="TraderChat", text="  hello  ",
-        from_profile="pax", label="Pax via Discord", thread=None,
+        root, room_id="rm-1", room_name="Launchpad", text="  hello  ",
+        from_profile="researcher", label="Ada via Discord", thread=None,
     )
     assert len(env["id"]) == 32 and env["text"] == "hello" and env["thread"] is None
     path = gr.relay_root(root) / gr.OUTBOX_DIR / f"{env['id']}.json"
@@ -51,7 +51,7 @@ def test_claim_pending_is_exactly_once_and_ordered(root):
 
 
 def test_claim_expires_stale_envelopes_with_error_line(root):
-    env = gr.enqueue(root, room_id="r", room_name="TraderChat", text="a", from_profile="p", label="l")
+    env = gr.enqueue(root, room_id="r", room_name="Launchpad", text="a", from_profile="p", label="l")
     path = gr.relay_root(root) / gr.OUTBOX_DIR / f"{env['id']}.json"
     stale = {**env, "created_at": int(time.time()) - 3600}
     path.write_text(json.dumps(stale))
@@ -59,7 +59,7 @@ def test_claim_expires_stale_envelopes_with_error_line(root):
     assert not path.exists()
     lines, _ = gr.read_reply_lines(root, env["id"])
     assert lines[0]["kind"] == "error" and lines[0]["reason"] == "queued_expired"
-    assert "TraderChat" in lines[0]["error"]
+    assert "Launchpad" in lines[0]["error"]
 
 
 def test_claim_ttl_zero_never_expires(root):
@@ -74,7 +74,7 @@ def test_reply_lines_append_and_incremental_read(root):
     gr.append_reply_line(root, env["id"], {"kind": "accepted", "thread": "tmtm1"})
     lines, off = gr.read_reply_lines(root, env["id"])
     assert [l["kind"] for l in lines] == ["accepted"] and lines[0]["thread"] == "tmtm1" and off > 0
-    gr.append_reply_line(root, env["id"], {"kind": "reply", "member": "socrates", "text": "hi"})
+    gr.append_reply_line(root, env["id"], {"kind": "reply", "member": "helper", "text": "hi"})
     gr.append_reply_line(root, env["id"], {"kind": "done", "status": "settled", "replies": 1})
     more, off2 = gr.read_reply_lines(root, env["id"], offset=off)
     assert [l["kind"] for l in more] == ["reply", "done"] and off2 > off
@@ -129,7 +129,7 @@ def test_sweep_and_cleanup_hook(root, monkeypatch):
 
 
 def test_gateway_root_resolves_profile_home_to_machine_root(tmp_path, monkeypatch):
-    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "pax"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "researcher"))
     assert gr.gateway_root() == tmp_path / ".hermes"
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
     assert gr.gateway_root() == tmp_path / ".hermes"

--- a/tests/tui_gateway/test_group_relay_methods.py
+++ b/tests/tui_gateway/test_group_relay_methods.py
@@ -1,0 +1,67 @@
+"""Tests: group_relay.* JSON-RPC handlers (tui_gateway/methods_group_relay.py)."""
+
+from __future__ import annotations
+
+import pytest
+
+import tui_gateway.server as srv
+from tools import group_relay as gr
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    h = tmp_path / ".hermes"
+    (h / "profiles" / "pax").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    return h
+
+
+def _result(envelope):
+    assert "error" not in envelope, envelope
+    return envelope["result"]
+
+
+def test_drain_returns_each_envelope_once(home):
+    env = gr.enqueue(home, room_id="rm", room_name="TraderChat", text="t", from_profile="pax", label="L")
+    first = _result(srv._methods["group_relay.outbox.drain"](1, {}))
+    assert [e["id"] for e in first["envelopes"]] == [env["id"]]
+    assert _result(srv._methods["group_relay.outbox.drain"](2, {}))["envelopes"] == []
+
+
+def test_drain_uses_machine_root_from_profile_home(tmp_path, monkeypatch):
+    root = tmp_path / ".hermes"
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "pax"))
+    env = gr.enqueue(root, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    got = _result(srv._methods["group_relay.outbox.drain"](1, {}))
+    assert [e["id"] for e in got["envelopes"]] == [env["id"]]
+
+
+def test_reply_appends_lines_and_rejects_bad_input(home):
+    env = gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    assert _result(srv._methods["group_relay.reply"](1, {"id": env["id"], "line": {"kind": "accepted", "thread": "x"}}))["ok"]
+    assert _result(srv._methods["group_relay.reply"](2, {"id": env["id"], "line": {"kind": "reply", "member": "a", "text": "hi"}}))["ok"]
+    lines, _ = gr.read_reply_lines(home, env["id"])
+    assert [l["kind"] for l in lines] == ["accepted", "reply"]
+
+    bad_id = srv._methods["group_relay.reply"](3, {"id": "../x", "line": {"kind": "accepted"}})
+    assert bad_id["error"]["code"] == 4096
+    not_obj = srv._methods["group_relay.reply"](4, {"id": env["id"], "line": "nope"})
+    assert not_obj["error"]["code"] == 4095
+    bad_kind = srv._methods["group_relay.reply"](5, {"id": env["id"], "line": {"kind": "zzz"}})
+    assert bad_kind["error"]["code"] == 4096
+
+
+def test_change_watch_registered():
+    assert "group_relay.outbox.pending" in srv._CHANGE_WATCHES
+    assert "group_relay.outbox.drain" in srv._methods and "group_relay.reply" in srv._methods
+
+
+def test_outbox_signature_is_monotone(home, monkeypatch):
+    monkeypatch.setattr(srv, "_watcher_home", lambda: home)
+    monkeypatch.setattr(srv, "_group_relay_outbox_seen", 0)
+    assert srv._group_relay_outbox_sig() is None
+    gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    first = srv._group_relay_outbox_sig()
+    assert first
+    gr.claim_pending(home)  # outbox now empty; signature must not regress
+    assert srv._group_relay_outbox_sig() == first

--- a/tests/tui_gateway/test_group_relay_methods.py
+++ b/tests/tui_gateway/test_group_relay_methods.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+import tui_gateway.change_watcher as cw
 import tui_gateway.server as srv
 from tools import group_relay as gr
 
@@ -52,7 +53,7 @@ def test_reply_appends_lines_and_rejects_bad_input(home):
 
 
 def test_change_watch_registered():
-    assert "group_relay.outbox.pending" in srv._CHANGE_WATCHES
+    assert "group_relay.outbox.pending" in cw._CHANGE_WATCHES
     assert "group_relay.outbox.drain" in srv._methods and "group_relay.reply" in srv._methods
 
 

--- a/tests/tui_gateway/test_group_relay_methods.py
+++ b/tests/tui_gateway/test_group_relay_methods.py
@@ -11,7 +11,7 @@ from tools import group_relay as gr
 @pytest.fixture
 def home(tmp_path, monkeypatch):
     h = tmp_path / ".hermes"
-    (h / "profiles" / "pax").mkdir(parents=True)
+    (h / "profiles" / "researcher").mkdir(parents=True)
     monkeypatch.setenv("HERMES_HOME", str(h))
     return h
 
@@ -22,7 +22,7 @@ def _result(envelope):
 
 
 def test_drain_returns_each_envelope_once(home):
-    env = gr.enqueue(home, room_id="rm", room_name="TraderChat", text="t", from_profile="pax", label="L")
+    env = gr.enqueue(home, room_id="rm", room_name="Launchpad", text="t", from_profile="researcher", label="L")
     first = _result(srv._methods["group_relay.outbox.drain"](1, {}))
     assert [e["id"] for e in first["envelopes"]] == [env["id"]]
     assert _result(srv._methods["group_relay.outbox.drain"](2, {}))["envelopes"] == []
@@ -30,14 +30,14 @@ def test_drain_returns_each_envelope_once(home):
 
 def test_drain_uses_machine_root_from_profile_home(tmp_path, monkeypatch):
     root = tmp_path / ".hermes"
-    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "pax"))
-    env = gr.enqueue(root, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    monkeypatch.setenv("HERMES_HOME", str(root / "profiles" / "researcher"))
+    env = gr.enqueue(root, room_id="rm", room_name="n", text="t", from_profile="researcher", label="L")
     got = _result(srv._methods["group_relay.outbox.drain"](1, {}))
     assert [e["id"] for e in got["envelopes"]] == [env["id"]]
 
 
 def test_reply_appends_lines_and_rejects_bad_input(home):
-    env = gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    env = gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="researcher", label="L")
     assert _result(srv._methods["group_relay.reply"](1, {"id": env["id"], "line": {"kind": "accepted", "thread": "x"}}))["ok"]
     assert _result(srv._methods["group_relay.reply"](2, {"id": env["id"], "line": {"kind": "reply", "member": "a", "text": "hi"}}))["ok"]
     lines, _ = gr.read_reply_lines(home, env["id"])
@@ -60,7 +60,7 @@ def test_outbox_signature_is_monotone(home, monkeypatch):
     monkeypatch.setattr(srv, "_watcher_home", lambda: home)
     monkeypatch.setattr(srv, "_group_relay_outbox_seen", 0)
     assert srv._group_relay_outbox_sig() is None
-    gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="pax", label="L")
+    gr.enqueue(home, room_id="rm", room_name="n", text="t", from_profile="researcher", label="L")
     first = srv._group_relay_outbox_sig()
     assert first
     gr.claim_pending(home)  # outbox now empty; signature must not regress

--- a/tools/group_relay.py
+++ b/tools/group_relay.py
@@ -1,0 +1,301 @@
+"""Group relay — gateway ↔ Desktop file plumbing for relaying into Desktop rooms.
+
+Desktop-coordinated Group Chats (``apps/desktop/src/plugins/hermes-bots``)
+keep their orchestration state in the Desktop's plugin storage and start
+member rounds only from the renderer (``sendToGroupChat``). Nothing outside
+the app can start a round, so ``hermes group send`` reaches those rooms the
+same way cross-connection DMs reach other machines (``tools/bot_relay.py``):
+plain files under the gateway's HERMES root that the Desktop drains.
+
+Layout — ``<root>/group_relay/``:
+
+- ``outbox/<id>.json``  — envelopes queued by the CLI. The Desktop claims
+  them (atomic rename into ``claimed/``) and calls ``sendToGroupChat`` on
+  the user's behalf.
+- ``replies/<id>.jsonl`` — append-only progress lines written by the Desktop
+  as the round runs, so the CLI's ``--wait`` can stream partial output:
+  ``accepted`` (thread minted) → ``reply`` (one per committed member
+  message) → ``done`` (``settled|capped|cancelled|timeout``) or ``error``.
+
+This is deliberately a sibling of ``bot_relay`` rather than an extension of
+it: the DM drain is cross-connection-only and its envelopes carry a
+different contract. Deleting this module and its callers removes the
+feature cleanly. Helpers never raise except for the documented validation
+errors; ids are 32 hex chars so paths cannot be steered.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Iterable
+
+logger = logging.getLogger(__name__)
+
+RELAY_DIR_NAME = "group_relay"
+OUTBOX_DIR = "outbox"
+CLAIMED_DIR = "claimed"
+REPLIES_DIR = "replies"
+
+# Reply files hold room transcript text; sweep on the same cadence as the DM
+# relay (six hours) via the gateway housekeeping loop.
+STALE_AFTER_SECONDS = 6 * 3600
+# Unclaimed envelopes older than this are expired at drain time with an
+# ``error`` line so a waiting CLI resolves instead of hanging until timeout.
+DEFAULT_ENVELOPE_TTL_SECONDS = 15 * 60
+
+MAX_TEXT_CHARS = 64 * 1024
+MAX_LABEL_CHARS = 200
+
+_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+_LINE_KINDS = frozenset({"accepted", "reply", "done", "error"})
+DONE_STATUSES = frozenset({"settled", "capped", "cancelled", "timeout"})
+
+
+class GroupRelayError(ValueError):
+    """Validation failure on an envelope or reply line."""
+
+
+def relay_root(root: Path | str) -> Path:
+    return Path(root) / RELAY_DIR_NAME
+
+
+def _ensure_dirs(root: Path | str) -> Path:
+    base = relay_root(root)
+    for sub in (OUTBOX_DIR, CLAIMED_DIR, REPLIES_DIR):
+        (base / sub).mkdir(parents=True, exist_ok=True)
+    return base
+
+
+def _validate_id(value: Any) -> str:
+    safe = str(value or "").strip()
+    if not _ID_RE.match(safe):
+        raise GroupRelayError(f"invalid group relay id: {value!r}")
+    return safe
+
+
+def _atomic_write_json(directory: Path, name: str, payload: dict, *, prefix: str) -> Path:
+    path = directory / name
+    fd, tmp = tempfile.mkstemp(dir=str(directory), prefix=prefix, suffix=".tmp")
+    with os.fdopen(fd, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False)
+    os.replace(tmp, path)
+    return path
+
+
+# ── envelopes (CLI → Desktop) ────────────────────────────────────────────────
+
+
+def enqueue(
+    root: Path | str,
+    *,
+    room_id: str,
+    room_name: str,
+    text: str,
+    from_profile: str,
+    label: str,
+    thread: str | None = None,
+) -> dict[str, Any]:
+    """Queue one relay request for the Desktop. Returns the envelope."""
+    room_id = str(room_id or "").strip()
+    room_name = str(room_name or "").strip()
+    body = str(text or "").strip()
+    who = str(label or "").strip()
+    if not room_id and not room_name:
+        raise GroupRelayError("room_id or room_name is required")
+    if not body:
+        raise GroupRelayError("text is required")
+    if len(body) > MAX_TEXT_CHARS:
+        raise GroupRelayError(f"text too long ({len(body)} > {MAX_TEXT_CHARS} chars)")
+    if len(who) > MAX_LABEL_CHARS:
+        raise GroupRelayError(f"label too long ({len(who)} > {MAX_LABEL_CHARS} chars)")
+    base = _ensure_dirs(root)
+    envelope = {
+        "id": uuid.uuid4().hex,
+        "created_at": int(time.time()),
+        "from_profile": str(from_profile or "default"),
+        "label": who,
+        "room_id": room_id,
+        "room_name": room_name,
+        "thread": (str(thread).strip() or None) if thread is not None else None,
+        "text": body,
+    }
+    _atomic_write_json(base / OUTBOX_DIR, f"{envelope['id']}.json", envelope, prefix=".env-")
+    return envelope
+
+
+def pending_count(root: Path | str, *, older_than_seconds: float = 0.0) -> int:
+    """Unclaimed envelopes (optionally only those older than N seconds)."""
+    outbox = relay_root(root) / OUTBOX_DIR
+    if not outbox.is_dir():
+        return 0
+    cutoff = time.time() - max(0.0, older_than_seconds)
+    count = 0
+    for path in outbox.glob("*.json"):
+        try:
+            if older_than_seconds <= 0 or path.stat().st_mtime < cutoff:
+                count += 1
+        except OSError:
+            continue
+    return count
+
+
+def claim_pending(root: Path | str, *, ttl_seconds: int | None = None) -> list[dict[str, Any]]:
+    """Drain the outbox (atomic rename → claimed/). Expired envelopes get an
+    ``error`` reply line and are dropped rather than delivered."""
+    base = _ensure_dirs(root)
+    _sweep_stale(base)
+    ttl = DEFAULT_ENVELOPE_TTL_SECONDS if ttl_seconds is None else int(ttl_seconds)
+    now = time.time()
+    out: list[dict[str, Any]] = []
+    for path in sorted((base / OUTBOX_DIR).glob("*.json")):
+        envelope: dict[str, Any] | None = None
+        try:
+            envelope = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            envelope = None
+        if ttl > 0 and isinstance(envelope, dict):
+            created = float(envelope.get("created_at") or path.stat().st_mtime)
+            if now - created > ttl:
+                try:
+                    append_reply_line(
+                        root,
+                        envelope.get("id"),
+                        {
+                            "kind": "error",
+                            "reason": "queued_expired",
+                            "error": (
+                                f"relay to group {envelope.get('room_name') or envelope.get('room_id')} "
+                                f"expired after {ttl}s waiting for the Desktop to drain it — "
+                                "it was NOT delivered. Is the Hermes app open?"
+                            ),
+                        },
+                    )
+                except GroupRelayError:
+                    pass
+                try:
+                    path.unlink()
+                except OSError:
+                    pass
+                continue
+        claimed = base / CLAIMED_DIR / path.name
+        try:
+            os.replace(path, claimed)
+            if envelope is None:
+                envelope = json.loads(claimed.read_text(encoding="utf-8"))
+            if isinstance(envelope, dict):
+                out.append(envelope)
+        except (OSError, ValueError):
+            continue
+    return out
+
+
+# ── reply lines (Desktop → CLI) ──────────────────────────────────────────────
+
+
+def _reply_path(root: Path | str, envelope_id: Any) -> Path:
+    return _ensure_dirs(root) / REPLIES_DIR / f"{_validate_id(envelope_id)}.jsonl"
+
+
+def append_reply_line(root: Path | str, envelope_id: Any, line: dict[str, Any]) -> Path:
+    """Append one progress line. ``line['kind']`` ∈ accepted|reply|done|error."""
+    if not isinstance(line, dict):
+        raise GroupRelayError("reply line must be an object")
+    kind = str(line.get("kind") or "")
+    if kind not in _LINE_KINDS:
+        raise GroupRelayError(f"invalid reply line kind: {kind!r}")
+    if kind == "done" and str(line.get("status") or "") not in DONE_STATUSES:
+        raise GroupRelayError(f"invalid done status: {line.get('status')!r}")
+    if kind == "reply" and not str(line.get("text") or "").strip():
+        raise GroupRelayError("reply line requires text")
+    path = _reply_path(root, envelope_id)
+    record = {"id": _validate_id(envelope_id), "at": int(time.time()), **line}
+    encoded = json.dumps(record, ensure_ascii=False) + "\n"
+    # O_APPEND writes below PIPE_BUF are atomic on POSIX; lines are small.
+    fd = os.open(str(path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o600)
+    try:
+        os.write(fd, encoded.encode("utf-8"))
+    finally:
+        os.close(fd)
+    return path
+
+
+def read_reply_lines(root: Path | str, envelope_id: Any, *, offset: int = 0) -> tuple[list[dict[str, Any]], int]:
+    """Return complete lines after byte ``offset`` and the new offset.
+
+    A partially written trailing line (no newline yet) is left for the next
+    read so a concurrent append never yields a truncated record.
+    """
+    path = relay_root(root) / REPLIES_DIR / f"{_validate_id(envelope_id)}.jsonl"
+    if not path.exists():
+        return [], offset
+    try:
+        with open(path, "rb") as handle:
+            handle.seek(max(0, int(offset)))
+            chunk = handle.read()
+    except OSError:
+        return [], offset
+    lines: list[dict[str, Any]] = []
+    consumed = 0
+    while True:
+        newline = chunk.find(b"\n", consumed)
+        if newline < 0:
+            break  # trailing partial line: leave for the next read
+        raw = chunk[consumed:newline]
+        consumed = newline + 1
+        if not raw.strip():
+            continue
+        try:
+            parsed = json.loads(raw.decode("utf-8"))
+        except ValueError:
+            continue
+        if isinstance(parsed, dict):
+            lines.append(parsed)
+    return lines, int(offset) + consumed
+
+
+# ── housekeeping ─────────────────────────────────────────────────────────────
+
+
+def _sweep_stale(base: Path, *, now: float | None = None) -> int:
+    cutoff = (time.time() if now is None else now) - STALE_AFTER_SECONDS
+    removed = 0
+    for sub, pattern in ((CLAIMED_DIR, "*.json"), (OUTBOX_DIR, "*.json"), (REPLIES_DIR, "*.jsonl")):
+        try:
+            for path in (base / sub).glob(pattern):
+                try:
+                    if path.stat().st_mtime < cutoff:
+                        path.unlink()
+                        removed += 1
+                except OSError:
+                    continue
+        except OSError:
+            continue
+    return removed
+
+
+def cleanup_group_relay_artifacts(max_age_hours: float | None = None) -> int:
+    """Housekeeping hook (same contract as ``cleanup_bot_relay_artifacts``)."""
+    del max_age_hours
+    try:
+        home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+        root = home.parent.parent if home.parent.name == "profiles" else home
+        base = relay_root(root)
+        if not base.is_dir():
+            return 0
+        return _sweep_stale(base)
+    except Exception:
+        logger.debug("group_relay artifact sweep failed", exc_info=True)
+        return 0
+
+
+def gateway_root() -> Path:
+    """Machine root (not the profile home) — the store is profile-independent."""
+    home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    return home.parent.parent if home.parent.name == "profiles" else home

--- a/tools/group_relay.py
+++ b/tools/group_relay.py
@@ -26,6 +26,7 @@ errors; ids are 32 hex chars so paths cannot be steered.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
 import os
@@ -60,6 +61,28 @@ DONE_STATUSES = frozenset({"settled", "capped", "cancelled", "timeout"})
 
 class GroupRelayError(ValueError):
     """Validation failure on an envelope or reply line."""
+
+
+class GroupRelayConflictError(GroupRelayError):
+    """An ``event_key`` was reused with different content."""
+
+
+def envelope_id_for_key(event_key: str) -> str:
+    """Deterministic 32-hex envelope id for a caller retry key."""
+    return hashlib.sha256(f"group-relay:{event_key}".encode("utf-8")).hexdigest()[:32]
+
+
+def _find_envelope(base: Path, envelope_id: str) -> dict[str, Any] | None:
+    for sub in (OUTBOX_DIR, CLAIMED_DIR):
+        path = base / sub / f"{envelope_id}.json"
+        if path.is_file():
+            try:
+                loaded = json.loads(path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                continue
+            if isinstance(loaded, dict):
+                return loaded
+    return None
 
 
 def relay_root(root: Path | str) -> Path:
@@ -101,8 +124,16 @@ def enqueue(
     from_profile: str,
     label: str,
     thread: str | None = None,
+    event_key: str | None = None,
 ) -> dict[str, Any]:
-    """Queue one relay request for the Desktop. Returns the envelope."""
+    """Queue one relay request for the Desktop. Returns the envelope.
+
+    With ``event_key`` the envelope id is deterministic: repeating the same
+    key with identical room/thread/text returns the already-queued (or
+    already-claimed) envelope instead of queueing a duplicate; the same key
+    with different content raises :class:`GroupRelayConflictError`. Without
+    a key every call is a fresh envelope.
+    """
     room_id = str(room_id or "").strip()
     room_name = str(room_name or "").strip()
     body = str(text or "").strip()
@@ -116,16 +147,31 @@ def enqueue(
     if len(who) > MAX_LABEL_CHARS:
         raise GroupRelayError(f"label too long ({len(who)} > {MAX_LABEL_CHARS} chars)")
     base = _ensure_dirs(root)
+    key = str(event_key or "").strip() or None
+    normalized_thread = (str(thread).strip() or None) if thread is not None else None
     envelope = {
-        "id": uuid.uuid4().hex,
+        "id": envelope_id_for_key(key) if key else uuid.uuid4().hex,
         "created_at": int(time.time()),
         "from_profile": str(from_profile or "default"),
         "label": who,
         "room_id": room_id,
         "room_name": room_name,
-        "thread": (str(thread).strip() or None) if thread is not None else None,
+        "thread": normalized_thread,
         "text": body,
+        **({"event_key": key} if key else {}),
     }
+    if key:
+        existing = _find_envelope(base, envelope["id"])
+        if existing is not None:
+            same = all(existing.get(field) == envelope[field] for field in ("room_id", "room_name", "thread", "text"))
+            if not same:
+                raise GroupRelayConflictError(
+                    f"event key {key!r} was already used with different content; pick a new key"
+                )
+            return existing
+        if (base / REPLIES_DIR / f"{envelope['id']}.jsonl").is_file():
+            # Claimed, acted on, and already swept from claimed/ — still the same request.
+            return envelope
     _atomic_write_json(base / OUTBOX_DIR, f"{envelope['id']}.json", envelope, prefix=".env-")
     return envelope
 

--- a/tools/group_relay.py
+++ b/tools/group_relay.py
@@ -188,20 +188,45 @@ def enqueue(
             return existing
         receipt = _receipt_from_replies(base, envelope["id"])
         if receipt is not None:
-            # Claimed, acted on, and swept from claimed/ — the receipt line at
-            # the head of the reply file is the durable record of what was sent.
+            # The receipt at the head of the reply file is the durable record
+            # of what this key sent; it outlives outbox/ and claimed/.
             if any(receipt.get(field) != envelope[field] for field in _IDEMPOTENCY_FIELDS):
                 raise conflict
-            return envelope
-        # First enqueue for this key: pin the receipt BEFORE the envelope is
-        # visible, so conflict detection survives every later sweep.
-        append_reply_line(
-            root,
-            envelope["id"],
-            {"kind": "receipt", **{field: envelope[field] for field in _IDEMPOTENCY_FIELDS}},
-        )
+            if _desktop_took_delivery(base, envelope["id"]):
+                return envelope
+            # Receipt exists but no envelope and the Desktop never saw it: a
+            # crash landed between the receipt and the outbox write (below).
+            # Recreate the outbox entry — idempotently, same id — so the
+            # message is not lost.
+        else:
+            # First enqueue for this key: pin the receipt BEFORE the envelope
+            # is visible so conflict detection survives every later sweep.
+            append_reply_line(
+                root,
+                envelope["id"],
+                {"kind": "receipt", **{field: envelope[field] for field in _IDEMPOTENCY_FIELDS}},
+            )
     _atomic_write_json(base / OUTBOX_DIR, f"{envelope['id']}.json", envelope, prefix=".env-")
     return envelope
+
+
+def _desktop_took_delivery(base: Path, envelope_id: str) -> bool:
+    """True once the reply file shows the Desktop acted on the envelope
+    (``accepted``/``done``/``error``) — the only states where suppressing a
+    requeue cannot lose the message."""
+    path = base / REPLIES_DIR / f"{envelope_id}.jsonl"
+    try:
+        with open(path, "rb") as handle:
+            for raw in handle:
+                try:
+                    line = json.loads(raw.decode("utf-8"))
+                except ValueError:
+                    continue
+                if isinstance(line, dict) and line.get("kind") in ("accepted", "reply", "done", "error"):
+                    return True
+    except OSError:
+        return False
+    return False
 
 
 def pending_count(root: Path | str, *, older_than_seconds: float = 0.0) -> int:

--- a/tools/group_relay.py
+++ b/tools/group_relay.py
@@ -55,7 +55,8 @@ MAX_TEXT_CHARS = 64 * 1024
 MAX_LABEL_CHARS = 200
 
 _ID_RE = re.compile(r"^[0-9a-f]{32}$")
-_LINE_KINDS = frozenset({"accepted", "reply", "done", "error"})
+_LINE_KINDS = frozenset({"receipt", "accepted", "reply", "done", "error"})
+_IDEMPOTENCY_FIELDS = ("room_id", "room_name", "thread", "text")
 DONE_STATUSES = frozenset({"settled", "capped", "cancelled", "timeout"})
 
 
@@ -70,6 +71,22 @@ class GroupRelayConflictError(GroupRelayError):
 def envelope_id_for_key(event_key: str) -> str:
     """Deterministic 32-hex envelope id for a caller retry key."""
     return hashlib.sha256(f"group-relay:{event_key}".encode("utf-8")).hexdigest()[:32]
+
+
+def _receipt_from_replies(base: Path, envelope_id: str) -> dict[str, Any] | None:
+    """The immutable idempotency receipt recorded as the reply file's first line."""
+    path = base / REPLIES_DIR / f"{envelope_id}.jsonl"
+    if not path.is_file():
+        return None
+    try:
+        with open(path, "rb") as handle:
+            first = handle.readline()
+        parsed = json.loads(first.decode("utf-8")) if first.strip() else None
+    except (OSError, ValueError):
+        return None
+    if isinstance(parsed, dict) and parsed.get("kind") == "receipt":
+        return parsed
+    return None
 
 
 def _find_envelope(base: Path, envelope_id: str) -> dict[str, Any] | None:
@@ -161,17 +178,28 @@ def enqueue(
         **({"event_key": key} if key else {}),
     }
     if key:
+        conflict = GroupRelayConflictError(
+            f"event key {key!r} was already used with different content; pick a new key"
+        )
         existing = _find_envelope(base, envelope["id"])
         if existing is not None:
-            same = all(existing.get(field) == envelope[field] for field in ("room_id", "room_name", "thread", "text"))
-            if not same:
-                raise GroupRelayConflictError(
-                    f"event key {key!r} was already used with different content; pick a new key"
-                )
+            if any(existing.get(field) != envelope[field] for field in _IDEMPOTENCY_FIELDS):
+                raise conflict
             return existing
-        if (base / REPLIES_DIR / f"{envelope['id']}.jsonl").is_file():
-            # Claimed, acted on, and already swept from claimed/ — still the same request.
+        receipt = _receipt_from_replies(base, envelope["id"])
+        if receipt is not None:
+            # Claimed, acted on, and swept from claimed/ — the receipt line at
+            # the head of the reply file is the durable record of what was sent.
+            if any(receipt.get(field) != envelope[field] for field in _IDEMPOTENCY_FIELDS):
+                raise conflict
             return envelope
+        # First enqueue for this key: pin the receipt BEFORE the envelope is
+        # visible, so conflict detection survives every later sweep.
+        append_reply_line(
+            root,
+            envelope["id"],
+            {"kind": "receipt", **{field: envelope[field] for field in _IDEMPOTENCY_FIELDS}},
+        )
     _atomic_write_json(base / OUTBOX_DIR, f"{envelope['id']}.json", envelope, prefix=".env-")
     return envelope
 

--- a/tui_gateway/change_watcher.py
+++ b/tui_gateway/change_watcher.py
@@ -170,6 +170,26 @@ def _bot_relay_outbox_sig():
     return _bot_relay_outbox_seen or None
 
 
+_group_relay_outbox_seen = 0
+
+
+def _group_relay_outbox_sig():
+    """Newest mtime across pending group-relay envelopes (monotone).
+
+    Sibling of ``_bot_relay_outbox_sig`` for ``hermes group send`` envelopes aimed at
+    Desktop-coordinated Group Chats (``tools/group_relay.py``); the Desktop reacts to
+    ``group_relay.outbox.pending`` with a debounced drain.
+    """
+    global _group_relay_outbox_seen
+    home = _watcher_home()
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    with contextlib.suppress(OSError):
+        for entry in (root / "group_relay" / "outbox").iterdir():
+            if entry.name.endswith(".json"):
+                _group_relay_outbox_seen = max(_group_relay_outbox_seen, _watcher_mtime_ns(entry) or 0)
+    return _group_relay_outbox_seen or None
+
+
 # event → (check interval, signature fn, payload fn). Signatures are stat-cheap; the interval
 # keeps pricier probes (pet resolves the sheet off disk) off the 0.5s tick. cron/jobs.json
 # moves on edits AND scheduler ticks; gateway_state.json is where the messaging gateway
@@ -181,7 +201,8 @@ _CHANGE_WATCHES: dict[str, tuple[float, Any, Any]] = {
     "platforms.changed": (2.0, lambda: _home_mtime_ns("gateway_state.json"), lambda: {}),
     "pairing.changed": (2.0, _pairing_sig, lambda: {}),
     # 1s so a queued DM envelope reaches the Desktop's push-triggered drain fast.
-    "bot_relay.outbox.pending": (1.0, _bot_relay_outbox_sig, lambda: {})}
+    "bot_relay.outbox.pending": (1.0, _bot_relay_outbox_sig, lambda: {}),
+    "group_relay.outbox.pending": (1.0, _group_relay_outbox_sig, lambda: {})}
 
 # state.db moves on every append of a streaming turn and gateway_state.json on
 # in-flight bookkeeping; the floor coalesces bursts to one broadcast per window,

--- a/tui_gateway/methods_group_relay.py
+++ b/tui_gateway/methods_group_relay.py
@@ -1,0 +1,54 @@
+"""Group-relay JSON-RPC handlers — the gateway door for ``hermes group send``
+into Desktop-coordinated Group Chats.
+
+Two methods the Desktop's ``hermes-bots`` plugin calls on its connection:
+
+- ``group_relay.outbox.drain`` — claim envelopes queued by the CLI
+  (``tools/group_relay.enqueue``). The Desktop then calls its own
+  ``sendToGroupChat`` on the user's behalf.
+- ``group_relay.reply`` — append one progress line (``accepted`` / ``reply``
+  / ``done`` / ``error``) for a claimed envelope; the CLI's ``--wait`` tails
+  the file.
+
+Storage lives in ``tools/group_relay.py``. Handlers are rebound onto
+server.py's globals at install time (see method_ctx.py) and reference
+``_ok``/``_err`` from there.
+"""
+
+from .method_ctx import HandlerRegistry
+
+_registry = HandlerRegistry()
+method = _registry.method
+
+
+@method("group_relay.outbox.drain")
+def _(rid, params: dict) -> dict:
+    """Claim every pending group-relay envelope on this gateway. Result: ``{envelopes}``."""
+    try:
+        from tools.group_relay import claim_pending, gateway_root
+
+        return _ok(rid, {"envelopes": claim_pending(gateway_root())})
+    except Exception as e:
+        return _err(rid, 5095, str(e))
+
+
+@method("group_relay.reply")
+def _(rid, params: dict) -> dict:
+    """Append one progress line for envelope ``id``. Params: ``id``, ``line`` (object)."""
+    try:
+        from tools.group_relay import GroupRelayError, append_reply_line, gateway_root
+
+        line = params.get("line")
+        if not isinstance(line, dict):
+            return _err(rid, 4095, "line must be an object")
+        try:
+            append_reply_line(gateway_root(), params.get("id"), line)
+        except GroupRelayError as exc:
+            return _err(rid, 4096, str(exc))
+        return _ok(rid, {"ok": True})
+    except Exception as e:
+        return _err(rid, 5096, str(e))
+
+
+def register(server) -> None:
+    _registry.install(server)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3208,6 +3208,7 @@ from . import (  # noqa: E402
     compute_host_bridge as _compute_host_bridge, session_workdir as _session_workdir,
     session_lifecycle as _session_lifecycle, session_reaper as _session_reaper,
     methods_browser_control as _methods_browser_control, methods_bot_relay as _methods_bot_relay,
+    methods_group_relay as _methods_group_relay,
     methods_complete as _methods_complete, methods_config as _methods_config,
     methods_config_set as _methods_config_set, methods_images as _methods_images,
     methods_profiles as _methods_profiles, methods_prompt as _methods_prompt, methods_session as _methods_session,
@@ -3221,6 +3222,6 @@ for _m in (
     _methods_complete_helpers, _methods_slash, _methods_voice, _methods_browser,
     _methods_browser_control, _methods_session, _methods_prompt, _methods_config,
     _methods_config_set, _methods_complete, _methods_tools, _methods_profiles, _methods_images,
-    _methods_bot_relay, _prompt_turn, _billing_view, _methods_projects):
+    _methods_bot_relay, _methods_group_relay, _prompt_turn, _billing_view, _methods_projects):
     _m.register(sys.modules[__name__])
 del _m

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -522,8 +522,10 @@ Threads follow the **relaying session**: the first `send` from a session
 starts a new room thread, later sends from the same session
 (`$HERMES_SESSION_ID`, which Hermes sets for every tool an agent spawns, or
 `--session`) continue it, and a different session gets its own thread.
-`--new-thread` starts over; `--thread` overrides for that send only. A room
-keeps only the latest pending user message per thread.
+`--new-thread` starts over; `--thread` overrides for that send only. Desktop
+rooms mint their thread on delivery, so continuity there needs `--wait` on
+the session's first send. A hosted room keeps only the latest pending user
+message per thread.
 
 **Desktop-coordinated rooms (interim).** `hermes group list` also shows the
 Group Chats the Desktop app coordinates, tagged `[desktop]`. Sending to one

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -507,7 +507,7 @@ background from an agent session and the completion output carries the
 replies — the same handoff shape as `hermes -p <agent> chat -q`:
 
 ```
-terminal(command='hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait',
+terminal(command='hermes group send DevTeam "Plan the release checklist" --as "Ada via Discord" --wait',
          background=True, notify=True)
 ```
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -525,6 +525,14 @@ starts a new room thread, later sends from the same session
 `--new-thread` starts over; `--thread` overrides for that send only. A room
 keeps only the latest pending user message per thread.
 
+**Desktop-coordinated rooms (interim).** `hermes group list` also shows the
+Group Chats the Desktop app coordinates, tagged `[desktop]`. Sending to one
+requires the Hermes Desktop to be open: the CLI queues the request on the
+gateway, the app writes it into the room on your behalf (it appears as
+"You"), and the members' replies stream back. Omit `--thread` to start a new
+thread; pass an existing Desktop thread id (see `hermes group log --json`) to
+continue one. Use `--kind hosted|desktop` when a name exists in both.
+
 Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
 received so far are already printed), `4` superseded by a room stop. A room
 stop is room-wide — it cancels every pending user turn in every thread,

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -523,7 +523,10 @@ concurrent relays should pass distinct `--thread` values, and a new relaying
 session should start its own thread rather than reuse another session's.
 
 Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
-received so far are already printed), `4` superseded by a room stop.
+received so far are already printed), `4` superseded by a room stop. A room
+stop is room-wide — it cancels every pending user turn in every thread,
+including a relay's — so `4` is correct even when the stop targeted another
+thread.
 
 ## `hermes secrets`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -54,6 +54,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes login` / `logout` | **Deprecated** — use `hermes auth` instead. |
 | `hermes send` | Send a one-shot message to a configured messaging platform (Telegram, Discord, Slack, Signal, SMS, …). Useful from shell scripts, cron jobs, CI hooks, and monitoring daemons — no agent loop, no LLM. |
 | `hermes peer` | Register peer Hermes gateways on other machines and DM their agents' canonical Bot Chats (`hermes peer dm <peer>[/<agent>] "…"`). The transport behind cross-machine bot-to-bot messaging. |
+| `hermes group` | Relay a user request into a gateway-hosted Group Chat from any session and stream the members' replies back (`hermes group send <group> "…" --wait`). |
 | `hermes secrets` | Manage external secret sources (currently Bitwarden Secrets Manager) for pulling API keys at process startup instead of from `~/.hermes/.env`. |
 | `hermes migrate` | Diagnose and (optionally) rewrite `config.yaml` to replace references to retired models or deprecated settings (e.g. `migrate xai`). |
 | `hermes status` | Show agent, auth, and platform status. |
@@ -483,6 +484,46 @@ cross-machine teammates without SOUL edits. See
 [Bot Mode](../user-guide/bot-mode.md).
 
 Exit codes: `0` on success, `1` on delivery/peer failure, `2` on usage errors.
+
+## `hermes group`
+
+```bash
+hermes group list [--json]
+hermes group create <name> --member <profile> --member <profile> [...] [--json]
+hermes group send <group> ["message"] [--thread ID] [--as LABEL] [--wait] [--timeout SECONDS] [--event-id KEY] [--json]
+hermes group log <group> [--since SEQ] [--json]
+```
+
+Relay a user's request into a **gateway-hosted Group Chat from any session**
+and bring the deliberation back. The caller acts *as the user* — it is a
+relay, not a room member, so no membership is needed: the message lands as a
+user message with the relaying profile and `--as` label recorded as who
+relayed it. Member turns run headlessly in the gateway's hosted-room worker
+(`hermes gateway` or the Desktop backend must be running).
+
+`send --wait` streams each committed member reply as `@handle: text` and
+exits when the room reports the discussion settled or bounded. Run it in the
+background from an agent session and the completion output carries the
+replies — the same handoff shape as `hermes -p <agent> chat -q`:
+
+```
+terminal(command='hermes group send DevTeam "Plan the release checklist" --as "Pax via Discord" --wait',
+         background=True, notify=True)
+```
+
+| Subcommand | Description |
+|--------|-------------|
+| `list` | Hosted groups on this machine with members and whether this gateway manages them. |
+| `create <name> --member …` | Create a hosted group of 2–6 local profiles (`default` is addressed as `hermes`). |
+| `send <group> [message]` | Append a user message (argument or stdin). `--thread` picks the thread (default `cli`; sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
+| `log <group>` | Print the committed transcript (`User (<label>)` / `@handle` lines) from `--since`. |
+
+Threads: a room keeps only the **latest pending user message per thread**, so
+concurrent relays should pass distinct `--thread` values, and a new relaying
+session should start its own thread rather than reuse another session's.
+
+Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
+received so far are already printed), `4` superseded by a room stop.
 
 ## `hermes secrets`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -515,12 +515,15 @@ terminal(command='hermes group send DevTeam "Plan the release checklist" --as "P
 |--------|-------------|
 | `list` | Hosted groups on this machine with members and whether this gateway manages them. |
 | `create <name> --member …` | Create a hosted group of 2–6 local profiles (`default` is addressed as `hermes`). |
-| `send <group> [message]` | Append a user message (argument or stdin). `--thread` picks the thread (default `cli`; sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
+| `send <group> [message]` | Append a user message (argument or stdin). The thread follows the session (see below); `--thread` overrides (sanitized to `[A-Za-z0-9._:-]`); `--event-id` makes retries idempotent; `--wait` follows the deliberation. |
 | `log <group>` | Print the committed transcript (`User (<label>)` / `@handle` lines) from `--since`. |
 
-Threads: a room keeps only the **latest pending user message per thread**, so
-concurrent relays should pass distinct `--thread` values, and a new relaying
-session should start its own thread rather than reuse another session's.
+Threads follow the **relaying session**: the first `send` from a session
+starts a new room thread, later sends from the same session
+(`$HERMES_SESSION_ID`, which Hermes sets for every tool an agent spawns, or
+`--session`) continue it, and a different session gets its own thread.
+`--new-thread` starts over; `--thread` overrides for that send only. A room
+keeps only the latest pending user message per thread.
 
 Exit codes: `0` settled/bounded, `1` error, `2` usage, `3` timeout (replies
 received so far are already printed), `4` superseded by a room stop. A room

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -101,6 +101,10 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 - **Not every Bot replies to every message.** Speaking is each member's own choice — a Bot replies only when it has something new to add and passes otherwise, and @-mentioning specific members scopes the round to them. Expect the members you addressed (or whoever has something to say) to speak, and the rest to stay quiet.
 - **Rooms can span machines.** The New Group Chat picker seats Bots from any registered connection; each member's turns run on its own machine, in its own `Group: <name>` session there. Cross-machine members carry a device badge (`dixie · Mac Mini`) in the room and in other members' transcripts, and the disambiguated `@name-device` handle works in room mentions — so same-named agents on two machines never blur together.
 
+### Relaying into a group from another session (`hermes group`)
+
+Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Pax via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. See [`hermes group`](../reference/cli-commands.md#hermes-group).
+
 ## Bot-to-bot messaging
 
 Bots message each other with attribution, and you can hand work off from any chat:

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -103,7 +103,7 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 
 ### Relaying into a group from another session (`hermes group`)
 
-Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Ada via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. See [`hermes group`](../reference/cli-commands.md#hermes-group).
+Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Ada via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. The same command reaches the Group Chats in the Bots pane (tagged `[desktop]` in `hermes group list`) while the app is open. See [`hermes group`](../reference/cli-commands.md#hermes-group).
 
 ## Bot-to-bot messaging
 

--- a/website/docs/user-guide/bot-mode.md
+++ b/website/docs/user-guide/bot-mode.md
@@ -103,7 +103,7 @@ Groups are standalone rows in the same activity-ordered roster as Bot DMs. A Bot
 
 ### Relaying into a group from another session (`hermes group`)
 
-Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Pax via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. See [`hermes group`](../reference/cli-commands.md#hermes-group).
+Any agent session — a Discord thread, the CLI, a Desktop chat — can push a request into a gateway-hosted group **on your behalf** and report the deliberation back: `hermes group send <group> "…" --as "Ada via Discord" --wait`. The relaying agent is not a member; the message lands as a user message with the relay recorded as who sent it, the members deliberate headlessly in the gateway's hosted-room worker, and `--wait` streams their replies until the room settles. Run it in the background and the completion notification carries the replies into the originating session. See [`hermes group`](../reference/cli-commands.md#hermes-group).
 
 ## Bot-to-bot messaging
 


### PR DESCRIPTION
## What does this PR do?

**Makes the Discord → Group Chat relay from #102637 work for the Group Chats users actually have today — the ones in the Desktop's Bots pane.**

#102637 lets a user in Discord (or any messaging gateway) say "run this by the DevTeam room" and get the deliberation back in the same thread, but only for rooms hosted by the gateway engine. The rooms people have built up in the Desktop are a different implementation: their orchestration lives in the Desktop plugin's storage and only the renderer can start a member round (`sendToGroupChat` → `runGroupChatRounds`). Until the Desktop client adopts the hosted engine, nothing outside the app can post into those rooms.

After this PR the same user experience covers both:

> **You, in Discord:** "Take this to the Launchpad room: which risk should we brief the client on first?"
> **Your bot:** "Sent to Launchpad — I'll report back."
> *(the message appears in the Desktop pane as "You", with the bot's label as provenance; the members reply there as usual)*
> **Your bot, back in Discord:** "Launchpad settled — **helper:** the vendor SLA… **ops:** …"

Only requirement: the Hermes Desktop app is open somewhere (it's the coordinator). `hermes group list` tags these rooms `[desktop]`; the CLI, skill, and user phrasing are otherwise identical to #102637.

**Why a bridge, and why it's deletable.** It's built to be removed as a unit when the client migration lands: one new store module, one new methods module, one new Desktop module, one new CLI transport module, and a guarded 3-line import — reverting the commits leaves #102637 untouched.

**How it works.**
1. CLI enqueues an envelope in `<root>/group_relay/outbox/` (`tools/group_relay.py` — a sibling of `bot_relay.py`, not an extension: the DM drain is gated on ≥2 connections and carries a different contract).
2. The Desktop plugin (`group-relay.ts`) drains it (5s interval + `group_relay.outbox.pending` push signal), resolves the room by durable `roomId` then exact name, and calls `sendToGroupChat` **on the user's behalf**. The entry renders as "You"; a new `GroupMessageAuthor.via` records the relay label and is projected into the `ui_meta` mirror (no UI change — maintainers' call whether to surface it).
3. A per-envelope watcher on `$groupChats`/`$groupActivity` streams committed member replies for the relay's thread and a terminal status through `group_relay.reply`, appended as JSONL lines (`accepted → reply* → done{settled|capped|cancelled|timeout} | error`) that the CLI's `--wait` tails — partial output survives a timeout.

**Thread continuity (Desktop half).** #102637 binds room threads to the relaying session for hosted rooms. Desktop rooms mint their thread on delivery, so here the first send from a session goes out with `thread: null`, the Desktop mints one, and `--wait` learns the id from the `accepted` line and binds it — later sends from that session continue it. `--help` and the reference note that Desktop continuity requires `--wait` on the session's first send; explicit `--thread` stays a one-off.

## Related Issue

Depends on #102637.

## Type of Change

- [x] ✨ New feature
- [x] ✅ Tests
- [x] 📝 Documentation update

## Changes Made

Backend
- `tools/group_relay.py` (new) — envelope store; atomic claim; JSONL reply lines (`O_APPEND`, 0600, partial-line-safe reads); 32-hex id gate; TTL expiry writes an `error` line so a waiting CLI resolves; housekeeping sweep. **Idempotency**: `--event-id` derives the envelope id; an immutable `receipt` line pins room/thread/text so a retry with identical content is a no-op in every lifecycle state (queued, claimed, swept) and different content fails closed; a crash between receipt and outbox write is recovered on retry without duplicating delivery.
- `tui_gateway/methods_group_relay.py` (new) — `group_relay.outbox.drain`, `group_relay.reply`.
- `tui_gateway/server.py` — register module; `_group_relay_outbox_sig` change-watch (1s, stat-only, same shape as the bot-relay one).
- `gateway/run.py` — sweep in the housekeeping loop.

Desktop (`apps/desktop/src/plugins/hermes-bots/`)
- `group-relay.ts` (new) — drain loop, room resolution, watcher, lifecycle; `plugin.tsx` start/stop hooks.
- `group-rounds.ts` — `sendToGroupChat(..., opts?: {via})`; `types.ts` — `GroupMessageAuthor.via`; `group-chat.ts` — `via` projected into the sync snapshot.

CLI
- `hermes_cli/subcommands/group_desktop.py` (new) — `DesktopTransport`: rooms from the default profile's `ui_meta['hermes-bots-groups']` projection; send/wait/log; fail-fast when the outbox is visibly undrained.
- `hermes_cli/subcommands/group.py` — guarded import; `--kind hosted|desktop`; bindings path routed through `group_relay`; Desktop wording in `--help`.

Tests
- `tests/tools/test_group_relay.py` (27), `tests/tui_gateway/test_group_relay_methods.py` (5), `tests/hermes_cli/test_group_cli_desktop.py` (17), (Desktop continuity tests included: bind-on-accept, per-session, `--new-thread`, explicit `--thread` non-rebinding).
- `group-relay.test.ts` (9) — drives the **real** `runGroupChatRounds` through the existing scripted-gateway harness; includes a race test that injects a member reply from inside the first store notification (fails against a post-send snapshot).

## How to Test

1. Build the Desktop from this branch and launch it; restart the gateway.
2. `hermes group list` → your Desktop rooms appear as `[desktop]`.
3. `hermes group send <DesktopRoom> "…" --as "me via CLI" --wait` → the message appears in the pane as "You", replies stream to the CLI, exit 0 with `[group …: settled (…), N replies]`.
3b. Send again from the same shell (same `$HERMES_SESSION_ID`, or `--session X` both times) → lands in the **same** room thread; `--session Y` → a new thread; `--new-thread` → a new thread.
4. Quit the Desktop and resend with `--timeout 60` → "Desktop hasn't picked this up" after 30s, exit 3.
5. `python -m pytest tests/hermes_cli/test_group_cli_desktop.py tests/tools/test_group_relay.py tests/tui_gateway/test_group_relay_methods.py -q`; `cd apps/desktop && npx tsc -p tsconfig.json --noEmit && npx vitest run src/plugins/hermes-bots/group-relay.test.ts src/plugins/hermes-bots/group-rounds.test.ts src/plugins/hermes-bots/group-turns.test.ts src/plugins/hermes-bots/group-chat.test.ts src/plugins/hermes-bots/relay.test.ts`.

## Checklist

### Code
- [x] Contributing Guide / Conventional Commits / no duplicate / only related changes
- [x] Tests pass (81 Python across the group suites; 144 vitest; tsc + eslint clean)
- [x] Tests added
- [x] Tested on macOS 15.7 (E2E against a real Desktop room)

### Documentation & Housekeeping
- [x] Docs — "Relaying into Desktop Group Chats (interim)" paragraph
- [x] Config keys — N/A
- [x] Cross-platform — file ops via `os.replace`/`O_APPEND`, no symlinks/PTYs; the Desktop side is platform-neutral TS
- [x] Tool schemas — N/A

## Screenshots / Logs

```
$ hermes group send Launchpad "…one thing a relayed message should include…" --as "Ada via CLI" --wait
@helper: The requested action tied to a named entity — …
@ops: The raw claim plus any attached data source …
[group Launchpad: settled (settled), 2 replies]
```
