### PR TITLE
fix(codex): uniquify replayed call_id repeats across turns (#102629)

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -369,7 +369,7 @@ def _replay_message_items(msg: Dict[str, Any], *, is_github_responses: bool) -> 
     return replayed
 
 
-def _replay_tool_call_items(msg: Dict[str, Any], *, start_index: int) -> List[Dict[str, Any]]:
+def _replay_tool_call_items(msg: Dict[str, Any], *, start_index: int, bind: Optional[Callable[[str], str]] = None) -> List[Dict[str, Any]]:
     """Convert an assistant message's ``tool_calls`` into ``function_call`` items."""
     replayed: List[Dict[str, Any]] = []
     for tc in _as_list(msg.get("tool_calls")):
@@ -381,14 +381,15 @@ def _replay_tool_call_items(msg: Dict[str, Any], *, start_index: int) -> List[Di
             continue
         index = start_index + len(replayed)
         call_id = _resolve_call_id(tc.get("call_id"), tc.get("id"), fn_name, str(arguments), index, canonicalize_fc=True)
+        wire_call_id = bind(call_id.strip()) if bind is not None else _clamp_responses_call_id(call_id)
         replayed.append({
-            "type": "function_call", "call_id": _clamp_responses_call_id(call_id),
+            "type": "function_call", "call_id": wire_call_id,
             "name": _sanitize_replayed_fn_name(fn_name), "arguments": _coerce_arguments(arguments),
         })
     return replayed
 
 
-def _tool_output_items(msg: Dict[str, Any]) -> List[Dict[str, Any]]:
+def _tool_output_items(msg: Dict[str, Any], *, bind: Optional[Callable[[str], str]] = None) -> List[Dict[str, Any]]:
     """Convert a tool-role message to ``[function_call_output]`` (``[]`` if unpairable)."""
     raw_tool_call_id = msg.get("tool_call_id")
     call_id, tool_response_item_id = _split_responses_tool_id(raw_tool_call_id)
@@ -404,7 +405,8 @@ def _tool_output_items(msg: Dict[str, Any]) -> List[Dict[str, Any]]:
     tool_content = msg.get("content")
     is_parts = isinstance(tool_content, list)
     output_value: Any = (_chat_content_to_responses_parts(tool_content) or "") if is_parts else str(tool_content or "")
-    return [{"type": "function_call_output", "call_id": _clamp_responses_call_id(call_id), "output": output_value}]
+    wire_output_id = bind(call_id.strip()) if bind is not None else _clamp_responses_call_id(call_id)
+    return [{"type": "function_call_output", "call_id": wire_output_id, "output": output_value}]
 
 
 def _chat_messages_to_responses_input(
@@ -456,6 +458,46 @@ def _chat_messages_to_responses_input(
     # `function_call_output` wrapper) that no longer carries it (#90976).
     item_sources: List[Optional[Dict[str, Any]]] = []
     seen_item_ids: set = set()
+    # Duplicate stored tool ids across turns (e.g. `terminal:0` on two turns)
+    # would otherwise replay the same Responses `call_id` twice and the
+    # provider rejects the payload with 400 Duplicate function_call_output.
+    # Pair calls and outputs through per-base-id slots: each side first binds
+    # to a slot left open by the opposite side (so out-of-order stored
+    # history still pairs), otherwise opens a fresh slot whose wire id
+    # uniquifies repeats — the first occurrence keeps the stored id
+    # (cache-prefix safe), repeats get a `__r<N>` suffix.
+    _call_slots: Dict[str, List[Dict[str, Any]]] = {}
+    _used_call_ids: set = set()
+
+    def _bind_call_slot(base_id: str, *, is_call: bool) -> str:
+        slots = _call_slots.setdefault(base_id, [])
+        # Bind to a slot opened by the opposite side that is still waiting.
+        for slot in slots:
+            if is_call and slot["output"] and not slot["call"]:
+                slot["call"] = True
+                return slot["id"]
+            if not is_call and slot["call"] and not slot["output"]:
+                slot["output"] = True
+                return slot["id"]
+        # Open a fresh slot with a unique (clamped) wire id. Occurrence 1
+        # keeps the stored id (free unless another pair already emitted it);
+        # later occurrences take the first FREE `__r<N>` suffix — the search
+        # is unbounded because a natural stored id can already occupy a
+        # generated suffix (e.g. a real `terminal:0__r2` pair), and giving
+        # up there would re-emit the duplicate this converter exists to
+        # eliminate.
+        occurrence = 0
+        while True:
+            occurrence += 1
+            slot_id = _clamp_responses_call_id(
+                base_id if occurrence == 1 else f"{base_id}__r{occurrence}"
+            )
+            if slot_id not in _used_call_ids:
+                break
+        _used_call_ids.add(slot_id)
+        slots.append({"id": slot_id, "call": is_call, "output": not is_call})
+        return slot_id
+
     def emit(new_items: List[Dict[str, Any]], msg: Dict[str, Any]) -> None:
         items.extend(new_items)
         item_sources.extend([msg] * len(new_items))
@@ -464,7 +506,7 @@ def _chat_messages_to_responses_input(
             continue
         role = msg.get("role")
         if role == "tool":
-            emit(_tool_output_items(msg), msg)
+            emit(_tool_output_items(msg, bind=lambda base: _bind_call_slot(base, is_call=False)), msg)
             continue
         if role not in {"user", "assistant"}:
             continue
@@ -490,7 +532,7 @@ def _chat_messages_to_responses_input(
             fallback = content_parts or (content_text if content_text.strip() else "" if reasoning_items else None)
             if fallback is not None:
                 emit([{"role": "assistant", "content": fallback}], msg)
-        emit(_replay_tool_call_items(msg, start_index=len(items)), msg)
+        emit(_replay_tool_call_items(msg, start_index=len(items), bind=lambda base: _bind_call_slot(base, is_call=True)), msg)
     # The server renders nothing placed before a compaction item, so pre-checkpoint history is
     # dead weight and plaintext asks / merged summaries silently vanish. Keep the newest checkpoint
     # first, retain pre-checkpoint USER and SUMMARY messages within a token budget, leave the tail.

--- a/tests/agent/test_codex_responses_duplicate_call_id.py
+++ b/tests/agent/test_codex_responses_duplicate_call_id.py
@@ -1,0 +1,175 @@
+"""Repeated tool call_id across turns must not replay as duplicate (400).
+
+A session that ran the same tool on two separate turns can store the same
+tool ``call_id`` twice (observed as ``terminal:0`` on both turns). Replaying
+both pairs verbatim makes the Responses payload carry the same ``call_id``
+twice and the provider rejects the whole request with::
+
+    400 Duplicate function_call_output for call_id 'terminal:0'
+
+The converter must uniquify repeats per occurrence while keeping each
+``function_call`` paired with its own ``function_call_output``.
+"""
+
+from collections import Counter
+
+from agent.codex_responses_adapter import _chat_messages_to_responses_input
+
+
+def _two_turn_duplicate_messages(call_id="terminal:0"):
+    return [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": call_id,
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": "first result"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": call_id,
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": call_id, "content": "second result"},
+    ]
+
+
+def test_repeated_call_id_replays_unique_and_paired():
+    """Each replayed call_id appears exactly twice: one call + one output."""
+    items = _chat_messages_to_responses_input(
+        _two_turn_duplicate_messages("terminal:0")
+    )
+
+    calls = [i["call_id"] for i in items if i.get("type") == "function_call"]
+    outputs = [i["call_id"] for i in items if i.get("type") == "function_call_output"]
+
+    assert len(calls) == 2
+    assert len(outputs) == 2
+    # First occurrence keeps the stored id (prompt-cache prefix safe).
+    assert calls[0] == "terminal:0"
+    assert outputs[0] == "terminal:0"
+    # The repeat must be uniquified, and the second pair must still match.
+    assert calls[1] == outputs[1]
+    assert calls[1] != calls[0]
+    # Wire invariant: each call_id has exactly one call + one output.
+    assert Counter(calls + outputs)[calls[0]] == 2
+    assert Counter(calls + outputs)[calls[1]] == 2
+    # Dense suffix sequence: the repeat is the second occurrence, so it
+    # takes `__r2` — not a skipped `__r3`.
+    assert calls[1] == "terminal:0__r2"
+
+
+def test_natural_suffixed_id_collision_stays_unique():
+    """A stored pair whose real id is already `terminal:0__r2` must not
+    collide with the generated suffix for the second `terminal:0` repeat
+    (andrexibiza review on #102640): the fresh-id search must skip occupied
+    candidates until it finds one actually free, in bounded-range order."""
+    messages = [
+        # Natural pair: real stored id happens to be terminal:0__r2.
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0__r2",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "terminal:0__r2", "content": "natural"},
+        # First terminal:0 pair.
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "terminal:0", "content": "first"},
+        # Second terminal:0 pair — its generated suffix must not land on
+        # the natural terminal:0__r2 already on the wire.
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "terminal:0", "content": "second"},
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    calls = [i["call_id"] for i in items if i.get("type") == "function_call"]
+    outputs = [
+        i["call_id"] for i in items if i.get("type") == "function_call_output"
+    ]
+
+    assert len(calls) == len(outputs) == 3
+    # No duplicate wire ids — the generated repeat skipped the occupied
+    # natural suffix instead of colliding with it.
+    assert len(set(calls)) == 3
+    # Pairs still matched.
+    assert calls == outputs
+    # The natural pair keeps its exact stored id.
+    assert "terminal:0__r2" in calls
+    assert calls.count("terminal:0__r2") == 1
+
+
+def test_out_of_order_output_pairs_with_later_call():
+    """A tool result stored BEFORE its assistant call (imported/foreign
+    history) must pair with that later call, not collide with it."""
+    messages = [
+        {"role": "tool", "tool_call_id": "terminal:0", "content": "early"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "call_id": "terminal:0",
+                    "function": {"name": "terminal", "arguments": "{}"},
+                }
+            ],
+        },
+    ]
+
+    items = _chat_messages_to_responses_input(messages)
+
+    calls = [i["call_id"] for i in items if i.get("type") == "function_call"]
+    outputs = [
+        i["call_id"] for i in items if i.get("type") == "function_call_output"
+    ]
+
+    assert len(calls) == len(outputs) == 1
+    assert calls[0] == outputs[0] == "terminal:0"
+
+
+def test_repeated_call_id_outputs_stay_in_order():
+    """Nth output pairs with Nth call even with interleaved user text."""
+    messages = _two_turn_duplicate_messages("terminal:0")
+    messages.insert(2, {"role": "user", "content": "keep going"})
+
+    items = _chat_messages_to_responses_input(messages)
+
+    calls = [i["call_id"] for i in items if i.get("type") == "function_call"]
+    outputs = [i["call_id"] for i in items if i.get("type") == "function_call_output"]
+
+    assert len(calls) == len(outputs) == 2
+    assert calls[0] == outputs[0]
+    assert calls[1] == outputs[1]
+    assert calls[0] != calls[1]


### PR DESCRIPTION
## What does this PR do?

Uniquifies replayed Responses `call_id`s when the same stored tool id recurs
across turns, while keeping each `function_call` paired with its own
`function_call_output`. A session whose stored history carries e.g.
`terminal:0` on two turns otherwise replays the same id twice and every
`/v1/responses` request fails with `400 Duplicate function_call_output` —
permanently, until the session is discarded.

Supersedes the narrower queue-based fix in #102634 (call-order pairing
only): this PR pairs through bidirectional slots, so out-of-order stored
history (a tool result preceding its assistant call) and duplicate orphan
outputs also stay unique and paired.

## Related Issue

Fixes #102629

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/codex_responses_adapter.py` — `_chat_messages_to_responses_input`
  now binds every replayed `function_call` / `function_call_output` to a
  per-base-id slot: each side first binds to a slot opened by the opposite
  side (pairing works in either storage order), otherwise opens a fresh
  slot whose wire id uniquifies repeats — first occurrence keeps the stored
  id (prompt-cache prefix safe), repeats get a `__r<N>` suffix, all through
  the existing `_clamp_responses_call_id` 64-char guard.
- `tests/agent/test_codex_responses_duplicate_call_id.py` — regression
  tests: duplicate across turns (uniquified + paired), out-of-order
  output→call pairing, interleaved user text.

## How to Test

1. `.venv/bin/python -m pytest tests/agent/test_codex_responses_duplicate_call_id.py -v` — 3 passed
2. Without the fix (`git stash` of the adapter change), the same suite fails with `Duplicate function_call_output`-shaped duplicates on the wire.
3. Full adapter suites: `tests/agent/test_codex_responses_adapter.py` + `tests/run_agent/test_run_agent_codex_responses.py` — 92 passed, no regressions.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Debian GNU/Linux 13 (trixie), x86_64

### Documentation & Housekeeping

- [x] N/A — no config keys, docs, or tool behavior changed

## Screenshots / Logs

Regression proof: on `origin/main` the converter emits both `terminal:0`
occurrences verbatim; with this PR the wire carries `terminal:0` and
`terminal:0__r2` (dense `__rN` sequence — 2nd occurrence is `__r2`), each
call_id exactly one call + one output. Post-review hardening: the suffix
sequence was made dense (first free `__rN`, no skips) with a test pinning
`terminal:0__r2` for the second occurrence.

---

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.20.5
