### PR TITLE
fix(inventory): honor model_catalog.excluded_providers for unconfigured picker rows

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -668,6 +668,12 @@ def _append_unconfigured_rows(
 
     seen = {r["slug"].lower() for r in rows}
     cur = (ctx.current_provider or "").lower()
+    # ``model_catalog.excluded_providers`` must hide a provider on every
+    # surface. list_authenticated_providers honours it for authenticated
+    # rows; the unconfigured skeletons appended here bypassed it, so an
+    # excluded provider still surfaced in the TUI/desktop/web pickers.
+    # The current provider stays visible even if excluded (saved-model row).
+    seen |= {str(p).strip().lower() for p in (ctx.excluded_providers or []) if p} - {cur}
     cur_model = str(ctx.current_model or "").strip()
     extras: list[dict] = []
     for entry in CANONICAL_PROVIDERS:

--- a/tests/hermes_cli/test_inventory_unconfigured_excluded.py
+++ b/tests/hermes_cli/test_inventory_unconfigured_excluded.py
@@ -1,0 +1,39 @@
+"""``model_catalog.excluded_providers`` must also hide the unconfigured
+"setup skeleton" rows that ``build_models_payload(include_unconfigured=True)``
+appends for the TUI / desktop / web pickers.
+
+``list_authenticated_providers`` already honours the exclusion for
+authenticated rows; the skeleton path bypassed it, so an excluded provider
+reappeared in every GUI picker as an empty row.
+"""
+
+from hermes_cli.inventory import ConfigContext, _append_unconfigured_rows
+
+
+def _ctx(**kw) -> ConfigContext:
+    base = dict(
+        current_provider="9router",
+        current_model="glm",
+        current_base_url="",
+        user_providers={},
+        custom_providers=[],
+        excluded_providers=[],
+    )
+    base.update(kw)
+    return ConfigContext(**base)
+
+
+def test_unconfigured_rows_honor_excluded_providers():
+    rows = _append_unconfigured_rows([], _ctx(excluded_providers=["Anthropic ", "openrouter"]))
+    slugs = {r["slug"] for r in rows}
+    assert "anthropic" not in slugs
+    assert "openrouter" not in slugs
+    assert "deepseek" in slugs  # unrelated canonical providers still listed
+
+
+def test_unconfigured_rows_keep_current_provider_even_if_excluded():
+    rows = _append_unconfigured_rows(
+        [], _ctx(current_provider="anthropic", excluded_providers=["anthropic"])
+    )
+    cur = [r for r in rows if r["slug"] == "anthropic"]
+    assert cur and cur[0]["is_current"] and cur[0]["source"] == "configured-current"


### PR DESCRIPTION
## Problem
`model_catalog.excluded_providers` is honored by `list_authenticated_providers()`, but `_append_unconfigured_rows()` — used whenever a picker asks for `include_unconfigured=True` (TUI `ModelPickerDialog`, desktop, web UI, `/api/model/options`) — appends a setup-skeleton row for every `CANONICAL_PROVIDERS` entry not already in the list. An excluded provider therefore reappears as an empty row, and with ~50 canonical providers the GUI pickers show the full universe no matter what the user excluded.

Repro on main with `model_catalog.excluded_providers: [anthropic, openrouter, ...]` (43 entries): `build_model_options_payload(ctx, include_unconfigured=True)` → 55 rows. With this fix → 13.

## Fix
Fold the exclusion set into the `seen` set in `_append_unconfigured_rows`, one line. The current provider is deliberately kept even if excluded so the `configured-current` saved-model row still renders.

## Tests
`tests/hermes_cli/test_inventory_unconfigured_excluded.py` — exclusion honored (incl. whitespace/case), unrelated providers still listed, current provider survives exclusion. Existing picker/inventory tests pass.