### PR TITLE
fix(agent): honor per-model custom-provider context_length in compressor lazy path

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1737,9 +1737,22 @@ class ContextCompressor(MicroCompactionMixin, ContextEngine):
     def _resolve_context_length(self) -> int:
         """Resolve and cache the model's context length on first access."""
         if self._resolved_context_length is None:
+            # Thread per-model custom-provider overrides through this path:
+            # every other resolution site (startup, /model switch, gateway
+            # /info) passes the compatible list, but this deferred call did
+            # not — so providers.*.models.*.context_length was silently
+            # skipped here and the catalog value won (#15779 family).
+            _cp = None
+            try:
+                from hermes_cli.config import get_compatible_custom_providers
+
+                _cp = get_compatible_custom_providers()
+            except Exception:
+                _cp = None
             self._resolved_context_length = get_model_context_length(
                 self.model, base_url=self.base_url, api_key=self.api_key,
                 config_context_length=self._config_context_length, provider=self.provider,
+                custom_providers=_cp,
             )
             # Raise-only small-context floor; must run after context_length resolves and before threshold_tokens derives.
             self.threshold_percent = self._effective_threshold_percent(self._resolved_context_length, self._base_threshold_percent)

--- a/tests/agent/test_compressor_custom_provider_context.py
+++ b/tests/agent/test_compressor_custom_provider_context.py
@@ -1,0 +1,83 @@
+"""Deferred compressor resolution must honor per-model provider overrides.
+
+``ContextCompressor._resolve_context_length`` is the only resolution site
+that did not thread the compatible custom-provider list into
+``get_model_context_length`` (startup, ``/model`` switch and gateway
+``/info`` all do — see #15779). As a result a
+``providers.<name>.models.<id>.context_length`` entry was silently skipped
+on the lazy path and ``/usage`` reported the catalog window instead.
+"""
+
+from agent.context_compressor import ContextCompressor
+
+
+def _providers(models):
+    return [
+        {
+            "name": "test-relay",
+            "base_url": "https://relay.internal.example.com/v1",
+            "models": models,
+        }
+    ]
+
+
+def test_lazy_resolution_honors_per_model_override(monkeypatch):
+    """The lazy path returns the override without any network probe."""
+    from hermes_cli import config as _config_mod
+
+    monkeypatch.setattr(
+        _config_mod,
+        "get_compatible_custom_providers",
+        lambda config=None: _providers(
+            {"zz-override-probe-model": {"context_length": 272000}}
+        ),
+    )
+    cc = ContextCompressor(
+        model="zz-override-probe-model",
+        base_url="https://relay.internal.example.com/v1",
+        provider="custom",
+        quiet_mode=True,
+    )
+    assert cc.context_length == 272000
+
+
+def test_explicit_config_context_length_still_wins(monkeypatch):
+    """Precedence is unchanged: explicit pin beats the per-model entry."""
+    from hermes_cli import config as _config_mod
+
+    monkeypatch.setattr(
+        _config_mod,
+        "get_compatible_custom_providers",
+        lambda config=None: _providers(
+            {"zz-override-probe-model": {"context_length": 272000}}
+        ),
+    )
+    cc = ContextCompressor(
+        model="zz-override-probe-model",
+        base_url="https://relay.internal.example.com/v1",
+        provider="custom",
+        config_context_length=100000,
+        quiet_mode=True,
+    )
+    assert cc.context_length == 100000
+
+
+def test_unlisted_model_ignores_override(monkeypatch):
+    """A model with no entry must not inherit another model's override."""
+    from hermes_cli import config as _config_mod
+
+    monkeypatch.setattr(
+        _config_mod,
+        "get_compatible_custom_providers",
+        lambda config=None: _providers(
+            {"zz-override-probe-model": {"context_length": 272000}}
+        ),
+    )
+    cc = ContextCompressor(
+        model="zz-unlisted-model",
+        base_url="https://relay.internal.example.com/v1",
+        provider="custom",
+        config_context_length=100000,
+        quiet_mode=True,
+    )
+    assert cc.context_length == 100000


### PR DESCRIPTION
Closes #102644.

`ContextCompressor._resolve_context_length` called `get_model_context_length` without `custom_providers`, so a `providers.<name>.models.<id>.context_length` entry was skipped on the deferred path while startup, `/model` switch and gateway `/info` all honored it. `/usage` `context_max` showed the catalog window instead of the override.

Change: lazily load `get_compatible_custom_providers()` in `_resolve_context_length` and pass it through. Precedence unchanged — an explicit `config_context_length` still wins (step 0 runs first).

Verification:
- new `tests/agent/test_compressor_custom_provider_context.py`: 3 passed (override honored, explicit pin still wins, unlisted model unaffected)
- `tests/agent/test_model_metadata.py`: 121 passed
- compressor suites (`test_compress_focus`, `test_compressed_summary_metadata`, `test_compression_attempt_lifecycle`): 23 passed
- `tests/run_agent/test_switch_model_context.py`: 9 passed