### PR TITLE
fix(agent): never persist sentinel-only stream text as final answer

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -460,6 +460,64 @@ def _provider_stream_error_from_text(
     return None
 
 
+def _is_interrupted_placeholder_text(text: Optional[str]) -> bool:
+    """True when *text* is exactly the internal interrupted-turn sentinel.
+
+    The send-time heal path writes ``[response interrupted]`` (22 chars) onto
+    empty non-final wire copies; a stream cut mid-sentinel surfaces the same
+    bytes without the closing bracket (21 chars). Either shape as a complete
+    final text with ``finish_reason=stop`` is transport/stream corruption,
+    never a legitimate model answer (#102566). Longer texts that merely
+    contain the sentinel are NOT matched — quoting the string (e.g. while
+    discussing this bug) must keep working.
+    """
+    from agent.agent_runtime_helpers import _INTERRUPTED_PLACEHOLDER
+
+    stripped = (text or "").strip()
+    return stripped in (
+        _INTERRUPTED_PLACEHOLDER,
+        _INTERRUPTED_PLACEHOLDER[:-1],
+    )
+
+
+def _provider_stream_placeholder_error(
+    full_content: Optional[str],
+    finish_reason: Optional[str],
+    *,
+    has_tool_calls: bool,
+) -> Optional[ProviderStreamError]:
+    """Convert a sentinel-only final stream text into a retryable stream error.
+
+    When a normal (``finish_reason=stop``) tool-free stream assembles to
+    exactly the internal ``[response interrupted]`` sentinel, the bytes came
+    from the transport — proxy error-injection or an interrupted-but-resumed
+    stream — not from the model (#102566). Persisting them as the visible
+    answer loses the real reply and pollutes the session; raising lets the
+    retry machinery refetch instead of freezing the placeholder.
+    """
+    if has_tool_calls:
+        return None
+    if str(finish_reason or "").lower() != "stop":
+        return None
+    if not _is_interrupted_placeholder_text(full_content or ""):
+        return None
+    return ProviderStreamError(
+        status_code=None,
+        body=_provider_error_body(
+            {
+                "code": "placeholder_stream_corruption",
+                "message": (
+                    "Stream delivered only the internal interrupted-turn "
+                    "placeholder as final text; treating as transient stream "
+                    "corruption, not a model answer."
+                ),
+            },
+            None,
+        ),
+        raw_text=full_content or "",
+    )
+
+
 def estimate_request_context_tokens(api_payload: Any) -> int:
     """Estimate context/load tokens from an API payload, dict or messages list.
 
@@ -4577,7 +4635,18 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             delta_content = flatten_message_text(getattr(delta, "content", None), sep="")
             if delta_content:
                 content_parts.append(delta_content)
-                if not tool_calls_acc:
+                if not tool_calls_acc and _is_interrupted_placeholder_text(delta_content):
+                    # #102566: sentinel bytes injected by the transport are not
+                    # model output — deliver nothing (no display, no streamed
+                    # buffer, no delivered flag). The bytes stay in
+                    # content_parts so the end-of-stream guard below converts
+                    # the turn into a retryable stream error instead of
+                    # persisting the placeholder as the visible answer.
+                    logger.debug(
+                        "Suppressing interrupted-placeholder stream delta "
+                        "(transport corruption, not model output)"
+                    )
+                elif not tool_calls_acc:
                     if pending_text_parts or _provider_stream_text_may_be_sse(delta_content):
                         pending_text_parts.append(delta_content)
                         pending_text = "".join(pending_text_parts)
@@ -4879,6 +4948,13 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         if provider_stream_error is not None:
             raise provider_stream_error
+        placeholder_stream_error = _provider_stream_placeholder_error(
+            full_content,
+            effective_finish_reason,
+            has_tool_calls=bool(mock_tool_calls),
+        )
+        if placeholder_stream_error is not None:
+            raise placeholder_stream_error
         _flush_pending_stream_text()
 
         full_reasoning = "".join(reasoning_parts) or None
@@ -5778,6 +5854,15 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             _partial_text = (
                 getattr(agent, "_current_streamed_assistant_text", "") or ""
             ).strip() or None
+            if _partial_text is not None and _is_interrupted_placeholder_text(_partial_text):
+                # #102566: sentinel bytes split across deltas escape the
+                # per-delta suppression above (no single fragment matches),
+                # so the streamed buffer can still assemble to exactly the
+                # placeholder. Never freeze those bytes as the stub answer:
+                # an EMPTY stub is skipped from history by the truncation
+                # path (see NOTE below), keeping the session clean while
+                # the continuation machinery still fires.
+                _partial_text = None
 
             # Append a user-visible warning if tool calls were dropped so
             # the user and model both know what was attempted.

--- a/tests/run_agent/test_102566_placeholder_stream_corruption.py
+++ b/tests/run_agent/test_102566_placeholder_stream_corruption.py
@@ -1,0 +1,188 @@
+"""Sentinel-only streams must never persist as the visible answer (#102566).
+
+Behavior contract: when a normal (finish_reason=stop) tool-free stream
+assembles to exactly the internal ``[response interrupted]`` sentinel (full
+22-char form or the 21-char mid-sentinel truncation), the bytes came from the
+transport — proxy error-injection or an interrupted-but-resumed stream — not
+from the model. The turn must surface a retryable ProviderStreamError (or a
+history-safe empty length stub when fragments were already delivered), never
+a persisted ``[response interrupted]`` assistant row.
+"""
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from run_agent import AIAgent
+
+
+def _make_chunk(content=None, tool_calls=None, finish_reason=None, model="test/model"):
+    """Build a SimpleNamespace mimicking an OpenAI streaming chunk."""
+    delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+    choice = SimpleNamespace(delta=delta, finish_reason=finish_reason)
+    return SimpleNamespace(model=model, choices=[choice])
+
+
+def _make_tool_defs(*names: str) -> list:
+    """Build minimal tool definition list accepted by AIAgent.__init__."""
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": n,
+                "description": f"{n} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for n in names
+    ]
+
+
+@pytest.fixture()
+def agent():
+    """Minimal AIAgent with mocked OpenAI client and tool loading."""
+    with (
+        patch(
+            "run_agent.get_tool_definitions", return_value=_make_tool_defs("web_search")
+        ),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        a = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        a.client = MagicMock()
+        return a
+
+
+def _placeholder_stream(contents, finish_reason="stop"):
+    chunks = [_make_chunk(content=c) for c in contents]
+    chunks.append(_make_chunk(finish_reason=finish_reason))
+    return chunks
+
+
+class TestIsInterruptedPlaceholderText:
+    def test_exact_sentinel_matches(self):
+        from agent.chat_completion_helpers import _is_interrupted_placeholder_text
+
+        assert _is_interrupted_placeholder_text("[response interrupted]") is True
+
+    def test_truncated_sentinel_matches(self):
+        from agent.chat_completion_helpers import _is_interrupted_placeholder_text
+
+        assert _is_interrupted_placeholder_text("[response interrupted") is True
+
+    def test_padded_sentinel_matches(self):
+        from agent.chat_completion_helpers import _is_interrupted_placeholder_text
+
+        assert _is_interrupted_placeholder_text("  [response interrupted]\n") is True
+
+    def test_normal_text_does_not_match(self):
+        from agent.chat_completion_helpers import _is_interrupted_placeholder_text
+
+        assert _is_interrupted_placeholder_text("Hello world!") is False
+        assert _is_interrupted_placeholder_text("") is False
+        assert _is_interrupted_placeholder_text(None) is False
+
+    def test_longer_text_merely_containing_sentinel_does_not_match(self):
+        """Quoting the sentinel (e.g. discussing this bug) must keep working."""
+        from agent.chat_completion_helpers import _is_interrupted_placeholder_text
+
+        assert (
+            _is_interrupted_placeholder_text(
+                "I saw [response interrupted] in my transcript, why?"
+            )
+            is False
+        )
+
+
+class TestPlaceholderOnlyStream:
+    def test_placeholder_only_stream_raises_provider_stream_error(self, agent):
+        """Single-delta sentinel with finish_reason=stop is stream corruption."""
+        from agent.chat_completion_helpers import ProviderStreamError
+
+        agent.client.chat.completions.create.return_value = iter(
+            _placeholder_stream(["[response interrupted]"])
+        )
+        agent.stream_delta_callback = MagicMock()
+
+        with pytest.raises(ProviderStreamError) as exc_info:
+            agent._interruptible_streaming_api_call({"messages": []})
+
+        assert exc_info.value.body["error"]["code"] == "placeholder_stream_corruption"
+        # Nothing was delivered to the display: no fake answer, no pollution.
+        agent.stream_delta_callback.assert_not_called()
+
+    def test_truncated_placeholder_variant_raises(self, agent):
+        """21-char mid-sentinel cut is the same corruption class."""
+        from agent.chat_completion_helpers import ProviderStreamError
+
+        agent.client.chat.completions.create.return_value = iter(
+            _placeholder_stream(["[response interrupted"])
+        )
+        agent.stream_delta_callback = MagicMock()
+
+        with pytest.raises(ProviderStreamError):
+            agent._interruptible_streaming_api_call({"messages": []})
+
+        agent.stream_delta_callback.assert_not_called()
+
+    def test_split_placeholder_never_persists_in_stub(self, agent):
+        """Sentinel split across deltas escapes per-delta suppression: each
+        fragment is delivered, so the error lands on the length-stub path —
+        but the stub must carry NO content (empty stubs are skipped from
+        history), never the assembled placeholder."""
+        agent.client.chat.completions.create.return_value = iter(
+            _placeholder_stream(["[response ", "interrupted]"])
+        )
+        agent.stream_delta_callback = MagicMock()
+
+        stub = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert stub.choices[0].finish_reason == "length"
+        assert stub.choices[0].message.content in (None, "")
+
+    def test_normal_text_stream_unaffected(self, agent):
+        """Control: ordinary text still completes and streams normally."""
+        agent.client.chat.completions.create.return_value = iter(
+            _placeholder_stream(["Hello", " world!"])
+        )
+        agent.stream_delta_callback = MagicMock()
+
+        response = agent._interruptible_streaming_api_call({"messages": []})
+
+        assert response.choices[0].message.content == "Hello world!"
+        assert response.choices[0].finish_reason == "stop"
+        assert agent.stream_delta_callback.called
+
+    def test_nonstop_finish_reason_not_flagged(self, agent):
+        """Only a *normal* stop turn is corruption; other terminals keep
+        their existing handling."""
+        from agent.chat_completion_helpers import _provider_stream_placeholder_error
+
+        assert (
+            _provider_stream_placeholder_error(
+                "[response interrupted]",
+                "length",
+                has_tool_calls=False,
+            )
+            is None
+        )
+
+    def test_tool_call_turn_not_flagged(self, agent):
+        """Tool-call turns have their own corruption handling; the guard
+        stays out of their way."""
+        from agent.chat_completion_helpers import _provider_stream_placeholder_error
+
+        assert (
+            _provider_stream_placeholder_error(
+                "[response interrupted]",
+                "stop",
+                has_tool_calls=True,
+            )
+            is None
+        )


### PR DESCRIPTION
Fixes #102566.

## What
A normal (`finish_reason=stop`) tool-free stream that assembles to exactly the internal `[response interrupted]` sentinel is transport/stream corruption, not a model answer — yet it was persisted verbatim as the visible final response (flush path writes content verbatim; exhaustive grep shows zero durable-content writers, so the bytes arrived via the ordinary `text_response` path). The user loses the real reply and the session is polluted.

## How (3 narrow guards, one fix)
1. **Display/delivery suppression** — a text delta that is exactly the sentinel (22-char full or 21-char mid-sentinel cut, per the issue's DB evidence) is kept in `content_parts` for diagnosis but never fired to display, never recorded in the streamed-text buffer, and never sets the delivered flag.
2. **End-of-stream error** — sentinel-only final text with `stop` and no tool calls raises `ProviderStreamError` (`placeholder_stream_corruption`), following the #65631 precedent, so the retry machinery refetches instead of freezing the placeholder. No deltas were delivered, so this propagates (raise path), exactly like the existing provider-error raise above it.
3. **Split-delta stub scrub** — sentinel bytes split across deltas escape per-delta suppression; if the streamed buffer still assembles to exactly the sentinel, the length-stub carries empty content (empty stubs are skipped from history by the truncation path), keeping the session clean while continuation still fires.

Longer texts merely *containing* the sentinel are untouched (quoting it keeps working); tool-call turns and non-`stop` terminals keep their existing handling.

## Tests (behavior-contract, RED→GREEN verified)
New `tests/run_agent/test_102566_placeholder_stream_corruption.py` (11 tests): exact/truncated/split sentinel streams, delivery suppression, history-safe stub, control stream, non-stop and tool-call scoping, plus unit cases for the predicate. Verified 10 fail without the fix, all pass with it.
Neighbors green: `test_streaming`, `test_81641_text_turn_incremental_persistence`, `test_sanitiser_escalation`, `test_steer`, `test_partial_stream_finish_reason`, `test_thinking_only_sanitizer`, `test_streamed_text_accumulation`, `test_stream_interrupt_retry` (178 tests total).

## Notes
- Distinct from #84423 / #91398 (bg-review cancellation race): those never write user-visible placeholders (h/t the reporter's analysis, verified against current main).
- @Wenfengcheng noted on the issue they are investigating the same area; no fix PR existed at branch time — flagging for coordination.
- Follow-ups (out of scope): sentinel-*prefixed* mixed corruption (the 7k-char row with raw stream separators), non-streaming completion path.

Credit: Bruno Bza (@BrunoBza)