### PR TITLE
fix(gateway): route background completions to the owning profile's bot (#102635)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2866,6 +2866,21 @@ def _resolve_hermes_bin() -> Optional[list[str]]:
     return None
 
 
+def _profile_from_session_key(session_key: str) -> "str | None":
+    """Return the multiplexed profile embedded in a namespaced session key.
+
+    Keys look like ``agent:main:{platform}:...`` for the default profile and
+    ``agent:<profile>:{platform}:...`` for a multiplexed secondary. Returns
+    ``None`` for the default profile and for keys that don't parse.
+    """
+    parts = (session_key or "").split(":")
+    if len(parts) >= 5 and parts[0] == "agent":
+        profile = parts[1]
+        if profile and profile != "main":
+            return profile
+    return None
+
+
 def _parse_session_key(session_key: str) -> "dict | None":
     """Parse a session key (``agent:main:{platform}:{chat_type}:{chat_id}[:{extra}...]``).
     For group/channel sessions the suffix may be a user_id, not a thread_id, so ``thread_id`` is omitted.

--- a/gateway/run_notifications.py
+++ b/gateway/run_notifications.py
@@ -832,9 +832,9 @@ class GatewayNotificationsMixin:
             with _log_suppressed(logging.ERROR, "Watch notification injection error: %s"):
                 await self._inject_watch_notification(synth_text, evt)
 
-    def _adapter_by_platform_value(self, platform_name: str):
+    def _adapter_by_platform_value(self, platform_name: str, adapters=None):
         """Literal ``p.value == platform_name`` scan over connected adapters (native adapters only)."""
-        for p, a in self.adapters.items():
+        for p, a in (adapters if adapters is not None else self.adapters).items():
             if p.value == platform_name:
                 return a
         return None
@@ -863,18 +863,19 @@ class GatewayNotificationsMixin:
             logger.warning(fail, raw_sid, e)
             return False
 
-    def _resolve_injection_adapter(self, platform_name: str):
+    def _resolve_injection_adapter(self, platform_name: str, adapters=None):
         """Adapter for a synthetic-event platform: alias-aware transport resolver first (one
         Platform.RELAY adapter fronts N logical platforms; native wins), literal ``p.value`` scan as
         fallback for minimal runner stubs / exotic platform strings when the resolver can't run."""
         from gateway.delivery import resolve_delivery_transport
+        adapter_map = adapters if adapters is not None else self.adapters
         try:
-            _transport = resolve_delivery_transport(Platform(platform_name), self.config, self.adapters)
+            _transport = resolve_delivery_transport(Platform(platform_name), self.config, adapter_map)
         except Exception:
             _transport = None
         if _transport is not None:
             return _transport.adapter
-        return self._adapter_by_platform_value(platform_name)
+        return self._adapter_by_platform_value(platform_name, adapters=adapter_map)
 
     async def _inject_watch_notification(self, synth_text: str, evt: dict) -> Optional[bool]:
         """Inject a watch/completion notification as a synthetic message event.
@@ -907,7 +908,33 @@ class GatewayNotificationsMixin:
             )
             return None
         platform_name = source.platform.value if hasattr(source.platform, "value") else str(source.platform)
-        adapter = self._resolve_injection_adapter(platform_name)
+        # Multiplex: a secondary profile's background output must route to
+        # THAT profile's adapters (its own bot), not the default profile's.
+        # self.adapters only ever holds the default profile's map; secondaries
+        # live in self._profile_adapters[name] (same disposition as the
+        # cron-handoff delivery path). A session_key like
+        # ``agent:<profile>:telegram:dm:<uid>`` carries the ownership — and
+        # because a Telegram DM's chat_id is the shared user id, ignoring it
+        # routes profile-B's output into profile-A's bot (#102635).
+        from gateway.run import _profile_from_session_key
+
+        profile_name = _profile_from_session_key(str(evt.get("session_key") or ""))
+        profile_adapters = None
+        if profile_name:
+            profile_adapters = (getattr(self, "_profile_adapters", None) or {}).get(profile_name)
+            if not profile_adapters:
+                # No live adapters for the owning profile (disconnected or
+                # stopped): drop rather than misroute through the default
+                # profile's bot.
+                logger.warning(
+                    "Background-process event for session %s routes to profile "
+                    "'%s', which has no live adapters in this gateway — "
+                    "dropping instead of delivering through the default "
+                    "profile's bot (#102635).",
+                    evt.get("session_key"), profile_name,
+                )
+                return None
+        adapter = self._resolve_injection_adapter(platform_name, adapters=profile_adapters)
         if not adapter:
             return None
         if not adapter_supports_push(adapter):

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -693,3 +693,55 @@ def test_gateway_drain_retains_and_formats_overflow_events():
     out_released = _format_gateway_process_notification(released)
     assert "notifications resumed" in out_released
     assert "exit code" not in out_released
+
+
+@pytest.mark.asyncio
+async def test_inject_routes_secondary_profile_to_its_own_adapter(monkeypatch, tmp_path):
+    """#102635: under multiplex, a background completion for a secondary
+    profile's session must route to THAT profile's bot — a Telegram DM's
+    chat_id is the shared user id, so keying on chat_id alone delivers
+    profile-B's output into profile-A's bot."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    default_adapter = runner.adapters[Platform.TELEGRAM]
+    secondary_adapter = SimpleNamespace(send=AsyncMock(), handle_message=AsyncMock())
+    runner._profile_adapters = {"profile-b": {Platform.TELEGRAM: secondary_adapter}}
+
+    evt = {
+        "session_id": "proc_profile_b",
+        "session_key": "agent:profile-b:telegram:dm:555",
+        "platform": "telegram",
+        "chat_id": "555",
+        "chat_type": "dm",
+    }
+
+    await runner._inject_watch_notification("[SYSTEM: Background process finished]", evt)
+
+    secondary_adapter.handle_message.assert_awaited_once()
+    default_adapter.handle_message.assert_not_awaited()
+    synth_event = secondary_adapter.handle_message.await_args.args[0]
+    assert synth_event.source.platform == Platform.TELEGRAM
+    assert synth_event.source.chat_id == "555"
+
+
+@pytest.mark.asyncio
+async def test_inject_drops_when_owning_profile_has_no_live_adapters(monkeypatch, tmp_path):
+    """No live adapters for the owning profile → drop rather than misroute
+    through the default profile's bot."""
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    default_adapter = runner.adapters[Platform.TELEGRAM]
+    runner._profile_adapters = {}  # secondary disconnected
+
+    evt = {
+        "session_id": "proc_profile_b",
+        "session_key": "agent:profile-b:telegram:dm:555",
+        "platform": "telegram",
+        "chat_id": "555",
+        "chat_type": "dm",
+    }
+
+    result = await runner._inject_watch_notification(
+        "[SYSTEM: Background process finished]", evt
+    )
+
+    assert result is None
+    default_adapter.handle_message.assert_not_awaited()


### PR DESCRIPTION
## What does this PR do?

Fixes #102635: under `gateway.multiplex_profiles` (each profile with its own Telegram bot), a background task started in a **secondary profile's** session delivered its live progress and completion output through the **default profile's bot** — profile-B's deploy log rendering live in profile-A's chat.

Root cause: a Telegram DM's `chat_id` is the shared user id, so both profiles' sessions carry the identical `chat_id` with different session keys (`agent:main:telegram:dm:<uid>` vs `agent:profile-b:telegram:dm:<uid>`). `_inject_watch_notification` resolved the delivery adapter from `self.adapters` (the DEFAULT profile's map) plus a literal platform scan — both return the first telegram adapter, i.e. the default bot.

## Related Issue

Fixes #102635

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py`
  - New `_profile_from_session_key()`: returns the multiplexed profile embedded in a namespaced session key (`agent:<profile>:platform:...`), `None` for the default profile.
  - `_inject_watch_notification()`: when the event's session key names a secondary profile, the delivery adapter is resolved from `self._profile_adapters[profile]` instead of `self.adapters` — mirroring the cron-handoff delivery path, which already documents that `self.adapters` only holds the default profile's adapters. When the owning profile has no live adapters (disconnected/stopped), the event is dropped with a warning rather than misrouted through the default profile's bot.
- `tests/gateway/test_background_process_notifications.py`: two multiplex regression tests — a secondary-profile completion routes to that profile's adapter (default adapter untouched), and a disconnected owning profile drops the event instead of misrouting.

## How to Test

1. Multiplex gateway, two profiles each with its own Telegram bot; the same user DMs both.
2. In the secondary profile's chat, run `terminal(background=true, notify_on_complete=true)` on a long task.
3. Before: progress/completion bubbles appear in the default profile's bot chat. After: they stay in the secondary profile's bot.

Automated: `scripts/run_tests.sh tests/gateway/test_background_process_notifications.py -q` — 25 passed (23 existing + 2 new).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — routing fix with deterministic multiplex regression tests. -->
