### PR TITLE
fix(tirith): keep Hermes-managed installs updated

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -498,7 +498,12 @@ terminal:
 # =============================================================================
 # Optional pre-exec command security scanning via tirith.
 # Detects homograph URLs, pipe-to-shell, terminal injection, env manipulation.
-# Install: brew install sheeki03/tap/tirith
+# With the default path, Hermes installs and updates its managed Tirith binary
+# in $HERMES_HOME/bin (or a platform-qualified subdirectory for immutable
+# images that share this data root with the host). PATH and explicitly
+# configured binaries stay externally managed. Set security.allow_lazy_installs
+# to false to disable Hermes-managed runtime installs and updates.
+# Manual install: brew install sheeki03/tap/tirith
 # Docs: https://github.com/sheeki03/tirith
 #
 # security:

--- a/contributors/emails/Masih-0x3@users.noreply.github.com
+++ b/contributors/emails/Masih-0x3@users.noreply.github.com
@@ -1,0 +1,2 @@
+Masih-0x3
+# PR #99131 salvage (tirith: honor lazy-install opt-out)

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -2756,13 +2756,11 @@ DEFAULT_CONFIG = {
         # <id>`; remove by editing the list directly. See
         # ``hermes_cli/security_advisories.py`` for the catalog.
         "acked_advisories": [],
-        # Allow Hermes to lazy-install opt-in backend packages from PyPI
-        # the first time the user enables a backend that needs them
-        # (e.g. installing ``elevenlabs`` when the user picks ElevenLabs as
-        # their TTS provider). Set to false to require explicit
-        # ``pip install`` for everything beyond the base set — appropriate
-        # for restricted networks, audited environments, or air-gapped
-        # systems where any runtime install is unacceptable.
+        # Allow Hermes to make runtime installs: opt-in backend packages from
+        # PyPI and managed helper binaries such as Tirith. Set to false to
+        # require explicit installation for everything beyond the base set —
+        # appropriate for restricted networks, audited environments, or
+        # air-gapped systems where any runtime install is unacceptable.
         "allow_lazy_installs": True,
     },
 

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -12,6 +12,10 @@ import pytest
 import tools.tirith_security as tirith
 
 
+def _state(path: str = "tirith"):
+    return tirith._runtime_state(path)
+
+
 def _config(path: str = "tirith") -> dict:
     return {
         "tirith_enabled": True,
@@ -57,18 +61,12 @@ class _CapturedThread:
 
 @pytest.fixture(autouse=True)
 def _reset_update_globals():
-    tirith._resolved_path = None
-    tirith._install_thread = None
-    tirith._install_failure_reason = ""
-    tirith._update_thread = None
+    tirith._reset_runtime_states_for_tests()
     with tirith._in_process_update_state_lock:
         tirith._in_process_update_states.clear()
     _CapturedThread.instances = []
     yield
-    tirith._resolved_path = None
-    tirith._install_thread = None
-    tirith._install_failure_reason = ""
-    tirith._update_thread = None
+    tirith._reset_runtime_states_for_tests()
     with tirith._in_process_update_state_lock:
         tirith._in_process_update_states.clear()
 
@@ -221,6 +219,9 @@ class TestCrossProcessUpdateLock:
         external.write_text("outside", encoding="utf-8")
         (tmp_path / ".tirith-update.lock").symlink_to(external)
 
+        lock_fd, status = tirith._acquire_update_lock_with_status()
+        assert lock_fd is None
+        assert status == "error"
         assert tirith._acquire_update_lock() is None
         assert external.read_text(encoding="utf-8") == "outside"
 
@@ -635,8 +636,9 @@ class TestManagedCachePlacement:
     ):
         assert tirith._managed_tirith_root_is_denied(root)
 
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
-    def test_peer_writable_managed_root_is_not_owned(self, tmp_path, monkeypatch):
+    def _assert_peer_writable_managed_root_is_not_owned(
+        self, tmp_path, monkeypatch
+    ):
         home = tmp_path / "home"
         managed = _write_executable(home / "bin" / "tirith")
         home.chmod(0o777)
@@ -644,9 +646,19 @@ class TestManagedCachePlacement:
 
         assert not tirith._is_managed_tirith(str(managed))
 
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
-    @pytest.mark.parametrize("mode", [0o775, 0o757, 0o777, 0o655])
-    def test_managed_binary_requires_private_owner_executable_mode(
+    @pytest.mark.linux_only
+    def test_peer_writable_managed_root_is_not_owned_linux(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_peer_writable_managed_root_is_not_owned(tmp_path, monkeypatch)
+
+    @pytest.mark.macos_only
+    def test_peer_writable_managed_root_is_not_owned_macos(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_peer_writable_managed_root_is_not_owned(tmp_path, monkeypatch)
+
+    def _assert_managed_binary_requires_private_owner_executable_mode(
         self, mode, tmp_path, monkeypatch
     ):
         home = tmp_path / "home"
@@ -656,8 +668,25 @@ class TestManagedCachePlacement:
 
         assert not tirith._is_managed_tirith(str(managed))
 
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
-    def test_managed_binary_must_be_owned_by_effective_user(
+    @pytest.mark.linux_only
+    @pytest.mark.parametrize("mode", [0o775, 0o757, 0o777, 0o655])
+    def test_managed_binary_requires_private_owner_executable_mode_linux(
+        self, mode, tmp_path, monkeypatch
+    ):
+        self._assert_managed_binary_requires_private_owner_executable_mode(
+            mode, tmp_path, monkeypatch
+        )
+
+    @pytest.mark.macos_only
+    @pytest.mark.parametrize("mode", [0o775, 0o757, 0o777, 0o655])
+    def test_managed_binary_requires_private_owner_executable_mode_macos(
+        self, mode, tmp_path, monkeypatch
+    ):
+        self._assert_managed_binary_requires_private_owner_executable_mode(
+            mode, tmp_path, monkeypatch
+        )
+
+    def _assert_managed_binary_must_be_owned_by_effective_user(
         self, tmp_path, monkeypatch
     ):
         managed = _write_executable(tmp_path / "tirith")
@@ -676,6 +705,22 @@ class TestManagedCachePlacement:
         )
 
         assert not tirith._is_owned_private_executable(str(managed))
+
+    @pytest.mark.linux_only
+    def test_managed_binary_must_be_owned_by_effective_user_linux(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_managed_binary_must_be_owned_by_effective_user(
+            tmp_path, monkeypatch
+        )
+
+    @pytest.mark.macos_only
+    def test_managed_binary_must_be_owned_by_effective_user_macos(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_managed_binary_must_be_owned_by_effective_user(
+            tmp_path, monkeypatch
+        )
 
     @pytest.mark.parametrize(
         "entries, expected",
@@ -830,8 +875,8 @@ class TestUpdateScheduling:
 
         assert len(_CapturedThread.instances) == 1
         thread = _CapturedThread.instances[0]
-        assert thread.target is tirith._background_update
-        assert thread.args == (str(managed),)
+        assert thread.target.__name__ == "run"
+        assert thread.args == (tirith._background_update, str(managed))
         assert thread.kwargs == {"log_failures": False}
         assert thread.daemon is True
         assert thread.started
@@ -951,7 +996,7 @@ class TestUpdateScheduling:
 
         # Startup performs the first maintenance check.
         assert tirith.ensure_installed(log_failures=False) == str(managed)
-        first_worker = tirith._update_thread
+        first_worker = _state().update_thread
         assert first_worker is not None
         first_worker.join(timeout=2)
         assert not first_worker.is_alive()
@@ -962,12 +1007,12 @@ class TestUpdateScheduling:
         # A normal command in the same process must not launch another worker
         # while the successful-check TTL is fresh.
         assert tirith._resolve_tirith_path("tirith") == str(managed)
-        assert tirith._update_thread is first_worker
+        assert _state().update_thread is first_worker
 
         # Model a Tirith release after startup by expiring the check state.
         assert tirith._write_update_state("current", now=1)
         assert tirith._resolve_tirith_path("tirith") == str(managed)
-        second_worker = tirith._update_thread
+        second_worker = _state().update_thread
         assert second_worker is not None
         assert second_worker is not first_worker
         second_worker.join(timeout=2)
@@ -1471,7 +1516,7 @@ class TestSelfUpdateSubprocess:
     def test_failed_update_keeps_scanner_path_and_binary(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         managed = _write_executable(tmp_path / "bin" / "tirith")
-        tirith._resolved_path = str(managed)
+        _state().resolved_path = str(managed)
         monkeypatch.setattr(
             tirith.subprocess,
             "run",
@@ -1481,11 +1526,12 @@ class TestSelfUpdateSubprocess:
         )
 
         assert tirith._run_tirith_update(str(managed)) == "failed"
-        assert tirith._resolved_path == str(managed)
+        assert _state().resolved_path == str(managed)
         assert managed.read_bytes() == b"old tirith"
 
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
-    def test_mode_drift_before_update_prevents_spawn(self, tmp_path, monkeypatch):
+    def _assert_mode_drift_before_update_prevents_spawn(
+        self, tmp_path, monkeypatch
+    ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         managed = _write_executable(tmp_path / "bin" / "tirith")
         managed.chmod(0o775)
@@ -1495,12 +1541,24 @@ class TestSelfUpdateSubprocess:
         assert tirith._run_tirith_update(str(managed)) == "failed"
         run.assert_not_called()
 
+    @pytest.mark.linux_only
+    def test_mode_drift_before_update_prevents_spawn_linux(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_mode_drift_before_update_prevents_spawn(tmp_path, monkeypatch)
+
+    @pytest.mark.macos_only
+    def test_mode_drift_before_update_prevents_spawn_macos(
+        self, tmp_path, monkeypatch
+    ):
+        self._assert_mode_drift_before_update_prevents_spawn(tmp_path, monkeypatch)
+
     def test_signature_required_failure_keeps_binary_without_weaker_retry(
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         managed = _write_executable(tmp_path / "bin" / "tirith")
-        tirith._resolved_path = str(managed)
+        _state().resolved_path = str(managed)
         run = MagicMock(
             return_value=subprocess.CompletedProcess(
                 args=[],
@@ -1512,7 +1570,7 @@ class TestSelfUpdateSubprocess:
         monkeypatch.setattr(tirith.subprocess, "run", run)
 
         assert tirith._run_tirith_update(str(managed)) == "failed"
-        assert tirith._resolved_path == str(managed)
+        assert _state().resolved_path == str(managed)
         assert managed.read_bytes() == b"old tirith"
         run.assert_called_once()
         assert "--allow-unsigned" not in run.call_args.args[0]
@@ -1544,7 +1602,7 @@ class TestBackgroundWorkerIsolation:
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         managed = _write_executable(tmp_path / "bin" / "tirith")
-        tirith._resolved_path = str(managed)
+        _state().resolved_path = str(managed)
         monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
         monkeypatch.setattr(
             tirith, "_maintain_managed_tirith", lambda *_a, **_kw: "failed"
@@ -1552,11 +1610,11 @@ class TestBackgroundWorkerIsolation:
 
         tirith._background_update(str(managed), log_failures=False)
 
-        assert tirith._resolved_path == str(managed)
+        assert _state().resolved_path == str(managed)
         assert managed.read_bytes() == b"old tirith"
         assert (tmp_path / ".tirith-update.lock").is_file()
         assert not (tmp_path / ".tirith-install-failed").exists()
-        assert tirith._install_failure_reason == ""
+        assert _state().install_failure_reason == ""
         state = json.loads(
             (tmp_path / ".tirith-update-state.json").read_text(encoding="utf-8")
         )
@@ -1577,6 +1635,31 @@ class TestBackgroundWorkerIsolation:
             tirith._release_update_lock(lock_fd)
 
         maintain.assert_not_called()
+        assert tirith._read_update_state() is None
+
+    def test_operational_lock_error_sets_short_backoff(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        maintain = MagicMock(return_value="current")
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith,
+            "_acquire_update_lock_with_status",
+            lambda: (None, "error"),
+        )
+        monkeypatch.setattr(tirith, "_maintain_managed_tirith", maintain)
+
+        tirith._background_update(str(managed), log_failures=False)
+
+        maintain.assert_not_called()
+        state = tirith._read_update_state()
+        assert state is not None
+        assert state["outcome"] == "failed"
+        assert not tirith._update_is_due(
+            now=state["checked_at"] + tirith._UPDATE_FAILURE_TTL - 1
+        )
 
     def test_shared_fresh_state_is_rechecked_after_lock(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -181,7 +181,7 @@ class TestUpdateState:
         assert tirith._update_is_due(now=1_000)
 
     def test_persistence_failure_still_throttles_this_process(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, caplog
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         monkeypatch.setattr(
@@ -190,8 +190,10 @@ class TestUpdateState:
             MagicMock(side_effect=OSError("read-only filesystem")),
         )
 
-        assert not tirith._write_update_state("failed", now=1_000)
+        with caplog.at_level("WARNING", logger="tools.tirith_security"):
+            assert not tirith._write_update_state("failed", now=1_000)
         assert not (tmp_path / ".tirith-update-state.json").exists()
+        assert "could not persist Tirith update backoff" in caplog.text
         assert not tirith._update_is_due(
             now=1_000 + tirith._UPDATE_FAILURE_TTL - 1
         )
@@ -396,6 +398,66 @@ class TestAtomicInstall:
 
 
 class TestSignedReplacementFreshness:
+    @pytest.mark.parametrize(
+        "failure_mode, verification_result, expected_reason",
+        [
+            ("artifacts", None, "cosign_artifacts_unavailable"),
+            ("rejected", (False, None), "cosign_verification_failed"),
+            ("unavailable", (None, None), "cosign_exec_failed"),
+        ],
+    )
+    def test_replacement_never_falls_back_when_provenance_is_unavailable(
+        self,
+        failure_mode,
+        verification_result,
+        expected_reason,
+        tmp_path,
+        monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"current tirith"
+        )
+        expected_sha256 = tirith._sha256_file(str(destination))
+
+        def download(url, dest, *, max_bytes, **_kwargs):
+            del max_bytes
+            if failure_mode == "artifacts" and url.endswith("checksums.txt.sig"):
+                raise OSError("signature unavailable")
+            Path(dest).write_bytes(b"downloaded")
+
+        verify = MagicMock(return_value=verification_result)
+        checksum = MagicMock(return_value=True)
+        extract = MagicMock(return_value=(str(tmp_path / "candidate"), ""))
+        replace = MagicMock()
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: "/usr/bin/cosign")
+        monkeypatch.setattr(tirith, "_download_file", download)
+        monkeypatch.setattr(tirith, "_verify_cosign", verify)
+        monkeypatch.setattr(tirith, "_verify_checksum", checksum)
+        monkeypatch.setattr(tirith, "_extract_release_archive", extract)
+        monkeypatch.setattr(tirith, "_atomic_replace_binary", replace)
+
+        installed, reason = tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=expected_sha256,
+            current_version=(0, 4, 0),
+        )
+
+        assert installed is None
+        assert reason == expected_reason
+        assert destination.read_bytes() == b"current tirith"
+        checksum.assert_not_called()
+        extract.assert_not_called()
+        replace.assert_not_called()
+        if failure_mode == "artifacts":
+            verify.assert_not_called()
+        else:
+            verify.assert_called_once()
+
     @pytest.mark.parametrize("candidate_version", [(0, 3, 9), (0, 4, 1)])
     def test_older_or_equal_signed_release_cannot_replace_current_binary(
         self, candidate_version, tmp_path, monkeypatch
@@ -758,6 +820,90 @@ class TestManagedCachePlacement:
             effective_uid=501,
         )
 
+    @pytest.mark.parametrize(
+        "entries, expected",
+        [
+            (
+                [
+                    (0x01, 7, 0xFFFF_FFFF),
+                    (0x04, 7, 0xFFFF_FFFF),
+                    (0x10, 7, 0xFFFF_FFFF),
+                    (0x20, 5, 0xFFFF_FFFF),
+                ],
+                False,
+            ),
+            (
+                [
+                    (0x01, 7, 0xFFFF_FFFF),
+                    (0x04, 7, 0xFFFF_FFFF),
+                    (0x10, 5, 0xFFFF_FFFF),
+                    (0x20, 5, 0xFFFF_FFFF),
+                ],
+                True,
+            ),
+            (
+                [
+                    (0x01, 7, 0xFFFF_FFFF),
+                    (0x04, 5, 0xFFFF_FFFF),
+                    (0x10, 5, 0xFFFF_FFFF),
+                    (0x20, 7, 0xFFFF_FFFF),
+                ],
+                False,
+            ),
+            (
+                [
+                    (0x01, 7, 0xFFFF_FFFF),
+                    (0x02, 7, 31_337),
+                    (0x04, 5, 0xFFFF_FFFF),
+                    (0x10, 5, 0xFFFF_FFFF),
+                    (0x20, 5, 0xFFFF_FFFF),
+                ],
+                True,
+            ),
+        ],
+    )
+    def test_linux_default_acl_applies_mask_and_rejects_foreign_write(
+        self, entries, expected
+    ):
+        assert tirith._linux_posix_acl_blob_is_private(
+            _linux_acl_blob(entries),
+            owner_uid=501,
+            effective_uid=501,
+            default_acl=True,
+        ) is expected
+
+    def test_linux_acl_reader_treats_default_acl_as_inheritance_policy(
+        self, tmp_path, monkeypatch
+    ):
+        directory = tmp_path / "managed"
+        directory.mkdir()
+        owner_uid = directory.stat().st_uid
+        default_acl = _linux_acl_blob(
+            [
+                (0x01, 7, 0xFFFF_FFFF),
+                (0x04, 7, 0xFFFF_FFFF),
+                (0x10, 7, 0xFFFF_FFFF),
+                (0x20, 5, 0xFFFF_FFFF),
+            ]
+        )
+
+        def getxattr(_path, name, *, follow_symlinks):
+            assert follow_symlinks is False
+            if name == "system.posix_acl_access":
+                raise OSError(tirith.errno.ENODATA, "no access ACL")
+            return default_acl
+
+        monkeypatch.setattr(tirith.os, "getxattr", getxattr, raising=False)
+        monkeypatch.setattr(
+            tirith.os,
+            "listxattr",
+            lambda *_args, **_kwargs: ["system.posix_acl_default"],
+            raising=False,
+        )
+        monkeypatch.setattr(tirith.os, "geteuid", lambda: owner_uid, raising=False)
+
+        assert not tirith._linux_acl_is_private(str(directory), directory=True)
+
     @pytest.mark.live_system_guard_bypass
     @pytest.mark.macos_only
     @pytest.mark.parametrize("component", ["binary", "directory"])
@@ -816,10 +962,9 @@ class TestManagedCachePlacement:
         home = tmp_path / "home"
         home.mkdir()
         external = tmp_path / "external"
+        external.mkdir()
         target = "x86_64-unknown-linux-gnu"
-        outside_binary = _write_executable(
-            external / target / "bin" / "tirith", b"outside"
-        )
+        outside_binary = external / target / "bin" / "tirith"
         (home / ".tirith-managed").symlink_to(
             external, target_is_directory=True
         )
@@ -833,12 +978,15 @@ class TestManagedCachePlacement:
             "_download_verified_tirith",
             lambda *_args, **_kwargs: (str(verified), "", True, (0, 4, 1)),
         )
+        replace = MagicMock()
+        monkeypatch.setattr(tirith, "_atomic_replace_binary", replace)
 
         installed, reason = tirith._install_tirith(log_failures=False)
 
         assert installed is None
-        assert reason == "destination_exists"
-        assert outside_binary.read_bytes() == b"outside"
+        assert reason == "managed_directory_untrusted"
+        assert not outside_binary.exists()
+        replace.assert_not_called()
         assert not tirith._is_managed_tirith(
             str(home / ".tirith-managed" / target / "bin" / "tirith")
         )
@@ -941,6 +1089,21 @@ class TestUpdateScheduling:
         assert tirith.ensure_installed() == str(explicit)
         assert not _CapturedThread.instances
 
+    def test_explicit_managed_cache_path_is_never_updated(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        managed = _write_executable(tmp_path / "home" / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_load_security_config", lambda: _config(str(managed))
+        )
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith, "_update_is_due", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert not _CapturedThread.instances
+
     def test_runtime_install_opt_out_disables_updates_not_scanning(
         self, tmp_path, monkeypatch
     ):
@@ -1026,6 +1189,53 @@ class TestUpdateScheduling:
 
 class TestLegacyReleaseProof:
     @pytest.mark.parametrize(
+        "version, verification_results, expected, expected_targets",
+        [
+            (
+                (0, 2, 12),
+                [(None, "binary_mismatch")],
+                (None, None, "binary_mismatch"),
+                ["aarch64-unknown-linux-gnu"],
+            ),
+            (
+                (0, 4, 1),
+                [(None, "binary_mismatch"), ("a" * 64, "")],
+                ("a" * 64, "aarch64-unknown-linux-musl", ""),
+                ["aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl"],
+            ),
+            (
+                (0, 4, 1),
+                [("b" * 64, "")],
+                ("b" * 64, "aarch64-unknown-linux-gnu", ""),
+                ["aarch64-unknown-linux-gnu"],
+            ),
+            (
+                (0, 4, 1),
+                [(None, "download_failed"), (None, "binary_mismatch")],
+                (None, None, "download_failed"),
+                ["aarch64-unknown-linux-gnu", "aarch64-unknown-linux-musl"],
+            ),
+        ],
+    )
+    def test_termux_release_verification_routes_across_published_targets(
+        self,
+        version,
+        verification_results,
+        expected,
+        expected_targets,
+        monkeypatch,
+    ):
+        verify = MagicMock(side_effect=verification_results)
+        monkeypatch.setattr(tirith, "_verify_legacy_release_binary", verify)
+
+        assert tirith._verify_termux_release_binary(
+            "/managed/tirith", version, log_failures=False
+        ) == expected
+        assert [
+            call.kwargs["target"] for call in verify.call_args_list
+        ] == expected_targets
+
+    @pytest.mark.parametrize(
         "installed_bytes, expected_reason",
         [
             (b"official release", ""),
@@ -1057,6 +1267,45 @@ class TestLegacyReleaseProof:
 
 
 class TestMaintenanceDecision:
+    def test_version_probe_failure_is_diagnosed(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: (None, "probe_failed")
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+
+        with caplog.at_level("WARNING", logger="tools.tirith_security"):
+            assert tirith._maintain_managed_tirith(str(managed)) == "failed"
+
+        assert "could not determine the installed version" in caplog.text
+
+    def test_provenance_probe_failure_is_diagnosed(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (None, "provenance_failed"),
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+
+        with caplog.at_level("WARNING", logger="tools.tirith_security"):
+            assert tirith._maintain_managed_tirith(str(managed)) == "failed"
+
+        assert "could not verify updater provenance" in caplog.text
+
     def test_pre_041_cache_is_bootstrapped_with_verified_installer(
         self, tmp_path, monkeypatch
     ):
@@ -1576,7 +1825,7 @@ class TestSelfUpdateSubprocess:
         assert "--allow-unsigned" not in run.call_args.args[0]
 
     def test_unexpected_success_payload_is_not_treated_as_fresh(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, caplog
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         managed = _write_executable(tmp_path / "bin" / "tirith")
@@ -1593,7 +1842,30 @@ class TestSelfUpdateSubprocess:
             ),
         )
 
-        assert tirith._run_tirith_update(str(managed)) == "failed"
+        with caplog.at_level("INFO", logger="tools.tirith_security"):
+            assert tirith._run_tirith_update(str(managed)) == "failed"
+
+        assert "unexpected action" in caplog.text
+
+    def test_malformed_success_payload_is_diagnosed(
+        self, tmp_path, monkeypatch, caplog
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith.subprocess,
+            "run",
+            MagicMock(
+                return_value=subprocess.CompletedProcess(
+                    args=[], returncode=0, stdout="not json", stderr=""
+                )
+            ),
+        )
+
+        with caplog.at_level("INFO", logger="tools.tirith_security"):
+            assert tirith._run_tirith_update(str(managed)) == "failed"
+
+        assert "returned malformed JSON" in caplog.text
 
 
 class TestBackgroundWorkerIsolation:

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -99,6 +99,35 @@ class TestVersionParsing:
     def test_rejects_unparseable_or_development_versions(self, output):
         assert tirith._parse_tirith_version(output) is None
 
+    @pytest.mark.parametrize(
+        "payload, expected",
+        [
+            (b"prefix\x00tirith 0.4.1\nsuffix", (0, 4, 1)),
+            (b"prefixshell-version0.2.12tirith.shsuffix", (0, 2, 12)),
+        ],
+    )
+    def test_reads_historical_release_version_without_execution(
+        self, payload, expected, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith", payload)
+
+        assert tirith._read_embedded_tirith_version(str(managed)) == (expected, "")
+
+    def test_rejects_ambiguous_embedded_release_versions(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(
+            tmp_path / "bin" / "tirith",
+            b"tirith 0.4.0\ntirith 0.4.1\n",
+        )
+
+        assert tirith._read_embedded_tirith_version(str(managed)) == (
+            None,
+            "unparseable",
+        )
+
 
 class TestUpdateState:
     def test_successful_check_is_fresh_for_24_hours(self, tmp_path, monkeypatch):
@@ -464,6 +493,59 @@ class TestSignedReplacementFreshness:
         assert installed == str(destination)
         assert reason == ""
         assert destination.read_bytes() == b"new tirith"
+
+    def test_same_signed_release_can_replace_verified_cross_abi_binary(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"glibc tirith"
+        )
+        candidate = _write_executable(
+            tmp_path / "download" / "tirith", b"musl tirith"
+        )
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_download_verified_tirith",
+            lambda *_args, **_kwargs: (str(candidate), "", True, (0, 4, 1)),
+        )
+
+        installed, reason = tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=tirith._sha256_file(str(destination)),
+            current_version=(0, 4, 1),
+            allow_same_version_replacement=True,
+        )
+
+        assert installed == str(destination)
+        assert reason == ""
+        assert destination.read_bytes() == b"musl tirith"
+
+    def test_same_version_replacement_is_termux_musl_only(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"current tirith"
+        )
+        download = MagicMock()
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(tirith, "_download_verified_tirith", download)
+
+        assert tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=tirith._sha256_file(str(destination)),
+            current_version=(0, 4, 1),
+            allow_same_version_replacement=True,
+        ) == (None, "invalid_replacement_request")
+        download.assert_not_called()
 
     def test_initial_install_is_create_only_when_destination_already_exists(
         self, tmp_path, monkeypatch
@@ -1138,6 +1220,15 @@ class TestMaintenanceDecision:
         )
         install = MagicMock(return_value=(str(managed), ""))
         update = MagicMock()
+        monkeypatch.setattr(
+            tirith,
+            "_verify_termux_release_binary",
+            lambda *_args, **_kwargs: (
+                expected_sha256,
+                "aarch64-unknown-linux-musl",
+                "",
+            ),
+        )
         monkeypatch.setattr(tirith, "_install_tirith", install)
         monkeypatch.setattr(tirith, "_run_tirith_update", update)
 
@@ -1149,8 +1240,81 @@ class TestMaintenanceDecision:
             log_failures=False,
             expected_existing_sha256=expected_sha256,
             current_version=(0, 4, 1),
+            minimum_candidate_version=(0, 4, 1),
+            allow_same_version_replacement=False,
         )
         update.assert_not_called()
+
+    def test_unexecutable_historical_termux_glibc_release_is_migrated(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(
+            tmp_path / "bin" / "tirith",
+            b"prefix\x00tirith 0.4.1\nsuffix",
+        )
+        expected_sha256 = tirith._sha256_file(str(managed))
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: (None, "probe_failed")
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        verify = MagicMock(
+            return_value=(
+                expected_sha256,
+                "aarch64-unknown-linux-gnu",
+                "",
+            )
+        )
+        provenance = MagicMock()
+        install = MagicMock(return_value=(str(managed), ""))
+        monkeypatch.setattr(tirith, "_verify_termux_release_binary", verify)
+        monkeypatch.setattr(tirith, "_probe_tirith_provenance", provenance)
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "updated"
+        )
+        verify.assert_called_once_with(
+            str(managed),
+            (0, 4, 1),
+            log_failures=False,
+        )
+        provenance.assert_not_called()
+        install.assert_called_once_with(
+            log_failures=False,
+            expected_existing_sha256=expected_sha256,
+            current_version=(0, 4, 1),
+            minimum_candidate_version=(0, 4, 1),
+            allow_same_version_replacement=True,
+        )
+
+    def test_unexecutable_unknown_termux_binary_is_never_replaced(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(
+            tmp_path / "bin" / "tirith",
+            b"prefix\x00tirith 0.4.1\nsuffix",
+        )
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: (None, "probe_failed")
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_verify_termux_release_binary",
+            lambda *_args, **_kwargs: (None, None, "binary_mismatch"),
+        )
+        install = MagicMock()
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "skipped"
+        install.assert_not_called()
 
     def test_termux_replayed_release_is_a_noop(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -1174,6 +1338,15 @@ class TestMaintenanceDecision:
         )
         monkeypatch.setattr(
             tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_verify_termux_release_binary",
+            lambda *_args, **_kwargs: (
+                tirith._sha256_file(str(managed)),
+                "aarch64-unknown-linux-musl",
+                "",
+            ),
         )
         monkeypatch.setattr(
             tirith,

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -279,6 +279,22 @@ class TestAtomicInstall:
         assert destination.read_bytes() == b"old tirith"
         assert not list(destination.parent.glob(".tirith-install-*"))
 
+    def test_absent_only_commit_does_not_clobber_concurrent_binary(self, tmp_path):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        destination = _write_executable(
+            tmp_path / "bin" / "tirith", b"concurrent tirith"
+        )
+
+        with pytest.raises(FileExistsError):
+            tirith._atomic_replace_binary(
+                str(source),
+                str(destination),
+                require_destination_absent=True,
+            )
+
+        assert destination.read_bytes() == b"concurrent tirith"
+        assert not list(destination.parent.glob(".tirith-install-*"))
+
     def test_changed_preimage_is_not_replaced(self, tmp_path):
         source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
         destination = _write_executable(tmp_path / "bin" / "tirith", b"changed")
@@ -405,7 +421,7 @@ class TestManagedCachePlacement:
         monkeypatch.setattr(
             tirith,
             "_download_verified_tirith",
-            lambda *_args: (str(verified), "", True),
+            lambda *_args, **_kwargs: (str(verified), "", True),
         )
 
         installed, reason = tirith._install_tirith(log_failures=False)
@@ -900,7 +916,7 @@ class TestSelfUpdateSubprocess:
             ({"action": "updated", "new_version": "0.4.2"}, "updated"),
         ],
     )
-    def test_invokes_noninteractive_checksum_verified_update(
+    def test_invokes_noninteractive_signed_update(
         self, payload, expected, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -919,10 +935,10 @@ class TestSelfUpdateSubprocess:
             str(managed),
             "update",
             "--yes",
-            "--allow-unsigned",
             "--format",
             "json",
         ]
+        assert "--allow-unsigned" not in args[0]
         assert kwargs["stdin"] is subprocess.DEVNULL
         assert kwargs["timeout"] == tirith._UPDATE_TIMEOUT
         assert kwargs["env"]["HERMES_HOME"] == str(tmp_path)
@@ -942,6 +958,28 @@ class TestSelfUpdateSubprocess:
         assert tirith._run_tirith_update(str(managed)) == "failed"
         assert tirith._resolved_path == str(managed)
         assert managed.read_bytes() == b"old tirith"
+
+    def test_signature_required_failure_keeps_binary_without_weaker_retry(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        tirith._resolved_path = str(managed)
+        run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[],
+                returncode=1,
+                stdout=json.dumps({"action": "error"}),
+                stderr="release signature verification is required",
+            )
+        )
+        monkeypatch.setattr(tirith.subprocess, "run", run)
+
+        assert tirith._run_tirith_update(str(managed)) == "failed"
+        assert tirith._resolved_path == str(managed)
+        assert managed.read_bytes() == b"old tirith"
+        run.assert_called_once()
+        assert "--allow-unsigned" not in run.call_args.args[0]
 
     def test_unexpected_success_payload_is_not_treated_as_fresh(
         self, tmp_path, monkeypatch
@@ -1047,7 +1085,7 @@ fi
     tirith._background_update(str(managed), log_failures=False)
 
     assert (tmp_path / "update-argv").read_text(encoding="utf-8").strip() == (
-        "update --yes --allow-unsigned --format json"
+        "update --yes --format json"
     )
     state = json.loads(
         (tmp_path / ".tirith-update-state.json").read_text(encoding="utf-8")

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -28,6 +28,15 @@ def _write_executable(path: Path, payload: bytes = b"old tirith") -> Path:
     return path
 
 
+def _linux_acl_blob(entries: list[tuple[int, int, int]]) -> bytes:
+    value = bytearray((2).to_bytes(4, "little"))
+    for tag, permissions, principal_id in entries:
+        value.extend(tag.to_bytes(2, "little"))
+        value.extend(permissions.to_bytes(2, "little"))
+        value.extend(principal_id.to_bytes(4, "little"))
+    return bytes(value)
+
+
 class _CapturedThread:
     instances = []
 
@@ -323,6 +332,160 @@ class TestAtomicInstall:
 
         assert destination.read_bytes() == b"outside"
 
+    @pytest.mark.live_system_guard_bypass
+    @pytest.mark.macos_only
+    def test_inherited_mutating_acl_on_staging_file_aborts_replacement(
+        self, tmp_path
+    ):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        destination = _write_executable(tmp_path / "bin" / "tirith", b"old tirith")
+        subprocess.run(
+            [
+                "/bin/chmod",
+                "+a",
+                "everyone allow write,file_inherit",
+                str(destination.parent),
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        try:
+            with pytest.raises(PermissionError, match="staging file"):
+                tirith._atomic_replace_binary(str(source), str(destination))
+
+            assert destination.read_bytes() == b"old tirith"
+            assert not list(destination.parent.glob(".tirith-install-*"))
+        finally:
+            subprocess.run(
+                ["/bin/chmod", "-N", str(destination.parent)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+
+class TestSignedReplacementFreshness:
+    @pytest.mark.parametrize("candidate_version", [(0, 3, 9), (0, 4, 1)])
+    def test_older_or_equal_signed_release_cannot_replace_current_binary(
+        self, candidate_version, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"current tirith"
+        )
+        candidate = _write_executable(
+            tmp_path / "download" / "tirith", b"replayed tirith"
+        )
+        expected_sha256 = tirith._sha256_file(str(destination))
+        replace = MagicMock()
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_download_verified_tirith",
+            lambda *_args, **_kwargs: (str(candidate), "", True, candidate_version),
+        )
+        monkeypatch.setattr(tirith, "_atomic_replace_binary", replace)
+
+        installed, reason = tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=expected_sha256,
+            current_version=(0, 4, 1),
+        )
+
+        assert installed is None
+        assert reason == "candidate_not_newer"
+        assert destination.read_bytes() == b"current tirith"
+        replace.assert_not_called()
+
+    def test_legacy_bootstrap_rejects_candidate_below_self_update_minimum(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"legacy tirith"
+        )
+        candidate = _write_executable(
+            tmp_path / "download" / "tirith", b"newer legacy tirith"
+        )
+        replace = MagicMock()
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_download_verified_tirith",
+            lambda *_args, **_kwargs: (str(candidate), "", True, (0, 4, 0)),
+        )
+        monkeypatch.setattr(tirith, "_atomic_replace_binary", replace)
+
+        installed, reason = tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=tirith._sha256_file(str(destination)),
+            current_version=(0, 3, 3),
+            minimum_candidate_version=tirith._SELF_UPDATE_MIN_VERSION,
+        )
+
+        assert installed is None
+        assert reason == "candidate_below_minimum"
+        assert destination.read_bytes() == b"legacy tirith"
+        replace.assert_not_called()
+
+    def test_newer_signed_release_replaces_preimage_bound_binary(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"current tirith"
+        )
+        candidate = _write_executable(
+            tmp_path / "download" / "tirith", b"new tirith"
+        )
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_download_verified_tirith",
+            lambda *_args, **_kwargs: (str(candidate), "", True, (0, 4, 2)),
+        )
+
+        installed, reason = tirith._install_tirith(
+            log_failures=False,
+            expected_existing_sha256=tirith._sha256_file(str(destination)),
+            current_version=(0, 4, 1),
+        )
+
+        assert installed == str(destination)
+        assert reason == ""
+        assert destination.read_bytes() == b"new tirith"
+
+    def test_initial_install_is_create_only_when_destination_already_exists(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        destination = _write_executable(
+            tmp_path / "home" / "bin" / "tirith", b"existing tirith"
+        )
+        download = MagicMock()
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(tirith, "_download_verified_tirith", download)
+
+        assert tirith._install_tirith(log_failures=False) == (
+            None,
+            "destination_exists",
+        )
+        assert destination.read_bytes() == b"existing tirith"
+        download.assert_not_called()
+
 
 class TestManagedCachePlacement:
     def test_source_and_package_installs_keep_historical_cache_path(
@@ -399,6 +562,126 @@ class TestManagedCachePlacement:
 
         assert not tirith._is_managed_tirith(str(managed))
 
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
+    @pytest.mark.parametrize("mode", [0o775, 0o757, 0o777, 0o655])
+    def test_managed_binary_requires_private_owner_executable_mode(
+        self, mode, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = _write_executable(home / "bin" / "tirith")
+        managed.chmod(mode)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert not tirith._is_managed_tirith(str(managed))
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
+    def test_managed_binary_must_be_owned_by_effective_user(
+        self, tmp_path, monkeypatch
+    ):
+        managed = _write_executable(tmp_path / "tirith")
+        executable_stat = managed.lstat()
+        stat_fields = list(executable_stat)
+        stat_fields[4] = os.geteuid() + 1
+        monkeypatch.setattr(
+            tirith.os,
+            "lstat",
+            lambda _path: os.stat_result(stat_fields),
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_trusted_unix_acl_is_private",
+            lambda *_args, **_kwargs: True,
+        )
+
+        assert not tirith._is_owned_private_executable(str(managed))
+
+    @pytest.mark.parametrize(
+        "entries, expected",
+        [
+            ([(0x01, 7, 0xFFFF_FFFF), (0x02, 7, 31_337)], False),
+            ([(0x01, 7, 0xFFFF_FFFF), (0x02, 5, 31_337)], True),
+            ([(0x01, 7, 0xFFFF_FFFF), (0x08, 7, 12_345)], False),
+            ([(0x01, 7, 0xFFFF_FFFF), (0x02, 7, 501)], True),
+        ],
+    )
+    def test_linux_acl_policy_rejects_only_foreign_mutation_grants(
+        self, entries, expected
+    ):
+        assert tirith._linux_posix_acl_blob_is_private(
+            _linux_acl_blob(entries),
+            owner_uid=501,
+            effective_uid=501,
+        ) is expected
+
+    @pytest.mark.parametrize(
+        "blob",
+        [
+            b"",
+            (3).to_bytes(4, "little"),
+            (2).to_bytes(4, "little") + b"short",
+            _linux_acl_blob([(0x40, 7, 1)]),
+        ],
+    )
+    def test_linux_acl_policy_fails_closed_on_malformed_or_unknown_data(
+        self, blob
+    ):
+        assert not tirith._linux_posix_acl_blob_is_private(
+            blob,
+            owner_uid=501,
+            effective_uid=501,
+        )
+
+    @pytest.mark.live_system_guard_bypass
+    @pytest.mark.macos_only
+    @pytest.mark.parametrize("component", ["binary", "directory"])
+    def test_macos_mutating_acl_is_rejected_even_with_private_mode_bits(
+        self, component, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = _write_executable(home / "bin" / "tirith")
+        target = managed if component == "binary" else managed.parent
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        subprocess.run(
+            ["/bin/chmod", "+a", "everyone allow write", str(target)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        try:
+            assert target.stat().st_mode & 0o777 == 0o755
+            assert not tirith._is_managed_tirith(str(managed))
+        finally:
+            subprocess.run(
+                ["/bin/chmod", "-N", str(target)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
+    @pytest.mark.live_system_guard_bypass
+    @pytest.mark.macos_only
+    def test_macos_deny_only_acl_does_not_widen_mutation_authority(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = _write_executable(home / "bin" / "tirith")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        subprocess.run(
+            ["/bin/chmod", "+a", "everyone deny delete", str(managed)],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        try:
+            assert tirith._is_managed_tirith(str(managed))
+        finally:
+            subprocess.run(
+                ["/bin/chmod", "-N", str(managed)],
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+
     @pytest.mark.require_symlinks
     def test_image_cache_intermediate_symlink_cannot_redirect_install(
         self, tmp_path, monkeypatch
@@ -421,13 +704,13 @@ class TestManagedCachePlacement:
         monkeypatch.setattr(
             tirith,
             "_download_verified_tirith",
-            lambda *_args, **_kwargs: (str(verified), "", True),
+            lambda *_args, **_kwargs: (str(verified), "", True, (0, 4, 1)),
         )
 
         installed, reason = tirith._install_tirith(log_failures=False)
 
         assert installed is None
-        assert reason == "managed_directory_untrusted"
+        assert reason == "destination_exists"
         assert outside_binary.read_bytes() == b"outside"
         assert not tirith._is_managed_tirith(
             str(home / ".tirith-managed" / target / "bin" / "tirith")
@@ -483,7 +766,7 @@ class TestUpdateScheduling:
         assert not _CapturedThread.instances
 
     @pytest.mark.require_symlinks
-    def test_managed_path_symlink_is_never_updated(self, tmp_path, monkeypatch):
+    def test_managed_path_symlink_is_rejected(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
         external = _write_executable(tmp_path / "external" / "tirith")
         managed = tmp_path / "home" / "bin" / "tirith"
@@ -495,11 +778,12 @@ class TestUpdateScheduling:
         monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
         monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
 
-        assert tirith.ensure_installed() == str(managed)
+        assert tirith.ensure_installed() is None
+        assert external.read_bytes() == b"old tirith"
         assert not _CapturedThread.instances
 
     @pytest.mark.require_symlinks
-    def test_managed_parent_symlink_is_never_updated(self, tmp_path, monkeypatch):
+    def test_managed_parent_symlink_is_rejected(self, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         external_dir = tmp_path / "external"
@@ -513,8 +797,9 @@ class TestUpdateScheduling:
         monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
         monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
 
-        assert tirith.ensure_installed() == str(managed)
+        assert tirith.ensure_installed() is None
         assert managed.samefile(external)
+        assert external.read_bytes() == b"old tirith"
         assert not _CapturedThread.instances
 
     def test_explicit_binary_is_never_updated(self, tmp_path, monkeypatch):
@@ -629,7 +914,7 @@ class TestLegacyReleaseProof:
         def fake_download(_base_url, _target, workdir, _log):
             released = Path(workdir) / "released-tirith"
             released.write_bytes(b"official release")
-            return str(released), "", True
+            return str(released), "", True, (0, 4, 1)
 
         monkeypatch.setattr(tirith, "_download_verified_tirith", fake_download)
 
@@ -670,8 +955,29 @@ class TestMaintenanceDecision:
         install.assert_called_once_with(
             log_failures=False,
             expected_existing_sha256="a" * 64,
+            current_version=(0, 4, 0),
+            minimum_candidate_version=tirith._SELF_UPDATE_MIN_VERSION,
         )
         update.assert_not_called()
+
+    def test_pre_041_replayed_release_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 0), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_verify_legacy_release_binary",
+            lambda *_args, **_kwargs: ("a" * 64, ""),
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_install_tirith",
+            lambda **_kwargs: (None, "candidate_not_newer"),
+        )
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "current"
 
     def test_pre_041_custom_build_is_left_untouched(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
@@ -842,8 +1148,40 @@ class TestMaintenanceDecision:
         install.assert_called_once_with(
             log_failures=False,
             expected_existing_sha256=expected_sha256,
+            current_version=(0, 4, 1),
         )
         update.assert_not_called()
+
+    def test_termux_replayed_release_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": "0.4.1",
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": False,
+                },
+                "",
+            ),
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_install_tirith",
+            lambda **_kwargs: (None, "candidate_not_newer"),
+        )
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "current"
 
     def test_termux_release_with_native_musl_provenance_uses_self_update(
         self, tmp_path, monkeypatch
@@ -972,6 +1310,17 @@ class TestSelfUpdateSubprocess:
         assert tirith._run_tirith_update(str(managed)) == "failed"
         assert tirith._resolved_path == str(managed)
         assert managed.read_bytes() == b"old tirith"
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
+    def test_mode_drift_before_update_prevents_spawn(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        managed.chmod(0o775)
+        run = MagicMock()
+        monkeypatch.setattr(tirith.subprocess, "run", run)
+
+        assert tirith._run_tirith_update(str(managed)) == "failed"
+        run.assert_not_called()
 
     def test_signature_required_failure_keeps_binary_without_weaker_retry(
         self, tmp_path, monkeypatch

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -1,0 +1,969 @@
+"""Behavioral tests for Hermes-managed Tirith background updates."""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+import tools.tirith_security as tirith
+
+
+def _config(path: str = "tirith") -> dict:
+    return {
+        "tirith_enabled": True,
+        "tirith_path": path,
+        "tirith_timeout": 5,
+        "tirith_fail_open": True,
+    }
+
+
+def _write_executable(path: Path, payload: bytes = b"old tirith") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(payload)
+    path.chmod(0o755)
+    return path
+
+
+class _CapturedThread:
+    instances = []
+
+    def __init__(self, *, target, args=(), kwargs=None, daemon=None):
+        self.target = target
+        self.args = args
+        self.kwargs = kwargs or {}
+        self.daemon = daemon
+        self.started = False
+        self.__class__.instances.append(self)
+
+    def start(self):
+        self.started = True
+
+    def is_alive(self):
+        return self.started
+
+
+@pytest.fixture(autouse=True)
+def _reset_update_globals():
+    tirith._resolved_path = None
+    tirith._install_thread = None
+    tirith._install_failure_reason = ""
+    tirith._update_thread = None
+    with tirith._in_process_update_state_lock:
+        tirith._in_process_update_states.clear()
+    _CapturedThread.instances = []
+    yield
+    tirith._resolved_path = None
+    tirith._install_thread = None
+    tirith._install_failure_reason = ""
+    tirith._update_thread = None
+    with tirith._in_process_update_state_lock:
+        tirith._in_process_update_states.clear()
+
+
+class TestVersionParsing:
+    @pytest.mark.parametrize(
+        "output, expected",
+        [
+            ("tirith 0.4.0\n", (0, 4, 0)),
+            ("tirith 0.4.1", (0, 4, 1)),
+            ("tirith 1.12.3\n", (1, 12, 3)),
+        ],
+    )
+    def test_accepts_stable_release_versions(self, output, expected):
+        assert tirith._parse_tirith_version(output) == expected
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "",
+            "0.4.1",
+            "tirith dev",
+            "tirith 0.4.1-dev",
+            "tirith 0.4",
+            "tirith 0.4.1 unexpected",
+        ],
+    )
+    def test_rejects_unparseable_or_development_versions(self, output):
+        assert tirith._parse_tirith_version(output) is None
+
+
+class TestUpdateState:
+    def test_successful_check_is_fresh_for_24_hours(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert tirith._write_update_state("current", now=1_000)
+
+        assert not tirith._update_is_due(now=1_000 + tirith._UPDATE_CHECK_TTL - 1)
+        assert tirith._update_is_due(now=1_000 + tirith._UPDATE_CHECK_TTL)
+
+    def test_failure_retries_after_shorter_backoff(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert tirith._write_update_state("failed", now=1_000)
+
+        assert not tirith._update_is_due(now=1_000 + tirith._UPDATE_FAILURE_TTL - 1)
+        assert tirith._update_is_due(now=1_000 + tirith._UPDATE_FAILURE_TTL)
+
+    def test_corrupt_or_future_state_never_suppresses_checks(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state = tmp_path / ".tirith-update-state.json"
+        state.write_text("not json", encoding="utf-8")
+        assert tirith._update_is_due(now=1_000)
+
+        state.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "checked_at": 2_000,
+                "outcome": "current",
+            }),
+            encoding="utf-8",
+        )
+        assert tirith._update_is_due(now=1_000)
+
+    def test_persistence_failure_still_throttles_this_process(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            tirith.os,
+            "replace",
+            MagicMock(side_effect=OSError("read-only filesystem")),
+        )
+
+        assert not tirith._write_update_state("failed", now=1_000)
+        assert not (tmp_path / ".tirith-update-state.json").exists()
+        assert not tirith._update_is_due(
+            now=1_000 + tirith._UPDATE_FAILURE_TTL - 1
+        )
+        assert tirith._update_is_due(now=1_000 + tirith._UPDATE_FAILURE_TTL)
+
+
+class TestCrossProcessUpdateLock:
+    def test_lock_is_process_bound_and_reusable(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        lock = tmp_path / ".tirith-update.lock"
+        owner = tirith._acquire_update_lock()
+        assert owner is not None
+        assert lock.is_file()
+        tirith._release_update_lock(owner)
+
+        next_owner = tirith._acquire_update_lock()
+        assert next_owner is not None
+        tirith._release_update_lock(next_owner)
+
+    @pytest.mark.require_symlinks
+    def test_lock_path_symlink_is_rejected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        external = tmp_path / "external-lock"
+        external.write_text("outside", encoding="utf-8")
+        (tmp_path / ".tirith-update.lock").symlink_to(external)
+
+        assert tirith._acquire_update_lock() is None
+        assert external.read_text(encoding="utf-8") == "outside"
+
+
+_LOCK_WORKER = """
+import sys
+from tools import tirith_security
+
+lock_fd = tirith_security._acquire_update_lock()
+print("locked" if lock_fd is not None else "blocked", flush=True)
+if lock_fd is not None and sys.argv[1] == "hold":
+    sys.stdin.readline()
+if lock_fd is not None:
+    tirith_security._release_update_lock(lock_fd)
+"""
+
+
+def _assert_process_lock_excludes_competitor(tmp_path):
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(tmp_path)
+    owner = subprocess.Popen(
+        [sys.executable, "-c", _LOCK_WORKER, "hold"],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert owner.stdout is not None
+        assert owner.stdout.readline().strip() == "locked"
+        contender = subprocess.run(
+            [sys.executable, "-c", _LOCK_WORKER, "once"],
+            cwd=Path(__file__).parents[2],
+            env=env,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=True,
+        )
+        assert contender.stdout.strip() == "blocked"
+    finally:
+        if owner.stdin is not None:
+            owner.stdin.write("release\n")
+            owner.stdin.flush()
+        owner.communicate(timeout=10)
+
+    successor = subprocess.run(
+        [sys.executable, "-c", _LOCK_WORKER, "once"],
+        cwd=Path(__file__).parents[2],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=10,
+        check=True,
+    )
+    assert successor.stdout.strip() == "locked"
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.linux_only
+def test_process_lock_excludes_competitor_on_linux(tmp_path):
+    _assert_process_lock_excludes_competitor(tmp_path)
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.macos_only
+def test_process_lock_excludes_competitor_on_macos(tmp_path):
+    _assert_process_lock_excludes_competitor(tmp_path)
+
+
+class TestAtomicInstall:
+    def test_replaces_existing_binary_atomically(self, tmp_path):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        destination = _write_executable(tmp_path / "bin" / "tirith", b"old tirith")
+
+        tirith._atomic_replace_binary(str(source), str(destination))
+
+        assert destination.read_bytes() == b"new tirith"
+        assert os.access(destination, os.X_OK)
+        assert not list(destination.parent.glob(".tirith-install-*"))
+
+    def test_failed_commit_preserves_working_binary(self, tmp_path, monkeypatch):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        destination = _write_executable(tmp_path / "bin" / "tirith", b"old tirith")
+        monkeypatch.setattr(
+            tirith.os, "replace", MagicMock(side_effect=OSError("busy"))
+        )
+
+        with pytest.raises(OSError, match="busy"):
+            tirith._atomic_replace_binary(str(source), str(destination))
+
+        assert destination.read_bytes() == b"old tirith"
+        assert not list(destination.parent.glob(".tirith-install-*"))
+
+    def test_changed_preimage_is_not_replaced(self, tmp_path):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        destination = _write_executable(tmp_path / "bin" / "tirith", b"changed")
+
+        with pytest.raises(OSError, match="changed after"):
+            tirith._atomic_replace_binary(
+                str(source),
+                str(destination),
+                expected_existing_sha256="0" * 64,
+            )
+
+        assert destination.read_bytes() == b"changed"
+        assert not list(destination.parent.glob(".tirith-install-*"))
+
+    @pytest.mark.require_symlinks
+    def test_redirected_destination_directory_is_rejected(self, tmp_path):
+        source = _write_executable(tmp_path / "download" / "tirith", b"new tirith")
+        external = tmp_path / "external"
+        destination = _write_executable(external / "tirith", b"outside")
+        managed = tmp_path / "managed"
+        managed.mkdir()
+        (managed / "bin").symlink_to(external, target_is_directory=True)
+
+        with pytest.raises(OSError):
+            tirith._atomic_replace_binary(str(source), str(managed / "bin" / "tirith"))
+
+        assert destination.read_bytes() == b"outside"
+
+
+class TestManagedCachePlacement:
+    def test_source_and_package_installs_keep_historical_cache_path(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(
+            tirith, "_uses_image_managed_tirith_root", lambda: False
+        )
+
+        assert tirith._managed_tirith_path() == str(tmp_path / "bin" / "tirith")
+
+    def test_image_cache_is_platform_qualified_away_from_shared_host_binary(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(tirith, "_uses_image_managed_tirith_root", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "x86_64-unknown-linux-gnu"
+        )
+        host_binary = _write_executable(tmp_path / "bin" / "tirith")
+
+        expected_root = (
+            tmp_path / ".tirith-managed" / "x86_64-unknown-linux-gnu"
+        )
+        assert tirith._managed_tirith_path() == str(expected_root / "bin" / "tirith")
+        assert not tirith._is_managed_tirith(str(host_binary))
+        assert tirith._update_state_path() == str(
+            expected_root / ".tirith-update-state.json"
+        )
+        assert tirith._tirith_subprocess_env()["HERMES_HOME"] == str(expected_root)
+
+    def test_tirith_children_do_not_inherit_hermes_credentials(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+        monkeypatch.setenv("OPENAI_API_KEY", "secret-key")
+        monkeypatch.setenv("TIRITH_TEST_SAFE_VALUE", "kept")
+        monkeypatch.setattr(
+            tirith, "_uses_image_managed_tirith_root", lambda: False
+        )
+
+        env = tirith._tirith_subprocess_env()
+
+        assert env["HERMES_HOME"] == str(tmp_path)
+        assert env["TIRITH_TEST_SAFE_VALUE"] == "kept"
+        assert "GITHUB_TOKEN" not in env
+        assert "OPENAI_API_KEY" not in env
+
+    @pytest.mark.parametrize(
+        "root",
+        [
+            "/usr/local",
+            "/opt/homebrew",
+            "/opt/homebrew/Cellar/tirith/0.4.0",
+            "/OPT/HOMEBREW/CELLAR/TIRITH/0.4.0",
+            "/home/linuxbrew/.linuxbrew/Cellar/tirith/0.4.0",
+            "/nix/store/example-tirith",
+            "/nix/var/nix/profiles/default",
+        ],
+    )
+    def test_package_manager_roots_never_gain_managed_ownership(
+        self, root
+    ):
+        assert tirith._managed_tirith_root_is_denied(root)
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
+    def test_peer_writable_managed_root_is_not_owned(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        managed = _write_executable(home / "bin" / "tirith")
+        home.chmod(0o777)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert not tirith._is_managed_tirith(str(managed))
+
+    @pytest.mark.require_symlinks
+    def test_image_cache_intermediate_symlink_cannot_redirect_install(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        home.mkdir()
+        external = tmp_path / "external"
+        target = "x86_64-unknown-linux-gnu"
+        outside_binary = _write_executable(
+            external / target / "bin" / "tirith", b"outside"
+        )
+        (home / ".tirith-managed").symlink_to(
+            external, target_is_directory=True
+        )
+        verified = _write_executable(tmp_path / "verified" / "tirith", b"new")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(tirith, "_uses_image_managed_tirith_root", lambda: True)
+        monkeypatch.setattr(tirith, "_detect_target", lambda: target)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith,
+            "_download_verified_tirith",
+            lambda *_args: (str(verified), "", True),
+        )
+
+        installed, reason = tirith._install_tirith(log_failures=False)
+
+        assert installed is None
+        assert reason == "managed_directory_untrusted"
+        assert outside_binary.read_bytes() == b"outside"
+        assert not tirith._is_managed_tirith(
+            str(home / ".tirith-managed" / target / "bin" / "tirith")
+        )
+
+
+class TestUpdateScheduling:
+    def test_managed_cache_returns_immediately_and_schedules_background_update(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith, "_update_is_due", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed(log_failures=False) == str(managed)
+
+        assert len(_CapturedThread.instances) == 1
+        thread = _CapturedThread.instances[0]
+        assert thread.target is tirith._background_update
+        assert thread.args == (str(managed),)
+        assert thread.kwargs == {"log_failures": False}
+        assert thread.daemon is True
+        assert thread.started
+
+    def test_external_path_binary_is_never_updated(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        external = _write_executable(tmp_path / "external" / "tirith")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: str(external))
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(external)
+        assert not _CapturedThread.instances
+
+    @pytest.mark.require_symlinks
+    def test_managed_path_symlink_is_never_updated(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        external = _write_executable(tmp_path / "external" / "tirith")
+        managed = tmp_path / "home" / "bin" / "tirith"
+        managed.parent.mkdir(parents=True)
+        managed.symlink_to(external)
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert not _CapturedThread.instances
+
+    @pytest.mark.require_symlinks
+    def test_managed_parent_symlink_is_never_updated(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        home.mkdir()
+        external_dir = tmp_path / "external"
+        external = _write_executable(external_dir / "tirith")
+        (home / "bin").symlink_to(external_dir, target_is_directory=True)
+        managed = home / "bin" / "tirith"
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert managed.samefile(external)
+        assert not _CapturedThread.instances
+
+    def test_explicit_binary_is_never_updated(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+        explicit = _write_executable(tmp_path / "custom" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_load_security_config", lambda: _config(str(explicit))
+        )
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(explicit)
+        assert not _CapturedThread.instances
+
+    def test_runtime_install_opt_out_disables_updates_not_scanning(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: False)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert not _CapturedThread.instances
+
+    def test_fresh_state_skips_thread(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        assert tirith._write_update_state("current")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert not _CapturedThread.instances
+
+    def test_only_one_update_thread_is_scheduled_per_process(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith, "_update_is_due", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        assert tirith.ensure_installed() == str(managed)
+        assert tirith.ensure_installed() == str(managed)
+        assert len(_CapturedThread.instances) == 1
+
+    def test_long_lived_process_rechecks_after_release_ttl(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(tirith, "_load_security_config", lambda: _config())
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(tirith.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        maintain = MagicMock(side_effect=["current", "updated"])
+        monkeypatch.setattr(tirith, "_maintain_managed_tirith", maintain)
+
+        # Startup performs the first maintenance check.
+        assert tirith.ensure_installed(log_failures=False) == str(managed)
+        first_worker = tirith._update_thread
+        assert first_worker is not None
+        first_worker.join(timeout=2)
+        assert not first_worker.is_alive()
+        first_state = tirith._read_update_state()
+        assert first_state is not None
+        assert first_state["outcome"] == "current"
+
+        # A normal command in the same process must not launch another worker
+        # while the successful-check TTL is fresh.
+        assert tirith._resolve_tirith_path("tirith") == str(managed)
+        assert tirith._update_thread is first_worker
+
+        # Model a Tirith release after startup by expiring the check state.
+        assert tirith._write_update_state("current", now=1)
+        assert tirith._resolve_tirith_path("tirith") == str(managed)
+        second_worker = tirith._update_thread
+        assert second_worker is not None
+        assert second_worker is not first_worker
+        second_worker.join(timeout=2)
+        assert not second_worker.is_alive()
+
+        assert maintain.call_count == 2
+        second_state = tirith._read_update_state()
+        assert second_state is not None
+        assert second_state["outcome"] == "updated"
+
+
+class TestLegacyReleaseProof:
+    @pytest.mark.parametrize(
+        "installed_bytes, expected_reason",
+        [
+            (b"official release", ""),
+            (b"custom build", "binary_mismatch"),
+        ],
+    )
+    def test_only_published_release_bytes_are_trusted(
+        self, installed_bytes, expected_reason, tmp_path, monkeypatch
+    ):
+        managed = _write_executable(tmp_path / "bin" / "tirith", installed_bytes)
+        monkeypatch.setattr(tirith, "_detect_target", lambda: "test-target")
+
+        def fake_download(_base_url, _target, workdir, _log):
+            released = Path(workdir) / "released-tirith"
+            released.write_bytes(b"official release")
+            return str(released), "", True
+
+        monkeypatch.setattr(tirith, "_download_verified_tirith", fake_download)
+
+        digest, reason = tirith._verify_legacy_release_binary(
+            str(managed), (0, 4, 0), log_failures=False
+        )
+
+        assert reason == expected_reason
+        if expected_reason:
+            assert digest is None
+        else:
+            assert digest == tirith._sha256_file(str(managed))
+
+
+class TestMaintenanceDecision:
+    def test_pre_041_cache_is_bootstrapped_with_verified_installer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 0), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_verify_legacy_release_binary",
+            lambda *_args, **_kwargs: ("a" * 64, ""),
+        )
+        install = MagicMock(return_value=(str(managed), ""))
+        update = MagicMock()
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "bootstrapped"
+        )
+        install.assert_called_once_with(
+            log_failures=False,
+            expected_existing_sha256="a" * 64,
+        )
+        update.assert_not_called()
+
+    def test_pre_041_custom_build_is_left_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith", b"custom build")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 0), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_verify_legacy_release_binary",
+            lambda *_args, **_kwargs: (None, "binary_mismatch"),
+        )
+        install = MagicMock()
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "skipped"
+        assert managed.read_bytes() == b"custom build"
+        install.assert_not_called()
+
+    def test_unparseable_version_is_left_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: (None, "unparseable")
+        )
+        install = MagicMock()
+        update = MagicMock()
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "skipped"
+        )
+        assert managed.read_bytes() == b"old tirith"
+        install.assert_not_called()
+        update.assert_not_called()
+
+    def test_development_build_is_left_untouched(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": "0.4.1",
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": True,
+                },
+                "",
+            ),
+        )
+        update = MagicMock()
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "skipped"
+        )
+        update.assert_not_called()
+
+    def test_policy_change_during_probes_defers_modern_update(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": "0.4.1",
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": False,
+                },
+                "",
+            ),
+        )
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: False)
+        run = MagicMock()
+        monkeypatch.setattr(tirith.subprocess, "run", run)
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "deferred"
+        run.assert_not_called()
+
+    @pytest.mark.parametrize("version", [(0, 4, 1), (0, 4, 2), (0, 4, 99)])
+    def test_compatible_release_build_delegates_to_tirith_self_update(
+        self, version, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: (version, "")
+        )
+        version_text = ".".join(str(part) for part in version)
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": version_text,
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": False,
+                },
+                "",
+            ),
+        )
+        update = MagicMock(return_value="current")
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "current"
+        )
+        update.assert_called_once_with(str(managed))
+
+    @pytest.mark.parametrize(
+        "override",
+        [
+            {"install_method": "homebrew"},
+            {"install_method_resolved": False},
+            {"version": "0.4.2"},
+            {"binary_path": "/somewhere/else/tirith"},
+        ],
+    )
+    def test_mismatched_provenance_is_left_untouched(
+        self, override, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        provenance = {
+            "version": "0.4.1",
+            "binary_path": str(managed),
+            "install_method": "hermes",
+            "install_method_resolved": True,
+            "dev_build": False,
+        }
+        provenance.update(override)
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (provenance, ""),
+        )
+        update = MagicMock()
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "skipped"
+        assert managed.read_bytes() == b"old tirith"
+        update.assert_not_called()
+
+
+class TestSelfUpdateSubprocess:
+    @pytest.fixture(autouse=True)
+    def _allow_runtime_updates(self, monkeypatch):
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+
+    @pytest.mark.parametrize(
+        "payload, expected",
+        [
+            ({"action": "none", "message": "already up to date"}, "current"),
+            ({"action": "updated", "new_version": "0.4.2"}, "updated"),
+        ],
+    )
+    def test_invokes_noninteractive_checksum_verified_update(
+        self, payload, expected, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        run = MagicMock(
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=0, stdout=json.dumps(payload), stderr=""
+            )
+        )
+        monkeypatch.setattr(tirith.subprocess, "run", run)
+
+        assert tirith._run_tirith_update(str(managed)) == expected
+
+        args, kwargs = run.call_args
+        assert args[0] == [
+            str(managed),
+            "update",
+            "--yes",
+            "--allow-unsigned",
+            "--format",
+            "json",
+        ]
+        assert kwargs["stdin"] is subprocess.DEVNULL
+        assert kwargs["timeout"] == tirith._UPDATE_TIMEOUT
+        assert kwargs["env"]["HERMES_HOME"] == str(tmp_path)
+
+    def test_failed_update_keeps_scanner_path_and_binary(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        tirith._resolved_path = str(managed)
+        monkeypatch.setattr(
+            tirith.subprocess,
+            "run",
+            MagicMock(
+                side_effect=subprocess.TimeoutExpired(cmd="tirith update", timeout=120)
+            ),
+        )
+
+        assert tirith._run_tirith_update(str(managed)) == "failed"
+        assert tirith._resolved_path == str(managed)
+        assert managed.read_bytes() == b"old tirith"
+
+    def test_unexpected_success_payload_is_not_treated_as_fresh(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith.subprocess,
+            "run",
+            MagicMock(
+                return_value=subprocess.CompletedProcess(
+                    args=[],
+                    returncode=0,
+                    stdout=json.dumps({"action": "use-package-manager"}),
+                    stderr="",
+                )
+            ),
+        )
+
+        assert tirith._run_tirith_update(str(managed)) == "failed"
+
+
+class TestBackgroundWorkerIsolation:
+    def test_failure_sets_backoff_without_disabling_working_scanner(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        tirith._resolved_path = str(managed)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(
+            tirith, "_maintain_managed_tirith", lambda *_a, **_kw: "failed"
+        )
+
+        tirith._background_update(str(managed), log_failures=False)
+
+        assert tirith._resolved_path == str(managed)
+        assert managed.read_bytes() == b"old tirith"
+        assert (tmp_path / ".tirith-update.lock").is_file()
+        assert not (tmp_path / ".tirith-install-failed").exists()
+        assert tirith._install_failure_reason == ""
+        state = json.loads(
+            (tmp_path / ".tirith-update-state.json").read_text(encoding="utf-8")
+        )
+        assert state["outcome"] == "failed"
+
+    def test_active_process_lock_prevents_duplicate_update(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        lock_fd = tirith._acquire_update_lock()
+        assert lock_fd is not None
+        maintain = MagicMock(return_value="current")
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith, "_maintain_managed_tirith", maintain)
+
+        try:
+            tirith._background_update(str(managed), log_failures=False)
+        finally:
+            tirith._release_update_lock(lock_fd)
+
+        maintain.assert_not_called()
+
+    def test_shared_fresh_state_is_rechecked_after_lock(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        assert tirith._write_update_state("updated")
+        maintain = MagicMock(return_value="current")
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith, "_maintain_managed_tirith", maintain)
+
+        tirith._background_update(str(managed), log_failures=False)
+
+        maintain.assert_not_called()
+        assert (tmp_path / ".tirith-update.lock").is_file()
+
+
+def _assert_managed_update_end_to_end_with_real_subprocess(tmp_path, monkeypatch):
+    """Exercise discovery, provenance, update, locking, and persisted state."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    managed = tmp_path / "bin" / "tirith"
+    provenance = json.dumps({
+        "version": "0.4.1",
+        "binary_path": str(managed),
+        "install_method": "hermes",
+        "install_method_resolved": True,
+        "dev_build": False,
+    })
+    script = f"""#!/bin/sh
+if [ "$1" = "--version" ]; then
+    printf 'tirith 0.4.1\\n'
+elif [ "$1" = "version" ]; then
+    printf '%s\\n' '{provenance}'
+elif [ "$1" = "update" ]; then
+    printf '%s\\n' "$*" > "$HERMES_HOME/update-argv"
+    printf '%s\\n' '{{"action":"none"}}'
+else
+    exit 64
+fi
+"""
+    _write_executable(managed, script.encode())
+    monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+
+    tirith._background_update(str(managed), log_failures=False)
+
+    assert (tmp_path / "update-argv").read_text(encoding="utf-8").strip() == (
+        "update --yes --allow-unsigned --format json"
+    )
+    state = json.loads(
+        (tmp_path / ".tirith-update-state.json").read_text(encoding="utf-8")
+    )
+    assert state["outcome"] == "current"
+    assert (tmp_path / ".tirith-update.lock").is_file()
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.linux_only
+def test_managed_update_end_to_end_on_linux(tmp_path, monkeypatch):
+    _assert_managed_update_end_to_end_with_real_subprocess(tmp_path, monkeypatch)
+
+
+@pytest.mark.live_system_guard_bypass
+@pytest.mark.macos_only
+def test_managed_update_end_to_end_on_macos(tmp_path, monkeypatch):
+    _assert_managed_update_end_to_end_with_real_subprocess(tmp_path, monkeypatch)

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -124,6 +124,26 @@ class TestUpdateState:
         )
         assert tirith._update_is_due(now=1_000)
 
+    @pytest.mark.parametrize(
+        "checked_at",
+        [10**1000, float("inf"), float("-inf"), float("nan")],
+    )
+    def test_non_finite_or_overflowing_state_never_suppresses_checks(
+        self, tmp_path, monkeypatch, checked_at
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state = tmp_path / ".tirith-update-state.json"
+        state.write_text(
+            json.dumps({
+                "schema_version": 1,
+                "checked_at": checked_at,
+                "outcome": "current",
+            }),
+            encoding="utf-8",
+        )
+
+        assert tirith._update_is_due(now=1_000)
+
     def test_persistence_failure_still_throttles_this_process(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -744,11 +744,90 @@ class TestMaintenanceDecision:
         )
         update = MagicMock(return_value="current")
         monkeypatch.setattr(tirith, "_run_tirith_update", update)
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
 
         assert (
             tirith._maintain_managed_tirith(str(managed), log_failures=False)
             == "current"
         )
+        update.assert_called_once_with(str(managed))
+
+    def test_termux_release_build_uses_verified_musl_installer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        expected_sha256 = tirith._sha256_file(str(managed))
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 1), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": "0.4.1",
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": False,
+                },
+                "",
+            ),
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        install = MagicMock(return_value=(str(managed), ""))
+        update = MagicMock()
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert (
+            tirith._maintain_managed_tirith(str(managed), log_failures=False)
+            == "updated"
+        )
+        install.assert_called_once_with(
+            log_failures=False,
+            expected_existing_sha256=expected_sha256,
+        )
+        update.assert_not_called()
+
+    def test_termux_release_with_native_musl_provenance_uses_self_update(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(
+            tirith, "_probe_tirith_version", lambda _path: ((0, 4, 2), "")
+        )
+        monkeypatch.setattr(
+            tirith,
+            "_probe_tirith_provenance",
+            lambda _path: (
+                {
+                    "version": "0.4.2",
+                    "binary_path": str(managed),
+                    "install_method": "hermes",
+                    "install_method_resolved": True,
+                    "dev_build": False,
+                    "target": "aarch64-unknown-linux-musl",
+                },
+                "",
+            ),
+        )
+        monkeypatch.setattr(
+            tirith, "_detect_target", lambda: "aarch64-unknown-linux-musl"
+        )
+        install = MagicMock()
+        update = MagicMock(return_value="current")
+        monkeypatch.setattr(tirith, "_install_tirith", install)
+        monkeypatch.setattr(tirith, "_run_tirith_update", update)
+
+        assert tirith._maintain_managed_tirith(str(managed)) == "current"
+        install.assert_not_called()
         update.assert_called_once_with(str(managed))
 
     @pytest.mark.parametrize(

--- a/tests/tools/test_tirith_managed_updates.py
+++ b/tests/tools/test_tirith_managed_updates.py
@@ -435,6 +435,20 @@ class TestManagedCachePlacement:
 
 
 class TestUpdateScheduling:
+    def test_unsupported_manager_never_schedules_managed_update(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        managed = _write_executable(tmp_path / "bin" / "tirith")
+        monkeypatch.setattr(tirith, "is_platform_supported", lambda: False)
+        monkeypatch.setattr(tirith, "_tirith_auto_install_allowed", lambda: True)
+        monkeypatch.setattr(tirith, "_update_is_due", lambda: True)
+        monkeypatch.setattr(tirith.threading, "Thread", _CapturedThread)
+
+        tirith._schedule_managed_update(str(managed), "tirith")
+
+        assert not _CapturedThread.instances
+
     def test_managed_cache_returns_immediately_and_schedules_background_update(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -10,8 +10,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from tools import lazy_deps as _lazy_deps
 import tools.tirith_security as _tirith_mod
 from tools.tirith_security import check_command_security, ensure_installed
+
+
+_REAL_ALLOW_LAZY_INSTALLS = _lazy_deps._allow_lazy_installs
 
 
 @pytest.fixture(autouse=True)
@@ -25,7 +29,11 @@ def _reset_resolved_path():
     _tirith_mod._install_failure_reason = ""
     _tirith_mod._crash_count = 0
     _tirith_mod._circuit_open = False
-    yield
+    # The global test fixture disables runtime installs. Most tests in this
+    # module exercise Tirith's installer mechanics, so opt them in explicitly;
+    # policy tests below override this nested patch with False.
+    with patch("tools.lazy_deps._allow_lazy_installs", return_value=True):
+        yield
     _tirith_mod._resolved_path = None
     _tirith_mod._install_thread = None
     _tirith_mod._install_failure_reason = ""
@@ -48,6 +56,14 @@ def _mock_run(returncode=0, stdout="", stderr=""):
 
 def _json_stdout(findings=None, summary=""):
     return json.dumps({"findings": findings or [], "summary": summary})
+
+
+def _mock_missing_tirith(monkeypatch):
+    monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+    monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: None)
+    monkeypatch.setattr(_tirith_mod.os.path, "isfile", lambda _path: False)
+    monkeypatch.setattr(_tirith_mod, "_read_failure_reason", lambda: None)
+    monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda: None)
 
 
 # ---------------------------------------------------------------------------
@@ -233,6 +249,134 @@ class TestEnsureInstalled:
             result = ensure_installed()
         assert result == "/usr/local/bin/tirith"
         _tirith_mod._resolved_path = None
+
+    def test_config_opt_out_prevents_tirith_download_thread(
+        self, tmp_path, monkeypatch
+    ):
+        """Exercise the real config loader, not only a mocked policy helper."""
+        hermes_home = tmp_path / ".hermes"
+        hermes_home.mkdir()
+        (hermes_home / "config.yaml").write_text(
+            "security:\n  allow_lazy_installs: false\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
+        monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_thread = None
+
+        cfg = {
+            "tirith_enabled": True,
+            "tirith_path": "tirith",
+            "tirith_timeout": 5,
+            "tirith_fail_open": True,
+        }
+        monkeypatch.setattr(
+            _lazy_deps, "_allow_lazy_installs", _REAL_ALLOW_LAZY_INSTALLS
+        )
+        monkeypatch.setattr(_tirith_mod, "_load_security_config", lambda: cfg)
+        _mock_missing_tirith(monkeypatch)
+        thread_factory = MagicMock()
+        monkeypatch.setattr(_tirith_mod.threading, "Thread", thread_factory)
+
+        assert ensure_installed(log_failures=False) is None
+
+        thread_factory.assert_not_called()
+        assert _tirith_mod._resolved_path is None
+
+
+class TestLazyInstallPolicy:
+    def test_low_level_installer_honors_global_opt_out(self):
+        """No direct Tirith installer call may bypass the global policy."""
+        with (
+            patch("tools.lazy_deps._allow_lazy_installs", return_value=False),
+            patch("tools.tirith_security._detect_target") as mock_target,
+            patch("tools.tirith_security._download_file") as mock_download,
+        ):
+            result = _tirith_mod._install_tirith(log_failures=False)
+
+        assert result == (None, "lazy_installs_disabled")
+        mock_target.assert_not_called()
+        mock_download.assert_not_called()
+
+    def test_resolver_policy_transition_does_not_cache_install_failure(
+        self, monkeypatch
+    ):
+        """A policy change during install must remain immediately reversible."""
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_failure_reason = ""
+
+        _mock_missing_tirith(monkeypatch)
+        policy_states = iter((True, False))
+        monkeypatch.setattr(
+            _lazy_deps, "_allow_lazy_installs", lambda: next(policy_states)
+        )
+        mark_failure = MagicMock()
+        monkeypatch.setattr(_tirith_mod, "_mark_install_failed", mark_failure)
+
+        assert _tirith_mod._resolve_tirith_path("tirith") == "tirith"
+
+        mark_failure.assert_not_called()
+        assert _tirith_mod._resolved_path is None
+        assert _tirith_mod._install_failure_reason == ""
+
+        monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", lambda: True)
+        install = MagicMock(return_value=("/tmp/tirith", ""))
+        monkeypatch.setattr(_tirith_mod, "_install_tirith", install)
+
+        assert _tirith_mod._resolve_tirith_path("tirith") == "/tmp/tirith"
+
+        install.assert_called_once_with()
+
+    def test_background_policy_transition_does_not_cache_install_failure(
+        self, monkeypatch
+    ):
+        """The background path must not persist a mid-install policy decision."""
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_failure_reason = ""
+
+        _mock_missing_tirith(monkeypatch)
+        policy_states = iter((True, False))
+        monkeypatch.setattr(
+            _lazy_deps, "_allow_lazy_installs", lambda: next(policy_states)
+        )
+        mark_failure = MagicMock()
+        monkeypatch.setattr(_tirith_mod, "_mark_install_failed", mark_failure)
+
+        _tirith_mod._background_install(log_failures=False)
+
+        mark_failure.assert_not_called()
+        assert _tirith_mod._resolved_path is None
+        assert _tirith_mod._install_failure_reason == ""
+
+        monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", lambda: True)
+        install = MagicMock(return_value=("/tmp/tirith", ""))
+        monkeypatch.setattr(_tirith_mod, "_install_tirith", install)
+
+        _tirith_mod._background_install(log_failures=False)
+
+        install.assert_called_once_with(log_failures=False)
+        assert _tirith_mod._resolved_path == "/tmp/tirith"
+
+    def test_local_binary_is_discovered_when_lazy_installs_are_disabled(
+        self, monkeypatch
+    ):
+        """The opt-out disables downloads, not discovery of an installed binary."""
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_failure_reason = ""
+
+        policy = MagicMock(return_value=False)
+        monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", policy)
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(
+            _tirith_mod.shutil, "which", lambda _name: "/usr/bin/tirith"
+        )
+        monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda: None)
+
+        assert _tirith_mod._resolve_tirith_path("tirith") == "/usr/bin/tirith"
+
+        policy.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -17,6 +17,11 @@ from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
 from cryptography.x509.oid import NameOID
 
+from hermes_constants import (
+    get_hermes_home,
+    reset_hermes_home_override,
+    set_hermes_home_override,
+)
 from tools import lazy_deps as _lazy_deps
 import tools.tirith_security as _tirith_mod
 from tools.tirith_security import check_command_security, ensure_installed
@@ -25,18 +30,18 @@ from tools.tirith_security import check_command_security, ensure_installed
 _REAL_ALLOW_LAZY_INSTALLS = _lazy_deps._allow_lazy_installs
 
 
+def _state(path: str = "tirith"):
+    return _tirith_mod._runtime_state(path)
+
+
 @pytest.fixture(autouse=True)
 def _reset_resolved_path():
     """Pre-set cached path to skip auto-install in scan tests.
     Tests that specifically test ensure_installed / resolve behavior
     reset this to None themselves.
     """
-    _tirith_mod._resolved_path = "tirith"
-    _tirith_mod._install_thread = None
-    _tirith_mod._install_failure_reason = ""
-    _tirith_mod._crash_count = 0
-    _tirith_mod._circuit_open = False
-    _tirith_mod._circuit_opened_at = None
+    _tirith_mod._reset_runtime_states_for_tests()
+    _state().resolved_path = "tirith"
     with _tirith_mod._in_process_update_state_lock:
         _tirith_mod._in_process_update_states.clear()
     # The global test fixture disables runtime installs. Most tests in this
@@ -44,12 +49,7 @@ def _reset_resolved_path():
     # policy tests below override this nested patch with False.
     with patch("tools.lazy_deps._allow_lazy_installs", return_value=True):
         yield
-    _tirith_mod._resolved_path = None
-    _tirith_mod._install_thread = None
-    _tirith_mod._install_failure_reason = ""
-    _tirith_mod._crash_count = 0
-    _tirith_mod._circuit_open = False
-    _tirith_mod._circuit_opened_at = None
+    _tirith_mod._reset_runtime_states_for_tests()
     with _tirith_mod._in_process_update_state_lock:
         _tirith_mod._in_process_update_states.clear()
 
@@ -100,7 +100,7 @@ def _mock_missing_tirith(monkeypatch):
     monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: None)
     monkeypatch.setattr(_tirith_mod.os.path, "isfile", lambda _path: False)
     monkeypatch.setattr(_tirith_mod, "_read_failure_reason", lambda: None)
-    monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda: None)
+    monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda *_args: None)
 
 
 # ---------------------------------------------------------------------------
@@ -182,7 +182,7 @@ class TestOSErrorFailOpen:
         result = check_command_security("echo hi")
         assert result["action"] == "allow"
         assert "unavailable" in result["summary"]
-        assert _tirith_mod._resolved_path is None
+        assert _state().resolved_path is None
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
@@ -273,7 +273,7 @@ class TestEnsureInstalled:
     def test_disabled_returns_none(self, mock_cfg):
         mock_cfg.return_value = {"tirith_enabled": False, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         assert ensure_installed() is None
 
     @patch("tools.tirith_security.shutil.which", return_value="/usr/local/bin/tirith")
@@ -281,12 +281,12 @@ class TestEnsureInstalled:
     def test_found_on_path_returns_immediately(self, mock_cfg, mock_which):
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("os.path.isfile", return_value=True), \
              patch("os.access", return_value=True):
             result = ensure_installed()
         assert result == "/usr/local/bin/tirith"
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
     def test_config_opt_out_prevents_tirith_download_thread(
         self, tmp_path, monkeypatch
@@ -301,8 +301,8 @@ class TestEnsureInstalled:
         monkeypatch.setenv("HERMES_HOME", str(hermes_home))
         monkeypatch.delenv("HERMES_DISABLE_LAZY_INSTALLS", raising=False)
         monkeypatch.delenv("HERMES_LAZY_INSTALL_TARGET", raising=False)
-        _tirith_mod._resolved_path = None
-        _tirith_mod._install_thread = None
+        _state().resolved_path = None
+        _state().install_thread = None
 
         cfg = {
             "tirith_enabled": True,
@@ -321,7 +321,7 @@ class TestEnsureInstalled:
         assert ensure_installed(log_failures=False) is None
 
         thread_factory.assert_not_called()
-        assert _tirith_mod._resolved_path is None
+        assert _state().resolved_path is None
         assert not (hermes_home / "bin").exists()
 
 
@@ -370,8 +370,8 @@ class TestLazyInstallPolicy:
         self, monkeypatch
     ):
         """A policy change during install must remain immediately reversible."""
-        _tirith_mod._resolved_path = None
-        _tirith_mod._install_failure_reason = ""
+        _state().resolved_path = None
+        _state().install_failure_reason = ""
 
         _mock_missing_tirith(monkeypatch)
         policy_states = iter((True, False))
@@ -384,8 +384,8 @@ class TestLazyInstallPolicy:
         assert _tirith_mod._resolve_tirith_path("tirith") == "tirith"
 
         mark_failure.assert_not_called()
-        assert _tirith_mod._resolved_path is None
-        assert _tirith_mod._install_failure_reason == ""
+        assert _state().resolved_path is None
+        assert _state().install_failure_reason == ""
 
         monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", lambda: True)
         install = MagicMock(return_value=("/tmp/tirith", ""))
@@ -399,8 +399,8 @@ class TestLazyInstallPolicy:
         self, monkeypatch
     ):
         """The background path must not persist a mid-install policy decision."""
-        _tirith_mod._resolved_path = None
-        _tirith_mod._install_failure_reason = ""
+        _state().resolved_path = None
+        _state().install_failure_reason = ""
 
         _mock_missing_tirith(monkeypatch)
         policy_states = iter((True, False))
@@ -413,8 +413,8 @@ class TestLazyInstallPolicy:
         _tirith_mod._background_install(log_failures=False)
 
         mark_failure.assert_not_called()
-        assert _tirith_mod._resolved_path is None
-        assert _tirith_mod._install_failure_reason == ""
+        assert _state().resolved_path is None
+        assert _state().install_failure_reason == ""
 
         monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", lambda: True)
         install = MagicMock(return_value=("/tmp/tirith", ""))
@@ -423,14 +423,14 @@ class TestLazyInstallPolicy:
         _tirith_mod._background_install(log_failures=False)
 
         install.assert_called_once_with(log_failures=False)
-        assert _tirith_mod._resolved_path == "/tmp/tirith"
+        assert _state().resolved_path == "/tmp/tirith"
 
     def test_local_binary_is_discovered_when_lazy_installs_are_disabled(
         self, tmp_path, monkeypatch
     ):
         """The opt-out disables downloads, not discovery of an installed binary."""
-        _tirith_mod._resolved_path = None
-        _tirith_mod._install_failure_reason = ""
+        _state().resolved_path = None
+        _state().install_failure_reason = ""
         local_tirith = tmp_path / "tirith"
         local_tirith.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         local_tirith.chmod(0o700)
@@ -441,7 +441,9 @@ class TestLazyInstallPolicy:
         monkeypatch.setattr(
             _tirith_mod.shutil, "which", lambda _name: str(local_tirith)
         )
-        monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda: None)
+        monkeypatch.setattr(
+            _tirith_mod, "_clear_install_failed", lambda *_args: None
+        )
 
         assert _tirith_mod._resolve_tirith_path("tirith") == str(local_tirith)
 
@@ -453,12 +455,7 @@ class TestLazyInstallPolicy:
 # ---------------------------------------------------------------------------
 
 class TestManagedCacheExecutionBoundary:
-    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
-    @pytest.mark.parametrize(
-        "fail_open, expected_action",
-        [(True, "allow"), (False, "block")],
-    )
-    def test_cached_managed_binary_mode_drift_is_never_spawned(
+    def _assert_cached_managed_binary_mode_drift_is_never_spawned(
         self, fail_open, expected_action, tmp_path, monkeypatch
     ):
         home = tmp_path / "home"
@@ -467,7 +464,7 @@ class TestManagedCacheExecutionBoundary:
         managed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
         managed.chmod(0o755)
         monkeypatch.setenv("HERMES_HOME", str(home))
-        _tirith_mod._resolved_path = str(managed)
+        _state().resolved_path = str(managed)
 
         # Simulate trust drift after successful resolution. The cached string
         # must not bypass the current filesystem proof.
@@ -490,9 +487,33 @@ class TestManagedCacheExecutionBoundary:
         result = check_command_security("echo guarded")
 
         assert result["action"] == expected_action
-        assert _tirith_mod._resolved_path is _tirith_mod._INSTALL_FAILED
-        assert _tirith_mod._install_failure_reason == "managed_cache_untrusted"
+        assert _state().resolved_path is _tirith_mod._INSTALL_FAILED
+        assert _state().install_failure_reason == "managed_cache_untrusted"
         run.assert_not_called()
+
+    @pytest.mark.linux_only
+    @pytest.mark.parametrize(
+        "fail_open, expected_action",
+        [(True, "allow"), (False, "block")],
+    )
+    def test_cached_managed_binary_mode_drift_is_never_spawned_linux(
+        self, fail_open, expected_action, tmp_path, monkeypatch
+    ):
+        self._assert_cached_managed_binary_mode_drift_is_never_spawned(
+            fail_open, expected_action, tmp_path, monkeypatch
+        )
+
+    @pytest.mark.macos_only
+    @pytest.mark.parametrize(
+        "fail_open, expected_action",
+        [(True, "allow"), (False, "block")],
+    )
+    def test_cached_managed_binary_mode_drift_is_never_spawned_macos(
+        self, fail_open, expected_action, tmp_path, monkeypatch
+    ):
+        self._assert_cached_managed_binary_mode_drift_is_never_spawned(
+            fail_open, expected_action, tmp_path, monkeypatch
+        )
 
     @pytest.mark.require_symlinks
     def test_path_alias_cannot_hide_untrusted_managed_binary(
@@ -507,7 +528,7 @@ class TestManagedCacheExecutionBoundary:
         alias.parent.mkdir()
         alias.symlink_to(managed)
         monkeypatch.setenv("HERMES_HOME", str(home))
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         monkeypatch.setattr(
             _tirith_mod,
             "_load_security_config",
@@ -526,7 +547,7 @@ class TestManagedCacheExecutionBoundary:
         result = check_command_security("echo guarded")
 
         assert result["action"] == "block"
-        assert _tirith_mod._install_failure_reason == "managed_cache_untrusted"
+        assert _state().install_failure_reason == "managed_cache_untrusted"
         run.assert_not_called()
 
     @pytest.mark.require_symlinks
@@ -542,7 +563,7 @@ class TestManagedCacheExecutionBoundary:
         alias.parent.mkdir()
         alias.symlink_to(managed)
         monkeypatch.setenv("HERMES_HOME", str(home))
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         monkeypatch.setattr(
             _tirith_mod,
             "_load_security_config",
@@ -561,7 +582,7 @@ class TestManagedCacheExecutionBoundary:
         result = check_command_security("echo safe")
 
         assert result["action"] == "allow"
-        assert _tirith_mod._resolved_path == str(managed)
+        assert _state().resolved_path == str(managed)
         assert run.call_args.args[0][0] == str(managed)
 
     @pytest.mark.macos_only
@@ -626,7 +647,7 @@ class TestUnsupportedPlatform:
         """Default fail-open remains silent when no local scanner exists."""
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.shutil.which", return_value=None) as mock_which, \
              patch("tools.tirith_security.subprocess.run") as mock_run, \
@@ -654,7 +675,7 @@ class TestUnsupportedPlatform:
             1,
             _json_stdout([{"rule_id": "homograph_url"}], "blocked"),
         )
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False):
             result = check_command_security("curl https://example.test")
 
@@ -663,27 +684,32 @@ class TestUnsupportedPlatform:
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
-    def test_default_path_scans_on_unsupported_platform(self, mock_cfg, mock_run):
+    def test_default_path_scans_on_unsupported_platform(
+        self, mock_cfg, mock_run, tmp_path
+    ):
         """Manager support does not suppress the ordinary PATH contract."""
+        binary = tmp_path / "tirith"
+        binary.write_text("scanner", encoding="utf-8")
+        binary.chmod(0o700)
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
         mock_run.return_value = _mock_run(2, _json_stdout(summary="review"))
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.shutil.which",
-                   return_value="/usr/local/bin/tirith"), \
+                   return_value=str(binary)), \
              patch("tools.tirith_security.threading.Thread") as mock_thread:
             result = check_command_security("curl https://example.test")
 
         assert result["action"] == "warn"
-        assert mock_run.call_args.args[0][0] == "/usr/local/bin/tirith"
+        assert mock_run.call_args.args[0][0] == str(binary)
         mock_thread.assert_not_called()
 
     @patch("tools.tirith_security._load_security_config")
     def test_unsupported_missing_scanner_honors_fail_closed(self, mock_cfg):
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": False}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.shutil.which", return_value=None), \
              patch("tools.tirith_security.subprocess.run") as mock_run:
@@ -705,7 +731,7 @@ class TestUnsupportedPlatform:
                                  "tirith_path": str(binary),
                                  "tirith_timeout": 5,
                                  "tirith_fail_open": True}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.threading.Thread") as mock_thread:
             assert ensure_installed() == str(binary)
@@ -713,15 +739,18 @@ class TestUnsupportedPlatform:
         mock_thread.assert_not_called()
 
     @patch("tools.tirith_security._load_security_config")
-    def test_ensure_installed_honors_path(self, mock_cfg):
+    def test_ensure_installed_honors_path(self, mock_cfg, tmp_path):
+        binary = tmp_path / "tirith"
+        binary.write_text("scanner", encoding="utf-8")
+        binary.chmod(0o700)
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.shutil.which",
-                   return_value="/usr/local/bin/tirith"), \
+                   return_value=str(binary)), \
              patch("tools.tirith_security.threading.Thread") as mock_thread:
-            assert ensure_installed() == "/usr/local/bin/tirith"
+            assert ensure_installed() == str(binary)
 
         mock_thread.assert_not_called()
 
@@ -739,19 +768,19 @@ class TestFailedDownloadCaching:
                                              mock_disk_check, mock_mark):
         """After a failed download, subsequent resolves must not retry."""
         from tools.tirith_security import _resolve_tirith_path, _INSTALL_FAILED
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
         # First call: tries install, fails
         _resolve_tirith_path("tirith")
         assert mock_install.call_count == 1
-        assert _tirith_mod._resolved_path is _INSTALL_FAILED
+        assert _state().resolved_path is _INSTALL_FAILED
         mock_mark.assert_called_once_with("download_failed")  # reason persisted
 
         # Second call: hits the cache, does NOT call _install_tirith again
         _resolve_tirith_path("tirith")
         assert mock_install.call_count == 1  # still 1, not 2
 
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
 
 # ---------------------------------------------------------------------------
@@ -764,14 +793,15 @@ class TestExplicitPathNoAutoDownload:
     def test_tilde_explicit_path_missing_no_download(self, mock_which, mock_install):
         """An explicit ~/path that doesn't exist must NOT trigger download."""
         from tools.tirith_security import _resolve_tirith_path, _INSTALL_FAILED
-        _tirith_mod._resolved_path = None
+        _state("~/bin/tirith").resolved_path = None
 
         result = _resolve_tirith_path("~/bin/tirith")
         mock_install.assert_not_called()
-        assert _tirith_mod._resolved_path is _INSTALL_FAILED
+        assert _state("~/bin/tirith").resolved_path is _INSTALL_FAILED
+        assert result is not None
         assert "~" not in result  # tilde still expanded
 
-        _tirith_mod._resolved_path = None
+        _state("~/bin/tirith").resolved_path = None
 
     @patch("tools.tirith_security._mark_install_failed")
     @patch("tools.tirith_security._is_install_failed_on_disk", return_value=False)
@@ -781,13 +811,13 @@ class TestExplicitPathNoAutoDownload:
                                               mock_disk_check, mock_mark):
         """The default bare 'tirith' SHOULD trigger auto-download."""
         from tools.tirith_security import _resolve_tirith_path
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
         result = _resolve_tirith_path("tirith")
         mock_install.assert_called_once()
         assert result == "/auto/tirith"
 
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
 
 # ---------------------------------------------------------------------------
@@ -1183,7 +1213,7 @@ class TestInstallArchiveMemberValidation:
 class TestBackgroundInstall:
     def test_ensure_installed_non_blocking(self):
         """ensure_installed must return immediately when download needed."""
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
         with patch("tools.tirith_security._load_security_config",
                    return_value={"tirith_enabled": True, "tirith_path": "tirith",
@@ -1201,28 +1231,28 @@ class TestBackgroundInstall:
             MockThread.assert_called_once()
             mock_thread.start.assert_called_once()
 
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
     def test_resolve_returns_default_when_thread_alive(self):
         """_resolve_tirith_path returns default while background thread runs."""
         from tools.tirith_security import _resolve_tirith_path
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = True
-        _tirith_mod._install_thread = mock_thread
+        _state().install_thread = mock_thread
 
         with patch("tools.tirith_security.shutil.which", return_value=None), \
              patch("tools.tirith_security._managed_tirith_path", return_value="/nonexistent/tirith"):
             result = _resolve_tirith_path("tirith")
             assert result == "tirith"  # returns configured default, doesn't block
 
-        _tirith_mod._install_thread = None
-        _tirith_mod._resolved_path = None
+        _state().install_thread = None
+        _state().resolved_path = None
 
     def test_approval_path_starts_missing_install_in_background(self):
         """A first command must not synchronously download Tirith."""
-        _tirith_mod._resolved_path = None
-        _tirith_mod._install_thread = None
+        _state().resolved_path = None
+        _state().install_thread = None
         mock_thread = MagicMock()
         mock_thread.is_alive.return_value = False
 
@@ -1256,6 +1286,180 @@ class TestBackgroundInstall:
         run.assert_not_called()
 
 
+class TestRuntimeProfileIsolation:
+    def test_interleaved_profiles_keep_distinct_managed_paths(
+        self, tmp_path, monkeypatch
+    ):
+        homes = [tmp_path / "profile-a", tmp_path / "profile-b"]
+        managed_paths = []
+        for home in homes:
+            home.mkdir(mode=0o700)
+            managed = home / "bin" / "tirith"
+            managed.parent.mkdir(mode=0o700)
+            managed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            managed.chmod(0o700)
+            managed_paths.append(managed)
+
+        monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(
+            _tirith_mod, "_uses_image_managed_tirith_root", lambda: False
+        )
+        monkeypatch.setattr(
+            _tirith_mod, "_schedule_managed_update", lambda *_args, **_kwargs: None
+        )
+
+        resolved = []
+        states = []
+        for home in (homes[0], homes[1], homes[0]):
+            token = set_hermes_home_override(home)
+            try:
+                resolved.append(_tirith_mod._resolve_tirith_path("tirith"))
+                states.append(_state())
+            finally:
+                reset_hermes_home_override(token)
+
+        assert resolved == [
+            str(managed_paths[0]),
+            str(managed_paths[1]),
+            str(managed_paths[0]),
+        ]
+        assert states[0] is states[2]
+        assert states[0] is not states[1]
+
+    def test_background_update_inherits_profile_context(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / "profile-b"
+        profile_home.mkdir()
+        seen = {}
+
+        def record_update(path, *, log_failures=True):
+            seen["home"] = get_hermes_home()
+            seen["path"] = path
+            seen["log_failures"] = log_failures
+
+        monkeypatch.setattr(_tirith_mod, "_background_update", record_update)
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(_tirith_mod, "_is_managed_tirith", lambda _path: True)
+        monkeypatch.setattr(
+            _tirith_mod, "_tirith_auto_install_allowed", lambda: True
+        )
+        monkeypatch.setattr(_tirith_mod, "_update_is_due", lambda: True)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            state = _state()
+            _tirith_mod._schedule_managed_update(
+                "/managed/tirith", "tirith", log_failures=False, state=state
+            )
+            worker = state.update_thread
+        finally:
+            reset_hermes_home_override(token)
+
+        assert worker is not None
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert seen == {
+            "home": profile_home,
+            "path": "/managed/tirith",
+            "log_failures": False,
+        }
+
+    def test_background_install_inherits_profile_context(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / "profile-b"
+        profile_home.mkdir()
+        seen = {}
+
+        def record_install(*, log_failures=True, state=None):
+            seen["home"] = get_hermes_home()
+            seen["log_failures"] = log_failures
+            seen["state"] = state
+
+        monkeypatch.setattr(_tirith_mod, "_background_install", record_install)
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_load_security_config",
+            lambda: {
+                "tirith_enabled": True,
+                "tirith_path": "tirith",
+                "tirith_timeout": 5,
+                "tirith_fail_open": True,
+            },
+        )
+        monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        monkeypatch.setattr(
+            _tirith_mod, "_uses_image_managed_tirith_root", lambda: False
+        )
+        monkeypatch.setattr(
+            _tirith_mod, "_tirith_auto_install_allowed", lambda: True
+        )
+        monkeypatch.setattr(_tirith_mod, "_read_failure_reason", lambda: None)
+
+        token = set_hermes_home_override(profile_home)
+        try:
+            state = _state()
+            assert ensure_installed(log_failures=False) is None
+            worker = state.install_thread
+        finally:
+            reset_hermes_home_override(token)
+
+        assert worker is not None
+        worker.join(timeout=5)
+        assert not worker.is_alive()
+        assert seen == {
+            "home": profile_home,
+            "log_failures": False,
+            "state": state,
+        }
+
+    def test_circuit_breakers_are_scoped_per_profile(
+        self, tmp_path, monkeypatch
+    ):
+        profile_a = tmp_path / "profile-a"
+        profile_b = tmp_path / "profile-b"
+        profile_a.mkdir()
+        profile_b.mkdir()
+        monkeypatch.setattr(_tirith_mod, "_load_security_config", lambda: _CFG)
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_resolve_tirith_path",
+            lambda *_args, **_kwargs: "tirith",
+        )
+        run = MagicMock(return_value=_mock_run(0, _json_stdout()))
+        monkeypatch.setattr(_tirith_mod.subprocess, "run", run)
+
+        token = set_hermes_home_override(profile_a)
+        try:
+            state_a = _state()
+            state_a.crash_count = _tirith_mod._CRASH_LIMIT
+            state_a.circuit_open = True
+            state_a.circuit_opened_at = time.monotonic()
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(profile_b)
+        try:
+            assert check_command_security("echo profile-b")["action"] == "allow"
+            state_b = _state()
+        finally:
+            reset_hermes_home_override(token)
+
+        token = set_hermes_home_override(profile_a)
+        try:
+            blocked_profile = check_command_security("echo profile-a")
+        finally:
+            reset_hermes_home_override(token)
+
+        assert state_a is not state_b
+        assert blocked_profile["action"] == "allow"
+        assert "circuit breaker" in blocked_profile["summary"]
+        run.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # Disk failure marker persistence (P2)
 # ---------------------------------------------------------------------------
@@ -1280,8 +1484,8 @@ class TestDiskFailureMarker:
     def test_in_memory_cosign_exec_failed_not_retried(self):
         """In-memory _INSTALL_FAILED with cosign_exec_failed is NOT retried."""
         from tools.tirith_security import _resolve_tirith_path, _INSTALL_FAILED
-        _tirith_mod._resolved_path = _INSTALL_FAILED
-        _tirith_mod._install_failure_reason = "cosign_exec_failed"
+        _state().resolved_path = _INSTALL_FAILED
+        _state().install_failure_reason = "cosign_exec_failed"
 
         with patch("tools.tirith_security.shutil.which", return_value=None), \
              patch("tools.tirith_security._managed_tirith_path", return_value="/nonexistent/tirith"), \
@@ -1290,7 +1494,7 @@ class TestDiskFailureMarker:
             assert result == "tirith"  # fallback
             mock_install.assert_not_called()
 
-        _tirith_mod._resolved_path = None
+        _state().resolved_path = None
 
 
 # ---------------------------------------------------------------------------
@@ -1363,22 +1567,22 @@ class TestCircuitBreakerRecovery:
     @patch("tools.tirith_security._load_security_config")
     def test_recognized_warn_resets_prior_failures(self, mock_cfg, mock_run):
         mock_cfg.return_value = _CFG
-        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        _state().crash_count = _tirith_mod._CRASH_LIMIT - 1
         mock_run.return_value = _mock_run(2, _json_stdout([], "review"))
 
         result = check_command_security("echo review")
 
         assert result["action"] == "warn"
-        assert _tirith_mod._crash_count == 0
-        assert not _tirith_mod._circuit_open
+        assert _state().crash_count == 0
+        assert not _state().circuit_open
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
     def test_open_circuit_honors_fail_closed(self, mock_cfg, mock_run):
         mock_cfg.return_value = {**_CFG, "tirith_fail_open": False}
-        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
-        _tirith_mod._circuit_open = True
-        _tirith_mod._circuit_opened_at = time.monotonic()
+        _state().crash_count = _tirith_mod._CRASH_LIMIT
+        _state().circuit_open = True
+        _state().circuit_opened_at = time.monotonic()
 
         result = check_command_security("echo blocked")
 
@@ -1390,9 +1594,9 @@ class TestCircuitBreakerRecovery:
     @patch("tools.tirith_security._load_security_config")
     def test_open_circuit_makes_half_open_recovery_probe(self, mock_cfg, mock_run):
         mock_cfg.return_value = _CFG
-        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
-        _tirith_mod._circuit_open = True
-        _tirith_mod._circuit_opened_at = 100.0
+        _state().crash_count = _tirith_mod._CRASH_LIMIT
+        _state().circuit_open = True
+        _state().circuit_opened_at = 100.0
         mock_run.return_value = _mock_run(0, _json_stdout())
 
         with patch(
@@ -1402,8 +1606,8 @@ class TestCircuitBreakerRecovery:
             result = check_command_security("echo recovered")
 
         assert result["action"] == "allow"
-        assert not _tirith_mod._circuit_open
-        assert _tirith_mod._circuit_opened_at is None
+        assert not _state().circuit_open
+        assert _state().circuit_opened_at is None
         mock_run.assert_called_once()
 
     @patch("tools.tirith_security.subprocess.run")
@@ -1412,12 +1616,15 @@ class TestCircuitBreakerRecovery:
         self, mock_cfg, mock_run
     ):
         mock_cfg.return_value = _CFG
-        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
-        _tirith_mod._circuit_open = True
-        _tirith_mod._circuit_opened_at = 100.0
+        state = _state()
+        state.resolved_path = None
+        state.crash_count = _tirith_mod._CRASH_LIMIT
+        state.circuit_open = True
+        state.circuit_opened_at = 100.0
         entered = threading.Event()
         release = threading.Event()
         first_result = {}
+        current_time = [100.0 + _tirith_mod._CIRCUIT_RETRY_SECONDS]
 
         def slow_success(*_args, **_kwargs):
             entered.set()
@@ -1426,9 +1633,20 @@ class TestCircuitBreakerRecovery:
 
         mock_run.side_effect = slow_success
 
-        with patch(
-            "tools.tirith_security.time.monotonic",
-            return_value=100.0 + _tirith_mod._CIRCUIT_RETRY_SECONDS,
+        with (
+            patch(
+                "tools.tirith_security.time.monotonic",
+                side_effect=lambda: current_time[0],
+            ),
+            patch(
+                "tools.tirith_security.shutil.which",
+                return_value="/usr/local/bin/tirith",
+            ),
+            patch(
+                "tools.tirith_security._validated_tirith_path",
+                side_effect=lambda path: path,
+            ),
+            patch("tools.tirith_security._schedule_managed_update"),
         ):
             worker = threading.Thread(
                 target=lambda: first_result.update(
@@ -1438,6 +1656,9 @@ class TestCircuitBreakerRecovery:
             worker.start()
             assert entered.wait(5), "half-open probe did not start"
 
+            # Even after several additional cooldown periods, the explicit
+            # in-flight claim prevents another probe from starting.
+            current_time[0] = 100.0 + 3 * _tirith_mod._CIRCUIT_RETRY_SECONDS
             second = check_command_security("echo second")
             assert second["action"] == "allow"
             assert "circuit breaker" in second["summary"]
@@ -1448,7 +1669,35 @@ class TestCircuitBreakerRecovery:
 
         assert not worker.is_alive()
         assert first_result["result"]["action"] == "allow"
-        assert not _tirith_mod._circuit_open
+        assert not _state().circuit_open
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_programming_error_releases_half_open_claim(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        state = _state()
+        state.crash_count = _tirith_mod._CRASH_LIMIT
+        state.circuit_open = True
+        state.circuit_opened_at = 100.0
+        mock_run.side_effect = [
+            AttributeError("unexpected bug"),
+            _mock_run(0, _json_stdout()),
+        ]
+
+        with patch(
+            "tools.tirith_security.time.monotonic",
+            return_value=100.0 + _tirith_mod._CIRCUIT_RETRY_SECONDS,
+        ):
+            with pytest.raises(AttributeError, match="unexpected bug"):
+                check_command_security("echo broken probe")
+
+            assert state.circuit_open
+            assert not state.circuit_probe_in_flight
+            recovered = check_command_security("echo retry probe")
+
+        assert recovered["action"] == "allow"
+        assert not state.circuit_open
+        assert mock_run.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -1,9 +1,11 @@
 """Tests for the tirith security scanning subprocess wrapper."""
 
+import base64
 import io
 import json
 import os
 import subprocess
+import sys
 import tarfile
 import threading
 import time
@@ -517,7 +519,7 @@ class TestManagedCacheExecutionBoundary:
 
     @pytest.mark.require_symlinks
     def test_path_alias_cannot_hide_untrusted_managed_binary(
-        self, tmp_path, monkeypatch
+        self, tmp_path, monkeypatch, caplog
     ):
         home = tmp_path / "home"
         managed = home / "bin" / "tirith"
@@ -544,10 +546,19 @@ class TestManagedCacheExecutionBoundary:
         run = MagicMock()
         monkeypatch.setattr(_tirith_mod.subprocess, "run", run)
 
-        result = check_command_security("echo guarded")
+        with caplog.at_level("WARNING", logger="tools.tirith_security"):
+            result = check_command_security("echo guarded")
+            repeated = check_command_security("echo guarded again")
 
         assert result["action"] == "block"
+        assert repeated["action"] == "block"
         assert _state().install_failure_reason == "managed_cache_untrusted"
+        trust_warnings = [
+            record
+            for record in caplog.records
+            if "failed ownership, mode, ACL, or link validation" in record.message
+        ]
+        assert len(trust_warnings) == 1
         run.assert_not_called()
 
     @pytest.mark.require_symlinks
@@ -705,6 +716,32 @@ class TestUnsupportedPlatform:
         assert mock_run.call_args.args[0][0] == str(binary)
         mock_thread.assert_not_called()
 
+    @pytest.mark.windows_only
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_native_windows_explicit_scanner_remains_usable(
+        self, mock_cfg, mock_run
+    ):
+        """Native Windows may scan with an external binary without manager support."""
+        mock_cfg.return_value = {
+            "tirith_enabled": True,
+            "tirith_path": sys.executable,
+            "tirith_timeout": 5,
+            "tirith_fail_open": False,
+        }
+        mock_run.return_value = _mock_run(
+            1,
+            _json_stdout([{"rule_id": "homograph_url"}], "blocked"),
+        )
+        state = _state(sys.executable)
+        state.resolved_path = None
+
+        assert not _tirith_mod.is_platform_supported()
+        result = check_command_security("curl https://example.test")
+
+        assert result["action"] == "block"
+        assert mock_run.call_args.args[0][0] == sys.executable
+
     @patch("tools.tirith_security._load_security_config")
     def test_unsupported_missing_scanner_honors_fail_closed(self, mock_cfg):
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
@@ -731,12 +768,15 @@ class TestUnsupportedPlatform:
                                  "tirith_path": str(binary),
                                  "tirith_timeout": 5,
                                  "tirith_fail_open": True}
-        _state().resolved_path = None
+        state = _state(str(binary))
+        state.resolved_path = None
+        state.install_failure_reason = "explicit_path_missing"
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
              patch("tools.tirith_security.threading.Thread") as mock_thread:
             assert ensure_installed() == str(binary)
 
         mock_thread.assert_not_called()
+        assert state.install_failure_reason == ""
 
     @patch("tools.tirith_security._load_security_config")
     def test_ensure_installed_honors_path(self, mock_cfg, tmp_path):
@@ -788,6 +828,17 @@ class TestFailedDownloadCaching:
 # ---------------------------------------------------------------------------
 
 class TestExplicitPathNoAutoDownload:
+    def test_explicit_path_recovery_clears_stale_failure_reason(self, tmp_path):
+        binary = tmp_path / "tirith"
+        binary.write_text("scanner", encoding="utf-8")
+        binary.chmod(0o700)
+        state = _state(str(binary))
+        state.resolved_path = _tirith_mod._INSTALL_FAILED
+        state.install_failure_reason = "explicit_path_missing"
+
+        assert _tirith_mod._resolve_tirith_path(str(binary)) == str(binary)
+        assert state.install_failure_reason == ""
+
     @patch("tools.tirith_security._install_tirith")
     @patch("tools.tirith_security.shutil.which", return_value=None)
     def test_tilde_explicit_path_missing_no_download(self, mock_which, mock_install):
@@ -894,6 +945,40 @@ class TestCosignVerification:
         )
         certificate = tmp_path / "checksums.txt.pem"
         _write_release_certificate(certificate, [prefix + "0.4.1", prefix + "0.4.2"])
+
+        assert _tirith_mod._release_identity_from_certificate(str(certificate)) is None
+
+    def test_upstream_base64_wrapped_certificate_is_accepted(self, tmp_path):
+        identity = (
+            "https://github.com/sheeki03/tirith/.github/workflows/"
+            "release.yml@refs/tags/v0.4.1"
+        )
+        certificate = tmp_path / "checksums.txt.pem"
+        _write_release_certificate(certificate, [identity])
+        certificate.write_bytes(base64.b64encode(certificate.read_bytes()) + b"\n")
+
+        assert _tirith_mod._release_identity_from_certificate(str(certificate)) == (
+            (0, 4, 1),
+            identity,
+        )
+
+    @pytest.mark.parametrize("malformation", ["trailing", "bundle", "double-wrap"])
+    def test_noncanonical_certificate_framing_is_rejected(
+        self, malformation, tmp_path
+    ):
+        identity = (
+            "https://github.com/sheeki03/tirith/.github/workflows/"
+            "release.yml@refs/tags/v0.4.1"
+        )
+        certificate = tmp_path / "checksums.txt.pem"
+        _write_release_certificate(certificate, [identity])
+        raw = certificate.read_bytes()
+        malformed = {
+            "trailing": raw + b"unexpected",
+            "bundle": raw + raw,
+            "double-wrap": base64.b64encode(base64.b64encode(raw)),
+        }[malformation]
+        certificate.write_bytes(malformed)
 
         assert _tirith_mod._release_identity_from_certificate(str(certificate)) is None
 
@@ -1563,16 +1648,22 @@ class TestSpawnWarningDedup:
 
 
 class TestCircuitBreakerRecovery:
+    @pytest.mark.parametrize(
+        "returncode, expected_action",
+        [(0, "allow"), (1, "block"), (2, "warn")],
+    )
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
-    def test_recognized_warn_resets_prior_failures(self, mock_cfg, mock_run):
+    def test_recognized_verdict_resets_prior_failures(
+        self, mock_cfg, mock_run, returncode, expected_action
+    ):
         mock_cfg.return_value = _CFG
         _state().crash_count = _tirith_mod._CRASH_LIMIT - 1
-        mock_run.return_value = _mock_run(2, _json_stdout([], "review"))
+        mock_run.return_value = _mock_run(returncode, _json_stdout([], "review"))
 
         result = check_command_security("echo review")
 
-        assert result["action"] == "warn"
+        assert result["action"] == expected_action
         assert _state().crash_count == 0
         assert not _state().circuit_open
 

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -7,10 +7,15 @@ import subprocess
 import tarfile
 import threading
 import time
+from datetime import datetime, timedelta, timezone
 from http.client import HTTPMessage
 from unittest.mock import MagicMock, patch
 
 import pytest
+from cryptography import x509
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import ed25519
+from cryptography.x509.oid import NameOID
 
 from tools import lazy_deps as _lazy_deps
 import tools.tirith_security as _tirith_mod
@@ -64,6 +69,30 @@ def _mock_run(returncode=0, stdout="", stderr=""):
 
 def _json_stdout(findings=None, summary=""):
     return json.dumps({"findings": findings or [], "summary": summary})
+
+
+def _write_release_certificate(path, identities):
+    """Write a minimal certificate with cosign-like URI SAN identities."""
+    key = ed25519.Ed25519PrivateKey.generate()
+    now = datetime.now(timezone.utc)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "test")])
+    certificate = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - timedelta(minutes=1))
+        .not_valid_after(now + timedelta(minutes=1))
+        .add_extension(
+            x509.SubjectAlternativeName(
+                [x509.UniformResourceIdentifier(identity) for identity in identities]
+            ),
+            critical=False,
+        )
+        .sign(key, algorithm=None)
+    )
+    path.write_bytes(certificate.public_bytes(serialization.Encoding.PEM))
 
 
 def _mock_missing_tirith(monkeypatch):
@@ -325,7 +354,7 @@ class TestLazyInstallPolicy:
         monkeypatch.setattr(
             _tirith_mod,
             "_download_verified_tirith",
-            lambda *_args, **_kwargs: (str(source), "", True),
+            lambda *_args, **_kwargs: (str(source), "", True, (0, 4, 1)),
         )
         replace = MagicMock()
         monkeypatch.setattr(_tirith_mod, "_atomic_replace_binary", replace)
@@ -397,23 +426,160 @@ class TestLazyInstallPolicy:
         assert _tirith_mod._resolved_path == "/tmp/tirith"
 
     def test_local_binary_is_discovered_when_lazy_installs_are_disabled(
-        self, monkeypatch
+        self, tmp_path, monkeypatch
     ):
         """The opt-out disables downloads, not discovery of an installed binary."""
         _tirith_mod._resolved_path = None
         _tirith_mod._install_failure_reason = ""
+        local_tirith = tmp_path / "tirith"
+        local_tirith.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        local_tirith.chmod(0o700)
 
         policy = MagicMock(return_value=False)
         monkeypatch.setattr(_lazy_deps, "_allow_lazy_installs", policy)
         monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
         monkeypatch.setattr(
-            _tirith_mod.shutil, "which", lambda _name: "/usr/bin/tirith"
+            _tirith_mod.shutil, "which", lambda _name: str(local_tirith)
         )
         monkeypatch.setattr(_tirith_mod, "_clear_install_failed", lambda: None)
 
-        assert _tirith_mod._resolve_tirith_path("tirith") == "/usr/bin/tirith"
+        assert _tirith_mod._resolve_tirith_path("tirith") == str(local_tirith)
 
         policy.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Managed-cache execution boundary
+# ---------------------------------------------------------------------------
+
+class TestManagedCacheExecutionBoundary:
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX ownership boundary")
+    @pytest.mark.parametrize(
+        "fail_open, expected_action",
+        [(True, "allow"), (False, "block")],
+    )
+    def test_cached_managed_binary_mode_drift_is_never_spawned(
+        self, fail_open, expected_action, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = home / "bin" / "tirith"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        managed.chmod(0o755)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _tirith_mod._resolved_path = str(managed)
+
+        # Simulate trust drift after successful resolution. The cached string
+        # must not bypass the current filesystem proof.
+        managed.chmod(0o775)
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_load_security_config",
+            lambda: {
+                "tirith_enabled": True,
+                "tirith_path": "tirith",
+                "tirith_timeout": 5,
+                "tirith_fail_open": fail_open,
+            },
+        )
+        monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: None)
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        run = MagicMock()
+        monkeypatch.setattr(_tirith_mod.subprocess, "run", run)
+
+        result = check_command_security("echo guarded")
+
+        assert result["action"] == expected_action
+        assert _tirith_mod._resolved_path is _tirith_mod._INSTALL_FAILED
+        assert _tirith_mod._install_failure_reason == "managed_cache_untrusted"
+        run.assert_not_called()
+
+    @pytest.mark.require_symlinks
+    def test_path_alias_cannot_hide_untrusted_managed_binary(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = home / "bin" / "tirith"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        managed.chmod(0o777)
+        alias = tmp_path / "path" / "tirith"
+        alias.parent.mkdir()
+        alias.symlink_to(managed)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _tirith_mod._resolved_path = None
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_load_security_config",
+            lambda: {
+                "tirith_enabled": True,
+                "tirith_path": "tirith",
+                "tirith_timeout": 5,
+                "tirith_fail_open": False,
+            },
+        )
+        monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: str(alias))
+        monkeypatch.setattr(_tirith_mod, "is_platform_supported", lambda: True)
+        run = MagicMock()
+        monkeypatch.setattr(_tirith_mod.subprocess, "run", run)
+
+        result = check_command_security("echo guarded")
+
+        assert result["action"] == "block"
+        assert _tirith_mod._install_failure_reason == "managed_cache_untrusted"
+        run.assert_not_called()
+
+    @pytest.mark.require_symlinks
+    def test_trusted_managed_path_alias_is_normalized_before_execution(
+        self, tmp_path, monkeypatch
+    ):
+        home = tmp_path / "home"
+        managed = home / "bin" / "tirith"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        managed.chmod(0o755)
+        alias = tmp_path / "path" / "tirith"
+        alias.parent.mkdir()
+        alias.symlink_to(managed)
+        monkeypatch.setenv("HERMES_HOME", str(home))
+        _tirith_mod._resolved_path = None
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_load_security_config",
+            lambda: {
+                "tirith_enabled": True,
+                "tirith_path": "tirith",
+                "tirith_timeout": 5,
+                "tirith_fail_open": False,
+            },
+        )
+        monkeypatch.setattr(_tirith_mod.shutil, "which", lambda _name: str(alias))
+        monkeypatch.setattr(_tirith_mod, "_schedule_managed_update", lambda *_a, **_kw: None)
+        run = MagicMock(return_value=_mock_run(0, _json_stdout()))
+        monkeypatch.setattr(_tirith_mod.subprocess, "run", run)
+
+        result = check_command_security("echo safe")
+
+        assert result["action"] == "allow"
+        assert _tirith_mod._resolved_path == str(managed)
+        assert run.call_args.args[0][0] == str(managed)
+
+    @pytest.mark.macos_only
+    def test_case_alias_is_recognized_as_managed_file(self, tmp_path, monkeypatch):
+        home = tmp_path / "home"
+        managed = home / "bin" / "tirith"
+        managed.parent.mkdir(parents=True)
+        managed.write_text("scanner", encoding="utf-8")
+        managed.chmod(0o755)
+        alias = managed.with_name("TIRITH")
+        if not alias.exists():
+            pytest.skip("test filesystem is case-sensitive")
+        monkeypatch.setenv("HERMES_HOME", str(home))
+
+        assert alias != managed
+        assert alias.samefile(managed)
+        assert _tirith_mod._is_managed_tirith_location(str(alias))
+        assert _tirith_mod._validated_tirith_path(str(alias)) == str(managed)
 
 
 # ---------------------------------------------------------------------------
@@ -631,18 +797,75 @@ class TestExplicitPathNoAutoDownload:
 class TestCosignVerification:
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security.shutil.which", return_value="/usr/bin/cosign")
-    def test_cosign_identity_pinned_to_release_workflow(self, mock_which, mock_run):
-        """Identity regexp must pin to the release workflow, not the whole repo."""
+    @patch(
+        "tools.tirith_security._release_identity_from_certificate",
+        return_value=(
+            (0, 4, 1),
+            "https://github.com/sheeki03/tirith/.github/workflows/"
+            "release.yml@refs/tags/v0.4.1",
+        ),
+    )
+    def test_cosign_identity_pinned_to_exact_release_tag(
+        self, mock_identity, mock_which, mock_run
+    ):
+        """Verification binds the manifest to one authenticated stable tag."""
+        del mock_identity, mock_which
         from tools.tirith_security import _verify_cosign
         mock_run.return_value = _mock_run(0, "Verified OK")
-        _verify_cosign("/tmp/checksums.txt", "/tmp/sig", "/tmp/cert")
+        assert _verify_cosign(
+            "/tmp/checksums.txt", "/tmp/sig", "/tmp/cert"
+        ) == (True, (0, 4, 1))
         args = mock_run.call_args[0][0]
-        # Find the value after --certificate-identity-regexp
-        idx = args.index("--certificate-identity-regexp")
-        identity = args[idx + 1]
-        # The identity contains regex-escaped dots
-        assert "workflows/release" in identity
-        assert "refs/tags/v" in identity
+        idx = args.index("--certificate-identity")
+        assert args[idx + 1].endswith("release.yml@refs/tags/v0.4.1")
+        assert "--certificate-identity-regexp" not in args
+
+    @pytest.mark.parametrize(
+        "identity, expected",
+        [
+            (
+                "https://github.com/sheeki03/tirith/.github/workflows/"
+                "release.yml@refs/tags/v0.4.1",
+                (0, 4, 1),
+            ),
+            (
+                "https://github.com/sheeki03/tirith/.github/workflows/"
+                "release.yml@refs/tags/v0.4.1-rc.1",
+                None,
+            ),
+            (
+                "https://github.com/sheeki03/tirith/.github/workflows/"
+                "release.yml@refs/tags/v00.4.1",
+                None,
+            ),
+            (
+                "https://github.com/sheeki03/tirith/.github/workflows/"
+                "other.yml@refs/tags/v0.4.1",
+                None,
+            ),
+        ],
+    )
+    def test_certificate_identity_accepts_only_stable_release_tag(
+        self, tmp_path, identity, expected
+    ):
+        certificate = tmp_path / "checksums.txt.pem"
+        _write_release_certificate(certificate, [identity])
+
+        parsed = _tirith_mod._release_identity_from_certificate(str(certificate))
+
+        assert (parsed[0] if parsed else None) == expected
+
+    def test_certificate_with_ambiguous_release_identities_is_rejected(
+        self, tmp_path
+    ):
+        prefix = (
+            "https://github.com/sheeki03/tirith/.github/workflows/"
+            "release.yml@refs/tags/v"
+        )
+        certificate = tmp_path / "checksums.txt.pem"
+        _write_release_certificate(certificate, [prefix + "0.4.1", prefix + "0.4.2"])
+
+        assert _tirith_mod._release_identity_from_certificate(str(certificate)) is None
 
 
     @patch(
@@ -678,7 +901,10 @@ class TestCosignVerification:
         del mock_target, mock_dl, mock_which
         from tools.tirith_security import _install_tirith
 
-        path, reason = _install_tirith(expected_existing_sha256="0" * 64)
+        path, reason = _install_tirith(
+            expected_existing_sha256="0" * 64,
+            current_version=(0, 4, 0),
+        )
 
         assert path is None
         assert reason == "cosign_missing"
@@ -701,7 +927,7 @@ class TestCosignVerification:
             existing = hermes_home / "bin" / "tirith"
             existing.parent.mkdir(parents=True)
             existing.write_bytes(b"concurrent tirith")
-            return str(verified), "", False
+            return str(verified), "", False, None
 
         monkeypatch.setattr(
             _tirith_mod, "_download_verified_tirith", unsigned_download
@@ -728,7 +954,7 @@ class TestCosignVerification:
         monkeypatch.setattr(
             _tirith_mod,
             "_download_verified_tirith",
-            lambda *_args, **_kwargs: (str(verified), "", False),
+            lambda *_args, **_kwargs: (str(verified), "", False, None),
         )
         real_directory_check = _tirith_mod._managed_install_directory_is_real
 

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -5,6 +5,7 @@ import json
 import os
 import subprocess
 import tarfile
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -1022,6 +1023,50 @@ class TestCircuitBreakerRecovery:
         assert not _tirith_mod._circuit_open
         assert _tirith_mod._circuit_opened_at is None
         mock_run.assert_called_once()
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_half_open_recovery_probe_is_single_flight(
+        self, mock_cfg, mock_run
+    ):
+        mock_cfg.return_value = _CFG
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
+        _tirith_mod._circuit_open = True
+        _tirith_mod._circuit_opened_at = 100.0
+        entered = threading.Event()
+        release = threading.Event()
+        first_result = {}
+
+        def slow_success(*_args, **_kwargs):
+            entered.set()
+            assert release.wait(5), "test did not release half-open probe"
+            return _mock_run(0, _json_stdout())
+
+        mock_run.side_effect = slow_success
+
+        with patch(
+            "tools.tirith_security.time.monotonic",
+            return_value=100.0 + _tirith_mod._CIRCUIT_RETRY_SECONDS,
+        ):
+            worker = threading.Thread(
+                target=lambda: first_result.update(
+                    result=check_command_security("echo first")
+                )
+            )
+            worker.start()
+            assert entered.wait(5), "half-open probe did not start"
+
+            second = check_command_security("echo second")
+            assert second["action"] == "allow"
+            assert "circuit breaker" in second["summary"]
+            assert mock_run.call_count == 1
+
+            release.set()
+            worker.join(5)
+
+        assert not worker.is_alive()
+        assert first_result["result"]["action"] == "allow"
+        assert not _tirith_mod._circuit_open
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -604,8 +604,8 @@ class TestReleaseDownloadLimits:
         response.__enter__.return_value = response
         response.__exit__.return_value = False
         response.read.return_value = b""
-        urlopen = MagicMock(return_value=response)
-        monkeypatch.setattr(_tirith_mod.urllib.request, "urlopen", urlopen)
+        secure_open = MagicMock(return_value=response)
+        monkeypatch.setattr(_tirith_mod, "open_credentialed_url", secure_open)
         monkeypatch.setattr(
             "agent.secret_scope.get_secret",
             lambda key: "secret-token" if key == "GITHUB_TOKEN" else None,
@@ -617,7 +617,8 @@ class TestReleaseDownloadLimits:
             max_bytes=4,
         )
 
-        initial_request = urlopen.call_args.args[0]
+        initial_request = secure_open.call_args.args[0]
+        assert secure_open.call_args.kwargs == {"timeout": 10}
         assert initial_request.get_header("Authorization") == "token secret-token"
         redirected_request = (
             _tirith_mod.urllib.request.HTTPRedirectHandler().redirect_request(
@@ -638,8 +639,8 @@ class TestReleaseDownloadLimits:
         response.__exit__.return_value = False
         response.read.side_effect = [b"12345", b""]
         monkeypatch.setattr(
-            _tirith_mod.urllib.request,
-            "urlopen",
+            _tirith_mod,
+            "open_credentialed_url",
             MagicMock(return_value=response),
         )
         destination = tmp_path / "metadata"

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -417,14 +417,11 @@ class TestLazyInstallPolicy:
 
 
 # ---------------------------------------------------------------------------
-# Unsupported platform (Windows etc.) — silent fast-path everywhere
+# Unsupported managed-install platform (Windows etc.)
 # ---------------------------------------------------------------------------
 
 class TestUnsupportedPlatform:
-    """When _detect_target() returns None (no tirith binary for this OS+arch),
-    the entire subsystem must stay silent: no PATH probes, no download thread,
-    no disk failure marker, no spawn attempts, no CLI banner. Pattern-matching
-    guards still cover the gap; tirith content scanning is just absent."""
+    """Manager support must not disable an operator-provided scanner."""
 
     @pytest.mark.parametrize("system, machine, expected", [
         ("Linux", "x86_64", True),
@@ -460,34 +457,107 @@ class TestUnsupportedPlatform:
 
     @patch("tools.tirith_security._load_security_config")
     def test_check_command_security_unsupported_allows_silently(self, mock_cfg):
-        """Windows: skip the resolver and spawn entirely — return allow with
-        an empty summary so callers can't accidentally surface 'tirith
-        unavailable' messaging to the user."""
+        """Default fail-open remains silent when no local scanner exists."""
         mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
-                                 "tirith_timeout": 5, "tirith_fail_open": True}
-        with patch("tools.tirith_security.is_platform_supported", return_value=False), \
-             patch("tools.tirith_security.subprocess.run") as mock_run, \
-             patch("tools.tirith_security._resolve_tirith_path") as mock_resolve:
-            result = check_command_security("rm -rf /")
-            assert result == {"action": "allow", "findings": [], "summary": ""}
-            mock_run.assert_not_called()
-            mock_resolve.assert_not_called()
-
-    @patch("tools.tirith_security._load_security_config")
-    def test_explicit_path_still_honored_on_unsupported_platform(self, mock_cfg):
-        """If a user explicitly configured a tirith_path (e.g. they built it
-        themselves under WSL), the unsupported-platform short-circuit must
-        NOT override that — explicit config wins."""
-        mock_cfg.return_value = {"tirith_enabled": True,
-                                 "tirith_path": "/opt/custom/tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}
         _tirith_mod._resolved_path = None
         with patch("tools.tirith_security.is_platform_supported", return_value=False), \
-             patch("os.path.isfile", return_value=True), \
-             patch("os.access", return_value=True):
-            result = _tirith_mod._resolve_tirith_path("/opt/custom/tirith")
-            assert result == "/opt/custom/tirith"
-            assert _tirith_mod._resolved_path == "/opt/custom/tirith"
+             patch("tools.tirith_security.shutil.which", return_value=None) as mock_which, \
+             patch("tools.tirith_security.subprocess.run") as mock_run, \
+             patch("tools.tirith_security._warn_once") as mock_warn:
+            result = check_command_security("rm -rf /")
+            assert result == {"action": "allow", "findings": [], "summary": ""}
+            mock_run.assert_not_called()
+            mock_warn.assert_not_called()
+            mock_which.assert_called_once_with("tirith")
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_explicit_path_scans_on_unsupported_platform(
+        self, mock_cfg, mock_run, tmp_path
+    ):
+        """A working explicit scanner remains authoritative everywhere."""
+        binary = tmp_path / "tirith"
+        binary.write_text("scanner", encoding="utf-8")
+        binary.chmod(0o700)
+        mock_cfg.return_value = {"tirith_enabled": True,
+                                 "tirith_path": str(binary),
+                                 "tirith_timeout": 5,
+                                 "tirith_fail_open": False}
+        mock_run.return_value = _mock_run(
+            1,
+            _json_stdout([{"rule_id": "homograph_url"}], "blocked"),
+        )
+        _tirith_mod._resolved_path = None
+        with patch("tools.tirith_security.is_platform_supported", return_value=False):
+            result = check_command_security("curl https://example.test")
+
+        assert result["action"] == "block"
+        assert mock_run.call_args.args[0][0] == str(binary)
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_default_path_scans_on_unsupported_platform(self, mock_cfg, mock_run):
+        """Manager support does not suppress the ordinary PATH contract."""
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        mock_run.return_value = _mock_run(2, _json_stdout(summary="review"))
+        _tirith_mod._resolved_path = None
+        with patch("tools.tirith_security.is_platform_supported", return_value=False), \
+             patch("tools.tirith_security.shutil.which",
+                   return_value="/usr/local/bin/tirith"), \
+             patch("tools.tirith_security.threading.Thread") as mock_thread:
+            result = check_command_security("curl https://example.test")
+
+        assert result["action"] == "warn"
+        assert mock_run.call_args.args[0][0] == "/usr/local/bin/tirith"
+        mock_thread.assert_not_called()
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_unsupported_missing_scanner_honors_fail_closed(self, mock_cfg):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": False}
+        _tirith_mod._resolved_path = None
+        with patch("tools.tirith_security.is_platform_supported", return_value=False), \
+             patch("tools.tirith_security.shutil.which", return_value=None), \
+             patch("tools.tirith_security.subprocess.run") as mock_run:
+            result = check_command_security("echo guarded")
+
+        assert result == {
+            "action": "block",
+            "findings": [],
+            "summary": "tirith path unavailable (fail-closed)",
+        }
+        mock_run.assert_not_called()
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_ensure_installed_honors_explicit_path(self, mock_cfg, tmp_path):
+        binary = tmp_path / "tirith"
+        binary.write_text("scanner", encoding="utf-8")
+        binary.chmod(0o700)
+        mock_cfg.return_value = {"tirith_enabled": True,
+                                 "tirith_path": str(binary),
+                                 "tirith_timeout": 5,
+                                 "tirith_fail_open": True}
+        _tirith_mod._resolved_path = None
+        with patch("tools.tirith_security.is_platform_supported", return_value=False), \
+             patch("tools.tirith_security.threading.Thread") as mock_thread:
+            assert ensure_installed() == str(binary)
+
+        mock_thread.assert_not_called()
+
+    @patch("tools.tirith_security._load_security_config")
+    def test_ensure_installed_honors_path(self, mock_cfg):
+        mock_cfg.return_value = {"tirith_enabled": True, "tirith_path": "tirith",
+                                 "tirith_timeout": 5, "tirith_fail_open": True}
+        _tirith_mod._resolved_path = None
+        with patch("tools.tirith_security.is_platform_supported", return_value=False), \
+             patch("tools.tirith_security.shutil.which",
+                   return_value="/usr/local/bin/tirith"), \
+             patch("tools.tirith_security.threading.Thread") as mock_thread:
+            assert ensure_installed() == "/usr/local/bin/tirith"
+
+        mock_thread.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -29,6 +29,8 @@ def _reset_resolved_path():
     _tirith_mod._install_failure_reason = ""
     _tirith_mod._crash_count = 0
     _tirith_mod._circuit_open = False
+    with _tirith_mod._in_process_update_state_lock:
+        _tirith_mod._in_process_update_states.clear()
     # The global test fixture disables runtime installs. Most tests in this
     # module exercise Tirith's installer mechanics, so opt them in explicitly;
     # policy tests below override this nested patch with False.
@@ -39,6 +41,8 @@ def _reset_resolved_path():
     _tirith_mod._install_failure_reason = ""
     _tirith_mod._crash_count = 0
     _tirith_mod._circuit_open = False
+    with _tirith_mod._in_process_update_state_lock:
+        _tirith_mod._in_process_update_states.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -284,6 +288,7 @@ class TestEnsureInstalled:
 
         thread_factory.assert_not_called()
         assert _tirith_mod._resolved_path is None
+        assert not (hermes_home / "bin").exists()
 
 
 class TestLazyInstallPolicy:
@@ -299,6 +304,33 @@ class TestLazyInstallPolicy:
         assert result == (None, "lazy_installs_disabled")
         mock_target.assert_not_called()
         mock_download.assert_not_called()
+
+    def test_installer_rechecks_opt_out_before_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        """A live policy change during download prevents filesystem mutation."""
+        source = tmp_path / "verified-tirith"
+        source.write_bytes(b"verified release")
+        hermes_home = tmp_path / "hermes-home"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        policy_states = iter((True, False))
+        monkeypatch.setattr(
+            _lazy_deps, "_allow_lazy_installs", lambda: next(policy_states)
+        )
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_download_verified_tirith",
+            lambda *_args: (str(source), "", True),
+        )
+        replace = MagicMock()
+        monkeypatch.setattr(_tirith_mod, "_atomic_replace_binary", replace)
+
+        assert _tirith_mod._install_tirith(log_failures=False) == (
+            None,
+            "lazy_installs_disabled",
+        )
+        replace.assert_not_called()
+        assert not hermes_home.exists()
 
     def test_resolver_policy_transition_does_not_cache_install_failure(
         self, monkeypatch
@@ -523,27 +555,49 @@ class TestCosignVerification:
         assert "refs/tags/v" in identity
 
 
-    @patch("tools.tirith_security.tarfile.open")
+    @patch(
+        "tools.tirith_security._extract_release_archive",
+        return_value=(None, "binary_not_in_archive"),
+    )
     @patch("tools.tirith_security._verify_checksum", return_value=True)
     @patch("tools.tirith_security.shutil.which", return_value=None)
     @patch("tools.tirith_security._download_file")
     @patch("tools.tirith_security._detect_target", return_value="aarch64-apple-darwin")
     def test_install_proceeds_without_cosign(self, mock_target, mock_dl,
                                               mock_which, mock_checksum,
-                                              mock_tarfile):
+                                              mock_extract):
         """_install_tirith proceeds with SHA-256 only when cosign is not on PATH."""
         from tools.tirith_security import _install_tirith
-        mock_tar = MagicMock()
-        mock_tar.__enter__ = MagicMock(return_value=mock_tar)
-        mock_tar.__exit__ = MagicMock(return_value=False)
-        mock_tar.getmembers.return_value = []
-        mock_tarfile.return_value = mock_tar
 
         path, reason = _install_tirith()
         # Reaches extraction (no binary in mock archive), but got past cosign
         assert path is None
         assert reason == "binary_not_in_archive"
         assert mock_checksum.called  # SHA-256 verification ran
+        mock_extract.assert_called_once()
+
+
+class TestReleaseDownloadLimits:
+    def test_download_rejects_response_over_limit(self, tmp_path, monkeypatch):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        response.read.side_effect = [b"12345", b""]
+        monkeypatch.setattr(
+            _tirith_mod.urllib.request,
+            "urlopen",
+            MagicMock(return_value=response),
+        )
+        destination = tmp_path / "metadata"
+
+        with pytest.raises(ValueError, match="exceeds 4-byte limit"):
+            _tirith_mod._download_file(
+                "https://example.invalid/checksums.txt",
+                str(destination),
+                max_bytes=4,
+            )
+
+        assert not destination.exists()
 
 
 class TestInstallArchiveMemberValidation:
@@ -562,8 +616,8 @@ class TestInstallArchiveMemberValidation:
         return archive, checksums
 
     def _download_side_effect(self, archive, checksums):
-        def _download(url, dest, timeout=10):
-            del timeout
+        def _download(url, dest, timeout=10, *, max_bytes):
+            del timeout, max_bytes
             if url.endswith(".tar.gz"):
                 with open(archive, "rb") as src, open(dest, "wb") as dst:
                     dst.write(src.read())
@@ -599,6 +653,7 @@ class TestInstallArchiveMemberValidation:
 
         assert reason == ""
         assert path == str(hermes_home / "bin" / "tirith")
+        assert path is not None
         assert os.path.isfile(path)
         assert not os.path.islink(path)
         with open(path, "rb") as f:
@@ -628,6 +683,62 @@ class TestInstallArchiveMemberValidation:
         assert reason == "binary_not_regular_file"
         assert not os.path.lexists(hermes_home / "bin" / "tirith")
 
+    def test_install_rejects_oversized_tirith_member(self, tmp_path):
+        member = tarfile.TarInfo("tirith")
+        member.size = _tirith_mod._MAX_TIRITH_BINARY_BYTES + 1
+        archive = MagicMock()
+        archive.__iter__.return_value = iter([member])
+
+        path, reason = _tirith_mod._extract_tirith_binary(
+            archive, str(tmp_path), lambda *_args: None
+        )
+
+        assert path is None
+        assert reason == "archive_member_too_large"
+        archive.extractfile.assert_not_called()
+
+    def test_install_rejects_too_many_archive_members(self, tmp_path):
+        members = [
+            tarfile.TarInfo(f"extra-{index}")
+            for index in range(_tirith_mod._MAX_RELEASE_ARCHIVE_MEMBERS + 1)
+        ]
+        archive = MagicMock()
+        archive.__iter__.return_value = iter(members)
+
+        path, reason = _tirith_mod._extract_tirith_binary(
+            archive, str(tmp_path), lambda *_args: None
+        )
+
+        assert path is None
+        assert reason == "too_many_archive_members"
+        archive.extractfile.assert_not_called()
+
+    def test_install_caps_pax_metadata_before_tarfile_yields_it(
+        self, tmp_path, monkeypatch
+    ):
+        archive = tmp_path / "pax-metadata.tar.gz"
+        with tarfile.open(archive, "w:gz", format=tarfile.PAX_FORMAT) as tar:
+            metadata_heavy = tarfile.TarInfo("nested/" + "a" * 16_384)
+            metadata_heavy.size = 0
+            tar.addfile(metadata_heavy)
+            binary = tarfile.TarInfo("tirith")
+            binary.size = 1
+            tar.addfile(binary, io.BytesIO(b"x"))
+
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_MAX_RELEASE_ARCHIVE_UNPACKED_BYTES",
+            4 * 1024,
+        )
+
+        path, reason = _tirith_mod._extract_release_archive(
+            str(archive), str(tmp_path), lambda *_args: None
+        )
+
+        assert path is None
+        assert reason == "archive_too_large"
+        assert not (tmp_path / "tirith").exists()
+
 
 # ---------------------------------------------------------------------------
 # Background install / non-blocking startup (P2)
@@ -642,7 +753,7 @@ class TestBackgroundInstall:
                    return_value={"tirith_enabled": True, "tirith_path": "tirith",
                                  "tirith_timeout": 5, "tirith_fail_open": True}), \
              patch("tools.tirith_security.shutil.which", return_value=None), \
-             patch("tools.tirith_security._hermes_bin_dir", return_value="/nonexistent"), \
+             patch("tools.tirith_security._managed_tirith_path", return_value="/nonexistent/tirith"), \
              patch("tools.tirith_security._is_install_failed_on_disk", return_value=False), \
              patch("tools.tirith_security.threading.Thread") as MockThread:
             mock_thread = MagicMock()
@@ -665,7 +776,7 @@ class TestBackgroundInstall:
         _tirith_mod._install_thread = mock_thread
 
         with patch("tools.tirith_security.shutil.which", return_value=None), \
-             patch("tools.tirith_security._hermes_bin_dir", return_value="/nonexistent"):
+             patch("tools.tirith_security._managed_tirith_path", return_value="/nonexistent/tirith"):
             result = _resolve_tirith_path("tirith")
             assert result == "tirith"  # returns configured default, doesn't block
 
@@ -701,7 +812,7 @@ class TestDiskFailureMarker:
         _tirith_mod._install_failure_reason = "cosign_exec_failed"
 
         with patch("tools.tirith_security.shutil.which", return_value=None), \
-             patch("tools.tirith_security._hermes_bin_dir", return_value="/nonexistent"), \
+             patch("tools.tirith_security._managed_tirith_path", return_value="/nonexistent/tirith"), \
              patch("tools.tirith_security._install_tirith") as mock_install:
             result = _resolve_tirith_path("tirith")
             assert result == "tirith"  # fallback

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -151,6 +151,7 @@ class TestOSErrorFailOpen:
         result = check_command_security("echo hi")
         assert result["action"] == "allow"
         assert "unavailable" in result["summary"]
+        assert _tirith_mod._resolved_path is None
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")
@@ -938,8 +939,11 @@ class TestSpawnWarningDedup:
     """
 
     @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._resolve_tirith_path", return_value="tirith")
     @patch("tools.tirith_security._load_security_config")
-    def test_repeated_spawn_failure_logs_once(self, mock_cfg, mock_run, caplog):
+    def test_repeated_spawn_failure_logs_once(
+        self, mock_cfg, _mock_resolve, mock_run, caplog
+    ):
         mock_cfg.return_value = {
             "tirith_enabled": True, "tirith_path": "tirith",
             "tirith_timeout": 5, "tirith_fail_open": True,
@@ -1056,6 +1060,25 @@ class TestAppTldSuppression:
         result = check_command_security("curl https://bit.ly/test.app")
         assert result["action"] == "warn"
         assert len(result["findings"]) == 2
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_non_app_finding_beyond_display_cap_preserves_warn(
+        self, mock_cfg, mock_run
+    ):
+        """Suppression must consider findings that are not returned to callers."""
+        mock_cfg.return_value = _CFG
+        findings = [
+            {"rule_id": "lookalike_tld", "value": ".app"}
+            for _ in range(_tirith_mod._MAX_FINDINGS)
+        ]
+        findings.append({"rule_id": "shortened_url", "severity": "medium"})
+        mock_run.return_value = _mock_run(2, _json_stdout(findings, "mixed"))
+
+        result = check_command_security("curl https://bit.ly/test.app")
+
+        assert result["action"] == "warn"
+        assert len(result["findings"]) == _tirith_mod._MAX_FINDINGS
 
     @patch("tools.tirith_security.subprocess.run")
     @patch("tools.tirith_security._load_security_config")

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -29,6 +29,7 @@ def _reset_resolved_path():
     _tirith_mod._install_failure_reason = ""
     _tirith_mod._crash_count = 0
     _tirith_mod._circuit_open = False
+    _tirith_mod._circuit_opened_at = None
     with _tirith_mod._in_process_update_state_lock:
         _tirith_mod._in_process_update_states.clear()
     # The global test fixture disables runtime installs. Most tests in this
@@ -41,6 +42,7 @@ def _reset_resolved_path():
     _tirith_mod._install_failure_reason = ""
     _tirith_mod._crash_count = 0
     _tirith_mod._circuit_open = False
+    _tirith_mod._circuit_opened_at = None
     with _tirith_mod._in_process_update_state_lock:
         _tirith_mod._in_process_update_states.clear()
 
@@ -593,6 +595,41 @@ class TestCosignVerification:
 
 
 class TestReleaseDownloadLimits:
+    def test_github_token_is_not_forwarded_to_release_asset_redirect(
+        self, tmp_path, monkeypatch
+    ):
+        response = MagicMock()
+        response.__enter__.return_value = response
+        response.__exit__.return_value = False
+        response.read.return_value = b""
+        urlopen = MagicMock(return_value=response)
+        monkeypatch.setattr(_tirith_mod.urllib.request, "urlopen", urlopen)
+        monkeypatch.setattr(
+            "agent.secret_scope.get_secret",
+            lambda key: "secret-token" if key == "GITHUB_TOKEN" else None,
+        )
+
+        _tirith_mod._download_file(
+            "https://github.com/sheeki03/tirith/releases/latest/download/checksums.txt",
+            str(tmp_path / "checksums.txt"),
+            max_bytes=4,
+        )
+
+        initial_request = urlopen.call_args.args[0]
+        assert initial_request.get_header("Authorization") == "token secret-token"
+        redirected_request = (
+            _tirith_mod.urllib.request.HTTPRedirectHandler().redirect_request(
+                initial_request,
+                None,
+                302,
+                "Found",
+                {},
+                "https://release-assets.githubusercontent.com/checksums.txt",
+            )
+        )
+        assert redirected_request is not None
+        assert redirected_request.get_header("Authorization") is None
+
     def test_download_rejects_response_over_limit(self, tmp_path, monkeypatch):
         response = MagicMock()
         response.__enter__.return_value = response
@@ -798,6 +835,42 @@ class TestBackgroundInstall:
         _tirith_mod._install_thread = None
         _tirith_mod._resolved_path = None
 
+    def test_approval_path_starts_missing_install_in_background(self):
+        """A first command must not synchronously download Tirith."""
+        _tirith_mod._resolved_path = None
+        _tirith_mod._install_thread = None
+        mock_thread = MagicMock()
+        mock_thread.is_alive.return_value = False
+
+        with (
+            patch(
+                "tools.tirith_security._load_security_config",
+                return_value={
+                    "tirith_enabled": True,
+                    "tirith_path": "tirith",
+                    "tirith_timeout": 5,
+                    "tirith_fail_open": True,
+                },
+            ),
+            patch("tools.tirith_security.is_platform_supported", return_value=True),
+            patch("tools.tirith_security.shutil.which", return_value=None),
+            patch(
+                "tools.tirith_security._managed_tirith_path",
+                return_value="/nonexistent/tirith",
+            ),
+            patch("tools.tirith_security._read_failure_reason", return_value=None),
+            patch("tools.tirith_security.threading.Thread", return_value=mock_thread),
+            patch("tools.tirith_security._install_tirith") as install,
+            patch("tools.tirith_security.subprocess.run") as run,
+        ):
+            result = check_command_security("echo hi")
+
+        assert result["action"] == "allow"
+        assert "unavailable" in result["summary"]
+        mock_thread.start.assert_called_once_with()
+        install.assert_not_called()
+        run.assert_not_called()
+
 
 # ---------------------------------------------------------------------------
 # Disk failure marker persistence (P2)
@@ -898,6 +971,55 @@ class TestSpawnWarningDedup:
         )
 
 
+class TestCircuitBreakerRecovery:
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_recognized_warn_resets_prior_failures(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT - 1
+        mock_run.return_value = _mock_run(2, _json_stdout([], "review"))
+
+        result = check_command_security("echo review")
+
+        assert result["action"] == "warn"
+        assert _tirith_mod._crash_count == 0
+        assert not _tirith_mod._circuit_open
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_open_circuit_honors_fail_closed(self, mock_cfg, mock_run):
+        mock_cfg.return_value = {**_CFG, "tirith_fail_open": False}
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
+        _tirith_mod._circuit_open = True
+        _tirith_mod._circuit_opened_at = time.monotonic()
+
+        result = check_command_security("echo blocked")
+
+        assert result["action"] == "block"
+        assert "fail-closed" in result["summary"]
+        mock_run.assert_not_called()
+
+    @patch("tools.tirith_security.subprocess.run")
+    @patch("tools.tirith_security._load_security_config")
+    def test_open_circuit_makes_half_open_recovery_probe(self, mock_cfg, mock_run):
+        mock_cfg.return_value = _CFG
+        _tirith_mod._crash_count = _tirith_mod._CRASH_LIMIT
+        _tirith_mod._circuit_open = True
+        _tirith_mod._circuit_opened_at = 100.0
+        mock_run.return_value = _mock_run(0, _json_stdout())
+
+        with patch(
+            "tools.tirith_security.time.monotonic",
+            return_value=100.0 + _tirith_mod._CIRCUIT_RETRY_SECONDS,
+        ):
+            result = check_command_security("echo recovered")
+
+        assert result["action"] == "allow"
+        assert not _tirith_mod._circuit_open
+        assert _tirith_mod._circuit_opened_at is None
+        mock_run.assert_called_once()
+
+
 # ---------------------------------------------------------------------------
 # .app TLD suppression (issue #24461)
 # ---------------------------------------------------------------------------
@@ -954,6 +1076,9 @@ class TestIsAppTldFinding:
         ({"rule_id": "lookalike_tld", "message": "Domain uses '.app' TLD"}, True),
         ({"rule_id": "shortened_url", "value": ".app"}, False),  # wrong rule_id
         ({"rule_id": "lookalike_tld", "value": ".zip"}, False),  # other TLD
+        ({"rule_id": "lookalike_tld", "value": ".apple"}, False),
+        ({"rule_id": "lookalike_tld", "description": "Domain uses '.application' TLD"}, False),
+        ({"rule_id": "lookalike_tld", "message": "Docs mention .app; domain uses '.zip' TLD"}, False),
     ])
     def test_app_tld_detection(self, finding, expected):
         from tools.tirith_security import _is_app_tld_finding

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -434,8 +434,23 @@ class TestUnsupportedPlatform:
         # could never execute honestly anyway — the second has no CI runner
         # on any lane.
         with patch("tools.tirith_security.platform.system", return_value=system), \
-             patch("tools.tirith_security.platform.machine", return_value=machine):
+             patch("tools.tirith_security.platform.machine", return_value=machine), \
+             patch("tools.tirith_security.is_termux", return_value=False):
             assert _tirith_mod.is_platform_supported() is expected
+
+    @pytest.mark.parametrize(
+        "machine, expected",
+        [
+            ("aarch64", "aarch64-unknown-linux-musl"),
+            ("arm64", "aarch64-unknown-linux-musl"),
+            ("x86_64", None),
+        ],
+    )
+    def test_termux_uses_only_published_musl_target(self, machine, expected):
+        with patch("tools.tirith_security.platform.system", return_value="Linux"), \
+             patch("tools.tirith_security.platform.machine", return_value=machine), \
+             patch("tools.tirith_security.is_termux", return_value=True):
+            assert _tirith_mod._detect_target() == expected
 
 
     @patch("tools.tirith_security._load_security_config")

--- a/tests/tools/test_tirith_security.py
+++ b/tests/tools/test_tirith_security.py
@@ -7,6 +7,7 @@ import subprocess
 import tarfile
 import threading
 import time
+from http.client import HTTPMessage
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -324,7 +325,7 @@ class TestLazyInstallPolicy:
         monkeypatch.setattr(
             _tirith_mod,
             "_download_verified_tirith",
-            lambda *_args: (str(source), "", True),
+            lambda *_args, **_kwargs: (str(source), "", True),
         )
         replace = MagicMock()
         monkeypatch.setattr(_tirith_mod, "_atomic_replace_binary", replace)
@@ -595,6 +596,90 @@ class TestCosignVerification:
         assert mock_checksum.called  # SHA-256 verification ran
         mock_extract.assert_called_once()
 
+    @patch("tools.tirith_security._extract_release_archive")
+    @patch("tools.tirith_security._verify_checksum")
+    @patch("tools.tirith_security.shutil.which", return_value=None)
+    @patch("tools.tirith_security._download_file")
+    @patch("tools.tirith_security._detect_target", return_value="aarch64-apple-darwin")
+    def test_replacement_requires_cosign(self, mock_target, mock_dl,
+                                         mock_which, mock_checksum,
+                                         mock_extract):
+        """Automatic replacement must not downgrade to checksum-only trust."""
+        del mock_target, mock_dl, mock_which
+        from tools.tirith_security import _install_tirith
+
+        path, reason = _install_tirith(expected_existing_sha256="0" * 64)
+
+        assert path is None
+        assert reason == "cosign_missing"
+        mock_checksum.assert_not_called()
+        mock_extract.assert_not_called()
+
+    def test_unsigned_initial_download_cannot_race_into_replacement(
+        self, tmp_path, monkeypatch
+    ):
+        """A concurrently created managed binary forces fail-closed replacement."""
+        hermes_home = tmp_path / "hermes-home"
+        verified = tmp_path / "verified-tirith"
+        verified.write_bytes(b"new tirith")
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            _tirith_mod, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+
+        def unsigned_download(*_args, **_kwargs):
+            existing = hermes_home / "bin" / "tirith"
+            existing.parent.mkdir(parents=True)
+            existing.write_bytes(b"concurrent tirith")
+            return str(verified), "", False
+
+        monkeypatch.setattr(
+            _tirith_mod, "_download_verified_tirith", unsigned_download
+        )
+
+        path, reason = _tirith_mod._install_tirith(log_failures=False)
+
+        assert path is None
+        assert reason == "cosign_required_for_replacement"
+        assert (hermes_home / "bin" / "tirith").read_bytes() == b"concurrent tirith"
+
+    def test_initial_install_cannot_clobber_late_concurrent_winner(
+        self, tmp_path, monkeypatch
+    ):
+        """The filesystem commit enforces no-clobber after the final path check."""
+        hermes_home = tmp_path / "hermes-home"
+        verified = tmp_path / "verified-tirith"
+        verified.write_bytes(b"new tirith")
+        destination = hermes_home / "bin" / "tirith"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+        monkeypatch.setattr(
+            _tirith_mod, "_detect_target", lambda: "aarch64-apple-darwin"
+        )
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_download_verified_tirith",
+            lambda *_args, **_kwargs: (str(verified), "", False),
+        )
+        real_directory_check = _tirith_mod._managed_install_directory_is_real
+
+        def concurrent_install_after_path_check():
+            destination.write_bytes(b"concurrent tirith")
+            destination.chmod(0o755)
+            return real_directory_check()
+
+        monkeypatch.setattr(
+            _tirith_mod,
+            "_managed_install_directory_is_real",
+            concurrent_install_after_path_check,
+        )
+
+        path, reason = _tirith_mod._install_tirith(log_failures=False)
+
+        assert path is None
+        assert reason == "install_replace_failed"
+        assert destination.read_bytes() == b"concurrent tirith"
+        assert os.access(destination, os.X_OK)
+
 
 class TestReleaseDownloadLimits:
     def test_github_token_is_not_forwarded_to_release_asset_redirect(
@@ -623,10 +708,10 @@ class TestReleaseDownloadLimits:
         redirected_request = (
             _tirith_mod.urllib.request.HTTPRedirectHandler().redirect_request(
                 initial_request,
-                None,
+                io.BytesIO(),
                 302,
                 "Found",
-                {},
+                HTTPMessage(),
                 "https://release-assets.githubusercontent.com/checksums.txt",
             )
         )

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -91,6 +91,19 @@ def _load_security_config() -> dict:
 # Auto-install
 # ---------------------------------------------------------------------------
 
+
+def _tirith_auto_install_allowed() -> bool:
+    """Return whether Hermes may download Tirith at runtime.
+
+    Tirith is a binary rather than a Python dependency, but it is still a
+    runtime install and therefore obeys the same user-facing kill switch as
+    every lazy backend dependency.
+    """
+    from tools.lazy_deps import _allow_lazy_installs
+
+    return _allow_lazy_installs()
+
+
 # Cached path after first resolution (avoids repeated shutil.which per command).
 # _INSTALL_FAILED means "we tried and failed" — prevents retry on every command.
 _resolved_path: str | None | bool = None
@@ -391,6 +404,9 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
     failure_reason is a short tag used by the disk marker to decide if the
     failure is retryable (e.g. "cosign_missing" clears when cosign appears).
     """
+    if not _tirith_auto_install_allowed():
+        return None, "lazy_installs_disabled"
+
     log = logger.warning if log_failures else logger.debug
 
     target = _detect_target()
@@ -556,6 +572,11 @@ def _resolve_tirith_path(configured_path: str) -> str:
         _clear_install_failed()
         return hermes_bin
 
+    # A policy opt-out is not an installation failure. Do not cache or persist
+    # it, so changing the setting can take effect immediately in this process.
+    if not _tirith_auto_install_allowed():
+        return expanded
+
     # Local checks failed.  If a previous install attempt already failed,
     # skip the network retry — UNLESS the failure was "cosign_missing" and
     # cosign is now available (retryable cause resolved in-process).
@@ -590,6 +611,8 @@ def _resolve_tirith_path(configured_path: str) -> str:
         _install_failure_reason = ""
         _clear_install_failed()
         return installed
+    if reason == "lazy_installs_disabled":
+        return expanded
 
     # Install failed — cache the miss and persist reason to disk
     _resolved_path = _INSTALL_FAILED
@@ -619,11 +642,16 @@ def _background_install(*, log_failures: bool = True):
             _install_failure_reason = ""
             return
 
+        if not _tirith_auto_install_allowed():
+            return
+
         installed, reason = _install_tirith(log_failures=log_failures)
         if installed:
             _resolved_path = installed
             _install_failure_reason = ""
             _clear_install_failed()
+        elif reason == "lazy_installs_disabled":
+            return
         else:
             _resolved_path = _INSTALL_FAILED
             _install_failure_reason = reason
@@ -689,6 +717,12 @@ def ensure_installed(*, log_failures: bool = True):
         _install_failure_reason = ""
         _clear_install_failed()
         return hermes_bin
+
+    # Preserve local discovery while honoring the global runtime-install
+    # policy. Keep state unresolved so an in-process config change is enough
+    # to enable a later attempt.
+    if not _tirith_auto_install_allowed():
+        return None
 
     # If previously failed in-memory, check if the cause is now resolved
     if _resolved_path is _INSTALL_FAILED:

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -50,6 +50,8 @@ import tempfile
 import threading
 import time
 import urllib.request
+from contextvars import copy_context
+from dataclasses import dataclass, field
 from typing import Protocol, TypedDict, cast
 
 from hermes_cli.urllib_security import open_credentialed_url
@@ -130,68 +132,108 @@ def _tirith_auto_install_allowed() -> bool:
     return _allow_lazy_installs()
 
 
-# Cached path after first resolution (avoids repeated shutil.which per command).
-# _INSTALL_FAILED means "we tried and failed" — prevents retry on every command.
-_resolved_path: str | None | bool = None
 _INSTALL_FAILED = False  # sentinel: distinct from "not yet tried"
-_install_failure_reason: str = ""  # reason tag when _resolved_path is _INSTALL_FAILED
+
+
+@dataclass
+class _RuntimeState:
+    """Process-local Tirith state isolated by profile and scanner config."""
+
+    key: tuple[str, str]
+    resolved_path: str | None | bool = None
+    install_failure_reason: str = ""
+    install_thread: threading.Thread | None = None
+    update_thread: threading.Thread | None = None
+    crash_count: int = 0
+    circuit_open: bool = False
+    circuit_opened_at: float | None = None
+    circuit_probe_in_flight: bool = False
+    circuit_lock: threading.Lock = field(default_factory=threading.Lock)
+    install_lock: threading.Lock = field(default_factory=threading.Lock)
+    update_schedule_lock: threading.Lock = field(default_factory=threading.Lock)
+
+
+_runtime_states: dict[tuple[str, str], _RuntimeState] = {}
+_runtime_states_lock = threading.Lock()
+
+
+def _runtime_scope_key(configured_path: str) -> tuple[str, str]:
+    home = os.path.normcase(os.path.abspath(os.path.expanduser(str(get_hermes_home()))))
+    return home, configured_path
+
+
+def _runtime_state(configured_path: str) -> _RuntimeState:
+    key = _runtime_scope_key(configured_path)
+    with _runtime_states_lock:
+        state = _runtime_states.get(key)
+        if state is None:
+            state = _RuntimeState(key=key)
+            _runtime_states[key] = state
+        return state
+
+
+def _reset_runtime_states_for_tests() -> None:
+    """Reset process-local state; test fixtures only."""
+    with _runtime_states_lock:
+        _runtime_states.clear()
 
 # Circuit breaker: after _CRASH_LIMIT consecutive spawn/execution failures,
 # pause Tirith briefly to prevent agent hangs (#41400), then permit one
 # half-open recovery probe. Any recognized Tirith verdict closes the breaker.
 #
-# Thread safety: crash counting remains lock-free; a race can only open the
-# breaker one call early. The retry lock covers just the monotonic timestamp
-# check and re-arm, never the subprocess call. That makes a half-open probe
-# single-flight without reintroducing the hang the breaker prevents.
+# Each profile has its own lock. It protects state transitions and the explicit
+# in-flight claim, never the subprocess call.
 _CRASH_LIMIT = 3
 _CIRCUIT_RETRY_SECONDS = 60.0
-_crash_count: int = 0
-_circuit_open: bool = False
-_circuit_opened_at: float | None = None
-_circuit_retry_lock = threading.Lock()
 
 
-def _reset_tirith_crash_state() -> None:
+def _reset_tirith_crash_state(state: _RuntimeState) -> None:
     """Close the circuit after Tirith or its managed install recovers."""
-    global _crash_count, _circuit_open, _circuit_opened_at
-    _crash_count = 0
-    _circuit_open = False
-    _circuit_opened_at = None
+    with state.circuit_lock:
+        state.crash_count = 0
+        state.circuit_open = False
+        state.circuit_opened_at = None
+        state.circuit_probe_in_flight = False
 
 
-def _record_tirith_crash() -> None:
+def _record_tirith_crash(state: _RuntimeState) -> None:
     """Increment the crash counter and open the circuit breaker if needed."""
-    global _crash_count, _circuit_open, _circuit_opened_at
-    _crash_count += 1
-    if _crash_count >= _CRASH_LIMIT:
-        _circuit_open = True
-        _circuit_opened_at = time.monotonic()
-        logger.warning(
-            "tirith circuit breaker opened after %d consecutive failures; "
-            "retrying after %.0fs",
-            _crash_count,
-            _CIRCUIT_RETRY_SECONDS,
-        )
+    with state.circuit_lock:
+        state.crash_count += 1
+        if state.crash_count >= _CRASH_LIMIT:
+            state.circuit_open = True
+            state.circuit_opened_at = time.monotonic()
+            logger.warning(
+                "tirith circuit breaker opened after %d consecutive failures; "
+                "retrying after %.0fs",
+                state.crash_count,
+                _CIRCUIT_RETRY_SECONDS,
+            )
 
 
-def _circuit_retry_is_due() -> bool:
-    """Atomically claim the half-open recovery probe when its TTL is due."""
-    global _circuit_opened_at
-    with _circuit_retry_lock:
-        if not _circuit_open or _circuit_opened_at is None:
-            return False
+def _circuit_scan_admission(state: _RuntimeState) -> tuple[bool, bool]:
+    """Atomically decide whether a scan may run and claim a recovery probe.
+
+    Returns ``(scan_allowed, probe_claimed)``. A single locked decision avoids
+    a stale open/closed observation racing with another scan that recovers the
+    same profile's breaker.
+    """
+    with state.circuit_lock:
+        if not state.circuit_open:
+            return True, False
+        if state.circuit_opened_at is None or state.circuit_probe_in_flight:
+            return False, False
         now = time.monotonic()
-        if now - _circuit_opened_at < _CIRCUIT_RETRY_SECONDS:
-            return False
-        # Keep the circuit open while the claimant probes, but re-arm its
-        # timestamp first so concurrent callers cannot start another probe.
-        _circuit_opened_at = now
-        return True
+        if now - state.circuit_opened_at < _CIRCUIT_RETRY_SECONDS:
+            return False, False
+        state.circuit_probe_in_flight = True
+        return True, True
 
-# Background install thread coordination
-_install_lock = threading.Lock()
-_install_thread: threading.Thread | None = None
+
+def _finish_circuit_probe(state: _RuntimeState) -> None:
+    """Release a half-open claim even when resolution or scanning raises."""
+    with state.circuit_lock:
+        state.circuit_probe_in_flight = False
 
 # Hermes-managed Tirith updates. Tirith 0.4.1 introduced Hermes-aware
 # provenance for its self-updater; older managed release binaries are
@@ -212,10 +254,6 @@ _MAX_RELEASE_ARCHIVE_UNPACKED_BYTES = 128 * 1024 * 1024
 _UPDATE_SUCCESS_OUTCOMES = frozenset(
     {"bootstrapped", "current", "installed", "skipped", "updated"}
 )
-
-_update_schedule_lock = threading.Lock()
-_update_thread: threading.Thread | None = None
-
 
 class _UpdateState(TypedDict):
     schema_version: int
@@ -797,15 +835,15 @@ def _update_is_due(*, now: float | None = None) -> bool:
     return (current_time - checked_at) >= ttl
 
 
-def _acquire_update_lock():
-    """Acquire a process-bound advisory lock, or return ``None`` if busy.
+def _acquire_update_lock_with_status() -> tuple[int | None, str]:
+    """Acquire the advisory lock and distinguish contention from I/O errors.
 
     Tirith only ships on POSIX platforms. ``flock`` releases automatically on
     process death, so there is no stale-file reclamation race and a suspended
     updater cannot be mistaken for a dead one.
     """
     if os.name == "nt":
-        return None
+        return None, "error"
 
     import fcntl
 
@@ -813,7 +851,7 @@ def _acquire_update_lock():
     try:
         os.makedirs(os.path.dirname(path), exist_ok=True)
     except OSError:
-        return None
+        return None, "error"
 
     flags = os.O_CREAT | os.O_RDWR
     if hasattr(os, "O_NOFOLLOW"):
@@ -821,16 +859,27 @@ def _acquire_update_lock():
     try:
         fd = os.open(path, flags, 0o600)
     except OSError:
-        return None
+        return None, "error"
     try:
         if not stat.S_ISREG(os.fstat(fd).st_mode):
             os.close(fd)
-            return None
+            return None, "error"
         os.fchmod(fd, 0o600)
         fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except (OSError, BlockingIOError):
+    except BlockingIOError:
         os.close(fd)
-        return None
+        return None, "busy"
+    except OSError as exc:
+        os.close(fd)
+        if exc.errno in {errno.EACCES, errno.EAGAIN}:
+            return None, "busy"
+        return None, "error"
+    return fd, "acquired"
+
+
+def _acquire_update_lock():
+    """Acquire a process-bound advisory lock, or return ``None``."""
+    fd, _status = _acquire_update_lock_with_status()
     return fd
 
 
@@ -906,12 +955,11 @@ def _mark_install_failed(reason: str = ""):
 
 
 def _clear_install_failed():
-    """Remove the failure marker after successful install."""
+    """Remove the install-failure marker after local recovery."""
     # Reset the warn-once dedupe set so a subsequent failure (e.g. user
     # deletes the binary) surfaces in the log again instead of being
     # silently suppressed by a stale dedupe key from before the fix.
     _reset_spawn_warning_state()
-    _reset_tirith_crash_state()
     try:
         os.unlink(_failure_marker_path())
     except OSError:
@@ -1644,7 +1692,8 @@ def _read_embedded_tirith_version(
     for pattern in _TIRITH_EMBEDDED_VERSION_RES:
         for match in pattern.finditer(payload):
             try:
-                versions.add(tuple(int(part) for part in match.groups()))
+                major, minor, patch = match.groups()
+                versions.add((int(major), int(minor), int(patch)))
             except ValueError:
                 return None, "unparseable"
     if len(versions) != 1:
@@ -1960,8 +2009,14 @@ def _background_update(path: str, *, log_failures: bool = True) -> None:
     """Failure-isolated worker for managed Tirith maintenance."""
     if not _tirith_auto_install_allowed() or not _is_managed_tirith(path):
         return
-    lock_fd = _acquire_update_lock()
+    lock_fd, lock_status = _acquire_update_lock_with_status()
     if lock_fd is None:
+        # Contention means another worker owns the outcome and will persist
+        # its own freshness state. Operational lock errors have no such owner;
+        # record a short failure backoff so every command cannot spawn a new
+        # doomed worker in a long-lived process.
+        if lock_status == "error":
+            _write_update_state("failed")
         return
     try:
         # Another process may have completed maintenance before we acquired the
@@ -1987,10 +2042,14 @@ def _background_update(path: str, *, log_failures: bool = True) -> None:
 
 
 def _schedule_managed_update(
-    path: str, configured_path: str, *, log_failures: bool = True
+    path: str,
+    configured_path: str,
+    *,
+    log_failures: bool = True,
+    state: _RuntimeState | None = None,
 ) -> None:
     """Launch at most one non-blocking managed update worker at a time."""
-    global _update_thread
+    state = state or _runtime_state(configured_path)
     if (
         not is_platform_supported()
         or _is_explicit_path(configured_path)
@@ -1999,17 +2058,18 @@ def _schedule_managed_update(
         or not _update_is_due()
     ):
         return
-    with _update_schedule_lock:
-        if _update_thread is not None and _update_thread.is_alive():
+    with state.update_schedule_lock:
+        if state.update_thread is not None and state.update_thread.is_alive():
             return
         # Re-check after serializing schedulers. A worker in this process or
         # another Hermes process may have refreshed the shared state while we
         # were waiting for the lock.
         if not _update_is_due():
             return
+        worker_context = copy_context()
         thread = threading.Thread(
-            target=_background_update,
-            args=(path,),
+            target=worker_context.run,
+            args=(_background_update, path),
             kwargs={"log_failures": log_failures},
             daemon=True,
         )
@@ -2020,7 +2080,7 @@ def _schedule_managed_update(
                 "could not start tirith background update thread", exc_info=True
             )
             return
-        _update_thread = thread
+        state.update_thread = thread
 
 
 def _is_explicit_path(configured_path: str) -> bool:
@@ -2029,7 +2089,10 @@ def _is_explicit_path(configured_path: str) -> bool:
 
 
 def _resolve_tirith_path(
-    configured_path: str, *, background_only: bool = False
+    configured_path: str,
+    *,
+    background_only: bool = False,
+    state: _RuntimeState | None = None,
 ) -> str | None:
     """Resolve the tirith binary path, auto-installing if necessary.
 
@@ -2045,45 +2108,50 @@ def _resolve_tirith_path(
     Failed installs are cached for the process lifetime (and persisted to
     disk for 24h) to avoid repeated network attempts.
     """
-    global _resolved_path, _install_failure_reason
+    state = state or _runtime_state(configured_path)
 
     # Fast path: successfully resolved on a previous call.
-    if isinstance(_resolved_path, str):
-        path = _resolved_path
+    if isinstance(state.resolved_path, str):
+        path = state.resolved_path
         if _is_managed_tirith_location(path):
             validated_path = _validated_tirith_path(path)
             if validated_path is None:
-                _resolved_path = _INSTALL_FAILED
-                _install_failure_reason = "managed_cache_untrusted"
+                state.resolved_path = _INSTALL_FAILED
+                state.install_failure_reason = "managed_cache_untrusted"
             else:
                 path = validated_path
-                _resolved_path = path
-        if isinstance(_resolved_path, str):
+                state.resolved_path = path
+        if isinstance(state.resolved_path, str):
             # The resolver is exercised for every scan, including in long-lived
             # gateways. Reconsider completed workers here so a Tirith release made
             # after Hermes startup is discovered once the shared TTL expires.
-            _schedule_managed_update(path, configured_path, log_failures=False)
+            _schedule_managed_update(
+                path,
+                configured_path,
+                log_failures=False,
+                state=state,
+            )
             return path
 
     expanded = os.path.expanduser(configured_path)
     explicit = _is_explicit_path(configured_path)
-    install_failed = _resolved_path is _INSTALL_FAILED
+    install_failed = state.resolved_path is _INSTALL_FAILED
 
     # Explicit path: check it and stop. Never auto-download a replacement.
     if explicit:
         validated_path = _validated_tirith_path(expanded)
         if validated_path is not None:
-            _resolved_path = validated_path
+            state.resolved_path = validated_path
             return validated_path
         # Also try shutil.which in case it's a bare name on PATH
         found = shutil.which(expanded)
         validated_path = _validated_tirith_path(found) if found else None
         if validated_path is not None:
-            _resolved_path = validated_path
+            state.resolved_path = validated_path
             return validated_path
         logger.warning("Configured tirith path %r not found; scanning disabled", configured_path)
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "explicit_path_missing"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "explicit_path_missing"
         return None if background_only else expanded
 
     # Default "tirith" — always re-run cheap local checks so a manual
@@ -2092,36 +2160,44 @@ def _resolve_tirith_path(
     found = shutil.which("tirith")
     validated_path = _validated_tirith_path(found) if found else None
     if validated_path is not None:
-        _resolved_path = validated_path
-        _install_failure_reason = ""
+        state.resolved_path = validated_path
+        state.install_failure_reason = ""
         _clear_install_failed()
         _schedule_managed_update(
-            validated_path, configured_path, log_failures=False
+            validated_path,
+            configured_path,
+            log_failures=False,
+            state=state,
         )
         return validated_path
     if found and _is_managed_tirith_location(found):
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "managed_cache_untrusted"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "managed_cache_untrusted"
         return None if background_only else expanded
 
     # Platform support controls Hermes' managed cache and installer, not
     # whether an operator-provided Tirith binary may scan commands. Explicit
     # paths and PATH discovery above therefore remain available everywhere.
     if not is_platform_supported():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "unsupported_platform"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "unsupported_platform"
         return None if background_only else expanded
 
     hermes_bin = _managed_tirith_path()
     if _is_managed_tirith(hermes_bin):
-        _resolved_path = hermes_bin
-        _install_failure_reason = ""
+        state.resolved_path = hermes_bin
+        state.install_failure_reason = ""
         _clear_install_failed()
-        _schedule_managed_update(hermes_bin, configured_path, log_failures=False)
+        _schedule_managed_update(
+            hermes_bin,
+            configured_path,
+            log_failures=False,
+            state=state,
+        )
         return hermes_bin
     if os.path.lexists(hermes_bin):
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "managed_cache_untrusted"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "managed_cache_untrusted"
         return None if background_only else expanded
 
     # A policy opt-out is not an installation failure. Do not cache or persist
@@ -2133,10 +2209,13 @@ def _resolve_tirith_path(
     # skip the network retry — UNLESS the failure was "cosign_missing" and
     # cosign is now available (retryable cause resolved in-process).
     if install_failed:
-        if _install_failure_reason == "cosign_missing" and shutil.which("cosign"):
+        if (
+            state.install_failure_reason == "cosign_missing"
+            and shutil.which("cosign")
+        ):
             # Retryable cause resolved — clear sentinel and fall through to retry
-            _resolved_path = None
-            _install_failure_reason = ""
+            state.resolved_path = None
+            state.install_failure_reason = ""
             _clear_install_failed()
             install_failed = False
         else:
@@ -2145,7 +2224,7 @@ def _resolve_tirith_path(
     # If a background install thread is running, don't start a parallel one —
     # return the configured path; the OSError handler in check_command_security
     # will apply fail_open until the thread finishes.
-    if _install_thread is not None and _install_thread.is_alive():
+    if state.install_thread is not None and state.install_thread.is_alive():
         return None if background_only else expanded
 
     # Approval is a latency-sensitive path. Startup normally starts this
@@ -2160,14 +2239,14 @@ def _resolve_tirith_path(
     # detect retryable causes (e.g. cosign_missing) without restart.
     disk_reason = _read_failure_reason()
     if disk_reason is not None and _is_install_failed_on_disk():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = disk_reason
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = disk_reason
         return expanded
 
     installed, reason = _install_tirith()
     if installed:
-        _resolved_path = installed
-        _install_failure_reason = ""
+        state.resolved_path = installed
+        state.install_failure_reason = ""
         _clear_install_failed()
         _write_update_state("installed")
         return installed
@@ -2175,41 +2254,45 @@ def _resolve_tirith_path(
         return expanded
 
     # Install failed — cache the miss and persist reason to disk
-    _resolved_path = _INSTALL_FAILED
-    _install_failure_reason = reason
+    state.resolved_path = _INSTALL_FAILED
+    state.install_failure_reason = reason
     if reason != "managed_directory_untrusted":
         _mark_install_failed(reason)
     return expanded
 
 
-def _background_install(*, log_failures: bool = True):
+def _background_install(
+    *,
+    log_failures: bool = True,
+    state: _RuntimeState | None = None,
+):
     """Background thread target: download and install tirith."""
-    global _resolved_path, _install_failure_reason
-    with _install_lock:
+    state = state or _runtime_state("tirith")
+    with state.install_lock:
         # Double-check after acquiring lock (another thread may have resolved)
-        if _resolved_path is not None:
+        if state.resolved_path is not None:
             return
 
         # Re-check local paths (may have been installed by another process)
         found = shutil.which("tirith")
         validated_path = _validated_tirith_path(found) if found else None
         if validated_path is not None:
-            _resolved_path = validated_path
-            _install_failure_reason = ""
+            state.resolved_path = validated_path
+            state.install_failure_reason = ""
             return
         if found and _is_managed_tirith_location(found):
-            _resolved_path = _INSTALL_FAILED
-            _install_failure_reason = "managed_cache_untrusted"
+            state.resolved_path = _INSTALL_FAILED
+            state.install_failure_reason = "managed_cache_untrusted"
             return
 
         hermes_bin = _managed_tirith_path()
         if _is_managed_tirith(hermes_bin):
-            _resolved_path = hermes_bin
-            _install_failure_reason = ""
+            state.resolved_path = hermes_bin
+            state.install_failure_reason = ""
             return
         if os.path.lexists(hermes_bin):
-            _resolved_path = _INSTALL_FAILED
-            _install_failure_reason = "managed_cache_untrusted"
+            state.resolved_path = _INSTALL_FAILED
+            state.install_failure_reason = "managed_cache_untrusted"
             return
 
         if not _tirith_auto_install_allowed():
@@ -2217,15 +2300,15 @@ def _background_install(*, log_failures: bool = True):
 
         installed, reason = _install_tirith(log_failures=log_failures)
         if installed:
-            _resolved_path = installed
-            _install_failure_reason = ""
+            state.resolved_path = installed
+            state.install_failure_reason = ""
             _clear_install_failed()
             _write_update_state("installed")
         elif reason == "lazy_installs_disabled":
             return
         else:
-            _resolved_path = _INSTALL_FAILED
-            _install_failure_reason = reason
+            state.resolved_path = _INSTALL_FAILED
+            state.install_failure_reason = reason
             if reason != "managed_directory_untrusted":
                 _mark_install_failed(reason)
 
@@ -2237,30 +2320,30 @@ def ensure_installed(*, log_failures: bool = True):
     daemon thread so startup never blocks. Safe to call multiple times.
     Returns the resolved path immediately if available, or None.
     """
-    global _resolved_path, _install_thread, _install_failure_reason
-
     cfg = _load_security_config()
     if not cfg["tirith_enabled"]:
         return None
+    configured_path = cfg["tirith_path"]
+    state = _runtime_state(configured_path)
 
     # Already resolved from a previous call
-    if isinstance(_resolved_path, str):
-        path = _resolved_path
+    if isinstance(state.resolved_path, str):
+        path = state.resolved_path
         validated_path = _validated_tirith_path(path)
         if validated_path is not None:
-            _resolved_path = validated_path
+            state.resolved_path = validated_path
             _schedule_managed_update(
                 validated_path,
-                cfg["tirith_path"],
+                configured_path,
                 log_failures=log_failures,
+                state=state,
             )
             return validated_path
         if not _is_managed_tirith_location(path):
             return None
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "managed_cache_untrusted"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "managed_cache_untrusted"
 
-    configured_path = cfg["tirith_path"]
     explicit = _is_explicit_path(configured_path)
     expanded = os.path.expanduser(configured_path)
 
@@ -2268,57 +2351,59 @@ def ensure_installed(*, log_failures: bool = True):
     if explicit:
         validated_path = _validated_tirith_path(expanded)
         if validated_path is not None:
-            _resolved_path = validated_path
+            state.resolved_path = validated_path
             return validated_path
         found = shutil.which(expanded)
         validated_path = _validated_tirith_path(found) if found else None
         if validated_path is not None:
-            _resolved_path = validated_path
+            state.resolved_path = validated_path
             return validated_path
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "explicit_path_missing"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "explicit_path_missing"
         return None
 
     # Default "tirith" — quick local checks first (no network)
     found = shutil.which("tirith")
     validated_path = _validated_tirith_path(found) if found else None
     if validated_path is not None:
-        _resolved_path = validated_path
-        _install_failure_reason = ""
+        state.resolved_path = validated_path
+        state.install_failure_reason = ""
         _clear_install_failed()
         _schedule_managed_update(
             validated_path,
             configured_path,
             log_failures=log_failures,
+            state=state,
         )
         return validated_path
     if found and _is_managed_tirith_location(found):
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "managed_cache_untrusted"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "managed_cache_untrusted"
         return None
 
     # Unsupported manager targets may still use explicit or PATH binaries,
     # but Hermes must not inspect its managed cache or start an installer for
     # an archive format it does not support.
     if not is_platform_supported():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "unsupported_platform"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "unsupported_platform"
         return None
 
     hermes_bin = _managed_tirith_path()
     if _is_managed_tirith(hermes_bin):
-        _resolved_path = hermes_bin
-        _install_failure_reason = ""
+        state.resolved_path = hermes_bin
+        state.install_failure_reason = ""
         _clear_install_failed()
         _schedule_managed_update(
             hermes_bin,
             configured_path,
             log_failures=log_failures,
+            state=state,
         )
         return hermes_bin
     if os.path.lexists(hermes_bin):
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "managed_cache_untrusted"
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = "managed_cache_untrusted"
         return None
 
     # Preserve local discovery while honoring the global runtime-install
@@ -2328,10 +2413,13 @@ def ensure_installed(*, log_failures: bool = True):
         return None
 
     # If previously failed in-memory, check if the cause is now resolved
-    if _resolved_path is _INSTALL_FAILED:
-        if _install_failure_reason == "cosign_missing" and shutil.which("cosign"):
-            _resolved_path = None
-            _install_failure_reason = ""
+    if state.resolved_path is _INSTALL_FAILED:
+        if (
+            state.install_failure_reason == "cosign_missing"
+            and shutil.which("cosign")
+        ):
+            state.resolved_path = None
+            state.install_failure_reason = ""
             _clear_install_failed()
         else:
             return None
@@ -2341,18 +2429,20 @@ def ensure_installed(*, log_failures: bool = True):
     # Preserve the marker's real reason for in-memory retry logic.
     disk_reason = _read_failure_reason()
     if disk_reason is not None and _is_install_failed_on_disk():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = disk_reason
+        state.resolved_path = _INSTALL_FAILED
+        state.install_failure_reason = disk_reason
         return None
 
     # Need to download — launch background thread so startup doesn't block
-    if _install_thread is None or not _install_thread.is_alive():
-        _install_thread = threading.Thread(
-            target=_background_install,
-            kwargs={"log_failures": log_failures},
+    if state.install_thread is None or not state.install_thread.is_alive():
+        worker_context = copy_context()
+        state.install_thread = threading.Thread(
+            target=worker_context.run,
+            args=(_background_install,),
+            kwargs={"log_failures": log_failures, "state": state},
             daemon=True,
         )
-        _install_thread.start()
+        state.install_thread.start()
 
     return None  # Not available yet; commands will fail-open until ready
 
@@ -2375,18 +2465,18 @@ def check_command_security(command: str) -> dict:
     Returns:
         {"action": "allow"|"warn"|"block", "findings": [...], "summary": str}
     """
-    global _crash_count, _circuit_open, _resolved_path
-
     cfg = _load_security_config()
 
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
+    state = _runtime_state(cfg["tirith_path"])
 
     # Circuit breaker: pause after repeated failures, then make a half-open
     # recovery attempt. Without this, a corrupted binary can make every tool
     # call hit the same slow failure; without the retry, a repaired or updated
     # binary stays disabled for the rest of a long-lived process.
-    if _circuit_open and not _circuit_retry_is_due():
+    scan_allowed, claimed_probe = _circuit_scan_admission(state)
+    if not scan_allowed:
         action = "allow" if cfg["tirith_fail_open"] else "block"
         return {
             "action": action,
@@ -2394,17 +2484,31 @@ def check_command_security(command: str) -> dict:
             "summary": f"tirith unavailable (circuit breaker, fail-{'open' if action == 'allow' else 'closed'})",
         }
 
+    try:
+        return _check_command_security_with_state(command, cfg, state)
+    finally:
+        if claimed_probe:
+            _finish_circuit_probe(state)
+
+
+def _check_command_security_with_state(
+    command: str,
+    cfg: dict,
+    state: _RuntimeState,
+) -> dict:
+    """Execute one scan after the caller applies circuit-breaker policy."""
+
     tirith_path = _resolve_tirith_path(
-        cfg["tirith_path"], background_only=True
+        cfg["tirith_path"], background_only=True, state=state
     )
     timeout = cfg["tirith_timeout"]
     fail_open = cfg["tirith_fail_open"]
 
     if tirith_path is None:
-        unsupported_manager = _install_failure_reason == "unsupported_platform"
+        unsupported_manager = state.install_failure_reason == "unsupported_platform"
         if not unsupported_manager:
             _warn_once(
-                "tirith_path_none",
+                f"{state.key!r}:tirith_path_none",
                 "tirith path resolved to None; scanning disabled",
             )
         if fail_open:
@@ -2417,8 +2521,9 @@ def check_command_security(command: str) -> dict:
     # private-cache policy on explicit or package-manager binaries.
     if _is_managed_tirith_location(tirith_path):
         if not _is_managed_tirith(tirith_path):
-            if _resolved_path == tirith_path:
-                _resolved_path = _INSTALL_FAILED
+            if state.resolved_path == tirith_path:
+                state.resolved_path = _INSTALL_FAILED
+                state.install_failure_reason = "managed_cache_untrusted"
             action = "allow" if fail_open else "block"
             return {
                 "action": action,
@@ -2431,8 +2536,8 @@ def check_command_security(command: str) -> dict:
         # cannot be swapped through an attacker-controlled alias directory.
         original_path = tirith_path
         tirith_path = os.path.abspath(_managed_tirith_path())
-        if _resolved_path == original_path:
-            _resolved_path = tirith_path
+        if state.resolved_path == original_path:
+            state.resolved_path = tirith_path
 
     try:
         result = subprocess.run(
@@ -2450,26 +2555,26 @@ def check_command_security(command: str) -> dict:
         # may have been repaired concurrently, in which case its newer cached
         # path must win. Clearing a stale cache lets the next command re-run
         # local discovery (and, when allowed, start managed recovery).
-        if _resolved_path == tirith_path:
-            _resolved_path = None
+        if state.resolved_path == tirith_path:
+            state.resolved_path = None
         # Dedupe by ``(errno, exc class)`` so a transient failure mode
         # surfaces once but doesn't drown the log on every command —
         # commonly seen on Windows when the configured path "tirith"
         # isn't on PATH yet (background install still running, or
         # install marked failed for the day).
         spawn_key = f"tirith_spawn_failed:{type(exc).__name__}:{getattr(exc, 'errno', '')}"
-        _warn_once(spawn_key, "tirith spawn failed: %s", exc)
-        _record_tirith_crash()
+        _warn_once(f"{state.key!r}:{spawn_key}", "tirith spawn failed: %s", exc)
+        _record_tirith_crash(state)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith unavailable: {exc}"}
         return {"action": "block", "findings": [], "summary": f"tirith spawn failed (fail-closed): {exc}"}
     except subprocess.TimeoutExpired:
         _warn_once(
-            f"tirith_timeout:{timeout}",
+            f"{state.key!r}:tirith_timeout:{timeout}",
             "tirith timed out after %ds",
             timeout,
         )
-        _record_tirith_crash()
+        _record_tirith_crash(state)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith timed out ({timeout}s)"}
         return {"action": "block", "findings": [], "summary": "tirith timed out (fail-closed)"}
@@ -2481,7 +2586,7 @@ def check_command_security(command: str) -> dict:
         # reset failures for warn/block verdicts too; otherwise unrelated
         # earlier failures accumulate and open a supposedly consecutive
         # failure breaker.
-        _reset_tirith_crash_state()
+        _reset_tirith_crash_state(state)
 
     if exit_code == 0:
         action = "allow"
@@ -2493,7 +2598,7 @@ def check_command_security(command: str) -> dict:
         # Unknown exit code (includes signal-killed processes like -11/SIGSEGV)
         # — respect fail_open
         logger.warning("tirith returned unexpected exit code %d", exit_code)
-        _record_tirith_crash()
+        _record_tirith_crash(state)
         if fail_open:
             return {"action": "allow", "findings": [], "summary": f"tirith exit code {exit_code} (fail-open)"}
         return {"action": "block", "findings": [], "summary": f"tirith exit code {exit_code} (fail-closed)"}

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -10,14 +10,14 @@ JSON stdout enriches findings/summary but never overrides the verdict.
 Operational failures (spawn error, timeout, unknown exit code) respect
 the fail_open config setting. Programming errors propagate.
 
-Auto-install: if tirith is not found on PATH or at the configured path,
-it is automatically downloaded from GitHub releases to Hermes' private cache.
-The download always verifies SHA-256 checksums.  When cosign is available on
-PATH, provenance verification (GitHub Actions workflow signature) is also
-performed.  If cosign is not installed, the download proceeds with SHA-256
-verification only — still secure via HTTPS + checksum, just without supply
-chain provenance proof.  Installation runs in a background thread so startup
-never blocks.
+Auto-install: when the default bare ``tirith`` cannot be found on PATH, Hermes
+automatically downloads it from GitHub releases to a private cache. Explicitly
+configured paths are authoritative and are never replaced by an auto-install.
+The download always verifies SHA-256 checksums. When cosign is available,
+Hermes attempts provenance verification (GitHub Actions workflow signature);
+an initial install falls back to SHA-256-only verification when provenance
+cannot be checked. Installation runs in a background thread so startup never
+blocks.
 
 Managed updates: only Hermes' private Tirith cache is maintained. This is
 $HERMES_HOME/bin/tirith for normal installs and a platform-qualified cache for
@@ -30,6 +30,8 @@ the release signature is unavailable, Hermes keeps the working binary and
 retries later instead of silently falling back to checksum-only verification.
 """
 
+import base64
+import binascii
 import errno
 import functools
 import gzip
@@ -137,7 +139,7 @@ _INSTALL_FAILED = False  # sentinel: distinct from "not yet tried"
 
 @dataclass
 class _RuntimeState:
-    """Process-local Tirith state isolated by profile and scanner config."""
+    """Process-local Tirith state isolated by profile and configured path."""
 
     key: tuple[str, str]
     resolved_path: str | None | bool = None
@@ -284,6 +286,22 @@ def _warn_once(key: str, message: str, *args) -> None:
     logger.warning(message, *args)
 
 
+def _warn_managed_cache_untrusted(state: _RuntimeState) -> None:
+    """Surface a managed-cache trust failure without hot-path log spam."""
+    _warn_once(
+        f"{state.key!r}:managed_cache_untrusted",
+        "Hermes-managed Tirith failed ownership, mode, ACL, or link validation; "
+        "scanning is disabled until HERMES_HOME and its Tirith cache are owned "
+        "by the current user, are not redirected, and are not peer-writable",
+    )
+
+
+def _set_managed_cache_untrusted(state: _RuntimeState) -> None:
+    state.resolved_path = _INSTALL_FAILED
+    state.install_failure_reason = "managed_cache_untrusted"
+    _warn_managed_cache_untrusted(state)
+
+
 def _reset_spawn_warning_state() -> None:
     """Clear the warn-once dedupe set. Called when tirith is freshly
     (re)installed so a subsequent failure surfaces again — e.g. user
@@ -416,6 +434,7 @@ def _linux_posix_acl_blob_is_private(
     *,
     owner_uid: int,
     effective_uid: int,
+    default_acl: bool = False,
 ) -> bool:
     """Validate one Linux ``system.posix_acl_*`` xattr value."""
     acl_ea_version = 0x0002
@@ -431,11 +450,57 @@ def _linux_posix_acl_blob_is_private(
         return False
     if int.from_bytes(value[:4], "little") != acl_ea_version:
         return False
+    entries: list[tuple[int, int, int]] = []
+    mask_permissions = None
     for offset in range(4, len(value), 8):
         entry = value[offset:offset + 8]
         tag = int.from_bytes(entry[:2], "little")
         permissions = int.from_bytes(entry[2:4], "little")
         principal_id = int.from_bytes(entry[4:8], "little")
+        if permissions & ~0o7:
+            return False
+        if tag == acl_mask:
+            if mask_permissions is not None:
+                return False
+            mask_permissions = permissions
+        elif tag not in {
+            acl_user_obj,
+            acl_user,
+            acl_group_obj,
+            acl_group,
+            acl_other,
+        }:
+            return False
+        entries.append((tag, permissions, principal_id))
+
+    if default_acl:
+        # Unlike access ACL base entries, default ACL entries are not reflected
+        # in st_mode. A write-bearing mask is harmless by itself, but it makes
+        # group-class entries effective and must therefore be applied here.
+        for tag, permissions, principal_id in entries:
+            effective_permissions = permissions
+            if tag in {acl_user, acl_group_obj, acl_group} and mask_permissions is not None:
+                effective_permissions &= mask_permissions
+            if tag in {acl_user_obj, acl_mask}:
+                continue
+            if tag == acl_user:
+                if effective_permissions & acl_write and principal_id not in {
+                    0,
+                    owner_uid,
+                    effective_uid,
+                }:
+                    return False
+                continue
+            if tag in {acl_group_obj, acl_group, acl_other}:
+                if effective_permissions & acl_write:
+                    return False
+                continue
+            return False
+        return True
+
+    # Access ACL base and mask entries are already represented by st_mode.
+    # Preserve the stricter historical policy for named principals.
+    for tag, permissions, principal_id in entries:
         if tag in {acl_user_obj, acl_group_obj, acl_mask, acl_other}:
             continue
         if tag == acl_user:
@@ -499,6 +564,7 @@ def _linux_acl_is_private(path: str, *, directory: bool) -> bool:
             value,
             owner_uid=owner_uid,
             effective_uid=effective_uid(),
+            default_acl=name == "system.posix_acl_default",
         ):
             return False
     return True
@@ -807,7 +873,14 @@ def _write_update_state(outcome: str, *, now: float | None = None) -> bool:
         os.replace(tmp_path, _update_state_path())
         tmp_path = ""
         return True
-    except (OSError, TypeError, ValueError):
+    except (OSError, TypeError, ValueError) as exc:
+        _warn_once(
+            f"tirith_update_state_persistence:{_update_state_key()}",
+            "could not persist Tirith update backoff at %r; "
+            "this process remains throttled, but another process may retry: %s",
+            _update_state_path(),
+            exc,
+        )
         return False
     finally:
         if fd >= 0:
@@ -1030,11 +1103,10 @@ def _detect_target() -> str | None:
 
 
 def is_platform_supported() -> bool:
-    """True when tirith ships a prebuilt binary for this OS+arch.
+    """True when Hermes can manage Tirith for this OS and architecture.
 
-    Used by callers (CLI banner, etc.) to distinguish "tirith failed to
-    install" from "tirith was never going to install here" — the latter
-    is silent because there is nothing the user can do about it.
+    An explicit or PATH-provided scanner can still run when this is false;
+    only Hermes' release downloader and managed updater are unavailable.
     """
     return _detect_target() is not None
 
@@ -1076,7 +1148,12 @@ def _download_file(
 def _release_identity_from_certificate(
     cert_path: str,
 ) -> tuple[tuple[int, int, int], str] | None:
-    """Return the one stable Tirith release identity carried by a certificate."""
+    """Return the one stable Tirith release identity carried by a certificate.
+
+    Sigstore release assets historically contain either a raw PEM certificate
+    or one strict standard-base64 layer around that PEM. Keep the downloaded
+    file unchanged for cosign itself; decoding here is only for SAN inspection.
+    """
     try:
         from cryptography import x509
     except ImportError as exc:
@@ -1085,7 +1162,32 @@ def _release_identity_from_certificate(
 
     try:
         with open(cert_path, "rb") as cert_file:
-            certificate = x509.load_pem_x509_certificate(cert_file.read())
+            raw_certificate = cert_file.read().strip()
+        candidates = [raw_certificate]
+        try:
+            candidates.append(
+                base64.b64decode(raw_certificate, validate=True).strip()
+            )
+        except (binascii.Error, ValueError):
+            pass
+
+        certificate = None
+        begin = b"-----BEGIN CERTIFICATE-----"
+        end = b"-----END CERTIFICATE-----"
+        for candidate in candidates:
+            if (
+                candidate.startswith(begin)
+                and candidate.endswith(end)
+                and candidate.count(begin) == 1
+                and candidate.count(end) == 1
+            ):
+                try:
+                    certificate = x509.load_pem_x509_certificate(candidate)
+                except ValueError:
+                    continue
+                break
+        if certificate is None:
+            raise ValueError("certificate is not one raw or base64-wrapped PEM block")
         san = certificate.extensions.get_extension_for_class(
             x509.SubjectAlternativeName
         ).value
@@ -1728,11 +1830,19 @@ def _probe_tirith_version(path: str) -> tuple[tuple[int, int, int] | None, str]:
             stdin=subprocess.DEVNULL,
             env=_tirith_subprocess_env(),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("tirith version probe failed: %s", exc)
         return None, "probe_failed"
     if result.returncode != 0:
+        logger.debug(
+            "tirith version probe exited with %d: %s",
+            result.returncode,
+            result.stderr.strip()[:500],
+        )
         return None, "probe_failed"
     version = _parse_tirith_version(result.stdout)
+    if version is None:
+        logger.debug("tirith version probe returned an unrecognized version")
     return (version, "") if version is not None else (None, "unparseable")
 
 
@@ -1798,15 +1908,23 @@ def _probe_tirith_provenance(path: str) -> tuple[dict | None, str]:
             stdin=subprocess.DEVNULL,
             env=_tirith_subprocess_env(),
         )
-    except (OSError, subprocess.TimeoutExpired):
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.debug("tirith provenance probe failed: %s", exc)
         return None, "provenance_failed"
     if result.returncode != 0:
+        logger.debug(
+            "tirith provenance probe exited with %d: %s",
+            result.returncode,
+            result.stderr.strip()[:500],
+        )
         return None, "provenance_failed"
     try:
         provenance = json.loads(result.stdout)
     except (json.JSONDecodeError, TypeError):
+        logger.debug("tirith provenance probe returned malformed JSON")
         return None, "provenance_failed"
     if not isinstance(provenance, dict):
+        logger.debug("tirith provenance probe returned non-object JSON")
         return None, "provenance_failed"
     return provenance, ""
 
@@ -1872,13 +1990,23 @@ def _run_tirith_update(path: str) -> str:
     try:
         payload = json.loads(result.stdout)
     except (json.JSONDecodeError, TypeError):
+        logger.info(
+            "tirith background update returned malformed JSON; keeping current binary"
+        )
         return "failed"
     if not isinstance(payload, dict):
+        logger.info(
+            "tirith background update returned non-object JSON; keeping current binary"
+        )
         return "failed"
     if payload.get("action") == "none":
         return "current"
     if payload.get("action") == "updated":
         return "updated"
+    logger.info(
+        "tirith background update returned unexpected action %r; keeping current binary",
+        str(payload.get("action"))[:100],
+    )
     return "failed"
 
 
@@ -1919,6 +2047,7 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
     if not _is_managed_tirith(path):
         return "skipped"
     path = os.path.abspath(_managed_tirith_path())
+    log = logger.warning if log_failures else logger.debug
 
     target = _detect_target()
     termux_musl_target = target == "aarch64-unknown-linux-musl"
@@ -1932,6 +2061,11 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
             logger.info("tirith background update skipped: unrecognized build version")
             return "skipped"
         if version is None:
+            log(
+                "tirith background update could not determine the installed version "
+                "(%s); keeping current binary",
+                reason,
+            )
             return "failed"
 
     if termux_musl_target:
@@ -1939,12 +2073,18 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
         # safely use its own updater. v0.4.1 reports GNU for both AArch64
         # builds, so older releases take the byte-matched migration below.
         if not version_was_embedded and version >= _SELF_UPDATE_MIN_VERSION:
-            provenance, _ = _probe_tirith_provenance(path)
+            provenance, provenance_reason = _probe_tirith_provenance(path)
             if provenance is not None and _provenance_allows_managed_update(
                 path, version, provenance
             ):
                 if provenance.get("target") == "aarch64-unknown-linux-musl":
                     return _run_tirith_update(path)
+            elif provenance is None:
+                logger.debug(
+                    "tirith native Termux updater provenance probe failed (%s); "
+                    "using the verified migration path",
+                    provenance_reason,
+                )
 
         expected_sha256, matched_target, verification_reason = (
             _verify_termux_release_binary(
@@ -1992,8 +2132,13 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
             return "current"
         return "failed"
 
-    provenance, _ = _probe_tirith_provenance(path)
+    provenance, provenance_reason = _probe_tirith_provenance(path)
     if provenance is None:
+        log(
+            "tirith background update could not verify updater provenance (%s); "
+            "keeping current binary",
+            provenance_reason,
+        )
         return "failed"
     if not _provenance_allows_managed_update(path, version, provenance):
         logger.info(
@@ -2116,11 +2261,11 @@ def _resolve_tirith_path(
         if _is_managed_tirith_location(path):
             validated_path = _validated_tirith_path(path)
             if validated_path is None:
-                state.resolved_path = _INSTALL_FAILED
-                state.install_failure_reason = "managed_cache_untrusted"
+                _set_managed_cache_untrusted(state)
             else:
                 path = validated_path
                 state.resolved_path = path
+                state.install_failure_reason = ""
         if isinstance(state.resolved_path, str):
             # The resolver is exercised for every scan, including in long-lived
             # gateways. Reconsider completed workers here so a Tirith release made
@@ -2142,12 +2287,14 @@ def _resolve_tirith_path(
         validated_path = _validated_tirith_path(expanded)
         if validated_path is not None:
             state.resolved_path = validated_path
+            state.install_failure_reason = ""
             return validated_path
         # Also try shutil.which in case it's a bare name on PATH
         found = shutil.which(expanded)
         validated_path = _validated_tirith_path(found) if found else None
         if validated_path is not None:
             state.resolved_path = validated_path
+            state.install_failure_reason = ""
             return validated_path
         logger.warning("Configured tirith path %r not found; scanning disabled", configured_path)
         state.resolved_path = _INSTALL_FAILED
@@ -2171,8 +2318,7 @@ def _resolve_tirith_path(
         )
         return validated_path
     if found and _is_managed_tirith_location(found):
-        state.resolved_path = _INSTALL_FAILED
-        state.install_failure_reason = "managed_cache_untrusted"
+        _set_managed_cache_untrusted(state)
         return None if background_only else expanded
 
     # Platform support controls Hermes' managed cache and installer, not
@@ -2196,8 +2342,7 @@ def _resolve_tirith_path(
         )
         return hermes_bin
     if os.path.lexists(hermes_bin):
-        state.resolved_path = _INSTALL_FAILED
-        state.install_failure_reason = "managed_cache_untrusted"
+        _set_managed_cache_untrusted(state)
         return None if background_only else expanded
 
     # A policy opt-out is not an installation failure. Do not cache or persist
@@ -2281,8 +2426,7 @@ def _background_install(
             state.install_failure_reason = ""
             return
         if found and _is_managed_tirith_location(found):
-            state.resolved_path = _INSTALL_FAILED
-            state.install_failure_reason = "managed_cache_untrusted"
+            _set_managed_cache_untrusted(state)
             return
 
         hermes_bin = _managed_tirith_path()
@@ -2291,8 +2435,7 @@ def _background_install(
             state.install_failure_reason = ""
             return
         if os.path.lexists(hermes_bin):
-            state.resolved_path = _INSTALL_FAILED
-            state.install_failure_reason = "managed_cache_untrusted"
+            _set_managed_cache_untrusted(state)
             return
 
         if not _tirith_auto_install_allowed():
@@ -2332,6 +2475,7 @@ def ensure_installed(*, log_failures: bool = True):
         validated_path = _validated_tirith_path(path)
         if validated_path is not None:
             state.resolved_path = validated_path
+            state.install_failure_reason = ""
             _schedule_managed_update(
                 validated_path,
                 configured_path,
@@ -2341,8 +2485,7 @@ def ensure_installed(*, log_failures: bool = True):
             return validated_path
         if not _is_managed_tirith_location(path):
             return None
-        state.resolved_path = _INSTALL_FAILED
-        state.install_failure_reason = "managed_cache_untrusted"
+        _set_managed_cache_untrusted(state)
 
     explicit = _is_explicit_path(configured_path)
     expanded = os.path.expanduser(configured_path)
@@ -2352,11 +2495,13 @@ def ensure_installed(*, log_failures: bool = True):
         validated_path = _validated_tirith_path(expanded)
         if validated_path is not None:
             state.resolved_path = validated_path
+            state.install_failure_reason = ""
             return validated_path
         found = shutil.which(expanded)
         validated_path = _validated_tirith_path(found) if found else None
         if validated_path is not None:
             state.resolved_path = validated_path
+            state.install_failure_reason = ""
             return validated_path
         state.resolved_path = _INSTALL_FAILED
         state.install_failure_reason = "explicit_path_missing"
@@ -2377,8 +2522,7 @@ def ensure_installed(*, log_failures: bool = True):
         )
         return validated_path
     if found and _is_managed_tirith_location(found):
-        state.resolved_path = _INSTALL_FAILED
-        state.install_failure_reason = "managed_cache_untrusted"
+        _set_managed_cache_untrusted(state)
         return None
 
     # Unsupported manager targets may still use explicit or PATH binaries,
@@ -2402,8 +2546,7 @@ def ensure_installed(*, log_failures: bool = True):
         )
         return hermes_bin
     if os.path.lexists(hermes_bin):
-        state.resolved_path = _INSTALL_FAILED
-        state.install_failure_reason = "managed_cache_untrusted"
+        _set_managed_cache_untrusted(state)
         return None
 
     # Preserve local discovery while honoring the global runtime-install
@@ -2506,7 +2649,10 @@ def _check_command_security_with_state(
 
     if tirith_path is None:
         unsupported_manager = state.install_failure_reason == "unsupported_platform"
-        if not unsupported_manager:
+        untrusted_cache = state.install_failure_reason == "managed_cache_untrusted"
+        if untrusted_cache:
+            _warn_managed_cache_untrusted(state)
+        elif not unsupported_manager:
             _warn_once(
                 f"{state.key!r}:tirith_path_none",
                 "tirith path resolved to None; scanning disabled",
@@ -2522,8 +2668,9 @@ def _check_command_security_with_state(
     if _is_managed_tirith_location(tirith_path):
         if not _is_managed_tirith(tirith_path):
             if state.resolved_path == tirith_path:
-                state.resolved_path = _INSTALL_FAILED
-                state.install_failure_reason = "managed_cache_untrusted"
+                _set_managed_cache_untrusted(state)
+            else:
+                _warn_managed_cache_untrusted(state)
             action = "allow" if fail_open else "block"
             return {
                 "action": action,

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -128,18 +128,16 @@ _install_failure_reason: str = ""  # reason tag when _resolved_path is _INSTALL_
 # pause Tirith briefly to prevent agent hangs (#41400), then permit one
 # half-open recovery probe. Any recognized Tirith verdict closes the breaker.
 #
-# Thread safety: the breaker fields are module-level globals
-# mutated without a lock. check_command_security can be called from
-# concurrent agent threads (gateway multi-session). The race is benign —
-# at worst two threads both increment past _CRASH_LIMIT and both set the
-# open timestamp, opening the breaker one call early. This intentionally matches
-# the lock-free style of error counters in mcp_tool.py rather than the
-# locked _warn_once pattern, because the worst case is harmless.
+# Thread safety: crash counting remains lock-free; a race can only open the
+# breaker one call early. The retry lock covers just the monotonic timestamp
+# check and re-arm, never the subprocess call. That makes a half-open probe
+# single-flight without reintroducing the hang the breaker prevents.
 _CRASH_LIMIT = 3
 _CIRCUIT_RETRY_SECONDS = 60.0
 _crash_count: int = 0
 _circuit_open: bool = False
 _circuit_opened_at: float | None = None
+_circuit_retry_lock = threading.Lock()
 
 
 def _reset_tirith_crash_state() -> None:
@@ -166,13 +164,18 @@ def _record_tirith_crash() -> None:
 
 
 def _circuit_retry_is_due() -> bool:
-    """Return whether an open circuit may make one recovery attempt."""
-    if not _circuit_open or _circuit_opened_at is None:
-        return False
-    if time.monotonic() - _circuit_opened_at < _CIRCUIT_RETRY_SECONDS:
-        return False
-    _reset_tirith_crash_state()
-    return True
+    """Atomically claim the half-open recovery probe when its TTL is due."""
+    global _circuit_opened_at
+    with _circuit_retry_lock:
+        if not _circuit_open or _circuit_opened_at is None:
+            return False
+        now = time.monotonic()
+        if now - _circuit_opened_at < _CIRCUIT_RETRY_SECONDS:
+            return False
+        # Keep the circuit open while the claimant probes, but re-arm its
+        # timestamp first so concurrent callers cannot start another probe.
+        _circuit_opened_at = now
+        return True
 
 # Background install thread coordination
 _install_lock = threading.Lock()

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -1824,7 +1824,7 @@ def check_command_security(command: str) -> dict:
     Returns:
         {"action": "allow"|"warn"|"block", "findings": [...], "summary": str}
     """
-    global _crash_count, _circuit_open
+    global _crash_count, _circuit_open, _resolved_path
 
     cfg = _load_security_config()
 
@@ -1876,6 +1876,12 @@ def check_command_security(command: str) -> dict:
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error.
+        # Invalidate only the path this call actually tried. A managed binary
+        # may have been repaired concurrently, in which case its newer cached
+        # path must win. Clearing a stale cache lets the next command re-run
+        # local discovery (and, when allowed, start managed recovery).
+        if _resolved_path == tirith_path:
+            _resolved_path = None
         # Dedupe by ``(errno, exc class)`` so a transient failure mode
         # surfaces once but doesn't drown the log on every command —
         # commonly seen on Windows when the configured path "tirith"
@@ -1924,6 +1930,7 @@ def check_command_security(command: str) -> dict:
 
     # Parse JSON for enrichment (never overrides the exit code verdict)
     findings = []
+    raw_findings = []
     summary = ""
     try:
         data = json.loads(result.stdout) if result.stdout.strip() else {}
@@ -1943,8 +1950,10 @@ def check_command_security(command: str) -> dict:
     # and the "can be confused with file extensions" heuristic generates false
     # positives for normal API calls.  Any other finding (including other
     # lookalike_tld entries for non-.app TLDs) preserves the warn action.
-    if action == "warn" and findings:
-        non_suppressible = [f for f in findings if not _is_app_tld_finding(f)]
+    if action == "warn" and raw_findings:
+        non_suppressible = [
+            f for f in raw_findings if not _is_app_tld_finding(f)
+        ]
         if not non_suppressible:
             action = "allow"
             findings = []

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -30,6 +30,7 @@ the release signature is unavailable, Hermes keeps the working binary and
 retries later instead of silently falling back to checksum-only verification.
 """
 
+import errno
 import functools
 import gzip
 import hashlib
@@ -58,8 +59,15 @@ logger = logging.getLogger(__name__)
 
 _REPO = "sheeki03/tirith"
 
-# Cosign provenance verification — pinned to the specific release workflow
-_COSIGN_IDENTITY_REGEXP = f"^https://github.com/{_REPO}/\\.github/workflows/release\\.yml@refs/tags/v"
+# Cosign provenance verification — pinned to one stable release tag from the
+# specific release workflow. The authenticated tag is also the update version.
+_COSIGN_IDENTITY_RE = re.compile(
+    rf"^https://github\.com/{re.escape(_REPO)}/\.github/workflows/"
+    r"release\.yml@refs/tags/v"
+    r"((?:0|[1-9][0-9]{0,9}))\."
+    r"((?:0|[1-9][0-9]{0,9}))\."
+    r"((?:0|[1-9][0-9]{0,9}))$"
+)
 _COSIGN_ISSUER = "https://token.actions.githubusercontent.com"
 
 # ---------------------------------------------------------------------------
@@ -360,7 +368,207 @@ def _is_owned_private_directory(path: str) -> bool:
             return False
         if directory_stat.st_mode & 0o022:
             return False
+        if not _trusted_unix_acl_is_private(path, directory=True):
+            return False
     return True
+
+
+def _linux_posix_acl_blob_is_private(
+    value: bytes,
+    *,
+    owner_uid: int,
+    effective_uid: int,
+) -> bool:
+    """Validate one Linux ``system.posix_acl_*`` xattr value."""
+    acl_ea_version = 0x0002
+    acl_user_obj = 0x01
+    acl_user = 0x02
+    acl_group_obj = 0x04
+    acl_group = 0x08
+    acl_mask = 0x10
+    acl_other = 0x20
+    acl_write = 0x02
+
+    if len(value) < 4 or (len(value) - 4) % 8 != 0:
+        return False
+    if int.from_bytes(value[:4], "little") != acl_ea_version:
+        return False
+    for offset in range(4, len(value), 8):
+        entry = value[offset:offset + 8]
+        tag = int.from_bytes(entry[:2], "little")
+        permissions = int.from_bytes(entry[2:4], "little")
+        principal_id = int.from_bytes(entry[4:8], "little")
+        if tag in {acl_user_obj, acl_group_obj, acl_mask, acl_other}:
+            continue
+        if tag == acl_user:
+            if permissions & acl_write and principal_id not in {
+                0,
+                owner_uid,
+                effective_uid,
+            }:
+                return False
+            continue
+        if tag == acl_group:
+            if permissions & acl_write:
+                return False
+            continue
+        return False
+    return True
+
+
+def _linux_acl_is_private(path: str, *, directory: bool) -> bool:
+    """Reject Linux access/default ACLs that grant foreign write authority."""
+    getxattr = getattr(os, "getxattr", None)
+    listxattr = getattr(os, "listxattr", None)
+    effective_uid = getattr(os, "geteuid", None)
+    if getxattr is None or listxattr is None or effective_uid is None:
+        return False
+    try:
+        owner_uid = os.lstat(path).st_uid
+        attribute_names = set(listxattr(path, follow_symlinks=False))
+    except (OSError, TypeError):
+        return False
+
+    expected_names = {
+        "system.posix_acl_access",
+        "system.posix_acl_default",
+    }
+    if any(
+        name.startswith("system.") and "acl" in name.lower()
+        and name not in expected_names
+        for name in attribute_names
+    ):
+        # NFSv4/rich ACL semantics are not equivalent to POSIX ACL xattrs.
+        return False
+
+    names = ["system.posix_acl_access"]
+    if directory:
+        names.append("system.posix_acl_default")
+    missing_xattr_errors = {errno.ENODATA}
+    enoattr = getattr(errno, "ENOATTR", None)
+    if enoattr is not None:
+        missing_xattr_errors.add(enoattr)
+    for name in names:
+        try:
+            value = getxattr(path, name, follow_symlinks=False)
+        except OSError as exc:
+            if exc.errno in missing_xattr_errors:
+                continue
+            return False
+        except TypeError:
+            return False
+        if len(value) > 64 * 1024 or not _linux_posix_acl_blob_is_private(
+            value,
+            owner_uid=owner_uid,
+            effective_uid=effective_uid(),
+        ):
+            return False
+    return True
+
+
+def _darwin_acl_is_private(path: str) -> bool:
+    """Reject mutating allow entries in a macOS extended ACL."""
+    import ctypes
+
+    acl_type_extended = 0x0000_0100
+    acl_first_entry = 0
+    acl_next_entry = -1
+    acl_extended_allow = 1
+    mutating_permissions = (
+        (1 << 2)
+        | (1 << 4)
+        | (1 << 5)
+        | (1 << 6)
+        | (1 << 8)
+        | (1 << 10)
+        | (1 << 12)
+        | (1 << 13)
+    )
+    encoded_path = os.fsencode(path)
+    if b"\0" in encoded_path:
+        return False
+    try:
+        libc = ctypes.CDLL(None, use_errno=True)
+        acl_get_file = libc.acl_get_file
+        acl_get_entry = libc.acl_get_entry
+        acl_get_tag_type = libc.acl_get_tag_type
+        acl_get_permset_mask_np = libc.acl_get_permset_mask_np
+        acl_free = libc.acl_free
+        acl_get_file.argtypes = [ctypes.c_char_p, ctypes.c_int]
+        acl_get_file.restype = ctypes.c_void_p
+        acl_get_entry.argtypes = [
+            ctypes.c_void_p,
+            ctypes.c_int,
+            ctypes.POINTER(ctypes.c_void_p),
+        ]
+        acl_get_entry.restype = ctypes.c_int
+        acl_get_tag_type.argtypes = [ctypes.c_void_p, ctypes.POINTER(ctypes.c_int)]
+        acl_get_tag_type.restype = ctypes.c_int
+        acl_get_permset_mask_np.argtypes = [
+            ctypes.c_void_p,
+            ctypes.POINTER(ctypes.c_uint64),
+        ]
+        acl_get_permset_mask_np.restype = ctypes.c_int
+        acl_free.argtypes = [ctypes.c_void_p]
+        acl_free.restype = ctypes.c_int
+    except (AttributeError, OSError):
+        return False
+
+    ctypes.set_errno(0)
+    acl = acl_get_file(encoded_path, acl_type_extended)
+    if not acl:
+        return ctypes.get_errno() == errno.ENOENT
+    try:
+        entry_id = acl_first_entry
+        while True:
+            entry = ctypes.c_void_p()
+            ctypes.set_errno(0)
+            if acl_get_entry(acl, entry_id, ctypes.byref(entry)) != 0:
+                return ctypes.get_errno() == errno.EINVAL
+            tag_type = ctypes.c_int()
+            permissions = ctypes.c_uint64()
+            if (
+                acl_get_tag_type(entry, ctypes.byref(tag_type)) != 0
+                or acl_get_permset_mask_np(entry, ctypes.byref(permissions)) != 0
+            ):
+                return False
+            if (
+                tag_type.value == acl_extended_allow
+                and permissions.value & mutating_permissions
+            ):
+                return False
+            entry_id = acl_next_entry
+    finally:
+        acl_free(acl)
+
+
+def _trusted_unix_acl_is_private(path: str, *, directory: bool) -> bool:
+    """Validate ACL mutation authority on supported managed Unix targets."""
+    system = platform.system()
+    if system == "Linux":
+        return _linux_acl_is_private(path, directory=directory)
+    if system == "Darwin":
+        return _darwin_acl_is_private(path)
+    return False
+
+
+def _is_owned_private_executable(path: str) -> bool:
+    """Return whether a managed executable is owner-only mutable and runnable."""
+    try:
+        executable_stat = os.lstat(path)
+    except OSError:
+        return False
+    if not stat.S_ISREG(executable_stat.st_mode):
+        return False
+    effective_uid = getattr(os, "geteuid", None)
+    if os.name == "posix" and effective_uid is not None:
+        return (
+            executable_stat.st_uid == effective_uid()
+            and executable_stat.st_mode & 0o022 == 0
+            and executable_stat.st_mode & stat.S_IXUSR != 0
+            and _trusted_unix_acl_is_private(path, directory=False)
+        )
+    return os.access(path, os.X_OK)
 
 
 def _managed_tirith_directory_chain() -> list[str]:
@@ -402,18 +610,41 @@ def _managed_install_directory_is_real() -> bool:
     return all(_is_owned_private_directory(directory) for directory in directories)
 
 
-def _is_managed_tirith(path: str) -> bool:
-    """Return whether ``path`` is inside Hermes' real managed-bin boundary."""
+def _is_managed_tirith_location(path: str) -> bool:
+    """Return whether ``path`` names or aliases Hermes' managed Tirith file.
+
+    Lexical comparison also covers an absent installation destination. For an
+    existing file, identity comparison prevents a PATH symlink, hard link, or
+    case alias from shedding the managed-cache trust policy.
+    """
     expected = os.path.normcase(os.path.abspath(_managed_tirith_path()))
     candidate = os.path.normcase(os.path.abspath(path))
-    if candidate != expected:
-        return False
+    if candidate == expected:
+        return True
     try:
-        return _managed_install_directory_is_real() and stat.S_ISREG(
-            os.lstat(path).st_mode
-        )
+        return os.path.samefile(candidate, expected)
     except OSError:
         return False
+
+
+def _is_managed_tirith(path: str) -> bool:
+    """Return whether ``path`` is inside Hermes' real managed-bin boundary."""
+    managed_path = os.path.abspath(_managed_tirith_path())
+    return (
+        _is_managed_tirith_location(path)
+        and _managed_install_directory_is_real()
+        and _is_owned_private_executable(managed_path)
+    )
+
+
+def _validated_tirith_path(path: str) -> str | None:
+    """Return a usable path, normalizing managed aliases to the owned path."""
+    if not os.path.isfile(path) or not os.access(path, os.X_OK):
+        return None
+    if not _is_managed_tirith_location(path):
+        return path
+    managed_path = os.path.abspath(_managed_tirith_path())
+    return managed_path if _is_managed_tirith(managed_path) else None
 
 
 def _update_state_path() -> str:
@@ -794,13 +1025,51 @@ def _download_file(
         raise
 
 
-def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool | None:
+def _release_identity_from_certificate(
+    cert_path: str,
+) -> tuple[tuple[int, int, int], str] | None:
+    """Return the one stable Tirith release identity carried by a certificate."""
+    try:
+        from cryptography import x509
+    except ImportError as exc:
+        logger.warning("cannot inspect cosign certificate: %s", exc)
+        return None
+
+    try:
+        with open(cert_path, "rb") as cert_file:
+            certificate = x509.load_pem_x509_certificate(cert_file.read())
+        san = certificate.extensions.get_extension_for_class(
+            x509.SubjectAlternativeName
+        ).value
+        identities = san.get_values_for_type(x509.UniformResourceIdentifier)
+    except (OSError, ValueError, x509.ExtensionNotFound, x509.DuplicateExtension) as exc:
+        logger.warning("cannot inspect cosign certificate identity: %s", exc)
+        return None
+
+    matches = []
+    for identity in identities:
+        match = _COSIGN_IDENTITY_RE.fullmatch(identity)
+        if match is not None:
+            matches.append((tuple(int(part) for part in match.groups()), identity))
+    if len(matches) != 1:
+        logger.warning(
+            "cosign certificate must contain exactly one stable Tirith release identity"
+        )
+        return None
+    return matches[0]
+
+
+def _verify_cosign(
+    checksums_path: str,
+    sig_path: str,
+    cert_path: str,
+) -> tuple[bool | None, tuple[int, int, int] | None]:
     """Verify cosign provenance signature on checksums.txt.
 
     Returns:
-        True  — cosign verified successfully
-        False — cosign found but verification failed
-        None  — cosign not available (not on PATH, or execution failed)
+        (True, version) — cosign verified one exact stable release identity
+        (False, None)   — cosign found but verification failed
+        (None, None)    — cosign not available or could not execute
 
     ``False`` is an explicit verification rejection. ``None`` lets the caller
     use Hermes' documented SHA-256-only fallback.
@@ -808,14 +1077,19 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
     cosign = shutil.which("cosign")
     if not cosign:
         logger.info("cosign not found on PATH")
-        return None
+        return None, None
+
+    release_identity = _release_identity_from_certificate(cert_path)
+    if release_identity is None:
+        return False, None
+    release_version, certificate_identity = release_identity
 
     try:
         result = subprocess.run(
             [cosign, "verify-blob",
              "--certificate", cert_path,
              "--signature", sig_path,
-             "--certificate-identity-regexp", _COSIGN_IDENTITY_REGEXP,
+             "--certificate-identity", certificate_identity,
              "--certificate-oidc-issuer", _COSIGN_ISSUER,
              checksums_path],
             capture_output=True,
@@ -826,14 +1100,14 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
         )
         if result.returncode == 0:
             logger.info("cosign provenance verification passed")
-            return True
+            return True, release_version
         else:
             logger.warning("cosign verification failed (exit %d): %s",
                           result.returncode, result.stderr.strip())
-            return False
+            return False, None
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning("cosign execution failed: %s", exc)
-        return None
+        return None, None
 
 
 def _verify_checksum(archive_path: str, checksums_path: str, archive_name: str) -> bool:
@@ -1025,6 +1299,12 @@ def _atomic_replace_binary(
             output.flush()
             os.fsync(output.fileno())
 
+        staged_path = os.path.join(destination_dir, staged_name)
+        if not _is_owned_private_executable(staged_path):
+            raise PermissionError(
+                "Tirith staging file is not owner-only mutable and executable"
+            )
+
         if expected_existing_sha256 is not None:
             current_flags = os.O_RDONLY
             if hasattr(os, "O_NOFOLLOW"):
@@ -1090,7 +1370,7 @@ def _download_verified_tirith(
     log,
     *,
     require_signed_release: bool = False,
-) -> tuple[str | None, str, bool]:
+) -> tuple[str | None, str, bool, tuple[int, int, int] | None]:
     """Download, verify, and extract one Tirith release into ``workdir``.
 
     Initial installation retains the historical HTTPS + SHA-256 fallback.
@@ -1116,9 +1396,10 @@ def _download_verified_tirith(
         )
     except Exception as exc:
         log("tirith download failed: %s", exc)
-        return None, "download_failed", False
+        return None, "download_failed", False, None
 
     cosign_verified = False
+    signed_version = None
     if shutil.which("cosign"):
         try:
             _download_file(
@@ -1134,42 +1415,47 @@ def _download_verified_tirith(
         except Exception as exc:
             if require_signed_release:
                 log("tirith release rejected: cosign artifacts unavailable: %s", exc)
-                return None, "cosign_artifacts_unavailable", False
+                return None, "cosign_artifacts_unavailable", False, None
             logger.info(
                 "cosign artifacts unavailable (%s), proceeding with SHA-256 only", exc
             )
         else:
-            cosign_result = _verify_cosign(checksums_path, sig_path, cert_path)
+            cosign_result, signed_version = _verify_cosign(
+                checksums_path, sig_path, cert_path
+            )
             if cosign_result is True:
                 cosign_verified = True
             elif cosign_result is False:
                 log("tirith release rejected: cosign provenance verification failed")
-                return None, "cosign_verification_failed", False
+                return None, "cosign_verification_failed", False, None
             else:
                 if require_signed_release:
                     log("tirith release rejected: cosign provenance could not be verified")
-                    return None, "cosign_exec_failed", False
+                    return None, "cosign_exec_failed", False, None
+                signed_version = None
                 logger.info("cosign execution failed, proceeding with SHA-256 only")
     else:
         if require_signed_release:
             log("tirith release replacement requires cosign provenance verification")
-            return None, "cosign_missing", False
+            return None, "cosign_missing", False, None
         logger.info(
             "cosign not on PATH — using SHA-256 verification only "
             "(install cosign for full supply chain verification)"
         )
 
     if not _verify_checksum(archive_path, checksums_path, archive_name):
-        return None, "checksum_failed", cosign_verified
+        return None, "checksum_failed", cosign_verified, signed_version
 
     src, reason = _extract_release_archive(archive_path, workdir, log)
-    return src, reason, cosign_verified
+    return src, reason, cosign_verified, signed_version
 
 
 def _install_tirith(
     *,
     log_failures: bool = True,
     expected_existing_sha256: str | None = None,
+    current_version: tuple[int, int, int] | None = None,
+    minimum_candidate_version: tuple[int, int, int] | None = None,
 ) -> tuple[str | None, str]:
     """Download and install Tirith to Hermes' private managed cache.
 
@@ -1183,6 +1469,12 @@ def _install_tirith(
     if not _tirith_auto_install_allowed():
         return None, "lazy_installs_disabled"
 
+    replacing_existing = expected_existing_sha256 is not None
+    if replacing_existing != (current_version is not None):
+        return None, "invalid_replacement_request"
+    if minimum_candidate_version is not None and not replacing_existing:
+        return None, "invalid_replacement_request"
+
     log = logger.warning if log_failures else logger.debug
 
     target = _detect_target()
@@ -1194,9 +1486,10 @@ def _install_tirith(
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
     managed_dest = _managed_tirith_path()
     destination_was_absent = not os.path.lexists(managed_dest)
-    replacing_existing = (
-        expected_existing_sha256 is not None or not destination_was_absent
-    )
+    # Initial installers are create-only. An existing path belongs to the
+    # process that installed it and cannot silently become a replacement call.
+    if not destination_was_absent and not replacing_existing:
+        return None, "destination_exists"
 
     try:
         tmpdir = tempfile.mkdtemp(prefix="tirith-install-")
@@ -1205,7 +1498,7 @@ def _install_tirith(
         return None, "no_space"
     try:
         logger.info("tirith not found — downloading latest release for %s...", target)
-        src, reason, cosign_verified = _download_verified_tirith(
+        src, reason, cosign_verified, signed_version = _download_verified_tirith(
             base_url,
             target,
             tmpdir,
@@ -1214,6 +1507,27 @@ def _install_tirith(
         )
         if src is None:
             return None, reason
+
+        if replacing_existing:
+            # The exact stable tag came from the certificate identity that
+            # cosign verified over the checksum manifest. It is therefore
+            # authenticated without executing downloaded bytes from /tmp.
+            if not cosign_verified or signed_version is None:
+                return None, "candidate_version_unverified"
+            assert current_version is not None
+            if signed_version <= current_version:
+                logger.info(
+                    "tirith replacement skipped: signed candidate v%s is not newer "
+                    "than installed v%s",
+                    ".".join(str(part) for part in signed_version),
+                    ".".join(str(part) for part in current_version),
+                )
+                return None, "candidate_not_newer"
+            if (
+                minimum_candidate_version is not None
+                and signed_version < minimum_candidate_version
+            ):
+                return None, "candidate_below_minimum"
 
         # Config is live and the verified download may have taken seconds.
         # Re-check before creating or replacing anything under HERMES_HOME.
@@ -1286,6 +1600,9 @@ def _tirith_subprocess_env() -> dict[str, str]:
 
 def _probe_tirith_version(path: str) -> tuple[tuple[int, int, int] | None, str]:
     """Return a stable Tirith version or an operational/parse reason."""
+    if not _is_managed_tirith(path):
+        return None, "managed_path_untrusted"
+    path = os.path.abspath(_managed_tirith_path())
     try:
         result = subprocess.run(
             [path, "--version"],
@@ -1328,7 +1645,7 @@ def _verify_legacy_release_binary(
     except OSError:
         return None, "no_space"
     try:
-        released, reason, _cosign_verified = _download_verified_tirith(
+        released, reason, _cosign_verified, _signed_version = _download_verified_tirith(
             base_url, target, tmpdir, log
         )
         if released is None:
@@ -1352,6 +1669,9 @@ def _verify_legacy_release_binary(
 
 def _probe_tirith_provenance(path: str) -> tuple[dict | None, str]:
     """Read provenance that Tirith 0.4.1+ exposes for updater ownership."""
+    if not _is_managed_tirith(path):
+        return None, "managed_path_untrusted"
+    path = os.path.abspath(_managed_tirith_path())
     try:
         result = subprocess.run(
             [path, "version", "--provenance", "--format", "json"],
@@ -1404,6 +1724,9 @@ def _provenance_allows_managed_update(
 
 def _run_tirith_update(path: str) -> str:
     """Run Tirith's noninteractive updater and classify its JSON result."""
+    if not _is_managed_tirith(path):
+        return "failed"
+    path = os.path.abspath(_managed_tirith_path())
     # The user may disable runtime installs while the background worker is
     # probing version/provenance. Re-check at the mutating/network sink so the
     # live opt-out takes effect without waiting for the worker to finish.
@@ -1448,6 +1771,7 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
     """Bootstrap or update an existing Hermes-managed Tirith binary."""
     if not _is_managed_tirith(path):
         return "skipped"
+    path = os.path.abspath(_managed_tirith_path())
 
     version, reason = _probe_tirith_version(path)
     if version is None:
@@ -1465,11 +1789,15 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
         installed, install_reason = _install_tirith(
             log_failures=log_failures,
             expected_existing_sha256=expected_sha256,
+            current_version=version,
+            minimum_candidate_version=_SELF_UPDATE_MIN_VERSION,
         )
         if installed and _is_managed_tirith(installed):
             return "bootstrapped"
         if install_reason == "lazy_installs_disabled":
             return "deferred"
+        if install_reason == "candidate_not_newer":
+            return "current"
         return "failed"
 
     provenance, _ = _probe_tirith_provenance(path)
@@ -1498,11 +1826,14 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
         installed, install_reason = _install_tirith(
             log_failures=log_failures,
             expected_existing_sha256=expected_sha256,
+            current_version=version,
         )
         if installed and _is_managed_tirith(installed):
             return "updated"
         if install_reason == "lazy_installs_disabled":
             return "deferred"
+        if install_reason == "candidate_not_newer":
+            return "current"
         return "failed"
 
     return _run_tirith_update(path)
@@ -1602,11 +1933,20 @@ def _resolve_tirith_path(
     # Fast path: successfully resolved on a previous call.
     if isinstance(_resolved_path, str):
         path = _resolved_path
-        # The resolver is exercised for every scan, including in long-lived
-        # gateways. Reconsider completed workers here so a Tirith release made
-        # after Hermes startup is discovered once the shared TTL expires.
-        _schedule_managed_update(path, configured_path, log_failures=False)
-        return path
+        if _is_managed_tirith_location(path):
+            validated_path = _validated_tirith_path(path)
+            if validated_path is None:
+                _resolved_path = _INSTALL_FAILED
+                _install_failure_reason = "managed_cache_untrusted"
+            else:
+                path = validated_path
+                _resolved_path = path
+        if isinstance(_resolved_path, str):
+            # The resolver is exercised for every scan, including in long-lived
+            # gateways. Reconsider completed workers here so a Tirith release made
+            # after Hermes startup is discovered once the shared TTL expires.
+            _schedule_managed_update(path, configured_path, log_failures=False)
+            return path
 
     expanded = os.path.expanduser(configured_path)
     explicit = _is_explicit_path(configured_path)
@@ -1614,14 +1954,16 @@ def _resolve_tirith_path(
 
     # Explicit path: check it and stop. Never auto-download a replacement.
     if explicit:
-        if os.path.isfile(expanded) and os.access(expanded, os.X_OK):
-            _resolved_path = expanded
-            return expanded
+        validated_path = _validated_tirith_path(expanded)
+        if validated_path is not None:
+            _resolved_path = validated_path
+            return validated_path
         # Also try shutil.which in case it's a bare name on PATH
         found = shutil.which(expanded)
-        if found:
-            _resolved_path = found
-            return found
+        validated_path = _validated_tirith_path(found) if found else None
+        if validated_path is not None:
+            _resolved_path = validated_path
+            return validated_path
         logger.warning("Configured tirith path %r not found; scanning disabled", configured_path)
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "explicit_path_missing"
@@ -1631,12 +1973,19 @@ def _resolve_tirith_path(
     # install is picked up even after a previous network failure (P2 fix:
     # long-lived gateway/CLI recovers without restart).
     found = shutil.which("tirith")
-    if found:
-        _resolved_path = found
+    validated_path = _validated_tirith_path(found) if found else None
+    if validated_path is not None:
+        _resolved_path = validated_path
         _install_failure_reason = ""
         _clear_install_failed()
-        _schedule_managed_update(found, configured_path, log_failures=False)
-        return found
+        _schedule_managed_update(
+            validated_path, configured_path, log_failures=False
+        )
+        return validated_path
+    if found and _is_managed_tirith_location(found):
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "managed_cache_untrusted"
+        return None if background_only else expanded
 
     # Platform support controls Hermes' managed cache and installer, not
     # whether an operator-provided Tirith binary may scan commands. Explicit
@@ -1647,12 +1996,16 @@ def _resolve_tirith_path(
         return None if background_only else expanded
 
     hermes_bin = _managed_tirith_path()
-    if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
+    if _is_managed_tirith(hermes_bin):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
         _clear_install_failed()
         _schedule_managed_update(hermes_bin, configured_path, log_failures=False)
         return hermes_bin
+    if os.path.lexists(hermes_bin):
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "managed_cache_untrusted"
+        return None if background_only else expanded
 
     # A policy opt-out is not an installation failure. Do not cache or persist
     # it, so changing the setting can take effect immediately in this process.
@@ -1722,15 +2075,24 @@ def _background_install(*, log_failures: bool = True):
 
         # Re-check local paths (may have been installed by another process)
         found = shutil.which("tirith")
-        if found:
-            _resolved_path = found
+        validated_path = _validated_tirith_path(found) if found else None
+        if validated_path is not None:
+            _resolved_path = validated_path
             _install_failure_reason = ""
+            return
+        if found and _is_managed_tirith_location(found):
+            _resolved_path = _INSTALL_FAILED
+            _install_failure_reason = "managed_cache_untrusted"
             return
 
         hermes_bin = _managed_tirith_path()
-        if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
+        if _is_managed_tirith(hermes_bin):
             _resolved_path = hermes_bin
             _install_failure_reason = ""
+            return
+        if os.path.lexists(hermes_bin):
+            _resolved_path = _INSTALL_FAILED
+            _install_failure_reason = "managed_cache_untrusted"
             return
 
         if not _tirith_auto_install_allowed():
@@ -1767,14 +2129,19 @@ def ensure_installed(*, log_failures: bool = True):
     # Already resolved from a previous call
     if isinstance(_resolved_path, str):
         path = _resolved_path
-        if os.path.isfile(path) and os.access(path, os.X_OK):
+        validated_path = _validated_tirith_path(path)
+        if validated_path is not None:
+            _resolved_path = validated_path
             _schedule_managed_update(
-                path,
+                validated_path,
                 cfg["tirith_path"],
                 log_failures=log_failures,
             )
-            return path
-        return None
+            return validated_path
+        if not _is_managed_tirith_location(path):
+            return None
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "managed_cache_untrusted"
 
     configured_path = cfg["tirith_path"]
     explicit = _is_explicit_path(configured_path)
@@ -1782,29 +2149,36 @@ def ensure_installed(*, log_failures: bool = True):
 
     # Explicit path: synchronous check only, no download
     if explicit:
-        if os.path.isfile(expanded) and os.access(expanded, os.X_OK):
-            _resolved_path = expanded
-            return expanded
+        validated_path = _validated_tirith_path(expanded)
+        if validated_path is not None:
+            _resolved_path = validated_path
+            return validated_path
         found = shutil.which(expanded)
-        if found:
-            _resolved_path = found
-            return found
+        validated_path = _validated_tirith_path(found) if found else None
+        if validated_path is not None:
+            _resolved_path = validated_path
+            return validated_path
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "explicit_path_missing"
         return None
 
     # Default "tirith" — quick local checks first (no network)
     found = shutil.which("tirith")
-    if found:
-        _resolved_path = found
+    validated_path = _validated_tirith_path(found) if found else None
+    if validated_path is not None:
+        _resolved_path = validated_path
         _install_failure_reason = ""
         _clear_install_failed()
         _schedule_managed_update(
-            found,
+            validated_path,
             configured_path,
             log_failures=log_failures,
         )
-        return found
+        return validated_path
+    if found and _is_managed_tirith_location(found):
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "managed_cache_untrusted"
+        return None
 
     # Unsupported manager targets may still use explicit or PATH binaries,
     # but Hermes must not inspect its managed cache or start an installer for
@@ -1815,7 +2189,7 @@ def ensure_installed(*, log_failures: bool = True):
         return None
 
     hermes_bin = _managed_tirith_path()
-    if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
+    if _is_managed_tirith(hermes_bin):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
         _clear_install_failed()
@@ -1825,6 +2199,10 @@ def ensure_installed(*, log_failures: bool = True):
             log_failures=log_failures,
         )
         return hermes_bin
+    if os.path.lexists(hermes_bin):
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "managed_cache_untrusted"
+        return None
 
     # Preserve local discovery while honoring the global runtime-install
     # policy. Keep state unresolved so an in-process config change is enough
@@ -1916,6 +2294,28 @@ def check_command_security(command: str) -> dict:
             summary = "" if unsupported_manager else "tirith path unavailable"
             return {"action": "allow", "findings": [], "summary": summary}
         return {"action": "block", "findings": [], "summary": "tirith path unavailable (fail-closed)"}
+
+    # Managed cache ownership is re-proved immediately before execution. This
+    # catches mode/ACL drift after path resolution without imposing Hermes'
+    # private-cache policy on explicit or package-manager binaries.
+    if _is_managed_tirith_location(tirith_path):
+        if not _is_managed_tirith(tirith_path):
+            if _resolved_path == tirith_path:
+                _resolved_path = _INSTALL_FAILED
+            action = "allow" if fail_open else "block"
+            return {
+                "action": action,
+                "findings": [],
+                "summary": "tirith managed cache is untrusted "
+                f"(fail-{'open' if fail_open else 'closed'})",
+            }
+        # Never execute a PATH/config alias after using file identity to
+        # classify it. The exact owned path has the validated parent chain and
+        # cannot be swapped through an attacker-controlled alias directory.
+        original_path = tirith_path
+        tirith_path = os.path.abspath(_managed_tirith_path())
+        if _resolved_path == original_path:
+            _resolved_path = tirith_path
 
     try:
         result = subprocess.run(

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -33,6 +33,7 @@ import hashlib
 import io
 import json
 import logging
+import math
 import os
 import platform
 import re
@@ -429,12 +430,13 @@ def _valid_update_state(state: object) -> _UpdateState | None:
         return None
     checked_at = state_dict.get("checked_at")
     outcome = state_dict.get("outcome")
-    if (
-        not isinstance(checked_at, (int, float))
-        or isinstance(checked_at, bool)
-        or checked_at != checked_at  # NaN
-        or checked_at < 0
-    ):
+    if not isinstance(checked_at, (int, float)) or isinstance(checked_at, bool):
+        return None
+    try:
+        normalized_checked_at = float(checked_at)
+    except (OverflowError, TypeError, ValueError):
+        return None
+    if not math.isfinite(normalized_checked_at) or normalized_checked_at < 0:
         return None
     if not isinstance(outcome, str) or (
         outcome != "failed" and outcome not in _UPDATE_SUCCESS_OUTCOMES
@@ -442,7 +444,7 @@ def _valid_update_state(state: object) -> _UpdateState | None:
         return None
     return {
         "schema_version": schema_version,
-        "checked_at": float(checked_at),
+        "checked_at": normalized_checked_at,
         "outcome": outcome,
     }
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -1456,6 +1456,7 @@ def _install_tirith(
     expected_existing_sha256: str | None = None,
     current_version: tuple[int, int, int] | None = None,
     minimum_candidate_version: tuple[int, int, int] | None = None,
+    allow_same_version_replacement: bool = False,
 ) -> tuple[str | None, str]:
     """Download and install Tirith to Hermes' private managed cache.
 
@@ -1472,7 +1473,9 @@ def _install_tirith(
     replacing_existing = expected_existing_sha256 is not None
     if replacing_existing != (current_version is not None):
         return None, "invalid_replacement_request"
-    if minimum_candidate_version is not None and not replacing_existing:
+    if (
+        minimum_candidate_version is not None or allow_same_version_replacement
+    ) and not replacing_existing:
         return None, "invalid_replacement_request"
 
     log = logger.warning if log_failures else logger.debug
@@ -1482,6 +1485,11 @@ def _install_tirith(
         logger.info("tirith auto-install: unsupported platform %s/%s",
                      platform.system(), platform.machine())
         return None, "unsupported_platform"
+    if (
+        allow_same_version_replacement
+        and target != "aarch64-unknown-linux-musl"
+    ):
+        return None, "invalid_replacement_request"
 
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
     managed_dest = _managed_tirith_path()
@@ -1515,10 +1523,14 @@ def _install_tirith(
             if not cosign_verified or signed_version is None:
                 return None, "candidate_version_unverified"
             assert current_version is not None
-            if signed_version <= current_version:
+            candidate_is_older = signed_version < current_version
+            candidate_is_same = signed_version == current_version
+            if candidate_is_older or (
+                candidate_is_same and not allow_same_version_replacement
+            ):
                 logger.info(
-                    "tirith replacement skipped: signed candidate v%s is not newer "
-                    "than installed v%s",
+                    "tirith replacement skipped: signed candidate v%s cannot "
+                    "replace installed v%s",
                     ".".join(str(part) for part in signed_version),
                     ".".join(str(part) for part in current_version),
                 )
@@ -1571,6 +1583,16 @@ def _install_tirith(
 
 
 _TIRITH_VERSION_RE = re.compile(r"^tirith ([0-9]+)\.([0-9]+)\.([0-9]+)$")
+_TIRITH_EMBEDDED_VERSION_RES = (
+    # Tirith 0.3+ keeps the exact clap --version output in the release binary.
+    re.compile(rb"tirith ([0-9]{1,10})\.([0-9]{1,10})\.([0-9]{1,10})(?:\r?\n|\x00)"),
+    # Tirith 0.2.12, the release current when Hermes first enabled Termux,
+    # predates that stable string but embeds its shell-hook version marker.
+    re.compile(
+        rb"shell-version([0-9]{1,10})\.([0-9]{1,10})\."
+        rb"([0-9]{1,10})tirith\.sh"
+    ),
+)
 
 
 def _parse_tirith_version(output: str) -> tuple[int, int, int] | None:
@@ -1585,6 +1607,49 @@ def _parse_tirith_version(output: str) -> tuple[int, int, int] | None:
         return int(major), int(minor), int(patch)
     except ValueError:
         return None
+
+
+def _read_embedded_tirith_version(
+    path: str,
+) -> tuple[tuple[int, int, int] | None, str]:
+    """Read a release version without executing an incompatible binary.
+
+    Historical Hermes builds downloaded Tirith's glibc AArch64 artifact on
+    Termux. Android's Bionic loader cannot execute it, so ``--version`` is not
+    available during migration. Only stable, release-generated markers are
+    accepted, and the caller must still byte-match the tagged release before
+    replacing anything.
+    """
+    if not _is_managed_tirith(path):
+        return None, "managed_path_untrusted"
+    try:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        with os.fdopen(fd, "rb") as binary:
+            binary_stat = os.fstat(binary.fileno())
+            if not stat.S_ISREG(binary_stat.st_mode):
+                return None, "binary_read_failed"
+            size = binary_stat.st_size
+            if size <= 0 or size > _MAX_TIRITH_BINARY_BYTES:
+                return None, "binary_size_invalid"
+            payload = binary.read(_MAX_TIRITH_BINARY_BYTES + 1)
+    except OSError:
+        return None, "binary_read_failed"
+    if len(payload) != size or len(payload) > _MAX_TIRITH_BINARY_BYTES:
+        return None, "binary_size_invalid"
+
+    versions: set[tuple[int, int, int]] = set()
+    for pattern in _TIRITH_EMBEDDED_VERSION_RES:
+        for match in pattern.finditer(payload):
+            try:
+                versions.add(tuple(int(part) for part in match.groups()))
+            except ValueError:
+                return None, "unparseable"
+    if len(versions) != 1:
+        return None, "unparseable"
+    return versions.pop(), ""
 
 
 def _tirith_subprocess_env() -> dict[str, str]:
@@ -1626,6 +1691,7 @@ def _verify_legacy_release_binary(
     path: str,
     version: tuple[int, int, int],
     *,
+    target: str | None = None,
     log_failures: bool = True,
 ) -> tuple[str | None, str]:
     """Prove a pre-Hermes-provenance binary matches published release bytes.
@@ -1634,7 +1700,7 @@ def _verify_legacy_release_binary(
     therefore verifies the matching tagged archive before replacing it. The
     returned digest binds that proof to the later atomic swap.
     """
-    target = _detect_target()
+    target = target or _detect_target()
     if target is None:
         return None, "unsupported_platform"
     log = logger.warning if log_failures else logger.debug
@@ -1767,17 +1833,94 @@ def _run_tirith_update(path: str) -> str:
     return "failed"
 
 
+def _verify_termux_release_binary(
+    path: str,
+    version: tuple[int, int, int],
+    *,
+    log_failures: bool,
+) -> tuple[str | None, str | None, str]:
+    """Match a managed Termux binary to its tagged GNU or musl release."""
+    targets = ["aarch64-unknown-linux-gnu"]
+    # Tirith first published a Termux-compatible AArch64 musl artifact in
+    # v0.3.0. Earlier tags legitimately return 404 for that asset.
+    if version >= (0, 3, 0):
+        targets.append("aarch64-unknown-linux-musl")
+
+    failures: list[str] = []
+    for release_target in targets:
+        expected_sha256, reason = _verify_legacy_release_binary(
+            path,
+            version,
+            target=release_target,
+            log_failures=log_failures,
+        )
+        if expected_sha256 is not None:
+            return expected_sha256, release_target, ""
+        failures.append(reason)
+    if failures and all(reason == "binary_mismatch" for reason in failures):
+        return None, None, "binary_mismatch"
+    return None, None, next(
+        (reason for reason in failures if reason != "binary_mismatch"),
+        "binary_mismatch",
+    )
+
+
 def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
     """Bootstrap or update an existing Hermes-managed Tirith binary."""
     if not _is_managed_tirith(path):
         return "skipped"
     path = os.path.abspath(_managed_tirith_path())
 
+    target = _detect_target()
+    termux_musl_target = target == "aarch64-unknown-linux-musl"
+    version_was_embedded = False
     version, reason = _probe_tirith_version(path)
     if version is None:
-        if reason == "unparseable":
+        if termux_musl_target and reason == "probe_failed":
+            version, reason = _read_embedded_tirith_version(path)
+            version_was_embedded = version is not None
+        if version is None and reason == "unparseable":
             logger.info("tirith background update skipped: unrecognized build version")
             return "skipped"
+        if version is None:
+            return "failed"
+
+    if termux_musl_target:
+        # A future Tirith release that identifies its native musl target can
+        # safely use its own updater. v0.4.1 reports GNU for both AArch64
+        # builds, so older releases take the byte-matched migration below.
+        if not version_was_embedded and version >= _SELF_UPDATE_MIN_VERSION:
+            provenance, _ = _probe_tirith_provenance(path)
+            if provenance is not None and _provenance_allows_managed_update(
+                path, version, provenance
+            ):
+                if provenance.get("target") == "aarch64-unknown-linux-musl":
+                    return _run_tirith_update(path)
+
+        expected_sha256, matched_target, verification_reason = (
+            _verify_termux_release_binary(
+                path,
+                version,
+                log_failures=log_failures,
+            )
+        )
+        if expected_sha256 is None:
+            return "skipped" if verification_reason == "binary_mismatch" else "failed"
+        installed, install_reason = _install_tirith(
+            log_failures=log_failures,
+            expected_existing_sha256=expected_sha256,
+            current_version=version,
+            minimum_candidate_version=_SELF_UPDATE_MIN_VERSION,
+            allow_same_version_replacement=(
+                matched_target == "aarch64-unknown-linux-gnu"
+            ),
+        )
+        if installed and _is_managed_tirith(installed):
+            return "bootstrapped" if version < _SELF_UPDATE_MIN_VERSION else "updated"
+        if install_reason == "lazy_installs_disabled":
+            return "deferred"
+        if install_reason == "candidate_not_newer":
+            return "current"
         return "failed"
 
     if version < _SELF_UPDATE_MIN_VERSION:
@@ -1809,32 +1952,6 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
             "Hermes-managed release build"
         )
         return "skipped"
-
-    # Tirith 0.4.1 reports every AArch64 Linux build as the glibc release
-    # target.  On Termux, delegating to its self-updater would therefore fetch
-    # an unusable glibc binary over the working musl one.  Keep the same
-    # provenance gate, then use Hermes' checksum-verified, preimage-bound
-    # installer until Tirith can distinguish the musl target itself.
-    if (
-        _detect_target() == "aarch64-unknown-linux-musl"
-        and provenance.get("target") != "aarch64-unknown-linux-musl"
-    ):
-        try:
-            expected_sha256 = _sha256_file(path)
-        except OSError:
-            return "failed"
-        installed, install_reason = _install_tirith(
-            log_failures=log_failures,
-            expected_existing_sha256=expected_sha256,
-            current_version=version,
-        )
-        if installed and _is_managed_tirith(installed):
-            return "updated"
-        if install_reason == "lazy_installs_disabled":
-            return "deferred"
-        if install_reason == "candidate_not_newer":
-            return "current"
-        return "failed"
 
     return _run_tirith_update(path)
 

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -25,6 +25,9 @@ immutable images whose data volume may also be mounted by a different host OS.
 Startup and later scans return that working binary immediately while due update
 checks run in a failure-isolated background thread. User-configured, PATH,
 package-manager, and development builds are never modified.
+Every automatic replacement requires signed release provenance; if cosign or
+the release signature is unavailable, Hermes keeps the working binary and
+retries later instead of silently falling back to checksum-only verification.
 """
 
 import functools
@@ -975,13 +978,15 @@ def _atomic_replace_binary(
     destination: str,
     *,
     expected_existing_sha256: str | None = None,
+    require_destination_absent: bool = False,
 ) -> None:
     """Stage ``source`` beside ``destination`` and atomically commit it.
 
     Download extraction happens in the system temporary directory, which may
     be on another filesystem. Copying into a sibling first makes the final
-    ``os.replace`` atomic and preserves an existing working scanner if any
-    staging or commit step fails.
+    commit atomic and preserves an existing working scanner if any staging or
+    commit step fails. Initial installs use an atomic hard-link commit so a
+    concurrent installer can win without being overwritten.
     """
     destination_dir = os.path.abspath(os.path.dirname(destination))
     os.makedirs(destination_dir, exist_ok=True)
@@ -1039,12 +1044,25 @@ def _atomic_replace_binary(
                 if current_fd >= 0:
                     os.close(current_fd)
 
-        os.replace(
-            staged_name,
-            destination_name,
-            src_dir_fd=directory_fd,
-            dst_dir_fd=directory_fd,
-        )
+        if require_destination_absent:
+            # A hard link is the portable POSIX no-clobber commit primitive:
+            # destination creation and the EEXIST check are one filesystem
+            # operation. The stage is a regular sibling on the same filesystem.
+            os.link(
+                staged_name,
+                destination_name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+                follow_symlinks=False,
+            )
+            os.unlink(staged_name, dir_fd=directory_fd)
+        else:
+            os.replace(
+                staged_name,
+                destination_name,
+                src_dir_fd=directory_fd,
+                dst_dir_fd=directory_fd,
+            )
         staged_name = ""
         try:
             os.fsync(directory_fd)
@@ -1070,8 +1088,15 @@ def _download_verified_tirith(
     target: str,
     workdir: str,
     log,
+    *,
+    require_signed_release: bool = False,
 ) -> tuple[str | None, str, bool]:
-    """Download, verify, and extract one Tirith release into ``workdir``."""
+    """Download, verify, and extract one Tirith release into ``workdir``.
+
+    Initial installation retains the historical HTTPS + SHA-256 fallback.
+    Callers replacing an existing managed executable set
+    ``require_signed_release`` so an unavailable signature fails closed.
+    """
     archive_name = f"tirith-{target}.tar.gz"
     archive_path = os.path.join(workdir, archive_name)
     checksums_path = os.path.join(workdir, "checksums.txt")
@@ -1107,6 +1132,9 @@ def _download_verified_tirith(
                 max_bytes=_MAX_METADATA_DOWNLOAD_BYTES,
             )
         except Exception as exc:
+            if require_signed_release:
+                log("tirith release rejected: cosign artifacts unavailable: %s", exc)
+                return None, "cosign_artifacts_unavailable", False
             logger.info(
                 "cosign artifacts unavailable (%s), proceeding with SHA-256 only", exc
             )
@@ -1118,8 +1146,14 @@ def _download_verified_tirith(
                 log("tirith release rejected: cosign provenance verification failed")
                 return None, "cosign_verification_failed", False
             else:
+                if require_signed_release:
+                    log("tirith release rejected: cosign provenance could not be verified")
+                    return None, "cosign_exec_failed", False
                 logger.info("cosign execution failed, proceeding with SHA-256 only")
     else:
+        if require_signed_release:
+            log("tirith release replacement requires cosign provenance verification")
+            return None, "cosign_missing", False
         logger.info(
             "cosign not on PATH — using SHA-256 verification only "
             "(install cosign for full supply chain verification)"
@@ -1139,8 +1173,9 @@ def _install_tirith(
 ) -> tuple[str | None, str]:
     """Download and install Tirith to Hermes' private managed cache.
 
-    Always verifies the SHA-256 checksum and verifies cosign provenance when
-    cosign is available.
+    Always verifies the SHA-256 checksum. Initial installation verifies cosign
+    provenance when available; replacement of an existing managed executable
+    requires it.
     Returns (installed_path, failure_reason).  On success failure_reason is "".
     failure_reason is a short tag used by the disk marker to decide if the
     failure is retryable (e.g. "cosign_missing" clears when cosign appears).
@@ -1157,6 +1192,11 @@ def _install_tirith(
         return None, "unsupported_platform"
 
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
+    managed_dest = _managed_tirith_path()
+    destination_was_absent = not os.path.lexists(managed_dest)
+    replacing_existing = (
+        expected_existing_sha256 is not None or not destination_was_absent
+    )
 
     try:
         tmpdir = tempfile.mkdtemp(prefix="tirith-install-")
@@ -1166,7 +1206,11 @@ def _install_tirith(
     try:
         logger.info("tirith not found — downloading latest release for %s...", target)
         src, reason, cosign_verified = _download_verified_tirith(
-            base_url, target, tmpdir, log
+            base_url,
+            target,
+            tmpdir,
+            log,
+            require_signed_release=replacing_existing,
         )
         if src is None:
             return None, reason
@@ -1181,6 +1225,12 @@ def _install_tirith(
         except OSError as exc:
             log("tirith install aborted: untrusted managed directory: %s", exc)
             return None, "managed_directory_untrusted"
+        # A different process may have installed a binary while this download
+        # was in flight. Never let an initial checksum-only download become an
+        # automatic replacement because of that race.
+        if os.path.lexists(dest) and not cosign_verified:
+            log("tirith replacement aborted: signed provenance is required")
+            return None, "cosign_required_for_replacement"
         if not _managed_install_directory_is_real():
             log("tirith install aborted: Hermes managed-bin directory is redirected")
             return None, "managed_directory_untrusted"
@@ -1189,6 +1239,7 @@ def _install_tirith(
                 src,
                 dest,
                 expected_existing_sha256=expected_existing_sha256,
+                require_destination_absent=destination_was_absent,
             )
         except OSError as exc:
             log("tirith install failed while replacing %s: %s", dest, exc)
@@ -1360,7 +1411,7 @@ def _run_tirith_update(path: str) -> str:
         return "deferred"
     try:
         result = subprocess.run(
-            [path, "update", "--yes", "--allow-unsigned", "--format", "json"],
+            [path, "update", "--yes", "--format", "json"],
             capture_output=True,
             text=True,
             encoding="utf-8",

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -48,6 +48,7 @@ import time
 import urllib.request
 from typing import Protocol, TypedDict, cast
 
+from hermes_cli.urllib_security import open_credentialed_url
 from hermes_constants import get_hermes_home, is_termux
 
 logger = logging.getLogger(__name__)
@@ -774,7 +775,7 @@ def _download_file(
         req.add_unredirected_header("Authorization", f"token {token}")
     written = 0
     try:
-        with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
+        with open_credentialed_url(req, timeout=timeout) as resp, open(dest, "wb") as f:
             while chunk := resp.read(min(1024 * 1024, max_bytes - written + 1)):
                 written += len(chunk)
                 if written > max_bytes:

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -1544,7 +1544,8 @@ def _schedule_managed_update(
     """Launch at most one non-blocking managed update worker at a time."""
     global _update_thread
     if (
-        _is_explicit_path(configured_path)
+        not is_platform_supported()
+        or _is_explicit_path(configured_path)
         or not _is_managed_tirith(path)
         or not _tirith_auto_install_allowed()
         or not _update_is_due()
@@ -1611,14 +1612,6 @@ def _resolve_tirith_path(
     explicit = _is_explicit_path(configured_path)
     install_failed = _resolved_path is _INSTALL_FAILED
 
-    # Platform is unsupported by Hermes' Tirith manager. Cache the verdict and
-    # return the unexpanded configured path; the spawn loop will fail-open via
-    # the dedupe'd OSError handler.
-    if not explicit and not is_platform_supported():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "unsupported_platform"
-        return None if background_only else expanded
-
     # Explicit path: check it and stop. Never auto-download a replacement.
     if explicit:
         if os.path.isfile(expanded) and os.access(expanded, os.X_OK):
@@ -1644,6 +1637,14 @@ def _resolve_tirith_path(
         _clear_install_failed()
         _schedule_managed_update(found, configured_path, log_failures=False)
         return found
+
+    # Platform support controls Hermes' managed cache and installer, not
+    # whether an operator-provided Tirith binary may scan commands. Explicit
+    # paths and PATH discovery above therefore remain available everywhere.
+    if not is_platform_supported():
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "unsupported_platform"
+        return None if background_only else expanded
 
     hermes_bin = _managed_tirith_path()
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
@@ -1775,14 +1776,6 @@ def ensure_installed(*, log_failures: bool = True):
             return path
         return None
 
-    # Platform is unsupported by Hermes' Tirith manager — don't probe PATH,
-    # start a download thread, or write a disk failure marker. Pattern-matching
-    # guards still run; this path stays silent.
-    if not is_platform_supported():
-        _resolved_path = _INSTALL_FAILED
-        _install_failure_reason = "unsupported_platform"
-        return None
-
     configured_path = cfg["tirith_path"]
     explicit = _is_explicit_path(configured_path)
     expanded = os.path.expanduser(configured_path)
@@ -1812,6 +1805,14 @@ def ensure_installed(*, log_failures: bool = True):
             log_failures=log_failures,
         )
         return found
+
+    # Unsupported manager targets may still use explicit or PATH binaries,
+    # but Hermes must not inspect its managed cache or start an installer for
+    # an archive format it does not support.
+    if not is_platform_supported():
+        _resolved_path = _INSTALL_FAILED
+        _install_failure_reason = "unsupported_platform"
+        return None
 
     hermes_bin = _managed_tirith_path()
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
@@ -1898,12 +1899,6 @@ def check_command_security(command: str) -> dict:
             "summary": f"tirith unavailable (circuit breaker, fail-{'open' if action == 'allow' else 'closed'})",
         }
 
-    # Unsupported manager platform (currently native Windows and unknown
-    # architectures). Skip the resolver entirely; pattern-matching guards
-    # still run via the rest of approval.py.
-    if not is_platform_supported():
-        return {"action": "allow", "findings": [], "summary": ""}
-
     tirith_path = _resolve_tirith_path(
         cfg["tirith_path"], background_only=True
     )
@@ -1911,12 +1906,15 @@ def check_command_security(command: str) -> dict:
     fail_open = cfg["tirith_fail_open"]
 
     if tirith_path is None:
-        _warn_once(
-            "tirith_path_none",
-            "tirith path resolved to None; scanning disabled",
-        )
+        unsupported_manager = _install_failure_reason == "unsupported_platform"
+        if not unsupported_manager:
+            _warn_once(
+                "tirith_path_none",
+                "tirith path resolved to None; scanning disabled",
+            )
         if fail_open:
-            return {"action": "allow", "findings": [], "summary": "tirith path unavailable"}
+            summary = "" if unsupported_manager else "tirith path unavailable"
+            return {"action": "allow", "findings": [], "summary": summary}
         return {"action": "block", "findings": [], "summary": "tirith path unavailable (fail-closed)"}
 
     try:

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -11,20 +11,32 @@ Operational failures (spawn error, timeout, unknown exit code) respect
 the fail_open config setting. Programming errors propagate.
 
 Auto-install: if tirith is not found on PATH or at the configured path,
-it is automatically downloaded from GitHub releases to $HERMES_HOME/bin/tirith.
+it is automatically downloaded from GitHub releases to Hermes' private cache.
 The download always verifies SHA-256 checksums.  When cosign is available on
 PATH, provenance verification (GitHub Actions workflow signature) is also
 performed.  If cosign is not installed, the download proceeds with SHA-256
 verification only — still secure via HTTPS + checksum, just without supply
 chain provenance proof.  Installation runs in a background thread so startup
 never blocks.
+
+Managed updates: only Hermes' private Tirith cache is maintained. This is
+$HERMES_HOME/bin/tirith for normal installs and a platform-qualified cache for
+immutable images whose data volume may also be mounted by a different host OS.
+Startup and later scans return that working binary immediately while due update
+checks run in a failure-isolated background thread. User-configured, PATH,
+package-manager, and development builds are never modified.
 """
 
+import functools
+import gzip
 import hashlib
+import io
 import json
 import logging
 import os
 import platform
+import re
+import secrets
 import shutil
 import stat
 import subprocess
@@ -33,6 +45,7 @@ import tempfile
 import threading
 import time
 import urllib.request
+from typing import Protocol, TypedDict, cast
 
 from hermes_constants import get_hermes_home
 
@@ -143,6 +156,39 @@ def _record_tirith_crash() -> None:
 _install_lock = threading.Lock()
 _install_thread: threading.Thread | None = None
 
+# Hermes-managed Tirith updates. Tirith 0.4.1 introduced Hermes-aware
+# provenance for its self-updater; older managed release binaries are
+# bootstrapped through Hermes' checksum-verified installer before future
+# updates are delegated to Tirith.
+_SELF_UPDATE_MIN_VERSION = (0, 4, 1)
+_UPDATE_CHECK_TTL = 86400  # 24 hours after a successful check
+_UPDATE_FAILURE_TTL = 3600  # 1 hour after an operational failure
+_UPDATE_TIMEOUT = 120
+_UPDATE_PROBE_TIMEOUT = 30
+_UPDATE_STATE_SCHEMA = 1
+_UPDATE_STATE_MAX_BYTES = 4096
+_MAX_ARCHIVE_DOWNLOAD_BYTES = 64 * 1024 * 1024
+_MAX_METADATA_DOWNLOAD_BYTES = 256 * 1024
+_MAX_TIRITH_BINARY_BYTES = 64 * 1024 * 1024
+_MAX_RELEASE_ARCHIVE_MEMBERS = 128
+_MAX_RELEASE_ARCHIVE_UNPACKED_BYTES = 128 * 1024 * 1024
+_UPDATE_SUCCESS_OUTCOMES = frozenset(
+    {"bootstrapped", "current", "installed", "skipped", "updated"}
+)
+
+_update_schedule_lock = threading.Lock()
+_update_thread: threading.Thread | None = None
+
+
+class _UpdateState(TypedDict):
+    schema_version: int
+    checked_at: float
+    outcome: str
+
+
+_in_process_update_states: dict[str, _UpdateState] = {}
+_in_process_update_state_lock = threading.Lock()
+
 # Warning de-duplication. The spawn/path warnings live in the hot path —
 # without this dedupe set, a Windows install where ``tirith`` isn't on PATH
 # (e.g. background install thread still running, or install marked failed)
@@ -180,9 +226,371 @@ def _get_hermes_home() -> str:
     return str(get_hermes_home())
 
 
+@functools.lru_cache(maxsize=1)
+def _uses_image_managed_tirith_root() -> bool:
+    """Return whether an immutable image owns this Hermes runtime."""
+    try:
+        from hermes_cli.image_provenance import read_image_provenance
+
+        # Presence is authoritative even when the immutable marker is invalid;
+        # absence preserves the historical path for source/package installs.
+        return read_image_provenance() is not None
+    except Exception:
+        return False
+
+
+def _managed_tirith_home() -> str:
+    """Return the provenance root for Hermes' platform-specific cache."""
+    home = _get_hermes_home()
+    if _uses_image_managed_tirith_root():
+        target = _detect_target()
+        if target is not None:
+            # The official image's /opt/data is commonly the host ~/.hermes.
+            # Never let a Linux container replace or execute a host macOS
+            # binary (or let mixed-architecture images fight over one cache).
+            return os.path.join(home, ".tirith-managed", target)
+    return home
+
+
+def _managed_tirith_path() -> str:
+    """Return the only Tirith binary Hermes is allowed to update."""
+    return os.path.join(_managed_tirith_home(), "bin", "tirith")
+
+
+_DENIED_MANAGED_TIRITH_ROOTS = frozenset(
+    {
+        "/",
+        "/bin",
+        "/sbin",
+        "/usr",
+        "/usr/bin",
+        "/usr/sbin",
+        "/usr/local",
+        "/usr/local/bin",
+        "/usr/local/sbin",
+        "/System",
+        "/Library",
+        "/Applications",
+        "/opt/homebrew",
+        "/home/linuxbrew/.linuxbrew",
+        "/nix",
+    }
+)
+_DENIED_MANAGED_TIRITH_PREFIXES = (
+    "/nix/store",
+    "/nix/var/nix/profiles",
+    "/opt/homebrew/Cellar",
+    "/home/linuxbrew/.linuxbrew/Cellar",
+)
+
+
+def _managed_tirith_root_is_denied(path: str) -> bool:
+    """Reject system and package-manager roots as Hermes-owned storage.
+
+    This mirrors Tirith 0.4.1+'s self-update ownership boundary. It is also
+    required for pre-0.4.1 bootstraps, where Hermes performs the replacement
+    itself after proving the old bytes match an official release.
+    """
+    # ``normcase`` is intentionally a no-op in Python's POSIX path module,
+    # even on the normally case-insensitive macOS filesystems.  Fold the
+    # comparison keys explicitly so spelling /OPT/HOMEBREW/... cannot grant
+    # Hermes ownership over the real /opt/homebrew tree.  Being conservative
+    # on a case-sensitive POSIX volume is preferable to ever self-replacing a
+    # package-manager binary.
+    def comparison_key(value: str) -> str:
+        return os.path.normcase(os.path.normpath(os.path.abspath(value))).casefold()
+
+    lexical_root = comparison_key(path)
+    canonical_root = comparison_key(os.path.realpath(path))
+    roots = {lexical_root, canonical_root}
+    denied_roots = {
+        comparison_key(value)
+        for value in _DENIED_MANAGED_TIRITH_ROOTS
+    }
+    if roots & denied_roots:
+        return True
+    for prefix in _DENIED_MANAGED_TIRITH_PREFIXES:
+        denied_prefix = comparison_key(prefix)
+        for root in roots:
+            if root == denied_prefix or root.startswith(denied_prefix + os.sep):
+                return True
+    return False
+
+
+def _is_owned_private_directory(path: str) -> bool:
+    """Return whether ``path`` is a real directory safe for executable data."""
+    try:
+        directory_stat = os.lstat(path)
+    except OSError:
+        return False
+    if not stat.S_ISDIR(directory_stat.st_mode):
+        return False
+    effective_uid = getattr(os, "geteuid", None)
+    if os.name == "posix" and effective_uid is not None:
+        if directory_stat.st_uid != effective_uid():
+            return False
+        if directory_stat.st_mode & 0o022:
+            return False
+    return True
+
+
+def _managed_tirith_directory_chain() -> list[str]:
+    """Return every directory from HERMES_HOME through managed ``bin``.
+
+    Immutable images add ``.tirith-managed/<target>`` below HERMES_HOME. Each
+    component is an ownership boundary: validating only the final target and
+    ``bin`` would let an intermediate symlink redirect replacement elsewhere.
+    """
+    base = os.path.abspath(_get_hermes_home())
+    managed_home = os.path.abspath(_managed_tirith_home())
+    try:
+        if os.path.commonpath((base, managed_home)) != base:
+            return []
+    except ValueError:
+        return []
+
+    relative = os.path.relpath(managed_home, base)
+    parts = [] if relative == os.curdir else relative.split(os.sep)
+    if any(part in {"", os.curdir, os.pardir} for part in parts):
+        return []
+
+    directories = [base]
+    current = base
+    for part in parts:
+        current = os.path.join(current, part)
+        directories.append(current)
+    directories.append(os.path.join(managed_home, "bin"))
+    return directories
+
+
+def _managed_install_directory_is_real() -> bool:
+    """Reject package-manager, redirected, or peer-writable managed roots."""
+    directories = _managed_tirith_directory_chain()
+    if not directories or any(
+        _managed_tirith_root_is_denied(directory) for directory in directories
+    ):
+        return False
+    return all(_is_owned_private_directory(directory) for directory in directories)
+
+
+def _is_managed_tirith(path: str) -> bool:
+    """Return whether ``path`` is inside Hermes' real managed-bin boundary."""
+    expected = os.path.normcase(os.path.abspath(_managed_tirith_path()))
+    candidate = os.path.normcase(os.path.abspath(path))
+    if candidate != expected:
+        return False
+    try:
+        return _managed_install_directory_is_real() and stat.S_ISREG(
+            os.lstat(path).st_mode
+        )
+    except OSError:
+        return False
+
+
+def _update_state_path() -> str:
+    return os.path.join(_managed_tirith_home(), ".tirith-update-state.json")
+
+
+def _update_process_lock_path() -> str:
+    return os.path.join(_managed_tirith_home(), ".tirith-update.lock")
+
+
+def _read_small_regular_file(path: str, max_bytes: int) -> str | None:
+    """Read a bounded regular file without following a final-component symlink."""
+    try:
+        file_stat = os.lstat(path)
+        if not stat.S_ISREG(file_stat.st_mode) or file_stat.st_size > max_bytes:
+            return None
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        fd = os.open(path, flags)
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as handle:
+                fd = -1
+                value = handle.read(max_bytes + 1)
+        finally:
+            if fd >= 0:
+                os.close(fd)
+        if len(value.encode("utf-8")) > max_bytes:
+            return None
+        return value
+    except (OSError, UnicodeError):
+        return None
+
+
+def _valid_update_state(state: object) -> _UpdateState | None:
+    """Return a validated update-state object, or ``None``."""
+    if not isinstance(state, dict):
+        return None
+    state_dict = cast(dict[str, object], state)
+    schema_version = state_dict.get("schema_version")
+    if type(schema_version) is not int or schema_version != _UPDATE_STATE_SCHEMA:
+        return None
+    checked_at = state_dict.get("checked_at")
+    outcome = state_dict.get("outcome")
+    if (
+        not isinstance(checked_at, (int, float))
+        or isinstance(checked_at, bool)
+        or checked_at != checked_at  # NaN
+        or checked_at < 0
+    ):
+        return None
+    if not isinstance(outcome, str) or (
+        outcome != "failed" and outcome not in _UPDATE_SUCCESS_OUTCOMES
+    ):
+        return None
+    return {
+        "schema_version": schema_version,
+        "checked_at": float(checked_at),
+        "outcome": outcome,
+    }
+
+
+def _update_state_key() -> str:
+    return os.path.normcase(os.path.abspath(_update_state_path()))
+
+
+def _read_update_state() -> _UpdateState | None:
+    disk_state = None
+    raw = _read_small_regular_file(_update_state_path(), _UPDATE_STATE_MAX_BYTES)
+    if raw is not None:
+        try:
+            disk_state = _valid_update_state(json.loads(raw))
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+    with _in_process_update_state_lock:
+        memory_state = _in_process_update_states.get(_update_state_key())
+        if memory_state is not None:
+            memory_state = memory_state.copy()
+
+    if disk_state is None:
+        return memory_state
+    if memory_state is None:
+        return disk_state
+    if memory_state["checked_at"] >= disk_state["checked_at"]:
+        return memory_state
+    return disk_state
+
+
+def _write_update_state(outcome: str, *, now: float | None = None) -> bool:
+    """Record update throttling state in memory and atomically on disk."""
+    payload = _valid_update_state(
+        {
+            "schema_version": _UPDATE_STATE_SCHEMA,
+            "checked_at": time.time() if now is None else now,
+            "outcome": outcome,
+        }
+    )
+    if payload is None:
+        return False
+
+    # A read-only/full home must not turn every later command in a long-lived
+    # process into another release-network attempt. Record the backoff before
+    # best-effort persistence; another process still relies on the disk copy.
+    with _in_process_update_state_lock:
+        _in_process_update_states[_update_state_key()] = payload.copy()
+
+    home = _managed_tirith_home()
+    tmp_path = ""
+    fd = -1
+    try:
+        os.makedirs(home, exist_ok=True)
+        fd, tmp_path = tempfile.mkstemp(prefix=".tirith-update-state-", dir=home)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            fd = -1
+            json.dump(payload, handle, sort_keys=True)
+            handle.write("\n")
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.chmod(tmp_path, 0o600)
+        os.replace(tmp_path, _update_state_path())
+        tmp_path = ""
+        return True
+    except (OSError, TypeError, ValueError):
+        return False
+    finally:
+        if fd >= 0:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+def _update_is_due(*, now: float | None = None) -> bool:
+    """Return whether Hermes should launch a managed Tirith update check."""
+    state = _read_update_state()
+    if state is None:
+        return True
+    current_time = time.time() if now is None else now
+    checked_at = state["checked_at"]
+    if checked_at > current_time:
+        return True
+    ttl = _UPDATE_FAILURE_TTL if state["outcome"] == "failed" else _UPDATE_CHECK_TTL
+    return (current_time - checked_at) >= ttl
+
+
+def _acquire_update_lock():
+    """Acquire a process-bound advisory lock, or return ``None`` if busy.
+
+    Tirith only ships on POSIX platforms. ``flock`` releases automatically on
+    process death, so there is no stale-file reclamation race and a suspended
+    updater cannot be mistaken for a dead one.
+    """
+    if os.name == "nt":
+        return None
+
+    import fcntl
+
+    path = _update_process_lock_path()
+    try:
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+    except OSError:
+        return None
+
+    flags = os.O_CREAT | os.O_RDWR
+    if hasattr(os, "O_NOFOLLOW"):
+        flags |= os.O_NOFOLLOW
+    try:
+        fd = os.open(path, flags, 0o600)
+    except OSError:
+        return None
+    try:
+        if not stat.S_ISREG(os.fstat(fd).st_mode):
+            os.close(fd)
+            return None
+        os.fchmod(fd, 0o600)
+        fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+    except (OSError, BlockingIOError):
+        os.close(fd)
+        return None
+    return fd
+
+
+def _release_update_lock(fd: int) -> None:
+    """Release a lock returned by :func:`_acquire_update_lock`."""
+    if os.name != "nt":
+        import fcntl
+
+        try:
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        except OSError:
+            pass
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+
 def _failure_marker_path() -> str:
     """Return the path to the install-failure marker file."""
-    return os.path.join(_get_hermes_home(), ".tirith-install-failed")
+    return os.path.join(_managed_tirith_home(), ".tirith-install-failed")
 
 
 def _read_failure_reason() -> str | None:
@@ -249,18 +657,37 @@ def _clear_install_failed():
 
 
 def _hermes_bin_dir() -> str:
-    """Return $HERMES_HOME/bin, creating it if needed."""
-    d = os.path.join(_get_hermes_home(), "bin")
-    os.makedirs(d, exist_ok=True)
-    return d
+    """Return Hermes' private Tirith bin directory, creating it if needed."""
+    directories = _managed_tirith_directory_chain()
+    if not directories or any(
+        _managed_tirith_root_is_denied(directory) for directory in directories
+    ):
+        raise OSError("Hermes managed Tirith directory is outside its trusted root")
+
+    # HERMES_HOME is the configured trust anchor. Once it is real, owned, and
+    # not peer-writable, create each descendant separately and lstat it before
+    # proceeding. A symlink can therefore never be traversed by a later mkdir.
+    os.makedirs(directories[0], mode=0o700, exist_ok=True)
+    if not _is_owned_private_directory(directories[0]):
+        raise OSError("Hermes home is redirected or peer-writable")
+    for directory in directories[1:]:
+        try:
+            os.mkdir(directory, 0o755)
+        except FileExistsError:
+            pass
+        if not _is_owned_private_directory(directory):
+            raise OSError("Hermes managed Tirith directory is redirected or peer-writable")
+    return directories[-1]
 
 
 def _detect_target() -> str | None:
     """Return the Rust target triple for the current platform, or None.
 
-    Windows is intentionally unsupported — tirith does not ship a Windows
-    build. Callers should treat `None` as "this platform will never have
-    tirith" and silently fall back to pattern-matching guards.
+    Hermes-managed install/update is currently limited to Tirith's macOS and
+    Linux tarballs. Native Windows has a Tirith release, but its ZIP packaging
+    and Hermes self-update ownership proof need a separate integration. Callers
+    treat ``None`` as unsupported by this manager and fall back to Hermes'
+    pattern-matching guards.
     """
     system = platform.system()
     machine = platform.machine().lower()
@@ -293,15 +720,35 @@ def is_platform_supported() -> bool:
     return _detect_target() is not None
 
 
-def _download_file(url: str, dest: str, timeout: int = 10):
-    """Download a URL to a local file."""
+def _download_file(
+    url: str,
+    dest: str,
+    timeout: int = 10,
+    *,
+    max_bytes: int,
+) -> None:
+    """Download a URL without allowing the response to exceed ``max_bytes``."""
     req = urllib.request.Request(url)
     from agent.secret_scope import get_secret
     token = get_secret("GITHUB_TOKEN")
     if token:
         req.add_header("Authorization", f"token {token}")
-    with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
-        shutil.copyfileobj(resp, f)
+    written = 0
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
+            while chunk := resp.read(min(1024 * 1024, max_bytes - written + 1)):
+                written += len(chunk)
+                if written > max_bytes:
+                    raise ValueError(
+                        f"download exceeds {max_bytes}-byte limit: {url}"
+                    )
+                f.write(chunk)
+    except Exception:
+        try:
+            os.unlink(dest)
+        except OSError:
+            pass
+        raise
 
 
 def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool | None:
@@ -312,8 +759,8 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
         False — cosign found but verification failed
         None  — cosign not available (not on PATH, or execution failed)
 
-    The caller treats both False and None as "abort auto-install" — only
-    True allows the install to proceed.
+    ``False`` is an explicit verification rejection. ``None`` lets the caller
+    use Hermes' documented SHA-256-only fallback.
     """
     cosign = shutil.which("cosign")
     if not cosign:
@@ -332,6 +779,7 @@ def _verify_cosign(checksums_path: str, sig_path: str, cert_path: str) -> bool |
             text=True, encoding='utf-8', errors='replace',
             timeout=15,
             stdin=subprocess.DEVNULL,
+            env=_tirith_subprocess_env(),
         )
         if result.returncode == 0:
             logger.info("cosign provenance verification passed")
@@ -359,20 +807,77 @@ def _verify_checksum(archive_path: str, checksums_path: str, archive_name: str) 
         logger.warning("No checksum entry for %s", archive_name)
         return False
 
-    sha = hashlib.sha256()
-    with open(archive_path, "rb") as f:
-        for chunk in iter(lambda: f.read(8192), b""):
-            sha.update(chunk)
-    actual = sha.hexdigest()
+    actual = _sha256_file(archive_path)
     if actual != expected:
         logger.warning("Checksum mismatch: expected %s, got %s", expected, actual)
         return False
     return True
 
 
-def _extract_tirith_binary(tar: tarfile.TarFile, dest_dir: str, log) -> tuple[str | None, str]:
+def _sha256_file(path: str) -> str:
+    """Return the SHA-256 digest of a regular filesystem path."""
+    sha = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(8192), b""):
+            sha.update(chunk)
+    return sha.hexdigest()
+
+
+class _ArchiveExpansionLimitExceeded(ValueError):
+    """Raised before a release archive expands past its process budget."""
+
+
+class _ReadableBytes(Protocol):
+    def read(self, size: int = -1) -> bytes: ...
+
+
+class _BoundedDecompressedReader(io.RawIOBase):
+    """Count bytes below ``tarfile`` so metadata bodies count toward the cap."""
+
+    def __init__(self, source: _ReadableBytes, max_bytes: int):
+        self._source = source
+        self._max_bytes = max_bytes
+        self._bytes_read = 0
+
+    def read(self, size: int = -1) -> bytes:
+        remaining_with_probe = self._max_bytes - self._bytes_read + 1
+        if size < 0 or size > remaining_with_probe:
+            size = remaining_with_probe
+        chunk = self._source.read(size)
+        self._bytes_read += len(chunk)
+        if self._bytes_read > self._max_bytes:
+            raise _ArchiveExpansionLimitExceeded(
+                "tirith release archive exceeds "
+                f"{self._max_bytes}-byte decompression limit"
+            )
+        return chunk
+
+    def readable(self) -> bool:
+        return True
+
+
+def _extract_tirith_binary(
+    tar: tarfile.TarFile,
+    dest_dir: str,
+    log,
+) -> tuple[str | None, str]:
     """Extract the tirith binary from a release archive into dest_dir."""
-    for member in tar.getmembers():
+    # Iterate lazily instead of calling getmembers(). The latter scans and
+    # decompresses the complete archive before we can enforce member limits.
+    for member_number, member in enumerate(tar, start=1):
+        if member_number > _MAX_RELEASE_ARCHIVE_MEMBERS:
+            log(
+                "tirith archive exceeds %d-member limit",
+                _MAX_RELEASE_ARCHIVE_MEMBERS,
+            )
+            return None, "too_many_archive_members"
+        if member.size > _MAX_TIRITH_BINARY_BYTES:
+            log(
+                "tirith archive member exceeds %d-byte limit: %s",
+                _MAX_TIRITH_BINARY_BYTES,
+                member.name,
+            )
+            return None, "archive_member_too_large"
         if member.name == "tirith" or member.name.endswith("/tirith"):
             if ".." in member.name:
                 continue
@@ -396,10 +901,206 @@ def _extract_tirith_binary(tar: tarfile.TarFile, dest_dir: str, log) -> tuple[st
     return None, "binary_not_in_archive"
 
 
-def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
-    """Download and install tirith to $HERMES_HOME/bin/tirith.
+def _extract_release_archive(
+    archive_path: str,
+    dest_dir: str,
+    log,
+) -> tuple[str | None, str]:
+    """Stream a gzip release through a total decompression budget.
 
-    Verifies provenance via cosign and SHA-256 checksum.
+    Bounding only yielded ``TarInfo`` members is insufficient: GNU long-name
+    and PAX extension records are inflated and consumed inside ``tarfile``
+    before iteration yields a member. The reader therefore enforces the cap
+    beneath the tar parser, covering headers, extension bodies, padding, and
+    ordinary member contents together.
+    """
+    try:
+        with gzip.open(archive_path, "rb") as decompressed:
+            bounded = _BoundedDecompressedReader(
+                decompressed,
+                _MAX_RELEASE_ARCHIVE_UNPACKED_BYTES,
+            )
+            with tarfile.open(fileobj=bounded, mode="r|") as tar:
+                return _extract_tirith_binary(tar, dest_dir, log)
+    except _ArchiveExpansionLimitExceeded as exc:
+        log("tirith release archive is too large when unpacked: %s", exc)
+        return None, "archive_too_large"
+    except (EOFError, OSError, tarfile.TarError) as exc:
+        log("tirith release archive could not be read: %s", exc)
+        return None, "archive_invalid"
+
+
+def _atomic_replace_binary(
+    source: str,
+    destination: str,
+    *,
+    expected_existing_sha256: str | None = None,
+) -> None:
+    """Stage ``source`` beside ``destination`` and atomically commit it.
+
+    Download extraction happens in the system temporary directory, which may
+    be on another filesystem. Copying into a sibling first makes the final
+    ``os.replace`` atomic and preserves an existing working scanner if any
+    staging or commit step fails.
+    """
+    destination_dir = os.path.abspath(os.path.dirname(destination))
+    os.makedirs(destination_dir, exist_ok=True)
+    directory_flags = os.O_RDONLY
+    if hasattr(os, "O_DIRECTORY"):
+        directory_flags |= os.O_DIRECTORY
+    if hasattr(os, "O_NOFOLLOW"):
+        directory_flags |= os.O_NOFOLLOW
+    directory_fd = os.open(destination_dir, directory_flags)
+    staged_name = ""
+    staged_fd = -1
+    try:
+        if not stat.S_ISDIR(os.fstat(directory_fd).st_mode):
+            raise NotADirectoryError(destination_dir)
+        destination_name = os.path.basename(destination)
+        for _attempt in range(32):
+            candidate = f".tirith-install-{secrets.token_hex(8)}"
+            try:
+                staged_fd = os.open(
+                    candidate,
+                    os.O_CREAT | os.O_EXCL | os.O_WRONLY,
+                    0o600,
+                    dir_fd=directory_fd,
+                )
+            except FileExistsError:
+                continue
+            staged_name = candidate
+            break
+        else:
+            raise FileExistsError("could not allocate a unique Tirith staging file")
+
+        with os.fdopen(staged_fd, "wb") as output, open(source, "rb") as input_file:
+            staged_fd = -1
+            shutil.copyfileobj(input_file, output)
+            os.fchmod(output.fileno(), 0o755)
+            output.flush()
+            os.fsync(output.fileno())
+
+        if expected_existing_sha256 is not None:
+            current_flags = os.O_RDONLY
+            if hasattr(os, "O_NOFOLLOW"):
+                current_flags |= os.O_NOFOLLOW
+            current_fd = os.open(destination_name, current_flags, dir_fd=directory_fd)
+            try:
+                with os.fdopen(current_fd, "rb") as current:
+                    current_fd = -1
+                    sha = hashlib.sha256()
+                    for chunk in iter(lambda: current.read(8192), b""):
+                        sha.update(chunk)
+                if sha.hexdigest() != expected_existing_sha256:
+                    raise OSError(
+                        "managed Tirith changed after its release bytes were verified"
+                    )
+            finally:
+                if current_fd >= 0:
+                    os.close(current_fd)
+
+        os.replace(
+            staged_name,
+            destination_name,
+            src_dir_fd=directory_fd,
+            dst_dir_fd=directory_fd,
+        )
+        staged_name = ""
+        try:
+            os.fsync(directory_fd)
+        except OSError:
+            # Some otherwise-supported filesystems reject directory fsync.
+            pass
+    finally:
+        if staged_fd >= 0:
+            try:
+                os.close(staged_fd)
+            except OSError:
+                pass
+        if staged_name:
+            try:
+                os.unlink(staged_name, dir_fd=directory_fd)
+            except OSError:
+                pass
+        os.close(directory_fd)
+
+
+def _download_verified_tirith(
+    base_url: str,
+    target: str,
+    workdir: str,
+    log,
+) -> tuple[str | None, str, bool]:
+    """Download, verify, and extract one Tirith release into ``workdir``."""
+    archive_name = f"tirith-{target}.tar.gz"
+    archive_path = os.path.join(workdir, archive_name)
+    checksums_path = os.path.join(workdir, "checksums.txt")
+    sig_path = os.path.join(workdir, "checksums.txt.sig")
+    cert_path = os.path.join(workdir, "checksums.txt.pem")
+
+    try:
+        _download_file(
+            f"{base_url}/{archive_name}",
+            archive_path,
+            max_bytes=_MAX_ARCHIVE_DOWNLOAD_BYTES,
+        )
+        _download_file(
+            f"{base_url}/checksums.txt",
+            checksums_path,
+            max_bytes=_MAX_METADATA_DOWNLOAD_BYTES,
+        )
+    except Exception as exc:
+        log("tirith download failed: %s", exc)
+        return None, "download_failed", False
+
+    cosign_verified = False
+    if shutil.which("cosign"):
+        try:
+            _download_file(
+                f"{base_url}/checksums.txt.sig",
+                sig_path,
+                max_bytes=_MAX_METADATA_DOWNLOAD_BYTES,
+            )
+            _download_file(
+                f"{base_url}/checksums.txt.pem",
+                cert_path,
+                max_bytes=_MAX_METADATA_DOWNLOAD_BYTES,
+            )
+        except Exception as exc:
+            logger.info(
+                "cosign artifacts unavailable (%s), proceeding with SHA-256 only", exc
+            )
+        else:
+            cosign_result = _verify_cosign(checksums_path, sig_path, cert_path)
+            if cosign_result is True:
+                cosign_verified = True
+            elif cosign_result is False:
+                log("tirith release rejected: cosign provenance verification failed")
+                return None, "cosign_verification_failed", False
+            else:
+                logger.info("cosign execution failed, proceeding with SHA-256 only")
+    else:
+        logger.info(
+            "cosign not on PATH — using SHA-256 verification only "
+            "(install cosign for full supply chain verification)"
+        )
+
+    if not _verify_checksum(archive_path, checksums_path, archive_name):
+        return None, "checksum_failed", cosign_verified
+
+    src, reason = _extract_release_archive(archive_path, workdir, log)
+    return src, reason, cosign_verified
+
+
+def _install_tirith(
+    *,
+    log_failures: bool = True,
+    expected_existing_sha256: str | None = None,
+) -> tuple[str | None, str]:
+    """Download and install Tirith to Hermes' private managed cache.
+
+    Always verifies the SHA-256 checksum and verifies cosign provenance when
+    cosign is available.
     Returns (installed_path, failure_reason).  On success failure_reason is "".
     failure_reason is a short tag used by the disk marker to decide if the
     failure is retryable (e.g. "cosign_missing" clears when cosign appears).
@@ -415,7 +1116,6 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
                      platform.system(), platform.machine())
         return None, "unsupported_platform"
 
-    archive_name = f"tirith-{target}.tar.gz"
     base_url = f"https://github.com/{_REPO}/releases/latest/download"
 
     try:
@@ -424,74 +1124,38 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
         log("tirith install failed: cannot create temp dir: %s", exc)
         return None, "no_space"
     try:
-        archive_path = os.path.join(tmpdir, archive_name)
-        checksums_path = os.path.join(tmpdir, "checksums.txt")
-        sig_path = os.path.join(tmpdir, "checksums.txt.sig")
-        cert_path = os.path.join(tmpdir, "checksums.txt.pem")
-
         logger.info("tirith not found — downloading latest release for %s...", target)
+        src, reason, cosign_verified = _download_verified_tirith(
+            base_url, target, tmpdir, log
+        )
+        if src is None:
+            return None, reason
+
+        # Config is live and the verified download may have taken seconds.
+        # Re-check before creating or replacing anything under HERMES_HOME.
+        if not _tirith_auto_install_allowed():
+            return None, "lazy_installs_disabled"
 
         try:
-            _download_file(f"{base_url}/{archive_name}", archive_path)
-            _download_file(f"{base_url}/checksums.txt", checksums_path)
-        except Exception as exc:
-            log("tirith download failed: %s", exc)
-            return None, "download_failed"
-
-        # Cosign provenance verification — preferred but not mandatory.
-        # When cosign is available, we verify that the release was produced
-        # by the expected GitHub Actions workflow (full supply chain proof).
-        # Without cosign, SHA-256 checksum + HTTPS still provides integrity
-        # and transport-level authenticity.
-        cosign_verified = False
-        if shutil.which("cosign"):
-            try:
-                _download_file(f"{base_url}/checksums.txt.sig", sig_path)
-                _download_file(f"{base_url}/checksums.txt.pem", cert_path)
-            except Exception as exc:
-                logger.info("cosign artifacts unavailable (%s), proceeding with SHA-256 only", exc)
-            else:
-                cosign_result = _verify_cosign(checksums_path, sig_path, cert_path)
-                if cosign_result is True:
-                    cosign_verified = True
-                elif cosign_result is False:
-                    # Verification explicitly rejected — abort, the release
-                    # may have been tampered with.
-                    log("tirith install aborted: cosign provenance verification failed")
-                    return None, "cosign_verification_failed"
-                else:
-                    # None = execution failure (timeout/OSError) — proceed
-                    # with SHA-256 only since cosign itself is broken.
-                    logger.info("cosign execution failed, proceeding with SHA-256 only")
-        else:
-            logger.info("cosign not on PATH — installing tirith with SHA-256 verification only "
-                        "(install cosign for full supply chain verification)")
-
-        if not _verify_checksum(archive_path, checksums_path, archive_name):
-            return None, "checksum_failed"
-
-        with tarfile.open(archive_path, "r:gz") as tar:
-            src, reason = _extract_tirith_binary(tar, tmpdir, log)
-            if src is None:
-                return None, reason
-
-        dest = os.path.join(_hermes_bin_dir(), "tirith")
+            dest = os.path.join(_hermes_bin_dir(), "tirith")
+        except OSError as exc:
+            log("tirith install aborted: untrusted managed directory: %s", exc)
+            return None, "managed_directory_untrusted"
+        if not _managed_install_directory_is_real():
+            log("tirith install aborted: Hermes managed-bin directory is redirected")
+            return None, "managed_directory_untrusted"
         try:
-            shutil.move(src, dest)
-        except OSError:
-            # Cross-device move (common in Docker, NFS): shutil.move() falls
-            # back to copy2 + unlink, but copy2's metadata step can raise
-            # PermissionError.  Use plain copy + manual chmod instead.
-            try:
-                shutil.copy(src, dest)
-            except OSError:
-                # Clean up partial dest to prevent a non-executable retry loop
-                try:
-                    os.unlink(dest)
-                except OSError:
-                    pass
-                return None, "cross_device_copy_failed"
-        os.chmod(dest, os.stat(dest).st_mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+            _atomic_replace_binary(
+                src,
+                dest,
+                expected_existing_sha256=expected_existing_sha256,
+            )
+        except OSError as exc:
+            log("tirith install failed while replacing %s: %s", dest, exc)
+            return None, "install_replace_failed"
+        if not _is_managed_tirith(dest):
+            log("tirith install boundary changed while replacing %s", dest)
+            return None, "managed_directory_changed"
 
         verification = "cosign + SHA-256" if cosign_verified else "SHA-256 only"
         logger.info("tirith installed to %s (%s)", dest, verification)
@@ -499,6 +1163,300 @@ def _install_tirith(*, log_failures: bool = True) -> tuple[str | None, str]:
 
     finally:
         shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+_TIRITH_VERSION_RE = re.compile(r"^tirith ([0-9]+)\.([0-9]+)\.([0-9]+)$")
+
+
+def _parse_tirith_version(output: str) -> tuple[int, int, int] | None:
+    """Parse only Tirith's stable ``tirith X.Y.Z`` version format."""
+    if len(output) > 128:
+        return None
+    match = _TIRITH_VERSION_RE.fullmatch(output.strip())
+    if match is None:
+        return None
+    try:
+        major, minor, patch = match.groups()
+        return int(major), int(minor), int(patch)
+    except ValueError:
+        return None
+
+
+def _tirith_subprocess_env() -> dict[str, str]:
+    from tools.environments.local import hermes_subprocess_env
+
+    env = hermes_subprocess_env(inherit_credentials=False)
+    # Tirith 0.4.1+ proves Hermes ownership against this exact root before it
+    # self-replaces. In image installs it deliberately differs from the shared
+    # data root so host/container binaries cannot collide.
+    env["HERMES_HOME"] = _managed_tirith_home()
+    return env
+
+
+def _probe_tirith_version(path: str) -> tuple[tuple[int, int, int] | None, str]:
+    """Return a stable Tirith version or an operational/parse reason."""
+    try:
+        result = subprocess.run(
+            [path, "--version"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_UPDATE_PROBE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            env=_tirith_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, "probe_failed"
+    if result.returncode != 0:
+        return None, "probe_failed"
+    version = _parse_tirith_version(result.stdout)
+    return (version, "") if version is not None else (None, "unparseable")
+
+
+def _verify_legacy_release_binary(
+    path: str,
+    version: tuple[int, int, int],
+    *,
+    log_failures: bool = True,
+) -> tuple[str | None, str]:
+    """Prove a pre-Hermes-provenance binary matches published release bytes.
+
+    Legacy Tirith cannot attest whether it is a release or local build. Hermes
+    therefore verifies the matching tagged archive before replacing it. The
+    returned digest binds that proof to the later atomic swap.
+    """
+    target = _detect_target()
+    if target is None:
+        return None, "unsupported_platform"
+    log = logger.warning if log_failures else logger.debug
+    release = ".".join(str(part) for part in version)
+    base_url = f"https://github.com/{_REPO}/releases/download/v{release}"
+    try:
+        tmpdir = tempfile.mkdtemp(prefix="tirith-legacy-proof-")
+    except OSError:
+        return None, "no_space"
+    try:
+        released, reason, _cosign_verified = _download_verified_tirith(
+            base_url, target, tmpdir, log
+        )
+        if released is None:
+            return None, reason
+        try:
+            expected = _sha256_file(released)
+            actual = _sha256_file(path)
+        except OSError:
+            return None, "binary_read_failed"
+        if actual != expected:
+            logger.info(
+                "tirith background update skipped: legacy binary does not match "
+                "the v%s release artifact",
+                release,
+            )
+            return None, "binary_mismatch"
+        return actual, ""
+    finally:
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+def _probe_tirith_provenance(path: str) -> tuple[dict | None, str]:
+    """Read provenance that Tirith 0.4.1+ exposes for updater ownership."""
+    try:
+        result = subprocess.run(
+            [path, "version", "--provenance", "--format", "json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_UPDATE_PROBE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            env=_tirith_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None, "provenance_failed"
+    if result.returncode != 0:
+        return None, "provenance_failed"
+    try:
+        provenance = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return None, "provenance_failed"
+    if not isinstance(provenance, dict):
+        return None, "provenance_failed"
+    return provenance, ""
+
+
+def _provenance_allows_managed_update(
+    path: str, version: tuple[int, int, int], provenance: dict
+) -> bool:
+    """Validate that Tirith itself recognizes this exact binary as Hermes-owned."""
+    reported_path = provenance.get("binary_path")
+    reported_version = provenance.get("version")
+    if not isinstance(reported_path, str) or not os.path.isabs(reported_path):
+        return False
+    try:
+        same_binary = os.path.samefile(path, reported_path)
+    except OSError:
+        same_binary = False
+    provenance_version = (
+        _parse_tirith_version(f"tirith {reported_version}")
+        if isinstance(reported_version, str)
+        else None
+    )
+    return (
+        same_binary
+        and provenance_version == version
+        and provenance.get("install_method") == "hermes"
+        and provenance.get("install_method_resolved") is True
+        and provenance.get("dev_build") is False
+    )
+
+
+def _run_tirith_update(path: str) -> str:
+    """Run Tirith's noninteractive updater and classify its JSON result."""
+    # The user may disable runtime installs while the background worker is
+    # probing version/provenance. Re-check at the mutating/network sink so the
+    # live opt-out takes effect without waiting for the worker to finish.
+    if not _tirith_auto_install_allowed():
+        return "deferred"
+    try:
+        result = subprocess.run(
+            [path, "update", "--yes", "--allow-unsigned", "--format", "json"],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            timeout=_UPDATE_TIMEOUT,
+            stdin=subprocess.DEVNULL,
+            env=_tirith_subprocess_env(),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        logger.info("tirith background update failed; keeping current binary: %s", exc)
+        return "failed"
+
+    if result.returncode != 0:
+        logger.info(
+            "tirith background update exited with %d; keeping current binary: %s",
+            result.returncode,
+            result.stderr.strip()[:500],
+        )
+        return "failed"
+    try:
+        payload = json.loads(result.stdout)
+    except (json.JSONDecodeError, TypeError):
+        return "failed"
+    if not isinstance(payload, dict):
+        return "failed"
+    if payload.get("action") == "none":
+        return "current"
+    if payload.get("action") == "updated":
+        return "updated"
+    return "failed"
+
+
+def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
+    """Bootstrap or update an existing Hermes-managed Tirith binary."""
+    if not _is_managed_tirith(path):
+        return "skipped"
+
+    version, reason = _probe_tirith_version(path)
+    if version is None:
+        if reason == "unparseable":
+            logger.info("tirith background update skipped: unrecognized build version")
+            return "skipped"
+        return "failed"
+
+    if version < _SELF_UPDATE_MIN_VERSION:
+        expected_sha256, verification_reason = _verify_legacy_release_binary(
+            path, version, log_failures=log_failures
+        )
+        if expected_sha256 is None:
+            return "skipped" if verification_reason == "binary_mismatch" else "failed"
+        installed, install_reason = _install_tirith(
+            log_failures=log_failures,
+            expected_existing_sha256=expected_sha256,
+        )
+        if installed and _is_managed_tirith(installed):
+            return "bootstrapped"
+        if install_reason == "lazy_installs_disabled":
+            return "deferred"
+        return "failed"
+
+    provenance, _ = _probe_tirith_provenance(path)
+    if provenance is None:
+        return "failed"
+    if not _provenance_allows_managed_update(path, version, provenance):
+        logger.info(
+            "tirith background update skipped: binary is not a verified "
+            "Hermes-managed release build"
+        )
+        return "skipped"
+    return _run_tirith_update(path)
+
+
+def _background_update(path: str, *, log_failures: bool = True) -> None:
+    """Failure-isolated worker for managed Tirith maintenance."""
+    if not _tirith_auto_install_allowed() or not _is_managed_tirith(path):
+        return
+    lock_fd = _acquire_update_lock()
+    if lock_fd is None:
+        return
+    try:
+        # Another process may have completed maintenance before we acquired the
+        # lock, so check the shared state again inside the critical section.
+        if not _update_is_due():
+            return
+        outcome = _maintain_managed_tirith(path, log_failures=log_failures)
+        if outcome != "deferred":
+            _write_update_state(
+                outcome if outcome in _UPDATE_SUCCESS_OUTCOMES else "failed"
+            )
+    except Exception as exc:
+        if log_failures:
+            logger.warning(
+                "tirith background update failed unexpectedly; keeping current binary: %s",
+                exc,
+            )
+        else:
+            logger.debug("tirith background update failed unexpectedly", exc_info=True)
+        _write_update_state("failed")
+    finally:
+        _release_update_lock(lock_fd)
+
+
+def _schedule_managed_update(
+    path: str, configured_path: str, *, log_failures: bool = True
+) -> None:
+    """Launch at most one non-blocking managed update worker at a time."""
+    global _update_thread
+    if (
+        _is_explicit_path(configured_path)
+        or not _is_managed_tirith(path)
+        or not _tirith_auto_install_allowed()
+        or not _update_is_due()
+    ):
+        return
+    with _update_schedule_lock:
+        if _update_thread is not None and _update_thread.is_alive():
+            return
+        # Re-check after serializing schedulers. A worker in this process or
+        # another Hermes process may have refreshed the shared state while we
+        # were waiting for the lock.
+        if not _update_is_due():
+            return
+        thread = threading.Thread(
+            target=_background_update,
+            args=(path,),
+            kwargs={"log_failures": log_failures},
+            daemon=True,
+        )
+        try:
+            thread.start()
+        except RuntimeError:
+            logger.debug(
+                "could not start tirith background update thread", exc_info=True
+            )
+            return
+        _update_thread = thread
 
 
 def _is_explicit_path(configured_path: str) -> bool:
@@ -515,8 +1473,8 @@ def _resolve_tirith_path(configured_path: str) -> str:
 
     For the default "tirith":
     1. PATH lookup via shutil.which
-    2. $HERMES_HOME/bin/tirith (previously auto-installed)
-    3. Auto-install from GitHub releases → $HERMES_HOME/bin/tirith
+    2. Hermes' private Tirith cache (previously auto-installed)
+    3. Auto-install from GitHub releases into that cache
 
     Failed installs are cached for the process lifetime (and persisted to
     disk for 24h) to avoid repeated network attempts.
@@ -524,17 +1482,21 @@ def _resolve_tirith_path(configured_path: str) -> str:
     global _resolved_path, _install_failure_reason
 
     # Fast path: successfully resolved on a previous call.
-    if _resolved_path is not None and _resolved_path is not _INSTALL_FAILED:
-        return _resolved_path
+    if isinstance(_resolved_path, str):
+        path = _resolved_path
+        # The resolver is exercised for every scan, including in long-lived
+        # gateways. Reconsider completed workers here so a Tirith release made
+        # after Hermes startup is discovered once the shared TTL expires.
+        _schedule_managed_update(path, configured_path, log_failures=False)
+        return path
 
     expanded = os.path.expanduser(configured_path)
     explicit = _is_explicit_path(configured_path)
     install_failed = _resolved_path is _INSTALL_FAILED
 
-    # Platform has no tirith build (Windows etc.). Cache the verdict and
-    # return the unexpanded configured path — the spawn loop will fail-open
-    # via the dedupe'd OSError handler, but only after the first call; on
-    # subsequent calls the fast-path above short-circuits before spawning.
+    # Platform is unsupported by Hermes' Tirith manager. Cache the verdict and
+    # return the unexpanded configured path; the spawn loop will fail-open via
+    # the dedupe'd OSError handler.
     if not explicit and not is_platform_supported():
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "unsupported_platform"
@@ -563,13 +1525,15 @@ def _resolve_tirith_path(configured_path: str) -> str:
         _resolved_path = found
         _install_failure_reason = ""
         _clear_install_failed()
+        _schedule_managed_update(found, configured_path, log_failures=False)
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = _managed_tirith_path()
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
         _clear_install_failed()
+        _schedule_managed_update(hermes_bin, configured_path, log_failures=False)
         return hermes_bin
 
     # A policy opt-out is not an installation failure. Do not cache or persist
@@ -610,6 +1574,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
         _resolved_path = installed
         _install_failure_reason = ""
         _clear_install_failed()
+        _write_update_state("installed")
         return installed
     if reason == "lazy_installs_disabled":
         return expanded
@@ -617,7 +1582,8 @@ def _resolve_tirith_path(configured_path: str) -> str:
     # Install failed — cache the miss and persist reason to disk
     _resolved_path = _INSTALL_FAILED
     _install_failure_reason = reason
-    _mark_install_failed(reason)
+    if reason != "managed_directory_untrusted":
+        _mark_install_failed(reason)
     return expanded
 
 
@@ -636,7 +1602,7 @@ def _background_install(*, log_failures: bool = True):
             _install_failure_reason = ""
             return
 
-        hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+        hermes_bin = _managed_tirith_path()
         if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
             _resolved_path = hermes_bin
             _install_failure_reason = ""
@@ -650,12 +1616,14 @@ def _background_install(*, log_failures: bool = True):
             _resolved_path = installed
             _install_failure_reason = ""
             _clear_install_failed()
+            _write_update_state("installed")
         elif reason == "lazy_installs_disabled":
             return
         else:
             _resolved_path = _INSTALL_FAILED
             _install_failure_reason = reason
-            _mark_install_failed(reason)
+            if reason != "managed_directory_untrusted":
+                _mark_install_failed(reason)
 
 
 def ensure_installed(*, log_failures: bool = True):
@@ -672,15 +1640,20 @@ def ensure_installed(*, log_failures: bool = True):
         return None
 
     # Already resolved from a previous call
-    if _resolved_path is not None and _resolved_path is not _INSTALL_FAILED:
+    if isinstance(_resolved_path, str):
         path = _resolved_path
         if os.path.isfile(path) and os.access(path, os.X_OK):
+            _schedule_managed_update(
+                path,
+                cfg["tirith_path"],
+                log_failures=log_failures,
+            )
             return path
         return None
 
-    # Platform has no tirith build (e.g. Windows) — don't probe PATH,
-    # don't start a download thread, don't write a disk failure marker.
-    # Pattern-matching guards still run; this path stays silent.
+    # Platform is unsupported by Hermes' Tirith manager — don't probe PATH,
+    # start a download thread, or write a disk failure marker. Pattern-matching
+    # guards still run; this path stays silent.
     if not is_platform_supported():
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "unsupported_platform"
@@ -709,13 +1682,23 @@ def ensure_installed(*, log_failures: bool = True):
         _resolved_path = found
         _install_failure_reason = ""
         _clear_install_failed()
+        _schedule_managed_update(
+            found,
+            configured_path,
+            log_failures=log_failures,
+        )
         return found
 
-    hermes_bin = os.path.join(_hermes_bin_dir(), "tirith")
+    hermes_bin = _managed_tirith_path()
     if os.path.isfile(hermes_bin) and os.access(hermes_bin, os.X_OK):
         _resolved_path = hermes_bin
         _install_failure_reason = ""
         _clear_install_failed()
+        _schedule_managed_update(
+            hermes_bin,
+            configured_path,
+            log_failures=log_failures,
+        )
         return hermes_bin
 
     # Preserve local discovery while honoring the global runtime-install
@@ -787,9 +1770,9 @@ def check_command_security(command: str) -> dict:
     if _circuit_open:
         return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
 
-    # Unsupported platform (Windows etc.) — tirith has no binary here and
-    # never will. Skip the resolver entirely so we don't even try to spawn.
-    # Pattern-matching guards still run via the rest of approval.py.
+    # Unsupported manager platform (currently native Windows and unknown
+    # architectures). Skip the resolver entirely; pattern-matching guards
+    # still run via the rest of approval.py.
     if not is_platform_supported():
         return {"action": "allow", "findings": [], "summary": ""}
 
@@ -814,6 +1797,7 @@ def check_command_security(command: str) -> dict:
             text=True, encoding='utf-8', errors='replace',
             timeout=timeout,
             stdin=subprocess.DEVNULL,
+            env=_tirith_subprocess_env(),
         )
     except OSError as exc:
         # Covers FileNotFoundError, PermissionError, exec format error.

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -125,33 +125,54 @@ _INSTALL_FAILED = False  # sentinel: distinct from "not yet tried"
 _install_failure_reason: str = ""  # reason tag when _resolved_path is _INSTALL_FAILED
 
 # Circuit breaker: after _CRASH_LIMIT consecutive spawn/execution failures,
-# disable tirith for the rest of the process to prevent agent hangs (#41400).
-# Reset on successful execution (see _record_tirith_crash / check_command_security).
+# pause Tirith briefly to prevent agent hangs (#41400), then permit one
+# half-open recovery probe. Any recognized Tirith verdict closes the breaker.
 #
-# Thread safety: _crash_count and _circuit_open are module-level globals
+# Thread safety: the breaker fields are module-level globals
 # mutated without a lock. check_command_security can be called from
 # concurrent agent threads (gateway multi-session). The race is benign —
-# at worst two threads both increment past _CRASH_LIMIT and both set
-# _circuit_open = True, opening the breaker one call early. No data
-# corruption or security bypass is possible. This intentionally matches
+# at worst two threads both increment past _CRASH_LIMIT and both set the
+# open timestamp, opening the breaker one call early. This intentionally matches
 # the lock-free style of error counters in mcp_tool.py rather than the
 # locked _warn_once pattern, because the worst case is harmless.
 _CRASH_LIMIT = 3
+_CIRCUIT_RETRY_SECONDS = 60.0
 _crash_count: int = 0
 _circuit_open: bool = False
+_circuit_opened_at: float | None = None
+
+
+def _reset_tirith_crash_state() -> None:
+    """Close the circuit after Tirith or its managed install recovers."""
+    global _crash_count, _circuit_open, _circuit_opened_at
+    _crash_count = 0
+    _circuit_open = False
+    _circuit_opened_at = None
 
 
 def _record_tirith_crash() -> None:
     """Increment the crash counter and open the circuit breaker if needed."""
-    global _crash_count, _circuit_open
+    global _crash_count, _circuit_open, _circuit_opened_at
     _crash_count += 1
     if _crash_count >= _CRASH_LIMIT:
         _circuit_open = True
+        _circuit_opened_at = time.monotonic()
         logger.warning(
             "tirith circuit breaker opened after %d consecutive failures; "
-            "disabling for the rest of the process",
+            "retrying after %.0fs",
             _crash_count,
+            _CIRCUIT_RETRY_SECONDS,
         )
+
+
+def _circuit_retry_is_due() -> bool:
+    """Return whether an open circuit may make one recovery attempt."""
+    if not _circuit_open or _circuit_opened_at is None:
+        return False
+    if time.monotonic() - _circuit_opened_at < _CIRCUIT_RETRY_SECONDS:
+        return False
+    _reset_tirith_crash_state()
+    return True
 
 # Background install thread coordination
 _install_lock = threading.Lock()
@@ -652,6 +673,7 @@ def _clear_install_failed():
     # deletes the binary) surfaces in the log again instead of being
     # silently suppressed by a stale dedupe key from before the fix.
     _reset_spawn_warning_state()
+    _reset_tirith_crash_state()
     try:
         os.unlink(_failure_marker_path())
     except OSError:
@@ -743,7 +765,10 @@ def _download_file(
     from agent.secret_scope import get_secret
     token = get_secret("GITHUB_TOKEN")
     if token:
-        req.add_header("Authorization", f"token {token}")
+        # ``urllib`` copies ordinary headers to redirect requests, including
+        # cross-origin GitHub release-asset redirects. Keep the credential on
+        # the initial github.com request only.
+        req.add_unredirected_header("Authorization", f"token {token}")
     written = 0
     try:
         with urllib.request.urlopen(req, timeout=timeout) as resp, open(dest, "wb") as f:
@@ -1499,7 +1524,9 @@ def _is_explicit_path(configured_path: str) -> bool:
     return configured_path != "tirith"
 
 
-def _resolve_tirith_path(configured_path: str) -> str:
+def _resolve_tirith_path(
+    configured_path: str, *, background_only: bool = False
+) -> str | None:
     """Resolve the tirith binary path, auto-installing if necessary.
 
     If the user explicitly set a path (anything other than the bare "tirith"
@@ -1535,7 +1562,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
     if not explicit and not is_platform_supported():
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "unsupported_platform"
-        return expanded
+        return None if background_only else expanded
 
     # Explicit path: check it and stop. Never auto-download a replacement.
     if explicit:
@@ -1550,7 +1577,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
         logger.warning("Configured tirith path %r not found; scanning disabled", configured_path)
         _resolved_path = _INSTALL_FAILED
         _install_failure_reason = "explicit_path_missing"
-        return expanded
+        return None if background_only else expanded
 
     # Default "tirith" — always re-run cheap local checks so a manual
     # install is picked up even after a previous network failure (P2 fix:
@@ -1574,7 +1601,7 @@ def _resolve_tirith_path(configured_path: str) -> str:
     # A policy opt-out is not an installation failure. Do not cache or persist
     # it, so changing the setting can take effect immediately in this process.
     if not _tirith_auto_install_allowed():
-        return expanded
+        return None if background_only else expanded
 
     # Local checks failed.  If a previous install attempt already failed,
     # skip the network retry — UNLESS the failure was "cosign_missing" and
@@ -1587,13 +1614,20 @@ def _resolve_tirith_path(configured_path: str) -> str:
             _clear_install_failed()
             install_failed = False
         else:
-            return expanded
+            return None if background_only else expanded
 
     # If a background install thread is running, don't start a parallel one —
     # return the configured path; the OSError handler in check_command_security
     # will apply fail_open until the thread finishes.
     if _install_thread is not None and _install_thread.is_alive():
-        return expanded
+        return None if background_only else expanded
+
+    # Approval is a latency-sensitive path. Startup normally starts this
+    # worker first, but alternate entrypoints and very early commands must not
+    # turn a release download into a synchronous approval stall.
+    if background_only:
+        ensure_installed(log_failures=False)
+        return None
 
     # Check disk failure marker before attempting network download.
     # Preserve the marker's real reason so in-memory retry logic can
@@ -1797,13 +1831,17 @@ def check_command_security(command: str) -> dict:
     if not cfg["tirith_enabled"]:
         return {"action": "allow", "findings": [], "summary": ""}
 
-    # Circuit breaker: if tirith has crashed _CRASH_LIMIT times in a row,
-    # stop trying for the rest of the process.  Without this, a corrupted
-    # or missing binary causes every tool call to hit the same spawn failure
-    # → fail-open → agent retry loop, hanging the user for 20+ minutes
-    # (issue #41400).
-    if _circuit_open:
-        return {"action": "allow", "findings": [], "summary": "tirith disabled (circuit breaker)"}
+    # Circuit breaker: pause after repeated failures, then make a half-open
+    # recovery attempt. Without this, a corrupted binary can make every tool
+    # call hit the same slow failure; without the retry, a repaired or updated
+    # binary stays disabled for the rest of a long-lived process.
+    if _circuit_open and not _circuit_retry_is_due():
+        action = "allow" if cfg["tirith_fail_open"] else "block"
+        return {
+            "action": action,
+            "findings": [],
+            "summary": f"tirith unavailable (circuit breaker, fail-{'open' if action == 'allow' else 'closed'})",
+        }
 
     # Unsupported manager platform (currently native Windows and unknown
     # architectures). Skip the resolver entirely; pattern-matching guards
@@ -1811,7 +1849,9 @@ def check_command_security(command: str) -> dict:
     if not is_platform_supported():
         return {"action": "allow", "findings": [], "summary": ""}
 
-    tirith_path = _resolve_tirith_path(cfg["tirith_path"])
+    tirith_path = _resolve_tirith_path(
+        cfg["tirith_path"], background_only=True
+    )
     timeout = cfg["tirith_timeout"]
     fail_open = cfg["tirith_fail_open"]
 
@@ -1860,10 +1900,15 @@ def check_command_security(command: str) -> dict:
 
     # Map exit code to action
     exit_code = result.returncode
+    if exit_code in (0, 1, 2):
+        # A recognized verdict proves the scanner is responsive. This must
+        # reset failures for warn/block verdicts too; otherwise unrelated
+        # earlier failures accumulate and open a supposedly consecutive
+        # failure breaker.
+        _reset_tirith_crash_state()
+
     if exit_code == 0:
         action = "allow"
-        # Successful execution — reset circuit breaker
-        _crash_count = 0
     elif exit_code == 1:
         action = "block"
     elif exit_code == 2:
@@ -1918,8 +1963,15 @@ def _is_app_tld_finding(finding: dict) -> bool:
         return False
     if finding.get("rule_id") != "lookalike_tld":
         return False
-    for field in ("value", "tld", "detail", "description", "message"):
+    for field in ("value", "tld", "detail"):
         val = finding.get(field)
-        if val is not None and ".app" in str(val).lower():
+        if val is not None and str(val).strip().casefold() in {"app", ".app"}:
+            return True
+    for field in ("description", "message"):
+        val = finding.get(field)
+        if val is not None and re.search(
+            r"(?i)(?:^|[\s\"'])\.app[\"']?\s+(?:tld|top-level domain)\b",
+            str(val),
+        ):
             return True
     return False

--- a/tools/tirith_security.py
+++ b/tools/tirith_security.py
@@ -47,7 +47,7 @@ import time
 import urllib.request
 from typing import Protocol, TypedDict, cast
 
-from hermes_constants import get_hermes_home
+from hermes_constants import get_hermes_home, is_termux
 
 logger = logging.getLogger(__name__)
 
@@ -692,10 +692,19 @@ def _detect_target() -> str | None:
     system = platform.system()
     machine = platform.machine().lower()
 
-    # Android (Termux) is ABI-compatible with Linux — reuse Linux binaries.
+    # Termux uses Android's Bionic libc, so Tirith's glibc Linux build cannot
+    # run there.  The release publishes a statically linked musl build for
+    # AArch64 Termux; no x86_64 Android artifact is currently published.
+    if is_termux():
+        return (
+            "aarch64-unknown-linux-musl"
+            if machine in {"aarch64", "arm64"}
+            else None
+        )
+
     if system == "Darwin":
         plat = "apple-darwin"
-    elif system in {"Linux", "Android"}:
+    elif system == "Linux":
         plat = "unknown-linux-gnu"
     else:
         return None
@@ -1390,6 +1399,30 @@ def _maintain_managed_tirith(path: str, *, log_failures: bool = True) -> str:
             "Hermes-managed release build"
         )
         return "skipped"
+
+    # Tirith 0.4.1 reports every AArch64 Linux build as the glibc release
+    # target.  On Termux, delegating to its self-updater would therefore fetch
+    # an unusable glibc binary over the working musl one.  Keep the same
+    # provenance gate, then use Hermes' checksum-verified, preimage-bound
+    # installer until Tirith can distinguish the musl target itself.
+    if (
+        _detect_target() == "aarch64-unknown-linux-musl"
+        and provenance.get("target") != "aarch64-unknown-linux-musl"
+    ):
+        try:
+            expected_sha256 = _sha256_file(path)
+        except OSError:
+            return "failed"
+        installed, install_reason = _install_tirith(
+            log_failures=log_failures,
+            expected_existing_sha256=expected_sha256,
+        )
+        if installed and _is_managed_tirith(installed):
+            return "updated"
+        if install_reason == "lazy_installs_disabled":
+            return "deferred"
+        return "failed"
+
     return _run_tirith_update(path)
 
 

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -703,7 +703,7 @@ security:
 
 When `tirith_fail_open` is `true` (default), commands proceed if tirith is not installed or times out. Set to `false` in high-security environments to block commands when tirith is unavailable.
 
-Tirith ships prebuilt binaries for Linux (x86_64 / aarch64) and macOS (x86_64 / arm64). On platforms with no prebuilt binary (Windows, etc.), tirith is silently skipped — pattern-matching guards still run, and the CLI does not surface an "unavailable" banner. To use tirith on Windows, run Hermes under WSL.
+Hermes-managed Tirith installation supports Linux (x86_64 / aarch64) and macOS (x86_64 / arm64). On other platforms, Hermes still uses a working `security.tirith_path` or `tirith` found on `PATH`, but it does not manage that binary. If no scanner is available, `tirith_fail_open` controls whether commands proceed; the default fail-open path stays silent. Native Windows users can install Tirith separately or run Hermes under WSL.
 
 Tirith's verdict integrates with the approval flow: safe commands pass through, while both suspicious and blocked commands trigger user approval with the full tirith findings (severity, title, description, safer alternatives). Users can approve or deny — the default choice is deny to keep unattended scenarios secure.
 


### PR DESCRIPTION
## What does this PR do?

Hermes currently downloads Tirith into its private cache once, then keeps using that binary indefinitely. A Hermes install that bootstrapped an older Tirith therefore remains stale until the user replaces it manually.

This PR makes Hermes maintain only the Tirith binary it owns:

- A missing Tirith is installed in the background from both startup and first-command paths, so approval never waits on a release download.
- An existing Hermes-managed Tirith is returned immediately and checked in a failure-isolated background worker when its 24-hour successful-check TTL expires. Startup and later command scans are the triggers; a completely idle process does not poll on a timer.
- A pre-0.4.1 managed binary is upgraded only after its bytes match that version's checksum-verified tagged release artifact and the replacement is bound to a signed stable release (at least 0.4.1) that cannot roll the installed version back. Equal-version replacement is allowed only for a byte-matched historical Termux GNU-to-musl migration.
- Tirith 0.4.1 and later are updated through Tirith's noninteractive JSON updater only after the binary proves the expected path, version, Hermes install method, and non-development provenance. On Termux, Hermes temporarily keeps using its own verified installer while Tirith 0.4.1 still reports the glibc target for its musl binary.
- PATH binaries, explicit `security.tirith_path` values, Nix, Homebrew, Cargo, npm, and other package-manager installations remain externally managed and are never modified by Hermes.
- Managed-cache directories, the executable itself, and path aliases are revalidated before scans and updates; unsafe ownership, modes, ACLs, symlinks, hard links, or case aliases cannot bypass the managed-file trust policy.
- `security.allow_lazy_installs: false` disables both Hermes-managed installation and updates while continuing to use an already installed scanner.
- Scanner failures retain the configured fail-open/fail-closed policy, and the circuit breaker makes a bounded half-open recovery attempt instead of disabling a repaired scanner for the process lifetime.
- Cached paths, install/update workers, failures, and circuit state are isolated by profile and configured Tirith path. Background workers inherit the active `HERMES_HOME` context, and a slow half-open probe remains single-flight even after additional cooldown periods elapse.
- Existing approval semantics are unchanged: this PR fixes scanner availability and freshness, not whether an interactive Hermes session permits a human to override a Tirith verdict.

As long as future Tirith releases preserve the 0.4.1+ provenance JSON, updater CLI, and release-artifact contract, Hermes-managed installs will discover and apply them without another Hermes PR. A future Tirith release that reports the native Termux musl target will automatically transition back to Tirith's own updater. A deliberately breaking updater/provenance change would still require coordinated Hermes work.

## Related Issue

- Supersedes #99131 while preserving Masih-0x3's authored commit and contributor attribution.
- Consolidates overlapping fixes from #76578 (verdict reset and exact `.app` handling), #73167 (single-flight half-open recovery), #53797 (fail-closed circuit behavior), and #46410 (Termux musl selection) into the managed-lifecycle change rather than presenting them as new or unrelated work.
- Native Windows management remains tracked separately by #69646 / #26068; this PR does not close or replace those efforts.
- Related to #50831: this provides Tirith to Hermes at runtime in immutable images, but intentionally does not promise that `tirith` is available on PATH in an arbitrary shell inside the image.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/config_defaults.py` and `cli-config.yaml.example`
  - Document `security.allow_lazy_installs` as the runtime-install/update opt-out.
  - Explain which Tirith installations Hermes owns and which remain externally managed.
- `website/docs/user-guide/security.md`
  - Clarify that Hermes maintains only its private Tirith installation; package-manager and explicitly configured binaries remain externally managed.
- `contributors/emails/Masih-0x3@users.noreply.github.com`
  - Preserve contributor attribution for the existing opt-out fix incorporated from #99131.
- `tools/tirith_security.py`
  - Add persistent 24-hour success and one-hour failure backoff, in-process scheduling guards, and a cross-process `flock` for managed maintenance.
  - Bootstrap stale pre-0.4.1 release binaries through a byte-bound replacement, then delegate compatible releases to `tirith update --yes --format json`; every automatic replacement requires signed release provenance and keeps the working binary if signature verification is unavailable.
  - Bind cosign verification to exactly one stable Tirith release tag from `release.yml`, accept either one raw PEM certificate or Tirith's canonical one-layer base64-wrapped PEM asset, reject noncanonical framing, prerelease or ambiguous identities, reject equal/older signed candidates, require 0.4.1 or newer for a legacy bootstrap, and keep initial installation create-only so it cannot become a checksum-only replacement race.
  - Validate same-user ownership, Unix mode bits, access/default ACLs, and the final managed executable before scanning, probing, or updating. Linux default ACLs are evaluated with their effective mask so inherited group/other write authority is rejected. Normalize symlink, hard-link, and macOS case aliases back to the exact managed path so aliases cannot shed those checks.
  - Use target-qualified managed paths for immutable images whose `HERMES_HOME` volume may be shared with a host of another OS or architecture.
  - Select Tirith's statically linked AArch64 musl artifact on Termux and avoid Tirith 0.4.1's glibc-target self-update path until upstream provenance reports the musl target.
  - Keep all network, verification, and update failures non-fatal so the last working scanner remains available.
  - Emit bounded, de-duplicated diagnostics when managed-cache trust, update probing, updater JSON, or cross-process backoff persistence fails, without changing fail-open/fail-closed behavior.
  - Re-schedule completed workers on later scans so long-lived active gateways can discover future releases without a restart.
  - Isolate cached paths, worker ownership, failure state, and circuit state by profile/configuration; propagate the active profile context into raw install/update threads.
  - Keep first-command installation asynchronous, recover the scanner circuit after a repair or cooldown with an explicitly claimed single-flight probe (including probes longer than the cooldown), preserve fail-closed behavior while the circuit is open, invalidate vanished cached binaries, and route release downloads through Hermes' trusted-CA/proxy opener without forwarding `GITHUB_TOKEN` to release-asset redirect origins.
  - Suppress only exact `.app` lookalike-TLD warnings rather than substring matches such as `.apple` or `.application`, and consider every finding before suppression even when the displayed list is capped.
- `tests/tools/test_tirith_security.py` and `tests/tools/test_tirith_managed_updates.py`
  - Cover the opt-out, TTL/backoff behavior, legacy bootstrap, current/future updater flow, Termux musl fallback and transition, provenance rejection, monotonic signed releases, create-only installation, executable/ACL/alias trust, external-install exclusion, concurrency, immutable-image separation, failure isolation/recovery, redirect credential isolation, exact warning suppression, and release-archive limits.

### Security-sensitive behavior

- Initial downloads are size-bounded and always verified against `checksums.txt`. Hermes attempts Sigstore/cosign provenance verification when cosign is available; an initial install falls back to SHA-256-only verification if signature artifacts are unavailable or cosign cannot run. Every automatic replacement requires successful cosign provenance for exactly one stable tag, cannot roll the installed version back, and fails closed while retaining the working binary if signature verification is unavailable. Equal-version replacement is restricted to a byte-matched historical Termux GNU-to-musl migration.
- Archive parsing limits metadata, member count, individual binary size, and aggregate decompression, including GNU/PAX extension bodies.
- Replacement is staged beside the destination, fsynced, and committed atomically through a directory file descriptor with no-follow checks. A first install is create-only and uses an atomic no-clobber commit, so a concurrent Hermes process can win without its binary being overwritten or turning the unsigned initial-install path into a replacement.
- Every managed directory component and the final executable are same-user-owned, non-symlinked, not group/world writable, and free of ACL entries that grant foreign mutation. System and package-manager roots—including case variants on case-insensitive macOS filesystems—are denied. Existing symlink, hard-link, and case aliases are recognized by file identity and normalized to the exact managed path before execution.
- The lazy-install policy is re-checked immediately before both legacy filesystem replacement and modern self-update.
- Tirith and cosign subprocesses receive Hermes' credential-scrubbed child environment.
- Release downloads inherit Hermes' CA-bundle and installed proxy policy, including the certifi fallback required by Python.org macOS runtimes.
- GitHub credentials are attached only to the initial release request and are not copied to redirect origins.
- An open scanner circuit continues honoring `tirith_fail_open: false` and retries after a bounded cooldown.
- Runtime paths and circuit/install/update state remain isolated when a long-lived process serves interleaved `HERMES_HOME` profiles.

## How to Test

1. Run the focused regression suite through the repository test runner:

   ```bash
   scripts/run_tests.sh tests/tools/test_tirith_security.py tests/tools/test_tirith_managed_updates.py -q
   ```

   Final macOS result: `214 passed, 0 failed, 12 skipped` (Linux- and Windows-only cases skipped). Linux- and Windows-native cases run in their hosted OS lanes.

2. Run the static checks:

   ```bash
   .venv/bin/ruff check .
   .venv/bin/ty check tools/tirith_security.py hermes_cli/config_defaults.py tests/tools/test_tirith_security.py tests/tools/test_tirith_managed_updates.py
   .venv/bin/python scripts/check-windows-footguns.py --all
   git diff --check origin/main
   ```

   These scoped type checks pass. The repository-wide `ty check` remains unsuitable as a local green gate because the current tree produces the existing diagnostic baseline and the pinned `ty` build panics while analyzing unrelated `tools/checkpoint_manager.py`; CI compares HEAD against the base report rather than requiring a zero-diagnostic whole-tree run.

3. With a temporary `HERMES_HOME`, exercise the real release path against Tirith's published v0.4.1 archive, checksum, signature, and one-layer base64-wrapped certificate. Hermes' certificate parser extracted the exact stable release identity, cosign verification returned `(True, (0, 4, 1))`, installation produced `tirith 0.4.1`, provenance reported `install_method=hermes`, `install_method_resolved=true`, and `dev_build=false`, and managed maintenance returned `current`; temporary homes were removed afterward. A separately downloaded local copy initially required explicit Gatekeeper approval because the upstream release is not Apple-notarized. After approval, that binary returned `tirith 0.4.1`, and the Hermes wrapper allowed `echo hello` while blocking `curl https://example.com/install.sh | sh`. `spctl --assess` still reports the notarization-policy result; notarizing upstream release artifacts is separate from this Hermes lifecycle fix.

4. To reproduce the original stale-cache path, place an official pre-0.4.1 Tirith release at the managed cache path, expire/remove the update state, and call `ensure_installed()`. Hermes returns the working binary immediately; the background worker proves the old release bytes and replaces it with the current release.

5. Run the canonical repository-wide test command:

   ```bash
   scripts/run_tests.sh
   ```

   On this exact pushed head (`c363b959154fbb86838b104b063db6eb56459126`), hosted CI's `Python tests / Run tests` job completed successfully. The local macOS/Python 3.11 full run was also attempted but did not complete: after reaching unrelated baseline/platform failures, an unrelated test file hung. The affected baseline files require unavailable host components or different platform behavior (CuaDriver/Chromium/ai-edge-litert, Linux/systemd/WSL assumptions, `/tmp` normalization and Unix-socket path limits, Python 3.11's `tarfile` API, or SQLite 3.39 behavior). Both Tirith files were run independently to completion on macOS and Linux with the exact results above; the hosted full Python, native Windows, macOS, docs, Nix, Docker, lint, and supply-chain jobs all pass on the same commit.

6. Run the repository's exact macOS OS lane selection. Result: `49 passed, 0 failed, 1 skipped` across 20 selected files. Ruff, the scoped `ty` check, the all-files Windows-footgun check (1,089 files), and `git diff --check` also pass. The canonical six-lens PR Review Toolkit pass (code, silent-failure, tests, comments, type design, and simplification) identified the certificate-asset compatibility, Linux default-ACL, diagnostics, and missing negative-test gaps addressed in this revision. A fresh post-fix adversarial bypass/regression review found no remaining actionable issue.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) and incorporated the existing work from #99131 instead of discarding it.
- [x] My PR contains **only** changes related to this fix (including the ownership and failure-path controls required to make automatic executable updates safe).
- [x] The canonical repository-wide test suite passes on this exact head in hosted CI (`Python tests / Run tests`). The local macOS/Python 3.11 attempt encountered unrelated baseline/platform failures and a hang; see the full-run receipt above. Both Tirith suites also pass independently on macOS and Linux.
- [x] I've added tests for my changes.
- [x] I've tested on my platform: macOS 27.0 (Build 26A5378j). Linux-specific tests are marked for the Linux CI lane; Termux target selection and updater routing have unit coverage; native Windows managed ZIP installation remains out of scope and the Windows-footgun scan passes.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (`cli-config.yaml.example`, `website/docs/user-guide/security.md`, and docstrings).
- [x] I've updated `cli-config.yaml.example` for the clarified runtime-install/update policy.
- [x] `CONTRIBUTING.md` / `AGENTS.md`: N/A; no contributor workflow or architecture policy changes.
- [x] I've considered cross-platform impact: macOS, glibc Linux, and AArch64 Termux/musl targets are explicit, immutable-image caches are target-qualified, package-manager ownership is preserved, unsupported x86_64 Termux is gated, and unsupported native Windows management remains gated.
- [x] Tool descriptions/schemas: N/A; this changes Tirith lifecycle management, not an agent tool schema.
