### PR TITLE
fix(delegation): resolve delegation.fallback_providers for child agents

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2233,5 +2233,67 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIn("missing-acp-binary", str(ctx.exception))
 
 
+class TestDelegationFallbackProviders(unittest.TestCase):
+    """#65038: delegation.fallback_providers must be consulted for children.
+
+    A delegated child with its own ``delegation.fallback_providers`` chain must
+    use that chain, not silently inherit the parent's resolved fallback chain.
+    """
+
+    @patch("tools.delegate_tool._load_config")
+    def test_child_uses_delegation_fallback_over_parent_chain(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent._fallback_chain = [{"provider": "nous", "model": "hermes-4"}]
+        mock_cfg.return_value = {
+            "fallback_providers": [{"provider": "openrouter", "model": "minimax/minimax-m2.7"}],
+        }
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Run on a cheap fallback",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="leaf",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(
+            kwargs["fallback_model"],
+            [{"provider": "openrouter", "model": "minimax/minimax-m2.7"}],
+        )
+
+    @patch("tools.delegate_tool._load_config")
+    def test_child_inherits_parent_chain_when_no_delegation_fallback(self, mock_cfg):
+        parent = _make_mock_parent()
+        parent._fallback_chain = [{"provider": "nous", "model": "hermes-4"}]
+        mock_cfg.return_value = {}
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="Inherit parent fallback",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+                role="leaf",
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(
+            kwargs["fallback_model"],
+            [{"provider": "nous", "model": "hermes-4"}],
+        )
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2018,10 +2018,14 @@ def _build_child_agent(
     except Exception as exc:
         logger.debug("Could not load delegation reasoning_effort: %s", exc)
 
-    # Inherit the parent's fallback provider chain so subagents can recover
-    # from rate-limits and credential exhaustion exactly like the top-level
-    # agent does.  _fallback_chain is a list accepted by AIAgent's
-    # fallback_model parameter (which handles both list and dict forms).
+    # Resolve the child's fallback provider chain.  A delegation-scoped
+    # ``fallback_providers`` (or legacy ``fallback_model``) entry is the most
+    # specific fallback intent for children and wins over everything else
+    # (#65038).  When no delegation-scoped chain is configured we inherit the
+    # parent's resolved chain so subagents recover from rate-limits and
+    # credential exhaustion exactly like the top-level agent does.
+    # _fallback_chain is a list accepted by AIAgent's fallback_model
+    # parameter (which handles both list and dict forms).
     #
     # EXCEPT when the user pinned delegation.provider: an explicit pin means
     # "children run on THIS provider".  Inheriting the parent chain would let
@@ -2030,7 +2034,10 @@ def _build_child_agent(
     # same class of silent-drag the override_provider filter-clearing below
     # already prevents for OpenRouter routing preferences.  Predictability >
     # liveness for explicit pins: the pinned child fails loudly instead.
-    parent_fallback = (
+    from hermes_cli.fallback_config import get_fallback_chain
+
+    delegation_fallback = get_fallback_chain(delegation_cfg) or None
+    parent_fallback = delegation_fallback or (
         None
         if override_provider
         else (getattr(parent_agent, "_fallback_chain", None) or None)


### PR DESCRIPTION
Fixes #65038.

## Problem
`delegation.fallback_providers` is accepted in config but never consulted. Delegated children unconditionally inherit the parent agent's top-level fallback chain via:

```python
parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
child = AIAgent(fallback_model=parent_fallback, ...)
```

This silently routes a failed delegated-worker request onto fallback models intended only for the head agent, breaking provider/model isolation.

## Root Cause
In `tools/delegate_tool.py`, `_build_child_agent()` reads the parent's resolved fallback chain but never checks `delegation_cfg.get("fallback_providers")`. The delegation config is used for provider, model, reasoning effort, and concurrency — but fallback_providers is ignored on this code path.

## Fix
Before constructing the child agent, check whether `delegation.fallback_providers` is configured:

```python
configured_child_fallbacks = delegation_cfg.get("fallback_providers")
if isinstance(configured_child_fallbacks, list) and configured_child_fallbacks:
    child_fallback = get_fallback_chain({"fallback_providers": configured_child_fallbacks}) or None
else:
    child_fallback = getattr(parent_agent, "_fallback_chain", None) or None
```

When no delegation-specific fallback is configured, the parent chain is inherited — preserving backward compatibility from #7481.

## Verification
- New test verifies a delegated child with its own fallback_providers uses that chain, not the parent's
- Backward compatible: child without delegation.fallback_providers still inherits parent chain
- Existing delegation tests pass