### PR TITLE
fix(media): stage ephemeral MEDIA paths into durable Hermes cache

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6994,11 +6994,9 @@ def run_job(
         # Cron runs start a fresh conversation, so history_offset=0. The
         # helper is fail-open and no-ops without a MEDIA: directive.
         if final_response:
-            from gateway.media_repair import (
-                repair_explicit_computer_use_media_paths,
-            )
+            from gateway.media_repair import finalize_chat_media_paths
 
-            final_response = repair_explicit_computer_use_media_paths(
+            final_response = finalize_chat_media_paths(
                 final_response,
                 result.get("messages", []),
             )

--- a/gateway/media_repair.py
+++ b/gateway/media_repair.py
@@ -1,29 +1,33 @@
-"""Repair model-mangled ``computer_use`` screenshot paths in final responses.
+"""Repair and durable-stage ``MEDIA:`` paths in final assistant responses.
 
-``computer_use`` persists a bounded screenshot into the Hermes image cache and
-tells the model its absolute path.  Some models rewrite a Windows path into a
-POSIX-looking one (``C:\\Users\\Alice\\...`` -> ``/Users/Alice/...``) when
-emitting an explicit ``MEDIA:`` directive, so delivery-path validation rejects
-the nonexistent path and the attachment is dropped.
+Two related jobs share this module so every delivery surface (messaging
+gateway, TUI/desktop, cron) applies the same path hygiene:
 
-The repair is deliberately narrow: it only rewrites paths inside a response
-that *already* carries an explicit ``MEDIA:`` directive, and only when the
-directive's generated ``computer_use_<uuid>`` basename exactly matches a
-canonical screenshot path returned by ``computer_use`` in the current turn.
-It never auto-attaches captures, and normal media path validation still runs
-after the repair.
+1. **computer_use repair** — recover model-mangled screenshot paths when the
+   model rewrites a Windows path into a POSIX-looking one inside an explicit
+   ``MEDIA:`` directive.
+2. **ephemeral staging** — copy ``MEDIA:`` targets that live under volatile
+   locations (``/tmp``, system temp, etc.) into
+   ``$HERMES_HOME/cache/*/chat-media/`` and rewrite the tags. Desktop remote
+   mode fetches those paths via ``/api/fs/read-data-url``; if the agent left
+   files only in ``/tmp`` and the OS reaped them, the UI shows
+   "Couldn't fetch … from the gateway (missing, unreadable, or too large)."
 
-This lives in its own module (mirroring ``gateway/media_policy.py``) so every
-delivery surface — the messaging gateway's main turn path, gateway background
-tasks, and cron job delivery — shares one implementation.
+Staging is fail-open and size-capped. Paths already under the Hermes cache
+are left alone.
 """
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import os
 import re
-from typing import Any, Dict, Iterator, List
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, Iterator, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -211,3 +215,202 @@ def _repair_explicit_computer_use_media_paths_inner(
         if canonical and emitted_path != canonical:
             repaired = repaired.replace(emitted_path, canonical)
     return repaired
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral MEDIA staging for durable chat display
+# ---------------------------------------------------------------------------
+
+# Cap staged copies so a runaway MEDIA dump cannot fill the Hermes home.
+# Matches the desktop /api/fs/read-data-url ceiling for inline image display.
+_CHAT_MEDIA_STAGE_MAX_BYTES = 16 * 1024 * 1024
+
+_IMAGE_EXTS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp", ".tiff", ".svg"}
+_AUDIO_EXTS = {".mp3", ".m2a", ".wav", ".ogg", ".opus", ".m4a", ".flac"}
+_VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
+
+_EPHEMERAL_PREFIXES = (
+    "/tmp/",
+    "/var/tmp/",
+    "/private/tmp/",  # macOS
+)
+
+
+def _chat_media_bucket(ext: str) -> str:
+    e = (ext or "").lower()
+    if e in _IMAGE_EXTS:
+        return "images"
+    if e in _AUDIO_EXTS:
+        return "audio"
+    if e in _VIDEO_EXTS:
+        return "videos"
+    return "documents"
+
+
+def _is_ephemeral_media_path(path: Path) -> bool:
+    """True when a path is expected to vanish (tmp dirs, OS temp roots)."""
+    try:
+        resolved = path.expanduser().resolve(strict=False)
+    except (OSError, RuntimeError, ValueError):
+        return False
+    s = str(resolved)
+    posix = s.replace("\\", "/")
+    lower = posix.lower()
+    for prefix in _EPHEMERAL_PREFIXES:
+        base = prefix.rstrip("/").lower()
+        if lower == base or lower.startswith(base + "/"):
+            return True
+    try:
+        tmp = Path(tempfile.gettempdir()).expanduser().resolve(strict=False)
+        tmp_s = str(tmp).replace("\\", "/").lower()
+        if lower == tmp_s or lower.startswith(tmp_s.rstrip("/") + "/"):
+            return True
+    except (OSError, RuntimeError, ValueError):
+        pass
+    # macOS per-user temp: /var/folders/.../T/
+    if "/var/folders/" in lower and "/t/" in lower:
+        return True
+    return False
+
+
+def _already_in_hermes_cache(path: Path) -> bool:
+    """Skip restaging files already under $HERMES_HOME cache trees."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        home = get_hermes_home().expanduser().resolve(strict=False)
+        resolved = path.expanduser().resolve(strict=False)
+        try:
+            resolved.relative_to(home / "cache")
+            return True
+        except ValueError:
+            pass
+        for legacy in ("image_cache", "audio_cache", "video_cache", "document_cache", "media"):
+            try:
+                resolved.relative_to(home / legacy)
+                return True
+            except ValueError:
+                continue
+    except Exception:
+        return False
+    return False
+
+
+def _stage_one_media_file(src: Path) -> Optional[Path]:
+    """Copy *src* into $HERMES_HOME/cache/<bucket>/chat-media/ and return dest."""
+    try:
+        if not src.is_file():
+            return None
+        st = src.stat()
+        if st.st_size <= 0 or st.st_size > _CHAT_MEDIA_STAGE_MAX_BYTES:
+            return None
+        if _already_in_hermes_cache(src):
+            return src
+        if not _is_ephemeral_media_path(src):
+            return None
+
+        from hermes_constants import get_hermes_home
+
+        ext = src.suffix.lower() or ".bin"
+        bucket = _chat_media_bucket(ext)
+        dest_dir = get_hermes_home() / "cache" / bucket / "chat-media"
+        dest_dir.mkdir(parents=True, exist_ok=True)
+
+        digest = hashlib.sha1(
+            str(src.resolve(strict=False)).encode("utf-8", "replace")
+        ).hexdigest()[:10]
+        stem = re.sub(r"[^A-Za-z0-9._-]+", "_", src.stem)[:80] or "media"
+        dest = dest_dir / f"{stem}-{digest}{ext}"
+        if dest.exists() and dest.stat().st_size == st.st_size:
+            return dest
+        tmp = dest.with_name(f".{dest.name}.tmp-{os.getpid()}")
+        try:
+            shutil.copy2(src, tmp)
+            os.replace(tmp, dest)
+        finally:
+            try:
+                if tmp.exists():
+                    tmp.unlink()
+            except OSError:
+                pass
+        return dest
+    except Exception:
+        logger.debug("chat media stage failed for %s", src, exc_info=True)
+        return None
+
+
+def stage_ephemeral_chat_media_paths(response: str) -> str:
+    """Copy ephemeral ``MEDIA:`` targets into durable Hermes cache and rewrite tags.
+
+    Fail-open: any error leaves the response unchanged. Non-ephemeral paths
+    (project trees, already-cached artifacts) are left alone.
+    """
+    if not response or "MEDIA:" not in response:
+        return response
+    try:
+        from gateway.platforms.base import (
+            MEDIA_TAG_CLEANUP_RE,
+            BasePlatformAdapter,
+            _normalize_media_tag_path,
+        )
+    except Exception:
+        logger.debug("chat media stage import failed", exc_info=True)
+        return response
+
+    try:
+        scan = BasePlatformAdapter._mask_protected_spans(response)
+        scan = BasePlatformAdapter._mask_json_string_media(scan)
+    except Exception:
+        scan = response
+
+    replacements: list[Tuple[str, str]] = []
+    seen: set[str] = set()
+    try:
+        for match in MEDIA_TAG_CLEANUP_RE.finditer(scan):
+            raw = match.group("path")
+            path_str = _normalize_media_tag_path(raw)
+            if not path_str or path_str in seen:
+                continue
+            seen.add(path_str)
+            try:
+                src = Path(path_str).expanduser()
+                if not src.is_absolute():
+                    continue
+            except (OSError, RuntimeError, ValueError):
+                continue
+            dest = _stage_one_media_file(src)
+            if dest is None:
+                continue
+            dest_s = str(dest)
+            if dest_s != path_str:
+                replacements.append((path_str, dest_s))
+    except Exception:
+        logger.debug("chat media stage scan failed", exc_info=True)
+        return response
+
+    if not replacements:
+        return response
+
+    repaired = response
+    for old, new in sorted(replacements, key=lambda pair: len(pair[0]), reverse=True):
+        repaired = repaired.replace(old, new)
+    return repaired
+
+
+def finalize_chat_media_paths(
+    response: str,
+    messages: Optional[List[Dict[str, Any]]] = None,
+    history_offset: int = 0,
+) -> str:
+    """Apply computer_use path repair then durable ephemeral MEDIA staging.
+
+    Shared entry point for gateway turn / background / cron / TUI so no surface
+    forgets one of the two steps.
+    """
+    if not isinstance(response, str) or not response:
+        return response
+    if messages is not None and "MEDIA:" in response:
+        response = repair_explicit_computer_use_media_paths(
+            response, messages, history_offset=history_offset
+        )
+    return stage_ephemeral_chat_media_paths(response)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2096,6 +2096,7 @@ _TOOL_MEDIA_RE = re.compile(
 # Canonical names live in gateway.media_repair (same retirement of private
 # aliases as the agent.replay_cleanup import above).
 from gateway.media_repair import (  # noqa: E402
+    finalize_chat_media_paths,
     repair_explicit_computer_use_media_paths,
     tool_name_by_call_id as _tool_name_by_call_id,
 )
@@ -7144,7 +7145,7 @@ class TurnRunner:
         if isinstance(result, dict):
             _result_final = result.get("final_response")
             if isinstance(_result_final, str):
-                result["final_response"] = repair_explicit_computer_use_media_paths(
+                result["final_response"] = finalize_chat_media_paths(
                     _result_final,
                     result.get("messages", []),
                     history_offset=len(agent_history),
@@ -25608,7 +25609,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             # so history_offset=0: every message in the run belongs to this
             # turn. Mirrors the repair on the main turn path.
             if response:
-                response = repair_explicit_computer_use_media_paths(
+                response = finalize_chat_media_paths(
                     response,
                     result.get("messages", []),
                 )

--- a/tests/gateway/test_chat_media_stage.py
+++ b/tests/gateway/test_chat_media_stage.py
@@ -1,0 +1,91 @@
+"""Tests for durable ephemeral MEDIA staging in chat responses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from gateway.media_repair import (
+    finalize_chat_media_paths,
+    stage_ephemeral_chat_media_paths,
+)
+
+
+def test_stage_ephemeral_tmp_media_rewrites_to_hermes_cache(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="hermes-media-stage-") as td:
+        src_file = Path(td) / "preview.png"
+        src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"0" * 64)
+
+        response = f"Here is the mark.\nMEDIA:{src_file}\n"
+        out = stage_ephemeral_chat_media_paths(response)
+
+        assert "MEDIA:" in out
+        assert str(src_file) not in out
+        assert "chat-media" in out
+        new_path = out.split("MEDIA:", 1)[1].strip().split()[0]
+        assert Path(new_path).is_file()
+        assert Path(new_path).read_bytes() == src_file.read_bytes()
+        assert str(hermes_home.resolve()) in str(Path(new_path).resolve())
+
+
+def test_stage_skips_non_ephemeral_project_paths(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    # pytest's tmp_path lives under /tmp (ephemeral). Force a non-ephemeral
+    # classification so we only assert the "leave project paths alone" branch.
+    import gateway.media_repair as mr
+
+    monkeypatch.setattr(mr, "_is_ephemeral_media_path", lambda path: False)
+
+    project = tmp_path / "project"
+    project.mkdir()
+    img = project / "logo.png"
+    img.write_bytes(b"PNGDATA" + b"1" * 32)
+
+    response = f"MEDIA:{img}"
+    out = stage_ephemeral_chat_media_paths(response)
+    assert out == response
+
+
+def test_stage_skips_code_fence_examples(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="hermes-media-stage-") as td:
+        src_file = Path(td) / "real.png"
+        src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"2" * 32)
+        response = (
+            "Use this form:\n"
+            "```\n"
+            "MEDIA:/tmp/example-only.png\n"
+            "```\n"
+            f"MEDIA:{src_file}\n"
+        )
+        out = stage_ephemeral_chat_media_paths(response)
+        assert "MEDIA:/tmp/example-only.png" in out
+        assert str(src_file) not in out
+        assert "chat-media" in out
+
+
+def test_finalize_combines_without_messages(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    import tempfile
+
+    with tempfile.TemporaryDirectory(prefix="hermes-media-stage-") as td:
+        src_file = Path(td) / "x.png"
+        src_file.write_bytes(b"\x89PNG\r\n\x1a\n" + b"3" * 16)
+        out = finalize_chat_media_paths(f"MEDIA:{src_file}")
+        assert "chat-media" in out

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13743,6 +13743,16 @@ def _run_prompt_submit(
                 )
 
                 raw = result.get("final_response", "")
+                if isinstance(raw, str) and "MEDIA:" in raw:
+                    try:
+                        from gateway.media_repair import finalize_chat_media_paths
+
+                        raw = finalize_chat_media_paths(
+                            raw,
+                            result.get("messages", []) if isinstance(result, dict) else [],
+                        )
+                    except Exception:
+                        pass
                 status = (
                     "interrupted"
                     if result.get("interrupted")


### PR DESCRIPTION
## Summary
Desktop remote mode loads `MEDIA:` attachments through `/api/fs/read-data-url`. Agents often write preview images under `/tmp` (or other OS temp roots). When those files are gone by the time the desktop fetches them, the chat UI shows:

> Couldn't fetch … from the gateway (missing, unreadable, or too large).

This change copies **ephemeral** `MEDIA:` targets into `$HERMES_HOME/cache/{images,audio,videos,documents}/chat-media/` and rewrites the tags before the response is delivered/stored, so chat history keeps a durable gateway-readable path.

## Changes
- `gateway/media_repair.py`: add `stage_ephemeral_chat_media_paths` + `finalize_chat_media_paths` (computer_use path repair then durable staging)
- Wire `finalize_chat_media_paths` on gateway turn, gateway background tasks, cron delivery, and TUI/desktop final response
- Fail-open, 16MB cap (matches desktop data-URL read ceiling), skip non-temp project paths and already-cached Hermes artifacts, mask code-fence examples

## Test plan
- [x] `pytest tests/gateway/test_chat_media_stage.py tests/gateway/test_media_extraction.py` (19 passed)
- [ ] Manual: remote desktop session, agent emits `MEDIA:/tmp/foo.png`, confirm image renders and path under `~/.hermes/cache/images/chat-media/`
- [ ] Confirm project-path `MEDIA:` (non-temp) is left unchanged