### PR TITLE
fix(tts): don't silently truncate spoken replies by default

### DIFF
--- a/tests/tools/test_tts_prepare_spoken.py
+++ b/tests/tools/test_tts_prepare_spoken.py
@@ -81,6 +81,16 @@ class TestNewlineFlattening:
         assert "First line" in spoken
         assert "Third paragraph" in spoken
 
+    def test_default_does_not_silently_truncate_visible_reply(self):
+        raw = "A" * 4500
+        spoken = prepare_spoken_text(raw)
+        assert len(spoken) == 4500
+
+    def test_explicit_max_chars_still_truncates_when_requested(self):
+        raw = "B" * 50
+        spoken = prepare_spoken_text(raw, max_chars=10)
+        assert spoken == "B" * 10
+
 
     def test_existing_punctuation_not_doubled(self):
         out = flatten_newlines_for_payload("Alpha.\nBeta!")

--- a/tools/tts_text_normalize.py
+++ b/tools/tts_text_normalize.py
@@ -258,7 +258,7 @@ def flatten_newlines_for_payload(text: str) -> str:
     return text.strip()
 
 
-def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
+def prepare_spoken_text(text: str, max_chars: int | None = None) -> str:
     """Return a TTS-friendly script from assistant text.
 
     Deterministic cleanup, not a semantic rewrite: it removes ``<think>``
@@ -267,6 +267,11 @@ def prepare_spoken_text(text: str, max_chars: int | None = 4000) -> str:
     turns visual line formatting into speakable sentence pauses, and flattens
     the result to a single line so newline-sensitive providers (Kokoro) speak
     the whole script.
+
+    Do not truncate by default. Christo expects spoken replies to match the
+    visible response, not a silent summary or shortened variant. Provider-safe
+    chunking and hard provider limits must be handled by the TTS tool/provider
+    layer so the caller can split, combine, or report an explicit failure.
     """
     spoken = strip_nonspoken_blocks(text)
     spoken = strip_markdown_for_tts(spoken)


### PR DESCRIPTION
## Qué cambia

`prepare_spoken_text` tenía `max_chars=4000` por defecto, lo que **truncaba silenciosamente** las respuestas largas antes de llegar al proveedor de TTS. El resultado era un audio que leía una versión cortada/resumida en lugar del texto visible completo.

Ahora el valor por defecto es **sin truncado**, para que el audio leído corresponda exactamente a la respuesta visible. El particionado seguro y los límites duros del proveedor se delegan a la capa del tool/provider de TTS, que puede dividir, combinar o reportar un fallo explícito en vez de perder texto en silencio.

## Por qué

Este responde a una regla operativa de uso continuo: el audio hablado debe leer **la misma respuesta textual** enviada, no un resumen ni una variante cortada.

## Tests

15/~15 pasan en `tests/tools/test_tts_prepare_spoken.py`, incluyendo dos nuevos: default sin truncado y truncado explícito por `max_chars`.