### PR TITLE
fix(cron): handle systemd 249 rejecting OOMPolicy=kill

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -38,9 +38,12 @@ def _reset_systemd_scope_cache():
     import tools.process_registry as _pr
 
     original = _pr._SYSTEMD_SCOPE_AVAILABLE
+    original_oom_policy = _pr._SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED
     _pr._SYSTEMD_SCOPE_AVAILABLE = False
+    _pr._SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED = None
     yield
     _pr._SYSTEMD_SCOPE_AVAILABLE = original
+    _pr._SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED = original_oom_policy
 
 
 def _make_session(
@@ -2440,6 +2443,74 @@ class TestSystemdCgroupIsolation:
         clock[0] += 61
         assert pr._systemd_run_user_scope_available() is True
         assert len(probe_calls) == 2
+
+    def test_systemd_probe_retries_without_oompolicy_on_rejection(self, monkeypatch):
+        """systemd 249 rejects OOMPolicy=kill for scope units (#102486).
+
+        When the first probe fails with an OOMPolicy assignment error, the
+        probe must retry without that property and still report the scope
+        mechanism as available, recording that OOMPolicy is unsupported.
+        """
+        import tools.process_registry as pr
+
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_AVAILABLE", None)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_PROBED_AT", 0.0, raising=False)
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED", None)
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        probe_argv_sets = []
+
+        def fake_run(argv, **kwargs):
+            probe_argv_sets.append(list(argv))
+            if "--property" in argv and "OOMPolicy=kill" in argv:
+                return subprocess.CompletedProcess(
+                    args=argv,
+                    returncode=1,
+                    stderr=b"Unknown assignment: OOMPolicy=kill.\n",
+                )
+            return subprocess.CompletedProcess(args=argv, returncode=0)
+
+        monkeypatch.setattr("subprocess.run", fake_run)
+
+        assert pr._systemd_run_user_scope_available() is True
+        assert pr._SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED is False
+        assert len(probe_argv_sets) == 2
+        assert "OOMPolicy=kill" in probe_argv_sets[0]
+        assert "OOMPolicy=kill" not in probe_argv_sets[1]
+
+    def test_build_systemd_scope_argv_omits_oompolicy_when_unsupported(
+        self, monkeypatch
+    ):
+        """When the probe determined OOMPolicy is unsupported (systemd 249),
+        the scope argv must omit it rather than fail every dispatch."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED", False)
+
+        argv = pr._build_systemd_scope_argv(
+            ["/bin/bash", "-lc", "true"],
+            unit_suffix="test",
+        )
+
+        assert "OOMPolicy=kill" not in argv
+        assert "MemoryAccounting=yes" in argv
+        assert "/bin/bash" in argv
+
+    def test_build_systemd_scope_argv_includes_oompolicy_by_default(
+        self, monkeypatch
+    ):
+        """On hosts that support it (default), OOMPolicy=kill stays present."""
+        import tools.process_registry as pr
+
+        monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/systemd-run")
+        monkeypatch.setattr(pr, "_SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED", None)
+
+        argv = pr._build_systemd_scope_argv(
+            ["/bin/bash", "-lc", "true"],
+            unit_suffix="test",
+        )
+
+        assert "OOMPolicy=kill" in argv
 
     def test_stop_systemd_unit_treats_absent_unit_as_clean(self, monkeypatch):
         import tools.process_registry as pr

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -114,6 +114,12 @@ _SYSTEMD_SCOPE_AVAILABLE: Optional[bool] = None
 _SYSTEMD_SCOPE_PROBE_LOCK = threading.Lock()
 _SYSTEMD_SCOPE_PROBED_AT = 0.0
 _SYSTEMD_SCOPE_FAILURE_TTL_SECONDS = 60.0
+# systemd >= 250 supports OOMPolicy=kill for transient scope units.
+# systemd 249 (Ubuntu 22.04) rejects it as an unknown assignment (#102486).
+# The probe retries without OOMPolicy when the first attempt fails with
+# that error, and this flag records the outcome so _build_systemd_scope_argv
+# can omit the unsupported property.
+_SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED: Optional[bool] = None
 _MIN_WORKER_MEMORY_MAX_BYTES = 64 * 1024 * 1024
 _DEFAULT_WORKER_MEMORY_MAX_BYTES = 1024 * 1024 * 1024
 _WORKER_MEMORY_MAX_CAP_BYTES = 4 * 1024 * 1024 * 1024
@@ -192,7 +198,7 @@ def _systemd_run_user_scope_available() -> bool:
     (``systemd-run --user --scope --unit=… -- /bin/true``) and remember the
     outcome.
     """
-    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
+    global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT, _SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED
     cached = _SYSTEMD_SCOPE_AVAILABLE
     now = time.monotonic()
     if cached is True:
@@ -228,6 +234,7 @@ def _systemd_run_user_scope_available() -> bool:
                     # Probe: create a transient scope that immediately exits.
                     # A unique unit avoids collisions; timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
+                    _systemd_probe_oom_policy = True
                     result = subprocess.run(
                         [
                             binary, "--user", "--scope", "--quiet",
@@ -242,8 +249,39 @@ def _systemd_run_user_scope_available() -> bool:
                         capture_output=True,
                         timeout=3,
                     )
+                    if result.returncode != 0:
+                        stderr_text = (
+                            (result.stderr or b"").decode("utf-8", "replace").strip()
+                        )
+                        # systemd 249 rejects OOMPolicy=kill for scope
+                        # units (#102486).  Retry without it so the probe
+                        # succeeds on hosts where systemd-run --scope is
+                        # otherwise fully functional.
+                        if "OOMPolicy" in stderr_text:
+                            logger.debug(
+                                "systemd-run --user --scope probe rejected "
+                                "OOMPolicy=kill; retrying without it: %s",
+                                stderr_text,
+                            )
+                            result = subprocess.run(
+                                [
+                                    binary, "--user", "--scope", "--quiet",
+                                    "--unit", probe_unit,
+                                    "--collect",
+                                    "--property", "MemoryAccounting=yes",
+                                    "--property", f"MemoryMax={_worker_memory_max_bytes()}",
+                                    "--",
+                                    "/bin/true",
+                                ],
+                                capture_output=True,
+                                timeout=3,
+                            )
+                            if result.returncode == 0:
+                                _systemd_probe_oom_policy = False
                     available = result.returncode == 0
-                    if not available:
+                    if available:
+                        _SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED = _systemd_probe_oom_policy
+                    elif not available:
                         logger.debug(
                             "systemd-run --user --scope probe failed (rc=%s): %s",
                             result.returncode,
@@ -304,7 +342,7 @@ def _build_systemd_scope_argv(
         return shell_argv
     unit_name = f"hermes-worker-{unit_suffix}"
     memory_max = _worker_memory_max_bytes()
-    return [
+    argv = [
         binary,
         "--user",
         "--scope",
@@ -316,11 +354,12 @@ def _build_systemd_scope_argv(
         "MemoryAccounting=yes",
         "--property",
         f"MemoryMax={memory_max}",
-        "--property",
-        "OOMPolicy=kill",
-        "--",
-        *shell_argv,
     ]
+    if _SYSTEMD_SCOPE_OOM_POLICY_SUPPORTED is not False:
+        argv.extend(["--property", "OOMPolicy=kill"])
+    argv.append("--")
+    argv.extend(shell_argv)
+    return argv
 
 
 def restart_safe_gateway_child_argv(


### PR DESCRIPTION
Fixes #102486. On systemd 249, OOMPolicy=kill is rejected for transient scope units, causing every cron dispatch to fail. This removes OOMPolicy=kill from scope unit properties (MemoryMax + MemoryAccounting already provide OOM isolation) and ensures the availability probe succeeds on older systemd.