### PR TITLE
fix(context): honor stringly model.context_length instead of silently auto-detecting (#102626)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3089,7 +3089,7 @@ def get_model_context_length(
     model: str,
     base_url: str = "",
     api_key: str = "",
-    config_context_length: int | None = None,
+    config_context_length: int | str | float | None = None,
     provider: str = "",
     custom_providers: list | None = None,
 ) -> int:
@@ -3622,7 +3622,7 @@ async def get_model_context_length_async(
     model: str,
     base_url: str = "",
     api_key: str = "",
-    config_context_length: int | None = None,
+    config_context_length: int | str | float | None = None,
     provider: str = "",
     custom_providers: list | None = None,
 ) -> int:

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -3060,6 +3060,31 @@ def _resolve_nous_context_length(
     return None, ""
 
 
+def coerce_context_length_override(value: Any) -> Optional[int]:
+    """Coerce a configured ``model.context_length`` to a positive int.
+
+    Config values can arrive as strings (hand-edited YAML, ``config set``,
+    REST/PUT payloads) or floats. Read boundaries previously strict-checked
+    ``isinstance(int)`` and silently fell through to auto-detection for
+    anything else — so an explicit ``"128000"`` was ignored and the
+    conversation used the detected window (#102626). Returns the positive
+    int, else None (unset/auto).
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value if value > 0 else None
+    if isinstance(value, float):
+        return int(value) if value > 0 and value.is_integer() else None
+    if isinstance(value, str):
+        try:
+            parsed = int(value.strip())
+        except (TypeError, ValueError):
+            return None
+        return parsed if parsed > 0 else None
+    return None
+
+
 def get_model_context_length(
     model: str,
     base_url: str = "",
@@ -3095,8 +3120,9 @@ def get_model_context_length(
     8. Hardcoded defaults (broad family patterns, longest-key-first)
     9. Default fallback (256K)"""
     # 0. Explicit config override — user knows best
-    if config_context_length is not None and isinstance(config_context_length, int) and config_context_length > 0:
-        return config_context_length
+    _override_ctx = coerce_context_length_override(config_context_length)
+    if _override_ctx is not None:
+        return _override_ctx
 
     # 0a. MoA virtual provider — ``model`` is a preset name, not a real model,
     # and ``base_url`` is the local virtual endpoint, so every probe below would

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -6093,10 +6093,14 @@ def _normalize_config_for_web(config: Dict[str, Any]) -> Dict[str, Any]:
     config = dict(config)  # shallow copy
     model_val = config.get("model")
     if isinstance(model_val, dict):
-        # Extract context_length before flattening the dict
+        # Extract context_length before flattening the dict. Values can be
+        # strings (hand-edited YAML) — coerce so an explicit override never
+        # displays as auto-detect (#102626).
+        from agent.model_metadata import coerce_context_length_override
+
         ctx_len = model_val.get("context_length", 0)
         config["model"] = model_val.get("default", model_val.get("name", ""))
-        config["model_context_length"] = ctx_len if isinstance(ctx_len, int) else 0
+        config["model_context_length"] = coerce_context_length_override(ctx_len) or 0
     else:
         config["model_context_length"] = 0
     return config
@@ -7444,8 +7448,12 @@ def get_model_info(profile: Optional[str] = None):
             auto_ctx = 0
 
         config_ctx_int = 0
-        if isinstance(config_ctx, int) and config_ctx > 0:
-            config_ctx_int = config_ctx
+        if config_ctx is not None:
+            from agent.model_metadata import coerce_context_length_override
+
+            # Coerce (hand-edited YAML can hold strings) so an explicit
+            # override is reported — never silently shown as auto (#102626).
+            config_ctx_int = coerce_context_length_override(config_ctx) or 0
 
         # Effective is what the agent actually uses
         effective_ctx = config_ctx_int if config_ctx_int > 0 else auto_ctx

--- a/tests/hermes_cli/test_custom_provider_context_length.py
+++ b/tests/hermes_cli/test_custom_provider_context_length.py
@@ -203,6 +203,63 @@ class TestGetModelContextLengthHonorsOverride:
                 p.stop()
         assert ctx == DEFAULT_FALLBACK_CONTEXT
 
+    def test_string_config_context_length_is_honored(self):
+        """A numeric string override (hand-edited YAML, REST payload) must
+        win at step 0 — never silently fall through to auto-detect (#102626).
+        """
+        from agent.model_metadata import get_model_context_length
+        ctx = get_model_context_length(
+            "m",
+            base_url="https://example.invalid/v1",
+            provider="custom",
+            config_context_length="500000",
+            custom_providers=None,
+        )
+        assert ctx == 500_000
+
+    def test_garbage_string_config_context_length_falls_through(self):
+        """A non-numeric override is not a window — resolution must fall
+        through to the normal chain instead of returning it (#102626).
+        """
+        from agent.model_metadata import get_model_context_length, DEFAULT_FALLBACK_CONTEXT
+        patches = self._mock_all_probes()
+        for p in patches:
+            p.start()
+        try:
+            ctx = get_model_context_length(
+                "unknown-model",
+                base_url="https://example.invalid/v1",
+                provider="custom",
+                config_context_length="not-a-number",
+                custom_providers=None,
+            )
+        finally:
+            for p in patches:
+                p.stop()
+        assert ctx == DEFAULT_FALLBACK_CONTEXT
+
+
+class TestCoerceContextLengthOverride:
+    """coerce_context_length_override: one contract for every read boundary."""
+
+    def test_coercion_table(self):
+        from agent.model_metadata import coerce_context_length_override
+        assert coerce_context_length_override(128000) == 128000
+        assert coerce_context_length_override("128000") == 128000
+        assert coerce_context_length_override("  128000  ") == 128000
+        assert coerce_context_length_override(128000.0) == 128000
+        assert coerce_context_length_override(None) is None
+        assert coerce_context_length_override(0) is None
+        assert coerce_context_length_override(-5) is None
+        assert coerce_context_length_override("0") is None
+        assert coerce_context_length_override("-5") is None
+        assert coerce_context_length_override("not-a-number") is None
+        assert coerce_context_length_override("128000.5") is None
+        assert coerce_context_length_override(128000.5) is None
+        assert coerce_context_length_override(True) is None
+        assert coerce_context_length_override(False) is None
+        assert coerce_context_length_override([128000]) is None
+
 
 class TestContextProbeTiers:
     def test_256k_is_top_tier_and_default(self):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -3165,6 +3165,30 @@ class TestModelContextLength:
         assert result["model"] == "anthropic/claude-sonnet-4"
         assert result["model_context_length"] == 0
 
+    def test_normalize_coerces_string_context_length(self):
+        """A numeric string on disk (hand-edited YAML) must surface as the
+        override — never display as auto-detect (#102626)."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        result = _normalize_config_for_web({
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "provider": "openrouter",
+                "context_length": "200000",
+            }
+        })
+        assert result["model_context_length"] == 200000
+
+    def test_normalize_rejects_garbage_context_length(self):
+        """Non-numeric/zero/negative values mean auto (0), not a window."""
+        from hermes_cli.web_server import _normalize_config_for_web
+
+        for bad in ("not-a-number", 0, -5, "0", None, True):
+            result = _normalize_config_for_web({
+                "model": {"default": "m", "context_length": bad}
+            })
+            assert result["model_context_length"] == 0, bad
+
 
     def test_denormalize_writes_context_length_into_model_dict(self):
         """denormalize should write model_context_length back into model dict."""
@@ -3334,6 +3358,26 @@ class TestModelInfoEndpoint:
         assert resp.status_code == 200
         data = resp.json()
         assert data["auto_context_length"] == 0
+
+    def test_model_info_string_context_length_is_effective(self, monkeypatch):
+        """A numeric string on disk must be reported as the override and win
+        as effective — never silently shown as auto-detect (#102626)."""
+        import hermes_cli.web_server as ws
+
+        monkeypatch.setattr(ws, "load_config", lambda: {
+            "model": {
+                "default": "anthropic/claude-opus-4.6",
+                "provider": "openrouter",
+                "context_length": "100000",
+            }
+        })
+
+        with patch("agent.model_metadata.get_model_context_length", return_value=200000):
+            resp = self.client.get("/api/model/info")
+
+        data = resp.json()
+        assert data["config_context_length"] == 100000
+        assert data["effective_context_length"] == 100000
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #102626 — a `model.context_length` override stored as a **string** (hand-edited `config.yaml`, REST/PUT payloads, `config set`) was silently ignored at every read boundary, so Desktop (and any consumer of `GET /api/model/info`) fell through to the auto-detected window even though the user explicitly set one.

## Root cause

Three read boundaries strict-checked `isinstance(value, int)` and treated anything else as "auto":

- `agent/model_metadata.py` — `get_model_context_length()` step 0 ("user knows best") returned the override only for `int`, so `"128000"` fell through to probing/defaults;
- `hermes_cli/web_server.py` — `_normalize_config_for_web()` surfaced `model_context_length: 0`, so Settings displayed auto-detect;
- `hermes_cli/web_server.py` — `GET /api/model/info` reported `config_context_length: 0` with `effective` = auto.

Meanwhile the write path (`_denormalize_config_from_web`), `agent_init`, the gateway blocks, and `get_custom_provider_context_length` all coerce via `int()` — so the value round-tripped into `config.yaml` fine and was then dropped on read. Reproduced pre-fix: `config_context_length="128000"` resolved to the 256K fallback with a log line telling the user to set the very key that was already set.

## Fix

One shared helper, `coerce_context_length_override()` in `agent/model_metadata.py` (positive-int contract: ints pass, numeric strings and integral floats coerce, zero/negative/garbage/bool → `None` = auto), applied at all three read boundaries. The async resolver delegates to the sync chain, so it is covered automatically. Precedence is unchanged — step 0 still outranks custom-providers (step 0b) and every probe.

## Tests

Behavior-contract tests (no snapshots):

- `tests/hermes_cli/test_custom_provider_context_length.py` — string override wins at step 0; garbage string falls through to the default; full coercion table for the helper;
- `tests/hermes_cli/test_web_server.py` — normalize coerces `"200000"` and rejects garbage; `/api/model/info` reports a string override as config *and* effective.

Suites run, all green: `test_custom_provider_context_length` (12) + `test_model_metadata_local_ctx` (37) + `test_web_server` (189) + context/compressor neighbors — `test_context_compressor`, `test_apply_model_switch_result_context`, `test_model_switch_context_display`, `test_ollama_num_ctx`, `test_switch_model_context` (176).

## Related work (no collision)

- Open #99305 by @fangliquanflq targets adjacent precedence (`Closes #99286`, custom-provider route) in `agent_init`/`context_compressor`/`config.py` — different files, compatible ordering (this fix sits strictly before that chain at step 0).
- Sibling #102644 by @spark4862 covers a different source (compressor lazy path vs `providers.<name>.models` entries), not the top-level pin fixed here.

---
 contributed by Bruno Bza (@BrunoBza)
