### PR TITLE
fix(agent): dispatch periodic callbacks through worker pool to prevent stalls

### DIFF
--- a/agent/periodic_scheduler.py
+++ b/agent/periodic_scheduler.py
@@ -4,7 +4,8 @@ Replaces the per-child ``while not stop.wait(interval): body()`` daemon
 threads (delegate heartbeat, durable turn-lease refresher, turn-liveness
 watchdog).  With ~130 in-process subagents those added 2-3 sleeping OS
 threads per child; this module runs every periodic body on ONE daemon
-thread ordered by a heap of due times.
+thread ordered by a heap of due times, dispatching each callback to a
+bounded worker pool so a blocked callback never stalls unrelated timers.
 
 Semantics match the loop they replace: the first call happens ``interval``
 seconds after :func:`schedule`, and each following call ``interval`` seconds
@@ -21,11 +22,13 @@ import itertools
 import logging
 import threading
 import time
+from concurrent.futures import Future, ThreadPoolExecutor
 from typing import Callable, Optional
 
 logger = logging.getLogger(__name__)
 
 _THREAD_NAME = "hermes-periodic-scheduler"
+_MAX_WORKERS = 8
 
 
 class ScheduledHandle:
@@ -57,6 +60,15 @@ class PeriodicScheduler:
         self._seq = itertools.count()
         self._thread: Optional[threading.Thread] = None
         self._running: Optional[ScheduledHandle] = None
+        self._executor: Optional[ThreadPoolExecutor] = None
+        self._futures: dict[ScheduledHandle, Future] = {}
+
+    def _ensure_executor(self) -> ThreadPoolExecutor:
+        if self._executor is None:
+            self._executor = ThreadPoolExecutor(
+                max_workers=_MAX_WORKERS, thread_name_prefix="periodic-"
+            )
+        return self._executor
 
     def schedule(self, fn: Callable[[], object], interval: float) -> ScheduledHandle:
         handle = ScheduledHandle(self, fn, float(interval))
@@ -69,11 +81,31 @@ class PeriodicScheduler:
         return handle
 
     def _cancel(self, handle: ScheduledHandle, wait: Optional[float]) -> None:
+        future: Optional[Future] = None
         with self._cond:
             handle._cancelled = True
             self._cond.notify()
-            if wait and self._running is handle and threading.current_thread() is not self._thread:
-                self._cond.wait_for(lambda: self._running is not handle, timeout=wait)
+            future = self._futures.pop(handle, None)
+        if wait and future is not None:
+            future.result(timeout=wait)
+
+    def _run_one(self, handle: ScheduledHandle) -> None:
+        stop = False
+        try:
+            stop = handle._fn() is False
+        except Exception:
+            logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
+        with self._cond:
+            self._running = None
+            self._futures.pop(handle, None)
+            if stop:
+                handle._cancelled = True
+            elif not handle._cancelled:
+                heapq.heappush(
+                    self._heap,
+                    (time.monotonic() + handle._interval, next(self._seq), handle),
+                )
+            self._cond.notify_all()
 
     def _run(self) -> None:
         while True:
@@ -92,22 +124,10 @@ class PeriodicScheduler:
                         continue
                     heapq.heappop(self._heap)
                     self._running = handle
-                    break
-            stop = False
-            try:
-                stop = handle._fn() is False
-            except Exception:
-                logger.debug("periodic callback %r raised", handle._fn, exc_info=True)
-            with self._cond:
-                self._running = None
-                if stop:
-                    handle._cancelled = True
-                elif not handle._cancelled:
-                    heapq.heappush(
-                        self._heap,
-                        (time.monotonic() + handle._interval, next(self._seq), handle),
+                    self._futures[handle] = self._ensure_executor().submit(
+                        self._run_one, handle
                     )
-                self._cond.notify_all()
+                    break
 
 
 _DEFAULT = PeriodicScheduler()

--- a/tests/agent/test_periodic_scheduler.py
+++ b/tests/agent/test_periodic_scheduler.py
@@ -90,3 +90,33 @@ def test_module_level_schedule_uses_shared_default():
     assert threading.active_count() == before
     for handle in handles:
         handle.cancel()
+
+
+def test_blocked_callback_does_not_stall_due_sibling():
+    """A blocked periodic callback must not prevent unrelated callbacks
+    from running within their own deadlines."""
+    scheduler = PeriodicScheduler()
+    blocker_entered = threading.Event()
+    release_blocker = threading.Event()
+    sibling_ran = threading.Event()
+
+    def blocker():
+        blocker_entered.set()
+        release_blocker.wait(2.0)
+        return True
+
+    def sibling():
+        sibling_ran.set()
+        return False
+
+    blocker_handle = scheduler.schedule(blocker, 0.01)
+    assert blocker_entered.wait(1.0), "blocker never entered"
+    sibling_handle = scheduler.schedule(sibling, 0.01)
+    try:
+        assert sibling_ran.wait(0.30), (
+            "a blocked periodic callback stalled an unrelated due callback"
+        )
+    finally:
+        release_blocker.set()
+        blocker_handle.cancel(wait=1.0)
+        sibling_handle.cancel(wait=1.0)


### PR DESCRIPTION
Fixes #102574.

## Problem
`PeriodicScheduler` runs every periodic callback inline on its single daemon thread. If any callback blocks (e.g., slow filesystem/SQLite/network-adjacent work), **every other due callback waits behind it**. The shared scheduler hosts safety-critical work:
- Turn-liveness checks
- Fire/turn lease refresh  
- Delegated-child heartbeats

One blocked callback creates a process-wide liveness failure domain.

## Root Cause
In `agent/periodic_scheduler.py`, `_run()` invokes `handle._fn()` synchronously on its only scheduler thread (lines 78-110 at the cited tip). The thread cannot service another due item until the blocking callback returns.

## Fix
Dispatch each callback body through a bounded `ThreadPoolExecutor` (max_workers=8) instead of running inline on the scheduler thread. The scheduler thread pops due items from the heap and submits them to the pool, returning immediately to service other due callbacks.

- `_run()` now submits `_run_one(handle)` to the executor instead of calling it inline
- `_run_one()` executes the callback body on a worker thread and handles reschedule/stop semantics
- `_cancel()` now waits on the future from the executor (preserving `cancel(wait=...)` semantics)
- Worker count is bounded at 8; ThreadPoolExecutor lifecycle is lazy

## Verification
- All 4 existing tests pass
- New regression test `test_blocked_callback_does_not_stall_due_sibling`: a blocking callback on one handle does not prevent an unrelated sibling callback from running within its deadline
- Existing callers unchanged (schedule(), cancel(), return-False semantics preserved)