### PR TITLE
fix(cron): use non-blocking delivery for bot-chat to avoid session lock conflicts

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -2642,6 +2642,48 @@ def _get_bot_chat_delivery_timeout() -> int:
         return 600
 
 
+# A bot-chat delivery subprocess is fenced out of the target profile's session
+# when another surface (CLI/TUI/Desktop) already owns it — the single-owner
+# session lease refuses a second writer. Retry a bounded number of times with
+# exponential backoff so a transient turn in flight doesn't drop scheduled
+# output, then give up with a clear error (#99956).
+#
+# Delays double each attempt (2s → 4s → 8s → 16s) for ~30s of total backoff,
+# enough for a bot mid-turn to finish without hanging the scheduler.
+_BOT_CHAT_LOCK_RETRY_ATTEMPTS = 5
+_BOT_CHAT_LOCK_RETRY_BASE_SECONDS = 2.0
+
+
+def _is_session_lock_refusal(text: str) -> bool:
+    """True when a bot-chat delivery failure is the single-owner session lease
+    refusing the subprocess (another surface owns the session, or the machine is
+    at its active-session cap) — transient contention a bounded retry can clear —
+    as opposed to auth/quota/config/model errors a retry cannot fix."""
+    lowered = (text or "").lower()
+    return "already has a live owner" in lowered or "active session limit" in lowered
+
+
+def _bot_chat_delivery_lock(profile: str):
+    """Per-profile turn lock for a cron bot-chat delivery.
+
+    Serializes with message_agent / relay delivery turns into the same profile
+    (mirrors ``tools.bot_mode_dm._delivery_lock``) so the scheduled subprocess is
+    not an uncoordinated writer. ``profile`` is ``""`` for the job's own profile,
+    whose lock key is the scheduler's own profile name; a named profile uses its
+    canonical name. Degrades to a no-op when the relay lock machinery is
+    unavailable rather than failing the delivery.
+    """
+    try:
+        from tools.bot_relay import acquire_turn_lock
+    except Exception:  # pragma: no cover — stripped installs / import guard
+        return contextlib.nullcontext()
+    home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
+    root = home.parent.parent if home.parent.name == "profiles" else home
+    if not profile:
+        profile = home.name if home.parent.name == "profiles" else "default"
+    return acquire_turn_lock(root, profile)
+
+
 def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]:
     """Deliver job output into a profile's canonical Bot Chat as an inbound turn.
 
@@ -2651,6 +2693,11 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
     bot receives the output as a real user-role message it can act on.
     Alternation-safe by construction: this is an inbound turn on the chat
     command lane, not a transcript splice.
+
+    The delivery turn runs under the per-profile relay turn lock (so it is
+    not an uncoordinated subprocess), and a single-owner session refusal —
+    the target profile already has a live CLI/TUI/Desktop surface — is
+    retried with backoff before giving up with a clear error (#99956).
 
     ``profile`` is ``""`` for the job's own profile (subprocess inherits this
     scheduler's HERMES_HOME) or a validated local profile name.  Returns None
@@ -2705,23 +2752,61 @@ def _deliver_to_bot_chat(job: dict, content: str, profile: str) -> Optional[str]
             "-Q", "--query-file", query_file,
         ]
 
-        result = subprocess.run(
-            argv,
-            capture_output=True,
-            text=True,
-            timeout=_get_bot_chat_delivery_timeout(),
-            env=env,
-            creationflags=windows_hide_flags(),
-        )
-        if result.returncode != 0:
-            tail = (result.stderr or result.stdout or "").strip()[-500:]
-            msg = (
-                f"bot-chat delivery to profile "
-                f"'{profile or '(own)'}' failed (exit {result.returncode})"
-                + (f": {tail}" if tail else "")
-            )
-            logger.warning("Job '%s': %s", job_id, msg)
-            return msg
+        with _bot_chat_delivery_lock(profile):
+            result = None
+            last_tail = ""
+            for attempt in range(_BOT_CHAT_LOCK_RETRY_ATTEMPTS):
+                result = subprocess.run(
+                    argv,
+                    capture_output=True,
+                    text=True,
+                    timeout=_get_bot_chat_delivery_timeout(),
+                    env=env,
+                    creationflags=windows_hide_flags(),
+                )
+                if result.returncode == 0:
+                    break
+                last_tail = (result.stderr or result.stdout or "").strip()[-500:]
+                if (
+                    not _is_session_lock_refusal(last_tail)
+                    or attempt == _BOT_CHAT_LOCK_RETRY_ATTEMPTS - 1
+                ):
+                    break
+                delay = _BOT_CHAT_LOCK_RETRY_BASE_SECONDS * (2 ** attempt)
+                logger.warning(
+                    "Job '%s': bot-chat delivery to profile '%s' fenced by a live "
+                    "session; retrying in %.1fs (attempt %d/%d)",
+                    job_id,
+                    profile or "(own)",
+                    delay,
+                    attempt + 1,
+                    _BOT_CHAT_LOCK_RETRY_ATTEMPTS,
+                )
+                time.sleep(delay)
+
+            if result.returncode != 0:
+                lowered = last_tail.lower()
+                if "already has a live owner" in lowered:
+                    msg = (
+                        f"bot-chat delivery to profile '{profile or '(own)'}' "
+                        "skipped: the target's Bot Chat is open on another surface "
+                        "(CLI/TUI/Desktop). Close that session or retry the job later."
+                    )
+                elif "active session limit" in lowered:
+                    msg = (
+                        f"bot-chat delivery to profile '{profile or '(own)'}' "
+                        "skipped: the machine is at the active session limit. "
+                        "Retry when a session frees up."
+                    )
+                else:
+                    msg = (
+                        f"bot-chat delivery to profile "
+                        f"'{profile or '(own)'}' failed (exit {result.returncode})"
+                        + (f": {last_tail}" if last_tail else "")
+                    )
+                logger.warning("Job '%s': %s", job_id, msg)
+                return msg
+
         logger.info(
             "Job '%s': delivered to Bot Chat of profile '%s'",
             job_id, profile or "(own)",

--- a/tests/cron/test_cron_bot_chat_delivery.py
+++ b/tests/cron/test_cron_bot_chat_delivery.py
@@ -3,9 +3,11 @@ into a local profile's canonical Bot Chat session as a real inbound turn.
 
 Covers token parsing, target resolution (own profile / named / missing),
 preflight exemption, create-time validation, the subprocess delivery lane,
-and the delivery-targets listing used by UI pickers.
+the single-owner session-lock retry/backoff (#99956), the per-profile turn
+lock, and the delivery-targets listing used by UI pickers.
 """
 
+import contextlib
 import subprocess
 from unittest import mock
 
@@ -15,11 +17,19 @@ from cron import scheduler as sched
 from cron.scheduler import (
     BOT_CHAT_PLATFORM,
     _deliver_to_bot_chat,
+    _is_session_lock_refusal,
     _preflight_check_delivery,
     _resolve_bot_chat_target,
     _resolve_delivery_targets,
     parse_bot_chat_deliver_token,
 )
+
+
+def _no_turn_lock():
+    """Neutralize the per-profile turn lock for subprocess-lane assertions."""
+    return mock.patch.object(
+        sched, "_bot_chat_delivery_lock", return_value=contextlib.nullcontext()
+    )
 
 
 # ── token parsing ────────────────────────────────────────────────────────────
@@ -127,7 +137,8 @@ def test_deliver_runs_canonical_bot_chat_lane():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
          mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the output", "")
 
@@ -152,7 +163,8 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
         calls["kwargs"] = kwargs
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
          mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
          mock.patch.dict(sched.os.environ, {"HERMES_HOME": "/tmp/other-profile"}):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "research")
@@ -165,19 +177,21 @@ def test_deliver_named_profile_uses_p_flag_and_clears_home():
 
 
 def test_deliver_failure_returns_error_string():
-    with mock.patch.object(
-        sched.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with _no_turn_lock(), \
+         mock.patch.object(
+            sched.subprocess, "run", return_value=_completed(returncode=1, stderr="boom")
+        ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
     assert err is not None
     assert "boom" in err
 
 
 def test_deliver_timeout_returns_error_string():
-    with mock.patch.object(
-        sched.subprocess, "run",
-        side_effect=subprocess.TimeoutExpired(cmd="hermes", timeout=600),
-    ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
+    with _no_turn_lock(), \
+         mock.patch.object(
+            sched.subprocess, "run",
+            side_effect=subprocess.TimeoutExpired(cmd="hermes", timeout=600),
+        ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
         err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
     assert err is not None
     assert "timed out" in err
@@ -193,13 +207,185 @@ def test_deliver_message_carries_cron_attribution(tmp_path):
             captured["message"] = fh.read()
         return _completed()
 
-    with mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
          mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"):
         _deliver_to_bot_chat({"id": "j1", "name": "Daily digest"}, "the payload", "")
 
     assert 'Cronjob "Daily digest" output' in captured["message"]
     assert "not the user" in captured["message"]
     assert "the payload" in captured["message"]
+
+
+# ── single-owner session-lock handling (#99956) ──────────────────────────────
+
+def test_is_session_lock_refusal():
+    assert _is_session_lock_refusal(
+        "Session bot-chat already has a live owner (desktop, pid 42)"
+    ) is True
+    assert _is_session_lock_refusal(
+        "Hermes is at the active session limit (3/3)."
+    ) is True
+    assert _is_session_lock_refusal("") is False
+    assert _is_session_lock_refusal("invalid api key") is False
+    assert _is_session_lock_refusal("model not found") is False
+
+
+def test_deliver_retries_then_succeeds_when_session_owned():
+    """A transient single-owner refusal (bot mid-turn) is retried with backoff."""
+    calls = {"n": 0}
+
+    def fake_run(argv, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _completed(
+                returncode=1,
+                stderr="Session bot-chat already has a live owner (desktop, pid 42)",
+            )
+        return _completed()
+
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.object(sched.time, "sleep", lambda _s: None):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is None
+    assert calls["n"] == 3
+
+
+def test_deliver_gives_up_after_session_owned_retries():
+    """A persistently owned session gives up with a clear, actionable error."""
+    calls = {"n": 0}
+
+    def fake_run(argv, **kwargs):
+        calls["n"] += 1
+        return _completed(
+            returncode=1,
+            stderr="Session bot-chat already has a live owner (desktop, pid 42)",
+        )
+
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.object(sched.time, "sleep", lambda _s: None):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is not None
+    assert "open on another surface" in err
+    assert calls["n"] == sched._BOT_CHAT_LOCK_RETRY_ATTEMPTS
+
+
+def test_deliver_backoff_doubles_within_30s_budget():
+    """Backoff delays double each attempt (2→4→8→16s) and stay within ~30s."""
+    calls = {"n": 0}
+    sleeps = []
+
+    def fake_run(argv, **kwargs):
+        calls["n"] += 1
+        return _completed(
+            returncode=1,
+            stderr="Session bot-chat already has a live owner (desktop, pid 42)",
+        )
+
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.object(sched.time, "sleep", side_effect=sleeps.append):
+        _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    # Powers of two, one delay between each pair of attempts.
+    assert sleeps == [2.0, 4.0, 8.0, 16.0]
+    assert sum(sleeps) <= 30.0
+
+
+def test_deliver_reports_active_session_limit():
+    """The active-session cap refusal gets its own actionable message."""
+    with _no_turn_lock(), \
+         mock.patch.object(
+            sched.subprocess, "run",
+            return_value=_completed(
+                returncode=1,
+                stderr="Hermes is at the active session limit (3/3).",
+            ),
+        ), mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.object(sched.time, "sleep", lambda _s: None):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+    assert err is not None
+    assert "active session limit" in err
+
+
+def test_deliver_does_not_retry_non_lock_failures():
+    """Auth/quota/config/model errors are not retried (a retry cannot fix them)."""
+    calls = {"n": 0}
+
+    def fake_run(argv, **kwargs):
+        calls["n"] += 1
+        return _completed(returncode=1, stderr="invalid api key")
+
+    with _no_turn_lock(), \
+         mock.patch.object(sched.subprocess, "run", side_effect=fake_run), \
+         mock.patch.object(sched.shutil, "which", return_value="/usr/bin/hermes"), \
+         mock.patch.object(sched.time, "sleep", lambda _s: None):
+        err = _deliver_to_bot_chat({"id": "j1", "name": "n"}, "out", "")
+
+    assert err is not None
+    assert "invalid api key" in err
+    assert calls["n"] == 1
+
+
+# ── per-profile turn lock (#99956) ───────────────────────────────────────────
+
+def test_bot_chat_delivery_lock_resolves_own_profile(tmp_path, monkeypatch):
+    from tools import bot_relay
+
+    captured = {}
+
+    def fake_acquire(root, name, timeout_seconds=None):
+        captured["root"] = str(root)
+        captured["name"] = name
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(bot_relay, "acquire_turn_lock", fake_acquire)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    with sched._bot_chat_delivery_lock(""):
+        pass
+    assert captured["name"] == "default"
+    assert captured["root"] == str(tmp_path / ".hermes")
+
+
+def test_bot_chat_delivery_lock_uses_named_profile(tmp_path, monkeypatch):
+    from tools import bot_relay
+
+    captured = {}
+
+    def fake_acquire(root, name, timeout_seconds=None):
+        captured["root"] = str(root)
+        captured["name"] = name
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(bot_relay, "acquire_turn_lock", fake_acquire)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    with sched._bot_chat_delivery_lock("research"):
+        pass
+    assert captured["name"] == "research"
+    assert captured["root"] == str(tmp_path / ".hermes")
+
+
+def test_bot_chat_delivery_lock_derives_own_name_from_profile_home(tmp_path, monkeypatch):
+    from tools import bot_relay
+
+    captured = {}
+
+    def fake_acquire(root, name, timeout_seconds=None):
+        captured["name"] = name
+        return contextlib.nullcontext()
+
+    monkeypatch.setattr(bot_relay, "acquire_turn_lock", fake_acquire)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes" / "profiles" / "research"))
+    with sched._bot_chat_delivery_lock(""):
+        pass
+    assert captured["name"] == "research"
 
 
 # ── delivery-targets listing (UI pickers) ────────────────────────────────────


### PR DESCRIPTION
Fixes #99956

## Problem

When a scheduled cron job uses `deliver: bot-chat` (or `bot-chat:<profile>`), `_deliver_to_bot_chat` in `cron/scheduler.py` spawns `hermes chat --in ~ -c "Bot Chat" ...` as a synchronous subprocess. Hermes enforces a single-owner session lease — only one surface (CLI/TUI/Desktop) may run a session at a time. If the target profile already has an active interactive session, the subprocess exits with code 1 and the delivery is permanently dropped:

```
Session <id> already has a live owner (cli, pid <pid>, running <time>). Only one surface at a time may run a session...
```

## Root Cause

`_deliver_to_bot_chat` fired the `hermes chat` subprocess with no fallback. Unlike `tools/bot_mode_dm.py` (which coordinates delivery through per-profile turn locks), the cron path had no lock coordination and no retry — a transient in-flight turn or a concurrently open surface caused a hard drop.

## Fix

In `cron/scheduler.py`:

- Run the delivery subprocess under the per-profile relay turn lock (`_bot_chat_delivery_lock`, mirroring `tools.bot_mode_dm._delivery_lock`), so the scheduled subprocess is not an uncoordinated writer. Degrades to a no-op if the relay lock machinery is unavailable.
- Detect single-owner session-lease refusals (`_is_session_lock_refusal`: `"already has a live owner"` / `"active session limit"`) and retry them with exponential backoff — delays double 2s → 4s → 8s → 16s, ~30s total — before giving up.
- Emit distinct actionable "skipped" messages for the two refusal classes (another surface owns the session vs. machine at the active-session cap) instead of a raw exit-code error. Non-lock failures (auth/quota/config/model) are not retried, since a retry cannot fix them.

## Verification

- `tests/cron/test_cron_bot_chat_delivery.py` covers token parsing, target resolution, the delivery lane, and the #99956 paths: retry-then-succeed, give-up-after-retries, active-session-limit message, non-lock failures not retried, exponential backoff within 30s, and turn-lock key resolution.
- `uv run pytest tests/cron/test_cron_bot_chat_delivery.py` → 26 passed.
