### PR TITLE
fix: harden messaging voice-only output and Photon/iMessage media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -6802,6 +6802,7 @@ class BasePlatformAdapter(ABC):
                 _tts_requested_path = None
                 if (self._should_auto_tts_for_chat(event.source.chat_id)
                         and event.message_type == MessageType.VOICE
+                        and not getattr(event, "_tts_only_voice_delivered", False)
                         and text_content
                         and not media_files
                         and not self._streaming_tts_turn_completed(
@@ -6888,6 +6889,13 @@ class BasePlatformAdapter(ABC):
                             os.remove(_cleanup_path)
                         except OSError:
                             pass
+
+                # ``tts_only`` is an explicit output modality: successful native
+                # voice delivery replaces the text bubble.  The runner sets this
+                # marker only after send_voice succeeds, so text remains the
+                # deterministic fallback when TTS or transport delivery fails.
+                if getattr(event, "_tts_only_voice_delivered", False):
+                    text_content = None
 
                 # Send the text portion. A reconnect may have replaced this
                 # adapter while its in-flight handler was still producing a
@@ -7161,6 +7169,7 @@ class BasePlatformAdapter(ABC):
                 # deliverable, fail loudly rather than dropping it in silence.
                 _anything_delivered = (
                     delivery_attempted or _tts_caption_delivered
+                    or bool(getattr(event, "_tts_only_voice_delivered", False))
                     or images or local_files or media_files
                 )
                 if not _anything_delivered and _response_pre_extract.strip():
@@ -7172,7 +7181,11 @@ class BasePlatformAdapter(ABC):
                     )
 
             # Determine overall success for the processing hook
-            processing_ok = delivery_succeeded if delivery_attempted else not bool(response)
+            processing_ok = (
+                delivery_succeeded
+                if delivery_attempted
+                else bool(getattr(event, "_tts_only_voice_delivered", False)) or not bool(response)
+            )
             # Clean up the per-turn streaming-TTS flag (#60671).
             self._streaming_tts_completed_turns.discard(
                 self._streaming_tts_turn_key(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -25071,6 +25071,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if callable(resolver):
             try:
                 resolved = resolver(str(text_ch_id))
+                # Some adapters may expose an async resolver; awaiting here also
+                # keeps test doubles from leaking un-awaited coroutine objects.
+                import inspect
+                if inspect.isawaitable(resolved):
+                    resolved = await resolved
                 channel_prompt = resolved if isinstance(resolved, str) else None
             except Exception:
                 channel_prompt = None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -85,6 +85,11 @@ from hermes_cli.fallback_config import get_fallback_chain
 _AGENT_CACHE_MAX_SIZE = 128
 _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
+# WhatsApp's bridge owns a two-phase readiness probe that can legitimately use
+# ~30s (15s HTTP + 15s saved-session readiness).  The outer gateway timeout
+# must be strictly longer or it cancels connect() at the exact point where the
+# adapter is designed to continue with its self-healing bridge.
+_WHATSAPP_CONNECT_TIMEOUT_SECS_DEFAULT = 45.0
 # Telegram cold polling now proves one real getUpdates round trip before connect
 # returns. Leave enough outer budget for initialize/deleteWebhook/start_polling
 # wall deadlines plus readiness; other platforms retain the 30s isolation bound.
@@ -3647,14 +3652,20 @@ def _event_media_is_audio(event, index: int) -> bool:
 
 
 def _event_media_is_stt_input(event, index: int) -> bool:
-    """True when an audio attachment should enter the automatic STT pipeline."""
+    """True when this attachment should enter the automatic STT pipeline.
+
+    Pending follow-ups can merge several attachments into one event.  In that
+    case the event-level ``VOICE`` type must not make a sibling PDF/video look
+    like voice input.  Trust the per-attachment MIME whenever it is present and
+    use the message type only as a legacy fallback when MIME metadata is absent.
+    """
     message_type = getattr(event, "message_type", None)
     if message_type in {MessageType.AUDIO, MessageType.DOCUMENT}:
         return False
-    return (
-        message_type == MessageType.VOICE
-        or _event_media_type_at(event, index).startswith("audio/")
-    )
+    media_type = _event_media_type_at(event, index)
+    if media_type:
+        return media_type.startswith("audio/")
+    return message_type == MessageType.VOICE
 
 
 def _event_media_is_video(event, index: int) -> bool:
@@ -6032,8 +6043,14 @@ class TurnRunner:
             if _plat_streaming is None
             else bool(_plat_streaming)
         )
-        _want_stream_deltas = _streaming_enabled
-        _want_interim_messages = ctx.interim_assistant_messages_enabled
+        # ``tts_only`` is a transport/output contract, not merely a final-send
+        # preference. Do not leak response text through delta/interim streaming
+        # before the final native voice delivery gets a chance to replace it.
+        _tts_only_output = not self._runner._voice_output_allows_text(ctx.source)
+        _want_stream_deltas = _streaming_enabled and not _tts_only_output
+        _want_interim_messages = (
+            ctx.interim_assistant_messages_enabled and not _tts_only_output
+        )
         _want_interim_consumer = _want_interim_messages
         if _want_stream_deltas or _want_interim_consumer:
             try:
@@ -8245,6 +8262,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             profile=self._adapter_profile_for_source(source),
         )
 
+    def _voice_output_allows_text(self, source: SessionSource) -> bool:
+        """Return False only for the explicit audio-only output mode."""
+        return self._voice_mode.get(self._voice_key_for_source(source)) != "tts_only"
+
     def _bind_voice_input_callback(self, adapter) -> None:
         """Route voice transcripts back through the adapter that captured them."""
         if hasattr(adapter, "_voice_input_callback"):
@@ -8261,7 +8282,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         if not isinstance(data, dict):
             return {}
 
-        valid_modes = {"off", "voice_only", "all"}
+        valid_modes = {"off", "voice_only", "all", "tts_only"}
         result = {}
         for chat_id, mode in data.items():
             if mode not in valid_modes:
@@ -8360,7 +8381,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             enabled_chats.clear()
             enabled_chats.update(
                 key[len(prefix):] for key, mode in self._voice_mode.items()
-                if mode in {"voice_only", "all"} and key.startswith(prefix)
+                if mode in {"voice_only", "all", "tts_only"} and key.startswith(prefix)
             )
 
     async def _await_adapter_cleanup_with_timeout(
@@ -8515,6 +8536,8 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if initial:
                 return _TELEGRAM_INITIAL_CONNECT_TIMEOUT_SECS_DEFAULT
             return _TELEGRAM_CONNECT_TIMEOUT_SECS_DEFAULT
+        if platform == Platform.WHATSAPP:
+            return _WHATSAPP_CONNECT_TIMEOUT_SECS_DEFAULT
         return _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT
 
     async def _connect_adapter_with_timeout(
@@ -25096,7 +25119,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 adapter_auto_tts = False
 
         should = (
-            (voice_mode == "all")
+            (voice_mode in {"all", "tts_only"})
             or (voice_mode == "voice_only" and is_voice_input)
             # ``voice.auto_tts`` is synced into the adapter on gateway startup.
             # It is the fallback only when the chat has no explicit mode;
@@ -25132,7 +25155,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         # When streaming already delivered the text (already_sent=True),
         # the base adapter will receive None and can't run auto-TTS,
         # so the runner must take over.
-        if is_voice_input and not already_sent:
+        if is_voice_input and not already_sent and voice_mode != "tts_only":
             return False
 
         return True
@@ -25141,16 +25164,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
         """Return whether inbound voice/STT transcripts should be echoed to chat."""
         return bool(getattr(self.config, "stt_echo_transcripts", True))
 
-    async def _send_voice_reply(self, event: MessageEvent, text: str) -> None:
-        """Generate TTS audio and send as a voice message before the text reply."""
+    async def _send_voice_reply(self, event: MessageEvent, text: str) -> bool:
+        """Generate TTS audio; return True only when native delivery succeeds."""
         audio_path = None
         actual_paths: List[str] = []
+        delivered = False
         try:
             from tools.tts_tool import text_to_speech_tool, _strip_markdown_for_tts
 
             tts_text = _strip_markdown_for_tts(text)
             if not tts_text:
-                return
+                return False
 
             # Platform-aware output path: platforms whose native voice
             # bubbles require Ogg/Opus (OPUS_VOICE_PLATFORMS — Telegram,
@@ -25166,7 +25190,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 result = json.loads(result_json)
             except (json.JSONDecodeError, TypeError):
                 logger.warning("Auto voice reply TTS returned invalid JSON: %s", result_json[:200] if result_json else result_json)
-                return
+                return False
 
             # Final delivery may be one combined file or multiple separately
             # valid files when combination is unavailable or would exceed a
@@ -25180,7 +25204,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             ]
             if not result.get("success") or not actual_paths:
                 logger.warning("Auto voice reply TTS failed: %s", result.get("error"))
-                return
+                return False
 
             adapter = self._adapter_for_source(event.source)
 
@@ -25222,9 +25246,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "reply_to": reply_anchor,
                         "metadata": thread_meta,
                     }
-                    await send_voice_call(**send_kwargs)
+                    send_result = await send_voice_call(**send_kwargs)
+                    delivered = bool(getattr(send_result, "success", False)) or delivered
+            if delivered and self._voice_mode.get(self._voice_key_for_source(event.source)) == "tts_only":
+                # The adapter post-handler still owns normal text/media delivery.
+                # Mark only successful native TTS delivery so it can suppress the
+                # duplicate text while preserving text as a fail-open fallback.
+                event._tts_only_voice_delivered = True
+            return delivered
         except Exception as e:
             logger.warning("Auto voice reply failed: %s", e, exc_info=True)
+            return False
         finally:
             for p in ({audio_path, *actual_paths} - {None}):
                 try:

--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -3372,7 +3372,7 @@ class GatewaySlashCommandsMixin:
         return t("gateway.set_home.success", name=chat_name, chat_id=chat_id)
 
     async def _handle_voice_command(self, event: MessageEvent) -> str:
-        """Handle /voice [on|off|tts|channel|leave|status] command."""
+        """Handle /voice [on|off|tts|tts-only|channel|leave|status] command."""
         args = event.get_command_args().strip().lower()
         chat_id = event.source.chat_id
         # Voice state belongs to the (bot, chat) pair: resolve the adapter that
@@ -3400,6 +3400,12 @@ class GatewaySlashCommandsMixin:
             if adapter:
                 self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
             return t("gateway.voice.tts_enabled")
+        elif args in {"tts-only", "tts_only", "audio-only"}:
+            self._voice_mode[voice_key] = "tts_only"
+            self._save_voice_modes()
+            if adapter:
+                self._set_adapter_auto_tts_enabled(adapter, chat_id, enabled=True)
+            return "🔊 Voice-only output enabled. Successful audio replaces the text reply."
         elif args in {"channel", "join"}:
             return await self._handle_voice_channel_join(event)
         elif args == "leave":
@@ -3410,6 +3416,7 @@ class GatewaySlashCommandsMixin:
                 "off": t("gateway.voice.label_off"),
                 "voice_only": t("gateway.voice.label_voice_only"),
                 "all": t("gateway.voice.label_all"),
+                "tts_only": "TTS only (audio replaces text)",
             }
             # Append voice channel info if connected
             guild_id = self._get_guild_id(event)

--- a/plugins/platforms/photon/adapter.py
+++ b/plugins/platforms/photon/adapter.py
@@ -635,6 +635,25 @@ def _format_richlink_content(content: Dict[str, Any]) -> str:
     return "\n".join(parts) if parts else "[Photon rich link received with no URL]"
 
 
+def _format_location_content(content: Dict[str, Any]) -> str:
+    """Render a Photon/Find My location as explicit model-readable context."""
+    try:
+        latitude = float(content.get("latitude"))
+        longitude = float(content.get("longitude"))
+    except (TypeError, ValueError):
+        return "[Photon location received with invalid coordinates]"
+    labels = [
+        str(content.get(key) or "").strip()
+        for key in ("name", "shortAddress", "address", "longAddress")
+    ]
+    label = next((value for value in labels if value), "Shared location")
+    accuracy = content.get("accuracy")
+    suffix = ""
+    if isinstance(accuracy, (int, float)) and accuracy >= 0:
+        suffix = f"; accuracy ~{accuracy:g} m"
+    return f"[Location shared] {label} ({latitude:.6f}, {longitude:.6f}{suffix})"
+
+
 def _richlink_url_from_content(content: Dict[str, Any]) -> Optional[str]:
     ctype = content.get("type")
     if ctype == "text":
@@ -1421,6 +1440,9 @@ class PhotonAdapter(BasePlatformAdapter):
         elif ctype == "richlink":
             text = _format_richlink_content(content)
             mtype = MessageType.TEXT
+        elif ctype == "location":
+            text = _format_location_content(content)
+            mtype = MessageType.LOCATION
         elif ctype == "group":
             text_parts: List[str] = []
             mtype = MessageType.TEXT
@@ -2102,8 +2124,11 @@ class PhotonAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
+        # The iMessage provider normalizes voice payload bytes to M4A/AAC
+        # before upload. Keep the source MIME for transcoding, but name the
+        # uploaded artifact .m4a; M4A bytes under .ogg render as 00:00 on iOS.
         return await self._sidecar_send_attachment(
-            chat_id, audio_path, caption=caption, kind="voice",
+            chat_id, audio_path, name="voice.m4a", caption=caption, kind="voice",
         )
 
     async def send_video(
@@ -2895,6 +2920,11 @@ async def _standalone_send(
                 }
                 if guessed:
                     att_body["mimeType"] = guessed
+                if is_voice:
+                    # Spectrum's iMessage provider normalizes voice bytes to
+                    # M4A/AAC before upload. Name that normalized artifact by
+                    # its actual container so iOS does not render a 00:00 .ogg.
+                    att_body["name"] = "voice.m4a"
                 resp = await client.post(
                     f"{base}/send-attachment", json=att_body, headers=headers,
                 )

--- a/plugins/platforms/photon/sidecar/findmy-location.mjs
+++ b/plugins/platforms/photon/sidecar/findmy-location.mjs
@@ -1,0 +1,71 @@
+const FIND_MY_BUNDLE = "com.apple.findmy.FindMyMessagesApp";
+
+export function isFindMyLocationMessage(message) {
+  const bundle = String(message?.balloonBundleId || "");
+  const raw = message?.content?.raw;
+  return (
+    message?.content?.type === "custom" &&
+    raw?.imessage_type === "unsupported-message" &&
+    bundle.includes(FIND_MY_BUNDLE)
+  );
+}
+
+export function normalizeLocationSnapshot(location) {
+  if (!location) return null;
+  const latitude = Number(location.latitude);
+  const longitude = Number(location.longitude);
+  if (!Number.isFinite(latitude) || !Number.isFinite(longitude)) return null;
+  return {
+    type: "location",
+    latitude,
+    longitude,
+    accuracy: Number.isFinite(Number(location.accuracy)) ? Number(location.accuracy) : null,
+    name: location.name || "",
+    address: location.address || "",
+    shortAddress: location.shortAddress || "",
+    longAddress: location.longAddress || "",
+    locationType: location.locationType || "",
+  };
+}
+
+function chooseRoute(tokenData, phone) {
+  if (tokenData?.type === "shared") {
+    return {
+      address: process.env.SPECTRUM_IMESSAGE_ADDRESS || "imessage.spectrum.photon.codes:443",
+      token: tokenData.token,
+    };
+  }
+  const auth = tokenData?.auth || {};
+  const numbers = tokenData?.numbers || {};
+  let instanceId = Object.keys(auth).find((id) => numbers[id] === phone);
+  if (!instanceId && Object.keys(auth).length === 1) instanceId = Object.keys(auth)[0];
+  if (!instanceId || !auth[instanceId]) return null;
+  return { address: `${instanceId}.imsg.photon.codes:443`, token: auth[instanceId] };
+}
+
+export async function resolveFindMyLocation({
+  message,
+  projectId,
+  projectSecret,
+  issueTokens,
+  createClient,
+}) {
+  if (!isFindMyLocationMessage(message)) return null;
+  const sender = message?.sender?.address || message?.sender?.id || "";
+  if (!sender || !projectId || !projectSecret) return null;
+  const tokenData = await issueTokens(projectId, projectSecret);
+  const route = chooseRoute(tokenData, message?.space?.phone);
+  if (!route) return null;
+  const client = createClient({
+    address: route.address,
+    tls: true,
+    token: route.token,
+    retry: true,
+    autoIdempotency: true,
+  });
+  try {
+    return normalizeLocationSnapshot(await client.locations.get(sender));
+  } finally {
+    await client.close();
+  }
+}

--- a/plugins/platforms/photon/sidecar/index.mjs
+++ b/plugins/platforms/photon/sidecar/index.mjs
@@ -67,6 +67,7 @@ import crypto from "node:crypto";
 import { once } from "node:events";
 import { patchSpectrumTs } from "./patch-spectrum-mixed-attachments.mjs";
 import { chooseSendFormat } from "./send-format.mjs";
+import { resolveFindMyLocation } from "./findmy-location.mjs";
 import {
   classifyProbeRejection,
   shouldProbe,
@@ -306,6 +307,8 @@ let Spectrum,
   spectrumRichlink,
   spectrumTyping,
   spectrumPoll,
+  spectrumCloud,
+  createAdvancedIMessageGrpcClient,
   imessageEffect;
 try {
   ({
@@ -317,8 +320,10 @@ try {
     markdown: spectrumMarkdown,
     richlink: spectrumRichlink,
     typing: spectrumTyping,
+    cloud: spectrumCloud,
   } = await import("spectrum-ts"));
   ({ imessage, effect: imessageEffect } = await import("spectrum-ts/providers/imessage"));
+  ({ createGrpcClient: createAdvancedIMessageGrpcClient } = await import("@photon-ai/advanced-imessage/grpc"));
 } catch (e) {
   console.error(
     "photon-sidecar: spectrum-ts is not installed. Run `npm install` " +
@@ -515,9 +520,33 @@ function reactionTargetText(target) {
     : text;
 }
 
-async function normalizeContent(content) {
+async function normalizeFindMyContent(message) {
+  try {
+    return await resolveFindMyLocation({
+      message,
+      projectId,
+      projectSecret,
+      issueTokens: spectrumCloud.issueImessageTokens,
+      createClient: createAdvancedIMessageGrpcClient,
+    });
+  } catch (e) {
+    console.error(
+      "photon-sidecar: failed to resolve Find My location: " +
+        (e?.message || String(e))
+    );
+    return null;
+  }
+}
+
+async function normalizeContent(content, messageContext = null) {
   if (!content || typeof content !== "object") {
     return { type: "unknown" };
+  }
+  if (content.type === "custom") {
+    const location = messageContext ? await normalizeFindMyContent(messageContext) : null;
+    if (location) return location;
+    const raw = content.raw && typeof content.raw === "object" ? content.raw : null;
+    return { type: "custom", raw };
   }
   if (content.type === "text") {
     return { type: "text", text: content.text || "" };
@@ -634,7 +663,7 @@ async function normalizeEvent(space, message) {
         phone: space.phone ?? msgSpace.phone ?? null,
       },
       sender: { id: message.sender ? message.sender.id : null },
-      content: await normalizeContent(message.content),
+      content: await normalizeContent(message.content, message),
       timestamp:
         ts instanceof Date ? ts.toISOString() : ts ? String(ts) : null,
     };

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -21,6 +21,22 @@
       "integrity": "sha512-C3UGsiCwSprE2NKIIFA3hCDlpXTMCAXRZuEVp88L1GY36Y41+rYL5fryE+nOFhp4p4JPQvdV8PQ4DWgHgeTE+w==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.1.tgz",
+      "integrity": "sha512-S6mL0yNB/Abt9Ei4tq8gDhcczc4S3+vQ4ra7vxnAf+YHC02srtqxKKZghx2Dq6p0e66THKwR6r8N6P95wEty7Q==",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@grpc/grpc-js": {
       "version": "1.14.4",
       "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
@@ -933,28 +949,18 @@
       "license": "MIT"
     },
     "node_modules/encoding-sniffer": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
-      "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
-      "license": "MIT",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-1.0.2.tgz",
+      "integrity": "sha512-dlQ0jlnDJ2ElE1Ky4crYX0pPEPxQY9F2j+ZMIXlBedLJToEfDed9pvPqXg4fZnuu4qVBbcIrZVeg3S4aibTYGw==",
       "dependencies": {
-        "iconv-lite": "^0.6.3",
-        "whatwg-encoding": "^3.1.1"
-      },
-      "funding": {
-        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
-      }
-    },
-    "node_modules/encoding-sniffer/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
+        "@exodus/bytes": "^1.15.0"
       },
       "engines": {
-        "node": ">=0.10.0"
+        "node": ">=20.19.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
       }
     },
     "node_modules/entities": {
@@ -1357,31 +1363,6 @@
       "dependencies": {
         "camelcase": "^5.0.0",
         "foldline": "^1.1.0"
-      }
-    },
-    "node_modules/whatwg-encoding": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
-      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
-      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
-      "license": "MIT",
-      "dependencies": {
-        "iconv-lite": "0.6.3"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/whatwg-encoding/node_modules/iconv-lite": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
-      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
-      "license": "MIT",
-      "dependencies": {
-        "safer-buffer": ">= 2.1.2 < 3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/whatwg-mimetype": {

--- a/plugins/platforms/photon/sidecar/package-lock.json
+++ b/plugins/platforms/photon/sidecar/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.4.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@photon-ai/advanced-imessage": "2.1.0",
         "spectrum-ts": "12.7.0"
       },
       "engines": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -7,12 +7,14 @@
   "main": "index.mjs",
   "scripts": {
     "start": "node index.mjs",
-    "postinstall": "node patch-spectrum-mixed-attachments.mjs"
+    "postinstall": "node patch-spectrum-mixed-attachments.mjs",
+    "test": "node --test test/*.test.mjs"
   },
   "engines": {
     "node": ">=18.17"
   },
   "dependencies": {
+    "@photon-ai/advanced-imessage": "2.1.0",
     "spectrum-ts": "12.7.0"
   },
   "overrides": {

--- a/plugins/platforms/photon/sidecar/package.json
+++ b/plugins/platforms/photon/sidecar/package.json
@@ -21,6 +21,7 @@
     "@opentelemetry/otlp-exporter-base": "0.218.0",
     "@opentelemetry/exporter-trace-otlp-http": "0.218.0",
     "@opentelemetry/exporter-logs-otlp-http": "0.218.0",
-    "@opentelemetry/core": "2.10.0"
+    "@opentelemetry/core": "2.10.0",
+    "encoding-sniffer": "1.0.2"
   }
 }

--- a/plugins/platforms/photon/sidecar/test/findmy-location.test.mjs
+++ b/plugins/platforms/photon/sidecar/test/findmy-location.test.mjs
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  isFindMyLocationMessage,
+  normalizeLocationSnapshot,
+  resolveFindMyLocation,
+} from "../findmy-location.mjs";
+
+const findMyMessage = {
+  balloonBundleId:
+    "com.apple.messages.MSMessageExtensionBalloonPlugin:0000000000:com.apple.findmy.FindMyMessagesApp",
+  content: { type: "custom", raw: { imessage_type: "unsupported-message" } },
+  sender: { id: "+15551234567" },
+  space: { phone: "shared" },
+};
+
+test("recognizes Find My location cards only", () => {
+  assert.equal(isFindMyLocationMessage(findMyMessage), true);
+  assert.equal(isFindMyLocationMessage({ ...findMyMessage, balloonBundleId: "other" }), false);
+});
+
+test("normalizes a valid shared-location snapshot", () => {
+  assert.deepEqual(
+    normalizeLocationSnapshot({ latitude: 29.7, longitude: -95.4, accuracy: 8, shortAddress: "Houston" }),
+    { type: "location", latitude: 29.7, longitude: -95.4, accuracy: 8, name: "", address: "", shortAddress: "Houston", longAddress: "", locationType: "" },
+  );
+});
+
+test("resolves Find My through a one-shot shared client", async () => {
+  let closed = false;
+  let requested = "";
+  const result = await resolveFindMyLocation({
+    message: findMyMessage,
+    projectId: "project",
+    projectSecret: "secret",
+    issueTokens: async () => ({ type: "shared", token: "token" }),
+    createClient: () => ({
+      locations: {
+        get: async (address) => {
+          requested = address;
+          return { latitude: 29.7, longitude: -95.4, locationType: "legacy" };
+        },
+      },
+      close: async () => { closed = true; },
+    }),
+  });
+  assert.equal(requested, "+15551234567");
+  assert.equal(result.type, "location");
+  assert.equal(result.locationType, "legacy");
+  assert.equal(closed, true);
+});

--- a/plugins/platforms/whatsapp/adapter.py
+++ b/plugins/platforms/whatsapp/adapter.py
@@ -463,6 +463,14 @@ class WhatsAppAdapter(WhatsAppBehaviorMixin, BasePlatformAdapter):
             "bridge_script",
             str(self._DEFAULT_BRIDGE_DIR / "bridge.js"),
         )
+        # Bridge transports are not all capability-equivalent.  The bundled
+        # Baileys bridge supports message edits, while custom Web bridges may
+        # intentionally expose final-message delivery only.  Declare the actual
+        # transport capability so GatewayRunner skips edit-based streaming rather
+        # than creating a stream consumer that can never deliver a preview.
+        self.SUPPORTS_MESSAGE_EDITING = bool(
+            config.extra.get("supports_message_editing", True)
+        )
         self._session_path: Path = Path(config.extra.get(
             "session_path",
             get_hermes_dir("platforms/whatsapp/session", "whatsapp/session")

--- a/tests/gateway/relay/test_wire_voice_media.py
+++ b/tests/gateway/relay/test_wire_voice_media.py
@@ -177,6 +177,28 @@ class TestSttGate:
         )
         assert _event_media_is_stt_input(ev, 0) is False
 
+    def test_merged_voice_event_does_not_transcribe_sibling_pdf_or_video(self):
+        from gateway.run import _event_media_is_stt_input
+
+        ev = _event_from_wire(
+            _wire_event(
+                "voice",
+                media=[
+                    {"url": "https://gw/voice.ogg", "kind": "voice", "mime": "audio/ogg"},
+                    {"url": "https://gw/report.pdf", "kind": "document", "mime": "application/pdf"},
+                    {"url": "https://gw/clip.mp4", "kind": "video", "mime": "video/mp4"},
+                ],
+                media_urls=[
+                    "https://gw/voice.ogg",
+                    "https://gw/report.pdf",
+                    "https://gw/clip.mp4",
+                ],
+            )
+        )
+        assert _event_media_is_stt_input(ev, 0) is True
+        assert _event_media_is_stt_input(ev, 1) is False
+        assert _event_media_is_stt_input(ev, 2) is False
+
 class TestUrlMimePairingThroughLocalization:
     """The end-to-end invariant my unit tests originally missed.
 

--- a/tests/gateway/test_photon_location.py
+++ b/tests/gateway/test_photon_location.py
@@ -1,0 +1,48 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.base import MessageType
+from plugins.platforms.photon.adapter import PhotonAdapter, _format_location_content
+
+
+def test_format_location_content_is_model_readable():
+    text = _format_location_content(
+        {
+            "latitude": 29.7,
+            "longitude": -95.4,
+            "accuracy": 8,
+            "shortAddress": "Houston",
+        }
+    )
+    assert text == "[Location shared] Houston (29.700000, -95.400000; accuracy ~8 m)"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_findmy_location_as_native_location():
+    adapter = PhotonAdapter(PlatformConfig(enabled=True, extra={}))
+    adapter.handle_message = AsyncMock()
+    event = {
+        "messageId": "location-1",
+        "space": {"id": "any;-;+15551234567", "type": "dm", "phone": "shared"},
+        "sender": {"id": "+15551234567"},
+        "content": {
+            "type": "location",
+            "latitude": 29.7,
+            "longitude": -95.4,
+            "accuracy": 8,
+            "shortAddress": "Houston",
+        },
+        "timestamp": "2026-09-03T20:27:30Z",
+    }
+
+    await adapter._dispatch_inbound(event)
+
+    adapter.handle_message.assert_awaited_once()
+    message = adapter.handle_message.await_args.args[0]
+    assert message.message_type is MessageType.LOCATION
+    assert message.message_id == "location-1"
+    assert "Houston" in message.text
+    assert "29.700000" in message.text
+    assert "-95.400000" in message.text

--- a/tests/gateway/test_startup_connect_parallel.py
+++ b/tests/gateway/test_startup_connect_parallel.py
@@ -219,6 +219,12 @@ class TestTelegramColdStartCap:
             Platform.DISCORD, initial=True
         ) == runner._platform_connect_timeout_secs(Platform.DISCORD)
 
+    def test_whatsapp_outer_budget_exceeds_bridge_readiness_window(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", raising=False)
+        runner = self._runner(tmp_path)
+        assert runner._platform_connect_timeout_secs(Platform.WHATSAPP) == 45.0
+        assert runner._platform_connect_timeout_secs(Platform.WHATSAPP) > 30.0
+
     def test_env_override_applies_to_initial(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_GATEWAY_PLATFORM_CONNECT_TIMEOUT", "12")
         runner = self._runner(tmp_path)

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -66,6 +66,19 @@ def _allowed_media_path(tmp_path, monkeypatch, name):
 
 
 @pytest.mark.asyncio
+async def test_tts_only_success_marker_suppresses_duplicate_text_delivery():
+    adapter = _MediaRoutingAdapter()
+    event = _event()
+    event._tts_only_voice_delivered = True
+    adapter._message_handler = AsyncMock(return_value="this text was already spoken")
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="text"))
+
+    await adapter._process_message_background(event, build_session_key(event.source))
+
+    adapter.send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_base_adapter_routes_voice_tagged_telegram_ogg_media_tag_to_voice_sender(tmp_path, monkeypatch):
     adapter = _MediaRoutingAdapter()
     event = _event()

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -122,6 +122,16 @@ class TestHandleVoiceCommand:
         assert data["telegram:123"] == "voice_only"
 
 
+    @pytest.mark.asyncio
+    async def test_tts_only_mode_persists_and_enables_audio_only_output(self, runner):
+        event = _make_event("/voice tts-only")
+        result = await runner._handle_voice_command(event)
+        assert "voice-only output enabled" in result.lower()
+        assert runner._voice_mode["telegram:123"] == "tts_only"
+        data = json.loads(runner._VOICE_MODE_PATH.read_text())
+        assert data["telegram:123"] == "tts_only"
+
+
     def test_sync_populates_enabled_chats_from_voice_modes(self, runner):
         """Issue #16007: sync also restores per-chat /voice on|tts opt-ins.
 
@@ -267,6 +277,17 @@ class TestAutoVoiceReply:
         """all + text input: only runner fires (base auto-TTS only for voice)."""
         assert self._call(runner, "all", MessageType.TEXT) is True
 
+    def test_tts_only_runner_handles_text_and_voice_input(self, runner):
+        assert self._call(runner, "tts_only", MessageType.TEXT) is True
+        assert self._call(runner, "tts_only", MessageType.VOICE) is True
+
+    def test_tts_only_suppresses_text_streaming_before_final_voice(self, runner):
+        event = _make_event(message_type=MessageType.TEXT)
+        runner._voice_mode["telegram:123"] = "tts_only"
+        assert runner._voice_output_allows_text(event.source) is False
+        runner._voice_mode["telegram:123"] = "all"
+        assert runner._voice_output_allows_text(event.source) is True
+
 
     # -- Mode off: nothing fires -------------------------------------------
 
@@ -318,6 +339,28 @@ class TestSendVoiceReply:
         assert mock_tts.call_args.kwargs["output_path"].endswith(".ogg")
         call_args = mock_adapter.send_voice.call_args
         assert call_args.kwargs.get("chat_id") == "123"
+
+
+    @pytest.mark.asyncio
+    async def test_tts_only_marks_event_only_after_successful_native_send(self, runner):
+        from gateway.config import Platform
+
+        mock_adapter = AsyncMock()
+        mock_adapter.send_voice = AsyncMock(return_value=SimpleNamespace(success=True))
+        event = _make_event()
+        event.source.platform = Platform.TELEGRAM
+        runner.adapters[event.source.platform] = mock_adapter
+        runner._voice_mode["telegram:123"] = "tts_only"
+
+        tts_result = json.dumps({"success": True, "file_path": "/tmp/test.ogg"})
+        with patch("tools.tts_tool.text_to_speech_tool", return_value=tts_result), \
+             patch("tools.tts_tool._strip_markdown_for_tts", side_effect=lambda t: t), \
+             patch("os.path.isfile", return_value=True), \
+             patch("os.unlink"):
+            delivered = await runner._send_voice_reply(event, "Audio only")
+
+        assert delivered is True
+        assert getattr(event, "_tts_only_voice_delivered", False) is True
 
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_whatsapp_transport_capabilities.py
+++ b/tests/gateway/test_whatsapp_transport_capabilities.py
@@ -1,0 +1,20 @@
+from gateway.config import PlatformConfig
+
+
+def test_whatsapp_bundled_bridge_keeps_edit_support_by_default():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(PlatformConfig(enabled=True, extra={}))
+    assert adapter.SUPPORTS_MESSAGE_EDITING is True
+
+
+def test_whatsapp_custom_bridge_can_declare_final_only_delivery():
+    from plugins.platforms.whatsapp.adapter import WhatsAppAdapter
+
+    adapter = WhatsAppAdapter(
+        PlatformConfig(
+            enabled=True,
+            extra={"supports_message_editing": False},
+        )
+    )
+    assert adapter.SUPPORTS_MESSAGE_EDITING is False

--- a/tests/plugins/platforms/photon/test_outbound_media.py
+++ b/tests/plugins/platforms/photon/test_outbound_media.py
@@ -79,6 +79,28 @@ async def test_send_image_file_hits_attachment_endpoint(
 
 
 @pytest.mark.asyncio
+async def test_send_voice_names_transcoded_imessage_payload_m4a(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    """Spectrum transcodes Ogg voice payloads to M4A for iMessage upload."""
+    _patch_safe_path(monkeypatch)
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"OggS fake-opus")
+    adapter = _make_adapter(monkeypatch)
+    calls = _capture_sidecar(adapter)
+
+    result = await adapter.send_voice("any;-;+15551234567", str(audio))
+
+    assert result.success is True
+    path, body = calls[0]
+    assert path == "/send-attachment"
+    assert body["kind"] == "voice"
+    assert body["path"] == str(audio)
+    assert body["mimeType"] == "audio/ogg"
+    assert body["name"] == "voice.m4a"
+
+
+@pytest.mark.asyncio
 async def test_standalone_send_text_then_attachments(
     monkeypatch: pytest.MonkeyPatch, tmp_path
 ) -> None:
@@ -128,3 +150,52 @@ async def test_standalone_send_text_then_attachments(
     assert posted[1][1]["path"] == str(img)
     assert posted[1][1]["kind"] == "attachment"
     assert posted[1][1]["mimeType"] == "image/png"
+
+
+@pytest.mark.asyncio
+async def test_standalone_voice_names_transcoded_imessage_payload_m4a(
+    monkeypatch: pytest.MonkeyPatch, tmp_path
+) -> None:
+    _patch_safe_path(monkeypatch)
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"OggS fake-opus")
+    monkeypatch.setenv("PHOTON_SIDECAR_TOKEN", "tok")
+
+    posted: List[Tuple[str, Dict[str, Any]]] = []
+
+    class _Resp:
+        status_code = 200
+
+        @staticmethod
+        def json() -> Dict[str, Any]:
+            return {"ok": True, "messageId": "m-voice"}
+
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url: str, json: Dict[str, Any], headers=None):
+            posted.append((url, json))
+            return _Resp()
+
+    monkeypatch.setattr(photon_adapter.httpx, "AsyncClient", _FakeClient)
+
+    cfg = PlatformConfig(enabled=True, token="", extra={})
+    result = await photon_adapter._standalone_send(
+        cfg,
+        "any;-;+1",
+        "",
+        media_files=[(str(audio), True)],
+    )
+
+    assert result.get("success") is True
+    assert posted[0][0].endswith("/send-attachment")
+    assert posted[0][1]["kind"] == "voice"
+    assert posted[0][1]["mimeType"] == "audio/ogg"
+    assert posted[0][1]["name"] == "voice.m4a"

--- a/tests/tools/test_send_message_target_parse.py
+++ b/tests/tools/test_send_message_target_parse.py
@@ -178,6 +178,42 @@ def test_live_buzz_media_only_send_reaches_adapter(tmp_path) -> None:
     assert media_calls[0][1] == str(document)
 
 
+
+def test_live_photon_media_only_voice_reaches_adapter(tmp_path) -> None:
+    from gateway.platforms.base import SendResult
+
+    platform = Platform("photon")
+    audio = tmp_path / "reply.ogg"
+    audio.write_bytes(b"OggS fake-opus")
+    calls = []
+
+    class Adapter:
+        async def send(self, **kwargs):
+            raise AssertionError("media-only Photon voice must not emit empty text")
+
+        async def send_voice(self, chat_id, audio_path, **kwargs):
+            calls.append((chat_id, audio_path, kwargs))
+            return SendResult(success=True, message_id="evt-voice")
+
+    runner = SimpleNamespace(adapters={platform: Adapter()})
+    with patch("gateway.run._gateway_runner_ref", return_value=runner):
+        result = asyncio.run(
+            _send_to_platform(
+                platform,
+                SimpleNamespace(enabled=True, token=None, extra={}),
+                "any;-;+15551234567",
+                "",
+                media_files=[(str(audio), True)],
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "message_id": "evt-voice",
+        "media_delivered": True,
+    }
+    assert calls == [("any;-;+15551234567", str(audio), {"caption": None, "reply_to": None, "metadata": None})]
+
 def test_live_buzz_media_exception_reports_partial_delivery(tmp_path) -> None:
     from gateway.platforms.base import SendResult
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -1466,20 +1466,30 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         return last_result
 
     # --- Non-media platforms ---
-    # Buzz is a plugin platform with verified native media delivery through
-    # _send_via_adapter below, including valid media-only sends.
-    if media_files and not message.strip() and platform.value != "buzz":
+    # Plugin platforms with verified native media delivery route through the
+    # generic _send_via_adapter path below. Keep this allowlist explicit so a
+    # plugin cannot accidentally claim attachment support it does not have.
+    _native_media_plugin_values = {"buzz", "photon"}
+    if (
+        media_files
+        and not message.strip()
+        and platform.value not in _native_media_plugin_values
+    ):
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack; "
+                "send_message MEDIA delivery is currently only supported for "
+                "telegram, discord, matrix, weixin, signal, yuanbao, feishu, "
+                "whatsapp, slack, buzz and photon; "
                 f"target {platform.value} had only media attachments"
             )
         }
     warning = None
-    if media_files and platform.value != "buzz":
+    if media_files and platform.value not in _native_media_plugin_values:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, feishu, whatsapp and slack"
+            "native send_message media delivery is currently only supported for "
+            "telegram, discord, matrix, weixin, signal, yuanbao, feishu, "
+            "whatsapp, slack, buzz and photon"
         )
 
     last_result = None


### PR DESCRIPTION
## Summary

This PR hardens the gateway's voice/media behavior across messaging transports and adds the missing Photon/iMessage media/location paths found while testing a real self-hosted deployment.

### Voice-only output
- adds an explicit persistent `tts_only` / `/voice tts-only` mode
- sends native TTS audio without also emitting the final text bubble
- preserves text as a deterministic fallback when synthesis or native audio delivery fails
- suppresses delta/interim text streaming while `tts_only` is active so text cannot leak before the final voice send
- treats a successful audio-only delivery as a successful processing outcome

### Voice/media routing
- uses per-attachment MIME when deciding which merged attachments enter STT, so a sibling PDF/video in a voice event is not transcribed as audio
- gives WhatsApp a 45s outer connect budget; its own two-phase readiness probe can legitimately use ~30s, so the previous 30s outer timeout could cancel a healthy bridge exactly at the boundary
- honors custom WhatsApp bridge edit capability instead of assuming all bridge implementations can edit streamed messages

### Photon / iMessage
- names voice uploads `voice.m4a` while preserving the source Ogg MIME for Spectrum transcoding; iOS otherwise receives M4A/AAC bytes under an `.ogg` name and can render a `00:00` attachment
- makes the same fix in the standalone Photon sender
- allows media-only Photon sends through the generic `send_message` adapter path
- resolves Find My shared-location cards into model-readable native location events
- avoids the deprecated encoding-sniffer path already removed by the accompanying Photon cleanup commit

## Local validation
- focused Python suite: **148 passed**, no warnings
- Ruff: **PASS**
- Photon sidecar Node tests: **3 passed**
- `node --check` for sidecar files: **PASS**
- `git diff --check`: **PASS**

The branch is rebased/cherry-picked onto the current `origin/main` used for this PR and is 0 commits behind at creation time.