### PR TITLE
fix(state): detect multi-process WAL writer set at state.db open

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -3616,6 +3616,79 @@ def _live_writer_holds_db(db_path: Path) -> bool:
     )
 
 
+# ── Multi-process WAL writer-set detection (#100896) ──
+# One state.db opened in WAL mode by several processes at once (a gateway
+# alongside a dashboard and/or webui — each a separate systemd unit) is the
+# writer-set shape behind the corruption cluster #100896 / #90837 / #100313.
+# WAL is safe across processes only while every opener coordinates through
+# SQLite's WAL locks; the tracked signature — lost/reordered page writes, a
+# torn `sessions` b-tree — is one connection's close-time checkpoint racing a
+# peer's WAL growth. There is no safe live downgrade once the set exists
+# (flipping journal_mode under concurrent openers destroys a peer's
+# committed-but-uncheckpointed WAL frames), so the only containment available
+# at open time is to DETECT the set and say so loudly, naming the durable fix:
+# `database.journal_mode: delete` in config.yaml (applied under exclusive
+# access). The in-process duplicate-handle warning (#98573) cannot see this —
+# it counts handles in ONE process, and fired 7 minutes before the #100896
+# onset while the second writer was a different process entirely.
+_multi_writer_warned_paths: set[str] = set()
+_multi_writer_warned_lock = threading.Lock()
+
+
+def _warn_if_multi_process_wal_writer_set(db_path: Path) -> None:
+    """Warn (once per process per path) when state.db is WAL and a peer holds it.
+
+    Fires at open time, before the first write, so a joining process names the
+    multi-process writer set the moment it forms. The scan runs at most once
+    per process per resolved path — the foreign-holder authority walks
+    ``/proc/*/fd``, which is cheap once but must not ride a per-request
+    ``SessionDB()`` open. Diagnostic containment only: it never flips the
+    journal mode under live peers, it makes the operator's durable fix
+    actionable.
+    """
+    try:
+        key = str(Path(db_path).resolve())
+    except OSError:
+        key = str(db_path)
+    with _multi_writer_warned_lock:
+        if key in _multi_writer_warned_paths:
+            return
+    # Scan BEFORE marking the path: a transient scan failure must be retried by
+    # the next open, not permanently silenced by an early mark.
+    try:
+        holders = _foreign_state_db_holders(db_path)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.debug(
+            "multi-process WAL writer-set check failed for %s: %s", db_path, exc
+        )
+        return
+    # Only positive evidence of a second writer warns. The authority encodes a
+    # failed or unavailable scan as a pid<0 sentinel; that is "cannot prove
+    # exclusive ownership", not "a second process exists", and a diagnostic
+    # must not raise it to the same alarm as an observed peer.
+    foreign = [holder for holder in holders if holder[0] > 0]
+    with _multi_writer_warned_lock:
+        if key in _multi_writer_warned_paths:
+            return
+        _multi_writer_warned_paths.add(key)
+    if not foreign:
+        return
+    pids = sorted({pid for pid, _ in foreign})
+    logger.warning(
+        "%s: state.db is in WAL mode with %d other process(es) holding the "
+        "database or its -wal/-shm sidecars open (PID(s): %s). This "
+        "multi-process WAL writer set is the corruption signature behind the "
+        "state.db damage cluster; if this deployment runs a gateway alongside "
+        "a dashboard or webui, set `database.journal_mode: delete` in "
+        "config.yaml to remove the multi-writer WAL class (apply it under "
+        "exclusive access, then restart). This warning fires once per process "
+        "per database.",
+        db_path,
+        len(pids),
+        ", ".join(str(pid) for pid in pids),
+    )
+
+
 def repair_state_db_schema(db_path: Path, *, backup: bool = True) -> Dict[str, Any]:
     """Repair a state.db whose ``sqlite_master`` schema is malformed or whose
     FTS indexes reject writes.
@@ -5558,6 +5631,12 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._wal_active = (
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
+                if self._wal_active:
+                    # #100896: name the multi-process WAL writer set the moment
+                    # this process joins it (gateway + dashboard + webui), so
+                    # the operator gets the corruption signature at open time
+                    # instead of inferring it after the fact.
+                    _warn_if_multi_process_wal_writer_set(self.db_path)
                 apply_database_pragmas(self._conn, db_label="state.db")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)

--- a/tests/state/test_multi_process_wal_writer_set.py
+++ b/tests/state/test_multi_process_wal_writer_set.py
@@ -1,0 +1,128 @@
+"""Cross-process WAL writer-set detection (#100896).
+
+A state.db opened in WAL mode by several processes at once — a gateway
+alongside a dashboard and/or webui — is the writer-set shape behind the
+corruption cluster #100896 / #90837 / #100313. The in-process
+duplicate-handle warning (#98573) cannot see it: it counts handles in ONE
+process, and in the #100896 report it fired 7 minutes before onset while the
+second writer was a different process entirely.
+
+This module pins the open-time detection: when a ``SessionDB`` lands in WAL
+mode, it asks the foreign-holder authority whether another process is holding
+the database or its ``-wal`` / ``-shm`` sidecars, and — on positive evidence
+only — emits a loud, once-per-process-per-path WARNING that names the set and
+points at the durable containment (`database.journal_mode: delete`).
+
+It is diagnostic containment, never a live downgrade: flipping journal_mode
+under concurrent openers destroys a peer's committed-but-uncheckpointed WAL
+frames, which is precisely the corruption it exists to prevent.
+"""
+
+import logging
+
+import pytest
+
+import hermes_state
+
+
+@pytest.fixture(autouse=True)
+def _clear_warned_paths():
+    """Isolate the per-process dedup set between tests."""
+    with hermes_state._multi_writer_warned_lock:
+        hermes_state._multi_writer_warned_paths.clear()
+    yield
+    with hermes_state._multi_writer_warned_lock:
+        hermes_state._multi_writer_warned_paths.clear()
+
+
+def _warned(caplog):
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if "multi-process WAL writer set" in r.getMessage()
+    ]
+
+
+def test_warns_on_foreign_holder(tmp_path, monkeypatch, caplog):
+    """A peer holding the DB open is named, with its PID, at detection time."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "_foreign_state_db_holders",
+        lambda p: [(4242, str(db_path))],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        hermes_state._warn_if_multi_process_wal_writer_set(db_path)
+
+    messages = _warned(caplog)
+    assert messages, "a second writer went unreported"
+    assert "4242" in messages[0]
+
+
+def test_stays_quiet_without_foreign_holder(tmp_path, monkeypatch, caplog):
+    """No peers, no warning — the scan is not allowed to alarm on absence."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(hermes_state, "_foreign_state_db_holders", lambda p: [])
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        hermes_state._warn_if_multi_process_wal_writer_set(db_path)
+
+    assert _warned(caplog) == []
+
+
+def test_scan_failure_does_not_warn(tmp_path, monkeypatch, caplog):
+    """A pid<0 sentinel (scan failed) is not positive evidence of a peer."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "_foreign_state_db_holders",
+        lambda p: [(-1, "open-file scan failed: nope")],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        hermes_state._warn_if_multi_process_wal_writer_set(db_path)
+
+    assert _warned(caplog) == []
+
+
+def test_warns_once_per_process_per_path(tmp_path, monkeypatch, caplog):
+    """The /proc scan must not ride every open; dedup bounds it to one warning."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "_foreign_state_db_holders",
+        lambda p: [(1, str(db_path)), (2, str(db_path))],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        hermes_state._warn_if_multi_process_wal_writer_set(db_path)
+        caplog.clear()
+        hermes_state._warn_if_multi_process_wal_writer_set(db_path)
+
+    assert _warned(caplog) == []
+
+
+@pytest.mark.requires_wal
+def test_session_db_open_warns_when_joining_wal_writer_set(
+    tmp_path, monkeypatch, caplog
+):
+    """The wiring: opening state.db in WAL with a peer present warns at open."""
+    db_path = tmp_path / "state.db"
+    monkeypatch.setattr(
+        hermes_state,
+        "_foreign_state_db_holders",
+        lambda p: [(4242, str(db_path))],
+    )
+
+    with caplog.at_level(logging.WARNING, logger="hermes_state"):
+        db = hermes_state.SessionDB(db_path=db_path)
+    try:
+        messages = _warned(caplog)
+        assert messages, (
+            "SessionDB opened in WAL alongside a peer process and did not name "
+            "the multi-process writer set"
+        )
+        assert "journal_mode: delete" in messages[0]
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

Closes #100896 (data point in the #90837 / #100313 / #89737 corruption cluster).

`state.db` opened in WAL mode from several processes at once — a gateway alongside a dashboard and/or webui, each a separate systemd unit — is the writer-set shape behind the tracked corruption: one connection's close-time checkpoint racing a peer's WAL growth produces lost/reordered page writes and a torn `sessions` b-tree.

The existing in-process duplicate-handle warning cannot see this. It counts handles in *one* process, and in the #100896 report it fired ~7 minutes before onset while the second writer was a different process entirely.

## Change

Add open-time detection in `SessionDB.__init__`: after the connection lands in WAL mode, ask the foreign-holder authority (`foreign_state_db_holders`) whether another process holds the database or its `-wal` / `-shm` sidecars. On positive evidence only, emit a loud, once-per-process-per-path WARNING naming the set and pointing at the durable containment:

```
database.journal_mode: delete   # in config.yaml, applied under exclusive access
```

The scan runs at most once per process per resolved path (the authority walks `/proc/*/fd`, which must not ride a per-request `SessionDB()` open). A failed or unavailable scan (the `pid < 0` sentinel) is deliberately *not* promoted to a warning — it is "cannot prove exclusive ownership", not "a second process exists".

This is diagnostic containment, never a live downgrade: flipping `journal_mode` under concurrent openers destroys a peer's committed-but-uncheckpointed WAL frames, which is precisely the corruption this detection exists to surface.

## Tests

- `tests/state/test_multi_process_wal_writer_set.py` — unit coverage of the detection (warns with PID, quiet with no peers, quiet on scan failure, dedup) plus an open-time wiring test gated on `requires_wal`.
- Verified end-to-end that opening a WAL `state.db` alongside a simulated peer emits exactly one warning naming the PID and the `journal_mode: delete` containment.