### PR TITLE
fix(tui): restore uppercase for Shift+letter via extended keyboard protocols

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event-shift.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event-shift.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest'
+
+import { parseMultipleKeypresses } from '../parse-keypress.js'
+
+import { InputEvent } from './input-event.js'
+
+function parseOne(sequence: string) {
+  const [keys] = parseMultipleKeypresses({ incomplete: '', mode: 'NORMAL' }, sequence)
+  expect(keys).toHaveLength(1)
+
+  return keys[0]!
+}
+
+describe('shifted letter reconstruction for extended keyboard protocols', () => {
+  it('restores uppercase from modifyOtherKeys Shift+A (Ghostty)', () => {
+    // Ghostty gets only the modifyOtherKeys push, so Shift+A arrives as
+    // ESC[27;2;65~ — modifier 2 (shift) + keycode 65 ('A'). keycodeToName
+    // lowercases the keycode to 'a' for ctrl-chord matching; the input string
+    // must still carry the uppercase glyph the user actually typed.
+    const event = new InputEvent(parseOne('\u001b[27;2;65~'))
+
+    expect(event.key.shift).toBe(true)
+    expect(event.input).toBe('A')
+  })
+
+  it('restores uppercase from kitty CSI-u Shift+A', () => {
+    // kitty reports the base (unshifted) codepoint plus a shift modifier:
+    // Shift+A → CSI 97;2u. Same lowercase-name + shift=true shape.
+    const event = new InputEvent(parseOne('\u001b[97;2u'))
+
+    expect(event.key.shift).toBe(true)
+    expect(event.input).toBe('A')
+  })
+
+  it('leaves an unshifted letter lowercase', () => {
+    const event = new InputEvent(parseOne('a'))
+
+    expect(event.key.shift).toBe(false)
+    expect(event.input).toBe('a')
+  })
+
+  it('does not uppercase ctrl+shift+letter chords (keeps ctrl matching lowercase)', () => {
+    // Ctrl+Shift+A via CSI u is a control chord, not printable input. A plain
+    // terminal sends it as a bare control byte with no shift flag, so the
+    // reconstructed input must stay lowercase to match ctrl+a handling.
+    const event = new InputEvent(parseOne('\u001b[97;6u'))
+
+    expect(event.key.ctrl).toBe(true)
+    expect(event.key.shift).toBe(true)
+    expect(event.input).toBe('a')
+  })
+
+  it('keeps shift+symbol glyphs as-is (modifyOtherKeys already sends the final char)', () => {
+    // Shift+1 on a US layout: modifyOtherKeys sends the '!' character (33)
+    // directly, not the base '1' — no reconstruction is needed for symbols.
+    const event = new InputEvent(parseOne('\u001b[27;2;33~'))
+
+    expect(event.key.shift).toBe(true)
+    expect(event.input).toBe('!')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/events/input-event.ts
@@ -157,6 +157,21 @@ function parseKey(keypress: ParsedKey): [Key, string] {
     key.shift = true
   }
 
+  // Reconstruct the shifted glyph for terminal protocols that report the base
+  // key plus a separate shift modifier — kitty keyboard protocol (CSI u) and
+  // xterm modifyOtherKeys (used by Ghostty). A plain terminal already sends
+  // the shifted character ('A' for Shift+A), but these protocols arrive as a
+  // lowercase key name with shift=true (keycodeToName lowercases the keycode
+  // so ctrl+letter matching stays case-insensitive), so the composer would
+  // otherwise insert the lowercase letter. Letters are the one
+  // layout-independent case — shift+symbol already arrives as the final
+  // character via modifyOtherKeys — so only a-z need restoring here.
+  // Ctrl+letter chords must stay lowercase so ctrl+a / ctrl+z matching keeps
+  // working (a plain terminal sends those as bare control bytes with no shift).
+  if (key.shift && !key.ctrl && input.length === 1 && input >= 'a' && input <= 'z') {
+    input = input.toUpperCase()
+  }
+
   return [key, input]
 }
 


### PR DESCRIPTION
## Problem

On Ghostty (macOS), typing **Shift+letter** in the prompt composer inserts a lowercase letter. Uppercase input is destroyed.

## Root cause

Ghostty is excluded from the kitty-keyboard-protocol push and gets only the xterm `modifyOtherKeys` push (`skipKittyKeyboardProtocol()` returns true for Ghostty). So Shift+A arrives as `ESC[27;2;65~` — modifier 2 (shift) + keycode 65 ('A').

In `parse-keypress.ts`, `keycodeToName()` lowercases printable ASCII keycodes (`String.fromCharCode(keycode).toLowerCase()`) so ctrl+letter chords stay case-insensitive, while the shift bit is captured separately (`shift: true`). The input event then derived `input = 'a'` from that lowercase name — and never re-applied the shift modifier — so the composer inserted the lowercase letter. A plain terminal already sends the shifted glyph ('A'), which is why this only surfaced on extended-keyboard-protocol terminals.

## Fix

In `input-event.ts`, when `key.shift` is set and the derived input is a single lowercase ASCII letter, restore the uppercase glyph. This covers both `modifyOtherKeys` and kitty `CSI u` paths.

- Ctrl+letter chords are left untouched (guarded by `!key.ctrl`) so ctrl+a / ctrl+z matching keeps working.
- Shift+symbol glyphs are left untouched — `modifyOtherKeys` already sends the final character ('!' for Shift+1), and reconstructing symbols from a base key + shift is keyboard-layout dependent.

## Tests

Added `packages/hermes-ink/src/ink/events/input-event-shift.test.ts` covering:

- modifyOtherKeys Shift+A → 'A' (the Ghostty case)
- kitty CSI-u Shift+A → 'A'
- unshifted letter stays lowercase
- ctrl+shift+letter stays lowercase
- shift+symbol ('!') preserved

All 42 tests across the input-event / parse-keypress suites pass.