### PR TITLE
fix(serve): register shell hooks on the serve command path

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -12782,7 +12782,7 @@ def _resolve_deferred_platform_cli_command(command_name: str | None) -> None:
         )
 
 
-_AGENT_COMMANDS = {None, "chat", "acp", "rl"}
+_AGENT_COMMANDS = {None, "chat", "acp", "rl", "serve"}
 _AGENT_SUBCOMMANDS = {
     "cron": ("cron_command", {"run", "tick"}),
     "gateway": ("gateway_command", {"run"}),


### PR DESCRIPTION
Fixes #102504.

## Problem
`hermes serve` (the desktop app's local agent backend) never registers config.yaml shell hooks. Every guard a user wires under `hooks:` — outbound-send guards, destructive-command guards, tenant guards — is silently absent in all sessions served by the desktop app, while the same guards work in CLI (`hermes chat`) and gateway sessions.

## Root Cause
In `hermes_cli/main.py`, `_prepare_agent_startup()` early-returns unless `args.command` is in `_AGENT_COMMANDS` or `_AGENT_SUBCOMMANDS`. `"serve"` was in neither set. The shell hook registration call at the end of `_prepare_agent_startup()`:

```python
from agent.shell_hooks import register_from_config
register_from_config(_hooks_cfg, accept_hooks=_accept_hooks)
```

therefore never ran for `hermes serve`. Plugins were discovered/loaded on the serve path (plugin-provided tools worked), making this especially confusing — everything plugin-owned worked, everything config-hook-owned was silently dead.

Note: `agent/outbound_webhooks.py` independently registers outbound webhooks on the serve path, so outbound webhooks survived — but shell hooks did not.

## Fix
Add `"serve"` to `_AGENT_COMMANDS` (one-line change): `{None, "chat", "acp", "rl", "serve"}`. This mirrors what `outbound_webhooks` already does on this path.

## Verification
- The reporter confirmed this gap by checking agent.log — zero shell-hook registration lines for the serve process
- Outbound webhooks already register on this path via their own independent call, confirming serve was simply overlooked
- One-line change with no side effects: commands in `_AGENT_COMMANDS` only control whether the agent startup path runs