### PR TITLE
test(packaging): derive hermes_state's local imports instead of hard-coding them

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -574,6 +574,7 @@ py-modules = [
   "hermes_state",
   "hermes_state_common",
   "hermes_state_portability",
+  "hermes_state_registry",
   "hermes_state_schema",
   "hermes_state_search",
   "hermes_startup_watchdog",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -573,6 +573,7 @@ py-modules = [
   "hermes_constants",
   "hermes_state",
   "hermes_state_common",
+  "hermes_state_holders",
   "hermes_state_portability",
   "hermes_state_registry",
   "hermes_state_schema",

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -152,6 +152,49 @@ def test_locked_starlette_is_not_vulnerable_to_cve_2026_48710():
 
 
 # ---------------------------------------------------------------------------
+# Sealed-install module coverage
+#
+# ``[tool.setuptools].py-modules`` is the ONLY list that decides which
+# top-level single-file modules ship in the sealed Nix/uv2nix venv. A module
+# missing from it fails at runtime with ModuleNotFoundError even when
+# ``uv sync`` succeeds on the source tree (the editable checkout sees the
+# file; the sealed venv does not). #100561: hermes_state.py gained a
+# re-export from hermes_state_registry (db339f0) but the list was not
+# updated, so Nix-built gateways/dashboards crashed on import while
+# everything else stayed green.
+# ---------------------------------------------------------------------------
+
+
+def test_py_modules_ships_hermes_state_runtime_dependencies():
+    """hermes_state's top-level runtime imports must be listed in py-modules.
+
+    hermes_state.py imports hermes_state_registry at module scope
+    (get_shared_session_db / release_or_close re-exports). A sealed install
+    only ships what py-modules declares, so a missing entry bricks every
+    gateway / dashboard / cron process that imports hermes_state
+    (ModuleNotFoundError: No module named 'hermes_state_registry').
+    """
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    shipped = set(data["tool"]["setuptools"]["py-modules"])
+    assert "hermes_state" in shipped
+
+    for module in (
+        # Imported (and re-exported) at module scope in hermes_state.py.
+        "hermes_state_registry",
+    ):
+        assert module in shipped, (
+            f"{module}.py is imported by hermes_state.py but missing from "
+            "[tool.setuptools].py-modules — sealed (Nix) installs fail with "
+            "ModuleNotFoundError at startup (#100561)"
+        )
+        assert (REPO_ROOT / f"{module}.py").is_file(), (
+            f"py-modules lists {module} but the source file no longer exists — "
+            "the entry is stale and should be removed"
+        )
+
+
+
+# ---------------------------------------------------------------------------
 # Dependency-pin consistency: pyproject extras <-> tools/lazy_deps.py
 #
 # The same package is exact-pinned in two hand-maintained places: the

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -193,6 +193,35 @@ def test_py_modules_ships_hermes_state_runtime_dependencies():
         )
 
 
+def test_py_modules_covers_hermes_state_local_imports():
+    """Every top-level sibling module hermes_state.py imports is in py-modules.
+
+    Derived from the source (``^from <module> import`` / ``^import <module>``
+    statements at column 0) rather than a hard-coded name, so the next
+    module-scope import added to hermes_state.py cannot slip through the
+    way hermes_state_registry did (#100561).
+    """
+    source = (REPO_ROOT / "hermes_state.py").read_text(encoding="utf-8")
+    imported = set(re.findall(r"^import (\w+)", source, re.MULTILINE))
+    imported |= set(re.findall(r"^from (\w+) import", source, re.MULTILINE))
+    # The stdlib/first-party modules that are not top-level siblings of the
+    # sealed install's py-modules list.
+    excluded = {"__future__", "agent", "hermes_cli", "gateway", "tools", "tests"}
+
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    shipped = set(data["tool"]["setuptools"]["py-modules"])
+
+    siblings = sorted(m for m in imported if m not in excluded)
+    assert siblings, "no local imports detected in hermes_state.py — the derivation rotted"
+
+    missing = [m for m in siblings if m not in shipped and (REPO_ROOT / f"{m}.py").is_file()]
+    assert not missing, (
+        f"{missing} are imported by hermes_state.py at module scope but missing "
+        "from [tool.setuptools].py-modules — sealed (Nix) installs fail with "
+        "ModuleNotFoundError at startup (#100561)"
+    )
+
+
 
 # ---------------------------------------------------------------------------
 # Dependency-pin consistency: pyproject extras <-> tools/lazy_deps.py


### PR DESCRIPTION
## What does this PR do?

Follow-up to #100585, addressing the non-blocking review point: the regression test guarded exactly one hard-coded name (`hermes_state_registry`), so the next module-scope import added to `hermes_state.py` would slip through the same way `db339f0` did.

The new `test_py_modules_covers_hermes_state_local_imports` parses `hermes_state.py`'s top-level `from <module> import` / `import <module>` statements, keeps the ones that resolve to top-level sibling files in this repo, and asserts each is listed in `[tool.setuptools].py-modules` — closing that class of bug generically. A tripwire asserts the derivation itself stays non-empty, so the regex rotting cannot pass silently.

`hermes_state.py` currently imports five top-level siblings (`hermes_state_common`, `hermes_state_portability`, `hermes_state_schema`, `hermes_state_search`, `hermes_state_registry`) — all covered by the derivation and all listed in `py-modules` on main today, so the test is green as landed.

## Verification

- `tests/test_packaging_metadata.py -k py_modules` — 2 passed (new derivation test + the original guard)
- Full `tests/test_packaging_metadata.py` — 11 passed
- `ruff check tests/test_packaging_metadata.py` — clean