### PR TITLE
test(gateway): guard startup-watchdog disarm at loop-confirmed-live (#102000)

### DIFF
--- a/tests/gateway/test_startup_watchdog.py
+++ b/tests/gateway/test_startup_watchdog.py
@@ -171,6 +171,57 @@ class TestContracts:
                         calls.append(node.lineno)
             assert calls, f"{rel} has no arm_startup_watchdog call ({reason})"
 
+    def test_gateway_runner_disarms_once_loop_confirmed_live(self):
+        """The startup watchdog must be disarmed in the same branch that
+        confirms the event loop is live (right after
+        ``_start_loop_liveness_guards``), so it can never outlive the
+        pre-loop window and fire on a healthy gateway. Regression guard for
+        #102000: the disarm site once dropped out of a shipped build and the
+        watchdog killed a fully-operational gateway every ~25 min."""
+        import ast
+        from pathlib import Path
+
+        repo_root = Path(__file__).resolve().parents[2]
+        tree = ast.parse((repo_root / "gateway" / "run.py").read_text())
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.If):
+                continue
+            # Match `if self._gateway_loop is not None:` — the
+            # loop-confirmed-live branch in GatewayRunner.start().
+            test = node.test
+            if not (
+                isinstance(test, ast.Compare)
+                and isinstance(test.left, ast.Attribute)
+                and test.left.attr == "_gateway_loop"
+                and any(isinstance(op, ast.IsNot) for op in test.ops)
+            ):
+                continue
+            calls = set()
+            for call_node in ast.walk(node):
+                if not isinstance(call_node, ast.Call):
+                    continue
+                fn = call_node.func
+                if isinstance(fn, ast.Name):
+                    calls.add(fn.id)
+                elif isinstance(fn, ast.Attribute):
+                    calls.add(fn.attr)
+            # Only the branch that hands off to the loop-liveness watchdog
+            # is the loop-confirmed-live branch.
+            if "_start_loop_liveness_guards" not in calls:
+                continue
+            assert "disarm_startup_watchdog" in calls, (
+                "gateway/run.py: the loop-confirmed-live branch that calls "
+                "_start_loop_liveness_guards() must also call "
+                "disarm_startup_watchdog() so the startup watchdog cannot "
+                "fire on a healthy gateway (#102000)"
+            )
+            return
+        pytest.fail(
+            "gateway/run.py: loop-confirmed-live branch "
+            "(`if self._gateway_loop is not None:` calling "
+            "_start_loop_liveness_guards) not found"
+        )
 
 
 class TestConfigResolution:


### PR DESCRIPTION
## Problem

#102000 reports a hosted Docker gateway (`nousresearch/hermes-agent`, s6-supervised) being killed and restarted every ~25 minutes with exit code 75 (`EX_TEMPFAIL`) by the startup-liveness watchdog (OOF-298) — even though startup completes in ~10–15 s and the gateway is fully operational ("Gateway running", all platforms connected, serving traffic). The watchdog is meant to fire **only** when the process wedges *before* the asyncio event loop comes alive.

## Root Cause

The watchdog is armed at process entry (argv fast-path in `hermes_cli/main.py`, config-bridge re-arm in `hermes_cli/gateway.py`, and the `gateway.run.main()` backstop) and is meant to be disarmed by `GatewayRunner` the moment the event loop is confirmed live. The reporter's shipped Docker digest lacked that disarm site, so the watchdog was never disarmed once the loop came up and eventually fired on a healthy process.

Verification on current `upstream/main` (`63279301b`): the disarm site **is present** — `GatewayRunner.start()` disarms the watchdog immediately after confirming a live loop, right alongside `_start_loop_liveness_guards()`:

```python
if self._gateway_loop is not None:
    self._start_loop_liveness_guards(self._gateway_loop)
    ...
    from gateway.startup_watchdog import disarm_startup_watchdog
    disarm_startup_watchdog()
```

`git log -S disarm_startup_watchdog -- gateway/run.py` shows the site was introduced by the OOF-298 commit and has never been removed on `main`; a contributor comment on the issue independently confirms this. The reported regression was a stale Docker digest, not a current source defect.

## Fix

No source change is required — the one-line disarm call is already wired into the loop-confirmed-live branch. What *was* missing is the regression guard the issue itself calls for ("plus a regression test … so the firing path can never trigger afterwards"). This PR adds that guard so the disarm site can never silently drop out of a future build again:

- `tests/gateway/test_startup_watchdog.py::TestContracts::test_gateway_runner_disarms_once_loop_confirmed_live` — parses `gateway/run.py` and asserts that the `if self._gateway_loop is not None:` branch which calls `_start_loop_liveness_guards()` **also** calls `disarm_startup_watchdog()`.

This mirrors the existing structural contract `test_all_documented_entry_points_arm_the_watchdog`, which locks the arm sites the same way.

## Verification

- `python -m pytest tests/gateway/test_startup_watchdog.py -q` → **54 passed** (53 existing + 1 new).
- `ruff check tests/gateway/test_startup_watchdog.py` → **All checks passed**.

Fixes #102000
