### PR TITLE
fix(gateway): stop Windows process probes from triggering shutdowns

### DIFF
--- a/agent/proxy_sources/iron_proxy.py
+++ b/agent/proxy_sources/iron_proxy.py
@@ -1665,10 +1665,11 @@ def _read_persisted_nonce() -> Optional[str]:
 def _pid_alive(pid: int) -> bool:
     """Return True iff ``pid`` is alive AND is an iron-proxy process.
 
-    Defends against PID reuse via three signals (in priority order):
+    Defends against PID reuse via these signals (in priority order):
     1. ``/proc/<pid>/environ`` contains our nonce  (most reliable, Linux)
     2. ``/proc/<pid>/cmdline`` basename matches the managed binary
-    3. ``ps -p <pid>`` command line contains the binary path
+    3. ``psutil`` reports the managed binary name
+    4. macOS ``ps -p <pid>`` reports the managed binary name
 
     The legacy ``"iron-proxy" in cmdline`` match was loose enough to match
     ``tail iron-proxy.log`` or an editor with that file open.  We tighten
@@ -1739,17 +1740,32 @@ def _pid_alive(pid: int) -> bool:
     except OSError:
         pass
 
-    # macOS / non-Linux fallback: ``ps`` command basename.
     try:
-        res = subprocess.run(  # noqa: S603
-            ["ps", "-p", str(pid), "-o", "comm="],
-            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2,
-        )
-        if res.returncode == 0:
-            comm = (res.stdout or "").strip()
-            return os.path.basename(comm).startswith("iron-proxy")
-    except (OSError, subprocess.TimeoutExpired):
+        import psutil  # type: ignore
+
+        process = psutil.Process(pid)
+        executable = process.exe() or process.name()
+        if executable:
+            return os.path.basename(executable).startswith("iron-proxy")
+    except Exception:
         pass
+
+    # ``ps`` is a POSIX utility. Never resolve its bare name on Windows,
+    # where an unrelated ps.exe may be found on PATH.
+    if platform.system() == "Darwin":
+        try:
+            res = subprocess.run(  # noqa: S603
+                ["ps", "-p", str(pid), "-o", "comm="],
+                capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=2,
+            )
+            if res.returncode == 0:
+                comm = (res.stdout or "").strip()
+                return os.path.basename(comm).startswith("iron-proxy")
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+
+    if platform.system() == "Windows":
+        return False
 
     # Exotic platforms: be conservative — if the OS says alive we believe
     # it.  This restores the previous behaviour for non-Linux/non-macOS.

--- a/tests/test_iron_proxy.py
+++ b/tests/test_iron_proxy.py
@@ -18,6 +18,7 @@ import os
 import sys
 import tarfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -47,6 +48,20 @@ def hermes_home(tmp_path, monkeypatch):
 # ---------------------------------------------------------------------------
 # Token mint + mapping discovery
 # ---------------------------------------------------------------------------
+
+
+def test_pid_identity_uses_process_api_without_invoking_ps(monkeypatch):
+    process = SimpleNamespace(name=lambda: "iron-proxy.exe", exe=lambda: "C:/Hermes/iron-proxy.exe")
+    fake_psutil = SimpleNamespace(pid_exists=lambda _pid: True, Process=lambda _pid: process)
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    monkeypatch.setattr(ip, "_read_persisted_nonce", lambda: None)
+    monkeypatch.setattr(
+        ip.subprocess,
+        "run",
+        lambda *_args, **_kwargs: pytest.fail("identity lookup must not invoke bare ps"),
+    )
+
+    assert ip._pid_alive(424242) is True
 
 
 def test_mint_proxy_token_has_prefix_and_length():

--- a/tests/tui_gateway/test_compute_host_phase1.py
+++ b/tests/tui_gateway/test_compute_host_phase1.py
@@ -5,10 +5,11 @@ import sys
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
-from tui_gateway import compute_host, server
+from tui_gateway import compute_host, host_supervisor, server
 from tui_gateway.compute_host import ComputeHost, _default_workers
 from tui_gateway.host_supervisor import (
     MUTATOR_ROUTE_TABLE,
@@ -46,6 +47,37 @@ def test_compute_host_workers_inherit_tui_pool_env_or_8(monkeypatch):
     # Dead-RC tombstone: malformed env falls back to 8, not the old except-branch 4.
     monkeypatch.setenv("HERMES_TUI_RPC_POOL_WORKERS", "not-an-int")
     assert _default_workers() == 8
+
+
+def test_compute_host_rss_uses_process_api_without_invoking_ps(monkeypatch):
+    process = SimpleNamespace(memory_info=lambda: SimpleNamespace(rss=3 * 1024 * 1024))
+    monkeypatch.setitem(sys.modules, "psutil", SimpleNamespace(Process=lambda pid: process))
+    monkeypatch.setattr(
+        compute_host.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: pytest.fail("RSS lookup must not invoke bare ps"),
+    )
+
+    assert compute_host._rss_mb(4242) == 3.0
+
+
+def test_supervisor_process_probes_use_process_api_without_invoking_ps(monkeypatch):
+    process = SimpleNamespace(cmdline=lambda: [sys.executable, "-m", "tui_gateway.compute_host"])
+    fake_psutil = SimpleNamespace(pid_exists=lambda pid: pid == 4242, Process=lambda pid: process)
+    monkeypatch.setitem(sys.modules, "psutil", fake_psutil)
+    monkeypatch.setattr(
+        host_supervisor.os,
+        "kill",
+        lambda *_args: pytest.fail("liveness lookup must not call os.kill when psutil is available"),
+    )
+    monkeypatch.setattr(
+        host_supervisor.subprocess,
+        "check_output",
+        lambda *_args, **_kwargs: pytest.fail("command lookup must not invoke bare ps"),
+    )
+
+    assert host_supervisor._pid_alive(4242) is True
+    assert host_supervisor._pid_command(4242).endswith("-m tui_gateway.compute_host")
 
 
 def test_compute_host_routes_clarify_response_to_child_pending_registry(monkeypatch):

--- a/tui_gateway/compute_host.py
+++ b/tui_gateway/compute_host.py
@@ -868,8 +868,9 @@ class ComputeHost:
 
 def _rss_mb(pid: int) -> float:
     try:
-        out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(pid)], text=True, encoding="utf-8", errors="replace", stdin=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2).strip()
-        return int(out.splitlines()[-1].strip()) / 1024.0 if out else 0.0
+        import psutil  # type: ignore
+
+        return float(psutil.Process(pid).memory_info().rss) / (1024.0 * 1024.0)
     except Exception:
         return 0.0
 

--- a/tui_gateway/host_supervisor.py
+++ b/tui_gateway/host_supervisor.py
@@ -94,6 +94,15 @@ def _pid_alive(pid: int) -> bool:
     if pid <= 0:
         return False
     try:
+        import psutil  # type: ignore
+
+        return bool(psutil.pid_exists(pid))
+    except Exception:
+        # ``os.kill(pid, 0)`` is not a no-op on Windows (bpo-14484). If
+        # psutil is unavailable, fail closed rather than signal a process.
+        if sys.platform == "win32":
+            return False
+    try:
         os.kill(pid, 0)
         return True
     except ProcessLookupError:
@@ -107,6 +116,14 @@ def _pid_alive(pid: int) -> bool:
 def _pid_command(pid: int) -> str:
     if pid <= 0:
         return ""
+    try:
+        import psutil  # type: ignore
+
+        argv = psutil.Process(pid).cmdline()
+        if argv:
+            return " ".join(str(part) for part in argv)
+    except Exception:
+        pass
     # Linux fast path.
     proc_cmdline = Path("/proc") / str(pid) / "cmdline"
     try:
@@ -115,6 +132,8 @@ def _pid_command(pid: int) -> str:
             return data.replace(b"\x00", b" ").decode("utf-8", errors="replace")
     except Exception:
         pass
+    if sys.platform == "win32":
+        return ""
     try:
         return subprocess.check_output(
             ["ps", "-p", str(pid), "-o", "command="],


### PR DESCRIPTION
## What does this PR do?

Prevents Windows dashboard process probes from resolving and launching an unrelated `ps.exe`. The affected probes now use the cross-platform `psutil` API, so a PATH collision can no longer execute arbitrary `ps` behavior such as the reported system shutdown.

### Symptom

On Windows, compute-host heartbeat and orphan reconciliation could invoke a bare Unix `ps` command. Windows could resolve that name to an unrelated `ps.exe` and execute it with Unix-style arguments.

### Impact

Affected Windows desktop users could execute an unrelated program during routine dashboard process inspection. The issue report captured such an executable initiating a planned Windows shutdown.

### Bug Cause

**Trigger:** `tui_gateway/compute_host.py:_rss_mb` and `tui_gateway/host_supervisor.py:_pid_command`

**Causal chain:**
1. The dashboard compute host reports RSS or reconciles a stale host registry.
2. The process probe invokes `ps` by bare executable name without excluding Windows.
3. Windows resolves an unrelated `ps.exe` from PATH, allowing that program's behavior to run inside Hermes process management.

**Why it is wrong:** Unix process inspection was reachable on Windows without a platform boundary. The supervisor also used `os.kill(pid, 0)`, which is not a side-effect-free Windows liveness probe.

**Working sibling / contrast:** Existing gateway and dashboard process-management paths either use `psutil` or explicitly return before POSIX `ps` fallbacks on Windows.

**Ruled out:** The problem is not limited to one installed executable. Source audit identified the unguarded bare-name calls, and removing the unrelated executable only changed name resolution rather than the unsafe call sites.

### Fix

Use `psutil` for compute-host RSS, liveness, command-line, and iron-proxy identity inspection. Retain POSIX fallbacks only behind explicit non-Windows boundaries, and fail closed on Windows when process identity cannot be established.

## Related Issue

Closes #102660

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tui_gateway/compute_host.py` - read RSS through `psutil.Process.memory_info()`.
- `tui_gateway/host_supervisor.py` - use `psutil` for liveness and command-line lookup, with Windows-safe fallback behavior.
- `agent/proxy_sources/iron_proxy.py` - use `psutil` for process identity and restrict the remaining `ps` fallback to macOS.
- `tests/tui_gateway/test_compute_host_phase1.py` and `tests/test_iron_proxy.py` - verify process probes do not invoke bare `ps`.

## How to Test

1. Run the focused regression tests on Windows 11.
2. Confirm all three process-probe regression tests pass.
3. Run Ruff and `git diff --check` on the changed files.

```bash
scripts/run_tests.sh tests/tui_gateway/test_compute_host_phase1.py tests/test_iron_proxy.py -k 'process_api' -q
uv run ruff check tui_gateway/compute_host.py tui_gateway/host_supervisor.py agent/proxy_sources/iron_proxy.py tests/tui_gateway/test_compute_host_phase1.py tests/test_iron_proxy.py
git diff --check
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all targeted regression tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation - N/A; no user-facing documentation changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior - N/A

## Screenshots / Logs

N/A - automated regression tests cover the process-probe behavior.
