### PR TITLE
fix(desktop): stop shelling out to bare ps from the Electron process probe

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -298,6 +298,7 @@ import {
   runPrimaryBackendStartup
 } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
+import { readProcessCommandLineSync } from './process-command-line'
 import {
   assertLocalProfileCanStart,
   decideProfileDeleteAction,
@@ -9596,17 +9597,15 @@ function isHermesProcess(pid) {
 
     return cmdline.includes('hermes')
   } catch {
-    // /proc not available (macOS) — fall back to ps. Use -o args= to inspect
-    // the full command line, not just the process name.  -o comm= would return
-    // "python3" for any Python process, creating false positives.
-    try {
-      const { execSync } = require('child_process')
-      const out = execSync(`ps -p ${pid} -o args=`, { encoding: 'utf8', timeout: 2000 })
-
-      return out.includes('hermes')
-    } catch {
-      return false
-    }
+    // /proc not available (macOS / Windows) — process-table lookup via
+    // process-command-line.ts (PowerShell CIM on Windows, ps elsewhere, no
+    // shell wrapper): on Windows a bare ps string command goes through
+    // cmd.exe and PATH-resolves to unrelated executables such as System32
+    // PS.exe, the legacy planned-shutdown tool (#102660). Full command line
+    // (not just the process name): a name-only probe would return "python3"
+    // for any Python process, creating false positives.
+    const cmdline = readProcessCommandLineSync(pid)
+    return cmdline !== null && cmdline.includes('hermes')
   }
 }
 

--- a/apps/desktop/electron/process-command-line.test.ts
+++ b/apps/desktop/electron/process-command-line.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict'
+
+import { beforeEach, test, vi } from 'vitest'
+
+const { execMock } = vi.hoisted(() => ({ execMock: vi.fn() }))
+
+vi.mock('node:child_process', () => ({ execFileSync: execMock }))
+
+import { readProcessCommandLineSync } from './process-command-line'
+
+beforeEach(() => {
+  execMock.mockReset()
+})
+
+test('windows platform probes PowerShell CIM, never bare ps (#102660)', () => {
+  execMock.mockReturnValue('python -m hermes gateway run\n')
+
+  const out = readProcessCommandLineSync(1234, 'win32')
+
+  assert.equal(out, 'python -m hermes gateway run\n')
+  assert.equal(execMock.mock.calls.length, 1)
+  const [command, args] = execMock.mock.calls[0]
+  assert.equal(command, 'powershell.exe')
+  assert.deepEqual(args.slice(0, 3), ['-NoProfile', '-NonInteractive', '-Command'])
+  // The pid rides as its own argv element, never inside the command text.
+  assert.equal(args[args.length - 1], '1234')
+})
+
+test('posix platform keeps the ps probe as a literal argv list', () => {
+  execMock.mockReturnValue('python hermes\n')
+
+  readProcessCommandLineSync(1234, 'darwin')
+
+  const [command, args] = execMock.mock.calls[0]
+  assert.equal(command, 'ps')
+  assert.deepEqual(args, ['-p', '1234', '-o', 'args='])
+})
+
+test('probe failure degrades to null', () => {
+  execMock.mockImplementation(() => {
+    throw new Error('probe failed')
+  })
+
+  assert.equal(readProcessCommandLineSync(1234, 'win32'), null)
+})
+
+test('invalid pid is rejected without executing anything', () => {
+  assert.equal(readProcessCommandLineSync(0, 'win32'), null)
+  assert.equal(readProcessCommandLineSync(-1, 'darwin'), null)
+  assert.equal(readProcessCommandLineSync(1.5, 'win32'), null)
+  assert.equal(readProcessCommandLineSync(Number.NaN, 'win32'), null)
+  assert.equal(execMock.mock.calls.length, 0)
+})

--- a/apps/desktop/electron/process-command-line.ts
+++ b/apps/desktop/electron/process-command-line.ts
@@ -1,0 +1,48 @@
+/**
+ * Cross-platform "full command line for a PID" lookup (#102660).
+ *
+ * Never a bare ``ps`` on Windows: there is no ps there, and a bare PATH
+ * lookup resolves to unrelated executables — System32 hosts PS.exe, the
+ * legacy planned-shutdown tool, which is how a Hermes desktop build ended up
+ * executing PS.exe from this exact site. PowerShell's Win32_Process
+ * CommandLine is the Windows equivalent of the POSIX ps full-command-line
+ * probe (the same probe backendCommandForPid uses).
+ *
+ * Both branches execute a fixed binary with a literal argv list (the pid
+ * rides as its own argv element, never inside a shell command string), so no
+ * platform routes this through a shell wrapper and a corrupted pid value can
+ * never alter which program runs. Platform policy is dependency-free and
+ * unit-testable the same way backend-claim.ts's probe policy is (#93608).
+ */
+import { execFileSync } from 'node:child_process'
+
+/**
+ * Synchronous full-command-line read for a live pid; null on any failure
+ * (missing process, probe timeout, invalid pid).
+ */
+export function readProcessCommandLineSync(pid: number, platform: string = process.platform): string | null {
+  if (!Number.isInteger(pid) || pid <= 0) {
+    return null
+  }
+  try {
+    if (platform === 'win32') {
+      const out = execFileSync('powershell.exe', [
+        '-NoProfile',
+        '-NonInteractive',
+        '-Command',
+        '(Get-CimInstance Win32_Process -Filter ("ProcessId = " + $args[0])).CommandLine',
+        String(pid)
+      ], {
+        encoding: 'utf8',
+        // PowerShell 5.1 cold starts routinely exceed 2s (#87169); a timeout
+        // degrades to null ("unknown") rather than hanging the caller.
+        timeout: 5_000
+      })
+      return typeof out === 'string' ? out : null
+    }
+    const out = execFileSync('ps', ['-p', String(pid), '-o', 'args='], { encoding: 'utf8', timeout: 2_000 })
+    return typeof out === 'string' ? out : null
+  } catch {
+    return null
+  }
+}


### PR DESCRIPTION
## What does this PR do?

On Windows, `isHermesProcess()` in `apps/desktop/electron/main.ts` probed candidate PIDs with `execSync('ps -p <pid> -o args=')`. Node wraps string commands on Windows as `cmd.exe /d /s /c "..."` — which is exactly the planned-shutdown chain reported in the issue (`Hermes.exe -> cmd.exe /d /s /c "ps -p <PID> -o args=" -> C:\Windows\System32\PS.exe`): a bare `ps` PATH lookup resolves to unrelated executables, and System32 ships `PS.exe`, the legacy planned-shutdown tool. Note this `cmd.exe /d /s /c` prefix is the fixed Node `execSync` shell wrapper — Python's `subprocess.check_output` with a list argv never goes through it — so the Electron site is the source of the reported Event ID 1074 chain, not the Python probes.

The fix replaces the shell-string probe with `readProcessCommandLineSync()`: on Windows a fixed-argv `execFileSync('powershell.exe', [...])` `Get-CimInstance Win32_Process` query (the binary and every argument are literal argv elements — the pid never rides inside a shell command string, so no corrupted value can alter which program runs); on POSIX `ps` with a literal argv. The helper is isolated in `process-command-line.ts` and unit-tested the same way `backend-claim.ts`'s probe policy is.

Scope note: this PR now intentionally covers **only the desktop Electron probe**. The Python-side probes named in the issue (`tui_gateway/compute_host.py`, `tui_gateway/host_supervisor.py`, `agent/proxy_sources/iron_proxy.py`) are covered by #102669, which was opened first — the two PRs are complementary and no longer touch any common file.

## Related Issue

Fixes #102660 (Electron-side site; Python-side sites are covered by #102669)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/electron/process-command-line.ts` (new): `readProcessCommandLineSync(pid)` — Windows: fixed-argv `execFileSync` PowerShell `Get-CimInstance Win32_Process` query with a 5s timeout (#87169 cold-start guidance), null on any failure; POSIX: `ps -p <pid> -o args=` with a literal argv.
- `apps/desktop/electron/process-command-line.test.ts` (new): 4 unit tests — Windows branch passes a literal argv (no shell string, bare-`ps` binary never used), POSIX branch preserved, invalid pids rejected, probe failures degrade to null.
- `apps/desktop/electron/main.ts`: `isHermesProcess()` now reads the command line via the new helper instead of the `execSync('ps ...')` shell string.

## How to Test

1. `cd apps/desktop && npx vitest run --project electron electron/process-command-line.test.ts`
   - Observed result: `Test Files 1 passed (1), Tests 4 passed (4)`.
2. The old code path (`execSync` with a `ps` shell string) no longer exists anywhere under `apps/desktop/electron/` — `grep -rn "execSync('ps" apps/desktop/electron/` returns nothing.
3. POSIX behavior is unchanged: the new helper still probes with `ps -p <pid> -o args=` via a literal argv.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — pure TypeScript change under `apps/desktop/electron/`, no Python files touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (darwin 25.4.0, arm64) — POSIX branch exercised; Windows branch covered by unit tests asserting the fixed-argv invocation

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- N/A

## Screenshots / Logs

```
$ npx vitest run --project electron electron/process-command-line.test.ts
 ✓ |electron| electron/process-command-line.test.ts (4 tests) 2ms
 Test Files  1 passed (1)
      Tests  4 passed (4)
```
