### PR TITLE
moa: expose and edit per-slot reasoning_effort / max_tokens in `hermes moa configure`

### DIFF
--- a/hermes_cli/moa_cmd.py
+++ b/hermes_cli/moa_cmd.py
@@ -26,6 +26,85 @@ def _prompt_choice(title: str, rows: list[str], default: int = 0) -> int:
             return default
 
 
+def _prompt_optional_max_tokens(current: int | None) -> tuple[bool, int | None]:
+    """Prompt for an optional per-slot ``max_tokens`` override.
+
+    Returns ``(changed, value)``. ``changed`` is False when the user kept the
+    existing value (empty input); ``value`` is None when the override was
+    cleared, matching ``_clean_slot``'s "None = preset default" contract.
+    """
+    shown = str(current) if current is not None else "preset default"
+    prompt = (
+        f"Max output tokens for this slot [{shown}] "
+        "(blank = keep, 'none' = use preset default): "
+    )
+    try:
+        raw = input(prompt).strip()
+    except (KeyboardInterrupt, EOFError):
+        print()
+        return False, current
+    if not raw:
+        return False, current
+    if raw.lower() in {"none", "default", "clear", "0"}:
+        return True, None
+    try:
+        value = int(raw)
+    except ValueError:
+        print(f"  Not a number: {raw!r} — keeping {shown}.")
+        return False, current
+    if value <= 0:
+        print("  max_tokens must be positive — using the preset default.")
+        return True, None
+    return True, value
+
+
+def _slot_reasoning_capability(provider: dict[str, Any], model: str) -> dict[str, Any]:
+    """Reasoning capability entry for ``model`` on ``provider``, or ``{}``.
+
+    ``build_models_payload(capabilities=True)`` attaches a per-model
+    ``{fast, reasoning, can_disable_reasoning?}`` map to every provider row;
+    the slot picker reuses it instead of re-probing any catalog.
+    """
+    caps = provider.get("capabilities")
+    if isinstance(caps, dict):
+        entry = caps.get(model)
+        if isinstance(entry, dict):
+            return entry
+    return {}
+
+
+def _prompt_slot_reasoning_effort(
+    provider: dict[str, Any],
+    model: str,
+    current: str | None,
+) -> tuple[bool, str | None]:
+    """Prompt for a per-slot reasoning effort using the primary-model flow.
+
+    Returns ``(changed, value)``; ``value`` is ``"none"`` when the user disabled
+    reasoning for this slot. Skipped entirely for models the picker already
+    knows take no reasoning parameter.
+    """
+    entry = _slot_reasoning_capability(provider, model)
+    if entry and not entry.get("reasoning", True):
+        return False, current
+
+    from hermes_constants import VALID_REASONING_EFFORTS
+
+    # Local import: hermes_cli.main imports cmd_moa from this module, so a
+    # module-level import would be circular.
+    from hermes_cli.main import _prompt_reasoning_effort_selection
+
+    selected = _prompt_reasoning_effort_selection(
+        list(VALID_REASONING_EFFORTS), current_effort=(current or "")
+    )
+    if selected is None:
+        return False, current
+    if selected == "none" and entry.get("can_disable_reasoning") is False:
+        print(f"  {model} cannot disable reasoning — keeping the current level.")
+        return False, current
+    return True, selected
+
+
 def _model_options() -> list[dict[str, Any]]:
     payload = build_models_payload(
         load_picker_context(),
@@ -49,30 +128,94 @@ def _model_options() -> list[dict[str, Any]]:
     ]
 
 
-def _pick_slot(current: dict[str, str] | None = None) -> dict[str, str]:
+def _pick_slot(current: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Interactive picker for one MoA slot (a reference model or the aggregator).
+
+    Prompts for provider + model, then the two per-slot tuning knobs the config
+    schema already supports but the flow never surfaced: ``reasoning_effort``
+    (#102582) and ``max_tokens`` (#102584). When ``current`` already names a
+    selectable provider/model, offers an in-place edit of just those knobs so
+    retuning a preset doesn't require re-walking both pickers (#102585).
+    """
     providers = _model_options()
     if not providers:
         raise RuntimeError("No configured model providers found. Run `hermes model` first.")
-    current_provider = (current or {}).get("provider", "")
+
+    current_provider = str((current or {}).get("provider") or "")
+    current_model = str((current or {}).get("model") or "")
+    current_effort = str((current or {}).get("reasoning_effort") or "").strip().lower() or None
+    current_max_tokens = (current or {}).get("max_tokens")
+    if not isinstance(current_max_tokens, int) or isinstance(current_max_tokens, bool):
+        current_max_tokens = None
+
     provider_default = next(
         (idx for idx, p in enumerate(providers) if p.get("slug") == current_provider),
         0,
     )
-    provider_rows = [f"{p.get('name') or p.get('slug')}  ({p.get('slug')})" for p in providers]
-    provider = providers[_prompt_choice("Select provider", provider_rows, provider_default)]
-    models = list(provider.get("models") or [])
-    if not models:
-        raise RuntimeError(f"Provider {provider.get('slug')} has no selectable models")
-    current_model = (current or {}).get("model", "")
-    model_default = models.index(current_model) if current_model in models else 0
-    model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
-    return {"provider": str(provider.get("slug") or ""), "model": str(model)}
+
+    # Edit-in-place is only offered when the existing pairing is still
+    # selectable, so "keep" can never pin a provider/model the picker dropped.
+    keep_existing = False
+    if current_provider and current_model:
+        existing = providers[provider_default]
+        if existing.get("slug") == current_provider and current_model in (existing.get("models") or []):
+            keep_existing = (
+                _prompt_choice(
+                    f"{current_provider}:{current_model}",
+                    [
+                        "Keep provider/model, edit tuning knobs",
+                        "Change provider/model",
+                    ],
+                    0,
+                )
+                == 0
+            )
+
+    if keep_existing:
+        provider = providers[provider_default]
+        model = current_model
+    else:
+        provider_rows = [f"{p.get('name') or p.get('slug')}  ({p.get('slug')})" for p in providers]
+        provider = providers[_prompt_choice("Select provider", provider_rows, provider_default)]
+        models = list(provider.get("models") or [])
+        if not models:
+            raise RuntimeError(f"Provider {provider.get('slug')} has no selectable models")
+        model_default = models.index(current_model) if current_model in models else 0
+        model = models[_prompt_choice(f"Select model for {provider.get('slug')}", models, model_default)]
+        # Both knobs are per-model budgets; carrying them onto a DIFFERENT model
+        # would silently apply a cap/effort the user chose for something else.
+        if str(model) != current_model:
+            current_effort = None
+            current_max_tokens = None
+
+    slot: dict[str, Any] = {
+        "provider": str(provider.get("slug") or ""),
+        "model": str(model),
+    }
+
+    effort_changed, effort = _prompt_slot_reasoning_effort(provider, str(model), current_effort)
+    effort = effort if effort_changed else current_effort
+    if effort:
+        slot["reasoning_effort"] = effort
+
+    mt_changed, max_tokens = _prompt_optional_max_tokens(current_max_tokens)
+    max_tokens = max_tokens if mt_changed else current_max_tokens
+    if isinstance(max_tokens, int) and not isinstance(max_tokens, bool) and max_tokens > 0:
+        slot["max_tokens"] = max_tokens
+
+    return slot
 
 
 def _format_slot(slot: dict[str, Any]) -> str:
     label = f"{slot['provider']}:{slot['model']}"
+    parts: list[str] = []
     effort = str(slot.get("reasoning_effort") or "").strip()
-    return f"{label} [reasoning={effort}]" if effort else label
+    if effort:
+        parts.append(f"reasoning={effort}")
+    max_tokens = slot.get("max_tokens")
+    if isinstance(max_tokens, int) and not isinstance(max_tokens, bool) and max_tokens > 0:
+        parts.append(f"max_tokens={max_tokens}")
+    return f"{label} [{', '.join(parts)}]" if parts else label
 
 
 def _print_config(config: dict[str, Any]) -> None:
@@ -106,7 +249,7 @@ def cmd_moa(args) -> None:
         current = moa["presets"].get(preset_name, moa["presets"][moa["default_preset"]])
         print(f"Configure MoA preset: {preset_name}")
         print("Pick at least one reference model; choose Done when finished.")
-        refs: list[dict[str, str]] = []
+        refs: list[dict[str, Any]] = []
         existing = list(current.get("reference_models") or [])
         idx = 0
         while True:

--- a/tests/hermes_cli/test_moa_slot_tuning_knobs.py
+++ b/tests/hermes_cli/test_moa_slot_tuning_knobs.py
@@ -1,0 +1,232 @@
+"""Per-slot MoA tuning knobs in ``hermes moa configure`` (#102582, #102584, #102585).
+
+``moa.presets.<name>.reference_models[].reasoning_effort`` and ``.max_tokens``
+have been first-class schema fields (``hermes_cli/moa_config.py::_clean_slot``)
+that the interactive flow never set, so the only way to use them was hand-editing
+config JSON. These tests pin the three behaviors that closed that gap:
+
+* ``_pick_slot`` prompts for both knobs and persists them on the slot.
+* ``_format_slot`` surfaces both in ``hermes moa list``.
+* An existing slot can be retuned in place, without re-picking provider/model.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import moa_cmd
+from hermes_cli.moa_config import normalize_moa_config
+
+PROVIDERS = [
+    {
+        "slug": "openrouter",
+        "name": "OpenRouter",
+        "models": ["anthropic/claude-opus-4.8", "deepseek/deepseek-v4-pro"],
+        "capabilities": {
+            "anthropic/claude-opus-4.8": {"fast": False, "reasoning": True},
+            "deepseek/deepseek-v4-pro": {"fast": False, "reasoning": True},
+        },
+    },
+    {
+        "slug": "nous",
+        "name": "Nous",
+        "models": ["hermes-4"],
+        # A route that takes no reasoning parameter at all.
+        "capabilities": {"hermes-4": {"fast": False, "reasoning": False}},
+    },
+]
+
+
+@pytest.fixture()
+def providers():
+    with patch.object(moa_cmd, "_model_options", return_value=PROVIDERS):
+        yield PROVIDERS
+
+
+class TestFormatSlot:
+    def test_bare_slot_has_no_bracket(self):
+        assert moa_cmd._format_slot({"provider": "nous", "model": "hermes-4"}) == "nous:hermes-4"
+
+    def test_reasoning_effort_is_shown(self):
+        slot = {"provider": "nous", "model": "hermes-4", "reasoning_effort": "high"}
+        assert moa_cmd._format_slot(slot) == "nous:hermes-4 [reasoning=high]"
+
+    def test_max_tokens_is_shown(self):
+        # #102584: _format_slot used to drop the per-slot cap entirely, so a
+        # configured override was invisible in `hermes moa list`.
+        slot = {"provider": "nous", "model": "hermes-4", "max_tokens": 2048}
+        assert moa_cmd._format_slot(slot) == "nous:hermes-4 [max_tokens=2048]"
+
+    def test_both_knobs_are_shown(self):
+        slot = {
+            "provider": "nous",
+            "model": "hermes-4",
+            "reasoning_effort": "low",
+            "max_tokens": 512,
+        }
+        assert moa_cmd._format_slot(slot) == "nous:hermes-4 [reasoning=low, max_tokens=512]"
+
+    def test_non_positive_max_tokens_is_not_shown(self):
+        slot = {"provider": "nous", "model": "hermes-4", "max_tokens": 0}
+        assert moa_cmd._format_slot(slot) == "nous:hermes-4"
+
+
+class TestPromptOptionalMaxTokens:
+    def test_blank_keeps_current(self):
+        with patch("builtins.input", return_value=""):
+            assert moa_cmd._prompt_optional_max_tokens(4096) == (False, 4096)
+
+    def test_number_sets_override(self):
+        with patch("builtins.input", return_value="1234"):
+            assert moa_cmd._prompt_optional_max_tokens(None) == (True, 1234)
+
+    @pytest.mark.parametrize("text", ["none", "default", "clear", "0"])
+    def test_sentinels_clear_the_override(self, text):
+        with patch("builtins.input", return_value=text):
+            assert moa_cmd._prompt_optional_max_tokens(4096) == (True, None)
+
+    def test_garbage_keeps_current(self):
+        with patch("builtins.input", return_value="lots"):
+            assert moa_cmd._prompt_optional_max_tokens(2048) == (False, 2048)
+
+    def test_negative_falls_back_to_preset_default(self):
+        with patch("builtins.input", return_value="-5"):
+            assert moa_cmd._prompt_optional_max_tokens(2048) == (True, None)
+
+    def test_interrupt_keeps_current(self):
+        with patch("builtins.input", side_effect=KeyboardInterrupt):
+            assert moa_cmd._prompt_optional_max_tokens(2048) == (False, 2048)
+
+
+class TestPromptSlotReasoningEffort:
+    def test_skipped_for_a_non_reasoning_model(self, providers):
+        # The picker already knows this route takes no reasoning parameter, so
+        # the prompt must not even be offered.
+        with patch("hermes_cli.main._prompt_reasoning_effort_selection") as prompt:
+            changed, value = moa_cmd._prompt_slot_reasoning_effort(PROVIDERS[1], "hermes-4", None)
+        prompt.assert_not_called()
+        assert (changed, value) == (False, None)
+
+    def test_selection_is_returned(self, providers):
+        with patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"):
+            assert moa_cmd._prompt_slot_reasoning_effort(
+                PROVIDERS[0], "anthropic/claude-opus-4.8", None
+            ) == (True, "high")
+
+    def test_skip_keeps_current(self, providers):
+        with patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value=None):
+            assert moa_cmd._prompt_slot_reasoning_effort(
+                PROVIDERS[0], "anthropic/claude-opus-4.8", "low"
+            ) == (False, "low")
+
+    def test_disable_refused_on_reasoning_mandatory_route(self):
+        provider = {
+            "slug": "nous",
+            "models": ["mandatory-thinker"],
+            "capabilities": {
+                "mandatory-thinker": {"reasoning": True, "can_disable_reasoning": False}
+            },
+        }
+        with patch("hermes_cli.main._prompt_reasoning_effort_selection", return_value="none"):
+            assert moa_cmd._prompt_slot_reasoning_effort(provider, "mandatory-thinker", "high") == (
+                False,
+                "high",
+            )
+
+
+class TestPickSlotTuningKnobs:
+    def test_new_slot_records_both_knobs(self, providers):
+        # provider idx 0, model idx 0, then the two knob prompts.
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[0, 0]), patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value="medium"
+        ), patch("builtins.input", return_value="3000"):
+            slot = moa_cmd._pick_slot()
+
+        assert slot == {
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus-4.8",
+            "reasoning_effort": "medium",
+            "max_tokens": 3000,
+        }
+        # And the write boundary keeps both fields.
+        cleaned = normalize_moa_config(
+            {"presets": {"p": {"reference_models": [slot], "aggregator": slot}}}
+        )["presets"]["p"]["reference_models"][0]
+        assert cleaned["reasoning_effort"] == "medium"
+        assert cleaned["max_tokens"] == 3000
+
+    def test_edit_in_place_keeps_provider_and_model(self, providers):
+        # #102585: choosing "Keep provider/model" must not walk the provider or
+        # model picker again — exactly one _prompt_choice call (the edit menu).
+        current = {
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-pro",
+            "reasoning_effort": "low",
+            "max_tokens": 512,
+        }
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[0]) as choice, patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value="high"
+        ), patch("builtins.input", return_value="4096"):
+            slot = moa_cmd._pick_slot(current)
+
+        assert choice.call_count == 1
+        assert slot == {
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-pro",
+            "reasoning_effort": "high",
+            "max_tokens": 4096,
+        }
+
+    def test_edit_in_place_preserves_untouched_knobs(self, providers):
+        current = {
+            "provider": "openrouter",
+            "model": "deepseek/deepseek-v4-pro",
+            "reasoning_effort": "low",
+            "max_tokens": 512,
+        }
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[0]), patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+        ), patch("builtins.input", return_value=""):
+            slot = moa_cmd._pick_slot(current)
+
+        assert slot["reasoning_effort"] == "low"
+        assert slot["max_tokens"] == 512
+
+    def test_changing_model_drops_stale_knobs(self, providers):
+        # Knobs are per-model; carrying an effort/cap onto a different model
+        # would silently apply a budget the user chose for something else.
+        current = {
+            "provider": "openrouter",
+            "model": "anthropic/claude-opus-4.8",
+            "reasoning_effort": "high",
+            "max_tokens": 512,
+        }
+        # edit menu -> "Change provider/model", provider idx 0, model idx 1.
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[1, 0, 1]), patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+        ), patch("builtins.input", return_value=""):
+            slot = moa_cmd._pick_slot(current)
+
+        assert slot == {"provider": "openrouter", "model": "deepseek/deepseek-v4-pro"}
+
+    def test_no_edit_menu_when_current_model_is_unselectable(self, providers):
+        # A slot naming a model the picker no longer offers must fall through to
+        # the full flow rather than letting "keep" pin a dead pairing.
+        current = {"provider": "openrouter", "model": "retired/model"}
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[0, 0]) as choice, patch(
+            "hermes_cli.main._prompt_reasoning_effort_selection", return_value=None
+        ), patch("builtins.input", return_value=""):
+            slot = moa_cmd._pick_slot(current)
+
+        # provider + model pickers only; no edit menu.
+        assert choice.call_count == 2
+        assert slot == {"provider": "openrouter", "model": "anthropic/claude-opus-4.8"}
+
+    def test_non_reasoning_model_never_gets_an_effort(self, providers):
+        # provider idx 1 (nous), model idx 0 (hermes-4, reasoning: False).
+        with patch.object(moa_cmd, "_prompt_choice", side_effect=[1, 0]), patch(
+            "builtins.input", return_value=""
+        ):
+            slot = moa_cmd._pick_slot()
+
+        assert slot == {"provider": "nous", "model": "hermes-4"}


### PR DESCRIPTION
Fixes #102582
Fixes #102584
Fixes #102585

## Problem

`moa_config._clean_slot` has long accepted per-slot `reasoning_effort` and
`max_tokens` on reference models and the aggregator, and `_format_slot` already
printed `reasoning_effort` — but `hermes moa configure` -> `_pick_slot()` only
ever prompted for provider and model. The only way to set either knob was
hand-editing the config JSON and knowing the internal field name.

## Change (`hermes_cli/moa_cmd.py`)

- **#102582 — per-slot reasoning effort.** `_prompt_slot_reasoning_effort()`
  reuses the primary-model flow (`_prompt_reasoning_effort_selection`) per slot.
  It reads the per-model capability map the slot picker already requests
  (`build_models_payload(capabilities=True)`), so it is skipped for models
  reported as taking no reasoning parameter, and refuses `none` on
  reasoning-mandatory routes (`can_disable_reasoning=False`) rather than saving
  a level the upstream answers with HTTP 400.
- **#102584 — per-slot `max_tokens`.** `_prompt_optional_max_tokens()` takes an
  optional positive int. Blank keeps the current value; `none` / `default` /
  `clear` / `0` falls back to the preset-level `reference_max_tokens`, matching
  `_clean_slot`'s documented "None = preset default" contract. `_format_slot()`
  now also renders `max_tokens`, so `hermes moa list` surfaces a configured
  override instead of hiding it.
- **#102585 — edit in place.** When a slot already names a *still-selectable*
  provider/model, `_pick_slot()` first offers "Keep provider/model, edit tuning
  knobs", so retuning does not re-walk both pickers. Changing the model clears
  the previous model's knobs instead of silently reapplying a budget chosen for
  a different model. A slot naming a model the picker no longer offers falls
  through to the full flow, so "keep" can never pin a dead pairing.

No schema change: both fields already round-trip through
`normalize_moa_config`.

## Tests

`tests/hermes_cli/test_moa_slot_tuning_knobs.py` — 24 new cases covering
`_format_slot` rendering (neither / either / both knobs), the `max_tokens`
prompt (blank, number, each clear sentinel, garbage, negative, `KeyboardInterrupt`),
the reasoning prompt (skipped for a non-reasoning route, selection, skip,
disable refused when mandatory), and `_pick_slot` (new slot records both knobs
and survives `normalize_moa_config`; edit-in-place makes exactly one
`_prompt_choice` call; untouched knobs preserved; changing model drops stale
knobs; no edit menu for an unselectable current model).

Verified: 38 passed across the new file plus `tests/cli/test_moa_command.py`,
`tests/hermes_cli/test_moa_config.py`, and
`tests/hermes_cli/test_moa_set_models_preserves_extra_keys.py`.
