### PR TITLE
fix(a2a): harden bot relay and task isolation

### DIFF
--- a/apps/desktop/e2e/bot-mode-row-click-mirrors-registry.spec.ts
+++ b/apps/desktop/e2e/bot-mode-row-click-mirrors-registry.spec.ts
@@ -125,7 +125,7 @@ test('a bot row click lands on the Bot Chat the row previews, not a side thread'
   await settle(page, 15_000)
 
   // A `+` side thread for alpha, with a real turn so it is a persisted tile.
-  await page.keyboard.press('Control+t')
+  await page.keyboard.press('ControlOrMeta+t')
   const composer = page.locator('[data-slot="composer-root"] [contenteditable="true"]').filter({ visible: true }).first()
   await expect(composer).toBeVisible({ timeout: 15_000 })
   await composer.click()

--- a/apps/desktop/e2e/bot-mode-tab-shows-bot-name.spec.ts
+++ b/apps/desktop/e2e/bot-mode-tab-shows-bot-name.spec.ts
@@ -122,7 +122,7 @@ test("an open Bot Chat's tab reads the bot's name, not the canonical 'Bot Chat' 
 
   // A `+` side thread beside the Bot Chat gives the main zone a tab strip —
   // the surface where every bot chat used to read "Bot Chat".
-  await page.keyboard.press('Control+t')
+  await page.keyboard.press('ControlOrMeta+t')
   const composer = page.locator('[data-slot="composer-root"] [contenteditable="true"]').filter({ visible: true }).first()
   await expect(composer).toBeVisible({ timeout: 15_000 })
   await composer.click()

--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -456,7 +456,7 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
     stopBotRelay()
   })
 
-  it('stays quiet with a single connection — there is no peer to relay to', async () => {
+  it('clears stale remote agents when only one connection remains', async () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
 
     const calls = respondWith(() => ({}))
@@ -465,7 +465,14 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
     startBotRelay()
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(calls).toHaveLength(0)
+    expect(calls).toEqual([
+      expect.objectContaining({ connectionId: 'a', method: 'profiles.list' }),
+      expect.objectContaining({
+        connectionId: 'a',
+        method: 'bot_relay.roster.sync',
+        params: { agents: [] }
+      })
+    ])
 
     stopBotRelay()
   })
@@ -507,6 +514,30 @@ describe('the drain loop wires drain → deliver → reply', () => {
     })
     // A delivered background DM is this bot's "good turn".
     expect(clearBotAttentionMock).toHaveBeenCalledWith('b::ops')
+
+    stopBotRelay()
+  })
+
+  it('keeps live-session acceptance distinct from a completed reply', async () => {
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain') {
+        return { envelopes: call.connectionId === 'a' ? [envelope] : [] }
+      }
+      if (call.method === 'bot_relay.deliver') {
+        return { status: 'accepted' }
+      }
+      return {}
+    })
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+
+    expect(calls.find(call => call.method === 'bot_relay.reply')?.params).toMatchObject({
+      id: 'env-1',
+      status: 'accepted'
+    })
+    expect(calls.find(call => call.method === 'bot_relay.reply')?.params.reply).toBeUndefined()
 
     stopBotRelay()
   })

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -236,8 +236,7 @@ async function relayAgentsOn(connection: RelayConnection): Promise<RelayAgentRow
 
 /** Last good agent rows per connection id — reused when a fetch blips so a
  *  transient failure never reads as "everyone on that machine went away".
- *  The sweep below drops disconnected ids, but only on a cycle that had two
- *  or more connections to relay between; the ceiling is what bounds the rest.
+ *  The sweep below drops disconnected ids on every non-empty registry cycle.
  *  Every live connection is rewritten each cycle, so eviction can only ever
  *  reach ids that stopped being fetched. */
 const RELAY_AGENTS_CACHE_MAX = 32
@@ -254,7 +253,7 @@ async function syncRelayRosters() {
   try {
     const connections = await relayConnections()
 
-    if (connections.length < 2) {
+    if (connections.length === 0) {
       return
     }
 
@@ -365,7 +364,12 @@ async function drainRelayOutboxes() {
         const envelopeId = String(envelope?.id || '')
         const target = byId.get(String(envelope?.target_connection || ''))
 
-        const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
+        const postReply = async (payload: {
+          error?: string
+          reason?: string
+          reply?: string
+          status?: 'accepted' | 'completed'
+        }) => {
           try {
             await host.requestProfile(sender.route, 'bot_relay.reply', {
               id: envelopeId,
@@ -393,7 +397,7 @@ async function drainRelayOutboxes() {
         const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
 
         try {
-          const res = await host.requestProfile<{ reply?: string }>(
+          const res = await host.requestProfile<{ reply?: string; status?: 'accepted' | 'completed' }>(
             target.route,
             'bot_relay.deliver',
             {
@@ -404,9 +408,11 @@ async function drainRelayOutboxes() {
           )
 
           clearBotAttention(attentionKey)
-          await postReply({
-            reply: String(res?.reply || '')
-          })
+          await postReply(
+            res?.status === 'accepted'
+              ? { status: 'accepted' }
+              : { status: 'completed', reply: String(res?.reply || '') }
+          )
         } catch (error: any) {
           // #93091: bot_relay.deliver classifies the failed turn and ships the
           // typed code in the JSON-RPC error's `data.reason`; forward it into

--- a/plugins/platforms/a2a/adapter.py
+++ b/plugins/platforms/a2a/adapter.py
@@ -30,6 +30,8 @@ Bind safety: with no token configured, the server binds 127.0.0.1 only.
 from __future__ import annotations
 
 import asyncio
+import hashlib
+import http.client
 import json
 import logging
 import os
@@ -66,12 +68,40 @@ _MAX_BODY = 1_048_576  # 1MB max request body — prevents DoS via memory exhaus
 _SSE_KEEPALIVE = 5  # seconds between SSE keepalive comments
 
 
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    def __init__(self, host: str, pinned_ip: str, **kwargs):
+        self._pinned_ip = pinned_ip
+        super().__init__(host, **kwargs)
+
+    def connect(self):
+        self.sock = self._create_connection(
+            (self._pinned_ip, self.port), self.timeout, self.source_address
+        )
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    def __init__(self, host: str, pinned_ip: str, **kwargs):
+        self._pinned_ip = pinned_ip
+        super().__init__(host, **kwargs)
+
+    def connect(self):
+        self.sock = self._create_connection(
+            (self._pinned_ip, self.port), self.timeout, self.source_address
+        )
+        self.sock = self._context.wrap_socket(self.sock, server_hostname=self.host)
+
+
 def _reply_timeout() -> float:
     """Seconds to wait for the agent to answer an inbound task."""
     try:
         return max(1.0, float(os.getenv("A2A_REPLY_TIMEOUT", "300")))
     except (ValueError, TypeError):
         return 300.0
+
+
+def _scoped_context_id(peer: str, agent_slug: str, tenant: str, context_id: str) -> str:
+    scope = "\0".join((peer, agent_slug, tenant, context_id)).encode()
+    return f"a2a-{hashlib.sha256(scope).hexdigest()}"
 
 
 def _profile_scoped() -> bool:
@@ -258,6 +288,13 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             self._json(200, payload)
             return
         if subpath == "/metrics":
+            identity = self.adapter._security_context.authenticate(
+                self.headers.get("Authorization"),
+                self.client_address[0] if self.client_address else "",
+            )
+            if identity is None:
+                self._json(401, {"error": "unauthorized"})
+                return
             self._json(200, protocol.metrics.snapshot())
             return
         self._json(404, {"error": "not found"})
@@ -333,28 +370,28 @@ class A2ARequestHandler(BaseHTTPRequestHandler):
             adapter._rpc_message_stream(self, req_id, params, identity, agent=agent)
             return
         if operation == "get":
-            self._json(200, adapter._rpc_tasks_get(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_get(req_id, params, peer=identity, agent=agent))
             return
         if operation == "list":
-            self._json(200, adapter._rpc_tasks_list(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_list(req_id, params, peer=identity, agent=agent))
             return
         if operation == "cancel":
-            self._json(200, adapter._rpc_tasks_cancel(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_tasks_cancel(req_id, params, peer=identity, agent=agent))
             return
         if operation == "subscribe":
-            adapter._rpc_tasks_subscribe(self, req_id, params, agent=agent)
+            adapter._rpc_tasks_subscribe(self, req_id, params, peer=identity, agent=agent)
             return
         if operation == "push_create":
-            self._json(200, adapter._rpc_push_config_create(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_create(req_id, params, peer=identity, agent=agent))
             return
         if operation == "push_get":
-            self._json(200, adapter._rpc_push_config_get(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_get(req_id, params, peer=identity, agent=agent))
             return
         if operation == "push_list":
-            self._json(200, adapter._rpc_push_config_list(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_list(req_id, params, peer=identity, agent=agent))
             return
         if operation == "push_delete":
-            self._json(200, adapter._rpc_push_config_delete(req_id, params, agent=agent))
+            self._json(200, adapter._rpc_push_config_delete(req_id, params, peer=identity, agent=agent))
             return
 
 
@@ -749,9 +786,11 @@ class A2AAdapter(BasePlatformAdapter):
         text = protocol.extract_text(params)
         context_id = protocol.extract_context_id(params) or protocol.new_context_id()
         task_id = protocol.new_task_id()
+        agent_slug, tenant = self._scope_for_agent(agent)
+        delivery_context_id = _scoped_context_id(peer, agent_slug, tenant, context_id)
 
         # Anti-loop ping-pong protection
-        turn = self._turns.track(context_id)
+        turn = self._turns.track(delivery_context_id)
         if turn > protocol.max_pingpong_turns():
             protocol.metrics.anti_loop_triggers += 1
             logger.warning("A2A: anti-loop triggered for context %s (turn %d > %d)",
@@ -776,16 +815,16 @@ class A2AAdapter(BasePlatformAdapter):
 
         framed = security.wrap_inbound(peer, text)
         security.audit("inbound", peer, task_id, text)
-        protocol.persist_message(context_id, "user", text, task_id)
+        protocol.persist_message(delivery_context_id, "user", text, task_id)
         protocol.metrics.inbound_total += 1
 
         rec = self.tasks.create(task_id, context_id, peer, *self._scope_for_agent(agent))
-        self._register_inline_push(task_id, params, agent=agent)
+        self._register_inline_push(task_id, params, peer=peer, agent=agent)
 
         if not agent.get("local", True):
-            reply, state = self._forward_to_profile(agent, peer, context_id, framed)
+            reply, state = self._forward_to_profile(agent, peer, delivery_context_id, framed)
             self.tasks.complete(task_id, state, reply)
-            protocol.persist_message(context_id, "agent", reply, task_id)
+            protocol.persist_message(delivery_context_id, "agent", reply, task_id)
             security.audit("outbound", peer, task_id, reply)
             if state == protocol.STATE_COMPLETED:
                 protocol.metrics.outbound_total += 1
@@ -804,13 +843,13 @@ class A2AAdapter(BasePlatformAdapter):
                 created_at=rec["created_iso"],
             ), None
 
-        fut = self._add_pending(task_id, context_id)
+        fut = self._add_pending(task_id, delivery_context_id)
 
         event = MessageEvent(
             text=framed,
             message_type=MessageType.TEXT,
             source=self.build_source(
-                chat_id=context_id,
+                chat_id=delivery_context_id,
                 chat_name=f"a2a:{peer}",
                 chat_type="dm",
                 user_id=peer,
@@ -835,6 +874,7 @@ class A2AAdapter(BasePlatformAdapter):
         return None, {
             "task_id": task_id,
             "context_id": context_id,
+            "delivery_context_id": delivery_context_id,
             "peer": peer,
             "future": fut,
             "created_iso": rec["created_iso"],
@@ -943,6 +983,7 @@ class A2AAdapter(BasePlatformAdapter):
         redaction and input-required detection."""
         task_id = pending["task_id"]
         context_id = pending["context_id"]
+        delivery_context_id = pending.get("delivery_context_id", context_id)
         peer = pending["peer"]
         self._pop_pending(task_id)
 
@@ -956,7 +997,7 @@ class A2AAdapter(BasePlatformAdapter):
                 state = protocol.STATE_INPUT_REQUIRED
                 reply = stripped[len(protocol.INPUT_REQUIRED_MARKER):].strip()
 
-        protocol.persist_message(context_id, "agent", reply, task_id)
+        protocol.persist_message(delivery_context_id, "agent", reply, task_id)
         security.audit("outbound", peer, task_id, reply)
 
         if state in (protocol.STATE_COMPLETED, protocol.STATE_INPUT_REQUIRED):
@@ -1071,10 +1112,12 @@ class A2AAdapter(BasePlatformAdapter):
         except (BrokenPipeError, ConnectionResetError):
             logger.debug("A2A: stream client disconnected")
 
-    def _rpc_tasks_subscribe(self, handler, req_id: Any, params: dict, agent: Optional[dict] = None) -> None:
+    def _rpc_tasks_subscribe(
+        self, handler, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> None:
         """Reconnect to an existing task's stream (v1.0 SubscribeToTask)."""
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer)
         if not rec:
             handler._json(200, protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}"))
@@ -1082,7 +1125,7 @@ class A2AAdapter(BasePlatformAdapter):
 
         self._sse_headers(handler)
         try:
-            fut = self.tasks.watch(task_id, *self._scope_for_agent(agent))
+            fut = self.tasks.watch(task_id, *self._scope_for_agent(agent), peer)
             if fut is None:
                 self._sse_write(handler, protocol.sse_done())
                 return
@@ -1102,9 +1145,11 @@ class A2AAdapter(BasePlatformAdapter):
 
     # ── Task queries ──────────────────────────────────────────────────────
 
-    def _rpc_tasks_get(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_get(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer)
         if not rec:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
@@ -1115,7 +1160,9 @@ class A2AAdapter(BasePlatformAdapter):
             history_len = None
         return protocol.jsonrpc_result(req_id, protocol.TaskStore.to_task(rec, history_length=history_len))
 
-    def _rpc_tasks_list(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_list(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         try:
             offset = int(params.get("pageToken") or 0)
         except (ValueError, TypeError):
@@ -1131,6 +1178,7 @@ class A2AAdapter(BasePlatformAdapter):
             offset=max(0, offset),
             agent_slug=self._scope_for_agent(agent)[0],
             tenant=self._scope_for_agent(agent)[1],
+            peer=peer,
             with_total=True,
         )
         include_artifacts = bool(params.get("includeArtifacts", False))
@@ -1146,9 +1194,11 @@ class A2AAdapter(BasePlatformAdapter):
             "totalSize": total,
         })
 
-    def _rpc_tasks_cancel(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_tasks_cancel(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         task_id = str(params.get("taskId") or params.get("id") or "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent))
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer)
         if not rec:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
@@ -1158,22 +1208,29 @@ class A2AAdapter(BasePlatformAdapter):
                 f"task {task_id} already {rec['state']}")
         self.tasks.complete(task_id, protocol.STATE_CANCELED, "")
         self._turns.reset(rec["context_id"])
+        self._turns.reset(_scoped_context_id(
+            rec["peer"], rec.get("agent_slug", ""), rec.get("tenant", ""), rec["context_id"]
+        ))
         self._resolve_task(task_id, protocol.STATE_CANCELED, "")
-        rec = self.tasks.get(task_id, *self._scope_for_agent(agent)) or rec
+        rec = self.tasks.get(task_id, *self._scope_for_agent(agent), peer) or rec
         return protocol.jsonrpc_result(req_id, protocol.TaskStore.to_task(rec))
 
     # ── Push notifications ────────────────────────────────────────────────
 
-    def _register_inline_push(self, task_id: str, params: dict, agent: Optional[dict] = None) -> None:
+    def _register_inline_push(
+        self, task_id: str, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> None:
         """v1.0: message/send can carry configuration.taskPushNotificationConfig."""
         cfg = (params.get("configuration") or {}).get("taskPushNotificationConfig") or {}
         if not isinstance(cfg, dict):
             return
         url = cfg.get("url") or (cfg.get("pushNotificationConfig") or {}).get("url") or ""
         if url:
-            self.tasks.set_push_config(task_id, str(url), *self._scope_for_agent(agent))
+            self.tasks.set_push_config(task_id, str(url), *self._scope_for_agent(agent), peer)
 
-    def _rpc_push_config_create(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_create(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         task_id = str(params.get("taskId") or "")
         cfg = params.get("pushNotificationConfig") or params.get("config") or {}
         url = str((cfg or {}).get("url") or "")
@@ -1181,43 +1238,49 @@ class A2AAdapter(BasePlatformAdapter):
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS,
                 "taskId and pushNotificationConfig.url required")
-        stored = self.tasks.set_push_config(task_id, url, *self._scope_for_agent(agent))
+        stored = self.tasks.set_push_config(task_id, url, *self._scope_for_agent(agent), peer)
         if stored is None:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND, f"task not found: {task_id}")
         return protocol.jsonrpc_result(req_id, stored)
 
-    def _rpc_push_config_get(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_get(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         """GetTaskPushNotificationConfig — retrieve a push config by task id."""
         task_id = str(params.get("taskId") or "")
         config_id = str(params.get("id") or params.get("configId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        cfg = self.tasks.get_push_config(task_id, config_id, *self._scope_for_agent(agent))
+        cfg = self.tasks.get_push_config(task_id, config_id, *self._scope_for_agent(agent), peer)
         if cfg is None:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND,
                 f"push config not found for task: {task_id}")
         return protocol.jsonrpc_result(req_id, cfg)
 
-    def _rpc_push_config_list(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_list(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         """ListTaskPushNotificationConfigs — list push configs for a task."""
         task_id = str(params.get("taskId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        configs = self.tasks.list_push_configs(task_id, *self._scope_for_agent(agent))
+        configs = self.tasks.list_push_configs(task_id, *self._scope_for_agent(agent), peer)
         return protocol.jsonrpc_result(req_id, {"configs": configs, "nextPageToken": ""})
 
-    def _rpc_push_config_delete(self, req_id: Any, params: dict, agent: Optional[dict] = None) -> dict:
+    def _rpc_push_config_delete(
+        self, req_id: Any, params: dict, peer: str = "", agent: Optional[dict] = None
+    ) -> dict:
         """DeleteTaskPushNotificationConfig — remove a push config."""
         task_id = str(params.get("taskId") or "")
         config_id = str(params.get("id") or params.get("configId") or "")
         if not task_id:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_INVALID_PARAMS, "taskId required")
-        deleted = self.tasks.delete_push_config(task_id, config_id, *self._scope_for_agent(agent))
+        deleted = self.tasks.delete_push_config(task_id, config_id, *self._scope_for_agent(agent), peer)
         if not deleted:
             return protocol.jsonrpc_error(
                 req_id, protocol.ERR_TASK_NOT_FOUND,
@@ -1235,10 +1298,11 @@ class A2AAdapter(BasePlatformAdapter):
         if not callback_url:
             return
 
-        if not security.is_safe_callback_url(
+        resolved = security.resolve_safe_callback_url(
             callback_url,
             localhost_mode=self._security_context.localhost_only(),
-        ):
+        )
+        if not resolved:
             logger.warning("A2A: push notification for task %s blocked — unsafe callback URL: %s",
                            task_id, callback_url)
             protocol.metrics.push_failed += 1
@@ -1254,14 +1318,25 @@ class A2AAdapter(BasePlatformAdapter):
 
         try:
             data = json.dumps(payload).encode("utf-8")
-            req = urllib.request.Request(callback_url, data=data, headers=headers, method="POST")
-            with urllib.request.urlopen(req, timeout=10) as resp:  # noqa: S310
+            parsed, pinned_ip = resolved
+            connection_cls = _PinnedHTTPSConnection if parsed.scheme == "https" else _PinnedHTTPConnection
+            connection = connection_cls(
+                parsed.hostname or "", pinned_ip, port=parsed.port, timeout=10
+            )
+            path = parsed.path or "/"
+            if parsed.query:
+                path += f"?{parsed.query}"
+            connection.request("POST", path, body=data, headers={**headers, "Host": parsed.netloc})
+            try:
+                resp = connection.getresponse()
                 if 200 <= resp.status < 300:
                     protocol.metrics.push_sent += 1
                     logger.debug("A2A: push notification sent for task %s", task_id)
                 else:
                     protocol.metrics.push_failed += 1
                     logger.warning("A2A: push notification for task %s got HTTP %d", task_id, resp.status)
+            finally:
+                connection.close()
         except Exception as e:
             protocol.metrics.push_failed += 1
             logger.warning("A2A: push notification for task %s failed: %s", task_id, e)
@@ -1290,7 +1365,7 @@ class A2AAdapter(BasePlatformAdapter):
         message_id = str(int(time.time() * 1000))
         if not (metadata or {}).get("notify"):
             logger.debug("A2A: ignoring non-final send for context %s", chat_id)
-            return SendResult(success=True, message_id=message_id)
+            return SendResult(success=False, error="A2A defers delivery until the final reply")
         if not self._resolve_oldest_for_context(chat_id, protocol.STATE_COMPLETED, content or ""):
             # No waiter (e.g. a late chunk or out-of-band send) — drop it.
             logger.debug("A2A: send() for context %s had no pending waiter", chat_id)

--- a/plugins/platforms/a2a/protocol.py
+++ b/plugins/platforms/a2a/protocol.py
@@ -590,10 +590,14 @@ class TaskStore:
         self._lock = threading.Lock()
 
     @staticmethod
-    def _in_scope(rec: dict, agent_slug: str = "", tenant: str = "") -> bool:
+    def _in_scope(
+        rec: dict, agent_slug: str = "", tenant: str = "", peer: str = ""
+    ) -> bool:
         if agent_slug and rec.get("agent_slug", "") != agent_slug:
             return False
         if tenant and rec.get("tenant", "") != tenant:
+            return False
+        if peer and rec.get("peer", "") != peer:
             return False
         return True
 
@@ -623,11 +627,11 @@ class TaskStore:
                 rec["state"] = state
 
     def set_push_config(self, task_id: str, url: str,
-                        agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+                        agent_slug: str = "", tenant: str = "", peer: str = "") -> Optional[dict]:
         """Attach a push notification config; returns the stored config or None."""
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             rec["push_url"] = url
             rec["push_config_id"] = "cfg-" + uuid.uuid4().hex[:12]
@@ -644,27 +648,29 @@ class TaskStore:
         }
 
     def get_push_config(self, task_id: str, config_id: str = "",
-                        agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+                        agent_slug: str = "", tenant: str = "", peer: str = "") -> Optional[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return None
             if config_id and rec.get("push_config_id") != config_id:
                 return None
             return self._push_config_view(rec)
 
-    def list_push_configs(self, task_id: str, agent_slug: str = "", tenant: str = "") -> list[dict]:
+    def list_push_configs(
+        self, task_id: str, agent_slug: str = "", tenant: str = "", peer: str = ""
+    ) -> list[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return []
             return [self._push_config_view(rec)]
 
     def delete_push_config(self, task_id: str, config_id: str = "",
-                           agent_slug: str = "", tenant: str = "") -> bool:
+                           agent_slug: str = "", tenant: str = "", peer: str = "") -> bool:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant) or not rec.get("push_url"):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer) or not rec.get("push_url"):
                 return False
             if config_id and rec.get("push_config_id") != config_id:
                 return False
@@ -680,10 +686,12 @@ class TaskStore:
             url, rec["push_url"] = rec["push_url"], ""
             return url
 
-    def get(self, task_id: str, agent_slug: str = "", tenant: str = "") -> Optional[dict]:
+    def get(
+        self, task_id: str, agent_slug: str = "", tenant: str = "", peer: str = ""
+    ) -> Optional[dict]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             return dict(rec)
 
@@ -705,10 +713,12 @@ class TaskStore:
                 fut.set_result((state, reply))
         return out
 
-    def watch(self, task_id: str, agent_slug: str = "", tenant: str = "") -> Optional[Future]:
+    def watch(
+        self, task_id: str, agent_slug: str = "", tenant: str = "", peer: str = ""
+    ) -> Optional[Future]:
         with self._lock:
             rec = self._tasks.get(task_id)
-            if not rec or not self._in_scope(rec, agent_slug, tenant):
+            if not rec or not self._in_scope(rec, agent_slug, tenant, peer):
                 return None
             fut: Future = Future()
             if rec["state"] in TERMINAL_STATES:
@@ -725,6 +735,7 @@ class TaskStore:
         offset: int = 0,
         agent_slug: str = "",
         tenant: str = "",
+        peer: str = "",
         with_total: bool = False,
     ):
         """Filtered task page (newest first).
@@ -735,8 +746,8 @@ class TaskStore:
         page_size = max(1, min(int(page_size or 50), 100))
         with self._lock:
             recs = [dict(r) for r in reversed(self._tasks.values())]
-        if agent_slug or tenant:
-            recs = [r for r in recs if self._in_scope(r, agent_slug, tenant)]
+        if agent_slug or tenant or peer:
+            recs = [r for r in recs if self._in_scope(r, agent_slug, tenant, peer)]
         if context_id:
             recs = [r for r in recs if r["context_id"] == context_id]
         if state:

--- a/plugins/platforms/a2a/security.py
+++ b/plugins/platforms/a2a/security.py
@@ -364,6 +364,7 @@ def sign_push_payload(payload: dict) -> str:
 # --------------------------------------------------------------------------
 
 import ipaddress
+import socket
 import urllib.parse
 
 # Blocked IP ranges for push callback URLs (SSRF prevention).
@@ -384,43 +385,52 @@ _BLOCKED_PREFIXES = (
 )
 
 
-def is_safe_callback_url(url: str, *, localhost_mode: Optional[bool] = None) -> bool:
-    """Check if a push notification callback URL is safe from SSRF.
-
-    Blocks internal/private/loopback/metadata addresses.
-    Only allows http:// and https:// schemes.
-    """
+def resolve_safe_callback_url(
+    url: str, *, localhost_mode: Optional[bool] = None
+) -> Optional[tuple[urllib.parse.ParseResult, str]]:
+    """Validate a callback and return the exact IP that must be dialed."""
     if localhost_mode is None:
         localhost_mode = localhost_only()
     if not url or not isinstance(url, str):
-        return False
+        return None
     try:
         parsed = urllib.parse.urlparse(url)
     except Exception:
-        return False
+        return None
     if parsed.scheme not in ("http", "https"):
-        return False
+        return None
     hostname = parsed.hostname or ""
     if not hostname:
-        return False
+        return None
     hostname_lower = hostname.lower()
     if hostname_lower == "localhost":
-        # Loopback callbacks only make sense for local testing.
-        return localhost_mode
+        return (parsed, "127.0.0.1") if localhost_mode else None
     for prefix in _BLOCKED_PREFIXES:
         if hostname_lower.startswith(prefix.lower()):
             if localhost_mode and prefix in ("127.", "::1"):
-                return True
-            return False
+                return parsed, hostname
+            return None
     try:
-        ip = ipaddress.ip_address(hostname)
-        if ip.is_loopback or ip.is_link_local or ip.is_private or ip.is_reserved:
-            if localhost_mode and ip.is_loopback:
-                return True
-            return False
+        addresses = [ipaddress.ip_address(hostname)]
     except ValueError:
-        pass  # not an IP, it's a hostname — fine
-    return True
+        try:
+            addresses = {
+                ipaddress.ip_address(info[4][0])
+                for info in socket.getaddrinfo(hostname, parsed.port or 443, type=socket.SOCK_STREAM)
+            }
+        except (OSError, ValueError):
+            return None
+    for ip in addresses:
+        if localhost_mode and ip.is_loopback:
+            continue
+        if not ip.is_global or ip.is_multicast or ip.is_unspecified:
+            return None
+    return parsed, str(next(iter(addresses)))
+
+
+def is_safe_callback_url(url: str, *, localhost_mode: Optional[bool] = None) -> bool:
+    """Check if a push notification callback URL is safe from SSRF."""
+    return resolve_safe_callback_url(url, localhost_mode=localhost_mode) is not None
 
 
 # --------------------------------------------------------------------------

--- a/plugins/platforms/a2a/tools.py
+++ b/plugins/platforms/a2a/tools.py
@@ -431,7 +431,9 @@ def a2a_orchestrate(args: dict, **_: Any) -> str:
 
     # Fan-out
     results: list[tuple[str, str]] = []
-    with ThreadPoolExecutor(max_workers=min(len(matches), _ORCHESTRATE_MAX_WORKERS)) as pool:
+    first_succeeded = False
+    pool = ThreadPoolExecutor(max_workers=min(len(matches), _ORCHESTRATE_MAX_WORKERS))
+    try:
         futures = {
             pool.submit(_call_peer_sync, name, entry, message, context_id): name
             for name, entry in matches
@@ -441,12 +443,15 @@ def a2a_orchestrate(args: dict, **_: Any) -> str:
             try:
                 results.append(fut.result())
                 if mode == "first" and not results[-1][1].startswith("Error:"):
+                    first_succeeded = True
                     # Got a good reply; cancel peers that haven't started yet.
                     for f in futures:
                         f.cancel()
                     break
             except Exception as e:
                 results.append((name, f"Error: {e}"))
+    finally:
+        pool.shutdown(wait=not first_succeeded, cancel_futures=first_succeeded)
 
     # Sort results by peer name for deterministic output
     results.sort(key=lambda r: r[0])

--- a/tests/plugins/test_a2a_phase23.py
+++ b/tests/plugins/test_a2a_phase23.py
@@ -445,6 +445,20 @@ class TestMetrics:
 
 
 class TestTaskStore:
+    def test_task_ownership_is_scoped_to_authenticated_peer(self):
+        store = protocol.TaskStore()
+        store.create("alice-task", "ctx", "alice", "agent", "tenant")
+        store.create("bob-task", "ctx", "bob", "agent", "tenant")
+
+        assert store.get("alice-task", "agent", "tenant", "alice") is not None
+        assert store.get("alice-task", "agent", "tenant", "bob") is None
+        records, _ = store.list(agent_slug="agent", tenant="tenant", peer="bob")
+        assert [record["task_id"] for record in records] == ["bob-task"]
+        assert store.set_push_config(
+            "alice-task", "https://example.com/hook", "agent", "tenant", "bob"
+        ) is None
+        assert store.watch("alice-task", "agent", "tenant", "bob") is None
+
     def test_create_and_get(self):
         store = protocol.TaskStore()
         store.create("t1", "c1", "peer-1")
@@ -646,6 +660,21 @@ class TestA2AOrchestrate:
         assert out.startswith("[first: ")
         assert "win" in out
 
+    def test_first_mode_returns_without_waiting_for_slowest_peer(self, monkeypatch):
+        monkeypatch.setattr(tools, "_load_config", lambda: _TWO_PEERS)
+
+        def call(name, entry, msg, ctx=""):
+            time.sleep(0.05 if name == "coder" else 0.5)
+            return name, f"win {name}"
+
+        monkeypatch.setattr(tools, "_call_peer_sync", call)
+        started = time.monotonic()
+
+        out = tools.a2a_orchestrate({"capability": "code", "message": "go", "mode": "first"})
+
+        assert out.startswith("[first: coder]")
+        assert time.monotonic() - started < 0.25
+
 
 # ═════════════════════════════════════════════════════════════════════════════
 # SSRF protection for push callbacks
@@ -653,6 +682,39 @@ class TestA2AOrchestrate:
 
 
 class TestSSRFProtection:
+    @pytest.mark.parametrize("address", ["100.64.0.1", "224.0.0.1", "0.0.0.0", "ff02::1"])
+    def test_special_use_addresses_are_blocked(self, monkeypatch, address):
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda *_args, **_kwargs: [(2, 1, 6, "", (address, 443))],
+        )
+
+        assert security.is_safe_callback_url(
+            "https://public-looking.example/hook", localhost_mode=False
+        ) is False
+
+    def test_hostname_resolving_to_private_address_is_blocked(self, monkeypatch):
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda *_args, **_kwargs: [(2, 1, 6, "", ("127.0.0.1", 443))],
+        )
+
+        assert security.is_safe_callback_url(
+            "https://public-looking.example/hook", localhost_mode=False
+        ) is False
+
+    def test_callback_resolution_returns_the_validated_ip(self, monkeypatch):
+        monkeypatch.setattr(
+            "socket.getaddrinfo",
+            lambda *_args, **_kwargs: [(2, 1, 6, "", ("93.184.216.34", 443))],
+        )
+
+        resolved = security.resolve_safe_callback_url(
+            "https://example.com/hook", localhost_mode=False
+        )
+
+        assert resolved[1] == "93.184.216.34"
+
     def test_safe_public_urls_allowed(self):
         assert security.is_safe_callback_url("https://example.com/webhook") is True
         assert security.is_safe_callback_url("http://example.com/webhook") is True

--- a/tests/plugins/test_a2a_plugin.py
+++ b/tests/plugins/test_a2a_plugin.py
@@ -606,6 +606,15 @@ def _bare_adapter():
 
 
 class TestReplyCapture:
+    def test_context_scope_separates_peers_and_agent_routes(self):
+        from plugins.platforms.a2a.adapter import _scoped_context_id
+
+        first = _scoped_context_id("peer-a", "agent", "tenant", "shared")
+
+        assert first == _scoped_context_id("peer-a", "agent", "tenant", "shared")
+        assert first != _scoped_context_id("peer-b", "agent", "tenant", "shared")
+        assert first != _scoped_context_id("peer-a", "other", "tenant", "shared")
+
     def test_send_waits_for_notify_marked_final_reply(self):
         """Interim/editable sends must not satisfy the blocked A2A RPC future."""
         adapter = _bare_adapter()
@@ -617,7 +626,8 @@ class TestReplyCapture:
                 "⏩ Steered into current run (iteration 1/200).",
                 metadata={"expect_edits": True},
             )
-            assert interim.success is True
+            assert interim.success is False
+            assert interim.message_id is None
             assert fut.done() is False
 
             final = await adapter.send(
@@ -694,6 +704,14 @@ class TestReplyCapture:
 # --------------------------------------------------------------------------
 
 class TestTaskRpcHandlers:
+    def test_task_queries_do_not_cross_authenticated_peers(self):
+        adapter = _bare_adapter()
+        adapter.tasks.create("alice-task", "ctx", "alice")
+
+        response = adapter._rpc_tasks_get(1, {"taskId": "alice-task"}, peer="bob")
+
+        assert response["error"]["code"] == protocol.ERR_TASK_NOT_FOUND
+
     def test_tasks_get_unknown_uses_spec_error_code(self):
         adapter = _bare_adapter()
         resp = adapter._rpc_tasks_get(1, {"taskId": "ghost"})
@@ -1184,6 +1202,14 @@ class TestInboundRoundTrip:
             err = await asyncio.to_thread(_post_unauth)
             assert err["error"]["code"] == protocol.ERR_UNAUTHORIZED
 
+            with pytest.raises(urllib.error.HTTPError) as metrics_error:
+                await asyncio.to_thread(_get_json, base + "/metrics")
+            assert metrics_error.value.code == 401
+            metrics = await asyncio.to_thread(
+                _get_json, base + "/metrics", {"Authorization": "Bearer topsecret"}
+            )
+            assert "inbound_total" in metrics
+
             # POST with the token succeeds.
             resp = await asyncio.to_thread(
                 _post_json, base + "/", _send_body("hello"),
@@ -1280,6 +1306,44 @@ class TestInboundRoundTrip:
 
 @pytest.mark.integration
 class TestPushNotificationEndToEnd:
+    def test_push_transport_dials_the_validated_ip(self):
+        from plugins.platforms.a2a.adapter import _PinnedHTTPConnection
+
+        connection = _PinnedHTTPConnection("example.com", "93.184.216.34", timeout=10)
+        seen = {}
+        connection._create_connection = lambda address, *_args: seen.setdefault("address", address)
+
+        connection.connect()
+
+        assert seen["address"] == ("93.184.216.34", 80)
+
+    def test_https_push_keeps_original_hostname_for_certificate_validation(self, monkeypatch):
+        from plugins.platforms.a2a.adapter import _PinnedHTTPSConnection
+
+        connection = _PinnedHTTPSConnection("callbacks.example", "93.184.216.34", timeout=10)
+        seen = {}
+        sock = object()
+        monkeypatch.setattr(
+            connection,
+            "_create_connection",
+            lambda address, *_args: seen.setdefault("address", address) and sock,
+        )
+
+        class Context:
+            def wrap_socket(self, value, *, server_hostname):
+                seen["socket"] = value
+                seen["server_hostname"] = server_hostname
+                return value
+
+        monkeypatch.setattr(connection, "_context", Context())
+        connection.connect()
+
+        assert seen == {
+            "address": ("93.184.216.34", 443),
+            "socket": sock,
+            "server_hostname": "callbacks.example",
+        }
+
     def test_inline_push_config_delivers_stream_response(self, monkeypatch):
         """message/send carrying configuration.taskPushNotificationConfig gets
         a signed v1.0 StreamResponse POSTed to the callback on completion."""

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -141,7 +141,7 @@ def test_deliver_lands_in_live_bot_chat_instead_of_subprocess(home, monkeypatch)
     # queued=True is the invariant: a DM never interrupts a turn in flight.
     assert submitted == [{"session_id": "live-ops", "text": "ping", "queued": True}]
     assert not spawned
-    assert "reply" in out
+    assert out == {"status": "accepted"}
 
     # A live session titled anything else for the same profile does not qualify:
     # the subprocess path runs exactly as before.

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -405,7 +405,8 @@ def claim_pending_envelopes(root: Path | str) -> list[dict]:
 
 
 def write_reply(
-    root: Path | str, envelope_id: str, *, reply: str = "", error: str = "", reason: str = ""
+    root: Path | str, envelope_id: str, *, reply: str = "", error: str = "", reason: str = "",
+    status: str = "completed",
 ) -> Path:
     """Persist the relayed reply (or delivery error) for the waiter.
 
@@ -431,6 +432,7 @@ def write_reply(
         "reply": str(reply or ""),
         "error": err,
         "reason": code,
+        "status": status if status in {"accepted", "completed"} else "completed",
     }
     fd, tmp = tempfile.mkstemp(dir=str(base / REPLIES_DIR), prefix=".rep-", suffix=".tmp")
     with os.fdopen(fd, "w", encoding="utf-8") as f:
@@ -521,6 +523,9 @@ def waiter_command(root: Path | str, envelope: dict) -> str:
         "            tag = ' [reason: ' + code + ']' if code else ''\n"
         "            print('Delivery to ' + label + ' failed' + tag + ': ' + d['error'])\n"
         "            sys.exit(1)\n"
+        "        if d.get('status') == 'accepted':\n"
+        "            print('Delivery to ' + label + ' was accepted; the reply will appear in the open Bot Chat.')\n"
+        "            sys.exit(0)\n"
         "        print('Reply from ' + label + ':')\n"
         "        print(d.get('reply') or '(empty reply)')\n"
         "        sys.exit(0)\n"

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -141,7 +141,7 @@ def _(rid, params: dict) -> dict:
                 return submitted
             return _ok(
                 rid,
-                {"reply": f"Delivered into @{resolved}'s open Bot Chat; the reply will appear there."},
+                {"status": "accepted"},
             )
 
         fd, tmp = tempfile.mkstemp(prefix="hermes-relay-dm-", suffix=".txt", text=True)
@@ -237,6 +237,7 @@ def _(rid, params: dict) -> dict:
             reply=str(params.get("reply") or ""),
             error=str(params.get("error") or ""),
             reason=str(params.get("reason") or ""),
+            status=str(params.get("status") or "completed"),
         )
         return _ok(rid, {"ok": True})
     except ValueError as e:


### PR DESCRIPTION
## Summary

- scope native A2A tasks, push configs, and conversation state to the authenticated peer and routed agent
- wait for final replies instead of treating preview sends or relay acknowledgements as completed work
- harden push callbacks against DNS rebinding, redirects, private/special-use addresses, and preserve HTTPS SNI while dialing the validated IP
- authenticate remote metrics, clear disconnected Bot rosters, and make `mode=first` return after the first successful peer
- correct the cross-platform Bot tab shortcut regression checks

## Verification

- `scripts/run_tests.sh tests/plugins/test_a2a_plugin.py tests/plugins/test_a2a_phase23.py tests/plugins/test_a2a_tools_gate.py tests/tools/test_a2a_reason_roundtrip.py tests/tools/test_bot_relay.py tests/tui_gateway/test_bot_relay_methods.py -q` — 208 passed
- `npm run typecheck` — passed
- `npx vitest run --project ui src/plugins/hermes-bots/relay.test.ts` — 22 passed
- `npm run build` — passed
- four targeted Desktop Bot Playwright specs — 4 passed
- independent security follow-up — GREEN LIGHT

## Safety

No credentials or user-specific configuration are included. Desktop Bot Mode and native A2A remain separate transports.