### PR TITLE
feat(signal): discover contacts and groups in the channel directory

### DIFF
--- a/contributors/emails/ryan+mannsion@recktek.com
+++ b/contributors/emails/ryan+mannsion@recktek.com
@@ -1,0 +1,1 @@
+mannsion

--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -539,7 +539,7 @@ class SignalAdapter(BasePlatformAdapter):
         while len(self._sent_message_timestamps) > self._max_sent_message_timestamps:
             self._sent_message_timestamps.popitem(last=False)
 
-    def _extract_contact_uuid(self, contact: Any, phone_number: str) -> Optional[str]:
+    def _extract_contact_uuid(self, contact: Any, phone_number: Optional[str] = None) -> Optional[str]:
         """Best-effort extraction of a Signal service ID from listContacts output."""
         if not isinstance(contact, dict):
             return None
@@ -547,8 +547,8 @@ class SignalAdapter(BasePlatformAdapter):
         profile = contact.get("profile")
         if not service_id and isinstance(profile, dict):
             service_id = profile.get("serviceId") or profile.get("uuid")
-        if service_id and _is_signal_service_id(service_id) and phone_number in (
-                contact.get("number"), contact.get("recipient")):
+        if service_id and _is_signal_service_id(service_id) and (
+                phone_number is None or phone_number in (contact.get("number"), contact.get("recipient"))):
             return service_id
         return None
 
@@ -568,6 +568,85 @@ class SignalAdapter(BasePlatformAdapter):
                 if number and service_id:
                     self._remember_recipient_identifiers(number, service_id)
             return self._recipient_uuid_by_number.get(chat_id, chat_id)
+
+    async def list_channels(self) -> Optional[List[Dict[str, Any]]]:
+        """Enumerate Signal contacts and groups for the channel directory."""
+        if not self.client:
+            return None
+
+        contacts, groups = await asyncio.gather(
+            self._rpc("listContacts", {"account": self.account, "allRecipients": True}, timeout=10.0),
+            self._rpc("listGroups", {"account": self.account}, timeout=10.0),
+        )
+        # A list replaces session discovery for the whole platform. Fall back
+        # to sessions if either RPC fails instead of publishing a partial list.
+        if not isinstance(contacts, list) or not isinstance(groups, list):
+            return None
+
+        channels: List[Dict[str, Any]] = []
+        for contact in contacts:
+            if not isinstance(contact, dict):
+                continue
+            if contact.get("unregistered") is True or contact.get("isBlocked") is True:
+                continue
+
+            profile = contact.get("profile")
+            if not isinstance(profile, dict):
+                profile = {}
+
+            number = contact.get("number")
+            service_id = self._extract_contact_uuid(contact)
+            recipient = number or service_id or contact.get("recipient")
+            if not recipient:
+                continue
+            recipient = str(recipient)
+            if number and service_id:
+                self._remember_recipient_identifiers(str(number), str(service_id))
+
+            contact_name = " ".join(
+                str(part).strip()
+                for part in (contact.get("givenName"), contact.get("familyName"))
+                if part
+            )
+            profile_name = " ".join(
+                str(part).strip()
+                for part in (profile.get("givenName"), profile.get("familyName"))
+                if part
+            )
+            name = next(
+                (
+                    str(value).strip()
+                    for value in (
+                        contact.get("name"),
+                        contact.get("nickName"),
+                        contact_name,
+                        profile_name,
+                        contact.get("username"),
+                    )
+                    if value and str(value).strip()
+                ),
+                recipient,
+            )
+            channels.append({"id": recipient, "name": name, "type": "dm"})
+
+        for group in groups:
+            if not isinstance(group, dict):
+                continue
+            if (
+                group.get("isMember") is False
+                or group.get("isBlocked") is True
+                or group.get("isTerminated") is True
+            ):
+                continue
+            group_id = group.get("id")
+            if not group_id:
+                continue
+            group_id = str(group_id)
+            target = group_id if group_id.startswith("group:") else f"group:{group_id}"
+            name = str(group.get("name") or "").strip() or group_id
+            channels.append({"id": target, "name": name, "type": "group"})
+
+        return channels
 
     async def _with_target(self, params: Dict[str, Any], chat_id: str, *, resolve: bool = True) -> Dict[str, Any]:
         """Add the groupId / recipient routing key for *chat_id* to *params* (in place)."""


### PR DESCRIPTION
## What does this PR do?

Discover Signal contacts and groups through the existing adapter `list_channels()` hook, so they appear in the channel directory and resolve by friendly name before their first Hermes conversation. Current upstream still relies on Signal session history for this directory; sending to explicit phone numbers, UUIDs, and group IDs already works.

## Related Issue

No linked issue. Searched existing issues and PRs for Signal contact/group discovery, `list_channels`, and the channel directory.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/signal.py`: concurrently request contacts and groups through the existing JSON-RPC client; resolve display names; retain phone/UUID routing; filter blocked/unregistered contacts and departed, blocked, or terminated groups. If either request fails or returns an invalid shape, preserve session-based discovery.
- `contributors/emails/ryan+mannsion@recktek.com`: map the commit author to `mannsion`, as required by the contributor-attribution check.

One commit rebased onto `79445a496c86a19332ad786494b8384d2167e2d0`. The rebase preserves upstream's refactored recipient helper and `_with_target` routing. All test files match upstream.

### Review follow-up

The independent discovery RPCs now run concurrently. Phone-first directory IDs match the adapter's normal inbound DM identity (`sourceNumber`, falling back to `sourceUuid`); UUID conversion occurs when routing outbound requests, without changing the session key. The manual check verifies a discovered phone target and a normal inbound envelope produce the same session key. This does not introduce session aliasing for historical UUID-only conversations.

The contributor file follows `contributors/README.md` and is needed for this commit's author email.

## How to Test

1. Configure Signal with contacts/groups that have no Hermes conversation history, then start or restart the messaging gateway to refresh its directory.
2. Run `hermes send --list signal`. Confirm contacts and joined groups appear by name, and group IDs have one `group:` prefix.
3. Verify failed enumeration falls back to known Signal sessions.
4. Run `scripts/run_tests.sh` and `scripts/run_tests.sh tests/e2e/`.

### Validation

Tested `f17c7285d6acca1bb86309081ef4e8df13d3356f` on Arch Linux / Python 3.11 in a fresh worktree, using an external virtual environment with the locked extras from `.github/workflows/tests.yml` (`all`, `dev`, `anthropic`, `mistral`, `fal`, `modal`, `daytona`, `hindsight`, `parallel-web`). The prescribed runner used its default isolation, timeouts, and retry policy.

- All 770 gateway test files passed: **7,681 tests**, including all 60 Signal adapter tests and all 21 channel-directory tests.
- Existing E2E suite: **61 passed, 0 failed, 7 skipped**.
- Full-suite result: **44,898 passed, 14 failed, 403 skipped** across 3,704 files; exit 1. `tests/tools/test_transcription_tools.py` passed on the runner's automatic retry after two timing-related failures on the first attempt (reported as flaky).
- Ruff, Windows footgun, compatibility-pointer, case-collision, profile-archive boundary, contributor-attribution, and whitespace checks passed.

<details>
<summary>Local full-suite failures and current-upstream comparison</summary>

All fourteen failing tests also reproduce on unmodified upstream `79445a496c`, with the same locked environment and original runner. No assertions, fixtures, skips, or test files were edited.

| Test | Observed cause |
| --- | --- |
| `test_local_quickstart.py::test_quickstart_runs_all_three_legs` | This host's NVIDIA GPU selects CUDA; Linux CUDA asset preflight returns HTTP 400 before the stubbed installer runs. |
| `test_session_recovery_lost_and_found.py::test_lost_and_found_lane_refuses_to_verify_a_physically_shifted_source` | SQLite rejects the fixture's table rename because the trigram view references the dropped `sessions` table. |
| `test_hermes_state.py::TestFTS5Search::test_search_projection_skips_context_enrichment_queries` | The traced connection differs from the pooled connection used by the context query; the trace count is zero although context is returned. |
| `test_browser_real_profile.py::TestReviewRound3::test_relaunch_path_does_snapshot` | The Chrome executable cannot be found in the local environment. |
| `test_update_head_moved_gate.py::test_update_success_when_head_moves` | The updater purges the mocked gateway modules, rediscovers a real Hermes process, and exits when the test guard blocks signaling a process outside the test subtree. |
| `test_update_yes_flag.py`: `test_yes_auto_migrates_without_input`, `test_no_yes_flag_still_prompts_in_tty`, `test_unicode_decode_error_in_tty_skips_and_prints_hint` | Same module-purge / live-process guard failure as the updater test above. |

`tests/hermes_cli/test_cmd_update.py` has the same live-process guard failure in six cases, also reproduced on current upstream: `test_version_bump_only_applies_silently_without_prompt`, `test_version_bump_only_surfaces_migration_resets`, `test_active_profile_included_in_skill_sync`, `test_single_profile_default_is_synced`, `test_branch_flag_pulls_against_named_branch`, and `test_wsl_update_skips_windows_npm_build_paths`.

The three baseline runs reported 5 passed / 1 failed (quickstart), 271 passed / 2 failed (state/recovery), and 121 passed / 11 failed (updater/browser). No host process was terminated; the existing test isolation guard blocked the updater's attempted signal.

These are local results, not claims about upstream GitHub Actions. The PR's workflow currently reports `action_required` and has run no jobs.

</details>

The manual integration check uses real imports, a loopback HTTP JSON-RPC server, and a temporary `HERMES_HOME`. It verifies concurrent requests, directory persistence and name resolution, contact/group filtering, deduplication, phone/UUID/group routing, inbound session identity, CLI listing, empty lists, and fallback for errors or malformed responses from either RPC. The same initial scenario on unmodified upstream `79445a496c` produces an empty directory and makes no enumeration requests, confirming the feature is still absent. No live linked Signal account or real message delivery was exercised.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — used the prescribed `scripts/run_tests.sh`; actual results above.
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — no test files changed; existing tests and manual integration checks above.
- [x] I've tested on my platform: Arch Linux, Python 3.11.

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — adapter method docstring added.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; existing adapter hook.
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — existing Python HTTP/path abstractions; native Windows/macOS execution was not performed locally.
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no schema changes.
