### PR TITLE
fix(desktop): coalesce projects/tree sidebar scans and memoize raw config parses

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -344,6 +344,13 @@ _LOAD_CONFIG_CACHE: Dict[str, Tuple[int, int, int, int, Dict[str, Any], Dict[str
 # _LOAD_CONFIG_CACHE but for read_raw_config() — used when callers want
 # the user's on-disk values without defaults merged in.
 _RAW_CONFIG_CACHE: Dict[str, Tuple[int, int, Dict[str, Any]]] = {}
+# (path, (st_dev, st_ino, st_size, st_mtime_ns)) -> parsed raw dict, memo for
+# read_user_config_raw() — same fingerprint pattern as _RAW_CONFIG_CACHE but
+# with (dev, ino) too because callers pass per-profile paths that can be
+# re-created between reads. Guarded by _CONFIG_LOCK like the caches above;
+# hits return a deepcopy so write-back mutation never corrupts the cache.
+_USER_CONFIG_RAW_CACHE: Dict[str, Tuple[Tuple[int, int, int, int], Dict[str, Any]]] = {}
+_USER_CONFIG_RAW_CACHE_MAX_ENTRIES = 128
 # Serializes all config read/write paths. libyaml's C extension is not
 # thread-safe for concurrent safe_load() on the same file, and multiple
 # tool threads (approval.py, browser_tool.py, setup flows) hit
@@ -3679,7 +3686,9 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """Read a user ``config.yaml`` EXACTLY as written on disk.
 
     No DEFAULT_CONFIG merge, no managed-scope overlay, no ``${ENV_VAR}``
-    expansion, no migration, no root-model normalization, no caching.
+    expansion, no migration, no root-model normalization. The parsed result is
+    memoized in-process on a file fingerprint, never a TTL — a legal write-back
+    round-trip always sees the on-disk state as of the last call.
 
     ONLY legal for write-back round-trips and raw-file diagnostics —
     behavioral reads must use load_config()/load_config_readonly().
@@ -3716,12 +3725,37 @@ def read_user_config_raw(config_path: Optional[Path] = None) -> Dict[str, Any]:
     """
     if config_path is None:
         config_path = get_config_path()
-    try:
-        with open(config_path, encoding="utf-8") as f:
-            data = fast_safe_load(f) or {}
-    except FileNotFoundError:
-        return {}
-    return data if isinstance(data, dict) else {}
+    # Parse memo keyed by file fingerprint (dev/ino/size/mtime_ns), same
+    # freshness strategy as read_raw_config(). Semantics are unchanged for
+    # every legal call site: each caller still receives a FRESH dict
+    # (deepcopy on hit), so write-back mutation never leaks into the cache;
+    # an on-disk edit (or an atomic re-write onto a fresh inode) changes the
+    # fingerprint and reparses on the next call. Failure semantics
+    # preserved: unparseable YAML still raises every time — errors are never
+    # cached. This memo exists because sidebar fan-outs (list_profiles over
+    # 50+ profiles) re-parse the same config.yaml files dozens of times per
+    # refresh and saturated both cores of a 2-vCore VPS.
+    with _CONFIG_LOCK:
+        try:
+            _st = os.stat(config_path)
+            _fp = (_st.st_dev, _st.st_ino, _st.st_size, _st.st_mtime_ns)
+        except OSError:
+            _fp = None
+        if _fp is not None:
+            _cached = _USER_CONFIG_RAW_CACHE.get(str(config_path))
+            if _cached is not None and _cached[0] == _fp:
+                return copy.deepcopy(_cached[1])
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                data = fast_safe_load(f) or {}
+        except FileNotFoundError:
+            return {}
+        result = data if isinstance(data, dict) else {}
+        if _fp is not None:
+            if len(_USER_CONFIG_RAW_CACHE) > _USER_CONFIG_RAW_CACHE_MAX_ENTRIES:
+                _USER_CONFIG_RAW_CACHE.clear()
+            _USER_CONFIG_RAW_CACHE[str(config_path)] = (_fp, copy.deepcopy(result))
+        return result
 
 
 def read_raw_config_readonly() -> Dict[str, Any]:

--- a/hermes_cli/web_routers/profiles.py
+++ b/hermes_cli/web_routers/profiles.py
@@ -629,6 +629,7 @@ def _merge_profile_tree(
 
 
 @sessions_router.get("/api/profiles/projects/tree")
+@_sidebar_singleflight_cache
 def get_profiles_projects_tree(preview_limit: int = 3, session_limit: int = 2000):
     """Project tree for every profile at once, for the all-profiles sidebar.
 

--- a/tests/hermes_cli/test_profiles_sidebar_cache.py
+++ b/tests/hermes_cli/test_profiles_sidebar_cache.py
@@ -172,6 +172,21 @@ class SidebarCacheTests(unittest.TestCase):
 
         self.assertEqual(inspect.signature(wrapped), inspect.signature(scan))
 
+    def test_heavy_sidebar_endpoints_are_all_single_flight_wrapped(self):
+        # HostHighCPU on a 2-vCore box: /api/profiles/projects/tree was the
+        # one heavy sidebar endpoint left uncoalesced, so every Desktop poll
+        # re-ran the full 50-profile fan-out. Any new heavy sidebar endpoint
+        # must carry the wrapper too — this pins the existing two.
+        for endpoint in (
+            profiles.get_profiles_sessions_sidebar,
+            profiles.get_profiles_projects_tree,
+        ):
+            self.assertTrue(
+                callable(getattr(endpoint, "cache_clear", None)),
+                f"{endpoint.__name__} lost its @_sidebar_singleflight_cache "
+                "wrapper — concurrent Desktop polls will re-scan every profile",
+            )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/hermes_cli/test_profiles_sidebar_scope.py
+++ b/tests/hermes_cli/test_profiles_sidebar_scope.py
@@ -14,6 +14,33 @@ Two behaviors that only show up with more than one profile on disk:
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def _cold_sidebar_singleflight_caches():
+    """Force a cold single-flight cache around every test in this file.
+
+    Both sidebar endpoints are wrapped in ``_sidebar_singleflight_cache``
+    (5s TTL). Each test builds a fresh tmp profile set, so a warm entry from
+    a previous test — same default query params, different disk state — would
+    answer with another test's payload. Clearing before and after keeps every
+    request cold without disabling the caching the endpoints rely on.
+    """
+    from hermes_cli.web_routers import profiles as profiles_routes
+
+    endpoints = (
+        profiles_routes.get_profiles_sessions_sidebar,
+        profiles_routes.get_profiles_projects_tree,
+    )
+    for endpoint in endpoints:
+        clear = getattr(endpoint, "cache_clear", None)
+        if clear is not None:
+            clear()
+    yield
+    for endpoint in endpoints:
+        clear = getattr(endpoint, "cache_clear", None)
+        if clear is not None:
+            clear()
+
+
 @pytest.fixture
 def profiles_on_disk(tmp_path, monkeypatch, _isolate_hermes_home):
     """An isolated default home plus one named profile, each with a state.db."""

--- a/tests/hermes_cli/test_user_config_raw_memo.py
+++ b/tests/hermes_cli/test_user_config_raw_memo.py
@@ -1,0 +1,110 @@
+"""Regression tests for the read_user_config_raw() parse memo.
+
+The memo exists because the desktop sidebar fan-out (list_profiles over 50+
+profiles) re-parsed the same config.yaml files dozens of times per refresh and
+saturated both cores of a 2-vCore VPS (HostHighCPU). These tests pin the
+semantics the memo must never break:
+
+* a hit returns a FRESH dict — write-back mutation cannot corrupt the cache;
+* an on-disk edit (or an atomic replace onto a new inode) reparses;
+* unparseable YAML raises on EVERY call — errors are never cached;
+* a missing file returns {} on every call without poisoning the memo.
+"""
+
+import pytest
+
+from hermes_cli import config as config_mod
+
+
+@pytest.fixture(autouse=True)
+def _cold_memo():
+    config_mod._USER_CONFIG_RAW_CACHE.clear()
+    yield
+    config_mod._USER_CONFIG_RAW_CACHE.clear()
+
+
+def _write(path, text):
+    path.write_text(text, encoding="utf-8")
+
+
+def test_hit_returns_deepcopy_so_mutation_cannot_leak(tmp_path):
+    p = tmp_path / "config.yaml"
+    _write(p, "display:\n  skin: warm\n")
+
+    first = config_mod.read_user_config_raw(p)
+    first["display"]["skin"] = "mutated"
+    first["injected"] = True
+
+    second = config_mod.read_user_config_raw(p)
+    assert second["display"]["skin"] == "warm"
+    assert "injected" not in second
+    assert second is not first
+
+
+def test_edit_invalidates_via_fingerprint(tmp_path):
+    p = tmp_path / "config.yaml"
+    _write(p, "model: aaaa\n")
+    assert config_mod.read_user_config_raw(p)["model"] == "aaaa"
+
+    # Different size AND mtime_ns — the fingerprint changes, memo misses.
+    _write(p, "model: bbbbbbbbbb\n")
+    assert config_mod.read_user_config_raw(p)["model"] == "bbbbbbbbbb"
+
+
+def test_atomic_replace_onto_new_inode_reparses(tmp_path):
+    p = tmp_path / "config.yaml"
+    _write(p, "model: old\n")
+    assert config_mod.read_user_config_raw(p)["model"] == "old"
+
+    # save_config() writes a temp file and os.replace()s it — new inode, and
+    # on coarse-mtime filesystems possibly even a matching mtime. (dev, ino)
+    # in the fingerprint is what catches this.
+    tmp = tmp_path / "config.yaml.tmp"
+    _write(tmp, "model: new\n")
+    tmp.replace(p)
+    assert config_mod.read_user_config_raw(p)["model"] == "new"
+
+
+def test_parse_errors_are_never_cached(tmp_path):
+    p = tmp_path / "config.yaml"
+    _write(p, "key: [unclosed\n")
+    with pytest.raises(Exception):
+        config_mod.read_user_config_raw(p)
+    # Still raises on the second call — a cached error would mask recovery.
+    with pytest.raises(Exception):
+        config_mod.read_user_config_raw(p)
+
+    # And once the file is fixed, the next call sees the fixed content.
+    _write(p, "key: [ok]\n")
+    assert config_mod.read_user_config_raw(p) == {"key": ["ok"]}
+
+
+def test_missing_file_returns_empty_every_time(tmp_path):
+    p = tmp_path / "config.yaml"
+    assert config_mod.read_user_config_raw(p) == {}
+    _write(p, "model: late\n")
+    assert config_mod.read_user_config_raw(p)["model"] == "late"
+
+
+def test_non_dict_root_normalizes_to_empty(tmp_path):
+    p = tmp_path / "config.yaml"
+    _write(p, "- just\n- a\n- list\n")
+    assert config_mod.read_user_config_raw(p) == {}
+
+
+def test_memo_reuses_parse_across_calls(tmp_path, monkeypatch):
+    """The whole point: a second read of an unchanged file skips the parser."""
+    p = tmp_path / "config.yaml"
+    _write(p, "model: memoized\n")
+
+    calls = []
+    real_load = config_mod.fast_safe_load
+
+    def counting_load(stream):
+        calls.append(1)
+        return real_load(stream)
+
+    monkeypatch.setattr(config_mod, "fast_safe_load", counting_load)
+    config_mod.read_user_config_raw(p)
+    config_mod.read_user_config_raw(p)
+    assert len(calls) == 1


### PR DESCRIPTION
Closes #102674

## What

Two changes that together take a 2-vCore VPS running `hermes serve` for the Desktop remote backend from a sustained `HostHighCPU` alert (110–116% CPU in the serve process) down to ~26% host CPU.

### 1. Wrap `/api/profiles/projects/tree` in `@_sidebar_singleflight_cache`

`get_profiles_sessions_sidebar` already carries the wrapper; `get_profiles_projects_tree` was the one heavy sidebar endpoint left uncoalesced. Every Desktop poll — and every concurrent reconnect/focus burst in the AnyIO worker pool — re-ran the full fan-out: `list_profiles()` over all profiles, `_build_project_tree()` per profile, `rglob("SKILL.md")` (~17k files on the reporting box). One decorator line, and the endpoint inherits the exact TTL / single-flight / `errors[]`-not-cached / deepcopy semantics the sibling endpoint already relies on.

### 2. Memoize `read_user_config_raw()` on a file fingerprint

The docstring said "no caching", and the sidebar fan-out paid for it: ~1.9s of pure YAML-parse CPU per refresh across 51 profiles. This adds the same strategy `read_raw_config()` already uses — fingerprint + deepcopy-per-hit under `_CONFIG_LOCK` — with `(st_dev, st_ino)` added to the `(st_size, st_mtime_ns)` key because callers pass per-profile paths that can be atomically replaced onto a fresh inode (which `save_config()` does via `atomic_replace`).

Semantics deliberately preserved for every legal call site:

- **Write-back round-trips** still receive a fresh dict per call (deepcopy on hit), so mutation can never corrupt the cache.
- **Failure semantics unchanged**: unparseable YAML raises on *every* call — errors are never cached — and a missing file still returns `{}`.
- **Freshness**: an on-disk edit changes size and/or `mtime_ns`; an atomic replace changes `st_ino`. Both miss the memo on the next call. No TTL, no staleness window.
- **Thread-safety**: the memo dict is guarded by the existing `_CONFIG_LOCK` (RLock), same as `_RAW_CONFIG_CACHE` / `_LOAD_CONFIG_CACHE`; libyaml's C loader stays serialized.
- Bounded: cleared past 128 entries (one entry per distinct config path; 51-profile boxes sit far under it).

## Tests

- `tests/hermes_cli/test_user_config_raw_memo.py` (new): deepcopy isolation, edit invalidation, atomic-replace-onto-new-inode reparse, error non-caching + recovery, missing-file behavior, non-dict root, and a parse-count assertion proving the second read skips the loader.
- `tests/hermes_cli/test_profiles_sidebar_cache.py`: pin asserting both heavy sidebar endpoints carry the single-flight wrapper (guards against a future refactor silently dropping it again).
- `tests/hermes_cli/test_profiles_sidebar_scope.py`: autouse cold-cache fixture — with the tree endpoint now cached for 5s, consecutive tests (each building a fresh tmp profile set behind the same default query params) would otherwise serve one test's payload to the next. This is the same interaction the sidebar endpoint already required; the fixture covers both.

## Measured (reporter's box: 2 vCore, 51 profiles, Desktop connected)

| Metric | Before | After |
|---|---|---|
| `list_profiles()` warm | 1.9 s | 0.16 s |
| `hermes serve` CPU | 110–116% | 22–34% |
| Host CPU | 50–70% | ~26% |

Targeted suites green: `test_user_config_raw_memo.py`, `test_profiles_sidebar_cache.py`, `test_profiles_sidebar_scope.py`, `test_config_read_guard.py`, `test_config_loader_e2e.py` — 29 passed. `ruff check` clean on all touched files. A full `tests/hermes_cli -k "config or sidebar or profiles"` sweep shows an identical 62-failure set before and after the patch (pre-existing test-order contamination in unrelated Windows/update-path tests on this runner; zero delta attributable to this change).
