### PR TITLE
fix(sessions): chunk IN-list ids in bulk delete to avoid 'too many SQL variables'

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -328,6 +328,18 @@ def _workspace_key_clause(key: str) -> Tuple[str, List[str]]:
     )
 
 
+#: Rows per ``IN (?,?,...)`` list. SQLite caps bound parameters at
+#: SQLITE_MAX_VARIABLE_NUMBER (999 on builds < 3.32, 32766 after); a bulk
+#: prune over a large cron-heavy store blew past it with "too many SQL
+#: variables". 500 is safely under both limits.
+_SQL_IN_CHUNK = 500
+
+
+def _chunked(seq: List[str], size: int = _SQL_IN_CHUNK):
+    for i in range(0, len(seq), size):
+        yield seq[i : i + size]
+
+
 def _collect_delegate_child_ids(conn, parent_ids: List[str]) -> List[str]:
     """Delegate-subagent ids to cascade-delete with *parent_ids*.
 
@@ -348,30 +360,35 @@ def _collect_delegate_child_ids(conn, parent_ids: List[str]) -> List[str]:
     found: set[str] = set(seeds)
     frontier = list(seeds)
     while frontier:
-        ph = ",".join("?" * len(frontier))
-        cursor = conn.execute(
-            f"SELECT id FROM sessions WHERE {df} IN ({ph}) "
-            f"OR (parent_session_id IN ({ph}) AND {df} IS NOT NULL)",
-            frontier + frontier,
-        )
-        frontier = [row["id"] for row in cursor.fetchall() if row["id"] not in found]
-        found.update(frontier)
+        next_frontier: List[str] = []
+        for chunk in _chunked(frontier):
+            ph = ",".join("?" * len(chunk))
+            cursor = conn.execute(
+                f"SELECT id FROM sessions WHERE {df} IN ({ph}) "
+                f"OR (parent_session_id IN ({ph}) AND {df} IS NOT NULL)",
+                chunk + chunk,
+            )
+            for row in cursor.fetchall():
+                if row["id"] not in found:
+                    found.add(row["id"])
+                    next_frontier.append(row["id"])
+        frontier = next_frontier
     # Return only the discovered children — never the parents themselves.
     return [sid for sid in found if sid not in seeds]
 
 
 def _delete_delegate_children(conn, parent_ids: List[str]) -> List[str]:
     ids = _collect_delegate_child_ids(conn, parent_ids)
-    if ids:
-        ph = ",".join("?" * len(ids))
-        conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", ids)
+    for chunk in _chunked(ids):
+        ph = ",".join("?" * len(chunk))
+        conn.execute(f"DELETE FROM messages WHERE session_id IN ({ph})", chunk)
         # FK safety: orphan any untagged stragglers pointing at a doomed row.
         conn.execute(
             f"UPDATE sessions SET parent_session_id = NULL "
             f"WHERE parent_session_id IN ({ph})",
-            ids,
+            chunk,
         )
-        conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", ids)
+        conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
     return ids
 
 T = TypeVar("T")
@@ -15517,37 +15534,37 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
         removed_delegate_ids: list[str] = []
 
         def _do(conn):
-            placeholders = ",".join("?" * len(unique_ids))
             # First, filter to IDs that actually exist — we want to
             # return the real deleted count, not the input length.
-            cursor = conn.execute(
-                f"SELECT id FROM sessions WHERE id IN ({placeholders})",
-                unique_ids,
-            )
-            existing = [row["id"] for row in cursor.fetchall()]
+            # Chunked: a bulk prune can carry tens of thousands of ids,
+            # well past SQLITE_MAX_VARIABLE_NUMBER for a single IN list.
+            existing: list[str] = []
+            for chunk in _chunked(unique_ids):
+                ph = ",".join("?" * len(chunk))
+                cursor = conn.execute(
+                    f"SELECT id FROM sessions WHERE id IN ({ph})", chunk
+                )
+                existing.extend(row["id"] for row in cursor.fetchall())
             if not existing:
                 return 0
 
-            existing_placeholders = ",".join("?" * len(existing))
             removed_delegate_ids.extend(_delete_delegate_children(conn, existing))
             # Orphan remaining children whose parent is in the kill list so the
             # FK constraint stays satisfied. Pin children whose parent
             # is itself in the kill list rather than NULL-ing parents
             # of survivors — the IN list on ``parent_session_id`` does
             # exactly this.
-            conn.execute(
-                f"UPDATE sessions SET parent_session_id = NULL "
-                f"WHERE parent_session_id IN ({existing_placeholders})",
-                existing,
-            )
-            conn.execute(
-                f"DELETE FROM messages WHERE session_id IN ({existing_placeholders})",
-                existing,
-            )
-            conn.execute(
-                f"DELETE FROM sessions WHERE id IN ({existing_placeholders})",
-                existing,
-            )
+            for chunk in _chunked(existing):
+                ph = ",".join("?" * len(chunk))
+                conn.execute(
+                    f"UPDATE sessions SET parent_session_id = NULL "
+                    f"WHERE parent_session_id IN ({ph})",
+                    chunk,
+                )
+                conn.execute(
+                    f"DELETE FROM messages WHERE session_id IN ({ph})", chunk
+                )
+                conn.execute(f"DELETE FROM sessions WHERE id IN ({ph})", chunk)
             self._delete_unreferenced_system_prompts(conn)
             removed_ids.extend(existing)
             return len(existing)

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -1500,6 +1500,47 @@ class TestBulkDeleteSessions:
         assert not (tmp_path / "s1.jsonl").exists()
         assert not (tmp_path / "s2.json").exists()
 
+    def test_exceeds_sqlite_variable_limit(self, db, monkeypatch):
+        """A bulk delete larger than SQLITE_MAX_VARIABLE_NUMBER must not
+        raise "too many SQL variables". Reproduced on a cron-heavy store
+        where ``hermes sessions prune --source cron`` matched ~50K rows.
+        The IN lists are chunked; force a tiny chunk so the test exercises
+        the multi-chunk path (incl. delegate cascade + child orphaning)
+        without needing 32K rows."""
+        import hermes_state as hs
+
+        monkeypatch.setattr(hs, "_SQL_IN_CHUNK", 3)
+        ids = [f"s{i}" for i in range(20)]
+        for sid in ids:
+            db.create_session(session_id=sid, source="cron")
+            db.append_message(sid, role="user", content="tick")
+        # child branch of one parent + a delegate child of another
+        db.create_session(session_id="kid", source="cli", parent_session_id="s5")
+        db.create_session(
+            session_id="dele",
+            source="subagent",
+            parent_session_id="s7",
+            model_config={"_delegate_from": "s7"},
+        )
+
+        assert db.delete_sessions(ids + ["ghost"]) == 20
+        assert all(db.get_session(sid) is None for sid in ids)
+        assert db.get_session("dele") is None  # delegate cascades
+        assert db.get_session("kid")["parent_session_id"] is None  # branch orphaned
+
+    def test_bulk_delete_real_variable_limit(self, db):
+        """Un-monkeypatched: 40K ids is above every SQLite build's limit."""
+        ids = [f"x{i}" for i in range(40_000)]
+
+        def _seed(conn):
+            conn.executemany(
+                "INSERT INTO sessions (id, source, started_at) VALUES (?, 'cron', 0)",
+                [(i,) for i in ids],
+            )
+
+        db._execute_write(_seed)
+        assert db.delete_sessions(ids) == 40_000
+
 
 class TestDeleteEmptySessions:
     """``delete_empty_sessions`` sweeps every ended, non-archived session


### PR DESCRIPTION
## Symptom
`hermes sessions prune --source cron --older-than 14` on a store with ~60K cron sessions (~50K matches):
```
sqlite3.OperationalError: too many SQL variables
```

## Cause
`SessionDB.delete_sessions`, `_collect_delegate_child_ids` and `_delete_delegate_children` each bind the full id list into a single `IN (?,?,...)`. SQLite caps bound parameters at `SQLITE_MAX_VARIABLE_NUMBER` (999 on < 3.32, 32766 after), so any bulk prune above that fails outright. `prune_sessions` feeds the whole match set into this path.

## Fix
Chunk every IN list at 500 ids (`_SQL_IN_CHUNK`, `_chunked`). Same transaction, same cascade/orphan contract; only the parameter binding is split.

## Tests
- `test_exceeds_sqlite_variable_limit`: forces a 3-id chunk so the multi-chunk path (incl. delegate cascade + branch orphaning) is exercised without 32K rows.
- `test_bulk_delete_real_variable_limit`: seeds 40K rows un-patched. Fails on main with the exact error, passes with the fix.

`pytest tests/test_hermes_state.py -k 'Delete or Prune or Bulk'` → 32 passed.
