### PR TITLE
fix(models): add claude-opus-5 and claude-fable-5.1 to native anthropic picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -461,7 +461,9 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "MiniMax-M2",
     ],
     "anthropic": [
+        "claude-fable-5.1",
         "claude-fable-5",
+        "claude-opus-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",


### PR DESCRIPTION
## Symptom
The native `anthropic` model picker (`hermes model`, TUI, Desktop) showed only pre-5th-gen models (`claude-fable-5`, `sonnet-5`, `opus-4-8/4-7/4-6`, dated snapshots) while the OpenRouter/Nous curated lists already shipped `claude-fable-5.1` and `claude-opus-5`.

## Root cause
`_PROVIDER_MODELS["anthropic"]` in `hermes_cli/models.py` (the offline fallback and the curated-first half of the live merge in `provider_model_ids("anthropic")`) was never synced when the aggregator lists were updated. With no live `/v1/models` result (no API key), the picker serves this static list verbatim.

## Change
+2 lines: `claude-fable-5.1` (spelling mirrors this repo's OpenRouter/Nous/Copilot slugs) and `claude-opus-5` (already a known native ID in `agent/model_metadata.py` and `agent/anthropic_adapter.py`), inserted most-capable-first to mirror OpenRouter curation order. Existing order otherwise untouched.

## Verification
- Imported the patched module and asserted the new aliases, order, live-merge (curated-first), dedupe/live-only-append, and offline-fallback-verbatim behavior with the live fetcher mocked (stdlib-only script; venv has no pytest).
- Existing `tests/hermes_cli/test_anthropic_picker_curated.py` is contract-style (references `_PROVIDER_MODELS` dynamically), so it is unaffected.

## Residual risk
`fable-5.1` dot spelling vs the native dash convention for 4.x point versions could not be confirmed against live `POST /v1/messages` (no Anthropic credential used in testing). The validation path accept-anys unknown IDs, so worst case is a first-use 400, not a picker break.