### PR TITLE
fix(kanban): stop worker SSE hangs and false protocol violations

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5763,6 +5763,15 @@ def run_conversation(
                 
                 error_type = type(api_error).__name__
                 error_msg = str(api_error).lower()
+                # Kanban workers: a Codex/xAI idle stream is almost always a
+                # giant write_file generation. Do not sit through 3× 60–120s
+                # retries of the same payload — fail this turn so spawn can
+                # resume with a "write in chunks" prompt.
+                if os.environ.get("HERMES_KANBAN_TASK") and (
+                    "no sse events" in error_msg
+                    or "codex stream" in error_msg
+                ):
+                    retry_count = max_retries
                 _error_summary = agent._summarize_api_error(api_error)
                 logger.warning(
                     "API call failed (attempt %s/%s) error_type=%s %s summary=%s",
@@ -7088,6 +7097,8 @@ def run_conversation(
                             "connection lost", "connection reset",
                             "connection closed", "network connection",
                             "network error", "terminated",
+                            "no sse events", "codex stream",
+                            "broken pipe",
                         ))
                     )
                     if _is_stream_drop:

--- a/cli.py
+++ b/cli.py
@@ -22414,6 +22414,27 @@ def main(
                 cli._print_exit_summary(clear_screen=False)
         finally:
             _finalize_single_query(cli)
+        # Kanban workers spawn as `chat -q` (not `-Q`). The quiet path exits
+        # 1 on provider failure; this human -q path used to always return 0.
+        # A clean 0 while the card is still `running` is a protocol
+        # violation (no kanban_complete / kanban_block) — including when
+        # grok-4.5's Codex stream dies mid-write_file. Nonzero lets the
+        # dispatcher retry and `--resume` the same session.
+        _kanban_tid = os.environ.get("HERMES_KANBAN_TASK")
+        if _kanban_tid:
+            _still_open = True
+            try:
+                from hermes_cli import kanban_db as _kb_exit
+                with _kb_exit.connect_closing() as _kconn:
+                    _ktask = _kb_exit.get_task(_kconn, _kanban_tid)
+                if _ktask is not None and _ktask.status not in (
+                    "running", "ready",
+                ):
+                    _still_open = False
+            except Exception:
+                _still_open = True
+            if _still_open:
+                sys.exit(1)
         return
     
     # Run interactive mode

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -10743,6 +10743,103 @@ def _restart_safe_worker_argv(task: Task, command: list[str]) -> list[str]:
     )
 
 
+_RESUME_MAX_MESSAGES = 80
+_RESUME_MAX_AGE_SECONDS = 7 * 24 * 3600
+
+
+def _interrupted_worker_resume_id(task: Task) -> Optional[str]:
+    """Return a prior kanban worker session id to ``--resume``, or None.
+
+    Dispatcher retries used to spawn a blank ``chat -q`` every time, so the
+    worker re-oriented from scratch and often hit the protocol-violation
+    bound before ``kanban_complete``. Resuming the last *ended* session for
+    this task (never ``-c`` / most-recent — that would mix sibling cards on
+    the same profile) lets it pick up mid-draft.
+
+    Skip when: config off, no state.db, session still live, too old, or the
+    transcript is already huge (fresh start is cheaper than a context bomb).
+    """
+    try:
+        from hermes_cli.config import load_config
+        enabled = (load_config() or {}).get("kanban", {}).get(
+            "resume_interrupted_workers", True,
+        )
+        if enabled is False:
+            return None
+    except Exception:
+        pass
+    if not task or not task.id or not task.assignee:
+        return None
+    try:
+        from hermes_cli.profiles import normalize_profile_name, resolve_profile_env
+        home = resolve_profile_env(normalize_profile_name(task.assignee))
+    except Exception:
+        return None
+    db_path = Path(home) / "state.db"
+    if not db_path.is_file():
+        return None
+    import time as _time
+    cutoff = _time.time() - _RESUME_MAX_AGE_SECONDS
+    title_prefix = f"Work kanban task {task.id}"
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                """
+                SELECT id, ended_at, message_count, started_at
+                  FROM sessions
+                 WHERE source = 'kanban'
+                   AND IFNULL(archived, 0) = 0
+                   AND title LIKE ?
+                 ORDER BY started_at DESC
+                 LIMIT 8
+                """,
+                (title_prefix + "%",),
+            ).fetchall()
+        finally:
+            conn.close()
+    except Exception as exc:
+        _log.debug("kanban worker: resume session lookup skipped (%s)", exc)
+        return None
+    live = False
+    candidates = []
+    for sid, ended_at, message_count, started_at in row:
+        if not sid:
+            continue
+        if ended_at is None:
+            live = True
+            break
+        try:
+            started = float(started_at or 0)
+        except (TypeError, ValueError):
+            started = 0.0
+        if started and started < cutoff:
+            continue
+        try:
+            n = int(message_count or 0)
+        except (TypeError, ValueError):
+            n = 0
+        if n < 2 or n > _RESUME_MAX_MESSAGES:
+            continue
+        # Poisoned retries: grok-4.5 died mid-write_file; resuming just
+        # re-attempts the same giant generation. Fresh spawn is cheaper.
+        if n > 28:
+            continue
+        candidates.append(str(sid))
+    if live:
+        # A live worker already owns this task's transcript; do not attach a second.
+        return None
+    try:
+        log_path = worker_logs_dir() / f"{task.id}.log"
+        if log_path.is_file():
+            tail = log_path.read_bytes()[-12000:].decode("utf-8", "replace").lower()
+            if "no sse events" in tail or "api call failed after" in tail:
+                return None
+    except Exception:
+        pass
+    return candidates[0] if candidates else None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -10769,7 +10866,6 @@ def _default_spawn(
 
     profile_arg = normalize_profile_name(task.assignee)
 
-    prompt = f"work kanban task {task.id}"
     from agent.secret_scope import is_multiplex_active
     from tools.environments.local import build_subprocess_env
 
@@ -10806,6 +10902,11 @@ def _default_spawn(
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id
     env["HERMES_KANBAN_WORKSPACE"] = workspace
+    # Fail-fast idle: giant write_file generations go silent; 3×120s retries
+    # were the hang. 90s then give up this turn (kanban loop skips extra retries).
+    env.setdefault("HERMES_CODEX_EVENT_STALE_TIMEOUT_SECONDS", "90")
+    # Cap a single completion so one write_file cannot be a 20k-char SSE hang.
+    env.setdefault("HERMES_MAX_TOKENS", "4096")
     # Tag the worker's session so it lands in state.db as `kanban`, not as an
     # untitled `cli` row. A worker is a dispatcher-owned run whose transcript is
     # read on the board and in `hermes kanban log` — it is not a conversation
@@ -10881,6 +10982,21 @@ def _default_spawn(
     # older hermes builds on PATH that predate the flag's precedence.
     env.pop("HERMES_TUI", None)
 
+    resume_id = _interrupted_worker_resume_id(task)
+    _chunk_rule = (
+        "HARD RULE: never one-shot write_file a long document (provider stream "
+        "hangs). First write_file must be a short skeleton (<4000 chars / ~80 "
+        "lines). Grow the file with patch in small sections. Then kanban_complete "
+        "in the same turn as the last patch. kanban_block if truly stuck."
+    )
+    if resume_id:
+        prompt = (
+            f"Continue kanban task {task.id}. {_chunk_rule} "
+            f"If you were about to emit a giant write_file, stop — skeleton + patch only."
+        )
+    else:
+        prompt = f"work kanban task {task.id}. {_chunk_rule}"
+
     cmd = [
         *_resolve_hermes_argv(),
         "-p", profile_arg,
@@ -10891,6 +11007,10 @@ def _default_spawn(
         # profile-local worker sessions still register configured hooks.
         "--accept-hooks",
     ]
+    if resume_id:
+        # Pin THIS task's last ended worker session. Never use --continue:
+        # -c is most-recent-on-the-profile and would mix sibling cards.
+        cmd.extend(["--resume", resume_id])
     # Per-task force-loaded skills. Each name goes in its own
     # `--skills X` pair rather than a single comma-joined arg: the CLI
     # accepts both forms (action='append' + comma-split), but

--- a/tests/hermes_cli/test_kanban_worker_session_source.py
+++ b/tests/hermes_cli/test_kanban_worker_session_source.py
@@ -62,6 +62,103 @@ def test_worker_spawn_tags_session_source_kanban(monkeypatch, tmp_path):
     assert captured["env"]["HERMES_SESSION_SOURCE"] == "kanban"
 
 
+def _spawn_task(tmp_path, task_id="t_b21733fb"):
+    from hermes_cli import kanban_db as kb
+    return kb.Task(
+        id=task_id,
+        title="ship it",
+        body=None,
+        assignee="default",
+        status="in_progress",
+        priority=0,
+        created_by=None,
+        created_at=0,
+        started_at=None,
+        completed_at=None,
+        workspace_kind="scratch",
+        workspace_path=None,
+        claim_lock=None,
+        claim_expires=None,
+        tenant=None,
+    )
+
+
+def test_interrupted_worker_spawn_resumes_prior_session(monkeypatch, tmp_path):
+    """Retries pin --resume to THIS task's last ended session, never -c."""
+    from hermes_cli import kanban_db as kb
+
+    captured = {}
+
+    class _Proc:
+        pid = 4321
+
+    def _fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return _Proc()
+
+    monkeypatch.setattr("subprocess.Popen", _fake_popen)
+    monkeypatch.setattr(kb, "_retag_legacy_worker_sessions", lambda _root: None)
+    monkeypatch.setattr(kb, "worker_logs_dir", lambda board=None: tmp_path / "logs")
+    monkeypatch.setattr(
+        kb, "_interrupted_worker_resume_id", lambda task: "20260903_223452_68400d"
+    )
+
+    workspace = str(tmp_path / "ws")
+    os.makedirs(workspace, exist_ok=True)
+    kb._default_spawn(_spawn_task(tmp_path), workspace)
+
+    cmd = captured["cmd"]
+    assert "--continue" not in cmd
+    assert "--resume" in cmd
+    assert cmd[cmd.index("--resume") + 1] == "20260903_223452_68400d"
+    q = cmd[cmd.index("-q") + 1]
+    assert "Continue kanban task t_b21733fb" in q
+
+
+def test_interrupted_worker_resume_skips_live_and_oversized(tmp_path, monkeypatch):
+    """Do not resume a still-running worker session or a context bomb."""
+    import sqlite3
+    import time
+
+    from hermes_cli import kanban_db as kb
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    db_path = tmp_path / "state.db"
+    con = sqlite3.connect(db_path)
+    con.execute(
+        "CREATE TABLE sessions (id TEXT, source TEXT, title TEXT, started_at REAL, "
+        "ended_at REAL, message_count INTEGER, archived INTEGER)"
+    )
+    now = time.time()
+    con.execute(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
+        ("live", "kanban", "Work kanban task t_abc123 #2", now, None, 10, 0),
+    )
+    con.execute(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
+        ("fat", "kanban", "Work kanban task t_abc123 #1", now - 60, now - 10, 200, 0),
+    )
+    con.commit()
+    con.close()
+
+    def _home(_name):
+        return str(tmp_path)
+
+    monkeypatch.setattr("hermes_cli.profiles.resolve_profile_env", _home)
+    task = _spawn_task(tmp_path, task_id="t_abc123")
+    assert kb._interrupted_worker_resume_id(task) is None
+
+    con = sqlite3.connect(db_path)
+    con.execute("UPDATE sessions SET ended_at = ? WHERE id = 'live'", (now - 5,))
+    con.execute(
+        "INSERT INTO sessions VALUES (?,?,?,?,?,?,?)",
+        ("ok", "kanban", "Work kanban task t_abc123 #0", now - 120, now - 90, 22, 0),
+    )
+    con.commit()
+    con.close()
+    assert kb._interrupted_worker_resume_id(task) == "live"
+
+
 def test_kanban_rows_stay_out_of_the_session_list(db):
     """A `kanban` row is filtered by the same exclude the sidebar sends."""
     db.create_session(session_id="chat", source="desktop")

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -2733,7 +2733,15 @@ WRITE_FILE_SCHEMA = {
         "type": "object",
         "properties": {
             "path": {"type": "string", "description": "Path to the file to write (will be created if it doesn't exist, overwritten if it does)"},
-            "content": {"type": "string", "description": "Complete content to write to the file"},
+            "content": {
+                "type": "string",
+                "description": (
+                    "Complete content to write. Very large write_file payloads "
+                    "can drop the provider stream (no SSE) and hang the session. "
+                    "For long documents, write a short skeleton first, then grow "
+                    "it with patch in sections."
+                ),
+            },
             # NOTE: the handler still accepts `cross_profile` (bool) — it now
             # bypasses only the #32049 sandbox-mirror lost-write guards, whose
             # rejection error teaches it. Unadvertised: the cross-PROFILE
@@ -2886,6 +2894,14 @@ def _handle_write_file(args, **kw):
         return tool_error(
             f"write_file: 'content' must be a string, got "
             f"{type(args['content']).__name__}."
+        )
+    _content = args["content"]
+    if os.environ.get("HERMES_KANBAN_TASK") and len(_content) > 6000:
+        return tool_error(
+            "write_file: content is too large "
+            f"({len(_content)} chars) for a kanban worker. Do NOT retry this "
+            "as one write_file — the provider stream will hang. Write a short "
+            "skeleton (under 4000 chars) first, then use patch to add sections."
         )
     return write_file_tool(
         path=args["path"], content=args["content"], task_id=tid,


### PR DESCRIPTION
## Summary

Kanban workers are spawned as `hermes chat -q` (not `-Q`). When the provider stream dies mid-`write_file` (xAI/Codex \"no SSE events\"), that path used to print a resume hint and **exit 0**. The dispatcher treated rc=0 + card still `running` as a **protocol violation** and retried, often with `--resume` on the same poisoned session, until `gave_up`.

This PR:

- Exits **1** from `chat -q` if `HERMES_KANBAN_TASK` is still `running`/`ready` after the turn
- Skips extra API retries on Codex/xAI idle streams for kanban workers (fail that turn instead of 3× 60–120s)
- Resumes **that task's last ended** worker session only (never `-c` / most-recent, which mixes sibling cards)
- Does **not** resume live, oversized, or stream-failed sessions (fresh spawn + chunked-write prompt)
- Sets worker env `HERMES_MAX_TOKENS=4096` and 90s stream-idle
- Caps `write_file` at 6k chars **only when** `HERMES_KANBAN_TASK` is set (interactive/CLI writes unchanged)

Proven on a multi-profile board: one-shot 20k+ `write_file` hung with zero bytes on disk; skeleton + `patch` produced the artifact and `kanban_complete`.

## Test plan

- [x] `tests/hermes_cli/test_kanban_worker_session_source.py` covers `--resume` vs `-c` and skip-live/oversized
- [ ] Dispatcher: worker `chat -q` that fails the API with card still running exits nonzero
- [ ] After a Codex \"no SSE events\" log, next spawn is a **fresh** session with the chunked-write prompt
- [ ] Interactive `write_file` of a large file (no `HERMES_KANBAN_TASK`) is **not** size-capped