### PR TITLE
fix(cli): prevent doctor shutdown hang

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5935,6 +5935,23 @@ def cmd_doctor(args):
 
     run_doctor(args)
 
+    # Diagnostics (and any --fix writes) are complete. A dependency can leave
+    # a non-daemon worker behind, stranding this standalone command in
+    # threading._shutdown after the summary has printed (#100792). Keep the
+    # exit here: run_doctor() is also used in-process by the dashboard.
+    for stream in (sys.stdout, sys.stderr):
+        try:
+            stream.flush()
+        except Exception:
+            pass
+    # os._exit skips atexit, including the queued logger's normal drain.
+    try:
+        from hermes_logging import drain_log_queue
+        drain_log_queue(timeout=1.0)
+    except Exception:
+        pass
+    os._exit(0)
+
 
 def cmd_verify(args):
     """Detect a project's run recipe and smoke-test it."""

--- a/tests/hermes_cli/test_doctor_process_exit.py
+++ b/tests/hermes_cli/test_doctor_process_exit.py
@@ -1,0 +1,61 @@
+"""Process-level regression coverage for the standalone doctor command."""
+
+from pathlib import Path
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+
+def test_doctor_command_exits_with_a_stuck_non_daemon_worker():
+    """Completed diagnostics must not hang during interpreter shutdown (#100792)."""
+    program = textwrap.dedent(
+        """
+        import sys
+        import threading
+
+        import hermes_cli.doctor as doctor
+        from hermes_cli.main import cmd_doctor
+
+        blocker = threading.Event()
+        def diagnostics(_args):
+            threading.Thread(
+                target=blocker.wait, name="stuck-doctor-dependency", daemon=False
+            ).start()
+            print("diagnostics complete")
+            print("diagnostic warning", file=sys.stderr)
+
+        doctor.run_doctor = diagnostics
+
+        cmd_doctor(object())
+        """
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", program],
+        cwd=Path(__file__).resolve().parents[2],
+        capture_output=True,
+        timeout=5,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout == b"diagnostics complete\n"
+    assert b"diagnostic warning\n" in result.stderr
+
+
+@pytest.mark.parametrize("error", [RuntimeError("diagnostics failed"), SystemExit(2)])
+def test_doctor_command_preserves_diagnostic_errors(monkeypatch, error):
+    import hermes_cli.doctor as doctor
+    from hermes_cli.main import cmd_doctor
+
+    def fail(_args):
+        raise error
+
+    monkeypatch.setattr(doctor, "run_doctor", fail)
+
+    with pytest.raises(type(error)) as caught:
+        cmd_doctor(object())
+
+    assert caught.value is error


### PR DESCRIPTION
## What does this PR do?

`hermes doctor` can finish printing its diagnostic summary and then hang indefinitely during Python's `threading._shutdown()` when a dependency leaves a non-daemon worker alive. The standalone doctor command now flushes stdout and stderr, drains the queued logger with a bounded timeout, and exits past interpreter finalization after diagnostics and any `--fix` writes are complete.

The hard-exit boundary is limited to `cmd_doctor`; `run_doctor()` remains safe for the dashboard's in-process use. Diagnostic exceptions and explicit error exits still propagate with their original status.

## Related Issue

Fixes #100792

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/main.py` to hard-exit only after standalone doctor diagnostics complete, with stdout/stderr flushing and a bounded log-queue drain.
- Added `tests/hermes_cli/test_doctor_process_exit.py` with a process-level regression that injects a stuck non-daemon worker and verifies clean exit plus preserved output.
- Added coverage proving diagnostic exceptions and `SystemExit(2)` are not converted to success.

## How to Test

1. Run `scripts/run_tests.sh tests/hermes_cli/test_doctor_process_exit.py -q`.
2. Run the doctor-focused suite: `scripts/run_tests.sh tests/hermes_cli/test_doctor.py tests/hermes_cli/test_doctor_live.py tests/hermes_cli/test_doctor_journal_modes.py tests/hermes_cli/test_doctor_command_install.py tests/hermes_cli/test_doctor_dedicated_provider_skip.py tests/hermes_cli/test_doctor_process_exit.py -q`.
3. Run `hermes doctor` and confirm the complete summary prints and the shell prompt returns.

Validation on macOS:

- New process-level regression: 3 passed.
- Doctor-focused suite: 139 passed.
- Manual isolated-home doctor run: exit 0 in 2.55 seconds with complete footer output.
- `ruff check hermes_cli/main.py tests/hermes_cli/test_doctor_process_exit.py`: passed.
- Full suite was attempted in a core+dev environment; unrelated collection/provider failures occurred because optional `acp` and Anthropic SDK dependencies were not installed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (Apple Silicon), Python 3.11.14

### Documentation & Housekeeping

- [x] Documentation update: N/A
- [x] `cli-config.yaml.example` update: N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` update: N/A
- [x] Cross-platform impact considered: behavior uses portable Python stream flushing and `os._exit`, with subprocess coverage
- [x] Tool descriptions/schemas update: N/A
