### PR TITLE
docs(models): add claude-opus-5 to curated anthropic fallback list

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -459,6 +459,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     ],
     "anthropic": [
         "claude-fable-5",
+        "claude-opus-5",
         "claude-sonnet-5",
         "claude-opus-4-8",
         "claude-opus-4-7",


### PR DESCRIPTION
claude-opus-5 is routable via Anthropic's API but absent from the curated offline-fallback list, so hosts without a direct API key silently lose a working model from the picker. The live /v1/models endpoint enumerates it.