### PR TITLE
desktop: recover an owner-less session.resume on the RPC dispatcher path

### DIFF
--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.test.ts
@@ -24,10 +24,18 @@ vi.mock('@/store/gateway', async importActual => ({
 
 const probe = vi.hoisted(() => ({ resolveSessionOwner: vi.fn(async () => undefined as unknown) }))
 const sessionMocks = vi.hoisted(() => ({ requestSessionResume: vi.fn() }))
+const storedTranscript = vi.hoisted(() => ({
+  fetchStoredTranscriptAcrossBackends: vi.fn(async () => null as unknown)
+}))
 
 vi.mock('@/app/session/hooks/use-session-actions/utils', async importActual => ({
   ...(await importActual<Record<string, unknown>>()),
   resolveSessionOwner: probe.resolveSessionOwner
+}))
+
+vi.mock('@/api/sessions', async importActual => ({
+  ...(await importActual<Record<string, unknown>>()),
+  fetchStoredTranscriptAcrossBackends: storedTranscript.fetchStoredTranscriptAcrossBackends
 }))
 
 vi.mock('@/store/session', async importActual => ({
@@ -35,9 +43,12 @@ vi.mock('@/store/session', async importActual => ({
   requestSessionResume: sessionMocks.requestSessionResume
 }))
 
-const { createSessionRpcDispatcher } = await import('./session-rpc-dispatcher')
+const { createSessionRpcDispatcher, readOnlyResumeResponse } = await import('./session-rpc-dispatcher')
 const { $connectionsRegistry } = await import('@/store/connection-registry-state')
 const { $profiles } = await import('@/store/profile')
+const { $readOnlyStoredTranscripts, isReadOnlyRuntimeId, isStoredTranscriptReadOnly } = await import(
+  '@/store/read-only-transcript'
+)
 const { $removedSessionIds, $sessionMutationsInFlight } = await import('@/store/session-removal')
 
 const { _resetSessionOwnerHintsForTests, setCronSessions, setMessagingSessions, setSessionOwnerHint, setSessions } =
@@ -67,6 +78,8 @@ beforeEach(() => {
   $connectionsRegistry.set({ connections: [{ id: 'local' }] } as never)
   $profiles.set([{ name: 'default' }, { name: 'omar' }] as never)
   probe.resolveSessionOwner.mockResolvedValue(undefined)
+  storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(null)
+  $readOnlyStoredTranscripts.set(new Set())
 })
 
 afterEach(() => {
@@ -78,6 +91,7 @@ afterEach(() => {
   $profiles.set([])
   $removedSessionIds.set(new Set())
   $sessionMutationsInFlight.set(new Set())
+  $readOnlyStoredTranscripts.set(new Set())
   _resetSessionOwnerHintsForTests({ storage: true })
   sessionMocks.requestSessionResume.mockReset()
   vi.clearAllMocks()
@@ -131,6 +145,103 @@ describe('createSessionRpcDispatcher: fail closed', () => {
     await expect(dispatcher().request('session.resume', { session_id: 'stored-x' })).rejects.toSatisfy(
       isSessionOwnerResolutionError
     )
+  })
+})
+
+describe('createSessionRpcDispatcher: session.resume no-owner recovery (#102618)', () => {
+  // #94724 gave the tile-delegate path a read-only stored-transcript recovery,
+  // but this dispatcher kept the BARE fail-closed gate — so an orphaned /
+  // owner-less session whose resume surfaced here dead-ended on "Couldn't open
+  // this session" behind a Retry that re-ran the same resume forever. The
+  // recovery has to live on both doors.
+  const transcript = {
+    messages: [
+      { content: 'what did we decide?', role: 'user' },
+      { content: 'we shipped it', role: 'assistant' }
+    ],
+    session_id: 'stored-orphan'
+  }
+
+  it('answers from the stored transcript instead of throwing, and never routes a live session', async () => {
+    storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(transcript)
+    const { ambientRequest, request } = dispatcher()
+
+    const resumed = await request<{ message_count: number; messages: unknown[]; session_id: string }>(
+      'session.resume',
+      { session_id: 'stored-orphan' }
+    )
+
+    expect(storedTranscript.fetchStoredTranscriptAcrossBackends).toHaveBeenCalledWith('stored-orphan')
+    expect(isReadOnlyRuntimeId(resumed.session_id)).toBe(true)
+    expect(resumed.messages).toEqual(transcript.messages)
+    expect(resumed.message_count).toBe(2)
+
+    // The whole point: no live routing happened on any socket.
+    expect(ambientRequest).not.toHaveBeenCalled()
+    expect(gatewayMocks.requestGatewayForAgent).not.toHaveBeenCalled()
+    expect(gatewayMocks.requestGatewayForProfile).not.toHaveBeenCalled()
+
+    // Latched so composer/submit surfaces refuse writes into a session with
+    // no routable runtime.
+    expect(isStoredTranscriptReadOnly('stored-orphan')).toBe(true)
+  })
+
+  it('still rejects with the ORIGINAL owner error when no backend holds the transcript', async () => {
+    storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(null)
+
+    await expect(dispatcher().request('session.resume', { session_id: 'stored-nowhere' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+    expect(isStoredTranscriptReadOnly('stored-nowhere')).toBe(false)
+  })
+
+  it('leaves every OTHER session-scoped method failing closed', async () => {
+    storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(transcript)
+
+    await expect(dispatcher().request('prompt.submit', { session_id: 'stored-orphan', text: 'hi' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+    await expect(dispatcher().request('session.activate', { session_id: 'stored-orphan' })).rejects.toSatisfy(
+      isSessionOwnerResolutionError
+    )
+    expect(storedTranscript.fetchStoredTranscriptAcrossBackends).not.toHaveBeenCalled()
+  })
+
+  it('does not recover a resume that failed for a REAL reason once the owner is known', async () => {
+    // A resolvable owner never enters the recovery path: a transport failure
+    // must keep its own semantics rather than being papered over with history.
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(transcript)
+    gatewayMocks.requestGatewayForAgent.mockRejectedValueOnce(new Error('backend exploded'))
+
+    await expect(dispatcher().request('session.resume', { session_id: 'stored-omar' })).rejects.toThrow(
+      'backend exploded'
+    )
+    expect(storedTranscript.fetchStoredTranscriptAcrossBackends).not.toHaveBeenCalled()
+  })
+
+  it('clears a stale read-only latch once the owner resolves again', async () => {
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    // Round 1: unresolvable owner (no row) → read-only.
+    storedTranscript.fetchStoredTranscriptAcrossBackends.mockResolvedValue(transcript)
+    setSessions([])
+    await dispatcher().request('session.resume', { session_id: 'stored-omar' })
+    expect(isStoredTranscriptReadOnly('stored-omar')).toBe(true)
+
+    // Round 2: the row is back (owner backfilled) → live resume clears the latch.
+    setSessions([makeSessionInfo({ connection_id: 'local', id: 'stored-omar', profile: 'omar' })])
+    await expect(dispatcher().request('session.resume', { session_id: 'stored-omar' })).resolves.toEqual({
+      routed: true
+    })
+    expect(isStoredTranscriptReadOnly('stored-omar')).toBe(false)
+  })
+
+  it('readOnlyResumeResponse reports an idle, non-running snapshot', () => {
+    const response = readOnlyResumeResponse('stored-9', transcript.messages as never)
+
+    expect(response.running).toBe(false)
+    expect(response.resumed).toBe('stored-9')
+    expect(isReadOnlyRuntimeId(response.session_id)).toBe(true)
   })
 })
 

--- a/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
+++ b/apps/desktop/src/app/contrib/session-rpc-dispatcher.ts
@@ -30,16 +30,29 @@
  * SessionOwnerResolutionError rather than riding the ambient socket (the one
  * exception: the legacy single-backend Desktop, where ambient IS the owner).
  * Only a request with NO session at all falls to the ambient socket.
+ *
+ * `session.resume` is the one method where failing closed is not the end of the
+ * story: #94724 gave the tile-delegate path a read-only stored-transcript
+ * recovery, but this dispatcher kept the bare gate, so an orphaned / owner-less
+ * tile whose resume surfaced HERE dead-ended on "Couldn't open this session"
+ * with a Retry that re-ran the same resume forever (#102618). The resume
+ * dispatch is therefore wrapped in the same `resumeWithStoredTranscriptFallback`
+ * recovery: an unresolvable owner marks the stored id read-only and answers
+ * from the id-only REST transcript read (which routes no live session at all),
+ * so the tile paints history instead of latching an unrecoverable error.
  */
 import type { MutableRefObject } from 'react'
 
+import { fetchStoredTranscriptAcrossBackends } from '@/api/sessions'
 import { resolveSessionOwner } from '@/app/session/hooks/use-session-actions/utils'
 import type { ClientSessionState } from '@/app/types'
+import { readOnlyRuntimeIdFor, resumeWithStoredTranscriptFallback } from '@/store/read-only-transcript'
 import { isSessionGoneForBackgroundPolling } from '@/store/runtime-gone'
 import { getSessionOwnerHint, knownSessionOwner, ownerLookupSessionRows, requestSessionResume } from '@/store/session'
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { requestForSessionProfile, type SessionOwnerScope } from '@/store/session-request-router'
 import { $focusedStoredSessionId, sessionTileOwnerRoute, storedSessionIdForRuntimeId } from '@/store/session-states'
+import type { SessionResumeResponse } from '@/types/hermes'
 
 import { findStoredIdForRuntimeId, resolveRoutingSessionId, resolveSessionRpcOwner } from './wiring-routing'
 
@@ -55,6 +68,24 @@ export interface SessionRpcDispatcherDeps {
   runtimeIdByStoredSessionIdRef: MutableRefObject<Map<string, string>>
   selectedStoredSessionIdRef: MutableRefObject<null | string>
   sessionStateByRuntimeIdRef: MutableRefObject<Map<string, ClientSessionState>>
+}
+
+/** A `session.resume` payload synthesized from a stored transcript read, for
+ *  the no-owner recovery. `session_id` is the synthetic read-only runtime id
+ *  (never a gateway runtime), and the stored id stays latched in
+ *  `$readOnlyStoredTranscripts` so write surfaces refuse to submit into a
+ *  session that has no routable runtime. */
+export function readOnlyResumeResponse(
+  storedSessionId: string,
+  messages: SessionResumeResponse['messages']
+): SessionResumeResponse {
+  return {
+    message_count: messages.length,
+    messages,
+    resumed: storedSessionId,
+    running: false,
+    session_id: readOnlyRuntimeIdFor(storedSessionId)
+  }
 }
 
 export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): AmbientGatewayRequest {
@@ -93,33 +124,70 @@ export function createSessionRpcDispatcher(deps: SessionRpcDispatcherDeps): Ambi
       }
     }
 
+    const dispatch = async <TResult>(): Promise<TResult> => {
+      try {
+        return await requestForSessionProfile<TResult>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
+      } catch (error) {
+        // A missed session.reclaimed leaves later RPCs answering 4001 against a
+        // still-resumable stored row. Prompt actions already retry their own
+        // calls; this seam covers the other session-scoped callers and wakes
+        // route-resume for the visible main session only. Do not retry the
+        // failing RPC — it may be destructive, and a fresh binding is async.
+        // A session the user just deleted is filtered by requestSessionResume,
+        // which drops resume requests for a removal-pending id.
+        if (
+          method !== 'session.resume' &&
+          method !== 'session.activate' &&
+          paramSessionId &&
+          routingSessionId &&
+          routingSessionId === selectedStoredSessionIdRef.current &&
+          isSessionGoneForBackgroundPolling(error)
+        ) {
+          requestSessionResume(routingSessionId, typeof owner === 'object' && owner ? owner : undefined)
+        }
+
+        throw error
+      }
+    }
+
     // A request that names a session but whose owner nobody can name must not
     // ride the ambient socket: that turns missing metadata into a misleading
     // backend "session not found" on a backend that never held the runtime.
-    assertSessionOwnerResolved(owner, { method, sessionId: paramSessionId ? routingSessionId : null })
+    //
+    // `session.resume` is the exception, and only in the recovery direction
+    // (#102618): failing closed here is right, but dead-ending is not — the
+    // stored transcript is reachable over an id-only REST read that routes no
+    // live session, so recover into a read-only open exactly as the
+    // tile-delegate path already does (#94724). Every other method, and every
+    // other failure mode of resume, keeps the bare fail-closed gate.
+    const gatedSessionId = paramSessionId ? routingSessionId : null
 
-    try {
-      return await requestForSessionProfile<T>(owner, ambientRequest, method, params ?? {}, timeoutMs, signal)
-    } catch (error) {
-      // A missed session.reclaimed leaves later RPCs answering 4001 against a
-      // still-resumable stored row. Prompt actions already retry their own
-      // calls; this seam covers the other session-scoped callers and wakes
-      // route-resume for the visible main session only. Do not retry the
-      // failing RPC — it may be destructive, and a fresh binding is async.
-      // A session the user just deleted is filtered by requestSessionResume,
-      // which drops resume requests for a removal-pending id.
-      if (
-        method !== 'session.resume' &&
-        method !== 'session.activate' &&
-        paramSessionId &&
-        routingSessionId &&
-        routingSessionId === selectedStoredSessionIdRef.current &&
-        isSessionGoneForBackgroundPolling(error)
-      ) {
-        requestSessionResume(routingSessionId, typeof owner === 'object' && owner ? owner : undefined)
-      }
+    if (method === 'session.resume' && gatedSessionId) {
+      const outcome = await resumeWithStoredTranscriptFallback(
+        gatedSessionId,
+        async () => {
+          assertSessionOwnerResolved(owner, { method, sessionId: gatedSessionId })
 
-      throw error
+          return dispatch<T>()
+        },
+        async () => {
+          const stored = await fetchStoredTranscriptAcrossBackends(gatedSessionId)
+
+          if (!stored) {
+            throw new Error('stored transcript unavailable on every reachable backend')
+          }
+
+          return stored
+        }
+      )
+
+      return outcome.mode === 'live'
+        ? outcome.resumed
+        : (readOnlyResumeResponse(gatedSessionId, outcome.transcript.messages ?? []) as T)
     }
+
+    assertSessionOwnerResolved(owner, { method, sessionId: gatedSessionId })
+
+    return dispatch<T>()
   }
 }


### PR DESCRIPTION
Fixes #102618

## Problem

There are two desktop call sites for the same fail-closed owner gate, and they
disagreed:

- `app/contrib/hooks/use-session-tile-delegate.ts` wraps
  `assertSessionOwnerResolved` in `resumeWithStoredTranscriptFallback` (#94724),
  so an unresolvable owner degrades to a **read-only** stored-transcript open.
- `app/contrib/session-rpc-dispatcher.ts` called the **bare** gate. A
  `session.resume` that surfaced through the dispatcher therefore hard-failed to
  `Couldn't open this session`, whose only affordance is **Retry** -> the same
  resume -> the same error, forever.

The reporter's session (`20260904_101555_82fa1c`) had no row in any backend's
`sessions` table, so with multiple profiles present
`ambientGatewayOwnsEverySession()` is false and the guard threw. The guard is
correct; the missing piece was the recovery that #94724 already built.

## Change

Apply the SAME recovery on the dispatcher path. `session.resume` for a session
whose owner nobody can name now falls back to the id-only REST transcript read
(`fetchStoredTranscriptAcrossBackends` — no gateway routing at all) and answers
a synthetic read-only resume snapshot, latching the stored id in
`$readOnlyStoredTranscripts` so composer/submit surfaces still refuse to write
into a session with no routable runtime.

Deliberately narrow:

- Only `session.resume`, and only for `SessionOwnerResolutionError`. Every other
  session-scoped method (`prompt.submit`, `session.activate`, …) keeps the bare
  fail-closed gate, and any other resume failure keeps its own semantics.
- A **resolvable** owner never enters the path, so a real transport failure is
  not papered over with history.
- When no reachable backend holds the transcript, the ORIGINAL
  owner-resolution error is rethrown, so the caller's diagnosis stays
  authoritative (that is already `resumeWithStoredTranscriptFallback`'s
  contract).
- A later successful live resume clears the read-only latch.

The stale-runtime 4001 rebind seam is unchanged — it moved into a `dispatch`
closure so both the recovery path and the normal path share exactly one
dispatch implementation.

## Tests

6 new cases in `src/app/contrib/session-rpc-dispatcher.test.ts`:

- recovery answers stored history, mints a read-only runtime id, and routes
  **nothing** on any socket (ambient / agent / profile all unused)
- a transcript no backend holds still rejects with the owner-resolution error
- `prompt.submit` / `session.activate` still fail closed and never read the
  transcript
- a resume that failed for a real reason with a KNOWN owner is not recovered
- a stale read-only latch clears once the owner resolves again
- `readOnlyResumeResponse` reports an idle, non-running snapshot

Verified: **50 passed** across `session-rpc-dispatcher`,
`use-session-tile-delegate`, `read-only-transcript`, `session-owner-resolution`,
`session-request-router`, and `session-tile-actions`.
