### PR TITLE
fix(delegation): report guardrail halts as failures

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -831,6 +831,57 @@ class TestDelegateFailedChildStatus(unittest.TestCase):
         self.assertEqual(entry["exit_reason"], "error")
         self.assertFalse(entry["truncated"])
 
+    def test_hard_guardrail_halt_is_not_completed(self):
+        """A controlled guardrail explanation is useful output, not success."""
+        entry = self._delegate_single(
+            {
+                "final_response": (
+                    "I stopped retrying web_search because it hit the tool-call "
+                    "guardrail (loop_web_search_cap)."
+                ),
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 12,
+                "messages": [],
+                "guardrail": {
+                    "action": "block",
+                    "code": "loop_web_search_cap",
+                    "message": "Blocked runaway search loop.",
+                    "tool_name": "web_search",
+                    "count": 10,
+                },
+            }
+        )
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "guardrail_halt")
+        self.assertFalse(entry["truncated"])
+        self.assertEqual(entry["failure_reason"], "guardrail_halt")
+        self.assertEqual(entry["guardrail"]["code"], "loop_web_search_cap")
+        self.assertNotIn("message", entry["guardrail"])
+        self.assertIn("loop_web_search_cap", entry["error"])
+
+    def test_non_halting_guardrail_warning_stays_completed(self):
+        """Warnings are metadata only and must not change successful status."""
+        entry = self._delegate_single(
+            {
+                "final_response": "All work completed.",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+                "guardrail": {
+                    "action": "warn",
+                    "code": "repeated_tool_warning",
+                    "message": "Repeated call warning.",
+                    "tool_name": "web_search",
+                    "count": 2,
+                },
+            }
+        )
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertEqual(entry["guardrail"]["action"], "warn")
+
     def test_empty_error_with_summary_is_completed(self):
         """REGRESSION PIN: an empty-string ``error`` field must NOT be treated as
         a failure. ``result.get('error')`` returns ``''`` which is falsy, so the

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -173,9 +173,11 @@ class _StubChild:
 
     def run_conversation(self, user_message, task_id=None, **_kwargs):
         self.calls.append(user_message)
-        text = self.responses.pop(0)
+        response = self.responses.pop(0)
+        if isinstance(response, dict):
+            return response
         return {
-            "final_response": text,
+            "final_response": response,
             "completed": True,
             "api_calls": 1,
             "messages": [],
@@ -300,6 +302,44 @@ class TestRunSingleChildSchemaValidation:
         entry = _run(child)
         assert entry["schema_valid"] is False
         assert entry["status"] == "failed"
+
+    def test_retry_side_guardrail_halt_is_terminal_failure(self):
+        """A schema retry that hits a hard guardrail must not inherit success
+        fields from the first turn or trigger another retry."""
+        child = _StubChild(
+            [
+                "not json at all",
+                {
+                    "final_response": (
+                        "I stopped retrying web_search because it hit the "
+                        "tool-call guardrail (loop_web_search_cap)."
+                    ),
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 2,
+                    "messages": [],
+                    "guardrail": {
+                        "action": "block",
+                        "code": "loop_web_search_cap",
+                        "message": "Blocked runaway search loop.",
+                        "tool_name": "web_search",
+                        "count": 10,
+                    },
+                },
+            ]
+        )
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        entry = _run(child)
+
+        assert len(child.calls) == 2
+        assert entry["schema_retries"] == 1
+        assert entry["schema_valid"] is False
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "guardrail_halt"
+        assert entry["failure_reason"] == "guardrail_halt"
+        assert entry["guardrail"]["code"] == "loop_web_search_cap"
+        assert "message" not in entry["guardrail"]
 
     def test_schema_valid_entry_still_completed(self):
         """Guard: schema_valid=True keeps status="completed" untouched."""

--- a/tests/tools/test_delegate_output_schema.py
+++ b/tests/tools/test_delegate_output_schema.py
@@ -303,6 +303,42 @@ class TestRunSingleChildSchemaValidation:
         assert entry["schema_valid"] is False
         assert entry["status"] == "failed"
 
+    def test_initial_guardrail_halt_skips_schema_retry(self):
+        """A hard halt on the first schema-bound turn is already terminal;
+        invalid halt prose must not trigger the bounded correction turn."""
+        child = _StubChild(
+            [
+                {
+                    "final_response": (
+                        "I stopped retrying web_search because it hit the "
+                        "tool-call guardrail (loop_web_search_cap)."
+                    ),
+                    "completed": True,
+                    "interrupted": False,
+                    "api_calls": 1,
+                    "messages": [],
+                    "guardrail": {
+                        "action": "block",
+                        "code": "loop_web_search_cap",
+                        "message": "Blocked runaway search loop.",
+                        "tool_name": "web_search",
+                        "count": 10,
+                    },
+                }
+            ]
+        )
+        child._delegate_output_schema = ADDRESS_SCHEMA
+
+        entry = _run(child)
+
+        assert len(child.calls) == 1
+        assert entry.get("schema_retries", 0) == 0
+        assert entry["status"] == "failed"
+        assert entry["exit_reason"] == "guardrail_halt"
+        assert entry["failure_reason"] == "guardrail_halt"
+        assert entry["guardrail"]["code"] == "loop_web_search_cap"
+        assert "message" not in entry["guardrail"]
+
     def test_retry_side_guardrail_halt_is_terminal_failure(self):
         """A schema retry that hits a hard guardrail must not inherit success
         fields from the first turn or trigger another retry."""

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2637,11 +2637,12 @@ def _run_single_child(
           ``error``) or a summary-less/invalid terminal state.
 
     ``exit_reason`` ∈ {``"completed"``, ``"max_iterations"``, ``"interrupted"``,
-    ``"error"``}:
+    ``"guardrail_halt"``, ``"error"``}:
         * ``"completed"``       — normal finish.
         * ``"max_iterations"``  — genuine per-child iteration-budget exhaustion
           (``completed=False`` with no failure fields).
         * ``"interrupted"``     — interrupted by the parent.
+        * ``"guardrail_halt"``  — a hard tool guardrail stopped the child turn.
         * ``"error"``           — provider rejection / terminal failure; NOT
           budget exhaustion (this is the case #97655 fixed).
 
@@ -3196,6 +3197,21 @@ def _run_single_child(
             # is stuck on blocking I/O, wait=True would hang forever.
             _timeout_executor.shutdown(wait=False)
 
+        _guardrail = result.get("guardrail")
+        _hard_guardrail = (
+            isinstance(_guardrail, dict)
+            and _guardrail.get("action") in {"block", "halt"}
+        )
+        _public_guardrail = (
+            {
+                key: _guardrail[key]
+                for key in ("action", "code", "tool_name", "count", "signature")
+                if key in _guardrail
+            }
+            if isinstance(_guardrail, dict)
+            else None
+        )
+
         # T1-24: structured-output contract validation + ONE bounded retry.
         # Runs only when a schema was attached at dispatch; schema-less
         # delegations take none of these branches and their result entry
@@ -3220,6 +3236,7 @@ def _run_single_child(
                 not _schema_valid
                 and _first_text.strip()
                 and not result.get("interrupted", False)
+                and not _hard_guardrail
             ):
                 # Exactly one retry turn, carrying the validation errors
                 # verbatim (no schema re-paste — the child already holds
@@ -3304,6 +3321,12 @@ def _run_single_child(
             # legacy/mock results that omit the structured failure fields.
             # (Community report Aug 2026; #97655.)
             status = "failed"
+        elif _hard_guardrail:
+            # A hard tool guardrail deliberately ends the turn with a useful
+            # explanatory assistant message. That text is not task success:
+            # the structured guardrail metadata must win over the generic
+            # summary-presence heuristic below.
+            status = "failed"
         elif _schema_valid is False:
             # T1-24 follow-up: a schema was declared and the final answer —
             # after the one bounded retry — still violates it (empty `{}`
@@ -3369,6 +3392,8 @@ def _run_single_child(
             # iteration-budget exhaustion — "max_iterations" is only truthful
             # when the child actually hit its per-delegation iteration cap.
             exit_reason = "error"
+        elif _hard_guardrail:
+            exit_reason = "guardrail_halt"
         elif completed:
             exit_reason = "completed"
         else:
@@ -3382,7 +3407,7 @@ def _run_single_child(
 
         # --- result entry contract (see _run_single_child docstring) ---
         # status ∈ {completed, interrupted, failed}
-        # exit_reason ∈ {completed, max_iterations, interrupted, error}
+        # exit_reason ∈ {completed, max_iterations, interrupted, guardrail_halt, error}
         # truncated is exactly (exit_reason == "max_iterations").
         entry: Dict[str, Any] = {
             "task_index": task_index,
@@ -3426,6 +3451,12 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        if _public_guardrail is not None:
+            # Keep only classification fields and the optional signature hash.
+            # The explanatory message is intentionally omitted here: delegate
+            # results cross an agent boundary, while the code/tool/count are
+            # sufficient for machine handling and contain no raw arguments.
+            entry["guardrail"] = _public_guardrail
         # Per-delegation spend, serialized back to the model alongside
         # tokens/api_calls so the parent can see what each delegation cost.
         # Mirrors _child_cost_usd (which is stripped pre-serialization and
@@ -3438,7 +3469,14 @@ def _run_single_child(
             else "unknown"
         )
         if status == "failed":
-            if _schema_valid is False and summary and not _empty_sentinel:
+            if _hard_guardrail:
+                _guardrail_code = str(_guardrail.get("code") or "unknown")
+                entry["error"] = (
+                    "Subagent halted by tool guardrail "
+                    f"({_guardrail_code})."
+                )
+                entry["failure_reason"] = "guardrail_halt"
+            elif _schema_valid is False and summary and not _empty_sentinel:
                 # The child DID respond — the response just violates the
                 # declared contract. Name that instead of the generic
                 # "no response" error; schema_errors (below) hold the

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3197,19 +3197,10 @@ def _run_single_child(
             # is stuck on blocking I/O, wait=True would hang forever.
             _timeout_executor.shutdown(wait=False)
 
-        _guardrail = result.get("guardrail")
-        _hard_guardrail = (
-            isinstance(_guardrail, dict)
-            and _guardrail.get("action") in {"block", "halt"}
-        )
-        _public_guardrail = (
-            {
-                key: _guardrail[key]
-                for key in ("action", "code", "tool_name", "count", "signature")
-                if key in _guardrail
-            }
-            if isinstance(_guardrail, dict)
-            else None
+        _initial_guardrail = result.get("guardrail")
+        _initial_hard_guardrail = (
+            isinstance(_initial_guardrail, dict)
+            and _initial_guardrail.get("action") in {"block", "halt"}
         )
 
         # T1-24: structured-output contract validation + ONE bounded retry.
@@ -3236,7 +3227,7 @@ def _run_single_child(
                 not _schema_valid
                 and _first_text.strip()
                 and not result.get("interrupted", False)
-                and not _hard_guardrail
+                and not _initial_hard_guardrail
             ):
                 # Exactly one retry turn, carrying the validation errors
                 # verbatim (no schema re-paste — the child already holds
@@ -3259,6 +3250,20 @@ def _run_single_child(
                     _retry_text = _retry_result.get("final_response") or ""
                     if _retry_text.strip():
                         result["final_response"] = _retry_text
+                    # The retry is the terminal child turn. Carry all fields
+                    # that drive honest completion classification; otherwise a
+                    # retry-side guardrail/error/interruption is mislabeled
+                    # from the stale first-turn state.
+                    for _terminal_key in (
+                        "completed",
+                        "interrupted",
+                        "failed",
+                        "error",
+                        "failure_reason",
+                        "guardrail",
+                    ):
+                        if _terminal_key in _retry_result:
+                            result[_terminal_key] = _retry_result[_terminal_key]
                     try:
                         result["api_calls"] = int(
                             result.get("api_calls", 0) or 0
@@ -3273,6 +3278,23 @@ def _run_single_child(
                     _schema_valid, _schema_errors = validate_output(
                         _retry_text, _output_schema
                     )
+
+        # Recompute from the terminal turn: a schema retry may itself hit a
+        # guardrail, fail, or be interrupted.
+        _guardrail = result.get("guardrail")
+        _hard_guardrail = (
+            isinstance(_guardrail, dict)
+            and _guardrail.get("action") in {"block", "halt"}
+        )
+        _public_guardrail = (
+            {
+                key: _guardrail[key]
+                for key in ("action", "code", "tool_name", "count", "signature")
+                if key in _guardrail
+            }
+            if isinstance(_guardrail, dict)
+            else None
+        )
 
         # Linearization boundary for registry steering. From this point on the
         # child cannot consume another steer. Closing under the registry lock


### PR DESCRIPTION
## Summary

- classify hard tool-guardrail terminations as failed delegated work before the generic summary-presence heuristic
- expose `exit_reason=guardrail_halt`, `failure_reason=guardrail_halt`, and a sanitized guardrail payload without explanatory text or raw arguments
- skip structured-output retry turns after a hard guardrail has deliberately stopped the child
- preserve normal completion, warning, interruption, provider-error, schema-error, and max-iteration behavior

## Verification

- `TestDelegateFailedChildStatus`: 8 passed
- guardrail/status plus output-schema/live-log suites: 54 passed
- `test_delegate.py` excluding one pre-existing macOS temp-path alias assertion: 82 passed
- the excluded `/private/var` versus `/var` assertion fails identically on unmodified `main`
- sabotage run: the new hard-guardrail regression test fails against `origin/main` and passes with this patch

Closes #102694
