### PR TITLE
fix: cap custom-provider wire message count

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -52,6 +52,103 @@ from agent.turn_context import drop_stale_api_content
 from utils import base_url_host_matches, base_url_hostname, env_var_enabled, atomic_json_write
 
 logger = logging.getLogger(__name__)
+_CUSTOM_PROVIDER_MAX_MESSAGES = 128
+
+
+def cap_custom_provider_messages(
+    agent, messages: List[Dict[str, Any]]
+) -> List[Dict[str, Any]]:
+    """Cap custom-provider wire messages without mutating session history.
+
+    Some OpenAI-compatible gateways enforce a hard message-count limit even
+    when their token context window is larger. Hermes' compression path can
+    legitimately preserve a long transcript after a failed or ineffective
+    summary attempt, so enforce the gateway contract at the final outbound
+    request boundary as a deterministic safety net.
+
+    The request copy keeps leading system/developer instructions and removes
+    the oldest conversation rows at a safe boundary. A boundary never starts
+    on a tool result or an assistant tool-call declaration, which prevents the
+    cap from creating an orphaned tool sequence. The durable transcript is
+    never changed.
+    """
+    provider = str(getattr(agent, "provider", "") or "").strip().lower()
+    if not (provider == "custom" or provider.startswith("custom:")):
+        return messages
+    if len(messages) <= _CUSTOM_PROVIDER_MAX_MESSAGES:
+        return messages
+
+    max_messages = _CUSTOM_PROVIDER_MAX_MESSAGES
+    prefix_end = 0
+    while (
+        prefix_end < len(messages)
+        and isinstance(messages[prefix_end], dict)
+        and messages[prefix_end].get("role") in {"system", "developer"}
+    ):
+        prefix_end += 1
+
+    def _safe_start(index: int) -> bool:
+        message = messages[index]
+        if not isinstance(message, dict):
+            return True
+        role = message.get("role")
+        return role != "tool" and not (
+            role == "assistant" and bool(message.get("tool_calls"))
+        )
+
+    required_drop = len(messages) - max_messages
+    tail_start = max(0, required_drop)
+    if prefix_end >= max_messages:
+        # A transcript with more leading instructions than the entire gateway
+        # budget is pathological, but still keep the hard count invariant and
+        # retain the latest conversation row for a useful provider error.
+        boundary = next(
+            (
+                index
+                for index in range(
+                    max(1, len(messages) - (max_messages - 1)), len(messages)
+                )
+                if _safe_start(index)
+            ),
+            None,
+        )
+        retained = (
+            messages[:1] + messages[boundary:]
+            if boundary is not None
+            else messages[:max_messages]
+        )
+    else:
+        boundary = next(
+            (
+                index
+                for index in range(max(prefix_end, tail_start), len(messages))
+                if _safe_start(index)
+            ),
+            None,
+        )
+        if boundary is None:
+            # A malformed input should already have been repaired by the
+            # normal sanitizer. Keep the count invariant even if no semantic
+            # boundary is available; the next sanitizer/provider response can
+            # diagnose it.
+            boundary = max(prefix_end, tail_start)
+        retained = messages[:prefix_end] + messages[boundary:]
+
+    if len(retained) > max_messages:
+        if prefix_end >= max_messages:
+            retained = messages[:1] + messages[-(max_messages - 1):]
+        else:
+            retained = retained[:prefix_end] + messages[-(max_messages - prefix_end):]
+
+    logger.warning(
+        "%sCapped custom-provider request messages: %d -> %d (limit=%d); "
+        "durable session history unchanged",
+        getattr(agent, "log_prefix", ""),
+        len(messages),
+        len(retained),
+        max_messages,
+    )
+    return retained
 
 
 # Max consecutive successful credential-pool token refreshes of the SAME entry

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -2004,8 +2004,19 @@ def build_api_kwargs(agent, api_messages: list, tools_for_api: list | None = Non
     OpenCode models). No-op for every other provider.
     """
     from agent.opencode_affinity import merge_opencode_session_headers
+    from agent.agent_runtime_helpers import cap_custom_provider_messages
+
+    # Custom OpenAI-compatible gateways may enforce a hard message-count
+    # limit independently of their token context window. Cap before building
+    # kwargs so cache keys and provider transformations describe the same wire
+    # request; cap again after transport conversion as the final guarantee.
+    api_messages = cap_custom_provider_messages(agent, api_messages)
 
     kwargs = _build_api_kwargs_for_mode(agent, api_messages, tools_for_api)
+    if isinstance(kwargs.get("messages"), list):
+        kwargs["messages"] = cap_custom_provider_messages(
+            agent, kwargs["messages"]
+        )
     return merge_opencode_session_headers(
         kwargs,
         getattr(agent, "provider", None),

--- a/tests/agent/test_custom_provider_message_budget.py
+++ b/tests/agent/test_custom_provider_message_budget.py
@@ -1,0 +1,81 @@
+"""Regression tests for custom OpenAI-compatible message-count limits."""
+
+from types import SimpleNamespace
+
+from agent.agent_runtime_helpers import cap_custom_provider_messages
+
+
+def _custom_agent():
+    return SimpleNamespace(provider="custom")
+
+
+def test_custom_provider_wire_copy_is_capped_without_mutating_transcript():
+    messages = [{"role": "system", "content": "instructions"}]
+    for index in range(64):
+        call_id = f"call-{index}"
+        messages.extend(
+            [
+                {"role": "user", "content": f"request {index}"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": call_id,
+                            "type": "function",
+                            "function": {"name": "inspect", "arguments": "{}"},
+                        }
+                    ],
+                },
+                {"role": "tool", "tool_call_id": call_id, "content": "done"},
+            ]
+        )
+    original_count = len(messages)
+
+    capped = cap_custom_provider_messages(_custom_agent(), messages)
+
+    assert len(messages) == original_count
+    assert len(capped) <= 128
+    assert capped[0]["role"] == "system"
+    assert capped[1]["role"] == "user"
+    assert capped[-1]["content"] == "done"
+    for index, message in enumerate(capped):
+        if message.get("role") == "assistant" and message.get("tool_calls"):
+            assert capped[index + 1]["role"] == "tool"
+
+
+def test_non_custom_provider_is_not_capped():
+    messages = [{"role": "user", "content": str(index)} for index in range(129)]
+
+    result = cap_custom_provider_messages(
+        SimpleNamespace(provider="openrouter"), messages
+    )
+
+    assert result is messages
+    assert len(result) == 129
+
+
+def test_build_api_kwargs_caps_final_transport_payload(monkeypatch):
+    from agent import chat_completion_helpers
+
+    monkeypatch.setattr(
+        chat_completion_helpers,
+        "_build_api_kwargs_for_mode",
+        lambda agent, api_messages, tools_for_api=None: {"messages": api_messages},
+    )
+    agent = SimpleNamespace(provider="custom", base_url="", session_id=None)
+    messages = [{"role": "user", "content": str(index)} for index in range(129)]
+
+    kwargs = chat_completion_helpers.build_api_kwargs(agent, messages)
+    assert len(kwargs["messages"]) == 128
+
+
+def test_cap_keeps_hard_limit_when_instructions_fill_budget():
+    messages = [{"role": "system", "content": "instruction"}] * 129
+    messages.append({"role": "user", "content": "latest"})
+
+    result = cap_custom_provider_messages(_custom_agent(), messages)
+
+    assert len(result) == 128
+    assert result[0]["role"] == "system"
+    assert result[-1]["content"] == "latest"


### PR DESCRIPTION
## Why

- Kemudi rejects requests with more than 128 `messages` entries.
- Hermes compression can fail or make insufficient progress while leaving the outbound transcript above that hard gateway limit.

## How

- Cap custom-provider API message copies at 128 immediately before request construction and again after transport conversion.
- Preserve leading system/developer instructions, retain the newest safe conversation boundary, and never mutate durable session history.
- Keep assistant tool-call declarations paired with their following tool results when trimming.

## Tests

- `python -m pytest -q tests/agent/test_custom_provider_message_budget.py tests/run_agent/test_message_sequence_repair.py tests/agent/test_preflight_compression_gate.py tests/run_agent/test_compression_abort_state_reset.py tests/agent/test_compression_progress.py tests/agent/test_compressor_truncated_summary_guard.py tests/providers/test_transport_parity.py tests/run_agent/test_preflight_compression_cap_e2e.py tests/run_agent/test_413_compression.py` — 122 passed
- `python -m compileall -q agent/agent_runtime_helpers.py agent/chat_completion_helpers.py` — passed
- Full `python -m pytest -q` — environment collection blocked by missing `pytest_asyncio` in the host venv; 2 collection errors, unrelated to this change.
