### PR TITLE
fix(gateway): disarm startup watchdog at s6 handoff (#102000)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -8474,6 +8474,26 @@ def _maybe_redirect_run_to_s6_supervision(args) -> bool:
         return False
     if not _dispatch_via_service_manager_if_s6("start"):
         return False
+    # The supervised child owns the gateway from here; this process will
+    # never reach a GatewayRunner, so the startup-liveness watchdog armed
+    # by hermes_cli.main's argv fast-path (argv IS ``gateway run``) has
+    # no downstream disarm site. On the ``os.execvp("sleep", ...)`` path
+    # that is academic — the image swap takes the watchdog thread with
+    # it — but the #36208 fallback parks in ``_block_until_terminated``
+    # on ``signal.pause()`` with ~zero CPU and no progress lease, which
+    # is precisely the parked-deadlock signature the watchdog exists to
+    # kill: it fires on schedule and ``os._exit(75)`` s the container's
+    # CMD process while the supervised gateway underneath is perfectly
+    # healthy (issue #102000 sibling class). Disarm at the handoff,
+    # before either heartbeat, so neither path can trip a false-positive
+    # startup-wedge kill. Never raises: watchdog helpers are best-effort
+    # here and the redirect must not be blocked by a stand-down glitch.
+    try:
+        from hermes_startup_watchdog import disarm_startup_watchdog
+
+        disarm_startup_watchdog()
+    except Exception:
+        logger.debug("Startup watchdog disarm at s6 handoff failed", exc_info=True)
     # Loud breadcrumb: explain the upgrade and how to opt out. Print to
     # stderr so it doesn't pollute stdout-parsing scripts. The
     # supervised gateway's own logs are routed by s6-log to both

--- a/tests/hermes_cli/test_gateway_s6_dispatch.py
+++ b/tests/hermes_cli/test_gateway_s6_dispatch.py
@@ -154,3 +154,125 @@ def test_redirect_falls_back_when_sleep_missing(
 
 
 
+
+
+# =============================================================================
+# Startup-watchdog stand-down at the s6 handoff (issue #102000 sibling class).
+#
+# The argv fast-path in ``hermes_cli.main`` arms the OOF-298 startup-liveness
+# watchdog whenever argv carries the adjacent tokens ``gateway run`` — which
+# is precisely the invocation ``_maybe_redirect_run_to_s6_supervision``
+# intercepts. Once the redirect fires, this process never reaches a
+# ``GatewayRunner``, so the disarm site inside ``GatewayRunner.start()`` is
+# unreachable for the CMD process. Left armed, the #36208 fallback parks in
+# ``_block_until_terminated`` on ``signal.pause()`` with ~zero CPU and no
+# progress lease — the exact wedged-startup signature — and the watchdog
+# ``os._exit(75)``s the container's main process on schedule while the
+# supervised gateway underneath is perfectly healthy.
+# =============================================================================
+
+
+def _arm_for_redirect(monkeypatch: pytest.MonkeyPatch):
+    """Arm the real startup watchdog the way the argv fast-path does.
+
+    A long timeout keeps the deadline out of the test's way: what is
+    under test is the handle's state at handoff, not the timer.
+    """
+    import hermes_startup_watchdog as sw
+
+    monkeypatch.delenv(sw.ENV_STARTUP_WATCHDOG, raising=False)
+    monkeypatch.delenv(sw.ENV_STARTUP_WATCHDOG_TIMEOUT_S, raising=False)
+    sw._reset_for_tests()
+    handle = sw.arm_startup_watchdog(timeout_s=3600)
+    assert handle is not None and handle.is_alive()
+    return sw, handle
+
+
+def test_redirect_disarms_startup_watchdog_before_parking(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """#102000 sibling class: the #36208 in-process heartbeat must not
+    park under an armed startup watchdog.
+
+    Reproduces the false-positive kill by arming the real watchdog with
+    the fast-path shape, then driving the redirect down the fallback
+    path and asserting the handle is disarmed *before* the parked
+    heartbeat runs. On the unfixed code the watchdog would still be
+    armed at parking time and would ``os._exit(75)`` the container.
+    """
+    from hermes_cli import gateway as gw
+
+    sw, handle = _arm_for_redirect(monkeypatch)
+    try:
+        _stub_s6(monkeypatch, on_s6=True)
+        monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+
+        def missing_sleep(file: str, args: list[str]) -> None:
+            raise FileNotFoundError(2, "No such file or directory", file)
+
+        monkeypatch.setattr("hermes_cli.gateway.os.execvp", missing_sleep)
+        disarmed_at_park: list[bool] = []
+        monkeypatch.setattr(
+            "hermes_cli.gateway._block_until_terminated",
+            lambda: disarmed_at_park.append(handle.disarmed),
+        )
+
+        assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is True
+
+        assert disarmed_at_park == [True], (
+            "the CMD process parked forever with the startup watchdog "
+            "still armed — it would be hard-exited with code 75 (#102000 "
+            "sibling class)"
+        )
+        # Singleton is cleared, so a later arm site cannot revive this
+        # handle's deadline.
+        assert sw._handle is None
+        # Timer thread actually stands down rather than lingering.
+        handle.join(timeout=5)
+        assert not handle.is_alive()
+    finally:
+        sw._reset_for_tests()
+    capsys.readouterr()
+
+
+def test_redirect_disarms_startup_watchdog_before_exec(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Same handoff on the normal ``sleep infinity`` exec path.
+
+    The exec replaces the process image (watchdog thread included), so
+    this arm is not a live hazard — but the disarm belongs to the
+    handoff, not to one of its two heartbeats. Pinning it here keeps a
+    future third heartbeat from silently inheriting the parked-process
+    bug.
+    """
+    from hermes_cli import gateway as gw
+
+    sw, handle = _arm_for_redirect(monkeypatch)
+    try:
+        _stub_s6(monkeypatch, on_s6=True)
+        monkeypatch.setattr("hermes_cli.gateway._profile_suffix", lambda: "")
+        monkeypatch.delenv("HERMES_S6_SUPERVISED_CHILD", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_NO_SUPERVISE", raising=False)
+
+        disarmed_at_exec: list[bool] = []
+
+        def fake_execvp(file: str, args: list[str]) -> None:
+            disarmed_at_exec.append(handle.disarmed)
+            # Simulate the exec succeeding (would replace the process
+            # image on a real host); we can't actually exec inside a test.
+
+        monkeypatch.setattr("hermes_cli.gateway.os.execvp", fake_execvp)
+
+        assert gw._maybe_redirect_run_to_s6_supervision(_Args()) is True
+        assert disarmed_at_exec == [True], (
+            "watchdog was still armed when execvp fired — a future "
+            "heartbeat that doesn't replace the process image would "
+            "inherit the #102000 sibling deadlock"
+        )
+        assert sw._handle is None
+    finally:
+        sw._reset_for_tests()
+    capsys.readouterr()


### PR DESCRIPTION
Fixes #102000. Supersedes #102668. Salvages #102024.

## What #102000 actually reports (and the misdiagnosis)

The reporter observes a real, painful crash: on the s6-supervised Docker image (`nousresearch/hermes-agent`), the gateway is killed and restarted every ~25 min with exit code 75 (`EX_TEMPFAIL`, from `hermes_startup_watchdog` / OOF-298), while the gateway itself is fully operational (platforms connected, serving traffic).

Their diagnosis — *\"the disarm site is missing from `gateway/run.py` in current builds\"* — does **not hold against the source**. On `origin/main` at `63279301b`, `git log -S disarm_startup_watchdog -- gateway/run.py` shows the disarm site has been in `GatewayRunner.start()` since the OOF-298 commit and has never been removed; the disarm is present and identical in **both** digests the report names (`593aa74c` and `e629c900`), and `git diff 593aa74c e629c900 -- gateway/run.py` touches no watchdog code. #102668's contributor confirmed this independently. This is the AGENTS.md *\"verify the premise\"* rule: the fix cannot be *\"restore the disarm site,\"* because there is nothing to restore.

But the symptom is real. The watchdog IS killing a healthy container every ~25 min on that image. Something armed it and nothing disarmed it — just not in the place the report guessed.

## Root cause (a sibling leak in the same watchdog class)

`hermes_cli/main.py`'s argv fast-path arms the watchdog whenever argv carries the adjacent tokens `gateway run`. Standard `docker run <image> gateway run` matches that shape verbatim — the CMD process ends up with an armed watchdog before *any* redirect logic runs.

`_maybe_redirect_run_to_s6_supervision()` in `hermes_cli/gateway.py` then hands the real gateway to s6-supervise (which spawns its own child that DOES reach `GatewayRunner` and disarms normally) and keeps the CMD process alive as a container heartbeat. The CMD process never reaches a `GatewayRunner`, so the `GatewayRunner.start()` disarm site is unreachable *for this process*.

Two heartbeat paths from there:

- **`os.execvp(\"sleep\", ...)` path (normal)**: exec replaces the process image — watchdog thread included. The leak is invisible because there's nothing left to fire.
- **#36208 fallback (`sleep` missing from PATH)**: falls into `_block_until_terminated()`, which installs a SIGTERM handler and parks on `signal.pause()` with ~zero CPU and no progress lease. That is precisely the parked-deadlock signature the watchdog exists to kill. It fires on the deadline and `os._exit(75)`s the container's CMD process, which /init reads as \"main process died\" and tears the whole container down — while the s6-supervised gateway underneath is perfectly healthy. Restart, repeat every ~25 min.

The reporter's environment matches the fallback path (large `state.db`, s6 image, no `sleep` on the trimmed PATH the fast-path sees at the moment of the arm+redirect). The forensic record then blames the last remembered progress phase (`state_db_data_migrations`), which finished minutes earlier — misleading, but consistent with the shape of the actual bug.

## Fix

Disarm at the handoff, before either heartbeat, right after `_dispatch_via_service_manager_if_s6(\"start\")` returns success. Once s6 owns the gateway, this process has no pre-loop window left to cover, and neither the exec path nor the parked-fallback path can trip a false-positive startup-wedge kill.

Best-effort try/except so a watchdog-module glitch can never block the redirect.

## Tests (regression guard, not source-reading contract)

Two new tests in `tests/hermes_cli/test_gateway_s6_dispatch.py` arm the **real** `hermes_startup_watchdog` with the fast-path shape and then drive the redirect:

- `test_redirect_disarms_startup_watchdog_before_parking` — the #36208 fallback path. Asserts `handle.disarmed is True` at the moment `_block_until_terminated` would park; also asserts the singleton is cleared (`sw._handle is None`) and the timer thread joins within 5 s, so a disarm that only flipped state without releasing the handle would still fail.
- `test_redirect_disarms_startup_watchdog_before_exec` — the exec path. Pins the invariant so a future third heartbeat can't silently inherit the parked-process bug.

Verified: **both tests fail on the unfixed handoff and pass with it** (bug-guard proof):

```
FAILED tests/hermes_cli/test_gateway_s6_dispatch.py::test_redirect_disarms_startup_watchdog_before_parking
FAILED tests/hermes_cli/test_gateway_s6_dispatch.py::test_redirect_disarms_startup_watchdog_before_exec
2 failed, 2 passed  (unfixed)
4 passed             (with fix)
```

Full run: `scripts/run_tests.sh tests/hermes_cli/test_gateway_s6_dispatch.py tests/gateway/test_startup_watchdog.py -q` → 53 passed (one pre-existing flake in `test_escort_stands_down_when_fire_completes`, unrelated, auto-retried green).

## Supersedes / salvages

- **Supersedes #102668** (itsflownium): test-only PR that adopts the report's misdiagnosis and uses `ast.parse()` on `gateway/run.py` to assert the call exists. This trips the AGENTS.md *\"Never read source code in tests\"* HARDLINE ban — it passes when the implementation is subtly broken (regex matches a call site that exists but is wired wrong) and fails on any pure structural refactor with identical runtime behavior. It also does not touch the actually-broken path (`hermes_cli/gateway.py`'s handoff).
- **Salvages #102024** (HexLab98): correctly identified the sibling leak and had a working fix + real-watchdog tests. Approach and receipts carried forward; credit preserved in commit trailer.