### PR TITLE
fix(delegate): classify hard guardrail halts as failed delegation status (#102694)

### DIFF
--- a/contributors/emails/shreyanshiitian1729@gmail.com
+++ b/contributors/emails/shreyanshiitian1729@gmail.com
@@ -1,0 +1,1 @@
+Shreyansh1729

--- a/tests/tools/test_delegate_guardrail_halt.py
+++ b/tests/tools/test_delegate_guardrail_halt.py
@@ -1,0 +1,110 @@
+import unittest
+from tools.delegate_tool import _run_single_child
+
+
+class _StubChild:
+    tool_progress_callback = None
+    _delegate_saved_tool_names: list = []
+    _credential_pool = None
+    _subagent_id = None
+    _delegate_depth = 1
+    _parent_subagent_id = None
+    _delegate_output_schema: dict | None = None
+    _tool_guardrail_halt_decision = None
+    model = "test-model"
+    session_prompt_tokens = 0
+    session_completion_tokens = 0
+    session_estimated_cost_usd = 0.0
+    session_reasoning_tokens = 0
+
+    def __init__(self, response_dict):
+        self.response_dict = response_dict
+
+    def get_activity_summary(self):
+        return {"api_call_count": 1, "max_iterations": 5, "current_tool": None}
+
+    def run_conversation(self, user_message, task_id=None, **_kwargs):
+        return dict(self.response_dict)
+
+    def close(self):
+        return None
+
+
+class _StubParent:
+    _current_task_id = None
+    _delegate_depth = 0
+
+    def _touch_activity(self, _desc):
+        return None
+
+
+class TestDelegateGuardrailHalt(unittest.TestCase):
+    def test_guardrail_halt_in_result_reported_as_failed(self):
+        guardrail_meta = {
+            "action": "halt",
+            "code": "loop_web_search_cap",
+            "tool_name": "web_search",
+            "count": 15,
+        }
+        child = _StubChild({
+            "final_response": "Search limit reached; stopped.",
+            "completed": True,
+            "turn_exit_reason": "guardrail_halt",
+            "guardrail": guardrail_meta,
+            "api_calls": 15,
+            "messages": [],
+        })
+        entry = _run_single_child(0, "research topic", child, _StubParent())
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "guardrail_halt")
+        self.assertIn("loop_web_search_cap", entry.get("error", ""))
+        self.assertEqual(entry.get("guardrail"), guardrail_meta)
+        self.assertEqual(entry["summary"], "Search limit reached; stopped.")
+
+    def test_guardrail_halt_on_child_attribute_reported_as_failed(self):
+        class _Decision:
+            def to_metadata(self):
+                return {
+                    "action": "halt",
+                    "code": "loop_web_search_cap",
+                    "tool_name": "web_search",
+                }
+
+        child = _StubChild({
+            "final_response": "Stopped by guardrail.",
+            "completed": True,
+            "api_calls": 5,
+            "messages": [],
+        })
+        child._tool_guardrail_halt_decision = _Decision()
+        entry = _run_single_child(0, "research topic", child, _StubParent())
+        self.assertEqual(entry["status"], "failed")
+        self.assertEqual(entry["exit_reason"], "guardrail_halt")
+        self.assertIn("loop_web_search_cap", entry.get("error", ""))
+        self.assertEqual(entry.get("guardrail", {}).get("code"), "loop_web_search_cap")
+
+    def test_normal_completion_retains_completed_status(self):
+        child = _StubChild({
+            "final_response": "Task finished successfully.",
+            "completed": True,
+            "api_calls": 2,
+            "messages": [],
+        })
+        entry = _run_single_child(0, "simple task", child, _StubParent())
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "completed")
+        self.assertNotIn("error", entry)
+        self.assertNotIn("guardrail", entry)
+
+    def test_max_iterations_without_guardrail_retains_classification(self):
+        child = _StubChild({
+            "final_response": "Partial summary of work done.",
+            "completed": False,
+            "api_calls": 5,
+            "messages": [],
+        })
+        entry = _run_single_child(0, "heavy task", child, _StubParent())
+        self.assertEqual(entry["status"], "completed")
+        self.assertEqual(entry["exit_reason"], "max_iterations")
+        self.assertTrue(entry.get("truncated"))
+        self.assertNotIn("guardrail", entry)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -3293,8 +3293,30 @@ def _run_single_child(
         # it instead of silently accepting zero-content "success".
         _empty_sentinel = summary.strip() == "(empty)"
 
+        _guardrail_meta = result.get("guardrail")
+        if not isinstance(_guardrail_meta, dict):
+            _child_guardrail = getattr(child, "_tool_guardrail_halt_decision", None)
+            if _child_guardrail is not None and hasattr(_child_guardrail, "to_metadata"):
+                try:
+                    _meta = _child_guardrail.to_metadata()
+                    _guardrail_meta = _meta if isinstance(_meta, dict) else None
+                except Exception:
+                    _guardrail_meta = None
+            else:
+                _guardrail_meta = None
+
+        _is_guardrail_halt = (
+            result.get("turn_exit_reason") == "guardrail_halt"
+            or (
+                isinstance(_guardrail_meta, dict)
+                and _guardrail_meta.get("action") in {"block", "halt"}
+            )
+        )
+
         if interrupted:
             status = "interrupted"
+        elif _is_guardrail_halt:
+            status = "failed"
         elif result.get("failed") or result.get("error"):
             # A structured failure (provider rejection / terminal exception)
             # must WIN over the summary-presence heuristic below. The child's
@@ -3364,6 +3386,8 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif _is_guardrail_halt:
+            exit_reason = "guardrail_halt"
         elif result.get("failed") or result.get("error"):
             # Provider rejection / terminal failure. Do NOT report this as
             # iteration-budget exhaustion — "max_iterations" is only truthful
@@ -3426,6 +3450,8 @@ def _run_single_child(
                 else 0.0
             ),
         }
+        if isinstance(_guardrail_meta, dict):
+            entry["guardrail"] = _guardrail_meta
         # Per-delegation spend, serialized back to the model alongside
         # tokens/api_calls so the parent can see what each delegation cost.
         # Mirrors _child_cost_usd (which is stripped pre-serialization and
@@ -3438,7 +3464,17 @@ def _run_single_child(
             else "unknown"
         )
         if status == "failed":
-            if _schema_valid is False and summary and not _empty_sentinel:
+            if _is_guardrail_halt:
+                _gr_code = (
+                    _guardrail_meta.get("code")
+                    if isinstance(_guardrail_meta, dict) and _guardrail_meta.get("code")
+                    else "guardrail_halt"
+                )
+                entry["error"] = (
+                    result.get("error")
+                    or f"Delegated subagent halted by tool guardrail: {_gr_code}"
+                )
+            elif _schema_valid is False and summary and not _empty_sentinel:
                 # The child DID respond — the response just violates the
                 # declared contract. Name that instead of the generic
                 # "no response" error; schema_errors (below) hold the


### PR DESCRIPTION
## What does this PR do?

Ensures that delegated child agents terminated by hard tool guardrails (such as `loop_web_search_cap`) are classified as `status="failed"` and `exit_reason="guardrail_halt"` rather than falsely reported as `status="completed"`.

Previously, `tools/delegate_tool.py::_run_single_child` applied a summary-presence heuristic after a child returned. Because a controlled guardrail halt outputs an explanatory response and does not raise an unhandled exception, `_run_single_child` marked the task as `status="completed"` and `exit_reason="completed"`.

This change:
- Inspects `turn_exit_reason == "guardrail_halt"` and `result["guardrail"]` before falling back to the summary-presence heuristic.
- Sets `status = "failed"` and `exit_reason = "guardrail_halt"`.
- Sets `entry["error"]` naming the specific guardrail code that halted execution.
- Preserves the public guardrail metadata in `entry["guardrail"]`.
- Ensures non-dict objects from test doubles do not contaminate serialization.

## Related Issue

Fixes #102694

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tools/delegate_tool.py`: Added guardrail halt check before summary presence fallback in `_run_single_child`; populated `status`, `exit_reason`, `error`, and `guardrail` fields on failure.
- `tests/tools/test_delegate_guardrail_halt.py`: Added regression test suite verifying status, exit reason, error, and metadata preservation for guardrail halts as well as normal completions and max iterations.

## How to Test

Run regression tests:
```bash
pytest tests/tools/test_delegate_guardrail_halt.py -v
```

Run related delegate suites:
```bash
pytest tests/tools/test_delegate_output_schema.py tests/tools/test_delegate_cost_footer.py tests/tools/test_delegate_summary_budget.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
