### PR TITLE
fix(gateway): clear the assistant status when a clarify prompt is posted

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6639,6 +6639,29 @@ class TurnRunner:
                 ctx._status_adapter.pause_typing_for_chat(ctx._status_chat_id)
             except Exception:
                 pass
+            # Pausing the refresh loop is enough where the indicator is
+            # ephemeral: Telegram/Discord typing expires in ~5s on its own once
+            # refreshes stop.  Slack's assistant status is durable — it stays on
+            # screen until explicitly cleared — so the last written
+            # "still working…" freezes above the question and the user reads the
+            # prompt as work in progress rather than as a question waiting on
+            # them.  Clear it BEFORE the prompt is scheduled: the clear and the
+            # post are both dispatched to the event loop, and clearing after the
+            # post can land behind the answer-time resume and blank an indicator
+            # that is legitimately active again (cf. #92201).
+            # _stop_typing_with_metadata is the shared chokepoint that forwards
+            # thread metadata only to adapters whose stop_typing accepts it, so
+            # metadata-less adapters are unaffected and a concurrent sibling
+            # thread in the same channel is never cleared by mistake.
+            safe_schedule_threadsafe(
+                ctx._status_adapter._stop_typing_with_metadata(
+                    ctx._status_chat_id,
+                    ctx._status_thread_metadata,
+                ),
+                ctx._loop_for_step,
+                logger=logger,
+                log_message="Clarify status clear failed to schedule",
+            )
 
             # Ordering barrier (#clarify-ordering): flush any buffered
             # assistant prose (interim commentary / streamed deltas) to the

--- a/tests/gateway/test_slack_clarify_status_cleared.py
+++ b/tests/gateway/test_slack_clarify_status_cleared.py
@@ -1,0 +1,192 @@
+"""Regression test: the clarify prompt must clear a durable status indicator.
+
+Pausing the typing refresh loop is sufficient where the indicator is
+ephemeral — Telegram's ``sendChatAction`` and Discord's typing trigger both
+expire within a few seconds once refreshes stop.  Slack's
+``assistant.threads.setStatus`` is durable: it stays on screen until it is
+explicitly cleared.  Without a clear, the last written "still working…"
+freezes above the clarify question and the user reads the prompt as
+work-in-progress rather than as a question waiting on them, so nobody answers
+and the turn hangs until ``clarify_timeout``.
+"""
+
+import importlib
+import inspect
+import sys
+import types
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class StatusCaptureAdapter(BasePlatformAdapter):
+    """Records the typing/status lifecycle in call order."""
+
+    def __init__(self, platform=Platform.SLACK, accepts_metadata=True):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.calls = []
+        self._accepts_metadata = accepts_metadata
+        if not accepts_metadata:
+            # Mimic an adapter that kept the historical stop_typing(chat_id)
+            # signature, so the metadata-forwarding chokepoint is exercised.
+            async def _legacy_stop_typing(chat_id):
+                self.calls.append(("stop_typing", chat_id))
+
+            self.stop_typing = _legacy_stop_typing
+
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        return SendResult(success=True, message_id="m-1")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        self.calls.append(("send_typing", chat_id))
+
+    async def stop_typing(self, chat_id, metadata=None) -> None:
+        self.calls.append(("stop_typing", chat_id, metadata))
+
+    def pause_typing_for_chat(self, chat_id) -> None:
+        self.calls.append(("pause_typing_for_chat", chat_id))
+        return super().pause_typing_for_chat(chat_id)
+
+    def resume_typing_for_chat(self, chat_id) -> None:
+        self.calls.append(("resume_typing_for_chat", chat_id))
+        return super().resume_typing_for_chat(chat_id)
+
+    async def send_clarify(self, **kwargs) -> SendResult:
+        self.calls.append(("send_clarify", kwargs.get("question")))
+        return SendResult(success=True, message_id="clarify-1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class ClarifyingAgent:
+    """Calls the gateway's clarify callback once, mid-turn."""
+
+    def __init__(self, **kwargs):
+        self.clarify_callback = None
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        got = self.clarify_callback("Which environment?", ["staging", "production"])
+        return {"final_response": f"got={got}", "messages": [], "api_calls": 1}
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = types.SimpleNamespace(loaded_hooks=False)
+    runner.config = types.SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+async def _run_clarify_turn(monkeypatch, tmp_path, adapter, answer="staging"):
+    runner = _make_runner(adapter)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *a, **k: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = ClarifyingAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_resolve_runtime_agent_kwargs", lambda: {"api_key": "***"})
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    # Resolve the wait immediately instead of blocking on a real user reply.
+    monkeypatch.setattr(gateway_run, "_clarify_send_then_wait", lambda fut, **kw: answer)
+
+    source = SessionSource(platform=adapter.platform, chat_id="C1", chat_type="channel")
+    return await runner._run_agent(
+        message="deploy it",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-clarify-status",
+        session_key=f"agent:main:{adapter.platform.value}:channel:C1",
+    )
+
+
+@pytest.mark.asyncio
+async def test_clarify_clears_status_before_posting_the_prompt(monkeypatch, tmp_path):
+    """The status is cleared, and cleared before the prompt is dispatched.
+
+    Ordering matters: the clear and the prompt are both handed to the event
+    loop, and a clear issued *after* the prompt can land behind the
+    answer-time resume and blank an indicator that is legitimately active
+    again (same hazard as #92201).
+    """
+    adapter = StatusCaptureAdapter()
+    result = await _run_clarify_turn(monkeypatch, tmp_path, adapter)
+
+    names = [c[0] for c in adapter.calls]
+    assert "stop_typing" in names, f"status never cleared; calls={adapter.calls}"
+    assert names.index("pause_typing_for_chat") < names.index("stop_typing")
+    assert names.index("stop_typing") < names.index("send_clarify")
+    assert result["final_response"] == "got=staging"
+
+
+@pytest.mark.asyncio
+async def test_clear_carries_thread_metadata(monkeypatch, tmp_path):
+    """The clear must be thread-scoped, not channel-wide.
+
+    A metadata-less clear falls back to "the only status in this channel",
+    which would blank the indicator of a concurrent turn running in a sibling
+    thread of the same channel.
+    """
+    adapter = StatusCaptureAdapter()
+    await _run_clarify_turn(monkeypatch, tmp_path, adapter)
+
+    clears = [c for c in adapter.calls if c[0] == "stop_typing"]
+    assert clears, f"status never cleared; calls={adapter.calls}"
+    # The call goes through _stop_typing_with_metadata, so an adapter whose
+    # stop_typing accepts metadata is called with the keyword form.
+    assert len(clears[0]) == 3, f"metadata not forwarded: {clears[0]}"
+
+
+@pytest.mark.asyncio
+async def test_legacy_adapter_signature_still_works(monkeypatch, tmp_path):
+    """Adapters that kept stop_typing(chat_id) are unaffected.
+
+    _stop_typing_with_metadata introspects the signature, so a metadata-less
+    adapter is called in its historical form rather than raising TypeError.
+    """
+    adapter = StatusCaptureAdapter(accepts_metadata=False)
+    await _run_clarify_turn(monkeypatch, tmp_path, adapter)
+
+    clears = [c for c in adapter.calls if c[0] == "stop_typing"]
+    assert clears, f"status never cleared; calls={adapter.calls}"
+    assert len(clears[0]) == 2, f"legacy adapter got metadata: {clears[0]}"
+
+
+def test_metadata_forwarding_chokepoint_exists():
+    """Guards the assumption this fix relies on."""
+    assert hasattr(BasePlatformAdapter, "_stop_typing_with_metadata")
+    sig = inspect.signature(BasePlatformAdapter._stop_typing_with_metadata)
+    assert "metadata" in sig.parameters


### PR DESCRIPTION
## What does this PR do?

On Slack the assistant status (`still working… (Nm)`) stays frozen above a clarify prompt for the whole
wait, so the question reads as work-in-progress and nobody answers. The turn then hangs until
`clarify_timeout` (default 3600s). Slack also disables the thread's compose box while an assistant status
is active, so the user may be unable to reply even after noticing.

`_clarify_callback_sync` calls `pause_typing_for_chat()` before posting the prompt. That is enough where
the indicator is ephemeral — Telegram's `sendChatAction` and Discord's typing trigger both expire within
seconds once refreshes stop. Slack's `assistant.threads.setStatus` is durable: it stays until explicitly
cleared, so pausing the refresh loop leaves the last written status on screen.

**The intent is already in the tree.** The comment at that pause site says the goal is to not "obscure the
prompt or block the user from typing an 'Other' response on platforms that disable input while typing is
active (Slack Assistant API)". The goal is stated; the flow does not reach it in **multi-choice mode**,
where the Slack override of `send_clarify` (`adapter.py:7386`) posts the buttons with a direct
`chat_postMessage` and issues no status write.

**This is a gap in an established rule, not a new rule.** The same Slack adapter already clears the status
whenever it posts through its ordinary paths:

| Slack adapter post path | clears the assistant status? |
|---|---|
| `send` (ordinary message) | yes — `_clear_thread_status_quietly`, 4 call sites |
| `edit_message` | yes — 2 call sites |
| `send_clarify`, open-ended (falls back to base → `self.send`) | yes, but only incidentally, and after the post |
| `send_clarify`, multi-choice (Slack override, direct `chat_postMessage`) | **no** |
| `send_exec_approval` | **no** |

Open-ended clarifies are safe only because they happen to fall back through `send()`
(`BasePlatformAdapter.send_clarify` posts via `self.send()`, which reaches the post-delivery clear at
`adapter.py:3063`). Add choices to the very same question and the clear disappears: the two paths that
build their own Block Kit payload and post it directly are the two that skip it — precisely the
interactive prompts, which is where a stuck status hurts most, since Slack disables the compose box while
it is up. #92202 owns the approval half; this PR closes the clarify half.

**Why this approach.** The change routes through `BasePlatformAdapter._stop_typing_with_metadata`
(`gateway/platforms/base.py`), the existing shared chokepoint — already used from
`gateway/slash_commands.py`, from `gateway/run.py`, and from three sites inside `base.py` itself. It
introspects the adapter's `stop_typing` signature and forwards thread metadata only where it is accepted,
which matters because the signature is not uniform:

| adapter | `stop_typing` signature |
|---|---|
| slack, relay | `(self, chat_id, metadata=None)` |
| discord / google_chat / matrix / photon / signal / weixin / bluebubbles | `(self, chat_id)` |
| yuanbao | `(self, chat_id, send_finish: bool = False)` |
| `BasePlatformAdapter` (default) | `(self, chat_id)` |

Passing metadata unconditionally would raise `TypeError` on the single-argument adapters — and on
`yuanbao` it would be worse than an exception: the second positional is a `bool`, so a metadata dict
would be silently coerced into `send_finish`. The chokepoint avoids all of it, so no new API, no
platform branch and no signature change is needed.

**Ordering matters.** The clear is issued *before* the prompt is scheduled. Both are dispatched to the
event loop, and a clear placed after the post can land behind the answer-time resume and blank an
indicator that is legitimately active again — the same hazard as #92201. This was observed while testing:
with the clear after `send_clarify`, the recorded order came out pause → resume → send_clarify →
stop_typing. Placing it at the pause site closes that window.

**Not the same defect as #92201.** That issue is a race — a slow in-flight `send_typing` lands after a
`stop_typing` clear and re-applies the status; #92203 fixes it by ordering the writes. It presupposes a
clear that is merely mis-sequenced. This is an omission: the multi-choice clarify path issues no clear at
all, so there is nothing to sequence. Neither fix subsumes the other — ordering guarantees cannot sequence
a call that is never made, and this clear does not remove the race elsewhere. They also fail differently:
#92201 is intermittent, this reproduces on every multi-choice clarify turn.

**Relationship to #64621.** That PR (merged 2026-07-15, closing #32295) fixed the *exit* of a clarify wait
— `/stop` clearing a stuck status, and the clarify text-response interception resuming typing after the
user answers. It did not add a clear at the moment the prompt is *posted*, which is what this PR adds. Its
resume path is deliberately scoped to the answered case (timeout/cancellation sentinels excluded) and is
left untouched here — no unconditional resume is introduced.

## Related Issue

Fixes #102704

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/run.py` — `_clarify_callback_sync`: clear the platform status via `_stop_typing_with_metadata`
  immediately after the existing `pause_typing_for_chat`, before the prompt is scheduled. One call site;
  +23 lines, of which 9 are code and 14 are the comment explaining the ordering constraint.
- `tests/gateway/test_slack_clarify_status_cleared.py` — new, 4 tests (+192).

No deletions; nothing else is touched.

## How to Test

1. Run the gateway with the Slack adapter in Socket Mode, in a workspace where the Slack app has the
   **Assistant** feature enabled — the assistant status API is what sticks, so a plain bot without it
   will not show the symptom. Invite the bot to a channel.
2. Ask for something that requires a clarifying question **with options** (e.g. `@bot save this to the
   shared drive` with no folder named), so the agent calls `clarify` with a non-empty `choices` list and
   Slack renders the Block Kit buttons. A clarify with no choices takes the open-ended path, which
   already clears via `send()` — it will not show the symptom.
3. **Before this change**: the `still working… (Nm)` status stays frozen above the question for the whole
   wait, and the thread's compose box is disabled — the question cannot be answered in that thread.
4. **After this change**: the status is cleared as the question is posted; the thread shows only the
   question and the compose box is usable.
5. Automated:
   ```
   pytest tests/gateway/test_slack_clarify_status_cleared.py -q   # 4 passed
   pytest tests/gateway -q -k "clarify or typing"                 # 126 passed, 5 skipped
   ```
   The second command covers the existing Slack, Telegram and Discord clarify/typing suites alongside the
   4 added here.

The four added tests cover: the clear happens; it happens **before** the post; it carries thread metadata
so a sibling thread in the same channel is not cleared; and a legacy `stop_typing(chat_id)` adapter still
works without `TypeError`.

## Checklist

- pytest: `tests/gateway` gives 118 fail on this branch vs **119 on unmodified `origin/main`** in the same
  environment; none attributable to this PR. The failing node IDs on this branch are a strict subset of
  those on `main`, and they are concentrated in the `discord` suites (optional deps absent here). Details
  under Screenshots / Logs.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — closest are #64621 (merged; the resume and `/stop` halves) and the open exec-approval work #92202 / #92204 / #92306, which is the same defect on the *other* prompt. Nothing open or merged clears the status when a **clarify** prompt is posted.
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — see the note above; I ran `tests/gateway` before/after rather than claiming a clean full-suite run I did not produce.
- [x] I've added tests for my changes (4 new tests; the existing clarify/typing suites act as regression guards)
- [x] I've tested on my platform: Ubuntu 24.04.3 LTS on WSL2, Python 3.11.15, x86_64 (Linux 6.18.33.2 kernel)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A. No user-facing surface change; the reasoning lives in an in-source comment at the call site.
- [x] I've updated `cli-config.yaml.example` — N/A. No config keys added or changed.
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A. No architecture or workflow change.
- [x] I've considered cross-platform impact — the clear goes through the metadata chokepoint, so adapters whose `stop_typing` takes no metadata are unaffected; a redundant clear on an auto-expiring indicator is a harmless no-op. Verified against the Telegram and Discord clarify suites.
- [x] I've updated tool descriptions/schemas — N/A. No tool behaviour change.

## Screenshots / Logs

Recorded call order in an isolated 0.21.0 checkout driving a real clarify turn against a recording adapter.

**Before**

```
1. pause_typing_for_chat  ('C1')
2. resume_typing_for_chat ('C1')
3. send_clarify           ('Which environment?')
```

`stop_typing` is never called.

**After**

```
1. pause_typing_for_chat  ('C1')
2. stop_typing            ('C1', metadata)   ← added
3. resume_typing_for_chat ('C1')
4. send_clarify           ('Which environment?')
```

3 and 4 appear inverted only because the harness replaces `_clarify_send_then_wait` with an immediate
return, so the resume runs synchronously while the scheduled `send_clarify` coroutine runs afterwards. In
production `_clarify_send_then_wait` waits for the send. What this verifies is that `stop_typing` occurs
right after the pause and before the post is scheduled.

**Regression comparison** — `pytest tests/gateway -q`, run twice in the same environment:

|  | failed | passed | errors |
|---|---|---|---|
| `origin/main` | 119 | 7459 | 87 |
| this branch | 118 | 7464 | 87 |

No test regresses. The `+5 passed` is the 4 tests added here plus
`test_hosted_rooms.py::test_room_log_pages_are_bounded_by_serialized_event_bytes` — **that one is not a
fix from this PR.** It is order-dependent: it passes standalone on unmodified `origin/main` (verified 3×)
and fails only inside a full run. Unrelated to this change; noting it so the delta is not read as more
than it is.

## Scope notes for reviewers

**Which clarifies are affected.** Multi-choice only. Open-ended clarifies delegate to
`BasePlatformAdapter.send_clarify`, post through `self.send()`, and so reach the post-delivery clear at
`adapter.py:3063`. The gateway-level clear in this PR still runs for them — one extra idempotent
`stop_typing` before a post that would have cleared afterwards anyway — which moves them from "cleared
once the prompt is already up" to "cleared before it appears". Nothing regresses; it is a redundant clear
on a path that was already safe. An adapter-level fix confined to the multi-choice branch would close the
reported hang too; the tradeoff is the next paragraph.

The two interactive prompts are structurally identical. In `gateway/run.py`, both
`_clarify_callback_sync` and `_approval_notify_sync` call `pause_typing_for_chat(...)` and then dispatch
their send, and neither adapter method writes status. **The same gateway-level block would apply
unchanged at the approval site and would cover both halves in one place.**

I deliberately did not do that here. #92202 already owns the approval half and has two independent open
PRs against it (#92204, #92306), both inside the Slack adapter; widening this PR would put a third,
differently-shaped fix on a problem other people started first. If the maintainers would prefer a single
gateway-level fix for both prompts, I'm happy to extend this PR and close the gap in one commit — just say
so on the issue. If they would rather keep these fixes inside the Slack adapter, so that this one stays
symmetric with #92204, that is a reasonable call too and I'll close this in favour of that shape.

Also out of scope, and unchanged: what happens once the prompt is up. Whether a Slack Block Kit button
click leaves the indicator in the right state is the Slack-side counterpart of #84028 (Telegram), and it
may already be covered — `_clarify_callback_sync` re-arms typing after an answered clarify (from #64621)
regardless of platform, and the Slack adapter carries no resume of its own. I did not verify that path, so
I am flagging it as an open question rather than asserting a gap; it is worth tracking separately either
way. The timeout/cancellation path is a distinct question again: #64621 excluded it from that re-arm
deliberately, and this PR leaves the decision untouched.

---

*Edited 2026-09-04: narrowed the described scope from all clarify turns to multi-choice ones, after
@xiechimon's observation on #102704 — open-ended clarifies route through `send()` and are already cleared
there. No code or test changes; the diff is untouched.*
