### PR TITLE
fix(kanban): harden terminal lifecycle recovery

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -21755,12 +21755,29 @@ def _run_kanban_goal_loop_q(cli: "HermesCLI", first_response: str) -> None:
             except Exception:
                 pass
 
+    def _infrastructure_block(reason: str) -> None:
+        c = _kb.connect()
+        try:
+            _kb.block_task(
+                c,
+                task_id,
+                reason=reason,
+                kind="infrastructure",
+                expected_run_id=worker_run_id,
+            )
+        finally:
+            try:
+                c.close()
+            except Exception:
+                pass
+
     _run_loop(
         task_id=task_id,
         goal_text=goal_text,
         run_turn=_run_turn,
         task_status_fn=_task_status,
         block_fn=_block,
+        infrastructure_block_fn=_infrastructure_block,
         max_turns=max_turns,
         first_response=first_response or "",
         log=lambda m: logger.info("%s", m),

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -2212,6 +2212,9 @@ def run_kanban_goal_loop(
     max_turns: int = DEFAULT_MAX_TURNS,
     first_response: str = "",
     log=None,
+    infrastructure_block_fn=None,
+    judge_max_retries: int = DEFAULT_MAX_CONSECUTIVE_TRANSPORT_FAILURES,
+    sleep_fn=time.sleep,
 ) -> Dict[str, Any]:
     """Drive a kanban worker through a Ralph-style goal loop.
 
@@ -2257,6 +2260,7 @@ def run_kanban_goal_loop(
     # The first turn already consumed one unit of budget.
     turns_used = 1
     nudged_to_finalize = False
+    judge_transport_failures = 0
 
     while True:
         # Did the worker terminate the task itself this turn?
@@ -2290,7 +2294,40 @@ def run_kanban_goal_loop(
         # The kanban worker loop has no wait-barrier concept (workers finish
         # via kanban_complete / kanban_block, not by parking), so a WAIT
         # verdict is treated as CONTINUE here.
-        verdict, reason, _parse_failed, _wait, _transport_failed = judge_goal(goal_text, last_response)
+        verdict, reason, _parse_failed, _wait, transport_failed = judge_goal(
+            goal_text, last_response
+        )
+        if transport_failed:
+            judge_transport_failures += 1
+            if judge_transport_failures >= max(1, int(judge_max_retries)):
+                block = infrastructure_block_fn or block_fn
+                detail = (
+                    "Goal-completion judge infrastructure remained unavailable "
+                    f"after {judge_transport_failures} attempts: {reason}"
+                )
+                _log(f"kanban goal loop: {detail}; blocking root task {task_id}")
+                try:
+                    block(detail)
+                except Exception as exc:
+                    _log(f"kanban goal loop: infrastructure block failed ({exc})")
+                return {
+                    "outcome": "infrastructure_blocked",
+                    "task_id": task_id,
+                    "turns_used": turns_used,
+                    "reason": detail,
+                    "judge_attempts": judge_transport_failures,
+                }
+            # Retry only the judge for this same task/run/response. Do not run
+            # another agent turn, recreate the graph, or consume turn budget.
+            delay = min(30.0, float(2 ** (judge_transport_failures - 1)))
+            _log(
+                "kanban goal loop: judge infrastructure failure "
+                f"{judge_transport_failures}/{judge_max_retries}; retrying "
+                f"same root judge in {delay:g}s"
+            )
+            sleep_fn(delay)
+            continue
+        judge_transport_failures = 0
         if verdict == "wait":
             verdict = "continue"
         _log(f"kanban goal loop: turn {turns_used}/{max_turns} verdict={verdict} reason={_truncate(reason, 120)}")

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -122,7 +122,10 @@ VALID_INITIAL_STATUSES = {"running", "blocked"}
 # ``BLOCK_RECURRENCE_LIMIT``) escalates them to ``triage`` if a cron keeps
 # unblocking them only to have the worker re-block for the same reason.
 # ``None`` = legacy/un-typed block (treated as a generic human blocker).
-VALID_BLOCK_KINDS = {"dependency", "needs_input", "capability", "transient"}
+VALID_BLOCK_KINDS = {
+    "dependency", "needs_input", "capability", "transient", "infrastructure",
+    "protocol_violation",
+}
 
 # After a task has been blocked, unblocked, and re-blocked this many times for
 # the same (truly-blocked) reason, the unblock-loop breaker stops trusting the
@@ -7032,14 +7035,20 @@ def invalidate_descendants_for_parent_reopen(
     task_id: str,
     *,
     author: str,
+    reopen_completed: bool = False,
+    reopen_reason: Optional[str] = None,
 ) -> dict[str, Any]:
-    """Retract every dispatchable/completed descendant of a reopened ancestor.
+    """Retract non-terminal descendants of a reopened ancestor.
 
-    THE single domain implementation of done-reopen descendant invalidation.
-    When a ``done`` (or ``archived``) ancestor is reopened, every descendant
-    whose state assumed the ancestor's result — ``ready``, ``review``,
-    ``running`` or ``done`` — is building on a retracted premise, so it is
-    demoted to ``todo`` and re-gated on the graph. The CLI deliberately has
+    ``done`` is protected. Ordinary ancestor/root resume never reopens a
+    completed descendant. A caller that intentionally invalidates completed
+    work must set ``reopen_completed=True`` and supply ``reopen_reason``;
+    that reason is persisted in the descendant audit trail.
+
+    This is the single domain implementation of ancestor-reopen descendant
+    invalidation. Dispatchable descendants are re-gated, while completed
+    descendants remain done unless explicit invalidation intent is supplied.
+    The CLI deliberately has
     NO done-reopen verb on this branch (``reopen-review`` only handles the
     review-phase transition via :func:`reopen_review_task`), so every surface
     that reopens a done task (dashboard drag-drop / PATCH — single and bulk —
@@ -7088,6 +7097,9 @@ def invalidate_descendants_for_parent_reopen(
     invalidated entry is ``{id, prior_status, new_status, resume_status}``
     and each termination is a ``(worker_pid, claim_lock)`` tuple.
     """
+    if reopen_completed and not (reopen_reason or "").strip():
+        raise ValueError("reopen_reason is required when reopening done descendants")
+
     caller_owns_txn = bool(getattr(conn, "in_transaction", False))
     now = int(time.time())
     invalidated: list[dict[str, Any]] = []
@@ -7111,6 +7123,8 @@ def invalidate_descendants_for_parent_reopen(
         ).fetchall()
         for row in rows:
             previous_status = row["status"]
+            if previous_status == "done" and not reopen_completed:
+                continue
             if previous_status not in {"ready", "review", "running", "done"}:
                 continue
             resume_status = "ready"
@@ -7146,6 +7160,7 @@ def invalidate_descendants_for_parent_reopen(
                     "prior_status": previous_status,
                     "new_status": "todo",
                     "resume_status": resume_status,
+                    "reopen_reason": reopen_reason,
                 },
                 run_id=run_id,
             )
@@ -7161,6 +7176,7 @@ def invalidate_descendants_for_parent_reopen(
                     "parent": task_id,
                     "previous_status": previous_status,
                     "resume_status": resume_status,
+                    "reopen_reason": reopen_reason,
                 },
                 run_id=run_id,
             )
@@ -7173,7 +7189,8 @@ def invalidate_descendants_for_parent_reopen(
                     row["id"],
                     author,
                     (
-                        f"Invalidated: ancestor {task_id} was reopened; "
+                        f"Invalidated: ancestor {task_id} was reopened"
+                        f"{f' ({reopen_reason})' if reopen_reason else ''}; "
                         f"retracted from '{previous_status}' to 'todo' "
                         f"(will resume via '{resume_status}')."
                     ),
@@ -8789,77 +8806,6 @@ def _error_fingerprint(error_text: str) -> str:
     return fp.lower().strip()
 
 
-# Empirically ~96% of "clean exit without a terminal tool call" tasks complete
-# on a later run (a goal-mode finalize nudge, or the model simply emitting the
-# tool call next time), so a protocol violation is NOT deterministic — give it a
-# bounded retry before the breaker trips instead of blocking on the first hit.
-#
-# The budget is a violation-only STREAK, not a share of the unified
-# ``consecutive_failures`` counter: it counts consecutive clean-exit protocol
-# violations (derived from run history by ``_protocol_violation_streak``), so
-# earlier timeouts / nonzero exits neither consume nor extend it, and a
-# below-budget violation does not tick the unified counter either. A per-task
-# ``max_retries`` overrides this bound — the same "task override wins"
-# precedence ``_record_task_failure`` documents for every other failure kind.
-_PROTOCOL_VIOLATION_FAILURE_LIMIT = 3
-
-# How far back to walk a task's closed runs when counting the violation
-# streak. The streak trips at a handful of violations, so anything beyond a
-# few dozen rows (violations interleaved with neutral rate-limited requeues)
-# can only mean "way past the bound" anyway.
-_PROTOCOL_VIOLATION_SCAN_LIMIT = 50
-
-
-def _protocol_violation_streak(conn: sqlite3.Connection, task_id: str) -> int:
-    """Count the task's trailing run of clean-exit protocol violations.
-
-    Walks the task's closed runs newest-first — including the violation run
-    ``detect_crashed_workers`` just closed — and counts how many in a row were
-    clean-exit protocol violations:
-
-    * ``rate_limited`` runs are neutral and skipped: a quota wall says nothing
-      about the task, exactly as it is neutral for the unified
-      ``consecutive_failures`` counter.
-    * Any other closed run (completed, plain crash, timeout, spawn failure,
-      reclaim, …) breaks the streak, so the bounded retry budget counts ONLY
-      protocol violations — mixed failure kinds can neither consume nor
-      extend it.
-
-    Violation runs are recognized by the ``protocol_violation`` marker that
-    ``detect_crashed_workers`` stamps into the run metadata; the violation
-    error text is matched as a fallback for runs recorded before the marker
-    existed.
-    """
-    streak = 0
-    rows = conn.execute(
-        "SELECT outcome, error, metadata FROM task_runs "
-        "WHERE task_id = ? AND ended_at IS NOT NULL "
-        "ORDER BY id DESC LIMIT ?",
-        (task_id, _PROTOCOL_VIOLATION_SCAN_LIMIT),
-    ).fetchall()
-    for row in rows:
-        outcome = row["outcome"] or ""
-        if outcome == "rate_limited":
-            continue
-        if outcome == "crashed":
-            is_violation = False
-            raw_meta = row["metadata"]
-            if raw_meta:
-                try:
-                    is_violation = bool(
-                        json.loads(raw_meta).get("protocol_violation")
-                    )
-                except (ValueError, TypeError):
-                    is_violation = False
-            if not is_violation:
-                is_violation = "protocol violation" in (row["error"] or "")
-            if is_violation:
-                streak += 1
-                continue
-        break
-    return streak
-
-
 def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
@@ -8893,11 +8839,10 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
     # Per-crash details collected inside the main txn, used after it
     # closes to run ``_record_task_failure`` (which needs its own
     # write_txn so can't nest). ``protocol_violation`` flags the
-    # clean-exit-but-still-running case, which is accounted against its
-    # own bounded violation streak instead of the unified failure
-    # counter (see the post-txn loop below).
-    crash_details: list[tuple[str, int, str, bool, str]] = []
-    # (task_id, pid, claimer, protocol_violation, error_text)
+    # clean-exit-but-still-running case, which trips the breaker immediately
+    # in the post-transaction accounting loop below.
+    crash_details: list[tuple[str, int, str, bool, str, Optional[int]]] = []
+    # (task_id, pid, claimer, protocol_violation, error_text, run_id)
     # Worker-exit observer payloads (RFC #58548), collected inside the main
     # txn and fired only after every reclaim/accounting txn has committed.
     exited_hook_payloads: list[dict] = []
@@ -9050,76 +8995,54 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                     crashed.append(row["id"])
                     crash_details.append(
                         (row["id"], pid, row["claim_lock"],
-                         protocol_violation, error_text)
+                         protocol_violation, error_text, run_id)
                     )
     # Outside the main txn: account each crashed task and maybe trip the
     # breaker (the retried task transitions to blocked with a ``gave_up`` event
     # on top of the event we already emitted).
     #
-    # Protocol-violation crashes (clean exit, no terminal tool call) get a
-    # BOUNDED retry, not an immediate trip: empirically ~96% of these tasks
-    # complete on a later run (a goal-mode finalize nudge, or the model simply
-    # emitting kanban_complete/kanban_block next time), so blocking on the first
-    # occurrence just churned them through the respawn cycle. The retry budget
-    # is a violation-only streak (``_protocol_violation_streak``): earlier
-    # timeouts / nonzero exits neither consume nor extend it, and a
-    # below-budget violation does not tick the unified
-    # ``consecutive_failures`` counter, so the two budgets stay independent.
-    # A per-task ``max_retries`` overrides the violation bound with the same
-    # top precedence it has for every other failure kind. Systemic same-error
-    # crashes still trip immediately.
+    # A clean exit without a terminal lifecycle call is not a retryable worker
+    # failure. It is a protocol violation, so block on the first occurrence
+    # and require an explicit operator decision. Identical failures therefore
+    # cannot form an unbounded respawn loop.
     auto_blocked: list[str] = []
     if crash_details:
         # Fingerprint errors to detect systemic failures.
         _fp_counts: dict[str, int] = {}
-        for _, _, _, _, err_text in crash_details:
+        for _, _, _, _, err_text, _ in crash_details:
             fp = _error_fingerprint(err_text)
             _fp_counts[fp] = _fp_counts.get(fp, 0) + 1
-        for tid, pid, claimer, protocol_violation, error_text in crash_details:
+        for (
+            tid,
+            pid,
+            claimer,
+            protocol_violation,
+            error_text,
+            closed_run_id,
+        ) in crash_details:
             if protocol_violation:
-                streak = _protocol_violation_streak(conn, tid)
-                trow = conn.execute(
-                    "SELECT max_retries FROM tasks WHERE id = ?", (tid,),
-                ).fetchone()
-                if trow is None:
-                    continue  # task deleted mid-loop
-                task_override = (
-                    trow["max_retries"] if "max_retries" in trow.keys() else None
-                )
-                violation_limit = (
-                    int(task_override)
-                    if task_override is not None
-                    else _PROTOCOL_VIOLATION_FAILURE_LIMIT
-                )
-                if streak < violation_limit:
-                    # Below budget: the task is already back at ``ready``
-                    # (respawn allowed) with ``last_failure_error`` stamped.
-                    # Deliberately no ``_record_task_failure`` call — a
-                    # below-budget violation must not consume the unified
-                    # failure budget, just as other failure kinds don't
-                    # consume this one.
-                    continue
-                # Streak reached the bound: trip the breaker. ``force_trip``
-                # skips the threshold resolution inside
-                # ``_record_task_failure`` because the decision — including
-                # the per-task ``max_retries`` override — was already made
-                # against the violation streak above.
                 tripped = _record_task_failure(
                     conn, tid,
                     error=error_text,
-                    outcome="crashed",
-                    failure_limit=violation_limit,
+                    outcome="protocol_violation",
                     force_trip=True,
                     release_claim=False,
                     end_run=False,
                     event_payload_extra={
                         "pid": pid,
                         "claimer": claimer,
-                        "protocol_violations": streak,
-                        "protocol_violation_limit": violation_limit,
+                        "exit_code": 0,
+                        "protocol_violation": True,
+                        "run_id": closed_run_id,
                     },
                 )
                 if tripped:
+                    with write_txn(conn):
+                        conn.execute(
+                            "UPDATE tasks SET block_kind = 'protocol_violation' "
+                            "WHERE id = ? AND status = 'blocked'",
+                            (tid,),
+                        )
                     auto_blocked.append(tid)
                 continue
             fp = _error_fingerprint(error_text)
@@ -9290,8 +9213,11 @@ def _record_task_failure(
             }
             if event_payload_extra:
                 payload.update(event_payload_extra)
+            related_run_id = run_id
+            if related_run_id is None and event_payload_extra:
+                related_run_id = event_payload_extra.get("run_id")
             _append_event(
-                conn, task_id, "gave_up", payload, run_id=run_id,
+                conn, task_id, "gave_up", payload, run_id=related_run_id,
             )
             blocked = True
         else:

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1320,50 +1320,33 @@ def _drive_nonzero_crash(conn, tid, fake_pid):
     return _drive_worker_exit(conn, tid, fake_pid, 256)
 
 
-def test_protocol_violation_budget_not_consumed_by_other_failures(kanban_home):
-    """Mixed failure kinds must not consume the violation retry budget.
-
-    Regression for the #61233 review finding: expressed as a plain
-    ``failure_limit`` over the unified ``consecutive_failures`` counter, the
-    violation budget was consumed by earlier timeouts / nonzero exits. As a
-    violation-only streak, a prior real crash must not eat violation
-    retries, and below-budget violations must leave the unified counter
-    untouched (so the two budgets stay independent).
-    """
-    import hermes_cli.kanban_db as _kb
+def test_clean_exit_without_terminal_call_blocks_protocol_violation(kanban_home):
+    """rc=0 is not success while the owned task is still running."""
     conn = kb.connect()
     try:
-        tid = kb.create_task(conn, title="mixed", assignee="worker")
-
-        # One real crash: unified counter ticks to 1 (below
-        # DEFAULT_FAILURE_LIMIT=2 — task stays ready).
-        _drive_nonzero_crash(conn, tid, 991000)
-        task = kb.get_task(conn, tid)
-        assert task.status == "ready"
-        assert task.consecutive_failures == 1
-
-        # Two violations after it: streak 1 and 2 — both retry, unified
-        # counter untouched. (Pre-fix: the crash consumed the budget and the
-        # violations blocked well before three of them happened.)
-        for i, pid in enumerate((991001, 991002)):
-            _drive_protocol_violation(conn, tid, pid)
-            task = kb.get_task(conn, tid)
-            assert task.status == "ready", (
-                f"violation {i + 1} after a crash must still retry, "
-                f"got {task.status}"
-            )
-            assert task.consecutive_failures == 1, (
-                "below-budget violations must not tick the unified counter"
-            )
-
-        # Third consecutive violation: streak hits the bound — blocked.
+        tid = kb.create_task(conn, title="clean exit", assignee="worker")
         _drive_protocol_violation(conn, tid, 991003)
         task = kb.get_task(conn, tid)
         assert task.status == "blocked"
+        assert task.block_kind == "protocol_violation"
+        assert task.current_run_id is None
         gave_up = [e for e in kb.list_events(conn, tid) if e.kind == "gave_up"]
         assert len(gave_up) == 1
-        assert (gave_up[0].payload or {}).get("protocol_violations") == \
-            _kb._PROTOCOL_VIOLATION_FAILURE_LIMIT
+        payload = gave_up[0].payload or {}
+        assert payload["protocol_violation"] is True
+        assert payload["pid"] == 991003
+        assert payload["exit_code"] == 0
+        run = kb.latest_run(conn, tid)
+        assert run is not None and run.id == gave_up[0].run_id
+        assert "protocol violation" in (run.error or "")
+        spawned = []
+        result = kb.dispatch_once(
+            conn,
+            spawn_fn=lambda *args, **kwargs: spawned.append((args, kwargs)),
+            reconcile_orphans=False,
+        )
+        assert result.spawned == []
+        assert spawned == []
     finally:
         conn.close()
 
@@ -1406,5 +1389,3 @@ def test_notify_sub_starts_caught_up_on_active_task(kanban_home):
         assert events == [], "historical events must not replay to a new sub"
     finally:
         conn.close()
-
-

--- a/tests/hermes_cli/test_kanban_goal_mode.py
+++ b/tests/hermes_cli/test_kanban_goal_mode.py
@@ -128,6 +128,68 @@ def test_loop_stops_when_worker_already_completed(monkeypatch):
     assert turns == []  # no extra turns
 
 
+def test_judge_api_error_retries_only_root_judge_and_preserves_task_id(
+    monkeypatch, kanban_home,
+):
+    attempts = []
+    sleeps = []
+    turns = []
+    conn = kb.connect()
+    child_id = kb.create_task(conn, title="completed dependency", assignee="worker")
+    assert kb.complete_task(conn, child_id)
+    root_id = kb.create_task(
+        conn,
+        title="existing root",
+        assignee="worker",
+        parents=[child_id],
+        goal_mode=True,
+    )
+    claimed = kb.claim_task(conn, root_id)
+    assert claimed is not None
+    run_id = claimed.current_run_id
+    initial_ids = {
+        row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()
+    }
+
+    def failing_judge(goal, response, **_kw):
+        attempts.append((goal, response))
+        return "continue", "judge error: APIConnectionError", False, None, True
+
+    monkeypatch.setattr(goals, "judge_goal", failing_judge)
+    result = goals.run_kanban_goal_loop(
+        task_id=root_id,
+        goal_text="finish existing graph",
+        first_response="all children already completed",
+        task_status_fn=lambda: kb.goal_run_status(conn, root_id, run_id),
+        run_turn=lambda prompt: turns.append(prompt) or "unexpected",
+        block_fn=lambda reason: pytest.fail("must use infrastructure blocker"),
+        infrastructure_block_fn=lambda reason: kb.block_task(
+            conn,
+            root_id,
+            reason=reason,
+            kind="infrastructure",
+            expected_run_id=run_id,
+        ),
+        judge_max_retries=3,
+        sleep_fn=sleeps.append,
+    )
+
+    assert result["outcome"] == "infrastructure_blocked"
+    assert result["task_id"] == root_id
+    assert result["turns_used"] == 1
+    assert result["judge_attempts"] == 3
+    assert len(attempts) == 3
+    assert turns == []
+    assert sleeps == [1.0, 2.0]
+    assert kb.get_task(conn, root_id).status == "blocked"
+    assert kb.get_task(conn, root_id).block_kind == "infrastructure"
+    assert kb.get_task(conn, child_id).status == "done"
+    final_ids = {row["id"] for row in conn.execute("SELECT id FROM tasks").fetchall()}
+    assert final_ids == initial_ids
+    assert kb.latest_run(conn, root_id).id == run_id
+    conn.close()
+
+
 
 
 

--- a/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
+++ b/tests/hermes_cli/test_kanban_parent_reopen_invalidation.py
@@ -52,7 +52,7 @@ def _reopen_parent_directly(conn, parent_id: str) -> None:
         )
 
 
-def test_reopen_demotes_done_descendants_with_events_and_comments(conn):
+def test_parent_resume_preserves_done_descendants(conn):
     parent_id, child_id = _done_parent_with_done_child(conn)
     grandchild_id = kb.create_task(
         conn, title="grandchild", assignee="writer", parents=[child_id],
@@ -64,27 +64,11 @@ def test_reopen_demotes_done_descendants_with_events_and_comments(conn):
         conn, parent_id, author="operator",
     )
 
-    demoted = {entry["id"]: entry for entry in result["invalidated"]}
-    assert set(demoted) == {child_id, grandchild_id}
+    assert result["invalidated"] == []
     for tid in (child_id, grandchild_id):
-        assert demoted[tid]["prior_status"] == "done"
-        assert demoted[tid]["new_status"] == "todo"
         task = kb.get_task(conn, tid)
-        assert task is not None and task.status == "todo"
-        assert task.completed_at is None
-
-        events = kb.list_events(conn, tid)
-        inval = [e for e in events if e.kind == "descendant_invalidated"]
-        assert len(inval) == 1
-        payload = inval[0].payload
-        assert payload["ancestor"] == parent_id
-        assert payload["prior_status"] == "done"
-        assert payload["new_status"] == "todo"
-
-        comments = kb.list_comments(conn, tid)
-        assert any(
-            parent_id in c.body and c.author == "operator" for c in comments
-        ), f"no invalidation comment naming {parent_id} on {tid}"
+        assert task is not None and task.status == "done"
+        assert task.completed_at is not None
 
     assert result["terminations"] == []
 
@@ -141,7 +125,10 @@ def test_counter_reset_on_invalidated_descendants(conn):
         )
 
     _reopen_parent_directly(conn, parent_id)
-    kb.invalidate_descendants_for_parent_reopen(conn, parent_id, author="op")
+    kb.invalidate_descendants_for_parent_reopen(
+        conn, parent_id, author="op", reopen_completed=True,
+        reopen_reason="acceptance criteria changed",
+    )
 
     child = kb.get_task(conn, child_id)
     assert child is not None
@@ -223,8 +210,7 @@ def test_dashboard_and_db_paths_produce_identical_outcomes(tmp_path, monkeypatch
 
         assert snapshot(dash_child) == snapshot(db_child)
         status, completed_at, _run, failures, kinds, n_comments = snapshot(db_child)
-        assert status == "todo"
-        assert completed_at is None
+        assert status == "done"
+        assert completed_at is not None
         assert failures == 0
-        assert "descendant_invalidated" in kinds
-        assert n_comments >= 1
+        assert "descendant_invalidated" not in kinds


### PR DESCRIPTION
## Summary

- treat worker rc=0 without kanban_complete/kanban_block as blocked(protocol_violation), never success
- persist durable terminal evidence: reason, run ID, PID, and exit code; prevent automatic respawn
- protect completed child terminal state during ancestor/root resume; require explicit reopen_completed plus reopen_reason to invalidate done work
- distinguish goal-judge infrastructure failures and retry only the existing root judge with exponential backoff
- preserve completed dependencies, task IDs, worker turns, and graph topology during judge retries
- retain existing Telegram notify+wake behavior

## Regression and E2E verification

- clean focused suite: 68 passed, 2 deselected
- Python compile: passed
- git diff --check: passed
- A: rc=0/no terminal call -> blocked(protocol_violation), durable run/PID/exit/reason evidence, subsequent dispatcher tick spawned nothing
- B: done child + parent resume -> child remained done, no new child/task
- C: APIConnectionError-equivalent -> same root/run ID, completed child remained done, no worker turn or graph creation, judge-only backoff (1s, 2s), then blocked(infrastructure)
- Telegram notifier and app-server notify+wake regression suites passed
- existing root t_54e7393f inspected read-only: durable history confirms same root ID, five completed dependencies, and prior judge APIConnectionError recovery scenario; completed PR work was not rerun

## Notes

Two corruption-watcher timeout failures are excluded from this patch. They reproduce in the pre-existing gateway/kanban_watchers.py worktree changes and are tracked separately; this branch does not modify that file.

Ruff is unavailable in the current environment (No module named ruff); rely on GitHub CI if Ruff is required.