### PR TITLE
fix: Live sessions ignore config default-model changes: persisted session model_override has no operator clear path (#102658)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3133,6 +3133,7 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
     neutralize_untrusted_inline_text,
+    read_model_default_snapshot,
 )
 from gateway.delivery import (
     DeliveryRouter,
@@ -29495,6 +29496,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             _rehydrate_state is not None
             and _rehydrate_state.conversation.model_override is not None
         ):
+            # Live in-memory override: still subject to the stale-pin drop
+            # below, so long-lived sessions follow default-model changes
+            # without waiting for a gateway restart (#102658).
+            self._drop_stale_session_model_override(session_key)
             return
         store = getattr(self, "session_store", None)
         if store is None:
@@ -29543,6 +29548,81 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             "Rehydrated persisted /model override for session=%s: model=%s provider=%s",
             session_key, override.get("model"), provider or "",
         )
+        # A just-rehydrated pin may already be stale (default migrated while
+        # the gateway was down) — same drop as the live path above (#102658).
+        self._drop_stale_session_model_override(session_key)
+
+    def _drop_stale_session_model_override(self, session_key: str) -> bool:
+        """Drop a session override that went stale after a default-model change.
+
+        ``SessionStore.set_model_override`` snapshots the config
+        ``(model.default, model.provider)`` each pin was taken against.  A pin
+        that merely *echoed* that default is redundant: once the operator
+        migrates the fleet default, the stale pin is cleared (in-memory +
+        persisted) so the session follows the new default on its next turn —
+        live sessions included, with no restart or per-session ``/new``
+        required.  An explicit *divergent* pin (override != pin-time default)
+        still wins, as do legacy pins that predate the snapshot (no snapshot
+        → keep).
+
+        Never raises: staleness hygiene must not break turn resolution.
+        """
+        try:
+            state = self._peek_session_state(session_key)
+            override = state.conversation.model_override if state else None
+            if not override:
+                return False
+            store = getattr(self, "session_store", None)
+            if store is None:
+                return False
+            pinned = store.get_model_override_pinned_default(session_key)
+            if not pinned:
+                return False
+            current = read_model_default_snapshot()
+            if not current:
+                return False
+            if (
+                str(override.get("model") or "")
+                != str(pinned.get("model") or "")
+                or str(override.get("provider") or "")
+                != str(pinned.get("provider") or "")
+            ):
+                return False
+            if (
+                str(pinned.get("model") or "")
+                == str(current.get("model") or "")
+                and str(pinned.get("provider") or "")
+                == str(current.get("provider") or "")
+            ):
+                return False
+            state.conversation.model_override = None
+            try:
+                store.set_model_override(session_key, None)
+            except Exception:
+                logger.debug(
+                    "Failed to clear stale session model override",
+                    exc_info=True,
+                )
+            try:
+                self._evict_cached_agent(session_key)
+            except Exception:
+                logger.debug(
+                    "Failed to evict agent after stale-override drop",
+                    exc_info=True,
+                )
+            logger.info(
+                "Dropped stale /model override for session=%s: "
+                "pinned=%s/%s now follows default=%s/%s (#102658)",
+                session_key,
+                pinned.get("model"), pinned.get("provider"),
+                current.get("model"), current.get("provider"),
+            )
+            return True
+        except Exception:
+            logger.debug(
+                "Stale session-model-override check failed", exc_info=True
+            )
+            return False
 
     def _apply_session_model_override(
         self, session_key: str, model: str, runtime_kwargs: dict

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -781,6 +781,40 @@ def sanitize_model_override(override: Optional[Dict[str, Any]]) -> Optional[Dict
     return cleaned or None
 
 
+# Metadata key recording the config ``model.default``/``model.provider`` seen
+# when a session-scoped /model override was pinned (#102658).  A pin that
+# merely echoed the default goes stale when the operator migrates the fleet
+# default — the runner then drops it so live sessions follow the change.  An
+# explicit divergent pin (override != pinned default) always keeps winning.
+PINNED_MODEL_DEFAULT_METADATA_KEY = "_model_override_pinned_default"
+
+
+def read_model_default_snapshot() -> Optional[Dict[str, str]]:
+    """Return the current config ``(model, provider)`` default, if readable.
+
+    Defensive: config may be absent/unreadable (tests, fresh installs) — then
+    ``None`` and every staleness check conservatively keeps the override.
+    ``model`` may be a flat string instead of a dict (see
+    ``resolve_persist_behavior``); a non-empty string IS the default model.
+    """
+    try:
+        from hermes_cli.config import load_config
+
+        model_cfg = load_config().get("model")
+    except Exception:
+        return None
+    if isinstance(model_cfg, dict):
+        model = str(model_cfg.get("default") or "").strip()
+        provider = str(model_cfg.get("provider") or "").strip()
+    elif isinstance(model_cfg, str):
+        model, provider = model_cfg.strip(), ""
+    else:
+        return None
+    if not (model or provider):
+        return None
+    return {"model": model, "provider": provider}
+
+
 @dataclass
 class SessionEntry:
     """
@@ -2599,6 +2633,7 @@ class SessionStore:
                 # persisted /model override too so a later message doesn't
                 # rehydrate it after the in-memory override was popped.
                 entry.model_override = None
+                entry.metadata.pop(PINNED_MODEL_DEFAULT_METADATA_KEY, None)
             self._save()
         # The expiry watcher calls this from a background task that never
         # entered ``_profile_runtime_scope``, so resolve the store from the
@@ -3341,6 +3376,11 @@ class SessionStore:
         are re-resolved at rehydration time via the normal runtime provider
         resolution.  Pass ``None`` (or a dict with no persistable values)
         to clear the persisted override, e.g. on /new.
+
+        On persist the current config default is snapshotted alongside
+        (see ``PINNED_MODEL_DEFAULT_METADATA_KEY``) so a pin that merely
+        echoed the default can go stale when the operator migrates the
+        fleet default (#102658); clearing drops the snapshot too.
         """
         with self._lock:
             self._ensure_loaded_locked()
@@ -3351,7 +3391,37 @@ class SessionStore:
             if entry.model_override == cleaned:
                 return
             entry.model_override = cleaned
+            if cleaned is None:
+                entry.metadata.pop(PINNED_MODEL_DEFAULT_METADATA_KEY, None)
+            else:
+                snapshot = read_model_default_snapshot()
+                if snapshot is not None:
+                    entry.metadata[PINNED_MODEL_DEFAULT_METADATA_KEY] = snapshot
+                else:
+                    entry.metadata.pop(PINNED_MODEL_DEFAULT_METADATA_KEY, None)
             self._save()
+
+    def get_model_override_pinned_default(
+        self, session_key: str
+    ) -> Optional[Dict[str, str]]:
+        """Return the pin-time config default recorded for *session_key*.
+
+        ``None`` when no override was pinned through :meth:`set_model_override`
+        since this tracking landed (legacy pins conservatively keep winning).
+        """
+        with self._lock:
+            self._ensure_loaded_locked()
+            entry = self._entries.get(session_key)
+            if entry is None:
+                return None
+            pinned = entry.metadata.get(PINNED_MODEL_DEFAULT_METADATA_KEY)
+            if not isinstance(pinned, dict):
+                return None
+            return {
+                k: str(v)
+                for k, v in pinned.items()
+                if k in ("model", "provider")
+            } or None
 
     def get_model_override(self, session_key: str) -> Optional[Dict[str, str]]:
         """Return the persisted /model override for *session_key*, if any."""

--- a/tests/gateway/test_102658_stale_model_override.py
+++ b/tests/gateway/test_102658_stale_model_override.py
@@ -1,0 +1,78 @@
+"""Stale session-model pins follow fleet default-model changes (#102658).
+
+A ``/model`` pin that merely echoed the config default goes stale when the
+operator migrates ``model.default``/``model.provider``: the runner drops it
+(live + post-restart) so the session follows the new default.  An explicit
+divergent pin still wins; legacy pins without a snapshot keep winning.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+
+OLD = {"model": {"default": "old-m", "provider": "old-p"}}
+NEW = {"model": {"default": "new-m", "provider": "new-p"}}
+
+
+@pytest.fixture
+def store(tmp_path, monkeypatch):
+    import hermes_state
+
+    def _raise(*a, **k):
+        raise RuntimeError("SQLite disabled in test")
+
+    monkeypatch.setattr(hermes_state, "SessionDB", _raise)
+    return SessionStore(sessions_dir=tmp_path, config=GatewayConfig())
+
+
+def _key(store):
+    src = SessionSource(platform=Platform.TELEGRAM, user_id="u", chat_id="c",
+                        user_name="t", chat_type="dm")
+    return store.get_or_create_session(src).session_key
+
+
+def _runner(store):
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.session_store = store
+    return runner
+
+
+def _rehydrate(store, key, cfg):
+    runner = _runner(store)
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        runner._rehydrate_session_model_override(key)
+    return runner
+
+
+def _live_override(runner, key):
+    state = runner._peek_session_state(key)
+    return state.conversation.model_override if state else None
+
+
+def test_stale_echo_pin_follows_default_change(store):
+    key = _key(store)
+    with patch("hermes_cli.config.load_config", return_value=OLD):
+        store.set_model_override(key, {"model": "old-m", "provider": "old-p"})
+    runner = _rehydrate(store, key, NEW)
+    assert _live_override(runner, key) is None
+    assert store.get_model_override(key) is None
+
+
+def test_explicit_divergent_pin_survives_default_change(store):
+    key = _key(store)
+    with patch("hermes_cli.config.load_config", return_value=OLD):
+        store.set_model_override(key, {"model": "other-m", "provider": "other-p"})
+    runner = _rehydrate(store, key, NEW)
+    assert (_live_override(runner, key) or {}).get("model") == "other-m"
+
+
+def test_legacy_pin_without_snapshot_keeps_winning(store):
+    key = _key(store)
+    with patch("hermes_cli.config.load_config", return_value={}):
+        store.set_model_override(key, {"model": "old-m", "provider": "old-p"})
+    runner = _rehydrate(store, key, NEW)
+    assert (_live_override(runner, key) or {}).get("model") == "old-m"


### PR DESCRIPTION
## What Problem This Solves
Fixes #102658 — Live sessions ignore config default-model changes: persisted session model_override has no operator clear path. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102658).

Closes #102658