### PR TITLE
fix(dashboard): give the mobile chat model/tools drawer an opaque background fallback

### DIFF
--- a/web/src/pages/ChatPage.test.tsx
+++ b/web/src/pages/ChatPage.test.tsx
@@ -457,3 +457,34 @@ describe("ChatPage PTY ticket connect deadline", () => {
     expect(apiMocks.buildWsUrl).toHaveBeenCalledTimes(1);
   });
 });
+
+describe("ChatPage mobile model/tools drawer surface", () => {
+  // Stock themes define no componentStyles.sidebar.background, so
+  // --component-sidebar-background is never injected by the theme context.
+  // The drawer's arbitrary background property must therefore carry an opaque
+  // var(--background-base) fallback; without it the declaration is invalid at
+  // computed-value time and the panel renders transparent over the page
+  // (#102695).
+  it("keeps the mobile drawer opaque when the theme defines no sidebar background", async () => {
+    vi.stubGlobal("matchMedia", () => ({
+      addEventListener() {},
+      matches: true,
+      media: "(max-width: 1023px)",
+      removeEventListener() {},
+    }));
+
+    const { default: ChatPage } = await import("./ChatPage");
+    await render(
+      <MemoryRouter initialEntries={["/chat"]}>
+        <ChatPage isActive />
+      </MemoryRouter>,
+    );
+    await vi.waitFor(() => expect(FakeWebSocket.instances).toHaveLength(1));
+
+    const drawer = document.getElementById("chat-side-panel");
+    expect(drawer).not.toBeNull();
+    expect(drawer!.className).toContain(
+      "[background:var(--component-sidebar-background,var(--background-base))]",
+    );
+  });
+});

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1744,7 +1744,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "border-l border-current/20 text-midground",
             "bg-background-base/95",
             "transition-transform duration-200 ease-out",
-            "[background:var(--component-sidebar-background)]",
+            "[background:var(--component-sidebar-background,var(--background-base))]",
             "[clip-path:var(--component-sidebar-clip-path)]",
             "[border-image:var(--component-sidebar-border-image)]",
             mobilePanelOpen


### PR DESCRIPTION
## What does this PR do?

Fixes the third transparent-surface call site from #102695: the mobile Chat model/tools drawer. Stock themes (e.g. `default`) define no `componentStyles.sidebar.background`, so `--component-sidebar-background` is never injected by the theme context. The drawer's `[background:var(--component-sidebar-background)]` arbitrary property then evaluates to invalid at computed-value time, and because that `background` shorthand outranks the `bg-background-base/95` utility in the cascade, the drawer surface becomes fully transparent — page headings, cards, and buttons bleed through the navigation labels on narrow viewports.

The fix adds a nested `var(--background-base)` fallback so the surface stays opaque whenever the theme provides no component override, while themed overrides keep working unchanged. This mirrors the two equivalent `App.tsx` fallbacks already present in #102109 (which does not touch this call site), so after both land, all three surfaces from the issue are covered.

## Related Issue

Fixes #102695

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `web/src/pages/ChatPage.tsx`: `[background:var(--component-sidebar-background)]` → `[background:var(--component-sidebar-background,var(--background-base))]` on the mobile model/tools drawer — one line.
- `web/src/pages/ChatPage.test.tsx`: appended a regression test that renders ChatPage with a narrow-viewport `matchMedia` stub and pins the drawer's emitted background declaration to the opaque fallback form (jsdom does not resolve `var()` chains, so the class-level contract is the testable surface).

## How to Test

1. `cd web && npm run check` — Observed result: typecheck clean, eslint 0 errors (27 pre-existing warnings, all in untouched files), 292/292 vitest tests pass, including the new `ChatPage mobile model/tools drawer surface > keeps the mobile drawer opaque when the theme defines no sidebar background`.
2. Red/green check: reverting only the one-line fallback (keeping the test) makes the new test fail with `expected className to contain "...,var(--background-base))]"`, confirming the test captures the previous transparent behavior; re-applying the fix turns it green again.
3. Manual: run the dashboard with the stock `default` theme, resize below the `lg` breakpoint, open the `/chat` model/tools drawer — Observed result: the drawer renders an opaque `--background-base` surface instead of compositing the page underneath.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass — change is web/-only (no Python files touched); `web` vitest suite (292 tests) is green
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4 (arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS, Linux) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A — CSS-level fallback fix; verification is the regression test above.
