### PR TITLE
fix(dashboard): add CSS fallback for mobile drawer/header transparency (#102695)

### DIFF
--- a/contributors/emails/shreyanshiitian1729@gmail.com
+++ b/contributors/emails/shreyanshiitian1729@gmail.com
@@ -1,0 +1,1 @@
+Shreyansh1729

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -532,7 +532,7 @@ export default function App() {
           "bg-background-base",
         )}
         style={{
-          background: "var(--component-header-background)",
+          background: "var(--component-header-background, var(--background-base))",
           borderImage: "var(--component-header-border-image)",
           clipPath: "var(--component-header-clip-path)",
         }}
@@ -591,7 +591,7 @@ export default function App() {
               collapsed && "lg:w-14",
             )}
             style={{
-              background: "var(--component-sidebar-background)",
+              background: "var(--component-sidebar-background, var(--background-base))",
               clipPath: "var(--component-sidebar-clip-path)",
               borderImage: "var(--component-sidebar-border-image)",
             }}

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -1744,7 +1744,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "border-l border-current/20 text-midground",
             "bg-background-base/95",
             "transition-transform duration-200 ease-out",
-            "[background:var(--component-sidebar-background)]",
+            "[background:var(--component-sidebar-background,var(--background-base))]",
             "[clip-path:var(--component-sidebar-clip-path)]",
             "[border-image:var(--component-sidebar-border-image)]",
             mobilePanelOpen


### PR DESCRIPTION
## What does this PR do?

Ensures that dashboard mobile drawers and the mobile header remain opaque on stock themes by adding `var(--background-base)` as a nested CSS custom-property fallback.

Themes that lack `componentStyles.header.background` or `componentStyles.sidebar.background` leave `--component-header-background` and `--component-sidebar-background` unresolved. Because those are applied via higher-priority inline `style` or Tailwind arbitrary-property declarations, the `bg-background-base` utility class cannot compensate — the computed `background` becomes `transparent` and the underlying page content bleeds through.

### Changes

- `web/src/App.tsx` (line 535): `var(--component-header-background)` → `var(--component-header-background, var(--background-base))`
- `web/src/App.tsx` (line 594): `var(--component-sidebar-background)` → `var(--component-sidebar-background, var(--background-base))`
- `web/src/pages/ChatPage.tsx` (line 1747): `[background:var(--component-sidebar-background)]` → `[background:var(--component-sidebar-background,var(--background-base))]`

## Related Issue

Fixes #102695

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

1. Start the dashboard with the stock `default` theme.
2. Resize the browser below the `lg` breakpoint (or open on a mobile device).
3. Open the left navigation drawer — it should now show an opaque background.
4. On `/chat`, open the model/tools drawer — same opaque background.
5. Switch to a custom theme with `componentStyles.sidebar.background` set — it should still apply the themed background.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: macOS 15.2 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A