### PR TITLE
fix(kanban): enforce server-stamped identity on CLI and dashboard comment authors (#102693)

### DIFF
--- a/contributors/emails/shreyanshiitian1729@gmail.com
+++ b/contributors/emails/shreyanshiitian1729@gmail.com
@@ -1,0 +1,1 @@
+Shreyansh1729

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -26,6 +26,12 @@ from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
 from hermes_cli import kanban_swarm as ks
+from hermes_cli.kanban_comments import (
+    _cmd_attach,
+    _cmd_attach_rm,
+    _cmd_attachments,
+    _cmd_comment,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -2205,98 +2211,7 @@ def _cmd_claim(args: argparse.Namespace) -> int:
     return 0
 
 
-def _cmd_comment(args: argparse.Namespace) -> int:
-    body = " ".join(args.text).strip()
-    if args.max_len is not None:
-        if args.max_len < 1:
-            print("kanban: --max-len must be positive", file=sys.stderr)
-            return 2
-        if len(body) > args.max_len:
-            suffix = f"\n\n[trimmed to {args.max_len} chars by --max-len]"
-            body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
-    author = args.author or _profile_author()
-    with kb.connect_closing() as conn:
-        kb.add_comment(conn, args.task_id, author, body)
-    print(f"Comment added to {args.task_id}")
-    return 0
 
-
-def _cmd_attach(args: argparse.Namespace) -> int:
-    """Attach a local file to a task.
-
-    Reads the file off disk, writes it under the task's attachments dir,
-    and records the metadata row via the shared ``store_attachment_bytes``
-    path (same code the dashboard upload and the agent tool use), so the
-    25 MB cap and name-sanitisation behave identically everywhere.
-    """
-    import mimetypes
-
-    src = Path(args.path).expanduser()
-    if not src.is_file():
-        print(f"kanban: no such file: {src}", file=sys.stderr)
-        return 1
-    data = src.read_bytes()
-    name = args.name or src.name
-    content_type = args.content_type or mimetypes.guess_type(name)[0]
-    uploaded_by = args.author or _profile_author()
-    try:
-        with kb.connect_closing() as conn:
-            att_id = kb.store_attachment_bytes(
-                conn,
-                args.task_id,
-                name,
-                data,
-                content_type=content_type,
-                uploaded_by=uploaded_by,
-            )
-    except kb.AttachmentTooLarge as exc:
-        print(f"kanban: {exc}", file=sys.stderr)
-        return 1
-    print(f"Attached {name} to {args.task_id} (attachment {att_id}, {len(data)} bytes)")
-    return 0
-
-
-def _cmd_attachments(args: argparse.Namespace) -> int:
-    """List a task's attachments."""
-    with kb.connect_closing() as conn:
-        if kb.get_task(conn, args.task_id) is None:
-            print(f"no such task: {args.task_id}", file=sys.stderr)
-            return 1
-        atts = kb.list_attachments(conn, args.task_id)
-    if getattr(args, "json", False):
-        print(json.dumps([
-            {
-                "id": a.id,
-                "filename": a.filename,
-                "content_type": a.content_type,
-                "size": a.size,
-                "uploaded_by": a.uploaded_by,
-                "stored_path": a.stored_path,
-                "created_at": a.created_at,
-            }
-            for a in atts
-        ], indent=2))
-        return 0
-    if not atts:
-        print(f"No attachments on {args.task_id}")
-        return 0
-    print(f"Attachments on {args.task_id}:")
-    for a in atts:
-        ct = a.content_type or "-"
-        print(f"  [{a.id}] {a.filename}  ({a.size} bytes, {ct}, by {a.uploaded_by or '-'})")
-        print(f"        {a.stored_path}")
-    return 0
-
-
-def _cmd_attach_rm(args: argparse.Namespace) -> int:
-    """Delete an attachment by id (removes the row and the on-disk blob)."""
-    with kb.connect_closing() as conn:
-        removed = kb.delete_attachment(conn, args.attachment_id)
-    if removed is None:
-        print(f"no such attachment: {args.attachment_id}", file=sys.stderr)
-        return 1
-    print(f"Deleted attachment {args.attachment_id} ({removed.filename}) from {removed.task_id}")
-    return 0
 
 
 def _worker_run_id_for(task_id: str) -> Optional[int]:

--- a/hermes_cli/kanban_comments.py
+++ b/hermes_cli/kanban_comments.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import argparse
+import json
+import mimetypes
+import os
+import sys
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+def _profile_author() -> str:
+    for env in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
+        v = os.environ.get(env)
+        if v:
+            return v
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+        return get_active_profile_name() or "user"
+    except Exception:
+        return "user"
+
+
+def _cmd_comment(args: argparse.Namespace) -> int:
+    body = " ".join(args.text).strip()
+    if args.max_len is not None:
+        if args.max_len < 1:
+            print("kanban: --max-len must be positive", file=sys.stderr)
+            return 2
+        if len(body) > args.max_len:
+            suffix = f"\n\n[trimmed to {args.max_len} chars by --max-len]"
+            body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
+    profile = _profile_author()
+    author = f"cli:{args.author}" if args.author else f"cli:{profile}"
+    with kb.connect_closing() as conn:
+        kb.add_comment(conn, args.task_id, author, body)
+    print(f"Comment added to {args.task_id}")
+    return 0
+
+
+def _cmd_attach(args: argparse.Namespace) -> int:
+    """Attach a local file to a task.
+
+    Reads the file off disk, writes it under the task's attachments dir,
+    and records the metadata row via the shared ``store_attachment_bytes``
+    path (same code the dashboard upload and the agent tool use), so the
+    25 MB cap and name-sanitisation behave identically everywhere.
+    """
+    src = Path(args.path).expanduser()
+    if not src.is_file():
+        print(f"kanban: no such file: {src}", file=sys.stderr)
+        return 1
+    data = src.read_bytes()
+    name = args.name or src.name
+    content_type = args.content_type or mimetypes.guess_type(name)[0]
+    profile = _profile_author()
+    uploaded_by = f"cli:{args.author}" if args.author else f"cli:{profile}"
+    try:
+        with kb.connect_closing() as conn:
+            att_id = kb.store_attachment_bytes(
+                conn,
+                args.task_id,
+                name,
+                data,
+                content_type=content_type,
+                uploaded_by=uploaded_by,
+            )
+    except kb.AttachmentTooLarge as exc:
+        print(f"kanban: {exc}", file=sys.stderr)
+        return 1
+    print(f"Attached {name} to {args.task_id} (attachment {att_id}, {len(data)} bytes)")
+    return 0
+
+
+def _cmd_attachments(args: argparse.Namespace) -> int:
+    """List a task's attachments."""
+    with kb.connect_closing() as conn:
+        if kb.get_task(conn, args.task_id) is None:
+            print(f"no such task: {args.task_id}", file=sys.stderr)
+            return 1
+        atts = kb.list_attachments(conn, args.task_id)
+    if getattr(args, "json", False):
+        print(json.dumps([
+            {
+                "id": a.id,
+                "filename": a.filename,
+                "content_type": a.content_type,
+                "size": a.size,
+                "uploaded_by": a.uploaded_by,
+                "stored_path": a.stored_path,
+                "created_at": a.created_at,
+            }
+            for a in atts
+        ], indent=2))
+        return 0
+    if not atts:
+        print(f"No attachments on {args.task_id}")
+        return 0
+    print(f"Attachments on {args.task_id}:")
+    for a in atts:
+        ct = a.content_type or "-"
+        print(f"  [{a.id}] {a.filename}  ({a.size} bytes, {ct}, by {a.uploaded_by or '-'})")
+        print(f"        {a.stored_path}")
+    return 0
+
+
+def _cmd_attach_rm(args: argparse.Namespace) -> int:
+    """Delete an attachment by id (removes the row and the on-disk blob)."""
+    with kb.connect_closing() as conn:
+        removed = kb.delete_attachment(conn, args.attachment_id)
+    if removed is None:
+        print(f"no such attachment: {args.attachment_id}", file=sys.stderr)
+        return 1
+    print(f"Deleted attachment {args.attachment_id} ({removed.filename}) from {removed.task_id}")
+    return 0

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1241,13 +1241,14 @@ class CommentBody(BaseModel):
 def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query(None)):
     if not payload.body.strip():
         raise HTTPException(status_code=400, detail="body is required")
+    author = "dashboard"
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
         if kanban_db.get_task(conn, task_id) is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         kanban_db.add_comment(
-            conn, task_id, author=payload.author or "dashboard", body=payload.body,
+            conn, task_id, author=author, body=payload.body,
         )
         return {"ok": True}
     finally:

--- a/tests/hermes_cli/test_kanban_comment_author_forgery.py
+++ b/tests/hermes_cli/test_kanban_comment_author_forgery.py
@@ -1,0 +1,155 @@
+"""Tests for kanban comment author identity enforcement.
+
+Verifies that the CLI and dashboard API surfaces stamp a machine identity
+on comment authors rather than accepting arbitrary caller-supplied strings.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli import kanban as kanban_cli
+from hermes_cli import kanban_comments as kc
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+@pytest.fixture
+def task_id(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="test task", assignee="tester")
+    return tid
+
+
+class TestCLICommentAuthorStamping:
+
+    def test_cli_comment_stamps_cli_prefix_on_profile_author(
+        self, task_id, monkeypatch
+    ):
+        monkeypatch.delenv("HERMES_PROFILE_NAME", raising=False)
+        monkeypatch.delenv("HERMES_PROFILE", raising=False)
+        ns = argparse.Namespace(
+            task_id=task_id,
+            text=["hello", "world"],
+            author=None,
+            max_len=None,
+        )
+        with patch.object(kc, "_profile_author", return_value="myprofile"):
+            rc = kc._cmd_comment(ns)
+        assert rc == 0
+        with kb.connect() as conn:
+            comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert comments[0].author == "cli:myprofile"
+
+    def test_cli_comment_stamps_cli_prefix_on_explicit_author(
+        self, task_id, monkeypatch
+    ):
+        ns = argparse.Namespace(
+            task_id=task_id,
+            text=["testing"],
+            author="bot-ci",
+            max_len=None,
+        )
+        with patch.object(kc, "_profile_author", return_value="myprofile"):
+            rc = kc._cmd_comment(ns)
+        assert rc == 0
+        with kb.connect() as conn:
+            comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert comments[0].author == "cli:bot-ci"
+
+    def test_cli_comment_author_cannot_impersonate_dashboard(
+        self, task_id, monkeypatch
+    ):
+        ns = argparse.Namespace(
+            task_id=task_id,
+            text=["forged"],
+            author="dashboard",
+            max_len=None,
+        )
+        with patch.object(kc, "_profile_author", return_value="attacker"):
+            rc = kc._cmd_comment(ns)
+        assert rc == 0
+        with kb.connect() as conn:
+            comments = kb.list_comments(conn, task_id)
+        assert len(comments) == 1
+        assert comments[0].author == "cli:dashboard"
+        assert comments[0].author != "dashboard"
+
+
+class TestCLIAttachAuthorStamping:
+
+    def test_cli_attach_stamps_cli_prefix(self, task_id, tmp_path, monkeypatch):
+        f = tmp_path / "test.txt"
+        f.write_text("content")
+        ns = argparse.Namespace(
+            task_id=task_id,
+            path=str(f),
+            author=None,
+            name=None,
+            content_type=None,
+        )
+        with patch.object(kc, "_profile_author", return_value="myprofile"):
+            rc = kc._cmd_attach(ns)
+        assert rc == 0
+        with kb.connect() as conn:
+            atts = kb.list_attachments(conn, task_id)
+        assert len(atts) == 1
+        assert atts[0].uploaded_by == "cli:myprofile"
+
+
+class TestDashboardAPIAuthorStamping:
+
+    @pytest.fixture(autouse=True)
+    def _require_fastapi(self):
+        pytest.importorskip("fastapi")
+
+    def test_dashboard_api_ignores_client_supplied_author(
+        self, task_id, monkeypatch
+    ):
+        from plugins.kanban.dashboard import plugin_api
+
+        class FakePayload:
+            body = "test comment"
+            author = "attacker-forged-name"
+
+        conn = kb.connect()
+        monkeypatch.setattr(
+            plugin_api, "_resolve_board", lambda b: None
+        )
+        monkeypatch.setattr(
+            plugin_api, "_conn", lambda board=None: conn
+        )
+        result = plugin_api.add_comment(task_id, FakePayload(), board=None)
+
+        assert result == {"ok": True}
+        with kb.connect() as conn2:
+            comments = kb.list_comments(conn2, task_id)
+        authored = [c for c in comments if c.body.strip() == "test comment"]
+        assert len(authored) == 1
+        assert authored[0].author == "dashboard"
+
+
+class TestKanbanModuleReExports:
+
+    def test_kanban_reexports_comment_and_attachment_handlers(self):
+        assert kanban_cli._cmd_comment is kc._cmd_comment
+        assert kanban_cli._cmd_attach is kc._cmd_attach
+        assert kanban_cli._cmd_attachments is kc._cmd_attachments
+        assert kanban_cli._cmd_attach_rm is kc._cmd_attach_rm
+


### PR DESCRIPTION
## What does this PR do?

Prevents kanban comment author forgery on the CLI and dashboard API surfaces by enforcing server-stamped identity, mirroring the defense already present in the agent tool path (`tools/kanban_tools.py`).

### Problem

`hermes kanban comment <task> <text> --author <name>` stored any author string verbatim. The dashboard plugin's comment endpoint likewise accepted a client-supplied `author` field (defaulting to `"dashboard"`). Any process with shell access — including a prompt-injected agent session running terminal commands — could mint comments that appear to come from a human user or the desktop UI.

The agent tool path already defends against exactly this: `tools/kanban_tools.py` ignores the caller-supplied author and stamps the worker's profile identity server-side, with an inline comment naming this exact forging threat.

### Changes

**`hermes_cli/kanban.py`**
- `_cmd_comment`: Derives author from the runtime profile identity and stamps it with a `cli:` prefix (e.g. `cli:myprofile`, `cli:bot-ci`).
- `_cmd_attach`: Same `cli:` prefixing for the `uploaded_by` label.

**`plugins/kanban/dashboard/plugin_api.py`**
- `add_comment`: Server-stamps `author = "dashboard"` regardless of the client-supplied `payload.author` value.

**`tests/hermes_cli/test_kanban_comment_author_forgery.py`** [NEW]
- `TestCLICommentAuthorStamping`: Verifies `cli:` prefix on both profile-derived and explicit `--author` values, and verifies impersonation of `"dashboard"` is prevented.
- `TestCLIAttachAuthorStamping`: Verifies `cli:` prefix on attachment `uploaded_by`.
- `TestDashboardAPIAuthorStamping`: Verifies server-stamped `"dashboard"` author regardless of payload (skips when fastapi is not installed).

## Related Issue

Fixes #102693

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## How to Test

```bash
pytest tests/hermes_cli/test_kanban_comment_author_forgery.py -v
```

Verify manually:
```bash
hermes kanban comment t_<id> "test message"
# Author should be "cli:<profile>" instead of raw profile name

hermes kanban comment t_<id> "test" --author "desktop-user"
# Author should be "cli:desktop-user", NOT "desktop-user"
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.2 (darwin arm64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A