### PR TITLE
fix: [Bug] v0.21.0 Desktop 多 profile 切换后旧 gateway 不释放，后续 profile 配置页/聊天卡死 (#102187)

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -288,7 +288,7 @@ import {
   releaseLocalBackendSlotAfterExit
 } from './pool-spawn-coordinator'
 import { createPoolStopper } from './pool-stop'
-import { poolTouchKeys } from './pool-touch-scope'
+import { markPoolScopeReleased, poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
 import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
@@ -12230,6 +12230,24 @@ function touchPoolBackend(profile) {
   }
 }
 
+// Event-driven release for #102187: a window's active route moved to another
+// profile, so the previous route's backend is no longer the live one. Without
+// this the pool only learns a backend is unused via timeouts (4-min fresh
+// window, 10-min idle reaper) while the 60s renderer keepalive already stopped
+// mattering the moment the socket closed — so visiting a 4th profile within
+// minutes of three others queued its spawn behind full slots until the 30s
+// ticket expired (config page / chat hang). Rewinding is race-free for
+// multi-window use: a backend another window still touches re-freshens itself.
+function releasePreviousRouteBackend(previous) {
+  if (!previous || typeof previous !== 'object') {
+    return
+  }
+
+  const poolKey = backendScopeKey(previous.connectionId, previous.profile)
+
+  markPoolScopeReleased(backendPool, poolKey, Date.now(), POOL_KEEPALIVE_FRESH_MS)
+}
+
 // Evict least-recently-used SPAWNED pool backends until at most `keep` remain —
 // but only ever evict backends without a live renderer socket (stale beyond the
 // keepalive window). When every backend is actively kept alive we let the pool
@@ -14679,6 +14697,9 @@ ipcMain.on('hermes:connection:active-route', (event, route) => {
     previous?.profile !== next?.profile ||
     previous?.registryScoped !== next?.registryScoped
   ) {
+    // #102187: the window switched away from the previous route — release its
+    // pool backend's slot now instead of waiting out the fresh/idle timeouts.
+    releasePreviousRouteBackend(previous)
     void resetPreviewReach(id)
   }
 

--- a/apps/desktop/electron/pool-touch-scope.test.ts
+++ b/apps/desktop/electron/pool-touch-scope.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 
-import { poolTouchKeys } from './pool-touch-scope'
+import { selectPoolEvictions } from './pool-eviction'
+import { markPoolScopeReleased, poolTouchKeys } from './pool-touch-scope'
 
 describe('poolTouchKeys', () => {
   it('falls back from an explicit local registry scope to its delegated bare profile', () => {
@@ -9,5 +10,17 @@ describe('poolTouchKeys', () => {
 
   it('does not alias non-local registry scopes', () => {
     expect(poolTouchKeys('conn:homelab::research')).toEqual(['conn:homelab::research'])
+  })
+})
+
+describe('markPoolScopeReleased (#102187)', () => {
+  it('a switched-away backend becomes LRU-evictable so the next spawn finds a slot', () => {
+    const now = 1_000_000
+    const freshMs = 4 * 60_000
+    const live = () => ({ process: { pid: 1 }, lastActiveAt: now - 1_000 })
+    const pool = new Map([['a', live()], ['b', live()], ['c', live()]])
+    expect(selectPoolEvictions(pool.entries(), 2, now, freshMs)).toEqual([])
+    markPoolScopeReleased(pool, 'a', now, freshMs)
+    expect(selectPoolEvictions(pool.entries(), 2, now, freshMs)).toEqual(['a'])
   })
 })

--- a/apps/desktop/electron/pool-touch-scope.ts
+++ b/apps/desktop/electron/pool-touch-scope.ts
@@ -17,3 +17,30 @@ export function poolTouchKeys(scope: unknown): string[] {
 
   return [key]
 }
+
+/**
+ * Event-driven release for #102187: the window's active route moved away from
+ * this scope (profile switch), so its backend is no longer plausibly live even
+ * though its last keepalive touch is still inside the fresh window. Rewind
+ * (don't zero) its freshness: the next spawn's LRU eviction reclaims the slot
+ * immediately, while the idle reaper still grants its normal tail grace and
+ * any genuine later use re-touches. Already-stale entries are untouched.
+ * Multi-window safe: another window's keepalive simply re-freshens a backend
+ * that is still in use.
+ */
+export function markPoolScopeReleased(
+  pool: Map<string, { lastActiveAt?: null | number }>,
+  scope: unknown,
+  now: number,
+  freshMs: number
+): void {
+  const staleAt = now - freshMs - 1
+
+  for (const key of poolTouchKeys(scope)) {
+    const entry = pool.get(key)
+
+    if (entry && (entry.lastActiveAt || 0) > staleAt) {
+      entry.lastActiveAt = staleAt
+    }
+  }
+}


### PR DESCRIPTION
## What Problem This Solves
Fixes #102187 — [Bug] v0.21.0 Desktop 多 profile 切换后旧 gateway 不释放，后续 profile 配置页/聊天卡死. Minimal diff, single shared guard, no new deps.

## Evidence
- Repro: local repro shows before→after.
- Related suites pass (see worktree 102187).

Closes #102187