### PR TITLE
fix(cron): sanitize last_error before writing jobs.json

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -483,6 +483,18 @@ _URL_USERINFO_RE = re.compile(
     r"(https?|wss?|ftp)://([^/\s:@]+):([^/\s@]+)@",
 )
 
+# Provider key-dashboard URLs embed a key identifier in the path, e.g.
+# OpenRouter's ``https://openrouter.ai/workspaces/default/keys/<KEY_ID>``.
+# The identifier is often NOT a known vendor prefix (sk-/ghp_), so
+# _PREFIX_RE misses it. Unlike OAuth / magic-link query tokens, a
+# ``/keys/<id>`` or ``/api-keys/<id>`` path is never a round-trip workflow
+# URL — it is a manage/revoke link. Always rewrite the id segment.
+# Issue #102700 (cron jobs.json persisting these unsanitized in last_error).
+_KEY_DASHBOARD_URL_RE = re.compile(
+    r"(https?://[^\s<>\"']+?/)(api-keys|api_keys|keys)/([^\s<>\"'/?#]+)",
+    re.IGNORECASE,
+)
+
 # Strict provider-egress URL redaction accepts more URL-reference forms than
 # the display/log helpers above. Parameter delimiters stay in capture groups so
 # redaction preserves the original query/fragment layout byte-for-byte, while
@@ -712,6 +724,19 @@ def _redact_url_userinfo(text: str) -> str:
     """
     return _URL_USERINFO_RE.sub(
         lambda m: f"{m.group(1)}://{m.group(2)}:***@",
+        text,
+    )
+
+
+def _redact_key_dashboard_urls(text: str) -> str:
+    """Rewrite provider key-dashboard URLs so the key id cannot persist.
+
+    Keeps the host and ``/keys/`` (or ``/api-keys/``) prefix so the operator
+    can still tell *which* dashboard the error pointed at; replaces only the
+    identifier segment.
+    """
+    return _KEY_DASHBOARD_URL_RE.sub(
+        lambda m: f"{m.group(1)}{m.group(2)}/[redacted]",
         text,
     )
 
@@ -1039,19 +1064,28 @@ def redact_sensitive_text(
     if "eyJ" in text:
         text = _JWT_RE.sub(lambda m: _mask_token(m.group(0)), text)
 
+    # Key-dashboard URLs (OpenRouter ``.../keys/<KEY_ID>``, etc.).
+    # Unconditional — a manage/revoke path is never a skill round-trip
+    # token, so this is NOT gated behind ``redact_url_credentials``.
+    # See _KEY_DASHBOARD_URL_RE / issue #102700.
+    if "keys/" in text.lower():
+        text = _redact_key_dashboard_urls(text)
+
     # NOTE: Web-URL redaction (query params + userinfo + HTTP access-log
     # request targets) is intentionally OFF. Many legitimate workflows pass
     # opaque tokens through query strings — magic-link checkouts, OAuth
     # callbacks the agent is meant to follow, pre-signed share URLs — and
     # blanket-redacting param values by name breaks those skills mid-flow.
     # Known credential shapes (sk-, ghp_, JWTs, etc.) inside URLs are still
-    # caught by _PREFIX_RE and _JWT_RE above. DB connection-string passwords
-    # are still caught by _DB_CONNSTR_RE. The ONE userinfo case still redacted
-    # is the colon-less bare-token form ``scheme://TOKEN@host`` (#6396, handled
-    # by _URL_BARE_TOKEN_RE in the ``://`` block above): a bare credential in
-    # userinfo is never a round-trip workflow token (those live in the query
-    # string), so masking it can't break a skill. The ``user:pass@`` form is
-    # left to pass through per #34029.
+    # caught by _PREFIX_RE and _JWT_RE above. Key-dashboard path identifiers
+    # (``/keys/<id>``, ``/api-keys/<id>``) are rewritten just above. DB
+    # connection-string passwords are still caught by _DB_CONNSTR_RE. The ONE
+    # userinfo case still redacted is the colon-less bare-token form
+    # ``scheme://TOKEN@host`` (#6396, handled by _URL_BARE_TOKEN_RE in the
+    # ``://`` block above): a bare credential in userinfo is never a
+    # round-trip workflow token (those live in the query string), so masking
+    # it can't break a skill. The ``user:pass@`` form is left to pass through
+    # per #34029.
 
     if redact_url_credentials:
         text = _redact_strict_url_credentials(text)

--- a/cron/executions.py
+++ b/cron/executions.py
@@ -249,6 +249,16 @@ def finish_execution(
     now = _hermes_now().isoformat()
     status = "completed" if success else "failed"
     detail = None if success else (str(error) if error else "unknown failure")
+    if detail is not None:
+        # executions.db is durable (survives restarts — same exposure class
+        # as jobs.json). Sanitize before the error lands on disk (#102700).
+        # Best-effort: import/redaction failure must never block recording
+        # the terminal execution state.
+        try:
+            from cron.jobs import _sanitize_persisted_error
+            detail = _sanitize_persisted_error(detail)
+        except Exception:
+            pass
     with _transaction() as conn:
         cur = conn.execute(
             """UPDATE executions

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -41,6 +41,41 @@ logger = logging.getLogger(__name__)
 from hermes_time import now as _hermes_now
 from utils import atomic_replace, atomic_write_text
 
+# Bound on persisted error text. Long enough to keep the failure class
+# readable; short enough that a provider dump cannot bloat jobs.json.
+# Issue #102700 suggested ~800 chars (incidents.py uses 500 for signatures).
+_MAX_PERSISTED_ERROR_CHARS = 800
+
+
+def _sanitize_persisted_error(error: Optional[str]) -> Optional[str]:
+    """Redact secrets and bound length before writing error text to jobs.json.
+
+    ``jobs.json`` lives in the profile directory indefinitely — unlike a log
+    line, a raw provider error written here (e.g. an OpenRouter 403 whose
+    body embeds ``.../workspaces/.../keys/<KEY_ID>``) sits on disk until the
+    field is next overwritten. Mirrors ``cron.incidents._redact_error`` and
+    ``cron.delivery_queue._finish``. A redaction failure must never block
+    recording that a job failed (see issue #102700).
+    """
+    if error is None:
+        return None
+    text = str(error)
+    if not text:
+        return text
+    try:
+        from agent.redact import redact_sensitive_text
+
+        text = redact_sensitive_text(
+            text, force=True, redact_url_credentials=True
+        )
+    except Exception:
+        logger.warning(
+            "Failed to redact sensitive text before persisting cron error",
+            exc_info=True,
+        )
+    return text[:_MAX_PERSISTED_ERROR_CHARS]
+
+
 # ``croniter`` compiles ~15 ms of regexes at import and only matters for
 # 5-field cron expressions. Resolve lazily; ``HAS_CRONITER`` stays a module
 # attribute (tests monkeypatch it, and a monkeypatched value wins because
@@ -2671,6 +2706,17 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
             f"Cron job field(s) cannot be updated: {', '.join(sorted(bad_fields))}"
         )
 
+    # Sanitize error fields that land in jobs.json. The scheduler's
+    # interrupted-run path writes ``last_delivery_error`` through update_job
+    # (bypassing mark_job_run), so this is the chokepoint for that sibling.
+    if updates:
+        if "last_error" in updates and updates["last_error"] is not None:
+            updates["last_error"] = _sanitize_persisted_error(updates["last_error"])
+        if "last_delivery_error" in updates and updates["last_delivery_error"] is not None:
+            updates["last_delivery_error"] = _sanitize_persisted_error(
+                updates["last_delivery_error"]
+            )
+
     with _jobs_lock():
         jobs = load_jobs()
         for i, job in enumerate(jobs):
@@ -3129,7 +3175,7 @@ def note_fire_forward_failure(job_id: str, detail: str) -> bool:
             if job["id"] == job_id:
                 job["last_fire_error"] = {
                     "at": _hermes_now().isoformat(),
-                    "detail": str(detail or "")[:500],
+                    "detail": (_sanitize_persisted_error(str(detail or "")) or "")[:500],
                 }
                 jobs[i] = job
                 save_jobs(jobs)
@@ -3201,7 +3247,9 @@ def _mark_job_run_locked(
                     job["last_status"] = "delivery_failed"
                 else:
                     job["last_status"] = "ok"
-                job["last_error"] = error if not success else None
+                job["last_error"] = (
+                    _sanitize_persisted_error(error) if not success else None
+                )
                 # A healthy run means the configuration validates again — drop
                 # the preflight alert-dedup marker so a FUTURE config break
                 # re-alerts instead of being silently swallowed. Same contract
@@ -3224,7 +3272,7 @@ def _mark_job_run_locked(
                 else:
                     job["failure_streak"] = int(job.get("failure_streak") or 0) + 1
                 # Track delivery failures separately — cleared on successful delivery
-                job["last_delivery_error"] = delivery_error
+                job["last_delivery_error"] = _sanitize_persisted_error(delivery_error)
                 # Clear any external-fire claim so a re-armed recurring job can
                 # be claimed again on its next fire (Phase 4C CAS).
                 job["fire_claim"] = None

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -85,6 +85,35 @@ class TestKnownPrefixes:
         assert redact_sensitive_text(text) == text
 
 
+class TestKeyDashboardUrls:
+    """OpenRouter-style ``/keys/<id>`` links are not vendor-prefix secrets.
+
+    The path identifier can still manage/revoke the credential on the
+    provider dashboard, so it must not survive redact_sensitive_text
+    (issue #102700).
+    """
+
+    def test_openrouter_keys_path_id_is_rewritten(self):
+        key_id = "or_key_" + "abcdef1234567890"
+        text = (
+            "HTTP 403: Key limit exceeded. Manage it using "
+            f"https://openrouter.ai/workspaces/default/keys/{key_id}"
+        )
+        result = redact_sensitive_text(text, force=True)
+        assert key_id not in result
+        assert "https://openrouter.ai/workspaces/default/keys/[redacted]" in result
+        assert "Key limit exceeded" in result
+
+    def test_api_keys_path_id_is_rewritten(self):
+        key_id = "keyid_" + "xyz9876543210"
+        text = f"see https://provider.example/v1/api-keys/{key_id}"
+        result = redact_sensitive_text(text, force=True)
+        assert key_id not in result
+        assert "/api-keys/[redacted]" in result
+
+    def test_unrelated_url_unchanged(self):
+        text = "docs at https://example.com/getting-started"
+        assert redact_sensitive_text(text, force=True) == text
 
 
 class TestEnvAssignments:

--- a/tests/cron/test_cron_jobs_error_redaction.py
+++ b/tests/cron/test_cron_jobs_error_redaction.py
@@ -12,7 +12,6 @@ the write, not after.
 import pytest
 
 from cron.jobs import (
-    JOBS_FILE,
     _MAX_PERSISTED_ERROR_CHARS,
     _sanitize_persisted_error,
     create_job,
@@ -87,6 +86,7 @@ class TestMarkJobRunRedactsLastError:
         assert _KEY_ID not in stored["last_error"]
         assert "Key limit exceeded" in stored["last_error"]
 
+        from cron.jobs import JOBS_FILE
         raw = JOBS_FILE.read_text(encoding="utf-8")
         assert _KEY_ID not in raw
 
@@ -97,6 +97,7 @@ class TestMarkJobRunRedactsLastError:
 
         stored = get_job(job["id"])
         assert _SK_OR not in stored["last_error"]
+        from cron.jobs import JOBS_FILE
         raw = JOBS_FILE.read_text(encoding="utf-8")
         assert _SK_OR not in raw
 
@@ -117,6 +118,7 @@ class TestMarkJobRunRedactsLastError:
 
         stored = get_job(job["id"])
         assert _KEY_ID not in stored["last_delivery_error"]
+        from cron.jobs import JOBS_FILE
         raw = JOBS_FILE.read_text(encoding="utf-8")
         assert _KEY_ID not in raw
 
@@ -136,6 +138,7 @@ class TestUpdateJobRedactsDeliveryError:
         job = create_job(prompt="watch prices", schedule="every 1h")
         updated = update_job(job["id"], {"last_delivery_error": _OPENROUTER_ERROR})
         assert _KEY_ID not in updated["last_delivery_error"]
+        from cron.jobs import JOBS_FILE
         raw = JOBS_FILE.read_text(encoding="utf-8")
         assert _KEY_ID not in raw
 

--- a/tests/cron/test_cron_jobs_error_redaction.py
+++ b/tests/cron/test_cron_jobs_error_redaction.py
@@ -1,0 +1,155 @@
+"""Regression tests for issue #102700.
+
+``cron/jobs.py`` persists ``last_error`` / ``last_delivery_error`` /
+``last_fire_error`` into ``jobs.json``, which survives gateway restarts,
+job edits, and profile backups. Provider error strings can embed a
+key-management link (e.g. OpenRouter's
+``https://openrouter.ai/workspaces/default/keys/<KEY_ID>``) or a vendor
+prefix secret (``sk-…``, ``sk-or-v1-…``). Those must be sanitized before
+the write, not after.
+"""
+
+import pytest
+
+from cron.jobs import (
+    JOBS_FILE,
+    _MAX_PERSISTED_ERROR_CHARS,
+    _sanitize_persisted_error,
+    create_job,
+    get_job,
+    mark_job_run,
+    note_fire_forward_failure,
+    update_job,
+)
+
+
+# Key id that does NOT match a vendor prefix (sk-/ghp_/…). Proves the
+# /keys/ URL rewrite, not the prefix redactor, is what strips it.
+_KEY_ID = "or_key_" + "abcdef1234567890"
+_OPENROUTER_ERROR = (
+    "HTTP 403: Key limit exceeded. Manage it using "
+    f"https://openrouter.ai/workspaces/default/keys/{_KEY_ID}"
+)
+_SK_OR = "sk-or-v1-" + "a" * 48
+_SK = "sk-" + "abcdefghijklmnopqrstuvwxyz123456"
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Redirect cron storage to a temp directory."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+@pytest.fixture(autouse=True)
+def _ensure_redaction_enabled(monkeypatch):
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True, raising=False)
+
+
+class TestSanitizePersistedError:
+    def test_openrouter_keys_url_is_rewritten(self):
+        sanitized = _sanitize_persisted_error(_OPENROUTER_ERROR)
+        assert _KEY_ID not in sanitized
+        assert "Key limit exceeded" in sanitized
+        assert "/keys/[redacted]" in sanitized
+
+    def test_sk_and_sk_or_v1_secrets_are_redacted(self):
+        error = f"HTTP 401: Invalid API key {_SK_OR} (also {_SK})"
+        sanitized = _sanitize_persisted_error(error)
+        assert _SK_OR not in sanitized
+        assert _SK not in sanitized
+        assert "Invalid API key" in sanitized
+
+    def test_benign_short_error_passes_through(self):
+        assert _sanitize_persisted_error("Connection timed out") == (
+            "Connection timed out"
+        )
+
+    def test_none_passthrough(self):
+        assert _sanitize_persisted_error(None) is None
+
+    def test_empty_string_passthrough(self):
+        assert _sanitize_persisted_error("") == ""
+
+    def test_bounds_length(self):
+        sanitized = _sanitize_persisted_error("x" * 50_000)
+        assert len(sanitized) == _MAX_PERSISTED_ERROR_CHARS
+
+
+class TestMarkJobRunRedactsLastError:
+    def test_last_error_redacted_on_persisted_job(self, tmp_cron_dir):
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        assert mark_job_run(job["id"], success=False, error=_OPENROUTER_ERROR) is True
+
+        stored = get_job(job["id"])
+        assert _KEY_ID not in stored["last_error"]
+        assert "Key limit exceeded" in stored["last_error"]
+
+        raw = JOBS_FILE.read_text(encoding="utf-8")
+        assert _KEY_ID not in raw
+
+    def test_sk_prefix_redacted_on_persisted_job(self, tmp_cron_dir):
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        error = f"provider rejected key {_SK_OR}"
+        assert mark_job_run(job["id"], success=False, error=error) is True
+
+        stored = get_job(job["id"])
+        assert _SK_OR not in stored["last_error"]
+        raw = JOBS_FILE.read_text(encoding="utf-8")
+        assert _SK_OR not in raw
+
+    def test_benign_error_unchanged_on_disk(self, tmp_cron_dir):
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        mark_job_run(job["id"], success=False, error="Connection timed out")
+        stored = get_job(job["id"])
+        assert stored["last_error"] == "Connection timed out"
+
+    def test_last_delivery_error_redacted_on_persisted_job(self, tmp_cron_dir):
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        assert (
+            mark_job_run(
+                job["id"], success=True, delivery_error=_OPENROUTER_ERROR
+            )
+            is True
+        )
+
+        stored = get_job(job["id"])
+        assert _KEY_ID not in stored["last_delivery_error"]
+        raw = JOBS_FILE.read_text(encoding="utf-8")
+        assert _KEY_ID not in raw
+
+
+class TestNoteFireForwardFailureRedactsDetail:
+    def test_last_fire_error_detail_redacted(self, tmp_cron_dir):
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        assert note_fire_forward_failure(job["id"], _OPENROUTER_ERROR) is True
+
+        detail = get_job(job["id"])["last_fire_error"]["detail"]
+        assert _KEY_ID not in detail
+
+
+class TestUpdateJobRedactsDeliveryError:
+    def test_update_job_sanitizes_last_delivery_error(self, tmp_cron_dir):
+        """Scheduler interrupt path writes delivery_error via update_job."""
+        job = create_job(prompt="watch prices", schedule="every 1h")
+        updated = update_job(job["id"], {"last_delivery_error": _OPENROUTER_ERROR})
+        assert _KEY_ID not in updated["last_delivery_error"]
+        raw = JOBS_FILE.read_text(encoding="utf-8")
+        assert _KEY_ID not in raw
+
+
+class TestExecutionsLedgerRedactsError:
+    def test_finish_execution_redacts_error(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "cron.executions.EXECUTIONS_FILE", tmp_path / "executions.db"
+        )
+        from cron.executions import create_execution, finish_execution
+
+        record = create_execution("job-1", source="test")
+        result = finish_execution(
+            record["id"], success=False, error=_OPENROUTER_ERROR
+        )
+        assert result is not None
+        assert _KEY_ID not in (result.get("error") or "")


### PR DESCRIPTION
## Summary

`cron/jobs.json` was storing the full provider error string on failed runs. OpenRouter 403s look like `…/workspaces/default/keys/<KEY_ID>` — that id sat on disk indefinitely.

## Fix

Sanitize before persist, using the existing redactor plus a `/keys/` and `/api-keys/` URL rewrite so ids that aren't `sk-` prefixes still can't land in the profile dir.

- `agent/redact.py` — rewrite key-dashboard path ids
- `cron/jobs.py` — `_sanitize_persisted_error()` on `last_error` / `last_delivery_error` / `last_fire_error` (and `update_job`)
- `cron/executions.py` — same for the executions ledger

## Test plan

- `scripts/run_tests.sh tests/cron/test_cron_jobs_error_redaction.py tests/agent/test_redact.py -q`

Fixes #102700

thx