### PR TITLE
fix(update): don't fail fleet verification on a settling STALE row

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10910,6 +10910,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # the gateway the first attempt just started.  Poll a bounded
             # window for the resumed gateway to publish its identity instead.
             _fleet_snapshot = []
+            _pre_restart_pid_set = {
+                int(p) for p in (_pre_restart_gateway_pids or []) if isinstance(p, int)
+            }
             if _fleet_rows_expected:
                 _fleet_deadline = _time.monotonic() + 30.0
                 while True:
@@ -10927,8 +10930,25 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # resumed gateway has published (no "down" rows remain)
                     # or the deadline passes, so a slow second gateway can't
                     # be misread as down and re-trigger the retry loop.
-                    if _fleet_snapshot and not any(
-                        row.get("state") == "down" for row in _fleet_snapshot
+                    #
+                    # A "stale" row is the SAME settling race caught at a
+                    # different instant: on systemd-managed restarts the
+                    # about-to-die old process can still answer the control
+                    # socket for a beat after the restart was signalled,
+                    # before the new process takes over and stamps its own
+                    # identity. Only treat it as still-settling when the row's
+                    # PID is a known pre-restart PID (i.e. provably the
+                    # outgoing process, not a genuinely stuck new one) —
+                    # otherwise a real stale-code failure would poll the
+                    # full 30s and still report correctly, just later.
+                    _settling_stale = any(
+                        row.get("state") == "stale" and row.get("pid") in _pre_restart_pid_set
+                        for row in _fleet_snapshot
+                    )
+                    if (
+                        _fleet_snapshot
+                        and not _settling_stale
+                        and not any(row.get("state") == "down" for row in _fleet_snapshot)
                     ):
                         break
                     if _time.monotonic() >= _fleet_deadline:

--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -10910,9 +10910,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # the gateway the first attempt just started.  Poll a bounded
             # window for the resumed gateway to publish its identity instead.
             _fleet_snapshot = []
-            _pre_restart_pid_set = {
-                int(p) for p in (_pre_restart_gateway_pids or []) if isinstance(p, int)
-            }
+            # Coerce every pre-restart PID to int via the shared helper
+            # rather than dropping anything that isn't already one
+            # (#102733 review): a PID arriving as a numeric string must
+            # still match a row's int pid below, or the settling-race fix
+            # this block exists for silently stops working for that
+            # gateway.
+            _pre_restart_pid_set = _coerce_pid_set(_pre_restart_gateway_pids)
             if _fleet_rows_expected:
                 _fleet_deadline = _time.monotonic() + 30.0
                 while True:
@@ -10942,7 +10946,8 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     # otherwise a real stale-code failure would poll the
                     # full 30s and still report correctly, just later.
                     _settling_stale = any(
-                        row.get("state") == "stale" and row.get("pid") in _pre_restart_pid_set
+                        row.get("state") == "stale"
+                        and _coerce_pid_set([row.get("pid")]) & _pre_restart_pid_set
                         for row in _fleet_snapshot
                     )
                     if (
@@ -11084,6 +11089,29 @@ def _cmd_update_impl(args, gateway_mode: bool):
             sys.exit(1)
 
 # --- Hoisted from the body of _cmd_update_impl (self-contained, no closure state) ---
+
+def _coerce_pid_set(pids) -> set[int]:
+    """Best-effort int-ify every PID in ``pids`` into a set.
+
+    Regression guard for #102733 review: PIDs feeding the settling-stale
+    check can arrive as ints or as numeric strings depending on their
+    source (subprocess output, JSON round-trips, etc). The original fix
+    used ``isinstance(p, int)`` to filter the input, which SILENTLY
+    DROPS any PID that isn't already an int instead of converting it —
+    so a string PID on either side of the later ``in`` membership check
+    would never match its int counterpart, quietly defeating the whole
+    settling-race fix for that gateway. Coerce with ``int()`` here
+    instead of filtering, so "1234" and 1234 are treated as the same
+    PID. Genuinely non-numeric/garbage values are dropped, not raised.
+    """
+    result: set[int] = set()
+    for p in pids or []:
+        try:
+            result.add(int(p))
+        except (TypeError, ValueError):
+            continue
+    return result
+
 
 def _restart_phase_failure_is_incomplete(surviving, pre_restart_pids) -> bool:
     """Whether an escaped gateway-restart-phase exception must fail the update.

--- a/tests/hermes_cli/test_update_fleet_pid_coercion.py
+++ b/tests/hermes_cli/test_update_fleet_pid_coercion.py
@@ -1,0 +1,50 @@
+"""Regression for PR #102733 review — pre-restart PID coercion.
+
+The settling-stale fix (b7e57cc0) compares each fleet row's pid against a
+snapshot of pre-restart gateway PIDs, only treating a "stale" row as
+still-settling when its pid provably belonged to the outgoing process.
+
+The original patch built that snapshot with:
+
+    {int(p) for p in (pre_restart_pids or []) if isinstance(p, int)}
+
+``isinstance(p, int)`` FILTERS the input instead of converting it: any PID
+that arrives as a numeric string (e.g. "1234") is silently dropped rather
+than coerced, so it can never match its int counterpart in a later ``in``
+check. That would silently defeat the whole settling-race fix for that
+gateway, re-introducing the false-positive failure it was meant to solve.
+
+``_coerce_pid_set()`` fixes this by converting with ``int()`` instead of
+filtering. These tests pin that behavior directly.
+"""
+
+from __future__ import annotations
+
+from hermes_cli.update_cmd import _coerce_pid_set
+
+
+class TestCoercePidSet:
+    def test_plain_ints_pass_through(self):
+        assert _coerce_pid_set([1234, 5678]) == {1234, 5678}
+
+    def test_numeric_strings_are_coerced_not_dropped(self):
+        # This is the exact scenario the reviewer on #102733 called out:
+        # a string PID must still end up in the set, not be silently lost.
+        assert _coerce_pid_set(["1234", 5678]) == {1234, 5678}
+
+    def test_all_numeric_strings(self):
+        assert _coerce_pid_set(["1234", "5678"]) == {1234, 5678}
+
+    def test_none_and_empty_are_safe(self):
+        assert _coerce_pid_set(None) == set()
+        assert _coerce_pid_set([]) == set()
+
+    def test_garbage_values_are_dropped_not_raised(self):
+        assert _coerce_pid_set([1234, "not-a-pid", None, "5678"]) == {1234, 5678}
+
+    def test_mixed_set_matches_regardless_of_original_type(self):
+        # The membership check this feeds must succeed whether either side
+        # started out as an int or a numeric string.
+        pre_restart = _coerce_pid_set(["1234"])
+        row_pid_as_string = "1234"
+        assert _coerce_pid_set([row_pid_as_string]) & pre_restart


### PR DESCRIPTION
## Summary

The post-restart fleet-version poll loop in `hermes update` treats a `down` row as still-settling (keeps polling up to 30s), but treats a `stale` row as an immediate, final failure. On systemd-managed restarts, the outgoing gateway process can keep answering the control socket for a beat after the restart unit is signalled — before the new process takes over and stamps its own code identity. That's the exact same settling race the `down` handling already accounts for, just observed at a slightly earlier instant in the transition.

**Real-world symptom:** a nightly `hermes update` cron job completed successfully — code pulled, deps installed, gateway restarted, dashboard restarted — but exited 1 because the verification probe caught the outgoing pid still reporting pre-update code a couple seconds before the new process came up. This produces a false-positive error alert even though the update genuinely succeeded.

## Fix

Treat a `stale` row as still-settling **only when its pid matches the pre-restart pid snapshot** (i.e. it's provably the outgoing process, not a genuinely stuck new one), and keep polling within the existing 30s deadline — same handling shape as the `down` case. A real failure (new process actually stuck on old code) still fails correctly, just at the same deadline as before, not artificially early.

## Test plan

- `python3 -m py_compile hermes_cli/update_cmd.py` — clean
- Ran the full existing fleet/update verification suite against the patched file in a clean venv:
  - `test_update_fleet_check_fail_closed.py`
  - `test_update_fleet_restart_pending.py`
  - `test_update_fleet_restart_timeout.py`
  - `test_update_launchd_fleet_restart.py`
  - `test_update_fleet_probe_resume_token.py`
  - `test_fleet_matrix_down_state.py`
  - **75 passed, 0 failed** — no regressions
- Verified on a live Raspberry Pi 5 install (systemd-managed `hermes-gateway.service`) where this exact race reproduced two nights in a row (2026-09-03, 2026-09-04 cron logs).