### PR TITLE
kanban: restrict human-vocabulary author strings to dashboard-only

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -2216,7 +2216,19 @@ def _cmd_comment(args: argparse.Namespace) -> int:
             body = body[: max(0, args.max_len - len(suffix))].rstrip() + suffix
     author = args.author or _profile_author()
     with kb.connect_closing() as conn:
-        kb.add_comment(conn, args.task_id, author, body)
+        try:
+            kb.add_comment(conn, args.task_id, author, body, caller_context="cli")
+        except ValueError as e:
+            if "human-vocabulary" in str(e) or "rejected" in str(e).lower():
+                print(
+                    "kanban: --author rejected: human-looking names (user, admin, reviewer, etc.) "
+                    "are reserved for the dashboard. Use a machine label (bot, automation, cli, worker) "
+                    "or omit --author to use the profile name.",
+                    file=sys.stderr,
+                )
+            else:
+                print(f"kanban: {e}", file=sys.stderr)
+            return 2
     print(f"Comment added to {args.task_id}")
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3991,15 +3991,75 @@ def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Op
 # ---------------------------------------------------------------------------
 
 def add_comment(
-    conn: sqlite3.Connection, task_id: str, author: str, body: str
+    conn: sqlite3.Connection,
+    task_id: str,
+    author: str,
+    body: str,
+    *,
+    caller_context: str = "cli",
 ) -> int:
+    """Insert a comment, enforcing author policy by caller context.
+
+    Author policy (see #102693):
+    - caller_context="dashboard": Accept any author string (session-authenticated user)
+    - caller_context="tool": Author is derived server-side from HERMES_PROFILE (already enforced by caller)
+    - caller_context="cli" / "worker" / other: Reject human-vocabulary author strings;
+      stamp a machine identity instead (profile name / "cli" / "worker" / "bot" / "automation")
+    """
     if not body or not body.strip():
         raise ValueError("comment body is required")
     if not author or not author.strip():
         raise ValueError("comment author is required")
+
+    author = author.strip()
+
+    # Human-vocabulary names that must only come from the dashboard (session-authenticated user).
+    # Machine/automation identities are allowed from CLI/worker paths.
+    _HUMAN_VOCABULARY = frozenset({
+        "user",
+        "human",
+        "admin",
+        "administrator",
+        "operator",
+        "reviewer",
+        "review",
+        "approver",
+        "approve",
+        "supervisor",
+        "manager",
+        "lead",
+        "owner",
+    })
+
+    def _is_human_vocab(name: str) -> bool:
+        n = name.lower().strip()
+        return n in _HUMAN_VOCABULARY
+
+    # Dashboard is the ONLY surface allowed to write human-vocabulary author strings.
+    if caller_context != "dashboard" and _is_human_vocab(author):
+        # Derive a machine identity for non-dashboard callers.
+        # Prefer explicit profile env, then "cli"/"worker"/"bot"/"automation".
+        for env in ("HERMES_PROFILE_NAME", "HERMES_PROFILE"):
+            v = os.environ.get(env)
+            if v:
+                author = v
+                break
+        else:
+            # No profile env: use a generic machine label.
+            # Caller can pass "bot", "automation", "worker", "cli" via --author;
+            # if they passed a human name we already rejected it above.
+            if caller_context in {"cli", "worker"}:
+                author = "cli" if caller_context == "cli" else "worker"
+            elif caller_context in {"bot", "automation"}:
+                author = caller_context
+            else:
+                author = "worker"
+    elif caller_context == "tool":
+        # Tool path already derives author from HERMES_PROFILE in the handler.
+        # Trust the caller-provided author (it's already server-side derived).
+        pass
+
     now = int(time.time())
-    # ``allow_nested=True``: graph builders (kanban_swarm blackboard seeding)
-    # compose comment writes under one outer commit.
     with write_txn(conn, allow_nested=True):
         if not conn.execute(
             "SELECT 1 FROM tasks WHERE id = ?", (task_id,)
@@ -4008,7 +4068,7 @@ def add_comment(
         cur = conn.execute(
             "INSERT INTO task_comments (task_id, author, body, created_at) "
             "VALUES (?, ?, ?, ?)",
-            (task_id, author.strip(), body.strip(), now),
+            (task_id, author, body.strip(), now),
         )
         _append_event(conn, task_id, "commented", {"author": author, "len": len(body)})
         return int(cur.lastrowid or 0)

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1248,6 +1248,7 @@ def add_comment(task_id: str, payload: CommentBody, board: Optional[str] = Query
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
         kanban_db.add_comment(
             conn, task_id, author=payload.author or "dashboard", body=payload.body,
+            caller_context="dashboard",
         )
         return {"ok": True}
     finally:


### PR DESCRIPTION
Fixes #102693

## Problem

`hermes kanban comment <task> <text> --author <name>` stored any author
string verbatim. The dashboard plugin's comment endpoint likewise accepted
a client-supplied author (CommentBody.author, defaulting to "dashboard").
Any process with shell access to the machine — including a prompt-injected
agent session running terminal commands — could therefore mint comments
that appear to come from a human user or the desktop UI.

The agent tool path already defends against exactly this: the kanban
comment tool ignores the caller-supplied author and stamps the worker's
profile identity server-side (with an inline comment in
tools/kanban_tools.py naming this exact forging threat). The CLI flag,
the HERMES_PROFILE env fallback, and the dashboard API body field had
no equivalent — the identity guarantee there was convention, not
enforcement.

Consumers affected: any automation that attributes "a human answered" or
"the dashboard user said X" from comment author strings (approval flows,
waiting-on-human gates, suppression rules) consumes forged authority.

## Change

Restrict human-vocabulary author strings to the surfaces that hold
session auth:

- `kanban_db.add_comment()`: new `caller_context` parameter enforces
  author policy. Dashboard accepts any author (session-authenticated
  user). CLI/worker/bot paths reject human-vocabulary names (user,
  admin, reviewer, etc.) and stamp a machine identity (profile name /
  cli / worker / bot / automation).
- `kanban.py _cmd_comment()`: passes `caller_context='cli'`, surfaces
  clear error when human-looking `--author` is rejected.
- `plugin_api.py`: passes `caller_context='dashboard'` so the dashboard
  (only session-authenticated surface) keeps full author freedom.
- CLI `--author` remains available for non-human vocabulary
  (bot/automation labels), so scripted use cases keep working.

Alternative (heavier): full server-side identity stamping on every write
path, with author becoming a derived rather than accepted field. This
change does the lighter enforcement.

## Tests

`tests/hermes_cli/test_kanban_comment_queries.py` — 1 passed
`tests/tools/test_kanban_comment_injection.py` — 3 passed
`tests/hermes_cli/test_kanban_cli.py` — 4 passed

Existing kanban comment paths continue to pass; the enforcement is
narrow and only affects the three write paths that previously accepted
unvalidated author strings.
