### PR TITLE
fix(desktop): publish a recovered runtime before the turn emits events

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/index.test.tsx
@@ -14,6 +14,7 @@ import { $goalsBySession, setSessionGoal } from '@/store/goals'
 import { $hudMode } from '@/store/hud'
 import { $notifications, clearNotifications } from '@/store/notifications'
 import {
+  $activeSessionId,
   $busy,
   $connection,
   $currentCwd,
@@ -22,6 +23,7 @@ import {
   $sessions,
   $terminalBackend,
   $turnStartedAt,
+  setActiveSessionId,
   setCurrentUsage,
   setMessages,
   setSessions
@@ -41,6 +43,7 @@ import { uploadComposerAttachment, usePromptActions } from '.'
 // never-settling in-flight promise from one test into the next.
 beforeEach(() => {
   clearSingleFlightSessionResumeState()
+  setActiveSessionId(null)
 })
 
 vi.mock('@/hermes', () => ({
@@ -2024,6 +2027,50 @@ describe('usePromptActions submit / queue drain semantics', () => {
     expect(typeof armed).toBe('number')
     expect(armed as number).toBeGreaterThanOrEqual(before)
     expect(armed as number).toBeLessThanOrEqual(Date.now())
+  })
+
+  it('publishes a directly resumed foreground runtime before its turn events arrive', async () => {
+    const activeSessionIdRef: MutableRefObject<string | null> = { current: 'rt-stale' }
+    const selectedStoredSessionIdRef: MutableRefObject<string | null> = { current: 'stored-session-a' }
+    let boundRuntimeId: null | string = null
+
+    const requestGateway = vi.fn(async (method: string) => {
+      if (method === 'session.resume') {
+        boundRuntimeId = 'rt-recovered'
+
+        return { session_id: boundRuntimeId } as never
+      }
+
+      return {} as never
+    })
+
+    setActiveSessionId('rt-stale')
+
+    let handle: HarnessHandle | null = null
+    await actRender(
+      <Harness
+        activeSessionId="rt-stale"
+        activeSessionIdRef={activeSessionIdRef}
+        getRoutedStoredSessionId={() => 'stored-session-a'}
+        getRuntimeIdForStoredSession={() => boundRuntimeId}
+        onReady={h => (handle = h)}
+        refreshSessions={async () => undefined}
+        requestGateway={requestGateway}
+        resumeStoredSession={async () => undefined}
+        selectedStoredSessionIdRef={selectedStoredSessionIdRef}
+        storedSessionId="stored-session-a"
+      />
+    )
+
+    await handle!.submitText('ask the user a question')
+
+    expect(activeSessionIdRef.current).toBe('rt-recovered')
+    expect($activeSessionId.get()).toBe('rt-recovered')
+    expect(requestGateway).toHaveBeenCalledWith(
+      'prompt.submit',
+      { session_id: 'rt-recovered', text: 'ask the user a question' },
+      1_800_000
+    )
   })
 
   it('keeps a live turn clock when a second seed races it (?? guard)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
+++ b/apps/desktop/src/app/session/hooks/use-prompt-actions/submit.ts
@@ -630,6 +630,13 @@ export function useSubmitPrompt(deps: SubmitPromptDeps) {
 
             if (targetIsCurrentView()) {
               activeSessionIdRef.current = sessionId
+              // Publish the recovered runtime to the visible renderer before
+              // prompt.submit can emit tool/clarify events against it. Keeping
+              // only the mutable ref current lets the turn run successfully in
+              // the new backend runtime while React still renders the reclaimed
+              // one; the next user message then appears to "unlock" a clarify
+              // card that was pending all along.
+              setActiveSessionId(sessionId)
             }
           }
         } catch {


### PR DESCRIPTION
## The bug

When a backend runtime is reclaimed mid-flight, only the mutable ref was updated. The turn then ran successfully in the **new** runtime while React continued rendering the **reclaimed** one.

The visible symptom: a clarify card that had been pending all along stays inert and unanswerable, then appears to "unlock" when the user sends an unrelated next message. From the user's chair the UI has silently desynchronised from the session actually running.

## The fix

Publish the recovered session id to the visible renderer via `setActiveSessionId` before `prompt.submit` can emit tool or clarify events against it, so the renderer and the running runtime agree before any event lands.

Seven lines in `submit.ts`.

## Testing

Against current `main` (`63279301b`):

- `tsc --noEmit` clean.
- `vitest run src/app/session/hooks/use-prompt-actions/index.test.tsx` - **133 passed**, including 47 lines of new coverage for the recovered-runtime publish ordering.

## Notes

Extracted from a larger downstream commit that mixed this with unrelated fork-local UI work. Only this fix is here. Applies to current `main` with no conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
