### PR TITLE
feat(desktop): keep only selected discovered models on a custom endpoint (#101764)

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
@@ -1,0 +1,208 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CustomEndpoint, CustomEndpointUpdate } from '@/types/hermes'
+
+import { CustomEndpointsSettings } from './custom-endpoints-settings'
+
+// #101764: Test finds N models, Save persisted all N and flooded the picker.
+// There was no way to keep only some. These tests pin the selection contract.
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: vi.fn(),
+  deleteCustomEndpoint: vi.fn(),
+  getCustomEndpoints: vi.fn(),
+  saveCustomEndpoint: vi.fn(),
+  validateCustomEndpoint: vi.fn()
+}))
+
+vi.mock('@/store/confirm', () => ({ confirm: vi.fn().mockResolvedValue(true) }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+import * as hermes from '@/hermes'
+
+const mocked = vi.mocked(hermes)
+
+// A plan-limited endpoint: the provider advertises many, the user pays for two.
+const DISCOVERED = [
+  'glm-5.3-flash',
+  'qwen3.8-flash',
+  'expensive-opus-a',
+  'expensive-opus-b',
+  'expensive-opus-c'
+]
+
+const ENDPOINT: CustomEndpoint = {
+  base_url: 'https://b.ai/v1',
+  discover_models: true,
+  has_api_key: true,
+  id: 'b-ai',
+  is_current: true,
+  model: 'glm-5.3-flash',
+  models: DISCOVERED,
+  name: 'B.AI'
+}
+
+function savedPayload(): CustomEndpointUpdate {
+  expect(mocked.saveCustomEndpoint).toHaveBeenCalledTimes(1)
+
+  return mocked.saveCustomEndpoint.mock.calls[0][0]
+}
+
+beforeEach(() => {
+  mocked.getCustomEndpoints.mockResolvedValue({
+    current: { base_url: ENDPOINT.base_url, model: ENDPOINT.model, provider: ENDPOINT.id },
+    endpoints: [ENDPOINT]
+  })
+  mocked.saveCustomEndpoint.mockResolvedValue({
+    current: { base_url: ENDPOINT.base_url, model: ENDPOINT.model, provider: ENDPOINT.id },
+    endpoints: [ENDPOINT],
+    id: ENDPOINT.id,
+    ok: true
+  })
+  mocked.validateCustomEndpoint.mockResolvedValue({
+    message: '',
+    models: DISCOVERED,
+    ok: true,
+    reachable: true
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderPane() {
+  const result = render(<CustomEndpointsSettings />)
+
+  // The editor hydrates from the current endpoint; wait for the picker.
+  await screen.findByText(/Models to keep/i)
+
+  return result
+}
+
+describe('#101764 custom endpoint model selection', () => {
+  it('lists every discovered model as a checkbox, all selected by default', async () => {
+    await renderPane()
+
+    expect(screen.getByText(`Models to keep (${DISCOVERED.length}/${DISCOVERED.length})`)).toBeTruthy()
+
+    // The endpoint row also shows each model's name, so assert presence via
+    // getAllByText and require every model to be rendered at least once.
+    for (const model of DISCOVERED) {
+      expect(screen.getAllByText(model).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('saves only the checked models and asserts catalogue authority', async () => {
+    await renderPane()
+
+    // Deselect the three models this plan does not cover.
+    for (const model of ['expensive-opus-a', 'expensive-opus-b', 'expensive-opus-c']) {
+      const row = screen.getByText(model).closest('label')
+
+      expect(row).toBeTruthy()
+      fireEvent.click(row!.querySelector('button, input')!)
+    }
+
+    expect(screen.getByText(`Models to keep (2/${DISCOVERED.length})`)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    const payload = savedPayload()
+
+    expect(payload.models).toEqual(['glm-5.3-flash', 'qwen3.8-flash'])
+    // Without this flag the backend merges additively and deselection is a
+    // no-op — the whole point of the issue.
+    expect(payload.replace_models).toBe(true)
+  })
+
+  it('always keeps the default model even when unchecked', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /Select none/i }))
+    expect(screen.getByText(`Models to keep (0/${DISCOVERED.length})`)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    // A saved endpoint with zero models would leave the picker empty and the
+    // provider unusable; the typed default is non-negotiable.
+    expect(savedPayload().models).toEqual(['glm-5.3-flash'])
+  })
+
+  it('Select all re-checks the full discovered catalogue', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /Select none/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Select all/i }))
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    expect(savedPayload().models).toEqual(DISCOVERED)
+  })
+
+  it('re-running Test preserves the existing selection instead of re-checking everything', async () => {
+    await renderPane()
+
+    for (const model of ['expensive-opus-a', 'expensive-opus-b', 'expensive-opus-c']) {
+      fireEvent.click(screen.getByText(model).closest('label')!.querySelector('button, input')!)
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    // Still 2 of 5 — a probe must not silently undo the user's narrowing.
+    await waitFor(() => expect(screen.getByText(`Models to keep (2/${DISCOVERED.length})`)).toBeTruthy())
+  })
+
+  it('drops selected models the endpoint no longer advertises', async () => {
+    await renderPane()
+
+    mocked.validateCustomEndpoint.mockResolvedValueOnce({
+      message: '',
+      models: ['glm-5.3-flash'],
+      ok: true,
+      reachable: true
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    await waitFor(() => expect(screen.getByText('Models to keep (1/1)')).toBeTruthy())
+  })
+
+  it('Test does not claim catalogue authority', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    // Probing is not saving: a validate payload must never carry the flag
+    // that authorizes deletion.
+    expect(mocked.validateCustomEndpoint.mock.calls[0][0].replace_models).toBeFalsy()
+  })
+
+  it('shows the stored catalogue size in the endpoint list', async () => {
+    await renderPane()
+
+    // A flooded save should be visible without opening the editor.
+    expect(screen.getByText(`${DISCOVERED.length} models`)).toBeTruthy()
+  })
+
+  it('hides the picker when nothing has been discovered', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue({
+      current: { base_url: '', model: '', provider: '' },
+      endpoints: []
+    })
+
+    render(<CustomEndpointsSettings />)
+
+    await screen.findByText(/No custom endpoints/i)
+    expect(screen.queryByText(/Models to keep/i)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -59,7 +59,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
   }
 }
 
-function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
+function toPayload(form: EndpointForm, models?: string[], replaceModels = false): CustomEndpointUpdate {
   const contextLength = Number.parseInt(form.contextLength, 10)
 
   return {
@@ -71,7 +71,10 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
     context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : undefined,
     discover_models: form.discoverModels,
     make_default: form.makeDefault,
-    models: models?.length ? models : undefined
+    models: models?.length ? models : undefined,
+    // Only Save asserts authority over the catalogue (#101764). Test must
+    // stay additive — it posts the same payload shape but is only probing.
+    replace_models: replaceModels || undefined
   }
 }
 
@@ -84,6 +87,11 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
   const [endpoints, setEndpoints] = useState<CustomEndpoint[]>([])
   const [form, setForm] = useState<EndpointForm>(EMPTY_FORM)
   const [discoveredModels, setDiscoveredModels] = useState<string[]>([])
+  // Which of `discoveredModels` the user wants persisted. An endpoint can
+  // advertise 100+ models while a plan covers two, and Save used to store
+  // every discovered id, flooding the model picker (#101764).
+  const [selectedModels, setSelectedModels] = useState<string[]>([])
+  const [modelFilter, setModelFilter] = useState('')
 
   async function refresh() {
     const data = await getCustomEndpoints()
@@ -107,6 +115,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
         if (current) {
           setForm(formFromEndpoint(current))
           setDiscoveredModels(current.models)
+          setSelectedModels(current.models)
         }
       } catch (err) {
         notifyError(err, 'Could not load custom endpoints')
@@ -119,21 +128,23 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
 
     void load()
 
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [])
 
   async function handleSave() {
     try {
       setSaving(true)
-      const response = await saveCustomEndpoint(toPayload(form, discoveredModels))
+      // The default model must always survive, even if the user never ticked
+      // it in the list (it may have been typed by hand).
+      const models = Array.from(new Set([...selectedModels, form.model.trim()].filter(Boolean)))
+      const response = await saveCustomEndpoint(toPayload(form, models, true))
       setEndpoints(response.endpoints)
       const saved = response.endpoints.find(endpoint => endpoint.id === response.id)
 
       if (saved) {
         setForm(formFromEndpoint(saved))
         setDiscoveredModels(saved.models)
+        setSelectedModels(saved.models)
       }
 
       if (saved && saved.is_current) {
@@ -155,6 +166,19 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
       setTesting(true)
       const response = await validateCustomEndpoint(toPayload(form))
       setDiscoveredModels(response.models)
+      // Keep whatever the user had already chosen that this probe still
+      // advertises; a re-Test must not silently re-tick 98 models they
+      // deselected. A first probe (nothing chosen yet) selects everything,
+      // preserving the pre-#101764 default of "save what you found".
+      setSelectedModels(previous => {
+        if (!previous.length) {
+          return response.models
+        }
+
+        const stillOffered = previous.filter(model => response.models.includes(model))
+
+        return stillOffered.length ? stillOffered : response.models
+      })
 
       if (response.ok) {
         if (!form.model && response.models[0]) {
@@ -209,6 +233,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
       if (form.id === endpoint.id) {
         setForm(EMPTY_FORM)
         setDiscoveredModels([])
+        setSelectedModels([])
       }
 
       onConfigSaved?.()
@@ -226,6 +251,17 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
 
   const allModelOptions = Array.from(new Set([...discoveredModels, form.model].filter(Boolean)))
   const canSave = form.name.trim() && form.baseUrl.trim() && form.model.trim()
+  const normalizedFilter = modelFilter.trim().toLowerCase()
+
+  const visibleModels = normalizedFilter
+    ? discoveredModels.filter(model => model.toLowerCase().includes(normalizedFilter))
+    : discoveredModels
+
+  function toggleModel(model: string, checked: boolean) {
+    setSelectedModels(previous =>
+      checked ? Array.from(new Set([...previous, model])) : previous.filter(entry => entry !== model)
+    )
+  }
 
   return (
     <SettingsContent>
@@ -241,6 +277,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                     onClick={() => {
                       setForm(formFromEndpoint(endpoint))
                       setDiscoveredModels(endpoint.models)
+                      setSelectedModels(endpoint.models)
+                      setModelFilter('')
                     }}
                     type="button"
                   >
@@ -259,6 +297,9 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                     </div>
                     <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
                       <span>{endpoint.model}</span>
+                      {/* Surface the stored catalogue size so a flooded save
+                          is visible without opening the editor (#101764). */}
+                      {endpoint.models.length > 1 && <span>{`${endpoint.models.length} models`}</span>}
                       {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
                     </div>
                   </button>
@@ -372,6 +413,54 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 Discover models
               </label>
             </div>
+            {discoveredModels.length > 0 && (
+              <div className="grid gap-2 rounded-md border border-border/50 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    {`Models to keep (${selectedModels.length}/${discoveredModels.length})`}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      onClick={() => setSelectedModels(discoveredModels)}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      Select all
+                    </Button>
+                    <Button onClick={() => setSelectedModels([])} size="sm" type="button" variant="ghost">
+                      Select none
+                    </Button>
+                  </div>
+                </div>
+                {discoveredModels.length > 8 && (
+                  <Input
+                    onChange={event => setModelFilter(event.target.value)}
+                    placeholder="Filter models"
+                    value={modelFilter}
+                  />
+                )}
+                <div className="max-h-56 overflow-y-auto">
+                  {visibleModels.length ? (
+                    visibleModels.map(model => (
+                      <label className="flex items-center gap-2 py-1 text-xs" key={model}>
+                        <Checkbox
+                          checked={selectedModels.includes(model)}
+                          onCheckedChange={checked => toggleModel(model, checked === true)}
+                        />
+                        <span className="truncate font-mono">{model}</span>
+                        {model === form.model.trim() && <Pill tone="primary">Default</Pill>}
+                      </label>
+                    ))
+                  ) : (
+                    <p className="py-1 text-xs text-muted-foreground">No models match that filter.</p>
+                  )}
+                </div>
+                <p className="text-[0.7rem] text-muted-foreground">
+                  Only checked models are saved. The default model is always kept.
+                </p>
+              </div>
+            )}
             <div className="flex flex-wrap gap-2">
               <Button
                 disabled={testing || !form.baseUrl.trim()}
@@ -390,6 +479,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 onClick={() => {
                   setForm(EMPTY_FORM)
                   setDiscoveredModels([])
+                  setSelectedModels([])
+                  setModelFilter('')
                 }}
                 type="button"
                 variant="ghost"

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -205,6 +205,9 @@ export interface CustomEndpointUpdate {
   model: string
   models?: string[]
   name: string
+  /** Treat `models` as the authoritative catalogue and drop anything absent
+   *  from it. Omit (or false) to keep the additive merge (#101764). */
+  replace_models?: boolean
 }
 
 export interface CustomEndpointValidationResponse {

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -60,6 +60,13 @@ class CustomEndpointUpdate(BaseModel):
     discover_models: bool = True
     make_default: bool = False
     models: Optional[List[str]] = None
+    # When True, ``models`` is the authoritative catalogue for this endpoint
+    # and any stored model absent from it is dropped. Default False keeps the
+    # additive merge #69988 introduced, so a client that omits ``models``
+    # (or an older UI) can never wipe a catalogue it does not know about.
+    # Only a caller that actually presents the full model set to the user —
+    # the Desktop endpoint editor's model picker — should set this.
+    replace_models: bool = False
 
 
 class MessagingPlatformUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8782,13 +8782,27 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
     # model survived Save, and every picker showed a single-entry list for a
     # provider serving dozens (#69988). A payload with no ``models`` (older
     # UI) still just ensures the named default is present.
+    #
+    # ``replace_models`` inverts that for one specific caller: the Desktop
+    # endpoint editor now shows the discovered catalogue as a checkbox list,
+    # so the set it submits IS the user's intended selection and models they
+    # unchecked must actually go away (#101764). Without an explicit opt-in
+    # flag an additive merge makes deselection impossible — an endpoint that
+    # advertises 100+ models could never be narrowed to the two the user's
+    # plan covers. The default stays additive so no other client can wipe a
+    # catalogue by omission.
     existing_models = entry.get("models")
-    models_map: Dict[str, Any] = dict(existing_models) if isinstance(existing_models, dict) else {}
+    stored_models: Dict[str, Any] = dict(existing_models) if isinstance(existing_models, dict) else {}
+    replace_models = bool(getattr(body, "replace_models", False)) and body.models is not None
+    models_map: Dict[str, Any] = {} if replace_models else dict(stored_models)
     for candidate in (*(body.models or ()), model):
         model_id = str(candidate).strip()
         if not model_id:
             continue
-        current = models_map.get(model_id)
+        # Carry the stored per-model settings (context_length, etc.) across a
+        # replace: dropping a model from the selection should not silently
+        # reset the tuning of the ones that stayed.
+        current = models_map.get(model_id, stored_models.get(model_id))
         models_map[model_id] = dict(current) if isinstance(current, dict) else {}
     entry["models"] = models_map
     if body.context_length and body.context_length > 0:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1982,6 +1982,110 @@ class TestWebServerEndpoints:
         assert get_env_value(custom_endpoint_key_env("local-8000")) == "sk-first"
         assert get_env_value(custom_endpoint_key_env("local-8001")) == "sk-second"
 
+    def test_custom_endpoint_models_merge_by_default(self):
+        """Without replace_models, Save is additive — a partial catalogue must
+        never drop stored models (#69988 kept the merge on purpose)."""
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "models": ["m", "extra-a"],
+            },
+        )
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                # A client that only knows about "m" must not wipe "extra-a".
+                "models": ["m"],
+            },
+        )
+
+        cfg = load_config()
+        assert set(cfg["providers"]["proxy"]["models"]) == {"m", "extra-a"}
+
+    def test_custom_endpoint_replace_models_prunes_and_keeps_model_settings(self):
+        """replace_models makes the submitted catalogue authoritative (#101764).
+
+        The Desktop endpoint editor shows discovered models as a checkbox
+        list; models the user unchecked must actually go away. Survivors keep
+        their stored per-model settings (context_length), and the named
+        default is always present.
+        """
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "keep-a",
+                "api_key": "sk-x",
+                "models": ["keep-a", "keep-b", "drop-c"],
+                "context_length": 128000,
+            },
+        )
+        cfg = load_config()
+        # context_length lands on the default model's per-model settings.
+        assert cfg["providers"]["proxy"]["models"]["keep-a"] == {"context_length": 128000}
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "keep-a",
+                "models": ["keep-a", "keep-b"],
+                "replace_models": True,
+            },
+        )
+
+        cfg = load_config()
+        models = cfg["providers"]["proxy"]["models"]
+        assert set(models) == {"keep-a", "keep-b"}, "unchecked model must be pruned"
+        assert "drop-c" not in models
+        # Survivors keep their tuning across the replace.
+        assert models["keep-a"] == {"context_length": 128000}
+
+    def test_custom_endpoint_replace_models_requires_a_catalogue(self):
+        """replace_models without models must not wipe the stored catalogue —
+        the flag only means something paired with the list it authorizes."""
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "models": ["m", "extra-a"],
+            },
+        )
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "replace_models": True,
+            },
+        )
+
+        cfg = load_config()
+        assert set(cfg["providers"]["proxy"]["models"]) == {"m", "extra-a"}
+
     def test_custom_endpoint_response_reports_a_key_held_in_env(self):
         """has_api_key must follow key_env, not just a plaintext api_key.
 


### PR DESCRIPTION
## Summary

Fixes #101764. Settings > Providers > Custom Endpoints: clicking **Test** shows "Found N models", and **Save** persisted ALL of them into `providers.<id>.models` — a provider like B.AI that advertises 100+ models floods the model picker even when the plan covers two. There was no way to keep only some.

## What changes

**Desktop editor** (`custom-endpoints-settings.tsx`):
- After Test (or after selecting an endpoint that has stored models), the editor shows a **model checkbox list** with Select all / Select none and a filter box for long catalogues. All checked by default — the pre-#101764 "save everything" path remains zero-effort.
- **Save submits only the checked models.** The typed default is always kept (an endpoint with zero models is unusable).
- Re-running Test preserves the user's existing selection that the probe still advertises — a probe must not silently re-tick 98 deselected models.
- The endpoint list shows the stored model count per endpoint, so a flooded save is visible without opening the editor.

**Backend** (`web_models.py` / `web_server.py`):
- New `CustomEndpointUpdate.replace_models` flag (default `False`). `_write_custom_endpoint`'s model-map merge (#69988) is additive by design, which makes deselection a **no-op** — no client could ever narrow an already-flooded endpoint. When `replace_models` is set, the submitted catalogue is authoritative: stored models absent from it are pruned, survivors keep their per-model settings (`context_length`), and the named default is always present.
- The flag is inert without a `models` list, so no client can wipe a catalogue by omission — the #69988 additive default is byte-for-byte preserved for every existing caller.

## Verification

```
backend  tests/hermes_cli/test_web_server.py -k custom_endpoint
         9 passed (6 pre-existing + 3 new:
           - merge-by-default: partial catalogue never drops stored models
           - replace prunes + preserves per-model settings
           - replace without models is inert)

frontend custom-endpoints-settings.test.tsx (new)
         9 passed (all-checked default, save payload asserts
         replace_models, default always kept, select all/none,
         re-Test preserves selection, dropped models pruned on probe,
         Test never claims catalogue authority, count pill, empty state)

tsc --noEmit: clean   eslint: clean
```

One commit on current `main`. Complementary to (does not duplicate) #90095 and #47010, which both *add* models to the catalogue — this is the missing subtract path.
