### PR TITLE
fix(desktop): preserve IME composition during session refresh

### DIFF
--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts
@@ -801,6 +801,352 @@ describe('typing-aware sessions.changed deferral', () => {
 
     expect(refreshSessions).toHaveBeenCalledTimes(1)
   })
+
+  it('holds sessions.changed refresh for the full IME composition, then lands once after keyboard quiet', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionend', { bubbles: true, data: 'กำ' }))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_499)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats insertFromComposition as a commit even when isComposing remains true', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      notifySessionsChanged()
+      window.dispatchEvent(
+        new window.InputEvent('input', {
+          bubbles: true,
+          data: 'กำ',
+          inputType: 'insertFromComposition',
+          isComposing: true
+        })
+      )
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_499)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    {
+      activity: () =>
+        window.dispatchEvent(new window.KeyboardEvent('keydown', { bubbles: true, isComposing: false, key: 'a' })),
+      source: 'keyboard'
+    },
+    {
+      activity: () =>
+        window.dispatchEvent(
+          new window.InputEvent('input', {
+            bubbles: true,
+            data: 'a',
+            inputType: 'insertText',
+            isComposing: false
+          })
+        ),
+      source: 'input'
+    }
+  ])('recovers from a missed compositionend after trustworthy non-composing $source activity', async ({ activity }) => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      notifySessionsChanged()
+      activity()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_499)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats beforeinput text insertion as typing even when an IME emits no keydown', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(
+        new window.InputEvent('beforeinput', { bubbles: true, data: 'ก', inputType: 'insertText' })
+      )
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_499)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not leak composition warmth when one of two sync mounts unmounts mid-composition', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    const first = renderTypingSync(refreshSessions)
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      first.unmount()
+      window.dispatchEvent(new window.CompositionEvent('compositionend', { bubbles: true, data: 'กำ' }))
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_499)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    {
+      activity: () =>
+        window.dispatchEvent(new window.KeyboardEvent('keydown', { bubbles: true, isComposing: true, key: 'Process' })),
+      metadata: 'KeyboardEvent.isComposing'
+    },
+    {
+      activity: () => {
+        const event = new window.KeyboardEvent('keydown', { bubbles: true, isComposing: false, key: 'Process' })
+        Object.defineProperties(event, {
+          keyCode: { value: 229 },
+          which: { value: 229 }
+        })
+        window.dispatchEvent(event)
+      },
+      metadata: 'legacy keyCode/which 229'
+    },
+    {
+      activity: () =>
+        window.dispatchEvent(
+          new window.InputEvent('input', {
+            bubbles: true,
+            data: 'ก',
+            inputType: 'insertText',
+            isComposing: true
+          })
+        ),
+      metadata: 'InputEvent.isComposing'
+    },
+    {
+      activity: () =>
+        window.dispatchEvent(
+          new window.InputEvent('beforeinput', {
+            bubbles: true,
+            data: 'ก',
+            inputType: 'insertCompositionText',
+            isComposing: false
+          })
+        ),
+      metadata: 'composition inputType'
+    }
+  ])('holds refresh while $metadata reports active IME composition', async ({ activity }) => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      activity()
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+  })
+
+  it('keeps composition active when focus moves between elements inside the renderer', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+    const input = document.createElement('input')
+    document.body.append(input)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      input.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      notifySessionsChanged()
+      input.dispatchEvent(new window.FocusEvent('blur', { bubbles: false }))
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(30_000)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).not.toHaveBeenCalled()
+
+    act(() => {
+      input.dispatchEvent(new window.CompositionEvent('compositionend', { bubbles: true, data: 'กำ' }))
+      input.remove()
+    })
+  })
+
+  it('releases an abandoned composition state on window blur and lands at the next quiet check', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      notifySessionsChanged()
+      window.dispatchEvent(new window.Event('blur'))
+    })
+
+    // The renderer is no longer typing as soon as the whole window blurs. The
+    // already-scheduled trailing refresh remains bounded by one quiet interval.
+    expect(isTypingBurstActive()).toBe(false)
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_500)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not create phantom typing warmth when an idle renderer blurs', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.Event('blur'))
+      notifySessionsChanged()
+    })
+
+    await act(async () => {
+      vi.advanceTimersByTime(0)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not carry abandoned composition warmth across a full sync teardown', async () => {
+    vi.useFakeTimers()
+    $changeEventsAvailable.set(true)
+    const refreshSessions = vi.fn(async () => undefined)
+
+    const first = renderTypingSync(refreshSessions)
+    await primeThrottle(refreshSessions)
+
+    act(() => {
+      window.dispatchEvent(new window.CompositionEvent('compositionstart', { bubbles: true, data: 'ก' }))
+      first.unmount()
+    })
+
+    renderTypingSync(refreshSessions)
+    refreshSessions.mockClear()
+    act(() => notifySessionsChanged())
+
+    await act(async () => {
+      vi.advanceTimersByTime(1_500)
+      await Promise.resolve()
+    })
+
+    expect(refreshSessions).toHaveBeenCalled()
+  })
 })
 
 describe('isTypingBurstActive', () => {

--- a/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
+++ b/apps/desktop/src/app/contrib/hooks/use-background-sync.ts
@@ -301,25 +301,73 @@ interface LiveSessionStatusResponse {
 // so an unscoped reap would dark out every other profile's running rows.
 const liveRuntimeIdsByProfile = new Map<string, Set<string>>()
 
-// Renderer-wide keyboard warmth, tracked at module scope like the live-runtime
-// bookkeeping above: any keydown anywhere in the window marks activity, and a
-// burst stays warm for TYPING_BURST_QUIET_MS after the last key. IME
-// composition still emits keydown (keyCode 229), so one listener covers both.
+// Renderer-wide text-input warmth, tracked at module scope like the live-runtime
+// bookkeeping above. Key and input events keep a burst warm, while an active
+// IME composition holds the refresh unconditionally: Windows text services do
+// not guarantee a keydown for every composition/input update.
 let lastRendererInputAt = 0
+let rendererCompositionActive = false
+let rendererInputTrackerMounts = 0
 
-/** Record renderer-wide keyboard activity (wired to a capture-phase window
- *  keydown listener by useBackgroundSync). */
+/** Record renderer-wide text-input activity (wired to capture-phase window
+ *  keydown, beforeinput, input, and composition listeners by useBackgroundSync). */
 export function noteRendererKeyboardActivity(nowMs = Date.now()): void {
   lastRendererInputAt = nowMs
+}
+
+function noteRendererKeyboardEvent(event: KeyboardEvent, nowMs = Date.now()): void {
+  // Chromium may drop compositionend while this renderer remains focused. A
+  // later ordinary key is trustworthy recovery evidence; legacy IMEs report
+  // active composition through keyCode/which 229 even when isComposing is false.
+  rendererCompositionActive = event.isComposing || event.keyCode === 229 || event.which === 229
+  lastRendererInputAt = nowMs
+}
+
+function noteRendererInputEvent(event: InputEvent, nowMs = Date.now()): void {
+  // insertFromComposition is authoritative commit evidence even when Chromium
+  // leaves isComposing true, so it starts the normal quiet window.
+  if (event.inputType === 'insertFromComposition') {
+    rendererCompositionActive = false
+    lastRendererInputAt = nowMs
+
+    return
+  }
+
+  rendererCompositionActive =
+    event.isComposing || event.inputType === 'insertCompositionText' || event.inputType === 'deleteCompositionText'
+  lastRendererInputAt = nowMs
+}
+
+function noteRendererCompositionStart(nowMs = Date.now()): void {
+  rendererCompositionActive = true
+  lastRendererInputAt = nowMs
+}
+
+function noteRendererCompositionEnd(nowMs = Date.now()): void {
+  if (!rendererCompositionActive) {
+    return
+  }
+
+  rendererCompositionActive = false
+  lastRendererInputAt = nowMs
+}
+
+function releaseRendererInputActivity(): void {
+  rendererCompositionActive = false
+  lastRendererInputAt = Number.NEGATIVE_INFINITY
 }
 
 /** True while a typing burst is still warm enough to hold the heavy list
  *  refresh (see TYPING_BURST_QUIET_MS). */
 export function isTypingBurstActive(nowMs = Date.now()): boolean {
-  return nowMs - lastRendererInputAt < TYPING_BURST_QUIET_MS
+  return rendererCompositionActive || nowMs - lastRendererInputAt < TYPING_BURST_QUIET_MS
 }
 
 function remainingTypingQuietMs(nowMs: number): number {
+  if (rendererCompositionActive) {
+    return TYPING_BURST_QUIET_MS
+  }
+
   return Math.max(0, TYPING_BURST_QUIET_MS - (nowMs - lastRendererInputAt))
 }
 
@@ -327,6 +375,7 @@ function remainingTypingQuietMs(nowMs: number): number {
  *  resetLiveRuntimeTracking). */
 export function resetTypingActivityTracking(): void {
   lastRendererInputAt = 0
+  rendererCompositionActive = false
 }
 
 /** Restore sidebar liveness after a renderer/backend reconnect. Stream events
@@ -771,16 +820,43 @@ export function useBackgroundSync({
     updateSessionState
   ])
 
-  // Keyboard warmth for the deferral above: capture phase on window. Any
-  // keydown in this renderer (composer, modal, settings) counts — conservative
-  // on purpose. Pure timestamp write, no React state.
+  // Text-input warmth for the deferral above: capture phase on window. Keep IME
+  // composition active even when the platform emits no keydown, and count
+  // beforeinput/input for accessibility and Windows text-service paths.
   useEffect(() => {
-    const markInput = (): void => noteRendererKeyboardActivity()
+    const markKeyboardInput = (event: KeyboardEvent): void => noteRendererKeyboardEvent(event)
+    const markTextInput = (event: InputEvent): void => noteRendererInputEvent(event)
+    const markCompositionStart = (): void => noteRendererCompositionStart()
+    const markCompositionUpdate = (): void => noteRendererCompositionStart()
+    const markCompositionEnd = (): void => noteRendererCompositionEnd()
+    const releaseInputActivity = (): void => releaseRendererInputActivity()
 
-    window.addEventListener('keydown', markInput, true)
+    rendererInputTrackerMounts += 1
+
+    window.addEventListener('keydown', markKeyboardInput, true)
+    window.addEventListener('beforeinput', markTextInput, true)
+    window.addEventListener('input', markTextInput, true)
+    window.addEventListener('compositionstart', markCompositionStart, true)
+    window.addEventListener('compositionupdate', markCompositionUpdate, true)
+    window.addEventListener('compositionend', markCompositionEnd, true)
+    // Window blur does not bubble, so non-capture observes only the renderer
+    // losing focus — not ordinary focus moves between controls inside it.
+    window.addEventListener('blur', releaseInputActivity)
 
     return () => {
-      window.removeEventListener('keydown', markInput, true)
+      window.removeEventListener('keydown', markKeyboardInput, true)
+      window.removeEventListener('beforeinput', markTextInput, true)
+      window.removeEventListener('input', markTextInput, true)
+      window.removeEventListener('compositionstart', markCompositionStart, true)
+      window.removeEventListener('compositionupdate', markCompositionUpdate, true)
+      window.removeEventListener('compositionend', markCompositionEnd, true)
+      window.removeEventListener('blur', releaseInputActivity)
+
+      rendererInputTrackerMounts = Math.max(0, rendererInputTrackerMounts - 1)
+
+      if (rendererInputTrackerMounts === 0) {
+        resetTypingActivityTracking()
+      }
     }
   }, [])
 


### PR DESCRIPTION
## What does this PR do?

Extends the existing typing-burst guard from #95033 so Windows IME composition cannot be interrupted by a heavy `sessions.changed` session-list refresh.

The existing guard treated `keydown` as the typing signal. Windows text services do not guarantee a keydown for every composition/input update, so a refresh could still land while Thai IME composition was active. This change:

- holds the refresh for the complete `compositionstart` → `compositionend` lifecycle;
- treats `beforeinput`, `input`, and `compositionupdate` as typing activity;
- self-heals a missed `compositionend` on trustworthy non-composing keyboard/input activity while preserving active IME and legacy key-code 229 signals;
- releases an abandoned composition when the renderer window loses focus;
- resets module-level tracking only after the last `useBackgroundSync` mount unmounts;
- keeps the existing trailing-edge behavior so the deferred refresh lands once after 1.5 seconds of quiet.

## Related Issue

Follow-up to #95033.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `apps/desktop/src/app/contrib/hooks/use-background-sync.ts`
  - Track renderer-wide composition state and input activity.
  - Register capture-phase IME/input listeners with symmetric cleanup.
  - Bound abandoned state on window blur and final hook teardown.
- `apps/desktop/src/app/contrib/hooks/use-background-sync.test.ts`
  - Cover composition hold/release, missed-`compositionend` self-healing, IME paths without keydown, legacy key-code 229, internal focus movement, window blur, multiple mounts, and full teardown.

## How to Test

1. Run `npx vitest run src/app/contrib/hooks/use-background-sync.test.ts` from `apps/desktop`.
2. Run `npm run check` from `apps/desktop`.
3. On Windows 11 with Thai IME, type continuously for 1–4 minutes while `sessions.changed` traffic occurs; switch Thai/English, edit mid-sentence, and switch sessions.

Local Windows 11 canary and verification evidence:

- Targeted sync-hook Vitest: **40/40 passed**.
- Full Desktop UI project (final isolated rerun): **6,736/6,736 passed**.
- TypeScript: passed.
- ESLint: **0 errors** (124 existing warnings).
- Production build: passed.
- Windows NSIS packaging: passed; installer and unpacked app artifacts produced.
- Electron platform project on Windows: **1,920 passed / 34 failed / 6 skipped**. The failures are unrelated POSIX/macOS permission, path, symlink, `/bin/sh`, and SSH control-socket assumptions; `origin/main` reproduces the same class with **1,919 passed / 35 failed / 6 skipped**.
- Packaged canary `app.asar` SHA-256: `8a2c9c7d19d2fc138df62bb05d9fe228751e2dd56cda8b5c6f4e5ade2fef90cc`.
- 24-hour owner soak: 0 composer flickers, lost cursors, or missing/duplicated Thai characters.
- 24-hour log gate: 0 renderer crash/exit, `Uncaught`, `ERR_`, unexpected backend restart, or focus/IME/composition indicators.
- Rollback remains retained until the separate 48-hour gate.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs and issues; no open duplicate was found
- [x] My PR contains only changes related to this fix
- [ ] I've run the repository test command and all applicable tests pass
- [x] I've added tests for the bug fix
- [x] I've tested on Windows 11

### Documentation & Housekeeping

- [x] Documentation update — N/A; no user-facing workflow or config changed
- [x] `cli-config.yaml.example` — N/A; no config keys changed
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A; no architecture or workflow changed
- [x] Cross-platform impact considered: standard DOM composition/input events with window-level listener cleanup
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

No customer/session content is attached. The evidence above reports only aggregate test, hash, process, and error-count results.
