### PR TITLE
fix(context): fall back to tool-readable paths for oversized @file refs

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -262,13 +262,16 @@ async def preprocess_context_references_async(
     warnings: list[str] = []
     blocks: list[str] = []
     injected_tokens = 0
+    hard_limit = max(1, int(context_length * 0.50))
+    soft_limit = max(1, int(context_length * 0.25))
 
     # Expand all references concurrently. Each _expand_reference is independent
     # (no shared state during expansion) — a message with several @url: refs
     # would otherwise pay one full web_extract round-trip per ref in series.
     # gather preserves positional order, so we reassemble warnings/blocks in the
-    # original ref order exactly as the prior serial loop did; the token-budget
-    # check below is unchanged (it runs once, after all refs are expanded).
+    # original ref order exactly as the prior serial loop did. Oversized text
+    # files may degrade individually to tool-readable paths; the aggregate
+    # token-budget check still runs once after all refs are expanded.
     expanded = await asyncio.gather(
         *(
             _expand_reference(
@@ -276,6 +279,7 @@ async def preprocess_context_references_async(
                 cwd_path,
                 url_fetcher=url_fetcher,
                 allowed_root=allowed_root_path,
+                max_inline_tokens=hard_limit,
             )
             for ref in refs
         )
@@ -287,8 +291,6 @@ async def preprocess_context_references_async(
             blocks.append(block)
             injected_tokens += estimate_tokens_rough(block)
 
-    hard_limit = max(1, int(context_length * 0.50))
-    soft_limit = max(1, int(context_length * 0.25))
     if injected_tokens > hard_limit:
         warnings.append(
             f"@ context injection refused: {injected_tokens} tokens exceeds the 50% hard limit ({hard_limit})."
@@ -336,10 +338,16 @@ async def _expand_reference(
     *,
     url_fetcher: Callable[[str], str | Awaitable[str]] | None = None,
     allowed_root: Path | None = None,
+    max_inline_tokens: int | None = None,
 ) -> tuple[str | None, str | None]:
     try:
         if ref.kind == "file":
-            return _expand_file_reference(ref, cwd, allowed_root=allowed_root)
+            return _expand_file_reference(
+                ref,
+                cwd,
+                allowed_root=allowed_root,
+                max_inline_tokens=max_inline_tokens,
+            )
         if ref.kind == "folder":
             return _expand_folder_reference(ref, cwd, allowed_root=allowed_root)
         if ref.kind == "diff":
@@ -375,6 +383,7 @@ def _expand_file_reference(
     cwd: Path,
     *,
     allowed_root: Path | None = None,
+    max_inline_tokens: int | None = None,
 ) -> tuple[str | None, str | None]:
     path = _resolve_path(cwd, ref.target, allowed_root=allowed_root)
     _ensure_reference_path_allowed(path)
@@ -401,7 +410,18 @@ def _expand_file_reference(
 
     lang = _code_fence_language(path)
     label = ref.raw
-    return None, f"📄 {label} ({estimate_tokens_rough(text)} tokens)\n```{lang}\n{text}\n```"
+    text_tokens = estimate_tokens_rough(text)
+    block = f"📄 {label} ({text_tokens} tokens)\n```{lang}\n{text}\n```"
+    if (
+        max_inline_tokens is not None
+        and estimate_tokens_rough(block) > max_inline_tokens
+    ):
+        return (
+            f"{ref.raw}: {text_tokens} tokens is too large to inline safely; "
+            "the agent received a tool-readable path instead",
+            _oversized_text_reference_block(ref, path, text_tokens),
+        )
+    return None, block
 
 
 def _expand_folder_reference(
@@ -696,6 +716,24 @@ def _binary_reference_block(ref: ContextReference, path: Path) -> str:
         f"It is available on disk at `{_agent_visible_path(path)}`. Use your tools to work with it "
         f"(read or convert it, extract its text, or view/render it as needed); "
         f"do not tell the user the file type is unsupported."
+    )
+
+
+def _oversized_text_reference_block(
+    ref: ContextReference,
+    path: Path,
+    text_tokens: int,
+) -> str:
+    try:
+        size = format_bytes(path.stat().st_size)
+    except OSError:
+        size = "unknown size"
+    return (
+        f"📎 {ref.raw} (text file, {size}, approximately {text_tokens} tokens) - "
+        "too large to inline safely. "
+        f"It is available on disk at `{_agent_visible_path(path)}`. "
+        "Use read_file with a narrow line range, search_files, or terminal/code tools "
+        "to inspect only the relevant parts; do not load the entire file into context."
     )
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -121,6 +121,65 @@ def test_missing_file_becomes_warning(sample_repo: Path):
     assert "not found" in result.message.lower()
 
 
+def test_oversized_text_file_falls_back_to_tool_readable_path(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    payload = tmp_path / "large.txt"
+    payload.write_text("FULL-CONTENT-MARKER\n" + ("x" * 8_000), encoding="utf-8")
+
+    result = preprocess_context_references(
+        f"Inspect @file:{payload.name}",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert str(payload) in result.message
+    assert "too large to inline safely" in result.message
+    assert "read_file" in result.message
+    assert "FULL-CONTENT-MARKER" not in result.message
+    assert any("tool-readable path instead" in warning for warning in result.warnings)
+
+
+def test_file_line_range_is_applied_before_oversized_fallback(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    payload = tmp_path / "large.txt"
+    payload.write_text(
+        "first line\nsecond line\n" + "\n".join("x" * 200 for _ in range(100)),
+        encoding="utf-8",
+    )
+
+    result = preprocess_context_references(
+        f"Inspect @file:{payload.name}:1-2",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    assert "first line\nsecond line" in result.message
+    assert "too large to inline safely" not in result.message
+
+
+def test_multiple_individually_safe_files_still_obey_aggregate_limit(tmp_path: Path):
+    from agent.context_references import preprocess_context_references
+
+    for name in ("first.txt", "second.txt"):
+        (tmp_path / name).write_text("x" * 1_200, encoding="utf-8")
+
+    result = preprocess_context_references(
+        "Inspect @file:first.txt and @file:second.txt",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.blocked
+    assert not result.expanded
+    assert "context injection refused" in "\n".join(result.warnings)
+
+
 def test_binary_reference_block_maps_host_attachment_to_container_path(tmp_path: Path, monkeypatch):
     """Docker backend: a staged binary attachment's host path is rendered as the
     bind-mounted in-container path so the agent's tools can read it.
@@ -149,6 +208,33 @@ def test_binary_reference_block_maps_host_attachment_to_container_path(tmp_path:
     # Default container base for the docker backend is /root/.hermes.
     assert "/root/.hermes/attachments/archive.zip" in result.message
     assert "binary file, not inlined" in result.message
+
+
+def test_oversized_text_reference_maps_host_attachment_to_container_path(
+    tmp_path: Path, monkeypatch
+):
+    from agent.context_references import preprocess_context_references
+
+    hermes_home = tmp_path / ".hermes"
+    attachments = hermes_home / "attachments"
+    attachments.mkdir(parents=True)
+    payload = attachments / "large.txt"
+    payload.write_text("x" * 8_000, encoding="utf-8")
+
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("TERMINAL_ENV", "docker")
+
+    result = preprocess_context_references(
+        f"Read the attachment @file:{payload}",
+        cwd=tmp_path,
+        context_length=1_000,
+    )
+
+    assert result.expanded
+    assert not result.blocked
+    attached_context = result.message.split("--- Attached Context ---", 1)[1]
+    assert "/root/.hermes/attachments/large.txt" in attached_context
+    assert "too large to inline safely" in result.message
 
 
 def test_binary_reference_block_keeps_host_path_on_local_backend(tmp_path: Path, monkeypatch):

--- a/tests/gateway/test_context_ref_expansion_runtime.py
+++ b/tests/gateway/test_context_ref_expansion_runtime.py
@@ -190,3 +190,28 @@ async def test_at_reference_ignores_global_context_for_runtime_route_override(mo
         event=MessageEvent(text="@file:note", source=source), source=source, history=[]
     )
     assert captured["config_context_length"] is None
+
+
+@pytest.mark.asyncio
+async def test_oversized_file_reference_reaches_gateway_as_tool_readable_path(
+    tmp_path, monkeypatch
+):
+    runner = _make_runner()
+    source = _source()
+    _patch_runtime_resolution(monkeypatch)
+
+    payload = tmp_path / "large.txt"
+    payload.write_text("FULL-CONTENT-MARKER\n" + ("x" * 300_000), encoding="utf-8")
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+
+    result = await runner._prepare_inbound_message_text(
+        event=MessageEvent(text=f"Inspect @file:{payload.name}", source=source),
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert str(payload) in result
+    assert "too large to inline safely" in result
+    assert "FULL-CONTENT-MARKER" not in result
+    assert "context injection refused" not in result


### PR DESCRIPTION
## What does this PR do?

Prevents an oversized local text attachment from turning an entire turn into a dead end.

`@file:` references currently inline the complete text before the shared context guard checks the result. When one file exceeds 50% of the active model's context window, Hermes rejects the whole turn with `@ context injection refused`, even though the validated file remains available to the agent's tools.

This change preserves the 50% safety limit. A text file that would exceed it now degrades to a small context block containing its validated, agent-readable path, size, and estimated token count. The agent can then inspect the file selectively with `read_file`, `search_files`, `terminal`, or `execute_code` instead of loading the complete file into context.

## Behavior and scope

- Applies a requested `@file:` line range before deciding whether the selected text fits.
- Keeps normal inline expansion for files that fit.
- Uses the existing host-to-backend path translation for container-backed sessions.
- Keeps workspace restrictions and credential deny-list checks unchanged.
- Keeps the aggregate hard limit for multiple individually acceptable references.
- Does not change `@url`, `@folder`, git, diff, or plugin-provided reference behavior.

## Validation

- `37 passed` across the context-reference, plugin-reference, CLI routing, and gateway runtime suites.
- Added direct coverage for oversized fallback, line-range behavior, aggregate limits, container path translation, and the real gateway ingestion path.
- Ruff checks pass for all changed files.
- Windows footgun scan passes.

Closes #61987.
Related to #57486.