### PR TITLE
docs: add codebase onboarding and architecture analysis

### DIFF
--- a/docs/CORE_FILES_RANKING.md
+++ b/docs/CORE_FILES_RANKING.md
@@ -1,0 +1,56 @@
+# 핵심 비즈니스 로직 파일 5개 — 랭킹 근거
+
+> 분석 기준일: 2026-09-04 · 대상 커밋: `63279301bc` (main)
+> 랭킹 기준은 **파일 크기가 아니라 레버리지** — 여기 한 줄을 바꿨을 때 시스템의 몇 퍼센트가 따라 바뀌는가.
+
+| 순위 | 파일 | LOC | 역할 |
+| --- | --- | --- | --- |
+| **1** | `agent/conversation_loop.py` | 9,339 | 한 번의 유저 턴을 끝까지 굴리는 실제 엔진 — 모델 호출, 툴 디스패치, 재시도/페일오버, 압축, 턴 후 훅, 메모리·스킬 리뷰 넛지 |
+| **2** | `run_agent.py` | 10,175 | `AIAgent` 클래스 본체 — 에이전트의 모든 상태(~60개 생성자 파라미터: 크리덴셜, 라우팅, 예산, 세션, 콜백)를 소유하는 객체 |
+| **3** | `model_tools.py` | 1,707 | `handle_function_call()` — 모든 툴 호출이 반드시 통과하는 단일 관문(플러그인 훅, 미들웨어, 관측성, 에러 분류) |
+| **4** | `hermes_state.py` | 17,370 | `SessionDB` — WAL + FTS5 SQLite 세션 스토어, 대화가 프로세스 밖에서 살아남는 유일한 지점 |
+| **5** | `agent/context_compressor.py` | 9,246 | 컨텍스트 압축 — 대화가 컨텍스트 윈도우를 넘어서도 계속되게 만드는 로직 |
+
+---
+
+## 1위와 2위를 가른 기준
+
+두 파일은 **"상태 소유자 vs 행위 소유자"**로 쪼개져 있습니다. `conversation_loop.py`의 함수들은 전부 `agent: Any`를 첫 인자로 받아 속성 조회로 부모 `AIAgent`의 상태에 접근합니다:
+
+```python
+def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
+def _should_rearm_compression_budget(agent, ...)
+def _restore_or_build_system_prompt(agent, system_message, conversation_history):
+```
+
+에이전트가 **무엇을 하는가**는 1위에, **무엇을 가지고 있는가**는 2위에 있습니다. 행위가 더 중요하다고 봐서 1위로 뒀습니다.
+
+같은 추출 패턴이 `agent/tool_executor.py`(2,940 LOC — 순차/동시 툴 디스패치)에도 적용돼 있습니다. `run_agent.py`가 `_ra()` 헬퍼로 원래 모듈을 되짚는 이유는 `run_agent._set_interrupt`, `handle_function_call`, `OpenAI` 같은 심볼을 패치하는 기존 테스트를 깨지 않기 위해서입니다.
+
+---
+
+## 3위가 1,700줄인데 3위인 이유
+
+크기가 아니라 **레버리지**입니다. 모든 툴 호출의 단일 병목이라 여기 한 줄을 바꾸면 40개 툴 전부의 동작이 바뀝니다. `handle_function_call()`의 시그니처가 그 사실을 드러냅니다 — `skip_pre_tool_call_hook`, `skip_tool_request_middleware`, `skip_tool_execution_middleware` 같은 파라미터는 이 함수가 훅/미들웨어 파이프라인의 주인이라는 뜻입니다.
+
+---
+
+## 4위: 왜 17k LOC짜리가 4위인가
+
+절대량은 1등이지만 상당 부분이 SQLite 운영 방어 로직(재시도, WAL 복구, 예외 계층 10종 — `DeletedWalGenerationError`, `SessionTurnLeaseLostError` 등)입니다. 다만 파일 상단 docstring이 밝히는 설계 결정들은 진짜 도메인 로직입니다:
+
+- 게이트웨이 멀티플랫폼 동시 접근을 위한 WAL 모드(다중 리더 + 단일 라이터)
+- **압축이 트리거하는 세션 분할** — `parent_session_id` 체인
+- 배치 러너와 RL 트라젝토리는 여기 저장하지 **않음**(별도 시스템)
+
+---
+
+## 5위: `toolsets.py`가 아니라 `context_compressor.py`인 이유
+
+`toolsets.py`(1,062 LOC)도 후보였습니다 — 매 API 호출에 어떤 툴 스키마가 실리는지를 결정하니 "좁은 허리" 원칙과 비용을 직접 지배하죠. 하지만 그건 본질적으로 선언적 딕셔너리입니다.
+
+`context_compressor.py`를 고른 건 **이 프로젝트가 신성불가침이라 선언한 프롬프트 캐싱 규칙의 유일한 예외**이기 때문입니다. AGENTS.md가 "과거 컨텍스트를 변형하는 건 하지 않는다 — 유일한 예외가 컨텍스트 압축"이라고 못박은 그 예외의 구현체이고, 장수 대화라는 제품 핵심을 성립시키는 알고리즘이 여기 있습니다.
+
+---
+
+**차점자:** `toolsets.py`(1,062), `agent/tool_executor.py`(2,940), `tools/registry.py`(1,372), `agent/system_prompt.py`(1,172)

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,0 +1,311 @@
+# Hermes Agent 온보딩
+
+새 팀원용 안내서. 분석 기준일 2026-09-04 · 커밋 `63279301bc` (main)
+
+더 깊은 내용은 세 문서로 나뉘어 있습니다.
+
+- [PROJECT_ANALYSIS.md](PROJECT_ANALYSIS.md) — 전체 구조 상세
+- [RUN_AGENT_TRACE.md](RUN_AGENT_TRACE.md) — 실행 흐름 8단계 추적
+- [CORE_FILES_RANKING.md](CORE_FILES_RANKING.md) — 핵심 파일 랭킹 근거
+
+---
+
+## 1. 프로젝트 개요
+
+**Nous Research가 만든 오픈소스 개인 AI 에이전트.** 하나의 파이썬 에이전트 코어를 CLI, 메시징 게이트웨이(Telegram·Discord·Slack 등 22종), TUI, Electron 데스크톱 앱이 공유합니다.
+
+차별점은 **닫힌 학습 루프**입니다. 경험에서 스킬을 자동 생성하고, 사용 중에 스킬을 스스로 개선하고, 메모리를 큐레이팅하고, 과거 대화를 FTS5로 검색합니다. 모델은 40개 프로바이더 플러그인으로 교체 가능하고, 로컬부터 서버리스까지 7종 터미널 백엔드에서 돕니다.
+
+라이선스 MIT · 파이썬 파일 5,128개 · 테스트 파일 3,794개.
+
+---
+
+## 2. 먼저 알아야 할 두 원칙
+
+코드를 읽기 전에 이것부터 알아야 합니다. **리뷰에서 PR이 반려되는 대부분의 이유가 이 둘입니다.**
+
+### 원칙 1 — 대화별 프롬프트 캐싱은 신성불가침
+
+장수 대화는 매 턴 캐시된 프리픽스를 재사용합니다. 과거 컨텍스트를 변형하거나, 툴셋을 교체하거나, 대화 도중 시스템 프롬프트를 재구성하면 캐시가 깨지고 사용자 비용이 배로 뜁니다. **유일한 예외가 컨텍스트 압축입니다.**
+
+실제 적용 사례: 스킬 슬래시 커맨드는 시스템 프롬프트가 아니라 **user 메시지로 주입**됩니다(`agent/skill_commands.py`). 시스템 프롬프트에 넣으면 캐시가 깨지기 때문입니다.
+
+### 원칙 2 — 코어는 좁은 허리, 기능은 가장자리에
+
+모델 툴은 매 API 호출마다 스키마가 전송됩니다. 그래서 새 *코어* 툴의 기준선이 매우 높습니다.
+
+새 기능을 넣을 때의 우선순위 (**Footprint Ladder**):
+
+1. 기존 코드 확장
+2. CLI 커맨드 + 스킬
+3. 서비스로 게이팅된 툴 (`check_fn`)
+4. 플러그인
+5. 카탈로그의 MCP 서버
+6. 새 코어 툴 (최후의 수단)
+
+오해하지 마세요 — 제품 자체는 공격적으로 확장합니다. 새 플랫폼 어댑터, 프로바이더, 데스크톱/TUI 기능은 크더라도 환영이고 정기적으로 머지됩니다. 절제는 **코어 에이전트와 모델 툴 스키마**에만 적용됩니다. *가장자리는 확장적으로, 허리는 보수적으로.*
+
+### 참고: 환영받는 작업
+
+- **실제 버그를 제대로 고치기.** 머지되는 대부분이 `fix(...)`입니다. 좋은 수정은 현재 `main`에서 증상을 재현하고, 발현 지점을 정확히 짚고, 형제 호출 경로까지 포함해 **버그 클래스 전체**를 고칩니다.
+- **god-file 리팩터링.** `cli.py` / `run_agent.py` / `gateway/run.py`에서 수천 줄 덩어리를 모듈로 추출하는 건 환영받는 작업입니다. diff가 크고 기계적이어도 괜찮습니다.
+
+---
+
+## 3. 디렉터리 구조
+
+### 코어
+
+| 경로 | 역할 |
+| --- | --- |
+| `run_agent.py` | `AIAgent` 클래스 — 에이전트 상태 소유자 |
+| `agent/` | 에이전트 내부 — 대화 루프, 프로바이더 어댑터, 메모리, 압축, 큐레이터 |
+| `model_tools.py` | 툴 오케스트레이션, `handle_function_call()` |
+| `toolsets.py` | 툴셋 30종 정의, `_HERMES_CORE_TOOLS` |
+| `tools/` | 툴 구현체 — `tools/registry.py`로 자동 발견 |
+| `tools/environments/` | 터미널 백엔드 7종 (local, docker, ssh, modal, daytona, singularity, vercel_sandbox) |
+| `hermes_state.py` | `SessionDB` — SQLite 세션 스토어 |
+| `hermes_constants.py` | `get_hermes_home()` — 프로필 인식 경로 |
+
+### 사용자 인터페이스
+
+| 경로 | 역할 |
+| --- | --- |
+| `hermes_cli/` | CLI 서브커맨드, 셋업 마법사, 플러그인 로더, 스킨 엔진 |
+| `cli.py` | `HermesCLI` — 인터랙티브 CLI 오케스트레이터 |
+| `ui-tui/` | Ink(React) 터미널 UI — `hermes --tui` |
+| `tui_gateway/` | TUI용 파이썬 JSON-RPC 백엔드 |
+| `apps/desktop/` | Electron 데스크톱 앱 (독립 채팅 표면) |
+| `web/` | Vite 대시보드 — xterm.js로 실제 TUI를 PTY 임베드 |
+| `gateway/` | 메시징 게이트웨이 — `run.py` + `session.py` + `platforms/` |
+| `acp_adapter/` | ACP 서버 (VS Code / Zed / JetBrains) |
+
+### 확장
+
+| 경로 | 역할 |
+| --- | --- |
+| `plugins/model-providers/` | 모델 프로바이더 40종 |
+| `plugins/platforms/` | 메시징 플랫폼 22종 |
+| `plugins/memory/` | 메모리 프로바이더 10종 (honcho, mem0, supermemory 등) |
+| `skills/` | 기본 탑재 스킬 |
+| `optional-skills/` | 무거운·틈새 스킬 — `hermes skills install`로 명시적 설치 |
+| `cron/` | 스케줄러 — `jobs.py`, `scheduler.py` |
+
+### 기타
+
+| 경로 | 역할 |
+| --- | --- |
+| `tests/` | Pytest 스위트 |
+| `scripts/` | `run_tests.sh`, `release.py` 등 |
+| `website/` | Docusaurus 문서 사이트 |
+| `AGENTS.md` | 96KB짜리 개발 규범 — 기여 루브릭, 함정, 테스트 안티패턴 |
+
+**사용자 데이터 위치:** `~/.hermes/config.yaml`(설정), `~/.hermes/.env`(API 키만), `~/.hermes/logs/`(로그)
+
+---
+
+## 4. 핵심 파일 5개
+
+중요도 순. 기준은 파일 크기가 아니라 **레버리지** — 한 줄을 바꿨을 때 시스템의 몇 퍼센트가 따라 바뀌는가.
+
+| 순위 | 파일 | LOC | 역할 |
+| --- | --- | --- | --- |
+| 1 | `agent/conversation_loop.py` | 9,339 | 한 번의 유저 턴을 끝까지 굴리는 실제 엔진 |
+| 2 | `run_agent.py` | 10,175 | `AIAgent` 클래스 — 에이전트의 모든 상태를 소유 |
+| 3 | `model_tools.py` | 1,707 | `handle_function_call()` — 모든 툴 호출의 단일 관문 |
+| 4 | `hermes_state.py` | 17,370 | `SessionDB` — WAL + FTS5 SQLite 세션 스토어 |
+| 5 | `agent/context_compressor.py` | 9,246 | 컨텍스트 압축 |
+
+**꼭 알아둘 것:** 1위와 2위는 "행위 소유자 vs 상태 소유자"로 쪼개져 있습니다. `AIAgent.run_conversation`(`run_agent.py:9272`)은 **얇은 포워더**이고, 실제 ~3,900줄짜리 루프 본문은 `agent/conversation_loop.py`에 있습니다. 추출된 함수들은 전부 부모 `AIAgent`를 첫 인자 `agent`로 받아 속성 조회로 상태에 접근합니다.
+
+`AGENTS.md`의 "The core loop is inside `run_conversation()`" 서술은 이 추출을 반영하지 못한 상태입니다. **루프를 읽으려면 `agent/conversation_loop.py`를 여세요.**
+
+랭킹 근거 전문은 [CORE_FILES_RANKING.md](CORE_FILES_RANKING.md)에 있습니다.
+
+---
+
+## 5. 주요 코드 흐름
+
+### 5-1. 파일 의존성 사슬
+
+```
+tools/registry.py  (의존성 0 — 모든 툴 파일이 import)
+       ↑ 각 tools/*.py가 import 시점에 register() 호출 — 자기등록
+model_tools.py  (registry import + 툴 디스커버리 트리거)
+       ↑
+run_agent.py, cli.py, batch_runner.py, environments/
+```
+
+**함정:** `discover_plugins()`는 `model_tools.py` import의 부수효과로만 실행됩니다. `model_tools.py`를 먼저 import하지 않고 플러그인 상태를 읽는 코드는 `discover_plugins()`를 명시적으로 호출해야 합니다(멱등).
+
+### 5-2. 한 턴이 도는 흐름
+
+```
+사용자 입력
+│
+├─ 진입점 (hermes → hermes_cli/main.py:13526)
+│    └─ AIAgent(...) 생성
+│
+└─ agent.run_conversation(message)
+     │
+     ├─ 포워더 (run_agent.py:9272)
+     │    ├─ 백그라운드 리뷰 선점
+     │    ├─ durable turn lease — state.db 프로세스 간 직렬화 (fail-closed)
+     │    └─ relay/accounting/portal 컨텍스트 세팅
+     │
+     ├─ 턴 프롤로그: build_turn_context()  (agent/turn_context.py:572)
+     │    ├─ 시스템 프롬프트 restore-or-build ← 원칙 1이 여기서 지켜짐
+     │    ├─ preflight 컨텍스트 압축
+     │    ├─ pre_llm_call 플러그인 훅
+     │    └─ 외부 메모리 prefetch
+     │
+     ├─ 메인 루프  (agent/conversation_loop.py:2289)
+     │    while (예산 남음) or (1턴 유예 호출):
+     │      ├─ 턴 중 유저 개입 흡수 (_drain_pending_redirect)
+     │      ├─ API 호출
+     │      ├─ finish_reason 분기: tool_calls / stop / length
+     │      ├─ 도구 실행 → 세그먼트 플래너
+     │      │     ├─ 1개 이하 → sequential
+     │      │     ├─ 전부 병렬 안전 → concurrent
+     │      │     └─ 혼합 → segmented (안전 구간만 병렬, 순서 보존)
+     │      │           → agent/tool_executor.py
+     │      │           → model_tools.handle_function_call()
+     │      └─ 회복: 드롭된 tool-call, Codex ack, 압축 재시도
+     │
+     └─ finalize_turn()  (agent/turn_finalizer.py:138)
+          ├─ _save_trajectory
+          ├─ _persist_session  → SessionDB
+          └─ 메모리/스킬 리뷰 넛지 ← 학습 루프가 여기서 발화
+```
+
+단계별 상세와 회복 분기는 [RUN_AGENT_TRACE.md](RUN_AGENT_TRACE.md)에 있습니다.
+
+### 5-3. 새 툴을 추가할 때
+
+**대부분의 경우 코어를 건드리면 안 됩니다.** 원칙 2의 Footprint Ladder를 먼저 확인하세요. 로컬 전용 툴이면 플러그인 경로를 씁니다.
+
+```
+~/.hermes/plugins/<name>/plugin.yaml
+~/.hermes/plugins/<name>/__init__.py   → ctx.register_tool(...)
+```
+
+플러그인 툴셋은 자동 발견되고, `tools/`나 `toolsets.py`를 건드리지 않고 켜고 끌 수 있습니다.
+
+### 5-4. 슬래시 커맨드를 추가할 때
+
+`hermes_cli/commands.py`의 `COMMAND_REGISTRY`에 `CommandDef` 하나를 추가하면 **모든 하위 소비자가 자동 파생**됩니다 — CLI 디스패치, 게이트웨이 디스패치, `/help` 출력, Telegram BotCommand 메뉴, Slack 서브커맨드 매핑, 자동완성.
+
+별칭만 추가하려면 기존 `CommandDef`의 `aliases` 튜플만 건드리면 됩니다.
+
+---
+
+## 6. 개발 시작하기
+
+### 6-1. 설치 (권장 경로)
+
+표준 인스톨러를 쓴 뒤, 인스톨러가 만든 git 체크아웃에서 작업합니다. 이 레이아웃이 `hermes update`, 관리 venv, 지연 의존성, 게이트웨이, 문서 도구가 전제하는 구조입니다.
+
+```bash
+curl -fsSL https://hermes-agent.nousresearch.com/install.sh | bash
+cd "${HERMES_HOME:-$HOME/.hermes}/hermes-agent"
+uv pip install -e ".[all,dev]"
+scripts/run_tests.sh
+```
+
+Windows(네이티브)는 PowerShell에서:
+
+```powershell
+iex (irm https://hermes-agent.nousresearch.com/install.ps1)
+```
+
+### 6-2. 설치 (수동 클론 — CI/일회성용)
+
+**venv를 소스 트리 밖에 만드세요.** 에이전트가 자기 체크아웃에 대해 상대 경로 명령을 실행하면 트리 안의 venv를 통째로 날려서 실행 중인 런타임을 죽일 수 있습니다.
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv venv ~/.hermes/venvs/hermes-dev --python 3.11
+source ~/.hermes/venvs/hermes-dev/bin/activate
+uv pip install -e ".[all,dev]"
+scripts/run_tests.sh
+```
+
+**버전 요구사항:** Python `>=3.11,<3.14` (상한은 장식이 아님 — 3.14는 pydantic-core에 cp314 휠이 없어 소스 빌드로 폴백해 실패), Node `^22.22.0 || ^24.11.0 || >=26.0.0`
+
+### 6-3. 실행
+
+```bash
+hermes                # 인터랙티브 CLI
+hermes --tui          # Ink 터미널 UI
+hermes model          # 프로바이더/모델 선택
+hermes tools          # 툴 켜고 끄기 (curses UI)
+hermes setup          # 전체 셋업 마법사
+hermes gateway        # 메시징 게이트웨이
+hermes doctor         # 문제 진단
+```
+
+디버깅용 독립 실행 (연구 경로 — 프로필·세션 복원을 거치지 않음):
+
+```bash
+python run_agent.py --query="..." --max_turns=10
+python run_agent.py --list_tools
+```
+
+### 6-4. 테스트 — 반드시 래퍼를 쓸 것
+
+**`pytest`를 직접 부르지 마세요.** `scripts/run_tests.sh`가 CI와의 환경 패리티를 강제합니다.
+
+```bash
+scripts/run_tests.sh                                     # 전체
+scripts/run_tests.sh tests/gateway/                      # 디렉터리 하나
+scripts/run_tests.sh tests/agent/test_foo.py -k test_x   # 파일 + 패턴
+scripts/run_tests.sh -j 4                                # 병렬도 제한
+scripts/run_tests.sh -v --tb=long                        # pytest 플래그 통과
+```
+
+래퍼가 강제하는 것:
+
+| | 래퍼 없이 | 래퍼로 |
+| --- | --- | --- |
+| 프로바이더 API 키 | 내 환경에 있는 것 (풀 자동 감지) | 소수 예외 빼고 전부 unset |
+| `HOME` / `~/.hermes/` | 실제 설정 + auth.json | 테스트마다 임시 디렉터리 |
+| 타임존 | 로컬 (KST 등) | UTC |
+| 로케일 | 환경값 | C.UTF-8 |
+
+파일마다 **새로 스폰된 서브프로세스**에서 돌기 때문에 모듈 레벨 dict/set과 ContextVar가 파일 간에 새지 않습니다. 16코어 개발 머신에서 API 키를 켜둔 채 직접 `pytest`를 돌리면 CI와 갈라져서 "로컬은 되는데 CI가 깨짐"(그리고 그 반대)이 반복적으로 발생했습니다.
+
+**Flake 정책:** 실패한 테스트 *파일*은 새 서브프로세스에서 1회 자동 재시도됩니다. 재시도 통과는 green으로 치되 `⚠ FLAKY` 섹션에 두 번의 출력이 함께 찍힙니다. **FLAKY 리포트는 무시할 노이즈가 아니라 고쳐야 할 버그입니다.**
+
+### 6-5. JS/TS 테스트
+
+워크스페이스별로 돌립니다.
+
+```bash
+cd ui-tui && npm run check     # build:ink + typecheck + test + lint
+cd web     && npm run check    # typecheck + test + lint
+cd apps/desktop && npx vitest run src/lib/desktop-slash-commands.test.ts
+```
+
+TUI 개발 중에는:
+
+```bash
+cd ui-tui
+npm install     # 최초 1회
+npm run dev     # watch 모드
+```
+
+---
+
+## 7. 첫날 밟기 쉬운 지뢰
+
+**`.venv`가 체크아웃에 없습니다.** `scripts/run_tests.sh`는 `.venv` → `venv` → `$HOME/.hermes/hermes-agent/venv` 순으로 탐색하되, **pytest가 실제로 설치된** venv만 고릅니다. 릴리스 venv에는 pytest가 없어서 건너뜁니다.
+
+**테스트를 잘못된 언어 스위트에 두지 마세요.** `package.json`, `tsconfig.json`, `.ts`/`.tsx` 내용을 검사하는 테스트는 파이썬이 아니라 vitest 쪽에 있어야 합니다. CI 변경 분류기가 JS 파일만 바뀐 PR에서는 파이썬 테스트를 돌리지 않아서, 회귀가 PR에서 green이고 `main`에서 red가 됩니다.
+
+**호스트 OS를 가짜로 만들지 마세요.** `sys.platform`을 패치하는 대신 `@pytest.mark.linux_only` / `macos_only` / `windows_only` 마커를 씁니다. 맨 `skipif`를 쓰면 Linux에서 skip되고 Windows 레인에서는 import조차 안 되어 **아무 호스트에서도 안 돌면서 green으로 보입니다.**
+
+**change-detector 테스트를 쓰지 마세요.** 모델 카탈로그 스냅샷, config 버전 리터럴, 열거 개수 assert는 정상적인 소스 업데이트마다 CI를 깨뜨립니다. 대신 배선·마이그레이션·불변식을 테스트하세요.
+
+**대시보드에 채팅 UI를 다시 만들지 마세요.** 대시보드는 실제 `hermes --tui`를 PTY로 임베드합니다. 트랜스크립트·컴포저·터미널은 Ink 소유이고, Ink에 추가하면 대시보드에 자동으로 나타납니다. 사이드바·인스펙터 같은 보조 UI는 React로 만들어도 됩니다.
+
+**의존성에 범위를 쓰지 마세요.** 모든 직접 의존성이 `==X.Y.Z`로 고정돼 있습니다. 2026-05-12 mistralai PyPI 웜 대응 정책입니다. 버전을 올릴 때는 `pyproject.toml` 핀을 바꾸고 `uv lock`으로 lockfile을 재생성합니다.

--- a/docs/PROJECT_ANALYSIS.md
+++ b/docs/PROJECT_ANALYSIS.md
@@ -1,0 +1,357 @@
+# Hermes Agent — 프로젝트 구조 분석
+
+> 분석 기준일: 2026-09-04 · 대상 커밋: `63279301bc` (main)
+> 출처: `README.md`, `AGENTS.md`, `pyproject.toml`, 실제 디렉터리 트리
+
+---
+
+## 1. 무엇을 하는 프로젝트인가
+
+**Nous Research가 만든 오픈소스 개인 AI 에이전트.** `pyproject.toml`의 한 줄 요약:
+
+> *"The self-improving AI agent — creates skills from experience, improves them during use, and runs anywhere"*
+
+기존 코딩/개인 에이전트의 세 가지 한계를 정면으로 겨냥한다.
+
+| 문제 | Hermes의 답 |
+| --- | --- |
+| 세션이 끝나면 배운 걸 다 잊는다 | **닫힌 학습 루프** — 경험에서 스킬을 자동 생성하고, 사용 중에 스킬을 스스로 개선하고, 메모리를 큐레이팅하고, 과거 대화를 FTS5로 검색한다 |
+| 노트북에 묶여 있다 | **어디서든 실행** — 로컬/Docker/SSH/Singularity/Modal/Daytona/Vercel Sandbox 7종 터미널 백엔드. Telegram으로 대화하면서 작업은 클라우드 VM에서 돌린다 |
+| 특정 모델 벤더에 락인된다 | **40개 모델 프로바이더 플러그인** — `hermes model` 한 줄로 교체, 코드 변경 없음 |
+
+라이선스 MIT. 파이썬 파일 5,128개, 테스트 파일 3,794개(~17k 테스트) 규모.
+
+---
+
+## 2. 아키텍처 — "하나의 코어, 여러 개의 프론트엔드"
+
+```
+            ┌─── cli.py (prompt_toolkit CLI, 22k LOC)
+            ├─── ui-tui/ (Ink/React TUI) ──JSON-RPC/stdio── tui_gateway/
+프론트엔드  ├─── apps/desktop/ (Electron + assistant-ui) ──WS/JSON-RPC──┐
+            ├─── web/ (Vite 대시보드, xterm.js로 TUI를 PTY 임베드)     │
+            ├─── gateway/ (Telegram·Discord·Slack·WhatsApp·Signal…)    │
+            └─── acp_adapter/ (VS Code / Zed / JetBrains)              │
+                              ↓                                        │
+              ┌────────────────────────────────────────────────────────┘
+              │
+코어      run_agent.py :: AIAgent  ← 동기 tool-calling 루프 (10k LOC)
+              │   agent/  — 프로바이더 어댑터, 압축, 캐싱, 메모리, 큐레이터
+              ├─ model_tools.py    — 툴 오케스트레이션 / handle_function_call()
+              ├─ toolsets.py       — 30개 툴셋 번들, _HERMES_CORE_TOOLS
+              ├─ tools/            — 툴 구현체 (import 시 registry에 자기등록)
+              │    └ environments/ — 터미널 백엔드 7종
+              └─ hermes_state.py   — SQLite 세션 스토어 + FTS5 검색 (17k LOC)
+```
+
+핵심은 **동일한 `AIAgent` 코어가 6개 프론트엔드에 공유된다**는 점이다. CLI든 Telegram이든 Electron이든 대화 루프·툴·세션은 같은 파이썬 코어에서 돈다.
+
+### 2.1 설계를 지배하는 두 원칙
+
+`AGENTS.md` 서두가 모든 설계 결정과 코드 리뷰의 렌즈로 못박은 두 가지:
+
+1. **"대화별 프롬프트 캐싱은 신성불가침이다."**
+   장수 대화는 매 턴 캐시된 프리픽스를 재사용한다. 과거 컨텍스트를 변형하거나, 툴셋을 교체하거나, 대화 도중 시스템 프롬프트를 재구성하면 캐시가 깨지고 사용자 비용이 배로 뛴다. 유일한 예외가 컨텍스트 압축.
+   → 그래서 스킬 슬래시 커맨드조차 시스템 프롬프트가 아니라 **user 메시지로 주입**한다 (`agent/skill_commands.py`).
+
+2. **"코어는 좁은 허리(narrow waist), 기능은 가장자리에."**
+   모델 툴은 매 API 호출마다 스키마가 전송되므로 새 *코어* 툴의 기준선이 매우 높다. 새 기능 대부분은 CLI 커맨드 + 스킬, 서비스로 게이팅된 툴, 또는 플러그인으로 가야 한다.
+   → 메시징 플랫폼 22종과 모델 프로바이더 40종이 전부 플러그인으로 코어 밖에 나가 있는 이유.
+
+### 2.2 파일 의존성 사슬
+
+```
+tools/registry.py  (의존성 0 — 모든 툴 파일이 import)
+       ↑
+tools/*.py  (각자 import 시점에 registry.register() 호출 — 자기등록)
+       ↑
+model_tools.py  (registry import + 툴 디스커버리 트리거)
+       ↑
+run_agent.py, cli.py, batch_runner.py, environments/
+```
+
+**함정:** `discover_plugins()`는 `model_tools.py` import의 부수효과로만 실행된다. `model_tools.py`를 먼저 import하지 않고 플러그인 상태를 읽는 코드 경로는 `discover_plugins()`를 명시적으로 호출해야 한다(멱등).
+
+### 2.3 에이전트 루프 — "상태 소유자 vs 행위 소유자" 분리
+
+**루프 본문은 `run_agent.py`에 없다.** `AIAgent.run_conversation`(`run_agent.py:9272`)은 얇은 포워더이고, 실제 ~3,900줄짜리 본문은 `agent/conversation_loop.py`로 추출되어 있다.
+
+```
+run_agent.py :: AIAgent            ← 상태 소유자 (~60개 생성자 파라미터)
+   └ run_conversation()  ────┐
+                             ↓ 얇은 포워더
+     agent/conversation_loop.py :: run_conversation(agent, ...)   ← 행위 소유자
+     agent/tool_executor.py   :: _execute_tool_calls_{sequential,concurrent}(agent, ...)
+```
+
+추출된 함수들은 전부 부모 `AIAgent`를 첫 인자 `agent`로 받아 속성 조회로 상태에 접근한다:
+
+```python
+def _maybe_inject_run_budget_wrapup(agent: Any, messages: List[Dict[str, Any]]) -> bool:
+def _should_rearm_compression_budget(agent, ...)
+def _restore_or_build_system_prompt(agent, system_message, conversation_history):
+```
+
+추출 모듈은 `_ra()` 헬퍼로 원래 `run_agent` 모듈을 되짚는다 — 프로덕션 코드와 테스트가 `run_agent._set_interrupt`, `handle_function_call`, `OpenAI` 같은 심볼을 직접 패치하기 때문에, 그 패치가 계속 먹히게 하려는 장치다.
+
+> **주의:** `AGENTS.md`의 "The core loop is inside `run_conversation()`" 서술은 이 추출을 반영하지 못한 상태다. 루프를 읽으려면 `agent/conversation_loop.py`를 열어야 한다.
+
+한 턴이 통과하는 단계: 모델 호출 → 툴 디스패치 → 재시도/페일오버 → 압축 → 턴 후 훅 → 백그라운드 메모리·스킬 리뷰 넛지. 각 단계의 실제 코드 경로와 회복 분기는 [RUN_AGENT_TRACE.md](RUN_AGENT_TRACE.md)의 Phase 4~7에 있다.
+
+개념적 골격은 아래와 같다. 전부 동기(synchronous)이며 인터럽트 체크, 예산 추적, 1턴 유예 호출이 얹혀 있다.
+
+```python
+while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) \
+        or self._budget_grace_call:
+    if self._interrupt_requested: break
+    response = client.chat.completions.create(model=model, messages=messages, tools=tool_schemas)
+    if response.tool_calls:
+        for tool_call in response.tool_calls:
+            result = handle_function_call(tool_call.name, tool_call.args, task_id)
+            messages.append(tool_result_message(result))
+        api_call_count += 1
+    else:
+        return response.content
+```
+
+메시지는 OpenAI 포맷(`system`/`user`/`assistant`/`tool`)을 따르고, reasoning 콘텐츠는 `assistant_msg["reasoning"]`에 보관한다.
+실제 `AIAgent.__init__`는 파라미터가 약 60개(크리덴셜, 라우팅, 콜백, 세션 컨텍스트, 예산, 크리덴셜 풀 등).
+
+---
+
+## 3. 디렉터리 지도
+
+| 경로 | 역할 |
+| --- | --- |
+| `run_agent.py` | `AIAgent` 클래스 — 에이전트 상태 소유자 (10,175 LOC). 루프 본문은 `agent/conversation_loop.py`로 추출됨 (§2.3) |
+| `cli.py` | `HermesCLI` — 인터랙티브 CLI 오케스트레이터 (22,426 LOC) |
+| `model_tools.py` | 툴 오케스트레이션, `discover_builtin_tools()`, `handle_function_call()` |
+| `toolsets.py` | 툴셋 정의, `_HERMES_CORE_TOOLS` 리스트 |
+| `hermes_state.py` | `SessionDB` — SQLite 세션 스토어 + FTS5 검색 (17,370 LOC) |
+| `hermes_constants.py` | `get_hermes_home()` — 프로필 인식 경로 |
+| `agent/` | 에이전트 내부 — 프로바이더 어댑터, 메모리, 캐싱, 압축, 큐레이터 |
+| `hermes_cli/` | CLI 서브커맨드, 셋업 마법사, 플러그인 로더, 스킨 엔진 |
+| `tools/` | 툴 구현체 — `tools/registry.py`로 자동 발견 |
+| `tools/environments/` | 터미널 백엔드 (local, docker, ssh, modal, daytona, singularity, vercel_sandbox) |
+| `gateway/` | 메시징 게이트웨이 — `run.py` + `session.py` + `platforms/` |
+| `plugins/` | 플러그인 시스템 (아래 §4.5) |
+| `skills/` / `optional-skills/` | 기본 탑재 스킬 / 무거운·틈새 스킬(명시적 설치) |
+| `ui-tui/` | Ink(React) 터미널 UI — `hermes --tui` |
+| `tui_gateway/` | TUI용 파이썬 JSON-RPC 백엔드 |
+| `apps/desktop/` | Electron 데스크톱 앱 (독립 채팅 표면) |
+| `web/` | Vite 대시보드 (xterm.js로 실제 TUI를 PTY 임베드) |
+| `acp_adapter/` | ACP 서버 (VS Code / Zed / JetBrains 연동) |
+| `cron/` | 스케줄러 — `jobs.py`, `scheduler.py` |
+| `website/` | Docusaurus 문서 사이트 |
+| `tests/` | Pytest 스위트 (~3,794 파일) |
+
+**사용자 설정:** `~/.hermes/config.yaml` (설정), `~/.hermes/.env` (API 키 전용)
+**로그:** `~/.hermes/logs/` — `agent.log`(INFO+), `errors.log`(WARNING+), `gateway.log`
+
+---
+
+## 4. 주요 서브시스템
+
+### 4.1 학습 루프 (이 프로젝트의 차별점)
+
+- **스킬 3계층** — `skills/`(기본 탑재) + `optional-skills/`(무거운/틈새, `hermes skills install`로 명시적 설치) + `~/.hermes/skills/`(에이전트가 만든 것). [agentskills.io](https://agentskills.io) 오픈 표준 호환.
+- **큐레이터** (`agent/curator.py`) — 에이전트 생성 스킬의 사용 통계를 추적해 stale → archive로 자동 전이. 불변식이 엄격하다:
+  - `created_by: "agent"` 프로비넌스인 스킬만 건드린다. 번들·허브 설치 스킬은 손대지 않는다.
+  - **절대 삭제하지 않는다.** 최대 파괴적 행동이 아카이브(`~/.hermes/skills/.archive/`, 복원 가능).
+  - pin된 스킬은 모든 자동 전이와 LLM 리뷰 패스에서 면제.
+- **메모리** — `agent/memory_manager.py` + `plugins/memory/` 10종 (honcho, mem0, supermemory, retaindb, byterover, hindsight, holographic, openviking …). Honcho는 dialectic 사용자 모델링.
+- **세션 검색** — `tools/session_search_tool.py` + FTS5 + LLM 요약으로 크로스 세션 리콜.
+
+### 4.2 툴 시스템
+
+`tools/registry.py`가 의존성 0인 최하위 레이어이고, 각 `tools/*.py`가 import 시점에 `register()`를 호출하는 **자기등록** 방식.
+
+툴셋 30종으로 번들링되어 플랫폼별로 다른 조합을 쓴다(예: Telegram은 `messaging` 베이스):
+
+`browser`, `clarify`, `code_execution`, `cronjob`, `debugging`, `delegation`, `discord`, `discord_admin`, `feishu_doc`, `feishu_drive`, `file`, `homeassistant`, `image_gen`, `kanban`, `memory`, `messaging`, `moa`, `rl`, `safe`, `search`, `session_search`, `skills`, `spotify`, `terminal`, `todo`, `tts`, `video`, `vision`, `web`, `yuanbao`
+
+설정은 `hermes tools`(curses UI) 또는 `config.yaml`의 `tools.<platform>.enabled/disabled`.
+
+### 4.3 위임 / 병렬화 (`delegate_task`)
+
+`tools/delegate_tool.py`가 격리된 컨텍스트 + 터미널 세션을 가진 서브에이전트를 스폰한다.
+
+- **형태:** 단일(`goal`) 또는 배치 병렬(`tasks: [...]`, 동시성 상한 `delegation.max_concurrent_children`, 기본 3)
+- **역할:** `leaf`(기본, 재위임·clarify·memory·send_message·cronjob 불가, `execute_code`는 유지) vs `orchestrator`(재위임 가능, `max_spawn_depth` 기본 2로 제한)
+- `background=true`면 위임 ID를 즉시 반환하고, 결과는 비동기 완료 큐를 통해 나중에 대화에 재진입
+- **내구성 규칙:** background 위임은 턴에서 분리되지만 여전히 프로세스 로컬이다. 프로세스 재시작을 살아남아야 하는 작업은 `cronjob` 또는 `terminal(background=True, notify_on_complete=True)`를 써야 한다.
+
+### 4.4 Kanban (멀티에이전트 작업 큐)
+
+SQLite 기반 durable 보드. 디스패처(기본 60초 주기)가 stale claim 회수 → ready 태스크 승격 → 원자적 claim → 배정된 프로필 스폰을 반복한다. 기본값 `kanban.dispatch_in_gateway: true`로 게이트웨이 안에서 돈다.
+
+- **격리 모델:** board = 하드 경계(워커 env에 `HERMES_KANBAN_BOARD` 고정 → 다른 보드가 안 보임), tenant = 보드 *내부*의 소프트 네임스페이스(워크스페이스 경로 + 메모리 키 격리)
+- 같은 태스크에서 `kanban.failure_limit`(기본 2)회 연속 실패하면 디스패처가 자동 차단해 스핀 루프를 막는다
+
+### 4.5 플러그인
+
+`register(ctx)` 함수 하나로 세 가지를 등록한다:
+
+- **라이프사이클 훅** — `pre_tool_call`, `post_tool_call`, `pre_llm_call`, `post_llm_call`, `on_session_start`, `on_session_end`
+- **툴** — `ctx.register_tool(...)`
+- **CLI 서브커맨드** — `ctx.register_cli_command(...)`. 플러그인의 argparse 트리가 시작 시 `hermes`에 배선되어 `main.py` 변경 없이 `hermes <pluginname> <subcmd>`가 동작
+
+디스커버리 소스: `~/.hermes/plugins/`, `./.hermes/plugins/`, pip entry points, 그리고 레포의 `plugins/`.
+
+레포에 실린 플러그인 카테고리:
+
+| 카테고리 | 내용 |
+| --- | --- |
+| `plugins/model-providers/` (40종) | anthropic, openrouter, gemini, bedrock, vertex, xai, deepseek, ollama-cloud, nous, copilot, openai-codex, qwen-oauth … |
+| `plugins/platforms/` (22종) | telegram, discord, slack, whatsapp, matrix, teams, feishu, wecom, dingtalk, line, irc, sms, email, ntfy, a2a … |
+| `plugins/memory/` (10종) | honcho, mem0, supermemory, retaindb, byterover, hindsight, holographic, openviking |
+| 기타 | kanban, observability, image_gen, video_gen, browser, spotify, google_meet, disk-cleanup, hermes-achievements, security-guidance, teams_pipeline |
+
+> 참고: `gateway/platforms/`에도 어댑터가 일부 남아 있다(api_server, webhook, signal, whatsapp_cloud, bluebubbles, weixin, yuanbao, qqbot). 신규 플랫폼 추가 가이드는 `gateway/platforms/ADDING_A_PLATFORM.md`.
+
+### 4.6 Cron (스케줄 작업)
+
+`cron/jobs.py`(잡 스토어) + `cron/scheduler.py`(틱 루프). 에이전트는 `cronjob` 툴로, 사용자는 `hermes cron <verb>` 또는 `/cron`으로 스케줄한다.
+
+- **스케줄 포맷:** duration(`30m`, `2h`), "every" 구문(`every monday 9am`), 5-field cron(`0 9 * * *`), ISO 타임스탬프(1회성)
+- **잡 필드:** `skills`, `model`/`provider` 오버라이드, `script`(사전 데이터 수집 스크립트 — stdout이 프롬프트에 주입, `no_agent=True`면 스크립트가 잡 전체), `context_from`(잡 A의 출력 → 잡 B의 프롬프트), `workdir`, 멀티플랫폼 전달
+- **하드닝 불변식:** 크론 세션에 3분 하드 인터럽트(폭주 루프가 스케줄러를 독점 불가), 캐치업 윈도우는 주기의 절반을 120s–2h로 클램프, 1회성 잡 놓친 발화에 120s 유예, `~/.hermes/cron/.tick.lock` 파일 락으로 프로세스 간 중복 틱 방지
+- 크론 세션은 기본 `skip_memory=True` — 메모리 프로바이더는 의도적으로 크론에서 돌지 않는다
+- 크론 전달은 대상 게이트웨이 세션에 미러링되지 **않는다**. 메인 대화의 메시지 role 교대가 깨지지 않도록 자체 크론 세션에 헤더/푸터 프레임과 함께 착지한다
+
+### 4.7 슬래시 커맨드 레지스트리
+
+`hermes_cli/commands.py`의 단일 `COMMAND_REGISTRY`(`CommandDef` 리스트)에서 **모든 하위 소비자가 자동 파생**된다: CLI 디스패치, 게이트웨이 디스패치, `/help` 출력, Telegram BotCommand 메뉴, Slack `/hermes` 서브커맨드 매핑, 자동완성, 카테고리별 CLI 도움말.
+
+→ 별칭 하나 추가하려면 기존 `CommandDef`의 `aliases` 튜플만 건드리면 된다. 나머지는 전부 자동 갱신.
+
+---
+
+## 5. UI 표면의 경계 규칙
+
+`AGENTS.md`가 명시적으로 못박은 "채팅 표면 중복 금지" 규칙:
+
+- **대시보드(`web/`)는 실제 `hermes --tui`를 PTY로 임베드한다.** 리라이트가 아니다. `hermes_cli/pty_bridge.py` + `web_server.py`의 `@app.websocket("/api/pty")` → 브라우저의 xterm.js(WebGL 렌더러). 메인 트랜스크립트·컴포저·터미널은 Ink 소유이므로, **React로 재구현하지 말고 Ink를 확장하라.** Ink에 추가한 것은 대시보드에 자동으로 나타난다.
+- 다만 **TUI를 둘러싼 구조화된 React UI는 허용** — 사이드바 위젯, 인스펙터, 요약, 상태 패널(`ChatSidebar`, `ModelPickerDialog`, `ToolCall` 등)처럼 트랜스크립트를 대체하지 않고 보완하는 것.
+- **Electron 데스크톱(`apps/desktop/`)만 예외적으로 독립 표면.** `hermes --tui`를 임베드하지 않고 자체 컴포저·트랜스크립트·슬래시 파이프라인을 갖는다. headless `hermes serve` 백엔드를 스폰하며, WS/JSON-RPC 트랜스포트는 `apps/shared`(`@hermes/shared`)에 있어 대시보드와 공유한다. 데스크톱은 대시보드 프론트엔드에 빌드/런타임 의존이 없다.
+
+---
+
+## 6. 눈에 띄는 엔지니어링 관행
+
+### 의존성 exact pin 정책
+
+모든 직접 의존성이 `==X.Y.Z`로 정확히 고정되어 있고 범위 지정이 금지되어 있다. `pyproject.toml`에 이유가 주석으로 박혀 있다 — **2026-05-12 mistralai 2.4.6을 덮친 Mini Shai-Hulud PyPI 웜** 대응. 범위였다면 격리 전 몇 시간 동안 모든 설치가 감염 버전을 끌어왔을 것이다.
+
+여기에 **스코프 규칙**이 붙는다: *모든* Hermes 세션이 쓰는 패키지만 코어 `dependencies`에 둔다. 프로바이더 종속적인 것(`anthropic`, `firecrawl-py`, `exa-py`, `fal-client`, `edge-tts`, `parallel-web`)은 extra로 빼고 `tools/lazy_deps.py`가 사용자가 그 백엔드를 고를 때 지연 설치한다. **코어 deps가 작을수록 다음 공급망 공격의 폭발 반경이 작다.**
+
+`requires-python = ">=3.11,<3.14"`의 상한도 장식이 아니다 — 상속된 `UV_PYTHON`이 3.14를 고르면 Rust 백엔드 트랜지티브(pydantic-core)에 cp314 휠이 없어 maturin 소스 빌드로 폴백해 실패한다. 상한이 있으면 uv가 시도 대신 명확한 에러를 낸다.
+
+### 문서 중심 규범
+
+`AGENTS.md`가 96KB. 기여 루브릭("The Footprint Ladder"), TypeScript 스타일 가이드(nanostore 우선, god hook 금지, 조건 사다리 대신 테이블 주도), 스킬 저작 표준(HARDLINE — `description` 60자 이하, 프로즈에서 셸 유틸 대신 네이티브 툴 이름 사용, `platforms:` 게이팅을 실제 import에 대해 감사), 알려진 함정, 테스트 안티패턴(모델 카탈로그 스냅샷 assert 금지, config 버전 리터럴 assert 금지 — 대신 배선/마이그레이션/불변식을 테스트하라)까지 전부 명문화되어 있다.
+
+### 기타
+
+- **프로필 기반 멀티 인스턴스** — `get_hermes_home()`이 경로를 프로필 인식으로 해석
+- 초대형 모듈이 존재한다: `cli.py` 22k LOC, `hermes_state.py` 17k LOC, `run_agent.py` 10k LOC, `agent/conversation_loop.py` 9.3k LOC, `agent/context_compressor.py` 9.2k LOC
+- **연구용 출력** — `batch_runner.py`(배치 트라젝토리 생성), `trajectory_compressor.py`(차세대 tool-calling 모델 학습용 압축), `mini_swe_runner.py`, `evals/`
+
+---
+
+## 7. 핵심 비즈니스 로직 파일 5개
+
+중요도 순. 랭킹 기준은 **파일 크기가 아니라 레버리지** — 여기 한 줄을 바꿨을 때 시스템의 몇 퍼센트가 따라 바뀌는가.
+
+| 순위 | 파일 | LOC | 역할 |
+| --- | --- | --- | --- |
+| **1** | `agent/conversation_loop.py` | 9,339 | 한 번의 유저 턴을 끝까지 굴리는 실제 엔진 — 모델 호출, 툴 디스패치, 재시도/페일오버, 압축, 턴 후 훅, 메모리·스킬 리뷰 넛지 |
+| **2** | `run_agent.py` | 10,175 | `AIAgent` 클래스 본체 — 에이전트의 모든 상태(~60개 생성자 파라미터: 크리덴셜, 라우팅, 예산, 세션, 콜백)를 소유하는 객체 |
+| **3** | `model_tools.py` | 1,707 | `handle_function_call()` — 모든 툴 호출이 반드시 통과하는 단일 관문(플러그인 훅, 미들웨어, 관측성, 에러 분류) |
+| **4** | `hermes_state.py` | 17,370 | `SessionDB` — WAL + FTS5 SQLite 세션 스토어, 대화가 프로세스 밖에서 살아남는 유일한 지점 |
+| **5** | `agent/context_compressor.py` | 9,246 | 컨텍스트 압축 — 대화가 컨텍스트 윈도우를 넘어서도 계속되게 만드는 로직 |
+
+**차점자:** `toolsets.py`(1,062), `agent/tool_executor.py`(2,940), `tools/registry.py`(1,372), `agent/system_prompt.py`(1,172)
+
+각 순위의 근거 — 1위와 2위를 가른 "상태 소유자 vs 행위 소유자" 기준, 3위가 1,700줄인데도 3위인 이유, 4위가 절대량 1등인데 4위인 이유, 5위로 `toolsets.py` 대신 압축을 고른 이유 — 는 [CORE_FILES_RANKING.md](CORE_FILES_RANKING.md)에 있다.
+
+---
+
+## 8. 더 파볼 만한 지점
+
+| 관심사 | 시작점 |
+| --- | --- |
+| 에이전트 루프 내부 | `agent/conversation_loop.py` → `agent/tool_executor.py`, `agent/turn_finalizer.py` |
+| 툴 등록·디스패치 경로 | `tools/registry.py` → `model_tools.py::handle_function_call` → `agent/tool_executor.py` |
+| 학습 루프 구현 | `agent/curator.py`, `agent/learn_prompt.py`, `agent/learning_graph.py`, `tools/skill_usage.py` |
+| 컨텍스트 압축 / 캐싱 | `agent/context_compressor.py`, `agent/prompt_caching.py`, `agent/prompt_cache_boundary.py` |
+| 게이트웨이 세션 관리 | `gateway/run.py`, `gateway/session.py`, `gateway/turn_lease.py` |
+| 프로바이더 어댑터 패턴 | `agent/anthropic_adapter.py`, `agent/bedrock_adapter.py`, `agent/vertex_adapter.py`, `plugins/model-providers/` |
+
+---
+
+## 9. 진입점(Entry Point)
+
+### 콘솔 스크립트 (`pyproject.toml:391`)
+
+```toml
+[project.scripts]
+hermes       = "hermes_cli.main:main"      # 주 진입점
+hermes-agent = "run_agent:main"            # 에이전트 직접 실행 (fire CLI)
+hermes-acp   = "acp_adapter.entry:main"    # ACP 서버 (VS Code/Zed/JetBrains)
+```
+
+레포 루트의 `./hermes` 셸 래퍼도 `hermes_cli.main:main`을 호출한다.
+
+`python run_agent.py`를 직접 실행했을 때의 전체 코드 흐름(모듈 임포트 부수효과 → `fire` CLI 파싱 → `AIAgent` 생성 → 턴 프롤로그 → 메인 루프 → finalize)은 [RUN_AGENT_TRACE.md](RUN_AGENT_TRACE.md)에 8단계로 추적해 뒀다. 그 경로는 연구·디버깅용이라 프로필·세션 복원·스킬 로딩을 거치지 않지만, `run_conversation()` 진입 시점부터는 `hermes` 경로와 합류하므로 실사용 흐름을 읽을 때도 그 문서의 Phase 4 이후가 그대로 적용된다.
+
+> **이 프로젝트는 import해서 쓰는 라이브러리가 아니다.** `setup.py`가 Nix 빌드 밖에서의 wheel/sdist 생성을 의도적으로 차단한다(`_GuardedBdistWheel`, `_GuardedSdist`). wheel이 번들 에셋(locales, skills, optional-mcps, web_dist, tui_dist, 플러그인 매니페스트) 없이 나가기 때문 — 이것들은 런타임에 env-var 오버라이드나 소스 체크아웃 레이아웃으로 해석된다. 개발은 editable install(`uv pip install -e .`)이 전제다.
+
+### `hermes` 실행 시 코드가 도는 순서
+
+`main()`은 `hermes_cli/main.py:13526`에 있지만, 거기 닿기 전에 import 부수효과로 도는 코드가 6단계 있다. 전부 "깨진 설치에서도 살아남기" 위한 방어 로직이다.
+
+| # | 위치 | 하는 일 |
+| --- | --- | --- |
+| **1** | `hermes_cli/__init__.py:92` — `_ensure_utf8()` | **가장 먼저 실행되는 코드.** `hermes_cli.main`을 import하려면 패키지 `__init__.py`가 먼저 돌기 때문 |
+| 2 | `main.py:60` — `import hermes_bootstrap` | Windows UTF-8 stdio (POSIX no-op) |
+| 3 | `main.py:72` — `suppress_platform_ver_console()` | Windows 콘솔 창 깜빡임 억제 |
+| 4 | `main.py:84` — `from hermes_cli import _startup_fast` | sys.path 부트스트랩 (스크립트 모드 대응) |
+| 5 | `main.py:101` — `_early_recovery_mod.recover_if_needed()` | venv 자가 치유 |
+| 6 | `main.py:128` — `_arm_sw()` | 게이트웨이 startup 워치독 무장 |
+| 7 | `main.py:13526` — `main()` | 실제 진입점 |
+
+**1단계가 최초인 이유** — `_ensure_utf8()`은 stdout/stderr가 UTF-8이 아니면 재구성한다. cp1252 Windows 서비스, latin-1/C 로케일 리눅스(최소 Debian, 라즈베리파이)에서 배선 문자(`┌│├└─`)와 `⚕` 글리프 출력이 `UnicodeEncodeError`를 던져 **커맨드가 시작도 못 하고 죽는 것**을 막는다.
+
+`main.py:56` 주석은 "hermes_bootstrap must be the very first import"라고 하지만 엄밀히는 패키지 `__init__.py`가 먼저 돈다. 모순이 아니라 의도된 계층이고, `__init__.py` docstring이 직접 밝힌다 — **`__init__` = 플랫폼 무관 최초 방어선, `hermes_bootstrap` = Windows 전용 후속 레이어**(이미 복구된 스트림에 대해서는 멱등 no-op).
+
+**2·5단계는 "부분 업데이트 생존" 장치**
+- 2단계는 `ModuleNotFoundError`를 삼킨다. `hermes_bootstrap`은 `py-modules`로 등록된 최상위 모듈이라, `hermes update`가 `git reset --hard`와 `uv pip install -e .` 사이에서 죽으면 editable 설치의 `.pth`가 옛 모듈 목록을 가리킨다. 가드가 없으면 hermes가 import에서 크래시하고 **사용자는 복구하려고 `hermes update`를 실행하는 것조차 불가능**해진다.
+- 5단계 `_early_recovery`는 stdlib만 쓴다(망가진 venv에서도 import 안전). 모듈 레벨 서드파티 import보다 **앞에** 있어야 하는 이유는, `main()` 안의 전체 복구 경로에 도달하기 전에 아래쪽 `from hermes_cli.env_loader import ...`가 먼저 크래시하기 때문이다.
+
+**6단계는 argv 형태를 정확히 매칭**
+
+```python
+def _argv_is_gateway_run(argv: list) -> bool:
+    return any(a == "gateway" and b == "run" for a, b in zip(argv, argv[1:]))
+```
+
+**인접한** 토큰 쌍만 매칭한다. `-p <profile>` 같은 전역 플래그가 끼어도 잡히지만, 두 단어를 다른 인자에서 우연히 언급하는 커맨드는 300초 하드 종료 타이머를 무장시키지 않는다. import 시점 데드락(네이티브 확장 초기화, import 락 경합)이 정확히 이 워치독의 대상이라 무거운 import 그래프 **이전에** 무장한다.
+
+### 모듈을 직접 import할 때 — `model_tools`가 진짜 폭탄
+
+`import model_tools`(또는 `import run_agent` — `run_agent.py:183`이 `model_tools`를 import한다)는 모듈 레벨 부수효과로 툴 디스커버리를 발화시킨다(`model_tools.py:230`):
+
+```python
+discover_builtin_tools()   # tools/*.py 전부 import → 각자 registry.register() 호출
+
+try:
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins()      # 사용자/프로젝트/pip 플러그인
+except Exception as e:
+    logger.debug("Plugin discovery failed: %s", e)
+```
+
+`discover_builtin_tools()`는 `tools/`의 모든 `*.py`를 glob해 import한다(`__init__.py`, `registry.py`, `mcp_tool.py` 제외). 파일당 AST 스캔이 ~100개 파일에 ~145ms라 `(mtime_ns, size)` 키로 디스크에 메모이즈한다.
+
+**MCP 디스커버리는 여기서 제외됐다** (#16856). `discover_mcp_tools()`가 내부적으로 `future.result(timeout=120)`으로 블로킹하는데, 게이트웨이가 asyncio 이벤트 루프 안에서 첫 사용자 메시지에 이 모듈을 lazy-import하면서 **Discord/Telegram 하트비트를 최대 120초 얼려버렸기** 때문이다. 지금은 각 진입점이 자기 시작 시점에 명시적으로 실행한다 — `gateway/run.py`는 `run_in_executor`, `cli.py`는 인라인, `tui_gateway/server.py`는 인라인, `acp_adapter/server.py`는 `asyncio.to_thread`.

--- a/docs/RUN_AGENT_TRACE.md
+++ b/docs/RUN_AGENT_TRACE.md
@@ -1,0 +1,336 @@
+# `python run_agent.py` 실행 흐름 추적
+
+분석 기준일: 2026-09-04 · 대상 커밋: `63279301bc` (main)
+
+## 전제: 이건 `hermes`가 타는 경로가 아니다
+
+`run_agent.py`를 직접 실행하는 건 **연구·디버깅용 독립 진입점**입니다. 일반 사용자의 `hermes`는 `hermes_cli/main.py:main()`을 타고, 거기서 `AIAgent`를 생성합니다. 두 경로는 Phase 4부터 합류합니다.
+
+- `hermes` → `hermes_cli/main.py:13526` → 설정/프로필/세션 해석 → `AIAgent(...)`
+- `python run_agent.py` → `fire.Fire(main)` → 최소 파라미터로 `AIAgent(...)`
+
+`run_agent.py`의 `main()`은 `max_turns=10`, OpenRouter 기본값 같은 연구용 프리셋을 씁니다. 프로필, 세션 복원, 스킬 로딩 같은 건 거치지 않습니다.
+
+---
+
+## Phase 0 — 프로세스 시작
+
+파일 맨 끝이 진입점입니다.
+
+```python
+if __name__ == "__main__":
+    import fire
+    fire.Fire(main)
+```
+
+하지만 이 두 줄에 닿기 전에 **모듈 레벨 코드가 전부 먼저 실행**됩니다. 실제 비용의 대부분이 여기 있습니다.
+
+---
+
+## Phase 1 — 모듈 임포트 부수효과 (진짜 무거운 구간)
+
+### 1-1. `hermes_bootstrap` (line 24)
+
+```python
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    pass
+```
+
+Windows UTF-8 stdio 설정. POSIX에서는 no-op. `ModuleNotFoundError`를 삼키는 이유는 `hermes update`가 `git reset --hard`와 `uv pip install -e .` 사이에서 죽었을 때 editable 설치의 `.pth`가 옛 모듈 목록을 가리키기 때문 — 가드가 없으면 여기서 크래시해서 복구 명령조차 못 돌립니다.
+
+### 1-2. 의도적으로 지연시킨 두 임포트
+
+**`OpenAI` SDK는 모듈 top에 없습니다.** SDK가 ~240ms의 임포트를 끌고 오기 때문에, 첫 호출이나 `isinstance` 체크 때 SDK를 로드하는 얇은 프록시 객체로 노출합니다. 이 설계가 지키는 두 가지:
+
+- `_create_openai_client`의 단일 `OpenAI(**client_kwargs)` 호출 지점
+- 약 28개 테스트 파일이 쓰는 `patch("run_agent.OpenAI", ...)` 패턴
+
+**`fire`도 `__main__` 블록 안에서만 임포트**합니다. 라이브러리로 쓸 때는 필요 없고, 데몬 스레드(예: 큐레이터의 fork된 리뷰 에이전트)에서 `run_agent`를 임포트할 때 `fire`가 없는 부분 설치에서 `ModuleNotFoundError`가 나지 않게 하려는 목적입니다.
+
+### 1-3. `model_tools` 임포트 (line 183) — 폭탄
+
+```python
+from model_tools import (...)
+```
+
+`model_tools.py:230`의 모듈 레벨 부수효과가 여기서 발화합니다.
+
+```python
+discover_builtin_tools()   # tools/*.py 전부 import → 각자 registry.register() 호출
+
+try:
+    from hermes_cli.plugins import discover_plugins
+    discover_plugins()      # 사용자/프로젝트/pip 플러그인
+except Exception as e:
+    logger.debug("Plugin discovery failed: %s", e)
+```
+
+`discover_builtin_tools()`는 `tools/`의 모든 `*.py`를 glob해 임포트합니다(`__init__.py`, `registry.py`, `mcp_tool.py` 제외). 파일당 AST 스캔이 ~100개 파일에 ~145ms라 `(mtime_ns, size)` 키로 디스크에 메모이즈합니다.
+
+**MCP 디스커버리는 여기서 빠져 있습니다.** `discover_mcp_tools()`가 내부적으로 `future.result(timeout=120)`으로 블로킹하는데, 게이트웨이가 asyncio 이벤트 루프 안에서 이 모듈을 lazy-import하면서 Discord/Telegram 하트비트를 최대 120초 얼려버렸기 때문입니다. 각 진입점이 자기 시작 시점에 명시적으로 실행합니다.
+
+`run_agent.py`는 `tools.terminal_tool`, `tools.interrupt`, `tools.browser_tool`도 직접 임포트합니다(line 189-191).
+
+---
+
+## Phase 2 — `fire.Fire(main)` — CLI 파싱
+
+`main()`의 시그니처가 그대로 CLI 플래그가 됩니다 (`run_agent.py:9959`).
+
+| 플래그 | 기본값 | 역할 |
+| --- | --- | --- |
+| `--query` | None | 자연어 질의. None이면 Python 3.13 예제 질의로 대체 |
+| `--model` | `""` | 빈 문자열 → `__init__`에서 설정/프로바이더로 해석 |
+| `--max_turns` | 10 | 툴 호출 이터레이션 상한 |
+| `--enabled_toolsets` | None | 쉼표 구분 문자열 → 리스트로 파싱 |
+| `--disabled_toolsets` | None | 쉼표 구분 문자열 → 리스트로 파싱 |
+| `--list_tools` | False | 툴 목록만 출력하고 조기 반환 |
+| `--save_trajectories` | False | `trajectory_samples.jsonl`에 append |
+| `--save_sample` | False | UUID 이름의 단일 JSON 파일로 저장 |
+
+`--list_tools`가 켜지면 툴셋/툴 목록을 출력하고 **`return`으로 끝납니다.** 에이전트는 생성되지 않습니다.
+
+`AIAgent`의 `max_iterations` 기본값은 `sys.maxsize`(무제한)이지만, `main()`은 `max_turns=10`을 넘겨 연구용으로 묶어둡니다.
+
+---
+
+## Phase 3 — `AIAgent` 생성
+
+```python
+agent = AIAgent(
+    base_url=base_url, model=model, api_key=api_key,
+    max_iterations=max_turns,
+    enabled_toolsets=enabled_toolsets_list,
+    disabled_toolsets=disabled_toolsets_list,
+    save_trajectories=save_trajectories,
+    verbose_logging=verbose, log_prefix_chars=log_prefix_chars,
+)
+```
+
+`RuntimeError`만 잡아서 `❌ Failed to initialize agent`로 출력하고 반환합니다. 다른 예외는 그대로 올라갑니다.
+
+`AIAgent.__init__`(`run_agent.py:490`)은 파라미터가 약 60개입니다 — 크리덴셜, 라우팅(`providers_allowed`/`providers_ignored`/`providers_order`), API 모드(`chat_completions` / `codex_responses` / `codex_app_server`), 세션 컨텍스트, 예산, 콜백, 크리덴셜 풀. `main()`이 채우는 건 그중 9개뿐이고 나머지는 기본값으로 해석됩니다.
+
+---
+
+## Phase 4 — `run_conversation()` 진입 (여기서 `hermes` 경로와 합류)
+
+```python
+result = agent.run_conversation(user_query)
+```
+
+`AIAgent.run_conversation`(`run_agent.py:9272`)은 **얇은 포워더**입니다. 루프 본문은 `agent/conversation_loop.py`에 있습니다. 다만 포워더도 그냥 넘기지는 않고, 넘기기 전에 턴 경계 작업을 합니다.
+
+### 4-1. 백그라운드 리뷰 선점
+
+```python
+cancel_background_review_for_live_turn(self)
+```
+
+백그라운드 리뷰는 프롬프트 캐시 패리티를 위해 같은 `session_id`를 공유합니다. 라이브 턴이 시작되면 리뷰 시작을 막거나 이미 들어간 요청을 인터럽트하고, 그 요청이 빠져나갈 때까지 기다린 뒤에야 같은 세션의 Relay/태스크 계측을 엽니다. 리뷰가 정해진 데드라인 안에 응답하지 않으면 포그라운드가 우선권을 유지합니다.
+
+### 4-2. 턴 라이브니스 마킹
+
+```python
+_review_queue.note_turn_started()
+```
+
+지연 리뷰 큐가 두 개의 빠른 프롬프트 사이 틈으로 끼어들지 못하게 합니다.
+
+### 4-3. Durable turn lease (`state.db` 프로세스 간 직렬화)
+
+게이트웨이의 asyncio lease는 한 프로세스 안에서만 별칭 라우팅을 닫습니다. 이 durable lease는 Desktop, CLI resume, 게이트웨이, 백그라운드 전달 프로세스가 **같은 `state.db`를 공유할 때** load → run → flush 구간 전체를 직렬화합니다.
+
+세션 행 존재 여부 확인이 예외로 실패하면 "세션 없음"이 아니라 **있는 것으로 간주하고 lease를 획득**합니다(fail-closed). 락 걸린 읽기가 실패했다고 행이 없다는 증거는 아니기 때문 — 예전에 fail-open으로 처리했다가 정확히 이 경합 지점에서 직렬화 없이 돌았습니다.
+
+### 4-4. 컨텍스트 토큰 세팅
+
+`relay_turn_id` 생성, accounting 컨텍스트, Portal affinity scope, 서브에이전트 부모 바인딩. 전부 `finally`에서 되돌립니다.
+
+---
+
+## Phase 5 — 턴 프롤로그: `build_turn_context()`
+
+`agent/turn_context.py:572`. 한 턴에 한 번만 하는 설정이 전부 여기 모여 있고, `agent` 객체를 변형한 뒤 루프가 읽을 로컬들을 반환합니다.
+
+수행 항목:
+
+- stdio 가드 설치, 재시도 카운터 리셋
+- 유저 메시지 sanitize (surrogate 제거)
+- todo / nudge 하이드레이션
+- **시스템 프롬프트 restore-or-build** — 세션별로 캐싱해서 프리픽스 캐싱을 지킴
+- idle 트리거 압축 (opt-in, `idle_compact_after_seconds`)
+- **preflight 컨텍스트 압축** — 보내기 전에 크기를 줄임
+- `pre_llm_call` 플러그인 훅
+- 외부 메모리 prefetch
+- 크래시 대비 persist
+- `api_content` 사이드카 — "보낸 것을 저장한다"
+
+### 조기 종료 경로: `PreflightCompressionTimedOut`
+
+압축이 호스트 타임아웃에 걸렸는데 요청이 여전히 오버사이즈면, **프로바이더 호출을 아예 보내지 않고** 타입 있는 복구 결과를 반환합니다.
+
+```python
+return {
+    "final_response": _final_response,
+    "messages": list(conversation_history or []),
+    "completed": False,
+    "api_calls": 0,
+    "error": _final_response,
+    "partial": True,
+    "failed": True,
+    "compression_exhausted": True,
+    "turn_exit_reason": "context_compression_timeout",
+}
+```
+
+일반 예외로 흘려보내지 않는 이유: 게이트웨이는 원시 예외 텍스트를 사용자에게 숨기기 때문에, 그러면 "`/compress` 실행 후 재시도" 같은 실행 가능한 안내가 묻히고 `compression_exhausted` 클린 세션 복구 계약도 건너뛰게 됩니다.
+
+이 경로는 인바운드 유저 행을 **의도적으로 저장하지 않습니다.** 게이트웨이가 `compression_exhausted` 결과에 대해 트랜스크립트 저장을 건너뛰어 세션 비대화 루프를 막고, 자동 리셋이 이후 입력을 클린 세션으로 옮깁니다.
+
+### 분기: `codex_app_server` 모드
+
+`agent.api_mode == "codex_app_server"`면 여기서 턴 전체를 Codex 앱 서버 서브프로세스에 넘기고 **기본 Hermes 경로를 완전히 우회**합니다. 터미널·파일 조작·패치가 전부 Codex 안에서 돕니다.
+
+---
+
+## Phase 6 — 메인 루프
+
+`agent/conversation_loop.py:2289`.
+
+```python
+while (api_call_count < agent.max_iterations
+       and agent.iteration_budget.remaining > 0) or agent._budget_grace_call:
+```
+
+`_budget_grace_call`이 `or`로 붙어 있어서, 예산이 소진돼도 **마무리용 1턴 유예 호출**이 가능합니다.
+
+### 이터레이션 구조
+
+**1. 턴 중 유저 개입 흡수**
+
+```python
+_redirect_text = agent._drain_pending_redirect()
+if _redirect_text:
+    _apply_active_turn_redirect(agent, messages, _redirect_text)
+    ...
+    agent._persist_session(messages, conversation_history)
+```
+
+에이전트가 도구를 돌리는 중에 사용자가 새 메시지를 보내면, 다음 이터레이션 진입 시점에 흡수되어 `original_user_message`에 `User correction during the turn:` 형태로 합쳐집니다.
+
+**2. API 호출**
+
+`api_call_count += 1` → `agent._touch_activity(...)` → `step_callback` → `api_request_id = f"{turn_id}:api:{api_call_count}"`로 요청 발행.
+
+**3. 응답 분기**
+
+`finish_reason`에 따라 갈립니다.
+
+- `tool_calls` → 도구 실행 (아래 6-1)
+- `stop` → `_strip_think_blocks()` 후 최종 응답 후보
+- `length` → 연속 이어붙이기(`length_continue_retries`, `truncated_response_parts`)
+
+**4. 회복 경로들**
+
+루프의 상당 부분이 프로바이더 이상 동작 복구입니다.
+
+- **드롭된 tool-call** — Copilot의 claude-opus-4.8/sonnet-4.5가 `finish_reason="tool_calls"`인데 `tool_calls` 배열이 비어서 오는 케이스. 최대 3회 연속까지 재프롬프트하고, 성공한 도구 라운드 후 예산이 리셋됩니다. 재프롬프트 쌍은 `_dropped_toolcall_nudge` 플래그로 표시해 durable 트랜스크립트에 쓰이지 않게 합니다.
+- **Codex ack 연속** — 중간 확인 응답을 최종 답으로 오인하지 않도록 `final_response = None`으로 되돌리고 계속.
+- **압축 재시도** — `max_compression_attempts`(기본 3, `compression.max_attempts`)로 상한. 완료된 압축은 프로바이더 응답이 임계치 미만의 프롬프트를 보고해야만 카운터를 재무장합니다.
+- **아웃터 루프 예외** — `_outer_error_count`가 `_MAX_OUTER_LOOP_ERRORS`를 넘으면 종료.
+
+### 6-1. 도구 실행 — 세그먼트 플래너
+
+단일 호출 지점(`conversation_loop.py:8158`)에서 `run_agent.py:9089`의 라우터로 갑니다.
+
+```
+_execute_tool_calls(assistant_message, messages, task_id, api_call_count)
+  │
+  ├─ len(tool_calls) <= 1 ────────────────→ _execute_tool_calls_sequential
+  │
+  └─ _plan_tool_batch_segments(...)
+       ├─ 세그먼트 1개 & parallel ────────→ _execute_tool_calls_concurrent
+       ├─ 세그먼트 1개 & sequential ──────→ _execute_tool_calls_sequential
+       └─ 혼합 ───────────────────────────→ execute_tool_calls_segmented
+```
+
+세그먼트 플래너는 배치를 **병렬 안전 호출의 최대 연속 구간**(읽기 전용 도구, 겹치지 않는 파일 대상, 병렬 opt-in한 MCP 도구)으로 쪼개고, 그 사이에 순차 배리어(대화형·비안전·미인식 도구)를 둡니다. 동종 배치는 원래의 단일 경로를 유지하고, 혼합 배치만 발행 순서대로 세그먼트 단위 실행해서 안전한 부분집합은 병렬로 돌리면서 부수효과 순서는 보존합니다.
+
+세 함수 모두 `agent/tool_executor.py`의 모듈 레벨 함수를 부르는 포워더이고, 최종적으로 `model_tools.handle_function_call()`에 도달합니다. `tool_executor.py`가 `_ra().handle_function_call`로 원래 모듈을 되짚는 이유는 테스트의 패치를 살리기 위해서입니다.
+
+---
+
+## Phase 7 — `finalize_turn()`
+
+`agent/turn_finalizer.py:138`. 루프가 어떤 이유로 끝났든 여기를 통과합니다.
+
+- `agent._save_trajectory(...)` — 파일 I/O + JSON 직렬화
+- `agent._persist_session(messages, conversation_history)` — SQLite 쓰기
+- 턴 종료 진단 로그 (`_turn_exit_reason`)
+- 메모리 / 스킬 리뷰 넛지 (`_should_review_memory`, `_should_review_skills`)
+
+각 정리 단계는 개별로 예외를 잡아 `_cleanup_errors`에 모읍니다. 예전에는 이 중 하나가 raise하면 결과 전체가 날아갔습니다.
+
+반환 dict의 주요 키: `final_response`, `messages`, `completed`, `api_calls`, `error`, `partial`, `failed`, `turn_exit_reason`.
+
+압축 타임아웃으로 끝난 턴은 반환 직전에 `error` / `partial` / `compression_exhausted`가 덮어씌워집니다.
+
+---
+
+## Phase 8 — `main()`으로 복귀
+
+```python
+print(f"✅ Completed: {result['completed']}")
+print(f"📞 API Calls: {result['api_calls']}")
+print(f"💬 Messages: {len(result['messages'])}")
+```
+
+`--save_sample`이 켜져 있으면 `agent._convert_to_trajectory_format(...)`으로 트라젝토리 형식(batch_runner와 동일)으로 변환해 `sample_<8자리>.json`에 저장합니다. 그리고 `👋 Agent execution completed!`로 종료.
+
+---
+
+## 전체 흐름 요약
+
+```
+python run_agent.py --query="..."
+│
+├─ [P1] 모듈 임포트
+│    ├─ hermes_bootstrap (Windows UTF-8, guarded)
+│    ├─ OpenAI/fire는 지연 (240ms 절약 + 부분설치 방어)
+│    └─ model_tools → discover_builtin_tools() + discover_plugins()
+│
+├─ [P2] fire.Fire(main) — 시그니처가 곧 CLI 플래그
+│    └─ --list_tools면 출력 후 조기 return
+│
+├─ [P3] AIAgent(...) — ~60개 파라미터 중 9개만 지정
+│
+└─ [P4] agent.run_conversation(query)          ← hermes 경로와 합류
+     │
+     ├─ 포워더 (run_agent.py:9272)
+     │    ├─ 백그라운드 리뷰 선점
+     │    ├─ 리뷰 큐 라이브니스 마킹
+     │    ├─ durable turn lease (state.db 직렬화, fail-closed)
+     │    └─ relay/accounting/portal 컨텍스트
+     │
+     ├─ [P5] build_turn_context()  (turn_context.py:572)
+     │    ├─ 시스템 프롬프트 restore-or-build (캐시 보존)
+     │    ├─ preflight 압축 → 타임아웃 시 타입 있는 조기 반환
+     │    ├─ pre_llm_call 훅 + 외부 메모리 prefetch
+     │    └─ api_mode=codex_app_server면 여기서 완전 우회
+     │
+     ├─ [P6] while (예산 남음) or (유예 호출)   (conversation_loop.py:2289)
+     │    ├─ 턴 중 유저 개입 흡수 (_drain_pending_redirect)
+     │    ├─ API 호출
+     │    ├─ finish_reason 분기: tool_calls / stop / length
+     │    ├─ 도구 실행 → 세그먼트 플래너 → tool_executor
+     │    │                              → handle_function_call
+     │    └─ 회복: 드롭된 tool-call, Codex ack, 압축 재시도
+     │
+     └─ [P7] finalize_turn()  (turn_finalizer.py:138)
+          ├─ _save_trajectory
+          ├─ _persist_session
+          └─ 메모리/스킬 리뷰 넛지
+```


### PR DESCRIPTION
Four cross-linked documents for new contributors, written from a read-through of the current tree rather than from AGENTS.md alone:

- ONBOARDING.md — entry point: the two design principles that gate review (prompt-cache invariance, the Footprint Ladder), directory map, core files, turn flow, install/run/test, and the traps that fail silently (bare skipif, JS assertions in the pytest suite, change-detector tests).
- PROJECT_ANALYSIS.md — full structure: architecture, subsystems, UI surface boundaries, dependency-pinning policy, entry points.
- RUN_AGENT_TRACE.md — `python run_agent.py` traced end to end in eight phases, from module-import side effects to finalize_turn.
- CORE_FILES_RANKING.md — the five highest-leverage files and why each ranks where it does.

Notes one discrepancy found while reading: AGENTS.md still describes the core loop as living inside run_conversation(), but that body was extracted to agent/conversation_loop.py and AIAgent.run_conversation (run_agent.py:9272) is now a thin forwarder. The docs point readers at the extracted module; AGENTS.md itself is left untouched here.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

