### PR TITLE
feat(desktop): add an all-gateway profile scope

### DIFF
--- a/apps/desktop/e2e/fleet-profile-rail.spec.ts
+++ b/apps/desktop/e2e/fleet-profile-rail.spec.ts
@@ -279,12 +279,31 @@ test.describe('fleet profile rail — two registered gateways', () => {
       [REMOTE_ID, false],
     ])
 
-    // Fleet pill replaces the default↔all toggle; the single-gateway plug is gone.
-    await expect(rail(page).getByRole('button', { name: 'All profiles on this gateway' })).toBeVisible()
+    // Fleet-wide scope leads the existing current-gateway scope.
+    const allGateways = rail(page).getByRole('button', { name: 'All profiles on all gateways' })
+    const thisGateway = rail(page).getByRole('button', { name: 'All profiles on this gateway' })
+    await expect(allGateways).toBeVisible()
+    await expect(thisGateway).toBeVisible()
+    await allGateways.click()
+    await expect(allGateways).toHaveAttribute('aria-pressed', 'true')
+    await expect(thisGateway).toHaveAttribute('aria-pressed', 'false')
+    await thisGateway.click()
+    await expect(thisGateway).toHaveAttribute('aria-pressed', 'true')
     await expect(rail(page).getByRole('button', { name: 'Manage gateways…' })).toHaveCount(0)
 
     await gatewayGroup(page, REMOTE_ID).getByRole('button', { name: `inbox · ${REMOTE_LABEL}` }).hover()
     await capture(page, '1-on-this-device-hover-inbox-homelab')
+  })
+
+  test('Manage profiles groups profiles from both gateways', async () => {
+    await rail(page).getByRole('button', { name: 'Manage profiles…' }).click()
+
+    await expect(page.getByText('This device', { exact: true }).first()).toBeVisible()
+    await expect(page.getByText(REMOTE_LABEL, { exact: true }).first()).toBeVisible()
+    await expect(page.getByRole('button', { name: 'inbox', exact: true }).first()).toBeVisible()
+    await capture(page, '2-manage-profiles-by-gateway')
+
+    await page.keyboard.press('Escape')
   })
 
   test('clicking an at-rest square re-homes onto that exact gateway and profile', async () => {

--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -308,7 +308,11 @@ import {
   resolveRouteProfile
 } from './profile-delete-routing'
 import { migrateActiveProfileIfMissing as migrateActiveProfileIfMissingPure } from './profile-migration'
-import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
+import {
+  dispatchConnectionScopedProfileRename,
+  prepareProfileRenameLifecycle,
+  profileRenameFromRequest
+} from './profile-rename-routing'
 import {
   buildSidebarSessionSliceParams,
   fetchPrimaryProfileSessions,
@@ -11407,6 +11411,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
   }
 
   const profileKey = String(profile ?? '').trim() || 'default'
+  profileDeletionGate.assertCanStart(profileKey)
   let resolvedRegistrySshConfig
   let registryEffectiveFingerprintPromise: null | Promise<string> = null
 
@@ -16517,6 +16522,18 @@ ipcMain.handle('hermes:api', async (_event, request) => {
   const deletingProfile = profileNameFromDeleteRequest(request)
   const mutatingProfile = deletingProfile || profileRenameFromRequest(request)?.oldName || null
   const registryConnectionId = apiRequestRegistryConnectionId(request)
+
+  if (mutatingProfile && !deletingProfile && registryConnectionId) {
+    return dispatchConnectionScopedProfileRename(request, {
+      acquire: profile => profileDeletionGate.acquire(profile),
+      connectionKind: connectionId => registryConnectionKind(connectionId),
+      dispatch: routeProfile =>
+        dispatchRegistryApiRequest(request, registryConnectionId, routeProfile, mutatingProfile),
+      isValidProfileName: profile => PROFILE_NAME_RE.test(profile),
+      prepareLocal: localRequest => prepareProfileRenameRequest(localRequest),
+      teardownConnection: (connectionId, profile) => teardownConnectionScopedProfileBackend(connectionId, profile)
+    })
+  }
 
   if (deletingProfile && registryConnectionId) {
     return dispatchConnectionScopedProfileDelete(request, {

--- a/apps/desktop/electron/profile-rename-routing.test.ts
+++ b/apps/desktop/electron/profile-rename-routing.test.ts
@@ -3,6 +3,8 @@ import assert from 'node:assert/strict'
 import { test } from 'vitest'
 
 import {
+  type ConnectionScopedProfileRenameDeps,
+  dispatchConnectionScopedProfileRename,
   prepareProfileRenameLifecycle,
   profileRenameFromRequest,
   type ProfileRenameLifecycleDeps
@@ -30,6 +32,41 @@ function lifecycleDeps(events: string[]): ProfileRenameLifecycleDeps {
     },
     writeActiveDesktopProfile: profile => {
       events.push(`write-active:${profile}`)
+    }
+  }
+}
+
+function connectionDeps(events: string[]): ConnectionScopedProfileRenameDeps<string> {
+  return {
+    acquire: profile => {
+      events.push(`gate:${profile}`)
+
+      return () => events.push(`release:${profile}`)
+    },
+    connectionKind: () => 'local',
+    dispatch: async routeProfile => {
+      events.push(`dispatch:${routeProfile ?? 'primary'}`)
+
+      return 'renamed'
+    },
+    isValidProfileName: profile => /^[a-z0-9][a-z0-9_-]{0,63}$/.test(profile),
+    prepareLocal: async request => {
+      events.push(`prepare:${request.connectionId}`)
+
+      return {
+        complete: async () => {
+          events.push('complete')
+        },
+        kind: 'pool',
+        rename: { newName: 'renamed-profile', oldName: 'primary-profile' },
+        rollback: async () => {
+          events.push('rollback')
+        },
+        routeProfile: null
+      }
+    },
+    teardownConnection: async (connectionId, profile) => {
+      events.push(`teardown:${connectionId}:${profile}`)
     }
   }
 }
@@ -129,4 +166,76 @@ test('prepareProfileRenameLifecycle ignores invalid profile names without side e
 
   assert.equal(lifecycle, null)
   assert.deepEqual(events, [])
+})
+
+test('explicit registered local rename runs the local lifecycle under one gate', async () => {
+  const events: string[] = []
+
+  const result = await dispatchConnectionScopedProfileRename(
+    { ...renameRequest, connectionId: 'local', profile: 'primary-profile' },
+    connectionDeps(events)
+  )
+
+  assert.equal(result, 'renamed')
+  assert.deepEqual(events, ['gate:primary-profile', 'prepare:local', 'dispatch:primary', 'complete', 'release:primary-profile'])
+})
+
+test('connection-scoped rename validates its connection and old/new names before side effects', async () => {
+  const events: string[] = []
+  const deps = connectionDeps(events)
+
+  await assert.rejects(dispatchConnectionScopedProfileRename(renameRequest, deps), /requires a connection/i)
+  await assert.rejects(
+    dispatchConnectionScopedProfileRename(
+      { ...renameRequest, body: { new_name: 'not valid!' }, connectionId: 'local' },
+      deps
+    ),
+    /invalid profile rename/i
+  )
+  assert.deepEqual(events, [])
+})
+
+test('explicit registered SSH rename tears down its exact source backend before owner dispatch', async () => {
+  const events: string[] = []
+  const deps = connectionDeps(events)
+  deps.connectionKind = () => 'ssh'
+  deps.prepareLocal = async () => assert.fail('SSH rename must not use the local lifecycle')
+
+  const result = await dispatchConnectionScopedProfileRename(
+    { ...renameRequest, connectionId: 'build-host', profile: 'primary-profile' },
+    deps
+  )
+
+  assert.equal(result, 'renamed')
+  assert.deepEqual(events, [
+    'gate:primary-profile',
+    'teardown:build-host:primary-profile',
+    'dispatch:primary',
+    'release:primary-profile'
+  ])
+})
+
+test('explicit local rename rolls back before releasing its gate when dispatch fails', async () => {
+  const events: string[] = []
+  const deps = connectionDeps(events)
+
+  deps.dispatch = async () => {
+    events.push('dispatch:failed')
+    throw new Error('rename failed')
+  }
+
+  await assert.rejects(
+    dispatchConnectionScopedProfileRename(
+      { ...renameRequest, connectionId: 'local', profile: 'primary-profile' },
+      deps
+    ),
+    /rename failed/
+  )
+  assert.deepEqual(events, [
+    'gate:primary-profile',
+    'prepare:local',
+    'dispatch:failed',
+    'rollback',
+    'release:primary-profile'
+  ])
 })

--- a/apps/desktop/electron/profile-rename-routing.ts
+++ b/apps/desktop/electron/profile-rename-routing.ts
@@ -2,8 +2,10 @@ import { profileNameFromPath } from './profile-delete-routing'
 
 export interface ProfileRenameRequest {
   body?: unknown
+  connectionId?: unknown
   method?: unknown
   path?: unknown
+  profile?: unknown
 }
 
 export interface ProfileRename {
@@ -27,6 +29,15 @@ export interface ProfileRenameLifecycle {
   rename: ProfileRename
   rollback: () => Promise<void>
   routeProfile: null
+}
+
+export interface ConnectionScopedProfileRenameDeps<T> {
+  acquire: (profile: string) => () => void
+  connectionKind: (connectionId: string) => string
+  dispatch: (routeProfile: null) => Promise<T>
+  isValidProfileName: (profile: string) => boolean
+  prepareLocal: (request: ProfileRenameRequest) => Promise<ProfileRenameLifecycle | null>
+  teardownConnection: (connectionId: string, profile: string) => Promise<void>
 }
 
 function parseJsonBody(body: unknown): Record<string, unknown> {
@@ -69,6 +80,53 @@ export function profileRenameFromRequest(request: ProfileRenameRequest | null | 
   }
 
   return { newName, oldName }
+}
+
+export async function dispatchConnectionScopedProfileRename<T>(
+  request: ProfileRenameRequest,
+  deps: ConnectionScopedProfileRenameDeps<T>
+): Promise<T> {
+  const rename = profileRenameFromRequest(request)
+  const connectionId = String(request.connectionId ?? '').trim()
+  const logicalProfile = String(request.profile ?? '').trim() || rename?.oldName || ''
+
+  if (!connectionId || !rename) {
+    throw new Error('Connection-scoped profile rename requires a connection and old/new profile names.')
+  }
+
+  if (!deps.isValidProfileName(rename.oldName) || !deps.isValidProfileName(rename.newName)) {
+    throw new Error('Invalid profile rename.')
+  }
+
+  const connectionKind = deps.connectionKind(connectionId)
+  const release = deps.acquire(rename.oldName)
+
+  try {
+    const lifecycle = connectionKind === 'local' ? await deps.prepareLocal(request) : null
+
+    if (connectionKind === 'local' && !lifecycle) {
+      throw new Error('Unable to prepare local profile rename.')
+    }
+
+    if (connectionKind !== 'local') {
+      await deps.teardownConnection(connectionId, logicalProfile)
+    }
+
+    let response: T
+
+    try {
+      response = await deps.dispatch(lifecycle?.routeProfile ?? null)
+    } catch (error) {
+      await lifecycle?.rollback()
+      throw error
+    }
+
+    await lifecycle?.complete()
+
+    return response
+  } finally {
+    release()
+  }
 }
 
 export async function prepareProfileRenameLifecycle(

--- a/apps/desktop/src/api/profiles.test.ts
+++ b/apps/desktop/src/api/profiles.test.ts
@@ -1,0 +1,26 @@
+import { beforeEach, expect, it, vi } from 'vitest'
+
+vi.mock('./client', () => ({
+  capabilityScoped: vi.fn(scope => scope),
+  hermesApi: vi.fn(),
+  STARTUP_REQUEST_TIMEOUT_MS: 60_000
+}))
+
+const client = await import('./client')
+const { createProfile, getProfilesForScope } = await import('./profiles')
+const hermesApi = vi.mocked(client.hermesApi)
+
+beforeEach(() => vi.clearAllMocks())
+
+it('routes profile reads and creates to an explicitly selected gateway', async () => {
+  hermesApi.mockResolvedValue({ profiles: [] } as never)
+  const scope = { connectionId: 'cloud' }
+
+  await getProfilesForScope(scope)
+  await createProfile({ clone_from: null, name: 'worker' }, scope)
+
+  expect(hermesApi.mock.calls.map(([request]) => request)).toEqual([
+    expect.objectContaining({ connectionId: 'cloud', path: '/api/profiles' }),
+    expect.objectContaining({ connectionId: 'cloud', method: 'POST', path: '/api/profiles' })
+  ])
+})

--- a/apps/desktop/src/api/profiles.ts
+++ b/apps/desktop/src/api/profiles.ts
@@ -15,8 +15,20 @@ export function getProfiles(): Promise<ProfilesResponse> {
   })
 }
 
-export function createProfile(body: ProfileCreatePayload): Promise<{ name: string; ok: boolean; path: string }> {
+export function getProfilesForScope(scope: ProfileScope): Promise<ProfilesResponse> {
+  return hermesApi<ProfilesResponse>({
+    ...capabilityScoped(scope),
+    path: '/api/profiles',
+    timeoutMs: STARTUP_REQUEST_TIMEOUT_MS
+  })
+}
+
+export function createProfile(
+  body: ProfileCreatePayload,
+  scope?: ProfileScope
+): Promise<{ name: string; ok: boolean; path: string }> {
   return hermesApi<{ name: string; ok: boolean; path: string }>({
+    ...(scope === undefined ? {} : capabilityScoped(scope)),
     path: '/api/profiles',
     method: 'POST',
     body

--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -1,6 +1,14 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const ownerBackfill = vi.hoisted(() => ({ maybeBackfillLegacySessionOwners: vi.fn() }))
+
+const connectionsRegistry = vi.hoisted(() => ({
+  get: vi.fn(() => ({ connections: [], primary: 'primary-gateway', version: 1 }))
+}))
+
 vi.mock('@/lib/gateway-rpc', () => ({ isMissingRestEndpoint: () => false }))
+vi.mock('@/lib/legacy-session-owner-backfill', () => ownerBackfill)
+vi.mock('@/store/connection-registry-state', () => ({ $connectionsRegistry: connectionsRegistry }))
 vi.mock('@/store/transcript-tail', () => ({ recordTranscriptTail: vi.fn() }))
 vi.mock('./client', () => ({
   capabilityScoped: vi.fn(),
@@ -11,8 +19,14 @@ vi.mock('./client', () => ({
 
 const client = await import('./client')
 
-const { deleteSession, setSessionArchived, setSessionPinnedRemote, setSessionUnreadRemote, listSidebarSessions } =
-  await import('./sessions')
+const {
+  deleteSession,
+  listAllProfileSessions,
+  listSidebarSessions,
+  setSessionArchived,
+  setSessionPinnedRemote,
+  setSessionUnreadRemote
+} = await import('./sessions')
 
 const hermesApi = vi.mocked(client.hermesApi)
 
@@ -153,6 +167,26 @@ describe('setSessionPinnedRemote / setSessionUnreadRemote profile scoping', () =
 })
 
 describe('listSidebarSessions remote ownership', () => {
+  it('drops the ambient source only for the all-gateways scope', async () => {
+    hermesApi.mockResolvedValue({
+      cron: { sessions: [] },
+      messaging: { sessions: [] },
+      recents: { sessions: [] }
+    } as never)
+
+    await listSidebarSessions({
+      allConnections: true,
+      recentsProfile: 'all',
+      recentsLimit: 40,
+      recentsExclude: [],
+      cronLimit: 20,
+      messagingLimit: 40,
+      messagingExclude: []
+    })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({ connectionId: '' })
+  })
+
   it('stamps active remote rows so a later resume stays on their gateway', async () => {
     hermesApi.mockResolvedValue({
       cron: { sessions: [] },
@@ -172,5 +206,51 @@ describe('listSidebarSessions remote ownership', () => {
     })
 
     expect(result.recents.sessions[0]).toMatchObject({ connection_id: 'prometheus', id: 'remote-session' })
+  })
+
+  it('stamps untagged fleet rows with the primary while preserving remote owners', async () => {
+    hermesApi.mockResolvedValue({
+      cron: { sessions: [] },
+      messaging: { sessions: [] },
+      recents: {
+        sessions: [
+          { id: 'primary-session', profile: 'default' },
+          { connection_id: 'remote-gateway', id: 'remote-session', profile: 'default' }
+        ]
+      }
+    } as never)
+
+    const result = await listSidebarSessions({
+      allConnections: true,
+      recentsProfile: 'all',
+      recentsLimit: 40,
+      recentsExclude: [],
+      cronLimit: 20,
+      messagingLimit: 40,
+      messagingExclude: []
+    })
+
+    expect(result.recents.sessions).toMatchObject([
+      { connection_id: 'primary-gateway', id: 'primary-session' },
+      { connection_id: 'remote-gateway', id: 'remote-session' }
+    ])
+    expect(ownerBackfill.maybeBackfillLegacySessionOwners).toHaveBeenCalledWith('primary-gateway')
+  })
+})
+
+describe('listAllProfileSessions fleet ownership', () => {
+  it('uses the registry primary instead of the ambient foreground connection', async () => {
+    hermesApi.mockResolvedValue({
+      has_more: false,
+      limit: 40,
+      offset: 0,
+      sessions: [{ id: 'primary-session', profile: 'default' }],
+      total: 1
+    } as never)
+
+    const result = await listAllProfileSessions(40, 0, 'exclude', 'recent', 'all', {}, true)
+
+    expect(result.sessions[0]).toMatchObject({ connection_id: 'primary-gateway', id: 'primary-session' })
+    expect(ownerBackfill.maybeBackfillLegacySessionOwners).toHaveBeenCalledWith('primary-gateway')
   })
 })

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -52,6 +52,21 @@ function stampActiveConnectionOwner(sessions: SessionInfo[]): SessionInfo[] {
   return stampRowsWithOwningConnection(sessions, getApiRequestConnection())
 }
 
+async function stampResponseOwner(sessions: SessionInfo[], allConnections: boolean): Promise<SessionInfo[]> {
+  if (!allConnections) {
+    return stampActiveConnectionOwner(sessions)
+  }
+
+  const { $connectionsRegistry } = await import('@/store/connection-registry-state')
+  const primaryConnectionId = $connectionsRegistry.get()?.primary
+
+  if (primaryConnectionId) {
+    maybeBackfillLegacySessionOwners(primaryConnectionId)
+  }
+
+  return stampRowsWithOwningConnection(sessions, primaryConnectionId)
+}
+
 /**
  * Trim a page to its window WITHOUT discarding pinned rows.
  *
@@ -112,7 +127,8 @@ export async function listAllProfileSessions(
   archived: 'exclude' | 'include' | 'only' = 'exclude',
   order: 'created' | 'recent' = 'recent',
   profile: 'all' | (string & {}) = 'all',
-  filter: SessionSourceFilter = {}
+  filter: SessionSourceFilter = {},
+  allConnections = false
 ): Promise<PaginatedSessions> {
   const sourceParam = filter.source ? `&source=${encodeURIComponent(filter.source)}` : ''
 
@@ -122,6 +138,9 @@ export async function listAllProfileSessions(
 
   const result = await hermesApi<PaginatedSessions>({
     ...profileScoped(),
+    // ponytail: an empty explicit id cancels the ambient source and reaches
+    // Electron's existing fleet aggregator; no second session-fetch stack.
+    ...(allConnections ? { connectionId: '' } : {}),
     path:
       `/api/profiles/sessions?limit=${limit}&offset=0&min_messages=${Math.max(0, minMessages)}` +
       `&archived=${archived}&order=${order}&profile=${encodeURIComponent(profile)}${sourceParam}${excludeParam}`,
@@ -130,7 +149,7 @@ export async function listAllProfileSessions(
 
   return {
     ...result,
-    sessions: pageWindow(stampActiveConnectionOwner(result.sessions), limit),
+    sessions: pageWindow(await stampResponseOwner(result.sessions, allConnections), limit),
     offset: 0
   }
 }
@@ -180,6 +199,8 @@ export interface SidebarSessionsResponse {
 }
 
 export interface SidebarSessionsRequest {
+  /** Bypass the active registry source so Electron can aggregate every connected gateway. */
+  allConnections?: boolean
   recentsProfile: 'all' | (string & {})
   recentsLimit: number
   recentsExclude: string[]
@@ -212,13 +233,33 @@ export function resetSidebarBatchCapability() {
 // interception as the pre-batching desktop, so remote profiles stay correct.
 async function listSidebarSessionsLegacy(req: SidebarSessionsRequest): Promise<SidebarSessionsResponse> {
   const [recents, cron, messaging] = await Promise.all([
-    listAllProfileSessions(req.recentsLimit, 1, 'exclude', 'recent', req.recentsProfile, {
-      excludeSources: req.recentsExclude
-    }),
-    listAllProfileSessions(req.cronLimit, 1, 'exclude', 'recent', req.recentsProfile, { source: 'cron' }),
-    listAllProfileSessions(req.messagingLimit, 1, 'exclude', 'recent', req.recentsProfile, {
-      excludeSources: req.messagingExclude
-    })
+    listAllProfileSessions(
+      req.recentsLimit,
+      1,
+      'exclude',
+      'recent',
+      req.recentsProfile,
+      { excludeSources: req.recentsExclude },
+      req.allConnections
+    ),
+    listAllProfileSessions(
+      req.cronLimit,
+      1,
+      'exclude',
+      'recent',
+      req.recentsProfile,
+      { source: 'cron' },
+      req.allConnections
+    ),
+    listAllProfileSessions(
+      req.messagingLimit,
+      1,
+      'exclude',
+      'recent',
+      req.recentsProfile,
+      { excludeSources: req.messagingExclude },
+      req.allConnections
+    )
   ])
 
   const recentsErrors = recents.errors ?? []
@@ -284,6 +325,9 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   try {
     result = await hermesApi<SidebarSessionsResponse>({
       ...profileScoped(),
+      // Empty overrides hermesApi's ambient connection tag, selecting the
+      // existing Electron fleet aggregator rather than the foreground gateway.
+      ...(req.allConnections ? { connectionId: '' } : {}),
       path: `/api/profiles/sessions/sidebar?${params.toString()}`,
       timeoutMs: SESSION_LIST_REQUEST_TIMEOUT_MS
     })
@@ -303,17 +347,17 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   return {
     recents: {
       ...result.recents,
-      sessions: stampActiveConnectionOwner(result.recents?.sessions ?? []),
+      sessions: await stampResponseOwner(result.recents?.sessions ?? [], Boolean(req.allConnections)),
       ...(result.errors?.length ? { errors: result.errors } : {})
     },
     cron: {
       ...result.cron,
-      sessions: stampActiveConnectionOwner(result.cron?.sessions ?? []),
+      sessions: await stampResponseOwner(result.cron?.sessions ?? [], Boolean(req.allConnections)),
       ...(result.errors?.length ? { errors: result.errors } : {})
     },
     messaging: {
       ...result.messaging,
-      sessions: stampActiveConnectionOwner(result.messaging?.sessions ?? []),
+      sessions: await stampResponseOwner(result.messaging?.sessions ?? [], Boolean(req.allConnections)),
       ...(result.errors?.length ? { errors: result.errors } : {})
     },
     errors: result.errors

--- a/apps/desktop/src/app/chat/sidebar/index.tsx
+++ b/apps/desktop/src/app/chat/sidebar/index.tsx
@@ -30,7 +30,7 @@ import { resolveProfileColor } from '@/lib/profile-color'
 import { sessionMatchesSearch } from '@/lib/session-search'
 import { normalizeSessionSource, sessionSourceLabel } from '@/lib/session-source'
 import { cn } from '@/lib/utils'
-import { $activeConnectionId } from '@/store/connections'
+import { $activeConnectionId, $connectionsRegistry } from '@/store/connections'
 import { $cronJobs } from '@/store/cron'
 import { $bindings } from '@/store/keybinds'
 import {
@@ -78,6 +78,7 @@ import {
   $profileColors,
   $profiles,
   $profileScope,
+  $showAllGateways,
   ALL_PROFILES,
   messagingTotalsKey,
   normalizeProfileKey,
@@ -391,7 +392,9 @@ export function ChatSidebar({
   const profiles = useStore($profiles)
   const profileColors = useStore($profileColors)
   const profileScope = useStore($profileScope)
+  const showAllGateways = useStore($showAllGateways)
   const activeConnectionId = useStore($activeConnectionId)
+  const connectionsRegistry = useStore($connectionsRegistry)
 
   // Toggle the persisted read-state watermark from a row menu. The row's own
   // `unread` prop mirrors what the dot paints; flip it and let the backend
@@ -1263,14 +1266,24 @@ export function ChatSidebar({
     }
 
     const groups = new Map<string, SidebarSessionGroup>()
+    const fleetScope = showAllGateways && profileScope === ALL_PROFILES
+
+    const connectionLabels = new Map(
+      (connectionsRegistry?.connections ?? []).map(connection => [connection.id, connection.label])
+    )
+
+    const primaryConnectionId = connectionsRegistry?.primary || activeConnectionId || 'local'
 
     for (const session of agentSessions) {
-      const key = normalizeProfileKey(session.profile)
+      const profile = normalizeProfileKey(session.profile)
+      const connectionId = session.connection_id || primaryConnectionId
+      const key = fleetScope ? `${connectionId}::${profile}` : profile
+      const gateway = connectionLabels.get(connectionId) || connectionId
 
       const group = groups.get(key) ?? {
-        color: resolveProfileColor(key, profileColors),
+        color: resolveProfileColor(profile, profileColors),
         id: key,
-        label: key,
+        label: fleetScope ? t.profiles.fleet.onGateway(profile, gateway) : profile,
         mode: 'profile',
         path: null,
         sessions: []
@@ -1281,11 +1294,23 @@ export function ChatSidebar({
       groups.set(key, group)
     }
 
-    // default (root) first, then the rest alphabetically.
-    return [...groups.values()].sort((a, b) =>
-      a.id === 'default' ? -1 : b.id === 'default' ? 1 : a.label.localeCompare(b.label)
-    )
-  }, [profileGrouped, agentSessions, profileColors])
+    // Default profiles first, then gateway-qualified labels alphabetically.
+    return [...groups.values()].sort((a, b) => {
+      const aDefault = a.id === 'default' || a.id.endsWith('::default')
+      const bDefault = b.id === 'default' || b.id.endsWith('::default')
+
+      return aDefault !== bDefault ? (aDefault ? -1 : 1) : a.label.localeCompare(b.label)
+    })
+  }, [
+    activeConnectionId,
+    agentSessions,
+    connectionsRegistry,
+    profileColors,
+    profileGrouped,
+    profileScope,
+    showAllGateways,
+    t.profiles.fleet
+  ])
 
   // The flat Sessions list always shows ALL recent sessions; Projects is a
   // parallel grouped view, not a filter on this one — nothing is hidden here.
@@ -1353,9 +1378,9 @@ export function ChatSidebar({
   // fetch its own set.
   useEffect(() => {
     if (showArchived) {
-      void loadArchivedSessions()
+      void loadArchivedSessions(profileScope === ALL_PROFILES && showAllGateways)
     }
-  }, [showArchived])
+  }, [profileScope, showAllGateways, showArchived])
 
   // Ranking by size is a question about the whole list ("what did I burn money
   // on"), so it drops the calendar dividers and ranks globally — "Today" above

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-connect.test.tsx
@@ -49,6 +49,7 @@ vi.mock('@/store/profile', () => ({
   $profileOrder: atom([]),
   $profiles: atom([{ is_default: true, name: 'default' }]),
   $profileScope: atom('default'),
+  $showAllGateways: atom(false),
   ALL_PROFILES: '*',
   normalizeProfileKey: (name: string) => name,
   profileLabel: (profile: { display_name?: string; name: string }) =>

--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -15,6 +15,7 @@ import { ProfileRail } from './profile-switcher'
 const navigate = vi.fn()
 const selectConnection = vi.fn()
 const selectProfile = vi.fn()
+const setShowAllProfiles = vi.fn()
 const getAgentRoster = vi.fn()
 
 vi.mock('react-router', () => ({
@@ -37,6 +38,7 @@ vi.mock('@/i18n', () => ({
         failedLoadSoul: 'Failed to load SOUL.md',
         failedSaveSoul: 'Failed to save SOUL.md',
         fleet: {
+          allOnAllGateways: 'All profiles on all gateways',
           allOnGateway: 'All profiles on this gateway',
           deleteOn: (gateway: string) => ` on ${gateway}`,
           gateway: (gateway: string) => `Profiles on ${gateway}`,
@@ -73,6 +75,7 @@ vi.mock('@/store/profile', () => ({
   $profileOrder: atom([]),
   $profiles: atom([{ is_default: true, name: 'default' }]),
   $profileScope: atom('default'),
+  $showAllGateways: atom(false),
   ALL_PROFILES: '*',
   normalizeProfileKey: (name: string) => name,
   profileLabel: (profile: { display_name?: string; name: string }) =>
@@ -81,7 +84,7 @@ vi.mock('@/store/profile', () => ({
   selectProfile: (name: string) => selectProfile(name),
   setProfileColor: vi.fn(),
   setProfileOrder: vi.fn(),
-  setShowAllProfiles: vi.fn(),
+  setShowAllProfiles: (...args: unknown[]) => setShowAllProfiles(...args),
   sortByProfileOrder: (profiles: unknown[]) => profiles
 }))
 
@@ -123,9 +126,10 @@ const connectionsRegistry = connectionsStore.$connectionsRegistry as ReturnType<
   typeof atom<DesktopConnectionsRegistry | null>
 >
 
-const { $profiles, $profileScope } = await import('@/store/profile')
+const { $profiles, $profileScope, $showAllGateways } = await import('@/store/profile')
 const profiles = $profiles as ReturnType<typeof atom<Array<{ is_default: boolean; name: string }>>>
 const profileScope = $profileScope as ReturnType<typeof atom<string>>
+const showAllGateways = $showAllGateways as ReturnType<typeof atom<boolean>>
 const { _resetFleetRosterForTests } = await import('@/store/fleet-roster')
 
 const registry: DesktopConnectionsRegistry = {
@@ -208,6 +212,7 @@ afterEach(() => {
   connectionsRegistry.set(null)
   activeConnectionId.set(null)
   profileScope.set('default')
+  showAllGateways.set(false)
   profiles.set([{ is_default: true, name: 'default' }])
   delete (window as { hermesDesktop?: unknown }).hermesDesktop
 })
@@ -257,8 +262,14 @@ describe('ProfileRail fleet mode', () => {
     expect(screen.getByRole('button', { name: 'scout' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'default' })).toBeTruthy()
 
-    // Fleet pill: "all on this gateway" replaces the default↔all toggle.
-    expect(screen.getByRole('button', { name: 'All profiles on this gateway' })).toBeTruthy()
+    // Fleet scope pills: global first, then the existing current-gateway scope.
+    const global = screen.getByRole('button', { name: 'All profiles on all gateways' })
+    const current = screen.getByRole('button', { name: 'All profiles on this gateway' })
+    expect(global.compareDocumentPosition(current) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy()
+    fireEvent.click(global)
+    expect(setShowAllProfiles).toHaveBeenLastCalledWith(true, 'fleet')
+    fireEvent.click(current)
+    expect(setShowAllProfiles).toHaveBeenLastCalledWith(true)
     expect(screen.queryByRole('button', { name: 'Manage gateways…' })).toBeNull()
   })
 

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -72,6 +72,7 @@ import {
   $profileOrder,
   $profiles,
   $profileScope,
+  $showAllGateways,
   ALL_PROFILES,
   normalizeProfileKey,
   profileLabel,
@@ -150,6 +151,7 @@ export function ProfileRail() {
   const p = t.profiles
   const profiles = useStore($profiles)
   const scope = useStore($profileScope)
+  const showAllGateways = useStore($showAllGateways)
   const gatewayProfile = useStore($activeGatewayProfile)
   const order = useStore($profileOrder)
   const colors = useStore($profileColors)
@@ -404,11 +406,19 @@ export function ProfileRail() {
       data-tour="profile-rail"
       role="group"
     >
-      {/* Fleet: every gateway carries its own home square inside its group, so
-          the pinned pill is purely the "all profiles on this gateway" toggle. */}
+      {/* Fleet: the global scope leads, immediately before the existing
+          "all profiles on this gateway" scope. */}
       {fleet && (
         <ProfilePill
-          active={isAll}
+          active={isAll && showAllGateways}
+          glyph="globe"
+          label={p.fleet.allOnAllGateways}
+          onSelect={() => setShowAllProfiles(true, 'fleet')}
+        />
+      )}
+      {fleet && (
+        <ProfilePill
+          active={isAll && !showAllGateways}
           glyph="layers"
           label={p.fleet.allOnGateway}
           onSelect={() => setShowAllProfiles(true)}

--- a/apps/desktop/src/app/contrib/wiring.tsx
+++ b/apps/desktop/src/app/contrib/wiring.tsx
@@ -52,6 +52,7 @@ import {
   $activeGatewayProfile,
   $freshSessionRequest,
   $profileScope,
+  $showAllGateways,
   ALL_PROFILES,
   ensureGatewayProfile,
   newSessionInProfile,
@@ -231,6 +232,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   const activeConnectionId = useStore($activeConnectionId)
   const activeGatewayProfile = useStore($activeGatewayProfile)
   const profileScope = useStore($profileScope)
+  const showAllGateways = useStore($showAllGateways)
   const boot = useStore($desktopBoot)
 
   const routedSessionId = routeSessionId(location.pathname)
@@ -314,7 +316,7 @@ export function ContribWiring({ children }: { children: ReactNode }) {
   )
 
   const { loadMoreMessagingForPlatform, loadMoreSessions, refreshCronJobs, refreshMessagingSessions, refreshSessions } =
-    useSessionListActions({ profileScope })
+    useSessionListActions({ allConnections: profileScope === ALL_PROFILES && showAllGateways, profileScope })
 
   const updateActiveSessionRuntimeInfo = useCallback(
     (info: { branch?: string; cwd?: string }) => {

--- a/apps/desktop/src/app/profiles/create-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/create-profile-dialog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 
+import type { ProfileScope } from '@/api/client'
 import { ActionStatus } from '@/components/ui/action-status'
 import { Button } from '@/components/ui/button'
 import {
@@ -33,12 +34,14 @@ export function CreateProfileDialog({
   onClose,
   onCreated,
   open,
-  profiles = []
+  profiles = [],
+  scope
 }: {
   onClose: () => void
   onCreated?: (name: string) => Promise<void> | void
   open: boolean
   profiles?: ProfileInfo[]
+  scope?: ProfileScope
 }) {
   const { t } = useI18n()
   const p = t.profiles
@@ -77,10 +80,12 @@ export function CreateProfileDialog({
     setError(null)
 
     try {
-      await createProfile({ name: trimmed, clone_from: cloneFrom })
+      await (scope == null
+        ? createProfile({ name: trimmed, clone_from: cloneFrom })
+        : createProfile({ name: trimmed, clone_from: cloneFrom }, scope))
 
       if (soul.trim()) {
-        await updateProfileSoul(trimmed, soul)
+        await (scope == null ? updateProfileSoul(trimmed, soul) : updateProfileSoul(trimmed, soul, scope))
       }
 
       await onCreated?.(trimmed)

--- a/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/delete-profile-dialog.tsx
@@ -2,7 +2,11 @@ import type { ProfileScope } from '@/api/client'
 import { ConfirmDialog } from '@/components/ui/confirm-dialog'
 import { deleteProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import {
+  activeGatewayConnectionId,
+  retireAgentGateways,
+  retireLocalProfileGateways
+} from '@/store/gateway'
 import { $activeGatewayProfile, normalizeProfileKey, selectProfile, setActiveProfile } from '@/store/profile'
 import { dropTilesForProfile } from '@/store/session-states'
 
@@ -59,22 +63,31 @@ export function DeleteProfileDialog({
         // backend. Capture that before the delete; reset *after* the host's
         // onDeleted refresh so our reset is the last write — a refreshActiveProfile
         // racing the (still-dying) backend can't clobber the pill back to it.
-        const remote = scope !== undefined && scope !== null
+        const scopedConnection = scope && typeof scope === 'object' ? String(scope.connectionId ?? '').trim() : ''
+        const scoped = scope !== undefined && scope !== null
+        const sameProfile = normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
 
         const wasActive =
-          !remote && normalizeProfileKey(profile.name) === normalizeProfileKey($activeGatewayProfile.get())
+          sameProfile && (!scopedConnection || scopedConnection === String(activeGatewayConnectionId() ?? '').trim())
 
-        if (!remote) {
+        if (scope == null) {
           retireLocalProfileGateways(profile.name)
+        } else if (typeof scope === 'object') {
+          retireAgentGateways(scope.connectionId ?? null, profile.name)
         }
 
         // Legacy arity when unscoped: callers and tests pin the one-arg call.
-        await (remote ? deleteProfile(profile.name, scope) : deleteProfile(profile.name))
+        await (scoped ? deleteProfile(profile.name, scope) : deleteProfile(profile.name))
         // The profile is gone. Drop its persisted tiles now — a leftover
         // session/Bot tile restores on relaunch and dials the deleted
         // profile's backend, whose ensure_hermes_home() re-creates the
         // directory the delete just removed (hermes-agent#94235).
-        dropTilesForProfile(profile.name)
+        dropTilesForProfile(
+          profile.name,
+          scope && typeof scope === 'object'
+            ? { connectionId: scope.connectionId ?? undefined, profile: profile.name }
+            : undefined
+        )
         await onDeleted?.()
 
         if (wasActive) {

--- a/apps/desktop/src/app/profiles/index.test.tsx
+++ b/apps/desktop/src/app/profiles/index.test.tsx
@@ -2,7 +2,8 @@ import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-libra
 import type * as Nanostores from 'nanostores'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { deleteProfile } from '@/hermes'
+import { deleteProfile, getProfilesForScope } from '@/hermes'
+import { $connectionsRegistry } from '@/store/connections'
 import { retireLocalProfileGateways } from '@/store/gateway'
 import { refreshProfiles, selectProfile, setActiveProfile } from '@/store/profile'
 import type { ProfileInfo } from '@/types/hermes'
@@ -16,8 +17,6 @@ import { ProfilesView } from './index'
 // stranding it on a dead backend. The drift that motivated the fix got in
 // precisely because nothing rendered this view.
 
-afterEach(cleanup)
-
 // Real i18n (useI18n falls back to English with no provider), so labels are the
 // actual strings — no brittle key snapshot to maintain here.
 
@@ -30,6 +29,7 @@ vi.mock('@/components/chat/code-editor', () => ({
 vi.mock('@/hermes', () => ({
   createProfile: vi.fn(async () => ({ name: 'x', ok: true, path: '/x' })),
   deleteProfile: vi.fn(async () => ({ ok: true, path: '/x' })),
+  getProfilesForScope: vi.fn(async () => ({ profiles: [] })),
   getProfileSoul: vi.fn(async () => ({ content: '', exists: true })),
   renameProfile: vi.fn(async () => ({ name: 'x', ok: true, path: '/x' })),
   updateProfileSoul: vi.fn(async () => ({ ok: true }))
@@ -41,6 +41,8 @@ vi.mock('@/store/notifications', () => ({
 }))
 
 vi.mock('@/store/gateway', () => ({
+  activeGatewayConnectionId: vi.fn(() => null),
+  retireAgentGateways: vi.fn(),
   retireLocalProfileGateways: vi.fn()
 }))
 
@@ -53,6 +55,22 @@ const { $activeGatewayProfile: activeGateway, $profileColors } = vi.hoisted(() =
   }
 })
 
+const connectionStores = vi.hoisted(() => {
+  const { atom } = require('nanostores') as typeof Nanostores
+
+  return {
+    active: atom<null | string>(null),
+    multiple: atom(false),
+    registry: atom(null)
+  }
+})
+
+vi.mock('@/store/connections', () => ({
+  $activeConnectionId: connectionStores.active,
+  $connectionsRegistry: connectionStores.registry,
+  $hasMultipleConnections: connectionStores.multiple
+}))
+
 vi.mock('@/store/profile', () => ({
   $activeGatewayProfile: activeGateway,
   $profileColors,
@@ -63,6 +81,14 @@ vi.mock('@/store/profile', () => ({
   selectProfile: vi.fn(),
   setActiveProfile: vi.fn()
 }))
+
+afterEach(() => {
+  cleanup()
+  $connectionsRegistry.set(null)
+  connectionStores.active.set(null)
+  connectionStores.multiple.set(false)
+  vi.clearAllMocks()
+})
 
 // The one non-default profile these tests act on. Its name doubles as the row's
 // accessible name, so the delete helper queries by it rather than a literal.
@@ -78,6 +104,18 @@ function makeProfile(name: string, isDefault = false): ProfileInfo {
     provider: null,
     skill_count: 0
   }
+}
+
+function deferred<T>() {
+  let reject!: (error: unknown) => void
+  let resolve!: (value: T) => void
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
 }
 
 // Radix's trigger opens on the pointerdown/up pair, not the synthetic click
@@ -119,6 +157,80 @@ async function deleteTheNamedProfile() {
 }
 
 describe('ProfilesView', () => {
+  it('loads and groups profiles from every registered gateway', async () => {
+    connectionStores.multiple.set(true)
+    $connectionsRegistry.set({
+      connections: [
+        { id: 'local', kind: 'local', label: 'This device' },
+        { id: 'cloud', kind: 'cloud', label: 'Cloud' }
+      ],
+      launchMode: 'primary',
+      lastUsed: 'local',
+      primary: 'local',
+      version: 2
+    } as never)
+    vi.mocked(getProfilesForScope).mockImplementation(async scope => ({
+      profiles:
+        typeof scope === 'object' && scope?.connectionId === 'cloud'
+          ? [makeProfile('cloud-work')]
+          : [makeProfile('local-work')]
+    }))
+
+    await renderProfilesView()
+
+    expect((await screen.findAllByRole('button', { name: 'local-work' })).length).toBeGreaterThan(0)
+    expect((await screen.findAllByRole('button', { name: 'cloud-work' })).length).toBeGreaterThan(0)
+    expect(screen.getAllByText('This device').length).toBeGreaterThan(0)
+    expect(screen.getAllByText('Cloud').length).toBeGreaterThan(0)
+    expect(getProfilesForScope).toHaveBeenCalledWith({ connectionId: 'local' })
+    expect(getProfilesForScope).toHaveBeenCalledWith({ connectionId: 'cloud' })
+  })
+
+  it('ignores an older fleet refresh after a newer refresh finishes', async () => {
+    connectionStores.multiple.set(true)
+    connectionStores.active.set('local')
+
+    const registry = {
+      connections: [
+        { id: 'local', kind: 'local', label: 'This device' },
+        { id: 'cloud', kind: 'cloud', label: 'Cloud' }
+      ],
+      launchMode: 'primary',
+      lastUsed: 'local',
+      primary: 'local',
+      version: 2
+    } as never
+
+    $connectionsRegistry.set(registry)
+    const oldLocal = deferred<{ profiles: ProfileInfo[] }>()
+    const oldCloud = deferred<{ profiles: ProfileInfo[] }>()
+    let request = 0
+    vi.mocked(getProfilesForScope).mockImplementation(async scope => {
+      const connectionId = typeof scope === 'object' ? scope?.connectionId : undefined
+      request += 1
+
+      if (request <= 2) {
+        return connectionId === 'local' ? oldLocal.promise : oldCloud.promise
+      }
+
+      return { profiles: [makeProfile(`new-${connectionId}`, connectionId === 'cloud')] }
+    })
+
+    await renderProfilesView()
+    await act(async () => connectionStores.active.set('cloud'))
+    expect(await screen.findByRole('heading', { name: 'new-cloud' })).toBeTruthy()
+
+    await act(async () => {
+      oldLocal.resolve({ profiles: [makeProfile('stale-local', true)] })
+      oldCloud.reject(new Error('offline'))
+      await Promise.allSettled([oldLocal.promise, oldCloud.promise])
+    })
+
+    expect(screen.queryByText('stale-local')).toBeNull()
+    expect(screen.queryByText('Cloud · unreachable')).toBeNull()
+    expect(screen.getByRole('heading', { name: 'new-cloud' })).toBeTruthy()
+  })
+
   it('opens the shared create dialog with the SOUL.md field (parity with the rail)', async () => {
     vi.mocked(refreshProfiles).mockResolvedValue([])
 

--- a/apps/desktop/src/app/profiles/index.tsx
+++ b/apps/desktop/src/app/profiles/index.tsx
@@ -1,17 +1,21 @@
 import { useStore } from '@nanostores/react'
 import type * as React from 'react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 
+import type { ProfileScope } from '@/api/client'
 import { CodeEditor } from '@/components/chat/code-editor'
 import { PageLoader } from '@/components/page-loader'
 import { Button } from '@/components/ui/button'
 import { ProfileGlyph } from '@/components/ui/profile-glyph'
-import { getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
+import type { DesktopRegistryConnection } from '@/global'
+import { getProfilesForScope, getProfileSoul, type ProfileInfo, updateProfileSoul } from '@/hermes'
 import { useI18n } from '@/i18n'
+import { sortConnectionsForDisplay } from '@/lib/connection-display'
 import { displayPath } from '@/lib/display-path'
 import { AlertTriangle, Save } from '@/lib/icons'
 import { resolveProfileColor } from '@/lib/profile-color'
 import { normalize } from '@/lib/text'
+import { $activeConnectionId, $connectionsRegistry, $hasMultipleConnections } from '@/store/connections'
 import { notify, notifyError } from '@/store/notifications'
 import { $profileColors, profileLabel, refreshProfiles } from '@/store/profile'
 
@@ -39,31 +43,107 @@ interface ProfilesViewProps {
   onClose: () => void
 }
 
+interface ProfileEntry {
+  connectionId: string
+  connectionLabel: string
+  profile: ProfileInfo
+}
+
+const entryKey = (entry: ProfileEntry) => `${entry.connectionId || 'ambient'}::${entry.profile.name}`
+
 export function ProfilesView({ onClose }: ProfilesViewProps) {
   const { t } = useI18n()
   const p = t.profiles
-  const [profiles, setProfiles] = useState<null | ProfileInfo[]>(null)
-  const [selectedName, setSelectedName] = useState<null | string>(null)
+  const registry = useStore($connectionsRegistry)
+  const multipleConnections = useStore($hasMultipleConnections)
+  const activeConnectionId = useStore($activeConnectionId)
+
+  const sources = useMemo(
+    () => (multipleConnections ? sortConnectionsForDisplay(registry?.connections ?? []) : []),
+    [multipleConnections, registry]
+  )
+
+  const [entries, setEntries] = useState<null | ProfileEntry[]>(null)
+  const [failedConnections, setFailedConnections] = useState<Set<string>>(new Set())
+  const [selectedKey, setSelectedKey] = useState<null | string>(null)
   const [query, setQuery] = useState('')
-  const [createOpen, setCreateOpen] = useState(false)
-  const [pendingRename, setPendingRename] = useState<null | ProfileInfo>(null)
-  const [pendingDelete, setPendingDelete] = useState<null | ProfileInfo>(null)
+  const [createOn, setCreateOn] = useState<null | string>(null)
+  const [pendingRename, setPendingRename] = useState<null | ProfileEntry>(null)
+  const [pendingDelete, setPendingDelete] = useState<null | ProfileEntry>(null)
+  const refreshGeneration = useRef(0)
 
   const refresh = useCallback(async () => {
-    try {
-      const list = await refreshProfiles()
-      setProfiles(list)
-      setSelectedName(current => {
-        if (current && list.some(p => p.name === current)) {
-          return current
+    const generation = ++refreshGeneration.current
+
+    if (!multipleConnections) {
+      try {
+        const profiles = await refreshProfiles()
+
+        if (generation !== refreshGeneration.current) {
+          return
         }
 
-        return list.find(p => p.is_default)?.name ?? list[0]?.name ?? null
-      })
-    } catch (err) {
-      notifyError(err, p.failedLoad)
+        const next = profiles.map(profile => ({ connectionId: '', connectionLabel: '', profile }))
+        setEntries(next)
+        setFailedConnections(new Set())
+        setSelectedKey(current =>
+          current && next.some(entry => entryKey(entry) === current)
+            ? current
+            : next[0]
+              ? entryKey(next.find(entry => entry.profile.is_default) ?? next[0])
+              : null
+        )
+      } catch (error) {
+        if (generation === refreshGeneration.current) {
+          notifyError(error, p.failedLoad)
+        }
+      }
+
+      return
     }
-  }, [p])
+
+    const results = await Promise.all(
+      sources.map(async source => {
+        try {
+          const profiles = (await getProfilesForScope({ connectionId: source.id })).profiles
+
+          return {
+            entries: profiles.map(profile => ({
+              connectionId: source.id,
+              connectionLabel: source.label,
+              profile
+            })),
+            failed: false,
+            source
+          }
+        } catch {
+          return { entries: [] as ProfileEntry[], failed: true, source }
+        }
+      })
+    )
+
+    const next = results.flatMap(result => result.entries)
+    const failed = new Set(results.filter(result => result.failed).map(result => result.source.id))
+
+    if (generation !== refreshGeneration.current) {
+      return
+    }
+
+    setEntries(next)
+    setFailedConnections(failed)
+    setSelectedKey(current => {
+      if (current && next.some(entry => entryKey(entry) === current)) {
+        return current
+      }
+
+      const preferred =
+        next.find(entry => entry.connectionId === activeConnectionId && entry.profile.is_default) ??
+        next.find(entry => entry.profile.is_default) ??
+        next[0]
+
+      return preferred ? entryKey(preferred) : null
+    })
+  }, [activeConnectionId, multipleConnections, p.failedLoad, sources])
 
   useRefreshHotkey(refresh)
 
@@ -71,45 +151,78 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
     void refresh()
   }, [refresh])
 
-  const selected = useMemo(() => {
-    if (!profiles) {
-      return null
-    }
+  const selected = useMemo(
+    () => entries?.find(entry => entryKey(entry) === selectedKey) ?? entries?.[0] ?? null,
+    [entries, selectedKey]
+  )
 
-    return profiles.find(p => p.name === selectedName) ?? profiles[0] ?? null
-  }, [profiles, selectedName])
-
-  const visibleProfiles = useMemo(() => {
+  const visibleEntries = useMemo(() => {
     const q = normalize(query)
 
-    if (!profiles || !q) {
-      return profiles ?? []
+    if (!entries || !q) {
+      return entries ?? []
     }
 
-    return profiles.filter(
-      profile => profile.name.toLowerCase().includes(q) || (profile.model ?? '').toLowerCase().includes(q)
+    return entries.filter(
+      entry =>
+        entry.profile.name.toLowerCase().includes(q) ||
+        (entry.profile.model ?? '').toLowerCase().includes(q) ||
+        entry.connectionLabel.toLowerCase().includes(q)
     )
-  }, [profiles, query])
+  }, [entries, query])
 
-  // The shared Create/Rename dialogs own the createProfile / renameProfile /
-  // updateProfileSoul calls; the panel just selects the resulting profile and
-  // re-pulls the list.
+  const scopeFor = (connectionId: string, profile?: string): ProfileScope =>
+    multipleConnections ? { connectionId, profile } : undefined
+
   const selectAndRefresh = useCallback(
-    async (name: string) => {
-      setSelectedName(name)
+    async (connectionId: string, name: string) => {
+      setSelectedKey(`${connectionId || 'ambient'}::${name}`)
       await refresh()
     },
     [refresh]
   )
 
+  const menuFor = (entry: ProfileEntry): PanelMenuItem[] =>
+    entry.profile.is_default
+      ? [{ icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(entry) }]
+      : [
+          { icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(entry) },
+          { icon: 'trash', label: t.common.delete, onSelect: () => setPendingDelete(entry), tone: 'danger' }
+        ]
+
+  const renderRows = (source: null | DesktopRegistryConnection) => {
+    const connectionId = source?.id ?? ''
+    const rows = visibleEntries.filter(entry => entry.connectionId === connectionId)
+
+    return (
+      <Fragment key={connectionId || 'ambient'}>
+        {source ? <PanelSectionLabel>{source.label}</PanelSectionLabel> : null}
+        {rows.map(entry => (
+          <ProfileRow
+            active={selected ? entryKey(selected) === entryKey(entry) : false}
+            key={entryKey(entry)}
+            menuItems={menuFor(entry)}
+            onSelect={() => setSelectedKey(entryKey(entry))}
+            profile={entry.profile}
+          />
+        ))}
+        {source && failedConnections.has(source.id) ? (
+          <p className="px-3 py-2 text-xs text-muted-foreground">{p.fleet.gatewayUnreachable(source.label)}</p>
+        ) : (
+          <PanelAddButton label={p.newProfile} onClick={() => setCreateOn(connectionId)} />
+        )}
+      </Fragment>
+    )
+  }
+
   return (
     <Panel closeLabel={p.close} onClose={onClose}>
-      {!profiles ? (
+      {!entries ? (
         <PageLoader label={p.loading} />
-      ) : profiles.length === 0 ? (
+      ) : entries.length === 0 && !multipleConnections ? (
         <PanelEmpty
           action={
-            <Button onClick={() => setCreateOpen(true)} size="sm">
+            <Button onClick={() => setCreateOn('')} size="sm">
               {p.newProfile}
             </Button>
           }
@@ -119,7 +232,7 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
         />
       ) : (
         <>
-          <PanelHeader subtitle={p.count(profiles.length)} title={p.title} />
+          <PanelHeader subtitle={p.count(entries.length)} title={p.title} />
           <PanelBody>
             <PanelList
               onSearchChange={setQuery}
@@ -127,34 +240,16 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
               searchPlaceholder={p.search}
               searchValue={query}
             >
-              {visibleProfiles.map(profile => (
-                <ProfileRow
-                  active={selected?.name === profile.name}
-                  key={profile.name}
-                  menuItems={
-                    profile.is_default
-                      ? // Renaming the default profile sets a presentation-only
-                        // display name (the canonical id stays "default").
-                        [{ icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(profile) }]
-                      : [
-                          { icon: 'edit', label: p.renameMenu, onSelect: () => setPendingRename(profile) },
-                          {
-                            icon: 'trash',
-                            label: t.common.delete,
-                            onSelect: () => setPendingDelete(profile),
-                            tone: 'danger'
-                          }
-                        ]
-                  }
-                  onSelect={() => setSelectedName(profile.name)}
-                  profile={profile}
-                />
-              ))}
-              <PanelAddButton label={p.newProfile} onClick={() => setCreateOpen(true)} />
+              {multipleConnections ? sources.map(source => renderRows(source)) : renderRows(null)}
             </PanelList>
 
             {selected ? (
-              <ProfileDetail key={selected.name} profile={selected} />
+              <ProfileDetail
+                connectionId={multipleConnections ? selected.connectionId : null}
+                connectionLabel={multipleConnections ? selected.connectionLabel : ''}
+                key={entryKey(selected)}
+                profile={selected.profile}
+              />
             ) : (
               <PanelEmpty description={p.selectPrompt} icon="account" />
             )}
@@ -163,28 +258,32 @@ export function ProfilesView({ onClose }: ProfilesViewProps) {
       )}
 
       <RenameProfileDialog
-        currentName={pendingRename?.name ?? ''}
-        isDefault={pendingRename?.is_default ?? false}
+        currentName={pendingRename?.profile.name ?? ''}
+        isDefault={pendingRename?.profile.is_default ?? false}
         onClose={() => setPendingRename(null)}
-        onRenamed={selectAndRefresh}
+        onRenamed={name => selectAndRefresh(pendingRename?.connectionId ?? '', name)}
         open={pendingRename !== null}
+        scope={pendingRename ? scopeFor(pendingRename.connectionId, pendingRename.profile.name) : undefined}
       />
 
       <CreateProfileDialog
-        onClose={() => setCreateOpen(false)}
-        onCreated={selectAndRefresh}
-        open={createOpen}
-        profiles={profiles ?? []}
+        onClose={() => setCreateOn(null)}
+        onCreated={name => selectAndRefresh(createOn ?? '', name)}
+        open={createOn !== null}
+        profiles={(entries ?? []).filter(entry => entry.connectionId === (createOn ?? '')).map(entry => entry.profile)}
+        scope={createOn !== null ? scopeFor(createOn) : undefined}
       />
 
       <DeleteProfileDialog
+        gatewayLabel={multipleConnections ? pendingDelete?.connectionLabel : undefined}
         onClose={() => setPendingDelete(null)}
         onDeleted={async () => {
-          setSelectedName(null)
+          setSelectedKey(null)
           await refresh()
         }}
         open={pendingDelete !== null}
-        profile={pendingDelete}
+        profile={pendingDelete?.profile ?? null}
+        scope={pendingDelete ? scopeFor(pendingDelete.connectionId, pendingDelete.profile.name) : undefined}
       />
     </Panel>
   )
@@ -223,7 +322,15 @@ function ProfileRow({
   )
 }
 
-function ProfileDetail({ profile }: { profile: ProfileInfo }) {
+function ProfileDetail({
+  connectionId,
+  connectionLabel,
+  profile
+}: {
+  connectionId: null | string
+  connectionLabel: string
+  profile: ProfileInfo
+}) {
   const { t } = useI18n()
   const p = t.profiles
 
@@ -235,6 +342,7 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
             <h3 className="text-[0.95rem] font-semibold tracking-tight text-foreground">{profileLabel(profile)}</h3>
             {profile.is_default && <PanelPill tone="good">{p.defaultBadge}</PanelPill>}
             {profile.has_env && <PanelPill tone="muted">.env</PanelPill>}
+            {connectionLabel ? <PanelPill tone="muted">{connectionLabel}</PanelPill> : null}
           </div>
           <p
             className="mt-1 truncate font-mono text-[0.66rem] text-muted-foreground/55"
@@ -262,12 +370,12 @@ function ProfileDetail({ profile }: { profile: ProfileInfo }) {
         />
       </header>
 
-      <SoulEditor profileName={profile.name} />
+      <SoulEditor connectionId={connectionId} profileName={profile.name} />
     </PanelDetail>
   )
 }
 
-function SoulEditor({ profileName }: { profileName: string }) {
+function SoulEditor({ connectionId, profileName }: { connectionId: null | string; profileName: string }) {
   const { t } = useI18n()
   const p = t.profiles
   const [content, setContent] = useState('')
@@ -275,11 +383,12 @@ function SoulEditor({ profileName }: { profileName: string }) {
   const [loading, setLoading] = useState(true)
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<null | string>(null)
-  const requestRef = useRef<string>(profileName)
+  const requestRef = useRef(`${connectionId ?? 'ambient'}::${profileName}`)
+  const requestKey = `${connectionId ?? 'ambient'}::${profileName}`
 
   // eslint-disable-next-line no-restricted-syntax -- legitimate non-atom ref write (see eslint rule comment)
   useEffect(() => {
-    requestRef.current = profileName
+    requestRef.current = requestKey
     setLoading(true)
     setError(null)
     setContent('')
@@ -287,23 +396,25 @@ function SoulEditor({ profileName }: { profileName: string }) {
 
     void (async () => {
       try {
-        const soul = await getProfileSoul(profileName)
+        const soul = connectionId
+          ? await getProfileSoul(profileName, { connectionId, profile: profileName })
+          : await getProfileSoul(profileName)
 
-        if (requestRef.current === profileName) {
+        if (requestRef.current === requestKey) {
           setContent(soul.content)
           setOriginal(soul.content)
         }
       } catch (err) {
-        if (requestRef.current === profileName) {
+        if (requestRef.current === requestKey) {
           setError(err instanceof Error ? err.message : p.failedLoadSoul)
         }
       } finally {
-        if (requestRef.current === profileName) {
+        if (requestRef.current === requestKey) {
           setLoading(false)
         }
       }
     })()
-  }, [p, profileName])
+  }, [connectionId, p.failedLoadSoul, profileName, requestKey])
 
   const dirty = content !== original
 
@@ -312,7 +423,12 @@ function SoulEditor({ profileName }: { profileName: string }) {
     setError(null)
 
     try {
-      await updateProfileSoul(profileName, content)
+      if (connectionId) {
+        await updateProfileSoul(profileName, content, { connectionId, profile: profileName })
+      } else {
+        await updateProfileSoul(profileName, content)
+      }
+
       setOriginal(content)
       notify({ kind: 'success', title: p.soulSaved, message: profileName })
     } catch (err) {
@@ -340,7 +456,7 @@ function SoulEditor({ profileName }: { profileName: string }) {
             filePath="SOUL.md"
             framed
             initialValue={content}
-            key={profileName}
+            key={requestKey}
             onChange={setContent}
             onSave={() => void handleSave()}
           />

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.test.tsx
@@ -22,6 +22,7 @@ vi.mock('@/hermes', () => ({
 }))
 
 vi.mock('@/store/gateway', () => ({
+  retireAgentGateways: vi.fn(),
   retireLocalProfileGateways: vi.fn()
 }))
 

--- a/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
+++ b/apps/desktop/src/app/profiles/rename-profile-dialog.tsx
@@ -17,7 +17,7 @@ import { renameProfile } from '@/hermes'
 import { useI18n } from '@/i18n'
 import { AlertTriangle } from '@/lib/icons'
 import { slug } from '@/lib/sanitize'
-import { retireLocalProfileGateways } from '@/store/gateway'
+import { retireAgentGateways, retireLocalProfileGateways } from '@/store/gateway'
 
 import { isValidProfileName } from './create-profile-dialog'
 
@@ -90,8 +90,12 @@ export function RenameProfileDialog({
       // backend teardown as a transient drop and redial, resurrecting the
       // old-name backend whose ensure_hermes_home() recreates the directory
       // the rename just moved (same class as the delete path, #88638).
-      if (!isDefault && scope == null) {
-        retireLocalProfileGateways(currentName)
+      if (!isDefault) {
+        if (scope == null) {
+          retireLocalProfileGateways(currentName)
+        } else if (typeof scope === 'object') {
+          retireAgentGateways(scope.connectionId ?? null, currentName)
+        }
       }
 
       await (scope == null ? renameProfile(currentName, trimmed) : renameProfile(currentName, trimmed, scope))

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.test.tsx
@@ -465,6 +465,19 @@ describe('refreshSessions batches slices into one request', () => {
     expect($messagingSessions.get().map(s => s.id)).toEqual(['m1'])
   })
 
+  it('requests the Electron fleet aggregator for the all-gateways scope', async () => {
+    listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
+    const { result } = renderHook(() => useSessionListActions({ allConnections: true, profileScope: '__all__' }))
+
+    await act(async () => {
+      await result.current.refreshSessions()
+    })
+
+    expect(listSidebarSessions).toHaveBeenCalledWith(
+      expect.objectContaining({ allConnections: true, recentsProfile: 'all' })
+    )
+  })
+
   it('forwards the active profile scope + section limits to the batched call', async () => {
     listSidebarSessions.mockResolvedValue(sidebar({ sessions: [] }))
     const { result } = renderHook(() => useSessionListActions({ profileScope: 'work' }))
@@ -675,7 +688,8 @@ describe('messaging profile scope', () => {
       'exclude',
       'recent',
       'work',
-      expect.objectContaining({ excludeSources: expect.any(Array) })
+      expect.objectContaining({ excludeSources: expect.any(Array) }),
+      false
     )
     expect($messagingSessions.get().map(s => s.id)).toEqual(['m1'])
   })

--- a/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-list-actions.ts
@@ -105,21 +105,24 @@ function sessionsToKeep(scope?: string): Set<string> {
 }
 
 interface UseSessionListActionsArgs {
+  allConnections?: boolean
   profileScope: string
 }
 
 /** Owns the sidebar's session-list fetching + paging: recents, cron runs/jobs,
  *  and the per-platform messaging slices. Returns the callbacks the controller
  *  wires into the sidebar and refresh effects. */
-export function useSessionListActions({ profileScope }: UseSessionListActionsArgs) {
+export function useSessionListActions({ allConnections = false, profileScope }: UseSessionListActionsArgs) {
   const profileScopeRef = useRef(profileScope)
+  const allConnectionsRef = useRef(allConnections)
   const loadMoreMessagingRequestRef = useRef<Record<string, number>>({})
   const refreshMessagingSessionsRequestRef = useRef(0)
   const refreshSessionsRequestRef = useRef(0)
 
   useLayoutEffect(() => {
     profileScopeRef.current = profileScope
-  }, [profileScope])
+    allConnectionsRef.current = allConnections
+  }, [allConnections, profileScope])
 
   /** Refresh the active profile's messaging-platform sidebar slice. */
   const refreshMessagingSessions = useCallback(async () => {
@@ -128,7 +131,10 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
     // A callback captured before a profile switch may still be queued by an
     // event subscription. Do not let it start a request against the old scope.
-    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    if (
+      sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
+      allConnectionsRef.current !== allConnections
+    ) {
       return
     }
 
@@ -136,13 +142,20 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     refreshMessagingSessionsRequestRef.current = requestId
 
     try {
-      const result = await listAllProfileSessions(MESSAGING_SECTION_LIMIT, 1, 'exclude', 'recent', sessionProfile, {
-        excludeSources: MESSAGING_EXCLUDED_SOURCES
-      })
+      const result = await listAllProfileSessions(
+        MESSAGING_SECTION_LIMIT,
+        1,
+        'exclude',
+        'recent',
+        sessionProfile,
+        { excludeSources: MESSAGING_EXCLUDED_SOURCES },
+        allConnections
+      )
 
       if (
         refreshMessagingSessionsRequestRef.current !== requestId ||
         sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
+        allConnectionsRef.current !== allConnections ||
         gatewayActivationEpoch() !== activationEpoch
       ) {
         return
@@ -159,7 +172,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the messaging sections just stay empty/stale.
     }
-  }, [profileScope])
+  }, [allConnections, profileScope])
 
   /** Page one messaging platform without replacing another platform's rows. */
   const loadMoreMessagingForPlatform = useCallback(
@@ -190,7 +203,8 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           'exclude',
           'recent',
           sessionProfile,
-          { source: platform }
+          { source: platform },
+          allConnections
         )
       } catch {
         // Non-fatal: leave the platform's loaded rows and total unchanged.
@@ -200,6 +214,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       if (
         loadMoreMessagingRequestRef.current[requestKey] !== requestId ||
         sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
+        allConnectionsRef.current !== allConnections ||
         gatewayActivationEpoch() !== activationEpoch
       ) {
         return
@@ -220,14 +235,17 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
 
       setMessagingPlatformTotals(prev => ({ ...prev, [requestKey]: Math.max(total, incoming.length) }))
     },
-    [profileScope]
+    [allConnections, profileScope]
   )
 
   /** Refresh cron jobs only while the profile that requested them remains active. */
   const refreshCronJobs = useCallback(async () => {
     const sessionProfile = sidebarProfileForScope(profileScope)
 
-    if (sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+    if (
+      sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
+      allConnectionsRef.current !== allConnections
+    ) {
       return
     }
 
@@ -236,7 +254,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
     } catch {
       // Non-fatal: the cron section just keeps its last-known jobs.
     }
-  }, [profileScope])
+  }, [allConnections, profileScope])
 
   /** Refresh every sidebar session slice without committing an obsolete profile response. */
   const refreshSessions = useCallback(
@@ -244,7 +262,11 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       const sessionProfile = sidebarProfileForScope(profileScope)
       const activationEpoch = gatewayActivationEpoch()
 
-      if (!shouldPublish() || sidebarProfileForScope(profileScopeRef.current) !== sessionProfile) {
+      if (
+        !shouldPublish() ||
+        sidebarProfileForScope(profileScopeRef.current) !== sessionProfile ||
+        allConnectionsRef.current !== allConnections
+      ) {
         return
       }
 
@@ -277,6 +299,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
         // source-scoped slices, instead of three separate listAllProfileSessions
         // calls that each reopened + re-counted every profile DB per refresh.
         const result = await listSidebarSessions({
+          allConnections,
           recentsProfile: sessionProfile,
           recentsLimit: limit,
           recentsExclude: SIDEBAR_EXCLUDED_SOURCES,
@@ -289,6 +312,7 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
           shouldPublish() &&
           refreshSessionsRequestRef.current === requestId &&
           sidebarProfileForScope(profileScopeRef.current) === sessionProfile &&
+          allConnectionsRef.current === allConnections &&
           gatewayActivationEpoch() === activationEpoch
         ) {
           const recents = result.recents
@@ -380,11 +404,15 @@ export function useSessionListActions({ profileScope }: UseSessionListActionsArg
       }
 
       // Cron *jobs* are a distinct API (getCronJobs), not a session slice.
-      if (shouldPublish() && sidebarProfileForScope(profileScopeRef.current) === sessionProfile) {
+      if (
+        shouldPublish() &&
+        sidebarProfileForScope(profileScopeRef.current) === sessionProfile &&
+        allConnectionsRef.current === allConnections
+      ) {
         void refreshCronJobs()
       }
     },
-    [profileScope, refreshCronJobs]
+    [allConnections, profileScope, refreshCronJobs]
   )
 
   const loadMoreSessions = useCallback(async () => {

--- a/apps/desktop/src/i18n/ar.ts
+++ b/apps/desktop/src/i18n/ar.ts
@@ -1418,6 +1418,7 @@ export const ar = defineLocale({
     switchToConnection: name => `التبديل إلى ${name}`,
     switchConnectionFailed: name => `تعذّر الاتصال بـ ${name}`,
     manageProfiles: 'إدارة الملفات الشخصية',
+    fleet: { allOnAllGateways: 'جميع الملفات الشخصية على جميع البوابات' },
     remoteOverride: {
       menuItem: 'الاتصال بمضيف بعيد…',
       badge: (host: string) => `يعمل على ${host}`,

--- a/apps/desktop/src/i18n/en.ts
+++ b/apps/desktop/src/i18n/en.ts
@@ -2004,6 +2004,7 @@ export const en: Translations = {
     manageProfiles: 'Manage profiles…',
     connectGateway: 'Manage gateways…',
     fleet: {
+      allOnAllGateways: 'All profiles on all gateways',
       allOnGateway: 'All profiles on this gateway',
       gateway: gateway => `Profiles on ${gateway}`,
       gatewayUnreachable: gateway => `${gateway} · unreachable`,

--- a/apps/desktop/src/i18n/ja.ts
+++ b/apps/desktop/src/i18n/ja.ts
@@ -1686,6 +1686,7 @@ export const ja = defineLocale({
     switchToConnection: name => `${name} に切り替え`,
     switchConnectionFailed: name => `${name} に接続できませんでした`,
     manageProfiles: 'プロファイルを管理…',
+    fleet: { allOnAllGateways: '全ゲートウェイのすべてのプロファイル' },
     remoteOverride: {
       menuItem: 'リモートホストに接続…',
       badge: (host: string) => `${host} で実行中`,

--- a/apps/desktop/src/i18n/ru.ts
+++ b/apps/desktop/src/i18n/ru.ts
@@ -2083,6 +2083,7 @@ export const ru = defineLocale({
     switchToConnection: name => `Переключиться на ${name}`,
     switchConnectionFailed: name => `Не удалось подключиться к ${name}`,
     manageProfiles: 'Управлять профилями…',
+    fleet: { allOnAllGateways: 'Все профили на всех шлюзах' },
     connectGateway: 'Управлять шлюзами…',
     actions: 'Действия',
     color: 'Цвет…',

--- a/apps/desktop/src/i18n/types.ts
+++ b/apps/desktop/src/i18n/types.ts
@@ -1704,6 +1704,7 @@ export interface Translations {
     manageProfiles: string
     connectGateway: string
     fleet: {
+      allOnAllGateways: string
       allOnGateway: string
       gateway: (gateway: string) => string
       gatewayUnreachable: (gateway: string) => string

--- a/apps/desktop/src/i18n/zh-hant.ts
+++ b/apps/desktop/src/i18n/zh-hant.ts
@@ -1617,6 +1617,7 @@ export const zhHant = defineLocale({
     switchToConnection: name => `切換至 ${name}`,
     switchConnectionFailed: name => `無法連線至 ${name}`,
     manageProfiles: '管理設定檔…',
+    fleet: { allOnAllGateways: '所有閘道上的所有設定檔' },
     remoteOverride: {
       menuItem: '連線至遠端主機…',
       badge: (host: string) => `執行於 ${host}`,

--- a/apps/desktop/src/i18n/zh.ts
+++ b/apps/desktop/src/i18n/zh.ts
@@ -2174,6 +2174,7 @@ export const zh: Translations = {
     manageProfiles: '管理配置档案…',
     connectGateway: '管理网关…',
     fleet: {
+      allOnAllGateways: '所有网关上的全部配置档案',
       allOnGateway: '此网关上的全部配置档案',
       gateway: gateway => `${gateway} 上的配置档案`,
       gatewayUnreachable: gateway => `${gateway} · 无法连接`,

--- a/apps/desktop/src/lib/legacy-session-owner-backfill.test.ts
+++ b/apps/desktop/src/lib/legacy-session-owner-backfill.test.ts
@@ -1,6 +1,24 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
+const api = vi.hoisted(() => ({
+  getApiRequestConnection: vi.fn(() => 'secondary-gateway'),
+  hermesApi: vi.fn(async () => ({ ok: true, profile: 'default', stamped: 0 }))
+}))
+
+vi.mock('@/api/client', () => api)
+vi.mock('@/lib/gateway-rpc', () => ({ isMissingRestEndpoint: () => false }))
+vi.mock('@/store/connection-registry-state', () => ({
+  $connectionsRegistry: { get: () => ({ connections: [{ id: 'local' }, { id: 'secondary-gateway' }] }) },
+  hasRegistryTopology: () => true
+}))
+
+import { maybeBackfillLegacySessionOwners, resetLegacyOwnerBackfillAttempts } from './legacy-session-owner-backfill'
 import { resolveLegacyOwnerBackfillScope } from './session-owner-stamp'
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resetLegacyOwnerBackfillAttempts()
+})
 
 describe('resolveLegacyOwnerBackfillScope (#94724 single-match owner backfill)', () => {
   it('targets the serving registered connection (the backend that serves a page owns its rows)', () => {
@@ -76,4 +94,13 @@ describe('resolveLegacyOwnerBackfillScope (#94724 single-match owner backfill)',
       })
     ).toBeNull()
   })
+})
+
+it('pins an explicit local primary backfill instead of inheriting the ambient remote', () => {
+  maybeBackfillLegacySessionOwners('local')
+
+  expect(api.hermesApi).toHaveBeenCalledWith(
+    expect.objectContaining({ connectionId: 'local', method: 'POST', path: '/api/sessions/owner-backfill' })
+  )
+  expect(api.getApiRequestConnection).not.toHaveBeenCalled()
 })

--- a/apps/desktop/src/lib/legacy-session-owner-backfill.ts
+++ b/apps/desktop/src/lib/legacy-session-owner-backfill.ts
@@ -44,13 +44,13 @@ function scopeKey(connectionId: null | string, profile: null | string): string {
  * synchronous-cheap on the no-op paths (no registry topology, scope already
  * attempted) and never blocks or fails the list request that triggered it.
  */
-export function maybeBackfillLegacySessionOwners(): void {
+export function maybeBackfillLegacySessionOwners(servingConnectionId = getApiRequestConnection()): void {
   const scope = resolveLegacyOwnerBackfillScope({
     hasRegistryTopology: hasRegistryTopology(),
     registryConnectionIds: ($connectionsRegistry.get()?.connections ?? []).map(
       (connection: { id: string }) => connection.id
     ),
-    servingConnectionId: getApiRequestConnection()
+    servingConnectionId
   })
 
   if (!scope) {
@@ -65,8 +65,10 @@ export function maybeBackfillLegacySessionOwners(): void {
 
   attemptedScopes.add(key)
 
+  const requestConnectionId = String(servingConnectionId ?? '').trim() || scope.connectionId
+
   void hermesApi<{ ok: boolean; profile: string; stamped: number }>({
-    ...(scope.connectionId ? { connectionId: scope.connectionId } : {}),
+    ...(requestConnectionId ? { connectionId: requestConnectionId } : {}),
     ...(scope.profile ? { profile: scope.profile } : {}),
     path: '/api/sessions/owner-backfill',
     method: 'POST',

--- a/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
+++ b/apps/desktop/src/store/gateway-connection-lifecycle.test.ts
@@ -65,6 +65,7 @@ const {
   pruneSecondaryGateways,
   reconnectSecondaryGateways,
   retainGatewayForAgent,
+  retireAgentGateways,
   retireLocalProfileGateways,
   setPrimaryGateway
 } = await import('./gateway')
@@ -347,6 +348,24 @@ describe('retireLocalProfileGateways', () => {
     expect(gatewayMocks.instances).toHaveLength(2)
     expect(gatewayMocks.instances[0].close).toHaveBeenCalledOnce()
     expect(gatewayMocks.instances[1].close).not.toHaveBeenCalled()
+  })
+})
+
+describe('retireAgentGateways', () => {
+  it('retires only the owning remote profile and preserves same-named siblings', async () => {
+    installDesktop({
+      getConnectionFor: vi.fn(async ({ connectionId, profile }: { connectionId: string; profile: string }) =>
+        descriptorFor(connectionId, profile)
+      )
+    })
+
+    await ensureGatewayForAgent('alpha', 'work')
+    await ensureGatewayForAgent('beta', 'work')
+
+    retireAgentGateways('beta', 'work')
+
+    expect(gatewayMocks.instances[0].close).not.toHaveBeenCalled()
+    expect(gatewayMocks.instances[1].close).toHaveBeenCalledOnce()
   })
 })
 

--- a/apps/desktop/src/store/gateway.ts
+++ b/apps/desktop/src/store/gateway.ts
@@ -1795,6 +1795,35 @@ export function retireLocalProfileGateways(profile: string): void {
   }
 }
 
+/** Retire one profile's retained socket without touching a same-named profile
+ * on another registered gateway. */
+export function retireAgentGateways(connectionId: null | string, profile: string): void {
+  const id = String(connectionId ?? '').trim()
+  const key = normKey(profile)
+
+  if (!id || id === 'local') {
+    retireLocalProfileGateways(key)
+
+    return
+  }
+
+  const scope = registryBackendScopeKey(id, key)
+  const entry = g.secondaries.get(scope)
+
+  if (!entry) {
+    return
+  }
+
+  const activeInvalidated = scope === g.activeKey
+  disposeSecondary(entry)
+  g.secondaries.delete(scope)
+  restoreActiveToPrimaryIfEvicted()
+
+  if (activeInvalidated) {
+    g.config?.onActiveConnectionInvalidated?.(g.primaryProfile, gatewayActivationEpoch())
+  }
+}
+
 // Registry lifecycle: a connection was removed or materially edited. Removal
 // disposes every scoped secondary immediately (a removed remote/cloud source
 // has no local process to die, so otherwise its WebSocket streams ghost

--- a/apps/desktop/src/store/profile.ts
+++ b/apps/desktop/src/store/profile.ts
@@ -766,12 +766,15 @@ export const messagingTotalsKey = (messagingProfile: string, sourceId: string): 
   `${messagingProfile}:${sourceId}`
 
 const SHOW_ALL_PROFILES_STORAGE_KEY = 'hermes.desktop.showAllProfiles'
+const SHOW_ALL_GATEWAYS_STORAGE_KEY = 'hermes.desktop.showAllGateways'
 
 // Opt-in unified view. When false, scope follows the live gateway profile, so
 // single-profile users (who never see the switcher) are completely unaffected.
 export const $showAllProfiles = atom<boolean>(storedBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, false))
+export const $showAllGateways = atom<boolean>(storedBoolean(SHOW_ALL_GATEWAYS_STORAGE_KEY, false))
 
 $showAllProfiles.subscribe(value => persistBoolean(SHOW_ALL_PROFILES_STORAGE_KEY, value))
+$showAllGateways.subscribe(value => persistBoolean(SHOW_ALL_GATEWAYS_STORAGE_KEY, value))
 
 // The profile context the sidebar is currently showing: a concrete profile key,
 // or ALL_PROFILES for the unified grouped view. Concrete scope is tied to the
@@ -790,7 +793,10 @@ export function selectProfile(name: string): void {
   // Switching profiles (or coming back from the all-profiles browse view) starts
   // fresh; re-tapping the profile you're already in leaves your session be.
   const switching = $showAllProfiles.get() || target !== normalizeProfileKey($activeGatewayProfile.get())
-  $showAllProfiles.set(false)
+  batch(() => {
+    $showAllProfiles.set(false)
+    $showAllGateways.set(false)
+  })
   $newChatProfile.set(target)
   $newChatRoute.set(null)
   // Clearing the agent route must NOT discard the registry identity: the pick
@@ -924,12 +930,15 @@ export function newSessionInAgent(route: AgentProfileRoute): void {
   })
 }
 
-export function setShowAllProfiles(value: boolean): void {
-  $showAllProfiles.set(value)
+export function setShowAllProfiles(value: boolean, scope: 'fleet' | 'gateway' = 'gateway'): void {
+  batch(() => {
+    $showAllProfiles.set(value)
+    $showAllGateways.set(value && scope === 'fleet')
+  })
 }
 
 export function toggleShowAllProfiles(): void {
-  $showAllProfiles.set(!$showAllProfiles.get())
+  setShowAllProfiles(!$showAllProfiles.get())
 }
 
 // ── Hotkey-driven profile switching ────────────────────────────────────────

--- a/apps/desktop/src/store/sidebar-archive.test.ts
+++ b/apps/desktop/src/store/sidebar-archive.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { listAllProfileSessions, type SessionInfo } from '@/hermes'
+
+import { $archivedSessions, $archivedSessionsLoading, loadArchivedSessions } from './sidebar-archive'
+
+vi.mock('@/hermes', () => ({ listAllProfileSessions: vi.fn() }))
+
+const row = (id: string) => ({ id }) as SessionInfo
+
+afterEach(() => {
+  $archivedSessions.set([])
+  $archivedSessionsLoading.set(false)
+  vi.clearAllMocks()
+})
+
+describe('loadArchivedSessions', () => {
+  it('lets a changed scope supersede an in-flight load', async () => {
+    let resolveCurrent!: (value: { sessions: SessionInfo[] }) => void
+
+    const current = new Promise<{ sessions: SessionInfo[] }>(resolve => {
+      resolveCurrent = resolve
+    })
+
+    vi.mocked(listAllProfileSessions)
+      .mockReturnValueOnce(current as ReturnType<typeof listAllProfileSessions>)
+      .mockResolvedValueOnce({ sessions: [row('all-gateways')] } as never)
+
+    const staleLoad = loadArchivedSessions(false)
+    await loadArchivedSessions(true)
+    resolveCurrent({ sessions: [row('current-gateway')] })
+    await staleLoad
+
+    expect(listAllProfileSessions).toHaveBeenCalledTimes(2)
+    expect($archivedSessions.get().map(session => session.id)).toEqual(['all-gateways'])
+    expect($archivedSessionsLoading.get()).toBe(false)
+  })
+})

--- a/apps/desktop/src/store/sidebar-archive.ts
+++ b/apps/desktop/src/store/sidebar-archive.ts
@@ -10,22 +10,33 @@ const ARCHIVED_FETCH_LIMIT = 200
 
 export const $archivedSessions = atom<SessionInfo[]>([])
 export const $archivedSessionsLoading = atom(false)
+let loadGeneration = 0
+let loadingScope: boolean | null = null
 
-export async function loadArchivedSessions(): Promise<void> {
-  if ($archivedSessionsLoading.get()) {
+export async function loadArchivedSessions(allConnections = false): Promise<void> {
+  if ($archivedSessionsLoading.get() && loadingScope === allConnections) {
     return
   }
 
+  const generation = ++loadGeneration
+  loadingScope = allConnections
   $archivedSessionsLoading.set(true)
 
   try {
-    const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only')
+    const result = await listAllProfileSessions(ARCHIVED_FETCH_LIMIT, 0, 'only', 'recent', 'all', {}, allConnections)
 
-    $archivedSessions.set(result.sessions)
+    if (generation === loadGeneration) {
+      $archivedSessions.set(result.sessions)
+    }
   } catch {
-    $archivedSessions.set([])
+    if (generation === loadGeneration) {
+      $archivedSessions.set([])
+    }
   } finally {
-    $archivedSessionsLoading.set(false)
+    if (generation === loadGeneration) {
+      loadingScope = null
+      $archivedSessionsLoading.set(false)
+    }
   }
 }
 


### PR DESCRIPTION
## What does this PR do?

Desktop could browse every profile on the foreground gateway, but had no scope for every connected gateway. Its Manage Profiles view also read only the foreground gateway, so remote and Cloud profiles could not be managed there.

This PR adds an **All profiles on all gateways** pill immediately before the existing **All profiles on this gateway** pill when the fleet rail contains multiple gateways. It reuses Electron's existing fleet session aggregator by deliberately clearing the ambient connection pin rather than adding another fetch stack.

Manage Profiles now reads and groups profiles by registered gateway. Create, rename, delete and SOUL.md actions carry the owning connection, so same-named profiles on different gateways remain independent. Unreachable gateways degrade in place rather than hiding the rest of the fleet.

The profile list and Archived view also use request-generation guards so an older gateway response cannot overwrite a newer scope.

## Related Issue

No issue filed. Builds on the fleet rail merged in #95635.

The cross-gateway Manage Profiles work incorporates and adapts Hayk's earlier profile-ownership work from #89915 (`b55bb456` and `91c3239e`); Hayk is credited as a co-author.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add a persisted fleet-wide all-profiles scope to the profile rail.
- Route fleet-wide current and archived session reads through the existing Electron aggregator, preserving and durably backfilling the registered primary owner.
- Qualify grouped sidebar profile identities by connection to prevent same-name collisions.
- Load Manage Profiles from every registered gateway and route CRUD/SOUL actions to the owner.
- Route connection-scoped renames through Electron's existing teardown/rollback lifecycle.
- Preserve partial results when one gateway is unreachable.
- Guard profile and archived-session refreshes against stale async completion.
- Add translations for every shipped locale.

## How to Test

1. Register two gateways with at least one same-named profile.
2. Click **All profiles on all gateways** and verify it is distinct from **All profiles on this gateway**.
3. Open **Manage profiles…** and verify profiles are grouped under both gateway names; edit a remote profile and confirm the request stays on its owner.
4. Run:
   - `cd apps/desktop && npm run test:ui` (7,177 passed)
   - focused regression suites (119 UI and 70 Electron tests passed)
   - `npm run typecheck`
   - `npm run lint` (0 errors; existing repository warnings only)
   - `npm run build`
   - `npx playwright test e2e/fleet-profile-rail.spec.ts --reporter=list` (6 passed against two real gateway processes)
   - `npm run test:desktop:all` (macOS app and DMG packaged successfully)

Regression proof: the new profile-rail and Manage Profiles checks fail against the pre-change implementations, then pass with this diff.

`npm run test:desktop:platforms` retains one unrelated macOS baseline failure in `managed-ssh-update.test.ts` (`'127' !== '0'`); the exact test fails identically on `origin/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched existing issues and PRs, including #89915, #95735 and #95635
- [x] My PR contains only changes related to this feature/fix
- [x] Python `pytest` is N/A; this is a Desktop-only change and the Desktop suites above pass
- [x] I've added regression tests
- [x] I've tested on macOS 26.3.1

### Documentation & Housekeeping

- [x] Documentation change is N/A; the controls are self-describing and no configuration changed
- [x] `cli-config.yaml.example` is N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` changes are N/A
- [x] Cross-platform impact considered; renderer/API logic is platform-neutral and the production Electron build passes
- [x] Tool descriptions/schemas are N/A

## Screenshots / Logs

The Playwright fixture boots Desktop against two real gateway processes and covers the selector order, grouped Manage Profiles view, gateway-specific switching and scoped profile actions.
