### PR TITLE
fix(bot-mode): deliver local DMs to Desktop-owned Bot Chats

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -456,16 +456,26 @@ describe('the roster loop pushes the OTHER connections’ agents', () => {
     stopBotRelay()
   })
 
-  it('stays quiet with a single connection — there is no peer to relay to', async () => {
+  it('publishes and drains a single connection for same-install Bot Mode DMs', async () => {
     hostMock.profileRoutes = vi.fn(async () => [route('a')])
 
-    const calls = respondWith(() => ({}))
+    const calls = respondWith(call =>
+      call.method === 'profiles.list' ? { profiles: [{ name: 'default' }] } : { envelopes: [] }
+    )
+
     const { startBotRelay, stopBotRelay } = await loadRelay()
 
     startBotRelay()
     await vi.advanceTimersByTimeAsync(0)
 
-    expect(calls).toHaveLength(0)
+    expect(calls.find(call => call.method === 'bot_relay.roster.sync')).toMatchObject({
+      connectionId: 'a',
+      params: { agents: [], local_connection_id: 'a' }
+    })
+
+    calls.length = 0
+    await pushAndSettle()
+    expect(calls.filter(call => call.method === 'bot_relay.outbox.drain')).toHaveLength(1)
 
     stopBotRelay()
   })
@@ -507,6 +517,93 @@ describe('the drain loop wires drain → deliver → reply', () => {
     })
     // A delivered background DM is this bot's "good turn".
     expect(clearBotAttentionMock).toHaveBeenCalledWith('b::ops')
+
+    stopBotRelay()
+  })
+
+  it('delivers an envelope back into the sender connection itself', async () => {
+    hostMock.profileRoutes = vi.fn(async () => [route('a')])
+
+    const localEnvelope = { ...envelope, target_connection: 'a', target_profile: 'default' }
+
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain') {
+        return { envelopes: [localEnvelope] }
+      }
+
+      if (call.method === 'bot_relay.deliver') {
+        return { reply: 'queued into live Bot Chat' }
+      }
+
+      return {}
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await pushAndSettle()
+
+    expect(calls.find(call => call.method === 'bot_relay.deliver')).toMatchObject({
+      connectionId: 'a',
+      params: { message: 'status?', profile: 'default' }
+    })
+    expect(calls.find(call => call.method === 'bot_relay.reply')).toMatchObject({
+      connectionId: 'a',
+      params: { id: 'env-1', reply: 'queued into live Bot Chat' }
+    })
+
+    stopBotRelay()
+  })
+
+  it('keeps draining while a delivered turn waits for a nested agent reply', async () => {
+    hostMock.profileRoutes = vi.fn(async () => [route('a')])
+
+    let releaseDelivery!: () => void
+
+    const heldDelivery = new Promise<{ reply: string }>(resolve => {
+      releaseDelivery = () => resolve({ reply: 'outer turn finished' })
+    })
+
+    let drains = 0
+
+    const calls = respondWith(call => {
+      if (call.method === 'bot_relay.outbox.drain') {
+        drains += 1
+
+        return {
+          envelopes: drains === 1 ? [{ ...envelope, target_connection: 'a', target_profile: 'alien-child' }] : []
+        }
+      }
+
+      if (call.method === 'bot_relay.deliver') {
+        return heldDelivery
+      }
+
+      return {}
+    })
+
+    const { startBotRelay, stopBotRelay } = await loadRelay()
+
+    startBotRelay()
+    await vi.advanceTimersByTimeAsync(0)
+    calls.length = 0
+    drains = 0
+
+    await pushAndSettle()
+    expect(calls.some(call => call.method === 'bot_relay.deliver')).toBe(true)
+
+    // This push represents the nested message_agent call from the target
+    // turn. It must claim immediately, before that outer delivery resolves.
+    await pushAndSettle()
+    expect(drains).toBeGreaterThan(1)
+    expect(calls.some(call => call.method === 'bot_relay.reply')).toBe(false)
+
+    releaseDelivery()
+    await vi.advanceTimersByTimeAsync(0)
+    expect(calls.find(call => call.method === 'bot_relay.reply')?.params).toMatchObject({
+      id: 'env-1',
+      reply: 'outer turn finished'
+    })
 
     stopBotRelay()
   })

--- a/apps/desktop/src/plugins/hermes-bots/relay.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.test.ts
@@ -555,59 +555,6 @@ describe('the drain loop wires drain → deliver → reply', () => {
     stopBotRelay()
   })
 
-  it('keeps draining while a delivered turn waits for a nested agent reply', async () => {
-    hostMock.profileRoutes = vi.fn(async () => [route('a')])
-
-    let releaseDelivery!: () => void
-
-    const heldDelivery = new Promise<{ reply: string }>(resolve => {
-      releaseDelivery = () => resolve({ reply: 'outer turn finished' })
-    })
-
-    let drains = 0
-
-    const calls = respondWith(call => {
-      if (call.method === 'bot_relay.outbox.drain') {
-        drains += 1
-
-        return {
-          envelopes: drains === 1 ? [{ ...envelope, target_connection: 'a', target_profile: 'alien-child' }] : []
-        }
-      }
-
-      if (call.method === 'bot_relay.deliver') {
-        return heldDelivery
-      }
-
-      return {}
-    })
-
-    const { startBotRelay, stopBotRelay } = await loadRelay()
-
-    startBotRelay()
-    await vi.advanceTimersByTimeAsync(0)
-    calls.length = 0
-    drains = 0
-
-    await pushAndSettle()
-    expect(calls.some(call => call.method === 'bot_relay.deliver')).toBe(true)
-
-    // This push represents the nested message_agent call from the target
-    // turn. It must claim immediately, before that outer delivery resolves.
-    await pushAndSettle()
-    expect(drains).toBeGreaterThan(1)
-    expect(calls.some(call => call.method === 'bot_relay.reply')).toBe(false)
-
-    releaseDelivery()
-    await vi.advanceTimersByTimeAsync(0)
-    expect(calls.find(call => call.method === 'bot_relay.reply')?.params).toMatchObject({
-      id: 'env-1',
-      reply: 'outer turn finished'
-    })
-
-    stopBotRelay()
-  })
-
   it('still posts a reply when the target connection is gone — the waiter must never dangle', async () => {
     const calls = respondWith(call =>
       call.method === 'bot_relay.outbox.drain'

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -313,85 +313,9 @@ async function syncRelayRosters() {
   }
 }
 
-/** Deliver one already-claimed envelope without occupying the outbox drain.
- *
- * A delivered Bot Chat turn may itself call `message_agent`. Keeping
- * `drainBusy` held while awaiting that turn creates a relay-level deadlock:
- * the nested reply is queued, but its push cannot drain until the outer turn
- * returns, while the outer turn is waiting for that reply. Backend turn locks
- * and queued `prompt.submit` remain the per-target ordering boundary. */
-async function deliverRelayEnvelope(
-  sender: RelayConnection,
-  target: RelayConnection | undefined,
-  envelope: RelayEnvelope
-) {
-  const envelopeId = String(envelope?.id || '')
-
-  if (!envelopeId) {
-    return
-  }
-
-  const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
-    try {
-      await host.requestProfile(sender.route, 'bot_relay.reply', {
-        id: envelopeId,
-        ...payload
-      })
-    } catch {
-      // Sender gateway unreachable — its waiter times out with guidance.
-    }
-  }
-
-  if (!target) {
-    await postReply({
-      error: `connection '${envelope?.target_connection}' is not connected to this Desktop right now`
-    })
-
-    return
-  }
-
-  // Needs-attention hook (#93091 item 3): a delivered background DM is
-  // this bot's "good turn"; a classified delivery failure badges it.
-  const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
-
-  try {
-    const res = await host.requestProfile<{ reply?: string }>(
-      target.route,
-      'bot_relay.deliver',
-      {
-        profile: String(envelope?.target_profile || ''),
-        message: String(envelope?.message || '')
-      },
-      RELAY_DELIVER_TIMEOUT_MS
-    )
-
-    clearBotAttention(attentionKey)
-    await postReply({
-      reply: String(res?.reply || '')
-    })
-  } catch (error: any) {
-    // #93091: bot_relay.deliver classifies the failed turn and ships the
-    // typed code in the JSON-RPC error's `data.reason`; forward it into
-    // the sender-side reply file so the waiter (and the sending agent)
-    // get the machine-readable cause, and prefer it for the badge —
-    // classified codes beat free-text re-parsing.
-    const reason = String(error?.data?.reason || '').trim()
-    noteBotAttention(attentionKey, reason || error?.message || error)
-    await postReply({
-      error: String(error?.message || error || 'delivery failed'),
-      ...(reason
-        ? {
-            reason
-          }
-        : {})
-    })
-  }
-}
-
-/** Claim every gateway's pending outbox envelopes, then start their target
- * deliveries independently. The claim pass stays short and responsive so a
- * nested agent reply can be claimed while the originating turn is still in
- * flight. */
+/** Drain every gateway's outbox and deliver each envelope on the target
+ *  connection's own socket; the reply (or error) is posted back to the
+ *  sender gateway for its waiter. */
 async function drainRelayOutboxes() {
   if (relay.disposed) {
     return
@@ -441,11 +365,68 @@ async function drainRelayOutboxes() {
           return
         }
 
+        const envelopeId = String(envelope?.id || '')
         const target = byId.get(String(envelope?.target_connection || ''))
 
-        // Do not await the target turn here. A nested message_agent reply must
-        // be able to trigger another outbox claim before this delivery ends.
-        void deliverRelayEnvelope(sender, target, envelope)
+        const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
+          try {
+            await host.requestProfile(sender.route, 'bot_relay.reply', {
+              id: envelopeId,
+              ...payload
+            })
+          } catch {
+            // Sender gateway unreachable — its waiter times out with guidance.
+          }
+        }
+
+        if (!envelopeId) {
+          continue
+        }
+
+        if (!target) {
+          await postReply({
+            error: `connection '${envelope?.target_connection}' is not connected to this Desktop right now`
+          })
+
+          continue
+        }
+
+        // Needs-attention hook (#93091 item 3): a delivered background DM is
+        // this bot's "good turn"; a classified delivery failure badges it.
+        const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
+
+        try {
+          const res = await host.requestProfile<{ reply?: string }>(
+            target.route,
+            'bot_relay.deliver',
+            {
+              profile: String(envelope?.target_profile || ''),
+              message: String(envelope?.message || '')
+            },
+            RELAY_DELIVER_TIMEOUT_MS
+          )
+
+          clearBotAttention(attentionKey)
+          await postReply({
+            reply: String(res?.reply || '')
+          })
+        } catch (error: any) {
+          // #93091: bot_relay.deliver classifies the failed turn and ships the
+          // typed code in the JSON-RPC error's `data.reason`; forward it into
+          // the sender-side reply file so the waiter (and the sending agent)
+          // get the machine-readable cause, and prefer it for the badge —
+          // classified codes beat free-text re-parsing.
+          const reason = String(error?.data?.reason || '').trim()
+          noteBotAttention(attentionKey, reason || error?.message || error)
+          await postReply({
+            error: String(error?.message || error || 'delivery failed'),
+            ...(reason
+              ? {
+                  reason
+                }
+              : {})
+          })
+        }
       }
     }
   } finally {

--- a/apps/desktop/src/plugins/hermes-bots/relay.ts
+++ b/apps/desktop/src/plugins/hermes-bots/relay.ts
@@ -243,7 +243,9 @@ async function relayAgentsOn(connection: RelayConnection): Promise<RelayAgentRow
 const RELAY_AGENTS_CACHE_MAX = 32
 const relayAgentsCache = new LruCache<string, RelayAgentRow[]>(RELAY_AGENTS_CACHE_MAX)
 
-/** Push every gateway the union roster of agents on the OTHER connections. */
+/** Push every gateway the union roster of agents on the OTHER connections,
+ *  plus its own connection id so same-install DMs can use this relay while
+ *  Desktop is present. */
 async function syncRelayRosters() {
   if (relay.disposed || relay.rosterBusy) {
     return
@@ -254,7 +256,7 @@ async function syncRelayRosters() {
   try {
     const connections = await relayConnections()
 
-    if (connections.length < 2) {
+    if (connections.length < 1) {
       return
     }
 
@@ -298,7 +300,8 @@ async function syncRelayRosters() {
 
         try {
           await host.requestProfile(connection.route, 'bot_relay.roster.sync', {
-            agents: others
+            agents: others,
+            local_connection_id: connection.id
           })
         } catch {
           // Older backend without the relay RPCs — skip this connection.
@@ -310,9 +313,85 @@ async function syncRelayRosters() {
   }
 }
 
-/** Drain every gateway's outbox and deliver each envelope on the target
- *  connection's own socket; the reply (or error) is posted back to the
- *  sender gateway for its waiter. */
+/** Deliver one already-claimed envelope without occupying the outbox drain.
+ *
+ * A delivered Bot Chat turn may itself call `message_agent`. Keeping
+ * `drainBusy` held while awaiting that turn creates a relay-level deadlock:
+ * the nested reply is queued, but its push cannot drain until the outer turn
+ * returns, while the outer turn is waiting for that reply. Backend turn locks
+ * and queued `prompt.submit` remain the per-target ordering boundary. */
+async function deliverRelayEnvelope(
+  sender: RelayConnection,
+  target: RelayConnection | undefined,
+  envelope: RelayEnvelope
+) {
+  const envelopeId = String(envelope?.id || '')
+
+  if (!envelopeId) {
+    return
+  }
+
+  const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
+    try {
+      await host.requestProfile(sender.route, 'bot_relay.reply', {
+        id: envelopeId,
+        ...payload
+      })
+    } catch {
+      // Sender gateway unreachable — its waiter times out with guidance.
+    }
+  }
+
+  if (!target) {
+    await postReply({
+      error: `connection '${envelope?.target_connection}' is not connected to this Desktop right now`
+    })
+
+    return
+  }
+
+  // Needs-attention hook (#93091 item 3): a delivered background DM is
+  // this bot's "good turn"; a classified delivery failure badges it.
+  const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
+
+  try {
+    const res = await host.requestProfile<{ reply?: string }>(
+      target.route,
+      'bot_relay.deliver',
+      {
+        profile: String(envelope?.target_profile || ''),
+        message: String(envelope?.message || '')
+      },
+      RELAY_DELIVER_TIMEOUT_MS
+    )
+
+    clearBotAttention(attentionKey)
+    await postReply({
+      reply: String(res?.reply || '')
+    })
+  } catch (error: any) {
+    // #93091: bot_relay.deliver classifies the failed turn and ships the
+    // typed code in the JSON-RPC error's `data.reason`; forward it into
+    // the sender-side reply file so the waiter (and the sending agent)
+    // get the machine-readable cause, and prefer it for the badge —
+    // classified codes beat free-text re-parsing.
+    const reason = String(error?.data?.reason || '').trim()
+    noteBotAttention(attentionKey, reason || error?.message || error)
+    await postReply({
+      error: String(error?.message || error || 'delivery failed'),
+      ...(reason
+        ? {
+            reason
+          }
+        : {})
+    })
+  }
+}
+
+/** Claim every gateway's pending outbox envelopes, then start their target
+ * deliveries independently. The claim pass stays short and responsive so a
+ * nested agent reply can be claimed while the originating turn is still in
+ * flight. */
 async function drainRelayOutboxes() {
   if (relay.disposed) {
     return
@@ -332,11 +411,11 @@ async function drainRelayOutboxes() {
   try {
     const connections = await relayConnections()
 
-    // Retention follows the relay-eligible set: with fewer than two
-    // connections there is nothing to relay, so nothing stays pinned.
+    // A single local connection already has the socket that received the
+    // outbox event; only cross-connection relay routes need extra retention.
     syncRelayRetention(connections.length >= 2 ? connections : [])
 
-    if (connections.length < 2) {
+    if (connections.length < 1) {
       return
     }
 
@@ -362,68 +441,11 @@ async function drainRelayOutboxes() {
           return
         }
 
-        const envelopeId = String(envelope?.id || '')
         const target = byId.get(String(envelope?.target_connection || ''))
 
-        const postReply = async (payload: { error?: string; reason?: string; reply?: string }) => {
-          try {
-            await host.requestProfile(sender.route, 'bot_relay.reply', {
-              id: envelopeId,
-              ...payload
-            })
-          } catch {
-            // Sender gateway unreachable — its waiter times out with guidance.
-          }
-        }
-
-        if (!envelopeId) {
-          continue
-        }
-
-        if (!target) {
-          await postReply({
-            error: `connection '${envelope?.target_connection}' is not connected to this Desktop right now`
-          })
-
-          continue
-        }
-
-        // Needs-attention hook (#93091 item 3): a delivered background DM is
-        // this bot's "good turn"; a classified delivery failure badges it.
-        const attentionKey = `${target.id}::${String(envelope?.target_profile || '')}`
-
-        try {
-          const res = await host.requestProfile<{ reply?: string }>(
-            target.route,
-            'bot_relay.deliver',
-            {
-              profile: String(envelope?.target_profile || ''),
-              message: String(envelope?.message || '')
-            },
-            RELAY_DELIVER_TIMEOUT_MS
-          )
-
-          clearBotAttention(attentionKey)
-          await postReply({
-            reply: String(res?.reply || '')
-          })
-        } catch (error: any) {
-          // #93091: bot_relay.deliver classifies the failed turn and ships the
-          // typed code in the JSON-RPC error's `data.reason`; forward it into
-          // the sender-side reply file so the waiter (and the sending agent)
-          // get the machine-readable cause, and prefer it for the badge —
-          // classified codes beat free-text re-parsing.
-          const reason = String(error?.data?.reason || '').trim()
-          noteBotAttention(attentionKey, reason || error?.message || error)
-          await postReply({
-            error: String(error?.message || error || 'delivery failed'),
-            ...(reason
-              ? {
-                  reason
-                }
-              : {})
-          })
-        }
+        // Do not await the target turn here. A nested message_agent reply must
+        // be able to trigger another outbox claim before this delivery ends.
+        void deliverRelayEnvelope(sender, target, envelope)
       }
     }
   } finally {

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -214,7 +214,25 @@ def _capture_spawn(monkeypatch):
 def _runner_parts(command):
     parts = shlex.split(command)
     marker = parts.index("--run-delivery")
-    return parts[marker + 1], parts[marker + 2], parts[marker + 3 :]
+    runner_args = parts[marker + 3 :]
+    if runner_args and runner_args[0] == "--relay-fallback":
+        runner_args = runner_args[6:]
+    return parts[marker + 1], parts[marker + 2], runner_args
+
+
+def _runner_relay_fallback(command):
+    parts = shlex.split(command)
+    marker = parts.index("--run-delivery")
+    runner_args = parts[marker + 3 :]
+    if not runner_args or runner_args[0] != "--relay-fallback":
+        return None
+    assert runner_args[5] == "--"
+    return {
+        "root": runner_args[1],
+        "target_profile": runner_args[2],
+        "sender_profile": runner_args[3],
+        "sender_handle": runner_args[4],
+    }
 
 
 def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
@@ -268,7 +286,9 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert '$(and this is not shell)' in content
 
 
-def test_local_delivery_uses_fresh_desktop_relay(tmp_path, monkeypatch):
+def test_local_delivery_carries_desktop_fallback_without_preempting_cli(
+    tmp_path, monkeypatch
+):
     calls = _capture_spawn(monkeypatch)
     home = _managed_home(tmp_path, teammates=("researcher",))
     from tools import bot_relay
@@ -282,12 +302,18 @@ def test_local_delivery_uses_fresh_desktop_relay(tmp_path, monkeypatch):
 
     assert result["status"] == "sent"
     command = calls[0]["command"]
-    assert "--run-delivery" not in command
-    assert "local-1" in command
-    envelopes = bot_relay.claim_pending_envelopes(home)
-    assert len(envelopes) == 1
-    assert envelopes[0]["target_connection"] == "local-1"
-    assert envelopes[0]["target_profile"] == "researcher"
+    mode, _dm_file, argv = _runner_parts(command)
+    assert mode == "query-file"
+    assert argv[1:3] == ["-p", "researcher"]
+    relay_fallback = _runner_relay_fallback(command)
+    assert relay_fallback is not None
+    assert Path(relay_fallback.pop("root")) == home
+    assert relay_fallback == {
+        "target_profile": "researcher",
+        "sender_profile": "default",
+        "sender_handle": "hermes",
+    }
+    assert bot_relay.claim_pending_envelopes(home) == []
 
 
 def test_local_delivery_keeps_subprocess_fallback_without_desktop(tmp_path, monkeypatch):
@@ -480,6 +506,59 @@ def test_delivery_runner_surfaces_live_owner_refusal(tmp_path, capsys):
     payload = json.loads(capsys.readouterr().out)
     assert payload["reason"] == "target_busy"
     assert "NOT delivered" in payload["error"]
+
+
+def test_delivery_runner_relays_only_after_live_owner_refusal(
+    tmp_path, monkeypatch, capsys
+):
+    dm_file = tmp_path / "message.txt"
+    dm_file.write_text("Message from bot: hi", encoding="utf-8")
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    from tools import bot_relay
+
+    bot_relay.write_remote_roster(home, [], local_connection_id="local-1")
+    runs = []
+
+    def owned(argv, **kwargs):
+        runs.append((argv, kwargs))
+        return subprocess.CompletedProcess(
+            argv,
+            1,
+            stdout="",
+            stderr="Session abc already has a live owner (desktop, pid 1).",
+        )
+
+    waited = []
+
+    def immediate_reply(root, envelope):
+        waited.append((Path(root), envelope))
+        print("relayed")
+        return 0
+
+    monkeypatch.setattr(subprocess, "run", owned)
+    monkeypatch.setattr(bot_relay, "wait_for_reply", immediate_reply)
+
+    returncode = bot_mode_dm._run_delivery(
+        ["hermes", "-p", "researcher"],
+        str(dm_file),
+        stdin_file=False,
+        relay_fallback={
+            "root": str(home),
+            "target_profile": "researcher",
+            "sender_profile": "default",
+            "sender_handle": "hermes",
+        },
+    )
+
+    assert returncode == 0
+    assert len(runs) == 1
+    assert len(waited) == 1
+    assert waited[0][0] == home
+    assert waited[0][1]["target_connection"] == "local-1"
+    assert waited[0][1]["target_profile"] == "researcher"
+    assert waited[0][1]["message"] == "Message from bot: hi"
+    assert capsys.readouterr().out == "relayed\n"
+    assert not dm_file.exists()
 
 
 def test_query_file_delivery_closes_stdin_for_initial_attempt_and_retry(

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -268,6 +268,43 @@ def test_local_delivery_command_and_ack(tmp_path, monkeypatch):
     assert '$(and this is not shell)' in content
 
 
+def test_local_delivery_uses_fresh_desktop_relay(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    from tools import bot_relay
+
+    bot_relay.write_remote_roster(home, [], local_connection_id="local-1")
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="status?", agent=agent)
+    )
+
+    assert result["status"] == "sent"
+    command = calls[0]["command"]
+    assert "--run-delivery" not in command
+    assert "local-1" in command
+    envelopes = bot_relay.claim_pending_envelopes(home)
+    assert len(envelopes) == 1
+    assert envelopes[0]["target_connection"] == "local-1"
+    assert envelopes[0]["target_profile"] == "researcher"
+
+
+def test_local_delivery_keeps_subprocess_fallback_without_desktop(tmp_path, monkeypatch):
+    calls = _capture_spawn(monkeypatch)
+    home = _managed_home(tmp_path, teammates=("researcher",))
+    agent = _FakeAgent(home, title="Bot Chat")
+
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="researcher", message="status?", agent=agent)
+    )
+
+    assert result["status"] == "sent"
+    mode, _dm_file, argv = _runner_parts(calls[0]["command"])
+    assert mode == "query-file"
+    assert argv[1:3] == ["-p", "researcher"]
+
+
 def test_peer_delivery_command_pins_registry_profile_for_secondary_bots(
     tmp_path, monkeypatch
 ):

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -67,6 +67,21 @@ def test_roster_roundtrip_and_validation(root):
     assert back[0]["title"] == "Moxie"
 
 
+def test_roster_persists_fresh_local_desktop_connection(root, monkeypatch):
+    bot_relay.write_remote_roster(root, [], local_connection_id="local-1")
+    assert bot_relay.read_local_connection_id(root) == "local-1"
+
+    roster_path = bot_relay.relay_root(root) / bot_relay.ROSTER_FILE
+    stale_now = roster_path.stat().st_mtime + bot_relay.ROSTER_FRESH_SECONDS + 1
+    monkeypatch.setattr(bot_relay.time, "time", lambda: stale_now)
+    assert bot_relay.read_local_connection_id(root) == ""
+
+
+def test_roster_rejects_invalid_local_desktop_connection(root):
+    bot_relay.write_remote_roster(root, [], local_connection_id="not a route")
+    assert bot_relay.read_local_connection_id(root) == ""
+
+
 def test_roster_read_missing_and_corrupt(root):
     assert bot_relay.read_remote_roster(root) == []
     base = bot_relay.relay_root(root)

--- a/tests/tools/test_bot_relay.py
+++ b/tests/tools/test_bot_relay.py
@@ -82,6 +82,18 @@ def test_roster_rejects_invalid_local_desktop_connection(root):
     assert bot_relay.read_local_connection_id(root) == ""
 
 
+def test_wait_for_reply_prints_relay_result(root, monkeypatch, capsys):
+    envelope = {
+        "id": "a" * 32,
+        "target_handle": "researcher",
+        "target_connection": "local-1",
+    }
+    bot_relay.write_reply(root, envelope["id"], reply="done")
+
+    assert bot_relay.wait_for_reply(root, envelope) == 0
+    assert capsys.readouterr().out == "Reply from @researcher on local-1:\ndone\n"
+
+
 def test_roster_read_missing_and_corrupt(root):
     assert bot_relay.read_remote_roster(root) == []
     base = bot_relay.relay_root(root)

--- a/tests/tui_gateway/test_bot_relay_methods.py
+++ b/tests/tui_gateway/test_bot_relay_methods.py
@@ -37,6 +37,7 @@ def test_roster_sync_persists_and_counts(home):
         srv._methods["bot_relay.roster.sync"](
             1,
             {
+                "local_connection_id": "local-1",
                 "agents": [
                     {"profile": "scout", "handle": "scout", "connection_id": "cloud-1"},
                     {"profile": "", "connection_id": "cloud-1"},  # dropped
@@ -46,6 +47,7 @@ def test_roster_sync_persists_and_counts(home):
     )
     assert out["count"] == 1
     assert [r["profile"] for r in bot_relay.read_remote_roster(home)] == ["scout"]
+    assert bot_relay.read_local_connection_id(home) == "local-1"
 
 
 def test_outbox_drain_returns_each_envelope_once(home):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -28,9 +28,11 @@ Containment contract (MUST hold — reviewers check all three):
 - Everything here is additive. The legacy protocol transports
   (``hermes -p`` / ``hermes peer dm``) keep working for older prompts.
 
-The transports themselves are unchanged and proven:
+Delivery starts with the proven transports:
 - local teammate  → ``hermes -p <name> chat --in ~ -c "Bot Chat"
-  --create-if-missing -Q --query-file <tmp>`` (one turn, reply on stdout)
+  --create-if-missing -Q --query-file <tmp>`` (one turn, reply on stdout). If
+  Desktop already owns that Bot Chat, the runner moves the refused turn onto
+  Desktop's live relay instead of dropping it.
 - peer teammate   → ``hermes peer dm <peer>[/<name>] < <tmp>``
 
 Both run through ``terminal_tool(background=True, notify_on_complete=True)``
@@ -359,24 +361,6 @@ def message_agent_tool(
             return relayed
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
-    # A Desktop-owned Bot Chat cannot be opened by the CLI subprocess below:
-    # the single-owner lease correctly fences it out. When Desktop has
-    # recently advertised this gateway's connection id, ride the existing
-    # relay instead; bot_relay.deliver queues the DM through prompt.submit on
-    # the live session. No fresh Desktop heartbeat means headless/CLI-only
-    # installs keep the direct subprocess path unchanged.
-    desktop_delivery = _try_local_desktop_delivery(
-        root,
-        resolved,
-        body,
-        me,
-        sender_handle,
-        task_id=task_id,
-        agent=agent,
-    )
-    if desktop_delivery is not None:
-        return desktop_delivery
-
     return _start_delivery(
         [
             "hermes",
@@ -393,32 +377,34 @@ def message_agent_tool(
         prefix + body,
         f"@{_handle(resolved)}",
         stdin_file=False,
+        relay_fallback={
+            "root": str(root),
+            "target_profile": resolved,
+            "sender_profile": me,
+            "sender_handle": sender_handle,
+        },
         task_id=task_id,
         agent=agent,
     )
 
 
-def _try_local_desktop_delivery(
-    root: Path,
-    profile: str,
-    body: str,
-    me: str,
-    sender_handle: str,
-    *,
-    task_id: Optional[str],
-    agent: Any,
-) -> Optional[str]:
-    """Queue a same-install DM through a live Desktop relay when available."""
+def _relay_after_live_owner(
+    dm_file: str,
+    relay_fallback: dict[str, str],
+) -> Optional[int]:
+    """Move a refused local turn onto Desktop's live connection, if present."""
     try:
         from tools.bot_relay import (
             enqueue_envelope,
             read_local_connection_id,
-            waiter_command,
+            wait_for_reply,
         )
 
+        root = Path(relay_fallback["root"])
         connection_id = read_local_connection_id(root)
         if not connection_id:
             return None
+        profile = relay_fallback["target_profile"]
         handle = _handle(profile)
         target = {
             "profile": profile,
@@ -429,20 +415,13 @@ def _try_local_desktop_delivery(
         envelope = enqueue_envelope(
             root,
             target=target,
-            message=f"Message from 🤖 {sender_handle} (@{sender_handle}): {body}",
-            sender_profile=me,
-            sender_handle=sender_handle,
+            message=Path(dm_file).read_text(encoding="utf-8"),
+            sender_profile=relay_fallback["sender_profile"],
+            sender_handle=relay_fallback["sender_handle"],
         )
-        return _spawn_delivery(
-            waiter_command(root, envelope),
-            f"@{handle}",
-            task_id=task_id,
-            agent=agent,
-        )
+        return wait_for_reply(root, envelope)
     except Exception:
-        # A disappearing/stale Desktop route is not a delivery failure yet:
-        # preserve the proven local subprocess as the next resolver rung.
-        logger.debug("local Desktop relay delivery unavailable", exc_info=True)
+        logger.debug("live-owner Desktop relay fallback unavailable", exc_info=True)
         return None
 
 
@@ -628,7 +607,13 @@ def _delivery_lock(argv: list[str], *, stdin_file: bool):
     return acquire_turn_lock(_hermes_root(home), argv[2])
 
 
-def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
+def _run_delivery(
+    argv: list[str],
+    dm_file: str,
+    *,
+    stdin_file: bool,
+    relay_fallback: Optional[dict[str, str]] = None,
+) -> int:
     """Run one DM transport and remove its plaintext file after consumption.
 
     The turn execution window (not the enqueue) holds the target profile's
@@ -642,6 +627,11 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
     compression lever; no fresh session is ever minted. Auth/quota/config
     failures never retry. Peer transports (stdin mode) retry on their own
     gateway's deliver path, not here.
+
+    A local live-owner refusal is different from a busy delivery lock: the
+    subprocess did not consume the message. When Desktop has advertised the
+    gateway's current connection id, release the turn lock and hand that same
+    message to the existing live-session relay.
     """
     try:
         with _delivery_lock(argv, stdin_file=stdin_file):
@@ -673,31 +663,43 @@ def _run_delivery(argv: list[str], dm_file: str, *, stdin_file: bool) -> int:
                         capture_output=True,
                         text=True,
                     )
-            # Re-emit the transport's streams: stdout is the reply text the
-            # completion notification carries back to the sending agent.
-            if proc.returncode != 0 and "already has a live owner" in (proc.stderr or ""):
-                # #100523: the target's Bot Chat is held live by another
-                # surface (Desktop). The turn never ran, so tell the sender
-                # plainly instead of leaking a raw lease error + exit code.
-                who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
-                print(json.dumps({
-                    "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
-                             "surface right now, so your message was NOT delivered. Try again later.",
-                    "reason": "target_busy",
-                }))
-                return 1
-            if proc.stdout:
-                sys.stdout.write(proc.stdout)
-                sys.stdout.flush()
-            if proc.stderr:
-                sys.stderr.write(proc.stderr)
-                sys.stderr.flush()
-            return proc.returncode
+        # Re-emit the transport's streams: stdout is the reply text the
+        # completion notification carries back to the sending agent.
+        live_owner = proc.returncode != 0 and "already has a live owner" in (
+            (proc.stderr or "") + (proc.stdout or "")
+        )
+        if live_owner and relay_fallback:
+            relayed = _relay_after_live_owner(dm_file, relay_fallback)
+            if relayed is not None:
+                return relayed
+        if live_owner:
+            # #100523: the target's Bot Chat is held live by another surface,
+            # but no usable Desktop relay was available. The turn never ran.
+            who = argv[argv.index("-p") + 1] if "-p" in argv[:-1] else "the teammate"
+            print(json.dumps({
+                "error": f"Delivery failed: @{who}'s Bot Chat is open on another "
+                         "surface right now, so your message was NOT delivered. Try again later.",
+                "reason": "target_busy",
+            }))
+            return 1
+        if proc.stdout:
+            sys.stdout.write(proc.stdout)
+            sys.stdout.flush()
+        if proc.stderr:
+            sys.stderr.write(proc.stderr)
+            sys.stderr.flush()
+        return proc.returncode
     finally:
         _unlink_dm_file(dm_file)
 
 
-def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str:
+def _delivery_command(
+    argv: list[str],
+    dm_file: str,
+    *,
+    stdin_file: bool,
+    relay_fallback: Optional[dict[str, str]] = None,
+) -> str:
     """Build an argv-safe command for the cleanup-owning background runner."""
     runner_argv = [
         sys.executable,
@@ -705,8 +707,19 @@ def _delivery_command(argv: list[str], dm_file: str, *, stdin_file: bool) -> str
         "--run-delivery",
         "stdin" if stdin_file else "query-file",
         dm_file,
-        *argv,
     ]
+    if relay_fallback:
+        runner_argv.extend(
+            [
+                "--relay-fallback",
+                relay_fallback["root"],
+                relay_fallback["target_profile"],
+                relay_fallback["sender_profile"],
+                relay_fallback["sender_handle"],
+                "--",
+            ]
+        )
+    runner_argv.extend(argv)
     if sys.platform == "win32":
         # The tracked local backend uses Git Bash on native Windows. Forward
         # slashes preserve native drive paths while remaining executable by
@@ -722,13 +735,19 @@ def _start_delivery(
     label: str,
     *,
     stdin_file: bool,
+    relay_fallback: Optional[dict[str, str]] = None,
     task_id: Optional[str],
     agent: Any,
 ) -> str:
     """Create a DM file and transfer its cleanup ownership to the runner."""
     dm_file = _write_dm_file(content)
     try:
-        command = _delivery_command(argv, dm_file, stdin_file=stdin_file)
+        command = _delivery_command(
+            argv,
+            dm_file,
+            stdin_file=stdin_file,
+            relay_fallback=relay_fallback,
+        )
     except BaseException:
         _unlink_dm_file(dm_file)
         raise
@@ -808,8 +827,25 @@ def _delivery_main(args: list[str]) -> int:
     if not stdin_file and args[1] != "query-file":
         return 2
     dm_file = args[2]
+    transport_argv = args[3:]
+    relay_fallback = None
+    if transport_argv and transport_argv[0] == "--relay-fallback":
+        if len(transport_argv) < 7 or transport_argv[5] != "--":
+            return 2
+        relay_fallback = {
+            "root": transport_argv[1],
+            "target_profile": transport_argv[2],
+            "sender_profile": transport_argv[3],
+            "sender_handle": transport_argv[4],
+        }
+        transport_argv = transport_argv[6:]
     try:
-        return _run_delivery(args[3:], dm_file, stdin_file=stdin_file)
+        return _run_delivery(
+            transport_argv,
+            dm_file,
+            stdin_file=stdin_file,
+            relay_fallback=relay_fallback,
+        )
     except Exception as exc:
         # 'target_busy' extends the #93091 item-1 structured refusal enum:
         # the queued delivery gave up after its bounded wait — surface the

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -359,6 +359,24 @@ def message_agent_tool(
             return relayed
         return _err("You can't message yourself. Pick a teammate from the roster.")
 
+    # A Desktop-owned Bot Chat cannot be opened by the CLI subprocess below:
+    # the single-owner lease correctly fences it out. When Desktop has
+    # recently advertised this gateway's connection id, ride the existing
+    # relay instead; bot_relay.deliver queues the DM through prompt.submit on
+    # the live session. No fresh Desktop heartbeat means headless/CLI-only
+    # installs keep the direct subprocess path unchanged.
+    desktop_delivery = _try_local_desktop_delivery(
+        root,
+        resolved,
+        body,
+        me,
+        sender_handle,
+        task_id=task_id,
+        agent=agent,
+    )
+    if desktop_delivery is not None:
+        return desktop_delivery
+
     return _start_delivery(
         [
             "hermes",
@@ -378,6 +396,54 @@ def message_agent_tool(
         task_id=task_id,
         agent=agent,
     )
+
+
+def _try_local_desktop_delivery(
+    root: Path,
+    profile: str,
+    body: str,
+    me: str,
+    sender_handle: str,
+    *,
+    task_id: Optional[str],
+    agent: Any,
+) -> Optional[str]:
+    """Queue a same-install DM through a live Desktop relay when available."""
+    try:
+        from tools.bot_relay import (
+            enqueue_envelope,
+            read_local_connection_id,
+            waiter_command,
+        )
+
+        connection_id = read_local_connection_id(root)
+        if not connection_id:
+            return None
+        handle = _handle(profile)
+        target = {
+            "profile": profile,
+            "handle": handle,
+            "connection_id": connection_id,
+            "connection_label": "this Desktop connection",
+        }
+        envelope = enqueue_envelope(
+            root,
+            target=target,
+            message=f"Message from 🤖 {sender_handle} (@{sender_handle}): {body}",
+            sender_profile=me,
+            sender_handle=sender_handle,
+        )
+        return _spawn_delivery(
+            waiter_command(root, envelope),
+            f"@{handle}",
+            task_id=task_id,
+            agent=agent,
+        )
+    except Exception:
+        # A disappearing/stale Desktop route is not a delivery failure yet:
+        # preserve the proven local subprocess as the next resolver rung.
+        logger.debug("local Desktop relay delivery unavailable", exc_info=True)
+        return None
 
 
 def _try_relay_delivery(

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -576,6 +576,43 @@ def waiter_command(root: Path | str, envelope: dict) -> str:
     return f"{shlex.quote(sys.executable or 'python3')} -c {shlex.quote(code)}"
 
 
+def wait_for_reply(root: Path | str, envelope: dict) -> int:
+    """Wait for one relay reply and print the standard completion payload.
+
+    This is the in-process equivalent of :func:`waiter_command`, used when a
+    local delivery runner discovers that Desktop already owns the target Bot
+    Chat and must move the same delivery onto Desktop's live relay.
+    """
+    envelope_id = str(envelope.get("id") or "")
+    reply_path = relay_root(root) / REPLIES_DIR / f"{envelope_id}.json"
+    label = (
+        f"@{envelope.get('target_handle', '')} "
+        f"on {envelope.get('target_connection', '')}"
+    )
+    deadline = time.time() + REPLY_WAIT_SECONDS
+    while time.time() < deadline:
+        if reply_path.exists():
+            try:
+                data = json.loads(reply_path.read_text(encoding="utf-8"))
+            except (OSError, ValueError):
+                time.sleep(0.25)
+                continue
+            if data.get("error"):
+                code = str(data.get("reason") or "").strip()
+                tag = f" [reason: {code}]" if code else ""
+                print(f"Delivery to {label} failed{tag}: {data['error']}")
+                return 1
+            print(f"Reply from {label}:")
+            print(data.get("reply") or "(empty reply)")
+            return 0
+        time.sleep(0.25)
+    print(
+        f"No reply from {label} within {REPLY_WAIT_SECONDS}s. The message may "
+        "still be delivered when the Desktop reconnects; do not resend blindly."
+    )
+    return 1
+
+
 # ── delivery command (used by the deliver RPC on the TARGET gateway) ────────
 
 

--- a/tools/bot_relay.py
+++ b/tools/bot_relay.py
@@ -9,8 +9,9 @@ itself the bug).
 
 How the relay works (three files under ``<root>/bot_relay/``):
 
-- ``roster.json`` — the union roster of agents on OTHER connections, pushed
-  by the Desktop over each connection's WebSocket (``bot_relay.roster.sync``).
+- ``roster.json`` — the union roster of agents on OTHER connections plus the
+  receiving gateway's own Desktop connection id, pushed over each connection's
+  WebSocket (``bot_relay.roster.sync``).
   ``tools/bot_mode_probe.py`` folds it into the Bot Chat protocol section so
   every bot knows every reachable teammate, and ``message_agent`` resolves
   cross-connection targets against it.
@@ -147,8 +148,19 @@ def _normalize_roster_row(row: Any) -> Optional[dict]:
     return out
 
 
-def write_remote_roster(root: Path | str, rows: Any) -> int:
-    """Atomically persist the Desktop-pushed remote roster. Returns count."""
+def write_remote_roster(
+    root: Path | str,
+    rows: Any,
+    *,
+    local_connection_id: str = "",
+) -> int:
+    """Atomically persist the Desktop-pushed remote roster and local route id.
+
+    ``local_connection_id`` is the connection through which this gateway is
+    attached to Desktop. A fresh value lets same-install DMs use the Desktop
+    relay and enter a live Bot Chat through ``prompt.submit``; older Desktop
+    clients omit it and retain the subprocess fallback.
+    """
     base = _ensure_dirs(root)
     cleaned: list[dict] = []
     seen: set[tuple[str, str]] = set()
@@ -162,7 +174,14 @@ def write_remote_roster(root: Path | str, rows: Any) -> int:
         seen.add(key)
         cleaned.append(norm)
     cleaned.sort(key=lambda r: (r["connection_id"], r["profile"]))
-    payload = {"updated_at": int(time.time()), "agents": cleaned}
+    local_connection_id = str(local_connection_id or "").strip()
+    if not _HANDLE_RE.match(local_connection_id):
+        local_connection_id = ""
+    payload = {
+        "updated_at": int(time.time()),
+        "local_connection_id": local_connection_id,
+        "agents": cleaned,
+    }
     target = base / ROSTER_FILE
     fd, tmp = tempfile.mkstemp(dir=str(base), prefix=".roster-", suffix=".tmp")
     try:
@@ -192,6 +211,23 @@ def read_remote_roster(root: Path | str) -> list[dict]:
     except Exception:
         logger.debug("bot_relay roster read failed", exc_info=True)
         return []
+
+
+def read_local_connection_id(root: Path | str) -> str:
+    """Return Desktop's fresh route id for this gateway, else ``""``.
+
+    A stale Desktop must not steal local DMs from the CLI subprocess fallback
+    and leave them in an outbox no renderer is present to drain.
+    """
+    try:
+        path = relay_root(root) / ROSTER_FILE
+        if time.time() - path.stat().st_mtime > ROSTER_FRESH_SECONDS:
+            return ""
+        data = json.loads(path.read_text(encoding="utf-8"))
+        connection_id = str(data.get("local_connection_id") or "").strip()
+        return connection_id if _HANDLE_RE.match(connection_id) else ""
+    except Exception:
+        return ""
 
 
 def resolve_remote_target(raw_target: str, roster: list[dict]) -> Any:
@@ -282,6 +318,11 @@ def _target_liveness(root: Path | str, target: dict) -> Optional[bool]:
     roster proves nothing → None, and callers fail open. Never raises.
     """
     try:
+        # Local profiles are intentionally absent from the remote-agent roster.
+        # For them the fresh Desktop route is itself the liveness signal.
+        target_connection = str(target.get("connection_id") or "")
+        if target_connection and target_connection == read_local_connection_id(root):
+            return True
         roster_path = relay_root(root) / ROSTER_FILE
         try:
             age = time.time() - roster_path.stat().st_mtime

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -7,9 +7,9 @@ owns every socket — and these four methods are the door it uses on EACH
 connected gateway:
 
 - ``bot_relay.roster.sync``  — Desktop pushes the union roster of agents on
-  the OTHER connections into this gateway's ``bot_relay/roster.json``, so
-  ``message_agent`` can resolve cross-connection targets and Bot Chat
-  prompts list them (capability-epoch refresh picks up changes).
+  the OTHER connections plus this gateway's Desktop connection id into
+  ``bot_relay/roster.json``, so ``message_agent`` can resolve both remote
+  targets and a live same-install Bot Chat.
 - ``bot_relay.outbox.drain`` — Desktop collects envelopes queued here by
   ``message_agent`` for targets on other connections.
 - ``bot_relay.deliver``      — Desktop hands an envelope to the TARGET
@@ -35,8 +35,9 @@ def _(rid, params: dict) -> dict:
     """Replace this gateway's view of agents on OTHER connections.
 
     Params: ``agents`` — list of rows ``{profile, handle, connection_id,
-    connection_label?, title?, description?}``. Rows failing validation are
-    dropped, not fatal. Result: ``{count}`` (accepted rows).
+    connection_label?, title?, description?}``; ``local_connection_id`` —
+    optional Desktop route for this gateway. Invalid values are dropped, not
+    fatal. Result: ``{count}`` (accepted agent rows).
     """
     try:
         import os

--- a/tui_gateway/methods_bot_relay.py
+++ b/tui_gateway/methods_bot_relay.py
@@ -46,7 +46,11 @@ def _(rid, params: dict) -> dict:
 
         home = Path(os.getenv("HERMES_HOME") or os.path.expanduser("~/.hermes"))
         root = home.parent.parent if home.parent.name == "profiles" else home
-        count = write_remote_roster(root, params.get("agents"))
+        count = write_remote_roster(
+            root,
+            params.get("agents"),
+            local_connection_id=params.get("local_connection_id") or "",
+        )
         return _ok(rid, {"count": count})
     except Exception as e:
         return _err(rid, 5090, str(e))


### PR DESCRIPTION
## What does this PR do?

Local `message_agent` deliveries normally open the target profile's canonical `Bot Chat` through a one-shot CLI process. When Desktop already owns that session, the single-owner lease correctly rejects the subprocess with `already has a live owner`, but the message is not delivered.

This keeps the existing CLI delivery as the first choice. Only after that exact refusal does the runner move the same message through Hermes' existing Desktop Bot relay and `prompt.submit` path.

This is a narrower alternative to #101564. It reuses the relay already shipped for cross-connection Bot Mode delivery instead of adding another filesystem mailbox and Desktop/TUI polling subsystem.

## Related Issue

Fixes #101060

Related: #101293, #101564

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Preserve the direct local CLI delivery path as the first resolver rung.
- Advertise Desktop's fresh local connection ID through the existing Bot relay roster.
- After an exact live-owner refusal, enqueue the original message through that live Desktop connection and wait for the standard relay result.
- Allow a single Desktop connection to drain and deliver its own local relay envelopes while retaining the existing cross-connection retention behavior.
- Keep relay draining sequential so message order and RPC worker capacity remain bounded.
- Add focused Python and Desktop tests for direct-first routing, local fallback metadata, single-connection roster/drain behavior, same-connection delivery, and reply handling.

## How to Test

1. Open the receiving bot's canonical `Bot Chat` in Desktop so Desktop owns its session lease.
2. From another local bot profile, call `message_agent` for the receiving bot.
3. Confirm the normal CLI attempt receives the live-owner refusal, the message appears in the already-open Desktop Bot Chat through the existing relay, and no duplicate local turn is created.

Focused automated verification performed:

- `npm test -- src/plugins/hermes-bots/relay.test.ts` (22 passed)
- `npm run typecheck` (passed)
- `scripts/run_tests.sh tests/tools/test_bot_mode_dm.py tests/tools/test_bot_relay.py tests/tui_gateway/test_bot_relay_methods.py -q -j 4`
- Directly reran the newly affected `bot_mode_dm` and gateway roster tests with the installed Hermes environment; all changed-path assertions passed.
- `python -m py_compile` for all changed Python source and test files (passed)
- `git diff --check origin/main` (passed)
- `python scripts/check-windows-footguns.py --diff origin/main` reported only four pre-existing test-file findings already present on `origin/main`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A. The regression is covered by focused relay and delivery-path tests.
