### PR TITLE
fix(config): disambiguate same-URL/model custom providers by persisted api_mode

### DIFF
--- a/hermes_cli/cli_model_switch_mixin.py
+++ b/hermes_cli/cli_model_switch_mixin.py
@@ -28,10 +28,11 @@ def _runtime_fields(cli) -> dict:
     return {key: getattr(cli, key, None) for key in _RUNTIME_FIELDS}
 
 
-def _heal_bare_custom_provider(provider, *, base_url, model):
+def _heal_bare_custom_provider(provider, *, base_url, model, api_mode=None):
     """Bare ``custom`` is a billing class, not a routable identity: persisting/restoring it makes a
     later resume hard-fail once the config default leaves the custom endpoint. Recover the durable
-    ``custom:<name>`` menu key from the endpoint, else drop the provider (None)."""
+    ``custom:<name>`` menu key from the endpoint, else drop the provider (None). The optional
+    ``api_mode`` hint disambiguates entries sharing a URL/model (issue #102725)."""
     if str(provider or "").strip().lower() != "custom":
         return provider
     try:
@@ -39,7 +40,8 @@ def _heal_bare_custom_provider(provider, *, base_url, model):
         # a routable identity. (Stricter than the TUI gateway's recovery, which keeps bare "custom" when a
         # base_url exists — the CLI's resolve path would hard-fail on it, #14676.)
         from hermes_cli.runtime_provider import canonical_custom_identity
-        return canonical_custom_identity(base_url=base_url or None, model=model or None) or None
+        return canonical_custom_identity(
+            base_url=base_url or None, model=model or None, api_mode=api_mode or None) or None
     except Exception:
         return None
 
@@ -324,6 +326,7 @@ class CLIModelSwitchMixin:
         route = {
             "provider": _heal_bare_custom_provider(
                 result.target_provider, base_url=result.base_url, model=result.new_model,
+                api_mode=getattr(result, "api_mode", None),
             ) or None,
             # Both shapes use the same or-None discipline so stale keys from a previous switch are deleted
             # (not merely omitted) in BOTH the nested gateway_runtime dict (CLI reader) and the top-level
@@ -359,7 +362,8 @@ class CLIModelSwitchMixin:
         # Stricter than the TUI gateway's recovery (which keeps bare "custom" when a
         # base_url exists) — the CLI's resolve path would hard-fail on it.
         stored_provider = _heal_bare_custom_provider(
-            _stored_runtime.get("provider") or None, base_url=stored_base_url, model=stored_model)
+            _stored_runtime.get("provider") or None, base_url=stored_base_url, model=stored_model,
+            api_mode=stored_api_mode)
         model_changed = stored_model != self.model
         provider_changed = bool(stored_provider) and stored_provider != self.provider
         if not model_changed and not provider_changed:

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -218,8 +218,12 @@ def _effective_custom_entry_api_mode(entry: Dict[str, Any]) -> str:
 def _pick_custom_identity(candidates, api_mode=None) -> Optional[str]:
     """Pick one ``(slug, entry)`` candidate, preferring an ``api_mode`` match.
 
-    Without a usable ``api_mode`` (or when nothing matches it) the first
-    candidate wins — the historical behavior every existing caller relies on.
+    Without a usable ``api_mode`` hint the first candidate wins — the
+    historical behavior every existing caller relies on. But when the hint is
+    set and every matching entry failed mode probing, return None instead of
+    the first sibling: a wrong-wire fallback is worse than no recovery, and
+    every caller already treats None as "drop the provider" (issue #102725
+    reviewer follow-up on #102748).
     """
     if not candidates:
         return None
@@ -231,6 +235,7 @@ def _pick_custom_identity(candidates, api_mode=None) -> Optional[str]:
                     return slug
             except Exception:
                 continue
+        return None
     return candidates[0][0]
 
 

--- a/hermes_cli/runtime_provider_custom.py
+++ b/hermes_cli/runtime_provider_custom.py
@@ -200,19 +200,56 @@ def has_named_custom_provider(requested_provider: str) -> bool:
 # ── identity recovery (bare "custom" -> durable ``custom:<name>``) ─────────────────────────
 
 
-def _find_custom_identity(matches: Callable[[Dict[str, Any]], bool]) -> Optional[str]:
+def _effective_custom_entry_api_mode(entry: Dict[str, Any]) -> str:
+    """Effective wire mode of a ``providers:`` / ``custom_providers:`` entry.
+
+    Mirrors the mode named-custom resolution would route this entry through:
+    explicit ``api_mode`` (or new-style ``transport``) first, then
+    hostname-based detection, then the ``chat_completions`` default. Used to
+    disambiguate entries that share a URL/model (issue #102725).
+    """
+    rp = _rp()
+    mode = rp._parse_api_mode(entry.get("api_mode") or entry.get("transport"))
+    if mode:
+        return mode
+    return rp._detect_api_mode_for_url(_entry_url(entry)) or "chat_completions"
+
+
+def _pick_custom_identity(candidates, api_mode=None) -> Optional[str]:
+    """Pick one ``(slug, entry)`` candidate, preferring an ``api_mode`` match.
+
+    Without a usable ``api_mode`` (or when nothing matches it) the first
+    candidate wins — the historical behavior every existing caller relies on.
+    """
+    if not candidates:
+        return None
+    wanted = _rp()._parse_api_mode(api_mode)
+    if wanted:
+        for slug, entry in candidates:
+            try:
+                if _effective_custom_entry_api_mode(entry) == wanted:
+                    return slug
+            except Exception:
+                continue
+    return candidates[0][0]
+
+
+def _find_custom_identity(matches: Callable[[Dict[str, Any]], bool],
+                           api_mode: Optional[str] = None) -> Optional[str]:
     """First entry in ``providers:`` then legacy ``custom_providers:`` where ``matches(entry)``
-    holds, as its canonical ``custom:<name>`` slug."""
+    holds, as its canonical ``custom:<name>`` slug. When several entries match and ``api_mode``
+    names one of their wire modes, that entry wins (issue #102725); otherwise the first wins."""
     rp = _rp()
     try:
         config = rp.load_config()
     except Exception:
         return None
+    candidates: list = []
     providers = config.get("providers")
     if isinstance(providers, dict):
         for ep_name, entry in providers.items():
             if isinstance(entry, dict) and matches(entry):
-                return custom_provider_slug(str(ep_name), str(ep_name))
+                candidates.append((custom_provider_slug(str(ep_name), str(ep_name)), entry))
     try:
         custom_providers = rp.get_compatible_custom_providers(config)
     except Exception:
@@ -220,28 +257,34 @@ def _find_custom_identity(matches: Callable[[Dict[str, Any]], bool]) -> Optional
     for entry in custom_providers or []:
         name = entry.get("name") if isinstance(entry, dict) else None
         if isinstance(name, str) and name.strip() and matches(entry):
-            return custom_provider_slug(name, str(entry.get("provider_key", "") or ""))
-    return None
+            candidates.append(
+                (custom_provider_slug(name, str(entry.get("provider_key", "") or "")), entry))
+    return _pick_custom_identity(candidates, api_mode)
 
 
-def find_custom_provider_identity(base_url: str) -> Optional[str]:
+def find_custom_provider_identity(base_url: str, api_mode: Optional[str] = None) -> Optional[str]:
     """Map an endpoint URL back to its canonical ``custom:<name>`` menu key. Session persistence
     stores the agent's *resolved* provider, which for every named custom endpoint is the literal
-    string ``"custom"`` — the entry name is lost, and the api_key is deliberately never persisted."""
+    string ``"custom"`` — the entry name is lost, and the api_key is deliberately never persisted.
+    When several entries share the URL, the one whose wire mode matches ``api_mode`` wins
+    (issue #102725); otherwise the first wins."""
     target = _normalize_base_url_for_match(base_url)
     if not target:
         return None
-    return _find_custom_identity(lambda entry: _normalize_base_url_for_match(_entry_url(entry)) == target)
+    return _find_custom_identity(lambda entry: _normalize_base_url_for_match(_entry_url(entry)) == target,
+                                 api_mode=api_mode)
 
 
 def _model_id_matches(value: Any, target: str) -> bool:
     return isinstance(value, str) and value.strip().lower() == target
 
 
-def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
+def find_custom_provider_identity_by_model(model: str, api_mode: Optional[str] = None) -> Optional[str]:
     """Map a model id back to the ``custom:<name>`` entry that serves it — companion to
     :func:`find_custom_provider_identity` for persistence paths where no base_url survived the
-    round-trip (the session row always stores the model name)."""
+    round-trip (the session row always stores the model name). When several entries serve the
+    model, the one whose wire mode matches ``api_mode`` wins (issue #102725); otherwise the
+    first wins."""
     target = str(model or "").strip().lower()
     if not target:
         return None
@@ -257,21 +300,24 @@ def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
                        for item in models)
         return False
 
-    return _find_custom_identity(_entry_serves_model)
+    return _find_custom_identity(_entry_serves_model, api_mode=api_mode)
 
 
 def canonical_custom_identity(*, base_url: Optional[str] = None, config_provider: Optional[str] = None,
-                              model: Optional[str] = None) -> Optional[str]:
+                              model: Optional[str] = None,
+                              api_mode: Optional[str] = None) -> Optional[str]:
     """Recover a routable ``custom:<name>`` identity for a bare custom provider. Every path that
     persists or restores a session's provider override must run the resolved provider through this
     so a bare ``"custom"`` is upgraded back to its durable menu key. Sources in priority order:
     (1) ``base_url`` reverse lookup — the one fact that always survives the round-trip when a URL
     was recorded; (2) ``model`` reverse lookup (``model``/``default_model``/``models`` catalog);
     (3) the configured provider (arg, ``model.provider``, ``HERMES_INFERENCE_PROVIDER``) when it
-    names a real entry."""
+    names a real entry. The optional ``api_mode`` hint (persisted in ``gateway_runtime`` alongside
+    the URL) disambiguates entries sharing a URL/model but serving different wire protocols
+    (issue #102725); without it recovery keeps first-match behavior."""
     rp = _rp()
-    identity = (find_custom_provider_identity(base_url) if base_url else None) or (
-        find_custom_provider_identity_by_model(model) if model else None)
+    identity = (find_custom_provider_identity(base_url, api_mode=api_mode) if base_url else None) or (
+        find_custom_provider_identity_by_model(model, api_mode=api_mode) if model else None)
     if identity:
         return identity
     candidate = str(config_provider or "").strip()
@@ -297,7 +343,7 @@ def canonical_custom_identity(*, base_url: Optional[str] = None, config_provider
     if entry is None:
         return None
     try:
-        identity = find_custom_provider_identity(str(entry.get("base_url") or ""))
+        identity = find_custom_provider_identity(str(entry.get("base_url") or ""), api_mode=api_mode)
     except Exception:
         return None
     return identity or custom_provider_slug(candidate_norm)

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -232,7 +232,7 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
 
     import hermes_cli.runtime_provider as rp
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: "custom:myendpoint")
+                        lambda base_url=None, model=None, api_mode=None: "custom:myendpoint")
     stub = _make_stub(_session_db=_DB(), session_id="s1")
     stub._persist_model_switch_to_session(_BareResult())
     assert written["patch"]["provider"] == "custom:myendpoint"
@@ -240,7 +240,7 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
     # Healing fails -> provider dropped (explicit None deletes any stale
     # persisted provider), never persisted bare.
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: None)
+                        lambda base_url=None, model=None, api_mode=None: None)
     written.clear()
     stub._persist_model_switch_to_session(_BareResult())
     assert written["patch"]["provider"] is None
@@ -251,7 +251,7 @@ def test_restore_session_model_heals_bare_custom_stored_rows(monkeypatch):
     """Rows persisted by older builds may carry bare 'custom' — heal or drop."""
     import hermes_cli.runtime_provider as rp
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: None)
+                        lambda base_url=None, model=None, api_mode=None: None)
     stub = _make_stub()
     stub._restore_session_model(_row(model_config={
         "gateway_runtime": {"provider": "custom"},

--- a/tests/hermes_cli/test_custom_provider_api_mode_disambiguation.py
+++ b/tests/hermes_cli/test_custom_provider_api_mode_disambiguation.py
@@ -56,12 +56,12 @@ def test_url_lookup_without_hint_keeps_first_match(monkeypatch):
     assert rp.find_custom_provider_identity(URL) == "custom:provider-chat"
 
 
-def test_url_lookup_with_unmatched_hint_falls_back_to_first(monkeypatch):
+def test_url_lookup_with_unmatched_hint_returns_none(monkeypatch):
+    """A usable hint that matches no candidate must NOT fall back to the first
+    entry (which may be a different wire mode) — reviewer follow-up on #102748.
+    Historical first-wins applies only when no usable ``api_mode`` is given."""
     _cfg(monkeypatch)
-    assert (
-        rp.find_custom_provider_identity(URL, api_mode="anthropic_messages")
-        == "custom:provider-chat"
-    )
+    assert rp.find_custom_provider_identity(URL, api_mode="anthropic_messages") is None
 
 
 def test_model_lookup_prefers_matching_api_mode(monkeypatch):
@@ -168,3 +168,41 @@ def test_healed_slug_resolves_back_with_right_mode(monkeypatch):
     assert entry is not None
     assert entry["api_mode"] == "codex_responses"
     assert entry["api_key"] == "sk-responses"
+
+
+def test_hint_with_all_entries_broken_returns_none_not_first(monkeypatch):
+    """Reviewer follow-up (#102748): when ``api_mode`` is set but every matching
+    entry throws during mode probing, recovery must return None — never the
+    first sibling, which may be a different wire mode."""
+    _cfg(
+        monkeypatch,
+        {
+            "custom_providers": [
+                {
+                    "name": "provider-chat",
+                    "base_url": URL,
+                    "api_key": "sk-chat",
+                    "api_mode": "chat_completions",
+                    "model": MODEL,
+                    "models": {MODEL: {"context_length": 1000000}},
+                },
+                {
+                    "name": "provider-responses",
+                    "base_url": URL,
+                    "api_key": "sk-responses",
+                    "api_mode": "codex_responses",
+                    "model": MODEL,
+                    "models": {MODEL: {"context_length": 1000000}},
+                },
+            ]
+        },
+    )
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider_custom._effective_custom_entry_api_mode",
+        lambda entry: (_ for _ in ()).throw(RuntimeError("probe failed")),
+    )
+    assert rp.find_custom_provider_identity(URL, api_mode="codex_responses") is None
+    assert (
+        rp.find_custom_provider_identity_by_model(MODEL, api_mode="codex_responses")
+        is None
+    )

--- a/tests/hermes_cli/test_custom_provider_api_mode_disambiguation.py
+++ b/tests/hermes_cli/test_custom_provider_api_mode_disambiguation.py
@@ -1,0 +1,170 @@
+"""Regression tests for issue #102725.
+
+Two named ``custom_providers`` entries that share one ``base_url`` and serve
+one model id but use different ``api_mode`` values must not collapse to the
+first config entry during identity recovery. The persisted ``api_mode``
+(stored alongside ``base_url`` in the session's ``gateway_runtime``)
+disambiguates them; without the hint the historical first-match behavior is
+preserved.
+"""
+
+import hermes_cli.runtime_provider as rp
+
+URL = "https://example.com/v1"
+MODEL = "model-x"
+
+CONFIG = {
+    "custom_providers": [
+        {
+            "name": "provider-chat",
+            "base_url": URL,
+            "api_key": "sk-chat",
+            "api_mode": "chat_completions",
+            "model": MODEL,
+            "models": {MODEL: {"context_length": 1000000}},
+        },
+        {
+            "name": "provider-responses",
+            "base_url": URL,
+            "api_key": "sk-responses",
+            "api_mode": "codex_responses",
+            "model": MODEL,
+            "models": {MODEL: {"context_length": 1000000}},
+        },
+    ]
+}
+
+
+def _cfg(monkeypatch, config=None):
+    monkeypatch.setattr(rp, "load_config", lambda: config if config is not None else CONFIG)
+
+
+def test_url_lookup_prefers_matching_api_mode(monkeypatch):
+    _cfg(monkeypatch)
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="codex_responses")
+        == "custom:provider-responses"
+    )
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="chat_completions")
+        == "custom:provider-chat"
+    )
+
+
+def test_url_lookup_without_hint_keeps_first_match(monkeypatch):
+    _cfg(monkeypatch)
+    assert rp.find_custom_provider_identity(URL) == "custom:provider-chat"
+
+
+def test_url_lookup_with_unmatched_hint_falls_back_to_first(monkeypatch):
+    _cfg(monkeypatch)
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="anthropic_messages")
+        == "custom:provider-chat"
+    )
+
+
+def test_model_lookup_prefers_matching_api_mode(monkeypatch):
+    _cfg(monkeypatch)
+    assert (
+        rp.find_custom_provider_identity_by_model(MODEL, api_mode="codex_responses")
+        == "custom:provider-responses"
+    )
+    assert (
+        rp.find_custom_provider_identity_by_model(MODEL, api_mode="chat_completions")
+        == "custom:provider-chat"
+    )
+
+
+def test_model_lookup_without_hint_keeps_first_match(monkeypatch):
+    _cfg(monkeypatch)
+    assert rp.find_custom_provider_identity_by_model(MODEL) == "custom:provider-chat"
+
+
+def test_canonical_identity_uses_api_mode_hint(monkeypatch):
+    _cfg(monkeypatch)
+    assert (
+        rp.canonical_custom_identity(
+            base_url=URL, model=MODEL, api_mode="codex_responses"
+        )
+        == "custom:provider-responses"
+    )
+    assert (
+        rp.canonical_custom_identity(
+            base_url=URL, model=MODEL, api_mode="chat_completions"
+        )
+        == "custom:provider-chat"
+    )
+    # Model-only recovery (no base_url survived) is disambiguated too.
+    assert (
+        rp.canonical_custom_identity(model=MODEL, api_mode="codex_responses")
+        == "custom:provider-responses"
+    )
+
+
+def test_canonical_identity_without_hint_keeps_first_match(monkeypatch):
+    _cfg(monkeypatch)
+    assert (
+        rp.canonical_custom_identity(base_url=URL, model=MODEL)
+        == "custom:provider-chat"
+    )
+
+
+def test_implicit_chat_entry_matches_chat_hint(monkeypatch):
+    """An entry with no explicit ``api_mode`` behaves as chat_completions."""
+    _cfg(
+        monkeypatch,
+        {
+            "custom_providers": [
+                {"name": "implicit-chat", "base_url": URL, "models": {MODEL: {}}},
+                {
+                    "name": "explicit-responses",
+                    "base_url": URL,
+                    "api_mode": "codex_responses",
+                    "models": {MODEL: {}},
+                },
+            ]
+        },
+    )
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="chat_completions")
+        == "custom:implicit-chat"
+    )
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="codex_responses")
+        == "custom:explicit-responses"
+    )
+
+
+def test_providers_dict_shape_with_transport(monkeypatch):
+    """New-style ``providers:`` entries using ``transport`` are honored."""
+    _cfg(
+        monkeypatch,
+        {
+            "providers": {
+                "ep-chat": {"api": URL, "transport": "chat_completions"},
+                "ep-responses": {"api": URL, "transport": "codex_responses"},
+            }
+        },
+    )
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="codex_responses")
+        == "custom:ep-responses"
+    )
+    assert (
+        rp.find_custom_provider_identity(URL, api_mode="chat_completions")
+        == "custom:ep-chat"
+    )
+
+
+def test_healed_slug_resolves_back_with_right_mode(monkeypatch):
+    """The healed identity must route through the intended entry's mode."""
+    _cfg(monkeypatch)
+    slug = rp.canonical_custom_identity(
+        base_url=URL, model=MODEL, api_mode="codex_responses"
+    )
+    assert slug == "custom:provider-responses"
+    entry = rp._get_named_custom_provider(slug)
+    assert entry is not None
+    assert entry["api_mode"] == "codex_responses"
+    assert entry["api_key"] == "sk-responses"

--- a/tui_gateway/methods_complete_helpers.py
+++ b/tui_gateway/methods_complete_helpers.py
@@ -171,7 +171,8 @@ def _model_picker_context(agent):
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
             provider = canonical_custom_identity(
-                base_url=base_url or None, config_provider=ctx.current_provider, model=model or None) or provider
+                base_url=base_url or None, config_provider=ctx.current_provider, model=model or None,
+                api_mode=(getattr(agent, "api_mode", "") or None) if agent else None) or provider
         except Exception:
             logger.debug("custom provider identity recovery failed (model picker)", exc_info=True)
     return ctx.with_overrides(

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1485,7 +1485,8 @@ def _stored_session_runtime_overrides(row: dict | None) -> dict:
         healed = None
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
-            healed = canonical_custom_identity(base_url=base_url or None, model=model or None)
+            healed = canonical_custom_identity(base_url=base_url or None, model=model or None,
+                                               api_mode=api_mode or None)
         except Exception:
             logger.debug("custom provider identity recovery failed", exc_info=True)
         if healed:
@@ -1520,7 +1521,8 @@ def _runtime_model_config(agent, existing: dict | None = None) -> dict:
         # identity (api_key is never persisted): recover ``custom:<name>`` from the endpoint URL.
         try:
             from hermes_cli.runtime_provider import canonical_custom_identity
-            provider = canonical_custom_identity(base_url=base_url, model=model or None) or provider
+            provider = canonical_custom_identity(base_url=base_url, model=model or None,
+                                                 api_mode=attr("api_mode") or None) or provider
         except Exception:
             logger.debug("custom provider identity lookup failed", exc_info=True)
     reasoning_config = getattr(agent, "reasoning_config", None)


### PR DESCRIPTION
Fixes #102725.

When two named `custom_providers` entries share one `base_url` and serve one model id but use different `api_mode` values, identity recovery always returned the first config entry — silently flipping sessions between wire protocols (display vs runtime desync).

## What changed

- `hermes_cli/runtime_provider_custom.py`
  - `_find_custom_identity()` now collects all matching candidates instead of returning the first hit.
  - New `_effective_custom_entry_api_mode()`: mirrors the mode named-custom resolution would route an entry through (explicit `api_mode`/`transport` → hostname detection → `chat_completions` default).
  - New `_pick_custom_identity()`: prefers the candidate whose effective mode matches an optional `api_mode` hint; without a hint (or no match) the first candidate wins — historical behavior preserved.
  - `find_custom_provider_identity()`, `find_custom_provider_identity_by_model()` and `canonical_custom_identity()` accept and forward the optional `api_mode` hint.
- Heal sites now pass the already-persisted `api_mode` through:
  - `hermes_cli/cli_model_switch_mixin.py` (`_heal_bare_custom_provider` + persist/resume callers),
  - `tui_gateway/server.py` (stale-provider heal + `_runtime_model_config`),
  - `tui_gateway/methods_complete_helpers.py` (model picker context).
- Tests: new `tests/hermes_cli/test_custom_provider_api_mode_disambiguation.py` (10 cases: URL/model/canonical × hint/no-hint/unmatched-hint, implicit-chat default, new-style `providers:` + `transport` shape, heal→re-resolve round trip); updated three `canonical_custom_identity` fakes in `tests/cli/test_resume_model_restore.py` for the widened signature.

## Verification

- New file: 10/10 pass.
- Related suites (`test_custom_provider_identity`, `test_canonical_custom_identity`, `test_runtime_provider_resolution`, `test_resume_model_restore`, `test_custom_provider_session_persistence`, `test_apply_model_switch_result_context`, `test_custom_provider_model_switch`): 165 passed.
- End-to-end check against the issue repro (two entries, one URL/model, `chat_completions` vs `codex_responses`): switch resolves, persist-heal and resume-heal land on the intended entry, legacy no-hint rows keep first-match.
- Rebased onto current `main` after the `runtime_provider*.py` / `cli_model_switch_mixin.py` extraction refactor (was `CONFLICTING`, now `MERGEABLE`); the port additionally covers the gateway heal paths that the refactor exposed.

## Notes for reviewers

- The fix only *adds* an optional hint; every caller that doesn't pass `api_mode` gets byte-identical behavior to before.
- One known adjacent gap deliberately left out of scope: entries sharing URL+model where *neither* side persists `api_mode` still heal to the first entry (nothing to disambiguate with). Happy to follow up if you want a `requested_provider`-based tiebreak there too.
