### PR TITLE
fix(agent): disambiguate custom providers sharing base_url by api_mode (#102725)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9317,6 +9317,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 provider = canonical_custom_identity(
                     base_url=result.base_url or None,
                     model=result.new_model or None,
+                    api_mode=result.api_mode or None,
                 ) or None
             except Exception:
                 provider = None
@@ -9394,6 +9395,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                 stored_provider = canonical_custom_identity(
                     base_url=stored_base_url or None,
                     model=stored_model or None,
+                    api_mode=stored_api_mode or None,
                 ) or None
             except Exception:
                 stored_provider = None

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -949,7 +949,9 @@ def has_named_custom_provider(requested_provider: str) -> bool:
         return False
 
 
-def find_custom_provider_identity(base_url: str) -> Optional[str]:
+def find_custom_provider_identity(
+    base_url: str, *, api_mode: Optional[str] = None,
+) -> Optional[str]:
     """Map an endpoint URL back to its canonical ``custom:<name>`` menu key.
 
     Returns the ``custom:<normalized-name>`` slug of the first ``providers:``
@@ -973,8 +975,15 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
     except Exception:
         return None
 
+    def _entry_api_mode(entry: Dict[str, Any]) -> Optional[str]:
+        raw = entry.get("api_mode")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+        return None
+
     providers = config.get("providers")
     if isinstance(providers, dict):
+        fallback: Optional[str] = None
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue
@@ -982,12 +991,19 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
                 entry.get("api") or entry.get("url") or entry.get("base_url") or ""
             )
             if _normalize_base_url_for_match(entry_url) == target:
-                return custom_provider_slug(str(ep_name), str(ep_name))
+                slug = custom_provider_slug(str(ep_name), str(ep_name))
+                if api_mode and _entry_api_mode(entry) == api_mode.lower():
+                    return slug
+                if fallback is None:
+                    fallback = slug
+        if fallback is not None:
+            return fallback
 
     try:
         custom_providers = get_compatible_custom_providers(config)
     except Exception:
         custom_providers = None
+    cp_fallback: Optional[str] = None
     for entry in custom_providers or []:
         if not isinstance(entry, dict):
             continue
@@ -995,15 +1011,23 @@ def find_custom_provider_identity(base_url: str) -> Optional[str]:
         if not isinstance(name, str) or not name.strip():
             continue
         if _normalize_base_url_for_match(entry.get("base_url")) == target:
-            return custom_provider_slug(
+            slug = custom_provider_slug(
                 name,
                 str(entry.get("provider_key", "") or ""),
             )
+            if api_mode and _entry_api_mode(entry) == api_mode.lower():
+                return slug
+            if cp_fallback is None:
+                cp_fallback = slug
+    if cp_fallback is not None:
+        return cp_fallback
 
     return None
 
 
-def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
+def find_custom_provider_identity_by_model(
+    model: str, *, api_mode: Optional[str] = None,
+) -> Optional[str]:
     """Map a model id back to the ``custom:<name>`` entry that serves it.
 
     Returns the ``custom:<normalized-name>`` slug of the first ``providers:``
@@ -1046,18 +1070,32 @@ def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
                         return True
         return False
 
+    def _entry_api_mode(entry: Dict[str, Any]) -> Optional[str]:
+        raw = entry.get("api_mode")
+        if isinstance(raw, str) and raw.strip():
+            return raw.strip().lower()
+        return None
+
     providers = config.get("providers")
     if isinstance(providers, dict):
+        fallback: Optional[str] = None
         for ep_name, entry in providers.items():
             if not isinstance(entry, dict):
                 continue
             if _entry_serves_model(entry):
-                return custom_provider_slug(str(ep_name), str(ep_name))
+                slug = custom_provider_slug(str(ep_name), str(ep_name))
+                if api_mode and _entry_api_mode(entry) == api_mode.lower():
+                    return slug
+                if fallback is None:
+                    fallback = slug
+        if fallback is not None:
+            return fallback
 
     try:
         custom_providers = get_compatible_custom_providers(config)
     except Exception:
         custom_providers = None
+    cp_fallback: Optional[str] = None
     for entry in custom_providers or []:
         if not isinstance(entry, dict):
             continue
@@ -1065,10 +1103,16 @@ def find_custom_provider_identity_by_model(model: str) -> Optional[str]:
         if not isinstance(name, str) or not name.strip():
             continue
         if _entry_serves_model(entry):
-            return custom_provider_slug(
+            slug = custom_provider_slug(
                 name,
                 str(entry.get("provider_key", "") or ""),
             )
+            if api_mode and _entry_api_mode(entry) == api_mode.lower():
+                return slug
+            if cp_fallback is None:
+                cp_fallback = slug
+    if cp_fallback is not None:
+        return cp_fallback
 
     return None
 
@@ -1078,6 +1122,7 @@ def canonical_custom_identity(
     base_url: Optional[str] = None,
     config_provider: Optional[str] = None,
     model: Optional[str] = None,
+    api_mode: Optional[str] = None,
 ) -> Optional[str]:
     """Recover a routable ``custom:<name>`` identity for a bare custom provider.
 
@@ -1114,13 +1159,13 @@ def canonical_custom_identity(
     """
     # 1. Reverse-lookup by endpoint URL.
     if base_url:
-        identity = find_custom_provider_identity(base_url)
+        identity = find_custom_provider_identity(base_url, api_mode=api_mode)
         if identity:
             return identity
 
     # 2. Reverse-lookup by the session's model name.
     if model:
-        identity = find_custom_provider_identity_by_model(model)
+        identity = find_custom_provider_identity_by_model(model, api_mode=api_mode)
         if identity:
             return identity
 

--- a/tests/cli/test_resume_model_restore.py
+++ b/tests/cli/test_resume_model_restore.py
@@ -232,7 +232,7 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
 
     import hermes_cli.runtime_provider as rp
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: "custom:myendpoint")
+                        lambda base_url=None, model=None, api_mode=None: "custom:myendpoint")
     stub = _make_stub(_session_db=_DB(), session_id="s1")
     stub._persist_model_switch_to_session(_BareResult())
     assert written["patch"]["provider"] == "custom:myendpoint"
@@ -240,7 +240,7 @@ def test_persist_model_switch_heals_bare_custom(monkeypatch):
     # Healing fails -> provider dropped (explicit None deletes any stale
     # persisted provider), never persisted bare.
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: None)
+                        lambda base_url=None, model=None, api_mode=None: None)
     written.clear()
     stub._persist_model_switch_to_session(_BareResult())
     assert written["patch"]["provider"] is None
@@ -251,7 +251,7 @@ def test_restore_session_model_heals_bare_custom_stored_rows(monkeypatch):
     """Rows persisted by older builds may carry bare 'custom' — heal or drop."""
     import hermes_cli.runtime_provider as rp
     monkeypatch.setattr(rp, "canonical_custom_identity",
-                        lambda base_url=None, model=None: None)
+                        lambda base_url=None, model=None, api_mode=None: None)
     stub = _make_stub()
     stub._restore_session_model(_row(model_config={
         "gateway_runtime": {"provider": "custom"},


### PR DESCRIPTION
Fixes #102725

## Root cause

`find_custom_provider_identity()` and `find_custom_provider_identity_by_model()` return the **first** config entry that matches the lookup key (base_url or model). When two `custom_providers` entries share the same base_url and model but differ in `api_mode` (e.g. `chat_completions` vs `codex_responses`), the first entry in config order always wins — regardless of which provider the user selected.

Session resume calls `canonical_custom_identity()` to heal bare `"custom"` back to `custom:<name>`, but without `api_mode` context the heal picks the wrong entry. The model picker still shows the originally selected provider, producing a display-vs-runtime desync (wrong wire protocol *and* wrong credentials).

## Fix

Thread the persisted `api_mode` through `canonical_custom_identity()` into both reverse-lookup functions. When `api_mode` is provided and matches an entry, prefer it over the first hit. Fall back to first-match when `api_mode` is absent or matches none (backward compatible).

Both CLI call sites now pass `api_mode`:
- `/model` switch path: `result.api_mode`
- `_restore_session_model` (resume): `stored_api_mode` from `gateway_runtime`

## Testing

- All 11 existing `test_canonical_custom_identity` tests pass
- All 22 existing `test_resume_model_restore` tests pass (3 lambda stubs updated to accept `api_mode` kwarg)
- `py_compile` clean on both `runtime_provider.py` and `cli.py`
