### PR TITLE
fix(feishu): propagate comment client to tool workers

### DIFF
--- a/tests/tools/test_feishu_tools.py
+++ b/tests/tools/test_feishu_tools.py
@@ -2,8 +2,10 @@
 
 import importlib
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 
 from tools.registry import registry
+from tools.thread_context import propagate_context_to_thread
 
 # Trigger tool discovery so feishu tools get registered
 importlib.import_module("tools.feishu_doc_tool")
@@ -36,6 +38,57 @@ class TestFeishuToolRegistration(unittest.TestCase):
             props = entry.schema["parameters"].get("properties", {})
             self.assertIn("file_token", props, f"{tool_name} missing file_token param")
             self.assertIn("file_type", props, f"{tool_name} missing file_type param")
+
+
+class TestFeishuCommentClientContext(unittest.TestCase):
+    """The comment client must survive concurrent tool dispatch."""
+
+    def setUp(self):
+        self.doc_tool = importlib.import_module("tools.feishu_doc_tool")
+        self.drive_tool = importlib.import_module("tools.feishu_drive_tool")
+        self.doc_tool.set_client(None)
+        self.drive_tool.set_client(None)
+
+    def tearDown(self):
+        self.doc_tool.set_client(None)
+        self.drive_tool.set_client(None)
+
+    def test_comment_client_reaches_propagated_tool_worker(self):
+        client = object()
+        self.doc_tool.set_client(client)
+        self.drive_tool.set_client(client)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            observed = executor.submit(
+                propagate_context_to_thread(
+                    lambda: (self.doc_tool.get_client(), self.drive_tool.get_client())
+                )
+            ).result()
+
+        self.assertEqual(observed, (client, client))
+
+    def test_cleared_comment_client_does_not_leak_to_reused_worker(self):
+        client = object()
+        self.doc_tool.set_client(client)
+        self.drive_tool.set_client(client)
+
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            first = executor.submit(
+                propagate_context_to_thread(
+                    lambda: (self.doc_tool.get_client(), self.drive_tool.get_client())
+                )
+            ).result()
+
+            self.doc_tool.set_client(None)
+            self.drive_tool.set_client(None)
+            second = executor.submit(
+                propagate_context_to_thread(
+                    lambda: (self.doc_tool.get_client(), self.drive_tool.get_client())
+                )
+            ).result()
+
+        self.assertEqual(first, (client, client))
+        self.assertEqual(second, (None, None))
 
 
 if __name__ == "__main__":

--- a/tools/feishu_doc_tool.py
+++ b/tools/feishu_doc_tool.py
@@ -6,24 +6,27 @@ Uses the same lazy-import + BaseRequest pattern as feishu_comment.py.
 
 import json
 import logging
-import threading
+import contextvars
 
 from tools.registry import registry, tool_error, tool_result
 
 logger = logging.getLogger(__name__)
 
-# Thread-local storage for the lark client injected by feishu_comment handler.
-_local = threading.local()
+# The comment handler runs an agent whose tools may be dispatched to a worker
+# thread.  ``tools.thread_context.propagate_context_to_thread`` carries
+# ContextVars into that worker, whereas ``threading.local`` would be empty
+# there and make an otherwise valid comment-context client disappear.
+_client_context = contextvars.ContextVar("feishu_doc_tool_client", default=None)
 
 
 def set_client(client):
-    """Store a lark client for the current thread (called by feishu_comment)."""
-    _local.client = client
+    """Store the comment-context lark client for this agent execution."""
+    _client_context.set(client)
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for this execution context, or None."""
+    return _client_context.get()
 
 
 # ---------------------------------------------------------------------------

--- a/tools/feishu_drive_tool.py
+++ b/tools/feishu_drive_tool.py
@@ -7,24 +7,25 @@ The lark client is injected per-thread by the comment event handler.
 
 import json
 import logging
-import threading
+import contextvars
 
 from tools.registry import registry, tool_error, tool_result
 
 logger = logging.getLogger(__name__)
 
-# Thread-local storage for the lark client injected by feishu_comment handler.
-_local = threading.local()
+# See ``tools.feishu_doc_tool``: comment-agent tool calls may run on a worker
+# thread, so the scoped client must follow Hermes' ContextVar propagation path.
+_client_context = contextvars.ContextVar("feishu_drive_tool_client", default=None)
 
 
 def set_client(client):
-    """Store a lark client for the current thread (called by feishu_comment)."""
-    _local.client = client
+    """Store the comment-context lark client for this agent execution."""
+    _client_context.set(client)
 
 
 def get_client():
-    """Return the lark client for the current thread, or None."""
-    return getattr(_local, "client", None)
+    """Return the lark client for this execution context, or None."""
+    return _client_context.get()
 
 
 def _check_feishu():


### PR DESCRIPTION
## Summary

When a Drive comment event starts a comment agent, the handler injects the Feishu client in the agent thread. Tool calls are then dispatched through the existing concurrent executor, which propagates `ContextVar`s but not `threading.local()` values. As a result, document/comment tools fail closed with `Feishu client not available` despite a valid comment context.

This replaces the two per-thread client holders with module-scoped `ContextVar`s. It keeps the client limited to the same comment-agent execution and preserves the existing missing-client failure for DM, CLI, and other non-comment contexts.

## Tests

- `uv run --locked --extra dev --extra feishu --extra mcp python -m pytest tests/tools/test_feishu_tools.py tests/gateway/test_feishu_comment.py -q`
- `uv run --locked --extra dev --extra feishu --extra mcp ruff check tools/feishu_doc_tool.py tools/feishu_drive_tool.py tests/tools/test_feishu_tools.py`

Adds coverage for propagation to a nested tool worker and for clearing the context before a reused worker runs.

Related: #29760. This is intentionally narrower than the shared-client/DM fallback proposals: it fixes the current comment-event tool-dispatch path without widening Feishu client availability.