### PR TITLE
feat(langfuse): tag traces by platform and trigger

### DIFF
--- a/plugins/observability/langfuse/README.md
+++ b/plugins/observability/langfuse/README.md
@@ -40,6 +40,9 @@ Generation observations include the Hermes system prompt when the provider
 uses a separate `system` param (Anthropic Messages API). Open an **LLM call**
 child span to inspect `role: system` (truncated via `HERMES_LANGFUSE_MAX_CHARS`).
 
+Root traces include `platform:<name>` and `trigger:cron|interactive` tags, so
+scheduled runs can be filtered separately from interactive sessions.
+
 ## Optional tuning
 
 ```bash

--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -507,6 +507,17 @@ def _usage_and_cost(response: Any, *, provider: str, model: str, base_url: str, 
         return {}, {}
 
 
+def _trace_tags(platform: str) -> list[str]:
+    """Return stable, content-free tags for the root Langfuse trace."""
+    normalized_platform = platform.strip().lower()
+    tags = ["hermes", "langfuse"]
+    if normalized_platform:
+        tags.append(f"platform:{normalized_platform}")
+    trigger = "cron" if normalized_platform == "cron" else "interactive"
+    tags.append(f"trigger:{trigger}")
+    return tags
+
+
 def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform: str, provider: str, model: str,
                       api_mode: str, messages: Any, client: Langfuse,
                       turn_id: str = "", api_request_id: str = "") -> TraceState:
@@ -531,7 +542,7 @@ def _start_root_trace(task_key: str, *, task_id: str, session_id: str, platform:
     if propagate_attributes is not None:
         try:
             with propagate_attributes(session_id=session_id or task_key, trace_name="Hermes turn",
-                                      tags=["hermes", "langfuse"]):
+                                      tags=_trace_tags(platform)):
                 root_ctx, root_span = open_root()
         except Exception:
             root_ctx = None

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -1138,6 +1138,87 @@ class TestCostTotal:
 # Capture modes: metadata | sanitized | full  (HERMES_LANGFUSE_CAPTURE)
 # ---------------------------------------------------------------------------
 
+class TestTraceTags:
+    def _fresh_plugin(self):
+        sys.modules.pop("plugins.observability.langfuse", None)
+        return importlib.import_module("plugins.observability.langfuse")
+
+    @pytest.mark.parametrize(
+        ("platform", "expected"),
+        [
+            ("cron", ["hermes", "langfuse", "platform:cron", "trigger:cron"]),
+            (
+                "telegram",
+                ["hermes", "langfuse", "platform:telegram", "trigger:interactive"],
+            ),
+            ("", ["hermes", "langfuse", "trigger:interactive"]),
+        ],
+    )
+    def test_trace_tags_expose_platform_and_trigger(self, platform, expected):
+        mod = self._fresh_plugin()
+
+        assert mod._trace_tags(platform) == expected
+
+    def test_root_trace_propagates_derived_tags(self, monkeypatch):
+        mod = self._fresh_plugin()
+        seen = {}
+
+        class _Attributes:
+            def __enter__(self):
+                return None
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Span:
+            def update(self, **kw):
+                pass
+
+            def end(self, **kw):
+                pass
+
+            def set_trace_io(self, **kw):
+                pass
+
+        class _RootCM:
+            def __enter__(self):
+                return _Span()
+
+            def __exit__(self, *exc):
+                return False
+
+        class _Client:
+            def create_trace_id(self, seed=None):
+                return "t1"
+
+            def start_as_current_observation(self, **kw):
+                return _RootCM()
+
+        def _propagate_attributes(**kwargs):
+            seen.update(kwargs)
+            return _Attributes()
+
+        monkeypatch.setattr(mod, "propagate_attributes", _propagate_attributes)
+
+        mod._start_root_trace(
+            "k",
+            task_id="t",
+            session_id="s",
+            platform="cron",
+            provider="p",
+            model="m",
+            api_mode="chat",
+            messages=[{"role": "user", "content": "hi"}],
+            client=_Client(),
+        )
+
+        assert seen["tags"] == [
+            "hermes",
+            "langfuse",
+            "platform:cron",
+            "trigger:cron",
+        ]
+
 class TestCaptureModes:
     def _fresh_plugin(self):
         sys.modules.pop("plugins.observability.langfuse", None)


### PR DESCRIPTION
## What does this PR do?

Adds stable, content-free tags to every Langfuse root trace:

- `platform:<name>` when Hermes provides a platform
- `trigger:cron` for scheduled runs
- `trigger:interactive` for all other runs

The platform value already reaches `_start_root_trace`; this PR only derives tags at that existing boundary and keeps the current `hermes` and `langfuse` tags.

No prompts, messages, tool arguments/results, user identifiers, credentials, or local paths are added to tags.

## Related Issue

Fixes #88502

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- derive normalized platform and trigger tags for Langfuse root traces
- document the new filtering tags
- cover cron, interactive, missing-platform, and propagation behavior

## How to Test

1. Run `scripts/run_tests.sh tests/plugins/test_langfuse_plugin.py -q`.
2. Confirm all 93 tests pass.
3. With Langfuse enabled, run one interactive turn and one cron job; filter root traces by `trigger:interactive` and `trigger:cron`.
4. Run Ruff on the changed source and test files.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature (no unrelated commits)
- [x] I've run the focused CI-equivalent test file and all 93 tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS (unit tests with a synthetic Langfuse SDK; no live credentials)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (plugin README)
- [x] `cli-config.yaml.example` update is N/A (no config keys changed)
- [x] `CONTRIBUTING.md` / `AGENTS.md` update is N/A (no architecture or workflow changes)
- [x] I've considered cross-platform impact; the change is pure string tagging with no platform-specific I/O
- [x] Tool descriptions/schemas update is N/A (no tool behavior changed)
