### PR TITLE
test(kanban): stop corruption-watcher test on connect signal, not to_thread counts

### DIFF
--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1061,7 +1061,7 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
     )
     monkeypatch.setattr(_kb, "kanban_db_path", lambda board=None: corrupt_db)
 
-    calls = {"connect": 0, "to_thread": 0}
+    calls = {"connect": 0}
 
     def _connect(*args, **kwargs):
         calls["connect"] += 1
@@ -1074,16 +1074,18 @@ def test_gateway_dispatcher_disables_corrupt_board_without_traceback(
         raise sqlite3.DatabaseError("file is not a database")
 
     async def _to_thread(fn, *args, **kwargs):
-        # PR salvage (#32857 commit 7): the dispatcher now reaps zombies at
-        # the top of each tick via ``asyncio.to_thread(_kb.reap_worker_zombies)``
-        # BEFORE the per-board tick work. Each tick now issues 3 ``to_thread``
-        # calls (reaper + ``_tick_once`` + ``_ready_nonempty``) instead of 2,
-        # so this counter must reach 6 to allow the same 2 dispatch ticks the
-        # pre-reaper test expected at 4. Connect counts in the assertion below
-        # are unchanged.
-        calls["to_thread"] += 1
         result = fn(*args, **kwargs)
-        if calls["to_thread"] >= 6:
+        # Stop on the CONNECT signal, not on a to_thread call count. Each
+        # tick's to_thread traffic (zombie reaper + tick + ready probes) is
+        # an implementation detail that changes when the watcher's control
+        # flow evolves (PR #102708's lifecycle work), and this test is not
+        # about it. What it IS about is the quarantine: the first tick's
+        # dispatch connect raises (once), and the second tick must skip the
+        # dispatch connect while still running the ready/review probes —
+        # exactly `calls["connect"] == 5`. Stopping on that signal keeps the
+        # test green across to_thread refactors and fails loudly only when
+        # the connect behavior it asserts actually changes.
+        if calls["connect"] >= 5:
             runner._running = False
         return result
 


### PR DESCRIPTION
Fixes #102710.

## What
- The corrupt-board dispatcher test (`test_gateway_dispatcher_disables_corrupt_board_without_traceback[sqlite|guard]`) flipped `runner._running` after a hard-coded **6** `asyncio.to_thread` calls (2 ticks × reaper + tick + ready probes).
- That count is an implementation detail of the watcher threading, orthogonal to what the test asserts — the gateway watcher control-flow changes in PR #102708 shift it, which is exactly how the issue observed both parametrized cases timing out under `asyncio.wait_for(..., 3.0)`.
- The stop condition is now derived from the same signal the assertions verify: two full dispatch ticks with exactly 5 `_kb.connect` calls (tick 1: dispatch connect raises once + ready/review probes; tick 2: dispatch connect suppressed by the corrupt-board quarantine, probes still connect).
- The dead `to_thread` counter was removed.

## Tests
- `uv run python -m pytest tests/hermes_cli/test_kanban_core_functionality.py::test_gateway_dispatcher_disables_corrupt_board_without_traceback` → **2 passed** (1.09s)
- Full file `tests/hermes_cli/test_kanban_core_functionality.py` → 22 passed, 1 skipped, 1 failed; the failure (`test_protocol_violation_budget_not_consumed_by_other_failures`) is **pre-existing on clean main** (verified by stashing the change and re-running — 1 failed on the pristine tree).
- `tests/gateway/test_kanban_watchers_mixin.py` → passed.
- Windows 11 native, git-bash, Python 3.11 venv.

## Notes
- Test-only change; no runtime code touched. With the stop tied to connect counts, a to_thread refactor (like #102708) no longer hangs this test, while a genuine change to quarantine/connect behavior still fails the assertions loudly.
- Not run: full repo suite (impractical locally); the touched test file + sibling kanban watcher tests are the relevant surface.