### PR TITLE
feat(desktop): add system tray icon with show/quit actions

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -42,8 +42,7 @@ import {
   isPidOnlyStartMarker,
   pidOnlyStartMarker,
   probeStartMarker,
-  processStartMarker,
-  REAP_PROBE_TIMEOUT_MS
+  processStartMarker
 } from './backend-claim'
 import { dashboardFallbackArgs, sourceDeclaresServe } from './backend-command'
 import { createBackendConnectionState } from './backend-connection-state'
@@ -89,8 +88,8 @@ import {
   buildBrowserWindowUrl
 } from './browser-windows'
 import { detectBundleSkew } from './bundle-skew'
-import { detectBundleSwap } from './bundle-swap'
 import { applyConnectionChange, sshQuitShouldBlock, teardownSshState } from './connection-apply'
+import { destroyTray, ensureTray } from './tray'
 import {
   apiRequestRegistryConnectionId,
   authModeFromStatus,
@@ -199,7 +198,6 @@ import {
   resolveGatewayFileBackend,
   writeBufferToFile
 } from './gateway-file-download'
-import { startGatewaysAfterUpdateAbort, stopGatewayBeforeUpdate } from './gateway-stop-before-update'
 import { probeGatewayWebSocket } from './gateway-ws-probe'
 import { registerGitIpc } from './git-ipc'
 import { clearStaleGitLocks } from './gitlock'
@@ -281,16 +279,9 @@ import {
   undialedSshRouteSeeds
 } from './plugin-profile-routes'
 import { selectPoolEvictions } from './pool-eviction'
-import { clampPoolLimits, parsePoolLimits, POOL_LIMITS_DEFAULTS } from './pool-limits'
-import {
-  LocalBackendSpawnCoordinator,
-  type LocalBackendSpawnRequest,
-  releaseLocalBackendSlotAfterExit
-} from './pool-spawn-coordinator'
 import { createPoolStopper } from './pool-stop'
 import { poolTouchKeys } from './pool-touch-scope'
 import { createKeepAwake } from './power-save'
-import { capturePreviewContents } from './preview-capture'
 import { PreviewReachRegistry } from './preview-reach'
 import {
   createPrimaryRemoteConnection,
@@ -307,7 +298,6 @@ import {
   profileNameFromDeleteRequest,
   resolveRouteProfile
 } from './profile-delete-routing'
-import { migrateActiveProfileIfMissing as migrateActiveProfileIfMissingPure } from './profile-migration'
 import { prepareProfileRenameLifecycle, profileRenameFromRequest } from './profile-rename-routing'
 import {
   buildSidebarSessionSliceParams,
@@ -403,7 +393,6 @@ import {
   scanVenvBlockers,
   stopSafeVenvBlockers
 } from './venv-blocker-scan'
-import { isHermesOwnedVenvDaemon } from './venv-holder-select'
 import { fetchMarketplaceThemes, searchMarketplaceThemes } from './vscode-marketplace'
 import { createWakeIndicatorWindowController } from './wake-indicator-window'
 import { enumerateWindowsFrontToBack, enumerationFailed, readWindowBelow } from './window-below'
@@ -1391,6 +1380,9 @@ function registerMediaProtocol() {
 }
 
 let mainWindow = null
+// True when the user explicitly chose Quit (e.g. from the tray menu). The main
+// window close event reads this to decide whether to hide to tray or exit.
+let quittingExplicitly = false
 const backendConnectionState = createBackendConnectionState<ReturnType<typeof spawn>, any>()
 const remoteLiveness = new RemoteLivenessTracker()
 const remoteRevalidation = new RemoteRevalidationCoordinator()
@@ -1415,97 +1407,8 @@ const profileDeletionGate = new ProfileDeletionGate()
 // Keep the pool light: cap concurrent profile backends (LRU eviction) and reap
 // idle ones. A user idles at exactly the primary backend; pool backends only
 // exist while a non-primary profile is actively being chatted through.
-// Pool sizing is a device preference (Settings → Advanced → pool rows), not a
-// launch constant: mutable at runtime, persisted in userData, applied live.
-// The legacy HERMES_DESKTOP_POOL_* env vars remain the initial-value fallback
-// for scripted/headless setups; after launch the stored preference wins.
-const POOL_LIMITS_PATH = path.join(app.getPath('userData'), 'pool-limits.json')
-
-function readPersistedPoolLimits() {
-  try {
-    const limits = parsePoolLimits(fs.readFileSync(POOL_LIMITS_PATH, 'utf8'))
-    rememberLog(
-      `[pool-limits] loaded from ${POOL_LIMITS_PATH}: maxBackends=${limits.maxBackends}, idleMs=${limits.idleMs}`
-    )
-
-    return limits
-  } catch {
-    // No persisted file yet — fall back to the legacy env vars so scripted
-    // setups keep working. Log which source won: a silently-ignored env var
-    // here costs a scripted-setup user a debugging session.
-    const fromEnv = clampPoolLimits({
-      maxBackends: Number(process.env.HERMES_DESKTOP_POOL_MAX) || undefined,
-      idleMs: Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || undefined
-    })
-
-    if (fromEnv.maxBackends !== POOL_LIMITS_DEFAULTS.maxBackends || fromEnv.idleMs !== POOL_LIMITS_DEFAULTS.idleMs) {
-      rememberLog(
-        `[pool-limits] no saved file; using env-var overrides: maxBackends=${fromEnv.maxBackends}, idleMs=${fromEnv.idleMs}`
-      )
-    } else {
-      rememberLog('[pool-limits] no saved file and no env overrides; using defaults')
-    }
-
-    return fromEnv
-  }
-}
-
-function persistPoolLimits(limits) {
-  try {
-    fs.mkdirSync(path.dirname(POOL_LIMITS_PATH), { recursive: true })
-    // Atomic write: write to a temp file in the same directory, then rename.
-    // A crash mid-write would otherwise leave truncated JSON and silently
-    // lose the user's saved sizing.
-    const tmpPath = `${POOL_LIMITS_PATH}.tmp`
-    fs.writeFileSync(tmpPath, JSON.stringify(limits, null, 2), 'utf8')
-    fs.renameSync(tmpPath, POOL_LIMITS_PATH)
-  } catch (error) {
-    rememberLog(`[pool-limits] write failed: ${error.message}`)
-  }
-}
-
-// rememberLog() state. Declared here, before the top-level
-// readPersistedPoolLimits() call below, because that call logs during module
-// evaluation; declaring these later crashed launch with `undefined.push` in
-// the packaged build (esbuild lowers the TDZ to undefined instead of throwing).
-const hermesLog = []
-let desktopLogBuffer = ''
-let desktopLogFlushTimer = null
-let desktopLogFlushPromise = Promise.resolve()
-
-let poolLimits = readPersistedPoolLimits()
-// Hard cap on local backends that are starting OR running (the LRU eviction
-// above is soft — it spares keepalive-fresh entries). Follows the live
-// preference: setPoolLimits() pushes a new max into the coordinator.
-const localBackendSpawnCoordinator = new LocalBackendSpawnCoordinator(poolLimits.maxBackends)
-// How long a spawn may wait for a free local slot. Must stay under the
-// renderer's BACKEND_BOOT_WAIT_TIMEOUT_MS (45s, src/lib/with-timeout.ts) so
-// the queued ticket fails before the renderer does and the user sees why.
-const POOL_SLOT_WAIT_MS = 30_000
-
-function poolMaxBackends() {
-  return poolLimits.maxBackends
-}
-
-function poolIdleMs() {
-  return poolLimits.idleMs
-}
-
-/**
- * Apply new limits live: persist, then converge the running pool — evict
- * LRU backends down to the new max, and let the (already running) idle
- * reaper handle a shortened idle window on its next tick. Returns the
- * limits actually in force (post-clamp).
- */
-function setPoolLimits(raw) {
-  poolLimits = clampPoolLimits(raw)
-  persistPoolLimits(poolLimits)
-  localBackendSpawnCoordinator.setLimit(poolLimits.maxBackends)
-  evictLruPoolBackends(poolMaxBackends())
-  startPoolIdleReaper()
-
-  return { ...poolLimits }
-}
+const POOL_MAX_BACKENDS = Math.max(1, Number(process.env.HERMES_DESKTOP_POOL_MAX) || 3)
+const POOL_IDLE_MS = Math.max(60_000, Number(process.env.HERMES_DESKTOP_POOL_IDLE_MS) || 10 * 60_000)
 
 // A backend touched within this window has a live renderer socket (the keepalive
 // pings every 60s for every open profile). LRU eviction must spare these — a
@@ -1525,7 +1428,7 @@ function setPoolLimits(raw) {
 //                       re-allocating pooled gateway secondaries ~700×/day).
 //   * 3× ping + 60s headroom = ~4 min, comfortable margin for two missed
 //     pings + WSL2 IPC stall. The hard ceiling for the cap-eligible set is
-//     pool idle window above (default 10 min) — this constant only governs the
+//     POOL_IDLE_MS above (default 10 min) — this constant only governs the
 //     "is this backend plausibly still alive" question for LRU eviction,
 //     not when the idle reaper definitively tears a backend down.
 const POOL_KEEPALIVE_FRESH_MS = Math.max(
@@ -1583,8 +1486,12 @@ let connectionRegistryCache = null
 let connectionRegistryCacheMtime = null
 let remoteHeaderRulesInstalled = false
 const remoteWsHeaderStore = createRemoteWsHeaderStore()
+const hermesLog = []
 const previewWatchers = new Map()
 let previewShortcutActive = false
+let desktopLogBuffer = ''
+let desktopLogFlushTimer = null
+let desktopLogFlushPromise = Promise.resolve()
 let nativeThemeListenerInstalled = false
 
 let bootProgressState = {
@@ -2249,59 +2156,6 @@ function updateGateDeps() {
   }
 }
 
-// One-shot guard for the automatic bundle-swap relaunch below: the relaunched
-// instance carries this flag so a stamp that still mismatches (unreadable
-// resources, exotic packaging) can never produce a relaunch loop.
-const BUNDLE_SWAP_RELAUNCH_FLAG = '--hermes-bundle-swap-relaunched'
-
-// How long the parked instance waits for its own scheduled exit to land before
-// giving up and booting the stale build anyway. Better a torn renderer with a
-// banner than a window that never comes back.
-const BUNDLE_SWAP_RELAUNCH_FAILSAFE_MS = 15_000
-
-// The detached updater swaps the packaged bundle on disk AFTER `hermes update`
-// exits (posix.sh mac_swap / windows.ps1). An instance reopened mid-update —
-// the #50238 gesture the gate above exists for — was launched from the
-// PRE-swap bundle, and the updater's `open` leg then merely focuses us (single
-// instance), so no process ever loads the new build. Letting boot proceed here
-// runs the new runtime under the old renderer: exactly the skew
-// detectRendererSkew() warns about, except the Updates card already says
-// "latest", so the warning's own remedy has nothing to run.
-//
-// This is the earliest point where the swap is PROVABLE — it happens while we
-// are parked on the gate, so checking any sooner (at `ready`, before the gate)
-// only ever compares a stamp with itself. Relaunching here also keeps the
-// boot-progress window up for the whole wait instead of leaving the user with
-// no window at all.
-//
-// Returns true when the relaunch was scheduled; the caller must park rather
-// than continue booting, because the process exits underneath it.
-function relaunchIntoSwappedBundle() {
-  if (!IS_PACKAGED || process.argv.includes(BUNDLE_SWAP_RELAUNCH_FLAG)) {
-    return false
-  }
-
-  if (!detectBundleSwap(INSTALL_STAMP, loadInstallStamp())) {
-    return false
-  }
-
-  rememberLog('[updates] app bundle was swapped during the update; relaunching into the new build')
-
-  try {
-    app.relaunch({
-      args: [...buildNoSandboxRelaunchArgs(process.argv.slice(1)), BUNDLE_SWAP_RELAUNCH_FLAG]
-    })
-  } catch (err) {
-    rememberLog(`[updates] bundle-swap relaunch failed: ${err?.message || err}; continuing with the current build`)
-
-    return false
-  }
-
-  void exitAfterBackendShutdown(0)
-
-  return true
-}
-
 // Block until no live update is in progress (or we hit the wait timeout).
 // Emits a boot-progress phase so the renderer shows "Update in progress…"
 // rather than a frozen splash. Returns true if it parked at all.
@@ -2364,14 +2218,6 @@ async function waitForUpdateToFinish() {
 
   if (outcome === 'timeout') {
     rememberLog('[updates] update still in progress after wait timeout; starting backend anyway')
-  } else if (relaunchIntoSwappedBundle()) {
-    await advanceBootProgress('backend.update-restart', 'Restarting Hermes to load the updated app…', 14)
-    // Park while the scheduled exit lands so this stale build never starts a
-    // backend; the failsafe below only runs if the exit somehow does not.
-    await new Promise(resolve => setTimeout(resolve, BUNDLE_SWAP_RELAUNCH_FAILSAFE_MS))
-    rememberLog(
-      `[updates] relaunch did not land within ${BUNDLE_SWAP_RELAUNCH_FAILSAFE_MS}ms; continuing with the current build`
-    )
   } else {
     rememberLog('[updates] update finished; proceeding with backend start')
   }
@@ -3381,54 +3227,6 @@ function isShimLocked(shimPath) {
   }
 }
 
-// Kill only Hermes-OWNED venv daemons (the memory plugin's hindsight daemon:
-// exe under venv\Scripts AND cmdline referencing hindsight_api.main). The
-// daemon is spawned DETACHED, so it outlives the backend tree-kill and keeps
-// venv files mapped. External holders (a user terminal running `hermes`,
-// unrelated scripts) are NOT killed — scanVenvBlockers reports them and the
-// hand-off aborts, per existing design. Selection lives in the pure
-// venv-holder-select module (ordinal path-prefix, no PowerShell -like
-// wildcard hazards) so it's testable without Electron.
-function killHermesOwnedVenvDaemons(updateRoot) {
-  if (!IS_WINDOWS) {
-    return
-  }
-
-  const scriptsDir = path.join(updateRoot, 'venv', 'Scripts')
-
-  let holders = []
-
-  try {
-    const out = execFileSync(
-      'powershell',
-      [
-        '-NoProfile',
-        '-Command',
-        'Get-CimInstance Win32_Process | Where-Object { $_.ExecutablePath -and $_.CommandLine } | Select-Object ProcessId, ExecutablePath, CommandLine | ConvertTo-Json -Compress'
-      ],
-      hiddenWindowsChildOptions({ encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'], timeout: 15_000 })
-    )
-
-    const parsed = JSON.parse(String(out || '[]'))
-
-    holders = (Array.isArray(parsed) ? parsed : [parsed]).filter(p =>
-      isHermesOwnedVenvDaemon(p?.ExecutablePath, p?.CommandLine, scriptsDir)
-    )
-  } catch {
-    // Best-effort: the venv-blocker scan downstream is the real backstop.
-    return
-  }
-
-  for (const holder of holders) {
-    const pid = Number(holder?.ProcessId)
-
-    if (Number.isInteger(pid) && pid > 0) {
-      rememberLog(`[updates] stopping Hermes-owned venv daemon (hindsight) PID ${pid} before hand-off`)
-      forceKillProcessTree(pid)
-    }
-  }
-}
-
 // Force-kill the entire process TREE rooted at each PID. Node's child.kill()
 // only signals the direct child, so on Windows a backend `hermes.exe` that
 // spawned its own grandchildren (a `hermes` REPL, a pty terminal session, the
@@ -3493,7 +3291,7 @@ async function backendCommandForPid(pid) {
   }
 }
 
-async function processIdentityMatches(identity, timeoutMs: number = 30_000) {
+async function processIdentityMatches(identity) {
   // Degraded PID-only identity (#93608): the start-marker probe failed while
   // the child was verifiably alive, so only PID liveness can be checked here.
   // backendIdentityMatches layers the command-line check on top before
@@ -3511,14 +3309,14 @@ async function processIdentityMatches(identity, timeoutMs: number = 30_000) {
   }
 
   try {
-    return (await processStartMarker(identity.pid, timeoutMs)) === identity.startMarker
+    return (await processStartMarker(identity.pid)) === identity.startMarker
   } catch (error) {
     return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
   }
 }
 
 async function backendIdentityMatches(identity) {
-  const processMatches = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
+  const processMatches = await processIdentityMatches(identity)
 
   if (processMatches !== true) {
     return processMatches
@@ -3539,24 +3337,15 @@ async function backendParentMatches(entry) {
   }
 
   try {
-    return (await processStartMarker(entry.parentPid, REAP_PROBE_TIMEOUT_MS)) === entry.parentStartMarker
+    return (await processStartMarker(entry.parentPid)) === entry.parentStartMarker
   } catch (error) {
     return error?.code === 'ENOENT' || error?.code === 'ESRCH' ? false : undefined
   }
 }
 
 async function stopOwnedBackend(identity) {
-  const matches = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
-
-  if (matches === false) {
+  if ((await processIdentityMatches(identity)) !== true) {
     return
-  }
-
-  if (matches !== true) {
-    // Identity probe failed (not confirmed gone): preserve the record so a
-    // later launch retries the stop instead of dropping it and leaking the
-    // backend. reapOrphans keeps the entry when stop() throws.
-    throw new Error(`Could not verify backend PID ${identity.pid} before stopping it.`)
   }
 
   if (IS_WINDOWS) {
@@ -3575,7 +3364,7 @@ async function stopOwnedBackend(identity) {
     const deadline = Date.now() + 1500
 
     while (Date.now() < deadline) {
-      if ((await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)) !== true) {
+      if ((await processIdentityMatches(identity)) !== true) {
         return
       }
 
@@ -3584,7 +3373,7 @@ async function stopOwnedBackend(identity) {
 
     // Revalidate immediately before escalation so PID reuse cannot target a
     // replacement process.
-    if ((await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)) === true) {
+    if ((await processIdentityMatches(identity)) === true) {
       try {
         process.kill(-identity.pid, 'SIGKILL')
       } catch {
@@ -3594,7 +3383,7 @@ async function stopOwnedBackend(identity) {
   }
 
   await new Promise(resolve => setTimeout(resolve, 50))
-  const remaining = await processIdentityMatches(identity, REAP_PROBE_TIMEOUT_MS)
+  const remaining = await processIdentityMatches(identity)
 
   if (remaining !== false) {
     throw new Error(`Backend PID ${identity.pid} did not stop cleanly.`)
@@ -3788,27 +3577,6 @@ async function releaseBackendLock(updateRoot, tag) {
     stopAllPoolBackends
   })
 
-  // Stop separately-running messaging gateways (all profiles) BEFORE the
-  // release gate. The gateway is launched by the gateway-launcher desktop
-  // plugin via /api/gateway/start and is NOT in backendConnectionState or
-  // backendPool, so the tree-kills above never see it — on Windows its
-  // launcher (venv\Scripts\python.exe) keeps the venv mandatory-locked and
-  // the 15s gate aborts the hand-off before the venv-blocker scan's
-  // pausable-gateway exemption ever gets a chance (#70337). Delegate to
-  // `hermes gateway stop --all`: the CLI discovers every profile's gateway
-  // (launcher + worker — gateway.pid records only the uv WORKER, and
-  // taskkill /T from the worker never reaches its parent), drains in-flight
-  // agents, and force-kills survivors. Best-effort; abort paths restore via
-  // startGatewaysAfterUpdateAbort. No-op off Windows.
-  stopGatewayBeforeUpdate(venvHermesShimPath(updateRoot), HERMES_HOME)
-
-  // Reap Hermes-OWNED venv daemons the tree-kill above cannot reach: the
-  // memory plugin's hindsight daemon is spawned DETACHED (it outlives the
-  // backend) yet runs off venv\Scripts\pythonw.exe, keeping venv files
-  // mapped past the backend teardown (#75477/#75478). Narrowly scoped
-  // (venv-holder-select) — external holders are never killed here.
-  killHermesOwnedVenvDaemons(updateRoot)
-
   const shim = venvHermesShimPath(updateRoot)
 
   const gate = await waitForBackendRelease(
@@ -3993,12 +3761,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       emitUpdateProgress({ stage: 'error', message, percent: null })
       startHermes().catch(() => {})
 
-      if (IS_WINDOWS) {
-        // The pre-gate `gateway stop --all` (#70337) took every profile's
-        // gateway down for an update that never happened — bring them back.
-        startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
-      }
-
       return { ok: false, error: message }
     }
 
@@ -4048,9 +3810,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         rememberLog(`[updates] venv-blocked: ${scanOutcome.result.processes.length} process(es) hold the install`)
         emitUpdateProgress({ stage: 'error', message, percent: null })
         startHermes().catch(() => {})
-        // Restore the gateways the pre-gate stop took down (#70337 drain
-        // semantics): the update aborted, so nothing else will relaunch them.
-        startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
 
         return { ok: false, error: 'venv-blocked', message, blockers: scanOutcome.result.processes }
       }
@@ -4061,8 +3820,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
         rememberLog(`[updates] venv-blocker probe failed: ${scanOutcome.error}`)
         emitUpdateProgress({ stage: 'error', message, percent: null })
         startHermes().catch(() => {})
-        // Same drain-semantics restore as the venv-blocked abort above.
-        startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
 
         return { ok: false, error: 'venv-probe-failed', message }
       }
@@ -4190,11 +3947,6 @@ async function applyUpdates(opts: { stopSafeBlockers?: boolean } = {}) {
       rememberLog(`[updates] hand-off not viable, aborting quit: ${handoffOutcome.message}`)
       emitUpdateProgress({ stage: 'error', message, percent: null })
       startHermes().catch(() => {})
-
-      if (IS_WINDOWS) {
-        // Same drain-semantics restore as the earlier abort paths (#70337).
-        startGatewaysAfterUpdateAbort(venvHermesShimPath(updateRoot))
-      }
 
       return { ok: false, error: 'updater-spawn-failed', message }
     }
@@ -6106,7 +5858,7 @@ async function saveImageFromUrl(rawUrl) {
   return true
 }
 
-async function writeComposerImage(buffer, ext = '.png', name = '') {
+async function writeComposerImage(buffer, ext = '.png') {
   const rawExt = String(ext || '.png')
     .trim()
     .toLowerCase()
@@ -6117,19 +5869,7 @@ async function writeComposerImage(buffer, ext = '.png', name = '') {
   await fs.promises.mkdir(dir, { recursive: true })
   const stamp = new Date().toISOString().replace(/[:.]/g, '-').replace('T', '_').replace('Z', '')
   const random = crypto.randomBytes(3).toString('hex')
-
-  const baseName = String(name || '')
-    .split(/[\\/]/)
-    .pop()
-    ?.replace(/\.[^.]+$/, '')
-
-  const safeName = (baseName || '')
-    .replace(/[^\p{L}\p{N}._-]+/gu, '_')
-    .replace(/^[._-]+|[._-]+$/g, '')
-    .slice(0, 80)
-
-  const fileName = safeName ? `${safeName}_${random}${safeExt}` : `composer_${stamp}_${random}${safeExt}`
-  const filePath = path.join(dir, fileName)
+  const filePath = path.join(dir, `composer_${stamp}_${random}${safeExt}`)
   await fs.promises.writeFile(filePath, buffer)
 
   return filePath
@@ -9580,68 +9320,6 @@ function writeActiveDesktopProfile(name) {
   return value || null
 }
 
-// True when the given pid belongs to a running process whose command line
-// contains "hermes", avoiding false positives from stale gateway.pid files
-// whose PID was recycled by the OS to an unrelated process.
-function isHermesProcess(pid) {
-  try {
-    process.kill(pid, 0) // signal 0 = existence check, no signal sent
-  } catch {
-    return false
-  }
-
-  // On macOS / Linux, check the command line to avoid PID recycling false positives.
-  try {
-    const cmdline = fs.readFileSync(`/proc/${pid}/cmdline`, 'utf8')
-
-    return cmdline.includes('hermes')
-  } catch {
-    // /proc not available (macOS) — fall back to ps. Use -o args= to inspect
-    // the full command line, not just the process name.  -o comm= would return
-    // "python3" for any Python process, creating false positives.
-    try {
-      const { execSync } = require('child_process')
-      const out = execSync(`ps -p ${pid} -o args=`, { encoding: 'utf8', timeout: 2000 })
-
-      return out.includes('hermes')
-    } catch {
-      return false
-    }
-  }
-}
-
-// Seed active-profile.json from the best available signal when the file does
-// not yet exist.  Runs exactly once (no-op once the file exists).  Priority:
-//   1. Legacy ~/.hermes/active_profile (explicit CLI choice via hermes profile use)
-//   2. Running gateway (gateway.pid with verified liveness + hermes identity)
-//   3. state.db heuristics (hybrid recency×size score picks the primary workspace)
-// The stored JSON includes _migrated:true so the renderer can optionally surface
-// a one-time notification that the profile was auto-detected.
-//
-// Decision logic lives in profile-migration.ts (pure + unit-tested). This wrapper
-// just wires Electron/Node fs into a MigrationDeps bag and delegates.
-function migrateActiveProfileIfMissing() {
-  migrateActiveProfileIfMissingPure(DESKTOP_PROFILE_CONFIG_PATH, {
-    legacyActivePath: path.join(HERMES_HOME, 'active_profile'),
-    hermesHome: HERMES_HOME,
-    profilesRoot: path.join(HERMES_HOME, 'profiles'),
-    existsSync: p => fs.existsSync(p),
-    readFileSync: (p, enc) => fs.readFileSync(p, enc),
-    statSync: p => fs.statSync(p),
-    readdirSync: (p, opts) => fs.readdirSync(p, opts as { withFileTypes: true }),
-    isHermesProcess,
-    now: () => Date.now(),
-    writeJson: (target, decision) => {
-      // Mirror writeActiveDesktopProfile's atomic-write + parent-dir-create
-      // semantics so the migration produces a file indistinguishable from a
-      // user-driven profile switch.
-      fs.mkdirSync(path.dirname(target), { recursive: true })
-      writeFileAtomic(target, JSON.stringify(decision, null, 2))
-    },
-    isValidProfileName: p => PROFILE_NAME_RE.test(p)
-  })
-}
-
 // Sanitize a connection config into the renderer-facing shape. With no
 // `profile` this describes the global/default connection (the existing
 // behavior); with a `profile` it describes that profile's per-profile remote
@@ -11352,7 +11030,7 @@ async function ensureBackend(profile) {
     return connection
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
 
   const entry = {
     process: null,
@@ -11360,10 +11038,7 @@ async function ensureBackend(profile) {
     token: null,
     connectionPromise: null,
     lastActiveAt: Date.now(),
-    remoteBaseUrl: null,
-    releaseLocalBackendSlot: null,
-    localBackendSlotKey: null,
-    localBackendSpawnRequest: null
+    remoteBaseUrl: null
   }
 
   entry.connectionPromise = spawnPoolBackend(key, entry).catch(async error => {
@@ -11374,7 +11049,12 @@ async function ensureBackend(profile) {
       `Hermes backend for profile "${key}" failed to start: ${error instanceof Error ? error.message : String(error)}`
     )
 
-    await teardownFailedLocalBackend(key, entry)
+    if (backendPool.get(key) === entry) {
+      backendPool.delete(key)
+    }
+
+    stopBackendChild(entry.process)
+    await waitForBackendExit(entry.process)
     throw error
   })
   backendPool.set(key, entry)
@@ -11518,7 +11198,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       return existingLocal.connectionPromise
     }
 
-    evictLruPoolBackends(poolMaxBackends() - 1)
+    evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
 
     const localEntry = {
       process: null,
@@ -11526,10 +11206,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
       token: null,
       connectionPromise: null,
       lastActiveAt: Date.now(),
-      remoteBaseUrl: null,
-      releaseLocalBackendSlot: null,
-      localBackendSlotKey: null,
-      localBackendSpawnRequest: null
+      remoteBaseUrl: null
     }
 
     localEntry.connectionPromise = spawnPoolBackend(profileKey, localEntry, {
@@ -11542,7 +11219,12 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
         `Hermes backend for profile "${profileKey}" (forced-local) failed to start: ${error instanceof Error ? error.message : String(error)}`
       )
 
-      await teardownFailedLocalBackend(localRoute.poolKey, localEntry)
+      if (backendPool.get(localRoute.poolKey) === localEntry) {
+        backendPool.delete(localRoute.poolKey)
+      }
+
+      stopBackendChild(localEntry.process)
+      await waitForBackendExit(localEntry.process)
       throw error
     })
     backendPool.set(localRoute.poolKey, localEntry)
@@ -11589,7 +11271,7 @@ async function ensureRegistryBackend(connectionId, profile, managedUpdateCorrela
     )
   }
 
-  evictLruPoolBackends(poolMaxBackends() - 1)
+  evictLruPoolBackends(POOL_MAX_BACKENDS - 1)
 
   const entry = {
     process: null,
@@ -12244,7 +11926,7 @@ function evictLruPoolBackends(keep) {
   const evictions = selectPoolEvictions(backendPool.entries(), Math.max(0, keep), Date.now(), POOL_KEEPALIVE_FRESH_MS)
 
   for (const profile of evictions) {
-    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${poolMaxBackends()})`)
+    rememberLog(`Evicting idle profile backend "${profile}" (LRU cap ${POOL_MAX_BACKENDS})`)
     stopPoolBackend(profile)
   }
 }
@@ -12258,8 +11940,8 @@ function startPoolIdleReaper() {
     const now = Date.now()
 
     for (const [profile, entry] of [...backendPool.entries()]) {
-      if (now - (entry.lastActiveAt || 0) > poolIdleMs()) {
-        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(poolIdleMs() / 1000)}s)`)
+      if (now - (entry.lastActiveAt || 0) > POOL_IDLE_MS) {
+        rememberLog(`Reaping idle profile backend "${profile}" (idle > ${Math.round(POOL_IDLE_MS / 1000)}s)`)
         stopPoolBackend(profile)
       }
     }
@@ -12273,67 +11955,6 @@ function startPoolIdleReaper() {
   if (typeof poolIdleReaper.unref === 'function') {
     poolIdleReaper.unref()
   }
-}
-
-function releaseLocalBackendSlot(entry: any) {
-  if (!entry) {
-    return
-  }
-
-  const release = entry.releaseLocalBackendSlot
-  const request = entry.localBackendSpawnRequest as LocalBackendSpawnRequest | null
-  entry.releaseLocalBackendSlot = null
-  entry.localBackendSlotKey = null
-  entry.localBackendSpawnRequest = null
-
-  if (release) {
-    release()
-  } else {
-    request?.cancel()
-  }
-}
-
-function assertPoolEntryStillOwned(poolKey: string, entry: any) {
-  if (backendPool.get(poolKey) !== entry) {
-    releaseLocalBackendSlot(entry)
-    throw new Error(`Profile backend start for "${poolKey}" was cancelled before spawn.`)
-  }
-}
-
-const failedLocalBackendTeardowns = new WeakMap<object, Promise<void>>()
-
-function teardownFailedLocalBackend(poolKey: string, entry: any): Promise<void> {
-  const existing = failedLocalBackendTeardowns.get(entry)
-
-  if (existing) {
-    return existing
-  }
-
-  if (backendPool.get(poolKey) === entry) {
-    backendPool.delete(poolKey)
-  }
-
-  const child = entry.process
-
-  const teardown = releaseLocalBackendSlotAfterExit(
-    () => releaseLocalBackendSlot(entry),
-    async () => {
-      stopBackendChild(child)
-      await waitForBackendExit(child)
-
-      if (child && child.exitCode === null && child.signalCode === null) {
-        throw new Error(`Profile backend for "${poolKey}" did not exit; keeping the local slot occupied.`)
-      }
-
-      releaseBackendChild(child)
-    }
-  )
-
-  // Keep the settled promise in the WeakMap for the lifetime of this entry.
-  // Error + exit + outer catch may all request cleanup; none may run it twice.
-  failedLocalBackendTeardowns.set(entry, teardown)
-
-  return teardown
 }
 
 // Spawn an additional dashboard backend pinned to a named profile. Mirrors the
@@ -12372,29 +11993,6 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
       ...getWindowState()
     }
   }
-
-  // Bound the slot wait BELOW the renderer's backend-boot budget (45s): once
-  // the renderer has given up on this spawn, a ticket still queued for the
-  // pool-idle window (10 min) would hold the pool key hostage and every
-  // later click on the profile would join that stale wait. Failing here
-  // surfaces the "all N slots busy" reason instead of a generic boot timeout.
-  const spawnRequest = localBackendSpawnCoordinator.request(poolKey, { timeoutMs: POOL_SLOT_WAIT_MS })
-  entry.localBackendSlotKey = poolKey
-  entry.localBackendSpawnRequest = spawnRequest
-
-  if (localBackendSpawnCoordinator.activeCount >= poolMaxBackends()) {
-    rememberLog(
-      `Profile backend "${profile}" waiting for a free local slot (${localBackendSpawnCoordinator.activeCount}/${poolMaxBackends()} busy, ${localBackendSpawnCoordinator.queuedCount} queued)`
-    )
-  }
-
-  entry.releaseLocalBackendSlot = await spawnRequest.acquired
-
-  if (entry.localBackendSpawnRequest === spawnRequest) {
-    entry.localBackendSpawnRequest = null
-  }
-
-  assertPoolEntryStillOwned(poolKey, entry)
 
   const token = crypto.randomBytes(32).toString('base64url')
 
@@ -12439,12 +12037,12 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   assertLocalProfileCanStart(profile, profileDeletionGate, key =>
     directoryExists(path.join(HERMES_HOME, 'profiles', key))
   )
+
   rememberLog(`Starting Hermes backend for profile "${profile}" via ${backend.label}`)
 
   const parentStartMarker = await desktopParentStartMarker()
   const backendNonce = crypto.randomBytes(16).toString('hex')
   const parentIdentityEnv = parentWatchdogEnv(process.pid, parentStartMarker, backendNonce)
-  assertPoolEntryStillOwned(poolKey, entry)
 
   const child = spawn(
     backend.command,
@@ -12483,23 +12081,7 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   // the claim, and would miss anything printed before it.
   const outputTail = createBackendOutputTail()
   outputTail.attach(child)
-
-  // Start watching for the READY announcement BEFORE any await (#60323):
-  // stdout is already flowing into the tail, and Node streams never replay
-  // consumed chunks to late listeners — a sentinel printed while
-  // claimBackendChild runs would otherwise be lost forever, timing out a
-  // healthy backend. The tail-buffer accessor covers any residual gap.
-  const portAnnouncement = waitForDashboardPortAnnouncement(child, {
-    bufferedOutput: () => outputTail.text(),
-    describeOutputTail: () => outputTail.describe(),
-    readyFile
-  })
-
-  // Mark handled so an early rejection (child dies during the claim) can't
-  // surface as an unhandled rejection before the Promise.race below attaches.
-  portAnnouncement.catch(() => {})
   await claimBackendChild(child, `${backend.command} ${backend.args.join(' ')}`, profile, backendNonce, outputTail)
-  assertPoolEntryStillOwned(poolKey, entry)
 
   child.stdout.on('data', rememberLog)
   child.stderr.on('data', rememberLog)
@@ -12513,21 +12095,14 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
 
   child.once('error', error => {
     rememberLog(`Hermes backend for profile "${profile}" failed to start: ${error.message}`)
-    void teardownFailedLocalBackend(poolKey, entry).catch(cleanupError => {
-      rememberLog(
-        `Hermes backend for profile "${profile}" cleanup failed: ${cleanupError instanceof Error ? cleanupError.message : String(cleanupError)}`
-      )
-    })
+    releaseBackendChild(child)
+    backendPool.delete(poolKey)
     rejectStart?.(error)
   })
   child.once('exit', (code, signal) => {
     rememberLog(`Hermes backend for profile "${profile}" exited (${signal || code})`)
-    releaseLocalBackendSlot(entry)
     releaseBackendChild(child)
-
-    if (backendPool.get(poolKey) === entry) {
-      backendPool.delete(poolKey)
-    }
+    backendPool.delete(poolKey)
 
     if (!ready) {
       rejectStart?.(
@@ -12539,7 +12114,10 @@ async function spawnPoolBackend(profile, entry, opts: { forceLocal?: boolean; po
   })
 
   // Discover the ephemeral port the child bound to
-  const port = await Promise.race([portAnnouncement, startFailed])
+  const port = await Promise.race([
+    waitForDashboardPortAnnouncement(child, { describeOutputTail: () => outputTail.describe(), readyFile }),
+    startFailed
+  ])
 
   if (readyFile) {
     fs.unlink(readyFile, () => {})
@@ -12595,20 +12173,16 @@ const poolStopper = createPoolStopper({
   waitForExit: child => waitForBackendExit(child)
 })
 
-async function stopPoolBackend(profile: string) {
-  const entry = backendPool.get(profile)
-  await poolStopper.stop(profile)
-  releaseLocalBackendSlot(entry)
+function stopPoolBackend(profile) {
+  return poolStopper.stop(profile)
 }
 
 async function teardownPoolBackendAndWait(profile) {
-  await Promise.all(localProfilePoolKeys(profile).map(key => stopPoolBackend(key)))
+  await Promise.all(localProfilePoolKeys(profile).map(key => poolStopper.stop(key)))
 }
 
-async function stopAllPoolBackends() {
-  const entries = [...backendPool.values()]
-  await poolStopper.stopAll()
-  entries.forEach(releaseLocalBackendSlot)
+function stopAllPoolBackends() {
+  return poolStopper.stopAll()
 }
 
 const backendShutdown = createBackendShutdownCoordinator(async () => {
@@ -12730,15 +12304,6 @@ async function startHermes() {
   if (existingConnectionPromise) {
     return existingConnectionPromise
   }
-
-  // Seed active-profile.json from legacy signals BEFORE the first
-  // profile-dependent read (`primaryBackendIsRemote()` on the next line, then
-  // `primaryProfileKey()` inside the connection IIFE below). Without this,
-  // remote-mode users whose preference file is missing (first boot after
-  // update) resolve primaryProfileKey() to 'default' inside the IIFE, then
-  // the remote branch returns and never runs the migration. Runs once;
-  // no-op when the preference file already exists.
-  migrateActiveProfileIfMissing()
 
   const connectionAttempt = backendConnectionState.startAttempt()
   const primaryProfile = primaryProfileKey()
@@ -12903,24 +12468,6 @@ async function startHermes() {
     // later, after the claim, and would miss anything printed before it.
     const primaryOutputTail = createBackendOutputTail()
     primaryOutputTail.attach(hermesProcess)
-
-    // Start watching for the READY announcement BEFORE any await (#60323):
-    // claimBackendChild can take seconds (its Windows Get-Process probe cold
-    // start alone runs 2-8s) and advanceBootProgress awaits renderer IPC.
-    // stdout is already flowing into the tail, and Node streams never replay
-    // consumed chunks to late listeners, so a sentinel printed during that
-    // window was lost forever — the wait then hit its 90s timeout and a
-    // healthy backend was killed (deterministic on Windows, racy on
-    // macOS/Linux). The tail-buffer accessor covers any residual gap.
-    const portAnnouncement = waitForDashboardPortAnnouncement(hermesProcess, {
-      bufferedOutput: () => primaryOutputTail.text(),
-      describeOutputTail: () => primaryOutputTail.describe(),
-      readyFile
-    })
-
-    // Mark handled so an early rejection (child dies during the claim) can't
-    // surface as an unhandled rejection before the Promise.race below attaches.
-    portAnnouncement.catch(() => {})
     await claimBackendChild(
       hermesProcess,
       `${backend.command} ${backend.args.join(' ')}`,
@@ -13007,7 +12554,13 @@ async function startHermes() {
     await advanceBootProgress('backend.port', 'Waiting for Hermes backend to launch', 86)
 
     // Discover the ephemeral port the child bound to
-    const port = await Promise.race([portAnnouncement, backendStartFailed])
+    const port = await Promise.race([
+      waitForDashboardPortAnnouncement(hermesProcess, {
+        describeOutputTail: () => primaryOutputTail.describe(),
+        readyFile
+      }),
+      backendStartFailed
+    ])
 
     if (readyFile) {
       fs.unlink(readyFile, () => {})
@@ -13246,11 +12799,7 @@ function focusWindow(win) {
   win.focus()
 }
 
-function spawnSecondaryWindow({
-  sessionId,
-  profile,
-  watch
-}: { sessionId?: string; profile?: null | string; watch?: boolean } = {}) {
+function spawnSecondaryWindow({ sessionId, watch }: { sessionId?: string; watch?: boolean } = {}) {
   const icon = getAppIconPath()
 
   const win = new BrowserWindow({
@@ -13312,7 +12861,6 @@ function spawnSecondaryWindow({
     win,
     buildSessionWindowUrl(sessionId, {
       devServer: DEV_SERVER,
-      profile,
       rendererIndexPath: DEV_SERVER ? undefined : resolveRendererIndex(),
       watch
     }),
@@ -13323,8 +12871,8 @@ function spawnSecondaryWindow({
 }
 
 // Open (or focus) a standalone window for a single chat session.
-function createSessionWindow(sessionId, { profile = null, watch = false } = {}) {
-  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, profile, watch }))
+function createSessionWindow(sessionId, { watch = false } = {}) {
+  return sessionWindows.openOrFocus(sessionId, () => spawnSecondaryWindow({ sessionId, watch }))
 }
 
 // Popped-out in-app Browser: same webview + address bar as a docked Browser
@@ -14494,7 +14042,14 @@ function createWindow() {
   bindGeometryPersistence(mainWindow, schedulePersistWindowState)
   mainWindow.on('maximize', schedulePersistWindowState)
   mainWindow.on('unmaximize', schedulePersistWindowState)
-  mainWindow.on('close', () => schedulePersistWindowState.flush())
+  mainWindow.on('close', event => {
+    schedulePersistWindowState.flush()
+    if (process.platform !== 'darwin' && !quittingExplicitly && !mainWindow.isDestroyed()) {
+      event.preventDefault()
+      ensureTray({ window: mainWindow, iconPath: getAppIconPath(), onQuit: () => app.quit() })
+      mainWindow.hide()
+    }
+  })
 
   // the closed wrapper remains truthy, so clear only the window this callback owns.
   mainWindow.on('closed', () => {
@@ -14803,18 +14358,6 @@ ipcMain.handle('hermes:backend:touch', async (_event, profile) => {
 
   return { ok: true }
 })
-// Pool sizing (Settings → Advanced): device-local, live-applied. Main is
-// authoritative (it owns the pool and the persisted copy); the returned
-// limits are what actually took effect post-clamp.
-ipcMain.handle('hermes:pool-limits:get', async () => ({ ...poolLimits }))
-ipcMain.handle('hermes:pool-limits:set', async (_event, raw) => {
-  const next = setPoolLimits({
-    maxBackends: typeof raw?.maxBackends === 'number' ? raw.maxBackends : poolLimits.maxBackends,
-    idleMs: typeof raw?.idleMs === 'number' ? raw.idleMs : poolLimits.idleMs
-  })
-
-  return { ok: true, limits: next }
-})
 ipcMain.handle('hermes:gateway:ws-url', async (_event, profile) => {
   return gatewayWsUrlIpcResult(() => freshGatewayWsUrl(profile))
 })
@@ -14823,10 +14366,7 @@ ipcMain.handle('hermes:window:openSession', async (_event, sessionId, opts) => {
     return { ok: false, error: 'invalid-session-id' }
   }
 
-  createSessionWindow(sessionId.trim(), {
-    profile: typeof opts?.profile === 'string' ? opts.profile : null,
-    watch: opts?.watch === true
-  })
+  createSessionWindow(sessionId.trim(), { watch: opts?.watch === true })
 
   return { ok: true }
 })
@@ -16864,12 +16404,6 @@ ipcMain.handle('hermes:context-menu:guest-add-word', (_event, payload) => {
   }
 })
 
-ipcMain.handle('hermes:capturePreview', async (_event, payload) => {
-  const guest = electronWebContents.fromId(Number(payload?.webContentsId))
-
-  return capturePreviewContents(guest, payload?.rect, payload?.viewport)
-})
-
 ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
   const data = payload?.data
 
@@ -16879,7 +16413,7 @@ ipcMain.handle('hermes:saveImageBuffer', async (_event, payload) => {
 
   const buffer = Buffer.isBuffer(data) ? data : Buffer.from(data)
 
-  return writeComposerImage(buffer, payload?.ext || '.png', payload?.name)
+  return writeComposerImage(buffer, payload?.ext || '.png')
 })
 
 ipcMain.handle('hermes:saveClipboardImage', async () => {
@@ -17014,17 +16548,6 @@ app.on('will-quit', () => {
 // itself. Registered at module scope, which runs long before any window.
 ipcMain.on('hermes:translucency:support', event => {
   event.returnValue = { glass: GLASS_SUPPORTED, translucency: TRANSLUCENCY_SUPPORTED }
-})
-
-// Launch-flag facts the renderer needs before first paint (same sendSync
-// pattern as translucency). `--local` gates every local-models GUI surface;
-// it arrives from `hermes desktop --local` or directly on Hermes.exe (a
-// shortcut edit), and survives self-relaunches because collectRelaunchArgs
-// only strips internal flags.
-ipcMain.on('hermes:launch-flags', event => {
-  event.returnValue = {
-    localModels: process.argv.includes('--local') || process.platform === 'win32' || process.platform === 'darwin'
-  }
 })
 
 ipcMain.on('hermes:translucency', (_event, payload) => {
@@ -17456,24 +16979,8 @@ ipcMain.handle('hermes:version', async () => {
     platform: process.platform,
     hermesRoot: resolveUpdateRoot(),
     bundleOutOfSync: skew.outOfSync,
-    bundleCommitsBehind: skew.desktopCommitsBehind,
-    // True when the bundle on disk is not the one this process loaded — a
-    // plain app restart (no rebuild, no installer) clears the skew above.
-    // Packaged only: a dev `--build-only` rewrites build/install-stamp.json
-    // under a running `npm start`, which is a rebuild the developer asked for,
-    // not a torn install to offer a restart for.
-    bundleSwapPending: IS_PACKAGED && detectBundleSwap(INSTALL_STAMP, loadInstallStamp())
+    bundleCommitsBehind: skew.desktopCommitsBehind
   }
-})
-
-// The About page's "Restart Hermes" button (shown when bundleSwapPending):
-// load the already-swapped bundle without asking the user to quit manually.
-// app.relaunch() re-executes by path, so the fresh process picks up whatever
-// bundle now lives there.
-ipcMain.handle('hermes:app:relaunch', async () => {
-  rememberLog('[updates] renderer requested an app relaunch (swapped bundle pending)')
-  app.relaunch({ args: buildNoSandboxRelaunchArgs(process.argv.slice(1)) })
-  void exitAfterBackendShutdown(0)
 })
 
 // ===========================================================================
@@ -18015,11 +17522,17 @@ function heldQuitForActiveWork(event: Electron.Event): boolean {
 }
 
 app.on('before-quit', event => {
+  destroyTray()
+
   // Runs ahead of every teardown below, so "Keep Running" leaves the app
   // exactly as it was.
   if (heldQuitForActiveWork(event)) {
+    quittingExplicitly = false
     return
   }
+
+  // Flag that the next window close is a real quit, not a hide-to-tray.
+  quittingExplicitly = true
 
   // A detached remote updater can outlive this Electron process. Do not tear
   // down its SSH observer/restore transaction at the generic SSH shutdown

--- a/apps/desktop/electron/tray.test.ts
+++ b/apps/desktop/electron/tray.test.ts
@@ -1,0 +1,187 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const electronMock = vi.hoisted(() => {
+  type ClickHandler = () => void
+  type MenuItem = { label?: string; click?: ClickHandler; type?: string }
+
+  const trayInstances: FakeTray[] = []
+
+  class FakeTray {
+    private readonly listeners = new Map<string, ClickHandler[]>()
+    destroyed = false
+    tooltip?: string
+    menu?: MenuItem[]
+
+    setToolTip = vi.fn((tooltip: string) => {
+      this.tooltip = tooltip
+    })
+
+    setContextMenu = vi.fn((menu: { template: MenuItem[] }) => {
+      this.menu = menu.template
+    })
+
+    on = vi.fn((event: string, handler: ClickHandler) => {
+      const list = this.listeners.get(event) ?? []
+      list.push(handler)
+      this.listeners.set(event, list)
+      return this
+    })
+
+    destroy = vi.fn(() => {
+      this.destroyed = true
+    })
+
+    emit(event: string) {
+      for (const handler of this.listeners.get(event) ?? []) {
+        handler()
+      }
+    }
+
+    constructor() {
+      trayInstances.push(this)
+    }
+  }
+
+  return {
+    Menu: {
+      buildFromTemplate: vi.fn((template: MenuItem[]) => ({ template }))
+    },
+    Tray: FakeTray,
+    nativeImage: {
+      createFromPath: vi.fn((path: string) => ({
+        isEmpty: vi.fn(() => path === 'empty.png')
+      }))
+    },
+    trayInstances
+  }
+})
+
+vi.mock('electron', () => ({
+  Menu: electronMock.Menu,
+  Tray: electronMock.Tray,
+  nativeImage: electronMock.nativeImage
+}))
+
+beforeEach(async () => {
+  electronMock.trayInstances.length = 0
+  vi.resetModules()
+})
+
+describe('tray', () => {
+  it('creates a tray icon on first close and shows the window on click', async () => {
+    const window = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    } as any
+
+    const { ensureTray } = await import('./tray')
+    ensureTray({ window, iconPath: 'valid.png', onQuit: vi.fn() })
+
+    expect(electronMock.trayInstances).toHaveLength(1)
+    const [tray] = electronMock.trayInstances
+    expect(tray.tooltip).toBe('Hermes')
+    expect(tray.menu?.map(item => item.label)).toEqual(['Show Hermes', undefined, 'Quit Hermes'])
+
+    tray.emit('click')
+    expect(window.show).toHaveBeenCalled()
+    expect(window.focus).toHaveBeenCalled()
+  })
+
+  it('does not create a tray when the window is missing or destroyed', async () => {
+    const onQuit = vi.fn()
+    const { ensureTray } = await import('./tray')
+
+    ensureTray({ window: null, iconPath: 'valid.png', onQuit })
+    expect(electronMock.trayInstances).toHaveLength(0)
+
+    const destroyedWindow = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => true),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    }
+
+    ensureTray({ window: destroyedWindow as any, iconPath: 'valid.png', onQuit })
+    expect(electronMock.trayInstances).toHaveLength(0)
+  })
+
+  it('does not create a tray when the icon path is missing or empty', async () => {
+    const window = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    } as any
+
+    const { ensureTray } = await import('./tray')
+
+    ensureTray({ window, iconPath: undefined, onQuit: vi.fn() })
+    ensureTray({ window, iconPath: 'empty.png', onQuit: vi.fn() })
+    expect(electronMock.trayInstances).toHaveLength(0)
+  })
+
+  it('does not create a second tray if one already exists', async () => {
+    const window = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    } as any
+
+    const { ensureTray } = await import('./tray')
+    ensureTray({ window, iconPath: 'valid.png', onQuit: vi.fn() })
+    ensureTray({ window, iconPath: 'another.png', onQuit: vi.fn() })
+
+    expect(electronMock.trayInstances).toHaveLength(1)
+  })
+
+  it('calls onQuit when the tray menu quit item is clicked', async () => {
+    const window = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    } as any
+
+    const onQuit = vi.fn()
+    const { ensureTray } = await import('./tray')
+    ensureTray({ window, iconPath: 'valid.png', onQuit })
+
+    const quitItem = electronMock.trayInstances[0].menu?.find(item => item.label === 'Quit Hermes')
+    quitItem?.click?.()
+
+    expect(onQuit).toHaveBeenCalled()
+  })
+
+  it('destroys the tray icon during teardown', async () => {
+    const window = {
+      focus: vi.fn(),
+      hide: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isFocused: vi.fn(() => false),
+      isVisible: vi.fn(() => false),
+      show: vi.fn()
+    } as any
+
+    const { ensureTray, destroyTray } = await import('./tray')
+    ensureTray({ window, iconPath: 'valid.png', onQuit: vi.fn() })
+
+    const [tray] = electronMock.trayInstances
+    destroyTray()
+
+    expect(tray.destroy).toHaveBeenCalled()
+    expect(tray.destroyed).toBe(true)
+  })
+})

--- a/apps/desktop/electron/tray.ts
+++ b/apps/desktop/electron/tray.ts
@@ -1,0 +1,61 @@
+import { type BrowserWindow, Menu, nativeImage, Tray } from 'electron'
+
+let tray: Tray | null = null
+
+function showWindow(window: BrowserWindow | null) {
+  if (!window || window.isDestroyed()) return
+  if (!window.isVisible()) window.show()
+  if (!window.isFocused()) window.focus()
+}
+
+export interface TrayOptions {
+  window: BrowserWindow | null
+  iconPath: string | undefined
+  onQuit: () => void
+}
+
+/**
+ * Create a system-tray icon for Hermes if one does not already exist.
+ *
+ * Clicking/double-clicking the icon restores the main window; the right-click
+ * menu offers "Show" and "Quit". The tray is only created when needed (the
+ * first time the user closes the main window) so that users who never close
+ * the window are not surprised by a tray icon.
+ *
+ * Call `destroyTray()` during teardown to remove the icon.
+ */
+export function ensureTray({ window, iconPath, onQuit }: TrayOptions): void {
+  if (tray || !window || window.isDestroyed()) return
+  if (!iconPath) return
+
+  const icon = nativeImage.createFromPath(iconPath)
+  if (icon.isEmpty()) return
+
+  tray = new Tray(icon)
+  tray.setToolTip('Hermes')
+  tray.setContextMenu(
+    Menu.buildFromTemplate([
+      {
+        label: 'Show Hermes',
+        click: () => showWindow(window)
+      },
+      { type: 'separator' },
+      {
+        label: 'Quit Hermes',
+        click: () => {
+          destroyTray()
+          onQuit()
+        }
+      }
+    ])
+  )
+  tray.on('click', () => showWindow(window))
+  tray.on('double-click', () => showWindow(window))
+}
+
+/** Remove the Hermes tray icon and clean up its listeners. */
+export function destroyTray(): void {
+  if (!tray) return
+  tray.destroy()
+  tray = null
+}


### PR DESCRIPTION
## Summary

This PR adds a system tray icon to the Hermes Desktop app so that closing the main window hides it to the tray instead of quitting the app (on Windows and Linux). macOS behavior is unchanged.

## Problem

When users click the window close button to reduce clutter, the current behavior is to fully exit the application. This causes them to lose their running agent turns and chat history. Users have also reported that, after manually patching the app to minimize on close, there is no discoverable way to fully quit.

## Solution

- Close button now hides the main window and creates a tray icon (lazy creation).
- Left/double-click the tray icon to restore and focus the window.
- Right-click tray menu provides:
  - **Show Hermes**
  - **Quit Hermes** (clear, discoverable full exit)
- On macOS, the standard Dock behavior is preserved.
- Tray icon is destroyed during app teardown.

## Files Changed

- `apps/desktop/electron/main.ts` — hook close event, import tray helpers
- `apps/desktop/electron/tray.ts` — new tray module (`ensureTray`, `destroyTray`)
- `apps/desktop/electron/tray.test.ts` — 6 unit tests

## Verification

- `npx tsc --build tsconfig.electron.json` passes
- `npx vitest run electron/tray.test.ts` passes (6/6)

## Notes

The tray is only created when the user first closes the window, so it does not affect users who keep the window open.