### PR TITLE
fix(subdirectory_hints): raise _MAX_ANCESTOR_WALK 5 → 8

### DIFF
--- a/agent/subdirectory_hints.py
+++ b/agent/subdirectory_hints.py
@@ -46,7 +46,7 @@ _COMMAND_TOOLS = {"terminal"}
 
 # How many parent directories to walk up when looking for hints.
 # Prevents scanning all the way to / for deeply nested paths.
-_MAX_ANCESTOR_WALK = 5
+_MAX_ANCESTOR_WALK = 8
 
 # Shared with broad recursive search probes so context discovery and search do
 # not drift into different dependency/cache/build trees.


### PR DESCRIPTION
## Problem

`SubdirectoryHintTracker._add_path_candidates` walks up at most `_MAX_ANCESTOR_WALK` levels from a touched file to discover hint files (e.g. `AGENTS.md`). With the current limit of 5, hint discovery silently fails in real-world deeply nested layouts — e.g. `workspace/projects/domain/subsystem/src/module/file.py` sits 6+ levels below the directory that holds the authoritative `AGENTS.md`, so the agent never picks it up.

## Change

One line: `_MAX_ANCESTOR_WALK` 5 → 8. (Keeping the patch as a carried commit locally after upgrades is what motivated this PR — it keeps getting clobbered by resets.)

## Why this is safe

The walk remains bounded by the existing safeguards, unchanged:

- `_EXCLUDED_DIR_NAMES` prune dependency/cache/VCS trees;
- early break when a directory is already in `_loaded_dirs`;
- break at filesystem root.

Three extra levels of `Path.parent` hops are negligible, and only run when hints were not already discovered at a shallower level.

## Testing

`pytest tests/agent -k subdirectory`: 61 passed, 1 skipped (platform-dependent), on Python 3.11 / macOS arm64.