### PR TITLE
feat(cli): add --quiet to `config set` for non-interactive writes

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -5950,7 +5950,7 @@ def _redirect_platform_display_key(key: str) -> tuple[str, Optional[str]]:
     return canonical, f"  (note: per-platform display setting — saved as {canonical})"
 
 
-def set_config_value(key: str, value: str, force: bool = False):
+def set_config_value(key: str, value: str, force: bool = False, quiet: bool = False):
     """Set a configuration value.
 
     Args:
@@ -5963,6 +5963,12 @@ def set_config_value(key: str, value: str, force: bool = False):
             mapping). Without --force, scalar writes over mapping sections are
             refused (bare ``model`` is redirected to ``model.default``). The
             CLI exposes this via ``hermes config set --force``.
+        quiet: When True, suppress the success confirmation line and the
+            post-write unknown-key notice so a script can trust "nothing on
+            stdout + exit 0" as the success signal (#96764). Real failures
+            still raise/exit non-zero and still print to stderr — --quiet
+            only mutes the human-oriented notes printed on the success path.
+            The CLI exposes this via ``hermes config set --quiet``.
     """
     if is_managed():
         managed_error("set configuration values")
@@ -6005,7 +6011,8 @@ def set_config_value(key: str, value: str, force: bool = False):
         from hermes_cli.credential_lifecycle import save_provider_env_credential
 
         save_provider_env_credential(key.upper(), value)
-        print(f"✓ Set {key} in {get_env_path()}")
+        if not quiet:
+            print(f"✓ Set {key} in {get_env_path()}")
         return
 
     # Unknown-key notice (#34067): the key is still written (arbitrary keys
@@ -6209,12 +6216,13 @@ def set_config_value(key: str, value: str, force: bool = False):
         _display_value = mask_secret(value)
     else:
         _display_value = value
-    print(f"✓ Set {key} = {_display_value} in {config_path}")
+    if not quiet:
+        print(f"✓ Set {key} = {_display_value} in {config_path}")
     warn_unpinned_cron_jobs_after_model_config_change(key, value, user_config)
 
     # Post-write unknown-key notice (#34067): value IS saved, but tell the
     # user the runtime may never read it and suggest the likely-intended path.
-    if not is_known and not force:
+    if not is_known and not force and not quiet:
         print(color(
             f"⚠ '{key}' is not a recognized config key — it was saved anyway, "
             "but Hermes may not read it.",
@@ -6335,8 +6343,9 @@ def config_command(args):
         key = getattr(args, 'key', None)
         value = getattr(args, 'value', None)
         force = bool(getattr(args, 'force', False))
+        quiet = bool(getattr(args, 'quiet', False))
         if not key or value is None:
-            print("Usage: hermes config set [--force] <key> <value>")
+            print("Usage: hermes config set [--force] [--quiet] <key> <value>")
             print()
             print("Examples:")
             print("  hermes config set model anthropic/claude-sonnet-4")
@@ -6345,9 +6354,12 @@ def config_command(args):
             print()
             print("  --force: skip the unknown-key notice for unrecognized keys,")
             print("           and allow a scalar to replace a whole mapping section")
+            print("  --quiet: suppress the success confirmation and unknown-key")
+            print("           notice — for scripted use where only the exit code")
+            print("           matters")
             sys.exit(1)
         try:
-            set_config_value(key, value, force=force)
+            set_config_value(key, value, force=force, quiet=quiet)
         except RuntimeError as exc:
             # Fail-closed write guard (unparseable / non-mapping / unreadable
             # config.yaml). Surface a clean CLI error instead of a traceback.

--- a/hermes_cli/subcommands/config.py
+++ b/hermes_cli/subcommands/config.py
@@ -46,6 +46,13 @@ def build_config_parser(subparsers, *, cmd_config: Callable) -> None:
         help="Skip the unknown-key notice printed after writing a key the "
         "running version doesn't recognize (the value is saved either way).",
     )
+    config_set.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the success confirmation line and the unknown-key "
+        "notice, for scripted/non-interactive use — exit code alone signals "
+        "success (0) or failure (non-zero); real errors still print.",
+    )
 
     # config unset
     config_unset = config_subparsers.add_parser(

--- a/tests/hermes_cli/test_set_config_value.py
+++ b/tests/hermes_cli/test_set_config_value.py
@@ -532,6 +532,81 @@ class TestSchemaValidation:
         assert "brand_new_future_key" in content
 
 
+# ---------------------------------------------------------------------------
+# #96764: --quiet for scripted/non-interactive `config set`
+# ---------------------------------------------------------------------------
+
+class TestQuietFlag:
+    """``quiet=True`` mutes the success-path confirmation and unknown-key
+    notice so a caller can trust "empty stdout + exit 0" as the success
+    signal. It must never suppress a real failure (those still raise /
+    exit non-zero and still print to stderr), and the value must still be
+    written exactly as it would be without --quiet."""
+
+    def test_quiet_suppresses_confirmation_line(self, _isolated_hermes_home, capsys):
+        set_config_value("model.reasoning_effort", "high", quiet=True)
+        out = capsys.readouterr().out
+        assert out == ""
+        # The value was still written — quiet only mutes the echo.
+        assert "reasoning_effort: high" in _read_config(_isolated_hermes_home)
+
+    def test_non_quiet_still_prints_confirmation_line(self, _isolated_hermes_home, capsys):
+        """Default behavior (quiet=False) is unchanged."""
+        set_config_value("model.reasoning_effort", "high")
+        out = capsys.readouterr().out
+        assert "Set model.reasoning_effort = high" in out
+
+    def test_quiet_suppresses_unknown_key_notice(self, _isolated_hermes_home, capsys):
+        set_config_value("brand_new_future_key", "value", quiet=True)
+        out = capsys.readouterr().out
+        assert out == ""
+        # The value was still written even though the key is unrecognized —
+        # --quiet mutes the notice, it does not change what gets saved.
+        assert "brand_new_future_key" in _read_config(_isolated_hermes_home)
+
+    def test_quiet_suppresses_env_key_confirmation(self, _isolated_hermes_home, capsys):
+        """API-key-shaped values route to .env through an earlier return —
+        that confirmation line must be muted too."""
+        set_config_value("OPENROUTER_API_KEY", "sk-or-test", quiet=True)
+        out = capsys.readouterr().out
+        assert out == ""
+        assert "OPENROUTER_API_KEY=sk-or-test" in _read_env(_isolated_hermes_home)
+
+    def test_quiet_does_not_suppress_real_failure(self, _isolated_hermes_home, capsys):
+        """A genuine write failure must still surface — --quiet only mutes
+        the success-path notes, never error signal."""
+        config_path = _isolated_hermes_home / "config.yaml"
+        config_path.write_text("broken: [unterminated\n", encoding="utf-8")
+        with pytest.raises(RuntimeError):
+            set_config_value("model.default", "gpt-4o", quiet=True)
+
+    def test_quiet_via_config_command_set(self, _isolated_hermes_home, capsys):
+        """The ``hermes config set --quiet`` CLI path threads through to
+        set_config_value the same way ``--force`` already does."""
+        ns = argparse.Namespace(
+            config_command="set", key="model.reasoning_effort", value="high",
+            force=False, quiet=True,
+        )
+        config_command(ns)
+        out = capsys.readouterr().out
+        assert out == ""
+        assert "reasoning_effort: high" in _read_config(_isolated_hermes_home)
+
+    def test_config_command_set_without_quiet_attr_defaults_false(
+        self, _isolated_hermes_home, capsys
+    ):
+        """A Namespace without a ``quiet`` attribute (e.g. built by an older
+        test or caller) must not break — defaults to the old, non-quiet
+        behavior via getattr."""
+        ns = argparse.Namespace(
+            config_command="set", key="model.reasoning_effort", value="high",
+            force=False,
+        )
+        config_command(ns)
+        out = capsys.readouterr().out
+        assert "Set model.reasoning_effort = high" in out
+
+
 class TestValidateConfigKey:
     """Unit tests for the validator itself."""
 

--- a/tests/hermes_cli/test_subcommands_batch.py
+++ b/tests/hermes_cli/test_subcommands_batch.py
@@ -95,6 +95,35 @@ def test_config_get_unset_subcommands_parse():
     assert ns.key == "terminal.backend"
 
 
+def test_config_set_quiet_flag_parses():
+    """#96764: `hermes config set --quiet` must parse (previously
+    `unrecognized arguments: --quiet`, exit code 2, no write)."""
+    parser = argparse.ArgumentParser(prog="hermes")
+    sub = parser.add_subparsers(dest="command")
+    handler = _h("config")
+    build_config_parser(sub, cmd_config=handler)
+
+    ns = parser.parse_args(
+        ["config", "set", "model.default", "glm-5.3-flash", "--quiet"]
+    )
+    assert ns.func is handler
+    assert ns.config_command == "set"
+    assert ns.key == "model.default"
+    assert ns.value == "glm-5.3-flash"
+    assert ns.quiet is True
+    assert ns.force is False
+
+    # Default is False, and --quiet composes with --force.
+    ns = parser.parse_args(["config", "set", "model.default", "x"])
+    assert ns.quiet is False
+
+    ns = parser.parse_args(
+        ["config", "set", "model.default", "x", "--force", "--quiet"]
+    )
+    assert ns.quiet is True
+    assert ns.force is True
+
+
 
 
 # ── deprecated `hermes login` fails gracefully, not with argparse error ────


### PR DESCRIPTION
`hermes config set <key> <value>` had no quiet mode, and the only "quiet-looking" flag script authors reached for, --quiet, was not a recognized argument: it aborted the whole command with an argparse usage dump and exit code 2, leaving the value unwritten. Even a correct, flag-free invocation always printed the human-oriented "Set <key> = <value> in <path>" confirmation line (and, for an unrecognized key, a second notice), so scripted callers had no way to treat stdout as a trustworthy success signal either. One reporter described a real incident: a scheduled maintenance script passed the invalid --quiet, got exit code 2, never checked the return code, and logged a config write as applied that never actually landed.

Add --quiet to the `config set` subparser and thread it through set_config_value(): when set, suppress the success confirmation line (both the config.yaml path and the .env-routed API-key path) and the post-write unknown-key notice. Exit-code semantics are unchanged -- 0 on success, non-zero on a real failure -- and failures still print to stderr regardless of --quiet, so a script can rely on "empty stdout + exit 0" as the success signal without losing error visibility. Other advisory prints on the success path (the bare-`model` redirect note, the --force destructive-overwrite warning, the api_base alias note, the unpinned-cron-job warning) are left as is -- out of scope per the issue's own suggested fix, and each carries information a script author would still want even when muting the routine confirmation.

Added tests/hermes_cli/test_set_config_value.py::TestQuietFlag (mutes both confirmation paths and the unknown-key notice while still writing the value, a real write failure still raises with --quiet set, the config_command() CLI dispatch threads --quiet through the same way --force already does, and a Namespace without a `quiet` attribute at all keeps the old default behavior via getattr) and tests/hermes_cli/test_subcommands_batch.py::test_config_set_quiet_flag_parses (the argparse flag itself, including composing with --force).

Fixes #96764

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

