### PR TITLE
fix(zai): clamp GLM-5.3-flash reasoning effort to low/high/max

### DIFF
--- a/agent/reasoning_effort.py
+++ b/agent/reasoning_effort.py
@@ -124,6 +124,15 @@ GLM52_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 GLM53_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
 GLM53_OVERRIDES: dict[str, str] = {"xhigh": "max"}
 
+#: GLM-5.3-flash narrows the knob back to low/high/max — verified live on
+#: api.z.ai/api/paas/v4 (2026-08-27): ``medium`` and ``disabled`` are
+#: rejected with HTTP 400 code 1210 ("This model always engages in thinking
+#: and cannot be disabled; please use low, high, or max").  ``medium``
+#: clamps down to ``low`` via the nearest-weaker policy; ``xhigh`` requests
+#: the top tier.
+GLM53FLASH_EFFORTS: tuple[str, ...] = ("low", "high", "max")
+GLM53FLASH_OVERRIDES: dict[str, str] = {"xhigh": "max"}
+
 #: DeepSeek V4 OpenAI-compat endpoint: low/medium/high/max; ``xhigh``
 #: requests the top tier (matches the shipped profile mapping).
 DEEPSEEK_V4_EFFORTS: tuple[str, ...] = ("low", "medium", "high", "max")
@@ -225,3 +234,18 @@ def requested_effort(reasoning_config: Optional[dict]) -> Optional[str]:
         return None
     effort = str(reasoning_config.get("effort") or "").strip().lower()
     return effort or None
+
+
+def is_glm53flash_model(model: Optional[str]) -> bool:
+    """True for Z.AI's GLM-5.3-flash.
+
+    The flash variant always thinks and narrows the reasoning-effort knob to
+    exactly low/high/max (HTTP 400 code 1210 for ``medium``/``disabled``,
+    verified live on api.z.ai, 2026-08-27), so transports must clamp against
+    :data:`GLM53FLASH_EFFORTS` instead of the wider GLM-5.3 vocabulary.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.3-flash", "glm-5-3-flash", "glm-5p3-flash"))
+

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -14,11 +14,14 @@ from typing import Any, Dict
 
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.reasoning_effort import (
+    GLM53FLASH_EFFORTS,
+    GLM53FLASH_OVERRIDES,
     KIMI_K3_EFFORTS,
     KIMI_K3_OVERRIDES,
     OPENAI_COMPAT_WIRE_EFFORTS,
     TOKENHUB_EFFORTS,
     clamp_effort,
+    is_glm53flash_model,
     kimi_supported_efforts,
     requested_effort,
 )
@@ -135,6 +138,31 @@ def _reasoning_config_for_model(model: str, reasoning_config: dict | None) -> di
         normalized["effort"] = clamped
         return normalized
     return reasoning_config
+
+
+def _glm_flash_reasoning(
+    reasoning_config: dict | None, model: str
+) -> dict[str, Any] | None:
+    """Wire value for ``extra_body.reasoning`` on Z.AI's GLM-5.3-flash.
+
+    The flash variant always thinks and accepts exactly low/high/max
+    (HTTP 400 code 1210 for ``medium`` and for ``thinking: disabled`` —
+    "This model always engages in thinking and cannot be disabled; please
+    use low, high, or max", verified live on api.z.ai 2026-08-27).  Returns
+    ``None`` when nothing should be emitted: no explicit effort preference
+    (server default thinking applies), an explicit disable (cannot be
+    honoured — omitting keeps thinking on), or the model is not the flash
+    variant.  A requested ``medium`` clamps to ``low`` (nearest weaker).
+    """
+    if not is_glm53flash_model(model):
+        return None
+    effort = requested_effort(reasoning_config)
+    if effort is None:
+        return None
+    return {
+        "enabled": True,
+        "effort": clamp_effort(effort, GLM53FLASH_EFFORTS, GLM53FLASH_OVERRIDES),
+    }
 
 
 def _build_gemini_thinking_config(model: str, reasoning_config: dict | None) -> dict | None:
@@ -691,10 +719,14 @@ class ChatCompletionsTransport(ProviderTransport):
                 if gh_reasoning is not None:
                     extra_body["reasoning"] = gh_reasoning
             else:
-                _effort = "medium"
-                if reasoning_config and isinstance(reasoning_config, dict):
-                    _effort = reasoning_config.get("effort", "medium") or "medium"
-                extra_body["reasoning"] = {"enabled": True, "effort": _effort}
+                _flash_reasoning = _glm_flash_reasoning(reasoning_config, model)
+                if _flash_reasoning is not None:
+                    extra_body["reasoning"] = _flash_reasoning
+                else:
+                    _effort = "medium"
+                    if reasoning_config and isinstance(reasoning_config, dict):
+                        _effort = reasoning_config.get("effort", "medium") or "medium"
+                    extra_body["reasoning"] = {"enabled": True, "effort": _effort}
 
         if provider_name == "gemini":
             raw_thinking_config = _build_gemini_thinking_config(model, reasoning_config)

--- a/plugins/model-providers/zai/__init__.py
+++ b/plugins/model-providers/zai/__init__.py
@@ -78,6 +78,22 @@ def _is_glm_5_3(model: str | None) -> bool:
     return any(token in m for token in ("glm-5.3", "glm-5-3", "glm-5p3"))
 
 
+def _is_glm_5_3_flash(model: str | None) -> bool:
+    """Detect GLM-5.3-flash — it narrows the effort knob to low/high/max.
+
+    The base 5.3 accepts a graded ``low``/``medium``/``high``/``max`` scale,
+    but the flash variant rejects ``medium`` and ``disabled`` with HTTP 400
+    code 1210 ("This model always engages in thinking and cannot be
+    disabled; please use low, high, or max"), verified live on
+    api.z.ai/api/paas/v4 (2026-08-27).  It therefore needs its own
+    vocabulary rather than inheriting the 5.3 set.
+    """
+    m = (model or "").strip().lower()
+    if not m:
+        return False
+    return any(token in m for token in ("glm-5.3-flash", "glm-5-3-flash", "glm-5p3-flash"))
+
+
 def _glm_5_2_reasoning_effort(
     reasoning_config: dict | None, *, model: str | None = None
 ) -> str | None:
@@ -107,10 +123,14 @@ def _glm_5_2_reasoning_effort(
         GLM52_OVERRIDES,
         GLM53_EFFORTS,
         GLM53_OVERRIDES,
+        GLM53FLASH_EFFORTS,
+        GLM53FLASH_OVERRIDES,
         clamp_effort,
     )
 
-    if _is_glm_5_3(model):
+    if _is_glm_5_3_flash(model):
+        efforts, overrides, floor = GLM53FLASH_EFFORTS, GLM53FLASH_OVERRIDES, "low"
+    elif _is_glm_5_3(model):
         efforts, overrides, floor = GLM53_EFFORTS, GLM53_OVERRIDES, "low"
     else:
         efforts, overrides, floor = GLM52_EFFORTS, GLM52_OVERRIDES, "high"
@@ -131,13 +151,25 @@ class ZaiProfile(ProviderProfile):
         if not _model_supports_thinking(model) and not _is_glm_5_2(model):
             return extra_body, top_level
 
+        if (
+            _is_glm_5_3_flash(model)
+            and isinstance(reasoning_config, dict)
+            and reasoning_config.get("enabled") is False
+        ):
+            # GLM-5.3-flash always thinks: the API rejects ``thinking:
+            # disabled`` (and ``reasoning_effort: medium``) with HTTP 400
+            # code 1210 (verified live on api.z.ai/api/paas/v4, 2026-08-27).
+            # An explicit "off" cannot be honoured, so serve the floor
+            # (low) as the closest honest match instead of hard-failing.
+            reasoning_config = {"enabled": True, "effort": "low"}
+
         # Only emit when the user expressed a preference; omitting the field
         # keeps the server default (enabled) exactly as before.
         if isinstance(reasoning_config, dict):
             enabled = reasoning_config.get("enabled") is not False
             extra_body["thinking"] = {"type": "enabled" if enabled else "disabled"}
 
-        if _is_glm_5_2(model):
+        if _is_glm_5_2(model) or _is_glm_5_3(model) or _is_glm_5_3_flash(model):
             effort = _glm_5_2_reasoning_effort(reasoning_config, model=model)
             if effort is not None:
                 top_level["reasoning_effort"] = effort

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -17,6 +17,59 @@ def transport():
     return get_transport("chat_completions")
 
 
+class TestGLM53FlashReasoning:
+    """GLM-5.3-flash wire narrowing in extra_body.reasoning.
+
+    The flash variant always thinks and accepts exactly low/high/max —
+    medium/disabled answer HTTP 400 code 1210 on api.z.ai (verified live
+    2026-08-27).  No explicit preference (or an explicit disable, which
+    cannot be honoured) emits nothing so the server default applies.
+    """
+
+    def test_non_flash_returns_none(self):
+        from agent.transports.chat_completions import _glm_flash_reasoning
+
+        assert (
+            _glm_flash_reasoning({"enabled": True, "effort": "medium"}, "glm-5.3")
+            is None
+        )
+        assert (
+            _glm_flash_reasoning({"enabled": True, "effort": "medium"}, "glm-5.2")
+            is None
+        )
+
+    @pytest.mark.parametrize(
+        ("reasoning_config", "expected"),
+        [
+            (None, None),  # no preference → server default thinking
+            ({"enabled": True}, None),  # enabled, no effort → default level
+            ({"enabled": False}, None),  # disable can't be honoured → omit
+            ({"enabled": False, "effort": "high"}, None),
+            ({"enabled": True, "effort": "low"}, {"enabled": True, "effort": "low"}),
+            ({"enabled": True, "effort": "medium"}, {"enabled": True, "effort": "low"}),
+            ({"enabled": True, "effort": "high"}, {"enabled": True, "effort": "high"}),
+            ({"enabled": True, "effort": "max"}, {"enabled": True, "effort": "max"}),
+            ({"enabled": True, "effort": "xhigh"}, {"enabled": True, "effort": "max"}),
+            ({"enabled": True, "effort": "minimal"}, {"enabled": True, "effort": "low"}),
+        ],
+    )
+    def test_flash_wire_value(self, reasoning_config, expected):
+        from agent.transports.chat_completions import _glm_flash_reasoning
+
+        assert _glm_flash_reasoning(reasoning_config, "glm-5.3-flash") == expected
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.3-flash", "glm-5-3-flash", "glm-5p3-flash", "z-ai/glm-5.3-flash"],
+    )
+    def test_flash_alias_spellings_clamp_medium(self, model):
+        from agent.transports.chat_completions import _glm_flash_reasoning
+
+        assert _glm_flash_reasoning(
+            {"enabled": True, "effort": "medium"}, model
+        ) == {"enabled": True, "effort": "low"}
+
+
 class TestChatCompletionsBasic:
     @pytest.mark.parametrize(
         "choice",

--- a/tests/plugins/model_providers/test_zai_profile.py
+++ b/tests/plugins/model_providers/test_zai_profile.py
@@ -182,6 +182,67 @@ class TestZaiGLM53ReasoningEffort:
         assert top_level == {"reasoning_effort": "high"}
 
 
+class TestZaiGLM53FlashReasoningEffort:
+    """GLM-5.3-flash narrows the knob to low/high/max.
+
+    Verified live on api.z.ai/api/paas/v4 (2026-08-27): ``medium`` and
+    ``disabled`` are rejected with HTTP 400 code 1210 ("This model always
+    engages in thinking and cannot be disabled; please use low, high, or
+    max").  ``medium`` therefore clamps to the nearest weaker level
+    (``low``), and an explicit disable is served the floor instead of a
+    hard error.
+    """
+
+    @pytest.mark.parametrize(
+        ("effort", "expected"),
+        [
+            ("low", "low"),
+            ("medium", "low"),  # not on the flash wire; nearest weaker
+            ("high", "high"),
+            ("max", "max"),
+            ("xhigh", "max"),
+            ("minimal", "low"),
+        ],
+    )
+    def test_flash_efforts_clamp(self, zai_profile, effort, expected):
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": effort},
+            model="glm-5.3-flash",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": expected}
+
+    def test_flash_disabled_serves_floor(self, zai_profile):
+        """``enabled=False`` cannot reach the wire as ``thinking: disabled``
+        (the API 400s "cannot be disabled"); it resolves to the floor
+        (low) instead."""
+        extra_body, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": False, "effort": "high"},
+            model="glm-5.3-flash",
+        )
+        assert extra_body == {"thinking": {"type": "enabled"}}
+        assert top_level == {"reasoning_effort": "low"}
+
+    @pytest.mark.parametrize(
+        "model",
+        ["glm-5.3-flash", "glm-5-3-flash", "glm-5p3-flash", "z-ai/glm-5.3-flash"],
+    )
+    def test_flash_alias_spellings_clamp_medium(self, zai_profile, model):
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model=model,
+        )
+        assert top_level == {"reasoning_effort": "low"}
+
+    def test_base_glm_5_3_still_accepts_medium(self, zai_profile):
+        """The flash narrowing must not leak into the full 5.3 wire."""
+        _, top_level = zai_profile.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+            model="glm-5.3",
+        )
+        assert top_level == {"reasoning_effort": "medium"}
+
+
 class TestZaiModelGating:
     """GLM 4.5+ get thinking; earlier GLM models are left untouched."""
 


### PR DESCRIPTION
## Summary

Z.AI's `glm-5.3-flash` always engages in thinking and accepts exactly three
effort levels: `low`, `high`, `max`. Both `reasoning_effort: "medium"` and
`thinking: {"type": "disabled"}` are rejected with HTTP 400 (error code 1210):

> This model always engages in thinking and cannot be disabled; please use
> low, high, or max

Hermes currently lets `medium` (and a disable request) reach the wire for this
model, so any session on `glm-5.3-flash` fails with a 400. Two code paths are
affected:

1. **Z.AI provider profile** (`plugins/model-providers/zai/__init__.py`) —
   `_glm_5_2_reasoning_effort` routes flash models into the *base* GLM-5.3
   vocabulary (`low/medium/high/max`), so `medium` passes through verbatim.
   A `reasoning_config={"enabled": False}` also emits
   `thinking: {"type": "disabled"}`, which hard-fails.

2. **Chat-completions transport** (`agent/transports/chat_completions.py`) —
   the generic `extra_body["reasoning"]` branch **defaults effort to
   `"medium"`** when the user expressed no preference. A flash request with
   *no* reasoning preference at all therefore still 400s — the bug fires even
   for users who never touched `/reasoning`.

## Fix

- Declare the narrowed vocabulary as data in `agent/reasoning_effort.py`:
  `GLM53FLASH_EFFORTS = ("low", "high", "max")` (with `xhigh → max`), plus a
  shared `is_glm53flash_model()` detector matching the usual alias spellings
  (`glm-5.3-flash`, `glm-5-3-flash`, `glm-5p3-flash`, provider-prefixed forms).
- Profile path: flash models clamp against the flash vocabulary — `medium`
  resolves to `low` via the existing nearest-weaker policy in `clamp_effort`;
  an explicit disable is served the floor (`low`) instead of emitting
  `thinking: disabled`.
- Transport path: flash models either clamp the requested effort or emit
  nothing (no preference → server default thinking; explicit disable → omit,
  since omitting keeps thinking on). Non-flash models are untouched.

## Verification

- Live probed api.z.ai (2026-08-27, code 1210): `medium` → 400, `disabled` →
  400, `low`/`high`/`max`/omitted → accepted. (Probes surfaced a separate
  billing-lane 429 on that day; parameter validation results were unaffected.)
- Wire simulation through the patched profile:
  `glm-5.3-flash + medium` → `thinking: enabled` + `reasoning_effort: "low"`;
  `glm-5.3 + medium` → unchanged (`"medium"`); `glm-5.2 + low` → unchanged
  (`"high"` floor).
- 150 tests pass: the Z.AI profile suite (12 new cases pinning the flash wire
  contract, incl. alias spellings), the chat-completions transport suite
  (14 new cases on `_glm_flash_reasoning`), and the reasoning-caps inventory.

## Notes

- Follows the repo's vocabulary-as-data convention: `clamp_effort` handles
  the policy; call sites never add vendor `if`s.
- No-silent-escalation preserved: `medium` never resolves *up*; it clamps
  down to `low`.
