### PR TITLE
feat(cli): add autonomous delivery coordinator

### DIFF
--- a/contributors/emails/local-bootstrap@invalid
+++ b/contributors/emails/local-bootstrap@invalid
@@ -1,0 +1,2 @@
+blue9694100-del
+# Hermes V1 autonomous coordinator

--- a/hermes_cli/autonomous_coordinator.py
+++ b/hermes_cli/autonomous_coordinator.py
@@ -1,0 +1,504 @@
+"""Durable, event-driven coordinator for one autonomous engineering outcome."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import threading
+import uuid
+from collections.abc import Callable, Mapping
+from enum import Enum
+from pathlib import Path
+from typing import Any, Literal
+
+from hermes_constants import get_hermes_home
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class AutonomousTaskStatus(str, Enum):
+    QUEUED = "QUEUED"
+    DEVELOPING = "DEVELOPING"
+    TESTING = "TESTING"
+    REPAIRING = "REPAIRING"
+    ACCEPTANCE_PRE_DEPLOY = "ACCEPTANCE_PRE_DEPLOY"
+    DELIVERING = "DELIVERING"
+    DEPLOYING = "DEPLOYING"
+    ACCEPTANCE_RUNTIME = "ACCEPTANCE_RUNTIME"
+    DONE = "DONE"
+    BLOCKED = "BLOCKED"
+
+
+OWNER_STOP_CONDITIONS = frozenset({
+    "PRODUCT_DECISION_REQUIRED",
+    "ENVIRONMENT_REQUIRED",
+    "HIGH_RISK_PRODUCTION_APPROVAL_REQUIRED",
+    "BLOCKED_BY_ARCHITECTURE",
+    "BLOCKED_BY_REPOSITORY_LINEAGE",
+})
+
+
+class AutonomousTaskState(BaseModel):
+    """The complete durable checkpoint needed to resume a coordinator."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    task_id: str = Field(min_length=1)
+    project: str = Field(min_length=1)
+    repository: str = Field(min_length=1)
+    target_branch: str = Field(min_length=1)
+    state: AutonomousTaskStatus = AutonomousTaskStatus.QUEUED
+    current_agent: Literal["developer", "tester", "acceptance"] | None = None
+    developer_commit: str | None = None
+    tester_verdict: str | None = None
+    acceptance_verdict: str | None = None
+    pr_number: int | None = None
+    ci_status: str | None = None
+    deployment_status: str | None = None
+    runtime_acceptance: str | None = None
+    repair_loops: int = 0
+    acceptance_loops: int = 0
+    last_error: str | None = None
+    next_action: str = "Dispatch Developer"
+    operation_id: str | None = None
+    repository_remote: str | None = None
+    deployment_retries: int = 0
+    revision: int = 0
+
+    def render(self) -> str:
+        owner_action = "YES" if self.state == AutonomousTaskStatus.BLOCKED else "NO"
+        return "\n".join((
+            f"TASK: {self.task_id}",
+            f"STATE: {self.state.value}",
+            f"REPAIR_LOOPS: {self.repair_loops}",
+            f"NEXT_ACTION: {self.next_action}",
+            f"OWNER_ACTION_REQUIRED: {owner_action}",
+        ))
+
+
+class CoordinatorEvent(BaseModel):
+    """A completion or progress event from an agent, CI, or deployment watcher."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    operation_id: str
+    status: Literal["PASS", "FAIL", "RUNNING", "BLOCKED"]
+    commit: str | None = None
+    verdict: str | None = None
+    pr_number: int | None = None
+    ci_status: str | None = None
+    deployment_status: str | None = None
+    error: str | None = None
+    blocker_code: str | None = None
+
+
+class ConcurrentCoordinatorUpdate(RuntimeError):
+    pass
+
+
+class AutonomousTaskStateStore:
+    """Small SQLite store with compare-and-swap updates for process-safe recovery."""
+
+    def __init__(self, path: str | Path | None = None) -> None:
+        self.path = Path(path or get_hermes_home() / "state" / "autonomous-tasks.db")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_lock = threading.Lock()
+        self._initialize()
+
+    def _connect(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.path, timeout=5)
+        conn.execute("PRAGMA busy_timeout=5000")
+        return conn
+
+    def _initialize(self) -> None:
+        with self._init_lock, self._connect() as conn:
+            conn.execute(
+                "CREATE TABLE IF NOT EXISTS autonomous_tasks ("
+                "task_id TEXT PRIMARY KEY, revision INTEGER NOT NULL, body TEXT NOT NULL)"
+            )
+
+    def create(self, state: AutonomousTaskState) -> AutonomousTaskState:
+        body = state.model_dump_json()
+        try:
+            with self._connect() as conn:
+                conn.execute(
+                    "INSERT INTO autonomous_tasks(task_id, revision, body) VALUES (?, ?, ?)",
+                    (state.task_id, state.revision, body),
+                )
+        except sqlite3.IntegrityError as exc:
+            raise ValueError(
+                f"autonomous task already exists: {state.task_id}"
+            ) from exc
+        return state
+
+    def load(self, task_id: str) -> AutonomousTaskState:
+        with self._connect() as conn:
+            row = conn.execute(
+                "SELECT body FROM autonomous_tasks WHERE task_id=?", (task_id,)
+            ).fetchone()
+        if row is None:
+            raise KeyError(f"unknown autonomous task: {task_id}")
+        return AutonomousTaskState.model_validate_json(row[0])
+
+    def save(self, state: AutonomousTaskState) -> AutonomousTaskState:
+        updated = state.model_copy(update={"revision": state.revision + 1})
+        with self._connect() as conn:
+            cursor = conn.execute(
+                "UPDATE autonomous_tasks SET revision=?, body=? "
+                "WHERE task_id=? AND revision=?",
+                (
+                    updated.revision,
+                    updated.model_dump_json(),
+                    updated.task_id,
+                    state.revision,
+                ),
+            )
+        if cursor.rowcount != 1:
+            raise ConcurrentCoordinatorUpdate(state.task_id)
+        return updated
+
+    def active(self) -> tuple[AutonomousTaskState, ...]:
+        with self._connect() as conn:
+            rows = conn.execute("SELECT body FROM autonomous_tasks").fetchall()
+        states = (AutonomousTaskState.model_validate_json(row[0]) for row in rows)
+        return tuple(
+            state
+            for state in states
+            if state.state
+            not in {AutonomousTaskStatus.DONE, AutonomousTaskStatus.BLOCKED}
+        )
+
+
+CoordinatorAction = Callable[[AutonomousTaskState, str], CoordinatorEvent | None]
+
+
+_AGENT_BY_STATE = {
+    AutonomousTaskStatus.DEVELOPING: "developer",
+    AutonomousTaskStatus.TESTING: "tester",
+    AutonomousTaskStatus.REPAIRING: "developer",
+    AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY: "acceptance",
+    AutonomousTaskStatus.ACCEPTANCE_RUNTIME: "acceptance",
+}
+
+_NEXT_ACTION = {
+    AutonomousTaskStatus.QUEUED: "Dispatch Developer",
+    AutonomousTaskStatus.DEVELOPING: "Wait for Developer completion",
+    AutonomousTaskStatus.TESTING: "Dispatch Independent Tester",
+    AutonomousTaskStatus.REPAIRING: "Dispatch Developer Repair",
+    AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY: "Dispatch Acceptance",
+    AutonomousTaskStatus.DELIVERING: "Repository lock and Git/PR/CI delivery",
+    AutonomousTaskStatus.DEPLOYING: "Monitor Dev deployment",
+    AutonomousTaskStatus.ACCEPTANCE_RUNTIME: "Dispatch Runtime Acceptance",
+    AutonomousTaskStatus.DONE: "DELIVERED_AND_VERIFIED",
+    AutonomousTaskStatus.BLOCKED: "Owner resolution required",
+}
+
+
+class VesselMindRepositoryLock:
+    """Resolve the approved VesselMind GitHub remote without rewriting user remotes."""
+
+    expected = "github.com/jasoncheungcn/ceramic-ai-designer-h5"
+
+    @staticmethod
+    def _canonical(url: str) -> str:
+        value = (
+            url.strip().removesuffix(".git").replace("git@github.com:", "github.com/")
+        )
+        for prefix in ("https://", "http://", "ssh://git@"):
+            if value.startswith(prefix):
+                value = value[len(prefix) :]
+        return value.rstrip("/").lower()
+
+    def verify(self, repository: str | Path) -> str:
+        repo = Path(repository).resolve()
+        names = subprocess.run(
+            ["git", "-C", str(repo), "remote"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if names.returncode:
+            raise RuntimeError(
+                "BLOCKED_BY_REPOSITORY_LINEAGE: repository is not readable"
+            )
+        for name in names.stdout.splitlines():
+            urls = subprocess.run(
+                ["git", "-C", str(repo), "remote", "get-url", "--all", name],
+                capture_output=True,
+                text=True,
+                check=False,
+            )
+            if urls.returncode == 0 and any(
+                self._canonical(url) == self.expected
+                for url in urls.stdout.splitlines()
+            ):
+                return name
+        raise RuntimeError(
+            "BLOCKED_BY_REPOSITORY_LINEAGE: approved VesselMind remote is unavailable"
+        )
+
+
+class CoordinatorRunner:
+    """Advance a persisted task until an external event is required or it is terminal."""
+
+    def __init__(
+        self,
+        store: AutonomousTaskStateStore,
+        actions: Mapping[AutonomousTaskStatus, CoordinatorAction],
+        *,
+        repository_lock: VesselMindRepositoryLock | None = None,
+        max_repair_loops: int = 5,
+        max_deployment_retries: int = 3,
+    ) -> None:
+        self.store = store
+        self.actions = actions
+        self.repository_lock = repository_lock or VesselMindRepositoryLock()
+        self.max_repair_loops = max_repair_loops
+        self.max_deployment_retries = max_deployment_retries
+
+    def submit(
+        self, *, task_id: str, project: str, repository: str, target_branch: str
+    ) -> AutonomousTaskState:
+        state = self.store.create(
+            AutonomousTaskState(
+                task_id=task_id,
+                project=project,
+                repository=repository,
+                target_branch=target_branch,
+            )
+        )
+        return self.run(state.task_id)
+
+    def resume_all(self) -> tuple[AutonomousTaskState, ...]:
+        return tuple(self.run(state.task_id) for state in self.store.active())
+
+    def run(self, task_id: str) -> AutonomousTaskState:
+        """Run immediate transitions; return silently when a watcher must wake us."""
+
+        for _ in range(64):
+            try:
+                state = self.store.load(task_id)
+                if state.state in {
+                    AutonomousTaskStatus.DONE,
+                    AutonomousTaskStatus.BLOCKED,
+                }:
+                    return state
+                if state.state == AutonomousTaskStatus.QUEUED:
+                    self._transition(state, AutonomousTaskStatus.DEVELOPING)
+                    continue
+                if state.repair_loops >= self.max_repair_loops:
+                    return self._block(
+                        state, "BLOCKED_BY_ARCHITECTURE", "repair loop limit reached"
+                    )
+
+                action = self.actions.get(state.state)
+                if action is None:
+                    return self._block(
+                        state,
+                        "BLOCKED_BY_ARCHITECTURE",
+                        f"no coordinator action for {state.state.value}",
+                    )
+                if state.state in {
+                    AutonomousTaskStatus.DELIVERING,
+                    AutonomousTaskStatus.DEPLOYING,
+                }:
+                    locked = self._lock_repository(state)
+                    if locked.state == AutonomousTaskStatus.BLOCKED:
+                        return locked
+                    state = locked
+                if state.operation_id is None:
+                    state = self.store.save(
+                        state.model_copy(
+                            update={
+                                "operation_id": uuid.uuid4().hex,
+                                "current_agent": _AGENT_BY_STATE.get(state.state),
+                                "next_action": _NEXT_ACTION[state.state],
+                                "last_error": None,
+                            }
+                        )
+                    )
+                try:
+                    event = action(state, state.operation_id)
+                # Action failures are ordinary repair/retry inputs, not owner stops.
+                except Exception as exc:
+                    event = CoordinatorEvent(
+                        operation_id=state.operation_id,
+                        status="FAIL",
+                        error=f"{type(exc).__name__}: {exc}",
+                    )
+                if event is None:
+                    return state
+                self._apply_event(state, event)
+            except ConcurrentCoordinatorUpdate:
+                continue
+        state = self.store.load(task_id)
+        return self._block(
+            state, "BLOCKED_BY_ARCHITECTURE", "coordinator step limit reached"
+        )
+
+    def handle_event(
+        self, task_id: str, event: CoordinatorEvent | Mapping[str, Any]
+    ) -> AutonomousTaskState:
+        """Persist one callback/watcher event and immediately re-enter the runner."""
+
+        parsed = (
+            event
+            if isinstance(event, CoordinatorEvent)
+            else CoordinatorEvent.model_validate(event)
+        )
+        for _ in range(2):
+            state = self.store.load(task_id)
+            if state.state in {AutonomousTaskStatus.DONE, AutonomousTaskStatus.BLOCKED}:
+                return state
+            if parsed.operation_id != state.operation_id:
+                return state  # stale or duplicate completion from an earlier attempt
+            try:
+                updated = self._apply_event(state, parsed)
+            except ConcurrentCoordinatorUpdate:
+                continue
+            if parsed.status == "RUNNING":
+                return updated
+            return self.run(task_id)
+        return self.store.load(task_id)
+
+    def completion_callback(self, task_id: str) -> Callable[[Mapping[str, Any]], None]:
+        """Return the direct continuation used by async delegation and watchers."""
+
+        def resume(result: Mapping[str, Any]) -> None:
+            event = result.get("coordinator_event")
+            if event is not None:
+                self.handle_event(task_id, event)
+
+        return resume
+
+    def _apply_event(
+        self, state: AutonomousTaskState, event: CoordinatorEvent
+    ) -> AutonomousTaskState:
+        updates: dict[str, Any] = {"last_error": event.error}
+        if event.pr_number is not None:
+            updates["pr_number"] = event.pr_number
+        if event.ci_status is not None:
+            updates["ci_status"] = event.ci_status
+        if event.deployment_status is not None:
+            updates["deployment_status"] = event.deployment_status
+        if event.status == "RUNNING":
+            return self.store.save(state.model_copy(update=updates))
+        if event.status == "BLOCKED":
+            code = event.blocker_code or "BLOCKED_BY_ARCHITECTURE"
+            if code not in OWNER_STOP_CONDITIONS:
+                code = "BLOCKED_BY_ARCHITECTURE"
+            return self._block(
+                state.model_copy(update=updates), code, event.error or code
+            )
+
+        current = state.state
+        if current in {AutonomousTaskStatus.DEVELOPING, AutonomousTaskStatus.REPAIRING}:
+            if event.status == "PASS":
+                updates.update(developer_commit=event.commit or state.developer_commit)
+                target = AutonomousTaskStatus.TESTING
+            else:
+                target = AutonomousTaskStatus.REPAIRING
+                updates["repair_loops"] = state.repair_loops + 1
+        elif current == AutonomousTaskStatus.TESTING:
+            updates["tester_verdict"] = event.verdict or event.status
+            target = (
+                AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY
+                if event.status == "PASS"
+                else AutonomousTaskStatus.REPAIRING
+            )
+            if event.status == "FAIL":
+                updates["repair_loops"] = state.repair_loops + 1
+        elif current == AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY:
+            updates["acceptance_verdict"] = event.verdict or event.status
+            target = (
+                AutonomousTaskStatus.DELIVERING
+                if event.status == "PASS"
+                else AutonomousTaskStatus.REPAIRING
+            )
+            if event.status == "FAIL":
+                updates["acceptance_loops"] = state.acceptance_loops + 1
+                updates["repair_loops"] = state.repair_loops + 1
+        elif current == AutonomousTaskStatus.DELIVERING:
+            target = (
+                AutonomousTaskStatus.DEPLOYING
+                if event.status == "PASS"
+                else AutonomousTaskStatus.REPAIRING
+            )
+            if event.status == "FAIL":
+                updates["repair_loops"] = state.repair_loops + 1
+        elif current == AutonomousTaskStatus.DEPLOYING:
+            if event.status == "PASS":
+                target = AutonomousTaskStatus.ACCEPTANCE_RUNTIME
+            else:
+                retries = state.deployment_retries + 1
+                if retries > self.max_deployment_retries:
+                    return self._block(
+                        state.model_copy(update=updates),
+                        "ENVIRONMENT_REQUIRED",
+                        event.error or "Dev deployment retry limit reached",
+                    )
+                target = AutonomousTaskStatus.DEPLOYING
+                updates["deployment_retries"] = retries
+        elif current == AutonomousTaskStatus.ACCEPTANCE_RUNTIME:
+            updates["runtime_acceptance"] = event.verdict or event.status
+            if event.status == "PASS":
+                target = AutonomousTaskStatus.DONE
+            else:
+                target = AutonomousTaskStatus.REPAIRING
+                updates["acceptance_loops"] = state.acceptance_loops + 1
+                updates["repair_loops"] = state.repair_loops + 1
+        else:  # QUEUED and terminal states never own an operation
+            return state
+        updates.update(
+            state=target,
+            operation_id=None,
+            current_agent=None,
+            next_action=_NEXT_ACTION[target],
+        )
+        return self.store.save(state.model_copy(update=updates))
+
+    def _transition(
+        self, state: AutonomousTaskState, target: AutonomousTaskStatus
+    ) -> AutonomousTaskState:
+        return self.store.save(
+            state.model_copy(
+                update={
+                    "state": target,
+                    "operation_id": None,
+                    "current_agent": None,
+                    "next_action": _NEXT_ACTION[target],
+                }
+            )
+        )
+
+    def _lock_repository(self, state: AutonomousTaskState) -> AutonomousTaskState:
+        if (
+            "vesselmind" not in state.project.lower()
+            and "ceramic-ai-designer-h5" not in state.repository
+        ):
+            return state
+        try:
+            remote = self.repository_lock.verify(state.repository)
+        except RuntimeError as exc:
+            return self._block(state, "BLOCKED_BY_REPOSITORY_LINEAGE", str(exc))
+        if remote == state.repository_remote:
+            return state
+        return self.store.save(state.model_copy(update={"repository_remote": remote}))
+
+    def _block(
+        self, state: AutonomousTaskState, code: str, error: str
+    ) -> AutonomousTaskState:
+        latest = self.store.load(state.task_id)
+        if latest.revision != state.revision:
+            return latest
+        return self.store.save(
+            state.model_copy(
+                update={
+                    "state": AutonomousTaskStatus.BLOCKED,
+                    "current_agent": None,
+                    "operation_id": None,
+                    "last_error": f"{code}: {error}",
+                    "next_action": _NEXT_ACTION[AutonomousTaskStatus.BLOCKED],
+                }
+            )
+        )

--- a/hermes_cli/feature_delivery.py
+++ b/hermes_cli/feature_delivery.py
@@ -18,6 +18,14 @@ from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_vali
 FEATURE_DELIVERY_WORKFLOW = "feature_delivery_v1"
 ACCEPTANCE_FINAL_MARKER = "FINAL: ACCEPT"
 MAX_FIX_LOOPS = 5
+RECOVERABLE_BLOCK_CODES = frozenset(
+    {
+        "external_environment_missing",
+        "profile_missing",
+        "stage_executor_missing",
+        "stage_execution_failed",
+    }
+)
 
 NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
 FullCommitSha = Annotated[
@@ -103,6 +111,31 @@ def can_transition_to_blocked(state: FeatureDeliveryState) -> bool:
     """Return whether infrastructure failure may terminally block ``state``."""
 
     return state in _BLOCKABLE_STATES
+
+
+def is_recoverable_block(reason_code: str | None) -> bool:
+    """Return whether a human may explicitly resume this blocked reason."""
+
+    return reason_code in RECOVERABLE_BLOCK_CODES
+
+
+def resolve_resume_target(
+    blocked_from_state: FeatureDeliveryState | None,
+    resume_stage: Literal["previous", "developer"],
+) -> FeatureDeliveryState:
+    """Resolve the only two human-approved recovery targets."""
+
+    if resume_stage == "developer":
+        return FeatureDeliveryState.DEVELOPING
+    if resume_stage != "previous":
+        raise ValueError(f"unsupported resume stage: {resume_stage}")
+    if blocked_from_state not in {
+        FeatureDeliveryState.DEVELOPING,
+        FeatureDeliveryState.TESTING,
+        FeatureDeliveryState.ACCEPTANCE,
+    }:
+        raise ValueError("blocked task has no recoverable previous stage")
+    return blocked_from_state
 
 
 def count_fix_loops(

--- a/hermes_cli/feature_delivery.py
+++ b/hermes_cli/feature_delivery.py
@@ -1,0 +1,383 @@
+"""Deterministic contracts and guards for Feature Delivery V1.
+
+This module defines validation only.  It does not run agents, mutate Git, or
+perform delivery.  ``DELIVERED`` means the feature delivery gate passed; it
+does not mean merged, pushed, deployed, or released.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from enum import Enum
+from typing import Annotated, Iterable, Literal, Self
+
+from pydantic import BaseModel, ConfigDict, Field, StringConstraints, model_validator
+
+
+FEATURE_DELIVERY_WORKFLOW = "feature_delivery_v1"
+ACCEPTANCE_FINAL_MARKER = "FINAL: ACCEPT"
+MAX_FIX_LOOPS = 5
+
+NonEmptyStr = Annotated[str, StringConstraints(strip_whitespace=True, min_length=1)]
+FullCommitSha = Annotated[
+    str,
+    StringConstraints(pattern=r"^[0-9a-f]{40}$"),
+]
+
+
+class FeatureDeliveryState(str, Enum):
+    NEW = "NEW"
+    CONTRACT_READY = "CONTRACT_READY"
+    DEVELOPING = "DEVELOPING"
+    READY_FOR_TEST = "READY_FOR_TEST"
+    TESTING = "TESTING"
+    TEST_FAILED = "TEST_FAILED"
+    TEST_PASSED = "TEST_PASSED"
+    ACCEPTANCE = "ACCEPTANCE"
+    REJECTED = "REJECTED"
+    BLOCKED = "BLOCKED"
+    DELIVERED = "DELIVERED"
+
+
+_BLOCKABLE_STATES = {
+    FeatureDeliveryState.CONTRACT_READY,
+    FeatureDeliveryState.DEVELOPING,
+    FeatureDeliveryState.READY_FOR_TEST,
+    FeatureDeliveryState.TESTING,
+    FeatureDeliveryState.TEST_FAILED,
+    FeatureDeliveryState.TEST_PASSED,
+    FeatureDeliveryState.ACCEPTANCE,
+    FeatureDeliveryState.REJECTED,
+}
+
+LEGAL_TRANSITIONS: dict[FeatureDeliveryState, frozenset[FeatureDeliveryState]] = {
+    FeatureDeliveryState.NEW: frozenset({FeatureDeliveryState.CONTRACT_READY}),
+    FeatureDeliveryState.CONTRACT_READY: frozenset(
+        {FeatureDeliveryState.DEVELOPING, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.DEVELOPING: frozenset(
+        {FeatureDeliveryState.READY_FOR_TEST, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.READY_FOR_TEST: frozenset(
+        {FeatureDeliveryState.TESTING, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.TESTING: frozenset(
+        {
+            FeatureDeliveryState.TEST_FAILED,
+            FeatureDeliveryState.TEST_PASSED,
+            FeatureDeliveryState.BLOCKED,
+        }
+    ),
+    FeatureDeliveryState.TEST_FAILED: frozenset(
+        {FeatureDeliveryState.DEVELOPING, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.TEST_PASSED: frozenset(
+        {FeatureDeliveryState.ACCEPTANCE, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.ACCEPTANCE: frozenset(
+        {
+            FeatureDeliveryState.REJECTED,
+            FeatureDeliveryState.BLOCKED,
+            FeatureDeliveryState.DELIVERED,
+        }
+    ),
+    FeatureDeliveryState.REJECTED: frozenset(
+        {FeatureDeliveryState.DEVELOPING, FeatureDeliveryState.BLOCKED}
+    ),
+    FeatureDeliveryState.BLOCKED: frozenset(),
+    FeatureDeliveryState.DELIVERED: frozenset(),
+}
+
+
+def is_legal_transition(
+    current: FeatureDeliveryState,
+    target: FeatureDeliveryState,
+) -> bool:
+    """Return whether an explicit Feature Delivery transition is permitted."""
+
+    return target in LEGAL_TRANSITIONS[current]
+
+
+def can_transition_to_blocked(state: FeatureDeliveryState) -> bool:
+    """Return whether infrastructure failure may terminally block ``state``."""
+
+    return state in _BLOCKABLE_STATES
+
+
+def count_fix_loops(
+    transitions: Iterable[tuple[FeatureDeliveryState, FeatureDeliveryState]],
+) -> int:
+    """Count only test- or acceptance-driven returns to development."""
+
+    fix_transitions = {
+        (FeatureDeliveryState.TEST_FAILED, FeatureDeliveryState.DEVELOPING),
+        (FeatureDeliveryState.REJECTED, FeatureDeliveryState.DEVELOPING),
+    }
+    return sum(transition in fix_transitions for transition in transitions)
+
+
+class FrozenModel(BaseModel):
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+
+class AcceptanceCriterion(FrozenModel):
+    id: NonEmptyStr
+    requirement: NonEmptyStr
+
+
+class TaskContract(FrozenModel):
+    task_id: NonEmptyStr
+    title: NonEmptyStr
+    objective: NonEmptyStr
+    repository: NonEmptyStr
+    base_commit: FullCommitSha
+    branch: NonEmptyStr
+    acceptance_criteria: tuple[AcceptanceCriterion, ...] = Field(min_length=1)
+    constraints: tuple[NonEmptyStr, ...] = ()
+    required_tests: tuple[NonEmptyStr, ...] = Field(min_length=1)
+    required_evidence: tuple[NonEmptyStr, ...] = Field(min_length=1)
+    out_of_scope: tuple[NonEmptyStr, ...] = ()
+    delivery_gate: Literal["acceptance_agent"] = "acceptance_agent"
+
+    @model_validator(mode="after")
+    def acceptance_criterion_ids_are_unique(self) -> Self:
+        ids = [criterion.id for criterion in self.acceptance_criteria]
+        if len(ids) != len(set(ids)):
+            raise ValueError("acceptance criterion ids must be unique")
+        return self
+
+
+def canonicalize_contract(contract: TaskContract) -> bytes:
+    """Return stable, compact, UTF-8 canonical JSON for ``contract``."""
+
+    return json.dumps(
+        contract.model_dump(mode="json"),
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def compute_contract_hash(contract: TaskContract) -> str:
+    return hashlib.sha256(canonicalize_contract(contract)).hexdigest()
+
+
+class DeveloperReportStatus(str, Enum):
+    READY_FOR_TEST = "READY_FOR_TEST"
+    BLOCKED = "BLOCKED"
+
+
+class TesterReportStatus(str, Enum):
+    TEST_PASS = "TEST_PASS"
+    TEST_FAIL = "TEST_FAIL"
+    BLOCKED = "BLOCKED"
+
+
+class AcceptanceReportStatus(str, Enum):
+    ACCEPT = "ACCEPT"
+    REJECT = "REJECT"
+    BLOCKED = "BLOCKED"
+
+
+class DeveloperReport(FrozenModel):
+    task_id: NonEmptyStr
+    agent: Literal["developer"]
+    status: DeveloperReportStatus
+    commit: FullCommitSha | None = None
+    changed_files: tuple[NonEmptyStr, ...] = ()
+    implementation_summary: NonEmptyStr
+    self_checks: tuple[NonEmptyStr, ...] = ()
+    known_risks: tuple[NonEmptyStr, ...] = ()
+
+    @model_validator(mode="after")
+    def ready_report_has_commit(self) -> Self:
+        if self.status == DeveloperReportStatus.READY_FOR_TEST and self.commit is None:
+            raise ValueError("READY_FOR_TEST requires a full commit SHA")
+        return self
+
+
+class TesterReport(FrozenModel):
+    task_id: NonEmptyStr
+    agent: Literal["tester"]
+    tested_commit: FullCommitSha | None = None
+    status: TesterReportStatus
+    test_results: tuple[NonEmptyStr, ...] = ()
+    blocking_issues: tuple[NonEmptyStr, ...] = ()
+    non_blocking_issues: tuple[NonEmptyStr, ...] = ()
+    evidence: tuple[NonEmptyStr, ...] = ()
+
+    @model_validator(mode="after")
+    def completed_test_has_commit(self) -> Self:
+        if self.status in {
+            TesterReportStatus.TEST_PASS,
+            TesterReportStatus.TEST_FAIL,
+        } and self.tested_commit is None:
+            raise ValueError("TEST_PASS and TEST_FAIL require a full commit SHA")
+        return self
+
+
+class AcceptanceCriterionResult(FrozenModel):
+    id: NonEmptyStr
+    met: bool
+    evidence: NonEmptyStr
+
+
+class AcceptanceReport(FrozenModel):
+    task_id: NonEmptyStr
+    agent: Literal["acceptance"]
+    accepted_commit: FullCommitSha | None = None
+    status: AcceptanceReportStatus
+    criteria: tuple[AcceptanceCriterionResult, ...] = ()
+    blocking_issues: tuple[NonEmptyStr, ...] = ()
+    evidence: tuple[NonEmptyStr, ...] = ()
+    final_marker: str | None = None
+
+    @model_validator(mode="after")
+    def validate_acceptance_shape(self) -> Self:
+        ids = [criterion.id for criterion in self.criteria]
+        if len(ids) != len(set(ids)):
+            raise ValueError("acceptance criterion ids must be unique")
+        if self.status in {
+            AcceptanceReportStatus.ACCEPT,
+            AcceptanceReportStatus.REJECT,
+        } and self.accepted_commit is None:
+            raise ValueError("ACCEPT and REJECT require a full commit SHA")
+        if self.status == AcceptanceReportStatus.ACCEPT:
+            if self.final_marker != ACCEPTANCE_FINAL_MARKER:
+                raise ValueError("ACCEPT requires exact final marker FINAL: ACCEPT")
+        elif self.final_marker == ACCEPTANCE_FINAL_MARKER:
+            raise ValueError("REJECT or BLOCKED cannot use FINAL: ACCEPT")
+        return self
+
+
+StageRole = Literal["developer", "tester", "acceptance"]
+StageReport = DeveloperReport | TesterReport | AcceptanceReport
+
+
+def validate_stage_report(expected_role: StageRole, report: object) -> bool:
+    """Validate report ownership by concrete type and exact agent identifier."""
+
+    expected = {
+        "developer": (DeveloperReport, "developer"),
+        "tester": (TesterReport, "tester"),
+        "acceptance": (AcceptanceReport, "acceptance"),
+    }[expected_role]
+    return isinstance(report, expected[0]) and report.agent == expected[1]
+
+
+class DeliveryCommitContext(FrozenModel):
+    developer_commit: FullCommitSha
+    tested_commit: FullCommitSha | None = None
+    accepted_commit: FullCommitSha | None = None
+    branch_head: FullCommitSha
+
+
+class DeliveryGateResult(FrozenModel):
+    allowed: bool
+    reasons: tuple[str, ...] = ()
+
+
+def validate_delivery_commit_integrity(
+    context: DeliveryCommitContext,
+) -> DeliveryGateResult:
+    """Require one exact commit to be developed, tested, accepted, and at HEAD."""
+
+    reasons: list[str] = []
+    if context.tested_commit is None:
+        reasons.append("tested commit is missing")
+    elif context.tested_commit != context.developer_commit:
+        reasons.append("tested commit does not match developer commit")
+    if context.accepted_commit is None:
+        reasons.append("accepted commit is missing")
+    elif context.accepted_commit != context.tested_commit:
+        reasons.append("accepted commit does not match tested commit")
+    if context.branch_head != context.accepted_commit:
+        reasons.append("branch HEAD does not match accepted commit")
+    return DeliveryGateResult(allowed=not reasons, reasons=tuple(reasons))
+
+
+def invalidate_downstream_evidence_on_new_developer_commit(
+    context: DeliveryCommitContext,
+    new_developer_commit: FullCommitSha,
+) -> DeliveryCommitContext:
+    """Clear test and acceptance evidence after developer code changes."""
+
+    if new_developer_commit == context.developer_commit:
+        return context
+    return DeliveryCommitContext(
+        developer_commit=new_developer_commit,
+        tested_commit=None,
+        accepted_commit=None,
+        branch_head=new_developer_commit,
+    )
+
+
+def _acceptance_criteria_reasons(
+    contract: TaskContract,
+    report: AcceptanceReport,
+) -> list[str]:
+    required_ids = {criterion.id for criterion in contract.acceptance_criteria}
+    reported_ids = [criterion.id for criterion in report.criteria]
+    reasons: list[str] = []
+    if len(reported_ids) != len(set(reported_ids)):
+        reasons.append("acceptance report contains duplicate criterion ids")
+    missing = sorted(required_ids - set(reported_ids))
+    unknown = sorted(set(reported_ids) - required_ids)
+    if missing:
+        reasons.append(f"missing acceptance criteria: {', '.join(missing)}")
+    if unknown:
+        reasons.append(f"unknown acceptance criteria: {', '.join(unknown)}")
+    unmet = sorted(
+        criterion.id
+        for criterion in report.criteria
+        if criterion.id in required_ids and not criterion.met
+    )
+    if unmet:
+        reasons.append(f"unmet acceptance criteria: {', '.join(unmet)}")
+    return reasons
+
+
+def evaluate_delivery_gate(
+    contract: TaskContract,
+    acceptance_report: object,
+    commit_context: DeliveryCommitContext,
+    *,
+    workflow_template_id: str,
+    current_state: FeatureDeliveryState,
+    expected_contract_hash: str,
+    stage_evidence: Iterable[str] = (),
+) -> DeliveryGateResult:
+    """Return explicit reasons unless the acceptance-only gate fully passes."""
+
+    reasons: list[str] = []
+    if workflow_template_id != FEATURE_DELIVERY_WORKFLOW:
+        reasons.append("workflow is not feature_delivery_v1")
+    if current_state != FeatureDeliveryState.ACCEPTANCE:
+        reasons.append("current state is not ACCEPTANCE")
+    if not validate_stage_report("acceptance", acceptance_report):
+        reasons.append("report is not a valid acceptance report")
+        return DeliveryGateResult(allowed=False, reasons=tuple(reasons))
+
+    report = acceptance_report
+    if report.task_id != contract.task_id:
+        reasons.append("acceptance report task does not match contract")
+    if report.status != AcceptanceReportStatus.ACCEPT:
+        reasons.append("acceptance status is not ACCEPT")
+    if report.final_marker != ACCEPTANCE_FINAL_MARKER:
+        reasons.append("acceptance final marker is invalid")
+    if compute_contract_hash(contract) != expected_contract_hash:
+        reasons.append("contract hash changed")
+    reasons.extend(_acceptance_criteria_reasons(contract, report))
+
+    present_evidence = set(report.evidence) | set(stage_evidence)
+    missing_evidence = sorted(set(contract.required_evidence) - present_evidence)
+    if missing_evidence:
+        reasons.append(f"missing required evidence: {', '.join(missing_evidence)}")
+
+    commit_result = validate_delivery_commit_integrity(commit_context)
+    reasons.extend(commit_result.reasons)
+    if report.accepted_commit != commit_context.accepted_commit:
+        reasons.append("acceptance report commit does not match commit context")
+
+    return DeliveryGateResult(allowed=not reasons, reasons=tuple(reasons))

--- a/hermes_cli/feature_delivery_runner.py
+++ b/hermes_cli/feature_delivery_runner.py
@@ -73,11 +73,22 @@ class StageExecutor(Protocol):
         target_commit: str,
         feedback: tuple[str, ...],
         stage_task_id: str,
+        tester_report: TesterReport | None = None,
     ) -> object: ...
 
 
 class DeliveryRunnerError(RuntimeError):
     pass
+
+
+class StageExecutionError(DeliveryRunnerError):
+    """Infrastructure failure reported by a concrete stage executor."""
+
+    def __init__(self, code: str, message: str):
+        if code not in BLOCKED_CODES:
+            raise ValueError(f"unsupported stage execution error code: {code}")
+        super().__init__(message)
+        self.code = code
 
 
 class ReportIntegrityError(DeliveryRunnerError):
@@ -508,7 +519,15 @@ class FeatureDeliveryRunner:
                 return
             before = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
             stored = self._execute_stage(
-                conn, root, stage, contract, "acceptance", target, workspace, ()
+                conn,
+                root,
+                stage,
+                contract,
+                "acceptance",
+                target,
+                workspace,
+                (),
+                tester_report=self._tester_report_for_commit(snapshot, target),
             )
             after = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
             if before != after or after:
@@ -615,6 +634,7 @@ class FeatureDeliveryRunner:
         target_commit: str,
         workspace: Path,
         feedback: tuple[str, ...],
+        tester_report: TesterReport | None = None,
     ) -> StoredStageReport | None:
         if self.executor is None:
             self._block(
@@ -637,6 +657,7 @@ class FeatureDeliveryRunner:
                 target_commit=target_commit,
                 feedback=feedback,
                 stage_task_id=stage.id,
+                tester_report=tester_report,
             )
             report = self._coerce_report(role, raw)
             if report.task_id != contract.task_id:
@@ -644,11 +665,26 @@ class FeatureDeliveryRunner:
             return self._record_report(conn, root, stage, run_id, role, target_commit, report)
         except (KeyboardInterrupt, SystemExit):
             raise
+        except StageExecutionError as exc:
+            self._fail_run(conn, stage, run_id, str(exc))
+            self._block(conn, root, exc.code, str(exc))
+            return None
         except Exception as exc:
             self._fail_run(conn, stage, run_id, str(exc))
             code = "invalid_report" if isinstance(exc, (ValidationError, ValueError)) else "stage_execution_failed"
             self._block(conn, root, code, str(exc))
             return None
+
+    @staticmethod
+    def _tester_report_for_commit(
+        snapshot: DeliverySnapshot,
+        target_commit: str,
+    ) -> TesterReport | None:
+        for stored in reversed(snapshot.reports):
+            report = stored.report
+            if isinstance(report, TesterReport) and report.tested_commit == target_commit:
+                return report
+        return None
 
     def _ensure_stage(
         self,

--- a/hermes_cli/feature_delivery_runner.py
+++ b/hermes_cli/feature_delivery_runner.py
@@ -125,9 +125,22 @@ class DeliverySnapshot:
     last_blocked_message: str | None = None
     last_unblock_target: FeatureDeliveryState | None = None
     resume_generation: int = 0
+    development_resume_head: str | None = None
+    developer_recovery_context: tuple[str, ...] = ()
     reports: tuple[StoredStageReport, ...] = ()
 
     def feedback(self) -> tuple[str, ...]:
+        if self.developer_recovery_context:
+            feedback = list(self.developer_recovery_context)
+            for stored in reversed(self.reports):
+                if isinstance(stored.report, TesterReport):
+                    feedback.insert(
+                        0,
+                        "LATEST_TESTER_REPORT: "
+                        + json.dumps(stored.report.model_dump(mode="json"), ensure_ascii=False),
+                    )
+                    break
+            return tuple(feedback)
         for stored in reversed(self.reports):
             report = stored.report
             if isinstance(report, TesterReport) and report.status == TesterReportStatus.TEST_FAIL:
@@ -284,6 +297,7 @@ class FeatureDeliveryRunner:
         *,
         resume_stage: Literal["previous", "developer"] = "previous",
         confirmed: bool = False,
+        developer_context: tuple[str, ...] = (),
     ) -> DeliveryStatus:
         """Authorize one guarded human recovery without running an agent."""
 
@@ -313,8 +327,15 @@ class FeatureDeliveryRunner:
                 target = resolve_resume_target(snapshot.blocked_from_state, resume_stage)
             except ValueError as exc:
                 raise DeliveryRunnerError(str(exc)) from exc
+            resume_commit, development_resume_head = self._resume_commit(
+                contract, metadata, snapshot, target
+            )
+            if developer_context and development_resume_head is None:
+                raise DeliveryRunnerError(
+                    "developer context is only allowed when resuming an unaccepted Developer BLOCKED HEAD"
+                )
             integrity_error = self._validate_resume_integrity(
-                root, contract, metadata, snapshot, target
+                root, contract, metadata, snapshot, target, resume_commit
             )
             if integrity_error:
                 self._record_unblock_rejection(
@@ -339,6 +360,16 @@ class FeatureDeliveryRunner:
                 "timestamp": approved_at,
                 "resume_generation": generation,
             }
+            audit_kind = "feature_delivery_unblocked"
+            if development_resume_head is not None:
+                audit_kind = "feature_delivery_development_resumed"
+                audit.update(
+                    {
+                        "development_resume_head": development_resume_head,
+                        "authoritative_developer_commit": snapshot.developer_commit,
+                        "developer_context": list(developer_context),
+                    }
+                )
             changed = kb.transition_workflow_step_cas(
                 conn,
                 task_id=root.id,
@@ -350,7 +381,7 @@ class FeatureDeliveryRunner:
                     "blocked_reason_code": snapshot.blocked_code,
                     "resume_generation": generation,
                 },
-                audit_event=("feature_delivery_unblocked", audit),
+                audit_event=(audit_kind, audit),
             )
             if not changed:
                 raise DeliveryRunnerError("feature delivery state changed before unblock")
@@ -478,7 +509,13 @@ class FeatureDeliveryRunner:
         metadata: dict,
         snapshot: DeliverySnapshot,
     ) -> None:
-        target = snapshot.developer_commit or contract.base_commit
+        target = (
+            snapshot.development_resume_head
+            if snapshot.last_stage == "developer"
+            and snapshot.last_report_status == DeveloperReportStatus.BLOCKED.value
+            and snapshot.development_resume_head is not None
+            else snapshot.developer_commit or contract.base_commit
+        )
         try:
             workspace = self._feature_workspace(conn, root, contract, metadata)
         except DeliveryRunnerError as exc:
@@ -1084,6 +1121,8 @@ class FeatureDeliveryRunner:
         last_blocked_message = None
         last_unblock_target = None
         resume_generation = 0
+        development_resume_head = None
+        developer_recovery_context: tuple[str, ...] = ()
         for event in kb.list_events(conn, root.id):
             payload = event.payload or {}
             if event.kind == "workflow_step_transitioned":
@@ -1103,14 +1142,22 @@ class FeatureDeliveryRunner:
                     blocked_code = None
                     blocked_message = None
                     blocked_from_state = None
-            elif event.kind == "feature_delivery_unblocked":
+            elif event.kind in {
+                "feature_delivery_unblocked",
+                "feature_delivery_development_resumed",
+            }:
                 try:
+                    development_resume_head = None
+                    developer_recovery_context = ()
                     last_unblock_target = FeatureDeliveryState(
                         payload["resume_target_state"]
                     )
                     resume_generation = max(
                         resume_generation, int(payload["resume_generation"])
                     )
+                    if event.kind == "feature_delivery_development_resumed":
+                        development_resume_head = payload["development_resume_head"]
+                        developer_recovery_context = tuple(payload.get("developer_context", ()))
                 except (KeyError, TypeError, ValueError):
                     continue
             elif event.kind == "feature_delivery_unblock_rejected":
@@ -1169,6 +1216,8 @@ class FeatureDeliveryRunner:
             last_blocked_message=last_blocked_message,
             last_unblock_target=last_unblock_target,
             resume_generation=resume_generation,
+            development_resume_head=development_resume_head,
+            developer_recovery_context=developer_recovery_context,
             reports=tuple(reports),
         )
 
@@ -1219,6 +1268,7 @@ class FeatureDeliveryRunner:
         metadata: dict,
         snapshot: DeliverySnapshot,
         target: FeatureDeliveryState,
+        expected: str,
     ) -> tuple[str, str] | None:
         if target == FeatureDeliveryState.TESTING and snapshot.developer_commit is None:
             return "commit_mismatch", "developer commit is missing"
@@ -1228,7 +1278,6 @@ class FeatureDeliveryRunner:
         ):
             return "commit_mismatch", "tested commit is missing or stale"
 
-        expected = snapshot.developer_commit or contract.base_commit
         repository = Path(metadata["repository"])
         if not self._commit_exists(repository, expected):
             return "commit_mismatch", "resume commit does not exist"
@@ -1254,6 +1303,27 @@ class FeatureDeliveryRunner:
                 if self._git(workspace, "rev-parse", "HEAD") != expected:
                     return "commit_mismatch", "developer worktree HEAD changed while blocked"
         return None
+
+    def _resume_commit(
+        self,
+        contract: TaskContract,
+        metadata: dict,
+        snapshot: DeliverySnapshot,
+        target: FeatureDeliveryState,
+    ) -> tuple[str, str | None]:
+        authoritative = snapshot.developer_commit or contract.base_commit
+        head = self._branch_head(Path(metadata["repository"]), contract.branch)
+        if head == authoritative:
+            return authoritative, None
+        if not (
+            target == FeatureDeliveryState.DEVELOPING
+            and snapshot.blocked_from_state == FeatureDeliveryState.DEVELOPING
+            and snapshot.last_stage == "developer"
+            and snapshot.last_report_status == DeveloperReportStatus.BLOCKED.value
+            and head not in {snapshot.tested_commit, snapshot.accepted_commit}
+        ):
+            return authoritative, None
+        return head, head
 
     def _record_unblock_rejection(
         self,

--- a/hermes_cli/feature_delivery_runner.py
+++ b/hermes_cli/feature_delivery_runner.py
@@ -1,0 +1,1276 @@
+"""Durable, opt-in runner for the fixed Feature Delivery V1 workflow.
+
+The runner owns root-state transitions. Stage executors only return typed
+reports; they cannot select a next state or mark delivery complete.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import subprocess
+import time
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Protocol
+
+from pydantic import ValidationError
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.feature_delivery import (
+    FEATURE_DELIVERY_WORKFLOW,
+    MAX_FIX_LOOPS,
+    AcceptanceReport,
+    AcceptanceReportStatus,
+    DeliveryCommitContext,
+    DeveloperReport,
+    DeveloperReportStatus,
+    FeatureDeliveryState,
+    StageReport,
+    StageRole,
+    TaskContract,
+    TesterReport,
+    TesterReportStatus,
+    canonicalize_contract,
+    compute_contract_hash,
+    count_fix_loops,
+    evaluate_delivery_gate,
+    is_legal_transition,
+    validate_stage_report,
+)
+
+
+BLOCKED_CODES = frozenset(
+    {
+        "contract_hash_mismatch",
+        "profile_missing",
+        "stage_executor_missing",
+        "invalid_report",
+        "commit_mismatch",
+        "dirty_worktree",
+        "tester_modified_source",
+        "acceptance_gate_denied",
+        "max_fix_loops_reached",
+        "external_environment_missing",
+        "stage_execution_failed",
+    }
+)
+_REPORT_NAME_RE = re.compile(r"^reports/(\d{3})-(developer|tester|acceptance)\.json$")
+
+
+class StageExecutor(Protocol):
+    """The only seam a future profile adapter needs to implement."""
+
+    def execute(
+        self,
+        *,
+        role: StageRole,
+        task_contract: TaskContract,
+        workspace: Path,
+        target_commit: str,
+        feedback: tuple[str, ...],
+        stage_task_id: str,
+    ) -> object: ...
+
+
+class DeliveryRunnerError(RuntimeError):
+    pass
+
+
+class ReportIntegrityError(DeliveryRunnerError):
+    pass
+
+
+class StageAlreadyRunning(DeliveryRunnerError):
+    pass
+
+
+@dataclass(frozen=True)
+class StoredStageReport:
+    role: StageRole
+    stage_task_id: str
+    run_id: int
+    report_path: str
+    report: StageReport
+
+
+@dataclass(frozen=True)
+class DeliverySnapshot:
+    developer_commit: str | None = None
+    tested_commit: str | None = None
+    accepted_commit: str | None = None
+    fix_loops: int = 0
+    last_stage: str | None = None
+    last_report_status: str | None = None
+    blocked_code: str | None = None
+    blocked_message: str | None = None
+    reports: tuple[StoredStageReport, ...] = ()
+
+    def feedback(self) -> tuple[str, ...]:
+        for stored in reversed(self.reports):
+            report = stored.report
+            if isinstance(report, TesterReport) and report.status == TesterReportStatus.TEST_FAIL:
+                return tuple(report.blocking_issues)
+            if (
+                isinstance(report, AcceptanceReport)
+                and report.status == AcceptanceReportStatus.REJECT
+            ):
+                return tuple(report.blocking_issues)
+        return ()
+
+
+@dataclass(frozen=True)
+class DeliveryStatus:
+    task_id: str
+    title: str
+    current_state: str
+    fix_loops: int
+    branch: str
+    base_commit: str
+    developer_commit: str | None
+    tested_commit: str | None
+    accepted_commit: str | None
+    contract_hash: str
+    last_stage: str | None
+    last_report_status: str | None
+    blocked_reason: str | None
+
+    @property
+    def delivery_status(self) -> str:
+        if self.current_state == FeatureDeliveryState.DELIVERED.value:
+            return "Feature Delivery Gate Passed"
+        if self.current_state == FeatureDeliveryState.BLOCKED.value:
+            return "BLOCKED"
+        return "IN PROGRESS"
+
+    def render(self) -> str:
+        values = (
+            ("Task ID", self.task_id),
+            ("Title", self.title),
+            ("Current State", self.current_state),
+            ("Fix Loops", str(self.fix_loops)),
+            ("Branch", self.branch),
+            ("Base Commit", self.base_commit),
+            ("Developer Commit", self.developer_commit or "-"),
+            ("Tested Commit", self.tested_commit or "-"),
+            ("Accepted Commit", self.accepted_commit or "-"),
+            ("Contract Hash", self.contract_hash),
+            ("Last Stage", self.last_stage or "-"),
+            ("Last Report Status", self.last_report_status or "-"),
+            ("Blocked Reason", self.blocked_reason or "-"),
+            ("Delivery Status", self.delivery_status),
+        )
+        return "\n".join(f"{label}: {value}" for label, value in values)
+
+
+class FeatureDeliveryRunner:
+    """Run only root tasks opted into ``feature_delivery_v1``."""
+
+    def __init__(self, executor: StageExecutor | None = None, *, board: str | None = None):
+        self.executor = executor
+        self.board = board
+        self._stage_busy = False
+
+    def create(self, contract_path: str | Path) -> str:
+        source = Path(contract_path).expanduser().resolve()
+        try:
+            contract = TaskContract.model_validate_json(source.read_text(encoding="utf-8"))
+        except (OSError, ValidationError, ValueError) as exc:
+            raise DeliveryRunnerError(f"invalid contract: {exc}") from exc
+
+        repository = self._validate_repository(contract)
+        canonical = canonicalize_contract(contract)
+        contract_hash = compute_contract_hash(contract)
+
+        with kb.connect(board=self.board) as conn:
+            root_id = kb.create_task(
+                conn,
+                title=contract.title,
+                body=contract.objective,
+                created_by="feature-delivery-runner",
+                workspace_kind="worktree",
+                workspace_path=str(repository),
+                branch_name=contract.branch,
+                idempotency_key=f"feature-delivery:{contract.task_id}:{contract_hash}",
+                board=self.board,
+            )
+            root = kb.get_task(conn, root_id)
+            if root is None:
+                raise DeliveryRunnerError("root task creation failed")
+            if root.workflow_template_id is None:
+                with kb.write_txn(conn):
+                    conn.execute(
+                        "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? "
+                        "WHERE id = ? AND workflow_template_id IS NULL",
+                        (
+                            FEATURE_DELIVERY_WORKFLOW,
+                            FeatureDeliveryState.CONTRACT_READY.value,
+                            root_id,
+                        ),
+                    )
+
+            attachment_dir = kb.task_attachments_dir(root_id, board=self.board)
+            destination = attachment_dir / "task-contract.json"
+            attachment_dir.mkdir(parents=True, exist_ok=True)
+            if destination.exists() and destination.read_bytes() != canonical:
+                raise DeliveryRunnerError("existing root contract attachment differs")
+            destination.write_bytes(canonical)
+            if not any(a.filename == "task-contract.json" for a in kb.list_attachments(conn, root_id)):
+                kb.add_attachment(
+                    conn,
+                    root_id,
+                    filename="task-contract.json",
+                    stored_path=str(destination),
+                    content_type="application/json",
+                    size=len(canonical),
+                    uploaded_by="feature-delivery-runner",
+                )
+            with kb.write_txn(conn):
+                existing = conn.execute(
+                    "SELECT 1 FROM task_events WHERE task_id = ? "
+                    "AND kind = 'feature_delivery_created'",
+                    (root_id,),
+                ).fetchone()
+                if not existing:
+                    kb._append_event(
+                        conn,
+                        root_id,
+                        "feature_delivery_created",
+                        {
+                            "contract_path": str(destination),
+                            "contract_sha256": contract_hash,
+                            "repository": str(repository),
+                            "base_commit": contract.base_commit,
+                            "branch": contract.branch,
+                            "contract_task_id": contract.task_id,
+                        },
+                    )
+        return root_id
+
+    def run(self, task_id: str) -> DeliveryStatus:
+        return self._drive(task_id)
+
+    def resume(self, task_id: str) -> DeliveryStatus:
+        return self._drive(task_id)
+
+    def status(self, task_id: str) -> DeliveryStatus:
+        with kb.connect(board=self.board) as conn:
+            root, metadata = self._root_and_metadata(conn, task_id)
+            try:
+                snapshot = self._snapshot(conn, root, recover=False)
+            except ReportIntegrityError as exc:
+                if root.current_step_key != FeatureDeliveryState.BLOCKED.value:
+                    raise
+                snapshot = DeliverySnapshot(
+                    last_report_status="INVALID_REPORT",
+                    blocked_code="invalid_report",
+                    blocked_message=str(exc),
+                )
+            return self._status(root, metadata, snapshot)
+
+    def _drive(self, task_id: str) -> DeliveryStatus:
+        self._stage_busy = False
+        with kb.connect(board=self.board) as conn:
+            for _ in range(64):
+                root, metadata = self._root_and_metadata(conn, task_id)
+                state = FeatureDeliveryState(root.current_step_key)
+                try:
+                    contract = self._load_contract(conn, root, metadata)
+                except DeliveryRunnerError:
+                    refreshed = kb.get_task(conn, task_id)
+                    if refreshed and refreshed.current_step_key == FeatureDeliveryState.BLOCKED.value:
+                        return self._status(
+                            refreshed,
+                            metadata,
+                            DeliverySnapshot(
+                                blocked_code="contract_hash_mismatch",
+                                blocked_message="contract attachment hash changed",
+                            ),
+                        )
+                    raise
+                if state in {FeatureDeliveryState.BLOCKED, FeatureDeliveryState.DELIVERED}:
+                    try:
+                        snapshot = self._snapshot(conn, root, recover=True)
+                    except ReportIntegrityError as exc:
+                        if state != FeatureDeliveryState.BLOCKED:
+                            raise
+                        snapshot = DeliverySnapshot(
+                            last_report_status="INVALID_REPORT",
+                            blocked_code="invalid_report",
+                            blocked_message=str(exc),
+                        )
+                    return self._status(root, metadata, snapshot)
+
+                try:
+                    snapshot = self._snapshot(conn, root, recover=True)
+                except ReportIntegrityError as exc:
+                    self._block(conn, root, "invalid_report", str(exc))
+                    continue
+
+                if state == FeatureDeliveryState.CONTRACT_READY:
+                    self._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+                    continue
+                if state == FeatureDeliveryState.DEVELOPING:
+                    self._run_developer(conn, root, contract, metadata, snapshot)
+                    if self._stage_busy:
+                        return self._status(
+                            root,
+                            metadata,
+                            self._snapshot(conn, root, recover=False),
+                        )
+                    continue
+                if state == FeatureDeliveryState.READY_FOR_TEST:
+                    if snapshot.developer_commit is None:
+                        self._block(conn, root, "invalid_report", "developer commit is missing")
+                    else:
+                        self._transition(conn, root, FeatureDeliveryState.TESTING)
+                    continue
+                if state == FeatureDeliveryState.TESTING:
+                    self._run_tester(conn, root, contract, metadata, snapshot)
+                    if self._stage_busy:
+                        return self._status(
+                            root,
+                            metadata,
+                            self._snapshot(conn, root, recover=False),
+                        )
+                    continue
+                if state == FeatureDeliveryState.TEST_FAILED:
+                    self._return_to_development(conn, root, snapshot)
+                    continue
+                if state == FeatureDeliveryState.TEST_PASSED:
+                    if snapshot.tested_commit != snapshot.developer_commit:
+                        self._block(conn, root, "commit_mismatch", "test evidence is stale")
+                    else:
+                        self._transition(conn, root, FeatureDeliveryState.ACCEPTANCE)
+                    continue
+                if state == FeatureDeliveryState.ACCEPTANCE:
+                    self._run_acceptance(conn, root, contract, metadata, snapshot)
+                    if self._stage_busy:
+                        return self._status(
+                            root,
+                            metadata,
+                            self._snapshot(conn, root, recover=False),
+                        )
+                    continue
+                if state == FeatureDeliveryState.REJECTED:
+                    self._return_to_development(conn, root, snapshot)
+                    continue
+                raise DeliveryRunnerError(f"unsupported feature delivery state: {state.value}")
+            root, metadata = self._root_and_metadata(conn, task_id)
+            self._block(conn, root, "stage_execution_failed", "runner iteration limit reached")
+            root, metadata = self._root_and_metadata(conn, task_id)
+            return self._status(root, metadata, self._snapshot(conn, root, recover=True))
+
+    def _run_developer(
+        self,
+        conn,
+        root: kb.Task,
+        contract: TaskContract,
+        metadata: dict,
+        snapshot: DeliverySnapshot,
+    ) -> None:
+        target = snapshot.developer_commit or contract.base_commit
+        try:
+            workspace = self._feature_workspace(conn, root, contract, metadata)
+        except DeliveryRunnerError as exc:
+            self._block(conn, root, "stage_execution_failed", str(exc))
+            return
+        stored = self._stage_report(
+            conn,
+            root,
+            contract,
+            "developer",
+            target,
+            snapshot.fix_loops + 1,
+            workspace,
+            snapshot.feedback(),
+        )
+        if stored is None:
+            return
+        report = stored.report
+        if not isinstance(report, DeveloperReport):
+            self._block(conn, root, "invalid_report", "developer returned the wrong report type")
+            return
+        if report.status == DeveloperReportStatus.BLOCKED:
+            self._block(conn, root, "external_environment_missing", report.implementation_summary)
+            return
+        assert report.commit is not None
+        error = self._validate_developer_commit(
+            contract, Path(metadata["repository"]), workspace, report.commit
+        )
+        if error:
+            self._block(conn, root, error[0], error[1])
+            return
+        self._transition(
+            conn,
+            root,
+            FeatureDeliveryState.READY_FOR_TEST,
+            {"developer_commit": report.commit},
+        )
+
+    def _run_tester(
+        self,
+        conn,
+        root: kb.Task,
+        contract: TaskContract,
+        metadata: dict,
+        snapshot: DeliverySnapshot,
+    ) -> None:
+        if snapshot.developer_commit is None:
+            self._block(conn, root, "commit_mismatch", "developer commit is missing")
+            return
+        stage = self._ensure_stage(
+            conn,
+            root,
+            "tester",
+            snapshot.developer_commit,
+            snapshot.fix_loops + 1,
+        )
+        existing = self._report_for_stage(conn, root, stage, recover=True)
+        if existing is None:
+            try:
+                workspace = self._frozen_workspace(
+                    conn, root, stage, metadata, snapshot.developer_commit
+                )
+            except DeliveryRunnerError as exc:
+                self._block(conn, root, "stage_execution_failed", str(exc))
+                return
+            before = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
+            existing = self._execute_stage(
+                conn,
+                root,
+                stage,
+                contract,
+                "tester",
+                snapshot.developer_commit,
+                workspace,
+                (),
+            )
+            after = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
+            if before != after or after:
+                self._block(
+                    conn,
+                    root,
+                    "tester_modified_source",
+                    "tester changed tracked files in the frozen worktree",
+                )
+                return
+        if existing is None:
+            return
+        report = existing.report
+        if not isinstance(report, TesterReport):
+            self._block(conn, root, "invalid_report", "tester returned the wrong report type")
+            return
+        if report.status == TesterReportStatus.BLOCKED:
+            self._block(conn, root, "external_environment_missing", "tester reported BLOCKED")
+            return
+        if report.tested_commit != snapshot.developer_commit:
+            self._block(conn, root, "commit_mismatch", "tested commit does not match developer commit")
+            return
+        if report.status == TesterReportStatus.TEST_PASS:
+            self._transition(
+                conn,
+                root,
+                FeatureDeliveryState.TEST_PASSED,
+                {"tested_commit": report.tested_commit},
+            )
+        else:
+            self._transition(conn, root, FeatureDeliveryState.TEST_FAILED)
+
+    def _run_acceptance(
+        self,
+        conn,
+        root: kb.Task,
+        contract: TaskContract,
+        metadata: dict,
+        snapshot: DeliverySnapshot,
+    ) -> None:
+        target = snapshot.tested_commit
+        if target is None or target != snapshot.developer_commit:
+            self._block(conn, root, "commit_mismatch", "tested commit is missing or stale")
+            return
+        stage = self._ensure_stage(
+            conn,
+            root,
+            "acceptance",
+            target,
+            snapshot.fix_loops + 1,
+        )
+        stored = self._report_for_stage(conn, root, stage, recover=True)
+        if stored is None:
+            try:
+                workspace = self._frozen_workspace(conn, root, stage, metadata, target)
+            except DeliveryRunnerError as exc:
+                self._block(conn, root, "stage_execution_failed", str(exc))
+                return
+            before = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
+            stored = self._execute_stage(
+                conn, root, stage, contract, "acceptance", target, workspace, ()
+            )
+            after = self._git(workspace, "status", "--porcelain", "--untracked-files=no")
+            if before != after or after:
+                self._block(
+                    conn,
+                    root,
+                    "dirty_worktree",
+                    "acceptance changed tracked files in the frozen worktree",
+                )
+                return
+        if stored is None:
+            return
+        report = stored.report
+        if not isinstance(report, AcceptanceReport):
+            self._block(conn, root, "invalid_report", "acceptance returned the wrong report type")
+            return
+        if report.status == AcceptanceReportStatus.BLOCKED:
+            self._block(conn, root, "external_environment_missing", "acceptance reported BLOCKED")
+            return
+        if report.accepted_commit != target:
+            self._block(conn, root, "commit_mismatch", "accepted commit does not match tested commit")
+            return
+        if report.status == AcceptanceReportStatus.REJECT:
+            self._transition(conn, root, FeatureDeliveryState.REJECTED)
+            return
+
+        branch_head = self._branch_head(Path(metadata["repository"]), contract.branch)
+        current = self._snapshot(conn, root, recover=True)
+        tester_evidence: tuple[str, ...] = ()
+        for prior in reversed(current.reports):
+            if isinstance(prior.report, TesterReport) and prior.report.tested_commit == target:
+                tester_evidence = tuple(prior.report.evidence)
+                break
+        result = evaluate_delivery_gate(
+            contract,
+            report,
+            DeliveryCommitContext(
+                developer_commit=target,
+                tested_commit=current.tested_commit,
+                accepted_commit=report.accepted_commit,
+                branch_head=branch_head,
+            ),
+            workflow_template_id=root.workflow_template_id or "",
+            current_state=FeatureDeliveryState.ACCEPTANCE,
+            expected_contract_hash=metadata["contract_sha256"],
+            stage_evidence=tester_evidence,
+        )
+        if not result.allowed:
+            self._block(
+                conn,
+                root,
+                "acceptance_gate_denied",
+                "; ".join(result.reasons),
+            )
+            return
+        self._transition(
+            conn,
+            root,
+            FeatureDeliveryState.DELIVERED,
+            {"accepted_commit": report.accepted_commit, "gate": "passed"},
+        )
+
+    def _return_to_development(
+        self, conn, root: kb.Task, snapshot: DeliverySnapshot
+    ) -> None:
+        self._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        refreshed = kb.get_task(conn, root.id)
+        assert refreshed is not None
+        loops = self._snapshot(conn, refreshed, recover=True).fix_loops
+        if loops >= MAX_FIX_LOOPS:
+            self._block(
+                conn,
+                refreshed,
+                "max_fix_loops_reached",
+                f"maximum fix loops reached ({MAX_FIX_LOOPS})",
+            )
+
+    def _stage_report(
+        self,
+        conn,
+        root: kb.Task,
+        contract: TaskContract,
+        role: StageRole,
+        target_commit: str,
+        attempt: int,
+        workspace: Path,
+        feedback: tuple[str, ...],
+    ) -> StoredStageReport | None:
+        stage = self._ensure_stage(conn, root, role, target_commit, attempt)
+        existing = self._report_for_stage(conn, root, stage, recover=True)
+        if existing is not None:
+            return existing
+        return self._execute_stage(
+            conn, root, stage, contract, role, target_commit, workspace, feedback
+        )
+
+    def _execute_stage(
+        self,
+        conn,
+        root: kb.Task,
+        stage: kb.Task,
+        contract: TaskContract,
+        role: StageRole,
+        target_commit: str,
+        workspace: Path,
+        feedback: tuple[str, ...],
+    ) -> StoredStageReport | None:
+        if self.executor is None:
+            self._block(
+                conn,
+                root,
+                "stage_executor_missing",
+                "No configured stage executor",
+            )
+            return None
+        try:
+            run_id = self._start_run(conn, root, stage, role, target_commit)
+        except StageAlreadyRunning:
+            self._stage_busy = True
+            return None
+        try:
+            raw = self.executor.execute(
+                role=role,
+                task_contract=contract,
+                workspace=workspace,
+                target_commit=target_commit,
+                feedback=feedback,
+                stage_task_id=stage.id,
+            )
+            report = self._coerce_report(role, raw)
+            if report.task_id != contract.task_id:
+                raise ValueError("report task_id does not match contract")
+            return self._record_report(conn, root, stage, run_id, role, target_commit, report)
+        except (KeyboardInterrupt, SystemExit):
+            raise
+        except Exception as exc:
+            self._fail_run(conn, stage, run_id, str(exc))
+            code = "invalid_report" if isinstance(exc, (ValidationError, ValueError)) else "stage_execution_failed"
+            self._block(conn, root, code, str(exc))
+            return None
+
+    def _ensure_stage(
+        self,
+        conn,
+        root: kb.Task,
+        role: StageRole,
+        target_commit: str,
+        attempt: int,
+    ) -> kb.Task:
+        rows = conn.execute(
+            "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id = t.id "
+            "WHERE l.parent_id = ? ORDER BY t.created_at, t.id",
+            (root.id,),
+        ).fetchall()
+        for row in rows:
+            task = kb.Task.from_row(row)
+            info = self._stage_info(task)
+            if info and info.get("role") == role and int(info.get("attempt", 0)) == attempt:
+                return task
+
+        key = f"feature-delivery-stage:{root.id}:{role}:{target_commit}:{attempt}"
+        stage_id = kb.create_task(
+            conn,
+            title=f"{root.title} [{role} {attempt}]",
+            body=json.dumps(
+                {
+                    "feature_delivery_stage": {
+                        "root_task_id": root.id,
+                        "role": role,
+                        "input_commit": target_commit,
+                        "attempt": attempt,
+                    }
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ),
+            created_by="feature-delivery-runner",
+            parents=[root.id],
+            idempotency_key=key,
+            board=self.board,
+        )
+        stage = kb.get_task(conn, stage_id)
+        if stage is None:
+            raise DeliveryRunnerError("stage task creation failed")
+        return stage
+
+    @staticmethod
+    def _stage_info(stage: kb.Task) -> dict | None:
+        try:
+            body = json.loads(stage.body or "{}")
+            info = body.get("feature_delivery_stage")
+            return info if isinstance(info, dict) else None
+        except (TypeError, json.JSONDecodeError):
+            return None
+
+    def _start_run(
+        self,
+        conn,
+        root: kb.Task,
+        stage: kb.Task,
+        role: StageRole,
+        target_commit: str,
+    ) -> int:
+        now = int(time.time())
+        with kb.write_txn(conn):
+            active = conn.execute(
+                "SELECT * FROM task_runs WHERE task_id = ? AND ended_at IS NULL "
+                "ORDER BY id DESC LIMIT 1",
+                (stage.id,),
+            ).fetchone()
+            if active:
+                pid = active["worker_pid"]
+                if pid and self._pid_alive(int(pid)):
+                    raise StageAlreadyRunning(f"stage {stage.id} is already running")
+                conn.execute(
+                    "UPDATE task_runs SET status = 'crashed', outcome = 'crashed', "
+                    "ended_at = ? WHERE id = ?",
+                    (now, active["id"]),
+                )
+            metadata = {
+                "root_task_id": root.id,
+                "stage_task_id": stage.id,
+                "role": role,
+                "input_commit": target_commit,
+                "report_path": None,
+                "report_status": None,
+            }
+            cursor = conn.execute(
+                "INSERT INTO task_runs "
+                "(task_id, profile, step_key, status, claim_lock, claim_expires, "
+                "worker_pid, started_at, metadata) "
+                "VALUES (?, ?, ?, 'running', ?, ?, ?, ?, ?)",
+                (
+                    stage.id,
+                    role,
+                    root.current_step_key,
+                    uuid.uuid4().hex,
+                    now + 3600,
+                    os.getpid(),
+                    now,
+                    json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+                ),
+            )
+            run_id = int(cursor.lastrowid)
+            conn.execute(
+                "UPDATE tasks SET status = 'running', current_run_id = ?, "
+                "started_at = COALESCE(started_at, ?) WHERE id = ?",
+                (run_id, now, stage.id),
+            )
+            kb._append_event(
+                conn,
+                stage.id,
+                "claimed",
+                {"run_id": run_id, "role": role, "root_task_id": root.id},
+                run_id=run_id,
+            )
+        return run_id
+
+    def _record_report(
+        self,
+        conn,
+        root: kb.Task,
+        stage: kb.Task,
+        run_id: int,
+        role: StageRole,
+        target_commit: str,
+        report: StageReport,
+    ) -> StoredStageReport:
+        data = report.model_dump(mode="json")
+        canonical = self._canonical_json(data)
+        report_hash = hashlib.sha256(canonical).hexdigest()
+        report_path = self._next_report_path(conn, root.id, role)
+        metadata = {
+            "root_task_id": root.id,
+            "stage_task_id": stage.id,
+            "role": role,
+            "input_commit": target_commit,
+            "report_path": report_path,
+            "report_status": report.status.value,
+            "report_sha256": report_hash,
+            "report": data,
+        }
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET status = 'report_persisting', metadata = ? "
+                "WHERE id = ? AND task_id = ? AND ended_at IS NULL",
+                (json.dumps(metadata, ensure_ascii=False, sort_keys=True), run_id, stage.id),
+            )
+        self._materialize_report(conn, root.id, report_path, canonical)
+        self._finish_report_run(conn, root, stage, run_id, metadata)
+        return StoredStageReport(role, stage.id, run_id, report_path, report)
+
+    def _materialize_report(
+        self, conn, root_id: str, report_path: str, canonical: bytes
+    ) -> None:
+        destination = kb.task_attachments_dir(root_id, board=self.board) / report_path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        if destination.exists():
+            try:
+                existing = self._canonical_json(json.loads(destination.read_text(encoding="utf-8")))
+            except (OSError, json.JSONDecodeError, TypeError) as exc:
+                raise ReportIntegrityError(f"malformed report attachment {report_path}") from exc
+            if existing != canonical:
+                raise ReportIntegrityError(f"report attachment mismatch: {report_path}")
+        else:
+            temporary = destination.with_suffix(destination.suffix + f".{uuid.uuid4().hex}.tmp")
+            temporary.write_bytes(canonical)
+            os.replace(temporary, destination)
+        attachments = kb.list_attachments(conn, root_id)
+        matches = [item for item in attachments if item.filename == report_path]
+        if matches and any(Path(item.stored_path).resolve() != destination.resolve() for item in matches):
+            raise ReportIntegrityError(f"report attachment path mismatch: {report_path}")
+        if not matches:
+            kb.add_attachment(
+                conn,
+                root_id,
+                filename=report_path,
+                stored_path=str(destination),
+                content_type="application/json",
+                size=len(canonical),
+                uploaded_by="feature-delivery-runner",
+            )
+
+    def _finish_report_run(self, conn, root, stage, run_id: int, metadata: dict) -> None:
+        now = int(time.time())
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET status = ?, outcome = 'completed', summary = ?, "
+                "metadata = ?, ended_at = ?, claim_lock = NULL, claim_expires = NULL, "
+                "worker_pid = NULL WHERE id = ? AND task_id = ?",
+                (
+                    metadata["report_status"],
+                    f"{metadata['role']} report: {metadata['report_status']}",
+                    json.dumps(metadata, ensure_ascii=False, sort_keys=True),
+                    now,
+                    run_id,
+                    stage.id,
+                ),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'done', current_run_id = NULL, completed_at = ? "
+                "WHERE id = ?",
+                (now, stage.id),
+            )
+            kb._append_event(
+                conn,
+                root.id,
+                "feature_delivery_report_saved",
+                {
+                    "stage_task_id": stage.id,
+                    "run_id": run_id,
+                    "role": metadata["role"],
+                    "report_path": metadata["report_path"],
+                    "report_status": metadata["report_status"],
+                },
+                run_id=run_id,
+            )
+
+    def _report_for_stage(
+        self, conn, root: kb.Task, stage: kb.Task, *, recover: bool
+    ) -> StoredStageReport | None:
+        row = conn.execute(
+            "SELECT * FROM task_runs WHERE task_id = ? AND metadata IS NOT NULL "
+            "ORDER BY id DESC LIMIT 1",
+            (stage.id,),
+        ).fetchone()
+        if row is None:
+            return None
+        try:
+            metadata = json.loads(row["metadata"])
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise ReportIntegrityError(f"malformed run metadata for stage {stage.id}") from exc
+        if not metadata.get("report"):
+            return None
+        if recover and row["ended_at"] is None:
+            canonical = self._canonical_json(metadata["report"])
+            self._materialize_report(conn, root.id, metadata["report_path"], canonical)
+            self._finish_report_run(conn, root, stage, int(row["id"]), metadata)
+        return self._validate_stored_report(
+            conn, root.id, stage.id, int(row["id"]), metadata
+        )
+
+    def _validate_stored_report(
+        self,
+        conn,
+        root_id: str,
+        stage_id: str,
+        run_id: int,
+        metadata: dict,
+    ) -> StoredStageReport:
+        role = metadata.get("role")
+        if role not in {"developer", "tester", "acceptance"}:
+            raise ReportIntegrityError(f"invalid report role for stage {stage_id}")
+        report_path = metadata.get("report_path")
+        if not isinstance(report_path, str) or not _REPORT_NAME_RE.match(report_path):
+            raise ReportIntegrityError(f"invalid report path for stage {stage_id}")
+        canonical = self._canonical_json(metadata.get("report"))
+        if hashlib.sha256(canonical).hexdigest() != metadata.get("report_sha256"):
+            raise ReportIntegrityError(f"report metadata hash mismatch: {report_path}")
+        destination = kb.task_attachments_dir(root_id, board=self.board) / report_path
+        if not destination.is_file():
+            raise ReportIntegrityError(f"report attachment missing: {report_path}")
+        try:
+            attachment_data = json.loads(destination.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ReportIntegrityError(f"malformed report attachment: {report_path}") from exc
+        if self._canonical_json(attachment_data) != canonical:
+            raise ReportIntegrityError(f"report attachment mismatch: {report_path}")
+        attachments = [a for a in kb.list_attachments(conn, root_id) if a.filename == report_path]
+        if len(attachments) != 1 or Path(attachments[0].stored_path).resolve() != destination.resolve():
+            raise ReportIntegrityError(f"report attachment metadata mismatch: {report_path}")
+        try:
+            report = self._coerce_report(role, metadata["report"])
+        except (ValidationError, ValueError, TypeError) as exc:
+            raise ReportIntegrityError(f"invalid stored report: {report_path}") from exc
+        if report.status.value != metadata.get("report_status"):
+            raise ReportIntegrityError(f"report status mismatch: {report_path}")
+        return StoredStageReport(role, stage_id, run_id, report_path, report)
+
+    def _snapshot(self, conn, root: kb.Task, *, recover: bool) -> DeliverySnapshot:
+        transitions: list[tuple[FeatureDeliveryState, FeatureDeliveryState]] = []
+        blocked_code = None
+        blocked_message = None
+        for event in kb.list_events(conn, root.id):
+            payload = event.payload or {}
+            if event.kind == "workflow_step_transitioned":
+                try:
+                    transitions.append(
+                        (
+                            FeatureDeliveryState(payload["from_step"]),
+                            FeatureDeliveryState(payload["to_step"]),
+                        )
+                    )
+                except (KeyError, ValueError):
+                    continue
+                if payload.get("to_step") == FeatureDeliveryState.BLOCKED.value:
+                    blocked_code = payload.get("code")
+                    blocked_message = payload.get("message")
+
+        rows = conn.execute(
+            "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id = t.id "
+            "WHERE l.parent_id = ? ORDER BY t.created_at, t.id",
+            (root.id,),
+        ).fetchall()
+        reports: list[StoredStageReport] = []
+        for row in rows:
+            stage = kb.Task.from_row(row)
+            if self._stage_info(stage) is None:
+                continue
+            stored = self._report_for_stage(conn, root, stage, recover=recover)
+            if stored is not None:
+                reports.append(stored)
+        reports.sort(key=lambda item: item.run_id)
+
+        developer_commit = tested_commit = accepted_commit = None
+        for stored in reports:
+            report = stored.report
+            if isinstance(report, DeveloperReport) and report.status == DeveloperReportStatus.READY_FOR_TEST:
+                developer_commit = report.commit
+                tested_commit = None
+                accepted_commit = None
+            elif (
+                isinstance(report, TesterReport)
+                and report.status == TesterReportStatus.TEST_PASS
+                and report.tested_commit == developer_commit
+            ):
+                tested_commit = report.tested_commit
+                accepted_commit = None
+            elif (
+                isinstance(report, AcceptanceReport)
+                and report.status == AcceptanceReportStatus.ACCEPT
+                and report.accepted_commit == tested_commit
+            ):
+                accepted_commit = report.accepted_commit
+        last = reports[-1] if reports else None
+        return DeliverySnapshot(
+            developer_commit=developer_commit,
+            tested_commit=tested_commit,
+            accepted_commit=accepted_commit,
+            fix_loops=count_fix_loops(transitions),
+            last_stage=last.role if last else None,
+            last_report_status=last.report.status.value if last else None,
+            blocked_code=blocked_code,
+            blocked_message=blocked_message,
+            reports=tuple(reports),
+        )
+
+    def _feature_workspace(
+        self, conn, root: kb.Task, contract: TaskContract, metadata: dict
+    ) -> Path:
+        repository = Path(metadata["repository"])
+        target = repository / ".worktrees" / root.id
+        kb._ensure_git_worktree(
+            repository,
+            target,
+            contract.branch,
+            start_point=contract.base_commit,
+        )
+        kb.set_workspace_path(conn, root.id, target)
+        return target
+
+    def _frozen_workspace(
+        self,
+        conn,
+        root: kb.Task,
+        stage: kb.Task,
+        metadata: dict,
+        commit: str,
+    ) -> Path:
+        repository = Path(metadata["repository"])
+        target = kb.task_attachments_dir(root.id, board=self.board) / "worktrees" / stage.id
+        kb._ensure_git_worktree(
+            repository,
+            target,
+            f"detached/{stage.id}",
+            start_point=commit,
+            detached=True,
+        )
+        if self._git(target, "rev-parse", "HEAD") != commit:
+            raise DeliveryRunnerError("frozen worktree is not at the required commit")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET workspace_kind = 'dir', workspace_path = ? WHERE id = ?",
+                (str(target), stage.id),
+            )
+        return target
+
+    def _validate_developer_commit(
+        self,
+        contract: TaskContract,
+        repository: Path,
+        workspace: Path,
+        commit: str,
+    ) -> tuple[str, str] | None:
+        if not self._commit_exists(repository, commit):
+            return "commit_mismatch", "developer commit does not exist"
+        if self._git(workspace, "status", "--porcelain"):
+            return "dirty_worktree", "developer worktree is not clean"
+        if self._git(workspace, "branch", "--show-current") != contract.branch:
+            return "commit_mismatch", "developer worktree is on the wrong branch"
+        if self._branch_head(repository, contract.branch) != commit:
+            return "commit_mismatch", "feature branch HEAD does not match developer report"
+        result = subprocess.run(
+            ["git", "-C", str(repository), "merge-base", "--is-ancestor", contract.base_commit, commit],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            return "commit_mismatch", "developer commit is not a descendant of base commit"
+        return None
+
+    def _validate_repository(self, contract: TaskContract) -> Path:
+        requested = Path(contract.repository).expanduser().resolve()
+        top_level = (
+            self._git(requested, "rev-parse", "--show-toplevel", check=False)
+            if requested.is_dir()
+            else ""
+        )
+        if not top_level:
+            raise DeliveryRunnerError(f"repository does not exist or is not Git: {requested}")
+        repository = Path(top_level).resolve()
+        if not self._commit_exists(repository, contract.base_commit):
+            raise DeliveryRunnerError(f"base commit does not exist: {contract.base_commit}")
+        if self._git(repository, "status", "--porcelain"):
+            raise DeliveryRunnerError("repository is dirty")
+        ref_check = subprocess.run(
+            ["git", "check-ref-format", "--branch", contract.branch],
+            cwd=repository,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if ref_check.returncode != 0:
+            raise DeliveryRunnerError(f"invalid feature branch: {contract.branch}")
+        if self._branch_exists(repository, contract.branch):
+            raise DeliveryRunnerError(f"feature branch already exists: {contract.branch}")
+        return repository
+
+    @staticmethod
+    def _commit_exists(repository: Path, commit: str) -> bool:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "cat-file", "-e", f"{commit}^{{commit}}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        return result.returncode == 0
+
+    @staticmethod
+    def _branch_exists(repository: Path, branch: str) -> bool:
+        result = subprocess.run(
+            ["git", "-C", str(repository), "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        return result.returncode == 0
+
+    def _branch_head(self, repository: Path, branch: str) -> str:
+        value = self._git(repository, "rev-parse", "--verify", f"refs/heads/{branch}", check=False)
+        return value if re.fullmatch(r"[0-9a-f]{40}", value) else "0" * 40
+
+    @staticmethod
+    def _git(path: Path, *args: str, check: bool = True) -> str:
+        result = subprocess.run(
+            ["git", "-C", str(path), *args],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=60,
+        )
+        if check and result.returncode != 0:
+            message = (result.stderr or result.stdout or "git command failed").strip()
+            raise DeliveryRunnerError(message)
+        return result.stdout.strip() if result.returncode == 0 else ""
+
+    def _root_and_metadata(self, conn, task_id: str) -> tuple[kb.Task, dict]:
+        root = kb.get_task(conn, task_id)
+        if root is None:
+            raise DeliveryRunnerError(f"unknown task: {task_id}")
+        if root.workflow_template_id != FEATURE_DELIVERY_WORKFLOW:
+            raise DeliveryRunnerError(f"task {task_id} is not a feature delivery root")
+        if root.current_step_key not in {state.value for state in FeatureDeliveryState}:
+            raise DeliveryRunnerError(f"task {task_id} has an invalid feature delivery state")
+        events = [
+            event
+            for event in kb.list_events(conn, task_id)
+            if event.kind == "feature_delivery_created" and event.payload
+        ]
+        if not events:
+            raise DeliveryRunnerError(f"task {task_id} is missing delivery metadata")
+        return root, dict(events[0].payload or {})
+
+    def _load_contract(self, conn, root: kb.Task, metadata: dict) -> TaskContract:
+        try:
+            data = Path(metadata["contract_path"]).read_bytes()
+            contract = TaskContract.model_validate_json(data)
+        except (KeyError, OSError, ValidationError, ValueError) as exc:
+            self._block(conn, root, "contract_hash_mismatch", f"cannot read canonical contract: {exc}")
+            raise DeliveryRunnerError("contract attachment is invalid") from exc
+        actual_hash = compute_contract_hash(contract)
+        if actual_hash != metadata.get("contract_sha256") or data != canonicalize_contract(contract):
+            self._block(conn, root, "contract_hash_mismatch", "contract attachment hash changed")
+            raise DeliveryRunnerError("contract hash mismatch")
+        return contract
+
+    def _transition(
+        self,
+        conn,
+        root: kb.Task,
+        target: FeatureDeliveryState,
+        payload: dict | None = None,
+    ) -> bool:
+        current = FeatureDeliveryState(root.current_step_key)
+        if not is_legal_transition(current, target):
+            raise DeliveryRunnerError(f"illegal transition {current.value} -> {target.value}")
+        changed = kb.transition_workflow_step_cas(
+            conn,
+            task_id=root.id,
+            workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+            expected_step=current.value,
+            new_step=target.value,
+            event_payload=payload,
+        )
+        if changed:
+            root.current_step_key = target.value
+            return True
+        refreshed = kb.get_task(conn, root.id)
+        return bool(refreshed and refreshed.current_step_key == target.value)
+
+    def _block(self, conn, root: kb.Task, code: str, message: str) -> None:
+        if code not in BLOCKED_CODES:
+            raise ValueError(f"unknown blocked reason code: {code}")
+        refreshed = kb.get_task(conn, root.id)
+        if refreshed is None or refreshed.current_step_key in {
+            FeatureDeliveryState.BLOCKED.value,
+            FeatureDeliveryState.DELIVERED.value,
+        }:
+            return
+        self._transition(
+            conn,
+            refreshed,
+            FeatureDeliveryState.BLOCKED,
+            {"code": code, "message": message},
+        )
+
+    def _status(self, root: kb.Task, metadata: dict, snapshot: DeliverySnapshot) -> DeliveryStatus:
+        reason = None
+        if snapshot.blocked_code:
+            reason = snapshot.blocked_code
+            if snapshot.blocked_message:
+                reason += f": {snapshot.blocked_message}"
+        return DeliveryStatus(
+            task_id=root.id,
+            title=root.title,
+            current_state=root.current_step_key or "",
+            fix_loops=snapshot.fix_loops,
+            branch=str(metadata.get("branch", "")),
+            base_commit=str(metadata.get("base_commit", "")),
+            developer_commit=snapshot.developer_commit,
+            tested_commit=snapshot.tested_commit,
+            accepted_commit=snapshot.accepted_commit,
+            contract_hash=str(metadata.get("contract_sha256", "")),
+            last_stage=snapshot.last_stage,
+            last_report_status=snapshot.last_report_status,
+            blocked_reason=reason,
+        )
+
+    def _next_report_path(self, conn, root_id: str, role: StageRole) -> str:
+        numbers = []
+        for attachment in kb.list_attachments(conn, root_id):
+            match = _REPORT_NAME_RE.match(attachment.filename)
+            if match:
+                numbers.append(int(match.group(1)))
+        return f"reports/{max(numbers, default=0) + 1:03d}-{role}.json"
+
+    @staticmethod
+    def _coerce_report(role: StageRole, raw: object) -> StageReport:
+        model = {
+            "developer": DeveloperReport,
+            "tester": TesterReport,
+            "acceptance": AcceptanceReport,
+        }[role]
+        report = raw if isinstance(raw, model) else model.model_validate(raw)
+        if not validate_stage_report(role, report):
+            raise ValueError(f"report does not belong to {role}")
+        return report
+
+    @staticmethod
+    def _canonical_json(value: object) -> bytes:
+        return json.dumps(
+            value,
+            ensure_ascii=False,
+            sort_keys=True,
+            separators=(",", ":"),
+        ).encode("utf-8")
+
+    def _fail_run(self, conn, stage: kb.Task, run_id: int, error: str) -> None:
+        now = int(time.time())
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE task_runs SET status = 'failed', outcome = 'failed', error = ?, "
+                "ended_at = ?, claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ?",
+                (error[:4000], now, run_id),
+            )
+            conn.execute(
+                "UPDATE tasks SET status = 'failed', current_run_id = NULL WHERE id = ?",
+                (stage.id,),
+            )
+
+    @staticmethod
+    def _pid_alive(pid: int) -> bool:
+        if pid == os.getpid():
+            return True
+        try:
+            os.kill(pid, 0)
+        except OSError:
+            return False
+        return True

--- a/hermes_cli/feature_delivery_runner.py
+++ b/hermes_cli/feature_delivery_runner.py
@@ -1591,7 +1591,8 @@ class FeatureDeliveryRunner:
         if pid == os.getpid():
             return True
         try:
-            os.kill(pid, 0)
-        except OSError:
+            from gateway.status import _pid_exists
+
+            return bool(_pid_exists(pid))
+        except Exception:
             return False
-        return True

--- a/hermes_cli/feature_delivery_runner.py
+++ b/hermes_cli/feature_delivery_runner.py
@@ -15,7 +15,7 @@ import time
 import uuid
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Protocol
+from typing import Literal, Protocol
 
 from pydantic import ValidationError
 
@@ -38,7 +38,9 @@ from hermes_cli.feature_delivery import (
     compute_contract_hash,
     count_fix_loops,
     evaluate_delivery_gate,
+    is_recoverable_block,
     is_legal_transition,
+    resolve_resume_target,
     validate_stage_report,
 )
 
@@ -118,6 +120,11 @@ class DeliverySnapshot:
     last_report_status: str | None = None
     blocked_code: str | None = None
     blocked_message: str | None = None
+    blocked_from_state: FeatureDeliveryState | None = None
+    last_blocked_code: str | None = None
+    last_blocked_message: str | None = None
+    last_unblock_target: FeatureDeliveryState | None = None
+    resume_generation: int = 0
     reports: tuple[StoredStageReport, ...] = ()
 
     def feedback(self) -> tuple[str, ...]:
@@ -148,6 +155,8 @@ class DeliveryStatus:
     last_stage: str | None
     last_report_status: str | None
     blocked_reason: str | None
+    last_blocked_reason: str | None
+    last_unblock_target: str | None
 
     @property
     def delivery_status(self) -> str:
@@ -172,6 +181,8 @@ class DeliveryStatus:
             ("Last Stage", self.last_stage or "-"),
             ("Last Report Status", self.last_report_status or "-"),
             ("Blocked Reason", self.blocked_reason or "-"),
+            ("Last Blocked Reason", self.last_blocked_reason or "-"),
+            ("Last Unblock Target", self.last_unblock_target or "-"),
             ("Delivery Status", self.delivery_status),
         )
         return "\n".join(f"{label}: {value}" for label, value in values)
@@ -266,6 +277,90 @@ class FeatureDeliveryRunner:
 
     def resume(self, task_id: str) -> DeliveryStatus:
         return self._drive(task_id)
+
+    def unblock(
+        self,
+        task_id: str,
+        *,
+        resume_stage: Literal["previous", "developer"] = "previous",
+        confirmed: bool = False,
+    ) -> DeliveryStatus:
+        """Authorize one guarded human recovery without running an agent."""
+
+        if not confirmed:
+            raise DeliveryRunnerError("explicit --confirm is required")
+        with kb.connect(board=self.board) as conn:
+            root, metadata = self._root_and_metadata(conn, task_id)
+            if root.current_step_key != FeatureDeliveryState.BLOCKED.value:
+                raise DeliveryRunnerError("feature delivery task is not BLOCKED")
+            snapshot = self._snapshot(conn, root, recover=False)
+            if not is_recoverable_block(snapshot.blocked_code):
+                raise DeliveryRunnerError(
+                    f"blocked reason is not recoverable: {snapshot.blocked_code or 'unknown'}"
+                )
+            try:
+                contract = self._load_contract(conn, root, metadata)
+            except DeliveryRunnerError as exc:
+                self._record_unblock_rejection(
+                    conn,
+                    root,
+                    snapshot.blocked_code,
+                    "contract_hash_mismatch",
+                    str(exc),
+                )
+                raise DeliveryRunnerError(f"contract_hash_mismatch: {exc}") from exc
+            try:
+                target = resolve_resume_target(snapshot.blocked_from_state, resume_stage)
+            except ValueError as exc:
+                raise DeliveryRunnerError(str(exc)) from exc
+            integrity_error = self._validate_resume_integrity(
+                root, contract, metadata, snapshot, target
+            )
+            if integrity_error:
+                self._record_unblock_rejection(
+                    conn,
+                    root,
+                    snapshot.blocked_code,
+                    integrity_error[0],
+                    integrity_error[1],
+                )
+                raise DeliveryRunnerError(
+                    f"{integrity_error[0]}: {integrity_error[1]}"
+                )
+
+            generation = snapshot.resume_generation + 1
+            approved_at = int(time.time())
+            audit = {
+                "blocked_reason_code": snapshot.blocked_code,
+                "previous_state": FeatureDeliveryState.BLOCKED.value,
+                "resume_target_state": target.value,
+                "approved_by": "human_cli",
+                "contract_hash": metadata["contract_sha256"],
+                "timestamp": approved_at,
+                "resume_generation": generation,
+            }
+            changed = kb.transition_workflow_step_cas(
+                conn,
+                task_id=root.id,
+                workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+                expected_step=FeatureDeliveryState.BLOCKED.value,
+                new_step=target.value,
+                event_payload={
+                    "human_resume": True,
+                    "blocked_reason_code": snapshot.blocked_code,
+                    "resume_generation": generation,
+                },
+                audit_event=("feature_delivery_unblocked", audit),
+            )
+            if not changed:
+                raise DeliveryRunnerError("feature delivery state changed before unblock")
+            refreshed = kb.get_task(conn, root.id)
+            assert refreshed is not None
+            return self._status(
+                refreshed,
+                metadata,
+                self._snapshot(conn, refreshed, recover=False),
+            )
 
     def status(self, task_id: str) -> DeliveryStatus:
         with kb.connect(board=self.board) as conn:
@@ -398,6 +493,7 @@ class FeatureDeliveryRunner:
             snapshot.fix_loops + 1,
             workspace,
             snapshot.feedback(),
+            generation=snapshot.resume_generation,
         )
         if stored is None:
             return
@@ -439,6 +535,7 @@ class FeatureDeliveryRunner:
             "tester",
             snapshot.developer_commit,
             snapshot.fix_loops + 1,
+            snapshot.resume_generation,
         )
         existing = self._report_for_stage(conn, root, stage, recover=True)
         if existing is None:
@@ -509,6 +606,7 @@ class FeatureDeliveryRunner:
             "acceptance",
             target,
             snapshot.fix_loops + 1,
+            snapshot.resume_generation,
         )
         stored = self._report_for_stage(conn, root, stage, recover=True)
         if stored is None:
@@ -615,8 +713,11 @@ class FeatureDeliveryRunner:
         attempt: int,
         workspace: Path,
         feedback: tuple[str, ...],
+        generation: int = 0,
     ) -> StoredStageReport | None:
-        stage = self._ensure_stage(conn, root, role, target_commit, attempt)
+        stage = self._ensure_stage(
+            conn, root, role, target_commit, attempt, generation
+        )
         existing = self._report_for_stage(conn, root, stage, recover=True)
         if existing is not None:
             return existing
@@ -693,6 +794,7 @@ class FeatureDeliveryRunner:
         role: StageRole,
         target_commit: str,
         attempt: int,
+        generation: int = 0,
     ) -> kb.Task:
         rows = conn.execute(
             "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id = t.id "
@@ -702,10 +804,18 @@ class FeatureDeliveryRunner:
         for row in rows:
             task = kb.Task.from_row(row)
             info = self._stage_info(task)
-            if info and info.get("role") == role and int(info.get("attempt", 0)) == attempt:
+            if (
+                info
+                and info.get("role") == role
+                and int(info.get("attempt", 0)) == attempt
+                and int(info.get("generation", 0)) == generation
+            ):
                 return task
 
-        key = f"feature-delivery-stage:{root.id}:{role}:{target_commit}:{attempt}"
+        key = (
+            f"feature-delivery-stage:{root.id}:{role}:{target_commit}:"
+            f"{attempt}:{generation}"
+        )
         stage_id = kb.create_task(
             conn,
             title=f"{root.title} [{role} {attempt}]",
@@ -716,6 +826,7 @@ class FeatureDeliveryRunner:
                         "role": role,
                         "input_commit": target_commit,
                         "attempt": attempt,
+                        "generation": generation,
                     }
                 },
                 sort_keys=True,
@@ -968,21 +1079,45 @@ class FeatureDeliveryRunner:
         transitions: list[tuple[FeatureDeliveryState, FeatureDeliveryState]] = []
         blocked_code = None
         blocked_message = None
+        blocked_from_state = None
+        last_blocked_code = None
+        last_blocked_message = None
+        last_unblock_target = None
+        resume_generation = 0
         for event in kb.list_events(conn, root.id):
             payload = event.payload or {}
             if event.kind == "workflow_step_transitioned":
                 try:
-                    transitions.append(
-                        (
-                            FeatureDeliveryState(payload["from_step"]),
-                            FeatureDeliveryState(payload["to_step"]),
-                        )
-                    )
+                    from_state = FeatureDeliveryState(payload["from_step"])
+                    to_state = FeatureDeliveryState(payload["to_step"])
+                    transitions.append((from_state, to_state))
                 except (KeyError, ValueError):
                     continue
-                if payload.get("to_step") == FeatureDeliveryState.BLOCKED.value:
+                if to_state == FeatureDeliveryState.BLOCKED:
                     blocked_code = payload.get("code")
                     blocked_message = payload.get("message")
+                    blocked_from_state = from_state
+                    last_blocked_code = blocked_code
+                    last_blocked_message = blocked_message
+                elif from_state == FeatureDeliveryState.BLOCKED:
+                    blocked_code = None
+                    blocked_message = None
+                    blocked_from_state = None
+            elif event.kind == "feature_delivery_unblocked":
+                try:
+                    last_unblock_target = FeatureDeliveryState(
+                        payload["resume_target_state"]
+                    )
+                    resume_generation = max(
+                        resume_generation, int(payload["resume_generation"])
+                    )
+                except (KeyError, TypeError, ValueError):
+                    continue
+            elif event.kind == "feature_delivery_unblock_rejected":
+                blocked_code = payload.get("code")
+                blocked_message = payload.get("message")
+                last_blocked_code = blocked_code
+                last_blocked_message = blocked_message
 
         rows = conn.execute(
             "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id = t.id "
@@ -1029,6 +1164,11 @@ class FeatureDeliveryRunner:
             last_report_status=last.report.status.value if last else None,
             blocked_code=blocked_code,
             blocked_message=blocked_message,
+            blocked_from_state=blocked_from_state,
+            last_blocked_code=last_blocked_code,
+            last_blocked_message=last_blocked_message,
+            last_unblock_target=last_unblock_target,
+            resume_generation=resume_generation,
             reports=tuple(reports),
         )
 
@@ -1071,6 +1211,70 @@ class FeatureDeliveryRunner:
                 (str(target), stage.id),
             )
         return target
+
+    def _validate_resume_integrity(
+        self,
+        root: kb.Task,
+        contract: TaskContract,
+        metadata: dict,
+        snapshot: DeliverySnapshot,
+        target: FeatureDeliveryState,
+    ) -> tuple[str, str] | None:
+        if target == FeatureDeliveryState.TESTING and snapshot.developer_commit is None:
+            return "commit_mismatch", "developer commit is missing"
+        if target == FeatureDeliveryState.ACCEPTANCE and (
+            snapshot.developer_commit is None
+            or snapshot.tested_commit != snapshot.developer_commit
+        ):
+            return "commit_mismatch", "tested commit is missing or stale"
+
+        expected = snapshot.developer_commit or contract.base_commit
+        repository = Path(metadata["repository"])
+        if not self._commit_exists(repository, expected):
+            return "commit_mismatch", "resume commit does not exist"
+        if self._branch_head(repository, contract.branch) != expected:
+            return "commit_mismatch", "feature branch HEAD changed while blocked"
+        ancestor = subprocess.run(
+            ["git", "-C", str(repository), "merge-base", "--is-ancestor", contract.base_commit, expected],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+        if ancestor.returncode != 0:
+            return "commit_mismatch", "resume commit is not a descendant of base commit"
+
+        if root.workspace_path:
+            workspace = Path(root.workspace_path)
+            if workspace.is_dir():
+                if self._git(workspace, "status", "--porcelain"):
+                    return "dirty_worktree", "developer worktree is not clean"
+                if self._git(workspace, "branch", "--show-current") != contract.branch:
+                    return "commit_mismatch", "developer worktree is on the wrong branch"
+                if self._git(workspace, "rev-parse", "HEAD") != expected:
+                    return "commit_mismatch", "developer worktree HEAD changed while blocked"
+        return None
+
+    def _record_unblock_rejection(
+        self,
+        conn,
+        root: kb.Task,
+        previous_code: str | None,
+        code: str,
+        message: str,
+    ) -> None:
+        with kb.write_txn(conn):
+            kb._append_event(
+                conn,
+                root.id,
+                "feature_delivery_unblock_rejected",
+                {
+                    "previous_blocked_reason_code": previous_code,
+                    "code": code,
+                    "message": message,
+                    "timestamp": int(time.time()),
+                },
+            )
 
     def _validate_developer_commit(
         self,
@@ -1242,6 +1446,11 @@ class FeatureDeliveryRunner:
             reason = snapshot.blocked_code
             if snapshot.blocked_message:
                 reason += f": {snapshot.blocked_message}"
+        last_reason = None
+        if snapshot.last_blocked_code:
+            last_reason = snapshot.last_blocked_code
+            if snapshot.last_blocked_message:
+                last_reason += f": {snapshot.last_blocked_message}"
         return DeliveryStatus(
             task_id=root.id,
             title=root.title,
@@ -1256,6 +1465,12 @@ class FeatureDeliveryRunner:
             last_stage=snapshot.last_stage,
             last_report_status=snapshot.last_report_status,
             blocked_reason=reason,
+            last_blocked_reason=last_reason,
+            last_unblock_target=(
+                snapshot.last_unblock_target.value
+                if snapshot.last_unblock_target
+                else None
+            ),
         )
 
     def _next_report_path(self, conn, root_id: str, role: StageRole) -> str:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4352,6 +4352,7 @@ def transition_workflow_step_cas(
     expected_step: str,
     new_step: str,
     event_payload: Optional[dict] = None,
+    audit_event: Optional[tuple[str, dict]] = None,
 ) -> bool:
     """Atomically advance one opt-in workflow step and record one event.
 
@@ -4377,6 +4378,8 @@ def transition_workflow_step_cas(
             }
         )
         _append_event(conn, task_id, "workflow_step_transitioned", payload)
+        if audit_event is not None:
+            _append_event(conn, task_id, audit_event[0], audit_event[1])
     return True
 
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3449,6 +3449,18 @@ def create_task(
             # compose create_task calls under one outer commit so the
             # dispatcher can never observe a partially constructed graph.
             with write_txn(conn, allow_nested=True):
+                # Close the small race left by the fast-path lookup above.
+                # Feature-delivery resume relies on one durable child task per
+                # idempotency key even when two runners wake at once.
+                if idempotency_key:
+                    existing = conn.execute(
+                        "SELECT id FROM tasks WHERE idempotency_key = ? "
+                        "AND status != 'archived' "
+                        "ORDER BY created_at DESC LIMIT 1",
+                        (idempotency_key,),
+                    ).fetchone()
+                    if existing:
+                        return existing["id"]
                 # Determine task status from parent status, unless the caller
                 # parks it directly in blocked for human-ops review or in
                 # triage for a specifier.
@@ -7757,7 +7769,14 @@ def _repo_root_for_worktree_target(path: Path) -> Optional[Path]:
         current = current.parent
 
 
-def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> None:
+def _ensure_git_worktree(
+    repo_root: Path,
+    target: Path,
+    branch_name: str,
+    *,
+    start_point: str = "HEAD",
+    detached: bool = False,
+) -> None:
     """Materialize ``target`` as a linked git worktree under ``repo_root``."""
     target = target.expanduser()
     repo_common = _git_common_dir(repo_root)
@@ -7766,12 +7785,17 @@ def _ensure_git_worktree(repo_root: Path, target: Path, branch_name: str) -> Non
         if target_common == repo_common:
             return
     target.parent.mkdir(parents=True, exist_ok=True)
-    if _git_branch_exists(repo_root, branch_name):
+    if detached:
+        cmd = [
+            "git", "-C", str(repo_root), "worktree", "add", "--detach",
+            str(target), start_point,
+        ]
+    elif _git_branch_exists(repo_root, branch_name):
         cmd = ["git", "-C", str(repo_root), "worktree", "add", str(target), branch_name]
     else:
         cmd = [
             "git", "-C", str(repo_root), "worktree", "add", "-b", branch_name,
-            str(target), "HEAD",
+            str(target), start_point,
         ]
     result = subprocess.run(
         cmd,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4332,6 +4332,42 @@ def _append_event(
     )
 
 
+def transition_workflow_step_cas(
+    conn: sqlite3.Connection,
+    *,
+    task_id: str,
+    workflow_template_id: str,
+    expected_step: str,
+    new_step: str,
+    event_payload: Optional[dict] = None,
+) -> bool:
+    """Atomically advance one opt-in workflow step and record one event.
+
+    The ordinary Kanban ``status`` column is intentionally untouched.  A stale
+    expected step, a different workflow, or a regular task with no workflow
+    returns ``False`` and writes no event.
+    """
+
+    with write_txn(conn):
+        cursor = conn.execute(
+            "UPDATE tasks SET current_step_key = ? "
+            "WHERE id = ? AND workflow_template_id = ? AND current_step_key = ?",
+            (new_step, task_id, workflow_template_id, expected_step),
+        )
+        if cursor.rowcount != 1:
+            return False
+        payload = dict(event_payload or {})
+        payload.update(
+            {
+                "workflow_template_id": workflow_template_id,
+                "from_step": expected_step,
+                "to_step": new_step,
+            }
+        )
+        _append_event(conn, task_id, "workflow_step_transitioned", payload)
+    return True
+
+
 def _end_run(
     conn: sqlite3.Connection,
     task_id: str,

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -514,6 +514,7 @@ from hermes_cli.subcommands.pairing import build_pairing_parser
 from hermes_cli.subcommands.plugins import build_plugins_parser
 from hermes_cli.subcommands.mcp import build_mcp_parser
 from hermes_cli.subcommands.claw import build_claw_parser
+from hermes_cli.subcommands.delivery import build_delivery_parser
 
 
 def _require_tty(command_name: str) -> None:
@@ -5913,6 +5914,13 @@ def cmd_kanban(args):
     from hermes_cli.kanban import kanban_command
 
     return kanban_command(args)
+
+
+def cmd_delivery(args):
+    """Durable Feature Delivery V1 runner."""
+    from hermes_cli.subcommands.delivery import delivery_command
+
+    return delivery_command(args)
 
 
 def cmd_project(args):
@@ -13983,6 +13991,8 @@ def main():
 
     kanban_parser = _build_kanban_parser(subparsers)
     kanban_parser.set_defaults(func=cmd_kanban)
+
+    build_delivery_parser(subparsers, cmd_delivery=cmd_delivery)
 
     # =========================================================================
     # project command — named, multi-folder workspaces

--- a/hermes_cli/profile_stage_executor.py
+++ b/hermes_cli/profile_stage_executor.py
@@ -1,0 +1,232 @@
+"""Run Feature Delivery stages through three fixed Hermes profiles."""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import time
+from pathlib import Path
+from typing import Callable
+
+from pydantic import ValidationError
+
+from hermes_cli.feature_delivery import (
+    AcceptanceReport,
+    DeveloperReport,
+    StageReport,
+    StageRole,
+    TaskContract,
+    TesterReport,
+)
+from hermes_cli.feature_delivery_runner import StageExecutionError
+from hermes_cli.kanban_db import _resolve_hermes_argv
+from hermes_cli.profiles import profile_exists, resolve_profile_env
+
+
+logger = logging.getLogger(__name__)
+
+PROFILE_BY_ROLE = {
+    "developer": "developer",
+    "tester": "tester",
+    "acceptance": "acceptance",
+}
+TOOLSETS_BY_ROLE = {
+    "developer": ("file", "terminal"),
+    "tester": ("terminal",),
+    "acceptance": ("terminal",),
+}
+PROFILE_STAGE_TIMEOUT_SECONDS = 1800
+
+_REPORT_MODEL = {
+    "developer": DeveloperReport,
+    "tester": TesterReport,
+    "acceptance": AcceptanceReport,
+}
+
+
+class ProfileStageExecutor:
+    """Invoke one approved profile once and return its validated report."""
+
+    def __init__(
+        self,
+        *,
+        run_command: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+    ) -> None:
+        self._run_command = run_command
+
+    def execute(
+        self,
+        *,
+        role: StageRole,
+        task_contract: TaskContract,
+        workspace: Path,
+        target_commit: str,
+        feedback: tuple[str, ...],
+        stage_task_id: str,
+        tester_report: TesterReport | None = None,
+    ) -> StageReport:
+        if role not in PROFILE_BY_ROLE:
+            raise ValueError(f"unsupported feature delivery role: {role}")
+        self._require_profiles()
+        profile = PROFILE_BY_ROLE[role]
+        prompt = self._stage_prompt(
+            role=role,
+            contract=task_contract,
+            workspace=workspace,
+            target_commit=target_commit,
+            feedback=feedback,
+            tester_report=tester_report,
+        )
+        env = dict(os.environ)
+        env.update(
+            {
+                "HERMES_HOME": resolve_profile_env(profile),
+                "HERMES_PROFILE": profile,
+                "TERMINAL_CWD": str(workspace.resolve()),
+            }
+        )
+        command = [
+            *_resolve_hermes_argv(),
+            "-p",
+            profile,
+            "--cli",
+            "--toolsets",
+            ",".join(TOOLSETS_BY_ROLE[role]),
+            "--oneshot",
+            prompt,
+        ]
+        started = time.monotonic()
+        logger.info(
+            "feature delivery stage started profile=%s stage=%s commit=%s",
+            profile,
+            stage_task_id,
+            target_commit,
+        )
+        try:
+            completed = self._run_command(
+                command,
+                cwd=str(workspace),
+                env=env,
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                timeout=PROFILE_STAGE_TIMEOUT_SECONDS,
+                check=False,
+                creationflags=subprocess.CREATE_NO_WINDOW if os.name == "nt" else 0,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise StageExecutionError(
+                "stage_execution_failed",
+                f"profile {profile} timed out after {PROFILE_STAGE_TIMEOUT_SECONDS}s",
+            ) from exc
+        except OSError as exc:
+            raise StageExecutionError(
+                "stage_execution_failed",
+                f"profile {profile} process could not start: {type(exc).__name__}",
+            ) from exc
+        if completed.returncode:
+            raise StageExecutionError(
+                "stage_execution_failed",
+                f"profile {profile} process exited with status {completed.returncode}",
+            )
+
+        report = self._parse_report(role, completed.stdout)
+        logger.info(
+            "feature delivery stage completed profile=%s stage=%s commit=%s status=%s duration_ms=%d",
+            profile,
+            stage_task_id,
+            target_commit,
+            report.status.value,
+            int((time.monotonic() - started) * 1000),
+        )
+        return report
+
+    @staticmethod
+    def _require_profiles() -> None:
+        missing = [profile for profile in PROFILE_BY_ROLE.values() if not profile_exists(profile)]
+        if missing:
+            raise StageExecutionError(
+                "profile_missing",
+                f"required Hermes profiles are missing: {', '.join(missing)}",
+            )
+
+    @staticmethod
+    def _parse_report(role: StageRole, output: str) -> StageReport:
+        decoder = json.JSONDecoder()
+        candidates: list[dict] = []
+        for index, char in enumerate(output):
+            if char != "{":
+                continue
+            try:
+                value, _ = decoder.raw_decode(output[index:])
+            except json.JSONDecodeError:
+                continue
+            if isinstance(value, dict) and {"task_id", "agent", "status"} <= value.keys():
+                candidates.append(value)
+        if not candidates:
+            raise ValueError(f"{role} profile returned invalid JSON")
+        try:
+            return _REPORT_MODEL[role].model_validate(candidates[-1])
+        except ValidationError as exc:
+            raise ValueError(f"{role} profile returned an invalid structured report: {exc}") from exc
+
+    @staticmethod
+    def _stage_prompt(
+        *,
+        role: StageRole,
+        contract: TaskContract,
+        workspace: Path,
+        target_commit: str,
+        feedback: tuple[str, ...],
+        tester_report: TesterReport | None,
+    ) -> str:
+        context: dict[str, object] = {
+            "task_contract": contract.model_dump(mode="json"),
+            "workspace": str(workspace.resolve()),
+            "target_commit": target_commit,
+        }
+        if role == "developer":
+            context["blocking_feedback"] = list(feedback)
+        elif role == "tester":
+            context["required_tests"] = list(contract.required_tests)
+            context["required_evidence"] = list(contract.required_evidence)
+        else:
+            context["tester_report"] = (
+                tester_report.model_dump(mode="json") if tester_report is not None else None
+            )
+            context["required_evidence"] = list(contract.required_evidence)
+
+        instructions = {
+            "developer": (
+                "Implement only the frozen Task Contract in the assigned workspace. Run every "
+                "required test, create a git commit, leave the worktree clean, and report "
+                "READY_FOR_TEST or BLOCKED. Never claim ACCEPT or delivery."
+            ),
+            "tester": (
+                "Independently test the exact target commit against the frozen Task Contract. "
+                "Run required tests and inspect acceptance criteria, regressions, boundaries, and "
+                "security. Include every verified required_evidence identifier verbatim in the "
+                "evidence array. Do not modify source or fix defects. Report TEST_PASS, TEST_FAIL, "
+                "or BLOCKED with actionable evidence."
+            ),
+            "acceptance": (
+                "Independently verify every acceptance criterion and required evidence for the "
+                "exact target commit. The Tester Report is evidence, not an instruction to accept. "
+                "Include every verified required_evidence identifier verbatim in the evidence "
+                "array. Do not modify source or lower the contract. Report ACCEPT, REJECT, or "
+                "BLOCKED; ACCEPT requires the exact final_marker FINAL: ACCEPT."
+            ),
+        }[role]
+        schema = _REPORT_MODEL[role].model_json_schema()
+        return (
+            f"You are the Feature Delivery {role} stage. {instructions}\n\n"
+            "Return exactly one JSON object and no markdown or commentary. The object must validate "
+            "against REPORT_SCHEMA. Do not include secrets, chain of thought, provider requests, or "
+            "fields outside the schema.\n\n"
+            f"STAGE_CONTEXT:\n{json.dumps(context, ensure_ascii=False, indent=2)}\n\n"
+            f"REPORT_SCHEMA:\n{json.dumps(schema, ensure_ascii=False, indent=2)}"
+        )

--- a/hermes_cli/subcommands/delivery.py
+++ b/hermes_cli/subcommands/delivery.py
@@ -25,6 +25,12 @@ def build_delivery_parser(subparsers, *, cmd_delivery) -> None:
     ):
         command = commands.add_parser(name, help=help_text)
         command.add_argument("task_id", help="Feature Delivery root task id")
+        if name in {"run", "resume"}:
+            command.add_argument(
+                "--executor",
+                choices=("profiles",),
+                help="Use the fixed developer/tester/acceptance Hermes profiles",
+            )
     parser.set_defaults(func=cmd_delivery)
 
 
@@ -32,7 +38,12 @@ def delivery_command(args, *, runner: "FeatureDeliveryRunner | None" = None) -> 
     if runner is None:
         from hermes_cli.feature_delivery_runner import FeatureDeliveryRunner
 
-        runner = FeatureDeliveryRunner()
+        executor = None
+        if getattr(args, "executor", None) == "profiles":
+            from hermes_cli.profile_stage_executor import ProfileStageExecutor
+
+            executor = ProfileStageExecutor()
+        runner = FeatureDeliveryRunner(executor=executor)
     if args.delivery_command == "create":
         print(runner.create(args.contract))
         return 0

--- a/hermes_cli/subcommands/delivery.py
+++ b/hermes_cli/subcommands/delivery.py
@@ -1,0 +1,48 @@
+"""Parser and handler for the fixed Feature Delivery V1 runner."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hermes_cli.feature_delivery_runner import FeatureDeliveryRunner
+
+
+def build_delivery_parser(subparsers, *, cmd_delivery) -> None:
+    parser = subparsers.add_parser(
+        "delivery",
+        help="Run a durable Feature Delivery V1 workflow",
+    )
+    commands = parser.add_subparsers(dest="delivery_command", required=True)
+
+    create = commands.add_parser("create", help="Create a delivery root from a JSON contract")
+    create.add_argument("--contract", required=True, help="Path to a TaskContract JSON file")
+
+    for name, help_text in (
+        ("run", "Run until delivered, blocked, or waiting for an executor"),
+        ("resume", "Resume a durable delivery root"),
+        ("status", "Show durable delivery state"),
+    ):
+        command = commands.add_parser(name, help=help_text)
+        command.add_argument("task_id", help="Feature Delivery root task id")
+    parser.set_defaults(func=cmd_delivery)
+
+
+def delivery_command(args, *, runner: "FeatureDeliveryRunner | None" = None) -> int:
+    if runner is None:
+        from hermes_cli.feature_delivery_runner import FeatureDeliveryRunner
+
+        runner = FeatureDeliveryRunner()
+    if args.delivery_command == "create":
+        print(runner.create(args.contract))
+        return 0
+    if args.delivery_command == "run":
+        print(runner.run(args.task_id).render())
+        return 0
+    if args.delivery_command == "resume":
+        print(runner.resume(args.task_id).render())
+        return 0
+    if args.delivery_command == "status":
+        print(runner.status(args.task_id).render())
+        return 0
+    raise ValueError(f"unknown delivery command: {args.delivery_command}")

--- a/hermes_cli/subcommands/delivery.py
+++ b/hermes_cli/subcommands/delivery.py
@@ -18,6 +18,27 @@ def build_delivery_parser(subparsers, *, cmd_delivery) -> None:
     create = commands.add_parser("create", help="Create a delivery root from a JSON contract")
     create.add_argument("--contract", required=True, help="Path to a TaskContract JSON file")
 
+    unblock = commands.add_parser(
+        "unblock",
+        help="Human-resume a recoverable delivery block",
+        description=(
+            "Only recoverable feature-delivery blocks can be resumed. "
+            "Terminal integrity blocks remain blocked."
+        ),
+    )
+    unblock.add_argument("task_id", help="Feature Delivery root task id")
+    unblock.add_argument(
+        "--resume-stage",
+        choices=("previous", "developer"),
+        default="previous",
+        help="Resume the blocked stage, or safely return to development",
+    )
+    unblock.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Confirm this human-approved state recovery",
+    )
+
     for name, help_text in (
         ("run", "Run until delivered, blocked, or waiting for an executor"),
         ("resume", "Resume a durable delivery root"),
@@ -52,6 +73,15 @@ def delivery_command(args, *, runner: "FeatureDeliveryRunner | None" = None) -> 
         return 0
     if args.delivery_command == "resume":
         print(runner.resume(args.task_id).render())
+        return 0
+    if args.delivery_command == "unblock":
+        print(
+            runner.unblock(
+                args.task_id,
+                resume_stage=args.resume_stage,
+                confirmed=args.confirm,
+            ).render()
+        )
         return 0
     if args.delivery_command == "status":
         print(runner.status(args.task_id).render())

--- a/hermes_cli/subcommands/delivery.py
+++ b/hermes_cli/subcommands/delivery.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -37,6 +38,10 @@ def build_delivery_parser(subparsers, *, cmd_delivery) -> None:
         "--confirm",
         action="store_true",
         help="Confirm this human-approved state recovery",
+    )
+    unblock.add_argument(
+        "--developer-context-file",
+        help="UTF-8 recovery context for an unaccepted Developer BLOCKED branch HEAD",
     )
 
     for name, help_text in (
@@ -75,11 +80,19 @@ def delivery_command(args, *, runner: "FeatureDeliveryRunner | None" = None) -> 
         print(runner.resume(args.task_id).render())
         return 0
     if args.delivery_command == "unblock":
+        context_file = getattr(args, "developer_context_file", None)
+        developer_context = ()
+        if context_file:
+            context = Path(context_file).read_text(encoding="utf-8")
+            if len(context.encode("utf-8")) > 65_536:
+                raise ValueError("developer context file exceeds 64 KiB")
+            developer_context = (context,)
         print(
             runner.unblock(
                 args.task_id,
                 resume_stage=args.resume_stage,
                 confirmed=args.confirm,
+                developer_context=developer_context,
             ).render()
         )
         return 0

--- a/tests/hermes_cli/test_autonomous_coordinator.py
+++ b/tests/hermes_cli/test_autonomous_coordinator.py
@@ -1,0 +1,453 @@
+from __future__ import annotations
+
+import subprocess
+import time
+
+import pytest
+
+from hermes_cli.autonomous_coordinator import (
+    AutonomousTaskState,
+    AutonomousTaskStateStore,
+    AutonomousTaskStatus,
+    ConcurrentCoordinatorUpdate,
+    CoordinatorEvent,
+    CoordinatorRunner,
+    VesselMindRepositoryLock,
+)
+
+
+class ScriptedActions:
+    def __init__(self, script):
+        self.script = {state: list(events) for state, events in script.items()}
+        self.calls = []
+
+    def action(self, state, operation_id):
+        self.calls.append((state.state, operation_id))
+        event = self.script[state.state].pop(0)
+        if event is None:
+            return None
+        return CoordinatorEvent(operation_id=operation_id, **event)
+
+    def mapping(self):
+        return {state: self.action for state in self.script}
+
+
+def event(status, **values):
+    return {"status": status, **values}
+
+
+def runner(tmp_path, script, **kwargs):
+    actions = ScriptedActions(script)
+    instance = CoordinatorRunner(
+        AutonomousTaskStateStore(tmp_path / "coordinator.db"),
+        actions.mapping(),
+        **kwargs,
+    )
+    return instance, actions
+
+
+def submit(instance, project="Hermes", repository="repo"):
+    return instance.submit(
+        task_id="VM-001",
+        project=project,
+        repository=repository,
+        target_branch="dev",
+    )
+
+
+def full_script():
+    return {
+        AutonomousTaskStatus.DEVELOPING: [event("PASS", commit="a" * 40)],
+        AutonomousTaskStatus.TESTING: [event("FAIL"), event("PASS")],
+        AutonomousTaskStatus.REPAIRING: [event("PASS", commit="b" * 40)],
+        AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY: [event("PASS")],
+        AutonomousTaskStatus.DELIVERING: [
+            event("PASS", pr_number=17, ci_status="SUCCESS")
+        ],
+        AutonomousTaskStatus.DEPLOYING: [event("PASS", deployment_status="SUCCESS")],
+        AutonomousTaskStatus.ACCEPTANCE_RUNTIME: [event("PASS")],
+    }
+
+
+def test_one_owner_task_runs_full_repair_delivery_and_runtime_flow(tmp_path):
+    instance, actions = runner(tmp_path, full_script())
+
+    result = submit(instance)
+
+    assert result.state == AutonomousTaskStatus.DONE
+    assert result.next_action == "DELIVERED_AND_VERIFIED"
+    assert result.repair_loops == 1
+    assert result.developer_commit == "b" * 40
+    assert result.tester_verdict == "PASS"
+    assert result.acceptance_verdict == "PASS"
+    assert result.pr_number == 17
+    assert result.ci_status == "SUCCESS"
+    assert result.deployment_status == "SUCCESS"
+    assert result.runtime_acceptance == "PASS"
+    assert [call[0] for call in actions.calls] == [
+        AutonomousTaskStatus.DEVELOPING,
+        AutonomousTaskStatus.TESTING,
+        AutonomousTaskStatus.REPAIRING,
+        AutonomousTaskStatus.TESTING,
+        AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY,
+        AutonomousTaskStatus.DELIVERING,
+        AutonomousTaskStatus.DEPLOYING,
+        AutonomousTaskStatus.ACCEPTANCE_RUNTIME,
+    ]
+
+
+@pytest.mark.parametrize(
+    ("waiting_state", "completion", "expected_next"),
+    [
+        (
+            AutonomousTaskStatus.DEVELOPING,
+            event("PASS", commit="a" * 40),
+            AutonomousTaskStatus.TESTING,
+        ),
+        (AutonomousTaskStatus.TESTING, event("FAIL"), AutonomousTaskStatus.REPAIRING),
+        (
+            AutonomousTaskStatus.DELIVERING,
+            event("PASS", ci_status="SUCCESS"),
+            AutonomousTaskStatus.DEPLOYING,
+        ),
+        (
+            AutonomousTaskStatus.DEPLOYING,
+            event("PASS", deployment_status="SUCCESS"),
+            AutonomousTaskStatus.ACCEPTANCE_RUNTIME,
+        ),
+        (
+            AutonomousTaskStatus.ACCEPTANCE_RUNTIME,
+            event("PASS"),
+            AutonomousTaskStatus.DONE,
+        ),
+    ],
+)
+def test_restart_resumes_from_persisted_waiting_state(
+    tmp_path, waiting_state, completion, expected_next
+):
+    path = tmp_path / "coordinator.db"
+    store = AutonomousTaskStateStore(path)
+    state = store.create(
+        AutonomousTaskState(
+            task_id="VM-restart",
+            project="Hermes",
+            repository="repo",
+            target_branch="dev",
+            state=waiting_state,
+            operation_id="same-operation",
+            current_agent={
+                AutonomousTaskStatus.DEVELOPING: "developer",
+                AutonomousTaskStatus.TESTING: "tester",
+                AutonomousTaskStatus.ACCEPTANCE_RUNTIME: "acceptance",
+            }.get(waiting_state),
+            next_action="waiting",
+        )
+    )
+    actions = ScriptedActions({expected_next: [None]})
+    restarted = CoordinatorRunner(store, actions.mapping())
+
+    result = restarted.handle_event(
+        state.task_id,
+        CoordinatorEvent(operation_id="same-operation", **completion),
+    )
+
+    assert result.state == expected_next
+
+
+def test_gateway_restart_resume_all_redispatches_same_operation_id(tmp_path):
+    path = tmp_path / "coordinator.db"
+    store = AutonomousTaskStateStore(path)
+    store.create(
+        AutonomousTaskState(
+            task_id="VM-restart-all",
+            project="Hermes",
+            repository="repo",
+            target_branch="dev",
+            state=AutonomousTaskStatus.DEVELOPING,
+            operation_id="durable-operation",
+            current_agent="developer",
+            next_action="Wait for Developer completion",
+        )
+    )
+    actions = ScriptedActions(full_script())
+    restarted = CoordinatorRunner(store, actions.mapping())
+
+    result = restarted.resume_all()[0]
+
+    assert result.state == AutonomousTaskStatus.DONE
+    assert actions.calls[0] == (
+        AutonomousTaskStatus.DEVELOPING,
+        "durable-operation",
+    )
+
+
+def test_running_ci_event_checkpoints_without_redispatch(tmp_path):
+    path = tmp_path / "coordinator.db"
+    store = AutonomousTaskStateStore(path)
+    store.create(
+        AutonomousTaskState(
+            task_id="VM-ci",
+            project="Hermes",
+            repository="repo",
+            target_branch="dev",
+            state=AutonomousTaskStatus.DELIVERING,
+            operation_id="ci-op",
+            next_action="Wait for CI",
+        )
+    )
+    calls = []
+    instance = CoordinatorRunner(
+        store,
+        {AutonomousTaskStatus.DELIVERING: lambda *_: calls.append(True)},
+    )
+
+    result = instance.handle_event(
+        "VM-ci",
+        CoordinatorEvent(
+            operation_id="ci-op", status="RUNNING", pr_number=9, ci_status="RUNNING"
+        ),
+    )
+
+    assert result.pr_number == 9
+    assert result.ci_status == "RUNNING"
+    assert calls == []
+
+
+def test_ci_failure_reenters_repair_without_owner_message(tmp_path):
+    script = full_script()
+    script[AutonomousTaskStatus.DELIVERING] = [
+        event("FAIL"),
+        event("PASS", ci_status="SUCCESS"),
+    ]
+    script[AutonomousTaskStatus.REPAIRING].append(event("PASS", commit="c" * 40))
+    script[AutonomousTaskStatus.TESTING].append(event("PASS"))
+    script[AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY].append(event("PASS"))
+    instance, _ = runner(tmp_path, script)
+
+    assert submit(instance).state == AutonomousTaskStatus.DONE
+
+
+def test_deployment_failure_retries_internally(tmp_path):
+    script = full_script()
+    script[AutonomousTaskStatus.DEPLOYING] = [
+        event("FAIL", error="temporary deploy failure"),
+        event("PASS", deployment_status="SUCCESS"),
+    ]
+    instance, actions = runner(tmp_path, script)
+
+    result = submit(instance)
+
+    assert result.state == AutonomousTaskStatus.DONE
+    assert result.deployment_retries == 1
+    assert [state for state, _ in actions.calls].count(
+        AutonomousTaskStatus.DEPLOYING
+    ) == 2
+
+
+def test_action_exception_is_repaired_without_owner_interaction(tmp_path):
+    script = full_script()
+
+    def crash_once(state, operation_id):
+        if not getattr(crash_once, "called", False):
+            crash_once.called = True
+            raise RuntimeError("worker crashed")
+        return CoordinatorEvent(
+            operation_id=operation_id, status="PASS", commit="b" * 40
+        )
+
+    actions = ScriptedActions(script)
+    mapping = actions.mapping()
+    mapping[AutonomousTaskStatus.DEVELOPING] = crash_once
+    mapping[AutonomousTaskStatus.REPAIRING] = crash_once
+    instance = CoordinatorRunner(
+        AutonomousTaskStateStore(tmp_path / "coordinator.db"), mapping
+    )
+
+    result = submit(instance)
+
+    assert result.state == AutonomousTaskStatus.DONE
+    assert result.repair_loops == 2
+
+
+def test_runtime_rejection_runs_developer_test_and_acceptance_again(tmp_path):
+    script = full_script()
+    script[AutonomousTaskStatus.ACCEPTANCE_RUNTIME] = [event("FAIL"), event("PASS")]
+    script[AutonomousTaskStatus.REPAIRING].append(event("PASS", commit="c" * 40))
+    script[AutonomousTaskStatus.TESTING].append(event("PASS"))
+    script[AutonomousTaskStatus.ACCEPTANCE_PRE_DEPLOY].append(event("PASS"))
+    script[AutonomousTaskStatus.DELIVERING].append(event("PASS", ci_status="SUCCESS"))
+    script[AutonomousTaskStatus.DEPLOYING].append(
+        event("PASS", deployment_status="SUCCESS")
+    )
+    instance, _ = runner(tmp_path, script)
+
+    result = submit(instance)
+
+    assert result.state == AutonomousTaskStatus.DONE
+    assert result.acceptance_loops == 1
+    assert result.repair_loops == 2
+
+
+def test_event_callback_reinvokes_runner_and_stale_event_is_ignored(tmp_path):
+    script = full_script()
+    script[AutonomousTaskStatus.DEVELOPING] = [None]
+    instance, _ = runner(tmp_path, script)
+    waiting = submit(instance)
+
+    stale = instance.handle_event(
+        waiting.task_id,
+        CoordinatorEvent(operation_id="old", status="PASS", commit="f" * 40),
+    )
+    assert stale.state == AutonomousTaskStatus.DEVELOPING
+
+    result = instance.handle_event(
+        waiting.task_id,
+        CoordinatorEvent(
+            operation_id=waiting.operation_id, status="PASS", commit="a" * 40
+        ),
+    )
+    assert result.state == AutonomousTaskStatus.DONE
+
+
+def test_async_delegation_completion_invokes_runner_not_only_footer(tmp_path):
+    from tools import async_delegation as delegation
+
+    script = full_script()
+    script[AutonomousTaskStatus.DEVELOPING] = [None]
+    instance, _ = runner(tmp_path, script)
+    waiting = submit(instance)
+
+    dispatch = delegation.dispatch_async_delegation(
+        goal="developer",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="test",
+        session_key="",
+        runner=lambda: {
+            "status": "completed",
+            "summary": "developer complete",
+            "coordinator_event": {
+                "operation_id": waiting.operation_id,
+                "status": "PASS",
+                "commit": "a" * 40,
+            },
+        },
+        completion_callback=instance.completion_callback(waiting.task_id),
+    )
+    assert dispatch["status"] == "dispatched"
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline:
+        if instance.store.load(waiting.task_id).state == AutonomousTaskStatus.DONE:
+            break
+        time.sleep(0.02)
+
+    assert instance.store.load(waiting.task_id).state == AutonomousTaskStatus.DONE
+
+
+def test_store_compare_and_swap_rejects_stale_writer(tmp_path):
+    store = AutonomousTaskStateStore(tmp_path / "coordinator.db")
+    original = store.create(
+        AutonomousTaskState(
+            task_id="VM-cas", project="Hermes", repository="repo", target_branch="dev"
+        )
+    )
+    store.save(original.model_copy(update={"next_action": "one"}))
+
+    with pytest.raises(ConcurrentCoordinatorUpdate):
+        store.save(original.model_copy(update={"next_action": "two"}))
+
+
+def test_store_persists_required_recovery_fields(tmp_path):
+    store = AutonomousTaskStateStore(tmp_path / "coordinator.db")
+    saved = store.create(
+        AutonomousTaskState(
+            task_id="VM-fields",
+            project="VesselMind",
+            repository="repo",
+            target_branch="dev",
+        )
+    )
+
+    assert {
+        "task_id",
+        "project",
+        "repository",
+        "target_branch",
+        "state",
+        "current_agent",
+        "developer_commit",
+        "tester_verdict",
+        "acceptance_verdict",
+        "pr_number",
+        "ci_status",
+        "deployment_status",
+        "runtime_acceptance",
+        "repair_loops",
+        "acceptance_loops",
+        "last_error",
+        "next_action",
+    } <= saved.model_dump().keys()
+
+
+def test_compact_owner_progress_contains_only_required_fields(tmp_path):
+    instance, _ = runner(tmp_path, {AutonomousTaskStatus.DEVELOPING: [None]})
+    result = submit(instance)
+
+    assert result.render().splitlines() == [
+        "TASK: VM-001",
+        "STATE: DEVELOPING",
+        "REPAIR_LOOPS: 0",
+        "NEXT_ACTION: Wait for Developer completion",
+        "OWNER_ACTION_REQUIRED: NO",
+    ]
+
+
+def git(path, *args):
+    result = subprocess.run(
+        ["git", "-C", str(path), *args], capture_output=True, text=True, check=True
+    )
+    return result.stdout.strip()
+
+
+def test_vesselmind_lock_recovers_when_approved_remote_is_not_origin(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    git(repo, "remote", "add", "origin", "https://github.com/wrong/repository.git")
+    git(
+        repo,
+        "remote",
+        "add",
+        "jason",
+        "git@github.com:JasonCheungCN/ceramic-ai-designer-h5.git",
+    )
+
+    assert VesselMindRepositoryLock().verify(repo) == "jason"
+
+
+def test_vesselmind_lock_blocks_unknown_lineage_before_delivery(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", str(repo)], check=True, capture_output=True)
+    git(repo, "remote", "add", "origin", "https://github.com/wrong/repository.git")
+    store = AutonomousTaskStateStore(tmp_path / "coordinator.db")
+    store.create(
+        AutonomousTaskState(
+            task_id="VM-lock",
+            project="VesselMind",
+            repository=str(repo),
+            target_branch="dev",
+            state=AutonomousTaskStatus.DELIVERING,
+            next_action="Deliver",
+        )
+    )
+    instance = CoordinatorRunner(
+        store,
+        {AutonomousTaskStatus.DELIVERING: lambda *_: pytest.fail("must not deliver")},
+    )
+
+    result = instance.run("VM-lock")
+
+    assert result.state == AutonomousTaskStatus.BLOCKED
+    assert "BLOCKED_BY_REPOSITORY_LINEAGE" in result.last_error

--- a/tests/hermes_cli/test_feature_delivery.py
+++ b/tests/hermes_cli/test_feature_delivery.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from hermes_cli.feature_delivery import (
+    ACCEPTANCE_FINAL_MARKER,
+    FEATURE_DELIVERY_WORKFLOW,
+    LEGAL_TRANSITIONS,
+    MAX_FIX_LOOPS,
+    AcceptanceCriterionResult,
+    AcceptanceReport,
+    DeveloperReport,
+    FeatureDeliveryState,
+    TaskContract,
+    TesterReport as FDTesterReport,
+    can_transition_to_blocked,
+    canonicalize_contract,
+    compute_contract_hash,
+    count_fix_loops,
+    is_legal_transition,
+    validate_stage_report,
+)
+
+
+SHA = "a" * 40
+
+
+def contract_data() -> dict:
+    return {
+        "task_id": "task-1",
+        "title": "Add deterministic delivery guards",
+        "objective": "Prevent unaccepted feature delivery",
+        "repository": "hermes-agent",
+        "base_commit": SHA,
+        "branch": "feature/feature-delivery-v1",
+        "acceptance_criteria": [
+            {"id": "AC-1", "requirement": "Contract validates"},
+            {"id": "AC-2", "requirement": "Delivery is acceptance-only"},
+        ],
+        "constraints": ["No runner"],
+        "required_tests": ["feature_delivery"],
+        "required_evidence": ["tests", "diff-check"],
+        "out_of_scope": ["merge", "deploy"],
+        "delivery_gate": "acceptance_agent",
+    }
+
+
+def developer_data() -> dict:
+    return {
+        "task_id": "task-1",
+        "agent": "developer",
+        "status": "READY_FOR_TEST",
+        "commit": SHA,
+        "changed_files": ["hermes_cli/feature_delivery.py"],
+        "implementation_summary": "Added guards",
+        "self_checks": ["tests passed"],
+        "known_risks": [],
+    }
+
+
+def _tester_data() -> dict:
+    return {
+        "task_id": "task-1",
+        "agent": "tester",
+        "tested_commit": SHA,
+        "status": "TEST_PASS",
+        "test_results": ["feature tests passed"],
+        "blocking_issues": [],
+        "non_blocking_issues": [],
+        "evidence": ["tests"],
+    }
+
+
+def acceptance_data() -> dict:
+    return {
+        "task_id": "task-1",
+        "agent": "acceptance",
+        "accepted_commit": SHA,
+        "status": "ACCEPT",
+        "criteria": [
+            {"id": "AC-1", "met": True, "evidence": "tests"},
+            {"id": "AC-2", "met": True, "evidence": "review"},
+        ],
+        "blocking_issues": [],
+        "evidence": ["tests", "diff-check"],
+        "final_marker": ACCEPTANCE_FINAL_MARKER,
+    }
+
+
+def test_feature_delivery_constants_are_exact():
+    assert FEATURE_DELIVERY_WORKFLOW == "feature_delivery_v1"
+    assert MAX_FIX_LOOPS == 5
+
+
+def test_valid_task_contract():
+    assert TaskContract.model_validate(contract_data()).task_id == "task-1"
+
+
+@pytest.mark.parametrize("base_commit", ["abc", "A" * 40, "g" * 40, "a" * 39])
+def test_invalid_base_commit(base_commit):
+    data = contract_data()
+    data["base_commit"] = base_commit
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+def test_duplicate_acceptance_criterion_id_rejected():
+    data = contract_data()
+    data["acceptance_criteria"][1]["id"] = "AC-1"
+    with pytest.raises(ValidationError, match="unique"):
+        TaskContract.model_validate(data)
+
+
+@pytest.mark.parametrize("field", ["id", "requirement"])
+def test_empty_acceptance_criterion_rejected(field):
+    data = contract_data()
+    data["acceptance_criteria"][0][field] = "  "
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+@pytest.mark.parametrize("field", ["task_id", "title", "objective", "repository", "branch"])
+def test_empty_required_contract_text_rejected(field):
+    data = contract_data()
+    data[field] = ""
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+def test_contract_requires_acceptance_criterion():
+    data = contract_data()
+    data["acceptance_criteria"] = []
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+@pytest.mark.parametrize("field", ["required_tests", "required_evidence"])
+def test_contract_requires_test_and_evidence_entries(field):
+    data = contract_data()
+    data[field] = []
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+def test_invalid_delivery_gate_rejected():
+    data = contract_data()
+    data["delivery_gate"] = "developer"
+    with pytest.raises(ValidationError):
+        TaskContract.model_validate(data)
+
+
+def test_contract_is_frozen():
+    contract = TaskContract.model_validate(contract_data())
+    with pytest.raises(ValidationError):
+        contract.title = "changed"
+
+
+def test_canonical_contract_hash_is_stable():
+    first = TaskContract.model_validate(contract_data())
+    reordered = TaskContract.model_validate(dict(reversed(list(contract_data().items()))))
+    assert canonicalize_contract(first) == canonicalize_contract(reordered)
+    assert compute_contract_hash(first) == compute_contract_hash(reordered)
+
+
+def test_canonical_contract_is_compact_utf8_json():
+    data = contract_data()
+    data["title"] = "功能交付"
+    contract = TaskContract.model_validate(data)
+    encoded = canonicalize_contract(contract)
+    assert b'": ' not in encoded
+    assert b'", ' not in encoded
+    assert json.loads(encoded.decode("utf-8"))["title"] == "功能交付"
+
+
+def test_contract_change_changes_hash():
+    first = TaskContract.model_validate(contract_data())
+    data = contract_data()
+    data["objective"] = "Different objective"
+    assert compute_contract_hash(first) != compute_contract_hash(TaskContract.model_validate(data))
+
+
+def test_contract_hash_is_lowercase_sha256():
+    value = compute_contract_hash(TaskContract.model_validate(contract_data()))
+    assert len(value) == 64
+    assert value == value.lower()
+    int(value, 16)
+
+
+def test_ready_developer_report_is_valid():
+    assert DeveloperReport.model_validate(developer_data()).commit == SHA
+
+
+def test_blocked_developer_report_allows_null_commit():
+    data = developer_data()
+    data.update(status="BLOCKED", commit=None)
+    assert DeveloperReport.model_validate(data).commit is None
+
+
+@pytest.mark.parametrize("status", ["ACCEPT", "TEST_PASS", "DELIVERED"])
+def test_developer_cannot_submit_other_stage_status(status):
+    data = developer_data()
+    data["status"] = status
+    with pytest.raises(ValidationError):
+        DeveloperReport.model_validate(data)
+
+
+def test_ready_developer_report_requires_commit():
+    data = developer_data()
+    data["commit"] = None
+    with pytest.raises(ValidationError, match="requires"):
+        DeveloperReport.model_validate(data)
+
+
+def test_developer_report_rejects_malformed_commit():
+    data = developer_data()
+    data["commit"] = "short"
+    with pytest.raises(ValidationError):
+        DeveloperReport.model_validate(data)
+
+
+@pytest.mark.parametrize("status", ["TEST_PASS", "TEST_FAIL"])
+def test_completed_tester_report_is_valid(status):
+    data = _tester_data()
+    data["status"] = status
+    assert FDTesterReport.model_validate(data).status.value == status
+
+
+def test_blocked_tester_report_allows_null_commit():
+    data = _tester_data()
+    data.update(status="BLOCKED", tested_commit=None)
+    assert FDTesterReport.model_validate(data).tested_commit is None
+
+
+@pytest.mark.parametrize("status", ["ACCEPT", "DELIVERED", "READY_FOR_TEST"])
+def test_tester_cannot_submit_other_stage_status(status):
+    data = _tester_data()
+    data["status"] = status
+    with pytest.raises(ValidationError):
+        FDTesterReport.model_validate(data)
+
+
+@pytest.mark.parametrize("status", ["TEST_PASS", "TEST_FAIL"])
+def test_completed_tester_report_requires_commit(status):
+    data = _tester_data()
+    data.update(status=status, tested_commit=None)
+    with pytest.raises(ValidationError, match="require"):
+        FDTesterReport.model_validate(data)
+
+
+def test_acceptance_accept_is_valid():
+    assert AcceptanceReport.model_validate(acceptance_data()).status.value == "ACCEPT"
+
+
+def test_acceptance_reject_is_valid():
+    data = acceptance_data()
+    data.update(status="REJECT", final_marker=None)
+    assert AcceptanceReport.model_validate(data).status.value == "REJECT"
+
+
+def test_acceptance_blocked_is_valid_with_null_commit():
+    data = acceptance_data()
+    data.update(status="BLOCKED", accepted_commit=None, final_marker=None)
+    assert AcceptanceReport.model_validate(data).accepted_commit is None
+
+
+@pytest.mark.parametrize("marker", [None, "accept", "approved", "FINAL ACCEPT"])
+def test_acceptance_requires_exact_final_marker(marker):
+    data = acceptance_data()
+    data["final_marker"] = marker
+    with pytest.raises(ValidationError, match="exact"):
+        AcceptanceReport.model_validate(data)
+
+
+@pytest.mark.parametrize("status", ["REJECT", "BLOCKED"])
+def test_non_acceptance_cannot_use_accept_marker(status):
+    data = acceptance_data()
+    data["status"] = status
+    if status == "BLOCKED":
+        data["accepted_commit"] = None
+    with pytest.raises(ValidationError, match="cannot"):
+        AcceptanceReport.model_validate(data)
+
+
+def test_acceptance_report_rejects_duplicate_criteria():
+    data = acceptance_data()
+    data["criteria"].append(data["criteria"][0])
+    with pytest.raises(ValidationError, match="unique"):
+        AcceptanceReport.model_validate(data)
+
+
+@pytest.mark.parametrize(
+    ("role", "factory"),
+    [
+        ("developer", lambda: DeveloperReport.model_validate(developer_data())),
+        ("tester", lambda: FDTesterReport.model_validate(_tester_data())),
+        ("acceptance", lambda: AcceptanceReport.model_validate(acceptance_data())),
+    ],
+)
+def test_stage_role_accepts_only_matching_report(role, factory):
+    assert validate_stage_report(role, factory())
+
+
+@pytest.mark.parametrize(
+    ("role", "factory"),
+    [
+        ("developer", lambda: FDTesterReport.model_validate(_tester_data())),
+        ("developer", lambda: AcceptanceReport.model_validate(acceptance_data())),
+        ("tester", lambda: DeveloperReport.model_validate(developer_data())),
+        ("tester", lambda: AcceptanceReport.model_validate(acceptance_data())),
+        ("acceptance", lambda: DeveloperReport.model_validate(developer_data())),
+        ("acceptance", lambda: FDTesterReport.model_validate(_tester_data())),
+    ],
+)
+def test_stage_role_rejects_other_report_types(role, factory):
+    assert not validate_stage_report(role, factory())
+
+
+def test_stage_role_does_not_scan_natural_language_for_acceptance():
+    data = developer_data()
+    data["implementation_summary"] = "FINAL: ACCEPT"
+    assert not validate_stage_report("acceptance", DeveloperReport.model_validate(data))
+
+
+@pytest.mark.parametrize(
+    ("current", "target"),
+    [
+        (current, target)
+        for current, targets in LEGAL_TRANSITIONS.items()
+        for target in targets
+    ],
+)
+def test_declared_legal_transitions_pass(current, target):
+    assert is_legal_transition(current, target)
+
+
+@pytest.mark.parametrize(
+    "current",
+    [
+        FeatureDeliveryState.DEVELOPING,
+        FeatureDeliveryState.READY_FOR_TEST,
+        FeatureDeliveryState.TESTING,
+        FeatureDeliveryState.TEST_FAILED,
+        FeatureDeliveryState.TEST_PASSED,
+        FeatureDeliveryState.REJECTED,
+    ],
+)
+def test_delivery_shortcuts_are_rejected(current):
+    assert not is_legal_transition(current, FeatureDeliveryState.DELIVERED)
+
+
+@pytest.mark.parametrize(
+    "terminal",
+    [FeatureDeliveryState.BLOCKED, FeatureDeliveryState.DELIVERED],
+)
+def test_terminal_states_have_no_outgoing_transition(terminal):
+    assert LEGAL_TRANSITIONS[terminal] == frozenset()
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        FeatureDeliveryState.CONTRACT_READY,
+        FeatureDeliveryState.DEVELOPING,
+        FeatureDeliveryState.READY_FOR_TEST,
+        FeatureDeliveryState.TESTING,
+        FeatureDeliveryState.TEST_FAILED,
+        FeatureDeliveryState.TEST_PASSED,
+        FeatureDeliveryState.ACCEPTANCE,
+        FeatureDeliveryState.REJECTED,
+    ],
+)
+def test_selected_nonterminal_states_can_block(state):
+    assert can_transition_to_blocked(state)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        FeatureDeliveryState.NEW,
+        FeatureDeliveryState.BLOCKED,
+        FeatureDeliveryState.DELIVERED,
+    ],
+)
+def test_new_and_terminal_states_cannot_block(state):
+    assert not can_transition_to_blocked(state)
+
+
+def test_test_failure_return_counts_as_fix_loop():
+    assert count_fix_loops([(FeatureDeliveryState.TEST_FAILED, FeatureDeliveryState.DEVELOPING)]) == 1
+
+
+def test_rejection_return_counts_as_fix_loop():
+    assert count_fix_loops([(FeatureDeliveryState.REJECTED, FeatureDeliveryState.DEVELOPING)]) == 1
+
+
+def test_other_transitions_do_not_count_as_fix_loops():
+    assert count_fix_loops(
+        [
+            (FeatureDeliveryState.NEW, FeatureDeliveryState.CONTRACT_READY),
+            (FeatureDeliveryState.DEVELOPING, FeatureDeliveryState.READY_FOR_TEST),
+        ]
+    ) == 0
+
+
+def test_acceptance_criterion_result_rejects_empty_evidence():
+    with pytest.raises(ValidationError):
+        AcceptanceCriterionResult(id="AC-1", met=True, evidence="")

--- a/tests/hermes_cli/test_feature_delivery_gate.py
+++ b/tests/hermes_cli/test_feature_delivery_gate.py
@@ -1,0 +1,374 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.feature_delivery import (
+    ACCEPTANCE_FINAL_MARKER,
+    FEATURE_DELIVERY_WORKFLOW,
+    AcceptanceReport,
+    DeliveryCommitContext,
+    DeveloperReport,
+    FeatureDeliveryState,
+    TaskContract,
+    compute_contract_hash,
+    evaluate_delivery_gate,
+    invalidate_downstream_evidence_on_new_developer_commit,
+    validate_delivery_commit_integrity,
+)
+
+
+SHA_A = "a" * 40
+SHA_B = "b" * 40
+
+
+def make_contract(**changes) -> TaskContract:
+    data = {
+        "task_id": "task-1",
+        "title": "Feature delivery",
+        "objective": "Gate delivery",
+        "repository": "hermes-agent",
+        "base_commit": SHA_A,
+        "branch": "feature/feature-delivery-v1",
+        "acceptance_criteria": [
+            {"id": "AC-1", "requirement": "Tests pass"},
+            {"id": "AC-2", "requirement": "Gate passes"},
+        ],
+        "constraints": ["No runner"],
+        "required_tests": ["feature tests"],
+        "required_evidence": ["tests", "diff-check"],
+        "out_of_scope": ["deploy"],
+        "delivery_gate": "acceptance_agent",
+    }
+    data.update(changes)
+    return TaskContract.model_validate(data)
+
+
+def make_acceptance(**changes) -> AcceptanceReport:
+    data = {
+        "task_id": "task-1",
+        "agent": "acceptance",
+        "accepted_commit": SHA_A,
+        "status": "ACCEPT",
+        "criteria": [
+            {"id": "AC-1", "met": True, "evidence": "tests"},
+            {"id": "AC-2", "met": True, "evidence": "review"},
+        ],
+        "blocking_issues": [],
+        "evidence": ["tests", "diff-check"],
+        "final_marker": ACCEPTANCE_FINAL_MARKER,
+    }
+    data.update(changes)
+    return AcceptanceReport.model_validate(data)
+
+
+def make_context(**changes) -> DeliveryCommitContext:
+    data = {
+        "developer_commit": SHA_A,
+        "tested_commit": SHA_A,
+        "accepted_commit": SHA_A,
+        "branch_head": SHA_A,
+    }
+    data.update(changes)
+    return DeliveryCommitContext.model_validate(data)
+
+
+def gate(**changes):
+    contract = changes.pop("contract", make_contract())
+    report = changes.pop("acceptance_report", make_acceptance())
+    context = changes.pop("commit_context", make_context())
+    defaults = {
+        "workflow_template_id": FEATURE_DELIVERY_WORKFLOW,
+        "current_state": FeatureDeliveryState.ACCEPTANCE,
+        "expected_contract_hash": compute_contract_hash(contract),
+    }
+    defaults.update(changes)
+    return evaluate_delivery_gate(contract, report, context, **defaults)
+
+
+def test_delivery_gate_allows_fully_accepted_commit():
+    result = gate()
+    assert result.allowed
+    assert result.reasons == ()
+
+
+def test_delivery_gate_rejects_missing_acceptance_criterion():
+    report = make_acceptance(criteria=[
+        {"id": "AC-1", "met": True, "evidence": "tests"},
+    ])
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("missing acceptance criteria" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_unknown_acceptance_criterion():
+    report = make_acceptance(criteria=[
+        {"id": "AC-1", "met": True, "evidence": "tests"},
+        {"id": "AC-2", "met": True, "evidence": "review"},
+        {"id": "AC-X", "met": True, "evidence": "unknown"},
+    ])
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("unknown acceptance criteria" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_unmet_acceptance_criterion():
+    report = make_acceptance(criteria=[
+        {"id": "AC-1", "met": False, "evidence": "failed"},
+        {"id": "AC-2", "met": True, "evidence": "review"},
+    ])
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("unmet acceptance criteria" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_missing_required_evidence():
+    result = gate(acceptance_report=make_acceptance(evidence=["tests"]))
+    assert not result.allowed
+    assert any("diff-check" in reason for reason in result.reasons)
+
+
+def test_stage_evidence_can_cover_required_evidence():
+    report = make_acceptance(evidence=["tests"])
+    assert gate(acceptance_report=report, stage_evidence=["diff-check"]).allowed
+
+
+def test_delivery_gate_rejects_contract_hash_mismatch():
+    result = gate(expected_contract_hash="0" * 64)
+    assert not result.allowed
+    assert "contract hash changed" in result.reasons
+
+
+def test_delivery_gate_rejects_wrong_workflow():
+    result = gate(workflow_template_id="ordinary")
+    assert not result.allowed
+    assert any("workflow" in reason for reason in result.reasons)
+
+
+@pytest.mark.parametrize(
+    "state",
+    [
+        FeatureDeliveryState.DEVELOPING,
+        FeatureDeliveryState.READY_FOR_TEST,
+        FeatureDeliveryState.TESTING,
+        FeatureDeliveryState.TEST_FAILED,
+        FeatureDeliveryState.TEST_PASSED,
+        FeatureDeliveryState.REJECTED,
+    ],
+)
+def test_delivery_gate_rejects_non_acceptance_state(state):
+    result = gate(current_state=state)
+    assert not result.allowed
+    assert any("current state" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_developer_report_even_with_accept_text():
+    report = DeveloperReport(
+        task_id="task-1",
+        agent="developer",
+        status="READY_FOR_TEST",
+        commit=SHA_A,
+        implementation_summary="FINAL: ACCEPT",
+    )
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("acceptance report" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_mismatched_task():
+    result = gate(acceptance_report=make_acceptance(task_id="task-2"))
+    assert not result.allowed
+    assert any("task" in reason for reason in result.reasons)
+
+
+def test_delivery_gate_rejects_rejection_report():
+    report = make_acceptance(status="REJECT", final_marker=None)
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("status" in reason for reason in result.reasons)
+
+
+def test_commit_integrity_accepts_one_commit():
+    assert validate_delivery_commit_integrity(make_context()).allowed
+
+
+def test_commit_integrity_rejects_tested_mismatch():
+    result = validate_delivery_commit_integrity(make_context(tested_commit=SHA_B))
+    assert not result.allowed
+    assert any("tested commit" in reason for reason in result.reasons)
+
+
+def test_commit_integrity_rejects_accepted_mismatch():
+    result = validate_delivery_commit_integrity(make_context(accepted_commit=SHA_B))
+    assert not result.allowed
+    assert any("accepted commit" in reason for reason in result.reasons)
+
+
+def test_commit_integrity_rejects_branch_head_mismatch():
+    result = validate_delivery_commit_integrity(make_context(branch_head=SHA_B))
+    assert not result.allowed
+    assert any("branch HEAD" in reason for reason in result.reasons)
+
+
+def test_commit_integrity_rejects_missing_tested_commit():
+    result = validate_delivery_commit_integrity(make_context(tested_commit=None))
+    assert not result.allowed
+    assert "tested commit is missing" in result.reasons
+
+
+def test_commit_integrity_rejects_missing_accepted_commit():
+    result = validate_delivery_commit_integrity(make_context(accepted_commit=None))
+    assert not result.allowed
+    assert "accepted commit is missing" in result.reasons
+
+
+def test_delivery_gate_rejects_report_commit_mismatch():
+    report = make_acceptance(accepted_commit=SHA_B)
+    result = gate(acceptance_report=report)
+    assert not result.allowed
+    assert any("report commit" in reason for reason in result.reasons)
+
+
+def test_new_developer_commit_clears_tested_commit():
+    updated = invalidate_downstream_evidence_on_new_developer_commit(make_context(), SHA_B)
+    assert updated.developer_commit == SHA_B
+    assert updated.tested_commit is None
+
+
+def test_new_developer_commit_clears_accepted_commit():
+    updated = invalidate_downstream_evidence_on_new_developer_commit(make_context(), SHA_B)
+    assert updated.accepted_commit is None
+    assert updated.branch_head == SHA_B
+
+
+def test_unchanged_developer_commit_preserves_evidence():
+    context = make_context()
+    assert invalidate_downstream_evidence_on_new_developer_commit(context, SHA_A) is context
+
+
+@pytest.fixture
+def workflow_task(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    db_path = home / "kanban.db"
+    conn = kb.connect(db_path)
+    task_id = kb.create_task(conn, title="feature delivery task")
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET workflow_template_id = ?, current_step_key = ? WHERE id = ?",
+            (FEATURE_DELIVERY_WORKFLOW, "ACCEPTANCE", task_id),
+        )
+    try:
+        yield conn, task_id
+    finally:
+        conn.close()
+
+
+def test_workflow_cas_updates_expected_state(workflow_task):
+    conn, task_id = workflow_task
+    original_status = kb.get_task(conn, task_id).status
+    assert kb.transition_workflow_step_cas(
+        conn,
+        task_id=task_id,
+        workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+        expected_step="ACCEPTANCE",
+        new_step="DELIVERED",
+    )
+    updated = kb.get_task(conn, task_id)
+    assert updated.current_step_key == "DELIVERED"
+    assert updated.status == original_status
+
+
+def test_workflow_cas_rejects_stale_expected_state(workflow_task):
+    conn, task_id = workflow_task
+    assert kb.transition_workflow_step_cas(
+        conn,
+        task_id=task_id,
+        workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+        expected_step="ACCEPTANCE",
+        new_step="DELIVERED",
+    )
+    assert not kb.transition_workflow_step_cas(
+        conn,
+        task_id=task_id,
+        workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+        expected_step="ACCEPTANCE",
+        new_step="DELIVERED",
+    )
+
+
+def test_workflow_cas_writes_transition_event_once(workflow_task):
+    conn, task_id = workflow_task
+    assert kb.transition_workflow_step_cas(
+        conn,
+        task_id=task_id,
+        workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+        expected_step="ACCEPTANCE",
+        new_step="DELIVERED",
+        event_payload={"contract_hash": "hash", "from_step": "forged"},
+    )
+    assert not kb.transition_workflow_step_cas(
+        conn,
+        task_id=task_id,
+        workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+        expected_step="ACCEPTANCE",
+        new_step="DELIVERED",
+    )
+    events = [event for event in kb.list_events(conn, task_id) if event.kind == "workflow_step_transitioned"]
+    assert len(events) == 1
+    assert events[0].payload == {
+        "contract_hash": "hash",
+        "workflow_template_id": FEATURE_DELIVERY_WORKFLOW,
+        "from_step": "ACCEPTANCE",
+        "to_step": "DELIVERED",
+    }
+
+
+def test_workflow_cas_rolls_back_step_when_event_write_fails(workflow_task, monkeypatch):
+    conn, task_id = workflow_task
+
+    def fail_event(*args, **kwargs):
+        raise RuntimeError("event write failed")
+
+    monkeypatch.setattr(kb, "_append_event", fail_event)
+    with pytest.raises(RuntimeError, match="event write failed"):
+        kb.transition_workflow_step_cas(
+            conn,
+            task_id=task_id,
+            workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+            expected_step="ACCEPTANCE",
+            new_step="DELIVERED",
+        )
+    assert kb.get_task(conn, task_id).current_step_key == "ACCEPTANCE"
+
+
+def test_workflow_cas_leaves_ordinary_kanban_task_unchanged(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    conn = kb.connect(home / "ordinary.db")
+    try:
+        task_id = kb.create_task(conn, title="ordinary task")
+        before = kb.get_task(conn, task_id)
+        assert not kb.transition_workflow_step_cas(
+            conn,
+            task_id=task_id,
+            workflow_template_id=FEATURE_DELIVERY_WORKFLOW,
+            expected_step="NEW",
+            new_step="CONTRACT_READY",
+        )
+        after = kb.get_task(conn, task_id)
+        assert after.status == before.status
+        assert after.workflow_template_id is None
+        assert after.current_step_key is None
+        assert not any(
+            event.kind == "workflow_step_transitioned"
+            for event in kb.list_events(conn, task_id)
+        )
+    finally:
+        conn.close()

--- a/tests/hermes_cli/test_feature_delivery_profiles.py
+++ b/tests/hermes_cli/test_feature_delivery_profiles.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+
+from hermes_cli.feature_delivery_runner import FeatureDeliveryRunner
+from hermes_cli.profile_stage_executor import ProfileStageExecutor
+from hermes_cli.subcommands.delivery import build_delivery_parser
+from tests.hermes_cli.test_feature_delivery_runner import delivery_env, git
+
+
+def test_profile_executor_drives_runner_to_delivery(delivery_env, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.profile_exists",
+        lambda name: name in {"developer", "tester", "acceptance"},
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.resolve_profile_env",
+        lambda name: f"/profiles/{name}",
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor._resolve_hermes_argv",
+        lambda: ["hermes"],
+    )
+    calls = []
+
+    def run(command, **kwargs):
+        profile = command[command.index("-p") + 1]
+        workspace = kwargs["cwd"]
+        prompt = command[-1]
+        workspace_path = Path(workspace)
+        calls.append((profile, git(workspace_path, "rev-parse", "HEAD"), prompt))
+        if profile == "developer":
+            feature = workspace_path / "feature.txt"
+            feature.write_text("profile feature\n", encoding="utf-8")
+            git(workspace_path, "add", "feature.txt")
+            git(workspace_path, "commit", "-m", "profile developer")
+            commit = git(workspace_path, "rev-parse", "HEAD")
+            payload = {
+                "task_id": delivery_env.contract["task_id"],
+                "agent": "developer",
+                "status": "READY_FOR_TEST",
+                "commit": commit,
+                "changed_files": ["feature.txt"],
+                "implementation_summary": "implemented feature",
+                "self_checks": ["runner tests"],
+                "known_risks": [],
+            }
+        elif profile == "tester":
+            commit = git(workspace_path, "rev-parse", "HEAD")
+            payload = {
+                "task_id": delivery_env.contract["task_id"],
+                "agent": "tester",
+                "tested_commit": commit,
+                "status": "TEST_PASS",
+                "test_results": ["runner tests"],
+                "blocking_issues": [],
+                "non_blocking_issues": [],
+                "evidence": ["tests"],
+            }
+        else:
+            commit = git(workspace_path, "rev-parse", "HEAD")
+            payload = {
+                "task_id": delivery_env.contract["task_id"],
+                "agent": "acceptance",
+                "accepted_commit": commit,
+                "status": "ACCEPT",
+                "criteria": [
+                    {"id": "AC-1", "met": True, "evidence": "tests"},
+                    {"id": "AC-2", "met": True, "evidence": "independent review"},
+                ],
+                "blocking_issues": [],
+                "evidence": ["diff-check"],
+                "final_marker": "FINAL: ACCEPT",
+            }
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    runner = FeatureDeliveryRunner(executor=ProfileStageExecutor(run_command=run))
+    root_id = runner.create(delivery_env.contract_path)
+    result = runner.run(root_id)
+
+    assert result.current_state == "DELIVERED"
+    assert [call[0] for call in calls] == ["developer", "tester", "acceptance"]
+    assert calls[1][1] == result.developer_commit
+    assert calls[2][1] == result.developer_commit
+    assert '"tester_report"' in calls[2][2]
+
+
+def test_missing_profile_blocks_runner_with_profile_missing(delivery_env, monkeypatch):
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.profile_exists",
+        lambda name: name != "tester",
+    )
+    runner = FeatureDeliveryRunner(executor=ProfileStageExecutor())
+    root_id = runner.create(delivery_env.contract_path)
+
+    result = runner.run(root_id)
+
+    assert result.current_state == "BLOCKED"
+    assert result.blocked_reason is not None
+    assert result.blocked_reason.startswith("profile_missing:")
+
+
+def test_profiles_executor_is_explicit_cli_opt_in():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_delivery_parser(subparsers, cmd_delivery=lambda args: None)
+
+    args = parser.parse_args(["delivery", "run", "task-1", "--executor", "profiles"])
+
+    assert args.executor == "profiles"
+    default_args = parser.parse_args(["delivery", "run", "task-1"])
+    assert default_args.executor is None

--- a/tests/hermes_cli/test_feature_delivery_resume.py
+++ b/tests/hermes_cli/test_feature_delivery_resume.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.feature_delivery import FeatureDeliveryState, TaskContract
+from hermes_cli.feature_delivery_runner import FeatureDeliveryRunner
+from tests.hermes_cli.test_feature_delivery_runner import (
+    FakeExecutor,
+    create,
+    delivery_env,
+    stage_rows,
+)
+
+
+def root_context(runner, root_id):
+    with kb.connect() as conn:
+        root, metadata = runner._root_and_metadata(conn, root_id)
+        contract = runner._load_contract(conn, root, metadata)
+        snapshot = runner._snapshot(conn, root, recover=True)
+    return root, metadata, contract, snapshot
+
+
+def test_resume_after_developer_stage_creation_reuses_child(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    with kb.connect() as conn:
+        root, _ = runner._root_and_metadata(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        root = kb.get_task(conn, root_id)
+        runner._ensure_stage(conn, root, "developer", delivery_env.base, 1)
+    assert len(stage_rows(root_id)) == 1
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert [json.loads(row["body"])["feature_delivery_stage"]["role"] for row in stage_rows(root_id)].count("developer") == 1
+
+
+def test_resume_after_developer_report_advances_without_rerun(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    with kb.connect() as conn:
+        root, metadata = runner._root_and_metadata(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        root = kb.get_task(conn, root_id)
+        contract = TaskContract.model_validate(delivery_env.contract)
+        workspace = runner._feature_workspace(conn, root, contract, metadata)
+        runner._stage_report(conn, root, contract, "developer", delivery_env.base, 1, workspace, ())
+    assert len(fake.calls) == 1
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert [call[0] for call in fake.calls].count("developer") == 1
+
+
+def test_resume_after_test_pass_continues_acceptance(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    with kb.connect() as conn:
+        root, metadata = runner._root_and_metadata(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        root = kb.get_task(conn, root_id)
+        contract = runner._load_contract(conn, root, metadata)
+        snapshot = runner._snapshot(conn, root, recover=True)
+        runner._run_developer(conn, root, contract, metadata, snapshot)
+        root = kb.get_task(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.TESTING)
+        root = kb.get_task(conn, root_id)
+        snapshot = runner._snapshot(conn, root, recover=True)
+        runner._run_tester(conn, root, contract, metadata, snapshot)
+    assert runner.status(root_id).current_state == "TEST_PASSED"
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert [call[0] for call in fake.calls] == ["developer", "tester", "acceptance"]
+
+
+def test_resume_after_accept_report_reruns_gate_not_executor(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    original = runner._transition
+
+    def crash(conn, root, target, payload=None):
+        if target == FeatureDeliveryState.DELIVERED:
+            raise KeyboardInterrupt
+        return original(conn, root, target, payload)
+
+    runner._transition = crash
+    with pytest.raises(KeyboardInterrupt):
+        runner.run(root_id)
+    assert [call[0] for call in fake.calls].count("acceptance") == 1
+    runner._transition = original
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert [call[0] for call in fake.calls].count("acceptance") == 1
+
+
+def test_repeated_resume_is_idempotent_after_delivery(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    assert runner.run(root_id).current_state == "DELIVERED"
+    calls = list(fake.calls)
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert runner.resume(root_id).current_state == "DELIVERED"
+    assert fake.calls == calls
+
+
+@pytest.mark.parametrize("role", ["developer", "tester", "acceptance"])
+def test_repeated_resume_does_not_duplicate_stage(delivery_env, role):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    assert runner.run(root_id).current_state == "DELIVERED"
+    runner.resume(root_id)
+    roles = [json.loads(row["body"])["feature_delivery_stage"]["role"] for row in stage_rows(root_id)]
+    assert roles.count(role) == 1
+
+
+def test_stale_cas_cannot_double_advance(delivery_env):
+    runner, root_id = create(delivery_env)
+    with kb.connect() as conn:
+        first = kb.get_task(conn, root_id)
+        stale = kb.get_task(conn, root_id)
+        assert runner._transition(conn, first, FeatureDeliveryState.DEVELOPING)
+        assert runner._transition(conn, stale, FeatureDeliveryState.DEVELOPING)
+        events = [e for e in kb.list_events(conn, root_id) if e.kind == "workflow_step_transitioned"]
+    assert len(events) == 1
+
+
+def test_live_stage_claim_prevents_duplicate_execution(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready")])
+    runner, root_id = create(delivery_env, fake)
+    with kb.connect() as conn:
+        root, _ = runner._root_and_metadata(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        root = kb.get_task(conn, root_id)
+        stage = runner._ensure_stage(conn, root, "developer", delivery_env.base, 1)
+        runner._start_run(conn, root, stage, "developer", delivery_env.base)
+    assert runner.resume(root_id).current_state == "DEVELOPING"
+    assert fake.calls == []
+    assert len(stage_rows(root_id)) == 1
+
+
+def test_report_metadata_contains_required_run_fields(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT r.metadata FROM task_runs r JOIN task_links l ON l.child_id=r.task_id "
+            "WHERE l.parent_id=? ORDER BY r.id",
+            (root_id,),
+        ).fetchall()
+    for row in rows:
+        metadata = json.loads(row["metadata"])
+        for field in ("root_task_id", "stage_task_id", "role", "input_commit", "report_path", "report_status"):
+            assert field in metadata
+        assert "chain_of_thought" not in metadata
+
+
+def test_stage_reports_are_linked_to_root(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    assert len(stage_rows(root_id)) == 3
+
+
+def test_tester_and_acceptance_use_detached_exact_commit(delivery_env):
+    class InspectingExecutor(FakeExecutor):
+        def execute(self, **kwargs):
+            if kwargs["role"] in {"tester", "acceptance"}:
+                assert git(kwargs["workspace"], "rev-parse", "HEAD") == kwargs["target_commit"]
+                assert git(kwargs["workspace"], "branch", "--show-current") == ""
+            return super().execute(**kwargs)
+
+    from tests.hermes_cli.test_feature_delivery_runner import git
+
+    fake = InspectingExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    assert runner.run(root_id).current_state == "DELIVERED"
+
+
+def test_run_records_no_profile_invocation(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    assert all(row["assignee"] is None for row in stage_rows(root_id))
+
+
+def test_root_is_only_task_with_workflow_state(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    assert all(row["workflow_template_id"] is None for row in stage_rows(root_id))
+
+
+def test_status_after_test_failure_reports_fix_loop(delivery_env):
+    script = [("developer", "ready"), ("tester", "fail"), ("developer", "blocked")]
+    runner, root_id = create(delivery_env, FakeExecutor(delivery_env.repo, script))
+    result = runner.run(root_id)
+    assert result.fix_loops == 1
+    assert result.last_stage == "developer"
+
+
+def test_report_role_in_metadata_is_validated(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    original = runner._transition
+
+    def crash(conn, root, target, payload=None):
+        if target == FeatureDeliveryState.READY_FOR_TEST:
+            raise KeyboardInterrupt
+        return original(conn, root, target, payload)
+
+    runner._transition = crash
+    with pytest.raises(KeyboardInterrupt):
+        runner.run(root_id)
+    with kb.connect() as conn:
+        row = conn.execute("SELECT id, metadata FROM task_runs ORDER BY id DESC LIMIT 1").fetchone()
+        metadata = json.loads(row["metadata"])
+        metadata["role"] = "acceptance"
+        conn.execute("UPDATE task_runs SET metadata=? WHERE id=?", (json.dumps(metadata), row["id"]))
+        conn.commit()
+    runner._transition = original
+    assert "invalid_report" in runner.resume(root_id).blocked_reason

--- a/tests/hermes_cli/test_feature_delivery_runner.py
+++ b/tests/hermes_cli/test_feature_delivery_runner.py
@@ -430,12 +430,17 @@ def test_ordinary_kanban_task_is_rejected_without_mutation(delivery_env):
     assert task.current_step_key is None
 
 
-def test_cli_parser_supports_only_four_delivery_commands():
+def test_cli_parser_supports_only_feature_delivery_commands():
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest="command")
     build_delivery_parser(subparsers, cmd_delivery=lambda _: 0)
-    for command in ("create", "run", "resume", "status"):
-        tail = ["--contract", "contract.json"] if command == "create" else ["task-id"]
+    for command in ("create", "run", "resume", "status", "unblock"):
+        if command == "create":
+            tail = ["--contract", "contract.json"]
+        elif command == "unblock":
+            tail = ["task-id", "--confirm"]
+        else:
+            tail = ["task-id"]
         args = parser.parse_args(["delivery", command, *tail])
         assert args.delivery_command == command
 

--- a/tests/hermes_cli/test_feature_delivery_runner.py
+++ b/tests/hermes_cli/test_feature_delivery_runner.py
@@ -89,6 +89,7 @@ class FakeExecutor:
         target_commit,
         feedback,
         stage_task_id,
+        tester_report=None,
     ):
         expected_role, outcome = self.script.pop(0)
         assert role == expected_role

--- a/tests/hermes_cli/test_feature_delivery_runner.py
+++ b/tests/hermes_cli/test_feature_delivery_runner.py
@@ -1,0 +1,459 @@
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.feature_delivery import FEATURE_DELIVERY_WORKFLOW, FeatureDeliveryState
+from hermes_cli.feature_delivery_runner import (
+    DeliveryRunnerError,
+    FeatureDeliveryRunner,
+)
+from hermes_cli.subcommands.delivery import build_delivery_parser, delivery_command
+
+
+def git(path: Path, *args: str, check: bool = True) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(path), *args],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if check and result.returncode:
+        raise AssertionError(result.stderr or result.stdout)
+    return result.stdout.strip()
+
+
+@dataclass
+class DeliveryFixture:
+    repo: Path
+    contract_path: Path
+    contract: dict
+    base: str
+
+
+@pytest.fixture
+def delivery_env(tmp_path, monkeypatch) -> DeliveryFixture:
+    home = tmp_path / "hermes-home"
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(home))
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(home / "kanban.db"))
+    monkeypatch.setenv("HERMES_KANBAN_ATTACHMENTS_ROOT", str(home / "attachments"))
+    repo = tmp_path / "target-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-b", "main", str(repo)], check=True, capture_output=True)
+    git(repo, "config", "user.email", "runner@example.invalid")
+    git(repo, "config", "user.name", "Runner Test")
+    (repo / "README.md").write_text("base\n", encoding="utf-8")
+    git(repo, "add", "README.md")
+    git(repo, "commit", "-m", "base")
+    base = git(repo, "rev-parse", "HEAD")
+    contract = {
+        "task_id": "contract-task-1",
+        "title": "Deliver a tested feature",
+        "objective": "Exercise the durable feature runner",
+        "repository": str(repo),
+        "base_commit": base,
+        "branch": "feature/durable-runner-test",
+        "acceptance_criteria": [
+            {"id": "AC-1", "requirement": "Tests pass"},
+            {"id": "AC-2", "requirement": "Acceptance passes"},
+        ],
+        "constraints": ["No deployment"],
+        "required_tests": ["runner tests"],
+        "required_evidence": ["tests", "diff-check"],
+        "out_of_scope": ["merge", "deploy"],
+        "delivery_gate": "acceptance_agent",
+    }
+    contract_path = tmp_path / "task-contract.json"
+    contract_path.write_text(json.dumps(contract), encoding="utf-8")
+    return DeliveryFixture(repo, contract_path, contract, base)
+
+
+class FakeExecutor:
+    def __init__(self, repo: Path, script: list[tuple[str, str]]):
+        self.repo = repo
+        self.script = list(script)
+        self.calls: list[tuple[str, str, str]] = []
+
+    def execute(
+        self,
+        *,
+        role,
+        task_contract,
+        workspace,
+        target_commit,
+        feedback,
+        stage_task_id,
+    ):
+        expected_role, outcome = self.script.pop(0)
+        assert role == expected_role
+        self.calls.append((role, target_commit, stage_task_id))
+        if role == "developer":
+            if outcome == "blocked":
+                return {
+                    "task_id": task_contract.task_id,
+                    "agent": "developer",
+                    "status": "BLOCKED",
+                    "commit": None,
+                    "implementation_summary": "missing external environment",
+                }
+            if outcome == "bad_commit":
+                commit = "a" * 40
+            elif outcome == "dirty":
+                (workspace / "dirty.txt").write_text("dirty", encoding="utf-8")
+                commit = target_commit
+            elif outcome == "non_descendant":
+                git(workspace, "checkout", "--orphan", "feature/orphan")
+                for item in workspace.iterdir():
+                    if item.name != ".git" and item.is_file():
+                        item.unlink()
+                (workspace / "orphan.txt").write_text("orphan\n", encoding="utf-8")
+                git(workspace, "add", "-A")
+                git(workspace, "commit", "-m", "orphan")
+                git(workspace, "branch", "-M", task_contract.branch)
+                commit = git(workspace, "rev-parse", "HEAD")
+            else:
+                feature = workspace / "feature.txt"
+                old = feature.read_text(encoding="utf-8") if feature.exists() else ""
+                feature.write_text(old + f"change {len(self.calls)}\n", encoding="utf-8")
+                git(workspace, "add", "feature.txt")
+                git(workspace, "commit", "-m", f"developer {len(self.calls)}")
+                commit = git(workspace, "rev-parse", "HEAD")
+            return {
+                "task_id": task_contract.task_id,
+                "agent": "developer",
+                "status": "READY_FOR_TEST",
+                "commit": commit,
+                "changed_files": ["feature.txt"],
+                "implementation_summary": "implemented feature",
+                "self_checks": ["local check"],
+            }
+        if role == "tester":
+            if outcome == "mutate":
+                (workspace / "README.md").write_text("changed by tester\n", encoding="utf-8")
+                outcome = "pass"
+            if outcome == "blocked":
+                return {
+                    "task_id": task_contract.task_id,
+                    "agent": "tester",
+                    "tested_commit": None,
+                    "status": "BLOCKED",
+                }
+            tested = "b" * 40 if outcome == "mismatch" else target_commit
+            return {
+                "task_id": task_contract.task_id,
+                "agent": "tester",
+                "tested_commit": tested,
+                "status": "TEST_FAIL" if outcome == "fail" else "TEST_PASS",
+                "test_results": ["runner tests"],
+                "blocking_issues": ["test failed"] if outcome == "fail" else [],
+                "evidence": ["tests"],
+            }
+        if outcome == "blocked":
+            return {
+                "task_id": task_contract.task_id,
+                "agent": "acceptance",
+                "accepted_commit": None,
+                "status": "BLOCKED",
+            }
+        if outcome == "wrong_marker":
+            marker = "ACCEPT"
+        else:
+            marker = "FINAL: ACCEPT" if outcome not in {"reject"} else None
+        evidence = ["diff-check"] if outcome != "missing_evidence" else []
+        if outcome == "stale_head":
+            tree = git(self.repo, "rev-parse", f"{target_commit}^{{tree}}")
+            moved = subprocess.run(
+                ["git", "-C", str(self.repo), "commit-tree", tree, "-p", target_commit, "-m", "move head"],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **__import__("os").environ,
+                    "GIT_AUTHOR_NAME": "Runner Test",
+                    "GIT_AUTHOR_EMAIL": "runner@example.invalid",
+                    "GIT_COMMITTER_NAME": "Runner Test",
+                    "GIT_COMMITTER_EMAIL": "runner@example.invalid",
+                },
+            ).stdout.strip()
+            git(self.repo, "update-ref", f"refs/heads/{task_contract.branch}", moved)
+        return {
+            "task_id": task_contract.task_id,
+            "agent": "acceptance",
+            "accepted_commit": target_commit,
+            "status": "REJECT" if outcome == "reject" else "ACCEPT",
+            "criteria": [
+                {"id": "AC-1", "met": outcome != "reject", "evidence": "tests"},
+                {"id": "AC-2", "met": outcome != "reject", "evidence": "review"},
+            ],
+            "blocking_issues": ["acceptance rejected"] if outcome == "reject" else [],
+            "evidence": evidence,
+            "final_marker": marker,
+        }
+
+
+def create(delivery_env, executor=None):
+    runner = FeatureDeliveryRunner(executor)
+    return runner, runner.create(delivery_env.contract_path)
+
+
+def stage_rows(root_id: str):
+    with kb.connect() as conn:
+        return conn.execute(
+            "SELECT t.* FROM tasks t JOIN task_links l ON l.child_id=t.id "
+            "WHERE l.parent_id=? ORDER BY t.created_at,t.id",
+            (root_id,),
+        ).fetchall()
+
+
+def test_create_valid_contract_creates_root(delivery_env):
+    runner, root_id = create(delivery_env)
+    with kb.connect() as conn:
+        root = kb.get_task(conn, root_id)
+    assert root.workflow_template_id == FEATURE_DELIVERY_WORKFLOW
+    assert root.current_step_key == "CONTRACT_READY"
+    assert runner.status(root_id).contract_hash
+
+
+def test_create_rejects_dirty_repository(delivery_env):
+    (delivery_env.repo / "dirty.txt").write_text("dirty", encoding="utf-8")
+    with pytest.raises(DeliveryRunnerError, match="dirty"):
+        FeatureDeliveryRunner().create(delivery_env.contract_path)
+
+
+def test_create_rejects_bad_base_commit(delivery_env):
+    delivery_env.contract["base_commit"] = "a" * 40
+    delivery_env.contract_path.write_text(json.dumps(delivery_env.contract), encoding="utf-8")
+    with pytest.raises(DeliveryRunnerError, match="base commit"):
+        FeatureDeliveryRunner().create(delivery_env.contract_path)
+
+
+def test_contract_is_stored_outside_target_repository(delivery_env):
+    _, root_id = create(delivery_env)
+    with kb.connect() as conn:
+        contract_attachment = next(
+            item for item in kb.list_attachments(conn, root_id) if item.filename == "task-contract.json"
+        )
+    assert delivery_env.repo not in Path(contract_attachment.stored_path).parents
+
+
+def test_contract_hash_is_stored_in_event(delivery_env):
+    _, root_id = create(delivery_env)
+    with kb.connect() as conn:
+        event = next(e for e in kb.list_events(conn, root_id) if e.kind == "feature_delivery_created")
+    assert len(event.payload["contract_sha256"]) == 64
+
+
+def test_happy_path_delivers(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    assert result.current_state == "DELIVERED"
+    assert result.delivery_status == "Feature Delivery Gate Passed"
+    assert result.developer_commit == result.tested_commit == result.accepted_commit
+
+
+def test_developer_blocked_stops(delivery_env):
+    runner, root_id = create(delivery_env, FakeExecutor(delivery_env.repo, [("developer", "blocked")]))
+    result = runner.run(root_id)
+    assert result.current_state == "BLOCKED"
+    assert "external_environment_missing" in result.blocked_reason
+
+
+@pytest.mark.parametrize(
+    ("outcome", "reason"),
+    [("bad_commit", "commit_mismatch"), ("dirty", "dirty_worktree"), ("non_descendant", "commit_mismatch")],
+)
+def test_invalid_developer_commit_is_blocked(delivery_env, outcome, reason):
+    runner, root_id = create(delivery_env, FakeExecutor(delivery_env.repo, [("developer", outcome)]))
+    assert reason in runner.run(root_id).blocked_reason
+
+
+def test_tester_pass_advances_to_acceptance_and_delivery(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    assert runner.run(root_id).current_state == "DELIVERED"
+    assert [call[0] for call in fake.calls] == ["developer", "tester", "acceptance"]
+
+
+def test_tester_fail_returns_to_new_developer_commit(delivery_env):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [("developer", "ready"), ("tester", "fail"), ("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")],
+    )
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    first_commit = fake.calls[1][1]
+    second_commit = fake.calls[3][1]
+    assert result.current_state == "DELIVERED"
+    assert result.fix_loops == 1
+    assert first_commit != second_commit == result.developer_commit
+
+
+def test_tester_commit_mismatch_blocks(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "mismatch")])
+    runner, root_id = create(delivery_env, fake)
+    assert "commit_mismatch" in runner.run(root_id).blocked_reason
+
+
+def test_tester_source_mutation_blocks(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "mutate")])
+    runner, root_id = create(delivery_env, fake)
+    assert "tester_modified_source" in runner.run(root_id).blocked_reason
+
+
+def test_acceptance_reject_returns_to_developer(delivery_env):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [("developer", "ready"), ("tester", "pass"), ("acceptance", "reject"), ("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")],
+    )
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    assert result.current_state == "DELIVERED"
+    assert result.fix_loops == 1
+
+
+def test_acceptance_blocked_stops(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "blocked")])
+    runner, root_id = create(delivery_env, fake)
+    assert runner.run(root_id).current_state == "BLOCKED"
+
+
+@pytest.mark.parametrize("outcome", ["stale_head", "missing_evidence"])
+def test_acceptance_gate_denial_blocks(delivery_env, outcome):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", outcome)])
+    runner, root_id = create(delivery_env, fake)
+    assert "acceptance_gate_denied" in runner.run(root_id).blocked_reason
+
+
+def test_wrong_acceptance_marker_never_delivers(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "wrong_marker")])
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    assert result.current_state == "BLOCKED"
+    assert "invalid_report" in result.blocked_reason
+
+
+def test_fifth_fix_loop_blocks_without_sixth_developer(delivery_env):
+    script = []
+    for _ in range(5):
+        script.extend([("developer", "ready"), ("tester", "fail")])
+    fake = FakeExecutor(delivery_env.repo, script)
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    assert result.current_state == "BLOCKED"
+    assert result.fix_loops == 5
+    assert [role for role, _, _ in fake.calls].count("developer") == 5
+    assert "max_fix_loops_reached" in result.blocked_reason
+
+
+def test_new_developer_commit_clears_old_test_and_acceptance_evidence(delivery_env):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [("developer", "ready"), ("tester", "pass"), ("acceptance", "reject"), ("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")],
+    )
+    runner, root_id = create(delivery_env, fake)
+    result = runner.run(root_id)
+    assert result.tested_commit == result.developer_commit
+    assert result.accepted_commit == result.developer_commit
+    assert fake.calls[1][1] != result.developer_commit
+
+
+def test_missing_executor_blocks_with_explicit_reason(delivery_env):
+    runner, root_id = create(delivery_env)
+    result = runner.run(root_id)
+    assert "stage_executor_missing" in result.blocked_reason
+    assert "No configured stage executor" in result.blocked_reason
+
+
+def test_contract_hash_mismatch_blocks_on_run(delivery_env):
+    runner, root_id = create(delivery_env, FakeExecutor(delivery_env.repo, []))
+    with kb.connect() as conn:
+        attachment = next(a for a in kb.list_attachments(conn, root_id) if a.filename == "task-contract.json")
+    Path(attachment.stored_path).write_text("{}", encoding="utf-8")
+    result = runner.run(root_id)
+    assert result.current_state == "BLOCKED"
+    assert "contract_hash_mismatch" in result.blocked_reason
+
+
+def test_report_attachment_metadata_mismatch_blocks(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    original_transition = runner._transition
+
+    def crash_before_ready(conn, root, target, payload=None):
+        if target == FeatureDeliveryState.READY_FOR_TEST:
+            raise KeyboardInterrupt
+        return original_transition(conn, root, target, payload)
+
+    runner._transition = crash_before_ready
+    with pytest.raises(KeyboardInterrupt):
+        runner.run(root_id)
+    with kb.connect() as conn:
+        report = next(a for a in kb.list_attachments(conn, root_id) if "developer.json" in a.filename)
+    Path(report.stored_path).write_text("{}", encoding="utf-8")
+    runner._transition = original_transition
+    result = runner.resume(root_id)
+    assert "invalid_report" in result.blocked_reason
+
+
+def test_report_files_have_stable_numbering(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "pass"), ("acceptance", "accept")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    with kb.connect() as conn:
+        names = [a.filename for a in kb.list_attachments(conn, root_id) if a.filename.startswith("reports/")]
+    assert names == ["reports/001-developer.json", "reports/002-tester.json", "reports/003-acceptance.json"]
+
+
+def test_status_output_contains_required_fields(delivery_env):
+    runner, root_id = create(delivery_env)
+    output = runner.status(root_id).render()
+    for label in ("Task ID", "Current State", "Fix Loops", "Branch", "Contract Hash", "Delivery Status"):
+        assert f"{label}:" in output
+
+
+def test_ordinary_kanban_task_is_rejected_without_mutation(delivery_env):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ordinary")
+    with pytest.raises(DeliveryRunnerError, match="not a feature delivery"):
+        FeatureDeliveryRunner().status(task_id)
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+    assert task.workflow_template_id is None
+    assert task.current_step_key is None
+
+
+def test_cli_parser_supports_only_four_delivery_commands():
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_delivery_parser(subparsers, cmd_delivery=lambda _: 0)
+    for command in ("create", "run", "resume", "status"):
+        tail = ["--contract", "contract.json"] if command == "create" else ["task-id"]
+        args = parser.parse_args(["delivery", command, *tail])
+        assert args.delivery_command == command
+
+
+def test_cli_create_and_status(delivery_env, capsys):
+    runner = FeatureDeliveryRunner()
+    create_args = argparse.Namespace(delivery_command="create", contract=str(delivery_env.contract_path))
+    assert delivery_command(create_args, runner=runner) == 0
+    root_id = capsys.readouterr().out.strip()
+    status_args = argparse.Namespace(delivery_command="status", task_id=root_id)
+    assert delivery_command(status_args, runner=runner) == 0
+    assert "Current State: CONTRACT_READY" in capsys.readouterr().out
+
+
+def test_cli_run_and_resume(delivery_env, capsys):
+    runner, root_id = create(delivery_env)
+    run_args = argparse.Namespace(delivery_command="run", task_id=root_id)
+    assert delivery_command(run_args, runner=runner) == 0
+    assert "Current State: BLOCKED" in capsys.readouterr().out
+    resume_args = argparse.Namespace(delivery_command="resume", task_id=root_id)
+    assert delivery_command(resume_args, runner=runner) == 0
+    assert "Current State: BLOCKED" in capsys.readouterr().out

--- a/tests/hermes_cli/test_feature_delivery_runner.py
+++ b/tests/hermes_cli/test_feature_delivery_runner.py
@@ -419,6 +419,15 @@ def test_status_output_contains_required_fields(delivery_env):
         assert f"{label}:" in output
 
 
+def test_pid_alive_uses_cross_platform_probe(monkeypatch):
+    import gateway.status
+
+    seen = []
+    monkeypatch.setattr(gateway.status, "_pid_exists", lambda pid: seen.append(pid) or True)
+    assert FeatureDeliveryRunner._pid_alive(4242) is True
+    assert seen == [4242]
+
+
 def test_ordinary_kanban_task_is_rejected_without_mutation(delivery_env):
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="ordinary")

--- a/tests/hermes_cli/test_feature_delivery_unblock.py
+++ b/tests/hermes_cli/test_feature_delivery_unblock.py
@@ -1,0 +1,309 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.feature_delivery import (
+    FeatureDeliveryState,
+    RECOVERABLE_BLOCK_CODES,
+    is_recoverable_block,
+    resolve_resume_target,
+)
+from hermes_cli.feature_delivery_runner import (
+    DeliveryRunnerError,
+    FeatureDeliveryRunner,
+    StageExecutionError,
+)
+from hermes_cli.subcommands.delivery import delivery_command
+from tests.hermes_cli.test_feature_delivery_runner import (
+    FakeExecutor,
+    create,
+    delivery_env,
+    git,
+    stage_rows,
+)
+
+
+class FailingExecutor:
+    def __init__(self, code: str):
+        self.code = code
+
+    def execute(self, **_kwargs):
+        raise StageExecutionError(self.code, f"{self.code} for test")
+
+
+def block_in_development(delivery_env, code: str):
+    runner, root_id = create(delivery_env)
+    with kb.connect() as conn:
+        root, _ = runner._root_and_metadata(conn, root_id)
+        runner._transition(conn, root, FeatureDeliveryState.DEVELOPING)
+        root = kb.get_task(conn, root_id)
+        runner._block(conn, root, code, "terminal test block")
+    return runner, root_id
+
+
+@pytest.mark.parametrize("code", sorted(RECOVERABLE_BLOCK_CODES))
+def test_recoverable_block_policy_allows_only_explicit_codes(code):
+    assert is_recoverable_block(code)
+
+
+@pytest.mark.parametrize(
+    "code",
+    [
+        "invalid_report",
+        "max_fix_loops_reached",
+        "contract_hash_mismatch",
+        "commit_mismatch",
+        "dirty_worktree",
+        "tester_modified_source",
+        "acceptance_gate_denied",
+    ],
+)
+def test_terminal_integrity_blocks_cannot_be_unblocked(delivery_env, code):
+    runner, root_id = block_in_development(delivery_env, code)
+    with pytest.raises(DeliveryRunnerError, match="not recoverable"):
+        runner.unblock(root_id, confirmed=True)
+    assert runner.status(root_id).current_state == "BLOCKED"
+
+
+def test_unblock_requires_blocked_state_and_explicit_confirmation(delivery_env):
+    runner, root_id = create(delivery_env)
+    with pytest.raises(DeliveryRunnerError, match="not BLOCKED"):
+        runner.unblock(root_id, confirmed=True)
+
+    blocked, blocked_id = create(
+        delivery_env,
+        FakeExecutor(delivery_env.repo, [("developer", "blocked")]),
+    )
+    blocked.run(blocked_id)
+    with pytest.raises(DeliveryRunnerError, match="confirm"):
+        blocked.unblock(blocked_id)
+
+
+def test_cli_unblock_requires_confirmation_and_does_not_run_agent(
+    delivery_env, capsys
+):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "blocked")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    args = argparse.Namespace(
+        delivery_command="unblock",
+        task_id=root_id,
+        resume_stage="previous",
+        confirm=False,
+    )
+    with pytest.raises(DeliveryRunnerError, match="confirm"):
+        delivery_command(args, runner=runner)
+
+    args.confirm = True
+    assert delivery_command(args, runner=runner) == 0
+    assert "Current State: DEVELOPING" in capsys.readouterr().out
+    assert [call[0] for call in fake.calls] == ["developer"]
+
+
+@pytest.mark.parametrize(
+    ("executor", "expected_code"),
+    [
+        (None, "stage_executor_missing"),
+        (FailingExecutor("profile_missing"), "profile_missing"),
+        (FailingExecutor("stage_execution_failed"), "stage_execution_failed"),
+    ],
+)
+def test_recoverable_executor_blocks_return_to_previous_stage(
+    delivery_env, executor, expected_code
+):
+    runner, root_id = create(delivery_env, executor)
+    assert expected_code in runner.run(root_id).blocked_reason
+    status = runner.unblock(root_id, confirmed=True)
+    assert status.current_state == "DEVELOPING"
+    assert status.blocked_reason is None
+    assert expected_code in status.last_blocked_reason
+
+
+def test_resume_target_policy_rejects_arbitrary_states():
+    assert (
+        resolve_resume_target(FeatureDeliveryState.TESTING, "previous")
+        == FeatureDeliveryState.TESTING
+    )
+    assert (
+        resolve_resume_target(FeatureDeliveryState.TESTING, "developer")
+        == FeatureDeliveryState.DEVELOPING
+    )
+    with pytest.raises(ValueError, match="unsupported"):
+        resolve_resume_target(FeatureDeliveryState.TESTING, "acceptance")
+
+
+def test_tester_block_can_resume_exact_commit_and_deliver(delivery_env):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [
+            ("developer", "ready"),
+            ("tester", "blocked"),
+            ("tester", "pass"),
+            ("acceptance", "accept"),
+        ],
+    )
+    runner, root_id = create(delivery_env, fake)
+    blocked = runner.run(root_id)
+    commit = blocked.developer_commit
+    old_stage = fake.calls[-1][2]
+
+    unblocked = runner.unblock(root_id, confirmed=True)
+    assert unblocked.current_state == "TESTING"
+    assert unblocked.fix_loops == 0
+    assert [call[0] for call in fake.calls] == ["developer", "tester"]
+
+    delivered = runner.resume(root_id)
+    assert delivered.current_state == "DELIVERED"
+    assert delivered.developer_commit == delivered.tested_commit == delivered.accepted_commit == commit
+    assert fake.calls[2][2] != old_stage
+
+
+def test_developer_override_invalidates_old_evidence_and_delivers_new_commit(
+    delivery_env,
+):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [
+            ("developer", "ready"),
+            ("tester", "blocked"),
+            ("developer", "ready"),
+            ("tester", "pass"),
+            ("acceptance", "accept"),
+        ],
+    )
+    runner, root_id = create(delivery_env, fake)
+    first = runner.run(root_id).developer_commit
+    report_count = len(
+        [row for row in stage_rows(root_id) if json.loads(row["body"])["feature_delivery_stage"]]
+    )
+
+    unblocked = runner.unblock(
+        root_id, resume_stage="developer", confirmed=True
+    )
+    assert unblocked.current_state == "DEVELOPING"
+    assert unblocked.fix_loops == 0
+
+    delivered = runner.resume(root_id)
+    assert delivered.current_state == "DELIVERED"
+    assert delivered.developer_commit != first
+    assert delivered.developer_commit == delivered.tested_commit == delivered.accepted_commit
+    assert len(stage_rows(root_id)) > report_count
+
+
+def test_acceptance_block_resumes_exact_tested_commit(delivery_env):
+    fake = FakeExecutor(
+        delivery_env.repo,
+        [
+            ("developer", "ready"),
+            ("tester", "pass"),
+            ("acceptance", "blocked"),
+            ("acceptance", "accept"),
+        ],
+    )
+    runner, root_id = create(delivery_env, fake)
+    blocked = runner.run(root_id)
+    assert blocked.current_state == "BLOCKED"
+    assert runner.unblock(root_id, confirmed=True).current_state == "ACCEPTANCE"
+    delivered = runner.resume(root_id)
+    assert delivered.developer_commit == delivered.tested_commit == delivered.accepted_commit
+
+
+def test_unblock_revalidates_contract_hash(delivery_env):
+    runner, root_id = create(
+        delivery_env,
+        FakeExecutor(delivery_env.repo, [("developer", "blocked")]),
+    )
+    runner.run(root_id)
+    with kb.connect() as conn:
+        attachment = next(
+            item
+            for item in kb.list_attachments(conn, root_id)
+            if item.filename == "task-contract.json"
+        )
+    original = Path(attachment.stored_path).read_bytes()
+    Path(attachment.stored_path).write_text("{}", encoding="utf-8")
+    with pytest.raises(DeliveryRunnerError, match="contract_hash_mismatch"):
+        runner.unblock(root_id, confirmed=True)
+    Path(attachment.stored_path).write_bytes(original)
+    assert runner.status(root_id).blocked_reason.startswith("contract_hash_mismatch")
+    with pytest.raises(DeliveryRunnerError, match="not recoverable"):
+        runner.unblock(root_id, confirmed=True)
+
+
+def test_commit_mismatch_prevents_unblock(delivery_env):
+    runner, root_id = create(
+        delivery_env,
+        FakeExecutor(
+            delivery_env.repo,
+            [("developer", "ready"), ("tester", "blocked")],
+        ),
+    )
+    runner.run(root_id)
+    with kb.connect() as conn:
+        workspace = Path(kb.get_task(conn, root_id).workspace_path)
+    (workspace / "drift.txt").write_text("drift\n", encoding="utf-8")
+    git(workspace, "add", "drift.txt")
+    git(workspace, "commit", "-m", "move blocked branch")
+    with pytest.raises(DeliveryRunnerError, match="commit_mismatch"):
+        runner.unblock(root_id, confirmed=True)
+    assert runner.status(root_id).blocked_reason.startswith("commit_mismatch")
+
+
+def test_dirty_worktree_becomes_a_terminal_block(delivery_env):
+    runner, root_id = create(
+        delivery_env,
+        FakeExecutor(
+            delivery_env.repo,
+            [("developer", "ready"), ("tester", "blocked")],
+        ),
+    )
+    runner.run(root_id)
+    with kb.connect() as conn:
+        workspace = Path(kb.get_task(conn, root_id).workspace_path)
+    drift = workspace / "drift.txt"
+    drift.write_text("drift\n", encoding="utf-8")
+    with pytest.raises(DeliveryRunnerError, match="dirty_worktree"):
+        runner.unblock(root_id, confirmed=True)
+    drift.unlink()
+    assert runner.status(root_id).blocked_reason.startswith("dirty_worktree")
+    with pytest.raises(DeliveryRunnerError, match="not recoverable"):
+        runner.unblock(root_id, confirmed=True)
+
+
+def test_unblock_event_preserves_block_history(delivery_env):
+    runner, root_id = create(
+        delivery_env,
+        FakeExecutor(delivery_env.repo, [("developer", "blocked")]),
+    )
+    runner.run(root_id)
+    status = runner.unblock(root_id, confirmed=True)
+    assert status.blocked_reason is None
+    assert "external_environment_missing" in status.last_blocked_reason
+    assert status.last_unblock_target == "DEVELOPING"
+    with kb.connect() as conn:
+        events = [
+            event
+            for event in kb.list_events(conn, root_id)
+            if event.kind == "feature_delivery_unblocked"
+        ]
+    assert len(events) == 1
+    assert events[0].payload["approved_by"] == "human_cli"
+    assert events[0].payload["previous_state"] == "BLOCKED"
+    assert events[0].payload["resume_target_state"] == "DEVELOPING"
+    assert events[0].payload["contract_hash"]
+
+
+def test_ordinary_kanban_unblock_is_unchanged(delivery_env):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="ordinary")
+        assert kb.block_task(conn, task_id, reason="wait")
+        assert kb.unblock_task(conn, task_id)
+        task = kb.get_task(conn, task_id)
+    assert task.status == "ready"
+    assert task.workflow_template_id is None
+    assert task.current_step_key is None

--- a/tests/hermes_cli/test_feature_delivery_unblock.py
+++ b/tests/hermes_cli/test_feature_delivery_unblock.py
@@ -298,6 +298,101 @@ def test_unblock_event_preserves_block_history(delivery_env):
     assert events[0].payload["contract_hash"]
 
 
+def test_developer_blocked_commit_is_only_a_resume_starting_point(delivery_env):
+    class CommitThenBlock(FakeExecutor):
+        developer_feedback: tuple[str, ...] = ()
+
+        def execute(self, **kwargs):
+            if kwargs["role"] == "developer" and self.script[0] == ("developer", "commit_blocked"):
+                self.script.pop(0)
+                self.calls.append(("developer", kwargs["target_commit"], kwargs["stage_task_id"]))
+                feature = kwargs["workspace"] / "blocked-work.txt"
+                feature.write_text("unaccepted work\n", encoding="utf-8")
+                git(kwargs["workspace"], "add", "blocked-work.txt")
+                git(kwargs["workspace"], "commit", "-m", "blocked developer work")
+                return {
+                    "task_id": kwargs["task_contract"].task_id,
+                    "agent": "developer",
+                    "status": "BLOCKED",
+                    "commit": None,
+                    "implementation_summary": "runtime unavailable",
+                }
+            if kwargs["role"] == "developer":
+                self.developer_feedback = kwargs["feedback"]
+            return super().execute(**kwargs)
+
+    fake = CommitThenBlock(
+        delivery_env.repo,
+        [
+            ("developer", "ready"),
+            ("tester", "fail"),
+            ("developer", "commit_blocked"),
+            ("developer", "ready"),
+            ("tester", "pass"),
+            ("acceptance", "accept"),
+        ],
+    )
+    runner, root_id = create(delivery_env, fake)
+    blocked = runner.run(root_id)
+    old_developer_commit = blocked.developer_commit
+    blocked_head = git(delivery_env.repo, "rev-parse", delivery_env.contract["branch"])
+    assert blocked.current_state == "BLOCKED"
+    assert blocked.last_stage == "developer"
+    assert blocked.last_report_status == "BLOCKED"
+    assert blocked_head != old_developer_commit
+
+    resumed = runner.unblock(
+        root_id,
+        resume_stage="developer",
+        confirmed=True,
+        developer_context=("complete every remaining contract item",),
+    )
+    assert resumed.current_state == "DEVELOPING"
+    assert resumed.developer_commit == old_developer_commit
+    assert resumed.fix_loops == 1
+
+    delivered = runner.resume(root_id)
+    new_developer_commit = delivered.developer_commit
+    assert fake.calls[3][1] == blocked_head
+    assert new_developer_commit not in {old_developer_commit, blocked_head}
+    assert new_developer_commit == delivered.tested_commit == delivered.accepted_commit
+    assert "complete every remaining contract item" in fake.developer_feedback
+    assert any(item.startswith("LATEST_TESTER_REPORT: ") for item in fake.developer_feedback)
+    with kb.connect() as conn:
+        event = next(
+            event
+            for event in kb.list_events(conn, root_id)
+            if event.kind == "feature_delivery_development_resumed"
+        )
+    assert event.payload["development_resume_head"] == blocked_head
+    assert event.payload["authoritative_developer_commit"] == old_developer_commit
+    assert event.payload["approved_by"] == "human_cli"
+
+
+def test_developer_head_recovery_rejects_dirty_worktree(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "blocked")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    with kb.connect() as conn:
+        workspace = Path(kb.get_task(conn, root_id).workspace_path)
+    (workspace / "uncommitted.txt").write_text("dirty\n", encoding="utf-8")
+    with pytest.raises(DeliveryRunnerError, match="dirty_worktree"):
+        runner.unblock(root_id, resume_stage="developer", confirmed=True)
+
+
+def test_tester_block_cannot_adopt_a_moved_head(delivery_env):
+    fake = FakeExecutor(delivery_env.repo, [("developer", "ready"), ("tester", "blocked")])
+    runner, root_id = create(delivery_env, fake)
+    runner.run(root_id)
+    with kb.connect() as conn:
+        workspace = Path(kb.get_task(conn, root_id).workspace_path)
+    (workspace / "drift.txt").write_text("drift\n", encoding="utf-8")
+    git(workspace, "add", "drift.txt")
+    git(workspace, "commit", "-m", "unaccepted drift")
+    with pytest.raises(DeliveryRunnerError, match="commit_mismatch"):
+        runner.unblock(root_id, resume_stage="developer", confirmed=True)
+
+
 def test_ordinary_kanban_unblock_is_unchanged(delivery_env):
     with kb.connect() as conn:
         task_id = kb.create_task(conn, title="ordinary")

--- a/tests/hermes_cli/test_profile_stage_executor.py
+++ b/tests/hermes_cli/test_profile_stage_executor.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.feature_delivery import TaskContract, TesterReport
+from hermes_cli.feature_delivery_runner import StageExecutionError
+from hermes_cli.profile_stage_executor import (
+    PROFILE_BY_ROLE,
+    TOOLSETS_BY_ROLE,
+    ProfileStageExecutor,
+)
+
+
+@pytest.fixture
+def contract(tmp_path) -> TaskContract:
+    return TaskContract.model_validate(
+        {
+            "task_id": "profile-stage-test",
+            "title": "Profile stage test",
+            "objective": "Exercise the profile executor",
+            "repository": str(tmp_path),
+            "base_commit": "a" * 40,
+            "branch": "feature/profile-stage-test",
+            "acceptance_criteria": [{"id": "AC-01", "requirement": "It works"}],
+            "required_tests": ["scripts/run_tests.sh tests/example.py -q"],
+            "required_evidence": ["test_results", "git_diff"],
+        }
+    )
+
+
+@pytest.fixture
+def profiles(monkeypatch, tmp_path):
+    roots = {name: tmp_path / "profiles" / name for name in PROFILE_BY_ROLE.values()}
+    for root in roots.values():
+        root.mkdir(parents=True)
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.profile_exists",
+        lambda name: roots[name].is_dir(),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.resolve_profile_env",
+        lambda name: str(roots[name]),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor._resolve_hermes_argv",
+        lambda: ["hermes"],
+    )
+    return roots
+
+
+def report_for(role: str, task_id: str, commit: str) -> dict:
+    if role == "developer":
+        return {
+            "task_id": task_id,
+            "agent": "developer",
+            "status": "READY_FOR_TEST",
+            "commit": commit,
+            "changed_files": ["feature.py"],
+            "implementation_summary": "implemented",
+            "self_checks": ["tests passed"],
+            "known_risks": [],
+        }
+    if role == "tester":
+        return {
+            "task_id": task_id,
+            "agent": "tester",
+            "tested_commit": commit,
+            "status": "TEST_PASS",
+            "test_results": ["tests passed"],
+            "blocking_issues": [],
+            "non_blocking_issues": [],
+            "evidence": ["test_results"],
+        }
+    return {
+        "task_id": task_id,
+        "agent": "acceptance",
+        "accepted_commit": commit,
+        "status": "ACCEPT",
+        "criteria": [{"id": "AC-01", "met": True, "evidence": "verified"}],
+        "blocking_issues": [],
+        "evidence": ["git_diff"],
+        "final_marker": "FINAL: ACCEPT",
+    }
+
+
+@pytest.mark.parametrize("role", ["developer", "tester", "acceptance"])
+def test_fixed_profile_mapping_and_workspace_injection(
+    role, contract, profiles, tmp_path
+):
+    captured = {}
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+
+    def run(command, **kwargs):
+        captured.update(command=command, **kwargs)
+        payload = report_for(role, contract.task_id, contract.base_commit)
+        return subprocess.CompletedProcess(command, 0, json.dumps(payload), "")
+
+    report = ProfileStageExecutor(run_command=run).execute(
+        role=role,
+        task_contract=contract,
+        workspace=workspace,
+        target_commit=contract.base_commit,
+        feedback=(),
+        stage_task_id="stage-1",
+    )
+
+    profile = PROFILE_BY_ROLE[role]
+    assert report.agent == role
+    assert captured["command"][captured["command"].index("-p") + 1] == profile
+    assert captured["command"][captured["command"].index("--toolsets") + 1] == ",".join(
+        TOOLSETS_BY_ROLE[role]
+    )
+    assert captured["cwd"] == str(workspace)
+    assert captured["env"]["TERMINAL_CWD"] == str(workspace.resolve())
+    assert captured["env"]["HERMES_HOME"] == str(profiles[profile])
+
+
+def test_arbitrary_profile_role_is_rejected(contract, profiles, tmp_path):
+    with pytest.raises(ValueError, match="unsupported feature delivery role"):
+        ProfileStageExecutor().execute(
+            role="release",  # type: ignore[arg-type]
+            task_contract=contract,
+            workspace=tmp_path,
+            target_commit=contract.base_commit,
+            feedback=(),
+            stage_task_id="stage-1",
+        )
+
+
+@pytest.mark.parametrize("missing", ["developer", "tester", "acceptance"])
+def test_missing_required_profile_blocks_before_process(
+    missing, contract, profiles, monkeypatch, tmp_path
+):
+    calls = []
+    monkeypatch.setattr(
+        "hermes_cli.profile_stage_executor.profile_exists",
+        lambda name: name != missing,
+    )
+    executor = ProfileStageExecutor(run_command=lambda *args, **kwargs: calls.append(args))
+
+    with pytest.raises(StageExecutionError) as caught:
+        executor.execute(
+            role="developer",
+            task_contract=contract,
+            workspace=tmp_path,
+            target_commit=contract.base_commit,
+            feedback=(),
+            stage_task_id="stage-1",
+        )
+
+    assert caught.value.code == "profile_missing"
+    assert calls == []
+
+
+@pytest.mark.parametrize(
+    ("role", "payload"),
+    [
+        ("developer", {"task_id": "profile-stage-test", "agent": "developer", "status": "ACCEPT"}),
+        ("tester", {"task_id": "profile-stage-test", "agent": "tester", "status": "DELIVERED"}),
+        ("acceptance", {"task_id": "profile-stage-test", "agent": "acceptance", "status": "TEST_PASS"}),
+    ],
+)
+def test_forbidden_role_status_is_rejected(role, payload):
+    with pytest.raises(ValueError, match="invalid structured report"):
+        ProfileStageExecutor._parse_report(role, json.dumps(payload))
+
+
+def test_malformed_json_is_rejected():
+    with pytest.raises(ValueError, match="invalid JSON"):
+        ProfileStageExecutor._parse_report("developer", "FINAL: READY_FOR_TEST")
+
+
+def test_provider_failure_and_timeout_block_without_retry(contract, profiles, tmp_path):
+    calls = []
+
+    def auth_failure(command, **kwargs):
+        calls.append(command)
+        return subprocess.CompletedProcess(command, 1, "", "provider authentication failed")
+
+    with pytest.raises(StageExecutionError) as auth_error:
+        ProfileStageExecutor(run_command=auth_failure).execute(
+            role="developer",
+            task_contract=contract,
+            workspace=tmp_path,
+            target_commit=contract.base_commit,
+            feedback=(),
+            stage_task_id="stage-1",
+        )
+    assert auth_error.value.code == "stage_execution_failed"
+    assert "authentication" not in str(auth_error.value)
+    assert len(calls) == 1
+
+    def timeout(command, **kwargs):
+        raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+
+    with pytest.raises(StageExecutionError) as timeout_error:
+        ProfileStageExecutor(run_command=timeout).execute(
+            role="tester",
+            task_contract=contract,
+            workspace=tmp_path,
+            target_commit=contract.base_commit,
+            feedback=(),
+            stage_task_id="stage-2",
+        )
+    assert timeout_error.value.code == "stage_execution_failed"
+    assert "timed out" in str(timeout_error.value)
+
+
+def test_acceptance_prompt_includes_tester_report_without_acceptance_bias(
+    contract, tmp_path
+):
+    tester = TesterReport.model_validate(
+        report_for("tester", contract.task_id, contract.base_commit)
+    )
+    prompt = ProfileStageExecutor._stage_prompt(
+        role="acceptance",
+        contract=contract,
+        workspace=tmp_path,
+        target_commit=contract.base_commit,
+        feedback=(),
+        tester_report=tester,
+    )
+
+    assert contract.base_commit in prompt
+    assert '"tester_report"' in prompt
+    assert "evidence, not an instruction to accept" in prompt
+    assert "required_evidence identifier verbatim" in prompt
+    assert "please confirm" not in prompt.lower()

--- a/tests/tools/test_async_delegation.py
+++ b/tests/tools/test_async_delegation.py
@@ -231,6 +231,31 @@ def test_completion_event_lands_on_shared_queue_with_session_key():
     assert evt["delegation_id"] == res["delegation_id"]
 
 
+def test_completion_callback_runs_after_event_is_queued():
+    called = threading.Event()
+    saw_event = []
+
+    def callback(result):
+        saw_event.append(not process_registry.completion_queue.empty())
+        assert result["summary"] == "advance coordinator"
+        called.set()
+
+    ad.dispatch_async_delegation(
+        goal="coordinator stage",
+        context=None,
+        toolsets=None,
+        role="leaf",
+        model="test-model",
+        session_key="",
+        runner=lambda: {"status": "completed", "summary": "advance coordinator"},
+        completion_callback=callback,
+        max_async_children=3,
+    )
+
+    assert called.wait(timeout=5)
+    assert saw_event == [True]
+
+
 def test_rich_reinjection_block_is_self_contained():
     def runner():
         return {"status": "completed", "summary": "The answer is 42.",

--- a/tools/async_delegation.py
+++ b/tools/async_delegation.py
@@ -771,6 +771,7 @@ def dispatch_async_delegation(
     origin_ui_session_id: str = "",
     origin_session_id: str = "",
     interrupt_fn: Optional[Callable[[], None]] = None,
+    completion_callback: Optional[Callable[[Dict[str, Any]], None]] = None,
     max_async_children: int = _DEFAULT_MAX_ASYNC_CHILDREN,
     progress_fn: Optional[Callable[[], tuple]] = None,
 ) -> Dict[str, Any]:
@@ -805,6 +806,10 @@ def dispatch_async_delegation(
         token past the stale threshold marks the delegation stuck (see the
         stale-detection block at the top of this module). When omitted, the
         delegation is not monitored.
+    completion_callback
+        Optional internal continuation invoked after the durable completion
+        event is queued. Coordinator callers use this to advance their state
+        machine; ordinary delegation keeps the existing advisory chat event.
     max_async_children
         Concurrency cap. When at capacity the dispatch is REJECTED (the caller
         should fall back to sync or tell the user) rather than queued, so a
@@ -839,6 +844,7 @@ def dispatch_async_delegation(
         "_progress_token": None,
         "_progress_ts": dispatched_at,
         "_interrupted_at": None,
+        "completion_callback": completion_callback,
     }
     # Capacity check and record insert under ONE lock hold — checking
     # active_count() separately would let two concurrent dispatches (e.g.
@@ -911,8 +917,14 @@ def _finalize(delegation_id: str, result: Dict[str, Any], status: str) -> None:
     if claimed is None:
         return
     event_record, _interrupt_fn = claimed
+    callback = event_record.pop("completion_callback", None)
 
     _push_completion_event(event_record, result, status)
+    if callable(callback):
+        try:
+            callback(result)
+        except Exception:
+            logger.exception("Async delegation %s completion callback failed", delegation_id)
     _finish_finalization(delegation_id, status)
 
 
@@ -1468,7 +1480,7 @@ def list_async_delegations() -> List[Dict[str, Any]]:
             item = {
                 k: v
                 for k, v in r.items()
-                if k not in {"interrupt_fn", "progress_fn"}
+                if k not in {"interrupt_fn", "progress_fn", "completion_callback"}
                 and not k.startswith("_")
             }
             status = r.get("status")


### PR DESCRIPTION
## What does this PR do?

Adds a durable autonomous delivery coordinator that advances a feature task through developer, tester, acceptance, Git/CI/deploy, and runtime-acceptance stages without requiring manual continue messages between normal stage completions. Recoverable failures return to the appropriate repair stage, while true owner-stop conditions remain blocked for explicit input.

The implementation reuses the existing feature-delivery runner, profile stage executor, Kanban durability, and async delegation queue. Async completion callbacks run only after the durable completion event is published.

## Related Issue

No linked issue.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Add the autonomous coordinator state machine and recovery loop.
- Add durable feature-delivery contracts, runner, profile execution, and CLI wiring.
- Make task creation idempotent inside the existing Kanban write transaction.
- Advance coordinator stages from async delegation completion callbacks without exposing callbacks in status output.
- Add focused contract, resume, gate, profile, coordinator, and async-delegation tests.

## How to Test

1. Run `scripts/run_tests.sh -j 4 tests/hermes_cli/test_autonomous_coordinator.py tests/hermes_cli/test_feature_delivery.py tests/hermes_cli/test_feature_delivery_gate.py tests/hermes_cli/test_feature_delivery_profiles.py tests/hermes_cli/test_feature_delivery_resume.py tests/hermes_cli/test_feature_delivery_runner.py tests/hermes_cli/test_feature_delivery_unblock.py tests/hermes_cli/test_profile_stage_executor.py tests/tools/test_async_delegation.py -q`.
2. Confirm 271 tests pass (one macOS-only case is skipped on Windows and remains covered by the macOS CI lane).
3. Run Ruff on all Python files changed from `main` and `git diff --check origin/main...HEAD`.

## Checklist

### Code

- [x] I've read the Contributing Guide.
- [x] My commit messages follow Conventional Commits.
- [x] I searched open and closed PRs/issues for duplicates.
- [x] My PR contains only changes related to this feature.
- [x] The focused CI-parity suite passes: 271 passed, 0 failed, 1 platform skip.
- [x] I've added tests for the new behavior.
- [x] I've tested on Windows 11 with the repository's canonical test runner.

### Documentation & Housekeeping

- [x] Documentation updates are N/A; public behavior is documented in CLI help and docstrings.
- [x] `cli-config.yaml.example` is N/A; no config key was added.
- [x] `CONTRIBUTING.md` / `AGENTS.md` updates are N/A.
- [x] Cross-platform impact was considered; process and path behavior use existing repository abstractions.
- [x] Tool descriptions/schemas are N/A.

## Screenshots / Logs

Focused local validation: 271 passed, 0 failed, 1 macOS-only skip. Ruff, diff-check, and secret scan passed.