### PR TITLE
fix(gemini): sanitize lone surrogates in native Gemini tool-call args (#102757)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -5022,54 +5022,65 @@ def run_conversation(
                 # first to strip surrogates, then once more for pure
                 # ASCII-only locale sanitization if needed.
                 # -----------------------------------------------------------
-                if isinstance(api_error, UnicodeEncodeError) and getattr(agent, '_unicode_sanitization_passes', 0) < 2:
+                if getattr(agent, '_unicode_sanitization_passes', 0) < 2:
                     _err_str = str(api_error).lower()
-                    _is_ascii_codec = "'ascii'" in _err_str or "ascii" in _err_str
-                    # Detect surrogate errors — utf-8 codec refusing to
-                    # encode U+D800..U+DFFF.  The error text is:
-                    #   "'utf-8' codec can't encode characters in position
-                    #    N-M: surrogates not allowed"
-                    _is_surrogate_error = (
-                        "surrogate" in _err_str
-                        or ("'utf-8'" in _err_str and not _is_ascii_codec)
-                    )
-                    # Sanitize surrogates from both the canonical `messages`
-                    # list AND `api_messages` (the API-copy, which may carry
-                    # `reasoning_content`/`reasoning_details` transformed
-                    # from `reasoning` — fields the canonical list doesn't
-                    # have directly).  Also clean `api_kwargs` if built and
-                    # `prefill_messages` if present.  Mirrors the ASCII
-                    # codec recovery below.
-                    _surrogates_found = _sanitize_messages_surrogates(messages)
-                    if isinstance(api_messages, list):
-                        if _sanitize_messages_surrogates(api_messages):
-                            _surrogates_found = True
-                    if isinstance(api_kwargs, dict):
-                        if _sanitize_structure_surrogates(api_kwargs):
-                            _surrogates_found = True
-                    if isinstance(getattr(agent, "prefill_messages", None), list):
-                        if _sanitize_messages_surrogates(agent.prefill_messages):
-                            _surrogates_found = True
-                    # Gate the retry on the error type, not on whether we
-                    # found anything — _force_ascii_payload / the extended
-                    # surrogate walker above cover all known paths, but a
-                    # new transformed field could still slip through.  If
-                    # the error was a surrogate encode failure, always let
-                    # the retry run; the proactive sanitizer at line ~8781
-                    # runs again on the next iteration.  Bounded by
-                    # _unicode_sanitization_passes < 2 (outer guard).
-                    if _surrogates_found or _is_surrogate_error:
-                        agent._unicode_sanitization_passes += 1
-                        if _surrogates_found:
-                            agent._buffer_vprint(
-                                "⚠️  Stripped invalid surrogate characters from messages. Retrying..."
-                            )
-                        else:
-                            agent._buffer_vprint(
-                                "⚠️  Surrogate encoding error — retrying after full-payload sanitization..."
-                            )
-                        continue
-                    if _is_ascii_codec:
+                    # Some providers (notably the native Gemini httpx path)
+                    # raise the surrogates error wrapped in a higher-level
+                    # exception (GeminiAPIError / HTTPError) whose type is
+                    # not UnicodeEncodeError but whose message still carries
+                    # "surrogates not allowed". Detect by string, not type
+                    # alone, so the stranded-surrogate history is cleaned
+                    # instead of being retried verbatim 3 times (issue #102757).
+                    _is_surrogate_string = "surrogate" in _err_str
+                    _is_unicode_type = isinstance(api_error, UnicodeEncodeError)
+                    if _is_surrogate_string or _is_unicode_type or "'utf-8'" in _err_str:
+                        _is_ascii_codec = "'ascii'" in _err_str or "ascii" in _err_str
+                        # Detect surrogate errors — utf-8 codec refusing to
+                        # encode U+D800..U+DFFF.  The error text is:
+                        #   "'utf-8' codec can't encode characters in position
+                        #    N-M: surrogates not allowed"
+                        _is_surrogate_error = (
+                            "surrogate" in _err_str
+                            or ("'utf-8'" in _err_str and not _is_ascii_codec)
+                        )
+                        # Sanitize surrogates from both the canonical `messages`
+                        # list AND `api_messages` (the API-copy, which may carry
+                        # `reasoning_content`/`reasoning_details` transformed
+                        # from `reasoning` — fields the canonical list doesn't
+                        # have directly).  Also clean `api_kwargs` if built and
+                        # `prefill_messages` if present.  Mirrors the ASCII
+                        # codec recovery below.
+                        _surrogates_found = _sanitize_messages_surrogates(messages)
+                        if isinstance(api_messages, list):
+                            if _sanitize_messages_surrogates(api_messages):
+                                _surrogates_found = True
+                        if isinstance(api_kwargs, dict):
+                            if _sanitize_structure_surrogates(api_kwargs):
+                                _surrogates_found = True
+                        if isinstance(getattr(agent, "prefill_messages", None), list):
+                            if _sanitize_messages_surrogates(agent.prefill_messages):
+                                _surrogates_found = True
+                        # Gate the retry on the error type, not on whether we
+                        # found anything — _force_ascii_payload / the extended
+                        # surrogate walker above cover all known paths, but a
+                        # new transformed field could still slip through.  If
+                        # the error was a surrogate encode failure, always let
+                        # the retry run; the proactive sanitizer at line ~8781
+                        # runs again on the next iteration.  Bounded by
+                        # _unicode_sanitization_passes < 2 (outer guard).
+                        if _surrogates_found or _is_surrogate_error:
+                            agent._unicode_sanitization_passes += 1
+                            if _surrogates_found:
+                                agent._buffer_vprint(
+                                    "⚠️  Stripped invalid surrogate characters from messages. Retrying..."
+                                )
+                            else:
+                                agent._buffer_vprint(
+                                    "⚠️  Surrogate encoding error — retrying after full-payload sanitization..."
+                                )
+                            continue
+                    if "'ascii'" in _err_str or "ascii" in _err_str:
+                        _is_ascii_codec = True
                         agent._force_ascii_payload = True
                         # ASCII codec: the system encoding can't handle
                         # non-ASCII characters at all. Sanitize all

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -33,6 +33,46 @@ from agent.gemini_schema import sanitize_gemini_tool_parameters
 
 logger = logging.getLogger(__name__)
 
+# Lone surrogates (U+D800..U+DFFF) are invalid in UTF-8 and crash
+# json.dumps(...).encode("utf-8") inside httpx. Native Gemini can return
+# them as JSON-escaped lone surrogates in functionCall args (issue #102757).
+# Clean them at the Gemini boundary so a single bad tool arg does not
+# poison the whole session history.
+_SURROGATE_RE = re.compile(r"[\ud800-\udfff]")
+
+
+def _sanitize_surrogate_text(text: str) -> str:
+    if _SURROGATE_RE.search(text):
+        return _SURROGATE_RE.sub("\ufffd", text)
+    return text
+
+
+def _sanitize_surrogate_structure(payload: Any) -> bool:
+    """Replace lone surrogates in nested dict/list payloads in-place. Returns True if replaced."""
+    found = False
+
+    def _walk(node: Any) -> None:
+        nonlocal found
+        if isinstance(node, dict):
+            for key, value in list(node.items()):
+                if isinstance(value, str):
+                    if _SURROGATE_RE.search(value):
+                        node[key] = _SURROGATE_RE.sub("\ufffd", value)
+                        found = True
+                elif isinstance(value, (dict, list)):
+                    _walk(value)
+        elif isinstance(node, list):
+            for idx, value in enumerate(node):
+                if isinstance(value, str):
+                    if _SURROGATE_RE.search(value):
+                        node[idx] = _SURROGATE_RE.sub("\ufffd", value)
+                        found = True
+                elif isinstance(value, (dict, list)):
+                    _walk(value)
+
+    _walk(payload)
+    return found
+
 try:
     import hermes_cli as _hermes_cli
 
@@ -337,6 +377,12 @@ def _translate_tool_call_to_gemini(
         args = {"_raw": args_raw}
     if not isinstance(args, dict):
         args = {"_value": args}
+    # Sanitize lone surrogates that may have entered history via a prior
+    # Gemini functionCall (issue #102757). The translate-time sanitize
+    # in translate_gemini_response handles new returns, but history replay
+    # must also be clean — otherwise building the next request's
+    # functionCall.args poisons json.dumps inside httpx.
+    _sanitize_surrogate_structure(args)
 
     part: Dict[str, Any] = {
         "functionCall": {
@@ -768,17 +814,32 @@ def translate_gemini_response(resp: Dict[str, Any], model: str) -> SimpleNamespa
         if not isinstance(part, dict):
             continue
         if part.get("thought") is True and isinstance(part.get("text"), str):
-            reasoning_pieces.append(part["text"])
+            reasoning_pieces.append(_sanitize_surrogate_text(part["text"]))
             continue
         if isinstance(part.get("text"), str):
-            text_pieces.append(part["text"])
+            text_pieces.append(_sanitize_surrogate_text(part["text"]))
             continue
         fc = part.get("functionCall")
         if isinstance(fc, dict) and fc.get("name"):
+            # Sanitize lone surrogates in the model-returned args before
+            # they enter the session. A Gemini functionCall can carry
+            # JSON-escaped lone surrogates (e.g. job_id "\ud800") that
+            # would otherwise poison all future turns with
+            # UnicodeEncodeError on json.dumps (issue #102757).
+            fc_args = fc.get("args") or {}
+            if isinstance(fc_args, dict):
+                # Work on a shallow copy so we don't mutate the raw response
+                fc_args = dict(fc_args)
+                _sanitize_surrogate_structure(fc_args)
+            else:
+                fc_args = {}
             try:
-                args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False)
+                args_str = json.dumps(fc_args, ensure_ascii=False)
             except (TypeError, ValueError):
                 args_str = "{}"
+            # Belt-and-suspenders: if any surrogate survived the structured
+            # pass (e.g. non-dict args), clean the serialized string too.
+            args_str = _sanitize_surrogate_text(args_str)
             tool_call = SimpleNamespace(
                 id=(
                     str(fc["id"])
@@ -911,17 +972,24 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
         if not isinstance(part, dict):
             continue
         if part.get("thought") is True and isinstance(part.get("text"), str):
-            chunks.append(_make_stream_chunk(model=model, reasoning=part["text"]))
+            chunks.append(_make_stream_chunk(model=model, reasoning=_sanitize_surrogate_text(part["text"])))
             continue
         if isinstance(part.get("text"), str) and part["text"]:
-            chunks.append(_make_stream_chunk(model=model, content=part["text"]))
+            chunks.append(_make_stream_chunk(model=model, content=_sanitize_surrogate_text(part["text"])))
         fc = part.get("functionCall")
         if isinstance(fc, dict) and fc.get("name"):
-            name = str(fc["name"])
+            name = _sanitize_surrogate_text(str(fc["name"]))
+            fc_args = fc.get("args") or {}
+            if isinstance(fc_args, dict):
+                fc_args = dict(fc_args)
+                _sanitize_surrogate_structure(fc_args)
+            else:
+                fc_args = {}
             try:
-                args_str = json.dumps(fc.get("args") or {}, ensure_ascii=False, sort_keys=True)
+                args_str = json.dumps(fc_args, ensure_ascii=False, sort_keys=True)
             except (TypeError, ValueError):
                 args_str = "{}"
+            args_str = _sanitize_surrogate_text(args_str)
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
             call_key = json.dumps(
                 {


### PR DESCRIPTION
Native Gemini can return JSON-escaped lone surrogates (e.g. `"job_id": "\ud800"`) in `functionCall` args. Hermes persisted the raw surrogate into the session, then `httpx/json.dumps` failed with `UnicodeEncodeError: surrogates not allowed` on every follow-up request, making the session unusable even though the tool returned normally.

- Sanitize at the Gemini boundary (`translate_gemini_response`, `translate_stream_event`) before tool calls enter history, so a single bad arg is replaced with U+FFFD before execution and never poisons later turns.
- Sanitize replayed history in `_translate_tool_call_to_gemini` (defense in depth for already-persisted poisoned turns).
- Sanitize text/reasoning parts in the same paths.
- Broaden `conversation_loop`'s `UnicodeEncodeError` recovery to trigger on wrapped errors whose message contains "surrogate" (GeminiAPIError), not just bare `UnicodeEncodeError`, so the 3-retry loop actually cleans history.

Fixes #102757

**Tests:** `test_surrogate_chokepoints` 7 passed, `test_unicode_ascii_codec` 17 passed, `test_gemini_native_adapter` 29 passed, plus manual repro covering ingestion, history replay, build_request, and streaming all show surrogates replaced and utf-8 encode succeeding.