### PR TITLE
fix(stream): distinguish clean-EOF no-finish_reason from a transport drop

### DIFF
--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3609,13 +3609,22 @@ def _build_partial_stream_stub(
     role, full_content, full_reasoning, model_name, usage_obj, *,
     dropped_tool_names=None,
 ):
-    """Build a partial-stream-stub response for mid-stream drop scenarios.
+    """Build a partial-stream-stub response for a clean-EOF drop.
 
     Used when the SSE stream ends without a ``finish_reason`` after
-    delivering content (text-only drops, tool-call-arg drops).  The stub
-    is tagged ``PARTIAL_STREAM_STUB_ID`` with ``FINISH_REASON_LENGTH`` so
-    the conversation loop enters its continuation/retry path instead of
-    silently accepting truncated output as a complete turn (#32086).
+    delivering content (text-only drops, tool-call-arg drops) — the
+    provider closed the connection with no exception, not a transport
+    failure.  The stub is tagged ``PARTIAL_STREAM_STUB_ID`` with
+    ``FINISH_REASON_LENGTH`` so the conversation loop enters its
+    continuation/retry path instead of silently accepting truncated
+    output as a complete turn (#32086).
+
+    ``_clean_eof`` distinguishes this case from the transport-exception
+    stub built after retries are exhausted (same id/finish_reason, but a
+    real ``httpx``/SDK error was caught) so the conversation loop and log
+    lines can stop conflating "the network dropped the connection" with
+    "the server ended the stream without ever sending finish_reason"
+    (#102766) — the two require opposite remediation.
     """
     mock_message = SimpleNamespace(
         role=role,
@@ -3634,6 +3643,7 @@ def _build_partial_stream_stub(
         choices=[mock_choice],
         usage=usage_obj,
         _dropped_tool_names=dropped_tool_names or None,
+        _clean_eof=True,
     )
 
 
@@ -4537,6 +4547,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 # upstreams have been seen sending 1 / "true".
                 if last_one in (True, 1, "true") and finish_reason is None:
                     finish_reason = "stop"
+                    _diag["finish_reason_seen"] = True
                 continue
 
             delta = chunk.choices[0].delta
@@ -4552,6 +4563,7 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
             chunk_finish_reason = getattr(chunk.choices[0], "finish_reason", None)
             if chunk_finish_reason:
                 finish_reason = chunk_finish_reason
+                _diag["finish_reason_seen"] = True
             if hasattr(chunk, "usage") and chunk.usage:
                 usage_obj = chunk.usage
 
@@ -4829,9 +4841,12 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
                 for idx in sorted(tool_calls_acc)
             ]
             logger.warning(
-                "Stream ended with no finish_reason while a tool call's "
-                "arguments were still incomplete (tools=%s); treating as a "
-                "mid-tool-call stream drop, not an output-length truncation.",
+                "Clean EOF, no finish_reason: server ended the stream (no "
+                "transport exception) while a tool call's arguments were "
+                "still incomplete (tools=%s). Not a network drop and not "
+                "an output-length truncation — the server or an "
+                "intermediary closed the connection without ever sending "
+                "a terminal chunk.",
                 _dropped_names,
             )
             return _build_partial_stream_stub(
@@ -4859,8 +4874,11 @@ def interruptible_streaming_api_call(agent, api_kwargs: dict, *, on_first_delta=
         )
         if _text_only_dropped_no_finish:
             logger.warning(
-                "Stream ended with no finish_reason after delivering text "
-                "with no tool calls; treating as a mid-stream drop."
+                "Clean EOF, no finish_reason: server ended the stream (no "
+                "transport exception) after delivering text with no tool "
+                "calls. Not a network drop — the server or an "
+                "intermediary closed the connection without ever sending "
+                "a terminal chunk."
             )
             return _build_partial_stream_stub(
                 role, full_content,

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4148,11 +4148,28 @@ def run_conversation(
 
                 if finish_reason == "length":
                     if getattr(response, "id", "") == PARTIAL_STREAM_STUB_ID:
-                        agent._vprint(
-                            f"{agent.log_prefix}⚠️  Response truncated — stream "
-                            f"ended before completion",
-                            force=True,
-                        )
+                        # Same stub id/finish_reason covers two distinct
+                        # failure modes (#102766): a genuine transport
+                        # exception (network dropped mid-stream — retry is
+                        # correct) versus a clean EOF where the server (or
+                        # an intermediary) closed the connection with no
+                        # exception and no finish_reason ever seen. Report
+                        # them differently so the user isn't sent chasing
+                        # a network problem that a stream_diag log with
+                        # finish_reason_seen=False would have ruled out.
+                        if getattr(response, "_clean_eof", False):
+                            agent._vprint(
+                                f"{agent.log_prefix}⚠️  Response truncated — "
+                                f"server ended the stream without ever "
+                                f"sending finish_reason (not a network drop)",
+                                force=True,
+                            )
+                        else:
+                            agent._vprint(
+                                f"{agent.log_prefix}⚠️  Response truncated — stream "
+                                f"ended before completion",
+                                force=True,
+                            )
                     else:
                         agent._vprint(
                             f"{agent.log_prefix}⚠️  Response truncated "

--- a/agent/stream_diag.py
+++ b/agent/stream_diag.py
@@ -52,6 +52,13 @@ def stream_diag_init() -> Dict[str, Any]:
         "bytes": 0,
         "headers": {},
         "http_status": None,
+        # Set True the moment a terminal chunk (finish_reason or an
+        # equivalent lastOne/close sentinel) is observed on this attempt.
+        # Read by log_stream_retry so a retry/exhaustion WARNING can tell
+        # "the connection died before the server ever finished" (type-1,
+        # this stays False) from "the server finished but something after
+        # that point still raised" (type-2, this is True) — see #102766.
+        "finish_reason_seen": False,
     }
 
 
@@ -137,9 +144,13 @@ def log_stream_retry(
     When *diag* is provided (the per-attempt stream-diagnostic dict from
     :func:`stream_diag_init`), the WARNING also captures upstream headers
     (cf-ray, x-openrouter-provider, x-openrouter-id), HTTP status, bytes
-    streamed before the drop, and elapsed time on the dying attempt.
-    These are the breadcrumbs needed to answer "is one CF edge / one
-    downstream provider responsible, or is it random across runs?"
+    streamed before the drop, elapsed time on the dying attempt, and
+    whether a terminal ``finish_reason`` was ever observed on this attempt
+    before *error* was raised. These are the breadcrumbs needed to answer
+    "is one CF edge / one downstream provider responsible, or is it random
+    across runs?" and, per #102766, to tell a mid-flight transport failure
+    (``finish_reason_seen=False``) from an exception raised after the
+    server had already reported completion.
     """
     try:
         try:
@@ -163,6 +174,7 @@ def log_stream_retry(
         _ttfb = None
         _headers_repr = "-"
         _http_status = "-"
+        _finish_reason_seen = False
         if isinstance(diag, dict):
             try:
                 _bytes = int(diag.get("bytes") or 0)
@@ -179,6 +191,7 @@ def log_stream_retry(
                     )
                 if diag.get("http_status") is not None:
                     _http_status = str(diag.get("http_status"))
+                _finish_reason_seen = bool(diag.get("finish_reason_seen"))
             except Exception:
                 pass
 
@@ -188,6 +201,7 @@ def log_stream_retry(
             "error_type=%s error=%s "
             "chain=%s "
             "http_status=%s bytes=%d chunks=%d elapsed=%.2fs ttfb=%s "
+            "finish_reason_seen=%s "
             "upstream=[%s]",
             kind,
             attempt,
@@ -204,6 +218,7 @@ def log_stream_retry(
             _chunks,
             _elapsed,
             f"{_ttfb:.2f}s" if _ttfb is not None else "-",
+            _finish_reason_seen,
             _headers_repr,
             extra={"mid_tool_call": mid_tool_call},
         )

--- a/tests/run_agent/test_partial_stream_finish_reason.py
+++ b/tests/run_agent/test_partial_stream_finish_reason.py
@@ -89,6 +89,12 @@ class TestPartialStreamStubFinishReason:
         )
         assert response.choices[0].message.content == "Here's my answer so far"
         assert response.choices[0].message.tool_calls is None
+        assert getattr(response, "_clean_eof", False) is False, (
+            "A stub built after a real transport exception (RuntimeError "
+            "here) must NOT be tagged _clean_eof — that tag is reserved "
+            "for a stream that ended with no exception and no "
+            "finish_reason, a distinct failure class (#102766)."
+        )
 
 
 class TestTerminalChunkFenceException:
@@ -179,6 +185,11 @@ class TestTerminalChunkFenceException:
 
         assert response.id == PARTIAL_STREAM_STUB_ID
         assert response.choices[0].finish_reason == FINISH_REASON_LENGTH
+        assert response._clean_eof is True, (
+            "The stream ended with no exception and no finish_reason — "
+            "that is the clean-EOF class the fix for #102766 must tag "
+            "distinctly from a genuine transport drop."
+        )
 
 
 # ── Clean stream-end mid-tool-call (no exception, no finish_reason) ─────────
@@ -236,6 +247,11 @@ class TestCleanStreamEndMidToolCall:
             "Incomplete tool args must never auto-execute."
         )
         assert getattr(response, "_dropped_tool_names", None) == ["execute_code"]
+        assert response._clean_eof is True, (
+            "No exception was raised and no finish_reason ever arrived — "
+            "this is the clean-EOF class the fix for #102766 must tag "
+            "distinctly from a genuine transport drop."
+        )
 
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4451,6 +4451,73 @@ class TestRunConversation:
         assert "truncated due to output length limit" in result["error"]
         mock_handle_function_call.assert_not_called()
 
+    def test_clean_eof_stub_gets_distinct_truncation_message(self, agent):
+        """#102766: a clean-EOF partial-stream stub (stream ended with no
+        transport exception and no finish_reason) must not print the same
+        'stream ended before completion' wording used for a genuine
+        network drop — that wording sends the user chasing a network
+        problem a stream_diag log with finish_reason_seen=False would
+        already have ruled out."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        self._setup_agent(agent)
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        resp = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
+        resp.id = PARTIAL_STREAM_STUB_ID
+        resp._clean_eof = True
+        agent.client.chat.completions.create.return_value = resp
+
+        printed = []
+        agent._print_fn = lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+
+        with (
+            patch("run_agent.handle_function_call"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("write the report")
+
+        text = " ".join(printed)
+        assert "server ended the stream without ever sending finish_reason" in text
+        assert "stream ended before completion" not in text
+
+    def test_transport_drop_stub_keeps_original_truncation_message(self, agent):
+        """Companion to the clean-EOF test above: a stub NOT tagged
+        _clean_eof (the shape built after a real transport exception) must
+        keep printing the original 'stream ended before completion'
+        wording — issue #102766 asks that this case's existing wording
+        stay as-is, only the clean-EOF case gets new wording."""
+        from hermes_constants import PARTIAL_STREAM_STUB_ID
+
+        self._setup_agent(agent)
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        resp = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
+        resp.id = PARTIAL_STREAM_STUB_ID
+        agent.client.chat.completions.create.return_value = resp
+
+        printed = []
+        agent._print_fn = lambda *a, **k: printed.append(" ".join(str(x) for x in a))
+
+        with (
+            patch("run_agent.handle_function_call"),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("write the report")
+
+        text = " ".join(printed)
+        assert "stream ended before completion" in text
+
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
         """When tool call args are truncated, the agent retries the API call
         (up to 3 times). If a retry succeeds (valid JSON args), tool execution

--- a/tests/run_agent/test_stream_drop_logging.py
+++ b/tests/run_agent/test_stream_drop_logging.py
@@ -43,6 +43,7 @@ def test_stream_diag_init_returns_well_formed_dict():
     assert diag["first_chunk_at"] is None
     assert diag["http_status"] is None
     assert diag["headers"] == {}
+    assert diag["finish_reason_seen"] is False
 
 
 class _FakeHeaders:
@@ -210,6 +211,37 @@ def test_emit_stream_drop_ui_includes_elapsed_when_available():
     assert "after" in msg and "s" in msg
 
 
+
+
+def test_log_stream_retry_reports_finish_reason_seen(caplog):
+    """#102766: the retry/exhaustion WARNING must say whether a terminal
+    finish_reason was ever observed on the dying attempt, so a post-hoc
+    grep can tell "the connection died before the server finished"
+    (finish_reason_seen=False, a genuine transport drop) from "something
+    raised after the server had already reported completion"
+    (finish_reason_seen=True) instead of treating every exception on a
+    streaming attempt as the same undifferentiated drop.
+    """
+    agent = _make_agent()
+    agent.provider = "openrouter"
+
+    diag_before_finish = AIAgent._stream_diag_init()
+    diag_after_finish = AIAgent._stream_diag_init()
+    diag_after_finish["finish_reason_seen"] = True
+
+    with caplog.at_level(logging.WARNING, logger="run_agent"):
+        agent._log_stream_retry(
+            kind="drop", error=ConnectionError("x"), attempt=1, max_attempts=3,
+            mid_tool_call=False, diag=diag_before_finish,
+        )
+        agent._log_stream_retry(
+            kind="drop", error=ConnectionError("y"), attempt=2, max_attempts=3,
+            mid_tool_call=False, diag=diag_after_finish,
+        )
+
+    msgs = [r.getMessage() for r in caplog.records if "Stream drop" in r.getMessage()]
+    assert "finish_reason_seen=False" in msgs[0]
+    assert "finish_reason_seen=True" in msgs[1]
 
 
 def test_quiet_mode_does_not_clobber_runagent_logger_level():


### PR DESCRIPTION
## What does this PR do?

Fixes #102766.

The user-visible warning "Response truncated — stream ended before
completion" and the log line "...treating as a mid-stream drop" fired
identically for two distinct failure classes:

1. **Genuine transport interruption** — an `httpx`/SDK exception
   (`RemoteProtocolError`, connection reset, etc.) killed the stream.
   Retrying is correct.
2. **Clean EOF** — the provider (or an intermediary) closed the SSE
   connection cleanly, no exception raised, but no terminal chunk ever
   carried `finish_reason`. This is not a network drop; it's the server
   (or Hermes's own terminal-chunk handling) never signalling
   completion.

Both cases built the same `PARTIAL_STREAM_STUB_ID` stub and printed the
same wording, so users chasing case 2 ended up debugging their network
when the network was never at fault (the issue's field report: 45
type-2 vs 4 type-1 events in one session, all logged identically).

### Changes

- `agent/chat_completion_helpers.py`: `_build_partial_stream_stub()` —
  used only by the two clean-EOF call sites inside the streaming loop
  (never by the exception-driven stub built after retries are
  exhausted) — now tags its stub `_clean_eof=True`. The two
  `logger.warning(...)` calls at those sites no longer say "drop"; they
  say "clean EOF, no finish_reason" and explicitly note no transport
  exception occurred.
- `agent/conversation_loop.py`: when reporting a `finish_reason ==
  "length"` stub, checks `_clean_eof` to pick distinct user-facing
  wording. The existing "stream ended before completion" wording for a
  genuine transport drop is unchanged, per the issue's ask ("current
  behavior, fine").
- `agent/stream_diag.py`: `stream_diag_init()`'s per-attempt dict gains
  `finish_reason_seen` (default `False`), set the moment a terminal
  chunk is observed on that attempt. `log_stream_retry()`'s structured
  WARNING now includes `finish_reason_seen=%s`, so a retry/exhaustion
  log line can say whether the server had already reported completion
  before the exception that triggered the retry.

`done_marker_seen` (also requested in the issue) was left out: the
OpenAI SDK's stream iterator consumes the raw `[DONE]` SSE sentinel
internally and doesn't expose it, so surfacing it would require
hooking the SDK's SSE decoder — out of scope for this fix.

## Test plan

Added/extended tests proving the new behavior and that it fails
without the fix:

- `tests/run_agent/test_partial_stream_finish_reason.py`:
  `test_genuine_truncation_without_finish_still_drops` and
  `test_no_finish_reason_partial_tool_args_routes_to_stub` now assert
  `response._clean_eof is True` for the two clean-EOF paths;
  `test_text_only_partial_returns_length` (exception-driven) asserts
  `_clean_eof` is *not* set.
- `tests/run_agent/test_stream_drop_logging.py`: new
  `test_log_stream_retry_reports_finish_reason_seen` asserts the
  WARNING carries `finish_reason_seen=False`/`True` correctly;
  `test_stream_diag_init_returns_well_formed_dict` extended for the new
  key.
- `tests/run_agent/test_run_agent.py`: new
  `test_clean_eof_stub_gets_distinct_truncation_message` and
  `test_transport_drop_stub_keeps_original_truncation_message` drive
  `run_conversation()` end-to-end and assert the printed message
  differs by `_clean_eof`.

Verified each new/extended assertion fails against the pre-fix source
(`git checkout HEAD~1 -- agent/chat_completion_helpers.py
agent/conversation_loop.py agent/stream_diag.py`, rerun, restore) —
e.g. `KeyError: 'finish_reason_seen'`, and the clean-EOF message test
failing because the old code prints the generic "stream ended before
completion" line for both classes.

```
$ python -m pytest tests/run_agent/test_stream_drop_logging.py tests/run_agent/test_partial_stream_finish_reason.py -q
34 passed in 9.59s

$ python -m pytest tests/run_agent/test_run_agent.py -q -k "clean_eof_stub or transport_drop_stub"
2 passed, 283 deselected in 2.98s

$ python -m pytest tests/run_agent/test_run_agent.py tests/run_agent/test_streaming.py tests/run_agent/test_first_chunk_at_hook.py tests/run_agent/test_continuation_ceiling_wedge.py tests/run_agent/test_continuation_repetition_guard.py tests/run_agent/test_direct_contexts_stream_inline.py -q
4 failed, 344 passed, 4 skipped, 1 warning in 74.81s
```

The 4 failures are pre-existing and unrelated: `ImportError: The
'anthropic' package is required for the Anthropic provider` — this
sandbox's venv doesn't have the optional `anthropic` extra installed.
Confirmed identical failure on the unmodified tree before these
changes.

`ruff check` on all changed files: all checks passed.

## AI assistance disclosure

This change was written by an AI coding agent (Claude, via Claude Code)
operating autonomously against the issue description and the current
codebase, including test authoring and verification.
