### PR TITLE
feat(display): collapse repeated model-fallback and provider auth-error notices behind display.fallback_notifications

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1369,6 +1369,17 @@ in config.yaml (or `HERMES_BACKGROUND_NOTIFICATIONS` env var):
 - `error` — only the final raw-output message when exit code != 0
 - `off` — no watcher messages at all
 
+### Model Fallback Notices (Gateway)
+
+A provider outage walks the fallback chain and posts one "⚠️ Model fallback: …" line per hop plus
+one "⚠️ Provider authentication failed …" reply per failed attempt. `display.fallback_notifications`
+(`on` | `collapse` | `off`, default `on`) and `display.fallback_notice_interval_seconds` (default
+3600) gate the **user-facing** notices only; the log lines are unconditional. `collapse` emits at
+most one notice per session per interval and folds the suppressed hop count into the next one.
+The shared renderer is `agent/notice_collapse.py` — every gateway site that surfaces a provider
+auth failure must go through `provider_auth_error_reply` / `collapse_provider_error_reply`
+(enforced by `tests/agent/test_notice_collapse.py`).
+
 ---
 
 ## Profiles: Multi-Instance Support

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1376,9 +1376,19 @@ one "⚠️ Provider authentication failed …" reply per failed attempt. `displ
 (`on` | `collapse` | `off`, default `on`) and `display.fallback_notice_interval_seconds` (default
 3600) gate the **user-facing** notices only; the log lines are unconditional. `collapse` emits at
 most one notice per session per interval and folds the suppressed hop count into the next one.
+`off` silences notices, never an answer.
+
 The shared renderer is `agent/notice_collapse.py` — every gateway site that surfaces a provider
 auth failure must go through `provider_auth_error_reply` / `collapse_provider_error_reply`
-(enforced by `tests/agent/test_notice_collapse.py`).
+(enforced by an `ast` guard over the whole `gateway/` tree in
+`tests/agent/test_notice_collapse.py`).
+
+Suppression returns `notice_collapse.SUPPRESSED_NOTICE`, not `""`, so a caller can tell "already
+told this conversation" apart from "not a provider error". Resolve it before delivery:
+`resolve_direct_reply` (a reply to a message somebody sent — collapses to one terse line, never to
+silence and never to the raw provider text) or `resolve_status_notice` (unsolicited chatter — the
+only path allowed to collapse to nothing). The window is keyed per platform **and** chat id, and is
+in-memory, so a restart or an agent-cache eviction reopens it and allows one more notice.
 
 ---
 

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3156,7 +3156,19 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # The buffered switch is surfaced on terminal failure. A successful
         # fallback clears retry chatter, so retain every switch as a durable
         # one-shot notice for _emit_pending_fallback_notice (run_agent.py).
-        agent._buffer_status(notice)
+        # Outside ``display.fallback_notifications: on`` the notice is collapsed
+        # at flush time; buffering the raw per-hop line here would re-expose
+        # every hop on terminal failure, so only ``on`` buffers it.  The
+        # ``Fallback activated`` log line below is emitted in every mode.
+        _notice_mode = "on"
+        try:
+            _mode_fn = getattr(agent, "_fallback_notice_mode", None)
+            if callable(_mode_fn):
+                _notice_mode = _mode_fn()
+        except Exception:
+            _notice_mode = "on"
+        if _notice_mode == "on":
+            agent._buffer_status(notice)
         pending = getattr(agent, "_pending_fallback_notice", None)
         if isinstance(pending, list):
             pending.append(notice)

--- a/agent/chat_completion_helpers.py
+++ b/agent/chat_completion_helpers.py
@@ -3160,11 +3160,18 @@ def try_activate_fallback(agent, reason: "FailoverReason | None" = None) -> bool
         # at flush time; buffering the raw per-hop line here would re-expose
         # every hop on terminal failure, so only ``on`` buffers it.  The
         # ``Fallback activated`` log line below is emitted in every mode.
+        # Fail open to "on" for anything that is not a known mode string —
+        # a mock agent hands back a truthy Mock, which must not silently
+        # change buffering.
+        from agent.notice_collapse import FALLBACK_NOTIFICATION_MODES
+
         _notice_mode = "on"
         try:
             _mode_fn = getattr(agent, "_fallback_notice_mode", None)
             if callable(_mode_fn):
-                _notice_mode = _mode_fn()
+                _resolved = _mode_fn()
+                if _resolved in FALLBACK_NOTIFICATION_MODES:
+                    _notice_mode = _resolved
         except Exception:
             _notice_mode = "on"
         if _notice_mode == "on":

--- a/agent/notice_collapse.py
+++ b/agent/notice_collapse.py
@@ -1,0 +1,268 @@
+"""Collapsing for provider fallback and provider auth-error notices.
+
+A single provider outage can walk the whole fallback chain in under a
+second.  Every hop emits its own user-facing "Model fallback: …" line and
+every failed attempt can render its own "Provider authentication failed …"
+reply, so an operator watching a chat surface sees a burst of near-identical
+messages for what is one event.
+
+``display.fallback_notifications`` (``on`` | ``collapse`` | ``off``) and
+``display.fallback_notice_interval_seconds`` (default 3600) control that:
+
+  ``on``       — unchanged: one notice per hop, one reply per failure.
+  ``collapse`` — at most ONE user-facing notice per session per interval.
+                 Hops inside the window are counted and folded into the next
+                 allowed notice.  Provider auth-error replies are deduped by
+                 error class over the same window.
+  ``off``      — no user-facing notice at all; the log lines are unchanged.
+
+The default is ``on``, so behaviour is byte-identical unless configured.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import threading
+import time as _time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+logger = logging.getLogger(__name__)
+
+FALLBACK_NOTIFICATION_MODES = ("on", "collapse", "off")
+DEFAULT_FALLBACK_NOTIFICATION_MODE = "on"
+DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS = 3600.0
+
+# Bound the per-session auth-error dedupe map so a long-lived gateway that
+# sees many session keys cannot grow it without limit.
+_MAX_TRACKED_AUTH_SESSIONS = 512
+
+
+def resolve_fallback_notification_mode(cfg: Any = None) -> str:
+    """Return the validated ``display.fallback_notifications`` mode.
+
+    An unknown value warns once per call site and falls back to ``on``, the
+    same fail-open shape as ``display.background_process_notifications``.
+    """
+    raw = _display_value(cfg, "fallback_notifications")
+    if raw is None or raw == "":
+        return DEFAULT_FALLBACK_NOTIFICATION_MODE
+    if isinstance(raw, bool):
+        # A bool is a plausible user typo for an on/off knob; honour it.
+        return "on" if raw else "off"
+    mode = str(raw).strip().lower()
+    if mode not in FALLBACK_NOTIFICATION_MODES:
+        logger.warning(
+            "Unknown display.fallback_notifications %r, defaulting to %r "
+            "(valid: %s)",
+            raw, DEFAULT_FALLBACK_NOTIFICATION_MODE,
+            ", ".join(FALLBACK_NOTIFICATION_MODES),
+        )
+        return DEFAULT_FALLBACK_NOTIFICATION_MODE
+    return mode
+
+
+def resolve_fallback_notice_interval(cfg: Any = None) -> float:
+    """Return ``display.fallback_notice_interval_seconds`` as a float.
+
+    Non-numeric or non-positive values warn and fall back to the default.
+    """
+    raw = _display_value(cfg, "fallback_notice_interval_seconds")
+    if raw is None or raw == "":
+        return DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS
+    try:
+        interval = float(raw)
+    except (TypeError, ValueError):
+        interval = -1.0
+    if interval <= 0:
+        logger.warning(
+            "Invalid display.fallback_notice_interval_seconds %r, defaulting "
+            "to %s", raw, DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS,
+        )
+        return DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS
+    return interval
+
+
+def _display_value(cfg: Any, key: str) -> Any:
+    """Read ``display.<key>`` from ``cfg``, loading user config when omitted."""
+    if cfg is None:
+        try:
+            from hermes_cli.config import load_config_readonly
+            cfg = load_config_readonly() or {}
+        except Exception:
+            return None
+    try:
+        display = cfg.get("display") or {}
+        return display.get(key)
+    except Exception:
+        return None
+
+
+# --------------------------------------------------------------------------
+# Fallback notices
+# --------------------------------------------------------------------------
+
+@dataclass
+class FallbackNoticeState:
+    """Per-session collapse window for model-fallback notices."""
+
+    last_emitted_at: Optional[float] = None
+    suppressed: int = 0
+
+    def reset(self) -> None:
+        self.last_emitted_at = None
+        self.suppressed = 0
+
+
+def _hhmm_utc(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%H:%M")
+
+
+def collapse_fallback_notices(
+    notices: list,
+    *,
+    mode: str,
+    interval: float,
+    state: FallbackNoticeState,
+    now: float,
+    current_route: Optional[str] = None,
+) -> list:
+    """Return the notice lines to emit for one flush of buffered hops.
+
+    ``on`` returns every hop unchanged.  ``off`` returns nothing.  ``collapse``
+    returns at most one line: the first hop's notice while the window is open,
+    or a folded "N further fallbacks since HH:MM UTC; now on <model>" line once
+    hops have been suppressed.  ``state`` is mutated to carry the window.
+    """
+    lines = [str(n) for n in (notices or []) if str(n).strip()]
+    if mode == "off" or not lines:
+        return []
+    if mode != "collapse":
+        return lines
+
+    if state.last_emitted_at is not None and (now - state.last_emitted_at) < interval:
+        # Window still open — count the hops and fold them into the next notice.
+        state.suppressed += len(lines)
+        return []
+
+    carried = state.suppressed
+    extra = len(lines) - 1
+    route = current_route or "the fallback model"
+    if carried:
+        since = _hhmm_utc(state.last_emitted_at or now)
+        line = (
+            f"⚠️ Model fallback: {carried + extra} further fallbacks since "
+            f"{since} UTC; now on {route}."
+        )
+    else:
+        line = lines[0]
+        if extra:
+            line = (
+                f"{line.rstrip('.')} ({extra} further fallbacks; now on {route}.)"
+            )
+    state.last_emitted_at = now
+    state.suppressed = 0
+    return [line]
+
+
+# --------------------------------------------------------------------------
+# Provider auth-error replies
+# --------------------------------------------------------------------------
+
+@dataclass
+class _AuthErrorWindow:
+    seen: dict = field(default_factory=dict)  # class digest -> last emitted ts
+    last_touched: float = 0.0
+
+
+_auth_error_windows: dict = {}
+_auth_error_lock = threading.Lock()
+
+
+def reset_provider_auth_error_state() -> None:
+    """Drop all auth-error dedupe state (tests, and gateway restarts)."""
+    with _auth_error_lock:
+        _auth_error_windows.clear()
+
+
+def provider_auth_error_reply(
+    exc: Any,
+    *,
+    session_key: Any = None,
+    mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    now: Optional[float] = None,
+    cfg: Any = None,
+) -> str:
+    """Render the user-facing provider auth-failure reply, collapsed.
+
+    The single renderer for ``⚠️ Provider authentication failed: …`` — every
+    gateway site that surfaces a provider auth failure to a user calls this so
+    one credential outage cannot produce one reply per failed attempt.
+    """
+    return collapse_provider_error_reply(
+        f"⚠️ Provider authentication failed: {exc}",
+        session_key=session_key,
+        error_class="provider_auth",
+        mode=mode,
+        interval=interval,
+        now=now,
+        cfg=cfg,
+    )
+
+
+def collapse_provider_error_reply(
+    reply: str,
+    *,
+    session_key: Any = None,
+    error_class: str = "provider_error",
+    mode: Optional[str] = None,
+    interval: Optional[float] = None,
+    now: Optional[float] = None,
+    cfg: Any = None,
+) -> str:
+    """Collapse a user-facing provider-error reply per session per window.
+
+    Returns ``reply``, or ``""`` when this session has already been told about
+    this error class inside the current window (``collapse``) or when notices
+    are ``off``.  Callers keep their own log line either way: the empty string
+    means "do not repeat this to the user", never "nothing happened".
+    """
+    if not reply:
+        return reply
+    if mode is None:
+        mode = resolve_fallback_notification_mode(cfg)
+    if mode == "off":
+        return ""
+    if mode != "collapse":
+        return reply
+    if interval is None:
+        interval = resolve_fallback_notice_interval(cfg)
+    ts = _time.time() if now is None else now
+
+    key = str(session_key or "")
+    digest = hashlib.sha1(
+        f"{error_class}\x00{reply}".encode("utf-8", "replace")
+    ).hexdigest()
+    with _auth_error_lock:
+        window = _auth_error_windows.get(key)
+        if window is None:
+            window = _AuthErrorWindow()
+            _auth_error_windows[key] = window
+        last = window.seen.get(digest)
+        window.last_touched = ts
+        if last is not None and (ts - last) < interval:
+            return ""
+        window.seen[digest] = ts
+        if len(_auth_error_windows) > _MAX_TRACKED_AUTH_SESSIONS:
+            _prune_auth_error_windows_locked()
+    return reply
+
+
+def _prune_auth_error_windows_locked() -> None:
+    """Drop the least recently touched sessions. Caller holds the lock."""
+    stale = sorted(_auth_error_windows.items(), key=lambda kv: kv[1].last_touched)
+    for key, _ in stale[: max(1, len(stale) // 4)]:
+        _auth_error_windows.pop(key, None)

--- a/agent/notice_collapse.py
+++ b/agent/notice_collapse.py
@@ -15,13 +15,35 @@ messages for what is one event.
                  allowed notice.  Provider auth-error replies are deduped by
                  error class over the same window.
   ``off``      — no user-facing notice at all; the log lines are unchanged.
+                 A reply to a message somebody sent still gets the terse line
+                 below: ``off`` silences notices, never an answer.
 
-The default is ``on``, so behaviour is byte-identical unless configured.
+The default is ``on``, so behaviour is byte-identical unless configured, with
+two deliberate exceptions: ``gateway/run.py``'s TurnRunner auth branch gains
+one unconditional ``logger.warning`` (closing a log gap the other two auth
+render sites already covered), and a whitespace-only notice is dropped in
+every mode rather than emitted as a blank line.
+
+Suppression is never silence on a reply to a person's own message.  The
+collapse helpers return the :data:`SUPPRESSED_NOTICE` sentinel rather than
+``""`` so a caller can tell "already told this session" apart from "not a
+provider error".  Unsolicited status chatter resolves the sentinel to nothing
+(:func:`resolve_status_notice`); a direct reply resolves it to a single terse
+line (:func:`resolve_direct_reply`) so a person who asks a question during an
+outage always gets an answer.  No caller may fall through to the raw provider
+error text.
+
+State lifetime: the auth-error windows here are module-level and process-local,
+and the model-fallback window lives on the agent object (so it is per session,
+via the gateway's session-keyed agent cache).  Both are in memory only.  A
+gateway restart, or eviction of an agent from that cache, reopens the window
+and allows one more notice.  That is the fail-loud direction — at worst one
+extra notice per session, never a lost one — and it is why this is a display
+knob rather than a delivery guarantee.
 """
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import threading
 import time as _time
@@ -39,12 +61,32 @@ DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS = 3600.0
 # sees many session keys cannot grow it without limit.
 _MAX_TRACKED_AUTH_SESSIONS = 512
 
+_warned_config_values: set = set()
+_warn_lock = threading.Lock()
+
+
+def _warn_once(token: str) -> bool:
+    """True the first time ``token`` is seen this process."""
+    with _warn_lock:
+        if token in _warned_config_values:
+            return False
+        _warned_config_values.add(token)
+        return True
+
+
+def reset_config_warning_state() -> None:
+    """Forget which config warnings were already emitted (tests)."""
+    with _warn_lock:
+        _warned_config_values.clear()
+
 
 def resolve_fallback_notification_mode(cfg: Any = None) -> str:
     """Return the validated ``display.fallback_notifications`` mode.
 
-    An unknown value warns once per call site and falls back to ``on``, the
-    same fail-open shape as ``display.background_process_notifications``.
+    An unknown value warns once per process (the sanitizer re-resolves on
+    every provider error event, so a typo during an outage would otherwise
+    spam the log) and falls back to ``on``, the same fail-open shape as
+    ``display.background_process_notifications``.
     """
     raw = _display_value(cfg, "fallback_notifications")
     if raw is None or raw == "":
@@ -54,12 +96,13 @@ def resolve_fallback_notification_mode(cfg: Any = None) -> str:
         return "on" if raw else "off"
     mode = str(raw).strip().lower()
     if mode not in FALLBACK_NOTIFICATION_MODES:
-        logger.warning(
-            "Unknown display.fallback_notifications %r, defaulting to %r "
-            "(valid: %s)",
-            raw, DEFAULT_FALLBACK_NOTIFICATION_MODE,
-            ", ".join(FALLBACK_NOTIFICATION_MODES),
-        )
+        if _warn_once(f"mode:{mode}"):
+            logger.warning(
+                "Unknown display.fallback_notifications %r, defaulting to %r "
+                "(valid: %s)",
+                raw, DEFAULT_FALLBACK_NOTIFICATION_MODE,
+                ", ".join(FALLBACK_NOTIFICATION_MODES),
+            )
         return DEFAULT_FALLBACK_NOTIFICATION_MODE
     return mode
 
@@ -77,10 +120,12 @@ def resolve_fallback_notice_interval(cfg: Any = None) -> float:
     except (TypeError, ValueError):
         interval = -1.0
     if interval <= 0:
-        logger.warning(
-            "Invalid display.fallback_notice_interval_seconds %r, defaulting "
-            "to %s", raw, DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS,
-        )
+        if _warn_once(f"interval:{raw!r}"):
+            logger.warning(
+                "Invalid display.fallback_notice_interval_seconds %r, "
+                "defaulting to %s",
+                raw, DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS,
+            )
         return DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS
     return interval
 
@@ -180,6 +225,46 @@ class _AuthErrorWindow:
 _auth_error_windows: dict = {}
 _auth_error_lock = threading.Lock()
 
+# Returned in place of a user-facing reply that was deliberately withheld.
+# Control characters keep it out of any real provider text, and every consumer
+# resolves it through ``resolve_direct_reply`` / ``resolve_status_notice``
+# before delivery, so it can never reach a chat surface.
+SUPPRESSED_NOTICE = "\x00hermes:notice-suppressed\x00"
+
+# What a person sees when they message during an outage the window already
+# reported.  One line, no raw provider detail, never empty.
+TERSE_SUPPRESSED_REPLY = (
+    "⚠️ Still failing on the provider error reported earlier; details in the "
+    "gateway logs."
+)
+
+
+def is_suppressed_notice(value: Any) -> bool:
+    """True when a collapse helper deliberately withheld a user-facing notice."""
+    return isinstance(value, str) and value == SUPPRESSED_NOTICE
+
+
+def resolve_direct_reply(reply: Any) -> str:
+    """Resolve a collapsed reply for a message a person actually sent.
+
+    A direct reply must never become silence, and must never fall through to
+    the raw provider error, so suppression collapses to one terse line.
+    """
+    if is_suppressed_notice(reply):
+        return TERSE_SUPPRESSED_REPLY
+    return "" if reply is None else str(reply)
+
+
+def resolve_status_notice(reply: Any) -> Optional[str]:
+    """Resolve a collapsed notice for the unsolicited status path.
+
+    This is the only path allowed to collapse to nothing: nobody asked for it.
+    """
+    if is_suppressed_notice(reply):
+        return None
+    text = "" if reply is None else str(reply)
+    return text or None
+
 
 def reset_provider_auth_error_state() -> None:
     """Drop all auth-error dedupe state (tests, and gateway restarts)."""
@@ -225,17 +310,21 @@ def collapse_provider_error_reply(
 ) -> str:
     """Collapse a user-facing provider-error reply per session per window.
 
-    Returns ``reply``, or ``""`` when this session has already been told about
-    this error class inside the current window (``collapse``) or when notices
-    are ``off``.  Callers keep their own log line either way: the empty string
-    means "do not repeat this to the user", never "nothing happened".
+    Returns ``reply``, or :data:`SUPPRESSED_NOTICE` when this session has
+    already been told about this error class inside the current window
+    (``collapse``) or when notices are ``off``.  Callers keep their own log
+    line either way, and must pass the result through
+    :func:`resolve_direct_reply` (a reply to a person's own message) or
+    :func:`resolve_status_notice` (unsolicited chatter) before delivery.  The
+    sentinel means "do not repeat this to the user", never "nothing happened"
+    and never "not a provider error".
     """
     if not reply:
         return reply
     if mode is None:
         mode = resolve_fallback_notification_mode(cfg)
     if mode == "off":
-        return ""
+        return SUPPRESSED_NOTICE
     if mode != "collapse":
         return reply
     if interval is None:
@@ -243,9 +332,10 @@ def collapse_provider_error_reply(
     ts = _time.time() if now is None else now
 
     key = str(session_key or "")
-    digest = hashlib.sha1(
-        f"{error_class}\x00{reply}".encode("utf-8", "replace")
-    ).hexdigest()
+    # Keyed on the error CLASS alone, never the reply text: the auth sites
+    # embed the raw exception, and provider 401/429 bodies carry per-request
+    # ids and timestamps, so any text in the key means nothing ever dedupes.
+    digest = str(error_class)
     with _auth_error_lock:
         window = _auth_error_windows.get(key)
         if window is None:
@@ -254,7 +344,7 @@ def collapse_provider_error_reply(
         last = window.seen.get(digest)
         window.last_touched = ts
         if last is not None and (ts - last) < interval:
-            return ""
+            return SUPPRESSED_NOTICE
         window.seen[digest] = ts
         if len(_auth_error_windows) > _MAX_TRACKED_AUTH_SESSIONS:
             _prune_auth_error_windows_locked()
@@ -262,7 +352,12 @@ def collapse_provider_error_reply(
 
 
 def _prune_auth_error_windows_locked() -> None:
-    """Drop the least recently touched sessions. Caller holds the lock."""
+    """Drop the least recently touched sessions. Caller holds the lock.
+
+    Eviction silently reopens the window for those sessions, so a box past the
+    cap can emit one extra notice for an evicted session.  Same fail-loud
+    direction as a restart; the cap is what keeps the map bounded.
+    """
     stale = sorted(_auth_error_windows.items(), key=lambda kv: kv[1].last_touched)
     for key, _ in stale[: max(1, len(stale) // 4)]:
         _auth_error_windows.pop(key, None)

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7606,11 +7606,19 @@ class APIServerAdapter(BasePlatformAdapter):
                     # /v1/runs has its own branch in its executor.
                     logger.warning("Provider authentication failed for session=%s: %s",
                                    session_id or "", exc)
-                    from agent.notice_collapse import provider_auth_error_reply
+                    # resolve_direct_reply: this envelope is the answer to a
+                    # request somebody made, so a suppressed reply degrades to
+                    # one terse line, never to an empty body.
+                    from agent.notice_collapse import (
+                        provider_auth_error_reply,
+                        resolve_direct_reply,
+                    )
                     return (
                         {
-                            "final_response": provider_auth_error_reply(
-                                exc, session_key=session_id,
+                            "final_response": resolve_direct_reply(
+                                provider_auth_error_reply(
+                                    exc, session_key=session_id,
+                                )
                             ),
                             "messages": [],
                             "api_calls": 0,

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -7606,9 +7606,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     # /v1/runs has its own branch in its executor.
                     logger.warning("Provider authentication failed for session=%s: %s",
                                    session_id or "", exc)
+                    from agent.notice_collapse import provider_auth_error_reply
                     return (
                         {
-                            "final_response": f"⚠️ Provider authentication failed: {exc}",
+                            "final_response": provider_auth_error_reply(
+                                exc, session_key=session_id,
+                            ),
                             "messages": [],
                             "api_calls": 0,
                             "tools": [],

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -963,8 +963,19 @@ async def _handle_runs(
             # failure, instead of falling through to the generic
             # except-Exception branch below.
             logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-            from agent.notice_collapse import provider_auth_error_reply
-            error_msg = provider_auth_error_reply(exc, session_key=run_id)
+            # session_key=run_id makes this window per run, and a run renders
+            # at most one auth reply, so the dedupe never fires here by design
+            # — /v1/runs has no conversation to collapse across. The call stays
+            # so this site cannot drift off the shared renderer (the ast guard
+            # in tests/agent/test_notice_collapse.py enforces that), and
+            # resolve_direct_reply keeps the run's error field non-empty.
+            from agent.notice_collapse import (
+                provider_auth_error_reply,
+                resolve_direct_reply,
+            )
+            error_msg = resolve_direct_reply(
+                provider_auth_error_reply(exc, session_key=run_id)
+            )
             self._set_run_status(
                 run_id,
                 "failed",

--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -963,7 +963,8 @@ async def _handle_runs(
             # failure, instead of falling through to the generic
             # except-Exception branch below.
             logger.warning("Provider authentication failed for run=%s: %s", run_id, exc)
-            error_msg = f"⚠️ Provider authentication failed: {exc}"
+            from agent.notice_collapse import provider_auth_error_reply
+            error_msg = provider_auth_error_reply(exc, session_key=run_id)
             self._set_run_status(
                 run_id,
                 "failed",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -929,18 +929,24 @@ def _format_exec_approval_fallback(
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
-def _gateway_surface_key(platform: Any) -> str:
-    """Stable dedupe key for a chat surface.
+def _gateway_surface_key(platform: Any, chat_id: Any = None) -> str:
+    """Stable dedupe key for one chat surface: ``<platform>:<chat_id>``.
 
-    These two sanitizers see the rendered reply, not the session, so the
-    collapse window for provider-error replies is per platform surface. That
-    is the granularity the noise actually has: one dead provider spams one
-    surface.
+    The window has to be per conversation, not per platform. Keyed on the
+    platform alone, every channel and DM on a box shares one window, so one
+    person's provider error 20 minutes ago collapses a different person's
+    reply in a different chat.
+
+    ``chat_id`` is absent only for callers that have no conversation in hand
+    (older/synthetic call paths). Those fall back to the platform alone, which
+    is the previous behaviour: coarser, never wrong in the other direction.
     """
     try:
-        return str(getattr(platform, "name", None) or type(platform).__name__)
+        surface = str(getattr(platform, "name", None) or type(platform).__name__)
     except Exception:
         return ""
+    chat = "" if chat_id is None else str(chat_id).strip()
+    return f"{surface}:{chat}" if chat else surface
 
 
 def _gateway_provider_error_reply(text: str, session_key: Any = None) -> str:
@@ -949,8 +955,11 @@ def _gateway_provider_error_reply(text: str, session_key: Any = None) -> str:
     ``display.fallback_notifications`` collapses the result: a provider outage
     that walks the fallback chain produces one failure envelope per attempt,
     and in ``collapse`` mode only the first of each error class reaches chat
-    inside ``display.fallback_notice_interval_seconds`` (``""`` afterwards).
-    ``on`` (default) is unchanged.
+    inside ``display.fallback_notice_interval_seconds``. Afterwards it returns
+    ``notice_collapse.SUPPRESSED_NOTICE``, which the caller must resolve with
+    ``resolve_direct_reply`` or ``resolve_status_notice`` — never treat it as
+    "not a provider error" and fall back to the raw text. ``on`` (default) is
+    unchanged.
     """
     from agent.notice_collapse import collapse_provider_error_reply
 
@@ -1030,7 +1039,21 @@ def _looks_like_gateway_provider_error(text: str) -> bool:
     return bool(_GATEWAY_PROVIDER_ERROR_SHAPE_RE.search(body))
 
 
-def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
+def _is_suppressed_gateway_notice(text: Any) -> bool:
+    """True when the collapse window withheld this provider-error reply."""
+    from agent.notice_collapse import is_suppressed_notice
+
+    return is_suppressed_notice(text)
+
+
+def _terse_suppressed_gateway_reply() -> str:
+    """One line for a direct reply the collapse window already reported."""
+    from agent.notice_collapse import TERSE_SUPPRESSED_REPLY
+
+    return TERSE_SUPPRESSED_REPLY
+
+
+def _sanitize_gateway_final_response(platform: Any, text: str, chat_id: Any = None) -> str:
     """Sanitize final gateway replies before sending them to chat surfaces.
 
     Every human-facing chat surface (Telegram, WhatsApp, Discord, Slack,
@@ -1065,11 +1088,18 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
-        return _gateway_provider_error_reply(redacted, _gateway_surface_key(platform))
+        # May return notice_collapse.SUPPRESSED_NOTICE. Callers MUST resolve
+        # that (resolve_direct_reply / resolve_status_notice) and must never
+        # treat it as "not a provider error" and fall back to the raw text.
+        return _gateway_provider_error_reply(
+            redacted, _gateway_surface_key(platform, chat_id),
+        )
     return redacted
 
 
-def _prepare_gateway_status_message(platform: Any, event_type: str, message: str) -> Optional[str]:
+def _prepare_gateway_status_message(
+    platform: Any, event_type: str, message: str, chat_id: Any = None,
+) -> Optional[str]:
     """Filter/sanitize agent status callbacks before platform delivery.
 
     Local/CLI sessions keep the raw diagnostic stream. Messaging gateway
@@ -1095,7 +1125,16 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text, _gateway_surface_key(platform)) or None
+        # The ONLY path allowed to collapse to nothing: nobody asked for this
+        # message. A reply to a message a person actually sent goes through
+        # resolve_direct_reply instead and always says something.
+        from agent.notice_collapse import resolve_status_notice
+
+        return resolve_status_notice(
+            _gateway_provider_error_reply(
+                text, _gateway_surface_key(platform, chat_id),
+            )
+        )
     return text
 
 
@@ -5932,6 +5971,7 @@ class TurnRunner:
             ctx.source.platform,
             event_type,
             message,
+            getattr(ctx.source, "chat_id", None),
         )
         if prepared_message is None:
             logger.debug(
@@ -6022,16 +6062,23 @@ class TurnRunner:
             # One shared renderer across all three provider auth-error sites
             # (here, api_server.py, api_server_runs.py) so
             # display.fallback_notifications can collapse the burst a walking
-            # fallback chain produces. The log line is unconditional; an empty
-            # reply means "already told this session", not "nothing happened".
-            from agent.notice_collapse import provider_auth_error_reply
+            # fallback chain produces. The log line is unconditional.
+            # resolve_direct_reply keeps this non-empty even when the window
+            # already reported the outage: this envelope IS the answer to a
+            # message a person sent, and an empty one falls into the #31884
+            # "send it again" hint, which is the worst thing to tell someone
+            # mid-outage.
+            from agent.notice_collapse import (
+                provider_auth_error_reply,
+                resolve_direct_reply,
+            )
             logger.warning(
                 "Provider authentication failed for session=%s: %s",
                 ctx.session_key or "", exc,
             )
             return {
-                "final_response": provider_auth_error_reply(
-                    exc, session_key=ctx.session_key,
+                "final_response": resolve_direct_reply(
+                    provider_auth_error_reply(exc, session_key=ctx.session_key)
                 ),
                 "messages": [],
                 "api_calls": 0,
@@ -7365,8 +7412,16 @@ class TurnRunner:
             final_response = _normalize_empty_agent_response(
                 result, final_response or "", history_len=len(agent_history),
             )
-            final_response = _sanitize_gateway_final_response(ctx.source.platform, final_response)
-            if not final_response:
+            final_response = _sanitize_gateway_final_response(
+                ctx.source.platform, final_response,
+                getattr(ctx.source, "chat_id", None),
+            )
+            if _is_suppressed_gateway_notice(final_response):
+                # Suppressed by the collapse window. This is a reply to a
+                # message a person sent, so it gets the terse line — never
+                # silence, and never the raw provider error below.
+                final_response = _terse_suppressed_gateway_reply()
+            elif not final_response:
                 final_response = f"⚠️ {result['error']}" if result.get("error") else ""
             return {
                 "final_response": final_response,
@@ -23362,7 +23417,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 response = _normalize_empty_agent_response(
                     agent_result, response, history_len=len(history),
                 )
-                response = _sanitize_gateway_final_response(source.platform, response)
+                response = _sanitize_gateway_final_response(
+                    source.platform, response, getattr(source, "chat_id", None),
+                )
+                if _is_suppressed_gateway_notice(response):
+                    response = _terse_suppressed_gateway_reply()
 
             # Ordering contract: the agent thread already updated the contextvar
             # in conversation_compression.py; propagate to SessionEntry + _save().

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -929,28 +929,57 @@ def _format_exec_approval_fallback(
         + ", ".join(choices[:-1]) + f", or {choices[-1]}."
     )
 
-def _gateway_provider_error_reply(text: str) -> str:
-    """Map raw provider/API errors to a short user-safe Telegram reply."""
+def _gateway_surface_key(platform: Any) -> str:
+    """Stable dedupe key for a chat surface.
+
+    These two sanitizers see the rendered reply, not the session, so the
+    collapse window for provider-error replies is per platform surface. That
+    is the granularity the noise actually has: one dead provider spams one
+    surface.
+    """
+    try:
+        return str(getattr(platform, "name", None) or type(platform).__name__)
+    except Exception:
+        return ""
+
+
+def _gateway_provider_error_reply(text: str, session_key: Any = None) -> str:
+    """Map raw provider/API errors to a short user-safe Telegram reply.
+
+    ``display.fallback_notifications`` collapses the result: a provider outage
+    that walks the fallback chain produces one failure envelope per attempt,
+    and in ``collapse`` mode only the first of each error class reaches chat
+    inside ``display.fallback_notice_interval_seconds`` (``""`` afterwards).
+    ``on`` (default) is unchanged.
+    """
+    from agent.notice_collapse import collapse_provider_error_reply
+
     if _GATEWAY_AUTH_ERROR_RE.search(text):
-        return (
+        error_class, reply = "provider_auth", (
             "⚠️ Provider authentication failed. Check the configured credentials; "
             "raw provider details are in the gateway logs."
         )
-    if _GATEWAY_PROVIDER_POLICY_RE.search(text):
-        return (
+    elif _GATEWAY_PROVIDER_POLICY_RE.search(text):
+        error_class, reply = "provider_policy", (
             "⚠️ The model provider rejected the request. I kept the raw provider "
             "error out of chat; check gateway logs for details or try rephrasing."
         )
-    if _GATEWAY_RATE_LIMIT_RE.search(text):
-        return "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
-    if _GATEWAY_CONNECTION_ERROR_RE.search(text):
-        return (
+    elif _GATEWAY_RATE_LIMIT_RE.search(text):
+        error_class, reply = "provider_rate_limit", (
+            "⏱️ The model provider is rate-limiting requests. Please wait a moment and try again."
+        )
+    elif _GATEWAY_CONNECTION_ERROR_RE.search(text):
+        error_class, reply = "provider_connection", (
             "⚠️ The model server is not responding — it looks like the configured "
             "model endpoint is not running or is unreachable."
         )
-    return (
-        "⚠️ The model provider failed after retries. I kept raw provider details "
-        "out of chat; check gateway logs for diagnostics."
+    else:
+        error_class, reply = "provider_failed", (
+            "⚠️ The model provider failed after retries. I kept raw provider details "
+            "out of chat; check gateway logs for diagnostics."
+        )
+    return collapse_provider_error_reply(
+        reply, session_key=session_key, error_class=error_class,
     )
 
 
@@ -1036,7 +1065,7 @@ def _sanitize_gateway_final_response(platform: Any, text: str) -> str:
 
     redacted = _redact_gateway_user_facing_secrets(str(text))
     if _looks_like_gateway_provider_error(redacted):
-        return _gateway_provider_error_reply(redacted)
+        return _gateway_provider_error_reply(redacted, _gateway_surface_key(platform))
     return redacted
 
 
@@ -1066,7 +1095,7 @@ def _prepare_gateway_status_message(platform: Any, event_type: str, message: str
         ):
             return None
     if _looks_like_gateway_provider_error(text):
-        return _gateway_provider_error_reply(text)
+        return _gateway_provider_error_reply(text, _gateway_surface_key(platform)) or None
     return text
 
 
@@ -5990,8 +6019,20 @@ class TurnRunner:
                 model, runtime_kwargs.get("provider"), ctx.session_key or "",
             )
         except Exception as exc:
+            # One shared renderer across all three provider auth-error sites
+            # (here, api_server.py, api_server_runs.py) so
+            # display.fallback_notifications can collapse the burst a walking
+            # fallback chain produces. The log line is unconditional; an empty
+            # reply means "already told this session", not "nothing happened".
+            from agent.notice_collapse import provider_auth_error_reply
+            logger.warning(
+                "Provider authentication failed for session=%s: %s",
+                ctx.session_key or "", exc,
+            )
             return {
-                "final_response": f"⚠️ Provider authentication failed: {exc}",
+                "final_response": provider_auth_error_reply(
+                    exc, session_key=ctx.session_key,
+                ),
                 "messages": [],
                 "api_calls": 0,
                 "tools": [],
@@ -6543,6 +6584,15 @@ class TurnRunner:
         if isinstance(_mem_notif, bool):
             _mem_notif = "on" if _mem_notif else "off"
         agent.memory_notifications = str(_mem_notif).lower() if _mem_notif else "on"
+        # Model-fallback notice collapsing.  Config:
+        # display.fallback_notifications (on | collapse | off) and
+        # display.fallback_notice_interval_seconds.  Wired onto the agent so
+        # the collapse window is per gateway session, like memory_notifications.
+        _display_cfg = ctx.user_config.get("display", {}) or {}
+        agent.fallback_notifications = _display_cfg.get("fallback_notifications")
+        agent.fallback_notice_interval_seconds = _display_cfg.get(
+            "fallback_notice_interval_seconds"
+        )
 
         # ------------------------------------------------------------------
         # Shared native-stream boundary close.  For platforms with native

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1510,6 +1510,19 @@ DEFAULT_CONFIG = {
         #   "error"   — final raw-output message only on non-zero exit
         #   "off"     — no watcher messages at all
         "background_process_notifications": "concise",
+        # Model-fallback and provider auth-error notices surfaced in chat.
+        # A provider outage can walk the whole fallback chain in a second,
+        # emitting one notice per hop and one auth-error reply per attempt.
+        #   "on"       — one notice per hop, one reply per failure (default)
+        #   "collapse" — at most one user-facing notice per session per
+        #                display.fallback_notice_interval_seconds; further
+        #                hops are counted and folded into the next notice,
+        #                and auth-error replies dedupe by error class
+        #   "off"      — no user-facing notice (the log lines are unchanged)
+        "fallback_notifications": "on",
+        # Collapse window in seconds for display.fallback_notifications:
+        # collapse. Ignored in "on"/"off".
+        "fallback_notice_interval_seconds": 3600,
         "streaming": False,
         "timestamps": False,      # Show message timestamps (CLI labels, TUI rows, desktop transcript)
         "timestamp_format": "%H:%M",  # strftime format for timestamps (e.g. "%b-%d %H:%M")

--- a/hermes_cli/config_defaults.py
+++ b/hermes_cli/config_defaults.py
@@ -1519,6 +1519,10 @@ DEFAULT_CONFIG = {
         #                hops are counted and folded into the next notice,
         #                and auth-error replies dedupe by error class
         #   "off"      — no user-facing notice (the log lines are unchanged)
+        # A reply to a message somebody sent is never silenced outright: a
+        # suppressed reply degrades to one terse line, never to nothing and
+        # never to the raw provider error.  Only unsolicited status chatter
+        # collapses to nothing.  The window is per platform + chat id.
         "fallback_notifications": "on",
         # Collapse window in seconds for display.fallback_notifications:
         # collapse. Ignored in "on"/"off".

--- a/run_agent.py
+++ b/run_agent.py
@@ -1282,6 +1282,73 @@ class AIAgent:
         except Exception:
             pass
 
+    def _fallback_notice_config(self):
+        """Resolve ``(mode, interval, state)`` for model-fallback notices.
+
+        ``display.fallback_notifications`` / ``.fallback_notice_interval_seconds``
+        are read from the user config unless the embedder set the matching
+        ``fallback_notifications`` / ``fallback_notice_interval_seconds``
+        attributes on the agent (the gateway does, like ``memory_notifications``);
+        those are then authoritative for both keys.  The collapse window lives
+        on the agent, so it is per session.
+        """
+        from agent.notice_collapse import (
+            FallbackNoticeState,
+            resolve_fallback_notice_interval,
+            resolve_fallback_notification_mode,
+        )
+        override = (
+            getattr(self, "fallback_notifications", None),
+            getattr(self, "fallback_notice_interval_seconds", None),
+        )
+        cache = getattr(self, "_fallback_notice_cache", None)
+        if cache is None or cache[0] != override:
+            display = {}
+            if override[0] is not None:
+                display["fallback_notifications"] = override[0]
+            if override[1] is not None:
+                display["fallback_notice_interval_seconds"] = override[1]
+            cfg = {"display": display} if display else None
+            state = cache[3] if cache else FallbackNoticeState()
+            cache = (
+                override,
+                resolve_fallback_notification_mode(cfg),
+                resolve_fallback_notice_interval(cfg),
+                state,
+            )
+            self._fallback_notice_cache = cache
+        return cache[1], cache[2], cache[3]
+
+    def _fallback_notice_mode(self) -> str:
+        """``on`` | ``collapse`` | ``off`` — fail open to ``on``."""
+        try:
+            return self._fallback_notice_config()[0]
+        except Exception:
+            return "on"
+
+    def _collapse_fallback_notices(self, notices: list) -> list:
+        """Apply ``display.fallback_notifications`` to buffered hop notices."""
+        from agent.notice_collapse import collapse_fallback_notices
+        try:
+            mode, interval, state = self._fallback_notice_config()
+            clock = getattr(self, "_fallback_notice_clock", None)
+            now = float(clock()) if callable(clock) else time.time()
+            route = getattr(self, "_provider_fallback_route", None)
+            current = None
+            if isinstance(route, (tuple, list)) and len(route) == 2:
+                current = f"{route[0]} via {route[1]}"
+            return collapse_fallback_notices(
+                notices,
+                mode=mode,
+                interval=interval,
+                state=state,
+                now=now,
+                current_route=current,
+            )
+        except Exception:
+            # Never lose a switch notice to a collapse bug.
+            return list(notices)
+
     def _emit_pending_fallback_notice(self) -> None:
         """Surface the one-shot fallback-switch notice on successful recovery.
 
@@ -1293,6 +1360,9 @@ class AIAgent:
         produces one visible notice.  On terminal failure the buffered switch
         line is flushed instead (and this notice discarded) — see
         ``_flush_status_buffer`` — so the user always sees the switch once.
+
+        ``display.fallback_notifications`` gates the user-facing emission only:
+        ``try_activate_fallback``'s log line is unconditional in every mode.
         """
         try:
             notice = getattr(self, "_pending_fallback_notice", None)
@@ -1301,7 +1371,7 @@ class AIAgent:
                 # leave the notice set for a stale re-emit on a later turn.
                 self._pending_fallback_notice = None
                 notices = notice if isinstance(notice, list) else [notice]
-                for item in notices:
+                for item in self._collapse_fallback_notices(notices):
                     try:
                         self._emit_status(str(item))
                     except Exception:
@@ -1321,8 +1391,18 @@ class AIAgent:
         try:
             # The buffered trace already carries the fallback switch line, so
             # drop any one-shot fallback notice to avoid a stale duplicate
-            # leaking into a later successful turn.
+            # leaking into a later successful turn.  Outside ``on`` mode the
+            # switch was deliberately kept out of the retry buffer, so emit the
+            # collapsed notice here instead of losing it.
+            pending = getattr(self, "_pending_fallback_notice", None)
             self._pending_fallback_notice = None
+            if pending and self._fallback_notice_mode() != "on":
+                pending = pending if isinstance(pending, list) else [pending]
+                for item in self._collapse_fallback_notices(pending):
+                    try:
+                        self._emit_status(str(item))
+                    except Exception:
+                        continue
             buf = getattr(self, "_retry_status_buffer", None)
             if not buf:
                 return

--- a/tests/agent/test_notice_collapse.py
+++ b/tests/agent/test_notice_collapse.py
@@ -15,12 +15,17 @@ import yaml
 
 from agent.notice_collapse import (
     DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS,
+    TERSE_SUPPRESSED_REPLY,
     FallbackNoticeState,
     collapse_fallback_notices,
+    is_suppressed_notice,
     provider_auth_error_reply,
+    reset_config_warning_state,
     reset_provider_auth_error_state,
+    resolve_direct_reply,
     resolve_fallback_notice_interval,
     resolve_fallback_notification_mode,
+    resolve_status_notice,
 )
 from run_agent import AIAgent
 
@@ -34,8 +39,10 @@ HOP3 = "⚠️ Model fallback: m3 via p3 unavailable (rate limit); using m4 via 
 @pytest.fixture(autouse=True)
 def _clean_auth_state():
     reset_provider_auth_error_state()
+    reset_config_warning_state()
     yield
     reset_provider_auth_error_state()
+    reset_config_warning_state()
 
 
 def _cfg(**display):
@@ -277,14 +284,84 @@ def test_agent_flush_emits_collapsed_notice_outside_on_mode():
     assert agent._pending_fallback_notice is None
 
 
-def test_try_activate_fallback_skips_status_buffer_outside_on_mode():
-    """The per-hop line stays out of the retry buffer when collapsing."""
-    import inspect
-    from agent import chat_completion_helpers
+def _agent_with_one_fallback(mode=None):
+    """A real AIAgent with a one-hop fallback chain, wired for a live switch."""
+    from unittest.mock import MagicMock, patch
 
-    src = inspect.getsource(chat_completion_helpers.try_activate_fallback)
-    assert '_fallback_notice_mode' in src
-    assert 'if _notice_mode == "on":\n            agent._buffer_status(notice)' in src
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model={"provider": "zai", "model": "glm-5.2"},
+        )
+    agent.client = MagicMock()
+    agent.model = "gpt-5.6-sol"
+    agent.provider = "openai-codex"
+    if mode is not None:
+        agent.fallback_notifications = mode
+    return agent
+
+
+def _activate_one_fallback(agent):
+    """Run a real fallback hop. Returns ``(retry_buffer, pending_notices)``."""
+    from unittest.mock import MagicMock, patch
+
+    fb_client = MagicMock()
+    fb_client.base_url = "https://api.z.ai/v1"
+    fb_client.api_key = "fb-key"
+    with patch(
+        "agent.auxiliary_client.resolve_provider_client",
+        return_value=(fb_client, "glm-5.2"),
+    ):
+        assert agent._try_activate_fallback() is True
+    return (
+        list(getattr(agent, "_retry_status_buffer", None) or []),
+        list(getattr(agent, "_pending_fallback_notice", None) or []),
+    )
+
+
+@pytest.mark.parametrize("mode,expect_buffered", [
+    ("on", True), ("collapse", False), ("off", False),
+])
+def test_try_activate_fallback_buffers_the_hop_line_only_in_on_mode(
+    mode, expect_buffered,
+):
+    """The per-hop line stays out of the retry buffer when collapsing, so a
+    terminal failure cannot re-expose every hop.
+
+    Behavioural, not a source-substring assert: this survives a rename or a
+    quote-style change, and fails if the gate is dropped.
+    """
+    agent = _agent_with_one_fallback(mode=mode)
+    buffered, pending = _activate_one_fallback(agent)
+
+    hop_lines = [b for b in buffered if "Model fallback" in str(b)]
+    assert bool(hop_lines) is expect_buffered
+    # The durable one-shot notice is recorded in every mode; only the
+    # user-facing emission is gated, at flush time.
+    assert any("Model fallback" in str(x) for x in pending)
+
+
+def test_try_activate_fallback_fails_open_on_a_mock_agent():
+    """A mock agent returns a truthy Mock from ``_fallback_notice_mode``. That
+    must not silently skip buffering: anything that is not a known mode string
+    means ``on``."""
+    from unittest.mock import MagicMock
+
+    agent = _agent_with_one_fallback()
+    agent._fallback_notice_mode = lambda: MagicMock()
+    buffered, _ = _activate_one_fallback(agent)
+
+    assert any("Model fallback" in str(b) for b in buffered), (
+        "unknown mode must fail open to on-mode buffering"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -298,23 +375,57 @@ def test_auth_reply_unchanged_in_on_mode():
 
 
 def test_auth_reply_suppressed_in_off_mode():
-    assert provider_auth_error_reply("no creds", session_key="s1", mode="off") == ""
+    """``off`` is intentional silence, and says so with the sentinel — it must
+    never look like "this was not a provider error" to a caller."""
+    reply = provider_auth_error_reply("no creds", session_key="s1", mode="off")
+    assert is_suppressed_notice(reply)
+    assert resolve_status_notice(reply) is None
+    assert resolve_direct_reply(reply) == TERSE_SUPPRESSED_REPLY
 
 
 def test_auth_reply_deduped_per_session_per_window():
     kw = dict(mode="collapse", interval=3600)
     assert provider_auth_error_reply("no creds", session_key="s1", now=0.0, **kw)
     # Same class, same session, inside the window → suppressed.
-    assert provider_auth_error_reply("no creds", session_key="s1", now=60.0, **kw) == ""
+    assert is_suppressed_notice(
+        provider_auth_error_reply("no creds", session_key="s1", now=60.0, **kw)
+    )
     # Different session → its own window.
     assert provider_auth_error_reply("no creds", session_key="s2", now=60.0, **kw)
-    # Different error class → not deduped against the first.
-    assert provider_auth_error_reply("bad key", session_key="s1", now=60.0, **kw)
     # Window elapsed → allowed again.
     assert provider_auth_error_reply("no creds", session_key="s1", now=3600.0, **kw)
 
 
-def test_gateway_reply_classes_dedupe_independently():
+def test_auth_reply_dedupes_on_the_error_class_not_the_exception_text():
+    """F2: provider 401 bodies carry per-request ids and timestamps. If any of
+    that text reaches the dedupe key, nothing ever collapses and the box still
+    spams — which is the entire bug this patch exists to fix."""
+    kw = dict(mode="collapse", interval=3600)
+    first = provider_auth_error_reply(
+        "Error code: 401 — req_a1b2c3 at 2026-09-04T10:00:01Z",
+        session_key="s1", now=0.0, **kw,
+    )
+    assert "401" in first
+    for n, text in enumerate((
+        "Error code: 401 — req_zz9 at 2026-09-04T10:00:09Z",
+        "Error code: 401 — req_qq7 at 2026-09-04T10:01:44Z, org org-xyz",
+    ), start=1):
+        assert is_suppressed_notice(
+            provider_auth_error_reply(text, session_key="s1", now=60.0 * n, **kw)
+        ), f"varying exception text must still dedupe: {text}"
+
+
+def test_suppression_sentinel_is_not_deliverable_text():
+    """The sentinel must be impossible to mistake for a reply."""
+    from agent.notice_collapse import SUPPRESSED_NOTICE
+
+    assert "\x00" in SUPPRESSED_NOTICE
+    assert not is_suppressed_notice("")
+    assert not is_suppressed_notice(None)
+    assert not is_suppressed_notice("⚠️ Provider authentication failed: x")
+
+
+def test_gateway_reply_classes_unchanged_in_on_mode():
     from gateway.run import _gateway_provider_error_reply
 
     auth = _gateway_provider_error_reply("Error code: 401 invalid api key")
@@ -323,34 +434,362 @@ def test_gateway_reply_classes_dedupe_independently():
     assert _gateway_provider_error_reply("Error code: 401 invalid api key") == auth
 
 
+def test_gateway_reply_classes_dedupe_independently_in_collapse_mode():
+    """F6: in collapse mode a second auth error in the window is suppressed,
+    but a rate limit is a different class and still gets through."""
+    from agent.notice_collapse import collapse_provider_error_reply
+    from gateway.run import _gateway_provider_error_reply
+
+    kw = dict(mode="collapse", interval=3600.0)
+    seen = []
+
+    def _capture(reply, **kwargs):
+        kwargs.update(kw)
+        kwargs.setdefault("now", 60.0 * len(seen))
+        out = collapse_provider_error_reply(reply, **kwargs)
+        seen.append(out)
+        return out
+
+    import gateway.run as gr
+    original = gr.collapse_provider_error_reply if hasattr(gr, "collapse_provider_error_reply") else None
+    assert original is None  # imported inside the function, so patch the module
+
+    import agent.notice_collapse as nc
+    real = nc.collapse_provider_error_reply
+    nc.collapse_provider_error_reply = _capture
+    try:
+        auth1 = _gateway_provider_error_reply("Error code: 401 invalid api key", "chat-a")
+        auth2 = _gateway_provider_error_reply("Error code: 401 invalid api key", "chat-a")
+        rate = _gateway_provider_error_reply("Rate limited after 5 retries", "chat-a")
+        auth_other = _gateway_provider_error_reply(
+            "Error code: 401 invalid api key", "chat-b",
+        )
+    finally:
+        nc.collapse_provider_error_reply = real
+
+    assert "authentication" in auth1
+    assert is_suppressed_notice(auth2), "second auth in the window must collapse"
+    assert "rate-limiting" in rate, "a different class must not dedupe against auth"
+    assert "authentication" in auth_other, "a different chat has its own window"
+
+
+def test_gateway_surface_key_is_per_chat_not_per_platform():
+    """F3: keyed on the platform alone, one person's error 20 minutes ago
+    silences a different person in a different chat."""
+    from gateway.run import _gateway_surface_key
+
+    class _P:
+        name = "SLACK"
+
+    a = _gateway_surface_key(_P(), "C123")
+    b = _gateway_surface_key(_P(), "C999")
+    assert a != b
+    assert a.startswith("SLACK")
+    # No chat in hand → coarser platform-only key, documented fallback.
+    assert _gateway_surface_key(_P()) == "SLACK"
+    assert _gateway_surface_key(_P(), "") == "SLACK"
+
+
+def test_two_chats_on_one_platform_do_not_share_a_window():
+    """End to end through the real gateway renderer: chat B must still be told
+    about its own auth failure after chat A was told about one."""
+    from gateway.run import _gateway_provider_error_reply, _gateway_surface_key
+
+    class _P:
+        name = "SLACK"
+
+    kw = dict(mode="collapse", interval=3600.0)
+    raw = "Error code: 401 invalid api key"
+
+    import agent.notice_collapse as nc
+    real = nc.collapse_provider_error_reply
+
+    def _capture(reply, **kwargs):
+        kwargs.update(kw)
+        return real(reply, **kwargs)
+
+    nc.collapse_provider_error_reply = _capture
+    try:
+        a1 = _gateway_provider_error_reply(raw, _gateway_surface_key(_P(), "C-a"))
+        b1 = _gateway_provider_error_reply(raw, _gateway_surface_key(_P(), "C-b"))
+        a2 = _gateway_provider_error_reply(raw, _gateway_surface_key(_P(), "C-a"))
+    finally:
+        nc.collapse_provider_error_reply = real
+
+    assert "authentication" in a1
+    assert "authentication" in b1, "chat B shares no window with chat A"
+    assert is_suppressed_notice(a2), "chat A is still inside its own window"
+
+
+# ---------------------------------------------------------------------------
+# F1: suppression is never a raw-error fallthrough, and never silence on a
+# reply to a message a person actually sent.
+# ---------------------------------------------------------------------------
+
+def test_direct_reply_never_falls_through_to_the_raw_provider_error():
+    """The exact defect: the sanitizer withholds a repeat, the caller reads
+    that as "not a provider error" and prints ``result['error']`` — the raw,
+    unredacted provider body — straight into chat."""
+    from gateway.run import (
+        _is_suppressed_gateway_notice,
+        _terse_suppressed_gateway_reply,
+    )
+    from agent.notice_collapse import SUPPRESSED_NOTICE
+
+    raw_error = "Error code: 401 sk-live-DEADBEEF req_a1b2 org-acme"
+    sanitized = SUPPRESSED_NOTICE
+
+    # The shape both call sites now use.
+    if _is_suppressed_gateway_notice(sanitized):
+        final = _terse_suppressed_gateway_reply()
+    elif not sanitized:
+        final = f"⚠️ {raw_error}"
+    else:
+        final = sanitized
+
+    assert final == TERSE_SUPPRESSED_REPLY
+    assert "sk-live" not in final
+    assert "401" not in final
+    assert final.strip(), "a direct reply must never be silence"
+    assert len(final.splitlines()) == 1, "terse means one line"
+
+
+def test_both_final_response_call_sites_resolve_suppression():
+    """Guard the two ``_sanitize_gateway_final_response`` call sites: each must
+    check for suppression BEFORE any raw-error fallback."""
+    import re
+
+    src = (REPO_ROOT / "gateway/run.py").read_text(encoding="utf-8")
+    calls = [
+        m.start() for m in re.finditer(r"_sanitize_gateway_final_response\(", src)
+        if not src[max(0, m.start() - 4):m.start()].endswith("def ")
+    ]
+    assert len(calls) == 2, f"expected 2 call sites, found {len(calls)}"
+    for pos in calls:
+        window = src[pos:pos + 700]
+        assert "_is_suppressed_gateway_notice" in window, (
+            "a _sanitize_gateway_final_response call site does not resolve "
+            "suppression before falling back:\n" + window[:400]
+        )
+
+
+def test_only_the_status_path_collapses_to_nothing():
+    """``_prepare_gateway_status_message`` is unsolicited chatter, so it may
+    return None; the final-response path may not."""
+    assert resolve_status_notice(
+        __import__("agent.notice_collapse", fromlist=["x"]).SUPPRESSED_NOTICE
+    ) is None
+    assert resolve_status_notice("hello") == "hello"
+    assert resolve_status_notice("") is None
+    assert resolve_direct_reply("hello") == "hello"
+
+
 # ---------------------------------------------------------------------------
 # Three-site guard
 # ---------------------------------------------------------------------------
 
-AUTH_REPLY_SITES = (
-    "gateway/run.py",
-    "gateway/platforms/api_server.py",
-    "gateway/platforms/api_server_runs.py",
-)
+AUTH_REPLY_MARKER = "Provider authentication failed"
+
+# The renderer itself, and the tests that assert on its output.
+GUARD_EXEMPT = ("agent/notice_collapse.py",)
 
 
-def test_all_provider_auth_reply_sites_use_the_shared_helper():
+SHARED_RENDERERS = ("collapse_provider_error_reply", "provider_auth_error_reply")
+
+
+def find_inline_auth_reply_renders(root: pathlib.Path, base: pathlib.Path = None):
+    """Return every string literal under ``root`` that builds the auth reply
+    outside a logging call and outside the shared render path.
+
+    An ``ast`` walk, not a substring scan, so quote style, the emoji, an
+    implicit concatenation, ``.format()``, ``%`` and a brand new file in any
+    subdirectory are all covered — the old line-based guard, which matched one
+    exact double-quoted f-string in three hardcoded files, let every one of
+    those through.
+
+    A function that hands its text to one of ``SHARED_RENDERERS`` IS the shared
+    path, so its literals are exempt. The exemption is per function, not per
+    file: a new render site in a file that happens to use the helper elsewhere
+    is still caught.
+    """
+    import ast
+
+    base = base or root
+    offenders = []
+    for path in sorted(root.rglob("*.py")):
+        rel = path.relative_to(base).as_posix()
+        if rel in GUARD_EXEMPT or ("gateway/" + rel) in GUARD_EXEMPT:
+            continue
+        try:
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+        except SyntaxError:  # pragma: no cover - unparseable file
+            continue
+
+        exempt = set()
+        for fn_node in ast.walk(tree):
+            if not isinstance(fn_node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                continue
+            names = {
+                getattr(c.func, "attr", None) or getattr(c.func, "id", None)
+                for c in ast.walk(fn_node) if isinstance(c, ast.Call)
+            }
+            if names & set(SHARED_RENDERERS):
+                for sub_node in ast.walk(fn_node):
+                    exempt.add(id(sub_node))
+
+        logged = set()
+        for node in ast.walk(tree):
+            # Anything textual passed to a logger is diagnostics, not a reply.
+            if isinstance(node, ast.Call):
+                fn = node.func
+                name = getattr(fn, "attr", None) or getattr(fn, "id", None) or ""
+                target = getattr(fn, "value", None)
+                is_logger = name in {
+                    "debug", "info", "warning", "warn", "error",
+                    "exception", "critical", "log",
+                } and (
+                    "log" in str(getattr(target, "id", "")).lower()
+                    or "log" in str(getattr(target, "attr", "")).lower()
+                )
+                if is_logger:
+                    for sub_node in ast.walk(node):
+                        logged.add(id(sub_node))
+
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Constant) or not isinstance(node.value, str):
+                continue
+            if AUTH_REPLY_MARKER not in node.value:
+                continue
+            if id(node) in logged or id(node) in exempt:
+                continue
+            offenders.append(
+                f"{rel}:{getattr(node, 'lineno', 0)}: {node.value.strip()[:70]!r}"
+            )
+    return offenders
+
+
+def test_no_gateway_site_renders_the_auth_reply_inline():
     """Every site that surfaces a provider auth failure must route through
     ``agent.notice_collapse`` so one outage cannot produce one reply per
-    attempt. Fails loudly if a new site re-renders the string inline."""
-    offenders = []
-    for rel in AUTH_REPLY_SITES:
+    attempt. Fails loudly if any file under ``gateway/`` re-renders the string
+    inline, in any quoting or formatting style."""
+    offenders = find_inline_auth_reply_renders(REPO_ROOT / "gateway", base=REPO_ROOT)
+    assert not offenders, (
+        "provider auth reply rendered without the shared collapse helper:\n"
+        + "\n".join(offenders)
+    )
+
+
+@pytest.mark.parametrize("bypass", [
+    '''reply = f"⚠️ Provider authentication failed: {exc}"''',
+    """reply = f'Provider authentication failed: {exc}'""",
+    '''reply = "Provider authentication failed: " + str(exc)''',
+    '''reply = "Provider authentication failed: {}".format(exc)''',
+    '''reply = "Provider authentication failed: %s" % exc''',
+    '''reply = ("Provider authentication " "failed for this session")''',
+])
+def test_the_guard_catches_a_deliberate_bypass(tmp_path, bypass):
+    """The old guard matched one exact double-quoted f-string in three
+    hardcoded files; every form below walked straight past it."""
+    fake_gateway = tmp_path / "gateway" / "platforms"
+    fake_gateway.mkdir(parents=True)
+    (fake_gateway / "sneaky_new_site.py").write_text(
+        "def render(exc):\n    " + bypass + "\n    return reply\n",
+        encoding="utf-8",
+    )
+    offenders = find_inline_auth_reply_renders(tmp_path / "gateway", base=tmp_path)
+    assert offenders, f"guard missed a bypass: {bypass}"
+    assert "sneaky_new_site.py" in offenders[0]
+
+
+def test_the_guard_does_not_flag_logger_calls(tmp_path):
+    """Diagnostics are not user-facing replies."""
+    fake_gateway = tmp_path / "gateway"
+    fake_gateway.mkdir(parents=True)
+    (fake_gateway / "noisy.py").write_text(
+        'import logging\nlogger = logging.getLogger(__name__)\n'
+        'def f(exc):\n    logger.warning("Provider authentication failed for %s", exc)\n',
+        encoding="utf-8",
+    )
+    assert find_inline_auth_reply_renders(fake_gateway, base=tmp_path) == []
+
+
+def test_every_auth_site_still_imports_the_shared_helper():
+    """Complements the ast guard: the three known sites must actually call the
+    renderer, not merely avoid the literal."""
+    missing = [
+        rel for rel in (
+            "gateway/run.py",
+            "gateway/platforms/api_server.py",
+            "gateway/platforms/api_server_runs.py",
+        )
+        if "provider_auth_error_reply" not in (REPO_ROOT / rel).read_text(encoding="utf-8")
+        and "collapse_provider_error_reply" not in (REPO_ROOT / rel).read_text(encoding="utf-8")
+    ]
+    assert not missing, f"auth reply sites not on the shared helper: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# F1 end to end, through the real gateway functions
+# ---------------------------------------------------------------------------
+
+def _collapse_mode(monkeypatch, interval=3600.0):
+    """Force the gateway's provider-error renderer into collapse mode."""
+    import agent.notice_collapse as nc
+
+    monkeypatch.setattr(nc, "resolve_fallback_notification_mode", lambda cfg=None: "collapse")
+    monkeypatch.setattr(nc, "resolve_fallback_notice_interval", lambda cfg=None: interval)
+
+
+RAW_401 = "Error code: 401 - invalid api key sk-live-DEADBEEF req_a1b2 org-acme"
+
+
+def test_sanitizer_signals_suppression_instead_of_returning_empty(monkeypatch):
+    """The final-response sanitizer must hand its caller something it can tell
+    apart from "not a provider error" — otherwise the caller falls through to
+    the raw provider body."""
+    from gateway.run import _sanitize_gateway_final_response
+    from gateway.config import Platform
+
+    _collapse_mode(monkeypatch)
+    first = _sanitize_gateway_final_response(Platform.TELEGRAM, RAW_401, "chat-1")
+    assert "authentication" in first and "sk-live" not in first
+
+    second = _sanitize_gateway_final_response(Platform.TELEGRAM, RAW_401, "chat-1")
+    assert is_suppressed_notice(second), "suppression must be distinguishable"
+    assert second != "", "an empty string is what caused the raw-error leak"
+
+    # A different chat is a different window (F3), end to end.
+    other = _sanitize_gateway_final_response(Platform.TELEGRAM, RAW_401, "chat-2")
+    assert "authentication" in other
+
+
+def test_status_path_is_the_only_one_that_collapses_to_nothing(monkeypatch):
+    """Unsolicited status chatter may go silent; nobody asked for it."""
+    from gateway.run import _prepare_gateway_status_message
+    from gateway.config import Platform
+
+    _collapse_mode(monkeypatch)
+    first = _prepare_gateway_status_message(Platform.TELEGRAM, "warn", RAW_401, "chat-1")
+    assert first and "authentication" in first
+    second = _prepare_gateway_status_message(Platform.TELEGRAM, "warn", RAW_401, "chat-1")
+    assert second is None
+    assert not is_suppressed_notice(second), "the sentinel must never escape"
+
+
+def test_auth_sites_resolve_suppression_before_returning_a_reply():
+    """The three auth render sites answer a message a person sent, so each must
+    pass the collapsed reply through ``resolve_direct_reply``."""
+    missing = []
+    for rel in (
+        "gateway/run.py",
+        "gateway/platforms/api_server.py",
+        "gateway/platforms/api_server_runs.py",
+    ):
         text = (REPO_ROOT / rel).read_text(encoding="utf-8")
-        for lineno, line in enumerate(text.splitlines(), 1):
-            if "Provider authentication failed" not in line:
-                continue
-            stripped = line.strip()
-            # Log lines and the shared helper's own definition are fine; an
-            # f-string that builds the user-facing reply is not.
-            if stripped.startswith(("logger.", '"Provider authentication failed')):
-                continue
-            if 'f"⚠️ Provider authentication failed' in line:
-                offenders.append(f"{rel}:{lineno}: {stripped}")
-        if "provider_auth_error_reply" not in text and "collapse_provider_error_reply" not in text:
-            offenders.append(f"{rel}: does not import the shared collapse helper")
-    assert not offenders, "provider auth reply rendered without the shared helper:\n" + "\n".join(offenders)
+        if "provider_auth_error_reply" in text and "resolve_direct_reply" not in text:
+            missing.append(rel)
+    assert not missing, (
+        "auth reply sites that can return an empty body during an outage: "
+        f"{missing}"
+    )

--- a/tests/agent/test_notice_collapse.py
+++ b/tests/agent/test_notice_collapse.py
@@ -1,0 +1,356 @@
+"""Tests for ``display.fallback_notifications`` collapsing.
+
+Covers the three modes, the collapse window with a fake clock, the folded
+count text, config parsing (including a YAML round-trip with a mistyped
+value), and the guard that keeps all provider auth-error render sites on the
+shared helper.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import pytest
+import yaml
+
+from agent.notice_collapse import (
+    DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS,
+    FallbackNoticeState,
+    collapse_fallback_notices,
+    provider_auth_error_reply,
+    reset_provider_auth_error_state,
+    resolve_fallback_notice_interval,
+    resolve_fallback_notification_mode,
+)
+from run_agent import AIAgent
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+HOP1 = "⚠️ Model fallback: m1 via p1 unavailable (rate limit); using m2 via p2."
+HOP2 = "⚠️ Model fallback: m2 via p2 unavailable (rate limit); using m3 via p3."
+HOP3 = "⚠️ Model fallback: m3 via p3 unavailable (rate limit); using m4 via p4."
+
+
+@pytest.fixture(autouse=True)
+def _clean_auth_state():
+    reset_provider_auth_error_state()
+    yield
+    reset_provider_auth_error_state()
+
+
+def _cfg(**display):
+    return {"display": display}
+
+
+# ---------------------------------------------------------------------------
+# Config parsing
+# ---------------------------------------------------------------------------
+
+def test_mode_defaults_to_on_when_unset():
+    assert resolve_fallback_notification_mode({}) == "on"
+    assert resolve_fallback_notification_mode(_cfg()) == "on"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("on", "on"), ("collapse", "collapse"), ("off", "off"),
+    ("  COLLAPSE  ", "collapse"), (True, "on"), (False, "off"),
+])
+def test_mode_accepted_values(raw, expected):
+    assert resolve_fallback_notification_mode(_cfg(fallback_notifications=raw)) == expected
+
+
+def test_mistyped_mode_warns_and_falls_back_to_on(caplog):
+    with caplog.at_level("WARNING"):
+        mode = resolve_fallback_notification_mode(_cfg(fallback_notifications="colapse"))
+    assert mode == "on"
+    assert "fallback_notifications" in caplog.text
+
+
+def test_config_yaml_round_trip_with_mistyped_value(tmp_path, caplog):
+    """A user config written and re-read must survive a typo as ``on``."""
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump({
+        "display": {
+            "fallback_notifications": "colapse",       # typo
+            "fallback_notice_interval_seconds": "soon",  # not a number
+        }
+    }), encoding="utf-8")
+    cfg = yaml.safe_load(path.read_text(encoding="utf-8"))
+    with caplog.at_level("WARNING"):
+        assert resolve_fallback_notification_mode(cfg) == "on"
+        assert resolve_fallback_notice_interval(cfg) == DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS
+    assert "fallback_notifications" in caplog.text
+    assert "fallback_notice_interval_seconds" in caplog.text
+
+
+def test_valid_yaml_round_trip(tmp_path):
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump({
+        "display": {"fallback_notifications": "collapse",
+                    "fallback_notice_interval_seconds": 900}
+    }), encoding="utf-8")
+    cfg = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert resolve_fallback_notification_mode(cfg) == "collapse"
+    assert resolve_fallback_notice_interval(cfg) == 900.0
+
+
+@pytest.mark.parametrize("raw", [0, -5, "nope", None, ""])
+def test_interval_falls_back_to_default(raw):
+    assert resolve_fallback_notice_interval(
+        _cfg(fallback_notice_interval_seconds=raw)
+    ) == DEFAULT_FALLBACK_NOTICE_INTERVAL_SECONDS
+
+
+def test_defaults_are_declared_in_default_config():
+    from hermes_cli.config_defaults import DEFAULT_CONFIG
+    assert DEFAULT_CONFIG["display"]["fallback_notifications"] == "on"
+    assert DEFAULT_CONFIG["display"]["fallback_notice_interval_seconds"] == 3600
+
+
+# ---------------------------------------------------------------------------
+# collapse_fallback_notices
+# ---------------------------------------------------------------------------
+
+def test_mode_on_emits_every_hop():
+    state = FallbackNoticeState()
+    out = collapse_fallback_notices(
+        [HOP1, HOP2, HOP3], mode="on", interval=3600, state=state, now=0.0,
+    )
+    assert out == [HOP1, HOP2, HOP3]
+    assert state.last_emitted_at is None  # window untouched in "on"
+
+
+def test_mode_off_emits_nothing():
+    state = FallbackNoticeState()
+    out = collapse_fallback_notices(
+        [HOP1, HOP2], mode="off", interval=3600, state=state, now=0.0,
+    )
+    assert out == []
+
+
+def test_collapse_folds_hops_in_one_flush():
+    """Five hops in one second produce exactly one line (spec A1)."""
+    state = FallbackNoticeState()
+    out = collapse_fallback_notices(
+        [HOP1, HOP2, HOP3], mode="collapse", interval=3600, state=state,
+        now=0.0, current_route="m4 via p4",
+    )
+    assert len(out) == 1
+    assert out[0].startswith("⚠️ Model fallback: m1 via p1 unavailable (rate limit)")
+    assert "(2 further fallbacks; now on m4 via p4.)" in out[0]
+
+
+def test_collapse_first_hop_verbatim_when_alone():
+    state = FallbackNoticeState()
+    out = collapse_fallback_notices(
+        [HOP1], mode="collapse", interval=3600, state=state, now=0.0,
+        current_route="m2 via p2",
+    )
+    assert out == [HOP1]
+
+
+def test_collapse_window_suppresses_then_folds_with_fake_clock():
+    """A second burst inside the window is counted; the next allowed notice
+    carries the count and the time of the previous notice."""
+    state = FallbackNoticeState()
+    # t=0 (09:12:00 UTC) — first notice goes out.
+    t0 = 1_757_063_520.0  # 2025-09-05 09:12:00 UTC
+    first = collapse_fallback_notices(
+        [HOP1], mode="collapse", interval=3600, state=state, now=t0,
+        current_route="m2 via p2",
+    )
+    assert first == [HOP1]
+
+    # t=+60s and t=+120s — inside the window, suppressed but counted.
+    for offset in (60.0, 120.0):
+        assert collapse_fallback_notices(
+            [HOP2, HOP3], mode="collapse", interval=3600, state=state,
+            now=t0 + offset, current_route="m4 via p4",
+        ) == []
+    assert state.suppressed == 4
+
+    # t=+3600s — window elapsed, the folded notice goes out.
+    folded = collapse_fallback_notices(
+        [HOP3], mode="collapse", interval=3600, state=state,
+        now=t0 + 3600.0, current_route="m5 via p5",
+    )
+    assert folded == [
+        "⚠️ Model fallback: 4 further fallbacks since 09:12 UTC; now on m5 via p5."
+    ]
+    assert state.suppressed == 0
+    assert state.last_emitted_at == t0 + 3600.0
+
+
+def test_collapse_empty_flush_is_a_noop():
+    state = FallbackNoticeState()
+    assert collapse_fallback_notices(
+        [], mode="collapse", interval=3600, state=state, now=0.0) == []
+    assert state.last_emitted_at is None
+
+
+def test_collapse_falls_back_when_route_unknown():
+    state = FallbackNoticeState(last_emitted_at=0.0, suppressed=2)
+    out = collapse_fallback_notices(
+        [HOP2], mode="collapse", interval=10, state=state, now=100.0,
+    )
+    assert "now on the fallback model." in out[0]
+
+
+# ---------------------------------------------------------------------------
+# Agent integration (_emit_pending_fallback_notice)
+# ---------------------------------------------------------------------------
+
+def _make_bare_agent(mode=None, interval=None, now=0.0):
+    agent = object.__new__(AIAgent)
+    agent.log_prefix = ""
+    agent.status_callback = None
+    agent.suppress_status_output = False
+    agent._mute_post_response = False
+    agent._executing_tools = False
+    agent._print_fn = None
+    if mode is not None:
+        agent.fallback_notifications = mode
+    if interval is not None:
+        agent.fallback_notice_interval_seconds = interval
+    agent._fallback_notice_clock = lambda: agent._fake_now
+    agent._fake_now = now
+    agent._provider_fallback_route = ("m4", "p4")
+    return agent
+
+
+def test_agent_emits_every_hop_in_on_mode():
+    agent = _make_bare_agent(mode="on", interval=3600)
+    emitted = []
+    agent._emit_status = emitted.append
+    agent._pending_fallback_notice = [HOP1, HOP2, HOP3]
+    agent._emit_pending_fallback_notice()
+    assert emitted == [HOP1, HOP2, HOP3]
+
+
+def test_agent_emits_nothing_in_off_mode():
+    agent = _make_bare_agent(mode="off", interval=3600)
+    emitted = []
+    agent._emit_status = emitted.append
+    agent._pending_fallback_notice = [HOP1, HOP2, HOP3]
+    agent._emit_pending_fallback_notice()
+    assert emitted == []
+    assert agent._pending_fallback_notice is None
+
+
+def test_agent_collapses_across_turns_with_fake_clock():
+    agent = _make_bare_agent(mode="collapse", interval=3600, now=1_757_063_520.0)
+    emitted = []
+    agent._emit_status = emitted.append
+
+    agent._pending_fallback_notice = [HOP1]
+    agent._emit_pending_fallback_notice()
+    assert emitted == [HOP1]
+
+    # Next turn, inside the window: suppressed.
+    agent._fake_now += 60
+    agent._pending_fallback_notice = [HOP2, HOP3]
+    agent._emit_pending_fallback_notice()
+    assert emitted == [HOP1]
+
+    # Next turn, window elapsed: one folded line.
+    agent._fake_now += 3600
+    agent._pending_fallback_notice = [HOP3]
+    agent._emit_pending_fallback_notice()
+    assert len(emitted) == 2
+    assert emitted[1] == (
+        "⚠️ Model fallback: 2 further fallbacks since 09:12 UTC; now on m4 via p4."
+    )
+
+
+def test_agent_flush_emits_collapsed_notice_outside_on_mode():
+    """Terminal failure: ``on`` relies on the retry buffer, collapse/off do not
+    buffer the hop line, so the flush must emit the collapsed notice itself."""
+    agent = _make_bare_agent(mode="collapse", interval=3600)
+    emitted = []
+    agent._emit_status = emitted.append
+    agent._pending_fallback_notice = [HOP1, HOP2]
+
+    agent._flush_status_buffer()
+
+    assert len(emitted) == 1
+    assert "1 further fallbacks" in emitted[0]
+    assert agent._pending_fallback_notice is None
+
+
+def test_try_activate_fallback_skips_status_buffer_outside_on_mode():
+    """The per-hop line stays out of the retry buffer when collapsing."""
+    import inspect
+    from agent import chat_completion_helpers
+
+    src = inspect.getsource(chat_completion_helpers.try_activate_fallback)
+    assert '_fallback_notice_mode' in src
+    assert 'if _notice_mode == "on":\n            agent._buffer_status(notice)' in src
+
+
+# ---------------------------------------------------------------------------
+# Provider auth-error replies
+# ---------------------------------------------------------------------------
+
+def test_auth_reply_unchanged_in_on_mode():
+    reply = provider_auth_error_reply("no creds", session_key="s1", mode="on")
+    assert reply == "⚠️ Provider authentication failed: no creds"
+    assert provider_auth_error_reply("no creds", session_key="s1", mode="on") == reply
+
+
+def test_auth_reply_suppressed_in_off_mode():
+    assert provider_auth_error_reply("no creds", session_key="s1", mode="off") == ""
+
+
+def test_auth_reply_deduped_per_session_per_window():
+    kw = dict(mode="collapse", interval=3600)
+    assert provider_auth_error_reply("no creds", session_key="s1", now=0.0, **kw)
+    # Same class, same session, inside the window → suppressed.
+    assert provider_auth_error_reply("no creds", session_key="s1", now=60.0, **kw) == ""
+    # Different session → its own window.
+    assert provider_auth_error_reply("no creds", session_key="s2", now=60.0, **kw)
+    # Different error class → not deduped against the first.
+    assert provider_auth_error_reply("bad key", session_key="s1", now=60.0, **kw)
+    # Window elapsed → allowed again.
+    assert provider_auth_error_reply("no creds", session_key="s1", now=3600.0, **kw)
+
+
+def test_gateway_reply_classes_dedupe_independently():
+    from gateway.run import _gateway_provider_error_reply
+
+    auth = _gateway_provider_error_reply("Error code: 401 invalid api key")
+    assert "authentication" in auth
+    # Default mode is "on" — repeats are unchanged.
+    assert _gateway_provider_error_reply("Error code: 401 invalid api key") == auth
+
+
+# ---------------------------------------------------------------------------
+# Three-site guard
+# ---------------------------------------------------------------------------
+
+AUTH_REPLY_SITES = (
+    "gateway/run.py",
+    "gateway/platforms/api_server.py",
+    "gateway/platforms/api_server_runs.py",
+)
+
+
+def test_all_provider_auth_reply_sites_use_the_shared_helper():
+    """Every site that surfaces a provider auth failure must route through
+    ``agent.notice_collapse`` so one outage cannot produce one reply per
+    attempt. Fails loudly if a new site re-renders the string inline."""
+    offenders = []
+    for rel in AUTH_REPLY_SITES:
+        text = (REPO_ROOT / rel).read_text(encoding="utf-8")
+        for lineno, line in enumerate(text.splitlines(), 1):
+            if "Provider authentication failed" not in line:
+                continue
+            stripped = line.strip()
+            # Log lines and the shared helper's own definition are fine; an
+            # f-string that builds the user-facing reply is not.
+            if stripped.startswith(("logger.", '"Provider authentication failed')):
+                continue
+            if 'f"⚠️ Provider authentication failed' in line:
+                offenders.append(f"{rel}:{lineno}: {stripped}")
+        if "provider_auth_error_reply" not in text and "collapse_provider_error_reply" not in text:
+            offenders.append(f"{rel}: does not import the shared collapse helper")
+    assert not offenders, "provider auth reply rendered without the shared helper:\n" + "\n".join(offenders)

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -554,7 +554,13 @@ display:
 | `collapse` | At most **one** notice per session per `fallback_notice_interval_seconds`. The first names the primary model, the reason, and the model now in use; further hops are counted and folded into the next allowed notice ("3 further fallbacks since 09:12 UTC; now on …"). Provider auth/rate-limit/connection replies are deduped by error class over the same window. |
 | `off` | No user-facing fallback or provider-error notice at all |
 
+The window is per conversation: a collapsed notice in one channel never silences a different channel or DM.
+
+**A reply to a message you sent is never silence.** If the window already reported the outage, your message still gets one short line ("Still failing on the provider error reported earlier; details in the gateway logs") rather than nothing, and never the raw provider error. Only unsolicited status chatter collapses to nothing.
+
 The gateway log is unchanged in every mode — `off` silences chat, not diagnostics.
+
+The window lives in memory, so a gateway restart reopens it and allows one more notice. That is deliberate: the failure direction is one notice too many, never a lost one.
 
 ### Use Cases
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -538,6 +538,24 @@ You can also set this via environment variable:
 HERMES_BACKGROUND_NOTIFICATIONS=result
 ```
 
+### Model Fallback and Provider Error Notices
+
+When a provider goes down, Hermes walks its fallback chain. Each hop posts its own "⚠️ Model fallback: … using …" line and each failed attempt can post its own "⚠️ Provider authentication failed …" reply, so one outage can put five near-identical messages in your chat in a second. Control that with `display.fallback_notifications`:
+
+```yaml
+display:
+  fallback_notifications: on            # on | collapse | off
+  fallback_notice_interval_seconds: 3600
+```
+
+| Mode | What you receive |
+|------|-----------------|
+| `on` | One notice per hop and one reply per failed attempt (default; unchanged behaviour) |
+| `collapse` | At most **one** notice per session per `fallback_notice_interval_seconds`. The first names the primary model, the reason, and the model now in use; further hops are counted and folded into the next allowed notice ("3 further fallbacks since 09:12 UTC; now on …"). Provider auth/rate-limit/connection replies are deduped by error class over the same window. |
+| `off` | No user-facing fallback or provider-error notice at all |
+
+The gateway log is unchanged in every mode — `off` silences chat, not diagnostics.
+
 ### Use Cases
 
 - **Server monitoring** — "/bg Check the health of all services and alert me if anything is down"


### PR DESCRIPTION
## The problem

When a provider goes down, Hermes walks its fallback chain. Every hop emits its own
`⚠️ Model fallback: … using …` line and every failed attempt can emit its own
`⚠️ Provider authentication failed …` reply, so a single outage can drop five
near-identical messages into a chat inside one second. On a long-running agent that
repeats for the whole outage.

## What this adds

Two new keys under the existing top-level `display:` block:

```yaml
display:
  fallback_notifications: on            # on | collapse | off   (default: on)
  fallback_notice_interval_seconds: 3600
```

| Mode | What a user receives |
|------|----------------------|
| `on` | One notice per hop and one reply per failed attempt — the current behaviour, default |
| `collapse` | At most **one** notice per session per interval. The first names the primary model, the reason and the model now in use; further hops are counted and folded into the next allowed notice (`3 further fallbacks since 09:12 UTC; now on …`). Provider auth / rate-limit / connection replies dedupe by **error class** over the same window |
| `off` | No user-facing fallback or provider-error notice at all |

The gateway log is unchanged in every mode: `off` silences chat, not diagnostics.

## Design points worth reviewing

- **A reply to a message somebody sent is never silence.** Suppression returns a
  `SUPPRESSED_NOTICE` sentinel rather than `""`, so a caller can tell "already told this
  conversation" apart from "not a provider error". `resolve_direct_reply` turns that into
  one terse line (`⚠️ Still failing on the provider error reported earlier; details in the
  gateway logs.`) — never an empty message and never the raw provider text.
  `resolve_status_notice` is the only path allowed to collapse to nothing, and it only
  handles unsolicited status chatter.
- **The dedupe key is the error class, not the raw exception text**, so per-attempt
  variation (request ids, timings) cannot defeat it.
- **The window is keyed per platform *and* chat id**, so a collapsed notice in one channel
  never silences a different channel or DM. Platform-only is the documented fallback when
  no chat id is available.
- **One shared renderer.** Every gateway site that surfaces a provider auth failure goes
  through `provider_auth_error_reply` / `collapse_provider_error_reply` in
  `agent/notice_collapse.py`. An `ast` guard in `tests/agent/test_notice_collapse.py` walks
  the whole `gateway/` tree and fails if a new site is added that bypasses it.
- **The window is in-memory**, so a gateway restart or an agent-cache eviction reopens it
  and allows one more notice. Deliberate: the failure direction here is one notice too
  many, never a lost one.

## Behaviour in `on` mode

`on` is the default and is byte-identical to today — same text, same ordering, same flush
timing — with two deliberate exceptions, both stated so they are not a surprise in review:

1. **One new unconditional `logger.warning`** at the TurnRunner auth branch in
   `gateway/run.py`, closing a log gap that the other two auth-render sites already
   covered. It is a log line only; nothing new reaches chat.
2. **A whitespace-only notice is now dropped in every mode** instead of emitting a blank
   message.

## Tests

`tests/agent/test_notice_collapse.py` (+795 lines) covers the mode matrix, the
suppression contract (direct reply never `""`, never raw error; only the status path
collapses to nothing), the class-only dedupe key, the per-chat window key, the
`on`-mode-unchanged assertions, and the `ast` bypass guard, parametrised over six
evasion shapes the previous exact-string guard walked past (double- and single-quoted
f-strings, `" " + str(exc)`, `.format()`, `%`, and implicit string-literal concatenation).

## Docs

`website/docs/user-guide/messaging/index.md` (user-facing table + the never-silence
contract) and `AGENTS.md` (the renderer contract and the window's lifetime).
