### PR TITLE
fix(env): stop profile cron ticks from hijacking desktop terminals

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -609,7 +609,9 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     loading (the historical env-driven behavior still applies).
     """
     try:
-        if Path(home_path).resolve() != _process_hermes_home().resolve():
+        from hermes_constants import get_process_hermes_home
+
+        if Path(home_path).resolve() != get_process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env
 

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -620,3 +620,39 @@ def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch
 
     # The other profile's .env value stands; the process config was not applied.
     assert os.getenv("TERMINAL_ENV") == "docker"
+
+
+def test_routed_profile_override_does_not_bridge_terminal_config(tmp_path, monkeypatch):
+    """A routed profile load must not pin its terminal config process-wide."""
+    from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+
+    process_home = tmp_path / "process-home"
+    process_home.mkdir()
+    (process_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+    monkeypatch.setenv("TERMINAL_ENV", "local")
+    monkeypatch.delenv("TERMINAL_DOCKER_VOLUMES", raising=False)
+
+    routed_home = tmp_path / "routed-profile"
+    routed_home.mkdir()
+    (routed_home / "config.yaml").write_text(
+        "terminal:\n"
+        "  backend: docker\n"
+        "  docker_volumes:\n"
+        "    - routed-session:/session\n",
+        encoding="utf-8",
+    )
+
+    token = set_hermes_home_override(routed_home)
+    try:
+        load_hermes_dotenv(
+            hermes_home=routed_home,
+            load_external_secrets=False,
+        )
+    finally:
+        reset_hermes_home_override(token)
+
+    assert os.environ["TERMINAL_ENV"] == "local"
+    assert "TERMINAL_DOCKER_VOLUMES" not in os.environ


### PR DESCRIPTION
## What does this PR do?

Stops a routed secondary profile from replacing the process-wide terminal backend and Docker volume settings used by the launch profile in a multi-profile `hermes serve` process. The terminal config bridge now compares against the true process launch home, rather than a context-local profile override.

### Symptom

After a secondary profile cron tick reloads its environment, a later unscoped launch-profile desktop session can run in the secondary profile's Docker backend and mount its configured volumes instead of using the launch profile's local backend.

### Impact

A multi-profile serve process can silently execute one profile's terminal session inside another profile's backend. This crosses the expected profile isolation boundary and can expose profile-specific mounted data to the wrong session.

### Bug Cause

**Trigger:** `hermes_cli/env_loader.py:_reapply_terminal_config_bridge` while `set_hermes_home_override()` scopes a routed cron tick.

**Causal chain:**
1. A secondary profile cron tick reloads its environment under a context-local Hermes home override.
2. `_reapply_terminal_config_bridge()` treats the routed home as the process home because `_process_hermes_home()` follows that override.
3. The secondary profile's `terminal.*` config is exported into process-global `TERMINAL_*`, so a later unscoped launch-profile session adopts the wrong backend and volumes.

**Why it is wrong:** A process-global bridge must be keyed to the process launch home, not to a temporary per-task profile override.

**Working sibling / contrast:** Loading a different profile without a context override already fails the home comparison and skips the bridge. Only the routed override path made both sides of the comparison resolve to the secondary profile.

**Ruled out:** The one-shot terminal tool fallback is not the writer on this path; the repeated `load_hermes_dotenv()` terminal bridge reproduces the mutation directly.

### Fix

Use `get_process_hermes_home()` for the bridge guard so routed profile config reloads cannot export their terminal settings process-wide. A regression test reproduces both the backend and Docker volume contamination under a real context-local home override.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/env_loader.py` - compare terminal bridge loads against the override-independent process launch home.
- `tests/hermes_cli/test_env_loader.py` - cover routed profile backend and Docker volume isolation.

## How to Test

1. Run the focused env-loader regression test and confirm it preserves the launch profile's `TERMINAL_ENV` and leaves routed Docker volumes out of `os.environ`.
2. Run the related env-loader, terminal bridge, terminal scope, gateway reload, and cron workdir suites.

```bash
scripts/run_tests.sh tests/hermes_cli/test_env_loader.py tests/tools/test_terminal_env_bridge.py tests/tools/test_terminal_scope_multiplex.py tests/gateway/test_runtime_env_reload_config_authority.py tests/cron/test_cron_workdir.py -k 'not tilde_expands' -q
```

Result: 61 passed on Windows 11. The excluded `test_tilde_expands` is an unrelated existing Windows-only HOME expansion mismatch.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run the relevant test suites and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Documentation update is N/A; behavior and regression coverage are self-contained
- [x] `cli-config.yaml.example` update is N/A; no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A; no architecture or workflow changed
- [x] I've considered cross-platform impact; the fix uses existing `pathlib.Path` and process-home resolution
- [x] Tool description/schema updates are N/A; no tool contract changed

## Screenshots / Logs

N/A; the automated regression directly asserts the process environment contamination and isolation behavior.
