### PR TITLE
feat(telegram): add opt-in per-message latency and typing diagnostics

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -26,6 +26,15 @@ logger = logging.getLogger(__name__)
 from agent.deadline import run_bounded_async
 
 
+def _telegram_latency_diagnostics_enabled() -> bool:
+    """Opt-in switch for per-message latency/typing diagnostics (#102761).
+
+    Disabled by default: this adds INFO-level logging on the hot inbound
+    path and must never fire unless an operator asks for it.
+    """
+    return env_var_enabled("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS")
+
+
 def _redact_telegram_error_text(error: object) -> str:
     """Redact secrets from Telegram transport errors before logging or returning them."""
     text = "" if error is None else str(error)
@@ -244,7 +253,7 @@ from plugins.platforms.telegram.telegram_network import (
     parse_fallback_ip_env,
     tcp_keepalive_socket_options,
 )
-from utils import atomic_replace, env_float, env_int
+from utils import atomic_replace, env_float, env_int, env_var_enabled
 
 _TELEGRAM_IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".webp", ".gif"}
 
@@ -8719,6 +8728,24 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot or self._typing_in_cooldown(chat_id):
             return
 
+        _diag = _telegram_latency_diagnostics_enabled()
+        _diag_start = time.monotonic() if _diag else None
+
+        def _log_typing_result(
+            outcome: str, thread_id: Optional[int], exc: Optional[Exception] = None
+        ) -> None:
+            if not _diag:
+                return
+            logger.info(
+                "[%s] Telegram sendChatAction(typing) %s in %.3fs (chat_id=%s, thread_id=%s)%s",
+                self.name,
+                outcome,
+                time.monotonic() - _diag_start,
+                chat_id,
+                thread_id,
+                f": {_redact_telegram_error_text(exc)}" if exc is not None else "",
+            )
+
         _is_dm_topic: bool = False
         message_thread_id: Optional[int] = None
         try:
@@ -8731,6 +8758,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 message_thread_id=message_thread_id,
             )
             self._telegram_typing_cooldown_until.pop(str(chat_id), None)
+            _log_typing_result("succeeded", message_thread_id)
         except Exception as e:
             # For DM topic lanes, Telegram may reject message_thread_id.
             # Fall back to sending typing without thread_id so the typing
@@ -8742,12 +8770,14 @@ class TelegramAdapter(BasePlatformAdapter):
                         action="typing",
                     )
                     self._telegram_typing_cooldown_until.pop(str(chat_id), None)
+                    _log_typing_result("succeeded", None)
                     return
                 except Exception as fallback_exc:
                     if self._is_transient_typing_error(fallback_exc):
                         self._record_typing_cooldown(chat_id, fallback_exc)
             elif self._is_transient_typing_error(e):
                 self._record_typing_cooldown(chat_id, e)
+            _log_typing_result("failed", message_thread_id, e)
             # Typing failures are non-fatal; log at debug level only.
             logger.debug(
                 "[%s] Failed to send Telegram typing indicator: %s",
@@ -11013,6 +11043,9 @@ class TelegramAdapter(BasePlatformAdapter):
             _chat_id_str if thread_id_str else None,
         )
 
+        if _telegram_latency_diagnostics_enabled():
+            self._log_telegram_message_age(message.date, update_id, message.message_id)
+
         return MessageEvent(
             text=message.text or "",
             message_type=msg_type,
@@ -11025,6 +11058,36 @@ class TelegramAdapter(BasePlatformAdapter):
             auto_skill=topic_skill,
             channel_prompt=_channel_prompt,
             timestamp=message.date,
+        )
+
+    def _log_telegram_message_age(
+        self,
+        platform_timestamp: Optional[datetime],
+        update_id: Optional[int],
+        message_id: Any,
+    ) -> None:
+        """Log wall-clock age of ``platform_timestamp`` at adapter accept time.
+
+        Diagnostic-only (see #102761): correlates with `update_id`/`message_id`,
+        never the message text. Clock skew that makes Telegram's timestamp
+        look like it is in the future is clamped to zero rather than logged
+        as a negative age.
+        """
+        if platform_timestamp is None:
+            return
+        try:
+            ts = platform_timestamp
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)
+            age_seconds = max(0.0, (datetime.now(timezone.utc) - ts).total_seconds())
+        except Exception:
+            return
+        logger.info(
+            "[%s] Telegram message age at adapter accept: %.3fs (update_id=%s, message_id=%s)",
+            self.name,
+            age_seconds,
+            update_id,
+            message_id,
         )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────

--- a/tests/gateway/test_telegram_latency_diagnostics.py
+++ b/tests/gateway/test_telegram_latency_diagnostics.py
@@ -1,0 +1,167 @@
+"""Tests for opt-in Telegram per-message latency/typing diagnostics (#102761).
+
+Disabled by default; ``HERMES_TELEGRAM_LATENCY_DIAGNOSTICS=1`` turns on
+INFO-level logs for (a) message age at adapter accept time and (b)
+sendChatAction(typing) duration/outcome. Must not change any Telegram
+processing behavior — only add logging.
+"""
+
+import logging
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig, Platform
+from gateway.platforms.base import MessageType
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+_LOGGER_NAME = "plugins.platforms.telegram.adapter"
+
+
+def _make_adapter():
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._config = config
+    adapter._platform = Platform.TELEGRAM
+    adapter.platform = Platform.TELEGRAM
+    adapter._connected = True
+    adapter._dm_topics = {}
+    adapter._dm_topics_config = []
+    adapter._reply_to_mode = "first"
+    adapter._fallback_ips = []
+    return adapter
+
+
+def _make_message(date):
+    import plugins.platforms.telegram.adapter as telegram_mod
+
+    return SimpleNamespace(
+        text="hi",
+        caption=None,
+        chat=SimpleNamespace(
+            id=-100123,
+            type=telegram_mod.ChatType.SUPERGROUP,
+            is_forum=False,
+            title="Group",
+        ),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        is_topic_message=False,
+        reply_to_message=None,
+        message_id=999,
+        date=date,
+    )
+
+
+def test_diagnostics_disabled_by_default(monkeypatch, caplog):
+    monkeypatch.delenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", raising=False)
+    adapter = _make_adapter()
+    message = _make_message(datetime.now(timezone.utc) - timedelta(seconds=5))
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=7)
+
+    assert "message age" not in caplog.text
+
+
+def test_message_age_logged_when_enabled(monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    message = _make_message(datetime.now(timezone.utc) - timedelta(seconds=5))
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=7)
+
+    matching = [r for r in caplog.records if "message age" in r.message]
+    assert len(matching) == 1
+    assert "update_id=7" in matching[0].message
+    assert "message_id=999" in matching[0].message
+    # age should be ~5s, not clamped, and not the raw message text.
+    assert "hi" not in matching[0].message
+
+
+def test_naive_timestamp_treated_as_utc(monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    naive_now = (datetime.now(timezone.utc) - timedelta(seconds=2)).replace(tzinfo=None)
+    message = _make_message(naive_now)
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=1)
+
+    matching = [r for r in caplog.records if "message age" in r.message]
+    assert len(matching) == 1
+
+
+def test_future_timestamp_clamped_to_zero(monkeypatch, caplog):
+    """Negative clock skew (platform timestamp in the future) must clamp to 0s."""
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    message = _make_message(datetime.now(timezone.utc) + timedelta(seconds=30))
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        adapter._build_message_event(message, msg_type=MessageType.TEXT, update_id=2)
+
+    matching = [r for r in caplog.records if "message age" in r.message]
+    assert len(matching) == 1
+    assert "0.000s" in matching[0].message
+
+
+@pytest.mark.asyncio
+async def test_typing_diagnostics_disabled_by_default(monkeypatch, caplog):
+    monkeypatch.delenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", raising=False)
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    adapter._telegram_typing_cooldown_until = {}
+    adapter._telegram_typing_cooldown_seconds = 30.0
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await adapter.send_typing("123")
+
+    assert "sendChatAction" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_typing_success_logs_duration_when_enabled(monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock()
+    adapter._telegram_typing_cooldown_until = {}
+    adapter._telegram_typing_cooldown_seconds = 30.0
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await adapter.send_typing("123")
+
+    matching = [r for r in caplog.records if "sendChatAction" in r.message]
+    assert len(matching) == 1
+    assert "succeeded" in matching[0].message
+    assert "chat_id=123" in matching[0].message
+
+
+_SECRET_TOKEN = "123456789:AAFakeSecretTelegramBotTokenABCDEFGHIJ"
+
+
+@pytest.mark.asyncio
+async def test_typing_failure_logs_sanitized_error_when_enabled(monkeypatch, caplog):
+    monkeypatch.setenv("HERMES_TELEGRAM_LATENCY_DIAGNOSTICS", "1")
+    adapter = _make_adapter()
+    adapter._bot = AsyncMock(
+        send_chat_action=AsyncMock(
+            side_effect=RuntimeError(
+                f"https://api.telegram.org/bot{_SECRET_TOKEN}/sendChatAction failed"
+            )
+        )
+    )
+    adapter._telegram_typing_cooldown_until = {}
+    adapter._telegram_typing_cooldown_seconds = 30.0
+
+    with caplog.at_level(logging.INFO, logger=_LOGGER_NAME):
+        await adapter.send_typing("123")
+
+    matching = [r for r in caplog.records if "sendChatAction" in r.message]
+    assert len(matching) == 1
+    assert "failed" in matching[0].message
+    assert _SECRET_TOKEN not in matching[0].message


### PR DESCRIPTION
## Summary

Closes #102761.

Some Telegram messages take 150-185s before Hermes shows any visible acknowledgement, and the existing logs can't tell whether that delay is Telegram->adapter, adapter->gateway, or the `sendChatAction(typing)` call itself, because:

- `_build_message_event()` (`plugins/platforms/telegram/adapter.py`) never logged when a message was accepted relative to its Telegram-side timestamp.
- `send_typing()`'s error path was `logger.debug(...)`-only with no timing at all, so a missing client-side "typing..." indicator couldn't be correlated from normal gateway logs.

This adds **opt-in, diagnostic-only** logging behind `HERMES_TELEGRAM_LATENCY_DIAGNOSTICS=1`:

- `_log_telegram_message_age()`: at adapter-accept time (end of `_build_message_event`, shared by all inbound message types), logs the wall-clock age of the Telegram-supplied `message.date` against `datetime.now(timezone.utc)`, tagged with `update_id`/`message_id` (never message text). Naive timestamps are treated as UTC; a platform timestamp that appears to be in the future (negative clock skew) is clamped to `0.000s` instead of logging a negative age.
- `send_typing()`: wraps the existing `sendChatAction(typing)` call (and its DM-topic fallback) with `time.monotonic()`-measured duration logging on both the success and failure paths, tagged with `chat_id`/`thread_id`. Failure messages are passed through the adapter's existing `_redact_telegram_error_text()` so no token/URL leaks into the new log line.

Both are no-ops when the env var is unset — no new per-message INFO logging by default, and no change to polling, batching, typing cadence, message routing, retries, or response delivery. The only control-flow change is the two added `_log_typing_result(...)` calls in `send_typing()`; every existing branch (cooldown, DM-topic fallback, transient-error cooldown) is untouched.

## Test plan

New file `tests/gateway/test_telegram_latency_diagnostics.py` (7 tests):

- Diagnostics off by default for both message-age and typing logging.
- Message age logged with `update_id`/`message_id` when enabled, message text never appears in the log line.
- A naive (tzinfo-less) `message.date` is still handled (treated as UTC).
- A platform timestamp in the future clamps to `0.000s` instead of a negative age.
- `send_typing()` success logs duration + `chat_id` when enabled.
- `send_typing()` failure logs duration + a redacted error (bot token stripped) when enabled.

Ran with the project's pinned test deps (`pytest==9.1.1`, `pytest-asyncio==1.3.0`):

```
$ python -m pytest tests/gateway/test_telegram_latency_diagnostics.py -v
...
7 passed in 0.46s
```

Confirmed the new tests fail without the fix (checked out `plugins/platforms/telegram/adapter.py` from the parent commit, the test file unchanged):

```
$ git stash push -- plugins/platforms/telegram/adapter.py
$ python -m pytest tests/gateway/test_telegram_latency_diagnostics.py -v
...
FAILED test_message_age_logged_when_enabled
FAILED test_naive_timestamp_treated_as_utc
FAILED test_future_timestamp_clamped_to_zero
FAILED test_typing_success_logs_duration_when_enabled
FAILED test_typing_failure_logs_sanitized_error_when_enabled
5 failed, 2 passed in 0.51s
$ git stash pop   # restored the fix
```

Regression check — full existing Telegram test surface still green with the change applied:

```
$ python -m pytest tests/gateway/ -k telegram -q --continue-on-collection-errors
751 passed, 5 skipped, 18 errors
```

(The 18 collection errors are `ModuleNotFoundError: No module named 'aiohttp.test_utils'` in unrelated `test_webhook_*`/`test_api_server_*`/`test_raft_adapter.py` files — a missing optional dependency in this sandbox, confirmed unrelated to this change and to Telegram.)

Lint: `ruff check plugins/platforms/telegram/adapter.py tests/gateway/test_telegram_latency_diagnostics.py` — all checks passed.

## AI assistance disclosure

This PR was written with AI assistance (Claude Code / Claude Sonnet 5), reviewed and tested by the human contributor before submission.
