### PR TITLE
fix(models): route codex-family static detection to openai-codex when the API key is unusable

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -3837,6 +3837,69 @@ def _resolve_static_model_alias(
     return None
 
 
+def _has_usable_codex_oauth() -> bool:
+    """Whether the user holds a usable openai-codex OAuth grant.
+
+    Checks the same two stores the runtime resolver consults: the singleton
+    ``providers.openai-codex.tokens`` entry and the ``credential_pool``
+    fallback. Never raises and never touches the network — an unreadable
+    store simply does not steer provider inference.
+    """
+    try:
+        from hermes_cli.auth import _load_auth_store, _load_provider_state
+
+        store = _load_auth_store()
+        state = _load_provider_state(store, "openai-codex")
+        tokens = state.get("tokens") if isinstance(state, dict) else None
+        if isinstance(tokens, dict):
+            access = tokens.get("access_token")
+            refresh = tokens.get("refresh_token")
+            if (
+                isinstance(access, str)
+                and access.strip()
+                and isinstance(refresh, str)
+                and refresh.strip()
+            ):
+                return True
+        pool = store.get("credential_pool")
+        entries = pool.get("openai-codex") if isinstance(pool, dict) else None
+        if isinstance(entries, list):
+            for entry in entries:
+                token = entry.get("access_token") if isinstance(entry, dict) else None
+                if isinstance(token, str) and token.strip():
+                    return True
+    except Exception:
+        pass
+    return False
+
+
+def _prefer_openai_codex_when_unkeyed(
+    detected: tuple[str, str],
+) -> tuple[str, str]:
+    """Break the openai-api/openai-codex catalog tie toward usable credentials.
+
+    The ``gpt-5.6-*`` family lives in both the ``openai-api`` and
+    ``openai-codex`` catalogs, and ``openai-api`` wins purely by dict order —
+    so a user with no usable ``OPENAI_API_KEY`` but a valid Codex OAuth grant
+    is routed to a guaranteed auth failure while their grant is ignored.
+    Flip only this pair, only on that credential combination; every other
+    detection keeps today's routing.
+    """
+    provider, model = detected
+    if provider != "openai-api":
+        return detected
+    if not any(m.lower() == model.lower() for m in _provider_catalog_names("openai-codex")):
+        return detected
+    api_key = os.getenv("OPENAI_API_KEY", "").strip()
+    from hermes_cli.auth import has_usable_secret
+
+    if has_usable_secret(api_key):
+        return detected
+    if _has_usable_codex_oauth():
+        return ("openai-codex", model)
+    return detected
+
+
 def detect_static_provider_for_model(
     model_name: str,
     current_provider: str,
@@ -3908,7 +3971,7 @@ def detect_static_provider_for_model(
         if _is_custom_current:
             continue
         if any(name_lower == m.lower() for m in _provider_catalog_names(pid)):
-            return (pid, name)
+            return _prefer_openai_codex_when_unkeyed((pid, name))
 
     # Borrow-list providers (re-expose other vendors' models) only after every
     # native-vendor catalog, and only when one is the current provider.

--- a/tests/hermes_cli/test_openai_codex_tiebreak.py
+++ b/tests/hermes_cli/test_openai_codex_tiebreak.py
@@ -1,0 +1,104 @@
+"""Credential tiebreak between the openai-api and openai-codex catalogs.
+
+The whole ``gpt-5.6-*`` family lives in both static catalogs, and the
+first-catalog-match loop prefers ``openai-api`` purely by dict order. When
+``OPENAI_API_KEY`` is missing or a placeholder but a Codex OAuth grant is
+stored, detection must route to ``openai-codex`` instead of a guaranteed
+auth failure. Every other combination keeps the historical routing.
+"""
+
+import pytest
+
+from hermes_cli import auth as _auth_mod
+from hermes_cli.models import detect_provider_for_model, detect_static_provider_for_model
+import hermes_cli.models as _models_mod
+
+
+def _patch_store(monkeypatch, store):
+    monkeypatch.setattr(_auth_mod, "_load_auth_store", lambda *a, **k: store)
+
+
+def _with_codex_oauth():
+    return {
+        "providers": {
+            "openai-codex": {
+                "tokens": {"access_token": "at-token", "refresh_token": "rt-token"}
+            }
+        }
+    }
+
+
+class TestCodexTiebreak:
+    def test_unkeyed_api_with_codex_oauth_routes_to_codex(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(monkeypatch, _with_codex_oauth())
+        assert detect_provider_for_model("gpt-5.6-luna", "deepseek") == (
+            "openai-codex",
+            "gpt-5.6-luna",
+        )
+
+    def test_placeholder_api_key_with_codex_oauth_routes_to_codex(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "placeholder")
+        _patch_store(monkeypatch, _with_codex_oauth())
+        assert detect_provider_for_model("gpt-5.6-terra", "deepseek") == (
+            "openai-codex",
+            "gpt-5.6-terra",
+        )
+
+    def test_usable_api_key_keeps_openai_api_routing(self, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-real-key-123")
+        _patch_store(monkeypatch, _with_codex_oauth())
+        assert detect_provider_for_model("gpt-5.6-luna", "deepseek") == (
+            "openai-api",
+            "gpt-5.6-luna",
+        )
+
+    def test_no_credentials_keeps_historical_openai_api(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(monkeypatch, {})
+        assert detect_provider_for_model("gpt-5.6-luna", "deepseek") == (
+            "openai-api",
+            "gpt-5.6-luna",
+        )
+
+    def test_model_outside_codex_catalog_untouched(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(monkeypatch, _with_codex_oauth())
+        assert detect_provider_for_model("gpt-4.1", "deepseek") == ("openai", "gpt-4.1")
+
+    def test_pool_only_codex_credentials_route_to_codex(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(
+            monkeypatch,
+            {"credential_pool": {"openai-codex": [{"access_token": "pool-token"}]}},
+        )
+        assert detect_provider_for_model("gpt-5.6-sol", "deepseek") == (
+            "openai-codex",
+            "gpt-5.6-sol",
+        )
+
+    def test_current_provider_codex_short_circuits_before_tiebreak(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(monkeypatch, _with_codex_oauth())
+        # detect_static_provider_for_model returns None when the model is in
+        # the current provider's catalog (step before the tiebreak loop).
+        assert detect_static_provider_for_model("gpt-5.6-luna", "openai-codex") is None
+
+    def test_broken_auth_store_does_not_break_detection(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+        def _boom(*a, **k):
+            raise RuntimeError("store unreadable")
+
+        monkeypatch.setattr(_auth_mod, "_load_auth_store", _boom)
+        assert detect_provider_for_model("gpt-5.6-luna", "deepseek") == (
+            "openai-api",
+            "gpt-5.6-luna",
+        )
+
+    def test_short_alias_path_unaffected(self, monkeypatch):
+        monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+        _patch_store(monkeypatch, _with_codex_oauth())
+        result = detect_provider_for_model("sonnet", "auto")
+        assert result is not None
+        assert result[0] == "anthropic"


### PR DESCRIPTION
## Summary
`detect_static_provider_for_model()` picked `openai-api` for the whole `gpt-5.6-*` family even when the user has no usable `OPENAI_API_KEY`, because the `openai-api` static catalog lists those models and sits earlier in `_PROVIDER_MODELS` dict order than `openai-codex`. A valid Codex OAuth grant (auth store or credential pool) was ignored, and `/model gpt-5.6-luna` failed with `No usable credentials found for provider 'openai-api'` while `--provider openai-codex` worked.

Root cause → fix: the static-catalog loop now routes its `(provider, model)` pick through a narrow credential tiebreak. When the detected provider is `openai-api`, the model is also in the `openai-codex` catalog, `OPENAI_API_KEY` is missing or a placeholder (per `has_usable_secret`), and a usable Codex OAuth grant exists in the same two stores the runtime resolver consults, detection returns `openai-codex` instead. Every other combination — usable API key, no Codex grant, model outside the codex catalog, non-`openai-api` providers, the short-alias path, and the current-provider short-circuit — keeps today's routing.

## Testing
- New regression suite `tests/hermes_cli/test_openai_codex_tiebreak.py` (9 tests): unkeyed+OAuth → codex; placeholder key+OAuth → codex; usable key → `openai-api` unchanged; no creds → `openai-api` unchanged; `gpt-4.1` (not in codex catalog) unchanged; pool-only codex creds → codex; current provider `openai-codex` still short-circuits; broken auth store falls back to historical routing; `sonnet` alias path unaffected.
- Neighbouring suites green: `test_models.py`, `test_model_switch_configured_provider_routing.py`, `test_gpt56_registration.py`, `test_openai_picker_curated.py`, `test_model_switch_openai_api_mode.py`, `test_provider_catalog.py`, `test_user_providers_model_switch.py`, `test_model_switch_copilot_api_mode.py`, `test_model_prefix_routing_87189.py`, `test_model_switch_opencode_anthropic.py`, `test_opencode_go_flat_namespace.py`, `test_model_validation.py`, `test_empty_model_fallback.py`, `test_runtime_provider_resolution.py` — 260 passed.
- `ruff check` clean on both files; `ruff format` does not touch the changed lines.

Manual repro on current `main` (before → after), with Codex OAuth present and `OPENAI_API_KEY` unset:
```
detect_provider_for_model('gpt-5.6-luna', 'deepseek')
# before: ('openai-api', 'gpt-5.6-luna')
# after:  ('openai-codex', 'gpt-5.6-luna')
```

Fixes #102775