### PR TITLE
feat(delegation): let the agent pick a per-task model tier

### DIFF
--- a/tests/tools/test_delegate_model_tiers.py
+++ b/tests/tools/test_delegate_model_tiers.py
@@ -1,0 +1,208 @@
+"""Tests for per-task model selection via ``delegation.model_tiers``.
+
+The model picks a TIER NAME (constrained by a schema enum built from the
+user's own config), not a raw model id — so a hallucinated model string can
+never reach a provider. Tier specs are partial delegation-config blocks
+layered over the global delegation config and resolved through the same
+``_resolve_delegation_credentials`` path as the global pin.
+
+Contract covered here:
+
+1. ``_load_model_tiers`` normalisation (mapping, string shorthand, junk).
+2. ``_resolve_tier_credentials`` layering, unknown-tier refusal, and the
+   no-tier passthrough that keeps existing calls byte-for-byte identical.
+3. Schema shaping: the ``model_tier`` property appears with the configured
+   enum ONLY when tiers exist, and is dropped entirely otherwise.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from tools.delegate_tool import (
+    _build_dynamic_schema_overrides,
+    _load_model_tiers,
+    _resolve_tier_credentials,
+)
+
+
+BASE_CREDS = {
+    "model": "default-model",
+    "provider": None,
+    "base_url": None,
+    "api_key": None,
+    "api_mode": None,
+    "request_overrides": None,
+    "max_output_tokens": None,
+}
+
+
+def _parent():
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.request_overrides = None
+    return parent
+
+
+# ── _load_model_tiers normalisation ────────────────────────────────────────
+
+
+def test_load_tiers_mapping_form():
+    cfg = {
+        "model_tiers": {
+            "fast": {"provider": "openrouter", "model": "cheap-model"},
+            "deep": {"model": "expensive-model"},
+        }
+    }
+    assert _load_model_tiers(cfg) == {
+        "fast": {"provider": "openrouter", "model": "cheap-model"},
+        "deep": {"model": "expensive-model"},
+    }
+
+
+def test_load_tiers_string_shorthand_expands_to_model():
+    """A bare string is shorthand for {model: <string>}."""
+    assert _load_model_tiers({"model_tiers": {"fast": "cheap-model"}}) == {
+        "fast": {"model": "cheap-model"}
+    }
+
+
+def test_load_tiers_names_are_lowercased():
+    assert set(_load_model_tiers({"model_tiers": {"Fast": "m", "DEEP": "n"}})) == {
+        "fast",
+        "deep",
+    }
+
+
+def test_load_tiers_absent_or_malformed_returns_empty():
+    for cfg in ({}, {"model_tiers": None}, {"model_tiers": "fast"}, {"model_tiers": []}):
+        assert _load_model_tiers(cfg) == {}
+
+
+def test_load_tiers_drops_junk_entries_without_raising():
+    """Garbage values are skipped, valid siblings survive — this runs inside
+    get_definitions() and must never break tool listing."""
+    cfg = {"model_tiers": {"fast": "cheap", "bad": 42, "": "x", "none": None}}
+    assert _load_model_tiers(cfg) == {"fast": {"model": "cheap"}}
+
+
+def test_load_tiers_does_not_alias_config_dicts():
+    """Mutating a returned tier spec must not write back into config."""
+    source = {"model": "cheap-model"}
+    cfg = {"model_tiers": {"fast": source}}
+    _load_model_tiers(cfg)["fast"]["model"] = "mutated"
+    assert source == {"model": "cheap-model"}
+
+
+# ── _resolve_tier_credentials ──────────────────────────────────────────────
+
+
+def test_no_tier_returns_base_creds_identity():
+    """Absent tier → the exact same object, so untiered calls are unchanged."""
+    for tier in (None, "", "   "):
+        creds, err = _resolve_tier_credentials(tier, {}, _parent(), BASE_CREDS)
+        assert err is None
+        assert creds is BASE_CREDS
+
+
+def test_tier_overrides_model_and_inherits_global_provider():
+    """A tier setting only `model` keeps the global provider/base_url."""
+    cfg = {
+        "base_url": "https://example.test/v1",
+        "api_key": "global-key-1234567890",
+        "model": "default-model",
+        "model_tiers": {"fast": {"model": "cheap-model"}},
+    }
+    creds, err = _resolve_tier_credentials("fast", cfg, _parent(), BASE_CREDS)
+    assert err is None
+    assert creds["model"] == "cheap-model"
+    assert creds["base_url"] == "https://example.test/v1"
+
+
+def test_tier_name_is_case_insensitive():
+    cfg = {"model": "default-model", "model_tiers": {"fast": {"model": "cheap"}}}
+    creds, err = _resolve_tier_credentials("FAST", cfg, _parent(), BASE_CREDS)
+    assert err is None
+    assert creds["model"] == "cheap"
+
+
+def test_unknown_tier_refuses_and_names_valid_tiers():
+    """A silent downgrade to the default model is exactly the failure mode
+    this feature must avoid — refuse loudly and list the real tiers."""
+    cfg = {"model_tiers": {"fast": "a", "deep": "b"}}
+    creds, err = _resolve_tier_credentials("turbo", cfg, _parent(), BASE_CREDS)
+    assert creds is BASE_CREDS
+    assert err is not None
+    assert "turbo" in err and "deep" in err and "fast" in err
+
+
+def test_tier_requested_with_no_tiers_configured_errors():
+    creds, err = _resolve_tier_credentials("fast", {}, _parent(), BASE_CREDS)
+    assert creds is BASE_CREDS
+    assert err is not None
+    assert "model_tiers" in err
+
+
+def test_model_tiers_key_never_reaches_credential_resolver():
+    """The nested mapping is not a credential key; it must be stripped before
+    _resolve_delegation_credentials sees the merged config-shaped dict."""
+    cfg = {"model": "default-model", "model_tiers": {"fast": {"model": "cheap"}}}
+    with patch("tools.delegate_tool._resolve_delegation_credentials") as mock_resolve:
+        mock_resolve.return_value = dict(BASE_CREDS)
+        _resolve_tier_credentials("fast", cfg, _parent(), BASE_CREDS)
+    merged = mock_resolve.call_args[0][0]
+    assert "model_tiers" not in merged
+    assert merged["model"] == "cheap"
+
+
+def test_tier_resolution_failure_surfaces_as_error_not_exception():
+    """A tier naming an unresolvable provider reports an error string; the
+    ValueError must not escape into the dispatch path."""
+    cfg = {"model_tiers": {"fast": {"provider": "nonexistent-provider"}}}
+    with patch("tools.delegate_tool._resolve_delegation_credentials") as mock_resolve:
+        mock_resolve.side_effect = ValueError("no such provider")
+        creds, err = _resolve_tier_credentials("fast", cfg, _parent(), BASE_CREDS)
+    assert creds is BASE_CREDS
+    assert err is not None and "no such provider" in err
+
+
+# ── Schema shaping ─────────────────────────────────────────────────────────
+
+
+def _task_item_props(overrides):
+    return overrides["parameters"]["properties"]["tasks"]["items"]["properties"]
+
+
+def test_schema_omits_model_tier_when_unconfigured():
+    """A default install must not advertise a knob that cannot work."""
+    with patch("tools.delegate_tool._load_model_tiers", return_value={}):
+        assert "model_tier" not in _task_item_props(_build_dynamic_schema_overrides())
+
+
+def test_schema_advertises_configured_tiers_as_enum():
+    tiers = {"fast": {"model": "cheap-model"}, "deep": {"model": "expensive-model"}}
+    with patch("tools.delegate_tool._load_model_tiers", return_value=tiers):
+        prop = _task_item_props(_build_dynamic_schema_overrides())["model_tier"]
+    assert prop["enum"] == ["deep", "fast"]
+    # The model names are surfaced so the model can judge cost/capability.
+    assert "cheap-model" in prop["description"]
+
+
+def test_schema_shaping_does_not_mutate_the_static_schema():
+    """_build_dynamic_schema_overrides runs on every get_definitions() call;
+    leaking model_tier into the module-level dict would make an unconfigured
+    session inherit a previous session's tiers."""
+    from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+
+    tiers = {"fast": {"model": "cheap-model"}}
+    with patch("tools.delegate_tool._load_model_tiers", return_value=tiers):
+        _build_dynamic_schema_overrides()
+
+    static_props = (
+        DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+    )
+    assert static_props["model_tier"]["description"] == (
+        "(injected at get_definitions() time)"
+    )
+    assert "enum" not in static_props["model_tier"]
+
+    with patch("tools.delegate_tool._load_model_tiers", return_value={}):
+        assert "model_tier" not in _task_item_props(_build_dynamic_schema_overrides())

--- a/tests/tools/test_delegate_model_tiers_e2e.py
+++ b/tests/tools/test_delegate_model_tiers_e2e.py
@@ -1,0 +1,84 @@
+"""End-to-end: a tiered task actually reaches _build_child_agent with the
+tier's model, while an untiered sibling in the SAME batch keeps the default.
+
+Guards the wiring (schema -> _resolve_tier_credentials -> per-task creds ->
+_build_child_agent), which the unit tests do not cover: a mixed batch is the
+case where a single batch-level `creds` object would silently win.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import tools.delegate_tool as dt
+
+
+CFG = {
+    "max_iterations": 5,
+    "base_url": "https://example.test/v1",
+    "api_key": "test-key-1234567890",
+    "model": "default-model",
+    "model_tiers": {
+        "fast": {"model": "cheap-model"},
+        "deep": {"model": "expensive-model"},
+    },
+}
+
+
+def _parent():
+    parent = MagicMock()
+    parent._delegate_depth = 0
+    parent.request_overrides = None
+    parent.session_id = "sess-test"
+    return parent
+
+
+def _dispatch(tasks):
+    """Run delegate_task far enough to capture per-child construction."""
+    built = []
+
+    def _fake_build(**kwargs):
+        built.append(kwargs)
+        return MagicMock()
+
+    with patch.object(dt, "_load_config", return_value=CFG), \
+         patch.object(dt, "_build_child_preserving_parent_tools", side_effect=_fake_build), \
+         patch("tools.async_delegation.dispatch_async_delegation_batch",
+               return_value={"status": "dispatched", "delegation_id": "d1"}), \
+         patch("tools.delegation_live_log.create_live_transcripts",
+               return_value=(None, [None] * len(tasks), [])):
+        dt.delegate_task(tasks=tasks, parent_agent=_parent(), background=True)
+    return built
+
+
+def test_mixed_batch_routes_each_child_to_its_own_model():
+    built = _dispatch([
+        {"goal": "Reformat the changelog entries into the house style."},
+        {"goal": "Redesign the retry policy for the ingest pipeline.",
+         "model_tier": "deep"},
+        {"goal": "Extract every TODO comment under src/ into a list.",
+         "model_tier": "fast"},
+    ])
+    assert [b["model"] for b in built] == [
+        "default-model",    # untiered -> global delegation pin
+        "expensive-model",  # deep
+        "cheap-model",      # fast
+    ]
+
+
+def test_unknown_tier_refuses_before_any_child_is_built():
+    """No child may spawn when one task names a bad tier — a partially
+    dispatched batch would leave orphaned children on a typo."""
+    built = []
+    with patch.object(dt, "_load_config", return_value=CFG), \
+         patch.object(dt, "_build_child_preserving_parent_tools",
+                      side_effect=lambda **kw: built.append(kw)):
+        result = dt.delegate_task(
+            tasks=[
+                {"goal": "A perfectly valid first task goal here."},
+                {"goal": "Second task naming a tier that does not exist.",
+                 "model_tier": "turbo"},
+            ],
+            parent_agent=_parent(),
+            background=True,
+        )
+    assert built == []
+    assert "turbo" in str(result)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -4115,6 +4115,21 @@ def delegate_task(
             return tool_error(f"Task {i} output_schema invalid: {schema_err}")
         task_schemas.append(coerced_schema)
 
+    # Per-task credentials: a task may name a `model_tier`, resolved against
+    # delegation.model_tiers and layered over the global delegation config.
+    # Resolved BEFORE any child is built (and before the live-transcript
+    # manifest is written, so it can record the effective per-task model) —
+    # an unknown tier fails the whole call loudly rather than silently
+    # downgrading one child to the default model.
+    task_creds: List[dict] = []
+    for i, task in enumerate(task_list):
+        tier_creds, tier_err = _resolve_tier_credentials(
+            task.get("model_tier"), cfg, parent_agent, creds
+        )
+        if tier_err:
+            return tool_error(f"Task {i}: {tier_err}")
+        task_creds.append(tier_creds)
+
     overall_start = time.monotonic()
     results = []
 
@@ -4134,7 +4149,8 @@ def delegate_task(
     )
 
     live_deleg_id, live_writers, live_paths = create_live_transcripts(
-        task_list, context, model=creds.get("model"), provider=creds.get("provider")
+        task_list, context, model=creds.get("model"), provider=creds.get("provider"),
+        task_models=[c.get("model") for c in task_creds],
     )
     # Announce the batch tag once so the later ``[tag n/N]`` completion lines
     # (and any nested batch's lines interleaving with them) are attributable.
@@ -4177,6 +4193,7 @@ def delegate_task(
     # subagent-lifecycle API).
     children = []
     for i, t in enumerate(task_list):
+        _creds = task_creds[i]
         # Per-task role beats top-level; normalise again so unknown
         # per-task values warn and degrade to leaf uniformly.
         effective_role = _normalize_role(t.get("role") or top_role)
@@ -4196,18 +4213,18 @@ def delegate_task(
                 # Subagents always inherit the parent's toolsets; the model
                 # cannot choose or narrow them (no model-facing toolsets arg).
                 toolsets=None,
-                model=creds["model"],
+                model=_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
-                override_request_overrides=creds.get("request_overrides"),
-                override_max_tokens=creds.get("max_output_tokens"),
-                override_acp_command=creds.get("command"),
-                override_acp_args=creds.get("args"),
+                override_provider=_creds["provider"],
+                override_base_url=_creds["base_url"],
+                override_api_key=_creds["api_key"],
+                override_api_mode=_creds["api_mode"],
+                override_request_overrides=_creds.get("request_overrides"),
+                override_max_tokens=_creds.get("max_output_tokens"),
+                override_acp_command=_creds.get("command"),
+                override_acp_args=_creds.get("args"),
                 role=effective_role,
             )
         except ValueError as exc:
@@ -5038,6 +5055,100 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
     }
 
 
+def _load_model_tiers(cfg: Optional[dict] = None) -> Dict[str, dict]:
+    """Return the user's ``delegation.model_tiers`` mapping, normalised.
+
+    Shape in config.yaml — each tier is a partial delegation config block,
+    resolved through the SAME ``_resolve_delegation_credentials`` path as the
+    global pin, so a tier can carry any subset of
+    ``{model, provider, base_url, api_key, api_mode, request_overrides}``::
+
+        delegation:
+          model: <default for untiered tasks>
+          model_tiers:
+            fast:  {provider: openrouter, model: z-ai/glm-5-air}
+            deep:  {provider: anthropic,  model: claude-opus-5}
+
+    A bare string is accepted as shorthand for ``{model: <string>}`` so the
+    common "same provider, different model" case needs no nesting.
+
+    Tier names are lowercased and must be non-empty strings; anything else is
+    dropped with a debug log rather than raising, because this runs inside
+    ``get_definitions()`` on every schema rebuild and a malformed config key
+    must never break tool listing.
+    """
+    if cfg is None:
+        cfg = _load_config()
+    raw = cfg.get("model_tiers")
+    if not isinstance(raw, dict):
+        return {}
+    tiers: Dict[str, dict] = {}
+    for name, spec in raw.items():
+        if not isinstance(name, str) or not name.strip():
+            continue
+        key = name.strip().lower()
+        if isinstance(spec, str) and spec.strip():
+            tiers[key] = {"model": spec.strip()}
+        elif isinstance(spec, dict):
+            tiers[key] = dict(spec)
+        else:
+            logger.debug(
+                "delegation.model_tiers['%s']: expected a string or mapping, "
+                "got %s — tier ignored",
+                name, type(spec).__name__,
+            )
+    return tiers
+
+
+def _resolve_tier_credentials(
+    tier: Optional[str],
+    cfg: dict,
+    parent_agent,
+    base_creds: dict,
+) -> tuple[dict, Optional[str]]:
+    """Resolve one task's credentials given its requested ``model_tier``.
+
+    Returns ``(creds, error)``. ``error`` is a user-facing string naming the
+    valid tiers when the requested tier is unknown — the spawn is refused
+    rather than silently downgraded to the default model, because a silent
+    clamp is exactly the failure mode that makes per-task model selection
+    untrustworthy (see the Claude Code subagent-model issues where an env pin
+    quietly overrode the caller's choice with no signal in the result).
+
+    An absent/empty tier returns ``base_creds`` unchanged, so every existing
+    call keeps its current behaviour byte-for-byte.
+
+    A tier's keys are layered OVER the global delegation config, so a tier
+    that sets only ``model`` inherits the global provider/base_url/api_key.
+    """
+    if not tier or not str(tier).strip():
+        return base_creds, None
+
+    key = str(tier).strip().lower()
+    tiers = _load_model_tiers(cfg)
+    if not tiers:
+        return base_creds, (
+            f"model_tier={tier!r} was requested but no delegation.model_tiers "
+            "are configured. Add them to config.yaml (delegation.model_tiers: "
+            "{fast: {...}, deep: {...}}) or omit model_tier to use the "
+            "default delegation model."
+        )
+    if key not in tiers:
+        return base_creds, (
+            f"Unknown model_tier {tier!r}. Configured tiers: "
+            f"{', '.join(sorted(tiers))}."
+        )
+
+    merged = {**cfg, **tiers[key]}
+    # model_tiers itself is not a credential key — drop it so the resolver
+    # never sees the nested mapping in a config-shaped dict.
+    merged.pop("model_tiers", None)
+    try:
+        return _resolve_delegation_credentials(merged, parent_agent), None
+    except ValueError as exc:
+        return base_creds, f"model_tier {tier!r} could not be resolved: {exc}"
+
+
 def _load_config() -> dict:
     """Load delegation config from the active Hermes config.
 
@@ -5153,7 +5264,21 @@ def _build_top_level_description() -> str:
         + restrictions_rule +
         "- Children inherit the parent model unless pinned via "
         "delegation.provider / delegation.model in config.yaml."
+        + (
+            " When delegation.model_tiers is configured, each task may name "
+            "a model_tier to run that child on a different model — see the "
+            "model_tier field."
+            if _has_model_tiers() else ""
+        )
     )
+
+
+def _has_model_tiers() -> bool:
+    """True when the user configured delegation.model_tiers (never raises)."""
+    try:
+        return bool(_load_model_tiers())
+    except Exception:
+        return False
 
 
 def _build_tasks_param_description() -> str:
@@ -5191,6 +5316,45 @@ def _build_role_param_description() -> str:
     )
 
 
+def _build_model_tier_property() -> Optional[dict]:
+    """Return the `model_tier` sub-property, or None when unconfigured.
+
+    The enum is the user's ACTUAL configured tier names, so the model can
+    only emit a value the runtime can resolve — mirroring how Claude Code's
+    Agent tool constrains its per-invocation `model` param to a fixed set of
+    aliases rather than accepting arbitrary model IDs. When no tiers are
+    configured the property is dropped from the schema entirely (see
+    _build_dynamic_schema_overrides) so the parameter never appears as a
+    dead knob.
+    """
+    try:
+        tiers = _load_model_tiers()
+    except Exception:
+        return None
+    if not tiers:
+        return None
+
+    described = []
+    for name in sorted(tiers):
+        spec = tiers[name]
+        label = str(spec.get("model") or "").strip()
+        described.append(f"{name} ({label})" if label else name)
+
+    return {
+        "type": "string",
+        "enum": sorted(tiers),
+        "description": (
+            "Which configured model tier runs THIS subagent: "
+            + ", ".join(described)
+            + ". Omit to use the default delegation model. Match the tier to "
+            "the task: cheap/fast tiers for mechanical, well-specified work "
+            "(extraction, formatting, bulk edits), stronger tiers for "
+            "open-ended reasoning, design, or debugging. Children are where "
+            "most tokens go, so tiering a fan-out is the main cost lever."
+        ),
+    }
+
+
 def _build_dynamic_schema_overrides() -> dict:
     """Return per-call schema overrides reflecting current config.
 
@@ -5206,6 +5370,20 @@ def _build_dynamic_schema_overrides() -> dict:
         k: dict(v) for k, v in DELEGATE_TASK_SCHEMA["parameters"]["properties"].items()
     }
     overrides_params["properties"]["tasks"]["description"] = _build_tasks_param_description()
+
+    # model_tier: inject the configured enum, or drop the property so an
+    # unconfigured install never advertises a tier knob with no tiers.
+    tasks_schema = dict(overrides_params["properties"]["tasks"])
+    items_schema = dict(tasks_schema.get("items") or {})
+    item_props = dict(items_schema.get("properties") or {})
+    tier_prop = _build_model_tier_property()
+    if tier_prop is None:
+        item_props.pop("model_tier", None)
+    else:
+        item_props["model_tier"] = tier_prop
+    items_schema["properties"] = item_props
+    tasks_schema["items"] = items_schema
+    overrides_params["properties"]["tasks"] = tasks_schema
 
     return {
         "description": _build_top_level_description(),
@@ -5270,6 +5448,16 @@ DELEGATE_TASK_SCHEMA = {
                                 "failure). Keep it forgiving — require only "
                                 "fields you will read."
                             ),
+                        },
+                        # Advertised ONLY when delegation.model_tiers is
+                        # configured — _build_dynamic_schema_overrides()
+                        # injects the enum of the user's actual tier names
+                        # and removes this property entirely otherwise, so a
+                        # model on a default install never sees a knob that
+                        # cannot work.
+                        "model_tier": {
+                            "type": "string",
+                            "description": "(injected at get_definitions() time)",
                         },
                     },
                     "required": ["goal"],

--- a/tools/delegation_live_log.py
+++ b/tools/delegation_live_log.py
@@ -315,12 +315,16 @@ def create_live_transcripts(
     delegation_id: Optional[str] = None,
     model: Optional[str] = None,
     provider: Optional[str] = None,
+    task_models: Optional[List[Optional[str]]] = None,
 ) -> tuple[Optional[str], List[Optional[LiveTranscriptWriter]], List[str]]:
     """Create one pre-headered writer per task + a manifest.json.
 
     Returns ``(delegation_id, writers, paths)``. On any top-level failure
     returns ``(None, [None]*n, [])`` so delegation proceeds untouched.
     Also opportunistically prunes stale live dirs (retention).
+
+    ``task_models`` records the EFFECTIVE model per task when a batch mixes
+    models (per-task ``model_tier``); ``model`` stays the batch-level default.
     """
     n = len(task_list)
     try:
@@ -341,7 +345,10 @@ def create_live_transcripts(
                 paths.append(str(w.path))
         if not paths:
             return None, [None] * n, []
-        _write_manifest(deleg_id, task_list, paths, model=model, provider=provider)
+        _write_manifest(
+            deleg_id, task_list, paths, model=model, provider=provider,
+            task_models=task_models,
+        )
         return deleg_id, writers, paths
     except Exception as exc:
         logger.debug("Live transcript creation failed: %s", exc)
@@ -354,8 +361,14 @@ def _manifest_path(delegation_id: str) -> Path:
 
 def _write_manifest(delegation_id: str, task_list: List[Dict[str, Any]],
                     paths: List[str], model: Optional[str] = None,
-                    provider: Optional[str] = None) -> None:
+                    provider: Optional[str] = None,
+                    task_models: Optional[List[Optional[str]]] = None) -> None:
     try:
+        def _task_model(i: int) -> Optional[str]:
+            if task_models is not None and i < len(task_models):
+                return task_models[i]
+            return None
+
         manifest = {
             "delegation_id": delegation_id,
             "started": time.strftime("%Y-%m-%d %H:%M:%S"),
@@ -373,6 +386,14 @@ def _write_manifest(delegation_id: str, task_list: List[Dict[str, Any]],
                     "goal": _redact(str(t.get("goal", ""))[:500]),
                     "log": paths[i] if i < len(paths) else None,
                     "status": "running",
+                    # Present only on mixed-model batches (per-task
+                    # model_tier); omitted entirely when the whole batch
+                    # shares the top-level "model" above.
+                    **(
+                        {"model": _task_model(i)}
+                        if _task_model(i) and _task_model(i) != model
+                        else {}
+                    ),
                 }
                 for i, t in enumerate(task_list)
             ],

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -190,7 +190,39 @@ delegation:
 
 Resolution order: `delegation.base_url` (direct endpoint) takes precedence, then `delegation.provider` (full credential bundle resolved via the runtime provider system), and when neither is set children inherit the parent's provider and credentials; `delegation.model` applies in all cases, and when it is empty children inherit the parent's model. Setting `delegation.provider` alongside `delegation.base_url` keeps the explicit endpoint but carries that provider's request overrides and max output tokens into the child. An explicit `delegation.request_overrides` dict is honored on every branch and merges over those runtime-derived values (see [Configuration](#configuration) below).
 
-Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model. For quality-sensitive subtasks that need a stronger model, either leave `delegation.model` unset for that session or hand the task to the [kanban board](kanban.md#per-task-model-override), which does support a per-task model override.
+### Per-task model tiers
+
+`delegation.model` is a single global pin — every child in a batch runs on it. When a fan-out mixes mechanical work with work that needs real judgment, define **model tiers** and let the agent pick one per task:
+
+```yaml
+# ~/.hermes/config.yaml
+delegation:
+  model: "your-inexpensive-model"      # default for tasks that name no tier
+  model_tiers:
+    fast: "your-cheapest-model"        # shorthand for {model: ...}
+    deep:                              # full form: any delegation-config keys
+      provider: "anthropic"
+      model: "your-frontier-model"
+```
+
+With tiers configured, each entry in `tasks` accepts an optional `model_tier`, and the agent chooses per subtask:
+
+```
+tasks: [
+  {goal: "Extract every TODO under src/ into a list.", model_tier: "fast"},
+  {goal: "Redesign the retry policy for the ingest pipeline.", model_tier: "deep"},
+  {goal: "Reformat the changelog entries."},   # no tier -> delegation.model
+]
+```
+
+Behaviour:
+
+- **The tier name is a schema enum built from your config.** The model can only emit a tier you actually defined, so it can never route a child to a hallucinated model id. When `delegation.model_tiers` is unset the `model_tier` field is not advertised at all.
+- **A tier is a partial delegation config**, layered over the global block and resolved through the same path as the global pin — a tier that sets only `model` inherits the global `provider`/`base_url`/`api_key`.
+- **An unknown tier fails the whole call before any child spawns**, rather than silently downgrading that child to the default model. A silent clamp is the failure mode that makes per-task model selection untrustworthy.
+- **The effective model is reported back** in each child's result and in the live-transcript `manifest.json`, so a mixed batch is auditable rather than inferred.
+
+For per-task pins outside a batch, the [kanban board](kanban.md#per-task-model-override) has its own per-card model override.
 
 ## The `/review` Command
 


### PR DESCRIPTION
## Problem

`delegate_task` has no per-task model parameter. `delegation.model` is a single global pin, so every child in a fan-out runs on the same model. The docs state this outright:

> Note that the pin is global: `delegate_task` has no per-task model parameter, so every child in a batch runs on the configured delegation model.

That forces one choice for the whole batch. A fan-out that mixes mechanical work (extraction, reformatting, bulk edits) with judgment work (design, debugging) either overpays for the cheap half or underpowers the expensive half. Children are where most of a run's tokens go, so this is the main cost lever in a delegation-heavy workflow — and today it can only be pulled globally.

Kanban already supports a per-card model override; `delegate_task` had no equivalent.

## Approach

Adds `delegation.model_tiers` — named tiers the agent selects per task:

```yaml
delegation:
  model: cheap-default              # tasks that name no tier
  model_tiers:
    fast: some-cheap-model          # shorthand for {model: ...}
    deep:
      provider: anthropic
      model: some-frontier-model
```

Each entry in `tasks` then accepts an optional `model_tier`:

```
tasks: [
  {goal: "Extract every TODO under src/ into a list.", model_tier: "fast"},
  {goal: "Redesign the retry policy for the ingest pipeline.", model_tier: "deep"},
  {goal: "Reformat the changelog entries."},   # -> delegation.model
]
```

### The tier name is an enum, not a free-form model id

The schema enum is generated from the user's own `model_tiers` keys at `get_definitions()` time, so the model can only emit a value the runtime can resolve. This mirrors how Claude Code constrains its Agent tool's per-invocation `model` parameter to a fixed alias set rather than accepting arbitrary model IDs — free-form strings there are a frontmatter/config concern, where a human wrote them.

When `model_tiers` is unset, the property is removed from the schema entirely and the tool description says nothing about tiers, so a default install never sees a knob that cannot work.

### Failures are loud

An unknown tier fails the whole call **before any child spawns**, naming the configured tiers. It does not silently fall back to the default model, and it does not spawn a partial batch on a typo.

This is deliberate. The equivalent Claude Code feature has a cluster of open issues where the requested model is silently replaced — [#57718](https://github.com/anthropics/claude-code/issues/57718) (env var overrides the per-call parameter with no signal in the tool result), [#43869](https://github.com/anthropics/claude-code/issues/43869) (allowlist rejection quietly substitutes the parent model). A model-selection feature that silently ignores the selection is worse than not having one, because the caller cannot tell. Accordingly the effective model per child is reported in each result (already the case) and is now also recorded per task in the live-transcript `manifest.json`, so a mixed batch is auditable rather than inferred.

## Compatibility

Untiered tasks are unchanged by construction: with no `model_tier`, `_resolve_tier_credentials` returns the batch-level `creds` object **by identity**. Installs without `model_tiers` see the exact schema and behaviour they see today.

A tier is a partial delegation-config block layered over the global one and resolved through the same `_resolve_delegation_credentials` path as the global pin, so a tier setting only `model` inherits the global `provider`/`base_url`/`api_key`, and `request_overrides` precedence is untouched.

## Tests

18 new tests across two files:

- `test_delegate_model_tiers.py` — tier normalisation (mapping form, string shorthand, case, malformed entries dropped without raising, no aliasing of config dicts), credential layering, unknown-tier refusal, `model_tiers` stripped before it reaches the credential resolver, resolution failure surfaced as an error rather than a raised `ValueError`, and schema shaping in both configured and unconfigured states including non-mutation of the module-level schema dict.
- `test_delegate_model_tiers_e2e.py` — a mixed batch asserting each child is actually built with its own model (`default` / `deep` / `fast`), and that an unknown tier builds **zero** children.

Full delegation suite: **336 passed, 1 skipped**. The one failure, `test_child_dedicated_db_follows_parents_db_path`, is a pre-existing macOS `/private` symlink path artifact — verified failing identically on an untouched `origin/main` worktree, unrelated to this change.

Docs updated at `website/docs/user-guide/features/delegation.md`, replacing the "the pin is global" paragraph with a "Per-task model tiers" section.
