### PR TITLE
fix(agent): honor model.default_headers on the gemini-native fallback path

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3223,7 +3223,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
                 from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
                 if is_native_gemini_base_url(base_url):
-                    return GeminiNativeClient(api_key=api_key, base_url=base_url), model
+                    return GeminiNativeClient(
+                        api_key=api_key, base_url=base_url,
+                        default_headers=_apply_user_default_headers(None),
+                    ), model
             extra = {}
             if base_url_host_matches(base_url, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -3263,7 +3266,10 @@ def _resolve_api_key_provider() -> Tuple[Optional[OpenAI], Optional[str]]:
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
-                return GeminiNativeClient(api_key=api_key, base_url=base_url), model
+                return GeminiNativeClient(
+                    api_key=api_key, base_url=base_url,
+                    default_headers=_apply_user_default_headers(None),
+                ), model
         extra = {}
         if base_url_host_matches(base_url, "api.kimi.com"):
             extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
@@ -7465,7 +7471,10 @@ def resolve_provider_client(
             from agent.gemini_native_adapter import GeminiNativeClient, is_native_gemini_base_url
 
             if is_native_gemini_base_url(base_url):
-                client = GeminiNativeClient(api_key=api_key, base_url=base_url)
+                client = GeminiNativeClient(
+                    api_key=api_key, base_url=base_url,
+                    default_headers=_apply_user_default_headers(None),
+                )
                 logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
                 return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                         else (client, final_model))

--- a/tests/agent/test_auxiliary_user_default_headers.py
+++ b/tests/agent/test_auxiliary_user_default_headers.py
@@ -95,6 +95,32 @@ class TestAuxClientHonorsUserDefaultHeaders:
         headers = mock_openai.call_args.kwargs.get("default_headers", {}) or {}
         assert "User-Agent" not in headers
 
+    def test_gemini_native_fallback_honors_override(self, tmp_path, monkeypatch):
+        """Gemini-native early return (#102788) must also honor model.default_headers.
+
+        The gemini-native branch builds ``GeminiNativeClient`` directly instead
+        of going through ``_create_openai_client``, so it has its own
+        (previously missing) call to ``_apply_user_default_headers``. Without
+        it, a referer-restricted API key makes the fallback chain fail with
+        ``403 PERMISSION_DENIED: Requests from referer <empty> are blocked``
+        even though the primary path (which does apply the override) works.
+        """
+        monkeypatch.setenv("GEMINI_API_KEY", "AIzaSy_TEST_KEY")
+        _write_config(tmp_path, {
+            "model": {
+                "default": "test-model",
+                "default_headers": {"Referer": "https://example.com/"},
+            },
+        })
+        with patch("agent.gemini_native_adapter.GeminiNativeClient") as mock_client:
+            mock_client.return_value = MagicMock()
+            from agent.auxiliary_client import resolve_provider_client
+            resolve_provider_client("gemini")
+
+        assert mock_client.called
+        headers = mock_client.call_args.kwargs.get("default_headers", {}) or {}
+        assert headers.get("Referer") == "https://example.com/"
+
     def test_named_custom_provider_honors_override(self, tmp_path):
         """A `custom_providers:` entry's aux calls also honor model.default_headers.
 


### PR DESCRIPTION
## Problem

Fixes #102788.

With a config like:

```yaml
model:
  default_headers:
    Referer: https://example.com/
fallback_providers:
  - provider: gemini
    model: gemini-3.5-flash
```

`model.default_headers` merges correctly on the primary path, but once a rate
limit triggers fallback to Gemini native, `agent/auxiliary_client.py`'s
`resolve_provider_client()` reaches one of three sites that construct
`GeminiNativeClient(api_key=..., base_url=...)` directly (both early returns
inside `_resolve_api_key_provider`, plus the auto-routing branch) — none of
them call `_apply_user_default_headers`, unlike every other provider branch
in the same function.

With a referer-restricted Google AI Studio key, the fallback then always
fails with `403 PERMISSION_DENIED: Requests from referer <empty> are
blocked`, i.e. the fallback chain is dead exactly when it's needed.
`GeminiNativeClient.__init__` already accepts and applies `default_headers`
(see `agent/gemini_native_adapter.py`'s `_headers()`); it just wasn't being
passed at these three sites.

## Fix

Pass `default_headers=_apply_user_default_headers(None)` at all three
`GeminiNativeClient(...)` construction sites in `agent/auxiliary_client.py`,
mirroring what the OpenAI-wire branches immediately below each of them
already do.

+9/-3 in `agent/auxiliary_client.py`, no behavior change when
`model.default_headers` / `model.extra_headers` isn't configured.

## Testing

Added `test_gemini_native_fallback_honors_override` to
`tests/agent/test_auxiliary_user_default_headers.py`, alongside the existing
tests for the OpenAI-wire paths of the same helper.

Confirmed the test fails without the fix (`git checkout HEAD~1 --
agent/auxiliary_client.py`, i.e. the pre-fix source):

```
$ python -m pytest tests/agent/test_auxiliary_user_default_headers.py -q
...
FAILED tests/agent/test_auxiliary_user_default_headers.py::TestAuxClientHonorsUserDefaultHeaders::test_gemini_native_fallback_honors_override
AssertionError: assert None == 'https://example.com/'
1 failed, 5 passed in 0.62s
```

And passes with the fix applied:

```
$ python -m pytest tests/agent/test_auxiliary_user_default_headers.py -q
......
6 passed in 0.51s
```

Also ran the broader auxiliary-client / gemini suites to check for
regressions:

```
$ python -m pytest tests/agent/test_auxiliary_client*.py -q
231 passed in 9.97s

$ python -m pytest tests/hermes_cli/test_gemini_provider.py tests/agent/test_gemini_native_adapter.py -q
47 passed in 3.48s
```

`ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_user_default_headers.py` — all checks passed.

## AI assistance disclosure

This change was written with the assistance of an AI coding agent (Claude).
The diff was reviewed, tested, and verified by the author before submission.
