### PR TITLE
fix(desktop): preview-file markdown links with spaces in the path

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6153,6 +6153,25 @@ function expandUserPath(filePath) {
   return value
 }
 
+/** Markdown hrefs must percent-encode spaces (`/my%20notes/x.md`), but the
+ *  on-disk path is the decoded form. When the raw path misses, retry decoded
+ *  so chat links to paths with spaces still open in the preview rail. */
+function decodedPathIfMissing(resolvedPath) {
+  if (!/%[0-9a-fA-F]{2}/.test(resolvedPath)) {
+    return null
+  }
+
+  let decoded
+
+  try {
+    decoded = decodeURIComponent(resolvedPath)
+  } catch {
+    return null
+  }
+
+  return decoded !== resolvedPath ? decoded : null
+}
+
 async function previewFileTarget(rawTarget, baseDir) {
   const raw = String(rawTarget || '').trim()
   const base = baseDir ? path.resolve(expandUserPath(baseDir)) : resolveHermesCwd()
@@ -6169,7 +6188,13 @@ async function previewFileTarget(rawTarget, baseDir) {
   const ext = path.extname(resolved).toLowerCase()
 
   if (!fileExists(resolved)) {
-    return null
+    const decoded = decodedPathIfMissing(resolved)
+
+    if (decoded && fileExists(decoded)) {
+      resolved = decoded
+    } else {
+      return null
+    }
   }
 
   ;({ resolvedPath: resolved } = await resolveReadableFileForIpc(resolved, { purpose: 'Preview target' }))

--- a/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
+++ b/apps/desktop/src/components/assistant-ui/markdown-text.filelinks.test.tsx
@@ -35,6 +35,31 @@ describe('MarkdownLink filesystem hrefs', () => {
     expect(screen.getAllByRole('button', { name: 'Open preview' })).toHaveLength(2)
   })
 
+  it('routes angle-bracket file links whose path contains spaces', async () => {
+    // CommonMark requires `<...>` destinations for paths with spaces; the
+    // old FILE_LINK_RE charset `[^\)\s]*` couldn't match them, so the link
+    // fell through to harden and rendered as "label [blocked]".
+    render(
+      <MarkdownTextContent isRunning={false} text={'See [notes](<~/My Notes/todo with spaces.md>)'} />
+    )
+
+    await screen.findByText('todo with spaces.md')
+    expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
+    expect(screen.queryByText(/blocked/)).toBeNull()
+  })
+
+  it('routes percent-encoded file links through the same preview pipeline', async () => {
+    // Markdown renderers emit the href percent-encoded; the renderer keeps
+    // the encoded form in the card label, and the electron side retries the
+    // decoded on-disk path when the file is opened.
+    render(
+      <MarkdownTextContent isRunning={false} text={'See [notes](~/My%20Notes/todo%20with%20spaces.md)'} />
+    )
+
+    await screen.findByText('todo%20with%20spaces.md')
+    expect(screen.getByRole('button', { name: 'Open preview' })).toBeTruthy()
+  })
+
   it('renders a media player for a media-extension path link', async () => {
     const { container } = render(<MarkdownTextContent isRunning={false} text="[clip](/tmp/demo.mp4)" />)
 

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -54,7 +54,7 @@ const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*
 // `[todo](~/todo.md)`, `[log](C:\logs\run.txt)`. Negative lookbehind keeps
 // image syntax (`![alt](path)`) on its existing inline pipeline. The target
 // char class excludes `)`/whitespace, matching how LLMs actually emit these.
-const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target><?(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*>?)\)/gi
+const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target>(?:<(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^>]*>)|(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*)\)/gi
 
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo


### PR DESCRIPTION
Closes #102782.

Two small fixes so assistant markdown links to local paths containing spaces stop rendering as `label [blocked]`:

- **`FILE_LINK_RE`** (`apps/desktop/src/lib/markdown-preprocess.ts`): added an angle-bracket branch — `<(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^>]*>` — so CommonMark `<...>` destinations (the only valid way to write spaces in a href) get rewritten to the `#preview/…` hash like every other file link instead of falling through to rehype-harden. `routeFileLinksToPreview` already strips the brackets.
- **`previewFileTarget`** (`electron/main.ts`): when the raw resolved path doesn't exist, retry its percent-decoded form (`decodedPathIfMissing`) — markdown hrefs carry `%20` for spaces, but the on-disk path is decoded, so the `%20`-encoded form of the same link stopped erroring with file-not-found on open.

Regression tests in `markdown-text.filelinks.test.tsx` cover both forms (bracketed-with-spaces renders the preview card with no `[blocked]`; percent-encoded routes through the same pipeline).

Local gates: `vitest run … --project ui` 6/6, `tsc --build tsconfig.electron.json` clean, `tsc -p . --noEmit` clean, `eslint` 0 errors (no new warnings on changed lines).