### PR TITLE
desktop: fix markdown links with spaces rendering as [blocked]

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -6153,6 +6153,25 @@ function expandUserPath(filePath) {
   return value
 }
 
+/** Markdown hrefs must percent-encode spaces (`/my%20notes/x.md`), but the
+ *  on-disk path is the decoded form. When the raw path misses, retry decoded
+ *  so chat links to paths with spaces still open in the preview rail. */
+function decodedPathIfMissing(resolvedPath) {
+  if (!/%[0-9a-fA-F]{2}/.test(resolvedPath)) {
+    return null
+  }
+
+  let decoded
+
+  try {
+    decoded = decodeURIComponent(resolvedPath)
+  } catch {
+    return null
+  }
+
+  return decoded !== resolvedPath ? decoded : null
+}
+
 async function previewFileTarget(rawTarget, baseDir) {
   const raw = String(rawTarget || '').trim()
   const base = baseDir ? path.resolve(expandUserPath(baseDir)) : resolveHermesCwd()
@@ -6169,7 +6188,12 @@ async function previewFileTarget(rawTarget, baseDir) {
   const ext = path.extname(resolved).toLowerCase()
 
   if (!fileExists(resolved)) {
-    return null
+    const decoded = decodedPathIfMissing(resolved)
+    if (decoded && fileExists(decoded)) {
+      resolved = decoded
+    } else {
+      return null
+    }
   }
 
   ;({ resolvedPath: resolved } = await resolveReadableFileForIpc(resolved, { purpose: 'Preview target' }))

--- a/apps/desktop/src/lib/markdown-preprocess.ts
+++ b/apps/desktop/src/lib/markdown-preprocess.ts
@@ -54,7 +54,7 @@ const CITATION_MARKER_RE = /(?<=[\p{L}\p{N})\].,!?:;"'”’])\[(?:\d+(?:\s*,\s*
 // `[todo](~/todo.md)`, `[log](C:\logs\run.txt)`. Negative lookbehind keeps
 // image syntax (`![alt](path)`) on its existing inline pipeline. The target
 // char class excludes `)`/whitespace, matching how LLMs actually emit these.
-const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target><?(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*>?)\)/gi
+const FILE_LINK_RE = /(?<!!)\[(?<label>[^\]\n]+)\]\((?<target>(?:<(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^>]*>)|(?:file:\/\/|\/|~\/|[a-z]:[\\/])[^)\s]*))\)/gi
 
 /**
  * Returns true when `body` contains a line that's exactly `marker` (modulo


### PR DESCRIPTION
Fixes #102781

## Problem

Desktop renders markdown links to local files containing spaces as dead text:
`label [blocked]`. Links without spaces work fine.

**Root cause (from issue):**
- `FILE_LINK_RE` in `markdown-preprocess.ts` uses `[^)\s]*` for the target —
  it cannot cross a literal space. Angle-bracket destinations (`[x](<path
  with spaces.md>)`) are the only CommonMark way to write spaces in a
  href, so exactly the links that need the rewrite never got it.
- For `%20`-encoded plain links, the rewrite *did* match, but the target
  kept its `%20` through `previewMarkdownHref`'s double-encoding;
  `previewFileTarget` in `electron/main.ts` then ran `fileExists()` on a
  path that still contained literal `%20` sequences and returned `null`.

## Change

**`apps/desktop/src/lib/markdown-preprocess.ts`** (line 57):
- `FILE_LINK_RE` now matches angle-bracket targets with spaces:
  ```diff
  - /(?<!!)\[(?<label>[^\]
]+)\]\((?<target><?(?:file:\/\/|\/|~\/|[a-z]:[\/])[^)\s]*>?)\)/gi
  + /(?<!!)\[(?<label>[^\]
]+)\]\((?<target>(?:<(?:file:\/\/|\/|~\/|[a-z]:[\/])[^>]*>)|(?:file:\/\/|\/|~\/|[a-z]:[\/])[^)\s]*))\)/gi
  ```
  The alternation explicitly matches `<...>` targets (allowing spaces)
  OR bare targets (no spaces).

**`apps/desktop/electron/main.ts`** (line 6156):
- Added `decodedPathIfMissing()` helper that retries with
  `decodeURIComponent()` when the raw path misses.
- `previewFileTarget` now calls it: if the raw path doesn't exist but
  its percent-decoded form does, use the decoded path.

## Test Plan

Per the issue:
1. `[notes](<~/My Notes/todo with spaces.md>)` → renders preview card, opens file
2. `[notes](~/My%20Notes/todo%20with%20spaces.md)` → renders preview card, opens file
3. `[notes](file:///home/user/My%20Notes/todo%20with%20spaces.md)` → already works
4. Spaceless links continue to work (regression test)

All three link forms should render the preview card and open the preview rail.
