### PR TITLE
fix(env): prevent cross-profile TERMINAL_* leak in multi-profile serve (#102769)

### DIFF
--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -607,9 +607,17 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     ``load_hermes_dotenv(hermes_home=...)`` call would bridge the wrong
     profile's config. Fail-open — a config problem must never break dotenv
     loading (the historical env-driven behavior still applies).
+
+    The guard must compare against the true process launch home
+    (``get_process_hermes_home``), not the context-overridden home
+    (``get_hermes_home``), otherwise a routed profile's cron tick can
+    bridge its own terminal config into the shared process environment
+    and hijack the launch profile's subsequent unscoped turns (#102769).
     """
     try:
-        if Path(home_path).resolve() != _process_hermes_home().resolve():
+        from hermes_constants import get_process_hermes_home
+
+        if Path(home_path).resolve() != get_process_hermes_home().resolve():
             return
         from hermes_cli.config import apply_terminal_config_to_env
 


### PR DESCRIPTION
## What does this PR do?

Fixes a cross-profile terminal config leak in multi-profile `hermes serve` where a secondary profile's cron tick would write its `terminal.*` config (e.g. `docker` backend + volumes) into the process-global `os.environ`, hijacking the launch profile's subsequent unscoped turns.

## Root cause

The `_reapply_terminal_config_bridge()` function in `hermes_cli/env_loader.py` was comparing `home_path` against `get_hermes_home()` (which follows context overrides set by `set_hermes_home_override()`). During a secondary profile's cron tick:

1. The multiplex cron ticker wraps the tick in `set_hermes_home_override(profile_home)`
2. `load_hermes_dotenv(hermes_home=profile_home)` runs the process-global dotenv load path (because `hermes serve` doesn't call `set_multiplex_active(True)`)
3. At the end, `_reapply_terminal_config_bridge(profile_home)` compares against `get_hermes_home()` — which, under the override, **is the routed profile's home**
4. The guard passes, and the routed profile's `terminal.backend: docker`, `docker_image`, `docker_volumes` are written into process-global `TERMINAL_*`
5. The launch profile's subsequent unscoped turn (no terminal scope) falls through to `os.environ` and lands in the wrong backend

## The fix

Compare against `get_process_hermes_home()` which ignores context overrides and returns the true process launch home. This ensures only the launch home's own dotenv loads can bridge terminal config into the shared env.

## Testing

- All 45 related tests pass: `test_env_loader.py`, `test_terminal_env_bridge.py`, `test_terminal_scope_multiplex.py`, `test_runtime_env_reload_config_authority.py`
- Existing suites `tests/hermes_cli/test_env_loader.py`, `tests/tools/test_terminal_env_bridge.py`, `tests/tools/test_terminal_scope_multiplex.py`, `tests/gateway/test_runtime_env_reload_config_authority.py`, `tests/cron/test_cron_workdir.py` all pass (61 passed)

## Related Issue

Fixes #102769