### PR TITLE
fix(schema): skip empty properties:{} injection on annotated nodes for Bedrock (#102795)

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -27,19 +27,20 @@ def test_object_without_properties_gets_empty_properties():
 
 
 def test_nested_object_without_properties_gets_empty_properties():
+    # NOTE (#102795): bare nested objects keep the llama.cpp injection;
+    # ANNOTATED ones (with description et al) skip it for Bedrock — see
+    # test_nested_annotated_empty_object_skips_properties_injection.
     tools = [_tool("t", {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
-            "arguments": {"type": "object", "description": "free-form"},
+            "arguments": {"type": "object"},
         },
         "required": ["name"],
     })]
     out = sanitize_tool_schemas(tools)
     args = out[0]["function"]["parameters"]["properties"]["arguments"]
-    assert args["type"] == "object"
-    assert args["properties"] == {}
-    assert args["description"] == "free-form"
+    assert args == {"type": "object", "properties": {}}
 
 
 def test_bare_string_object_value_replaced_with_schema_dict():
@@ -517,3 +518,50 @@ def test_collapse_is_deterministic():
     first = collapse_const_unions(copy.deepcopy(schema))
     second = collapse_const_unions(copy.deepcopy(schema))
     assert first == second == {"type": "string", "enum": ["b", "a"]}
+
+
+def test_annotated_empty_object_skips_properties_injection_bedrock():
+    # Issue #102795: Bedrock (draft 2020-12 strict) rejects
+    # {type: object, description: ..., properties: {}} while accepting
+    # both halves separately. The llama.cpp-motivated empty-properties
+    # injection must not fire on annotated nodes (e.g. delegate_task's
+    # per-task output_schema).
+    tools = [_tool("t", {"type": "object", "description": "free-form"})]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"] == {
+        "type": "object", "description": "free-form"}
+
+
+def test_nested_annotated_empty_object_skips_properties_injection():
+    # Same shape as delegate_task tasks[].output_schema.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "output_schema": {"type": "object", "description": "child schema"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    nested = out[0]["function"]["parameters"]["properties"]["output_schema"]
+    assert nested == {"type": "object", "description": "child schema"}
+
+
+def test_bare_empty_object_still_gets_properties_for_llamacpp():
+    # Guard: unannotated free-form objects keep the llama.cpp injection.
+    tools = [_tool("t", {"type": "object"})]
+    out = sanitize_tool_schemas(tools)
+    assert out[0]["function"]["parameters"] == {
+        "type": "object", "properties": {}}
+
+
+def test_each_annotation_key_skips_empty_properties_injection():
+    # Issue #102795 follow-up: every key in _ANNOTATION_KEYS triggers
+    # the Bedrock exception, not just description.
+    from tools.schema_sanitizer import _ANNOTATION_KEYS
+    assert len(_ANNOTATION_KEYS) >= 2
+    for key in sorted(_ANNOTATION_KEYS):
+        node = {"type": "object", key: "x"}
+        tools = [_tool("t", {"type": "object",
+                             "properties": {"p": node}})]
+        out = sanitize_tool_schemas(tools)
+        got = out[0]["function"]["parameters"]["properties"]["p"]
+        assert got == node, key

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -32,6 +32,14 @@ def _rewrite(schema: Any, fn: Callable[[dict], Any]) -> Any:
         return schema
     return fn({k: _rewrite(v, fn) for k, v in schema.items()})
 
+# Annotation keywords that make an object node "annotated" for the #102795
+# Bedrock exception below: Bedrock rejects {type: object, <annotation>,
+# properties: {}} while accepting the annotation without properties.
+_ANNOTATION_KEYS = frozenset({
+    "description", "title", "examples", "default", "deprecated",
+    "readOnly", "writeOnly",
+})
+
 
 def sanitize_property_key(key: str) -> str:
     """Deterministically map an arbitrary property key to a conforming one."""
@@ -94,8 +102,11 @@ def _sanitize_single_tool(tool: dict) -> dict:
     top = _sanitize_node(params, path=name)
     top = top if isinstance(top, dict) else {}  # guarantee an object with properties on top
     top["type"] = "object"
-    if not isinstance(top.get("properties"), dict):
-        top["properties"] = {}
+    if "properties" not in top or not isinstance(top.get("properties"), dict):
+        # Same #102795 Bedrock exception as in _sanitize_node: skip the empty
+        # properties injection on annotated nodes.
+        if not (_ANNOTATION_KEYS & top.keys()):
+            top["properties"] = {}
     # The recursive pass only handles array-form ``type: [X, "null"]``; collapse anyOf unions
     # here, keeping ``nullable: true`` so ``tools.arg_coercion._schema_allows_null`` still coerces.
     top = strip_nullable_unions(top, keep_nullable_hint=True)
@@ -291,7 +302,13 @@ def _sanitize_node(node: Any, path: str) -> Any:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
     if out.get("type") == "object":
         if not isinstance(out.get("properties"), dict):
-            out["properties"] = {}
+            # Exception (#102795): Bedrock's strict draft 2020-12 validator rejects
+            # {type: object, description: ..., properties: {}} while accepting both
+            # halves separately — so skip the injection on annotated nodes that
+            # would otherwise gain an EMPTY properties dict (e.g. delegate_task's
+            # per-task output_schema). Bare objects keep the injection.
+            if not (_ANNOTATION_KEYS & out.keys()):
+                out["properties"] = {}
         if isinstance(out.get("required"), list):
             valid = [r for r in out["required"] if isinstance(r, str) and r in out["properties"]]
             if valid:


### PR DESCRIPTION
Fixes #102795.

## Problem
Subagent dispatches on Bedrock-fronted models fail with
`TOOL_SCHEMA_INVALID` (strict draft 2020-12): Bedrock rejects
`{type: object, description, properties: {}}` while accepting both
halves separately. The llama.cpp-motivated empty-`properties`
injection manufactured exactly that combo on `delegate_task`'s
per-task `output_schema`, so every dispatch with tools 400d.

## Approach
In `tools/schema_sanitizer.py`, skip the empty-`properties: {}`
injection when the node already carries annotation keywords
(`description`, `title`, `examples`, `default`, `deprecated`,
`readOnly`, `writeOnly`) and would otherwise gain an empty dict.
Bare objects keep the injection (llama.cpp contract preserved).
Both injection sites covered: `_sanitize_node` and the top-level
guarantee in `_sanitize_single_tool`.

## How to Test
- `tests/tools/test_schema_sanitizer.py`: 36 passed (4 new:
  top-level annotated, nested annotated in the `output_schema`
  shape, bare-object guard, per-key parametrization).
- Sabotage: the new tests FAIL on pre-fix code.
- `tests/tools/test_delegate_output_schema.py` +
  `tests/tools/test_delegate.py`: 108 passed.
- Live: full 37-tool wire payload returns 200 instead of
  TOOL_SCHEMA_INVALID.

## Risk
llama.cpp behavior for *annotated* empty objects changes (no
`properties: {}` injected). Bare objects unaffected. No other
call sites modified.

## Exclusions
- No change to the Bedrock/Anthropic transport or
  `_normalize_tool_input_schema`.
- One pre-existing test re-scoped to a bare node (llama.cpp pin
  preserved); annotated coverage moved to the new tests.

## Follow-ups (non-blocking, from adversarial review)
- Schemas declaring the rejected shape explicitly (bypassing the
  sanitizer) are out of scope.
- No live E2E test against Bedrock; other annotation keys
  verified by unit logic + one live `description` probe.

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.21.0
