### PR TITLE
fix(gemini): stop parallel tool-call args gluing when thought signatures attach (#102787)

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -923,11 +923,18 @@ def translate_stream_event(event: Dict[str, Any], model: str, tool_call_indices:
             except (TypeError, ValueError):
                 args_str = "{}"
             thought_signature = part.get("thoughtSignature") if isinstance(part.get("thoughtSignature"), str) else ""
+            # Slot key must be STABLE for the life of one call.  Gemini
+            # re-delivers functionCall parts when the turn's thought
+            # signatures are attached, so a signature entering the key
+            # mid-stream spawns a phantom second slot that re-emits the
+            # full args — the consumer appends them and the arguments
+            # arrive glued as "{...}{...}" (#102787).  Identity is
+            # (part_index, name); thought_signature stays out of the key
+            # and still rides to the consumer via extra_content below.
             call_key = json.dumps(
                 {
                     "part_index": part_index,
                     "name": name,
-                    "thought_signature": thought_signature,
                 },
                 sort_keys=True,
             )

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -675,3 +675,68 @@ def test_text_only_tool_result_has_no_parts():
     )
     fr = request["contents"][1]["parts"][0]["functionResponse"]
     assert "parts" not in fr
+
+
+def test_stream_signature_attach_keeps_parallel_call_slots():
+    """#102787: a thoughtSignature arriving on an already-open functionCall
+    part must NOT create a new slot.
+
+    Gemini re-delivers functionCall parts once the turn's thought signatures
+    are attached. The slot key previously included the signature, so the
+    signatureless chunk and the signed chunk mapped to two different slots;
+    the new slot re-emitted the FULL args (prefix dedup is per-slot), and
+    the consumer appended them to the original call ->
+    '{"a":1}{"b":2}' glued into one arguments string, which the sanitizer
+    then collapses to '{}' and the tool runs with empty args.
+    """
+    from agent.gemini_native_adapter import translate_stream_event
+
+    def event(parts, finish=None):
+        cand = {"content": {"parts": parts}}
+        if finish:
+            cand["finishReason"] = finish
+        return {"candidates": [cand]}
+
+    def fcall(name, args, sig=None, fid=None):
+        fcall_obj = {"name": name, "args": args}
+        if fid:
+            fcall_obj["id"] = fid
+        part = {"functionCall": fcall_obj}
+        if sig is not None:
+            part["thoughtSignature"] = sig
+        return part
+
+    slots: dict = {}
+    by_id: dict = {}
+    order: list = []
+
+    def feed(ev):
+        for chunk in translate_stream_event(event(ev) if isinstance(ev, list) else ev,
+                                            "gemini-flash-latest", slots):
+            delta = chunk.choices[0].delta
+            if delta and delta.tool_calls:
+                for tcd in delta.tool_calls:
+                    entry = by_id.setdefault(tcd.id, {"name": "", "args": ""})
+                    if tcd.id not in order:
+                        order.append(tcd.id)
+                    if tcd.function.name:
+                        entry["name"] = tcd.function.name
+                    entry["args"] += tcd.function.arguments or ""
+
+    # Turn 1: two parallel calls, no signatures yet.
+    feed([fcall("read_file", {"path": "a.json"}, fid="fc_0"),
+          fcall("read_file", {"path": "b.json"}, fid="fc_1")])
+    # Turn 2: SAME parts re-delivered with signatures attached (the API
+    # stamps them at turn close).
+    feed(event([fcall("read_file", {"path": "a.json"}, sig="SIG_A", fid="fc_0"),
+                fcall("read_file", {"path": "b.json"}, sig="SIG_B", fid="fc_1")],
+               finish="STOP"))
+
+    # Exactly two logical calls — no phantom slot when the signature lands.
+    assert len(order) == 2, f"signature re-delivery spawned extra calls: {order}"
+    # Each accumulated arguments string must parse on its own.
+    for cid, entry in by_id.items():
+        json.loads(entry["args"])
+    assert by_id[order[0]]["args"] == '{"path": "a.json"}'
+    assert by_id[order[1]]["args"] == '{"path": "b.json"}'
+    assert not any("}{" in e["args"] for e in by_id.values())


### PR DESCRIPTION
## Problem

On the native Gemini streaming path, parallel tool calls arrive glued together: one call's `arguments` is `{...}{...}` (two JSON objects concatenated), which fails to parse and breaks the turn. Reproduced deterministically against `origin/main` — `json.decoder.JSONDecodeError: Extra data: line 1 column 19`.

## Root cause

`translate_stream_event` keys its per-call accumulator slots with `json.dumps({"part_index", "name", "thought_signature"})`. Gemini delivers a `functionCall` part first *without* a `thoughtSignature`, then re-delivers the same part once the turn's thought signatures are attached. When that happens the key changes mid-stream (`"thought_signature": ""` → the real signature), so the second delivery does **not** find the existing slot: it opens a phantom second slot at a new index and re-emits the full arguments. The consumer (`chat_completion_helpers`, which appends streamed `arguments` fragments per call index) therefore appends the complete args a second time onto the first call's slot — producing `{"a":1}{"b":2}` on one call and a spurious duplicate on the other.

## Fix

Make the slot key stable for the life of one call: `(part_index, name)` only. The signature is excluded from the key and still rides to the consumer via `extra_content` (unchanged), so round-tripping signatures back to Gemini on the next request is unaffected.

## TDD

- New regression test `test_stream_signature_attach_keeps_parallel_call_slots` streams the exact issue shape (two `read_file` calls, signature attached on the second delivery) and asserts every slot parses as single JSON.
- **RED on `origin/main`** (63279301b): `1 failed — json.decoder.JSONDecodeError: Extra data: line 1 column 19 (char 18)`
- **GREEN on this branch**: `1 passed`; full file `29 passed, 1 deselected` (the deselected `test_async_native_client_...` fails identically on clean `origin/main` — pre-existing event-loop flake, unrelated).
- Adjacent lanes: `tests/run_agent/test_repair_tool_call_arguments.py`, `test_streaming_tool_call_repair.py`, `tests/agent/test_gemini_schema.py` → `14 passed`.

## Linked issue

Closes #102787
