### PR TITLE
fix(update): add clear messaging for web UI build phase

### DIFF
--- a/hermes_cli/update_cmd.py
+++ b/hermes_cli/update_cmd.py
@@ -2490,7 +2490,9 @@ def _update_via_zip(args, *, had_desktop_app_before_update: bool = False) -> boo
         _m().sys.exit(1)
 
     node_failures = _update_node_dependencies()
+    print("→ Building web UI (dashboard frontend)...")
     _m()._build_web_ui(_m().PROJECT_ROOT / "web")
+    print("  ✓ Web UI built")
     desktop_build_ok = _rebuild_desktop_after_update(
         _m().PROJECT_ROOT / "apps" / "desktop",
         had_desktop_app_before_update=had_desktop_app_before_update,


### PR DESCRIPTION
The `hermes update` command builds the dashboard frontend as part of the update, but the user only saw "✓ Web UI built" at the end with no context about WHY the build was happening. This led to confusion when the update took longer than usual and a Vite/Rolldown plugin timing message leaked through.

Fix: add a clear pre-build message explaining that the dashboard frontend is being rebuilt as part of the update, and keep the existing completion line. This matches the pattern used by other update phases (Node deps, skills sync, desktop rebuild).

Closes #102540.