### PR TITLE
fix(tools): bypass read dedup in execute_code

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -1264,6 +1264,7 @@ def handle_function_call(
     tool_request_middleware_trace: Optional[List[Dict[str, Any]]] = None,
     enabled_toolsets: Optional[List[str]] = None,
     disabled_toolsets: Optional[List[str]] = None,
+    suppress_read_dedup: bool = False,
 ) -> str:
     """
     Main function call dispatcher that routes calls to the tool registry.
@@ -1285,6 +1286,9 @@ def handle_function_call(
                        matching ``get_tool_definitions`` semantics.
         disabled_toolsets: The session's disabled toolsets, applied as a
                        subtraction when scoping the bridge catalog.
+        suppress_read_dedup: Internal execute_code path flag.  Programmatic
+                       sandbox reads should return actual content on repeated
+                       calls instead of the model-facing dedup status stub.
 
     Returns:
         Function result as a JSON string.
@@ -1569,6 +1573,13 @@ def handle_function_call(
                     )
             else:
                 def _dispatch(next_args: Dict[str, Any]) -> Any:
+                    if function_name == "read_file" and suppress_read_dedup:
+                        return registry.dispatch(
+                            function_name, next_args,
+                            task_id=task_id,
+                            user_task=user_task,
+                            suppress_dedup=True,
+                        )
                     return registry.dispatch(
                         function_name, next_args,
                         task_id=task_id,

--- a/tests/tools/test_code_execution.py
+++ b/tests/tools/test_code_execution.py
@@ -63,7 +63,7 @@ from tools.code_execution_tool import (
 from tools.registry import registry
 
 
-def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None):
+def _mock_handle_function_call(function_name, function_args, task_id=None, user_task=None, **kwargs):
     """Mock dispatcher that returns canned responses for each tool."""
     if function_name == "terminal":
         cmd = function_args.get("command", "")
@@ -295,6 +295,35 @@ print(result.get("output", ""))
         self.assertIn("mock output for: echo hello", result["output"])
         self.assertEqual(result["tool_calls_made"], 1)
 
+    def test_read_file_calls_suppress_parent_dedup(self):
+        """Sandbox read_file calls must not receive the model-facing dedup stub."""
+        calls = []
+
+        def mock_dispatch(function_name, function_args, **kwargs):
+            calls.append((function_name, kwargs))
+            if function_name == "read_file":
+                return json.dumps({"content": "line 1\n", "total_lines": 1})
+            return json.dumps({"error": f"unexpected tool: {function_name}"})
+
+        code = """
+from hermes_tools import read_file
+first = read_file("notes.txt")
+second = read_file("notes.txt")
+print(first["content"].strip())
+print(second["content"].strip())
+"""
+        with patch("model_tools.handle_function_call", side_effect=mock_dispatch):
+            result = json.loads(execute_code(
+                code=code,
+                task_id="test-task",
+                enabled_tools=["read_file"],
+            ))
+
+        self.assertEqual(result["status"], "success")
+        self.assertEqual(result["tool_calls_made"], 2)
+        read_kwargs = [kwargs for name, kwargs in calls if name == "read_file"]
+        self.assertEqual(len(read_kwargs), 2)
+        self.assertTrue(all(kwargs.get("suppress_read_dedup") is True for kwargs in read_kwargs))
 
     def test_concurrent_tool_calls_match_responses(self):
         """Regression for the UDS RPC race: multiple threads inside the

--- a/tests/tools/test_file_read_guards.py
+++ b/tests/tools/test_file_read_guards.py
@@ -421,6 +421,29 @@ class TestFileDedup(unittest.TestCase):
         self.assertNotIn("content", r2)
 
     @patch("tools.file_tools._get_file_ops")
+    def test_suppress_dedup_returns_content_on_repeated_reads(self, mock_ops):
+        """Programmatic callers can opt out of model-facing read dedup stubs."""
+        mock_ops.return_value = _make_fake_ops(
+            content="line one\nline two\n", file_size=20,
+        )
+
+        r1 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+        r2 = json.loads(read_file_tool(
+            self._tmpfile,
+            task_id="sandbox",
+            suppress_dedup=True,
+        ))
+
+        self.assertEqual(r1.get("content"), "line one\nline two\n")
+        self.assertEqual(r2.get("content"), "line one\nline two\n")
+        self.assertNotIn("dedup", r1)
+        self.assertNotIn("dedup", r2)
+
+    @patch("tools.file_tools._get_file_ops")
     def test_write_rejects_internal_read_status_text(self, mock_ops):
         """write_file must not persist internal read_file status text."""
         fake = MagicMock()

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -746,7 +746,10 @@ def _rpc_server_loop(
 
     if dispatch is None:
         def dispatch(tool_name, tool_args):
-            return handle_function_call(tool_name, tool_args, task_id=task_id)
+            dispatch_kwargs: Dict[str, Any] = {"task_id": task_id}
+            if tool_name == "read_file":
+                dispatch_kwargs["suppress_read_dedup"] = True
+            return handle_function_call(tool_name, tool_args, **dispatch_kwargs)
 
     conn = None
     try:
@@ -1102,9 +1105,12 @@ def _rpc_poll_loop(
 
                     # Dispatch through the standard tool handler
                     try:
+                        dispatch_kwargs: Dict[str, Any] = {"task_id": task_id}
+                        if tool_name == "read_file":
+                            dispatch_kwargs["suppress_read_dedup"] = True
                         with thread_scoped_silence():
                             tool_result = handle_function_call(
-                                tool_name, tool_args, task_id=task_id
+                                tool_name, tool_args, **dispatch_kwargs
                             )
                     except Exception as exc:
                         logger.error("Tool call failed in remote sandbox: %s",

--- a/tools/code_kernel.py
+++ b/tools/code_kernel.py
@@ -323,7 +323,10 @@ class CellAuthority:
             except Exception:
                 previous = None
         try:
-            return handle_function_call(tool_name, tool_args, task_id=self.task_id)
+            dispatch_kwargs: Dict[str, Any] = {"task_id": self.task_id}
+            if tool_name == "read_file":
+                dispatch_kwargs["suppress_read_dedup"] = True
+            return handle_function_call(tool_name, tool_args, **dispatch_kwargs)
         finally:
             if previous is not None and self._callback_setters is not None:
                 set_approval, set_sudo = self._callback_setters

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1654,7 +1654,13 @@ def _special_file_kind(path) -> str | None:
     return "a special (non-regular) file"
 
 
-def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str = "default") -> str:
+def read_file_tool(
+    path: str,
+    offset: int = 1,
+    limit: int = 2000,
+    task_id: str = "default",
+    suppress_dedup: bool = False,
+) -> str:
     """Read a file with pagination and line numbers."""
     try:
         offset, limit = normalize_read_pagination(offset, limit)
@@ -1843,7 +1849,7 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             cached_mtime = task_data.get("dedup", {}).get(dedup_key)
             content_served_in_generation = dedup_key in generation_reads
 
-        if cached_mtime is not None:
+        if cached_mtime is not None and not suppress_dedup:
             try:
                 current_mtime = os.path.getmtime(resolved_str)
                 if current_mtime == cached_mtime and content_served_in_generation:
@@ -1972,12 +1978,15 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             task_data["dedup_hits"].pop(dedup_key, None)
             task_data.setdefault("dedup_generation_reads", set()).add(dedup_key)
             task_data["read_history"].add((path, offset, limit))
-            if task_data["last_key"] == read_key:
+            if suppress_dedup:
+                count = 1
+            elif task_data["last_key"] == read_key:
                 task_data["consecutive"] += 1
+                count = task_data["consecutive"]
             else:
                 task_data["last_key"] = read_key
                 task_data["consecutive"] = 1
-            count = task_data["consecutive"]
+                count = task_data["consecutive"]
 
             # Store mtime at read time for two purposes:
             # 1. Dedup: skip identical re-reads of unchanged files.
@@ -1985,7 +1994,8 @@ def read_file_tool(path: str, offset: int = 1, limit: int = 2000, task_id: str =
             #    the agent last read it (external edit, concurrent agent, etc.).
             try:
                 _mtime_now = os.path.getmtime(resolved_str)
-                task_data["dedup"][dedup_key] = _mtime_now
+                if not suppress_dedup:
+                    task_data["dedup"][dedup_key] = _mtime_now
                 task_data.setdefault("read_timestamps", {})[resolved_str] = _mtime_now
             except OSError:
                 pass  # Can't stat — skip tracking for this entry
@@ -2864,7 +2874,13 @@ SEARCH_FILES_SCHEMA = {
 
 def _handle_read_file(args, **kw):
     tid = kw.get("task_id") or "default"
-    return read_file_tool(path=args.get("path", ""), offset=args.get("offset", 1), limit=args.get("limit", 500), task_id=tid)
+    return read_file_tool(
+        path=args.get("path", ""),
+        offset=args.get("offset", 1),
+        limit=args.get("limit", 500),
+        task_id=tid,
+        suppress_dedup=bool(kw.get("suppress_dedup", False)),
+    )
 
 
 def _handle_write_file(args, **kw):


### PR DESCRIPTION
## What does this PR do?

Fixes `execute_code` sandbox `read_file()` calls leaking the model-facing read dedup response into programmatic code.

The normal `read_file` tool intentionally returns a lightweight `status: "unchanged"` response on repeated same-range reads to save model context. Inside `execute_code`, that optimization breaks the documented `hermes_tools.read_file()` API shape: a second read can omit `content`, causing sandbox scripts to hit `KeyError` even though the file is readable.

This adds an internal dedup-suppression path for execute_code RPC calls to `read_file` only. Normal model-facing `read_file` calls keep the existing dedup behavior, while sandbox reads consistently return the actual content payload.

**Supersedes #44847** — same approach, rebased onto current `main` (the original PR has merge conflicts and its branch is stale since July). All credit for the original fix goes to @Pluviobyte; this PR resolves the conflicts and extends coverage to one dispatch path that did not exist when the original was written: main now routes `execute_code` through persistent session kernels (`tools/code_kernel.py` `CellAuthority._invoke`), so the suppression flag is applied there as well, in addition to the local RPC loop and remote poll loop.

## Related Issue

Fixes #44843

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `tools/code_execution_tool.py`: pass an internal dedup-suppression flag for sandbox `read_file` RPC calls in both the local RPC loop (via the default `dispatch` closure) and the remote `_rpc_poll_loop` path.
- `tools/code_kernel.py`: apply the same flag in the session-kernel `CellAuthority._invoke` dispatch (the default execute_code path on current main).
- `model_tools.py` and `tools/file_tools.py`: route the internal flag to `read_file_tool` without exposing it in the public tool schema.
- `tests/tools/test_code_execution.py`: cover execute_code forwarding the dedup-suppression flag for repeated sandbox reads.
- `tests/tools/test_file_read_guards.py`: cover repeated programmatic reads returning content while normal dedup remains unchanged.

## How to Test

1. Reproduce the issue from #44843: call `hermes_tools.read_file()` twice for the same file/range inside `execute_code`; before this patch the second call can return the `content_returned: false` dedup stub instead of `content`.
2. Focused validation on this branch (Linux, Python 3.12):

```text
$ python -m pytest tests/tools/test_file_read_guards.py tests/tools/test_code_execution.py -q
85 passed, 5 subtests passed in 3.53s

$ python -m pytest tests/tools/test_code_kernel.py tests/tools/test_code_kernel_remote.py tests/test_model_tools.py -q
69 passed (3 pre-existing async-bridge failures in test_model_tools_async_bridge.py,
identical on unmodified main — unrelated environment flakiness)

$ ruff check model_tools.py tools/code_execution_tool.py tools/code_kernel.py tools/file_tools.py tests/tools/test_code_execution.py tests/tools/test_file_read_guards.py
All checks passed!
```

## Checklist

### Code

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — this supersedes the stale, conflicting #44847 (approved, CI green, sweeper verdict `keep_open / salvageability=high`) with an identical, rebased fix
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes (carried over from #44847, all passing)
- [x] I've tested on my platform: Linux (WSL), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no behavior change to the public tool schema)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've considered cross-platform impact — N/A (flag is platform-neutral; dedup logic unchanged for model-facing reads)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal flag only, not exposed in schemas)
