### PR TITLE
fix(cron): sanitize API keys/tokens in error messages before persisting to jobs.json

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1585,27 +1585,32 @@ def record_ticker_error(message: str) -> None:
 
     The ticker thread lives inside the gateway process; ``hermes cron
     status``/``list`` run in a separate process and previously could only
-    infer "ticks may be failing" from marker staleness, with no clue WHY.
+    infer ``ticks may be failing`` from marker staleness, with no clue WHY.
     A root-owned ``jobs.json`` (#68483) failed every tick for ~14h with the
     reason visible only in the gateway's errors.log. Writing the last error
     next to the heartbeat markers gives the CLI something concrete to show.
 
-    Best-effort: a write failure must never disrupt the tick loop.
+    Best‑effort: a write failure must never disrupt the tick loop.
     """
     store = _current_cron_store()
     path = store.cron_dir / "ticker_last_error"
-    # Sanitize potential API keys or tokens from the message before persisting.
-    # This removes common patterns like "API_KEY=abcd1234..." or "token: abcdef...".
-    # The regex is case‑insensitive and looks for a key name followed by = or :
-    # and a long alphanumeric string (>=8 chars). The value is replaced with ***.
+    # First, run the shared redactor to strip known secret patterns.
+    # ``force=True`` guarantees redaction even if the global config disables
+    # it, and ``redact_url_credentials=True`` also masks credentials in URLs.
     import re
-    # Updated sanitization regex to also catch keys with spaces and additional
-    # token types (bearer, secret). The pattern now matches:
-    #   - "api key", "api-key", "api_key" (case‑insensitive)
-    #   - "token", "bearer", "secret"
-    # followed by optional whitespace, ':' or '=', then a value consisting of
-    # alphanumerics, dashes, underscores, or periods (minimum 8 characters).
-    sanitized = re.sub(r"(?i)(api[\s_-]?key|token|bearer|secret)[\s=:]+[A-Za-z0-9\-_.]{8,}", r"\1=***", message)
+    try:
+        from agent.redact import redact_sensitive_text
+        sanitized = redact_sensitive_text(message, force=True, redact_url_credentials=True)
+    except Exception:
+        # If the redactor itself fails, fall back to the raw message.
+        sanitized = message
+    # Apply an additional custom regex layer for any remaining API‑key‑like
+    # tokens that the central redactor might have missed.
+    sanitized = re.sub(
+        r"(?i)(api[\s_-]?key|token|bearer|secret)[\s=:]+[A-Za-z0-9\-\._]{8,}",
+        r"\\1=***",
+        sanitized,
+    )
     sanitized = sanitized.strip()
     try:
         ensure_dirs()
@@ -1625,6 +1630,7 @@ def record_ticker_error(message: str) -> None:
                 pass
             raise
     except Exception:
+        # Swallow any I/O errors – the ticker must keep running.
         pass
 
 

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -1594,6 +1594,19 @@ def record_ticker_error(message: str) -> None:
     """
     store = _current_cron_store()
     path = store.cron_dir / "ticker_last_error"
+    # Sanitize potential API keys or tokens from the message before persisting.
+    # This removes common patterns like "API_KEY=abcd1234..." or "token: abcdef...".
+    # The regex is case‑insensitive and looks for a key name followed by = or :
+    # and a long alphanumeric string (>=8 chars). The value is replaced with ***.
+    import re
+    # Updated sanitization regex to also catch keys with spaces and additional
+    # token types (bearer, secret). The pattern now matches:
+    #   - "api key", "api-key", "api_key" (case‑insensitive)
+    #   - "token", "bearer", "secret"
+    # followed by optional whitespace, ':' or '=', then a value consisting of
+    # alphanumerics, dashes, underscores, or periods (minimum 8 characters).
+    sanitized = re.sub(r"(?i)(api[\s_-]?key|token|bearer|secret)[\s=:]+[A-Za-z0-9\-_.]{8,}", r"\1=***", message)
+    sanitized = sanitized.strip()
     try:
         ensure_dirs()
         fd, tmp_path = tempfile.mkstemp(
@@ -1601,7 +1614,7 @@ def record_ticker_error(message: str) -> None:
         )
         try:
             with os.fdopen(fd, "w", encoding="utf-8") as f:
-                f.write(f"{time.time()}\n{message.strip()}\n")
+                f.write(f"{time.time()}\n{sanitized}\n")
                 f.flush()
                 os.fsync(f.fileno())
             atomic_replace(tmp_path, path)


### PR DESCRIPTION
## What does this PR do?

Sanitizes potential API keys/tokens from error messages before they get persisted to `jobs.json` via `record_ticker_error()`. Previously, raw provider error messages (e.g. from 0x, Alchemy, OpenAI) could contain leaked credentials that got written to disk as-is with no redaction.

## Related Issue

Fixes #102700

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] 🔒 Security fix

## Changes Made

- `cron/jobs.py`: Added case-insensitive regex sanitization in `record_ticker_error()` that matches "api key"/"api-key"/"api_key", "token", "bearer", and "secret" patterns followed by `:` or `=` and an 8+ character value, replacing the value with `***` while preserving the key name for debuggability.

## How to Test

1. Trigger a cron job error where the underlying provider API returns an error message containing a credential (e.g. "Invalid API Key=abc12345xyz")
2. Check the persisted `ticker_last_error` file after the error is recorded
3. Confirm the message shows `API Key=***` instead of the raw key value