### PR TITLE
tui_gateway: fix live session history not updating after compute-host compression

### DIFF
--- a/tui_gateway/methods_session.py
+++ b/tui_gateway/methods_session.py
@@ -3046,6 +3046,13 @@ def _(rid, params: dict) -> dict:
         if ack.get("type") in {"control.error", "error"}:
             return _err(rid, 4009, str(ack.get("message") or "compute-host compress failed"))
         _apply_compute_host_metadata_mirror(session, ack)
+        # Mirror the compressed message history from the compute host so the
+        # serving process's session history stays in sync. The host returns the
+        # full compressed transcript in ack["messages"].
+        if isinstance(ack.get("messages"), list):
+            with session["history_lock"]:
+                session["history"] = _history_to_messages(ack["messages"])
+                session["history_version"] = int(session.get("history_version", 0)) + 1
         host_result = ack.get("result")
         if isinstance(host_result, dict):
             # The host owns the isolated session's agent/history, so preserve


### PR DESCRIPTION
Fixes #102780

## Problem

When using turn isolation (compute-host), manual `/compress` runs in the
isolated compute-host process. The compressed transcript was returned in
the host ack but never applied to the serving process's session history,
so the live TUI session continued serving the pre-compression message
list (history kept growing from the old base instead of restarting at
the compressed count).

Observed behavior:
- User runs `/compress 5` in long-running TUI session (502 messages, ~379k tokens)
- Backend logs show compression success: `messages=502->105`, `rough_tokens=~84,582`
- But live TUI session continues serving pre-compression message list:
  `history=504 → 508 → 510` (keeps growing from old 502 base)
- Status bar context % stays at pre-compression value (~36% instead of ~9%)
- Only workaround: restart TUI with `hermes --tui --continue`

## Root Cause

When using turn isolation (compute-host), manual `/compress` runs in the
isolated compute-host process. The compressed transcript was returned in
the host ack (`ack["messages"]`) but never applied to the serving
process's session history. The `_apply_compute_host_metadata_mirror`
function only mirrors metadata (`session_key`, `history_version`,
`message_count`, `session_info`), not the actual message history.

The in-process compression path (`_compress_session_history` in
`server.py`) correctly updates `session["history"]` under the
`history_lock` (line 7407-7408), but the compute-host path was missing
this step.

## Fix

After `_apply_compute_host_metadata_mirror(session, ack)`, mirror the
compressed message history from the host ack into the serving process's
`session["history"]` under the `history_lock`, same as the in-process
compression path does in `_compress_session_history` (server.py:7407-7408).

## Testing

- Manual `/compress` in TUI with turn isolation now correctly updates
  the live session history
- Status bar context percentage drops from pre-compression value to
  post-compression value
- Subsequent turns use the compressed message list (history restarts
  at compressed count instead of growing from old base)
- Related: #94001 (Desktop status-bar context usage stale after compression)
