### PR TITLE
fix(gateway): redirect busy image follow-ups

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3687,6 +3687,33 @@ def _build_media_placeholder(event) -> str:
     return "\n".join(parts)
 
 
+def _build_image_followup_text(event) -> str:
+    """Represent an image-only busy follow-up for active-turn redirect."""
+    media_urls = list(getattr(event, "media_urls", None) or [])
+    if not media_urls or not all(
+        _event_media_is_image(event, index) for index in range(len(media_urls))
+    ):
+        return ""
+
+    text = (getattr(event, "text", None) or "").strip()
+    if text.lower() in {
+        "(attachment)",
+        "[attachment]",
+        "(image)",
+        "[image]",
+        "(the user sent a message with no text content)",
+    }:
+        text = ""
+    image_note = (
+        "[The user sent image attachment(s) during this run. "
+        "Inspect each image with vision_analyze before answering. "
+        "Treat the image as continuation/context for the unresolved user request; "
+        "do not ask the user to resend it.]\n"
+        + _build_media_placeholder(event)
+    )
+    return f"{text}\n\n{image_note}".strip() if text else image_note
+
+
 def _build_document_context_note(
     display_name: str,
     agent_path: str,
@@ -11494,21 +11521,28 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if not steered:
                 # Fall back to queue (merge into pending messages, no interrupt)
                 effective_mode = "queue"
-        elif (
-            effective_mode == "interrupt"
-            and event.message_type == MessageType.TEXT
-            and not event.media_urls
-            and not event.media_types
-            and running_agent is not None
-            and running_agent is not _AGENT_PENDING_SENTINEL
-            and getattr(running_agent, "_supports_active_turn_redirect", False) is True
-            and hasattr(running_agent, "redirect")
-        ):
-            try:
-                redirected = bool(running_agent.redirect((event.text or "").strip()))
-            except Exception as exc:
-                logger.warning("Gateway redirect failed for session %s: %s", session_key, exc)
-                redirected = False
+        elif effective_mode == "interrupt":
+            redirect_text = ""
+            if (
+                event.message_type == MessageType.TEXT
+                and not event.media_urls
+                and not event.media_types
+            ):
+                redirect_text = (event.text or "").strip()
+            else:
+                redirect_text = _build_image_followup_text(event)
+            if (
+                redirect_text
+                and running_agent is not None
+                and running_agent is not _AGENT_PENDING_SENTINEL
+                and getattr(running_agent, "_supports_active_turn_redirect", False) is True
+                and hasattr(running_agent, "redirect")
+            ):
+                try:
+                    redirected = bool(running_agent.redirect(redirect_text))
+                except Exception as exc:
+                    logger.warning("Gateway redirect failed for session %s: %s", session_key, exc)
+                    redirected = False
 
         # Store the message so it's processed as the next turn after the
         # current run finishes (or is interrupted).  Skip this for a
@@ -19449,14 +19483,40 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     event, _cmd_def_inner, _quick_key, source,
                 )
 
+            effective_busy_input_mode = self._effective_busy_input_mode(source)
             if event.message_type == MessageType.PHOTO:
+                image_followup_text = _build_image_followup_text(event)
+                photo_state = self._peek_session_state(_quick_key)
+                photo_agent = photo_state.turn.agent if photo_state else None
+                can_redirect_image = (
+                    effective_busy_input_mode == "interrupt"
+                    and bool(image_followup_text)
+                    and photo_agent is not None
+                    and photo_agent is not _AGENT_PENDING_SENTINEL
+                    and getattr(photo_agent, "_supports_active_turn_redirect", False)
+                    is True
+                    and hasattr(photo_agent, "redirect")
+                )
+                if can_redirect_image:
+                    try:
+                        if photo_agent.redirect(image_followup_text):
+                            logger.debug(
+                                "PRIORITY image redirect for session %s",
+                                _quick_key,
+                            )
+                            return None
+                    except Exception as exc:
+                        logger.warning(
+                            "PRIORITY image redirect failed for session %s: %s",
+                            _quick_key,
+                            exc,
+                        )
                 logger.debug("PRIORITY photo follow-up for session %s — queueing without interrupt", _quick_key)
                 adapter = self._adapter_for_source(source)
                 if adapter:
                     merge_pending_message_event(adapter._pending_messages, _quick_key, event)
                 return None
 
-            effective_busy_input_mode = self._effective_busy_input_mode(source)
             _telegram_followup_grace = float(
                 os.getenv("HERMES_TELEGRAM_FOLLOWUP_GRACE_SECONDS", "3.0")
             )

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -188,6 +188,36 @@ class TestBusySessionAck:
         # Verify agent interrupt was called
         agent.interrupt.assert_called_once_with("Are you working?")
 
+    @pytest.mark.asyncio
+    async def test_interrupt_mode_redirects_image_followup_into_active_turn(self):
+        """A busy image continues the active request instead of aborting it."""
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="")
+        event.message_type = MessageType.PHOTO
+        event.media_urls = ["/tmp/follow-up.jpg"]
+        event.media_types = ["image/jpeg"]
+        sk = build_session_key(event.source)
+        runner.adapters[event.source.platform] = adapter
+
+        agent = MagicMock()
+        agent._supports_active_turn_redirect = True
+        agent._active_children = []
+        agent.redirect.return_value = True
+        runner._running_agents[sk] = agent
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        redirected = agent.redirect.call_args.args[0]
+        assert "vision_analyze" in redirected
+        assert "[User sent an image: /tmp/follow-up.jpg]" in redirected
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages
+        content = adapter._send_with_retry.call_args.kwargs["content"]
+        assert "Redirected" in content
+
 
     @pytest.mark.asyncio
     async def test_steer_mode_calls_agent_steer_no_interrupt_no_queue(self, monkeypatch):
@@ -446,7 +476,7 @@ class TestBusySessionOnboardingHint:
 
         # The flag is now persisted to tmp_path/config.yaml
         import yaml
-        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text())
+        cfg = yaml.safe_load((tmp_path / "config.yaml").read_text(encoding="utf-8"))
         assert cfg["onboarding"]["seen"]["busy_input_prompt"] is True
 
 

--- a/tests/gateway/test_telegram_photo_interrupts.py
+++ b/tests/gateway/test_telegram_photo_interrupts.py
@@ -46,3 +46,38 @@ async def test_handle_message_does_not_priority_interrupt_photo_followup():
     assert result is None
     running_agent.interrupt.assert_not_called()
     assert runner.adapters[Platform.TELEGRAM]._pending_messages[session_key] is event
+
+
+@pytest.mark.asyncio
+async def test_handle_message_priority_redirects_photo_when_supported():
+    runner = _make_runner()
+    runner._busy_input_mode = "interrupt"
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="u1",
+    )
+    session_key = build_session_key(source)
+    running_agent = MagicMock()
+    running_agent._supports_active_turn_redirect = True
+    running_agent._active_children = []
+    running_agent.redirect.return_value = True
+    runner._running_agents[session_key] = running_agent
+
+    event = MessageEvent(
+        text="",
+        message_type=MessageType.PHOTO,
+        source=source,
+        media_urls=["/tmp/photo-a.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    result = await runner._handle_message(event)
+
+    assert result is None
+    redirected = running_agent.redirect.call_args.args[0]
+    assert "vision_analyze" in redirected
+    assert "[User sent an image: /tmp/photo-a.jpg]" in redirected
+    running_agent.interrupt.assert_not_called()
+    assert session_key not in runner.adapters[Platform.TELEGRAM]._pending_messages


### PR DESCRIPTION
## What does this PR do?

Busy `interrupt` mode only redirects plain-text follow-ups into the active turn. An image follow-up therefore takes the hard-interrupt path: it aborts the unresolved request, queues the image as a separate turn, and can leave a captionless image detached from the question it was meant to clarify.

This PR makes all-image follow-ups redirectable when the active agent supports `redirect()`:

- build a text-safe continuation envelope that points the agent at the cached image paths and requires `vision_analyze`
- use that envelope in both the normal busy-session handler and the PRIORITY fast path
- preserve captions while ignoring platform-generated empty-attachment sentinels
- keep existing fallback behavior for older/rejecting runtimes and for voice, documents, video, and mixed-media events

This is complementary to #70303 and #75683, which address `busy_input_mode: steer`; this PR addresses `busy_input_mode: interrupt` and active-turn redirect.

## Related Issue

No issue filed; the failure was reproduced from a live Telegram gateway receipt.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: add an all-image continuation envelope and route it through active-turn redirect in both busy ingress paths.
- `tests/gateway/test_busy_session_ack.py`: cover normal busy-session image redirect without interrupt or queue.
- `tests/gateway/test_telegram_photo_interrupts.py`: cover PRIORITY image redirect while preserving the existing queue fallback test.
- `tests/gateway/test_busy_session_ack.py`: specify UTF-8 for an existing touched-file config read required by the Windows footgun gate.

## How to Test

1. Start a turn in `busy_input_mode: interrupt` and keep it active in a tool call.
2. Send a captionless image from the same session.
3. Confirm `redirect()` receives the image continuation envelope, `interrupt()` is not called, and no duplicate next-turn event is queued.

Regression proof:

```text
Without the implementation: 2 new tests fail.
With the implementation: 19/19 focused tests pass.
```

Commands run:

```bash
HERMES_TEST_FILE_RETRIES=0 scripts/run_tests.sh \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_telegram_photo_interrupts.py \
  tests/gateway/test_image_input_routing_runtime.py \
  tests/gateway/test_mixed_attachment_routing.py -q

.venv/bin/ruff check gateway/run.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_telegram_photo_interrupts.py

.venv/bin/python -m py_compile gateway/run.py \
  tests/gateway/test_busy_session_ack.py \
  tests/gateway/test_telegram_photo_interrupts.py

git diff --check
python scripts/check-windows-footguns.py --diff upstream/main
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run the entire `pytest tests/ -q` suite; focused affected tests are 19/19 green
- [x] I've added tests for my changes
- [x] I've tested on Ubuntu Linux

### Documentation & Housekeeping

- [x] Documentation update — N/A; no public contract or config key changed
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform impact considered; Windows footgun check passes
- [x] Tool descriptions/schemas — N/A

## Screenshots / Logs

The live receipt showed the sequence `active request → image arrival → Operation interrupted → detached image turn`. The regression tests encode the same control-flow boundary without including private chat content.
