### PR TITLE
fix(skills): respect skill routing boundaries during selection

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2210,8 +2210,9 @@ def _build_skills_system_prompt_inner(
             "as a routing contract, including when not to use it. A counter-trigger is not a match, "
             "and topical overlap alone is not enough. If a description positively matches your task, "
             "you MUST load it with skill_view(name) and follow its instructions. A skill shown without "
-            "a description (including one in a [names only] category) may still be loaded when the user "
-            "explicitly names it or its visible name/category clearly matches the task. When several "
+            "a substantive routing description (including one with only provenance or collision annotations, "
+            "or one in a [names only] category) may still be loaded when the user explicitly names it or "
+            "its visible name/category clearly matches the task. When several "
             "skills match, load only those needed for the task. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
             "and proven workflows that outperform general-purpose approaches. Load the skill "
@@ -2229,7 +2230,7 @@ def _build_skills_system_prompt_inner(
             "</available_skills>\n"
             "\n"
             "Proceed without loading a skill when no description positively matches and no skill shown "
-            "without a description has an explicit or clear name/category match."
+            "without a substantive routing description has an explicit or clear name/category match."
             + hidden_note
         )
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2206,10 +2206,12 @@ def _build_skills_system_prompt_inner(
 
         result = (
             "## Skills\n"
-            "Before replying, scan the skills below. Treat each description as a routing contract, "
-            "including when not to use it. If a skill's description matches your task, you MUST "
-            "load it with skill_view(name) and follow its instructions. Topical overlap alone is not "
-            "enough; when several skills match, load only those needed for the task. "
+            "Before replying, scan the skills below. For fully described skills, treat each description "
+            "as a routing contract, including when not to use it. A counter-trigger is not a match, "
+            "and topical overlap alone is not enough. If a description positively matches your task, "
+            "you MUST load it with skill_view(name) and follow its instructions. A [names only] "
+            "skill may still be loaded when the user explicitly names it or its visible name/category "
+            "clearly matches the task. When several skills match, load only those needed for the task. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
             "and proven workflows that outperform general-purpose approaches. Load the skill "
             f"even if you think you could handle the task with basic tools like {_basic_tools}. "
@@ -2225,7 +2227,8 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Proceed without loading a skill when no description matches the task."
+            "Proceed without loading a skill when no description positively matches and no [names only] "
+            "entry has an explicit or clear name/category match."
             + hidden_note
         )
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2206,10 +2206,10 @@ def _build_skills_system_prompt_inner(
 
         result = (
             "## Skills\n"
-            "Before replying, scan the skills below. If a skill matches or is even partially relevant "
-            "to your task, you MUST load it with skill_view(name) and follow its instructions. "
-            "Err on the side of loading — it is always better to have context you don't need "
-            "than to miss critical steps, pitfalls, or established workflows. "
+            "Before replying, scan the skills below. Treat each description as a routing contract, "
+            "including when not to use it. If a skill's description matches your task, you MUST "
+            "load it with skill_view(name) and follow its instructions. Topical overlap alone is not "
+            "enough; when several skills match, load only those needed for the task. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
             "and proven workflows that outperform general-purpose approaches. Load the skill "
             f"even if you think you could handle the task with basic tools like {_basic_tools}. "
@@ -2225,7 +2225,7 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Only proceed without loading a skill if genuinely none are relevant to the task."
+            "Proceed without loading a skill when no description matches the task."
             + hidden_note
         )
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -2209,9 +2209,10 @@ def _build_skills_system_prompt_inner(
             "Before replying, scan the skills below. For fully described skills, treat each description "
             "as a routing contract, including when not to use it. A counter-trigger is not a match, "
             "and topical overlap alone is not enough. If a description positively matches your task, "
-            "you MUST load it with skill_view(name) and follow its instructions. A [names only] "
-            "skill may still be loaded when the user explicitly names it or its visible name/category "
-            "clearly matches the task. When several skills match, load only those needed for the task. "
+            "you MUST load it with skill_view(name) and follow its instructions. A skill shown without "
+            "a description (including one in a [names only] category) may still be loaded when the user "
+            "explicitly names it or its visible name/category clearly matches the task. When several "
+            "skills match, load only those needed for the task. "
             "Skills contain specialized knowledge — API endpoints, tool-specific commands, "
             "and proven workflows that outperform general-purpose approaches. Load the skill "
             f"even if you think you could handle the task with basic tools like {_basic_tools}. "
@@ -2227,8 +2228,8 @@ def _build_skills_system_prompt_inner(
             + "\n".join(index_lines) + "\n"
             "</available_skills>\n"
             "\n"
-            "Proceed without loading a skill when no description positively matches and no [names only] "
-            "entry has an explicit or clear name/category match."
+            "Proceed without loading a skill when no description positively matches and no skill shown "
+            "without a description has an explicit or clear name/category match."
             + hidden_note
         )
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -341,7 +341,9 @@ class TestBuildSkillsSystemPrompt:
 
         assert "description as a routing contract" in result
         assert "including when not to use it" in result
-        assert "Topical overlap alone is not enough" in result
+        assert "A counter-trigger is not a match" in result
+        assert "topical overlap alone is not enough" in result
+        assert "description positively matches" in result
         assert "you MUST load it" in result
 
 
@@ -361,6 +363,10 @@ class TestBuildSkillsSystemPrompt:
         )
         assert "thread-writer" in compact
         assert "Write threads" not in compact
+        assert "A [names only] skill may still be loaded" in compact
+        assert "user explicitly names it" in compact
+        assert "visible name/category clearly matches the task" in compact
+        assert "no [names only] entry has an explicit or clear name/category match" in compact
         # Unfiltered call must not be served from the compacted cache entry.
         full = build_skills_system_prompt()
         assert "Write threads" in full

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -346,6 +346,24 @@ class TestBuildSkillsSystemPrompt:
         assert "description positively matches" in result
         assert "you MUST load it" in result
 
+    def test_guidance_preserves_recall_for_skill_without_description(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "email" / "mail-helper"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mail-helper\n---\n\n# Mail Helper\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "email:\n    - mail-helper\n" in result
+        assert "A skill shown without a description" in result
+        assert "including one in a [names only] category" in result
+        assert "explicitly names it or its visible name/category clearly matches" in result
+        assert "no skill shown without a description has an explicit or clear" in result
+
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path
@@ -363,10 +381,10 @@ class TestBuildSkillsSystemPrompt:
         )
         assert "thread-writer" in compact
         assert "Write threads" not in compact
-        assert "A [names only] skill may still be loaded" in compact
-        assert "user explicitly names it" in compact
+        assert "including one in a [names only] category" in compact
+        assert "explicitly names it" in compact
         assert "visible name/category clearly matches the task" in compact
-        assert "no [names only] entry has an explicit or clear name/category match" in compact
+        assert "no skill shown without a description has an explicit or clear" in compact
         # Unfiltered call must not be served from the compacted cache entry.
         full = build_skills_system_prompt()
         assert "Write threads" in full

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -324,6 +324,26 @@ class TestBuildSkillsSystemPrompt:
         # "search" should appear only once per category
         assert result.count("- search") == 1
 
+    def test_guidance_treats_descriptions_as_routing_contracts(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        skill_dir = tmp_path / "skills" / "tools" / "specialist"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: specialist\n"
+            "description: Use for deep audits; do not use for quick checks.\n"
+            "---\n"
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "description as a routing contract" in result
+        assert "including when not to use it" in result
+        assert "Topical overlap alone is not enough" in result
+        assert "you MUST load it" in result
+
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
         self, monkeypatch, tmp_path

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -359,10 +359,32 @@ class TestBuildSkillsSystemPrompt:
         result = build_skills_system_prompt()
 
         assert "email:\n    - mail-helper\n" in result
-        assert "A skill shown without a description" in result
-        assert "including one in a [names only] category" in result
+        assert "A skill shown without a substantive routing description" in result
+        assert "or one in a [names only] category" in result
         assert "explicitly names it or its visible name/category clearly matches" in result
-        assert "no skill shown without a description has an explicit or clear" in result
+        assert "without a substantive routing description has an explicit or clear" in result
+
+    def test_guidance_preserves_recall_for_annotation_only_project_skill(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        local_skills = tmp_path / "skills"
+        local_skills.mkdir()
+        project_skills = tmp_path / "project-skills"
+        skill_dir = project_skills / "email" / "mail-helper"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: mail-helper\n---\n\n# Mail Helper\n"
+        )
+        monkeypatch.setattr(
+            "agent.skill_utils.get_project_skills_dirs", lambda: [project_skills]
+        )
+
+        result = build_skills_system_prompt()
+
+        assert "email:\n    - mail-helper: [project]\n" in result
+        assert "only provenance or collision annotations" in result
+        assert "without a substantive routing description has an explicit or clear" in result
 
 
     def test_compact_categories_demote_nested_and_miss_cache_separately(
@@ -381,10 +403,10 @@ class TestBuildSkillsSystemPrompt:
         )
         assert "thread-writer" in compact
         assert "Write threads" not in compact
-        assert "including one in a [names only] category" in compact
+        assert "or one in a [names only] category" in compact
         assert "explicitly names it" in compact
         assert "visible name/category clearly matches the task" in compact
-        assert "no skill shown without a description has an explicit or clear" in compact
+        assert "without a substantive routing description has an explicit or clear" in compact
         # Unfiltered call must not be served from the compacted cache entry.
         full = build_skills_system_prompt()
         assert "Write threads" in full


### PR DESCRIPTION
## What does this PR do?

Skills whose topics merely overlap a task can currently be loaded even when their descriptions say not to use them, adding unnecessary context and weakening progressive disclosure. This change keeps mandatory loading for description-matched skills while making each description, including its counter-triggers, the routing contract.

### Symptom

The generated Skills guidance says to load any skill that is "even partially relevant" and to prefer extra context over skipping a skill. That instruction conflicts with skill descriptions such as "Don't use for quick checks."

### Impact

The prompt can steer models to load topically related but inapplicable skills, expanding conversation context unnecessarily. The model-dependent frequency and token cost are not measured here.

### Bug Cause

**Trigger:** `agent/prompt_builder.py:2208` / `_build_skills_system_prompt_inner`

**Causal chain:**
1. A task shares a topic with a listed skill but falls under that skill's negative routing condition.
2. The global prompt treats partial relevance as a mandatory load and explicitly favors unused context.
3. The model can load the full skill despite the description's narrower contract.

**Why it is wrong:** The global loading threshold overrides the progressive-disclosure boundary carried by each indexed description.

**Working sibling / contrast:** A description that directly matches the task remains mandatory and still takes precedence over solving the task with general-purpose tools.

**Ruled out:** The aggressive wording was not accidental; PR #8209 deliberately introduced it to improve skill recall. This change therefore preserves mandatory loading for actual description matches instead of restoring the old permissive escape hatch.

### Fix

Treat each skill description as the routing contract, explicitly honor negative conditions, reject topical overlap as sufficient by itself, and load only the matching skills needed for the task. A regression test verifies both the selective routing boundary and the retained mandatory-load instruction.

## Related Issue

Fixes #102811

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `agent/prompt_builder.py` - refine skill selection guidance around description matches and counter-triggers.
- `tests/agent/test_prompt_builder.py` - verify the generated prompt preserves selective and mandatory routing.

## How to Test

1. Build a skills prompt containing a description with both positive and negative routing conditions.
2. Confirm the generated guidance treats that description as the routing contract and does not equate topical overlap with a match.
3. Run:

```bash
scripts/run_tests.sh tests/agent/test_prompt_builder.py -q
scripts/run_tests.sh tests/agent/test_skills_guidance_content_filter.py tests/agent/test_ghost_skill_pruning.py -q
```

Result: 100 tests passed, 1 skipped.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the repository test entry on the relevant tests and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation update: N/A - the prompt assembly guide already describes loading only clearly matching skills
- [x] `cli-config.yaml.example` update: N/A - no configuration changed
- [x] `CONTRIBUTING.md` or `AGENTS.md` update: N/A - no architecture or workflow changed
- [x] Cross-platform impact considered: prompt text generation is platform-independent
- [x] Tool descriptions/schemas update: N/A - no tool behavior changed
