### PR TITLE
fix(skills): honor active profile in file write guard

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -478,6 +478,97 @@ class TestSensitivePathCheck:
         # /etc (and its macOS /private/etc mirror) stay blocked.
         assert _check_sensitive_path("/private/etc/hosts") is not None
 
+    def test_write_file_blocks_skills_in_custom_hermes_home(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "custom-profile"
+        target = profile_home / "skills" / "demo" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("original", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(
+            "tools.write_approval.write_approval_enabled",
+            lambda category, **kwargs: True,
+        )
+
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool(str(target), "poisoned"))
+
+        assert "error" in result
+        assert "skills.write_approval is enabled" in result["error"]
+        assert target.read_text(encoding="utf-8") == "original"
+
+    def test_skill_write_guard_fails_closed_when_config_load_errors(
+        self, tmp_path, monkeypatch
+    ):
+        profile_home = tmp_path / "profile"
+        target = profile_home / "skills" / "demo" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("original", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+        def _raise():
+            raise RuntimeError("config unavailable")
+
+        monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+
+        from tools.file_tools import write_file_tool
+
+        result = json.loads(write_file_tool(str(target), "poisoned"))
+
+        assert "error" in result
+        assert "cannot verify skills.write_approval" in result["error"].lower()
+        assert target.read_text(encoding="utf-8") == "original"
+
+    def test_skill_write_guard_normalizes_case(self, tmp_path, monkeypatch):
+        profile_home = tmp_path / "profile"
+        target = profile_home / "skills" / "demo" / "SKILL.md"
+        monkeypatch.setenv("HERMES_HOME", str(profile_home))
+        monkeypatch.setattr(
+            "tools.write_approval.write_approval_enabled",
+            lambda category, **kwargs: True,
+        )
+        monkeypatch.setattr("tools.file_tools.sys.platform", "darwin")
+        monkeypatch.setattr(
+            "tools.file_tools._resolve_path_for_task",
+            lambda filepath, task_id: str(target).upper(),
+        )
+
+        from tools.file_tools import _check_sensitive_path
+
+        result = _check_sensitive_path(str(target).upper())
+
+        assert result is not None
+        assert "skills.write_approval is enabled" in result
+
+    def test_patch_blocks_skills_in_context_scoped_profile(self, tmp_path, monkeypatch):
+        from hermes_constants import reset_hermes_home_override, set_hermes_home_override
+        from tools.file_tools import patch_tool
+
+        profile_home = tmp_path / "context-profile"
+        target = profile_home / "skills" / "demo" / "SKILL.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("original", encoding="utf-8")
+        monkeypatch.setattr(
+            "tools.write_approval.write_approval_enabled",
+            lambda category, **kwargs: True,
+        )
+        token = set_hermes_home_override(profile_home)
+        try:
+            result = json.loads(
+                patch_tool(
+                    mode="replace",
+                    path=str(target),
+                    old_string="original",
+                    new_string="poisoned",
+                )
+            )
+        finally:
+            reset_hermes_home_override(token)
+
+        assert "error" in result
+        assert "skills.write_approval is enabled" in result["error"]
+        assert target.read_text(encoding="utf-8") == "original"
+
     @patch("tools.file_tools._get_file_ops")
     def test_normal_file_not_blocked(self, mock_get, monkeypatch):
         monkeypatch.setattr("tools.file_tools._hermes_config_resolved", "/home/user/.hermes/config.yaml")

--- a/tests/tools/test_write_approval.py
+++ b/tests/tools/test_write_approval.py
@@ -48,6 +48,19 @@ def test_invalid_subsystem_is_off(hermes_home):
     assert wa.write_approval_enabled("bogus") is False
 
 
+def test_config_error_can_fail_closed(hermes_home, monkeypatch):
+    from tools import write_approval as wa
+
+    def _raise():
+        raise RuntimeError("config unavailable")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", _raise)
+
+    assert wa.write_approval_enabled("skills") is False
+    with pytest.raises(RuntimeError, match="config unavailable"):
+        wa.write_approval_enabled("skills", raise_on_error=True)
+
+
 def test_normalize_enabled_coerces_values():
     from tools import write_approval as wa
     # Real bools pass through.

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -685,6 +685,21 @@ def _get_hermes_config_resolved() -> str | None:
     return _hermes_config_resolved
 
 
+def _path_is_same_or_within(path: str, root: str) -> bool:
+    """Return whether path is root or a descendant under platform path rules."""
+    normalized_path = os.path.normcase(os.path.normpath(path))
+    normalized_root = os.path.normcase(os.path.normpath(root))
+    if sys.platform == "darwin":
+        # normcase preserves case on macOS even though default APFS/HFS+
+        # volumes are case-insensitive. Conservatively protect case variants.
+        normalized_path = normalized_path.casefold()
+        normalized_root = normalized_root.casefold()
+    return (
+        normalized_path == normalized_root
+        or normalized_path.startswith(normalized_root + os.sep)
+    )
+
+
 def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None:
     """Return an error message if the path targets a sensitive system location."""
     try:
@@ -712,32 +727,44 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
-    # When skills.write_approval is enabled, block write_file/patch from directly
-    # writing to ~/.hermes/skills/ so the approval gate cannot be bypassed.
-    # The agent must use skill_manage() instead, which correctly stages writes
-    # and returns a pending_id for user approval.
+    # Block direct write_file/patch mutations under the active profile's skills
+    # directory whenever the skill write-approval gate is enabled. Resolve the
+    # profile live on each call because context-local overrides may differ
+    # between concurrent tasks in the same process.
     try:
-        from tools import write_approval as _wa
-        if _wa.write_approval_enabled(_wa.SKILLS):
-            _skills_prefix = os.path.join(
-                os.path.normpath(_expand_tilde("~/.hermes")),
-                "skills",
-            )
-            _skills_prefix_resolved = os.path.realpath(_skills_prefix)
-            if (
-                resolved.startswith(_skills_prefix_resolved + os.sep)
-                or resolved == _skills_prefix_resolved
-                or normalized.startswith(_skills_prefix + os.sep)
-                or normalized == _skills_prefix
-            ):
-                return (
-                    f"Refusing to write to skills directory: {filepath}\n"
-                    "skills.write_approval is enabled. "
-                    "Use skill_manage(action=...) to create, edit, patch, or "
-                    "delete skills instead of write_file or patch."
-                )
+        from hermes_constants import get_hermes_home
+        _skills_prefix = os.path.normpath(str(get_hermes_home() / "skills"))
     except Exception:
-        pass  # Fail open on import error — let the write proceed
+        return (
+            f"Refusing to write while the active Hermes home cannot be resolved: {filepath}\n"
+            "Cannot safely determine whether this path is protected by "
+            "skills.write_approval."
+        )
+
+    _skills_prefix_resolved = os.path.realpath(_skills_prefix)
+    targets_skills = (
+        _path_is_same_or_within(resolved, _skills_prefix_resolved)
+        or _path_is_same_or_within(normalized, _skills_prefix)
+    )
+    if targets_skills:
+        try:
+            from tools import write_approval as _wa
+            approval_enabled = _wa.write_approval_enabled(
+                _wa.SKILLS,
+                raise_on_error=True,
+            )
+        except Exception:
+            return (
+                f"Refusing to write to skills directory: {filepath}\n"
+                "Cannot verify skills.write_approval state; failing closed."
+            )
+        if approval_enabled:
+            return (
+                f"Refusing to write to skills directory: {filepath}\n"
+                "skills.write_approval is enabled. "
+                "Use skill_manage(action=...) to create, edit, patch, or "
+                "delete skills instead of write_file or patch."
+            )
     return None
 
 

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -712,6 +712,32 @@ def _check_sensitive_path(filepath: str, task_id: str = "default") -> str | None
             "Agent cannot modify security-sensitive configuration. "
             "Edit ~/.hermes/config.yaml directly or use 'hermes config' instead."
         )
+    # When skills.write_approval is enabled, block write_file/patch from directly
+    # writing to ~/.hermes/skills/ so the approval gate cannot be bypassed.
+    # The agent must use skill_manage() instead, which correctly stages writes
+    # and returns a pending_id for user approval.
+    try:
+        from tools import write_approval as _wa
+        if _wa.write_approval_enabled(_wa.SKILLS):
+            _skills_prefix = os.path.join(
+                os.path.normpath(_expand_tilde("~/.hermes")),
+                "skills",
+            )
+            _skills_prefix_resolved = os.path.realpath(_skills_prefix)
+            if (
+                resolved.startswith(_skills_prefix_resolved + os.sep)
+                or resolved == _skills_prefix_resolved
+                or normalized.startswith(_skills_prefix + os.sep)
+                or normalized == _skills_prefix
+            ):
+                return (
+                    f"Refusing to write to skills directory: {filepath}\n"
+                    "skills.write_approval is enabled. "
+                    "Use skill_manage(action=...) to create, edit, patch, or "
+                    "delete skills instead of write_file or patch."
+                )
+    except Exception:
+        pass  # Fail open on import error — let the write proceed
     return None
 
 

--- a/tools/write_approval.py
+++ b/tools/write_approval.py
@@ -71,12 +71,15 @@ CONFIG_KEY = "write_approval"
 # Config resolution
 # ---------------------------------------------------------------------------
 
-def write_approval_enabled(subsystem: str) -> bool:
+def write_approval_enabled(subsystem: str, *, raise_on_error: bool = False) -> bool:
     """Return whether the approval gate is enabled for ``subsystem``.
 
     Reads ``<subsystem>.write_approval`` from config.yaml. Defaults to
     ``False`` (gate off — writes flow freely) for any unset / invalid value so
     existing installs keep their current behaviour until the user opts in.
+    Security boundaries may pass ``raise_on_error=True`` to distinguish a
+    config-loading failure from an explicitly disabled gate while preserving
+    the default for existing callers.
     """
     if subsystem not in _SUBSYSTEMS:
         return False
@@ -85,6 +88,8 @@ def write_approval_enabled(subsystem: str) -> bool:
         cfg = load_config()
         raw = cfg_get(cfg, subsystem, CONFIG_KEY, default=False)
     except Exception:
+        if raise_on_error:
+            raise
         return False
     return _normalize_enabled(raw)
 


### PR DESCRIPTION
## Summary

- preserve #60482's `write_file` / `patch` guard and original authorship
- resolve the guarded skills root through `get_hermes_home()` instead of literal `~/.hermes`
- use platform-aware path normalization and fail closed when an in-scope approval state cannot be verified
- cover process-level `HERMES_HOME`, context-local profile overrides, and both real file-tool entry points

## Problem

#60482 correctly closes the direct file-tool bypass for the default `~/.hermes/skills` directory. Hermes profiles can use a different active home, however, through `HERMES_HOME` or a context-local home override. In those cases, `skills.write_approval: true` was active but `write_file` and `patch` could still modify the current profile's skills directly because the guard compared against the default home.

Case-sensitive prefix comparisons could also miss case-variant paths on case-insensitive filesystems.

## Fix

Use Hermes' existing `get_hermes_home()` source of truth when building the guarded skills path. It resolves context-local overrides first, then `HERMES_HOME`, then the platform default. The home is resolved live per call so one task's context-local profile is not cached into another.

A shared containment helper normalizes both operands with platform path rules and conservatively case-folds them on macOS. Existing realpath and lexical checks remain in place for symlink and traversal aliases.

The existing `write_approval_enabled()` behavior remains unchanged by default. Security-boundary callers can request configuration errors to be raised; the file-tool guard uses that mode and refuses the write when it cannot verify the approval state.

This does not attempt to solve the broader filesystem TOCTOU race between path validation and the eventual write; that behavior predates this change and applies to the existing file-tool safety guards generally.

## Attribution

This PR includes and extends webtecnica's commit from #60482. That commit is retained unchanged so its original authorship is preserved.

## Testing

- `uv run pytest tests/tools/test_file_tools.py tests/tools/test_file_write_safety.py tests/tools/test_cross_profile_guard.py tests/tools/test_write_approval.py -q`
- Result: **135 passed, 2 skipped**
- New profile, config-failure, and case-normalization regressions were observed failing before their fixes and passing afterward.

Fixes #60440
