### PR TITLE
api_server: bind the declared X-Hermes-Session-Key on /v1/runs

### DIFF
--- a/gateway/platforms/api_server_runs.py
+++ b/gateway/platforms/api_server_runs.py
@@ -806,7 +806,12 @@ async def _handle_runs(
                             # background delegations stay forced-sync
                             # (no wake target).
                             chat_id=session_id or "",
-                            session_key=approval_session_key,
+                            # The tools identity is the key the client declared
+                            # (X-Hermes-Session-Key), exactly as _run_agent binds it
+                            # for chat completions. Binding the run id here left every
+                            # session-keyed tool with an unknown session on /v1/runs;
+                            # approvals still key on the run id.
+                            session_key=gateway_session_key or approval_session_key,
                             session_id=session_id or "",
                             browser_control_principal=(
                                 request_browser_control_principal


### PR DESCRIPTION
POST /v1/runs bound the run id as the task-local session key, so a tool that reads HERMES_SESSION_KEY saw a run id instead of the key the client declared with X-Hermes-Session-Key, while POST /v1/chat/completions bound the header (_run_agent). This binds the declared key first, exactly as the chat path does; approvals still key on the run id. Run-API test suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)