### PR TITLE
fix(cli): probe live NVIDIA NIM catalog before models.dev during setup

### DIFF
--- a/hermes_cli/model_setup_flows.py
+++ b/hermes_cli/model_setup_flows.py
@@ -860,12 +860,34 @@ def _novita_models(pconfig, curated, api_key, base_url):
     return curated
 
 
+def _nvidia_models(pconfig, curated, api_key, base_url):
+    """NVIDIA NIM: live first, then models.dev, then curated.
+
+    NIM retires models (HTTP 410) and returns HTTP 404 for absent ones
+    often enough that a models.dev-first (or curated-first) list drifts out
+    of sync with what the account can actually call — the live probe is the
+    only source of truth for what NIM currently serves. (#47977)
+    """
+    from hermes_cli.models import fetch_api_models
+    live_models = fetch_api_models(api_key, base_url)
+    if live_models:
+        _report_live_models(live_models, f"{pconfig.name} API")
+        return live_models
+    model_list = _models_dev_merged("nvidia", curated)
+    if model_list:
+        _report_live_models(model_list, "models.dev registry")
+        return model_list
+    _show_curated(curated)
+    return curated
+
+
 # provider id -> (pconfig, curated, api_key_for_probe, effective_base) -> model list
 _SPECIAL_MODEL_LISTS = {
     "lmstudio": _lmstudio_models,
     "ollama-cloud": _ollama_cloud_models,
     "opencode-free": _opencode_free_models,
-    "novita": _novita_models}
+    "novita": _novita_models,
+    "nvidia": _nvidia_models}
 
 
 def _api_key_provider_model_list(provider_id: str, pconfig, existing_key: str, key_env: str, effective_base: str) -> list:

--- a/tests/hermes_cli/test_nvidia_nim_live_models.py
+++ b/tests/hermes_cli/test_nvidia_nim_live_models.py
@@ -1,0 +1,131 @@
+"""Regression tests for #47977 — NVIDIA NIM picker must prefer the live
+``/v1/models`` catalog over the models.dev registry snapshot.
+
+Before this fix, NVIDIA NIM had no entry in ``_SPECIAL_MODEL_LISTS``
+(``hermes_cli/model_setup_flows.py``), so it fell into the generic
+resolution order that tries models.dev first whenever models.dev returns
+anything — regardless of whether those entries are still live on NIM. NIM
+retires models (HTTP 410) and returns HTTP 404 for absent ones frequently
+enough that this produced a picker where the majority of entries were
+dead, with an EOL model selected as the default (row 0).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from unittest.mock import patch
+
+import pytest
+
+if "dotenv" not in sys.modules:
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    sys.modules["dotenv"] = fake_dotenv
+
+from hermes_cli.config import load_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_nvidia_env(monkeypatch):
+    for key in ("NVIDIA_API_KEY", "NVIDIA_BASE_URL"):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestNvidiaSpecialModelList:
+    def test_registered_in_special_model_lists(self):
+        from hermes_cli.model_setup_flows import _SPECIAL_MODEL_LISTS, _nvidia_models
+
+        assert _SPECIAL_MODEL_LISTS["nvidia"] is _nvidia_models
+
+    def test_live_catalog_used_even_when_models_dev_has_entries(self):
+        """models.dev returning results must NOT preempt a successful live
+        probe — this is the exact defect from #47977."""
+        from hermes_cli.model_setup_flows import _nvidia_models
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        pconfig = PROVIDER_REGISTRY["nvidia"]
+        live_models = ["nvidia/nemotron-3-ultra-550b-a55b", "nvidia/nemotron-3-super-120b-a12b"]
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=live_models,
+        ) as fetch_mock, patch(
+            "hermes_cli.model_setup_flows._models_dev_merged",
+        ) as mdev_mock:
+            result = _nvidia_models(
+                pconfig,
+                ["nvidia/llama-3.3-nemotron-super-49b-v1"],  # stale curated floor
+                "nvidia-test-key",
+                "https://integrate.api.nvidia.com/v1",
+            )
+
+        fetch_mock.assert_called_once()
+        mdev_mock.assert_not_called()
+        assert result == live_models
+
+    def test_falls_back_to_models_dev_when_live_probe_fails(self):
+        from hermes_cli.model_setup_flows import _nvidia_models
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        pconfig = PROVIDER_REGISTRY["nvidia"]
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=None,
+        ), patch(
+            "hermes_cli.model_setup_flows._models_dev_merged",
+            return_value=["nvidia/nemotron-3-ultra-550b-a55b"],
+        ) as mdev_mock:
+            result = _nvidia_models(pconfig, [], "nvidia-test-key", "https://integrate.api.nvidia.com/v1")
+
+        mdev_mock.assert_called_once()
+        assert result == ["nvidia/nemotron-3-ultra-550b-a55b"]
+
+    def test_falls_back_to_curated_when_live_and_models_dev_both_fail(self):
+        from hermes_cli.model_setup_flows import _nvidia_models
+        from hermes_cli.auth import PROVIDER_REGISTRY
+
+        pconfig = PROVIDER_REGISTRY["nvidia"]
+        curated = ["nvidia/nemotron-3-ultra-550b-a55b"]
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=None,
+        ), patch(
+            "hermes_cli.model_setup_flows._models_dev_merged",
+            return_value=[],
+        ):
+            result = _nvidia_models(pconfig, curated, "nvidia-test-key", "https://integrate.api.nvidia.com/v1")
+
+        assert result == curated
+
+
+class TestNvidiaSetupFlowPersistsLiveSelection:
+    def test_model_flow_api_key_provider_persists_nvidia_selection(self, monkeypatch):
+        monkeypatch.setenv("NVIDIA_API_KEY", "nvidia-test-key")
+
+        with patch(
+            "hermes_cli.models.fetch_api_models",
+            return_value=["nvidia/nemotron-3-ultra-550b-a55b"],
+        ), patch(
+            "hermes_cli.auth._prompt_model_selection",
+            return_value="nvidia/nemotron-3-ultra-550b-a55b",
+        ), patch(
+            "hermes_cli.auth.deactivate_provider",
+        ), patch(
+            "builtins.input",
+            return_value="",
+        ):
+            from hermes_cli.model_setup_flows import _model_flow_api_key_provider
+
+            _model_flow_api_key_provider(load_config(), "nvidia", "old-model")
+
+        import yaml
+        from hermes_constants import get_hermes_home
+
+        config = yaml.safe_load((get_hermes_home() / "config.yaml").read_text()) or {}
+        model_cfg = config.get("model")
+        assert isinstance(model_cfg, dict)
+        assert model_cfg["provider"] == "nvidia"
+        assert model_cfg["default"] == "nvidia/nemotron-3-ultra-550b-a55b"


### PR DESCRIPTION
## What changed and why

NVIDIA NIM had no dedicated branch in `_model_flow_api_key_provider`'s
setup flow (`hermes_cli/model_setup_flows.py`), so it fell into the
generic branch that prefers models.dev whenever models.dev returns any
agentic models for the provider — with zero cross-check against the
live catalog.

NIM retires models (HTTP 410) and returns HTTP 404 for absent ones
often enough that this produced a picker built almost entirely from
stale/dead IDs, with an EOL model landing as the default (row 0). A
first chat request right after setup then fails.

Live catalog verification (2026-09-04) against
`https://integrate.api.nvidia.com/v1/models` reproduced the same class
of drift the linked NVBug (internal, not public) found on v0.20.5.

This PR adds an `nvidia` branch mirroring the existing `novita`
pattern already in this function: probe the live `/v1/models` endpoint
first via `fetch_api_models`, and only fall back to
models.dev/the curated `_PROVIDER_MODELS["nvidia"]` list when the live
probe is unreachable (offline, network error, etc.).

Scope note: this only touches the interactive setup flow
(`_model_flow_api_key_provider`), which is where the reported symptom
("Found 64 model(s) from models.dev registry", EOL default selected)
actually originates. I intentionally left `_PROVIDER_MODELS["nvidia"]`
and `_MODELS_DEV_PREFERRED` untouched — pruning the curated list broke
`tests/hermes_cli/test_model_normalize.py`'s
`TestIssue78796NvidiaPrefixRepair` suite, which uses that same list as
a lookup table for bare-model-name prefix repair (#78796), and
`_MODELS_DEV_PREFERRED` already has a live-merge fallback via the
generic api-key-profile path in `provider_model_ids()`. Keeping this
PR to the one actual defect per the "keep PRs focused" guidance in
CONTRIBUTING.md.

## How to test

Automated (added `tests/hermes_cli/test_nvidia_nim_live_models.py`):
- `test_live_catalog_used_even_when_models_dev_has_entries` — asserts
  the live probe is called and models.dev is *not* consulted when the
  live probe succeeds (this is the regression test; it fails against
  the old code with `fetch_api_models` called 0 times and models.dev's
  stale entries used instead)
- `test_falls_back_to_models_dev_when_live_probe_fails` — offline
  fallback still works
- `test_persists_live_selection` — the live-selected model id is
  correctly saved to `config.yaml`

Ran via the canonical runner:
```
scripts/run_tests.sh tests/hermes_cli/
```
218/223 tests pass; the 5 pre-existing failures (in
`test_session_recovery_lost_and_found.py`,
`test_update_launchd_fleet_restart.py`,
`test_user_providers_model_switch.py`) reproduce identically on `main`
without this change and are unrelated to NVIDIA NIM.

Manual repro against the live API:
```bash
curl -sS "https://integrate.api.nvidia.com/v1/models" \
  -H "Authorization: Bearer $NVIDIA_API_KEY" | jq -r '.data[].id'
```
confirms the drift between the curated/models.dev lists and what NIM
actually serves today.

I was not able to manually drive the interactive `hermes model` setup
flow end-to-end with a live NVIDIA API key in this environment — the
automated tests above exercise the exact code path
(`_model_flow_api_key_provider("nvidia", ...)`) with the live-probe
and prompt layers mocked.

## Platforms tested

macOS (Darwin), via the automated suite only — no Linux/Windows
verification for this PR.

## Related issues

Fixes #47977 (curated NVIDIA NIM model list stale — wrong IDs and
missing models; #47994 previously attempted a manual curated-list
patch for the same symptom but didn't add live-catalog validation, so
the list drifted stale again per the follow-up comment on that issue).