### PR TITLE
fix(desktop): raise default warm backend pool cap from 3 to 8

### DIFF
--- a/apps/desktop/electron/pool-limits.test.ts
+++ b/apps/desktop/electron/pool-limits.test.ts
@@ -8,6 +8,15 @@ import {
   POOL_LIMITS_MIN
 } from './pool-limits'
 
+describe('POOL_LIMITS_DEFAULTS', () => {
+  it('defaults to a warm pool that fits a multi-bot roster (#102822)', () => {
+    // The renderer store mirrors this constant by hand; if either side
+    // drifts, prewarm's saturation guard and main's eviction disagree.
+    expect(POOL_LIMITS_DEFAULTS.maxBackends).toBe(8)
+    expect(POOL_LIMITS_DEFAULTS.maxBackends).toBeGreaterThan(3)
+  })
+})
+
 describe('parsePoolLimits', () => {
   it('falls back to defaults for null/empty/corrupt input', () => {
     expect(parsePoolLimits(null)).toEqual(POOL_LIMITS_DEFAULTS)

--- a/apps/desktop/electron/pool-limits.ts
+++ b/apps/desktop/electron/pool-limits.ts
@@ -9,8 +9,11 @@
  * app restart. The renderer mirrors the values for its UI and prewarm
  * guard over IPC.
  *
- * Defaults preserve the historical hard-coded behavior (3 backends, 10min
- * idle) so machines that never open Settings behave exactly as before.
+ * Defaults keep the warm pool large enough for a realistic multi-bot roster
+ * (the old 3-backend ceiling silently LRU-evicted spawned backends on
+ * 6-bot setups, #102822) while staying far under the RAM budget of the
+ * machines that run Desktop at all; 10min idle preserves the historical
+ * behavior for machines that never open Settings.
  */
 
 export interface PoolLimits {
@@ -21,7 +24,7 @@ export interface PoolLimits {
 }
 
 export const POOL_LIMITS_DEFAULTS: PoolLimits = {
-  maxBackends: 3,
+  maxBackends: 8,
   idleMs: 10 * 60_000
 }
 

--- a/apps/desktop/src/store/pool-limits.ts
+++ b/apps/desktop/src/store/pool-limits.ts
@@ -20,7 +20,7 @@ export interface PoolLimits {
 }
 
 export const POOL_LIMITS_DEFAULTS: PoolLimits = {
-  maxBackends: 3,
+  maxBackends: 8,
   idleMs: 10 * 60_000
 }
 


### PR DESCRIPTION
## Summary

Desktop's warm-backend pool capped concurrent spawned bot backends at **3** by default. On a multi-bot roster (the reporter runs 6: 1 remote + 5 local) the LRU cap evicts the least-recently-used idle backend as soon as a 4th is opened, so earlier bots pay a cold start every time they're revisited — matching the "ones I created first become no longer accessible until I re-prompt Hermes" report in #102822.

- The pool was already fully configurable (Settings → Advanced "Warm Bot Backends", clamp range 1–64, `HERMES_DESKTOP_POOL_MAX` env fallback); only the *default* was stale — it preserved the original hard-coded ceiling from before multi-bot rosters were common.
- Raised the default `maxBackends` 3 → 8 in both authoritative places: `apps/desktop/electron/pool-limits.ts` (main process: pool + persisted preference) and its hand-mirrored renderer copy `apps/desktop/src/store/pool-limits.ts` (Settings rows + `prewarmProfileBackend` saturation guard). Values already persisted in `userData` are untouched — users who lowered the cap keep theirs.
- At ~60MB per warm backend the new default budgets ~480MB across 8 bots, in line with machines that run Desktop with a multi-bot roster; single-bot users still spawn exactly one backend — the cap only bounds *concurrently warm* ones.
- Added a pinning test asserting the default stays a multi-bot-sized pool (>3), with a comment explaining the two mirrored constants must not drift.

## Testing

- `npx vitest run electron/pool-limits.test.ts --project electron` — 9 passed (incl. new pinning test)
- `npx vitest run electron/pool-spawn-coordinator.test.ts electron/pool-eviction.test.ts --project electron` — 22 passed
- `npx vitest run src/store/profile.test.ts --project ui` — 20 passed
- `npx tsc --build tsconfig.electron.json` — exit 0
- `npx tsc -p . --noEmit` (renderer) — exit 0
- `eslint` on all three touched files — exit 0

Fixes #102822