### PR TITLE
feat(desktop): add system tray icon and minimize-to-tray support

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -429,6 +429,7 @@ import {
 import { createWindowOpenHandler } from './window-open-policy'
 import { installWindowRendererLifecycle } from './window-renderer-lifecycle'
 import { createWindowRevealController } from './window-reveal'
+import { hasSystemTray, initSystemTray, destroySystemTray } from './system-tray'
 import {
   bindGeometryPersistence,
   computeWindowOptions,
@@ -18151,7 +18152,8 @@ app.whenReady().then(() => {
   void resumeManagedSshRecoveries()
   createWindow()
 
-  // Win/Linux cold start: the launching hermes:// URL is in our own argv.
+  // Initialise system tray (non-macOS: window hides to tray on close instead of quitting).
+  initSystemTray(mainWindow)
   const _coldStartLink = _extractDeepLink(process.argv)
 
   if (_coldStartLink) {
@@ -18364,6 +18366,13 @@ app.on('window-all-closed', () => {
   // full timeout and the user is left with an invisible app (or an uninstall
   // that appears to do nothing).
   if (process.platform !== 'darwin' || isQuittingForHandoff) {
+    // When the system tray is active, hide the window instead of quitting so
+    // the app lives in the tray. The user can still fully quit via the tray's
+    // "Quit Hermes" item or File > Quit.
+    if (hasSystemTray() && mainWindow && !mainWindow.isDestroyed()) {
+      mainWindow.hide()
+      return
+    }
     app.quit()
   }
 })

--- a/apps/desktop/electron/system-tray.ts
+++ b/apps/desktop/electron/system-tray.ts
@@ -1,0 +1,165 @@
+import fs from 'node:fs'
+import path from 'node:path'
+
+import {
+  app,
+  BrowserWindow,
+  Menu,
+  nativeImage,
+  Tray
+} from 'electron'
+
+import { appIconCandidates, resolveAppIcon } from './app-icon'
+
+// ── Module state ────────────────────────────────────────────────
+let tray: Tray | null = null
+
+/** Whether the tray has been initialized this session. */
+let initialized = false
+
+/** The main window reference, set by the integration call. */
+let mainWindowRef: BrowserWindow | null = null
+
+// ── Helpers ─────────────────────────────────────────────────────
+
+/**
+ * Resolve a 16×16 or 22×22 tray icon from the app's icon candidates.
+ * Falls back to a 16×16 empty image so the tray still appears.
+ */
+function resolveTrayIcon(): Electron.NativeImage {
+  const candidates = appIconCandidates()
+  const iconPath = resolveAppIcon(candidates, '16x16')
+
+  if (iconPath) {
+    try {
+      const img = nativeImage.createFromPath(iconPath)
+      if (!img.isEmpty()) return img
+    } catch {
+      // fall through
+    }
+  }
+
+  // Generate a 16×16 image from a larger icon
+  const largeIcon = resolveAppIcon(candidates)
+  if (largeIcon) {
+    try {
+      const img = nativeImage.createFromPath(largeIcon)
+      if (!img.isEmpty()) return img.resize({ width: 16, height: 16 })
+    } catch {
+      // fall through
+    }
+  }
+
+  // Last resort: blank 16×16
+  return nativeImage.createEmpty()
+}
+
+// ── Context menu ────────────────────────────────────────────────
+
+function buildContextMenu(): Electron.Menu {
+  return Menu.buildFromTemplate([
+    {
+      label: 'Show Hermes',
+      click: () => {
+        if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+          if (mainWindowRef.isMinimized()) mainWindowRef.restore()
+          mainWindowRef.show()
+          mainWindowRef.focus()
+        }
+      }
+    },
+    { type: 'separator' },
+    {
+      label: 'Quit Hermes',
+      click: () => {
+        app.quit()
+      }
+    }
+  ])
+}
+
+// ── Public API ──────────────────────────────────────────────────
+
+/**
+ * Initialise the system tray icon and its context menu.
+ * Safe to call multiple times — only the first call takes effect.
+ *
+ * @param mainWindow - The primary BrowserWindow to show/hide via the tray.
+ */
+export function initSystemTray(mainWindow: BrowserWindow | null): void {
+  if (initialized) return
+  initialized = true
+
+  mainWindowRef = mainWindow
+
+  // Don't create a tray in tests or headless environments
+  if (app.isPackaged === false && process.env.ELECTRON_RUN_AS_NODE) return
+  if (!app.requestSingleInstanceLock?.()) return
+
+  try {
+    const icon = resolveTrayIcon()
+    tray = new Tray(icon)
+    tray.setToolTip('Hermes')
+    tray.setContextMenu(buildContextMenu())
+
+    // Left-click (or single-click on some platforms) shows the window
+    tray.on('click', () => {
+      if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+        if (mainWindowRef.isMinimized()) mainWindowRef.restore()
+        if (mainWindowRef.isVisible()) {
+          mainWindowRef.focus()
+        } else {
+          mainWindowRef.show()
+          mainWindowRef.focus()
+        }
+      }
+    })
+
+    tray.on('double-click', () => {
+      if (mainWindowRef && !mainWindowRef.isDestroyed()) {
+        if (mainWindowRef.isMinimized()) mainWindowRef.restore()
+        mainWindowRef.show()
+        mainWindowRef.focus()
+      }
+    })
+
+    // Update icon when the app icon changes (theme-aware)
+    app.on('will-quit', () => {
+      destroySystemTray()
+    })
+  } catch {
+    // Tray creation failed silently (possible in non-DBus Linux envs)
+    tray = null
+  }
+}
+
+/**
+ * Destroy the system tray. Safe to call when none exists.
+ */
+export function destroySystemTray(): void {
+  if (tray) {
+    tray.destroy()
+    tray = null
+  }
+  initialized = false
+  mainWindowRef = null
+}
+
+/**
+ * Update the tray icon (e.g. after a theme change).
+ */
+export function updateTrayIcon(): void {
+  if (!tray) return
+  try {
+    tray.setImage(resolveTrayIcon())
+  } catch {
+    // ignore
+  }
+}
+
+/**
+ * Whether the system tray is active.
+ */
+export function hasSystemTray(): boolean {
+  return tray !== null
+}


### PR DESCRIPTION
Closes feature request [#38007](https://github.com/NousResearch/hermes-agent/issues/38007) (system tray, 13 thumbs up). Re-implements previously closed [#38024](https://github.com/NousResearch/hermes-agent/pull/38024) — ported from stale .cjs to active TypeScript entry point per maintainer review feedback.

New file apps/desktop/electron/system-tray.ts: tray icon, context menu (Show/Quit), hide-to-tray on non-macOS close, click/double-click restore. Graceful fallback on platforms without tray support. macOS behavior unchanged.