### PR TITLE
fix(desktop): restore Star Map node context menu

### DIFF
--- a/apps/desktop/src/app/starmap/context-menu-boundary.test.tsx
+++ b/apps/desktop/src/app/starmap/context-menu-boundary.test.tsx
@@ -1,0 +1,21 @@
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { StarmapContextMenuBoundary } from './index'
+
+describe('StarmapContextMenuBoundary', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  it('marks the Star Map as owning plain right-clicks', () => {
+    render(
+      <StarmapContextMenuBoundary>
+        <canvas data-testid="starmap-canvas" />
+      </StarmapContextMenuBoundary>
+    )
+
+    const canvas = screen.getByTestId('starmap-canvas')
+    expect(canvas.closest('[data-context-menu-skip]')).toBeTruthy()
+  })
+})

--- a/apps/desktop/src/app/starmap/context-menu-boundary.test.tsx
+++ b/apps/desktop/src/app/starmap/context-menu-boundary.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it } from 'vitest'
 
-import { StarmapContextMenuBoundary } from './index'
+import { StarmapContextMenuBoundary } from './context-menu-boundary'
 
 describe('StarmapContextMenuBoundary', () => {
   afterEach(() => {

--- a/apps/desktop/src/app/starmap/context-menu-boundary.tsx
+++ b/apps/desktop/src/app/starmap/context-menu-boundary.tsx
@@ -1,0 +1,12 @@
+import type { ReactNode } from 'react'
+
+export function StarmapContextMenuBoundary({ children }: { children: ReactNode }) {
+  // The Star Map owns plain right-clicks so its canvas-level handler can open
+  // NodeContextMenu. The app-wide capture handler still handles owned targets
+  // (links, images, editables, selections) inside this boundary.
+  return (
+    <div className="contents" data-context-menu-skip="">
+      {children}
+    </div>
+  )
+}

--- a/apps/desktop/src/app/starmap/index.tsx
+++ b/apps/desktop/src/app/starmap/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState } from 'react'
+import { useEffect, useState, type ReactNode } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { useI18n } from '@/i18n'
@@ -15,6 +15,17 @@ import { StarMap } from './star-map'
 // the map itself lives in ./star-map. The chrome is owned by the map itself
 // (timeline scrubber + legend float over the canvas), so there's no panel
 // header here.
+export function StarmapContextMenuBoundary({ children }: { children: ReactNode }) {
+  // The Star Map owns plain right-clicks so its canvas-level handler can open
+  // NodeContextMenu. The app-wide capture handler still handles owned targets
+  // (links, images, editables, selections) inside this boundary.
+  return (
+    <div className="contents" data-context-menu-skip="">
+      {children}
+    </div>
+  )
+}
+
 export function StarmapView({ onClose }: { onClose: () => void }) {
   const { t } = useI18n()
   const graph = useStore($starmapGraph)
@@ -46,12 +57,14 @@ export function StarmapView({ onClose }: { onClose: () => void }) {
       ) : shown && shown.nodes.length === 0 && !imported ? (
         <PanelEmpty description={t.starmap.emptyDesc} icon="lightbulb" title={t.starmap.emptyTitle} />
       ) : shown ? (
-        <StarMap
-          graph={shown}
-          imported={imported !== null}
-          onImport={setImported}
-          onResetMap={() => setImported(null)}
-        />
+        <StarmapContextMenuBoundary>
+          <StarMap
+            graph={shown}
+            imported={imported !== null}
+            onImport={setImported}
+            onResetMap={() => setImported(null)}
+          />
+        </StarmapContextMenuBoundary>
       ) : null}
     </Panel>
   )

--- a/apps/desktop/src/app/starmap/index.tsx
+++ b/apps/desktop/src/app/starmap/index.tsx
@@ -1,5 +1,5 @@
 import { useStore } from '@nanostores/react'
-import { useEffect, useState, type ReactNode } from 'react'
+import { useEffect, useState } from 'react'
 
 import { PageLoader } from '@/components/page-loader'
 import { useI18n } from '@/i18n'
@@ -8,6 +8,7 @@ import type { StarmapGraph } from '@/types/hermes'
 
 import { Panel, PanelEmpty } from '../overlays/panel'
 
+import { StarmapContextMenuBoundary } from './context-menu-boundary'
 import { StarMap } from './star-map'
 
 // Star map overlay: a top-down map of what Hermes has learned for a profile,
@@ -15,17 +16,6 @@ import { StarMap } from './star-map'
 // the map itself lives in ./star-map. The chrome is owned by the map itself
 // (timeline scrubber + legend float over the canvas), so there's no panel
 // header here.
-export function StarmapContextMenuBoundary({ children }: { children: ReactNode }) {
-  // The Star Map owns plain right-clicks so its canvas-level handler can open
-  // NodeContextMenu. The app-wide capture handler still handles owned targets
-  // (links, images, editables, selections) inside this boundary.
-  return (
-    <div className="contents" data-context-menu-skip="">
-      {children}
-    </div>
-  )
-}
-
 export function StarmapView({ onClose }: { onClose: () => void }) {
   const { t } = useI18n()
   const graph = useStore($starmapGraph)


### PR DESCRIPTION
## What does this PR do?

Fixes #100676.

The app-wide context-menu listener runs in capture phase and stops propagation for plain right-clicks before the Star Map canvas can receive its own `contextmenu` event. The app context menu already has an explicit `data-context-menu-skip` contract for surfaces that own plain right-clicks themselves.

This change wraps the rendered Star Map in that existing boundary so plain right-clicks reach the canvas-level node handler and can open `NodeContextMenu`. Owned DOM targets inside the map remain handled by the app-wide menu, matching the existing skip contract.

## Changes

- Add a small `StarmapContextMenuBoundary` component using the existing `data-context-menu-skip` marker.
- Wrap the live `StarMap` with that boundary without changing layout (`display: contents`).
- Add a focused regression test that verifies the canvas is nested under the skip marker.

## Test

CI should run the desktop Vitest/typecheck suite. The focused regression is:

`apps/desktop/src/app/starmap/context-menu-boundary.test.tsx`

## AI assistance disclosure

This PR was prepared with AI assistance. The issue selection was live duplicate-checked before claiming and again immediately before opening this PR.