### PR TITLE
fix(desktop): distinct icon for the at-rest local default pill

### DIFF
--- a/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx
@@ -253,6 +253,18 @@ describe('ProfileRail fleet mode', () => {
     expect(within(local).getByRole('button', { name: 'default · This device' })).toBeTruthy()
     expect(within(local).getByRole('button', { name: 'omer · This device' })).toBeTruthy()
 
+    // The local default pill must not read as a plain "default profile" home
+    // shortcut — clicking it can silently trigger a first-launch install
+    // (#102826), so it carries a distinct glyph from every other gateway's
+    // default pill.
+    const localHome = within(local).getByRole('button', { name: 'default · This device' })
+    expect(localHome.querySelector('.codicon-device-desktop')).toBeTruthy()
+    expect(localHome.querySelector('.codicon-home')).toBeNull()
+
+    const vps = container.querySelector('[data-slot="profile-rail-gateway"][data-connection-id="vps"]') as HTMLElement
+    const vpsHome = within(vps).getByRole('button', { name: 'default · VPS' })
+    expect(vpsHome.querySelector('.codicon-home')).toBeTruthy()
+
     // The active gateway's own squares are unchanged and unqualified.
     expect(screen.getByRole('button', { name: 'scout' })).toBeTruthy()
     expect(screen.getByRole('button', { name: 'default' })).toBeTruthy()

--- a/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
+++ b/apps/desktop/src/app/chat/sidebar/profile-switcher.tsx
@@ -984,7 +984,11 @@ function FleetRestGroup({
         <ProfilePill
           active={false}
           connectionId={group.connectionId}
-          glyph="home"
+          // The at-rest "This device" default reads as a Home/default-profile
+          // shortcut if it shares the home glyph — but picking it can silently
+          // kick off a first-launch local install (#102826). A distinct glyph
+          // signals "switch device", not "go to default profile".
+          glyph={group.kind === 'local' ? 'device-desktop' : 'home'}
           label={p.fleet.onGateway(group.defaultAgent.profile, group.label)}
           muted
           onSelect={() => onSelect(group.defaultAgent)}


### PR DESCRIPTION
## What does this PR do?

Fixes #102826.

The fleet profile rail's at-rest "This device" default pill
(`FleetRestGroup` in `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx`)
used the same `home` glyph as every gateway's default-profile shortcut, and
its accessible name/tooltip is `"default · This device"` (built from
`p.fleet.onGateway(...)`). That combination — a house icon plus a
"default · This device" label — reads as ordinary navigation (Home / a
default-profile shortcut), not as a device switch.

The consequence is worse than a cosmetic mix-up: picking that pill calls
`selectConnection(connectionId, { profile })`, which on a machine with no
usable local runtime silently starts the first-launch bootstrap install with
no confirmation (see backend chain in the issue: `electron/main.ts`
`resolveHermesBackend` → `ensureRuntime` → `runBootstrap`). A single misclick
on a Home-looking icon can kick off a multi-step local install.

## Fix

Give the local connection kind a distinct glyph (`device-desktop`, already
used elsewhere in this codebase for the same concept) on that specific pill,
so it no longer shares icon language with the default-profile home
shortcut. Every other gateway kind (`remote`, `ssh`, `cloud`) keeps the
`home` glyph — switching to an already-registered gateway's default profile
carries no install risk, so there's nothing to disambiguate there.

This is the minimum of the two remedies the issue itself proposes ("at
minimum ... an icon distinct from the default profile / Home"). A full
pre-confirmation dialog before `runBootstrap()` is a larger, product-design
decision (dialog copy, button set, i18n across every locale) that touches
the main-process bootstrap flow and is left for a follow-up / maintainer
call.

## Changes Made

- `apps/desktop/src/app/chat/sidebar/profile-switcher.tsx` — `FleetRestGroup`'s
  default pill now picks `glyph={group.kind === 'local' ? 'device-desktop' : 'home'}`
- `apps/desktop/src/app/chat/sidebar/profile-rail-fleet.test.tsx` — regression
  test asserting the local default pill renders `.codicon-device-desktop`
  (not `.codicon-home`), while a non-local gateway's default pill
  (`vps`, kind `ssh`) still renders `.codicon-home`

## How to Test

```
cd apps/desktop
npx vitest run src/app/chat/sidebar/profile-rail-fleet.test.tsx
npx vitest run src/app/chat/sidebar/
npx tsc -p . --noEmit
npx eslint src/app/chat/sidebar/profile-switcher.tsx src/app/chat/sidebar/profile-rail-fleet.test.tsx
```

### Actual output

```
$ npx vitest run src/app/chat/sidebar/profile-rail-fleet.test.tsx
 Test Files  1 passed (1)
      Tests  8 passed (8)

$ npx vitest run src/app/chat/sidebar/
 Test Files  25 passed (25)
      Tests  226 passed (226)

$ npx tsc -p . --noEmit
(no output — clean)

$ npx eslint src/app/chat/sidebar/profile-switcher.tsx src/app/chat/sidebar/profile-rail-fleet.test.tsx
(no output — clean)
```

Confirmed the new assertions fail without the fix: checked out
`profile-switcher.tsx` from the prior commit (glyph hardcoded to `"home"`)
with the test changes in place —

```
FAIL  src/app/chat/sidebar/profile-rail-fleet.test.tsx > ProfileRail fleet mode
      > lays every other gateway on the strip as an at-rest group, in switcher order
AssertionError: expected null to be truthy
 ❯ src/app/chat/sidebar/profile-rail-fleet.test.tsx:261:64
```

then restored the fix and re-ran — 8/8 pass.

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched existing issues and PRs for duplicates and related work —
      no open PR touches this pill or this glyph choice
- [x] My PR contains only changes related to this fix
- [x] I've added a test proving the fix (fails on the prior code, passes
      with it)
- [x] `npx tsc -p . --noEmit` and `npx eslint` clean on the touched files

## AI-assistance disclosure

This PR was prepared by an autonomous coding agent (Claude, via an
OSS-contribution pipeline) working from the public issue text and the
current `main` source. All commands above were actually executed against
this branch; no output is fabricated.
