### PR TITLE
fix(desktop): stop runtime model/provider heartbeats from overwriting the composer selection

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx
@@ -265,6 +265,34 @@ describe('useSessionStateCache — per-session turn timer', () => {
     expect($currentServiceTier.get()).toBe('')
     expect($currentFastMode.get()).toBe(false)
   })
+
+  it('mirrors runtime model/provider into the view without persisting over the composer selection (#102793)', () => {
+    // A real user pick: persisted to localStorage, the same as picking a
+    // provider in the model menu.
+    setCurrentModel('claude-opus-5')
+    setCurrentProvider('anthropic')
+    expect(window.localStorage.getItem('hermes.desktop.composer.provider')).toBe('anthropic')
+
+    let cache!: Cache
+
+    render(<Harness activeSessionId="fg-runtime" onReady={c => (cache = c)} selectedStoredSessionId="fg-stored" />)
+
+    // A session.info heartbeat reports the resolved runtime class — `custom`
+    // for a named custom provider — for the same foreground session.
+    act(() => {
+      cache.updateSessionState(
+        'fg-runtime',
+        state => ({ ...state, model: 'claude-opus-5', provider: 'custom' }),
+        'fg-stored'
+      )
+    })
+
+    // The visible status area follows the runtime...
+    expect($currentProvider.get()).toBe('custom')
+    // ...but the user's persisted composer selection must survive the
+    // heartbeat, so a fresh chat still follows it instead of `custom`.
+    expect(window.localStorage.getItem('hermes.desktop.composer.provider')).toBe('anthropic')
+  })
 })
 
 interface LayoutProbeHarnessProps {

--- a/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-state-cache.ts
@@ -12,9 +12,9 @@ import {
   $messages,
   setActiveSessionStoredIdRotation,
   setCurrentFastMode,
-  setCurrentModel,
+  setCurrentModelTransient,
   setCurrentPersonality,
-  setCurrentProvider,
+  setCurrentProviderTransient,
   setCurrentReasoningEffort,
   setCurrentServiceTier,
   setTurnStartedAt,
@@ -41,8 +41,13 @@ interface SessionStateCacheOptions {
 }
 
 function syncRuntimeMetadataToView(state: ClientSessionState) {
-  setCurrentModel(state.model ?? '')
-  setCurrentProvider(state.provider ?? '')
+  // Transient: this runs on every session-state sync, including the periodic
+  // session.info heartbeat, whose reported model/provider is the runtime's
+  // resolved identity (e.g. the generic `custom` billing class), not a user
+  // pick. The persisting setters would silently overwrite the composer's
+  // sticky localStorage selection with that runtime value (#102793).
+  setCurrentModelTransient(state.model ?? '')
+  setCurrentProviderTransient(state.provider ?? '')
   setCurrentReasoningEffort(state.reasoningEffort ?? '')
   setCurrentServiceTier(state.serviceTier ?? '')
   setCurrentFastMode(state.fast ?? false)

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -1327,6 +1327,19 @@ export const setCurrentProvider = (next: Updater<string>) => {
   }
 }
 
+/** Move the visible model/provider without claiming it as the composer's sticky
+ *  selection.
+ *
+ *  For values that come from the RUNTIME rather than the user: the periodic
+ *  `session.info` heartbeat's resolved model/provider (e.g. the generic `custom`
+ *  billing class a named provider resolves to). Persisting those through
+ *  `setCurrentModel`/`setCurrentProvider` overwrote the user's actual composer
+ *  pick in localStorage on every heartbeat, so a later new chat followed the
+ *  last-seen runtime class instead of the selection or the Settings default.
+ */
+export const setCurrentModelTransient = (next: Updater<string>) => updateAtom($currentModel, next)
+export const setCurrentProviderTransient = (next: Updater<string>) => updateAtom($currentProvider, next)
+
 export const getCurrentModelSource = (): ComposerModelSource => {
   const source = storedComposerString(COMPOSER_MODEL_SOURCE_KEY)
 


### PR DESCRIPTION
## What does this PR do?

Hermes Desktop persisted the runtime's resolved model/provider (reported on every
`session.info` heartbeat, roughly once a second) into the composer's sticky,
localStorage-backed selection. When a named custom provider resolves to the
generic `custom` billing class, the very next heartbeat silently overwrote the
user's actual composer pick with `custom:<model>` — so a subsequent new chat
followed the last-seen runtime class instead of the user's selection or the
Settings default.

`use-message-stream/gateway-event/session-info.ts` already has a comment
explaining this exact hazard and deliberately avoids calling
`setCurrentModel`/`setCurrentProvider` directly for that reason — but it notes
the active-session model/provider "still flows through the session state cache
via `updateSessionState` → `syncRuntimeMetadataToView`", and that indirect path
in `use-session-state-cache.ts` was still using the *persisting* setters, so
the same heartbeat still clobbered the selection through the back door.

## Related Issue

Fixes #102793

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `apps/desktop/src/store/session.ts`: add `setCurrentModelTransient` /
  `setCurrentProviderTransient`, mirroring the existing
  `setCurrentCwdTransient` pattern — update the visible atom without writing
  through to the persisted composer key.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.ts`:
  `syncRuntimeMetadataToView` (the function invoked on every session-state
  sync, including periodic heartbeats) now uses the transient setters for
  model/provider instead of the persisting ones.
- `apps/desktop/src/app/session/hooks/use-session-state-cache.test.tsx`: new
  regression test — a persisted `anthropic` composer selection must survive a
  simulated heartbeat that reports the runtime resolved to `custom`, while the
  visible status atom still follows the runtime value.

## How to Test

1. Configure two named providers exposing the same model; set one as the
   profile default, manually select the other in the Desktop composer, start a
   conversation.
2. Previously: after the session started, the composer's persisted selection
   silently became `custom:<model>`, and a subsequent new chat followed that
   instead of the actual selection.
3. With this fix, periodic `session.info` heartbeats update only the visible
   status atoms; the composer's localStorage selection is left untouched.

```text
cd apps/desktop
npx vitest run src/app/session/hooks/use-session-state-cache.test.tsx src/store/session.test.ts src/app/chat/composer/model-pill.test.tsx src/app/session/hooks/use-model-controls.test.tsx src/app/session/hooks/use-session-actions/utils.test.ts src/store/profile-agent-activation.test.ts src/app/session/hooks/use-message-stream/session-info-side-effects.test.tsx src/app/session/hooks/use-message-stream/composer-model-event.test.tsx

 Test Files  8 passed (8)
      Tests  297 passed (297)

npx tsc -p . --noEmit
# clean, no errors

npx eslint src/store/session.ts src/app/session/hooks/use-session-state-cache.ts src/app/session/hooks/use-session-state-cache.test.tsx
# clean, no errors
```

Confirmed the new test fails without the fix: reverted the two source files
(`git checkout HEAD -- apps/desktop/src/store/session.ts
apps/desktop/src/app/session/hooks/use-session-state-cache.ts`, before this
was committed) and re-ran — the new test failed with `expected 'custom' to be
'anthropic'`, confirming it exercises the regression before the fix and passes
after.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [x] Tested on Linux (headless, via vitest/jsdom) — not runtime-tested against a live Electron window

### Documentation & Housekeeping

- [x] N/A — no documentation, config key, or tool schema changes
