### PR TITLE
docs(memory): add deja, a standalone provider over the sessions already on disk

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -670,6 +670,39 @@ hermes memory setup
 
 ---
 
+### deja
+
+Memory from the coding sessions already on the machine. deja indexes the transcripts Hermes, Claude Code, Codex, Cursor and 18 other agents write to disk — including months from before it was installed — and recalls the relevant one before a turn. No model, no key, no server; one Go binary.
+
+| | |
+|---|---|
+| **Best for** | Coding on a machine that already has agent history; recall that works the minute it is installed |
+| **Requires** | `brew install deja-vu` (or `go install github.com/vshulcz/deja-vu/cmd/deja@latest`), then `deja install hermes-auto` |
+| **Data storage** | Local index under `~/.cache/deja` (or `DEJA_INDEX_DIR`); nothing leaves the machine |
+| **Cost** | Free (MIT) |
+
+**Tools:** `deja_recall` (search past sessions across every agent), `deja_fix` (what was run after this error before), `deja_blame` (which sessions touched a file and what they concluded)
+
+**Setup:**
+```bash
+brew install deja-vu
+deja install hermes-auto      # writes ~/.hermes/plugins/deja-memory/
+
+hermes memory setup           # select "deja-memory"
+# Or manually:
+hermes config set memory.provider deja-memory
+```
+
+**Key features:**
+- Starts full: the first session already knows what the last months decided, in Hermes and in every other agent on the disk
+- Per-turn recall is the same digest deja injects in Claude Code and Codex; silent when nothing matches
+- Keys and tokens are stripped as the index is built
+- Sessions are read where the agents write them; nothing is captured or mirrored
+
+See the [deja Hermes guide](https://vshulcz.github.io/deja-vu/guide/memory-for-hermes.html) and the [plugin README](https://github.com/vshulcz/deja-vu).
+
+---
+
 ## Provider Comparison
 
 | Provider | Storage | Cost | Tools | Dependencies | Unique Feature |
@@ -683,12 +716,14 @@ hermes memory setup
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
+| **deja** | Local | Free | 3 | `deja` binary | Indexes the session history already on disk, across 22 agents |
 
 ## Profile Isolation
 
 Each provider's data is isolated per [profile](/user-guide/profiles):
 
 - **Local storage providers** (Holographic, ByteRover) use `$HERMES_HOME/` paths which differ per profile
+- **deja** keeps one machine-wide index outside `$HERMES_HOME`, shared by every profile and every agent on the machine
 - **Config file providers** (Honcho, Mem0, Hindsight, Supermemory) store config in `$HERMES_HOME/` so each profile has its own credentials
 - **Cloud providers** (RetainDB) auto-derive profile-scoped project names
 - **Env var providers** (OpenViking) are configured via each profile's `.env` file

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -672,7 +672,7 @@ hermes memory setup
 
 ### deja
 
-Memory from the coding sessions already on the machine. deja indexes the transcripts Hermes, Claude Code, Codex, Cursor and 18 other agents write to disk — including months from before it was installed — and recalls the relevant one before a turn. No model, no key, no server; one Go binary.
+Memory from the coding sessions already on the machine. deja indexes the transcripts Hermes, Claude Code, Codex, Cursor and 18 other agents — 22 in all — write to disk — including months from before it was installed — and recalls the relevant one before a turn. No model, no key, no server; one Go binary.
 
 | | |
 |---|---|

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -672,7 +672,7 @@ hermes memory setup
 
 ### deja
 
-Memory from the coding sessions already on the machine. deja indexes the transcripts Hermes, Claude Code, Codex, Cursor and 18 other agents — 22 in all — write to disk — including months from before it was installed — and recalls the relevant one before a turn. No model, no key, no server; one Go binary.
+Memory from the coding sessions already on the machine. deja indexes the transcripts Hermes, Claude Code, Codex, Cursor and 19 other agents — 23 in all — write to disk — including months from before it was installed — and recalls the relevant one before a turn. No model, no key, no server; one Go binary.
 
 | | |
 |---|---|
@@ -716,7 +716,7 @@ See the [deja Hermes guide](https://vshulcz.github.io/deja-vu/guide/memory-for-h
 | **ByteRover** | Local/Cloud | Free/Paid | 3 | `brv` CLI | Pre-compression extraction |
 | **Supermemory** | Cloud/Self-hosted | Free/Paid | 4 | `supermemory` | Context fencing + session graph ingest + multi-container |
 | **Memori** | Cloud | Free/Paid | 5 | `hermes-memori` | Tool-aware memory + structured recall |
-| **deja** | Local | Free | 3 | `deja` binary | Indexes the session history already on disk, across 22 agents |
+| **deja** | Local | Free | 3 | `deja` binary | Indexes the session history already on disk, across 23 agents |
 
 ## Profile Isolation
 


### PR DESCRIPTION
## What does this PR do?

Adds deja to the Memory Providers page, in the same shape as the Memori section: a standalone provider (not bundled, per CONTRIBUTING) that users install with `deja install hermes-auto` into `~/.hermes/plugins/deja-memory/`. It implements the `MemoryProvider` ABC over the deja binary — `prefetch` returns recall from the session history already on the machine (Hermes' own store plus Claude Code, Codex, Cursor and 18 other agents), tools `deja_recall` / `deja_fix` / `deja_blame`, no config schema, no network. Also a row in the comparison table and a line under Profile Isolation (one machine-wide index, outside `$HERMES_HOME`).

Provider source: https://github.com/vshulcz/deja-vu/blob/main/cmd/deja/install_hermes_memory.go (shipped in deja v0.19.3). Verified against `agent/memory_provider.py` from a current checkout: `register(ctx)` hands over a `MemoryProvider` instance, `is_available()` makes no network call, `hermes memory setup` lists it as "no setup needed".

## Related Issue

N/A — documentation for an external provider.

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- `website/docs/user-guide/features/memory-providers.md`: deja section before Provider Comparison, comparison row, profile-isolation line