### PR TITLE
fix(desktop): add dismiss affordance to the failed install footer

### DIFF
--- a/apps/desktop/src/components/desktop-install-overlay.test.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.test.tsx
@@ -32,6 +32,7 @@ function installDesktopMock(state: DesktopBootstrapState) {
       return () => bootstrapListeners.delete(listener)
     }),
     continueBootstrapLocal: vi.fn().mockResolvedValue({ ok: true }),
+    resetBootstrap: vi.fn().mockResolvedValue({ ok: true }),
     probeConnectionConfig: vi.fn(),
     testConnectionConfig: vi.fn(),
     applyConnectionConfig: vi.fn(),
@@ -572,5 +573,30 @@ describe('DesktopInstallOverlay first-run setup', () => {
 
     await waitFor(() => expect(screen.queryByText('Gateway URL')).toBeNull())
     expect(screen.queryByText('Hermes needs a one-time install')).toBeNull()
+  })
+
+  it('dismisses a cancelled/failed install via the footer Close button, without reloading or resetting bootstrap', async () => {
+    const desktop = installDesktopMock(bootstrapState({ error: 'cancelled by user' }))
+
+    render(<DesktopInstallOverlay />)
+
+    expect(await screen.findByText('Installation failed')).toBeTruthy()
+
+    fireEvent.click(screen.getByText('Close'))
+
+    await waitFor(() => expect(screen.queryByText('Installation failed')).toBeNull())
+    expect(desktop.resetBootstrap).not.toHaveBeenCalled()
+  })
+
+  it('dismisses a failed install on Escape', async () => {
+    installDesktopMock(bootstrapState({ error: 'cancelled by user' }))
+
+    render(<DesktopInstallOverlay />)
+
+    expect(await screen.findByText('Installation failed')).toBeTruthy()
+
+    fireEvent.keyDown(window, { key: 'Escape' })
+
+    await waitFor(() => expect(screen.queryByText('Installation failed')).toBeNull())
   })
 })

--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -360,7 +360,8 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
     window.addEventListener('keydown', onKeyDown)
 
     return () => window.removeEventListener('keydown', onKeyDown)
-  }, [state.error])
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- only the failed/not-failed transition matters, not error text changes
+  }, [Boolean(state.error)])
 
   // The choice remains mounted while main hands off to local bootstrap. Once
   // a manifest/failure takes ownership (or a later repair presents a fresh

--- a/apps/desktop/src/components/desktop-install-overlay.tsx
+++ b/apps/desktop/src/components/desktop-install-overlay.tsx
@@ -343,6 +343,25 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
     }
   }, [state.error])
 
+  // Escape dismisses a failed install the same way the footer's Close button
+  // does -- local-only, no resetBootstrap + reload. Scoped to the failed
+  // state so a running install is still only cancellable via its own button.
+  useEffect(() => {
+    if (!state.error) {
+      return
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setState(EMPTY_STATE)
+      }
+    }
+
+    window.addEventListener('keydown', onKeyDown)
+
+    return () => window.removeEventListener('keydown', onKeyDown)
+  }, [state.error])
+
   // The choice remains mounted while main hands off to local bootstrap. Once
   // a manifest/failure takes ownership (or a later repair presents a fresh
   // choice), this transient button state must not leak across phases — so it
@@ -673,6 +692,9 @@ export function DesktopInstallOverlay({ enabled = true }: DesktopInstallOverlayP
                 <code className="font-mono text-(--ui-text-secondary)">%LOCALAPPDATA%\hermes\logs\</code>
               </span>
               <div className="flex gap-2">
+                <Button onClick={() => setState(EMPTY_STATE)} size="sm" variant="ghost">
+                  {t.common.close}
+                </Button>
                 <Button
                   onClick={async () => {
                     const text = state.log


### PR DESCRIPTION
## What does this PR do?

Fixes #102824.

After cancelling (or otherwise failing) the first-launch local install, the
"Installation failed" modal only offered **Copy output** and **Reload and
retry**. "Reload and retry" clears the latched failure and reloads the app,
which re-enters the bootstrap path — there was no non-destructive way back to
the previous view short of quitting the app.

`apps/desktop/src/components/desktop-install-overlay.tsx`'s failed footer
(around the old lines 668-719) had no dismiss control and no Escape handling.
The only `dismissed` event is broadcast from `electron/main.ts`
(`abandonFirstRunSetupChoiceForRemoteApply`) solely for the abandon-to-remote
path, not for a plain cancelled/failed install.

## Fix

Add a **Close** button to the failed footer (reusing the existing
`common.close` translation, so every locale picks it up with no new i18n
keys), plus `Escape` key handling scoped to the failed state. Both just reset
the overlay's local React state back to empty — no `resetBootstrap()` IPC
call, no backend teardown, no page reload. Since the overlay is "mounted
always" over the rest of the app, dismissing it simply reveals whatever view
sits behind it (e.g. the connect/local choice or onboarding flow), exactly as
the issue requested. "Reload and retry" is untouched and remains the explicit
opt-in retry path.

## Changes Made

- `apps/desktop/src/components/desktop-install-overlay.tsx` — Close button in
  the failed footer + Escape-key effect scoped to `state.error`.
- `apps/desktop/src/components/desktop-install-overlay.test.tsx` — two new
  tests covering the Close button and Escape dismissal.

## Test plan

Added tests, run via `npx vitest run --project ui src/components/desktop-install-overlay.test.tsx`:

```
 Test Files  1 passed (1)
      Tests  15 passed (15)
```

Confirmed the two new tests fail without the fix (reverted only the source
file with `git checkout HEAD -- apps/desktop/src/components/desktop-install-overlay.tsx`,
kept the test file):

```
 Test Files  1 failed (1)
      Tests  2 failed | 13 passed (15)

 ❯ dismisses a cancelled/failed install via the footer Close button, without reloading or resetting bootstrap
   Unable to find an element with the text: Close.
 ❯ dismisses a failed install on Escape
   AssertionError: expected <h2>Installation failed</h2> to be null
```

Also ran, both clean on the changed files:

```
npx tsc -p . --noEmit                                   # no output / 0 errors
npx eslint src/components/desktop-install-overlay.tsx \
           src/components/desktop-install-overlay.test.tsx   # 0 errors (1 pre-existing unrelated warning)
```

## Checklist

- [x] Contributing Guide read
- [x] Conventional Commits format
- [x] Duplicate PR check done (searched open PRs/issues for
      `desktop-install-overlay`, "installation failed", "dismiss overlay" —
      no existing PR addresses this dismiss affordance)
- [x] Tests added and passing

## AI assistance disclosure

This PR was prepared with AI assistance (Claude Code), with the change,
tests, and this description reviewed before submission.
