### PR TITLE
fix(desktop): record owner stub for unlisted tile drafts so session.resume routes (#102792)

### DIFF
--- a/apps/desktop/src/api/sessions.test.ts
+++ b/apps/desktop/src/api/sessions.test.ts
@@ -92,6 +92,7 @@ describe('setSessionArchived profile scoping', () => {
     // the body, not only as request.profile (Electron routing), or on a remote
     // gateway the archive lands on the wrong state.db and silently no-ops.
     hermesApi.mockResolvedValue({ ok: true } as never)
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'tommy' })
 
     await setSessionArchived('sess-a', true, 'tommy')
 
@@ -100,6 +101,24 @@ describe('setSessionArchived profile scoping', () => {
       path: '/api/sessions/sess-a',
       profile: 'tommy',
       body: { archived: true, profile: 'tommy' }
+    })
+  })
+
+  it('pins the exact connection for an object scope, keeping the profile in the body', async () => {
+    // A same-named profile on another source must not swallow the PATCH: the
+    // connection travels as request routing while body.profile still selects
+    // the backend DB.
+    hermesApi.mockResolvedValue({ ok: true } as never)
+    vi.mocked(client.capabilityScoped).mockReturnValue({ profile: 'work', connectionId: 'source-a' })
+
+    await setSessionArchived('sess-c', true, { connectionId: 'source-a', profile: 'work' })
+
+    expect(hermesApi.mock.calls[0][0]).toMatchObject({
+      method: 'PATCH',
+      path: '/api/sessions/sess-c',
+      connectionId: 'source-a',
+      profile: 'work',
+      body: { archived: true, profile: 'work' }
     })
   })
 

--- a/apps/desktop/src/api/sessions.ts
+++ b/apps/desktop/src/api/sessions.ts
@@ -329,20 +329,23 @@ export async function listSidebarSessions(req: SidebarSessionsRequest): Promise<
   }
 }
 
-// Mutations take the owning `profile` so Electron can route them to the correct
+// Mutations take the owning scope so Electron can route them to the correct
 // remote backend or local profile scope. Omit for the current/default profile.
-export function setSessionArchived(id: string, archived: boolean, profile?: string | null): Promise<{ ok: boolean }> {
+export function setSessionArchived(id: string, archived: boolean, scope?: ProfileScope): Promise<{ ok: boolean }> {
   // Carry the owning profile IN THE PATCH BODY, mirroring renameSession — the
   // backend reads its target DB from body.profile (_open_session_db_for_profile).
   // Passing it only as request.profile (Electron routing) is not enough on a
   // remote gateway with no remoteProfile alias: the archive lands on the wrong
   // (default) state.db, no-ops on a missing row, and the archived/unarchived
   // state silently fails to stick — the same class as the unscoped DELETE.
+  // An exact object scope additionally pins the connection, so a same-named
+  // profile on another source can't swallow the PATCH.
+  const bodyProfile = typeof scope === 'object' ? scope?.profile : scope
   return hermesApi<{ ok: boolean }>({
-    ...(profile ? { profile } : {}),
+    ...sessionScoped(scope),
     path: `/api/sessions/${encodeURIComponent(id)}`,
     method: 'PATCH',
-    body: { archived, ...(profile ? { profile } : {}) }
+    body: { archived, ...(bodyProfile ? { profile: bodyProfile } : {}) }
   })
 }
 

--- a/apps/desktop/src/app/chat/session-tile-actions.test.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.test.ts
@@ -37,6 +37,40 @@ describe('session tile optimistic owner metadata', () => {
     $sessionTiles.set([])
   })
 
+  it('carries the unlisted stub owner into the first-send row', async () => {
+    // Draft minted on work, sent after switching to default: the replacement
+    // row must keep work and evict the stub — never re-stamp ambient.
+    const { $activeGatewayProfile } = await import('@/store/profile')
+    const { $unlistedSessionOwnerRows, setUnlistedSessionOwnerRows } = await import('@/store/session')
+    const { upsertUnlistedSessionOwner } = await import('../session/hooks/use-session-actions/utils')
+
+    $activeGatewayProfile.set('work')
+    upsertUnlistedSessionOwner(
+      {
+        info: { cwd: '', model: 'model-a', skills: {}, tools: {} },
+        session_id: 'rt-stub-carry',
+        stored_session_id: 'stored-stub-carry'
+      } as never,
+      'stored-stub-carry',
+      null
+    )
+    $activeGatewayProfile.set('default')
+
+    expect(
+      listTileSessionRow({
+        preview: 'first send',
+        runtimeId: 'rt-stub-carry',
+        sessions: [],
+        storedSessionId: 'stored-stub-carry'
+      })
+    ).toBe(true)
+
+    expect($sessions.get().find(session => session.id === 'stored-stub-carry')).toMatchObject({ profile: 'work' })
+    expect($unlistedSessionOwnerRows.get()).toEqual([])
+    $activeGatewayProfile.set('default')
+    setUnlistedSessionOwnerRows([])
+  })
+
   it('keeps the tile source on its first optimistic sidebar row', () => {
     const storedSessionId = 'stored-tile-owner-metadata'
     const ownerRoute = { connectionId: 'source-a', profile: 'default' }

--- a/apps/desktop/src/app/chat/session-tile-actions.ts
+++ b/apps/desktop/src/app/chat/session-tile-actions.ts
@@ -25,6 +25,7 @@ import { clearAllPrompts } from '@/store/prompts'
 import { $sessions, knownSessionOwner, ownerLookupSessionRows, sessionMatchesStoredId } from '@/store/session'
 import {
   requestForSessionProfile,
+  sessionOwnerRouteFromRow,
   type SessionOwnerScope,
   type SessionProfileRoute
 } from '@/store/session-request-router'
@@ -64,7 +65,7 @@ import {
   type SubmitTextOptions,
   withSessionNotFoundResume
 } from '../session/hooks/use-prompt-actions/utils'
-import { upsertOptimisticSession } from '../session/hooks/use-session-actions/utils'
+import { findUnlistedSessionOwner, upsertOptimisticSession } from '../session/hooks/use-session-actions/utils'
 
 import type { ComposerScope } from './composer/scope'
 
@@ -102,6 +103,13 @@ export function listTileSessionRow(deps: {
   const ownerRoute: SessionProfileRoute | undefined =
     knownOwner && typeof knownOwner === 'object' ? knownOwner : undefined
 
+  // The first send lists the tile: carry the unlisted stub's owner into the
+  // replacement row BEFORE the upsert below removes it. Without this, a draft
+  // minted on one profile and sent after a switch re-stamps to the ambient
+  // profile and destroys its only correct owner record.
+  const stub = findUnlistedSessionOwner(deps.storedSessionId)
+  const stubRoute = stub ? sessionOwnerRouteFromRow(stub) : undefined
+
   upsertOptimisticSession(
     { info: { cwd: deps.cwd, model: deps.model }, session_id: deps.runtimeId, stored_session_id: deps.storedSessionId },
     deps.storedSessionId,
@@ -109,7 +117,8 @@ export function listTileSessionRow(deps: {
     preview,
     null,
     undefined,
-    ownerRoute
+    ownerRoute ?? stubRoute,
+    stub?.profile
   )
   broadcastSessionsChanged()
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -42,8 +42,11 @@ import {
   $selectedStoredSessionId,
   $sessions,
   $turnStartedAt,
+  $unlistedSessionOwnerRows,
+  _resetSessionOwnerHintsForTests,
   getSessionOwnerHint,
   knownSessionOwner,
+  ownerLookupSessionRows,
   sessionMatchesStoredId,
   setActiveSessionId,
   setActiveSessionStoredIdRotation,
@@ -63,8 +66,10 @@ import {
   setResumeFailedSessionId,
   setSelectedStoredSessionId,
   setSessions,
-  setTurnStartedAt
+  setTurnStartedAt,
+  setUnlistedSessionOwnerRows
 } from '@/store/session'
+import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { $removedSessionIds, $sessionMutationsInFlight } from '@/store/session-removal'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
 import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
@@ -77,6 +82,7 @@ import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
 import { useSessionStateCache } from './use-session-state-cache'
+import { upsertOptimisticSession } from './use-session-actions/utils'
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),
@@ -4138,6 +4144,119 @@ describe('openNewSessionTile workspace target', () => {
     })
 
     expect(createParams).not.toHaveProperty('cwd')
+  })
+})
+
+describe('openNewSessionTile unlisted owner (#102792)', () => {
+  const STORED_UNLISTED = 'stored-unlisted-102792'
+
+  function createRequestGateway(stored: string = STORED_UNLISTED) {
+    return vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        return {
+          info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: stored
+        } as never
+      }
+
+      return {} as never
+    })
+  }
+
+  async function readyHandle(requestGateway: <T>(method: string, params?: Record<string, unknown>) => Promise<T>) {
+    let handle: HarnessHandle | null = null
+    render(<Harness onReady={value => (handle = value)} requestGateway={requestGateway} />)
+    await waitFor(() => expect(handle).not.toBeNull())
+
+    return handle!
+  }
+
+  beforeEach(() => {
+    setSessions([])
+    setMessagingSessions([])
+    setCronSessions([])
+    setUnlistedSessionOwnerRows([])
+    _resetSessionOwnerHintsForTests()
+    $profiles.set(profiles('default', 'omar'))
+    $activeGatewayProfile.set('omar')
+    $sessionTiles.set([])
+  })
+
+  afterEach(() => {
+    cleanup()
+    setSessions([])
+    setMessagingSessions([])
+    setCronSessions([])
+    setUnlistedSessionOwnerRows([])
+    _resetSessionOwnerHintsForTests()
+    $profiles.set([])
+    $activeGatewayProfile.set('default')
+    $sessionTiles.set([])
+    vi.restoreAllMocks()
+  })
+
+  it('records the ambient-profile owner for an unlisted tile created on the null (legacy ambient) route', async () => {
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    // The draft stays out of the visible sidebar list ...
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
+    // ... but its owner still resolves on the row rung (bare ambient profile),
+    // so the tile's immediate session.resume passes the fail-closed gate.
+    const owner = knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)
+    expect(owner).toBe('omar')
+    expect(() =>
+      assertSessionOwnerResolved(owner, { method: 'session.resume', sessionId: STORED_UNLISTED })
+    ).not.toThrow()
+    expect($sessionTiles.get().some(t => t.storedSessionId === STORED_UNLISTED)).toBe(true)
+  })
+
+  it('stamps the exact connection tag for an unlisted tile created on a routed connection', async () => {
+    vi.mocked(requestGatewayForAgent).mockResolvedValue({
+      info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+      session_id: RUNTIME_SESSION_ID,
+      stored_session_id: STORED_UNLISTED
+    } as never)
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: { connectionId: 'conn-1', profile: 'omar' } })
+    })
+
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
+    expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toEqual(
+      expect.objectContaining({ connectionId: 'conn-1', profile: 'omar' })
+    )
+  })
+
+  it('evicts the stub once a real row lists the same id', async () => {
+    const stored = 'stored-unlisted-102792-b'
+    const handle = await readyHandle(createRequestGateway(stored))
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    expect($unlistedSessionOwnerRows.get()).toHaveLength(1)
+
+    // First send lists the draft through the normal optimistic upsert ...
+    upsertOptimisticSession(
+      {
+        info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+        session_id: RUNTIME_SESSION_ID,
+        stored_session_id: stored
+      } as never,
+      stored
+    )
+
+    // ... which supersedes the stub instead of leaving a stale double.
+    expect($unlistedSessionOwnerRows.get()).toHaveLength(0)
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, stored))).toBe(true)
+    expect(knownSessionOwner(ownerLookupSessionRows(), stored)).toBe('omar')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -81,8 +81,8 @@ import { NEW_CHAT_ROUTE, sessionRoute } from '../../routes'
 import type { ClientSessionState } from '../../types'
 
 import { useSessionActions } from './use-session-actions'
-import { useSessionStateCache } from './use-session-state-cache'
 import { upsertOptimisticSession } from './use-session-actions/utils'
+import { useSessionStateCache } from './use-session-state-cache'
 
 vi.mock('@/hermes', async importOriginal => ({
   ...(await importOriginal<Record<string, unknown>>()),

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -72,7 +72,12 @@ import {
 import { assertSessionOwnerResolved } from '@/store/session-owner-resolution'
 import { $removedSessionIds, $sessionMutationsInFlight } from '@/store/session-removal'
 import { requestForSessionProfile, type SessionProfileRoute } from '@/store/session-request-router'
-import { $sessionTiles, sessionTileOwnerRoute } from '@/store/session-states'
+import {
+  $sessionTiles,
+  knownOwnerForSession,
+  requestForOwnedSession,
+  sessionTileOwnerRoute
+} from '@/store/session-states'
 import { $sessionSeenCounts, $unreadFinishedMarkers } from '@/store/session-unread'
 
 import sessionResumeActiveTurn from '../../../../../../tests/fixtures/session-resume-active-turn.json'
@@ -4257,6 +4262,39 @@ describe('openNewSessionTile unlisted owner (#102792)', () => {
     expect($unlistedSessionOwnerRows.get()).toHaveLength(0)
     expect($sessions.get().some(s => sessionMatchesStoredId(s, stored))).toBe(true)
     expect(knownSessionOwner(ownerLookupSessionRows(), stored)).toBe('omar')
+  })
+
+  it('resolves the ephemeral runtime id through the stub for session.control.read without hitting ambient', async () => {
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    // The composer banner calls with the ephemeral runtime id, not the stored
+    // id — it must see the same bare ambient profile as the stored-id rung.
+    expect(knownOwnerForSession(RUNTIME_SESSION_ID)).toBe('omar')
+
+    const ambient = vi.fn(async () => ({}) as never)
+    vi.mocked(requestGatewayForProfile).mockResolvedValue({ control: {} } as never)
+
+    await expect(
+      requestForOwnedSession(RUNTIME_SESSION_ID, ambient, 'session.control.read', {
+        session_id: RUNTIME_SESSION_ID
+      })
+    ).resolves.toEqual({ control: {} })
+
+    // Bare profile routes through the profile-pool door, never ambient ...
+    expect(ambient).not.toHaveBeenCalled()
+    expect(requestGatewayForProfile).toHaveBeenCalledWith(
+      'omar',
+      'session.control.read',
+      expect.objectContaining({ session_id: RUNTIME_SESSION_ID }),
+      undefined,
+      undefined
+    )
+    // ... and the draft stays out of the sidebar.
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4197,6 +4197,7 @@ describe('openNewSessionTile unlisted owner (#102792)', () => {
     _resetSessionOwnerHintsForTests()
     $profiles.set([])
     $activeGatewayProfile.set('default')
+    $newChatProfile.set(null)
     $sessionTiles.set([])
     vi.restoreAllMocks()
   })
@@ -4389,6 +4390,56 @@ describe('openNewSessionTile unlisted owner (#102792)', () => {
 
     expect($unlistedSessionOwnerRows.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(true)
     expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toBe('omar')
+  })
+
+  it('prefers the explicit profile over new-chat/active ambient for params and stamp', async () => {
+    // Profile-group drag passes profile:'omar' with a null legacy route while
+    // everything ambient says default: both the create RPC and the stub must
+    // carry omar.
+    $activeGatewayProfile.set('default')
+    $newChatProfile.set('default')
+    let createParams: Record<string, unknown> | undefined
+    const gateway = vi.fn(async (method: string, params?: Record<string, unknown>) => {
+      if (method === 'session.create') {
+        createParams = params
+
+        return {
+          info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: STORED_UNLISTED
+        } as never
+      }
+
+      return {} as never
+    })
+    const handle = await readyHandle(gateway)
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, profile: 'omar', route: null })
+    })
+
+    expect(createParams?.profile).toBe('omar')
+    expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toBe('omar')
+  })
+
+  it('routes delete of an unlisted draft from its stub when probes miss', async () => {
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    // Active profile moved on; the draft was never persisted, so every
+    // by-id probe 404s and only the stub names the owner.
+    $activeGatewayProfile.set('default')
+    vi.mocked(getSession).mockRejectedValue(new Error('404: Session not found'))
+    vi.mocked(deleteSession).mockResolvedValue({ ok: true })
+
+    await act(async () => {
+      await handle.removeSession(STORED_UNLISTED)
+    })
+
+    expect(vi.mocked(deleteSession)).toHaveBeenCalledWith(STORED_UNLISTED, 'omar')
   })
 })
 describe('selectSidebarItem', () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4296,6 +4296,70 @@ describe('openNewSessionTile unlisted owner (#102792)', () => {
     // ... and the draft stays out of the sidebar.
     expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
   })
+
+  it('freezes the ambient owner from before the create round-trip (profile switch mid-create)', async () => {
+    // The backend mints the session with params.profile, fixed pre-await to
+    // 'omar'. The user switching to 'default' while session.create is in
+    // flight must not re-stamp the stub.
+    const switchingGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        $activeGatewayProfile.set('default')
+        return {
+          info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: STORED_UNLISTED
+        } as never
+      }
+
+      return {} as never
+    })
+    const handle = await readyHandle(switchingGateway)
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toBe('omar')
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
+  })
+
+  it('restores the stub when delete of an unlisted draft fails', async () => {
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    expect($unlistedSessionOwnerRows.get()).toHaveLength(1)
+    vi.mocked(getSession).mockRejectedValue(new Error('404: Session not found'))
+    vi.mocked(deleteSession).mockRejectedValueOnce(new Error('backend down'))
+
+    await act(async () => {
+      await handle.removeSession(STORED_UNLISTED)
+    })
+
+    expect($unlistedSessionOwnerRows.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(true)
+    expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toBe('omar')
+  })
+
+  it('restores the stub when archive of an unlisted draft fails', async () => {
+    const handle = await readyHandle(createRequestGateway())
+
+    await act(async () => {
+      await handle.openNewSessionTile('center', { listed: false, route: null })
+    })
+
+    expect($unlistedSessionOwnerRows.get()).toHaveLength(1)
+    vi.mocked(getSession).mockRejectedValue(new Error('404: Session not found'))
+    vi.mocked(setSessionArchived).mockRejectedValueOnce(new Error('archive failed'))
+
+    await act(async () => {
+      await handle.archiveSession(STORED_UNLISTED)
+    })
+
+    expect($unlistedSessionOwnerRows.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(true)
+    expect(knownSessionOwner(ownerLookupSessionRows(), STORED_UNLISTED)).toBe('omar')
+  })
 })
 describe('selectSidebarItem', () => {
   it('fronts the workspace pane when navigating to a sidebar route (issue #72602)', async () => {

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4593,6 +4593,25 @@ describe('removeSession / archiveSession profile routing (#78836)', () => {
     expect($messagingSessions.get()).toEqual([])
   })
 
+  it('archives a connection-tagged row against its exact connection scope', async () => {
+    // A promoted routed draft says {connectionId: source-a, profile: work}
+    // while source-b is active exposing the same profile name: the PATCH must
+    // ride source-a, never the ambient source.
+    mockSetSessionArchived.mockResolvedValue({ ok: true })
+    setSessions([storedSession({ id: 'desk-routed', connection_id: 'source-a', profile: 'work', source: 'desktop' })])
+
+    const handle = await readyActions()
+    await act(async () => {
+      await handle.archiveSession('desk-routed')
+    })
+
+    expect(mockSetSessionArchived).toHaveBeenCalledWith('desk-routed', true, {
+      connectionId: 'source-a',
+      profile: 'work'
+    })
+    expect($sessions.get()).toEqual([])
+  })
+
   it('restores a failed archive to the messaging slice', async () => {
     setMessagingSessions([storedSession({ id: 'tg-arch-fail', profile: 'winefox', source: 'telegram' })])
     mockSetSessionArchived.mockRejectedValue(new Error('archive failed'))

--- a/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
+++ b/apps/desktop/src/app/session/hooks/use-session-actions.test.tsx
@@ -4323,6 +4323,36 @@ describe('openNewSessionTile unlisted owner (#102792)', () => {
     expect($sessions.get().some(s => sessionMatchesStoredId(s, STORED_UNLISTED))).toBe(false)
   })
 
+  it('freezes the ambient owner on the send path too (profile switch mid-create)', async () => {
+    // Same guard as the tile path, for createBackendSessionForSend: the first
+    // send mints with params.profile fixed pre-await to 'omar'; a switch to
+    // 'default' in flight must not re-stamp the listed row.
+    const stored = 'stored-send-102792'
+    const switchingGateway = vi.fn(async (method: string) => {
+      if (method === 'session.create') {
+        $activeGatewayProfile.set('default')
+        return {
+          info: { cwd: '', model: 'test-model', skills: {}, tools: {} },
+          session_id: RUNTIME_SESSION_ID,
+          stored_session_id: stored
+        } as never
+      }
+
+      return {} as never
+    })
+    const handle = await readyHandle(switchingGateway)
+
+    let created: null | string = null
+
+    await act(async () => {
+      created = await handle.createBackendSessionForSend('hello')
+    })
+
+    expect(created).toBe(RUNTIME_SESSION_ID)
+    expect($sessions.get().some(s => sessionMatchesStoredId(s, stored))).toBe(true)
+    expect(knownSessionOwner(ownerLookupSessionRows(), stored)).toBe('omar')
+  })
+
   it('restores the stub when delete of an unlisted draft fails', async () => {
     const handle = await readyHandle(createRequestGateway())
 

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2629,6 +2629,16 @@ export function useSessionActions({
       // lives in the stub atom, so a failed archive must restore it.
       const unlistedStub = findUnlistedSessionOwner(storedSessionId)
 
+      // Route the PATCH at the exact owner, like removeSession: a connection-
+      // tagged row (or stub) names its backend, so a same-named profile on
+      // the active source can't swallow the archive.
+      const archivedOwner: SessionOwnerScope = archived?.connection_id
+        ? {
+            connectionId: archived.connection_id,
+            profile: archived.profile || 'default'
+          }
+        : (sessionOwnerRouteFromRow(unlistedStub) ?? (unlistedStub?.profile?.trim() || undefined) ?? profile)
+
       if (
         listed &&
         !stampedProfile &&
@@ -2658,7 +2668,7 @@ export function useSessionActions({
       }
 
       try {
-        await setSessionArchived(storedSessionId, true, profile)
+        await setSessionArchived(storedSessionId, true, archivedOwner)
         // Archived rows never reach the sidebar, so their persisted unread can
         // only rot. Dropped after the RPC so a failed archive keeps it.
         forgetSessionUnread(archivedIds, profile)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -294,7 +294,8 @@ function reconcileAuthoritativeMessages(
 // value is a mirror of Settings → Model and must not pin the new chat.
 async function desktopSessionCreateParams(
   cwd: string,
-  capturedRoute = resolveNewChatOwnerRoute()
+  capturedRoute = resolveNewChatOwnerRoute(),
+  uncapturedProfile?: string
 ): Promise<Record<string, unknown>> {
   // Treat Send as the linearization point for the visible selector state. The
   // profile handshake below can yield long enough for background config/model
@@ -313,7 +314,11 @@ async function desktopSessionCreateParams(
     provider: isManualSelection ? $currentProvider.get().trim() : ''
   }
 
-  const profile = capturedRoute?.profile || $newChatProfile.get() || normalizeProfileKey($activeGatewayProfile.get())
+  const profile =
+    capturedRoute?.profile ||
+    uncapturedProfile ||
+    $newChatProfile.get() ||
+    normalizeProfileKey($activeGatewayProfile.get())
 
   if (capturedRoute) {
     await ensureGatewayAgent(capturedRoute.connectionId, profile)
@@ -792,13 +797,19 @@ export function useSessionActions({
         // fixes params.profile pre-await, but the row/stub below stamps
         // post-await ambient. A profile switch during the seconds-long
         // session.create round-trip would otherwise stamp the wrong owner.
-        const capturedAmbientProfile = normalizeProfileKey($newChatProfile.get() || $activeGatewayProfile.get())
+        // One effective profile for an unrouted create: the caller's explicit
+        // profile (profile-group drag) wins over the new-chat/active ambient,
+        // and it feeds BOTH the create params and the owner stamp.
+        const uncapturedProfile = options?.profile?.trim() || undefined
+        const capturedAmbientProfile = normalizeProfileKey(
+          uncapturedProfile || $newChatProfile.get() || $activeGatewayProfile.get()
+        )
 
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
         const params = {
-          ...(await desktopSessionCreateParams(cwd, capturedRoute)),
+          ...(await desktopSessionCreateParams(cwd, capturedRoute, uncapturedProfile)),
           ...(workspaceScope.workspaceMode === 'bots' ? { hidden: true } : {})
         }
 
@@ -2491,7 +2502,12 @@ export function useSessionActions({
             connectionId: removed.connection_id,
             profile: removed.profile || 'default'
           }
-        : profile
+        : // An unsent draft has no listed row for cachedSessionRow to find, so
+          // resolveSessionProfile above misses it. Route the DELETE from its
+          // stub (exact connection route when present, else bare profile) —
+          // an unscoped delete hits the wrong backend, fakes already_absent
+          // success, and orphans the live runtime.
+          (sessionOwnerRouteFromRow(unlistedStub) ?? (unlistedStub?.profile?.trim() || undefined) ?? profile)
 
       const previousArchived = $archivedSessions.get()
       // Pins are keyed on the durable lineage-root id; the stored id may be the

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -172,7 +172,8 @@ import {
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
   toBranchMessages,
-  upsertOptimisticSession
+  upsertOptimisticSession,
+  upsertUnlistedSessionOwner
 } from './utils'
 
 interface SessionActionsOptions {
@@ -829,9 +830,16 @@ export function useSessionActions({
         // Seed the per-runtime cache so the tile renders immediately without a
         // redundant resume. Only add the row to the SIDEBAR when `listed` — an
         // unlisted (draft) tab stays out of the session list until its first
-        // turn persists and a refresh surfaces it.
+        // turn persists and a refresh surfaces it. An unlisted draft still
+        // records an ownership stub (same stamps, off-list atom): without it a
+        // draft minted on the legacy ambient route (null route) owns NOTHING
+        // the ladder reads — no tile route, no hint, no row — and its
+        // immediate session.resume fails closed on multi-profile installs
+        // (#102792).
         if (listed) {
           upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute)
+        } else {
+          upsertUnlistedSessionOwner(created, stored, capturedRoute)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -156,6 +156,7 @@ import {
   dedupeInflightUserAgainstTranscript,
   dropListedSession,
   findListedSession,
+  findUnlistedSessionOwner,
   goneSessionVerdict,
   isSessionGoneError,
   overlayConcurrentMessageChanges,
@@ -168,6 +169,7 @@ import {
   resolveSessionProfile,
   resolveStoredSession,
   restoreListedSession,
+  restoreUnlistedSessionOwner,
   selectBranchMessages,
   sessionMatchesStoredId,
   sessionShouldHaveTranscript,
@@ -771,6 +773,12 @@ export function useSessionActions({
 
         const workspaceScope = options?.workspaceScope ?? { workspaceMode: 'sessions' }
 
+        // Freeze the ambient owner BEFORE any await: desktopSessionCreateParams
+        // fixes params.profile pre-await, but the row/stub below stamps
+        // post-await ambient. A profile switch during the seconds-long
+        // session.create round-trip would otherwise stamp the wrong owner.
+        const capturedAmbientProfile = normalizeProfileKey($newChatProfile.get() || $activeGatewayProfile.get())
+
         const cwd =
           options?.cwd === null ? '' : typeof options?.cwd === 'string' ? options.cwd.trim() : resolveNewSessionCwd()
 
@@ -837,9 +845,9 @@ export function useSessionActions({
         // immediate session.resume fails closed on multi-profile installs
         // (#102792).
         if (listed) {
-          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute)
+          upsertOptimisticSession(created, stored, null, null, null, undefined, capturedRoute, capturedAmbientProfile)
         } else {
-          upsertUnlistedSessionOwner(created, stored, capturedRoute)
+          upsertUnlistedSessionOwner(created, stored, capturedRoute, capturedAmbientProfile)
         }
 
         // A tile lives in its OWN worktree, so it must not run the full
@@ -2430,6 +2438,11 @@ export function useSessionActions({
       const removed =
         listed?.session ?? $archivedSessions.get().find(session => sessionMatchesStoredId(session, storedSessionId))
 
+      // An unsent draft lives ONLY in the unlisted stub atom: snapshot it
+      // before the optimistic drop so a failed DELETE can restore the tile's
+      // sole owner record alongside the listed row.
+      const unlistedStub = findUnlistedSessionOwner(storedSessionId)
+
       // Messaging/cron rows frequently arrive without an inline profile; fall
       // back to the stored-session ownership lookup so their DELETE routes to
       // the owning profile instead of the ambient one.
@@ -2523,6 +2536,10 @@ export function useSessionActions({
           restoreListedSession(listed.session, listed.slice)
         }
 
+        if (unlistedStub) {
+          restoreUnlistedSessionOwner(unlistedStub)
+        }
+
         // Restore the archived-view row too (no-op when it wasn't archived).
         $archivedSessions.set(previousArchived)
 
@@ -2577,6 +2594,10 @@ export function useSessionActions({
       const stampedProfile = archived?.profile?.trim()
       const profile = stampedProfile || (await resolveSessionProfile(storedSessionId))
 
+      // Same snapshot as removeSession: an unsent draft's sole owner record
+      // lives in the stub atom, so a failed archive must restore it.
+      const unlistedStub = findUnlistedSessionOwner(storedSessionId)
+
       if (
         listed &&
         !stampedProfile &&
@@ -2624,6 +2645,10 @@ export function useSessionActions({
       } catch (err) {
         if (archived) {
           restoreListedSession(archived, listed?.slice)
+        }
+
+        if (unlistedStub) {
+          restoreUnlistedSessionOwner(unlistedStub)
         }
 
         untombstoneSessions(archivedIds)

--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -575,6 +575,12 @@ export function useSessionActions({
         // reduce the owner to a bare profile name that later RPCs dial on a
         // different socket than the one that minted the runtime.
         const capturedRoute = resolveNewChatOwnerRoute()
+        // Freeze the ambient owner BEFORE any await: params.profile is fixed
+        // pre-await, but the optimistic row below stamps post-await ambient.
+        // A profile switch during the seconds-long session.create round-trip
+        // would otherwise stamp the wrong owner (same guard as
+        // openNewSessionTile for unlisted drafts).
+        const capturedAmbientProfile = normalizeProfileKey($newChatProfile.get() || $activeGatewayProfile.get())
 
         const params = {
           ...(await desktopSessionCreateParams(cwd, capturedRoute)),
@@ -676,7 +682,16 @@ export function useSessionActions({
           // server later returns its own preview/title and supersedes this.
           // The row carries the create route's exact owner (backend profile +
           // connection), never the ambient profile — see upsertOptimisticSession.
-          upsertOptimisticSession(created, stored, null, preview?.trim() || null, null, undefined, capturedRoute)
+          upsertOptimisticSession(
+            created,
+            stored,
+            null,
+            preview?.trim() || null,
+            null,
+            undefined,
+            capturedRoute,
+            capturedAmbientProfile
+          )
           navigate(sessionRoute(stored), { replace: true })
           // Other windows (e.g. the main window when this is the pop-out) can't
           // see this session until they re-pull the shared list.

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -15,6 +15,7 @@ import {
   $currentCwd,
   $messagingSessions,
   $sessions,
+  $unlistedSessionOwnerRows,
   commitWorkspaceCwdForSelectedSession,
   getSessionOwnerHint,
   knownSessionOwner,
@@ -1274,9 +1275,19 @@ export function upsertOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  owner?: null | SessionProfileRoute
+  owner?: null | SessionProfileRoute,
+  ambientProfile?: string
 ) {
-  const session = buildOptimisticSession(created, id, title, preview, parentSessionId, lastActive, owner)
+  const session = buildOptimisticSession(
+    created,
+    id,
+    title,
+    preview,
+    parentSessionId,
+    lastActive,
+    owner,
+    ambientProfile
+  )
 
   if (owner) {
     setSessionOwnerHint(id, owner)
@@ -1301,9 +1312,10 @@ export function upsertOptimisticSession(
 export function upsertUnlistedSessionOwner(
   created: SessionCreateResponse,
   id: string,
-  owner?: null | SessionProfileRoute
+  owner?: null | SessionProfileRoute,
+  ambientProfile?: string
 ) {
-  const stub = buildOptimisticSession(created, id, null, null, null, undefined, owner)
+  const stub = buildOptimisticSession(created, id, null, null, null, undefined, owner, ambientProfile)
   setSessionOwnerHintForStub(id, owner)
   setUnlistedSessionOwnerRows(prev => [stub, ...prev.filter(s => s.id !== id)])
 }
@@ -1321,7 +1333,8 @@ function buildOptimisticSession(
   preview: string | null = null,
   parentSessionId: string | null = null,
   lastActive?: number,
-  owner?: null | SessionProfileRoute
+  owner?: null | SessionProfileRoute,
+  ambientProfile?: string
 ): SessionInfo {
   const now = lastActive ?? Date.now() / 1000
   // Stamp the profile the session was just created on so the scoped sidebar
@@ -1334,7 +1347,11 @@ function buildOptimisticSession(
   // a concurrent source switch can move the active gateway before this row is
   // inserted), so a row stamped `default` then misroutes every session-scoped
   // RPC that resolves its owner off the row ("session not found" on turn two).
-  const profileKey = normalizeProfileKey(owner ? owner.targetProfile || owner.profile : $activeGatewayProfile.get())
+  // Callers pass the pre-create ambient profile so a profile switch during the
+  // seconds-long session.create round-trip cannot stamp the wrong owner.
+  const profileKey = normalizeProfileKey(
+    owner ? owner.targetProfile || owner.profile : ambientProfile || $activeGatewayProfile.get()
+  )
   const connectionId = owner?.connectionId.trim() || ''
 
   const session: SessionInfo = {
@@ -1410,6 +1427,21 @@ export function dropListedSession(storedSessionId: string): void {
   setMessagingSessions(prev => prev.filter(keep))
   setCronSessions(prev => prev.filter(keep))
   setUnlistedSessionOwnerRows(prev => prev.filter(keep))
+}
+
+/**
+ * The unlisted-draft stub for a stored id, if one exists. An unsent draft
+ * lives ONLY in this atom (no listed row), so optimistic delete/archive must
+ * snapshot it before drop and restore it when the backend mutation fails —
+ * otherwise the still-open tile loses its sole owner record.
+ */
+export function findUnlistedSessionOwner(storedSessionId: string): SessionInfo | undefined {
+  return $unlistedSessionOwnerRows.get().find(session => sessionMatchesStoredId(session, storedSessionId))
+}
+
+/** Re-insert a stub snapshotted before an optimistic drop (failed delete/archive rollback). */
+export function restoreUnlistedSessionOwner(stub: SessionInfo): void {
+  setUnlistedSessionOwnerRows(prev => [stub, ...prev.filter(existing => !sessionMatchesStoredId(existing, stub.id))])
 }
 
 export function restoreListedSession(session: SessionInfo, slice?: ListedSessionSlice): void {

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -21,7 +21,6 @@ import {
   ownerLookupSessionRows,
   releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
-  setUnlistedSessionOwnerRows,
   setCronSessions,
   setCurrentBranch,
   setCurrentCwdTransient,
@@ -35,6 +34,7 @@ import {
   setMessagingSessions,
   setSessionOwnerHint,
   setSessions,
+  setUnlistedSessionOwnerRows,
   setWorkspaceCwdOwner,
   setYoloActive
 } from '@/store/session'

--- a/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/utils.ts
@@ -21,6 +21,7 @@ import {
   ownerLookupSessionRows,
   releaseWorkspaceCwdOwner,
   sessionMatchesStoredId,
+  setUnlistedSessionOwnerRows,
   setCronSessions,
   setCurrentBranch,
   setCurrentCwdTransient,
@@ -1275,6 +1276,53 @@ export function upsertOptimisticSession(
   lastActive?: number,
   owner?: null | SessionProfileRoute
 ) {
+  const session = buildOptimisticSession(created, id, title, preview, parentSessionId, lastActive, owner)
+
+  if (owner) {
+    setSessionOwnerHint(id, owner)
+  }
+
+  // A real row supersedes any unlisted-draft stub for the same id (first send
+  // on a ⌘T tab lists it); drop the stub so the atom stays bounded. The
+  // lookup shadow-filter covers any path that lists without passing here.
+  setUnlistedSessionOwnerRows(prev => (prev.some(s => s.id === id) ? prev.filter(s => s.id !== id) : prev))
+
+  setSessions(prev => [session, ...prev.filter(s => s.id !== id)])
+}
+
+/**
+ * Record the owner of an UNLISTED draft tile without touching the visible
+ * sidebar list (see `openNewSessionTile` with `listed: false`, #102792). The
+ * stub carries the same stamps an optimistic row would — ambient profile for
+ * an unrouted create, exact connection tag for a routed one — and rides only
+ * the owner-lookup path, never the sidebar render path. A later real row for
+ * the same id shadows it; the first send replaces it outright.
+ */
+export function upsertUnlistedSessionOwner(
+  created: SessionCreateResponse,
+  id: string,
+  owner?: null | SessionProfileRoute
+) {
+  const stub = buildOptimisticSession(created, id, null, null, null, undefined, owner)
+  setSessionOwnerHintForStub(id, owner)
+  setUnlistedSessionOwnerRows(prev => [stub, ...prev.filter(s => s.id !== id)])
+}
+
+function setSessionOwnerHintForStub(id: string, owner?: null | SessionProfileRoute): void {
+  if (owner) {
+    setSessionOwnerHint(id, owner)
+  }
+}
+
+function buildOptimisticSession(
+  created: SessionCreateResponse,
+  id: string,
+  title: string | null = null,
+  preview: string | null = null,
+  parentSessionId: string | null = null,
+  lastActive?: number,
+  owner?: null | SessionProfileRoute
+): SessionInfo {
   const now = lastActive ?? Date.now() / 1000
   // Stamp the profile the session was just created on so the scoped sidebar
   // shows the new row immediately instead of filtering it out as "default"
@@ -1313,11 +1361,7 @@ export function upsertOptimisticSession(
     ...(connectionId ? { connection_id: connectionId } : {})
   }
 
-  if (owner) {
-    setSessionOwnerHint(id, owner)
-  }
-
-  setSessions(prev => [session, ...prev.filter(s => s.id !== id)])
+  return session
 }
 
 export function patchSessionWorkspace(sessionId: string, cwd: string | undefined) {
@@ -1365,6 +1409,7 @@ export function dropListedSession(storedSessionId: string): void {
   setSessions(prev => prev.filter(keep))
   setMessagingSessions(prev => prev.filter(keep))
   setCronSessions(prev => prev.filter(keep))
+  setUnlistedSessionOwnerRows(prev => prev.filter(keep))
 }
 
 export function restoreListedSession(session: SessionInfo, slice?: ListedSessionSlice): void {

--- a/apps/desktop/src/app/settings/sessions-settings.test.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+import { act, cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  confirm: vi.fn(),
+  deleteSession: vi.fn(),
+  listAllProfileSessions: vi.fn(),
+  setSessionArchived: vi.fn()
+}))
+
+vi.mock('@/hermes', async importOriginal => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  deleteSession: (...args: unknown[]) => mocks.deleteSession(...args),
+  listAllProfileSessions: (...args: unknown[]) => mocks.listAllProfileSessions(...args),
+  setSessionArchived: (...args: unknown[]) => mocks.setSessionArchived(...args)
+}))
+
+vi.mock('@/i18n', () => ({
+  useI18n: () => ({
+    t: {
+      settings: {
+        sessions: {
+          archivedIntro: 'Archived intro',
+          archivedTitle: 'Archived',
+          autoArchiveDaysLabel: 'days',
+          autoArchiveDaysUnit: 'd',
+          autoArchiveDesc: 'desc',
+          autoArchiveFailed: 'auto failed',
+          autoArchiveTitle: 'Auto',
+          change: 'Change',
+          choose: 'Choose',
+          clear: 'Clear',
+          clearDirFailed: 'clear failed',
+          defaultDirDesc: 'dir desc',
+          defaultDirTitle: 'dir title',
+          defaultsTo: (dir: string) => dir,
+          deleteConfirm: (title: string) => `Delete ${title}?`,
+          deleteFailed: 'delete failed',
+          deletePermanently: 'Delete permanently',
+          emptyArchivedDesc: 'empty desc',
+          emptyArchivedTitle: 'empty',
+          failedLoad: 'load failed',
+          getDefaultProjectDir: 'get dir',
+          messages: (n: number) => `${n} messages`,
+          notSet: 'not set',
+          pickDefaultProjectDir: 'pick',
+          restored: 'restored',
+          setDefaultProjectDir: 'set dir',
+          unarchive: 'Unarchive',
+          unarchiveFailed: 'unarchive failed',
+          updateDirFailed: 'update failed'
+        }
+      }
+    }
+  })
+}))
+
+vi.mock('@/store/confirm', () => ({
+  confirm: (...args: unknown[]) => mocks.confirm(...args)
+}))
+
+import type { SessionInfo } from '@/types/hermes'
+
+import { SessionsSettings } from './sessions-settings'
+
+function archivedRow(over: Partial<SessionInfo> = {}): SessionInfo {
+  return {
+    archived: true,
+    cwd: null,
+    ended_at: null,
+    id: 'arch-1',
+    input_tokens: 0,
+    is_active: false,
+    last_active: 1,
+    message_count: 2,
+    model: null,
+    output_tokens: 0,
+    parent_session_id: null,
+    preview: null,
+    profile: 'work',
+    source: 'desktop',
+    started_at: 1,
+    title: 'archived chat',
+    tool_call_count: 0,
+    ...over
+  } as SessionInfo
+}
+
+async function renderWith(rows: SessionInfo[]) {
+  mocks.listAllProfileSessions.mockResolvedValue({ sessions: rows })
+  render(<SessionsSettings />)
+  await waitFor(() => expect(mocks.listAllProfileSessions).toHaveBeenCalled())
+  await screen.findByText('archived chat')
+}
+
+describe('SessionsSettings owner scope', () => {
+  beforeEach(() => {
+    mocks.confirm.mockResolvedValue(true)
+    mocks.deleteSession.mockResolvedValue({ ok: true })
+    mocks.setSessionArchived.mockResolvedValue({ ok: true })
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('unarchives a connection-tagged row against its exact scope', async () => {
+    await renderWith([archivedRow({ connection_id: 'source-a' })])
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Unarchive'))
+    })
+
+    expect(mocks.setSessionArchived).toHaveBeenCalledWith('arch-1', false, {
+      connectionId: 'source-a',
+      profile: 'work'
+    })
+  })
+
+  it('permanently deletes a connection-tagged row against its exact scope', async () => {
+    await renderWith([archivedRow({ connection_id: 'source-a' })])
+
+    await act(async () => {
+      fireEvent.click(screen.getByLabelText('Delete permanently'))
+    })
+
+    expect(mocks.deleteSession).toHaveBeenCalledWith('arch-1', {
+      connectionId: 'source-a',
+      profile: 'work'
+    })
+  })
+
+  it('keeps the bare profile form for untagged rows', async () => {
+    await renderWith([archivedRow()])
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('Unarchive'))
+    })
+
+    expect(mocks.setSessionArchived).toHaveBeenCalledWith('arch-1', false, 'work')
+  })
+})

--- a/apps/desktop/src/app/settings/sessions-settings.tsx
+++ b/apps/desktop/src/app/settings/sessions-settings.tsx
@@ -29,6 +29,15 @@ const DEFAULT_AUTO_ARCHIVE_DAYS = 3
 
 const ARCHIVED_FETCH_LIMIT = 200
 
+// Registry rows carry their source in connection_id: route the mutation at
+// the exact owner, not the ambient connection. Untagged rows keep the bare
+// profile form.
+function sessionOwnerScope(session: SessionInfo) {
+  return session.connection_id?.trim()
+    ? { connectionId: session.connection_id.trim(), profile: session.profile || 'default' }
+    : session.profile
+}
+
 export function SessionsSettings() {
   const { t } = useI18n()
   const s = t.settings.sessions
@@ -58,7 +67,7 @@ export function SessionsSettings() {
       setBusyId(session.id)
 
       try {
-        await setSessionArchived(session.id, false, session.profile)
+        await setSessionArchived(session.id, false, sessionOwnerScope(session))
         setLocalSessions(prev => prev.filter(s => s.id !== session.id))
         // Surface it again in the sidebar without waiting for a full refresh, and
         // lift any optimistic eviction so the grouped tree shows it again too.
@@ -90,7 +99,7 @@ export function SessionsSettings() {
       setBusyId(session.id)
 
       try {
-        await deleteSession(session.id, session.profile)
+        await deleteSession(session.id, sessionOwnerScope(session))
         // Permanent delete bypasses removeSession, so retire the persisted
         // unread state here too rather than leaving it to rot.
         forgetSessionUnread([session.id, session._lineage_root_id], session.profile)

--- a/apps/desktop/src/store/session.test.ts
+++ b/apps/desktop/src/store/session.test.ts
@@ -1473,4 +1473,33 @@ describe('knownSessionOwner', () => {
 
     expect(knownSessionOwner([], 'hidden-session')).toEqual(owner)
   })
+
+  it('prefers an agreeing full hint over a target-aliased tagged row', () => {
+    // Bot-style route: the creating socket is (source-a, desk) but the row
+    // stamps the backend alias. The collapsed row alone would dial
+    // (source-a, back) — a socket that never held the runtime.
+    const owner = { connectionId: 'source-a', profile: 'desk', targetProfile: 'back' }
+    setSessionOwnerHint('aliased-session', owner)
+
+    expect(
+      knownSessionOwner(
+        [session({ connection_id: 'source-a', id: 'aliased-session', profile: 'back' })],
+        'aliased-session'
+      )
+    ).toEqual(owner)
+  })
+
+  it('ignores a hint from another connection on a tagged row', () => {
+    setSessionOwnerHint('foreign-hint', { connectionId: 'source-b', profile: 'desk', targetProfile: 'back' })
+
+    expect(
+      knownSessionOwner([session({ connection_id: 'source-a', id: 'foreign-hint', profile: 'back' })], 'foreign-hint')
+    ).toEqual({ connectionId: 'source-a', profile: 'back' })
+  })
+
+  it('collapses a tagged row with no hint exactly as before', () => {
+    expect(
+      knownSessionOwner([session({ connection_id: 'source-a', id: 'no-hint', profile: 'back' })], 'no-hint')
+    ).toEqual({ connectionId: 'source-a', profile: 'back' })
+  })
 })

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -793,6 +793,44 @@ export const $messagingPlatformTotals = atom<Record<string, number>>({})
 export const $messagingTruncated = atom<boolean>(false)
 
 /**
+ * Ownership stubs for UNLISTED draft tiles (the tab-strip "+" / project
+ * sidebar "+" with `listed: false`, see `openNewSessionTile`). A brand-new
+ * backend session is in-memory only until its first turn persists a row, so
+ * these drafts have no row in any sidebar slice — yet the tile's immediate
+ * `session.resume` must still name the backend that minted them. Without a
+ * stub, a draft minted on the legacy ambient route (null owner route: local
+ * source + named profile) records its owner NOWHERE — no tile route, no hint,
+ * no row — and every session-scoped RPC fails closed with
+ * SessionOwnerResolutionError on multi-profile installs (#102792).
+ *
+ * Stubs carry the SAME owner stamps an optimistic row would (ambient profile
+ * when the create was unrouted, exact connection tag when routed) but live
+ * outside $sessions so the drafts stay out of the visible sidebar list. Real
+ * rows always outrank stubs (shadow-filtered below); the first send replaces
+ * the stub via the normal optimistic upsert.
+ */
+export const $unlistedSessionOwnerRows = atom<SessionInfo[]>([])
+
+/** Drop stubs shadowed by a real row `id` already present in `rows`. Returns
+ *  `rows` untouched (same reference) when there is nothing to append, so
+ *  per-list memo caches keyed on the array identity still hit. */
+function withUnlistedOwnerStubs(rows: SessionInfo[], stubs: readonly SessionInfo[]): SessionInfo[] {
+  if (!stubs.length) {
+    return rows
+  }
+
+  const listed = new Set<string>()
+
+  for (const row of rows) {
+    listed.add(row.id)
+  }
+
+  const visible = stubs.filter(stub => !listed.has(stub.id))
+
+  return visible.length ? [...rows, ...visible] : rows
+}
+
+/**
  * Every session row the renderer knows, for OWNER lookups. The sidebar splits
  * its fetch into three source-scoped slices ($sessions / $cronSessions /
  * $messagingSessions), and each slice's rows carry the same `profile` (and,
@@ -802,19 +840,22 @@ export const $messagingTruncated = atom<boolean>(false)
  * install failed closed with SessionOwnerResolutionError even though the row
  * naming its owner was already in memory, one atom over. Concatenation order
  * mirrors lookup priority: recents first (they can carry fresher optimistic
- * connection tags), then the cron and messaging slices.
+ * connection tags), then the cron and messaging slices. Unlisted-draft stubs
+ * ($unlistedSessionOwnerRows) ride last: a real row for the same id always
+ * shadows its stub, so a listed session never resolves off a stale stamp.
  */
 export function ownerLookupSessionRows(): SessionInfo[] {
   const cron = $cronSessions.get()
   const messaging = $messagingSessions.get()
+  const stubs = $unlistedSessionOwnerRows.get()
 
   // Recents-only stays the common case; keep its array identity (no copy) so
   // per-list memo caches (lineageAliases) keyed on the reference still hit.
   if (!cron.length && !messaging.length) {
-    return $sessions.get()
+    return withUnlistedOwnerStubs($sessions.get(), stubs)
   }
 
-  return [...$sessions.get(), ...cron, ...messaging]
+  return withUnlistedOwnerStubs([...$sessions.get(), ...cron, ...messaging], stubs)
 }
 
 // Whether a profile's last session page was CAPPED by the request limit, keyed
@@ -1191,6 +1232,7 @@ export const setConnection = (next: Updater<HermesConnection | null>) => {
 
 export const setGatewayState = (next: Updater<ConnectionState>) => updateAtom($gatewayState, next)
 export const setSessions = (next: Updater<SessionInfo[]>) => updateAtom($sessions, next)
+export const setUnlistedSessionOwnerRows = (next: Updater<SessionInfo[]>) => updateAtom($unlistedSessionOwnerRows, next)
 export const setCronSessions = (next: Updater<SessionInfo[]>) => updateAtom($cronSessions, next)
 export const setMessagingSessions = (next: Updater<SessionInfo[]>) => updateAtom($messagingSessions, next)
 export const setMessagingPlatformTotals = (next: Updater<Record<string, number>>) =>

--- a/apps/desktop/src/store/session.ts
+++ b/apps/desktop/src/store/session.ts
@@ -196,6 +196,19 @@ export function knownSessionOwner(sessions: readonly SessionInfo[], sessionId: n
   const hint = getSessionOwnerHint(sessionId)
 
   if (connectionId) {
+    // A full hint agreeing with the tagged row carries the Desktop route
+    // profile plus its backend alias (targetProfile): prefer it over the
+    // collapsed row, whose profile field may hold the backend alias the
+    // creating socket was never keyed by (socket key is connectionId +
+    // Desktop profile; the alias only rewrites params at RPC time).
+    if (
+      hint &&
+      hint.connectionId.trim() === connectionId &&
+      (hint.profile.trim() === (profile || 'default') || hint.targetProfile?.trim() === (profile || 'default'))
+    ) {
+      return hint
+    }
+
     return { connectionId, profile: profile || 'default' }
   }
 


### PR DESCRIPTION
## Bug Description

Fixes #102792.

Tab-strip / project-sidebar "+" (`listed: false`) minted a real backend session but recorded its owner NOWHERE when the owner route was null (local source + named profile): no tile route, no hint, no row. The tile's immediate `session.resume` then failed closed with `SessionOwnerResolutionError` on multi-profile installs — Retry could never succeed.

## Root Cause

Chain through `openNewSessionTile` (`apps/desktop/src/app/session/hooks/use-session-actions/index.ts`): `resolveNewChatOwnerRoute()` returns null on that combination (legacy profile-only door), so `if (stored && capturedRoute)` skipped the hint, and `listed: false` skipped the optimistic row — the only rung that stamps the ambient profile. All four owner-ladder rungs missed.

## Fix

- `openNewSessionTile` records an ownership stub (`upsertUnlistedSessionOwner`) in a dedicated off-list atom (`$unlistedSessionOwnerRows`): same stamps as an optimistic row (ambient profile unrouted, exact connection tag routed), visible only to the owner ladder — never the sidebar.
- `ownerLookupSessionRows()` appends unshadowed stubs last (real rows win; same `$sessions` reference when empty, preserving memo caches).
- Stub evicted on first-send list (`upsertOptimisticSession`) and on `dropListedSession`.
- `upsertOptimisticSession` extracted to `buildOptimisticSession` with no behavior change.

## How to Verify

1. Multi-profile install, named active profile, local source, main chat occupied → tab-strip "+".
2. Tile opens instead of "Couldn't open this session"; `session.resume` routes to the creating profile's backend.
3. Unused draft never appears in the sidebar; first send lists it normally.

## How to Test

- `npx vitest run src/app/session/hooks/use-session-actions.test.tsx -t "102792"` — 10 tests (prior 8 + explicit-profile precedence for params+stamp; stub-routed delete), plus first-send carry in `src/app/chat/session-tile-actions.test.ts` (create-on-`work`/send-on-`default` keeps `work`), plus routed-archive scope in the `#78836` suite, object-scope routing in `src/api/sessions.test.ts`, hint-first tagged rows in `src/store/session.test.ts`, and exact-scope settings actions in `src/app/settings/sessions-settings.test.tsx`.
- Sabotage verified per hunk: each new test fails with its fix reverted (`1 failed`, rest green) and passes with it.
- Neighbors green (240 tests across 6 files), `tsc --noEmit` clean except pre-existing main-side `telegram-qr-setup.tsx`/`qrcode` error in a file this PR doesn't touch, prettier clean.
- CI: see checks below.

## Test Plan

- [x] Added regression test for this bug
- [x] Existing tests still pass
- [x] Manual verification on multi-profile Desktop — @monthviewsales, packaged `Hermes.app` with this head merged into current `main` (13 profiles, gilfoyle active, pool defaults): 4x "+" opened cleanly, `prompt.submit` → stub → lazy row persisted, 0 `SessionOwnerResolutionError` ([repro](https://github.com/NousResearch/hermes-agent/issues/102792#issuecomment-5604572478), [verification](https://github.com/NousResearch/hermes-agent/issues/102792#issuecomment-5607731898))
- Rig note (from verification): a dev build of a local merge can't self-bootstrap — pin `HERMES_DESKTOP_HERMES` (plus isolated `HERMES_DESKTOP_USER_DATA_DIR` + copied `HERMES_HOME`).
- Second manual validation — @VonLuderitz, macOS at `6251a6b` (clean worktree, fresh app, no suppression workaround): main occupied → `+` in-project → 3 sends, zero owner errors ([report](https://github.com/NousResearch/hermes-agent/pull/102840#issuecomment-5625125275))

## Risk Assessment

Low — adds one data rung to the owner ladder; gate, dispatcher, and sidebar render paths untouched. Complements (does not compete with) #102690/#102618: that recovers the orphan on the dispatcher path, this stops manufacturing it.

**🛠️ Dev:** Halldrix
**🤖 Sidekick:** Hermes Agent v0.21.0








