### PR TITLE
fix(dashboard): close theme flash on first load for user themes

### DIFF
--- a/web/src/themes/context.test.ts
+++ b/web/src/themes/context.test.ts
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { readCachedThemeDefs, writeCachedThemeDefs } from "./context";
+import { defaultTheme } from "./presets";
+import type { DashboardTheme } from "./types";
+
+const STORAGE_KEY = "hermes-dashboard-theme-def";
+
+function makeTheme(name: string): DashboardTheme {
+  return { ...defaultTheme, name, label: name };
+}
+
+describe("theme definition cache (flash-mitigation)", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("returns an empty map when nothing is cached", () => {
+    expect(readCachedThemeDefs()).toEqual({});
+  });
+
+  it("round-trips a written definitions map", () => {
+    const defs = { bigcaptain: makeTheme("bigcaptain") };
+    writeCachedThemeDefs(defs);
+    expect(readCachedThemeDefs()).toEqual(defs);
+  });
+
+  it("is resilient to corrupt JSON in the cache", () => {
+    window.localStorage.setItem(STORAGE_KEY, "{not-json");
+    expect(readCachedThemeDefs()).toEqual({});
+  });
+
+  it("is resilient to a non-object JSON value in the cache", () => {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify("a string"));
+    expect(readCachedThemeDefs()).toEqual({});
+  });
+
+  it("overwrites a previous cache on subsequent writes", () => {
+    writeCachedThemeDefs({ old: makeTheme("old") });
+    writeCachedThemeDefs({ fresh: makeTheme("fresh") });
+    expect(readCachedThemeDefs()).toEqual({ fresh: makeTheme("fresh") });
+  });
+});

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -40,6 +40,43 @@ const STORAGE_KEY = "hermes-dashboard-theme";
  *  the React tree mounts (see `main.tsx`) to avoid a font flash. */
 const FONT_STORAGE_KEY = "hermes-dashboard-font";
 
+/** LocalStorage key caching the *full* definition of the active user theme
+ *  (name alone isn't enough to paint — the definition lives in
+ *  ~/.hermes/dashboard-themes/*.yaml and only reaches the client via the
+ *  async `/api/dashboard/themes` call). Without this, a user-theme name
+ *  cached under `STORAGE_KEY` still resolves to `defaultTheme` on the very
+ *  first render (userThemeDefs starts empty), so `applyTheme` paints the
+ *  built-in palette via inline styles — which win the cascade over the
+ *  server's critical-CSS flash mitigation — and only repaints correctly
+ *  once the API response lands a moment later. Seeding this cache lets the
+ *  first render already resolve the real user theme, closing that gap. */
+const THEME_DEF_STORAGE_KEY = "hermes-dashboard-theme-def";
+
+/** Best-effort read of the cached user-theme-definitions map. Never throws —
+ *  a corrupt/missing cache just means the flash-mitigation gap reopens
+ *  until the next successful `/api/dashboard/themes` response repopulates it. */
+export function readCachedThemeDefs(): Record<string, DashboardTheme> {
+  if (typeof window === "undefined") return {};
+  try {
+    const raw = window.localStorage.getItem(THEME_DEF_STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+export function writeCachedThemeDefs(defs: Record<string, DashboardTheme>) {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(THEME_DEF_STORAGE_KEY, JSON.stringify(defs));
+  } catch {
+    // Storage full/unavailable — the flash-mitigation cache is best-effort,
+    // never worth failing the theme apply over.
+  }
+}
+
 /** Renames of built-in theme keys we've shipped previously. Without this,
  *  users who saved one of the old names in localStorage (or had it
  *  persisted server-side) would silently fall back to `defaultTheme`
@@ -433,10 +470,12 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
   );
 
   /** Full definitions for user themes keyed by name — the API provides
-   *  these so custom YAMLs apply without a client-side stub. */
+   *  these so custom YAMLs apply without a client-side stub. Seeded from
+   *  the localStorage cache so a returning visitor's user theme resolves
+   *  correctly on the very first render (see `THEME_DEF_STORAGE_KEY`). */
   const [userThemeDefs, setUserThemeDefs] = useState<
     Record<string, DashboardTheme>
-  >({});
+  >(readCachedThemeDefs);
 
   /** Active font-override id (independent of theme). `THEME_DEFAULT_FONT_ID`
    *  = no override. Seeded from localStorage so it's applied flash-free. */
@@ -493,7 +532,15 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
               defs[entry.name] = entry.definition;
             }
           }
-          if (Object.keys(defs).length > 0) setUserThemeDefs(defs);
+          if (Object.keys(defs).length > 0) {
+            setUserThemeDefs(defs);
+            writeCachedThemeDefs(defs);
+          } else {
+            // No user themes on the server (all deleted, or none ever
+            // existed) — drop the stale cache so a future visit doesn't
+            // resolve a since-removed theme from localStorage alone.
+            writeCachedThemeDefs({});
+          }
         }
         if (resp.active) {
           const migratedActive = migrateThemeName(resp.active);


### PR DESCRIPTION
## Problem

A custom dashboard theme loaded from `~/.hermes/dashboard-themes/*.yaml` briefly flashes the built-in default palette on every hard reload before settling on the configured theme.

## Root cause

Only the *name* of the active theme is cached in `localStorage` (`hermes-dashboard-theme`). On first render, before the async `/api/dashboard/themes` response lands, `userThemeDefs` is still empty, so `resolveTheme()` can't find the user theme's definition and falls back to `defaultTheme`. `applyTheme()` then paints that default via inline styles, which win the cascade over the server's own critical-CSS flash mitigation -- and only repaints correctly once the API call resolves a moment later.

## Fix

Also cache the full theme *definition* (not just its name) in `localStorage`, keyed separately (`hermes-dashboard-theme-def`), and seed `userThemeDefs` from that cache synchronously on mount. This lets the very first render already resolve the real user theme, closing the gap entirely for a returning visitor. A first-ever load (nothing cached yet) still briefly shows the default, same as before -- there's nothing to seed from until the first successful API response.

## Testing

- Added unit tests for the new `readCachedThemeDefs`/`writeCachedThemeDefs` helpers (empty cache, round-trip, corrupt JSON, non-object JSON, overwrite) -- `web/src/themes/context.test.ts`.
- `npm run typecheck` and `npm run test` pass (296/296 existing tests + 5 new, Node 22).
- Manually verified in a real browser against a custom theme: reload previously flashed the built-in teal palette before repainting the custom theme; after this fix it paints the custom theme immediately, verified across multiple reloads.
