### PR TITLE
fix(desktop): defer global default flip until manual provider connect is confirmed

### DIFF
--- a/apps/desktop/src/components/onboarding/index.tsx
+++ b/apps/desktop/src/components/onboarding/index.tsx
@@ -218,13 +218,13 @@ export function DesktopOnboardingOverlay({
     const reduce = typeof window !== 'undefined' && window.matchMedia?.('(prefers-reduced-motion: reduce)').matches
 
     if (reduce) {
-      confirmOnboardingModel(ctx)
+      void confirmOnboardingModel(ctx)
 
       return
     }
 
     setLeaving(true)
-    window.setTimeout(() => confirmOnboardingModel(ctx), ONBOARDING_EXIT_MS)
+    window.setTimeout(() => void confirmOnboardingModel(ctx), ONBOARDING_EXIT_MS)
   }
 
   useEffect(() => {

--- a/apps/desktop/src/store/onboarding.test.ts
+++ b/apps/desktop/src/store/onboarding.test.ts
@@ -7,6 +7,7 @@ import type { OAuthProvider } from '@/types/hermes'
 
 import {
   $desktopOnboarding,
+  confirmOnboardingModel,
   type DesktopOnboardingState,
   type OnboardingContext,
   refreshOnboarding,
@@ -468,6 +469,136 @@ describe('OAuth onboarding', () => {
     expect(state.flow.status).toBe('error')
     expect(state.flow.status === 'error' ? state.flow.message : '').toContain('Confirm this expensive model.')
     expect(requestGatewayMock).not.toHaveBeenCalledWith('setup.runtime_check', expect.anything())
+  })
+})
+
+describe('manual onboarding (Settings / Add provider on an already-configured install)', () => {
+  beforeEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+  })
+
+  afterEach(() => {
+    window.localStorage.clear()
+    $desktopOnboarding.set(baseState())
+    vi.restoreAllMocks()
+  })
+
+  it('does not flip the global default until the user confirms on the confirm card', async () => {
+    const model = 'nous/hermes-5'
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/providers/oauth/nous/submit') {
+        return { ok: true, status: 'approved' }
+      }
+
+      if (path.startsWith('/api/model/options')) {
+        return { providers: [{ name: 'Nous Portal', slug: 'nous', models: [model] }] }
+      }
+
+      if (path.startsWith('/api/model/recommended-default?')) {
+        return { provider: 'nous', model, free_tier: false }
+      }
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'nous', model, gateway_tools: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    const requestGateway: OnboardingContext['requestGateway'] = async (method, params) => {
+      if (method === 'reload.env') {
+        return {} as never
+      }
+
+      if (method === 'setup.status') {
+        return { provider_configured: true } as never
+      }
+
+      if (method === 'setup.runtime_check') {
+        // Still validated against the just-connected provider, not the
+        // (unchanged) config default — this is what makes deferring the
+        // persist safe.
+        expect(params).toEqual({ provider: 'nous' })
+
+        return { ok: true } as never
+      }
+
+      throw new Error(`unexpected gateway method: ${method}`)
+    }
+
+    // The user already has a working, different default configured — the
+    // exact scenario from the bug report (anthropic default, connecting Nous
+    // Portal as an *additional* provider from Settings).
+    $desktopOnboarding.set(
+      baseState({
+        manual: true,
+        flow: {
+          status: 'awaiting_user',
+          provider: makeOAuthProvider('nous', 'Nous Portal'),
+          start: {
+            auth_url: 'https://portal.example/auth',
+            expires_in: 600,
+            flow: 'pkce',
+            session_id: 'portal-session'
+          },
+          code: 'fresh-code'
+        },
+        requested: true
+      })
+    )
+
+    await submitOnboardingCode(onboardingContext(requestGateway))
+
+    const state = $desktopOnboarding.get()
+    expect(state.flow.status).toBe('confirming_model')
+
+    // OAuth succeeded and the confirm card is showing the new provider's
+    // model, but nothing has been written to config yet.
+    expect(calls.some(c => c.path === '/api/model/set')).toBe(false)
+
+    // Dismissing here (closeManualOnboarding) leaves the previous default
+    // untouched precisely because this call never fires.
+  })
+
+  it('persists the confirmed model only when the user clicks Begin', async () => {
+    const model = 'nous/hermes-5'
+    const calls: { body?: unknown; path: string }[] = []
+
+    installApiMock(async ({ body, path }: { body?: unknown; path: string }) => {
+      calls.push({ body, path })
+
+      if (path === '/api/model/set') {
+        return { ok: true, provider: 'nous', model, gateway_tools: [] }
+      }
+
+      throw new Error(`unexpected api path: ${path}`)
+    })
+
+    $desktopOnboarding.set(
+      baseState({
+        manual: true,
+        configured: true,
+        flow: {
+          status: 'confirming_model',
+          providerSlug: 'nous',
+          currentModel: model,
+          label: 'Nous Portal',
+          saving: false
+        }
+      })
+    )
+
+    const onCompleted = vi.fn()
+    await confirmOnboardingModel({ requestGateway: vi.fn(), onCompleted })
+
+    const assign = calls.find(c => c.path === '/api/model/set')
+    expect(assign?.body).toMatchObject({ scope: 'main', provider: 'nous', model })
+    expect(onCompleted).toHaveBeenCalledTimes(1)
   })
 })
 

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -338,10 +338,19 @@ async function completeWithModelConfirm(
 
   const defaults = await fetchProviderDefaultModel(preferredSlugs)
 
-  if (defaults) {
-    // Persist the chosen provider/model before the runtime gate so a stale
-    // config provider (e.g. anthropic from a prior failed setup) cannot make
-    // setup.runtime_check validate the wrong backend after a fresh OAuth login.
+  // Manual connect (Settings / model picker "Add provider" on an already-
+  // configured install): the global default must NOT change until the user
+  // explicitly confirms a model on the confirm card. checkRuntime below
+  // already passes preferredSlugs[0] as requestedProvider, so the runtime
+  // gate can validate the just-connected provider without persisting first.
+  // confirmOnboardingModel persists on Begin instead.
+  const manual = $desktopOnboarding.get().manual
+
+  if (defaults && !manual) {
+    // First-run only: persist the chosen provider/model before the runtime
+    // gate so a stale config provider (e.g. anthropic from a prior failed
+    // setup) cannot make setup.runtime_check validate the wrong backend
+    // after a fresh OAuth login. There's no prior default to protect here.
     try {
       const res = await setMainModelAssignment(
         {
@@ -965,15 +974,36 @@ export async function setOnboardingModel(model: string) {
   }
 }
 
-// User clicked "Start chatting" on the confirm card. Finalizes onboarding
-// — the model was already persisted by completeWithModelConfirm (or by
-// setOnboardingModel if they changed it), so all that's left is to mark
-// onboarding done and unblock the rest of the app.
-export function confirmOnboardingModel(ctx: OnboardingContext) {
-  const { flow } = $desktopOnboarding.get()
+// User clicked "Start chatting" on the confirm card. First-run: the model
+// was already persisted by completeWithModelConfirm (or by setOnboardingModel
+// if they changed it), so this only marks onboarding done. Manual connect
+// (Settings / "Add provider"): completeWithModelConfirm deliberately skipped
+// the persist so the previous default survives a dismiss, so this is where
+// the picked model finally gets written — the user just confirmed it.
+export async function confirmOnboardingModel(ctx: OnboardingContext) {
+  const { flow, manual } = $desktopOnboarding.get()
 
   if (flow.status !== 'confirming_model') {
     return
+  }
+
+  if (manual) {
+    // Best-effort: the overlay is already on its way out (cinematic exit
+    // choreography in the caller isn't gated on this), so a failure here is
+    // reported and swallowed rather than left blocking — same as the rest of
+    // this file's non-blocking gateway calls. The alternative (silently
+    // keeping the previous default) is still safer than the bug this fixes.
+    try {
+      const res = await setMainModelAssignment(
+        { provider: flow.providerSlug, model: flow.currentModel },
+        undefined,
+        { skipConfirmPrompt: true }
+      )
+
+      notifyGatewayTools(res.gateway_tools)
+    } catch (error) {
+      notifyError(error, 'Could not save the selected model.')
+    }
   }
 
   // No success toast here: the confirm-model screen already showed "<provider>


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop onboarding store flipping the global default model
provider before the user confirms anything, when connecting an
*additional* provider from an already-configured install (Settings →
Providers, Settings → Model, or the model picker's "Add provider" —
all of these set `manual: true` on the shared onboarding store).

`completeWithModelConfirm()` in `store/onboarding.ts` persisted
`{ provider: <just-connected>, model: <recommended-default> }` via
`setMainModelAssignment()` immediately after OAuth/API-key success —
before the confirm card was shown, before the user picked a model, and
before they clicked Begin. If the user then closed the overlay or
picked a different model on the confirm screen, the working default
had already been overwritten and stayed that way.

The early persist was written for the runtime-readiness gate ("a stale
config provider ... cannot make `setup.runtime_check` validate the
wrong backend after a fresh OAuth login" — see the comment it
replaces), but `checkRuntime()` already forwards `preferredSlugs[0]` as
`requestedProvider`, and `fetchRuntimeReadinessSignals()` sends that
straight through to `setup.runtime_check` as `{ provider }`. So the
gate can validate the just-connected provider without touching config
at all. That's confirmed by the existing test
`clears stale readiness errors after OAuth succeeds...`, which already
asserts `setup.runtime_check` is called with `{ provider: 'nous' }`.

## Fix

- `completeWithModelConfirm()`: skip the eager `setMainModelAssignment`
  call when `manual` is true. First-run (`manual: false`) keeps the
  exact previous behavior — there's no prior default to protect there.
- `confirmOnboardingModel()` (fires on "Begin"): now async. For the
  manual path, persists `{ provider: flow.providerSlug, model:
  flow.currentModel }` at this point instead — i.e. only once the user
  has actually looked at the confirm card and proceeded. A failure is
  reported via `notifyError` (matching the rest of this file's
  non-blocking gateway calls) rather than silently swallowed.
- `closeManualOnboarding()` (dismiss) needed no change: since nothing
  is written until Begin, dismissing now simply never persists
  anything, so the previous default is left untouched by construction.
- `components/onboarding/index.tsx`: the two call sites now `void` the
  now-async `confirmOnboardingModel`.

Out of scope: the sibling "Change picker persists against the
sign-in provider instead of the picked provider" bug (#80762) already
has an open PR (#80775) — not duplicated here.

## Related Issue

Fixes #102829

## Testing

Added two tests in `apps/desktop/src/store/onboarding.test.ts` under a
new `manual onboarding (Settings / Add provider on an already-configured
install)` describe block:

- `does not flip the global default until the user confirms on the
  confirm card` — drives `submitOnboardingCode` with `manual: true` and
  asserts `/api/model/set` is never called while the confirm card is
  showing (it also asserts `setup.runtime_check` is still called with
  `{ provider: 'nous' }`, proving the gate doesn't need the early
  write).
- `persists the confirmed model only when the user clicks Begin` —
  starts from a `confirming_model` flow state with `manual: true`,
  calls `confirmOnboardingModel`, and asserts `/api/model/set` fires
  with the confirmed provider/model only then.

Verified both fail without the fix (checked out `onboarding.ts` and
`index.tsx` at the prior commit while keeping the new tests, via `git
stash`):

```
FAIL  src/store/onboarding.test.ts > manual onboarding ... > does not flip the global default until the user confirms on the confirm card
AssertionError: expected true to be false
FAIL  src/store/onboarding.test.ts > manual onboarding ... > persists the confirmed model only when the user clicks Begin
AssertionError: expected undefined to match object { scope: 'main', … }
```

And pass with the fix:

```
$ npx vitest run src/store/onboarding.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Full desktop suite (unaffected areas, no regressions):

```
$ npx vitest run
 Test Files  866 passed | 2 skipped (868)
      Tests  9275 passed | 6 skipped (9281)
```

Typecheck and lint on the touched files are clean:

```
$ npx tsc -p . --noEmit
$ npx eslint src/store/onboarding.ts src/store/onboarding.test.ts src/components/onboarding/index.tsx
```
(both exit 0, no output)

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Checklist

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(desktop): ...`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix (no unrelated commits)
- [x] I've added tests for my changes
- [ ] I've tested on my platform — not tested manually in the Electron app itself; verified via the store's unit tests and the runtime-readiness contract those tests pin down

## AI assistance disclosure

This PR was prepared by an AI coding agent (Claude), which read the
issue, verified its root-cause claims against current `main`
(including confirming `checkRuntime`/`fetchRuntimeReadinessSignals`
already forward the requested provider to `setup.runtime_check`),
wrote the fix and tests, and confirmed the new tests fail without the
fix and pass with it. A human should review before merge.
