### PR TITLE
fix(tools): skip empty-properties injection for annotated empty objects

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -27,19 +27,44 @@ def test_object_without_properties_gets_empty_properties():
 
 
 def test_nested_object_without_properties_gets_empty_properties():
+    # A *bare* nested object (no annotation keywords) still needs the
+    # llama.cpp empty-properties injection.
     tools = [_tool("t", {
         "type": "object",
         "properties": {
             "name": {"type": "string"},
-            "arguments": {"type": "object", "description": "free-form"},
+            "arguments": {"type": "object"},
         },
         "required": ["name"],
     })]
     out = sanitize_tool_schemas(tools)
     args = out[0]["function"]["parameters"]["properties"]["arguments"]
-    assert args["type"] == "object"
-    assert args["properties"] == {}
-    assert args["description"] == "free-form"
+    assert args == {"type": "object", "properties": {}}
+
+
+def test_annotated_object_without_properties_keeps_no_properties():
+    # Regression for #102795: strict draft-2020-12 validators (Bedrock)
+    # reject `{type: object, description: ..., properties: {}}` with
+    # TOOL_SCHEMA_INVALID, so the llama.cpp empty-properties injection must
+    # NOT be applied to objects that already carry annotation keywords.
+    # delegate_task's per-task `output_schema` (annotated free-form object)
+    # is the canonical hit — it blocked subagent dispatches on Bedrock.
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "name": {"type": "string"},
+            "arguments": {"type": "object", "description": "free-form"},
+            "title_obj": {"type": "object", "title": "free-form title"},
+        },
+        "required": ["name"],
+    })]
+    out = sanitize_tool_schemas(tools)
+    params = out[0]["function"]["parameters"]["properties"]
+    args = params["arguments"]
+    assert args == {"type": "object", "description": "free-form"}
+    assert "properties" not in args
+    assert params["title_obj"] == {"type": "object", "title": "free-form title"}
+    assert "properties" not in params["title_obj"]
 
 
 def test_bare_string_object_value_replaced_with_schema_dict():
@@ -132,6 +157,41 @@ def test_anyof_nested_objects_sanitized():
     variants = out[0]["function"]["parameters"]["properties"]["opt"]["anyOf"]
     assert variants[0] == {"type": "object", "properties": {}}
     assert variants[1] == {"type": "string"}
+
+
+def test_delegate_task_annotated_output_schema_shape_stable():
+    # Mirrors delegate_task's wire shape that Bedrock rejected before the
+    # #102795 fix: tasks[].output_schema is an annotated free-form object
+    # and must leave the sanitizer WITHOUT an injected empty ``properties``.
+    tools = [_tool("delegate_task", {
+        "type": "object",
+        "properties": {
+            "tasks": {
+                "type": "array",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "goal": {"type": "string"},
+                        "output_schema": {
+                            "type": "object",
+                            "description": "Optional JSON Schema this child's final answer must validate against.",
+                        },
+                    },
+                },
+            },
+        },
+        "required": [],
+    })]
+    out = sanitize_tool_schemas(tools)
+    output_schema = (
+        out[0]["function"]["parameters"]["properties"]["tasks"]
+        ["items"]["properties"]["output_schema"]
+    )
+    assert output_schema == {
+        "type": "object",
+        "description": "Optional JSON Schema this child's final answer must validate against.",
+    }
+    assert "properties" not in output_schema
 
 
 def test_missing_parameters_gets_default_object_schema():

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -156,7 +156,13 @@ def _sanitize_single_tool(tool: dict) -> dict:
     else:
         if top.get("type") != "object":
             top["type"] = "object"
-        if "properties" not in top or not isinstance(top.get("properties"), dict):
+        # Mirror the recursive rule below: only *bare* top-level objects get
+        # the empty-properties injection (llama.cpp); annotated ones are left
+        # alone because strict validators reject `properties: {}` + annotation.
+        if (
+            not isinstance(top.get("properties"), dict)
+            and not _carries_annotation(top)
+        ):
             top["properties"] = {}
     # Final pass: collapse nullable anyOf/oneOf unions that the recursive
     # sanitizer above leaves intact (it only handles the array-form
@@ -398,6 +404,20 @@ def collapse_const_unions(schema: Any) -> Any:
     return out
 
 
+# Annotation keywords that make an object-typed node "guided" rather than
+# bare. Strict draft-2020-12 validators (Bedrock) reject an empty
+# ``properties: {}`` injected next to these keywords on an object node
+# (``{type: object, description: ..., properties: {}}`` -> TOOL_SCHEMA_INVALID),
+# while llama.cpp's grammar generator still needs the empty ``properties``
+# dict on a completely bare ``{type: object}``.
+_OBJECT_ANNOTATION_KEYWORDS = frozenset({"title", "description"})
+
+
+def _carries_annotation(node: dict) -> bool:
+    """Return True when a schema node already carries annotation keywords."""
+    return bool(set(node) & _OBJECT_ANNOTATION_KEYWORDS)
+
+
 def _sanitize_node(node: Any, path: str) -> Any:
     """Recursively sanitize a JSON-Schema fragment.
 
@@ -521,9 +541,19 @@ def _sanitize_node(node: Any, path: str) -> Any:
         else:
             out[key] = _sanitize_node(value, f"{path}.{key}") if isinstance(value, (dict, list)) else value
 
-    # Object nodes without properties: inject empty properties dict.
-    # llama.cpp's grammar generator can't constrain a free-form object.
-    if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
+    # Object nodes without properties: inject ``properties: {}`` only for
+    # *bare* objects — llama.cpp's grammar generator can't constrain a
+    # completely unguided free-form object. Annotated empty objects
+    # (description/title) are left as-is: strict validators (Bedrock
+    # draft-2020-12) reject ``{type: object, description: ..., properties:
+    # {}}``, so the empty-properties injection would manufacture that
+    # failure on exactly the tools that carry annotated free-form args
+    # (e.g. delegate_task's per-task ``output_schema``).
+    if (
+        out.get("type") == "object"
+        and not isinstance(out.get("properties"), dict)
+        and not _carries_annotation(out)
+    ):
         out["properties"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense


### PR DESCRIPTION
## Summary

Fixes #102795 — subagent dispatches (`delegate_task`) through OpenAI-compatible proxies fronting Bedrock fail in ~3s with `HTTP 400 TOOL_SCHEMA_INVALID`, which blocks every subagent-with-tools run on that backend.

## Root cause

`tools/schema_sanitizer.py::_sanitize_node` injects `properties: {}` into every object-typed node that lacks it (llama.cpp grammar compatibility). For annotated empty objects such as `delegate_task`'s per-task `output_schema`:

```json
{"type": "object", "description": "Optional JSON Schema ..."}
```

the injection manufactures:

```json
{"type": "object", "description": "...", "properties": {}}
```

which Bedrock's strict draft-2020-12 validator rejects (`TOOL_SCHEMA_INVALID`). Wire-level bisect in the issue confirms this exact combo is the single culprit — while `{"type": "object", "properties": {}}` (no description) and `{"type": "object", "description": "..."}` (no properties) both pass.

## Fix

Only inject the empty `properties` dict into **bare** `{type: object}` nodes (which llama.cpp's grammar generator still needs). Annotated empty objects (`title`/`description`) are left untouched — they already carry model guidance, and strict validators accept them as-is.

- `_sanitize_node`: injection is now gated on `_carries_annotation(node)`.
- `_sanitize_single_tool`: top-level parameters follow the same rule for consistency.

## Tests

- Updated `test_nested_object_without_properties_gets_empty_properties` — the old fixture's shape was exactly the Bedrock-hostile combo; the bare-object variant still asserts injection.
- Added `test_annotated_object_without_properties_keeps_no_properties` — pins both wire shapes (description and title variants, nested).
- Added `test_delegate_task_annotated_output_schema_shape_stable` — mirrors the real `delegate_task` schema through the sanitizer and asserts no `properties` is injected.

Full `tests/tools/test_schema_sanitizer.py` passes (34 tests).
