### PR TITLE
fix(gateway): omit sys.maxsize iteration denominator in user-facing status

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -68,7 +68,7 @@ from agent.interrupt_compat import request_hard_interrupt
 from agent.turn_context import (
     compression_made_progress,
 )
-from hermes_cli.config import _is_ssh_remote_tilde_cwd, cfg_get
+from hermes_cli.config import TURN_LIMIT_UNLIMITED, _is_ssh_remote_tilde_cwd, cfg_get
 from hermes_cli.fallback_config import get_fallback_chain
 
 # --- Agent cache tuning ---------------------------------------------------
@@ -2432,6 +2432,20 @@ def _current_max_iterations() -> int:
     _reload_runtime_env_preserving_config_authority()
     from hermes_cli.config import resolve_turn_limit as _resolve_turn_limit
     return _resolve_turn_limit(os.getenv("HERMES_MAX_ITERATIONS"))
+
+
+def _format_iteration_progress(iteration: int, max_iterations: int) -> str:
+    """Render an iteration counter for user-facing status lines.
+
+    Unbounded budgets default to ``TURN_LIMIT_UNLIMITED`` (sys.maxsize) unless
+    the user sets an explicit ``agent.max_turns`` cap. Showing that sentinel as
+    a denominator (``iteration 2/9223372036854775807``) reads as a bug to a
+    user, so unbounded runs render ``iteration N`` only; bounded runs keep the
+    ``iteration N/M`` form (the bound is meaningful there).
+    """
+    if max_iterations and max_iterations != TURN_LIMIT_UNLIMITED:
+        return f"iteration {iteration}/{max_iterations}"
+    return f"iteration {iteration}"
 
 
 from contextlib import (
@@ -11626,7 +11640,7 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     if elapsed_min > 0:
                         status_parts.append(f"{elapsed_min} min elapsed")
                 if max_iter:
-                    status_parts.append(f"iteration {iteration}/{max_iter}")
+                    status_parts.append(_format_iteration_progress(iteration, max_iter))
                 if current_tool:
                     status_parts.append(f"running: {current_tool}")
             except Exception:
@@ -32136,7 +32150,10 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         _parts = []
                         if _want_iteration_detail:
                             _parts.append(
-                                f"iteration {_a['api_call_count']}/{_a['max_iterations']}"
+                                _format_iteration_progress(
+                                    _a.get("api_call_count", 0),
+                                    _a.get("max_iterations", 0),
+                                )
                             )
                         _action = _a.get("current_tool") or _a.get("last_activity_desc")
                         if _action:
@@ -32468,6 +32485,11 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                 _cur_tool = _activity.get("current_tool")
                 _iter_n = _activity.get("api_call_count", 0)
                 _iter_max = _activity.get("max_iterations", 0)
+                # User-facing lines below omit the sys.maxsize denominator for
+                # unbounded budgets (see _format_iteration_progress); the
+                # error log right after keeps the raw resolved values for
+                # operator diagnostics.
+                _iter_progress = _format_iteration_progress(_iter_n, _iter_max)
 
                 logger.error(
                     "Agent idle for %.0fs (timeout %.0fs) in session %s "
@@ -32493,12 +32515,12 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                     _diag_lines.append(
                         f"The agent appears stuck on tool `{_cur_tool}` "
                         f"({_secs_ago:.0f}s since last activity, "
-                        f"iteration {_iter_n}/{_iter_max})."
+                        f"{_iter_progress})."
                     )
                 else:
                     _diag_lines.append(
                         f"Last activity: {_last_desc} ({_secs_ago:.0f}s ago, "
-                        f"iteration {_iter_n}/{_iter_max}). "
+                        f"{_iter_progress}). "
                         "The agent may have been waiting on an API response."
                     )
                 _diag_lines.append(

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -471,3 +471,64 @@ class TestLongRunningNotificationOwnership:
         ) is False
 
 
+class TestIterationProgressFormatting:
+    """User-facing iteration lines must not show the sys.maxsize sentinel as
+    a denominator when the turn budget is unbounded by default (#102806)."""
+
+    def test_bounded_budget_keeps_denominator(self):
+        from gateway.run import _format_iteration_progress
+
+        assert _format_iteration_progress(21, 60) == "iteration 21/60"
+
+    def test_unbounded_budget_omits_denominator(self):
+        import sys
+        from gateway.run import _format_iteration_progress
+
+        assert _format_iteration_progress(2, sys.maxsize) == "iteration 2"
+
+    def test_zero_max_iterations_omits_denominator(self):
+        from gateway.run import _format_iteration_progress
+
+        assert _format_iteration_progress(0, 0) == "iteration 0"
+
+    @pytest.mark.asyncio
+    async def test_busy_ack_omits_unbounded_denominator(self, monkeypatch):
+        """Ack with the default (unbounded) budget renders iteration N only."""
+        import sys
+
+        import gateway.run as _gr
+
+        monkeypatch.setattr(
+            _gr,
+            "_load_gateway_config",
+            lambda: {"display": {"platforms": {"telegram": {"busy_ack_detail": True}}}},
+        )
+        runner, sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+
+        event = _make_event(text="yo")
+        sk = build_session_key(event.source)
+
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 21,
+            "max_iterations": sys.maxsize,  # default: unbounded
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 0.5,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time() - 600  # 10 min
+        runner.adapters[event.source.platform] = adapter
+
+        await runner._handle_active_session_busy_message(event, sk)
+
+        call_kwargs = adapter._send_with_retry.call_args
+        content = call_kwargs.kwargs.get("content", "")
+        assert "iteration 21" in content
+        assert str(sys.maxsize) not in content  # no sentinel denominator
+        assert "terminal" in content  # current tool still shown
+
+


### PR DESCRIPTION
## Summary

Part of #102806 (the heartbeat defect). With `display.busy_ack_detail: true`, long-running heartbeats rendered the unbounded iteration sentinel to users:

```
⏳ Working — 3 min — iteration 2/9223372036854775807, receiving stream response
```

## Root cause

`agent.max_turns` is unbounded by default: `resolve_turn_limit()` maps an absent/unlimited config to `TURN_LIMIT_UNLIMITED == sys.maxsize`. Three user-facing status lines in `gateway/run.py` rendered that sentinel verbatim as a denominator (busy-ack status detail, the long-running heartbeat, and the gateway-timeout diagnostic message). The number is meaningless to a user and reads as a bug.

## Fix

Added `_format_iteration_progress(iteration, max_iterations)`:

- bounded budgets keep `iteration N/M` (the bound is meaningful),
- unbounded budgets render `iteration N` only.

The three user-facing render sites now use it. Operator-facing error logs keep the raw resolved value (`max_iterations=%d`) for diagnostics.

## Tests

Added `TestIterationProgressFormatting` to `tests/gateway/test_busy_session_ack.py`:

- helper: bounded keeps denominator, unbounded (sys.maxsize) omits it, zero/absent max is safe,
- integration: a busy-ack with the default unbounded budget renders `iteration 21` and never leaks the sentinel.

Full `tests/gateway/test_busy_session_ack.py` passes (14 tests).
