### PR TITLE
feat(image-gen): support configurable OpenRouter fallbacks

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1611,6 +1611,14 @@ stt:
 #   deepinfra:
 #     # Leave `model` blank for the first live `image-gen`-tagged result.
 #     model: ""
+#
+# OpenRouter-compatible providers can instead use a primary model with ordered
+# fallbacks:
+# image_gen:
+#   provider: "openrouter"
+#   model: "google/gemini-3.1-flash-image"
+#   fallback_models:
+#     - "openai/gpt-5.4-image-2"
 
 # =============================================================================
 # Response Pacing (Messaging Platforms)

--- a/plugins/image_gen/openrouter/__init__.py
+++ b/plugins/image_gen/openrouter/__init__.py
@@ -39,6 +39,31 @@ _MAX_REFERENCE_IMAGES = 3  # Gemini Flash Image accepts up to 3 input images per
 _REQUEST_TIMEOUT = 300.0  # per image call; a cold quality-first row can run past 3 minutes.
 
 # Curated metadata for well-known chat-completions image models.
+
+
+def _dedupe_models(models: list[str]) -> list[str]:
+    out: list[str] = []
+    seen: set[str] = set()
+    for model in models:
+        m = (model or "").strip()
+        if not m or m in seen:
+            continue
+        seen.add(m)
+        out.append(m)
+    return out
+
+
+def _coerce_model_list(value: Any) -> list[str]:
+    """Accept one model id or an ordered list from image_gen config."""
+    if isinstance(value, str):
+        values = [value]
+    elif isinstance(value, (list, tuple)):
+        values = value
+    else:
+        return []
+    return _dedupe_models([item for item in values if isinstance(item, str)])
+
+
 _KNOWN_MODEL_META = {
     DEFAULT_MODEL: {
         "display": "OpenAI GPT-5.4 Image 2",
@@ -599,16 +624,43 @@ class OpenRouterCompatImageProvider(ImageGenProvider):
         return self._resolve_model_chain(explicit)[0]
 
     def _resolve_model_chain(self, explicit: Optional[str] = None) -> list[str]:
-        """``model`` kwarg → ``*_IMAGE_MODEL`` env → ``image_gen.<provider>.model`` →
-        ``image_gen.model`` → default chain. Only the bare default chain carries a fallback."""
-        for candidate in (explicit, os.environ.get(self._model_env_var)):
-            if isinstance(candidate, str) and candidate.strip():
-                return [candidate.strip()]
+        """Ordered model attempts for this request.
+
+        Precedence: explicit caller override (the ``model`` kwarg) → the
+        provider's ``*_IMAGE_MODEL`` env override → scoped
+        ``image_gen.<provider>.model`` → top-level ``image_gen.model`` (written
+        by ``hermes tools``) → the quality-first default chain.
+
+        ``image_gen.fallback_models`` (or the provider-scoped equivalent) is
+        appended to a configured primary model in order. Explicit caller/env
+        model overrides remain exact selections and bypass configured fallbacks.
+        """
+        if isinstance(explicit, str) and explicit.strip():
+            return [explicit.strip()]
+        env_override = os.environ.get(self._model_env_var, "").strip()
+        if env_override:
+            return [env_override]
+
         cfg = _load_image_gen_config()
-        for candidate in (_dict_at(cfg, self._config_key).get("model"), cfg.get("model")):
-            if isinstance(candidate, str) and candidate.strip():
-                return [candidate.strip()]
-        return list(_DEFAULT_MODEL_CHAIN)
+        scoped = _dict_at(cfg, self._config_key)
+        primary: Optional[str] = None
+        fallback_value: Any = None
+        value = scoped.get("model")
+        if isinstance(value, str) and value.strip():
+            primary = value.strip()
+        if "fallback_models" in scoped:
+            fallback_value = scoped.get("fallback_models")
+
+        if primary is None:
+            top = cfg.get("model") if isinstance(cfg, dict) else None
+            if isinstance(top, str) and top.strip():
+                primary = top.strip()
+        if fallback_value is None and isinstance(cfg, dict):
+            fallback_value = cfg.get("fallback_models")
+
+        if primary:
+            return _dedupe_models([primary, *_coerce_model_list(fallback_value)])
+        return _dedupe_models(list(_DEFAULT_MODEL_CHAIN))
 
     def _generate_via_image_api(
         self, *, model_id: str, prompt: str, semantic_aspect: str, references: List[str],

--- a/tests/plugins/image_gen/test_openrouter_compat_provider.py
+++ b/tests/plugins/image_gen/test_openrouter_compat_provider.py
@@ -121,6 +121,39 @@ class TestProviderClass:
         with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
             assert nous._resolve_model_chain() == ["openai/gpt-image-2"]
 
+    def test_configured_primary_and_fallback_models(self):
+        cfg = {
+            "model": "google/gemini-3.1-flash-image",
+            "fallback_models": ["openai/gpt-5.4-image-2"],
+        }
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert _openrouter()._resolve_model_chain() == [
+                "google/gemini-3.1-flash-image",
+                "openai/gpt-5.4-image-2",
+            ]
+
+    def test_scoped_fallback_models_override_top_level_fallbacks(self):
+        cfg = {
+            "model": "google/gemini-3.1-flash-image",
+            "fallback_models": ["top-level/fallback"],
+            "openrouter": {"fallback_models": ["openai/gpt-5.4-image-2"]},
+        }
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert _openrouter()._resolve_model_chain() == [
+                "google/gemini-3.1-flash-image",
+                "openai/gpt-5.4-image-2",
+            ]
+
+    def test_explicit_model_kwarg_still_bypasses_configured_fallback(self):
+        cfg = {
+            "model": "google/gemini-3.1-flash-image",
+            "fallback_models": ["openai/gpt-5.4-image-2"],
+        }
+        with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
+            assert _openrouter()._resolve_model_chain("some/explicit-model") == [
+                "some/explicit-model"
+            ]
+
     def test_explicit_model_kwarg_wins_over_config(self):
         cfg = {"model": "openai/gpt-image-2"}
         with patch("plugins.image_gen.openrouter._load_image_gen_config", return_value=cfg):
@@ -560,6 +593,34 @@ class TestImageApiSurface:
         assert payload["aspect_ratio"] == "1:1"
         assert "messages" not in payload and "modalities" not in payload
         assert result["endpoint"] == "images/generations"
+
+    def test_configured_primary_retries_with_fallback(self, monkeypatch):
+        import requests as req_lib
+
+        monkeypatch.setattr(
+            "plugins.image_gen.openrouter._load_image_gen_config",
+            lambda: {
+                "model": "google/gemini-3.1-flash-image",
+                "fallback_models": ["openai/gpt-5.4-image-2"],
+            },
+        )
+        missing = MagicMock()
+        missing.status_code = 404
+        missing.json.return_value = {"error": {"message": "model unavailable"}}
+        missing.raise_for_status.side_effect = req_lib.HTTPError(response=missing)
+
+        with patch(_RUNTIME, return_value=_runtime_ok()), \
+             patch("requests.post", side_effect=[missing, _mock_chat_response([_PNG_DATA_URI])]) as mock_post, \
+             patch("plugins.image_gen.openrouter.save_b64_image", return_value=Path("/tmp/i.png")):
+            result = _openrouter_image_api().generate(prompt="a red square")
+
+        assert result["success"] is True
+        assert result["model"] == "openai/gpt-5.4-image-2"
+        assert mock_post.call_count == 2
+        assert [call.kwargs["json"]["model"] for call in mock_post.call_args_list] == [
+            "google/gemini-3.1-flash-image",
+            "openai/gpt-5.4-image-2",
+        ]
 
     def test_chat_model_still_uses_chat_completions(self):
         """The new surface must not capture the existing default chain."""

--- a/website/docs/user-guide/features/image-generation.md
+++ b/website/docs/user-guide/features/image-generation.md
@@ -87,6 +87,23 @@ update needed. Generation routes each model to the surface that serves it
 Nous Portal proxies the chat-completions protocol only, so its picker offers
 the chat-served models.
 
+For an OpenRouter primary/fallback chain, configure the primary in `model` and
+ordered fallbacks in `fallback_models`:
+
+```yaml
+image_gen:
+  provider: openrouter
+  model: google/gemini-3.1-flash-image  # Nano Banana 2
+  fallback_models:
+    - openai/gpt-5.4-image-2          # latest GPT Image 2 variant
+```
+
+Fallbacks are tried for retryable provider failures such as model availability,
+timeouts, rate limits, and server errors. Each configured fallback adds one more
+sequential request, so keep the chain short when outage latency or retry cost
+matters. An explicit per-call model or the `OPENROUTER_IMAGE_MODEL` environment
+override remains an exact selection and bypasses the configured fallback chain.
+
 Optional per-request knobs for Image API models go under the scoped config
 section (or `OPENROUTER_IMAGE_API_*` env vars):
 


### PR DESCRIPTION
## What does this PR do?

Adds configurable, ordered fallback model chains for OpenRouter-compatible image generation while preserving the existing default chain and exact explicit model overrides.

## Related Issue

No related issue. This is a standalone feature enhancement.

## Related Work

- [#32320](https://github.com/NousResearch/hermes-agent/pull/32320) is an open, broader image-generation fallback PR covering fallback providers and the `/image_model` command. This PR is narrower: it adds an ordered model fallback list inside the OpenRouter-compatible backend.
- [#55655](https://github.com/NousResearch/hermes-agent/pull/55655) addressed configured image-model selection but did not add configurable fallback chains; it is closed without merge.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- Added `image_gen.fallback_models` support for OpenRouter-compatible providers.
- Supports a top-level ordered fallback list and a provider-scoped fallback list.
- Deduplicates model IDs while preserving their configured order.
- Keeps per-call model arguments and `OPENROUTER_IMAGE_MODEL` as exact selections that bypass configured fallbacks.
- Added coverage for configuration precedence and retrying with the next model.
- Documented the configuration in `website/docs/user-guide/features/image-generation.md` and `cli-config.yaml.example`.
- No custom fallback configuration leaves the existing built-in fallback behavior unchanged.

## How to Test

- `python -m pytest -q tests/plugins/image_gen` — **212 image-generation tests passed**.
- `git diff --check` — passed.

Example configuration:

```yaml
image_gen:
  provider: openrouter
  model: google/gemini-3.1-flash-image
  fallback_models:
    - openai/gpt-5.4-image-2
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit message follows [Conventional Commits](https://www.conventionalcommits.org/) (`feat(image-gen): ...`)
- [x] I searched existing GitHub PRs and issues for related work
- [x] This PR contains only changes related to this feature
- [x] I've added tests for the new behavior
- [x] I've tested on Ubuntu/Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation
- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] Architecture/workflow documentation update: N/A
- [x] Tool descriptions/schemas update: N/A

## Screenshots / Logs

Not applicable.
