### PR TITLE
fix(matrix): decline unauthorized room invites instead of leaving them pending

### DIFF
--- a/plugins/platforms/matrix/adapter.py
+++ b/plugins/platforms/matrix/adapter.py
@@ -3821,11 +3821,25 @@ class MatrixAdapter(BasePlatformAdapter):
         if not allow_all and not (
             self._allowed_user_ids and inviter in self._allowed_user_ids
         ):
+            # Reject = actually decline. Logging-only leaves the invite
+            # pending forever, so every restart re-lists it and re-warns
+            # (observed for 2 months with stale self-invites and spam
+            # invites). Declining persists the rejection and keeps the
+            # allow-list gate intact: unauthorized users simply cannot
+            # hold the bot's presence in a pending state.
             logger.warning(
-                "Matrix: rejecting invite to %s from unauthorized user %s",
+                "Matrix: declining invite to %s from unauthorized user %s",
                 room_id,
                 inviter,
             )
+            try:
+                await self._client.leave_room(RoomID(room_id))
+            except Exception as exc:
+                logger.warning(
+                    "Matrix: failed to decline invite to %s: %s",
+                    room_id,
+                    exc,
+                )
             return
 
         logger.info(


### PR DESCRIPTION
## Problem

When the Matrix adapter receives a room invite from a user not on the allow-list, `_on_invite` only logs a warning and returns — it never declines the invite. The pending invite survives every restart, so the same rooms are re-listed and re-warned at **every** gateway startup, indefinitely.

Observed on a production instance for ~2 months (2026-07-11 → 2026-09-03): ~6 warnings per day, always the same rooms, including invites sent by the bot's **own account** (stale self-invites from an earlier tool run). Log excerpt per startup:

```
Matrix: rejecting invite to !IqDuhTwNIVvAYeEPrX:matrix.org from unauthorized user @schrottbot:matrix.org
Matrix: rejecting invite to !JRxSNxmQmxZUsdaVDO:matrix.org from unauthorized user @schrottbot:matrix.org
```

## Root cause

Logging without declining never resolves the invite membership state (`invite`), so the invite reappears in every sync after a restart.

## Fix

Decline unauthorized invites via `leave_room()` after logging, so the rejection persists. The allow-list gate is unchanged — unauthorized users still cannot pull the bot into rooms; the pending-invite noise is cleaned up instead of recurring forever. Failed declines are logged and retried on the next invite event.

## Verification

- The stale pending invites were resolved on the production account via the same `leave_room` API call; warnings stopped at the following restart.
- Authorized invites still auto-join via `_schedule_invite_join` (unchanged path).