### PR TITLE
fix(cron): add resnapshot so an agent can clear a drift-guard skip

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -2722,6 +2722,14 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                         "completed": (job.get("repeat") or {}).get("completed", 0),
                     }
 
+            # ``resnapshot`` is a one-shot instruction, not a stored field:
+            # re-capture the CURRENT global inference config for every
+            # unpinned axis so the drift guard passes again after an
+            # operator-approved config change. Explicit pins in the same
+            # update already recompute snapshots below, so the flag only
+            # matters when no pin is supplied.
+            resnapshot = bool(updates.pop("resnapshot", False))
+
             previous_inference_axes = _normalized_inference_axes(job)
             updated = _apply_skill_fields({**job, **updates})
 
@@ -2806,7 +2814,7 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                         )
                     updated["next_run_at"] = updated_next_run
 
-            if inference_fields_changed:
+            if inference_fields_changed or resnapshot:
                 provider_snapshot, model_snapshot = _compute_provider_model_snapshots(
                     provider=updated.get("provider"),
                     model=updated.get("model"),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -6623,11 +6623,12 @@ def run_job(
                     )
                 else:
                     _remediation = (
-                        "To run on the new config, on the host running Hermes "
-                        "pin it explicitly: "
+                        "To run on the new config, re-snapshot it: "
+                        f"`cronjob_manage action=update job_id={job_id} "
+                        "resnapshot=true`. To keep the original values, on the "
+                        "host running Hermes pin them explicitly: "
                         f"`hermes cron edit {job_id} --provider <provider> "
-                        "--model <model>` (or pin the original values to keep "
-                        "them)."
+                        "--model <model>`."
                     )
                 logger.warning(
                     "Job '%s': SKIPPED — global inference config drifted since "

--- a/tests/cron/test_cron_drift_resnapshot.py
+++ b/tests/cron/test_cron_drift_resnapshot.py
@@ -1,0 +1,168 @@
+"""Drift-guard escape hatch: ``resnapshot`` on update.
+
+The #44585 guard skips an unpinned job whose creation-time snapshot differs
+from the current global config. Pins are user-owned (``hermes cron edit``),
+so an agent had no way to repair the skip except delete-and-recreate, which
+loses run history and metadata.
+
+Contract:
+- ``update`` with ``resnapshot=true`` adopts the CURRENT global config; the job fires.
+- ``update`` without it leaves the snapshot alone; the job still skips.
+- A user-set pin (programmatic ``cronjob`` caller) replaces the stale snapshot.
+- A drift skip makes zero inference calls.
+- The skip message names ``resnapshot=true`` and the host-side pin command.
+- The agent schema still exposes no model/provider/base_url.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+from tests.cron.test_cron_provider_pin import (
+    _base_job,
+    _run_with_current_provider_and_model,
+)
+
+OLD_MODEL = "old-cheap-model"
+NEW_MODEL = "new-premium-model"
+
+
+@pytest.fixture
+def cron_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    (hermes_home / "cron" / "output").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+    import cron.jobs as jobs_mod
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", hermes_home)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", hermes_home / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", hermes_home / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", hermes_home / "cron" / "output")
+    # The global config the job was created under.
+    (hermes_home / "config.yaml").write_text(f"model:\n  default: {OLD_MODEL}\n")
+    return hermes_home
+
+
+def _create_drifted_job(cron_env):
+    """Create an unpinned job under OLD_MODEL, then move global config to NEW_MODEL."""
+    from cron.jobs import create_job
+
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={"provider": "openrouter"},
+    ):
+        job = create_job(prompt="hello", schedule="every 5m", deliver="local")
+    assert job["model_snapshot"] == OLD_MODEL
+    (cron_env / "config.yaml").write_text(f"model:\n  default: {NEW_MODEL}\n")
+    return job
+
+
+def _fire(job_id, tmp_path):
+    from cron.jobs import get_job
+
+    job = _base_job(**get_job(job_id))
+    return _run_with_current_provider_and_model(job, "openrouter", NEW_MODEL, tmp_path)
+
+
+def _update(**kwargs):
+    from tools.cronjob_tools import cronjob
+
+    return json.loads(cronjob(action="update", **kwargs))
+
+
+def test_programmatic_pin_clears_stale_snapshot_and_fires(cron_env, tmp_path):
+    """Pins stay user-owned; a direct cronjob() caller (CLI/dashboard) pins."""
+    from cron.jobs import get_job
+
+    job = _create_drifted_job(cron_env)
+    result = _update(job_id=job["id"], provider="openrouter", model=NEW_MODEL)
+    assert result["success"], result
+    stored = get_job(job["id"])
+    assert stored["model"] == NEW_MODEL
+    assert stored["model_snapshot"] is None
+    assert stored["provider_snapshot"] is None
+
+    success, _out, _final, error, agent_constructed = _fire(job["id"], tmp_path)
+    assert agent_constructed is True
+    assert success is True, error
+
+
+def test_update_with_resnapshot_adopts_current_config(cron_env, tmp_path):
+    from cron.jobs import get_job
+
+    job = _create_drifted_job(cron_env)
+    with patch(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        return_value={"provider": "openrouter"},
+    ):
+        result = _update(job_id=job["id"], resnapshot=True)
+    assert result["success"], result
+    stored = get_job(job["id"])
+    assert stored["model"] is None, "resnapshot must not pin"
+    assert stored["model_snapshot"] == NEW_MODEL
+    assert "resnapshot" not in stored
+
+    success, _out, _final, error, agent_constructed = _fire(job["id"], tmp_path)
+    assert agent_constructed is True
+    assert success is True, error
+
+
+def test_resnapshot_and_pin_are_mutually_exclusive(cron_env):
+    job = _create_drifted_job(cron_env)
+    result = _update(job_id=job["id"], resnapshot=True, model=NEW_MODEL)
+    assert result["success"] is False
+    assert "mutually exclusive" in result["error"]
+
+
+def test_resnapshot_rejected_on_pinned_job(cron_env):
+    from cron.jobs import create_job
+
+    job = create_job(prompt="hello", schedule="every 5m", deliver="local", model="pinned")
+    result = _update(job_id=job["id"], resnapshot=True)
+    assert result["success"] is False
+    assert "pinned" in result["error"]
+
+
+def test_update_without_pin_or_resnapshot_still_skips(cron_env, tmp_path):
+    from cron.jobs import get_job
+
+    job = _create_drifted_job(cron_env)
+    result = _update(job_id=job["id"], name="renamed")
+    assert result["success"], result
+    assert get_job(job["id"])["model_snapshot"] == OLD_MODEL
+
+    success, output, _final, error, agent_constructed = _fire(job["id"], tmp_path)
+    assert agent_constructed is False, "drift skip must make zero inference calls"
+    assert success is False
+    blob = f"{error}\n{output}"
+    assert "drifted" in blob
+    assert f"cronjob_manage action=update job_id={job['id']} resnapshot=true" in blob
+    assert f"hermes cron edit {job['id']} --provider <provider> --model <model>" in blob
+    assert "cronjob action=update" not in blob
+
+
+def test_schema_exposes_resnapshot_only():
+    from tools.cronjob_tools import CRONJOB_SCHEMA
+
+    props = CRONJOB_SCHEMA["parameters"]["properties"]
+    assert props["resnapshot"]["type"] == "boolean"
+    for user_owned in ("model", "provider", "base_url"):
+        assert user_owned not in props
+
+
+def test_registry_handler_forwards_resnapshot_only():
+    import tools.cronjob_tools  # noqa: F401  (registers the tool)
+    from tools.registry import registry
+
+    handler = registry.get_entry("cronjob_manage").handler
+    with patch("tools.cronjob_tools.cronjob", return_value="{}") as fn:
+        handler({"action": "update", "job_id": "j", "model": "m", "provider": "p", "resnapshot": True})
+    kwargs = fn.call_args.kwargs
+    assert kwargs["resnapshot"] is True
+    assert "model" not in kwargs and "provider" not in kwargs

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -1533,6 +1533,7 @@ def cronjob(
     monitor_url: Optional[str] = None,
     reasoning_effort: Optional[str] = None,
     failure_deliver: Optional[Union[str, List[str]]] = None,
+    resnapshot: Optional[bool] = None,
     task_id: str = None,
     session_id: Optional[str] = None,
 ) -> str:
@@ -1887,6 +1888,26 @@ def cronjob(
                 # CLI-only lane (see create above): update_job validates
                 # against the canonical grammar; empty string clears the pin.
                 updates["reasoning_effort"] = reasoning_effort
+            if resnapshot:
+                if updates.get("model") or updates.get("provider"):
+                    return tool_error(
+                        "resnapshot=true and an explicit provider/model pin are "
+                        "mutually exclusive — a pin already replaces the snapshot.",
+                        success=False,
+                    )
+                if job.get("model") or job.get("provider"):
+                    return tool_error(
+                        "resnapshot has no effect on a pinned job; pinned axes "
+                        "are exempt from the drift guard.",
+                        success=False,
+                    )
+                if job.get("no_agent"):
+                    return tool_error(
+                        "resnapshot has no effect on a no_agent job (script-only "
+                        "jobs carry no inference snapshot).",
+                        success=False,
+                    )
+                updates["resnapshot"] = True
             # Re-validate the EFFECTIVE provider/base_url on EVERY update, not
             # only when this update supplies provider/base_url. A job persisted
             # before this guard (or written directly to the jobs store) may
@@ -2102,6 +2123,10 @@ Jobs run in a fresh session with no current-chat context, so prompts must be sel
                 "type": "string",
                 "description": "Optional absolute existing path to run the job from: injects that directory's AGENTS.md/context files and anchors terminal/file tools there. On update, '' clears."
             },
+            "resnapshot": {
+                "type": "boolean",
+                "description": "For update: re-capture the CURRENT global inference config as the job's drift-guard snapshot. Use this after a job was skipped with 'global inference config drifted' and the user confirms the new config is intended. Does not pin a model; pins are user-owned (hermes cron edit --model)."
+            },
             "attach_to_session": {
                 "type": "boolean",
                 "description": "True = the job's delivery is CONTINUABLE — the user can reply and the agent has the brief in context (threads on thread-capable platforms, mirrored into the DM elsewhere). Use for conversational recurring jobs (briefings); leave unset for fire-and-forget alerts. Scope: the job's own conversation only — the origin chat, the home-channel fallback when deliver='origin' captured no origin (script-created jobs), or the job's single explicit platform:chat target (this flag is the only way to attach an explicit target). Broadcast targets are never attached; no effect when deliver='local'."
@@ -2165,6 +2190,8 @@ def _cronjob_handler(args, **kw):
         # `hermes cron create/edit --model`, or hand-edited jobs). The agent
         # must not be able to point unattended spend at a different model.
         # Programmatic callers of cronjob() itself retain the parameters.
+        # resnapshot only re-adopts the config the operator already chose.
+        resnapshot=args.get("resnapshot"),
         reason=args.get("reason"),
         script=args.get("script"),
         context_from=args.get("context_from"),


### PR DESCRIPTION
### Problem

The #44585 drift guard skips an unpinned cron job whose creation-time `model_snapshot` / `provider_snapshot` differs from the current global inference config. Pins are user-owned (`hermes cron edit --model`, per #17fa4e2944), so an agent that receives the skip alert has no way to repair the job. The only repair is delete-and-recreate, which loses run history, `created_at`, and origin/delivery metadata.

### Change

- `update` accepts `resnapshot: true`. `update_job` pops the flag (never stored) and recomputes the snapshots from the CURRENT global config. No pin is stored, so the agent can only re-adopt the config the operator already chose. The flag is rejected together with a pin, on an already pinned job, and on `no_agent` jobs.
- The skip message now names `cronjob_manage action=update job_id=<id> resnapshot=true` and keeps the host-side `hermes cron edit` pin command.

### Guard behavior unchanged

`model` / `provider` / `base_url` stay out of the agent schema (`TestAgentCannotSetModelPin` passes). Unpinned + drifted still skips. A skip still constructs no agent and makes no inference call. Jobs with no snapshot (legacy, `no_agent`) still run.

### Note for reviewers

`resnapshot` is not a pin. An injected cron prompt cannot use it to pick a model; it can only accept the global config the operator set. If the alert must stay silent on any agent-side command, drop the message change and keep the flag; the tests are separable.

### Tests

`tests/cron/test_cron_drift_resnapshot.py` (8 tests). `tests/cron/` + `tests/tools/test_cronjob_tools.py`: 1295 passed, 1 skipped, 1 failed (`test_cron_multiplex_shared_route_delivery.py::test_satellite_routes_exact_target_through_primary_adapter`, which also fails on clean `main` in the full run and passes alone; order-dependent, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
