### PR TITLE
fix(cli): hermes auth status openrouter reports logged in with valid credential

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -7870,9 +7870,16 @@ def get_xai_oauth_auth_status() -> Dict[str, Any]:
         }
 
 
-def get_api_key_provider_status(provider_id: str) -> Dict[str, Any]:
-    """Status snapshot for API-key providers (z.ai, Kimi, MiniMax)."""
-    pconfig = PROVIDER_REGISTRY.get(provider_id)
+def get_api_key_provider_status(
+    provider_id: str, pconfig: Optional[ProviderConfig] = None,
+) -> Dict[str, Any]:
+    """Status snapshot for API-key providers (z.ai, Kimi, MiniMax, OpenRouter).
+
+    ``pconfig`` is an optional override for providers that deliberately stay
+    out of ``PROVIDER_REGISTRY`` (openrouter — runtime resolution relies on
+    it being absent there); when omitted, the registry entry is used.
+    """
+    pconfig = pconfig if pconfig is not None else PROVIDER_REGISTRY.get(provider_id)
     if not pconfig or pconfig.auth_type != "api_key":
         return {"configured": False}
 
@@ -8046,6 +8053,25 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
         return get_minimax_oauth_auth_status()
     if target == "azure-foundry":
         return _get_azure_foundry_auth_status()
+    if target == "openrouter":
+        # OpenRouter deliberately stays out of PROVIDER_REGISTRY — runtime
+        # provider resolution relies on it being absent there (see the
+        # registry auto-extension guard above). Synthesize the same minimal
+        # pconfig the model-setup flow uses and route it through the api-key
+        # status resolver. Without this branch the dispatcher falls through
+        # to ``{"logged_in": False}`` and ``hermes auth status openrouter``
+        # falsely reports logged out even with a valid OPENROUTER_API_KEY or
+        # credential-pool entry (#95878).
+        return get_api_key_provider_status(
+            target,
+            pconfig=ProviderConfig(
+                id="openrouter",
+                name="OpenRouter",
+                auth_type="api_key",
+                api_key_env_vars=("OPENROUTER_API_KEY",),
+                inference_base_url=OPENROUTER_BASE_URL,
+            ),
+        )
     pconfig = PROVIDER_REGISTRY.get(target)
     # External-process providers (copilot-acp today; kiro/devin/junie-style ACP
     # backends tomorrow) — dispatch on auth_type, not a hardcoded slug, so every

--- a/tests/hermes_cli/test_auth_key_prefix_skip.py
+++ b/tests/hermes_cli/test_auth_key_prefix_skip.py
@@ -174,3 +174,34 @@ class TestValidEnvKeyStillWins:
         )
         assert key == "sk-or-v1-second-var-good"
         assert source == "OPENROUTER_KEY"
+
+
+class TestAuthStatusOpenRouter:
+    """#95878: ``hermes auth status openrouter`` reports logged out even with
+    a valid credential because openrouter is deliberately absent from
+    PROVIDER_REGISTRY and the status dispatcher fell through to the default
+    ``{"logged_in": False}`` before ever consulting .env / credential pool."""
+
+    def test_env_key_reports_logged_in(self, isolated_hermes_home):
+        _write_env_file(
+            isolated_hermes_home, OPENROUTER_API_KEY="sk-or-v1-valid-key-abc123"
+        )
+
+        from hermes_cli.auth import get_auth_status
+        status = get_auth_status("openrouter")
+        assert status.get("logged_in") is True
+        assert status.get("configured") is True
+
+    def test_pool_credential_reports_logged_in(self, isolated_hermes_home):
+        pool = _mock_pool(_entry("sk-or-v1-pool-key-abc123"))
+
+        from hermes_cli.auth import get_auth_status
+        with patch("agent.credential_pool.load_pool", return_value=pool):
+            status = get_auth_status("openrouter")
+        assert status.get("logged_in") is True
+
+    def test_no_credential_reports_logged_out(self, isolated_hermes_home):
+        from hermes_cli.auth import get_auth_status
+        status = get_auth_status("openrouter")
+        assert status.get("logged_in") is False
+        assert status.get("configured") is False


### PR DESCRIPTION
## Summary

Fixes #95878 — `hermes auth status openrouter` reports `logged out` even when a valid OpenRouter API key is stored and usable, while `hermes auth list`, `hermes config check`, and `hermes debug share --local` all see the credential.

## Root cause

`get_auth_status()` in `hermes_cli/auth.py` dispatches API-key providers through `PROVIDER_REGISTRY`. OpenRouter is **deliberately absent** from the registry — runtime provider resolution relies on that (`_model_flow_openrouter()` synthesizes a minimal pconfig instead). So `PROVIDER_REGISTRY.get("openrouter")` returns `None`, neither the API-key nor the AWS-SDK branch matches, and the dispatcher falls through to the default `{"logged_in": False}` without ever consulting `.env` or the credential pool. This is a diagnostic false-negative only — the credential works at runtime.

## Fix

Follow the issue's proposed Option A (narrow, minimal footprint):

- `get_api_key_provider_status()` now accepts an optional `pconfig` override (defaults to the registry entry — existing callers unchanged).
- `get_auth_status()` synthesizes the same minimal `ProviderConfig` the model-setup flow uses (`api_key_env_vars=("OPENROUTER_API_KEY",)`, `inference_base_url=OPENROUTER_BASE_URL`) and routes `openrouter` through the API-key status resolver.

`PROVIDER_REGISTRY` is not mutated and runtime resolution is untouched — the registry auto-extension guard's explicit `openrouter` exclusion stays as-is (Option B was deliberately not taken to avoid auditing those special cases).

The status resolver already honors declared key prefixes (`KNOWN_PROVIDER_KEY_PREFIXES`, `sk-or-`), so a malformed env value still falls through to the credential pool with a warning, and an absent credential still reports `logged out`.

## Tests

Added `TestAuthStatusOpenRouter` to `tests/hermes_cli/test_auth_key_prefix_skip.py` (reusing its isolated-HERMES_HOME fixture):

- valid `OPENROUTER_API_KEY` in `.env` → `logged_in: True`
- valid credential-pool entry → `logged_in: True`
- no credential → `logged_in: False` (no false positive)

Full `tests/hermes_cli/test_auth_key_prefix_skip.py` (9), `test_api_key_providers.py` + `test_auth_commands.py` (136 total) pass.
