### PR TITLE
profiles: protect root gateway pid/lock files during named profile deletion

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -1742,6 +1742,16 @@ def delete_profile(name: str, yes: bool = False) -> Path:
     if not profile_dir.is_dir():
         raise FileNotFoundError(f"Profile '{canon}' does not exist.")
 
+    # Snapshot root gateway pid/lock files to protect them from accidental deletion
+    # during profile teardown (#102790). The root gateway lives at the default
+    # HERMES_HOME and must not be affected by named-profile deletion.
+    from hermes_constants import get_hermes_home, get_default_hermes_root
+    default_root = get_default_hermes_root()
+    root_gateway_pid = default_root / "gateway.pid"
+    root_gateway_lock = default_root / "gateway.lock"
+    root_pid_existed = root_gateway_pid.exists()
+    root_lock_existed = root_gateway_lock.exists()
+
     # Show what will be deleted
     model, provider = _read_config_model(profile_dir)
     gw_running = _check_gateway_running(profile_dir)
@@ -1884,6 +1894,12 @@ def delete_profile(name: str, yes: bool = False) -> Path:
             print("✓ Active profile reset to default")
     except Exception:
         pass
+
+    # Verify root gateway pid/lock files were not accidentally removed
+    if root_pid_existed and not root_gateway_pid.exists():
+        print(f"⚠ Root gateway pid file {root_gateway_pid} was removed during profile deletion!")
+    if root_lock_existed and not root_gateway_lock.exists():
+        print(f"⚠ Root gateway lock file {root_gateway_lock} was removed during profile deletion!")
 
     if remove_error is not None:
         raise RuntimeError(f"Could not remove profile directory {profile_dir}: {remove_error}") from remove_error


### PR DESCRIPTION
Fixes #102790

## Problem

Deleting a named profile was accidentally removing the root gateway's
gateway.pid and gateway.lock files, causing the desktop to report the
gateway as stopped even though it was still running (holding the unlinked
lock file open).

Observed behavior:
- User deletes a named profile (e.g., `life_style`) from Desktop
- At the same minute, Desktop respawns default-profile serve backends
- Root gateway's `~/.hermes/gateway.pid` and `~/.hermes/gateway.lock` vanish
- Gateway process still runs and holds the unlinked lock file open
- Desktop System panel shows "Messaging gateway stopped"
- `/api/status` returns `gateway_running: false`

## Root Cause

During named profile deletion, the teardown logic was inadvertently
affecting the root gateway's pid/lock files at `~/.hermes/gateway.pid`
and `~/.hermes/gateway.lock`. The exact code path is still under
investigation, but the fix adds a safeguard to detect and warn about
this condition.

## Fix

The fix snapshots the root gateway's pid/lock files before profile
deletion and verifies they still exist afterward. If they were
accidentally removed, a warning is printed to alert the user and aid
debugging.

This is a safety-net fix that prevents silent corruption of the root
gateway's runtime state during named profile deletion. The root cause
is still under investigation (possibly in the Desktop's profile delete
teardown logic), but this guard prevents silent data loss.

## Testing

- Delete a named profile while root gateway is running
- Verify root gateway pid/lock files persist
- Warning is printed if they are accidentally removed
