### PR TITLE
fix(agent): bind kanban worker guidance to dispatched tasks

### DIFF
--- a/agent/agent_init.py
+++ b/agent/agent_init.py
@@ -1643,15 +1643,13 @@ def init_agent(
     elif not agent.quiet_mode:
         print("🛠️  No tools loaded (all tools filtered out or unavailable)")
 
-    # Kanban worker/orchestrator lifecycle guidance is session-static:
-    # the dispatcher decides at spawn time whether this process is a kanban
-    # worker (kanban_show tool is present iff HERMES_KANBAN_TASK is set).
-    # Resolving the ~835-token block once here avoids re-running the
-    # membership test + reference on every system-prompt rebuild
-    # (init + each context compression).
-    from agent.prompt_builder import KANBAN_GUIDANCE
-    agent._kanban_worker_guidance = (
-        KANBAN_GUIDANCE if "kanban_show" in agent.valid_tool_names else ""
+    # Kanban worker lifecycle guidance is session-static. Tool availability is
+    # insufficient: explicitly configured orchestrators also expose kanban_show,
+    # while only a dispatcher-owned HERMES_KANBAN_TASK binding owns a current
+    # task. Resolve once for init + context-compression prompt rebuilds.
+    from agent.system_prompt import resolve_kanban_worker_guidance
+    agent._kanban_worker_guidance = resolve_kanban_worker_guidance(
+        agent.valid_tool_names
     )
 
     # Check tool requirements

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -58,6 +58,31 @@ from pathlib import Path
 from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
+
+
+def resolve_kanban_worker_guidance(valid_tool_names) -> str:
+    """Return lifecycle guidance only for the task-bound dispatcher worker.
+
+    Orchestrator profiles intentionally expose ``kanban_show`` without owning a
+    current task, and cron/delegate executions can run inside a worker process
+    while explicitly disowning its ambient task identity.
+    """
+    if "kanban_show" not in valid_tool_names:
+        return ""
+    if not os.environ.get("HERMES_KANBAN_TASK"):
+        return ""
+    try:
+        from agent.delegation_context import is_dispatcher_owned_worker_context
+
+        if not is_dispatcher_owned_worker_context():
+            return ""
+    except Exception:
+        # Lifecycle instructions can mutate durable board state; an ambiguous
+        # ownership check must fail closed rather than borrow an ambient task.
+        return ""
+    return KANBAN_GUIDANCE
+
+
 _PLUGIN_SECTION_FRAME_RE = re.compile(
     r"^## Plugin Context: (?P<id>[a-z0-9][a-z0-9._-]{0,127})\n"
     r"<!-- hermes-plugin-section-chars:(?P<chars>[0-9]{1,4}) -->\n\n",
@@ -538,16 +563,14 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         tool_guidance.append(SESSION_SEARCH_GUIDANCE)
     if "skill_manage" in agent.valid_tool_names:
         tool_guidance.append(SKILLS_GUIDANCE)
-    # Kanban worker/orchestrator lifecycle — only present when the
-    # dispatcher spawned this process (kanban_show check_fn gates on
-    # HERMES_KANBAN_TASK env var). Normal chat sessions never see
-    # this block. Resolved once at __init__ (see _kanban_worker_guidance).
+    # Kanban worker lifecycle is task-bound, not tool-bound. Configured
+    # orchestrators also expose kanban_show so they can inspect explicit task IDs,
+    # but must not be told to orient or finish a nonexistent current task.
     _kanban_guidance = getattr(agent, "_kanban_worker_guidance", None)
+    if _kanban_guidance is None:
+        _kanban_guidance = resolve_kanban_worker_guidance(agent.valid_tool_names)
     if _kanban_guidance:
         tool_guidance.append(_kanban_guidance)
-    elif _kanban_guidance is None and "kanban_show" in agent.valid_tool_names:
-        # Fallback for code paths that bypass agent_init (rare).
-        tool_guidance.append(KANBAN_GUIDANCE)
     if tool_guidance:
         stable_parts.append(" ".join(tool_guidance))
 

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -129,6 +129,83 @@ def _prompt_parts(agent):
         return build_system_prompt_parts(agent)
 
 
+class TestKanbanWorkerGuidance:
+    @staticmethod
+    def _initialized_agent():
+        from run_agent import AIAgent
+
+        kanban_show = {
+            "type": "function",
+            "function": {
+                "name": "kanban_show",
+                "description": "Inspect a task",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        with (
+            patch("run_agent.get_tool_definitions", return_value=[kanban_show]),
+            patch("run_agent.check_toolset_requirements", return_value={}),
+            patch("run_agent.OpenAI"),
+        ):
+            return AIAgent(
+                api_key="test-key",
+                base_url="https://example.test/v1",
+                quiet_mode=True,
+                skip_context_files=True,
+                skip_memory=True,
+                platform="cron",
+            )
+
+    def test_agent_init_caches_no_protocol_without_task_binding(self, monkeypatch):
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+        assert getattr(self._initialized_agent(), "_kanban_worker_guidance") == ""
+
+    def test_agent_init_caches_protocol_for_bound_worker(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_bound")
+
+        assert "Kanban task execution protocol" in getattr(
+            self._initialized_agent(), "_kanban_worker_guidance"
+        )
+
+    def test_unbound_kanban_orchestrator_does_not_get_worker_protocol(
+        self, monkeypatch
+    ):
+        """Having kanban_show available is not a dispatcher task binding."""
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        agent = _make_agent(
+            valid_tool_names=["kanban_show"],
+            _kanban_worker_guidance=None,
+            platform="cron",
+        )
+
+        assert "Kanban task execution protocol" not in _stable_prompt(agent)
+
+    def test_bound_dispatcher_worker_gets_worker_protocol(self, monkeypatch):
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_bound")
+        agent = _make_agent(
+            valid_tool_names=["kanban_show"],
+            _kanban_worker_guidance=None,
+        )
+
+        assert "Kanban task execution protocol" in _stable_prompt(agent)
+
+    def test_cron_context_does_not_borrow_parent_worker_protocol(
+        self, monkeypatch
+    ):
+        from agent.delegation_context import non_dispatcher_owned_context
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent_worker")
+        agent = _make_agent(
+            valid_tool_names=["kanban_show"],
+            _kanban_worker_guidance=None,
+            platform="cron",
+        )
+
+        with non_dispatcher_owned_context():
+            assert "Kanban task execution protocol" not in _stable_prompt(agent)
+
+
 def _init_code_repo(path):
     """A git repo that actually holds code — the coding posture requires a source
     file (or manifest), not a bare ``.git`` (a prose/notes repo stays general)."""

--- a/tests/cron/test_cron_kanban_env_isolation.py
+++ b/tests/cron/test_cron_kanban_env_isolation.py
@@ -272,6 +272,23 @@ class TestRunJobKanbanIsolation:
             "workdir": None, "schedule_display": "manual",
         }
 
+    def test_unbound_cron_keeps_final_response(self, monkeypatch):
+        """An ordinary cron run completes normally without a current task binding."""
+        import cron.scheduler as sched
+
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        observed: dict = {}
+        self._install_stubs(monkeypatch, observed)
+
+        success, _output, final_response, error = sched.run_job(
+            self._job("unbound-cron-final")
+        )
+
+        assert success is True
+        assert final_response == "done"
+        assert error is None
+        assert observed["dispatcher_owned_during_init"] is False
+
     def test_agent_runs_as_non_dispatcher(self, monkeypatch, worker_env):
         import cron.scheduler as sched
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -80,6 +80,19 @@ def test_show_defaults_to_env_task_id(worker_env):
     assert "runs" in d
 
 
+def test_orchestrator_show_accepts_explicit_task_id_without_worker_binding(
+    monkeypatch, worker_env
+):
+    """Removing implicit worker guidance must not remove explicit inspection."""
+    monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+
+    from tools import kanban_tools as kt
+
+    d = json.loads(kt._handle_show({"task_id": worker_env}))
+    assert d["task"]["id"] == worker_env
+    assert "worker_context" in d
+
+
 def test_list_filters_tasks(monkeypatch, worker_env):
     """kanban_list gives orchestrators filtered board discovery."""
     monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)


### PR DESCRIPTION
## Summary
- gate dispatcher-only Kanban lifecycle guidance on a nonempty task binding and canonical dispatcher ownership
- keep configured orchestrators able to inspect explicit task IDs without telling them to orient a nonexistent current task
- cover unbound cron final responses, real workers, inherited worker context, and explicit task-id inspection

## Verification
- `scripts/run_tests.sh tests/agent/test_system_prompt.py tests/tools/test_kanban_tools.py tests/cron/test_cron_kanban_env_isolation.py -q` (106 passed)
- `ruff check` on all changed Python files
- `python -m compileall -q` on all changed Python files
- independent review: PASS, no blocking security or logic findings

## Rollout
No gateway process was replaced or restarted. Activation remains deferred while the existing cumulative gateway verification window is active.