### PR TITLE
fix(state): serialize self-heal reopens per database path (#102827)

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -5949,34 +5949,41 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
             self.db_path,
             context,
         )
-        try:
-            conn = _connect_tracked_db(
-                str(self.db_path),
-                check_same_thread=False,
-                timeout=1.0,
-                isolation_level=None,
-            )
-        except Exception as exc:
-            raise sqlite3.OperationalError(
-                f"state.db connection was closed while a {context} was still "
-                f"in flight (a session-teardown path called close() before "
-                f"this worker finished — #94736) and the automatic reopen "
-                f"failed: {exc}"
-            ) from exc
-        try:
-            conn.row_factory = sqlite3.Row
-            self._wal_active = (
-                apply_wal_with_fallback(conn, db_label="state.db") == "wal"
-            )
-            apply_database_pragmas(conn, db_label="state.db")
-            conn.execute("PRAGMA foreign_keys=ON")
-            self._fts_cjk_loaded = load_fts5_cjk_extension(conn)
-        except Exception as exc:
-            self._close_connection_quietly(conn)
-            raise sqlite3.OperationalError(
-                f"state.db reopen after close() succeeded but connection "
-                f"setup failed: {exc}"
-            ) from exc
+        # Acquire the process-global reopen lock for this database path to
+        # serialize self-heal reopens across all SessionDB instances sharing
+        # this database file. This prevents concurrent reopens from multiple
+        # SessionDB instances (e.g. cron + gateway) from corrupting the
+        # database via concurrent writers.
+        reopen_lock = _get_db_reopen_lock(self.db_path)
+        with reopen_lock:
+            try:
+                conn = _connect_tracked_db(
+                    str(self.db_path),
+                    check_same_thread=False,
+                    timeout=1.0,
+                    isolation_level=None,
+                )
+            except Exception as exc:
+                raise sqlite3.OperationalError(
+                    f"state.db connection was closed while a {context} was still "
+                    f"in flight (a session-teardown path called close() before "
+                    f"this worker finished — #94736) and the automatic reopen "
+                    f"failed: {exc}"
+                ) from exc
+            try:
+                conn.row_factory = sqlite3.Row
+                self._wal_active = (
+                    apply_wal_with_fallback(conn, db_label="state.db") == "wal"
+                )
+                apply_database_pragmas(conn, db_label="state.db")
+                conn.execute("PRAGMA foreign_keys=ON")
+                self._fts_cjk_loaded = load_fts5_cjk_extension(conn)
+            except Exception as exc:
+                self._close_connection_quietly(conn)
+                raise sqlite3.OperationalError(
+                    f"state.db reopen after close() succeeded but connection "
+                    f"setup failed: {exc}"
+                ) from exc
         # Schema was initialised by this instance's original open; the file
         # cannot have lost it, so no _init_schema here (no DDL races with
         # sibling processes during teardown).

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -461,6 +461,31 @@ _read_open_denied_fd_headroom = 0
 _fd_usage_lock = threading.Lock()
 _fd_usage_cache: "tuple[float, Optional[int]]" = (0.0, None)
 
+# Process-global lock registry per database path: serializes self-heal
+# reopens (_reopen_after_close_locked) across all SessionDB instances
+# sharing the same database file. Without this, concurrent self-heal
+# reopens from different SessionDB instances (e.g. cron + gateway) can
+# race and corrupt the database (#102827, #99509).
+_db_reopen_locks: "dict[str, threading.Lock]" = {}
+_db_reopen_locks_lock = threading.Lock()
+
+
+def _get_db_reopen_lock(db_path: Path) -> threading.Lock:
+    """Return the process-global reopen lock for the given database path.
+
+    Creates the lock on first use. The lock ensures that only one
+    SessionDB instance at a time can perform a self-heal reopen for a
+    given database file, preventing concurrent reopens from corrupting
+    the database (torn pages/WAL from concurrent writers).
+    """
+    key = str(db_path.resolve())
+    with _db_reopen_locks_lock:
+        lock = _db_reopen_locks.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _db_reopen_locks[key] = lock
+        return lock
+
 
 def _open_fd_count() -> Optional[int]:
     """Descriptors open in THIS process, or None when it cannot be measured.


### PR DESCRIPTION
## What does this PR do?

Fixes the state.db structural corruption (NOTADB/malformed) that occurs when the #99509 self-heal reopen path runs concurrently from multiple SessionDB instances sharing the same database file.

## Root cause

The #99509 self-heal reopen (`_reopen_after_close_locked`) was only protected by the per-instance `self._lock`. When multiple SessionDB instances share the same database file (e.g., cron job's SessionDB + gateway's SessionDB + platform adapters), the self-heal reopen could run concurrently from different instances, allowing concurrent writers to corrupt the database (torn pages, WAL corruption → NOTADB/malformed).

This was observed in production on v0.21.0: a cron job's LLM timeouts triggered the #99509 self-heal reopen, which raced with active gateway platform adapter writers, causing structural corruption requiring offline dump/restore.

## The fix

Added a process-global lock registry (`_db_reopen_locks`) keyed by resolved database path. The `_reopen_after_close_locked` method now acquires the global reopen lock for the database path before performing the reopen, serializing self-heal reopens across all SessionDB instances sharing the same database file.

## Testing

- All 282 existing state tests pass (1 pre-existing FTS5 search projection test failure is unrelated)
- All related state tests pass: `test_hermes_state_conn_lock_audit.py`, `test_hermes_state_readonly_preflight.py`, `test_hermes_state_wal_fallback.py`
- The fix is minimal and targeted: only adds the global lock acquisition around the reopen connection logic

## Related Issue

Fixes #102827

Related to: #94736 (original race), #99509 (self-heal reopen), #101118 (quiesce thread pool), #100313 (corruption at cron dispatch)