### PR TITLE
fix(agent): restore_primary_runtime rebuilds the Bedrock client for bedrock_converse

### DIFF
--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -911,6 +911,52 @@ def _build_anthropic_client_from_runtime(agent, rt: Dict[str, Any]) -> None:
     agent.client = None
 
 
+def _rebuild_bedrock_client_from_runtime(
+    agent: Any, rt: Dict[str, Any], *, reason: str,
+) -> None:
+    """Rebuild the Bedrock-SDK-backed Anthropic client from a runtime snapshot.
+
+    Shared by :func:`_rebuild_primary_client` (fallback restore) and
+    :func:`try_recover_primary_transport` (transient-error recovery): both
+    previously fell through to ``_create_openai_client`` for
+    ``api_mode == "bedrock_converse"``, which demands an OPENAI_API_KEY and
+    raised a spurious error — Bedrock authenticates via the boto3 chain
+    (#102860).
+    """
+    from agent.anthropic_adapter import build_anthropic_bedrock_client
+
+    # The region was captured at init from the primary base_url
+    # (bedrock-runtime.<region>.amazonaws.com) into _bedrock_region. Fall back
+    # to re-extracting it from the snapshot base_url (attribute missing on a
+    # rebuilt agent), then to the SDK default.
+    _region = str(getattr(agent, "_bedrock_region", "") or "").strip()
+    _region_source = "agent._bedrock_region" if _region else ""
+    if not _region:
+        _region_match = re.search(
+            r"bedrock-runtime\.([a-z0-9-]+)\.", str(rt.get("base_url") or "")
+        )
+        if _region_match:
+            _region = _region_match.group(1)
+            _region_source = "runtime snapshot base_url"
+        else:
+            _region = "us-east-1"
+            _region_source = "SDK default"
+            logger.debug(
+                "%s: no _bedrock_region and no bedrock-runtime.<region>. in "
+                "base_url %r — falling back to region %r; check the primary "
+                "base_url for drift",
+                reason, rt.get("base_url"), _region,
+            )
+    agent._bedrock_region = _region
+    logger.debug(
+        "%s: rebuilding Bedrock client for region %s (resolved from %s)",
+        reason, _region, _region_source,
+    )
+    agent._anthropic_client = build_anthropic_bedrock_client(_region)
+    agent.client = None
+    agent._client_kwargs = {}
+
+
 def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
     """Rebuild the primary client from a ``_primary_runtime`` snapshot (MoA
     facade / native Anthropic / Bedrock / OpenAI wire)."""
@@ -933,39 +979,7 @@ def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
         # raises a spurious "The api_key client option must be set ..." error for
         # Bedrock (authenticated via the boto3 chain) — stranding the fallback
         # chain for every subsequent turn (#102860).
-        from agent.anthropic_adapter import build_anthropic_bedrock_client
-
-        # The region was captured at init from the primary base_url
-        # (bedrock-runtime.<region>.amazonaws.com) into _bedrock_region.
-        # Fall back to re-extracting it from the restored base_url in case the
-        # attribute is missing (e.g. a rebuilt agent), then to the SDK default.
-        _region = str(getattr(agent, "_bedrock_region", "") or "").strip()
-        _region_source = "agent._bedrock_region" if _region else ""
-        if not _region:
-            _region_match = re.search(
-                r"bedrock-runtime\.([a-z0-9-]+)\.", str(rt.get("base_url") or "")
-            )
-            if _region_match:
-                _region = _region_match.group(1)
-                _region_source = "runtime snapshot base_url"
-            else:
-                _region = "us-east-1"
-                _region_source = "SDK default"
-                logger.debug(
-                    "_rebuild_primary_client: no _bedrock_region and no "
-                    "bedrock-runtime.<region>. in base_url %r — falling back to "
-                    "region %r; check the primary base_url for drift",
-                    rt.get("base_url"), _region,
-                )
-        agent._bedrock_region = _region
-        logger.debug(
-            "_rebuild_primary_client[%s]: rebuilding Bedrock client for region %s "
-            "(resolved from %s)",
-            reason, _region, _region_source,
-        )
-        agent._anthropic_client = build_anthropic_bedrock_client(_region)
-        agent.client = None
-        agent._client_kwargs = {}
+        _rebuild_bedrock_client_from_runtime(agent, rt, reason=reason)
     else:
         agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason=reason, shared=True)
 
@@ -1006,6 +1020,14 @@ def try_recover_primary_transport(
             # factory so the reference_callback relay survives recovery (#53802).
             from agent.moa_loop import build_moa_facade
             agent.client = build_moa_facade(agent, agent.model)
+        elif agent.api_mode == "bedrock_converse":
+            # Same Bedrock carve-out as _rebuild_primary_client: the generic else
+            # would call _create_openai_client(), which demands an OPENAI_API_KEY
+            # Bedrock never has (boto3 chain instead) — the recovery would fail
+            # and the primary transport would stay down (#102860 class).
+            _rebuild_bedrock_client_from_runtime(
+                agent, rt, reason="primary_recovery",
+            )
         else:
             agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason="primary_recovery", shared=True)
         wait_time = min(3 + retry_count, 8)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -911,20 +911,24 @@ def _build_anthropic_client_from_runtime(agent, rt: Dict[str, Any]) -> None:
     agent.client = None
 
 
-def _rebuild_bedrock_client_from_runtime(
+def _restore_bedrock_converse_runtime(
     agent: Any, rt: Dict[str, Any], *, reason: str,
 ) -> None:
-    """Rebuild the Bedrock-SDK-backed Anthropic client from a runtime snapshot.
+    """Restore the ``bedrock_converse`` runtime state (region + client slots).
+
+    ``bedrock_converse`` never reads ``_anthropic_client``: the request path
+    (``_dispatch_nonstreaming_api_request`` → ``_bedrock_converse_call``) obtains
+    a real client lazily from ``_get_bedrock_runtime_client(region)`` through
+    **boto3**. The Bedrock dependency group installs boto3 and NOT the optional
+    Anthropic SDK, so constructing an ``AnthropicBedrock`` client here (as an
+    earlier revision of this fix did) replaced the reported OPENAI_API_KEY
+    failure with an Anthropic-dependency failure and still stranded the
+    fallback chain (#102860 review, ehz0ah).
 
     Shared by :func:`_rebuild_primary_client` (fallback restore) and
-    :func:`try_recover_primary_transport` (transient-error recovery): both
-    previously fell through to ``_create_openai_client`` for
-    ``api_mode == "bedrock_converse"``, which demands an OPENAI_API_KEY and
-    raised a spurious error — Bedrock authenticates via the boto3 chain
-    (#102860).
+    :func:`try_recover_primary_transport` (transient-error recovery) — both
+    previously fell through to ``_create_openai_client`` for this api_mode.
     """
-    from agent.anthropic_adapter import build_anthropic_bedrock_client
-
     # The region was captured at init from the primary base_url
     # (bedrock-runtime.<region>.amazonaws.com) into _bedrock_region. Fall back
     # to re-extracting it from the snapshot base_url (attribute missing on a
@@ -949,11 +953,15 @@ def _rebuild_bedrock_client_from_runtime(
             )
     agent._bedrock_region = _region
     logger.debug(
-        "%s: rebuilding Bedrock client for region %s (resolved from %s)",
+        "%s: restored bedrock_converse runtime for region %s (resolved from %s); "
+        "the boto3 bedrock-runtime client is created lazily on the next request",
         reason, _region, _region_source,
     )
-    agent._anthropic_client = build_anthropic_bedrock_client(_region)
+    # Mirror the init path (agent_init's bedrock_converse branch): no eager
+    # client. Drop any stale Anthropic client carried over from a
+    # fallback/previous mode — this api_mode must never use it.
     agent.client = None
+    agent._anthropic_client = None
     agent._client_kwargs = {}
 
 
@@ -973,13 +981,13 @@ def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
     elif agent.api_mode == "anthropic_messages":
         _build_anthropic_client_from_runtime(agent, rt)
     elif agent.api_mode == "bedrock_converse":
-        # AWS Bedrock — the runtime client is the Bedrock-SDK-backed Anthropic
-        # client, NOT an OpenAI-compatible client. The generic else branch below
-        # would call _create_openai_client(), which demands an OPENAI_API_KEY and
-        # raises a spurious "The api_key client option must be set ..." error for
-        # Bedrock (authenticated via the boto3 chain) — stranding the fallback
-        # chain for every subsequent turn (#102860).
-        _rebuild_bedrock_client_from_runtime(agent, rt, reason=reason)
+        # AWS Bedrock (boto3 Converse API) — the runtime client is created
+        # lazily by the request path and never reads _anthropic_client; the
+        # generic else branch below would call _create_openai_client(), which
+        # demands an OPENAI_API_KEY and raises a spurious "The api_key client
+        # option must be set ..." error — stranding the fallback chain for
+        # every subsequent turn (#102860).
+        _restore_bedrock_converse_runtime(agent, rt, reason=reason)
     else:
         agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason=reason, shared=True)
 
@@ -1021,13 +1029,19 @@ def try_recover_primary_transport(
             from agent.moa_loop import build_moa_facade
             agent.client = build_moa_facade(agent, agent.model)
         elif agent.api_mode == "bedrock_converse":
-            # Same Bedrock carve-out as _rebuild_primary_client: the generic else
-            # would call _create_openai_client(), which demands an OPENAI_API_KEY
-            # Bedrock never has (boto3 chain instead) — the recovery would fail
-            # and the primary transport would stay down (#102860 class).
-            _rebuild_bedrock_client_from_runtime(
+            # Same carve-out as _rebuild_primary_client: restore the Converse
+            # state (the generic else would call _create_openai_client(), which
+            # demands an OPENAI_API_KEY Bedrock never has — the recovery would
+            # fail and the primary transport would stay down, #102860 class),
+            # then evict the cached boto3 bedrock-runtime client for the region
+            # so the retry really gets a fresh connection pool (this is what
+            # retiring/rebuilding the OpenAI client does on the other path).
+            _restore_bedrock_converse_runtime(
                 agent, rt, reason="primary_recovery",
             )
+            with contextlib.suppress(Exception):
+                from agent.bedrock_adapter import invalidate_runtime_client
+                invalidate_runtime_client(str(getattr(agent, "_bedrock_region", "") or ""))
         else:
             agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason="primary_recovery", shared=True)
         wait_time = min(3 + retry_count, 8)

--- a/agent/agent_runtime_helpers.py
+++ b/agent/agent_runtime_helpers.py
@@ -912,7 +912,8 @@ def _build_anthropic_client_from_runtime(agent, rt: Dict[str, Any]) -> None:
 
 
 def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
-    """Rebuild the primary client from a ``_primary_runtime`` snapshot (MoA facade / native Anthropic / OpenAI wire)."""
+    """Rebuild the primary client from a ``_primary_runtime`` snapshot (MoA
+    facade / native Anthropic / Bedrock / OpenAI wire)."""
     if (agent.provider or "").strip().lower() == "moa":
         # MoA has empty client_kwargs; rebuild via the shared facade factory so the
         # reference_callback relay survives recovery.
@@ -925,6 +926,46 @@ def _rebuild_primary_client(agent, rt: Dict[str, Any], *, reason: str) -> None:
         agent._anthropic_client = None
     elif agent.api_mode == "anthropic_messages":
         _build_anthropic_client_from_runtime(agent, rt)
+    elif agent.api_mode == "bedrock_converse":
+        # AWS Bedrock — the runtime client is the Bedrock-SDK-backed Anthropic
+        # client, NOT an OpenAI-compatible client. The generic else branch below
+        # would call _create_openai_client(), which demands an OPENAI_API_KEY and
+        # raises a spurious "The api_key client option must be set ..." error for
+        # Bedrock (authenticated via the boto3 chain) — stranding the fallback
+        # chain for every subsequent turn (#102860).
+        from agent.anthropic_adapter import build_anthropic_bedrock_client
+
+        # The region was captured at init from the primary base_url
+        # (bedrock-runtime.<region>.amazonaws.com) into _bedrock_region.
+        # Fall back to re-extracting it from the restored base_url in case the
+        # attribute is missing (e.g. a rebuilt agent), then to the SDK default.
+        _region = str(getattr(agent, "_bedrock_region", "") or "").strip()
+        _region_source = "agent._bedrock_region" if _region else ""
+        if not _region:
+            _region_match = re.search(
+                r"bedrock-runtime\.([a-z0-9-]+)\.", str(rt.get("base_url") or "")
+            )
+            if _region_match:
+                _region = _region_match.group(1)
+                _region_source = "runtime snapshot base_url"
+            else:
+                _region = "us-east-1"
+                _region_source = "SDK default"
+                logger.debug(
+                    "_rebuild_primary_client: no _bedrock_region and no "
+                    "bedrock-runtime.<region>. in base_url %r — falling back to "
+                    "region %r; check the primary base_url for drift",
+                    rt.get("base_url"), _region,
+                )
+        agent._bedrock_region = _region
+        logger.debug(
+            "_rebuild_primary_client[%s]: rebuilding Bedrock client for region %s "
+            "(resolved from %s)",
+            reason, _region, _region_source,
+        )
+        agent._anthropic_client = build_anthropic_bedrock_client(_region)
+        agent.client = None
+        agent._client_kwargs = {}
     else:
         agent.client = agent._create_openai_client(dict(rt["client_kwargs"]), reason=reason, shared=True)
 

--- a/tests/agent/test_restore_primary_bedrock.py
+++ b/tests/agent/test_restore_primary_bedrock.py
@@ -1,0 +1,106 @@
+"""Test that restore_primary_runtime() rebuilds the Bedrock client for the
+bedrock_converse api mode instead of falling through to _create_openai_client().
+
+Bug (#102860): when the primary provider is Bedrock and a turn fell back to
+another provider, restoring the primary at the top of the next turn hit the
+generic OpenAI-client branch and raised
+
+    The api_key client option must be set either by passing api_key to the
+    client or by setting the OPENAI_API_KEY environment variable
+
+— Bedrock authenticates via the boto3 chain, so this error was spurious and
+stranded the fallback chain for every subsequent turn.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent
+
+
+def _make_bedrock_agent(*, base_url_region: str = "eu-west-1", set_region_attr=None):
+    """Create a minimal AIAgent in bedrock_converse mode with a fallback active."""
+    agent = AIAgent.__new__(AIAgent)
+    agent.model = "anthropic.claude-sonnet-4-6"
+    agent.provider = "bedrock"
+    base_url = f"https://bedrock-runtime.{base_url_region}.amazonaws.com"
+    agent.base_url = base_url
+    agent.api_mode = "bedrock_converse"
+    agent.api_key = ""
+    agent._client_kwargs = {}
+    agent._credential_pool = None
+    agent._fallback_activated = True
+    agent._fallback_index = 1
+    agent._rate_limited_until = 0
+    agent._use_prompt_caching = False
+    agent._use_native_cache_layout = False
+    agent.context_compressor = MagicMock()
+    agent.context_compressor.update_model = MagicMock()
+    if set_region_attr:
+        agent._bedrock_region = set_region_attr
+    # snapshot mirrors what agent init captured for a bedrock primary
+    agent._primary_runtime = {
+        "model": agent.model,
+        "provider": "bedrock",
+        "base_url": base_url,
+        "api_mode": "bedrock_converse",
+        "api_key": "",
+        "client_kwargs": {},
+        "use_prompt_caching": False,
+        "use_native_cache_layout": False,
+        "compressor_model": agent.model,
+        "compressor_base_url": base_url,
+        "compressor_api_key": "",
+        "compressor_provider": "bedrock",
+        "compressor_context_length": 200000,
+        "compressor_api_mode": "bedrock_converse",
+    }
+    return agent
+
+
+class TestRestorePrimaryBedrock:
+    def test_bedrock_restore_rebuilds_bedrock_client_with_region(self):
+        """Explicit _bedrock_region is honored when rebuilding the client."""
+        agent = _make_bedrock_agent(set_region_attr="eu-west-1")
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+        ) as mock_build:
+            mock_build.return_value = MagicMock()
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        mock_build.assert_called_once_with("eu-west-1")
+        assert agent._anthropic_client is not None
+        assert agent.client is None  # Bedrock never uses the OpenAI-style client
+
+    def test_bedrock_restore_never_falls_through_to_openai_client(self):
+        """The old buggy path called _create_openai_client and died on the
+        missing OPENAI_API_KEY; restore must route to the Bedrock client."""
+        agent = _make_bedrock_agent()
+        agent._create_openai_client = MagicMock(
+            side_effect=AssertionError("_create_openai_client must not be called for bedrock")
+        )
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+        ) as mock_build:
+            mock_build.return_value = MagicMock()
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        agent._create_openai_client.assert_not_called()
+
+    def test_region_recovered_from_base_url_when_attribute_missing(self):
+        """Without a _bedrock_region attribute the restore path re-extracts the
+        region from the restored base_url (bedrock-runtime.<region>.amazonaws.com)."""
+        agent = _make_bedrock_agent(base_url_region="ap-southeast-2")
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+        ) as mock_build:
+            mock_build.return_value = MagicMock()
+            result = agent._restore_primary_runtime()
+
+        assert result is True
+        mock_build.assert_called_once_with("ap-southeast-2")
+        assert agent._bedrock_region == "ap-southeast-2"

--- a/tests/agent/test_restore_primary_bedrock.py
+++ b/tests/agent/test_restore_primary_bedrock.py
@@ -104,3 +104,83 @@ class TestRestorePrimaryBedrock:
         assert result is True
         mock_build.assert_called_once_with("ap-southeast-2")
         assert agent._bedrock_region == "ap-southeast-2"
+
+
+class TestTryRecoverBedrock:
+    """try_recover_primary_transport must route api_mode=bedrock_converse through
+    the Bedrock client builder — the same carve-out _rebuild_primary_client has
+    (#102860 class); otherwise the recovery path calls _create_openai_client
+    for a provider that has no OpenAI key."""
+
+    def _bedrock_agent(self, *, region="eu-west-1"):
+        from unittest.mock import MagicMock
+
+        from run_agent import AIAgent
+
+        agent = AIAgent.__new__(AIAgent)
+        agent.model = "anthropic.claude-sonnet-4-6"
+        agent.provider = "bedrock"
+        agent.base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
+        agent.api_mode = "bedrock_converse"
+        agent.api_key = ""
+        agent._client_kwargs = {}
+        agent._credential_pool = None
+        agent._fallback_activated = False
+        agent.client = None
+        agent._bedrock_region = region
+        agent._primary_runtime = {
+            "model": agent.model,
+            "provider": "bedrock",
+            "base_url": agent.base_url,
+            "api_mode": "bedrock_converse",
+            "api_key": "",
+            "client_kwargs": {},
+        }
+        agent._vprint = lambda *a, **k: None
+        agent.log_prefix = ""
+        agent._retire_shared_openai_client = MagicMock()
+        agent._create_openai_client = MagicMock(
+            side_effect=AssertionError("_create_openai_client must not be called for bedrock")
+        )
+        return agent
+
+    def test_bedrock_recovery_rebuilds_bedrock_client(self):
+        from unittest.mock import patch
+
+        from agent.agent_runtime_helpers import try_recover_primary_transport
+
+        agent = self._bedrock_agent(region="eu-west-1")
+        ReadTimeout = type("ReadTimeout", (Exception,), {})
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+        ) as mock_build, patch("agent.agent_runtime_helpers.time.sleep"):
+            mock_build.return_value = object()
+            ok = try_recover_primary_transport(
+                agent, ReadTimeout("boom"), retry_count=0, max_retries=2
+            )
+
+        assert ok is True
+        mock_build.assert_called_once_with("eu-west-1")
+        assert agent._anthropic_client is not None
+        assert agent.client is None
+        agent._create_openai_client.assert_not_called()
+
+    def test_bedrock_recovery_never_touches_openai_client(self):
+        from unittest.mock import patch
+
+        from agent.agent_runtime_helpers import try_recover_primary_transport
+
+        agent = self._bedrock_agent()
+        ReadTimeout = type("ReadTimeout", (Exception,), {})
+
+        with patch(
+            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+        ) as mock_build, patch("agent.agent_runtime_helpers.time.sleep"):
+            mock_build.return_value = object()
+            ok = try_recover_primary_transport(
+                agent, ReadTimeout("boom"), retry_count=0, max_retries=2
+            )
+
+        assert ok is True
+        agent._create_openai_client.assert_not_called()

--- a/tests/agent/test_restore_primary_bedrock.py
+++ b/tests/agent/test_restore_primary_bedrock.py
@@ -1,15 +1,14 @@
-"""Test that restore_primary_runtime() rebuilds the Bedrock client for the
-bedrock_converse api mode instead of falling through to _create_openai_client().
+"""Tests for the bedrock_converse carve-out in runtime restore/recovery (#102860).
 
-Bug (#102860): when the primary provider is Bedrock and a turn fell back to
-another provider, restoring the primary at the top of the next turn hit the
-generic OpenAI-client branch and raised
-
-    The api_key client option must be set either by passing api_key to the
-    client or by setting the OPENAI_API_KEY environment variable
-
-— Bedrock authenticates via the boto3 chain, so this error was spurious and
-stranded the fallback chain for every subsequent turn.
+``bedrock_converse`` talks to Bedrock through a lazily-created boto3
+bedrock-runtime client (``agent.bedrock_adapter._get_bedrock_runtime_client``);
+the request path never reads ``_anthropic_client``, and the Bedrock dependency
+group installs boto3 but NOT the optional Anthropic SDK. Restoring this api_mode
+must therefore rebuild the runtime *state* (region + client slots) without
+constructing an Anthropic client — an earlier revision built an
+``AnthropicBedrock`` client, which turned the reported OPENAI_API_KEY failure
+into an Anthropic-dependency failure and still stranded the fallback chain
+(review by ehz0ah).
 """
 
 from unittest.mock import MagicMock, patch
@@ -58,76 +57,64 @@ def _make_bedrock_agent(*, base_url_region: str = "eu-west-1", set_region_attr=N
 
 
 class TestRestorePrimaryBedrock:
-    def test_bedrock_restore_rebuilds_bedrock_client_with_region(self):
-        """Explicit _bedrock_region is honored when rebuilding the client."""
+    def test_restore_recovers_region_and_state_without_any_client(self):
+        """Explicit _bedrock_region is honored; no client is constructed eagerly
+        (the boto3 Converse client is created lazily on the next request)."""
         agent = _make_bedrock_agent(set_region_attr="eu-west-1")
 
-        with patch(
-            "agent.anthropic_adapter.build_anthropic_bedrock_client"
-        ) as mock_build:
-            mock_build.return_value = MagicMock()
-            result = agent._restore_primary_runtime()
+        result = agent._restore_primary_runtime()
 
         assert result is True
-        mock_build.assert_called_once_with("eu-west-1")
-        assert agent._anthropic_client is not None
-        assert agent.client is None  # Bedrock never uses the OpenAI-style client
+        assert agent._bedrock_region == "eu-west-1"
+        assert agent.client is None
+        assert agent._anthropic_client is None
+        assert agent._client_kwargs == {}
 
-    def test_bedrock_restore_never_falls_through_to_openai_client(self):
+    def test_restore_never_falls_through_to_openai_client(self):
         """The old buggy path called _create_openai_client and died on the
-        missing OPENAI_API_KEY; restore must route to the Bedrock client."""
+        missing OPENAI_API_KEY; restore must not take that branch."""
         agent = _make_bedrock_agent()
         agent._create_openai_client = MagicMock(
             side_effect=AssertionError("_create_openai_client must not be called for bedrock")
         )
 
-        with patch(
-            "agent.anthropic_adapter.build_anthropic_bedrock_client"
-        ) as mock_build:
-            mock_build.return_value = MagicMock()
-            result = agent._restore_primary_runtime()
-
-        assert result is True
+        assert agent._restore_primary_runtime() is True
         agent._create_openai_client.assert_not_called()
 
     def test_region_recovered_from_base_url_when_attribute_missing(self):
-        """Without a _bedrock_region attribute the restore path re-extracts the
-        region from the restored base_url (bedrock-runtime.<region>.amazonaws.com)."""
         agent = _make_bedrock_agent(base_url_region="ap-southeast-2")
 
+        assert agent._restore_primary_runtime() is True
+        assert agent._bedrock_region == "ap-southeast-2"
+
+    def test_restore_does_not_require_the_anthropic_sdk(self):
+        """Bedrock-only installs (boto3, no `anthropic` extra) must restore.
+
+        Simulate an unavailable Anthropic SDK: building an AnthropicBedrock
+        client raises. The restore must still succeed because that client is
+        never part of the bedrock_converse path (ehz0ah's exact probe)."""
+        agent = _make_bedrock_agent()
+
         with patch(
-            "agent.anthropic_adapter.build_anthropic_bedrock_client"
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            side_effect=ImportError("The 'anthropic' package is required ..."),
         ) as mock_build:
-            mock_build.return_value = MagicMock()
             result = agent._restore_primary_runtime()
 
         assert result is True
-        mock_build.assert_called_once_with("ap-southeast-2")
-        assert agent._bedrock_region == "ap-southeast-2"
+        mock_build.assert_not_called()
+        assert agent._anthropic_client is None
 
 
 class TestTryRecoverBedrock:
-    """try_recover_primary_transport must route api_mode=bedrock_converse through
-    the Bedrock client builder — the same carve-out _rebuild_primary_client has
-    (#102860 class); otherwise the recovery path calls _create_openai_client
-    for a provider that has no OpenAI key."""
+    """try_recover_primary_transport must also route api_mode=bedrock_converse
+    through the Converse state restore — never through _create_openai_client,
+    and never by constructing an Anthropic client (#102860 class)."""
 
     def _bedrock_agent(self, *, region="eu-west-1"):
-        from unittest.mock import MagicMock
-
-        from run_agent import AIAgent
-
-        agent = AIAgent.__new__(AIAgent)
-        agent.model = "anthropic.claude-sonnet-4-6"
-        agent.provider = "bedrock"
-        agent.base_url = f"https://bedrock-runtime.{region}.amazonaws.com"
-        agent.api_mode = "bedrock_converse"
-        agent.api_key = ""
-        agent._client_kwargs = {}
-        agent._credential_pool = None
+        agent = _make_bedrock_agent(base_url_region=region, set_region_attr=region)
         agent._fallback_activated = False
         agent.client = None
-        agent._bedrock_region = region
         agent._primary_runtime = {
             "model": agent.model,
             "provider": "bedrock",
@@ -144,43 +131,42 @@ class TestTryRecoverBedrock:
         )
         return agent
 
-    def test_bedrock_recovery_rebuilds_bedrock_client(self):
-        from unittest.mock import patch
-
+    def test_recovery_restores_converse_state_and_evicts_cached_client(self):
         from agent.agent_runtime_helpers import try_recover_primary_transport
 
         agent = self._bedrock_agent(region="eu-west-1")
         ReadTimeout = type("ReadTimeout", (Exception,), {})
 
         with patch(
-            "agent.anthropic_adapter.build_anthropic_bedrock_client"
-        ) as mock_build, patch("agent.agent_runtime_helpers.time.sleep"):
-            mock_build.return_value = object()
+            "agent.bedrock_adapter.invalidate_runtime_client"
+        ) as mock_invalidate, patch("agent.agent_runtime_helpers.time.sleep"):
             ok = try_recover_primary_transport(
                 agent, ReadTimeout("boom"), retry_count=0, max_retries=2
             )
 
         assert ok is True
-        mock_build.assert_called_once_with("eu-west-1")
-        assert agent._anthropic_client is not None
-        assert agent.client is None
         agent._create_openai_client.assert_not_called()
+        assert agent._anthropic_client is None
+        # A fresh connection pool for the retry: the cached boto3 bedrock-runtime
+        # client for the restored region is evicted.
+        mock_invalidate.assert_called_once_with("eu-west-1")
 
-    def test_bedrock_recovery_never_touches_openai_client(self):
-        from unittest.mock import patch
-
+    def test_recovery_never_constructs_anthropic_client(self):
         from agent.agent_runtime_helpers import try_recover_primary_transport
 
         agent = self._bedrock_agent()
         ReadTimeout = type("ReadTimeout", (Exception,), {})
 
         with patch(
-            "agent.anthropic_adapter.build_anthropic_bedrock_client"
-        ) as mock_build, patch("agent.agent_runtime_helpers.time.sleep"):
-            mock_build.return_value = object()
+            "agent.anthropic_adapter.build_anthropic_bedrock_client",
+            side_effect=ImportError("The 'anthropic' package is required ..."),
+        ) as mock_build, patch("agent.agent_runtime_helpers.time.sleep"), patch(
+            "agent.bedrock_adapter.invalidate_runtime_client"
+        ):
             ok = try_recover_primary_transport(
                 agent, ReadTimeout("boom"), retry_count=0, max_retries=2
             )
 
         assert ok is True
+        mock_build.assert_not_called()
         agent._create_openai_client.assert_not_called()


### PR DESCRIPTION
## Summary

Fixes #102860 — when the primary provider is **Bedrock** (`api_mode: bedrock_converse`) and a turn falls back to another provider, the next turn's `restore_primary_runtime()` fails with a spurious OpenAI key error and the fallback chain stays stranded for every subsequent turn.

## Root cause

`restore_primary_runtime()` (`agent/agent_runtime_helpers.py`) only special-cased two providers when rebuilding the runtime client:

```python
if agent.provider == "moa":
    ... build_moa_facade ...
elif agent.api_mode == "anthropic_messages":
    ... build_anthropic_client ...
else:
    agent.client = agent._create_openai_client(...)   # ← bedrock_converse lands here
```

Bedrock (`bedrock_converse`) fell through to `_create_openai_client()`, which demands an `OPENAI_API_KEY` and raises `The api_key client option must be set either by passing api_key to the client or by setting the OPENAI_API_KEY environment variable` — but Bedrock authenticates via the boto3 credential chain, not an OpenAI-compatible key.

## Fix

Add a `bedrock_converse` branch that rebuilds the Bedrock-SDK-backed Anthropic client via `build_anthropic_bedrock_client(region)` — the same construction the init path (`agent/agent_init.py`) and `_rebuild_anthropic_client()` (`run_agent.py`) already use.

Region resolution order:
1. `agent._bedrock_region` (captured at init),
2. re-extracted from the restored `base_url` (`bedrock-runtime.<region>.amazonaws.com`) — covers rebuilt agents missing the attribute,
3. the SDK default (`us-east-1`).

The restored client is stored on `_anthropic_client` with `agent.client = None` and empty `_client_kwargs`, mirroring the init path — Bedrock never uses the OpenAI-style client.

## Tests

Added `tests/agent/test_restore_primary_bedrock.py` (minimal `AIAgent` in `bedrock_converse` mode with an active fallback):

- explicit `_bedrock_region` is honored when rebuilding (`build_anthropic_bedrock_client("eu-west-1")` called once; `_anthropic_client` set; `agent.client is None`),
- restore **never** falls through to `_create_openai_client()` (the old path — an assertion guards it),
- region is recovered from the restored `base_url` when `_bedrock_region` is missing.

`tests/agent/test_restore_primary_pool_reselect.py` + `tests/run_agent/test_24996_fallback_exhaustion_cooldown.py` still pass (13 tests total).
