### PR TITLE
fix(delegate): guardrail-halted children are not reported as completed

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2233,5 +2233,86 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIn("missing-acp-binary", str(ctx.exception))
 
 
+class TestGuardrailHaltClassification(unittest.TestCase):
+    """#102694: a child stopped by a hard tool guardrail must NOT surface as
+    status="completed" — the child's controlled closing message is a stop, not
+    a successful finish. Previously the summary-presence heuristic labeled any
+    non-empty final_response as completed, so coordinators that consume the
+    structured status accepted guardrail-aborted delegations as success."""
+
+    def test_guardrail_halt_reported_as_failed_with_metadata(self):
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            # The child still produced a controlled final message — this is
+            # exactly the shape that used to be mislabeled "completed".
+            mock_child.run_conversation.return_value = {
+                "final_response": (
+                    "Stopping: web_search was invoked 12 times in a loop; "
+                    "halting to avoid runaway costs."
+                ),
+                "completed": False,
+                "interrupted": False,
+                "api_calls": 4,
+                "messages": [],
+                "guardrail": {
+                    "action": "halt",
+                    "code": "loop_web_search_cap",
+                    "message": "web_search invoked 12 times in a loop; halting",
+                    "tool_name": "web_search",
+                    "count": 12,
+                    "signature": {"tool_name": "web_search", "args_hash": "a1b2c3"},
+                },
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="guardrail halt", parent_agent=parent))
+            entry = result["results"][0]
+
+            self.assertEqual(entry["status"], "failed")
+            self.assertEqual(entry["exit_reason"], "guardrail_halt")
+            self.assertFalse(entry.get("truncated"))
+            # The public guardrail code is preserved (hashes only — no raw
+            # tool argument values leak through).
+            guardrail = entry.get("guardrail")
+            self.assertIsNotNone(guardrail)
+            self.assertEqual(guardrail.get("action"), "halt")
+            self.assertEqual(guardrail.get("code"), "loop_web_search_cap")
+            self.assertEqual(guardrail.get("signature", {}).get("args_hash"), "a1b2c3")
+            self.assertNotIn("arguments", json.dumps(guardrail))
+            # The error names the public guardrail code.
+            self.assertIn("loop_web_search_cap", entry.get("error", ""))
+            self.assertIn("guardrail", entry.get("error", "").lower())
+
+    def test_normal_completion_still_completed(self):
+        """Guardrail detection must not change classifications for clean runs."""
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.model = "claude-sonnet-4-6"
+            mock_child.session_prompt_tokens = 0
+            mock_child.session_completion_tokens = 0
+            mock_child.run_conversation.return_value = {
+                "final_response": "done",
+                "completed": True,
+                "interrupted": False,
+                "api_calls": 2,
+                "messages": [],
+            }
+            MockAgent.return_value = mock_child
+
+            result = json.loads(delegate_task(goal="clean run", parent_agent=parent))
+            entry = result["results"][0]
+            self.assertEqual(entry["status"], "completed")
+            self.assertEqual(entry["exit_reason"], "completed")
+            self.assertNotIn("guardrail", entry)
+
+
 if __name__ == "__main__":
     unittest.main()
+

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2634,16 +2634,20 @@ def _run_single_child(
           hit its iteration budget; see ``exit_reason``).
         * ``"interrupted"`` — the child was interrupted (``interrupted=True``).
         * ``"failed"``    — a structured failure (``failed=True`` or a non-empty
-          ``error``) or a summary-less/invalid terminal state.
+          ``error``) or a summary-less/invalid terminal state. A hard tool
+          guardrail halt is also classified here: the task was stopped, not
+          completed (#102694).
 
     ``exit_reason`` ∈ {``"completed"``, ``"max_iterations"``, ``"interrupted"``,
-    ``"error"``}:
+    ``"error"``, ``"guardrail_halt"``}:
         * ``"completed"``       — normal finish.
         * ``"max_iterations"``  — genuine per-child iteration-budget exhaustion
           (``completed=False`` with no failure fields).
         * ``"interrupted"``     — interrupted by the parent.
         * ``"error"``           — provider rejection / terminal failure; NOT
           budget exhaustion (this is the case #97655 fixed).
+        * ``"guardrail_halt"``  — a hard tool guardrail (e.g.
+          ``loop_web_search_cap``) stopped the child mid-task (#102694).
 
     ``truncated`` is derived as ``exit_reason == "max_iterations"`` only, so the
     parent-visible truncation flag stays truthful for all of the above.
@@ -3293,8 +3297,26 @@ def _run_single_child(
         # it instead of silently accepting zero-content "success".
         _empty_sentinel = summary.strip() == "(empty)"
 
+        # A hard tool guardrail halt (e.g. loop_web_search_cap cutting a runaway
+        # loop) is NOT completion: the child stopped because a guardrail decided
+        # the task must not continue. Detect it BEFORE the summary-presence
+        # heuristic, which would otherwise label the child's controlled closing
+        # message (its ``final_response``) as status="completed" (#102694). Only
+        # real halts reach here — warn/allow decisions never set the child's
+        # halt decision, so result["guardrail"] is absent for them.
+        _guardrail = result.get("guardrail")
+        _guardrail_halt = (
+            isinstance(_guardrail, dict)
+            and _guardrail.get("action") == "halt"
+        )
+
         if interrupted:
             status = "interrupted"
+        elif _guardrail_halt:
+            # Hard guardrail stop must never surface as successful completion
+            # to coordinators that consume the structured status. The child
+            # produced a controlled message, but the task was aborted.
+            status = "failed"
         elif result.get("failed") or result.get("error"):
             # A structured failure (provider rejection / terminal exception)
             # must WIN over the summary-presence heuristic below. The child's
@@ -3364,6 +3386,8 @@ def _run_single_child(
         # Determine exit reason
         if interrupted:
             exit_reason = "interrupted"
+        elif _guardrail_halt:
+            exit_reason = "guardrail_halt"
         elif result.get("failed") or result.get("error"):
             # Provider rejection / terminal failure. Do NOT report this as
             # iteration-budget exhaustion — "max_iterations" is only truthful
@@ -3382,7 +3406,8 @@ def _run_single_child(
 
         # --- result entry contract (see _run_single_child docstring) ---
         # status ∈ {completed, interrupted, failed}
-        # exit_reason ∈ {completed, max_iterations, interrupted, error}
+        # exit_reason ∈ {completed, max_iterations, interrupted, error,
+        #                 guardrail_halt}
         # truncated is exactly (exit_reason == "max_iterations").
         entry: Dict[str, Any] = {
             "task_index": task_index,
@@ -3438,7 +3463,17 @@ def _run_single_child(
             else "unknown"
         )
         if status == "failed":
-            if _schema_valid is False and summary and not _empty_sentinel:
+            if _guardrail_halt:
+                # A hard guardrail stop is a controlled abort, not a provider
+                # or transport failure — name the public guardrail code/message
+                # so coordinators can tell "stopped by policy" from "broke".
+                _gr_code = _guardrail.get("code") or "halt"
+                _gr_message = _guardrail.get("message") or ""
+                entry["error"] = (
+                    f"Subagent halted by tool guardrail ({_gr_code})"
+                    + (f": {_gr_message}" if _gr_message else "")
+                )
+            elif _schema_valid is False and summary and not _empty_sentinel:
                 # The child DID respond — the response just violates the
                 # declared contract. Name that instead of the generic
                 # "no response" error; schema_errors (below) hold the
@@ -3460,6 +3495,13 @@ def _run_single_child(
             _failure_reason = result.get("failure_reason")
             if isinstance(_failure_reason, str) and _failure_reason:
                 entry["failure_reason"] = _failure_reason
+
+        # Preserve the public guardrail metadata (action/code/message/
+        # tool_name/count, plus signature hashes only — never raw argument
+        # values) so orchestrators can inspect why a delegation was halted
+        # without parsing prose (#102694).
+        if isinstance(_guardrail, dict):
+            entry["guardrail"] = _guardrail
 
         # T1-24: schema-validation outcome — emitted ONLY when a schema was
         # requested, so legacy (schema-less) payloads keep their exact shape.


### PR DESCRIPTION
## Summary

Fixes #102694 — a delegated child that is stopped by a **hard tool guardrail** (e.g. `loop_web_search_cap` cutting a runaway search loop) was reported as `status="completed"`, even though the task did not complete.

## Root cause

When a hard guardrail halts the child, `agent/conversation_loop.py` records `turn_exit_reason = "guardrail_halt"` and `agent/turn_finalizer.py` exposes the decision as `result["guardrail"]` (the `ToolGuardrailDecision.to_metadata()` dict: `action`/`code`/`message`/`tool_name`/`count` + signature **hashes only**).

`tools/delegate_tool.py::_run_single_child` never inspected `result["guardrail"]`. Its summary-presence heuristic classified any non-empty `final_response` — including the child's controlled closing message after a guardrail stop — as `status="completed"`, `exit_reason="completed"`. Coordinators that consume the structured status accepted guardrail-aborted delegations as success.

## Fix

In `_run_single_child`, detect a returned hard guardrail decision (`action == "halt"`) **before** the summary-presence heuristic:

- `status` → `"failed"` (never successful completion),
- `exit_reason` → `"guardrail_halt"` (distinct from provider errors and budget exhaustion),
- the entry's `error` names the public guardrail code (e.g. `Subagent halted by tool guardrail (loop_web_search_cap): ...`),
- the guardrail metadata is preserved on the entry under `guardrail` — hashes only, never raw tool argument values.

Warn/allow decisions never set the child's halt decision, so non-halting guardrails are unaffected. Docstring and contract comment updated (`exit_reason` now ∈ {`completed`, `max_iterations`, `interrupted`, `error`, `guardrail_halt`}).

## Tests

Added `TestGuardrailHaltClassification` to `tests/tools/test_delegate.py`:

- guardrail-halted child (controlled final message + `result["guardrail"]`) → `status="failed"`, `exit_reason="guardrail_halt"`, `truncated=False`, error names the code, metadata preserved without raw args,
- clean completion still classified `completed` (no `guardrail` key).

Full `tests/tools/test_delegate.py` passes (83 tests).
