### PR TITLE
fix(auth): pair the staging Portal with the staging inference host in the network allowlist

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -3103,8 +3103,47 @@ _ALLOWED_NOUS_INFERENCE_HOSTS: FrozenSet[str] = frozenset({
     "inference-api.nousresearch.com",
 })
 
+# Non-production Portal → the inference host it legitimately pairs with. A
+# token minted by the staging Portal is meant to be spent at the staging
+# inference gateway; the staging Portal's refresh response says so, and until
+# this pairing existed that value was rejected as "not in allowlist" and
+# healed to PROD — so a `hermes -p staging` session silently sent its
+# staging-issued JWT to the production gateway (which 401s it) unless the
+# operator ALSO set NOUS_INFERENCE_BASE_URL or `model.base_url`. The pairing
+# is keyed on the Portal host so the original protection stays intact: a
+# PROD-portal session that finds a staging inference URL in its state (the
+# 2026-07 poisoned-auth.json incident) is still rejected and healed.
+_NOUS_PORTAL_PAIRED_INFERENCE_HOSTS: Dict[str, FrozenSet[str]] = {
+    "portal.staging-nousresearch.com": frozenset({
+        "stg-inference-api.nousresearch.com",
+    }),
+}
 
-def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[str]:
+
+def _allowed_nous_inference_hosts_for_portal(
+    portal_base_url: Optional[str],
+) -> FrozenSet[str]:
+    """Allowlisted inference hosts for a token issued by *portal_base_url*.
+
+    Always includes the production host; adds the paired non-production host
+    only when the Portal itself is that environment's Portal.
+    """
+    if not isinstance(portal_base_url, str) or not portal_base_url.strip():
+        return _ALLOWED_NOUS_INFERENCE_HOSTS
+    try:
+        portal_host = urlparse(portal_base_url.strip()).hostname
+    except Exception:
+        return _ALLOWED_NOUS_INFERENCE_HOSTS
+    paired = _NOUS_PORTAL_PAIRED_INFERENCE_HOSTS.get(portal_host or "")
+    if not paired:
+        return _ALLOWED_NOUS_INFERENCE_HOSTS
+    return _ALLOWED_NOUS_INFERENCE_HOSTS | paired
+
+
+def _validate_nous_inference_url_from_network(
+    url: Optional[str],
+    portal_base_url: Optional[str] = None,
+) -> Optional[str]:
     """Validate a Portal-returned inference URL against the host allowlist.
 
     Returns ``url`` (normalised by stripping trailing slashes) if it's a
@@ -3141,7 +3180,7 @@ def _validate_nous_inference_url_from_network(url: Optional[str]) -> Optional[st
             parsed.scheme,
         )
         return None
-    if parsed.hostname not in _ALLOWED_NOUS_INFERENCE_HOSTS:
+    if parsed.hostname not in _allowed_nous_inference_hosts_for_portal(portal_base_url):
         logger.warning(
             "nous: refusing inference URL host %r from Portal response "
             "(not in allowlist); falling back to default",
@@ -6948,7 +6987,9 @@ def refresh_nous_oauth_pure(
             # was poisoned before the allowlist existed keeps re-validating to
             # None on every refresh and silently re-uses the dead endpoint —
             # the "falling back to default" warning never actually takes effect.
-            refreshed_url = _validate_nous_inference_url_from_network(refreshed.get("inference_base_url"))
+            refreshed_url = _validate_nous_inference_url_from_network(
+                refreshed.get("inference_base_url"), state.get("portal_base_url")
+            )
             state["inference_base_url"] = refreshed_url or DEFAULT_NOUS_INFERENCE_URL
             state["obtained_at"] = now.isoformat()
             state["expires_in"] = access_ttl
@@ -7157,7 +7198,8 @@ def resolve_nous_runtime_credentials(
             # The env override is runtime-only and must never be persisted.
             stored_inference_url = (
                 _validate_nous_inference_url_from_network(
-                    _optional_base_url(state.get("inference_base_url"))
+                    _optional_base_url(state.get("inference_base_url")),
+                    portal_url,
                 )
                 or DEFAULT_NOUS_INFERENCE_URL
             )
@@ -7343,7 +7385,9 @@ def resolve_nous_runtime_credentials(
                         # persisted to auth.json below. The NOUS_INFERENCE_BASE_URL
                         # env override is layered on for the client/return value
                         # only (see below) — it is never persisted.
-                        refreshed_url = _validate_nous_inference_url_from_network(refreshed.get("inference_base_url"))
+                        refreshed_url = _validate_nous_inference_url_from_network(
+                            refreshed.get("inference_base_url"), portal_base_url
+                        )
                         stored_inference_base_url = refreshed_url or DEFAULT_NOUS_INFERENCE_URL
                         inference_base_url = (
                             _nous_inference_env_override() or stored_inference_base_url
@@ -7413,6 +7457,10 @@ def resolve_nous_runtime_credentials(
     return {
         "provider": "nous",
         "base_url": inference_base_url,
+        # The Portal this token was issued by. Consumers that re-validate
+        # ``base_url`` (proxy adapter) need it to apply the same
+        # portal→inference-host pairing as the source layer.
+        "portal_base_url": portal_base_url,
         "api_key": api_key,
         "key_id": state.get("agent_key_id"),
         "expires_at": expires_at,

--- a/hermes_cli/proxy/adapters/nous_portal.py
+++ b/hermes_cli/proxy/adapters/nous_portal.py
@@ -145,7 +145,9 @@ class NousPortalAdapter(UpstreamAdapter):
             # source-layer bypass).
             base_url = (
                 _nous_inference_env_override()
-                or _validate_nous_inference_url_from_network(refreshed.get("base_url"))
+                or _validate_nous_inference_url_from_network(
+                    refreshed.get("base_url"), refreshed.get("portal_base_url")
+                )
                 or DEFAULT_NOUS_INFERENCE_URL
             )
             base_url = base_url.rstrip("/")

--- a/tests/hermes_cli/test_nous_inference_url_validation.py
+++ b/tests/hermes_cli/test_nous_inference_url_validation.py
@@ -21,6 +21,8 @@ These tests verify:
 
 from __future__ import annotations
 
+import re
+
 import logging
 
 from hermes_cli.auth import (
@@ -100,8 +102,15 @@ class TestCallSiteWiring:
         drops, someone removed protection; if it grows, audit the new
         site to be sure validation is appropriate."""
         source = self._read_auth_source()
-        refresh_count = source.count(
-            '_validate_nous_inference_url_from_network(refreshed.get("inference_base_url"))'
+        # Both refresh sites pass the issuing Portal so the validator can apply
+        # the portal→inference-host pairing (staging portal ⇒ staging gateway).
+        refresh_count = len(
+            re.findall(
+                r'_validate_nous_inference_url_from_network\(\s*'
+                r'refreshed\.get\("inference_base_url"\),\s*'
+                r'(?:portal_base_url|state\.get\("portal_base_url"\))\s*\)',
+                source,
+            )
         )
         mint_count = source.count(
             '_validate_nous_inference_url_from_network(mint_payload.get("inference_base_url"))'

--- a/tests/hermes_cli/test_nous_portal_inference_pairing.py
+++ b/tests/hermes_cli/test_nous_portal_inference_pairing.py
@@ -1,0 +1,133 @@
+"""Nous Portal → inference-host pairing for non-production Portals.
+
+A token minted by the STAGING Portal (``portal.staging-nousresearch.com``) is
+meant to be spent at the STAGING inference gateway
+(``stg-inference-api.nousresearch.com``), and the staging Portal's refresh
+response says exactly that. Before this pairing, that Portal-returned URL was
+rejected by ``_ALLOWED_NOUS_INFERENCE_HOSTS`` (prod-only) and healed to the
+PRODUCTION default — so a plain ``hermes -p staging`` session (portal env
+override set, per the Confluence runbook) shipped its staging-issued JWT to
+the prod gateway, which 401s it, unless the operator ALSO set
+``NOUS_INFERENCE_BASE_URL`` or ``model.base_url``. ``hermes -p staging status``
+then reported ``Inference: https://inference-api.nousresearch.com/v1`` even
+with the documented env in place.
+
+The pairing is keyed on the PORTAL host so the original protection (#30611,
+#49735) is unchanged for prod sessions: a prod-portal state carrying a staging
+inference URL is still a poisoned value and is still healed.
+"""
+
+from __future__ import annotations
+
+import hermes_cli.auth as auth
+from hermes_cli.auth import (
+    DEFAULT_NOUS_INFERENCE_URL,
+    DEFAULT_NOUS_PORTAL_URL,
+    _ALLOWED_NOUS_INFERENCE_HOSTS,
+    _allowed_nous_inference_hosts_for_portal,
+    _validate_nous_inference_url_from_network,
+)
+
+STAGING_PORTAL = "https://portal.staging-nousresearch.com"
+STAGING_INFERENCE = "https://stg-inference-api.nousresearch.com/v1"
+
+
+class TestAllowedHostsForPortal:
+    def test_prod_portal_is_prod_only(self):
+        assert (
+            _allowed_nous_inference_hosts_for_portal(DEFAULT_NOUS_PORTAL_URL)
+            == _ALLOWED_NOUS_INFERENCE_HOSTS
+        )
+
+    def test_missing_portal_is_prod_only(self):
+        assert _allowed_nous_inference_hosts_for_portal(None) == _ALLOWED_NOUS_INFERENCE_HOSTS
+        assert _allowed_nous_inference_hosts_for_portal("") == _ALLOWED_NOUS_INFERENCE_HOSTS
+
+    def test_staging_portal_adds_staging_inference_host_only(self):
+        hosts = _allowed_nous_inference_hosts_for_portal(STAGING_PORTAL)
+        assert "stg-inference-api.nousresearch.com" in hosts
+        assert "inference-api.nousresearch.com" in hosts
+        assert hosts - _ALLOWED_NOUS_INFERENCE_HOSTS == {"stg-inference-api.nousresearch.com"}
+
+    def test_unknown_portal_host_gets_no_extra(self):
+        assert (
+            _allowed_nous_inference_hosts_for_portal("https://portal.evil.example")
+            == _ALLOWED_NOUS_INFERENCE_HOSTS
+        )
+
+
+class TestValidatorPairing:
+    def test_staging_url_accepted_for_staging_portal(self):
+        assert (
+            _validate_nous_inference_url_from_network(STAGING_INFERENCE, STAGING_PORTAL)
+            == STAGING_INFERENCE
+        )
+
+    def test_staging_url_still_rejected_for_prod_portal(self):
+        """The 2026-07 poisoned-auth.json case: prod session, staging URL."""
+        assert (
+            _validate_nous_inference_url_from_network(STAGING_INFERENCE, DEFAULT_NOUS_PORTAL_URL)
+            is None
+        )
+
+    def test_staging_url_still_rejected_when_portal_unknown(self):
+        """Callers that pass no portal keep the strict prod-only behaviour."""
+        assert _validate_nous_inference_url_from_network(STAGING_INFERENCE) is None
+
+    def test_prod_url_accepted_for_staging_portal(self):
+        assert (
+            _validate_nous_inference_url_from_network(DEFAULT_NOUS_INFERENCE_URL, STAGING_PORTAL)
+            == DEFAULT_NOUS_INFERENCE_URL
+        )
+
+    def test_pairing_does_not_open_other_hosts(self):
+        assert (
+            _validate_nous_inference_url_from_network(
+                "https://stg-inference-api.evil.example/v1", STAGING_PORTAL
+            )
+            is None
+        )
+
+
+class TestRefreshKeepsStagingPairing:
+    """End-to-end through ``refresh_nous_oauth_from_state``: a staging-portal
+    state refreshed against the staging Portal keeps the staging inference
+    URL it is handed, instead of healing it to prod."""
+
+    def _patch(self, monkeypatch, returned_inference_url):
+        monkeypatch.setattr(auth, "_nous_invoke_jwt_status", lambda *a, **k: "needs_refresh")
+        monkeypatch.setattr(
+            auth,
+            "_refresh_access_token",
+            lambda **k: {
+                "access_token": "newtok",
+                "refresh_token": "newrtok",
+                "expires_in": 3600,
+                "inference_base_url": returned_inference_url,
+            },
+        )
+        monkeypatch.setattr(auth, "_assert_nous_inference_jwt_usable", lambda *a, **k: None)
+        monkeypatch.setattr(auth, "_select_nous_invoke_jwt", lambda *a, **k: None)
+
+    def _state(self, portal):
+        return {
+            "access_token": "tok",
+            "refresh_token": "rtok",
+            "client_id": "hermes-cli",
+            "portal_base_url": portal,
+            "inference_base_url": DEFAULT_NOUS_INFERENCE_URL,
+        }
+
+    def test_staging_portal_keeps_staging_inference_url(self, monkeypatch):
+        self._patch(monkeypatch, STAGING_INFERENCE)
+        result = auth.refresh_nous_oauth_from_state(
+            self._state(STAGING_PORTAL), force_refresh=True
+        )
+        assert result["inference_base_url"] == STAGING_INFERENCE
+
+    def test_prod_portal_still_heals_staging_inference_url(self, monkeypatch):
+        self._patch(monkeypatch, STAGING_INFERENCE)
+        result = auth.refresh_nous_oauth_from_state(
+            self._state(DEFAULT_NOUS_PORTAL_URL), force_refresh=True
+        )
+        assert result["inference_base_url"] == DEFAULT_NOUS_INFERENCE_URL


### PR DESCRIPTION
## Summary

`_ALLOWED_NOUS_INFERENCE_HOSTS` (the allowlist applied to inference URLs the Nous Portal returns) was production-only. When the **staging** Portal returns its own inference gateway, `stg-inference-api.nousresearch.com`, the validator rejected it as "not in allowlist" and healed the stored URL to the **production** default — so a staging-issued JWT was sent to the prod gateway (401).

This PR makes the allowlist portal-keyed: `_validate_nous_inference_url_from_network(url, portal_base_url)` admits `stg-inference-api.nousresearch.com` only when the issuing Portal is `portal.staging-nousresearch.com`. Prod-portal sessions are unchanged.

## Who / when / why

Found 2026-09-04 while following the internal runbook "Setting up Hermes to test GMI" (staging profile with `HERMES_PORTAL_BASE_URL=https://portal.staging-nousresearch.com` and `NOUS_INFERENCE_BASE_URL=…stg…` in the profile `.env`). The runbook's check — `hermes -p staging status | grep Inference` should show the staging URL — fails on current main: it prints `https://inference-api.nousresearch.com/v1`. The profile's `agent.log` from 2026-07-20 carries the same warning:

```
nous: refusing inference URL host 'stg-inference-api.nousresearch.com' from Portal response (not in allowlist); falling back to default
```

Staging requests only worked because that profile also had `model.base_url` pointed at staging in `config.yaml` — a crutch, not the documented setup.

## Why not just add the host to the flat set

The allowlist exists to stop a poisoned `auth.json` / MITM'd refresh response from redirecting a **prod** session's bearer to another host (#30611, #49735; the 2026-07 incident was exactly a prod session carrying a stale staging URL). A flat `{prod, staging}` set would make that stale-staging-URL case valid again. Keying on the issuing Portal keeps the protection: prod portal ⇒ prod host only; staging portal ⇒ prod or staging host.

## What

- `hermes_cli/auth.py`
  - `_NOUS_PORTAL_PAIRED_INFERENCE_HOSTS` (`portal.staging-nousresearch.com` → `{stg-inference-api.nousresearch.com}`) and `_allowed_nous_inference_hosts_for_portal(portal_base_url)`.
  - `_validate_nous_inference_url_from_network(url, portal_base_url=None)` — default keeps the strict prod-only behaviour for any caller that does not pass a portal.
  - Both refresh call sites pass the portal the token was refreshed against; the shared-merge revalidation passes the resolved portal.
  - `resolve_nous_runtime_credentials()` now also returns `portal_base_url` so downstream re-validation can pair.
- `hermes_cli/proxy/adapters/nous_portal.py` — defense-in-depth re-validation passes `portal_base_url` (otherwise it would undo the fix at the forward boundary).
- `tests/hermes_cli/test_nous_portal_inference_pairing.py` (+11): host sets per portal; staging URL accepted for staging portal, still rejected for prod portal and when portal is unknown; unrelated `stg-inference-api.evil.example` still rejected; end-to-end `refresh_nous_oauth_from_state` keeps the staging URL for a staging-portal state and still heals it for a prod-portal state.
- `tests/hermes_cli/test_nous_inference_url_validation.py` — call-site wiring assertion updated to the new two-arg shape (still requires exactly 2 refresh sites).

## Tests

- `ruff` clean on touched files.
- `pytest tests/hermes_cli/test_nous_portal_inference_pairing.py test_nous_inference_url_validation.py test_nous_portal_staging_allowlist.py test_sale_pricing.py -o addopts=` → 32 passed.
- `pytest tests -k "nous_portal or proxy_adapter or nous_adapter"` → 49 passed, 3 skipped.
- Mutation: disabling the pairing entry fails 3 of the new tests.
- Pre-existing failures on origin/main unrelated to this change (env-dependent, reproduce on pristine main): `test_runtime_provider_resolution.py::test_qwen_oauth_auto_fallthrough_on_auth_failure`, `test_auth_commands.py::test_seed_from_singletons_respects_hermes_pkce_suppression`.

Not changed: `NOUS_INFERENCE_BASE_URL` / `HERMES_PORTAL_BASE_URL` env overrides keep bypassing the allowlist as before (documented, operator-trusted). `_NOUS_PORTAL_ALLOWED_HOSTS` is untouched — the staging portal is already reachable via the env override path.
