### PR TITLE
fix(agent): render per-op previews for batch skill_manage reviews

### DIFF
--- a/agent/background_review.py
+++ b/agent/background_review.py
@@ -865,7 +865,57 @@ def summarize_background_review_actions(
                 ops_raw if isinstance(ops_raw, list) else []
             )
             max_preview = 120
-            if is_skill:
+            # Batch payloads (``operations=[...]``) carry their action per
+            # op, not at the top level — render each op the same way the
+            # memory batch arm below does, so a skill batch never falls
+            # through to the empty-action "Skill " line (#102853).
+            if is_skill and operations:
+                rendered = 0
+                for op in operations:
+                    # Legacy codepaths may serialize an entry as a bare
+                    # string/None — skip items without actionable fields.
+                    if not isinstance(op, dict):
+                        continue
+                    op_act = op.get("action", "")
+                    op_name = op.get("name") or skill_name
+                    op_content = op.get("content") or op.get("file_content") or ""
+                    op_old = op.get("old_string") or op.get("old_text") or ""
+                    op_new = op.get("new_string") or ""
+                    if op_act == "patch" and (op_old or op_new):
+                        old_preview = op_old[:80].replace("\n", " ") + (
+                            "…" if len(op_old) > 80 else ""
+                        )
+                        new_preview = op_new[:80].replace("\n", " ") + (
+                            "…" if len(op_new) > 80 else ""
+                        )
+                        actions.append(
+                            f"📝 Skill '{op_name}' patched: "
+                            f"\"{old_preview}\" → \"{new_preview}\""
+                        )
+                        rendered += 1
+                    elif op_act == "create" and op_content:
+                        preview = op_content[:max_preview] + (
+                            "…" if len(op_content) > max_preview else ""
+                        )
+                        actions.append(f"📝 Skill '{op_name}' created: {preview}")
+                        rendered += 1
+                    elif op_act == "write_file" and op_content:
+                        preview = op_content[:max_preview] + (
+                            "…" if len(op_content) > max_preview else ""
+                        )
+                        actions.append(f"📝 Skill '{op_name}' wrote file: {preview}")
+                        rendered += 1
+                    elif op_act == "remove_file":
+                        actions.append(f"📝 Skill '{op_name}' removed a file")
+                        rendered += 1
+                if not rendered:
+                    # Batch whose ops carried no previewable fields — fall
+                    # back to the tool's own message instead of an empty
+                    # action label.
+                    actions.append(
+                        f"📝 {message}" if message else "Skill batch applied"
+                    )
+            elif is_skill:
                 # ``_change`` is a free-form dict the skill tool leaves in
                 # the response.  Older / wrapper MCP backends return it
                 # as a list, an int, or a JSON-shaped scalar — normalize

--- a/tests/run_agent/test_background_review_summary.py
+++ b/tests/run_agent/test_background_review_summary.py
@@ -7,6 +7,7 @@ history before the review started (e.g. an earlier "Cron job '...' created.").
 
 import json
 
+from agent.background_review import summarize_background_review_actions
 from run_agent import AIAgent
 
 
@@ -92,6 +93,62 @@ def test_empty_inputs():
     assert _summarize(None, None) == []
 
 
+
+
+def _skill_batch_review():
+    """Batch skill_manage call: operations list, no top-level action."""
+    return [
+        {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": "call_skill_batch",
+                    "function": {
+                        "name": "skill_manage",
+                        "arguments": json.dumps(
+                            {
+                                "operations": [
+                                    {"action": "create", "name": "alpha", "content": "A new skill body"},
+                                    {
+                                        "action": "patch",
+                                        "name": "beta",
+                                        "old_string": "old text",
+                                        "new_string": "new text",
+                                    },
+                                    {"action": "write_file", "name": "alpha", "file_path": "references/x.md", "file_content": "data"},
+                                ]
+                            }
+                        ),
+                    },
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "tool_call_id": "call_skill_batch",
+            "content": json.dumps(
+                {
+                    "success": True,
+                    "message": "batch(3 ops: create, patch, write_file) on alpha, beta",
+                }
+            ),
+        },
+    ]
+
+
+def test_skill_batch_renders_per_op_lines():
+    """Issue #102853: a batch skill_manage call must render per-op previews,
+    never the empty-action "Skill " line."""
+    verbose = summarize_background_review_actions(
+        _skill_batch_review(), [], notification_mode="verbose"
+    )
+    assert verbose, "expected at least one rendered line"
+    joined = "\n".join(verbose)
+    assert "Skill 'alpha' created" in joined
+    assert "Skill 'beta' patched" in joined
+    assert "Skill 'alpha' wrote file" in joined
+    assert not any(line == "Skill " or line.rstrip() == "Skill" for line in verbose), verbose
+    assert not any("Skill ?" in line for line in verbose), verbose
 
 
 def test_removed_or_replaced_relabels_by_target():


### PR DESCRIPTION
## Summary

The verbose self-improvement review rendered **"Skill "** (empty action) for batch `skill_manage` calls: the `is_skill` chain ran before the `elif operations:` arm, and a batch payload has no top-level `action`, so every specific sub-branch failed its guard and the final `else` emitted `"Skill " + ""` (surfaced in Desktop as `Self-improvement review: Skill ?`).

The fix hoists batch handling ahead of the single-op chain: `if is_skill and operations:` now renders each op — patch diffs (old → new previews), create/write_file content previews, remove_file lines — mirroring the memory-batch arm. Ops with no previewable fields fall back to the tool's own message instead of an empty-action label. Single-op rendering is unchanged.

Fixes #102853

## Testing

- New `test_skill_batch_renders_per_op_lines` covers the batch shape (create + patch + write_file) and asserts no `Skill `/`Skill ?` line can appear
- Existing suites pass: `tests/run_agent/test_background_review_summary.py` (7), `tests/test_background_review_list_shapes.py` (7), `tests/run_agent/test_background_review.py` (12)
- `ruff check` clean on both files; `ruff format` diff vs baseline shows zero new hunks in the changed regions
