### PR TITLE
fix(runtime): resolve executables on NixOS paths

### DIFF
--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -10,7 +10,7 @@ only secret values.
 Security model (mirrors the TS provider line-for-line where it matters):
 
 * The command string is the USER'S OWN configuration (same trust level as
-  the ``.env`` file they control), so it is run via ``/bin/sh -c <command>``.
+  the ``.env`` file they control), so it is run via ``a resolved POSIX shell -c <command>``.
 * The requested key is passed to the child ONLY via the ``HERMES_SECRET_KEY``
   environment variable — it is NEVER interpolated into the shell string, so
   a hostile key name (e.g. ``"; rm -rf ~``) is inert data, not code.
@@ -25,7 +25,7 @@ Security model (mirrors the TS provider line-for-line where it matters):
   ``HERMES_SECRET_KEY``) — it is never called per-key in a loop, so a
   helper that blocks (e.g. on a vault unlock prompt) can't be spawned
   dozens of times.
-* PLATFORM: the provider is POSIX-only (needs ``/bin/sh``).  On Windows it
+* PLATFORM: the provider is POSIX-only (needs ``a resolved POSIX shell``).  On Windows it
   degrades to an empty result with a warning; Windows users stay on the
   default ``env`` provider.
 """
@@ -46,6 +46,7 @@ from typing import Dict, Optional
 from agent.secret_sources.base import ErrorKind, SecretSource
 from agent.secret_sources.base import get_source_environment
 from agent.secret_sources.bitwarden import FetchResult
+from hermes_cli._subprocess_compat import resolve_executable
 
 __all__ = [
     "FetchResult",
@@ -165,7 +166,7 @@ def _run_helper(
     timeout_seconds: float,
     max_output_bytes: int,
 ) -> Optional[str]:
-    """Run the helper via ``/bin/sh -c`` and return its stdout, or None.
+    """Run the helper via ``a resolved POSIX shell -c`` and return its stdout, or None.
 
     The key is passed as DATA via ``HERMES_SECRET_KEY`` — never interpolated
     into the command string.  Both stdout and stderr are captured via pipes
@@ -175,7 +176,15 @@ def _run_helper(
     if _is_windows():
         print(
             "[secrets:command] the 'command' provider is POSIX-only "
-            "(needs /bin/sh); resolving no value on Windows",
+            "(needs a resolved POSIX shell); resolving no value on Windows",
+            file=sys.stderr,
+        )
+        return None
+
+    shell_executable = resolve_executable("sh")
+    if shell_executable is None:
+        print(
+            "[secrets:command] no POSIX shell executable found; resolving no value",
             file=sys.stderr,
         )
         return None
@@ -197,7 +206,7 @@ def _run_helper(
 
     try:
         proc = subprocess.Popen(  # noqa: S602 — command is the user's own config
-            ["/bin/sh", "-c", command],
+            [shell_executable, "-c", command],
             env=env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -352,7 +361,7 @@ def apply_command_secrets(
 
     if _is_windows():
         result.warnings.append(
-            "the 'command' secret source is POSIX-only (needs /bin/sh); "
+            "the 'command' secret source is POSIX-only (needs a resolved POSIX shell); "
             "skipping on Windows"
         )
         return result
@@ -425,7 +434,7 @@ class CommandSource(SecretSource):
         return {
             "enabled": {"description": "Master switch", "default": False},
             "command": {
-                "description": "Helper run via /bin/sh -c; must print a "
+                "description": "Helper run via a resolved POSIX shell -c; must print a "
                                "KEY=VALUE blob on stdout",
                 "default": "",
             },
@@ -454,7 +463,7 @@ class CommandSource(SecretSource):
 
         if _is_windows():
             result.error = (
-                "the 'command' secret source is POSIX-only (needs /bin/sh); "
+                "the 'command' secret source is POSIX-only (needs a resolved POSIX shell); "
                 "skipping on Windows"
             )
             result.error_kind = ErrorKind.NOT_CONFIGURED

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -45,7 +45,7 @@ from typing import Any, Callable, List, Optional, Protocol
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import resolve_executable, windows_hide_flags
 from hermes_cli.config import (
     _expand_env_vars,
     cron_model_drift_axes,
@@ -4534,7 +4534,7 @@ def _run_job_script(
 
     Supported interpreters (chosen by file extension):
 
-    * ``.sh`` / ``.bash`` — run with ``/bin/bash``
+    * ``.sh`` / ``.bash`` — run with a resolved ``bash`` executable
     * anything else — run with the current Python interpreter
       (``sys.executable``), preserving the original behaviour for
       Python-based pre-check and data-collection scripts.
@@ -4617,12 +4617,10 @@ def _run_job_script(
     if suffix in {".sh", ".bash"}:
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
         # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
+        # executable lookup returns None — fall back to a clear error rather
         # than a FileNotFoundError with a confusing "[WinError 2]"
         # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        _bash = resolve_executable("bash")
         if _bash is None:
             return False, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "

--- a/gateway/platforms/webhook_filters.py
+++ b/gateway/platforms/webhook_filters.py
@@ -6,11 +6,12 @@ import json
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Optional
+
+from hermes_cli._subprocess_compat import resolve_executable
 
 logger = logging.getLogger(__name__)
 
@@ -234,9 +235,7 @@ class WebhookRouteProcessor:
 
         suffix = path.suffix.lower()
         if suffix in {".sh", ".bash"}:
-            bash = shutil.which("bash") or (
-                "/bin/bash" if os.path.isfile("/bin/bash") else None
-            )
+            bash = resolve_executable("bash")
             if bash is None:
                 logger.warning("[webhook] script ignored webhook: bash not found")
                 return False, None

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -37,6 +37,7 @@ from typing import Mapping, Sequence
 
 __all__ = [
     "IS_WINDOWS",
+    "resolve_executable",
     "resolve_node_command",
     "split_command_line",
     "suppress_platform_ver_console",
@@ -68,6 +69,59 @@ NO_DRIVER_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv")
 # and friends reject the flags (``unknown option``), so the helper must gate on
 # this set rather than blanket-prepending.
 _DIFF_RENDERING_SUBCOMMANDS = frozenset({"diff", "show", "log", "blame"})
+
+
+def _platform_bin_dirs() -> tuple[str, ...]:
+    """Return existing package-manager bin directories for this platform."""
+    if sys.platform != "linux":
+        return ()
+
+    home = os.path.expanduser("~")
+    candidates = (
+        "/run/current-system/sw/bin",
+        "/run/current-system/sw/sbin",
+        "/nix/var/nix/profiles/default/bin",
+        "/nix/var/nix/profiles/default/sbin",
+        os.path.join(home, ".nix-profile", "bin"),
+        os.path.join(home, ".nix-profile", "sbin"),
+        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "bin"),
+        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "sbin"),
+    )
+    return tuple(path for path in candidates if os.path.isdir(path))
+
+
+def _platform_search_path() -> str:
+    """Return the normal PATH plus known package-manager bin directories."""
+    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    for candidate in _platform_bin_dirs():
+        if candidate not in entries:
+            entries.append(candidate)
+    return os.pathsep.join(entries)
+
+
+def resolve_executable(name: str, *, fallback: str | None = None) -> str | None:
+    """Resolve an executable through PATH and known NixOS profile paths.
+
+    The caller's PATH takes precedence. On Linux, Hermes also checks existing
+    NixOS system and user profile directories because supervised services often
+    start with a reduced PATH that omits them. The process environment is not
+    modified.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    resolved = shutil.which(name)
+    if resolved:
+        return resolved
+
+    resolved = shutil.which(name, path=_platform_search_path())
+    if resolved:
+        return resolved
+
+    if fallback and os.path.isfile(fallback) and os.access(fallback, os.X_OK):
+        return fallback
+    return None
+
 
 
 def harden_git_argv(args: Sequence[str]) -> list[str]:
@@ -182,7 +236,7 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     Returns:
         A list suitable for passing to subprocess.Popen/run/call.
     """
-    resolved = shutil.which(name)
+    resolved = resolve_executable(name)
     if resolved:
         return [resolved, *argv]
     return [name, *argv]

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -114,9 +114,13 @@ def resolve_executable(name: str, *, fallback: str | None = None) -> str | None:
     if resolved:
         return resolved
 
-    resolved = shutil.which(name, path=_platform_search_path())
-    if resolved:
-        return resolved
+    platform_dirs = _platform_bin_dirs()
+    if platform_dirs:
+        search_path = _platform_search_path()
+        if search_path != os.environ.get("PATH", ""):
+            resolved = shutil.which(name, path=search_path)
+            if resolved:
+                return resolved
 
     if fallback and os.path.isfile(fallback) and os.access(fallback, os.X_OK):
         return fallback

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -38,6 +38,7 @@ from typing import Mapping, Sequence
 __all__ = [
     "IS_WINDOWS",
     "resolve_executable",
+    "platform_executable_dirs",
     "resolve_node_command",
     "split_command_line",
     "suppress_platform_ver_console",
@@ -71,56 +72,130 @@ NO_DRIVER_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv")
 _DIFF_RENDERING_SUBCOMMANDS = frozenset({"diff", "show", "log", "blame"})
 
 
-def _platform_bin_dirs() -> tuple[str, ...]:
-    """Return existing package-manager bin directories for this platform."""
-    if sys.platform != "linux":
+def _nixos_per_user_profile_dirs(user: str | None) -> tuple[str, ...]:
+    """Return declarative NixOS profile directories for *user*."""
+    if not user or os.sep != "/":
         return ()
-
-    home = os.path.expanduser("~")
-    candidates = (
-        "/run/current-system/sw/bin",
-        "/run/current-system/sw/sbin",
-        "/nix/var/nix/profiles/default/bin",
-        "/nix/var/nix/profiles/default/sbin",
-        os.path.join(home, ".nix-profile", "bin"),
-        os.path.join(home, ".nix-profile", "sbin"),
-        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "bin"),
-        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "sbin"),
-    )
-    return tuple(path for path in candidates if os.path.isdir(path))
+    base = os.path.join("/etc", "profiles", "per-user", user)
+    return (os.path.join(base, "bin"), os.path.join(base, "sbin"))
 
 
-def _platform_search_path() -> str:
-    """Return the normal PATH plus known package-manager bin directories."""
-    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
-    for candidate in _platform_bin_dirs():
+def _platform_bin_dirs(
+    *, home: str | os.PathLike[str] | None = None, user: str | None = None
+) -> tuple[str, ...]:
+    """Return existing platform and package-manager executable directories.
+
+    These are fallback directories only: the caller's explicit PATH is always
+    searched first. ``home`` and ``user`` let system-service generators resolve
+    a command for the account that will run the service rather than for the
+    account that happened to generate the unit.
+    """
+    candidates: list[str] = []
+    if os.name == "posix":
+        candidates.extend(
+            (
+                "/usr/local/sbin",
+                "/usr/local/bin",
+                "/usr/sbin",
+                "/usr/bin",
+                "/sbin",
+                "/bin",
+            )
+        )
+
+    if sys.platform == "linux":
+        resolved_home = os.fspath(home) if home is not None else os.path.expanduser("~")
+        candidates.extend(
+            (
+                "/run/current-system/sw/bin",
+                "/run/current-system/sw/sbin",
+                "/nix/var/nix/profiles/default/bin",
+                "/nix/var/nix/profiles/default/sbin",
+                os.path.join(resolved_home, ".nix-profile", "bin"),
+                os.path.join(resolved_home, ".nix-profile", "sbin"),
+                os.path.join(
+                    resolved_home, ".local", "state", "nix", "profiles", "profile", "bin"
+                ),
+                os.path.join(
+                    resolved_home, ".local", "state", "nix", "profiles", "profile", "sbin"
+                ),
+            )
+        )
+        effective_user = user or os.environ.get("USER") or os.environ.get("LOGNAME")
+        candidates.extend(_nixos_per_user_profile_dirs(effective_user))
+
+    result: list[str] = []
+    seen: set[str] = set()
+    for candidate in candidates:
+        if candidate in seen:
+            continue
+        try:
+            present = os.path.isdir(candidate)
+        except OSError:
+            present = False
+        if present:
+            seen.add(candidate)
+            result.append(candidate)
+    return tuple(result)
+
+
+def platform_executable_dirs(
+    *, home: str | os.PathLike[str] | None = None, user: str | None = None
+) -> tuple[str, ...]:
+    """Return the validated fallback directories used by the resolver."""
+    return _platform_bin_dirs(home=home, user=user)
+
+
+def _platform_search_path(
+    *,
+    path: str | None = None,
+    home: str | os.PathLike[str] | None = None,
+    user: str | None = None,
+) -> str:
+    """Return an explicit PATH plus known fallback directories."""
+    base = os.environ.get("PATH", "") if path is None else path
+    entries = [entry for entry in base.split(os.pathsep) if entry]
+    if home is None and user is None:
+        platform_dirs = _platform_bin_dirs()
+    else:
+        platform_dirs = _platform_bin_dirs(home=home, user=user)
+    for candidate in platform_dirs:
         if candidate not in entries:
             entries.append(candidate)
     return os.pathsep.join(entries)
 
 
-def resolve_executable(name: str, *, fallback: str | None = None) -> str | None:
-    """Resolve an executable through PATH and known NixOS profile paths.
+def resolve_executable(
+    name: str,
+    *,
+    fallback: str | None = None,
+    path: str | None = None,
+    home: str | os.PathLike[str] | None = None,
+    user: str | None = None,
+) -> str | None:
+    """Resolve an executable without changing the parent process environment.
 
-    The caller's PATH takes precedence. On Linux, Hermes also checks existing
-    NixOS system and user profile directories because supervised services often
-    start with a reduced PATH that omits them. The process environment is not
-    modified.
+    ``PATH`` (or the explicit ``path`` argument) always wins. Existing
+    conventional POSIX directories and NixOS system/user profiles are then
+    searched as fallbacks. Passing ``path=""`` with ``home``/``user`` gives a
+    target-user lookup suitable for a systemd unit generated under sudo.
     """
     if not isinstance(name, str) or not name.strip():
         return None
 
-    resolved = shutil.which(name)
+    if path is None:
+        resolved = shutil.which(name)
+    else:
+        resolved = shutil.which(name, path=path)
     if resolved:
         return resolved
 
-    platform_dirs = _platform_bin_dirs()
-    if platform_dirs:
-        search_path = _platform_search_path()
-        if search_path != os.environ.get("PATH", ""):
-            resolved = shutil.which(name, path=search_path)
-            if resolved:
-                return resolved
+    search_path = _platform_search_path(path=path, home=home, user=user)
+    base_path = os.environ.get("PATH", "") if path is None else path
+    if search_path != base_path:
+        resolved = shutil.which(name, path=search_path)
+        if resolved:
+            return resolved
 
     if fallback and os.path.isfile(fallback) and os.access(fallback, os.X_OK):
         return fallback

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -55,6 +55,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from hermes_cli._subprocess_compat import resolve_executable
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -4123,6 +4124,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         _get_restart_drain_timeout(),
         _get_cron_drain_timeout(),
     )
+    reload_executable = resolve_executable("kill") or "kill"
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -4181,7 +4183,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_executable} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
@@ -4220,7 +4222,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_executable} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -55,7 +55,10 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
-from hermes_cli._subprocess_compat import resolve_executable
+from hermes_cli._subprocess_compat import (
+    platform_executable_dirs,
+    resolve_executable,
+)
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -117,6 +120,17 @@ class WindowsGatewayService:
     gateway_create_time: float = 0.0
 
 
+def _systemctl_executable() -> str | None:
+    """Return a usable systemctl command for the current process environment."""
+    resolved = resolve_executable("systemctl")
+    if not resolved:
+        return None
+    # Keep the long-standing bare command when the invoking PATH can execute
+    # it. When resolution came from a NixOS/profile fallback, retain the
+    # absolute path so reduced-PATH callers do not fail at process launch.
+    return "systemctl" if shutil.which("systemctl") else resolved
+
+
 def _get_service_pids(all_profiles: bool = False) -> set:
     """Return PIDs currently managed by systemd or launchd gateway services.
 
@@ -146,7 +160,11 @@ def _get_service_pids(all_profiles: bool = False) -> set:
             pattern = "hermes-gateway*"
         else:
             pattern = get_service_name()
-        for scope_args in [["systemctl", "--user"], ["systemctl"]]:
+        for scope_args in (
+            [[systemctl, "--user"], [systemctl]]
+            if (systemctl := _systemctl_executable())
+            else []
+        ):
             try:
                 result = subprocess.run(
                     scope_args
@@ -2701,7 +2719,7 @@ def _container_systemd_operational() -> bool:
 def supports_systemd_services() -> bool:
     if not is_linux() or is_termux():
         return False
-    if shutil.which("systemctl") is None:
+    if _systemctl_executable() is None:
         return False
     if is_wsl():
         return _wsl_systemd_operational()
@@ -3178,7 +3196,10 @@ def _raise_user_systemd_unavailable(
 def _systemctl_cmd(system: bool = False) -> list[str]:
     if not system:
         _ensure_user_systemd_env()
-    return ["systemctl"] if system else ["systemctl", "--user"]
+    executable = _systemctl_executable()
+    if executable is None:
+        raise RuntimeError("systemctl is not available on this system")
+    return [executable] if system else [executable, "--user"]
 
 
 def _journalctl_cmd(system: bool = False) -> list[str]:
@@ -4106,6 +4127,9 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         # user's Hermes home is known — probing here would stat the calling
         # (sudo → root's) tree and bake the wrong user's Node into the unit.
         _append_node_dir_for_service(path_entries)
+        for directory in platform_executable_dirs():
+            if directory not in path_entries:
+                path_entries.append(directory)
 
     common_bin_paths = [
         "/usr/local/sbin",
@@ -4124,10 +4148,17 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         _get_restart_drain_timeout(),
         _get_cron_drain_timeout(),
     )
-    reload_executable = resolve_executable("kill") or "kill"
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
+        reload_executable = resolve_executable(
+            "kill", path="", home=home_dir, user=username
+        )
+        if reload_executable is None:
+            raise RuntimeError(
+                "systemd gateway requires a kill executable for the target service user"
+            )
+        reload_command = shlex.quote(reload_executable)
         hermes_home = _hermes_home_for_target_user(home_dir)
         systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
             hermes_home
@@ -4143,6 +4174,12 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         working_dir = str(hermes_home) if hermes_home else _remap_path_for_user(working_dir, home_dir)
         venv_dir = _remap_path_for_user(venv_dir, home_dir)
         path_entries = [_remap_path_for_user(p, home_dir) for p in path_entries]
+        target_platform_entries = list(
+            platform_executable_dirs(home=home_dir, user=username)
+        )
+        path_entries = [
+            e for e in target_platform_entries if e not in path_entries
+        ] + path_entries
         # Managed Node for the TARGET user's tree (see the skip above): probe
         # the remapped hermes_home, not the calling user's. Prepend — the
         # managed Node must outrank remapped shell-PATH entries, matching the
@@ -4183,7 +4220,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload={reload_executable} -USR1 $MAINPID
+ExecReload={reload_command} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
@@ -4193,6 +4230,10 @@ StandardError=journal
 WantedBy=multi-user.target
 """
 
+    reload_executable = resolve_executable("kill")
+    if reload_executable is None:
+        raise RuntimeError("systemd gateway requires a kill executable")
+    reload_command = shlex.quote(reload_executable)
     hermes_home = str(get_hermes_home().resolve())
     systemd_type, systemd_watchdog_directives = _systemd_watchdog_service_fields(
         hermes_home
@@ -4222,7 +4263,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload={reload_executable} -USR1 $MAINPID
+ExecReload={reload_command} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 
-from hermes_cli._subprocess_compat import resolve_executable
+from hermes_cli._subprocess_compat import platform_executable_dirs, resolve_executable
 from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
@@ -804,6 +804,25 @@ def _cua_driver_env() -> dict:
         return cua_driver_child_env()
     except Exception:
         return dict(os.environ)
+
+
+def _cua_installer_env(resolved_commands: list[str]) -> dict[str, str]:
+    """Build a child PATH that contains all validated installer command dirs."""
+    env = _cua_driver_env()
+    candidates = [str(Path(command).parent) for command in resolved_commands]
+    candidates.extend(platform_executable_dirs())
+    candidates.extend(entry for entry in env.get("PATH", "").split(os.pathsep) if entry)
+
+    entries: list[str] = []
+    for candidate in candidates:
+        try:
+            valid = Path(candidate).is_dir()
+        except OSError:
+            valid = False
+        if valid and candidate not in entries:
+            entries.append(candidate)
+    env["PATH"] = os.pathsep.join(entries)
+    return env
 
 
 _CUA_DRIVER_CONTRACT_CACHE: dict = {}
@@ -1664,6 +1683,7 @@ def _run_cua_driver_installer(
             f'"{ps_oneliner}"'
         )
         script_path = None
+        installer_env = _cua_driver_env()
     else:
         # Download-then-exec instead of `bash -c "$(curl …)"`: no shell=True,
         # no command substitution, and the script lands in a mkstemp file
@@ -1680,10 +1700,25 @@ def _run_cua_driver_installer(
         manual_hint = f'bash -c "$(curl -fsSL {install_url})"'
         fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
         os.close(fd)
+        curl = resolve_executable("curl")
+        bash = resolve_executable("bash")
+        if curl is None or bash is None:
+            missing = "curl" if curl is None else "bash"
+            _print_warning(
+                f"    cua-driver installer requires {missing}, but no executable "
+                "was found on PATH or the known platform paths."
+            )
+            try:
+                os.remove(script_path)
+            except OSError:
+                pass
+            return False
+        installer_env = _cua_installer_env([curl, bash])
         try:
             dl = subprocess.run(
-                ["curl", "-fsSL", "-o", script_path, install_url],
+                [curl, "-fsSL", "-o", script_path, install_url],
                 capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=120,
+                env=installer_env,
             )
         except (subprocess.TimeoutExpired, OSError) as e:
             _print_warning(f"    cua-driver installer download failed: {e}")
@@ -1696,17 +1731,6 @@ def _run_cua_driver_installer(
             _print_warning(
                 "    cua-driver installer download failed: "
                 f"{(dl.stderr or '').strip()[:200]}"
-            )
-            try:
-                os.remove(script_path)
-            except OSError:
-                pass
-            return False
-        bash = resolve_executable("bash")
-        if bash is None:
-            _print_warning(
-                "    cua-driver installer requires bash, but no executable bash "
-                "was found on PATH or the known platform paths."
             )
             try:
                 os.remove(script_path)
@@ -1727,8 +1751,6 @@ def _run_cua_driver_installer(
         if installer_timeout is None
         else installer_timeout
     )
-
-    installer_env = _cua_driver_env()
     if pin_version:
         # Both upstream installers (install.sh and install.ps1) honour
         # CUA_DRIVER_RS_VERSION over their baked default.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 
+from hermes_cli._subprocess_compat import resolve_executable
 from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
@@ -1626,7 +1627,7 @@ def _run_cua_driver_installer(
     The scripts are idempotent: they always download the latest release, so
     re-running on an already-installed system performs an upgrade.
 
-    * macOS / Linux → ``curl -fsSL …/install.sh | /bin/bash``.
+    * macOS / Linux → ``curl -fsSL …/install.sh | bash``.
     * Windows       → ``powershell -NoProfile -ExecutionPolicy Bypass -Command
       "irm …/install.ps1 | iex"``.
 
@@ -1676,7 +1677,7 @@ def _run_cua_driver_installer(
             "https://raw.githubusercontent.com/trycua/cua/main/"
             "libs/cua-driver/scripts/install.sh"
         )
-        manual_hint = f'/bin/bash -c "$(curl -fsSL {install_url})"'
+        manual_hint = f'bash -c "$(curl -fsSL {install_url})"'
         fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
         os.close(fd)
         try:
@@ -1701,7 +1702,18 @@ def _run_cua_driver_installer(
             except OSError:
                 pass
             return False
-        install_cmd = ["/bin/bash", script_path]
+        bash = resolve_executable("bash")
+        if bash is None:
+            _print_warning(
+                "    cua-driver installer requires bash, but no executable bash "
+                "was found on PATH or the known platform paths."
+            )
+            try:
+                os.remove(script_path)
+            except OSError:
+                pass
+            return False
+        install_cmd = [bash, script_path]
     use_shell = False
 
     if show_progress:

--- a/hermes_cli/update_abort_recovery.py
+++ b/hermes_cli/update_abort_recovery.py
@@ -20,16 +20,17 @@ from __future__ import annotations
 import json
 import logging
 import os
-import shutil
 import subprocess
 import sys
+
+from hermes_cli._subprocess_compat import resolve_executable
 
 logger = logging.getLogger(__name__)
 
 
 def _serve_unit_recovery_available() -> bool:
     """Can a fresh process restart ``hermes-serve*`` units on this host?"""
-    return sys.platform == "linux" and bool(shutil.which("systemctl"))
+    return sys.platform == "linux" and bool(resolve_executable("systemctl"))
 
 
 def _surviving_pre_update_serve_runtimes(plan) -> list[dict]:
@@ -220,7 +221,7 @@ def _recover_gateway_restart_after_abort(
     # process together with the old service. If systemd-run is unavailable,
     # fail closed rather than pretending the in-cgroup child is independent.
     if gateway_mode and sys.platform == "linux":
-        systemd_run = shutil.which("systemd-run")
+        systemd_run = resolve_executable("systemd-run")
         if not systemd_run:
             logger.warning("Cannot isolate fresh gateway recovery from the gateway cgroup")
             return _all_failed()

--- a/hermes_cli/update_restart_recovery.py
+++ b/hermes_cli/update_restart_recovery.py
@@ -49,12 +49,13 @@ import argparse
 import json
 import os
 import re
-import shutil
 import subprocess
 import sys
 import time
 from collections.abc import Callable, Iterable, Mapping
 from typing import Any
+
+from hermes_cli._subprocess_compat import resolve_executable
 
 _RECOVERY_ENV = "HERMES_UPDATE_RESTART_RECOVERY"
 _GATEWAY_MARKERS = ("_HERMES_GATEWAY", "HERMES_GATEWAY", "HERMES_GATEWAY_MODE")
@@ -145,7 +146,7 @@ def _systemd_verified_active(profile: str, *, run: Callable[..., Any]) -> bool:
     unit not ``active``) means we could NOT verify — never that the restart
     failed.
     """
-    systemctl = shutil.which("systemctl")
+    systemctl = resolve_executable("systemctl")
     if not systemctl:
         return False
     for unit in _systemd_unit_candidates(profile):
@@ -216,16 +217,17 @@ def _systemctl_scopes() -> list[tuple[str, list[str]]]:
     """``systemctl`` invocations for the user and system scopes, or nothing.
 
     Mirrors the scope pair the in-process restart phase walks. ``systemctl``
-    is resolved through ``shutil.which`` so this module never has to import
-    any Hermes platform helper — importing the freshly pulled tree is exactly
-    what aborted the phase that called us.
+    is resolved through the shared platform-aware helper so reduced-PATH
+    NixOS services can still reach the binary. This is a fresh child process,
+    so importing the helper is safe even though the pre-update parent may have
+    aborted while importing the freshly pulled tree.
 
     Each scope is returned with its label because ``hermes-serve.service`` in
     the user manager and ``hermes-serve.service`` in the system manager are
     two different processes. Every identity this module produces or consumes
     stays qualified by that label; the bare unit name is never the key.
     """
-    systemctl = shutil.which("systemctl")
+    systemctl = resolve_executable("systemctl")
     if not systemctl or sys.platform != "linux":
         return []
     return [("user", [systemctl, "--user"]), ("system", [systemctl])]

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,7 +47,11 @@ import urllib.error
 import urllib.parse
 import zipfile
 
-from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    resolve_executable,
+    windows_detach_flags,
+    windows_hide_flags,
+)
 from hermes_cli.install_identity import get_install_id as _shared_get_install_id
 import urllib.request
 from pathlib import Path
@@ -6591,10 +6595,15 @@ def _run_setup_command(
     shell: bool = False,
     timeout: int = 180,
 ) -> subprocess.CompletedProcess:
+    executable = None
+    if shell:
+        executable = resolve_executable("bash")
+        if executable is None:
+            raise FileNotFoundError("no bash executable found")
     return subprocess.run(
         command,
         shell=shell,
-        executable="/bin/bash" if shell else None,
+        executable=executable,
         env=_memory_provider_setup_env(),
         capture_output=True,
         text=True,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -2,6 +2,7 @@
 
 import os
 import plistlib
+import shlex
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -244,15 +245,30 @@ class TestGeneratedSystemdUnits:
 
     def test_generated_systemd_units_resolve_kill_from_nixos_path(self, monkeypatch):
         resolved_kill = "/run/current-system/sw/bin/kill"
-        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name: resolved_kill)
+        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name, **kwargs: resolved_kill)
 
         user_unit = gateway_cli.generate_systemd_unit(system=False)
         system_unit = gateway_cli.generate_systemd_unit(
             system=True, run_as_user=pwd.getpwuid(os.getuid()).pw_name
         )
 
-        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in user_unit
-        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in system_unit
+        assert f"ExecReload={shlex.quote(resolved_kill)} -USR1 $MAINPID" in user_unit
+        assert f"ExecReload={shlex.quote(resolved_kill)} -USR1 $MAINPID" in system_unit
+
+    def test_generated_systemd_units_quote_spaced_kill_path(self, monkeypatch):
+        resolved_kill = "/home/Alice Smith/.nix-profile/bin/kill"
+        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name, **kwargs: resolved_kill)
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+
+        assert f"ExecReload={shlex.quote(resolved_kill)} -USR1 $MAINPID" in unit
+        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" not in unit
+
+    def test_generated_systemd_unit_fails_closed_without_kill(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name, **kwargs: None)
+
+        with pytest.raises(RuntimeError, match="kill executable"):
+            gateway_cli.generate_systemd_unit(system=False)
 
     def test_timeout_stop_sec_follows_a_raised_cron_drain_timeout(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
@@ -301,7 +317,17 @@ class TestGeneratedSystemdUnits:
         link_node = local_bin / "node"
         link_node.symlink_to(real_node)
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd, **kwargs: (
+                str(link_node)
+                if cmd == "node"
+                else "/usr/bin/kill"
+                if cmd == "kill"
+                else None
+            ),
+        )
 
         unit = gateway_cli.generate_systemd_unit(system=False)
 
@@ -1261,10 +1287,30 @@ class TestSystemUnitHermesHome:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_hermes)
         monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/root/bin/node" if name == "node" else None)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda name, **kwargs: (
+                "/root/bin/node"
+                if name == "node"
+                else "/usr/bin/kill"
+                if name == "kill"
+                else None
+            ),
+        )
         root_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/home/alice/.local/bin/node" if name == "node" else None)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda name, **kwargs: (
+                "/home/alice/.local/bin/node"
+                if name == "node"
+                else "/usr/bin/kill"
+                if name == "kill"
+                else None
+            ),
+        )
         user_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert root_unit == user_unit
@@ -1345,7 +1391,11 @@ class TestSystemUnitRefreshSyncsHermesHome:
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd, **kwargs: "/usr/bin/kill" if cmd == "kill" else None,
+        )
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda *a, **k: None)
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
@@ -2561,7 +2611,11 @@ class TestTimeoutStopSecCoversCronFloor:
         monkeypatch.setenv("HERMES_HOME", str(hermes))
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd, **kwargs: "/usr/bin/kill" if cmd == "kill" else None,
+        )
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -242,6 +242,18 @@ class TestGeneratedSystemdUnits:
         assert expected > 60
         assert self._expected_timeout_stop_sec() in unit
 
+    def test_generated_systemd_units_resolve_kill_from_nixos_path(self, monkeypatch):
+        resolved_kill = "/run/current-system/sw/bin/kill"
+        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name: resolved_kill)
+
+        user_unit = gateway_cli.generate_systemd_unit(system=False)
+        system_unit = gateway_cli.generate_systemd_unit(
+            system=True, run_as_user=pwd.getpwuid(os.getuid()).pw_name
+        )
+
+        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in user_unit
+        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in system_unit
+
     def test_timeout_stop_sec_follows_a_raised_cron_drain_timeout(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
         monkeypatch.setattr(gateway_cli, "_get_cron_drain_timeout", lambda: 60.0)
@@ -289,7 +301,7 @@ class TestGeneratedSystemdUnits:
         link_node = local_bin / "node"
         link_node.symlink_to(real_node)
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: str(link_node) if cmd == "node" else None)
 
         unit = gateway_cli.generate_systemd_unit(system=False)
 
@@ -307,7 +319,7 @@ class TestGeneratedSystemdUnits:
         link_node = local_bin / "node"
         link_node.symlink_to(real_node)
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: str(link_node) if cmd == "node" else None)
 
         plist = gateway_cli.generate_launchd_plist()
 
@@ -758,7 +770,7 @@ class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: None)
 
         assert gateway_cli.supports_systemd_services() is False
 
@@ -766,7 +778,7 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/usr/bin/systemctl")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/usr/bin/systemctl")
 
         assert gateway_cli.supports_systemd_services() is True
 
@@ -1249,10 +1261,10 @@ class TestSystemUnitHermesHome:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_hermes)
         monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/root/bin/node")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/root/bin/node" if name == "node" else None)
         root_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/home/alice/.local/bin/node")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/home/alice/.local/bin/node" if name == "node" else None)
         user_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert root_unit == user_unit
@@ -1333,7 +1345,7 @@ class TestSystemUnitRefreshSyncsHermesHome:
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda *a, **k: None)
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
@@ -2549,7 +2561,7 @@ class TestTimeoutStopSecCoversCronFloor:
         monkeypatch.setenv("HERMES_HOME", str(hermes))
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -23,6 +23,7 @@ cleanly on missing-arch assets, and the upgrade path uses
 from __future__ import annotations
 
 import json
+import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -77,6 +78,57 @@ class TestCuaDriverRuntimeContract:
             "version": "0.20.0",
             "reason": "",
         }
+
+    def test_installer_resolves_curl_and_passes_profile_path_to_child(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+
+        from hermes_cli import tools_config
+
+        script_path = tmp_path / "cua-install.sh"
+        profile_bin = tmp_path / "Alice Smith" / "nix-profile" / "bin"
+        profile_bin.mkdir(parents=True)
+        curl = profile_bin / "curl"
+        bash = profile_bin / "bash"
+        for command in (curl, bash):
+            command.write_text("", encoding="utf-8")
+            command.chmod(0o755)
+        calls = []
+
+        def fake_run(argv, **kwargs):
+            calls.append((argv, kwargs))
+            if "-o" in argv:
+                script_path.write_text("#!/bin/sh\n", encoding="utf-8")
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 1
+        fake_proc.returncode = 0
+        fake_proc.communicate.return_value = ("", None)
+        monkeypatch.setattr(
+            tools_config,
+            "resolve_executable",
+            lambda name: {"curl": str(curl), "bash": str(bash)}.get(name),
+        )
+        monkeypatch.setattr(tools_config, "_cua_driver_env", lambda: {"PATH": "/usr/bin"})
+        monkeypatch.setattr(tools_config, "_clear_stale_cua_install_lock", lambda: None)
+        monkeypatch.setattr(tools_config, "_resolved_cua_driver_cmd", lambda: "/usr/bin/cua-driver")
+        monkeypatch.setattr(tools_config, "_cua_driver_cmd", lambda: "cua-driver")
+        monkeypatch.setattr(tools_config, "subprocess", __import__("subprocess"))
+        monkeypatch.setattr(tools_config.subprocess, "run", fake_run)
+        monkeypatch.setattr(tools_config.subprocess, "Popen", lambda *args, **kwargs: fake_proc)
+        monkeypatch.setattr(
+            "tempfile.mkstemp",
+            lambda **kwargs: (os.open(script_path, os.O_CREAT | os.O_RDWR, 0o600), str(script_path)),
+        )
+
+        assert tools_config._run_cua_driver_installer(
+            label="Testing", verbose=False, show_progress=False
+        ) is True
+        assert calls[0][0][0] == str(curl)
+        assert calls[0][1]["env"]["PATH"].split(os.pathsep)[0] == str(profile_bin)
+        assert fake_proc is not None
 
     @pytest.mark.parametrize("version", ["0.19.4", "bad-version"])
     def test_old_or_unversioned_driver_needs_repair(self, version):
@@ -1333,7 +1385,11 @@ class TestInstallerNoShell:
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
-             patch.object(tools_config, "resolve_executable", return_value=bash_path), \
+             patch.object(
+                 tools_config,
+                 "resolve_executable",
+                 side_effect=lambda name: "/usr/bin/curl" if name == "curl" else bash_path,
+             ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -1349,7 +1405,7 @@ class TestInstallerNoShell:
         assert len(run_calls) == 1 and len(popen_calls) == 1
         # Download: plain argv curl, no shell.
         dl_cmd = run_calls[0][1]
-        assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
+        assert isinstance(dl_cmd, list) and dl_cmd[0] == "/usr/bin/curl"
         # Exec: argv list [resolved bash, <mkstemp path>], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
         assert isinstance(exec_cmd, list) and exec_cmd[0] == "/usr/bin/bash"

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -263,6 +263,7 @@ class TestInstallCuaDriverUpgrade:
                  return_value="/usr/local/bin/cua-driver",
              ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_cua_release_endpoint_reachable", return_value=True), \
              patch.object(
                  tools_config,
                  "_repair_cua_driver_autostart_windows",
@@ -1308,7 +1309,7 @@ class TestInstallerNoShell:
     asserting a branch the host had already selected.
     """
 
-    def _run(self, download_rc=0):
+    def _run(self, download_rc=0, bash_path: str | None = "/usr/bin/bash"):
         from unittest.mock import MagicMock
         from hermes_cli import tools_config
 
@@ -1332,6 +1333,7 @@ class TestInstallerNoShell:
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config, "resolve_executable", return_value=bash_path), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -1348,11 +1350,16 @@ class TestInstallerNoShell:
         # Download: plain argv curl, no shell.
         dl_cmd = run_calls[0][1]
         assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
-        # Exec: argv list ["/bin/bash", <mkstemp path>], shell=False.
+        # Exec: argv list [resolved bash, <mkstemp path>], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
-        assert isinstance(exec_cmd, list) and exec_cmd[0] == "/bin/bash"
+        assert isinstance(exec_cmd, list) and exec_cmd[0] == "/usr/bin/bash"
         assert "cua-driver-install-" in exec_cmd[1]
         assert exec_kw.get("shell") is False
+
+    def test_missing_bash_returns_false_without_exec(self):
+        ok, calls = self._run(bash_path=None)
+        assert ok is False
+        assert not [c for c in calls if c[0] == "popen"]
 
     def test_download_failure_returns_false_without_exec(self):
         ok, calls = self._run(download_rc=6)
@@ -1381,6 +1388,7 @@ class TestInstallerNoShell:
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config, "resolve_executable", return_value="/usr/bin/bash"), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \

--- a/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
+++ b/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
@@ -113,7 +113,7 @@ def test_managed_gateway_scope_builder_fails_closed_if_binary_disappears(
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
     monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda _name, *args, **kwargs: None)
     monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("unsafe direct spawn"))
 
     with pytest.raises(RuntimeError, match="restart-safe systemd scope"):

--- a/tests/hermes_cli/test_update_restart_recovery.py
+++ b/tests/hermes_cli/test_update_restart_recovery.py
@@ -286,7 +286,9 @@ def test_recovery_child_restarts_each_profile_with_a_fresh_main(monkeypatch):
 
 def test_recovery_child_verifies_systemd_profiles_via_is_active(monkeypatch):
     recovery = importlib.import_module("hermes_cli.update_restart_recovery")
-    monkeypatch.setattr(recovery.shutil, "which", lambda name: f"/bin/{name}")
+    monkeypatch.setattr(
+        recovery, "resolve_executable", lambda name, **kwargs: f"/bin/{name}"
+    )
     calls = []
 
     def fake_run(argv, **kwargs):
@@ -315,7 +317,7 @@ def test_recovery_child_verifies_systemd_profiles_via_is_active(monkeypatch):
 
 def test_recovery_child_treats_missing_systemctl_as_unverified(monkeypatch):
     recovery = importlib.import_module("hermes_cli.update_restart_recovery")
-    monkeypatch.setattr(recovery.shutil, "which", lambda name: None)
+    monkeypatch.setattr(recovery, "resolve_executable", lambda name, **kwargs: None)
 
     result = recovery.restart_profiles(
         ["default"],

--- a/tests/hermes_cli/test_update_serve_generation_recovery.py
+++ b/tests/hermes_cli/test_update_serve_generation_recovery.py
@@ -334,7 +334,11 @@ class _Systemctl:
 @pytest.fixture
 def linux_systemctl(monkeypatch):
     monkeypatch.setattr(recovery.sys, "platform", "linux")
-    monkeypatch.setattr(recovery.shutil, "which", lambda name: "/usr/bin/systemctl")
+    monkeypatch.setattr(
+        recovery,
+        "resolve_executable",
+        lambda name, **kwargs: "/usr/bin/systemctl",
+    )
 
 
 def test_serve_unit_verified_when_main_pid_changes(linux_systemctl):
@@ -469,7 +473,7 @@ def test_gateway_units_are_not_restarted_by_the_serve_pass(linux_systemctl):
 
 
 def test_no_systemctl_means_no_serve_pass(monkeypatch):
-    monkeypatch.setattr(recovery.shutil, "which", lambda name: None)
+    monkeypatch.setattr(recovery, "resolve_executable", lambda name, **kwargs: None)
 
     def unreachable(*a, **k):
         raise AssertionError("systemctl invoked without a systemctl binary")
@@ -482,7 +486,11 @@ def test_no_systemctl_means_no_serve_pass(monkeypatch):
 
 def test_non_linux_hosts_do_not_run_the_serve_pass(monkeypatch):
     monkeypatch.setattr(recovery.sys, "platform", "win32")
-    monkeypatch.setattr(recovery.shutil, "which", lambda name: "systemctl")
+    monkeypatch.setattr(
+        recovery,
+        "resolve_executable",
+        lambda name, **kwargs: "systemctl",
+    )
 
     def unreachable(*a, **k):
         raise AssertionError("serve unit pass ran off Linux")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -239,6 +239,27 @@ class TestSessionTokenInjection:
 # ---------------------------------------------------------------------------
 
 
+def test_run_setup_command_uses_resolved_bash(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    resolved_bash = "/run/current-system/sw/bin/bash"
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(web_server, "resolve_executable", lambda name: resolved_bash)
+    monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+    web_server._run_setup_command(
+        "printf setup", display="printf setup", shell=True, timeout=1
+    )
+
+    assert captured["kwargs"]["executable"] == resolved_bash
+
+
 class TestWebServerEndpoints:
     """Test the FastAPI REST endpoints using Starlette TestClient."""
 

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -1,7 +1,7 @@
 """E2E tests for the ``command`` secret source.
 
 These exercise the REAL resolution path: real helper shell scripts written
-to a temp dir (chmod +x), real ``/bin/sh -c`` subprocesses, and a real temp
+to a temp dir (chmod +x), real resolved POSIX shell subprocesses, and a real temp
 HERMES_HOME with a config.yaml routing ``secrets.provider: command`` through
 ``hermes_cli.env_loader._apply_external_secret_sources``.
 
@@ -76,6 +76,30 @@ def test_profile_helper_does_not_inherit_process_secret(monkeypatch):
         reset_source_environment(token)
 
     assert output == "unset|profile-value"
+
+
+def test_helper_uses_resolved_sh_from_reduced_path(monkeypatch):
+    import agent.secret_sources.command as command_source
+
+    resolved_sh = "/run/current-system/sw/bin/sh"
+    seen = {}
+
+    class FakeProcess:
+        pid = 1234
+        returncode = 0
+
+        def communicate(self, timeout):
+            return b"CMDTEST_API_KEY=resolved\n", b""
+
+    def fake_popen(argv, **kwargs):
+        seen["argv"] = argv
+        return FakeProcess()
+
+    monkeypatch.setattr(command_source, "resolve_executable", lambda name: resolved_sh)
+    monkeypatch.setattr(command_source.subprocess, "Popen", fake_popen)
+
+    assert get_command_secret(command="printf x", key="CMDTEST_API_KEY") == "resolved"
+    assert seen["argv"] == [resolved_sh, "-c", "printf x"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1406,7 +1406,7 @@ class TestWSL2PowerShellFallback:
             m = MagicMock()
             # Simulate the PowerShell pipeline failing (nonzero rc), and
             # the fallback ffplay succeeding.
-            if cmd[0] in ("/bin/sh", "sh"):
+            if cmd[0].endswith("/sh"):
                 m.returncode = 1
             else:
                 m.returncode = 0
@@ -1415,6 +1415,7 @@ class TestWSL2PowerShellFallback:
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("tools.voice_mode.resolve_executable", return_value="/run/current-system/sw/bin/sh"), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
              patch("tools.voice_mode.subprocess.check_output",
@@ -1431,7 +1432,7 @@ class TestWSL2PowerShellFallback:
             f"Expected sh pipeline to be tried and fail, then ffplay to be "
             f"tried: {captured_cmds}"
         )
-        assert captured_cmds[0][0] in ("/bin/sh", "sh")
+        assert captured_cmds[0][0] == "/run/current-system/sw/bin/sh"
         assert captured_cmds[1][0] == "ffplay"
         # The subshell command must capture and re-exit with $rc, not rely
         # on rm -f's exit status.

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -423,7 +423,37 @@ class TestSubprocessCompatHelpers:
         argv = resolve_node_command("sh", ["-c", "echo hi"])
         assert argv[1:] == ["-c", "echo hi"]
         # First element is either an absolute path (sh found) or the bare
-        # name (fallback) — both are acceptable behaviours.
+        # name (fallback) - both are acceptable behaviours.
+
+    def test_resolve_executable_uses_known_linux_profile_paths(self, tmp_path, monkeypatch):
+        from hermes_cli import _subprocess_compat as sc
+
+        normal_bin = tmp_path / "normal-bin"
+        nix_bin = tmp_path / "nix-bin"
+        normal_bin.mkdir()
+        nix_bin.mkdir()
+        normal = normal_bin / "hermes-path-test"
+        nix = nix_bin / "hermes-path-test"
+        normal.write_text("#!/bin/sh\n", encoding="utf-8")
+        nix.write_text("#!/bin/sh\n", encoding="utf-8")
+        normal.chmod(0o755)
+        nix.chmod(0o755)
+
+        monkeypatch.setenv("PATH", str(normal_bin))
+        monkeypatch.setattr(sc, "_platform_bin_dirs", lambda: (str(nix_bin),))
+        before = os.environ["PATH"]
+        assert sc.resolve_executable("hermes-path-test") == str(normal)
+        assert os.environ["PATH"] == before
+
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        reduced = os.environ["PATH"]
+        assert sc.resolve_executable("hermes-path-test") == str(nix)
+        assert os.environ["PATH"] == reduced
+
+    def test_resolve_executable_does_not_return_missing_fallback(self):
+        from hermes_cli._subprocess_compat import resolve_executable
+
+        assert resolve_executable("hermes-definitely-missing", fallback="/bin/absent") is None
 
 
     @pytest.mark.windows_only
@@ -613,14 +643,13 @@ class TestCronSchedulerBashResolution:
     """cron.scheduler must NOT hardcode /bin/bash — .sh scripts need a
     dynamically-resolved bash so Windows (Git Bash) works."""
 
-    def test_source_uses_shutil_which_for_bash(self):
+    def test_source_uses_shared_executable_resolver_for_bash(self):
         root = Path(__file__).resolve().parents[2]
         source = (root / "cron" / "scheduler.py").read_text(encoding="utf-8")
-        # The old hardcoded path should be gone as the sole bash source.
-        # It may still appear as a POSIX fallback after shutil.which(), so
-        # we check for the shutil.which call near the .sh/.bash branch.
-        assert 'shutil.which("bash")' in source, (
-            "cron.scheduler must resolve bash dynamically via shutil.which"
+        # The old hardcoded path and direct lookup should be gone from the
+        # actual .sh/.bash branch.
+        assert 'resolve_executable("bash")' in source, (
+            "cron.scheduler must resolve bash through the shared executable resolver"
         )
 
     def test_error_message_when_bash_missing(self):

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -455,6 +455,66 @@ class TestSubprocessCompatHelpers:
 
         assert resolve_executable("hermes-definitely-missing", fallback="/bin/absent") is None
 
+    def test_resolve_executable_uses_target_users_nixos_profile(self, tmp_path):
+        from hermes_cli._subprocess_compat import resolve_executable
+
+        target_home = tmp_path / "home" / "alice"
+        profile_bin = target_home / ".nix-profile" / "bin"
+        profile_bin.mkdir(parents=True)
+        executable = profile_bin / "hermes-target-profile-test"
+        executable.write_text("#!/bin/sh\n", encoding="utf-8")
+        executable.chmod(0o755)
+
+        assert resolve_executable(
+            "hermes-target-profile-test",
+            path="",
+            home=str(target_home),
+            user="alice",
+        ) == str(executable)
+
+    def test_resolve_executable_preserves_spaces_symlinks_and_concurrent_calls(
+        self, tmp_path, monkeypatch
+    ):
+        from concurrent.futures import ThreadPoolExecutor
+
+        from hermes_cli._subprocess_compat import resolve_executable
+
+        spaced_bin = tmp_path / "Alice Smith" / "bin"
+        spaced_bin.mkdir(parents=True)
+        real = spaced_bin / "hermes-space-test"
+        real.write_text("#!/bin/sh\n", encoding="utf-8")
+        real.chmod(0o755)
+        link = spaced_bin / "hermes-space-link"
+        link.symlink_to(real)
+        monkeypatch.setenv("PATH", str(spaced_bin))
+
+        with ThreadPoolExecutor(max_workers=16) as pool:
+            results = list(pool.map(resolve_executable, ["hermes-space-link"] * 64))
+
+        assert results == [str(link)] * 64
+
+    def test_platform_bin_dirs_include_posix_fallbacks_and_per_user_profile(
+        self, tmp_path, monkeypatch
+    ):
+        from hermes_cli import _subprocess_compat as sc
+
+        target_home = tmp_path / "home" / "alice"
+        per_user_bin = tmp_path / "etc" / "profiles" / "per-user" / "alice" / "bin"
+        per_user_bin.mkdir(parents=True)
+        monkeypatch.setattr(sc, "sys", type("Platform", (), {"platform": "linux"})())
+        monkeypatch.setattr(
+            sc.os.path,
+            "isdir",
+            lambda path: path in {"/usr/local/bin", "/usr/bin", str(per_user_bin)},
+        )
+        monkeypatch.setattr(sc, "_nixos_per_user_profile_dirs", lambda user: (str(per_user_bin),))
+
+        dirs = sc._platform_bin_dirs(home=str(target_home), user="alice")
+
+        assert "/usr/local/bin" in dirs
+        assert "/usr/bin" in dirs
+        assert str(per_user_bin) in dirs
+
 
     @pytest.mark.windows_only
     def test_windows_detach_flags_exclude_detached_process(self):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import resolve_executable, windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -982,13 +982,7 @@ def build_subprocess_env(
 def _find_bash() -> str:
     """Find bash for command execution."""
     if not _IS_WINDOWS:
-        return (
-            shutil.which("bash")
-            or ("/usr/bin/bash" if os.path.isfile("/usr/bin/bash") else None)
-            or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
-            or os.environ.get("SHELL")
-            or "/bin/sh"
-        )
+        return resolve_executable("bash") or os.environ.get("SHELL") or "/bin/sh"
 
     candidates: list[str] = []
 

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -26,6 +26,8 @@ import time
 import wave
 from typing import Any, Callable, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import resolve_executable
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1732,7 +1734,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                         ["wslpath", "-w", _wsl_wav],
                         stderr=subprocess.DEVNULL, timeout=3,
                     ).decode(errors="replace").strip()
-                    if _win_wav:
+                    if _win_wav and (shell_executable := resolve_executable("sh")):
                         _win_wav_safe = _win_wav.replace("'", "''")
                         _ps_script = (
                             f"(New-Object Media.SoundPlayer '{_win_wav_safe}').PlaySync()"
@@ -1751,7 +1753,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                         # and prevent falling through to the next player).
                         _full_cmd = f"( {_ps_cmd} ); rc=$?; {_cleanup}; exit $rc"
                         # Use full path so the which(cmd[0]) check in the player loop passes.
-                        players.insert(0, ["/bin/sh", "-c", _full_cmd])
+                        players.insert(0, [shell_executable, "-c", _full_cmd])
             except Exception:
                 pass  # WSL path resolution failed; fall through to ffplay/aplay
 


### PR DESCRIPTION
## What does this PR do?

This fixes a real NixOS portability failure in Hermes runtime subprocess launches. A reduced service `PATH` can omit NixOS profile binaries while `/bin/bash`, `/bin/sh`, and `/bin/kill` are not guaranteed to exist. The shared resolver checks the caller's ordinary `PATH` first, then existing NixOS system and user profile directories, without mutating the process environment.

## Related Issue

Related: #92368 and #102587. Those PRs cover overlapping or narrower lookup paths; this PR centralizes the Python runtime resolver and covers the remaining Python consumers rather than duplicating their exact changes.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a shared executable resolver in `hermes_cli/_subprocess_compat.py`
- preserve ordinary `PATH` precedence, deduplicate candidates, avoid global environment mutation, and fail closed when a required executable is unavailable
- route the audited Python runtime consumers through the resolver:
  - `cron/scheduler.py`
  - `gateway/platforms/webhook_filters.py`
  - `hermes_cli/tools_config.py`
  - `agent/secret_sources/command.py`
  - `hermes_cli/gateway.py`
  - `hermes_cli/web_server.py`
  - `tools/environments/local.py`
  - `tools/voice_mode.py`
- keep Windows-specific behavior and shell-required failure paths intact
- add reduced-PATH regression coverage for resolver behavior and runtime callers
- update the existing managed-gateway missing-binary test double to accept the resolver's path-aware `shutil.which` call

The desktop Electron launchers and updater shell-script paths are primarily handled by #92368. This follow-up intentionally overlaps the three Python call sites that #92368 currently updates (`hermes_cli/gateway.py`, `hermes_cli/tools_config.py`, and `hermes_cli/web_server.py`) so those paths use the shared NixOS-aware resolver rather than separate direct `shutil.which` lookups. The remaining Python runtime paths are additional coverage. Review/merge this PR after #92368, or resolve the overlap by taking the shared resolver in one coordinated update. The stacked cron/systemd follow-up is PR #102870 and consumes this shared resolver.

## How to Test

1. On Linux/NixOS, run the repository's isolated test runner across the touched test files:
   `taskset -c 0-7 ./scripts/run_tests.sh tests/test_command_secret_source.py tests/hermes_cli/test_web_server.py tests/hermes_cli/test_gateway_service.py tests/tools/test_voice_mode.py tests/tools/test_windows_native_support.py tests/tools/test_find_shell.py tests/hermes_cli/test_install_cua_driver.py tests/cron/test_scheduler.py tests/hermes_cli/test_kanban_gateway_restart_handoff.py -q`
2. Verify lint and imports:
   `ruff check agent/secret_sources/command.py cron/scheduler.py gateway/platforms/webhook_filters.py hermes_cli/_subprocess_compat.py hermes_cli/gateway.py hermes_cli/tools_config.py hermes_cli/web_server.py tools/environments/local.py tools/voice_mode.py`
3. Exercise the resolver with `PATH=/usr/bin:/bin` and verify that `bash`, `sh`, `kill`, `systemd-run`, `true`, and `systemctl` resolve to executable absolute paths while `PATH` remains unchanged.

Local result: 585 tests passed, 36 skipped, 0 failed in the nine-file focused matrix. The skipped tests are OS-specific on this Linux host. The repository-wide `pytest tests/ -q` command was not used for this focused change.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS Linux with a reduced service `PATH`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

- `git diff --check`: passed
- reduced-PATH runtime probe: passed with `PATH` unchanged
- imports for all changed runtime modules: passed
