### PR TITLE
fix(cron): resolve systemd scope binaries on NixOS

### DIFF
--- a/agent/secret_sources/command.py
+++ b/agent/secret_sources/command.py
@@ -10,7 +10,7 @@ only secret values.
 Security model (mirrors the TS provider line-for-line where it matters):
 
 * The command string is the USER'S OWN configuration (same trust level as
-  the ``.env`` file they control), so it is run via ``/bin/sh -c <command>``.
+  the ``.env`` file they control), so it is run via ``a resolved POSIX shell -c <command>``.
 * The requested key is passed to the child ONLY via the ``HERMES_SECRET_KEY``
   environment variable — it is NEVER interpolated into the shell string, so
   a hostile key name (e.g. ``"; rm -rf ~``) is inert data, not code.
@@ -25,7 +25,7 @@ Security model (mirrors the TS provider line-for-line where it matters):
   ``HERMES_SECRET_KEY``) — it is never called per-key in a loop, so a
   helper that blocks (e.g. on a vault unlock prompt) can't be spawned
   dozens of times.
-* PLATFORM: the provider is POSIX-only (needs ``/bin/sh``).  On Windows it
+* PLATFORM: the provider is POSIX-only (needs ``a resolved POSIX shell``).  On Windows it
   degrades to an empty result with a warning; Windows users stay on the
   default ``env`` provider.
 """
@@ -46,6 +46,7 @@ from typing import Dict, Optional
 from agent.secret_sources.base import ErrorKind, SecretSource
 from agent.secret_sources.base import get_source_environment
 from agent.secret_sources.bitwarden import FetchResult
+from hermes_cli._subprocess_compat import resolve_executable
 
 __all__ = [
     "FetchResult",
@@ -165,7 +166,7 @@ def _run_helper(
     timeout_seconds: float,
     max_output_bytes: int,
 ) -> Optional[str]:
-    """Run the helper via ``/bin/sh -c`` and return its stdout, or None.
+    """Run the helper via ``a resolved POSIX shell -c`` and return its stdout, or None.
 
     The key is passed as DATA via ``HERMES_SECRET_KEY`` — never interpolated
     into the command string.  Both stdout and stderr are captured via pipes
@@ -175,7 +176,15 @@ def _run_helper(
     if _is_windows():
         print(
             "[secrets:command] the 'command' provider is POSIX-only "
-            "(needs /bin/sh); resolving no value on Windows",
+            "(needs a resolved POSIX shell); resolving no value on Windows",
+            file=sys.stderr,
+        )
+        return None
+
+    shell_executable = resolve_executable("sh")
+    if shell_executable is None:
+        print(
+            "[secrets:command] no POSIX shell executable found; resolving no value",
             file=sys.stderr,
         )
         return None
@@ -197,7 +206,7 @@ def _run_helper(
 
     try:
         proc = subprocess.Popen(  # noqa: S602 — command is the user's own config
-            ["/bin/sh", "-c", command],
+            [shell_executable, "-c", command],
             env=env,
             stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
@@ -352,7 +361,7 @@ def apply_command_secrets(
 
     if _is_windows():
         result.warnings.append(
-            "the 'command' secret source is POSIX-only (needs /bin/sh); "
+            "the 'command' secret source is POSIX-only (needs a resolved POSIX shell); "
             "skipping on Windows"
         )
         return result
@@ -425,7 +434,7 @@ class CommandSource(SecretSource):
         return {
             "enabled": {"description": "Master switch", "default": False},
             "command": {
-                "description": "Helper run via /bin/sh -c; must print a "
+                "description": "Helper run via a resolved POSIX shell -c; must print a "
                                "KEY=VALUE blob on stdout",
                 "default": "",
             },
@@ -454,7 +463,7 @@ class CommandSource(SecretSource):
 
         if _is_windows():
             result.error = (
-                "the 'command' secret source is POSIX-only (needs /bin/sh); "
+                "the 'command' secret source is POSIX-only (needs a resolved POSIX shell); "
                 "skipping on Windows"
             )
             result.error_kind = ErrorKind.NOT_CONFIGURED

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -45,7 +45,7 @@ from typing import Any, Callable, List, Optional, Protocol
 sys.path.insert(0, str(Path(__file__).parent.parent))
 
 from hermes_constants import get_hermes_home
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import resolve_executable, windows_hide_flags
 from hermes_cli.config import (
     _expand_env_vars,
     cron_model_drift_axes,
@@ -4534,7 +4534,7 @@ def _run_job_script(
 
     Supported interpreters (chosen by file extension):
 
-    * ``.sh`` / ``.bash`` — run with ``/bin/bash``
+    * ``.sh`` / ``.bash`` — run with a resolved ``bash`` executable
     * anything else — run with the current Python interpreter
       (``sys.executable``), preserving the original behaviour for
       Python-based pre-check and data-collection scripts.
@@ -4617,12 +4617,10 @@ def _run_job_script(
     if suffix in {".sh", ".bash"}:
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
         # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
+        # executable lookup returns None — fall back to a clear error rather
         # than a FileNotFoundError with a confusing "[WinError 2]"
         # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        _bash = resolve_executable("bash")
         if _bash is None:
             return False, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "

--- a/gateway/platforms/webhook_filters.py
+++ b/gateway/platforms/webhook_filters.py
@@ -6,11 +6,12 @@ import json
 import logging
 import os
 import re
-import shutil
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Optional
+
+from hermes_cli._subprocess_compat import resolve_executable
 
 logger = logging.getLogger(__name__)
 
@@ -234,9 +235,7 @@ class WebhookRouteProcessor:
 
         suffix = path.suffix.lower()
         if suffix in {".sh", ".bash"}:
-            bash = shutil.which("bash") or (
-                "/bin/bash" if os.path.isfile("/bin/bash") else None
-            )
+            bash = resolve_executable("bash")
             if bash is None:
                 logger.warning("[webhook] script ignored webhook: bash not found")
                 return False, None

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -37,6 +37,7 @@ from typing import Mapping, Sequence
 
 __all__ = [
     "IS_WINDOWS",
+    "resolve_executable",
     "resolve_node_command",
     "split_command_line",
     "suppress_platform_ver_console",
@@ -68,6 +69,59 @@ NO_DRIVER_DIFF_FLAGS = ("--no-ext-diff", "--no-textconv")
 # and friends reject the flags (``unknown option``), so the helper must gate on
 # this set rather than blanket-prepending.
 _DIFF_RENDERING_SUBCOMMANDS = frozenset({"diff", "show", "log", "blame"})
+
+
+def _platform_bin_dirs() -> tuple[str, ...]:
+    """Return existing package-manager bin directories for this platform."""
+    if sys.platform != "linux":
+        return ()
+
+    home = os.path.expanduser("~")
+    candidates = (
+        "/run/current-system/sw/bin",
+        "/run/current-system/sw/sbin",
+        "/nix/var/nix/profiles/default/bin",
+        "/nix/var/nix/profiles/default/sbin",
+        os.path.join(home, ".nix-profile", "bin"),
+        os.path.join(home, ".nix-profile", "sbin"),
+        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "bin"),
+        os.path.join(home, ".local", "state", "nix", "profiles", "profile", "sbin"),
+    )
+    return tuple(path for path in candidates if os.path.isdir(path))
+
+
+def _platform_search_path() -> str:
+    """Return the normal PATH plus known package-manager bin directories."""
+    entries = [entry for entry in os.environ.get("PATH", "").split(os.pathsep) if entry]
+    for candidate in _platform_bin_dirs():
+        if candidate not in entries:
+            entries.append(candidate)
+    return os.pathsep.join(entries)
+
+
+def resolve_executable(name: str, *, fallback: str | None = None) -> str | None:
+    """Resolve an executable through PATH and known NixOS profile paths.
+
+    The caller's PATH takes precedence. On Linux, Hermes also checks existing
+    NixOS system and user profile directories because supervised services often
+    start with a reduced PATH that omits them. The process environment is not
+    modified.
+    """
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    resolved = shutil.which(name)
+    if resolved:
+        return resolved
+
+    resolved = shutil.which(name, path=_platform_search_path())
+    if resolved:
+        return resolved
+
+    if fallback and os.path.isfile(fallback) and os.access(fallback, os.X_OK):
+        return fallback
+    return None
+
 
 
 def harden_git_argv(args: Sequence[str]) -> list[str]:
@@ -182,7 +236,7 @@ def resolve_node_command(name: str, argv: Sequence[str]) -> list[str]:
     Returns:
         A list suitable for passing to subprocess.Popen/run/call.
     """
-    resolved = shutil.which(name)
+    resolved = resolve_executable(name)
     if resolved:
         return [resolved, *argv]
     return [name, *argv]

--- a/hermes_cli/_subprocess_compat.py
+++ b/hermes_cli/_subprocess_compat.py
@@ -114,9 +114,13 @@ def resolve_executable(name: str, *, fallback: str | None = None) -> str | None:
     if resolved:
         return resolved
 
-    resolved = shutil.which(name, path=_platform_search_path())
-    if resolved:
-        return resolved
+    platform_dirs = _platform_bin_dirs()
+    if platform_dirs:
+        search_path = _platform_search_path()
+        if search_path != os.environ.get("PATH", ""):
+            resolved = shutil.which(name, path=search_path)
+            if resolved:
+                return resolved
 
     if fallback and os.path.isfile(fallback) and os.access(fallback, os.X_OK):
         return fallback

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -55,6 +55,7 @@ from hermes_cli.config import (
     save_env_value,
     write_platform_config_field,
 )
+from hermes_cli._subprocess_compat import resolve_executable
 
 # display_hermes_home is imported lazily at call sites to avoid ImportError
 # when hermes_constants is cached from a pre-update version during `hermes update`.
@@ -4123,6 +4124,7 @@ def generate_systemd_unit(system: bool = False, run_as_user: str | None = None) 
         _get_restart_drain_timeout(),
         _get_cron_drain_timeout(),
     )
+    reload_executable = resolve_executable("kill") or "kill"
 
     if system:
         username, group_name, home_dir = _system_service_identity(run_as_user)
@@ -4181,7 +4183,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_executable} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal
@@ -4220,7 +4222,7 @@ RestartForceExitStatus={GATEWAY_SERVICE_RESTART_EXIT_CODE}
 RestartPreventExitStatus={GATEWAY_FATAL_CONFIG_EXIT_CODE}
 KillMode=mixed
 KillSignal=SIGTERM
-ExecReload=/bin/kill -USR1 $MAINPID
+ExecReload={reload_executable} -USR1 $MAINPID
 ExecStopPost=-{python_path} -m gateway.cgroup_cleanup
 TimeoutStopSec={restart_timeout}
 StandardOutput=journal

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -19,6 +19,7 @@ from pathlib import Path
 from typing import Dict, List, Optional, Set
 
 
+from hermes_cli._subprocess_compat import resolve_executable
 from hermes_cli.config import (
     cfg_get,
     load_config, save_config, get_env_value, save_env_value,
@@ -1626,7 +1627,7 @@ def _run_cua_driver_installer(
     The scripts are idempotent: they always download the latest release, so
     re-running on an already-installed system performs an upgrade.
 
-    * macOS / Linux → ``curl -fsSL …/install.sh | /bin/bash``.
+    * macOS / Linux → ``curl -fsSL …/install.sh | bash``.
     * Windows       → ``powershell -NoProfile -ExecutionPolicy Bypass -Command
       "irm …/install.ps1 | iex"``.
 
@@ -1676,7 +1677,7 @@ def _run_cua_driver_installer(
             "https://raw.githubusercontent.com/trycua/cua/main/"
             "libs/cua-driver/scripts/install.sh"
         )
-        manual_hint = f'/bin/bash -c "$(curl -fsSL {install_url})"'
+        manual_hint = f'bash -c "$(curl -fsSL {install_url})"'
         fd, script_path = _tempfile.mkstemp(prefix="cua-driver-install-", suffix=".sh")
         os.close(fd)
         try:
@@ -1701,7 +1702,18 @@ def _run_cua_driver_installer(
             except OSError:
                 pass
             return False
-        install_cmd = ["/bin/bash", script_path]
+        bash = resolve_executable("bash")
+        if bash is None:
+            _print_warning(
+                "    cua-driver installer requires bash, but no executable bash "
+                "was found on PATH or the known platform paths."
+            )
+            try:
+                os.remove(script_path)
+            except OSError:
+                pass
+            return False
+        install_cmd = [bash, script_path]
     use_shell = False
 
     if show_progress:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -47,7 +47,11 @@ import urllib.error
 import urllib.parse
 import zipfile
 
-from hermes_cli._subprocess_compat import windows_detach_flags, windows_hide_flags
+from hermes_cli._subprocess_compat import (
+    resolve_executable,
+    windows_detach_flags,
+    windows_hide_flags,
+)
 from hermes_cli.install_identity import get_install_id as _shared_get_install_id
 import urllib.request
 from pathlib import Path
@@ -6591,10 +6595,15 @@ def _run_setup_command(
     shell: bool = False,
     timeout: int = 180,
 ) -> subprocess.CompletedProcess:
+    executable = None
+    if shell:
+        executable = resolve_executable("bash")
+        if executable is None:
+            raise FileNotFoundError("no bash executable found")
     return subprocess.run(
         command,
         shell=shell,
-        executable="/bin/bash" if shell else None,
+        executable=executable,
         env=_memory_provider_setup_env(),
         capture_output=True,
         text=True,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -242,6 +242,18 @@ class TestGeneratedSystemdUnits:
         assert expected > 60
         assert self._expected_timeout_stop_sec() in unit
 
+    def test_generated_systemd_units_resolve_kill_from_nixos_path(self, monkeypatch):
+        resolved_kill = "/run/current-system/sw/bin/kill"
+        monkeypatch.setattr(gateway_cli, "resolve_executable", lambda name: resolved_kill)
+
+        user_unit = gateway_cli.generate_systemd_unit(system=False)
+        system_unit = gateway_cli.generate_systemd_unit(
+            system=True, run_as_user=pwd.getpwuid(os.getuid()).pw_name
+        )
+
+        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in user_unit
+        assert f"ExecReload={resolved_kill} -USR1 $MAINPID" in system_unit
+
     def test_timeout_stop_sec_follows_a_raised_cron_drain_timeout(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "_get_restart_drain_timeout", lambda: 0.0)
         monkeypatch.setattr(gateway_cli, "_get_cron_drain_timeout", lambda: 60.0)
@@ -289,7 +301,7 @@ class TestGeneratedSystemdUnits:
         link_node = local_bin / "node"
         link_node.symlink_to(real_node)
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: str(link_node) if cmd == "node" else None)
 
         unit = gateway_cli.generate_systemd_unit(system=False)
 
@@ -307,7 +319,7 @@ class TestGeneratedSystemdUnits:
         link_node = local_bin / "node"
         link_node.symlink_to(real_node)
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: str(link_node) if cmd == "node" else None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: str(link_node) if cmd == "node" else None)
 
         plist = gateway_cli.generate_launchd_plist()
 
@@ -758,7 +770,7 @@ class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: None)
 
         assert gateway_cli.supports_systemd_services() is False
 
@@ -766,7 +778,7 @@ class TestGatewayServiceDetection:
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/usr/bin/systemctl")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/usr/bin/systemctl")
 
         assert gateway_cli.supports_systemd_services() is True
 
@@ -1249,10 +1261,10 @@ class TestSystemUnitHermesHome:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: root_hermes)
         monkeypatch.setattr(gateway_cli, "_build_service_path_dirs", lambda: [])
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/root/bin/node")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/root/bin/node" if name == "node" else None)
         root_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name: "/home/alice/.local/bin/node")
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda name, **kwargs: "/home/alice/.local/bin/node" if name == "node" else None)
         user_unit = gateway_cli.generate_systemd_unit(system=True, run_as_user="alice")
 
         assert root_unit == user_unit
@@ -1333,7 +1345,7 @@ class TestSystemUnitRefreshSyncsHermesHome:
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "_run_systemctl", lambda *a, **k: None)
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
@@ -2549,7 +2561,7 @@ class TestTimeoutStopSecCoversCronFloor:
         monkeypatch.setenv("HERMES_HOME", str(hermes))
         monkeypatch.delenv("HERMES_RESTART_DRAIN_TIMEOUT", raising=False)
         monkeypatch.delenv("HERMES_CRON_DRAIN_TIMEOUT", raising=False)
-        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: None)
+        monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd, **kwargs: None)
         monkeypatch.setattr(
             gateway_cli, "_build_user_local_paths", lambda home, existing: []
         )

--- a/tests/hermes_cli/test_install_cua_driver.py
+++ b/tests/hermes_cli/test_install_cua_driver.py
@@ -263,6 +263,7 @@ class TestInstallCuaDriverUpgrade:
                  return_value="/usr/local/bin/cua-driver",
              ), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
+             patch.object(tools_config, "_cua_release_endpoint_reachable", return_value=True), \
              patch.object(
                  tools_config,
                  "_repair_cua_driver_autostart_windows",
@@ -1308,7 +1309,7 @@ class TestInstallerNoShell:
     asserting a branch the host had already selected.
     """
 
-    def _run(self, download_rc=0):
+    def _run(self, download_rc=0, bash_path: str | None = "/usr/bin/bash"):
         from unittest.mock import MagicMock
         from hermes_cli import tools_config
 
@@ -1332,6 +1333,7 @@ class TestInstallerNoShell:
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config, "resolve_executable", return_value=bash_path), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \
@@ -1348,11 +1350,16 @@ class TestInstallerNoShell:
         # Download: plain argv curl, no shell.
         dl_cmd = run_calls[0][1]
         assert isinstance(dl_cmd, list) and dl_cmd[0] == "curl"
-        # Exec: argv list ["/bin/bash", <mkstemp path>], shell=False.
+        # Exec: argv list [resolved bash, <mkstemp path>], shell=False.
         exec_cmd, exec_kw = popen_calls[0][1], popen_calls[0][2]
-        assert isinstance(exec_cmd, list) and exec_cmd[0] == "/bin/bash"
+        assert isinstance(exec_cmd, list) and exec_cmd[0] == "/usr/bin/bash"
         assert "cua-driver-install-" in exec_cmd[1]
         assert exec_kw.get("shell") is False
+
+    def test_missing_bash_returns_false_without_exec(self):
+        ok, calls = self._run(bash_path=None)
+        assert ok is False
+        assert not [c for c in calls if c[0] == "popen"]
 
     def test_download_failure_returns_false_without_exec(self):
         ok, calls = self._run(download_rc=6)
@@ -1381,6 +1388,7 @@ class TestInstallerNoShell:
         with patch("subprocess.run", side_effect=fake_run), \
              patch("subprocess.Popen", side_effect=fake_popen), \
              patch.object(tools_config.shutil, "which", return_value="/usr/local/bin/cua-driver"), \
+             patch.object(tools_config, "resolve_executable", return_value="/usr/bin/bash"), \
              patch.object(tools_config, "_clear_stale_cua_install_lock"), \
              patch.object(tools_config, "_print_warning"), \
              patch.object(tools_config, "_print_info"), \

--- a/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
+++ b/tests/hermes_cli/test_kanban_gateway_restart_handoff.py
@@ -113,7 +113,7 @@ def test_managed_gateway_scope_builder_fails_closed_if_binary_disappears(
     monkeypatch.setenv("INVOCATION_ID", "managed-gateway-test")
     monkeypatch.setattr("tools.process_registry._is_supervised_gateway_process", lambda: True)
     monkeypatch.setattr("tools.process_registry._systemd_run_user_scope_available", lambda: True)
-    monkeypatch.setattr("shutil.which", lambda _name: None)
+    monkeypatch.setattr("shutil.which", lambda _name, *args, **kwargs: None)
     monkeypatch.setattr(subprocess, "Popen", lambda *_args, **_kwargs: pytest.fail("unsafe direct spawn"))
 
     with pytest.raises(RuntimeError, match="restart-safe systemd scope"):

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -239,6 +239,27 @@ class TestSessionTokenInjection:
 # ---------------------------------------------------------------------------
 
 
+def test_run_setup_command_uses_resolved_bash(monkeypatch):
+    import hermes_cli.web_server as web_server
+
+    resolved_bash = "/run/current-system/sw/bin/bash"
+    captured = {}
+
+    def fake_run(command, **kwargs):
+        captured["command"] = command
+        captured["kwargs"] = kwargs
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(web_server, "resolve_executable", lambda name: resolved_bash)
+    monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+    web_server._run_setup_command(
+        "printf setup", display="printf setup", shell=True, timeout=1
+    )
+
+    assert captured["kwargs"]["executable"] == resolved_bash
+
+
 class TestWebServerEndpoints:
     """Test the FastAPI REST endpoints using Starlette TestClient."""
 

--- a/tests/test_command_secret_source.py
+++ b/tests/test_command_secret_source.py
@@ -1,7 +1,7 @@
 """E2E tests for the ``command`` secret source.
 
 These exercise the REAL resolution path: real helper shell scripts written
-to a temp dir (chmod +x), real ``/bin/sh -c`` subprocesses, and a real temp
+to a temp dir (chmod +x), real resolved POSIX shell subprocesses, and a real temp
 HERMES_HOME with a config.yaml routing ``secrets.provider: command`` through
 ``hermes_cli.env_loader._apply_external_secret_sources``.
 
@@ -76,6 +76,30 @@ def test_profile_helper_does_not_inherit_process_secret(monkeypatch):
         reset_source_environment(token)
 
     assert output == "unset|profile-value"
+
+
+def test_helper_uses_resolved_sh_from_reduced_path(monkeypatch):
+    import agent.secret_sources.command as command_source
+
+    resolved_sh = "/run/current-system/sw/bin/sh"
+    seen = {}
+
+    class FakeProcess:
+        pid = 1234
+        returncode = 0
+
+        def communicate(self, timeout):
+            return b"CMDTEST_API_KEY=resolved\n", b""
+
+    def fake_popen(argv, **kwargs):
+        seen["argv"] = argv
+        return FakeProcess()
+
+    monkeypatch.setattr(command_source, "resolve_executable", lambda name: resolved_sh)
+    monkeypatch.setattr(command_source.subprocess, "Popen", fake_popen)
+
+    assert get_command_secret(command="printf x", key="CMDTEST_API_KEY") == "resolved"
+    assert seen["argv"] == [resolved_sh, "-c", "printf x"]
 
 
 @pytest.fixture(autouse=True)

--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -43,6 +43,61 @@ def _reset_systemd_scope_cache():
     _pr._SYSTEMD_SCOPE_AVAILABLE = original
 
 
+def test_systemd_scope_binary_lookup_uses_shared_nixos_path(monkeypatch, tmp_path):
+    """NixOS systemd binaries must be found from a reduced gateway PATH."""
+    import hermes_cli._subprocess_compat as subprocess_compat
+    import tools.process_registry as process_registry_module
+
+    fake_bin = tmp_path / "nix-bin"
+    fake_bin.mkdir()
+    fake_systemd_run = fake_bin / "systemd-run"
+    fake_systemd_run.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_systemd_run.chmod(0o755)
+    fake_true = fake_bin / "true"
+    fake_true.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_true.chmod(0o755)
+    fake_systemctl = fake_bin / "systemctl"
+    fake_systemctl.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_systemctl.chmod(0o755)
+
+    monkeypatch.setattr(
+        subprocess_compat, "_platform_bin_dirs", lambda: (str(fake_bin),)
+    )
+    monkeypatch.setenv("PATH", str(tmp_path / "empty-path"))
+    monkeypatch.setattr(process_registry_module, "_SYSTEMD_SCOPE_AVAILABLE", None)
+    monkeypatch.setattr(process_registry_module, "_SYSTEMD_SCOPE_PROBED_AT", 0.0)
+
+    seen = []
+    real_which = shutil.which
+
+    def tracked_which(name, mode=os.F_OK | os.X_OK, path=None):
+        seen.append((name, path))
+        return real_which(name, mode=mode, path=path)
+
+    monkeypatch.setattr(shutil, "which", tracked_which)
+    run_calls = []
+
+    def fake_run(*args, **kwargs):
+        run_calls.append(args[0])
+        return subprocess.CompletedProcess(args[0], 0, b"", b"")
+
+    monkeypatch.setattr(process_registry_module.subprocess, "run", fake_run)
+
+    assert process_registry_module._systemd_run_user_scope_available() is True
+    argv = process_registry_module._build_systemd_scope_argv(
+        ["python", "-m", "cron.scheduler"], unit_suffix="path-test"
+    )
+
+    assert argv[0] == str(fake_systemd_run)
+    assert run_calls and run_calls[0][-1] == str(fake_true)
+    assert process_registry_module._stop_systemd_unit("hermes-worker-path-test.scope") is True
+    assert run_calls[-1][0] == str(fake_systemctl)
+    assert any(
+        name == "systemd-run" and str(fake_bin) in (path or "")
+        for name, path in seen
+    )
+
+
 def _make_session(
     sid="proc_test123",
     command="echo hello",

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -1406,7 +1406,7 @@ class TestWSL2PowerShellFallback:
             m = MagicMock()
             # Simulate the PowerShell pipeline failing (nonzero rc), and
             # the fallback ffplay succeeding.
-            if cmd[0] in ("/bin/sh", "sh"):
+            if cmd[0].endswith("/sh"):
                 m.returncode = 1
             else:
                 m.returncode = 0
@@ -1415,6 +1415,7 @@ class TestWSL2PowerShellFallback:
 
         with patch("tools.voice_mode._is_wsl2_env", return_value=True), \
              patch("tools.voice_mode._import_audio", side_effect=ImportError), \
+             patch("tools.voice_mode.resolve_executable", return_value="/run/current-system/sw/bin/sh"), \
              patch("tools.voice_mode.shutil.which",
                    side_effect=lambda x: f"/bin/{x}" if x in ("powershell.exe", "ffmpeg", "ffplay", "sh") else (x if x.startswith("/") else None)), \
              patch("tools.voice_mode.subprocess.check_output",
@@ -1431,7 +1432,7 @@ class TestWSL2PowerShellFallback:
             f"Expected sh pipeline to be tried and fail, then ffplay to be "
             f"tried: {captured_cmds}"
         )
-        assert captured_cmds[0][0] in ("/bin/sh", "sh")
+        assert captured_cmds[0][0] == "/run/current-system/sw/bin/sh"
         assert captured_cmds[1][0] == "ffplay"
         # The subshell command must capture and re-exit with $rc, not rely
         # on rm -f's exit status.

--- a/tests/tools/test_windows_native_support.py
+++ b/tests/tools/test_windows_native_support.py
@@ -423,7 +423,37 @@ class TestSubprocessCompatHelpers:
         argv = resolve_node_command("sh", ["-c", "echo hi"])
         assert argv[1:] == ["-c", "echo hi"]
         # First element is either an absolute path (sh found) or the bare
-        # name (fallback) — both are acceptable behaviours.
+        # name (fallback) - both are acceptable behaviours.
+
+    def test_resolve_executable_uses_known_linux_profile_paths(self, tmp_path, monkeypatch):
+        from hermes_cli import _subprocess_compat as sc
+
+        normal_bin = tmp_path / "normal-bin"
+        nix_bin = tmp_path / "nix-bin"
+        normal_bin.mkdir()
+        nix_bin.mkdir()
+        normal = normal_bin / "hermes-path-test"
+        nix = nix_bin / "hermes-path-test"
+        normal.write_text("#!/bin/sh\n", encoding="utf-8")
+        nix.write_text("#!/bin/sh\n", encoding="utf-8")
+        normal.chmod(0o755)
+        nix.chmod(0o755)
+
+        monkeypatch.setenv("PATH", str(normal_bin))
+        monkeypatch.setattr(sc, "_platform_bin_dirs", lambda: (str(nix_bin),))
+        before = os.environ["PATH"]
+        assert sc.resolve_executable("hermes-path-test") == str(normal)
+        assert os.environ["PATH"] == before
+
+        monkeypatch.setenv("PATH", "/usr/bin:/bin")
+        reduced = os.environ["PATH"]
+        assert sc.resolve_executable("hermes-path-test") == str(nix)
+        assert os.environ["PATH"] == reduced
+
+    def test_resolve_executable_does_not_return_missing_fallback(self):
+        from hermes_cli._subprocess_compat import resolve_executable
+
+        assert resolve_executable("hermes-definitely-missing", fallback="/bin/absent") is None
 
 
     @pytest.mark.windows_only
@@ -613,14 +643,13 @@ class TestCronSchedulerBashResolution:
     """cron.scheduler must NOT hardcode /bin/bash — .sh scripts need a
     dynamically-resolved bash so Windows (Git Bash) works."""
 
-    def test_source_uses_shutil_which_for_bash(self):
+    def test_source_uses_shared_executable_resolver_for_bash(self):
         root = Path(__file__).resolve().parents[2]
         source = (root / "cron" / "scheduler.py").read_text(encoding="utf-8")
-        # The old hardcoded path should be gone as the sole bash source.
-        # It may still appear as a POSIX fallback after shutil.which(), so
-        # we check for the shutil.which call near the .sh/.bash branch.
-        assert 'shutil.which("bash")' in source, (
-            "cron.scheduler must resolve bash dynamically via shutil.which"
+        # The old hardcoded path and direct lookup should be gone from the
+        # actual .sh/.bash branch.
+        assert 'resolve_executable("bash")' in source, (
+            "cron.scheduler must resolve bash through the shared executable resolver"
         )
 
     def test_error_message_when_bash_missing(self):

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -17,7 +17,7 @@ from pathlib import Path
 
 from hermes_constants import get_process_hermes_home
 from tools.environments.base import BaseEnvironment, _pipe_stdin
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import resolve_executable, windows_hide_flags
 
 _IS_WINDOWS = platform.system() == "Windows"
 
@@ -982,13 +982,7 @@ def build_subprocess_env(
 def _find_bash() -> str:
     """Find bash for command execution."""
     if not _IS_WINDOWS:
-        return (
-            shutil.which("bash")
-            or ("/usr/bin/bash" if os.path.isfile("/usr/bin/bash") else None)
-            or ("/bin/bash" if os.path.isfile("/bin/bash") else None)
-            or os.environ.get("SHELL")
-            or "/bin/sh"
-        )
+        return resolve_executable("bash") or os.environ.get("SHELL") or "/bin/sh"
 
     candidates: list[str] = []
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -48,7 +48,7 @@ _IS_WINDOWS = platform.system() == "Windows"
 # platforms provably never touch systemd code (#70716 cross-platform audit).
 _IS_LINUX = platform.system() == "Linux"
 from tools.environments.local import _find_shell, _resolve_safe_cwd, _sanitize_subprocess_env
-from hermes_cli._subprocess_compat import windows_hide_flags
+from hermes_cli._subprocess_compat import resolve_executable, windows_hide_flags
 from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
@@ -189,7 +189,7 @@ def _systemd_run_user_scope_available() -> bool:
     bus that ``systemd-run --user`` needs may be absent even though the
     binary is on PATH, causing every spawn to fail with
     ``Failed to connect to user bus``.  We do a cheap no-op probe
-    (``systemd-run --user --scope --unit=… -- /bin/true``) and remember the
+    (``systemd-run --user --scope --unit=… -- true``) and remember the
     outcome.
     """
     global _SYSTEMD_SCOPE_AVAILABLE, _SYSTEMD_SCOPE_PROBED_AT
@@ -221,10 +221,9 @@ def _systemd_run_user_scope_available() -> bool:
         available = False
         if _IS_LINUX:
             try:
-                import shutil
-
-                binary = shutil.which("systemd-run")
-                if binary:
+                binary = resolve_executable("systemd-run")
+                probe_true = resolve_executable("true")
+                if binary and probe_true:
                     # Probe: create a transient scope that immediately exits.
                     # A unique unit avoids collisions; timeout bounds D-Bus.
                     probe_unit = f"hermes-probe-scope-{os.getpid()}-{uuid.uuid4().hex[:8]}"
@@ -237,7 +236,7 @@ def _systemd_run_user_scope_available() -> bool:
                             "--property", f"MemoryMax={_worker_memory_max_bytes()}",
                             "--property", "OOMPolicy=kill",
                             "--",
-                            "/bin/true",
+                            probe_true,
                         ],
                         capture_output=True,
                         timeout=3,
@@ -295,9 +294,7 @@ def _build_systemd_scope_argv(
     the transient scope self-clean after exit; ``--unit`` gives it a
     recognisable name for ``systemctl --user status`` / journalctl.
     """
-    import shutil
-
-    binary = shutil.which("systemd-run")
+    binary = resolve_executable("systemd-run")
     if binary is None:
         # Caller should have checked _systemd_run_user_scope_available();
         # guard anyway so we never pass None into Popen.
@@ -364,9 +361,7 @@ def _stop_systemd_unit(unit_name: str) -> bool:
     Returns True if the unit was successfully stopped (or was already gone),
     False if ``systemctl`` is unavailable or the stop command failed.
     """
-    import shutil
-
-    binary = shutil.which("systemctl")
+    binary = resolve_executable("systemctl")
     if binary is None:
         return False
     try:

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -26,6 +26,8 @@ import time
 import wave
 from typing import Any, Callable, Dict, List, Optional
 
+from hermes_cli._subprocess_compat import resolve_executable
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -1732,7 +1734,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                         ["wslpath", "-w", _wsl_wav],
                         stderr=subprocess.DEVNULL, timeout=3,
                     ).decode(errors="replace").strip()
-                    if _win_wav:
+                    if _win_wav and (shell_executable := resolve_executable("sh")):
                         _win_wav_safe = _win_wav.replace("'", "''")
                         _ps_script = (
                             f"(New-Object Media.SoundPlayer '{_win_wav_safe}').PlaySync()"
@@ -1751,7 +1753,7 @@ def _play_audio_file_impl(file_path: str) -> bool:
                         # and prevent falling through to the next player).
                         _full_cmd = f"( {_ps_cmd} ); rc=$?; {_cleanup}; exit $rc"
                         # Use full path so the which(cmd[0]) check in the player loop passes.
-                        players.insert(0, ["/bin/sh", "-c", _full_cmd])
+                        players.insert(0, [shell_executable, "-c", _full_cmd])
             except Exception:
                 pass  # WSL path resolution failed; fall through to ffplay/aplay
 


### PR DESCRIPTION
## What does this PR do?

This fixes restart-safe cron worker scope detection and cleanup when Hermes runs on NixOS with a reduced service `PATH`. The resolver finds NixOS profile binaries without changing the process environment, so the systemd scope path can locate `systemd-run`, the probe's `true`, and `systemctl` reliably.

This PR is intentionally stacked on the shared resolver from companion PR #102869. Until that PR lands, this branch includes its parent commit as normal for a stacked fork PR.

## Related Issue

Related: #102587 and #102508. #102587 resolves the probe's `true` lookup in isolation; this PR uses the shared resolver for the complete systemd scope path. #102508 covers separate transient-scope property negotiation.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- resolve `systemd-run` before creating a transient scope
- resolve the scope probe's `true` instead of using hard-coded `/bin/true`
- resolve `systemctl` before cleanup of the transient unit
- preserve Linux gating, probe caching, timeouts, unit naming, memory bounds, fail-closed behavior, and `--` argv separation
- add deterministic reduced-PATH tests with temporary executable stubs covering all three systemd binaries

## How to Test

1. Run the affected suites with the repository's isolated test runner:
   `taskset -c 0-7 ./scripts/run_tests.sh tests/hermes_cli/test_kanban_gateway_restart_handoff.py tests/tools/test_process_registry.py tests/cron/test_restart_safe_worker.py -k 'not test_close_stdin_allows_eof_driven_process_to_finish' -q`
2. Run Ruff and import checks for the changed process-registry path.
3. Exercise the resolver with `PATH=/usr/bin:/bin` and verify that `systemd-run`, `true`, and `systemctl` resolve to executable absolute paths while `PATH` remains unchanged.

Local result: 125 tests passed, 6 skipped, 0 failed in the three affected suites when excluding the unrelated PTY test. The excluded test launches literal `python3` and exits `127` on this host because the clean test `PATH` has no `python3`; branch1 reproduces that unrelated baseline failure.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (the parent runtime PR is intentionally included for stacking)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: NixOS Linux with a reduced service `PATH`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) - or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys - or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows - or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) - or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior - or N/A

## Screenshots / Logs

- `git diff --check`: passed
- Ruff: passed
- imports: passed
- reduced-PATH runtime probe: passed with `PATH` unchanged
