### PR TITLE
fix(gateway): capture agent end after delivery finalization

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23428,13 +23428,38 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
             if _footer_line and response and not agent_result.get("already_sent") and not _intentional_silence:
                 response = f"{response}\n\n{_footer_line}"
 
-            # Emit agent:end hook
-            await self.hooks.emit("agent:end", {
+            # Emit agent:end after the adapter has delivered the visible
+            # response.  Capture hooks read the delivery ledger, so firing
+            # before BasePlatformAdapter sends can race the obligation write
+            # and lose the final outbound receipt.
+            _agent_end_context = {
                 **hook_ctx,
                 "response": (response or "")[:500],
                 "model": agent_result.get("model", ""),
                 "provider": agent_result.get("provider", ""),
-            })
+            }
+            _hook_adapter = self._adapter_for_source(source)
+            _register_post_delivery = getattr(
+                _hook_adapter, "register_post_delivery_callback", None
+            ) if _hook_adapter else None
+            if session_key and callable(_register_post_delivery):
+                async def _emit_agent_end_after_delivery() -> None:
+                    await self.hooks.emit("agent:end", _agent_end_context)
+
+                try:
+                    _register_post_delivery(
+                        session_key,
+                        _emit_agent_end_after_delivery,
+                        generation=run_generation,
+                    )
+                except Exception:
+                    logger.debug(
+                        "agent:end post-delivery registration failed",
+                        exc_info=True,
+                    )
+                    await self.hooks.emit("agent:end", _agent_end_context)
+            else:
+                await self.hooks.emit("agent:end", _agent_end_context)
             
             # Check for pending process watchers (check_interval on background processes)
             try:

--- a/tests/gateway/test_gateway_silence_tokens.py
+++ b/tests/gateway/test_gateway_silence_tokens.py
@@ -195,3 +195,60 @@ async def test_agent_end_hook_includes_model_and_provider(monkeypatch, tmp_path)
     )
     assert end_context["model"] == "gpt-5.6-terra"
     assert end_context["provider"] == "openai-codex"
+
+
+class _DeferredHookAdapter:
+    platform = Platform.TELEGRAM
+
+    def __init__(self):
+        self.callbacks = []
+
+    async def send(self, *args, **kwargs):
+        return MagicMock(success=True)
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks.append((session_key, callback, generation))
+
+
+@pytest.mark.asyncio
+async def test_agent_end_hook_waits_for_post_delivery(monkeypatch, tmp_path):
+    runner = _runner(monkeypatch, tmp_path)
+    adapter = _DeferredHookAdapter()
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    runner._run_agent = AsyncMock(return_value={
+        "final_response": "done",
+        "messages": [
+            {"role": "user", "content": "question"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "tools": [],
+        "history_offset": 0,
+        "last_prompt_tokens": 0,
+        "api_calls": 1,
+        "failed": False,
+        "model": "gpt-5.6-terra",
+        "provider": "openai-codex",
+    })
+
+    await runner._handle_message_with_agent(
+        _event(), _source(), "agent:main:telegram:group:-1001:12345", 1
+    )
+
+    assert not [
+        call for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    ]
+    assert len(adapter.callbacks) == 1
+    session_key, callback, generation = adapter.callbacks[0]
+    assert session_key == "agent:main:telegram:group:-1001:12345"
+    assert generation == 1
+
+    await callback()
+
+    end_context = next(
+        call.args[1]
+        for call in runner.hooks.emit.await_args_list
+        if call.args[0] == "agent:end"
+    )
+    assert end_context["model"] == "gpt-5.6-terra"
+    assert end_context["provider"] == "openai-codex"


### PR DESCRIPTION
## Summary\n- forward-port the tested Selim WhatsApp durable OUT-capture ordering fix onto current upstream main\n- defer the existing agent:end hook through the adapter's post-delivery callback so capture sees the finalized delivery obligation\n- preserve immediate fallback for adapters without the reviewed callback seam\n\n## Verification\n- focused gateway/hook/delivery tests: 21 passed\n- Buzz/WhatsApp adapter and websocket matrix: 318 passed, 5 skipped (one pre-existing macOS PATH_MAX fixture deselected)\n- run/adjacent gateway tests: 78 passed\n- ruff, compileall, and git diff --check: green\n\nThe one excluded test is the existing nested-long-path fixture, which cannot create its 6x150-character path on macOS (Errno 63, PATH_MAX); it is unrelated to this diff. No live Hermes profile, service, or outbound message was changed.