### PR TITLE
plugins: add Inline platform to community index

### DIFF
--- a/hermes_cli/data/plugin_index.json
+++ b/hermes_cli/data/plugin_index.json
@@ -1,6 +1,6 @@
 {
   "schema_version": 1,
-  "generated_at": "2026-08-12T00:00:00Z",
+  "generated_at": "2026-09-04T00:00:00Z",
   "plugins": [
     {
       "name": "hermes-media-studio",
@@ -63,6 +63,19 @@
       "capabilities": ["tools"],
       "api_version": 1,
       "added_at": "2026-08-12"
+    },
+    {
+      "name": "inline-platform",
+      "description": "Use Hermes Agent from Inline work-chat DMs, chats, and reply threads.",
+      "author": "Inline",
+      "tags": ["inline", "work-chat", "messaging", "gateway"],
+      "repo": "inline-chat/inline",
+      "subdir": "hermes-agent/plugin/inline",
+      "ref": "32944bd9bc5be716a615136fc02d65fb81ac0ae9",
+      "homepage": "https://github.com/inline-chat/inline/tree/main/hermes-agent",
+      "capabilities": ["platform"],
+      "api_version": 1,
+      "added_at": "2026-09-04"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- add the external Inline platform adapter to the bundled community plugin index
- pin installation to the published `0.0.15` source commit
- keep all plugin implementation code in `inline-chat/inline`; this PR adds metadata only

## Install target

```text
inline-chat/inline/hermes-agent/plugin/inline
32944bd9bc5be716a615136fc02d65fb81ac0ae9
```

The entry declares the `platform` capability, so after installation and enablement, Inline is discovered by the messaging-platform setup picker.

This complements #86154 and #86214: the current default remote index is not available, so the bundled seed is the working fallback and should contain third-party catalog records until the canonical index path is restored.

## Validation

- `scripts/run_tests.sh tests/hermes_cli/test_plugin_index_search.py` — 38 passed
- isolated install from the exact repository/subdirectory/SHA — installed and enabled `inline-platform` v0.0.15
- isolated platform enumeration — `Inline (inline)` appeared in the setup picker
- JSON parse and `git diff --check`
