### PR TITLE
fix(desktop): restrict self-update to the canonical managed bundle

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -392,6 +392,7 @@ import {
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
+  resolveUpdateTarget,
   sandboxFallbackFromEnv,
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker,
@@ -4473,13 +4474,26 @@ async function applyUpdatesPosixHandoff(opts: any) {
   const args = [...handoff.args, '--install-root', updateRoot, '--branch', branch, '--desktop-pid', String(process.pid)]
   const updateStartedAt = Math.floor(Date.now() / 1000)
 
-  // Relaunch target: the running .app bundle on mac (script swaps the
-  // rebuilt bundle over it), the running binary elsewhere. The script's gate
-  // (an exact port of update-relaunch.ts's decideRelaunchOutcome) relaunches
-  // only a binary the rebuild replaced with a launchable sandbox helper —
-  // replaying the original launch context (filtered args, cwd, sandbox
-  // opt-out) so a deep-link or --no-sandbox launch survives the update.
-  const targetApp = IS_MAC ? runningAppBundle() : process.execPath
+  // Relaunch target: resolve the canonical managed bundle from updateRoot.
+  // A packaged self-update may promote only to the normalized bundle under
+  // the update root.  A running worktree, artifact, symlink escape, or
+  // outside-install path must stop before updater spawn, marker write,
+  // rm, ditto, or mv — surface a clear manual outcome instead.
+  const targetResult = resolveUpdateTarget(updateRoot, IS_MAC ? runningAppBundle() : null)
+
+  if (IS_MAC && targetResult.canonical && !targetResult.ok) {
+    rememberLog(`[updates] refusing noncanonical relaunch target (expected ${targetResult.canonical})`)
+    emitUpdateProgress({
+      stage: 'manual',
+      message: 'This copy of Hermes cannot self-update — it is running from outside the managed install location. Reinstall Hermes to enable automatic updates.',
+      percent: null
+    })
+    // Same contract as the no-handoff-script path: ok=true means the check
+    // succeeded, manual=true means the update needs user action.
+    return { ok: true, manual: true, message: 'noncanonical-install', hermesRoot: updateRoot }
+  }
+
+  const targetApp = targetResult.canonical || (IS_MAC ? null : process.execPath)
 
   if (targetApp) {
     args.push('--relaunch-target', targetApp)

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -11,6 +11,7 @@ import {
   resolvePosixScriptHandoff,
   resolveStagedUpdaterBinary,
   resolveUpdateScriptHandoff,
+  resolveUpdateTarget,
   sandboxFallbackFromEnv,
   spawnUpdaterProcess,
   stagedUpdaterSupportsPrewrittenMarker,
@@ -459,4 +460,69 @@ test('observeUpdaterHandoff settles ok for children without an event interface',
   const outcome = await outcomePromise
 
   assert.equal(outcome.ok, true)
+})
+
+// ── resolveUpdateTarget ───────────────────────────────────────────────
+
+const MANAGED_ROOT = '/home/hermes/.hermes/hermes-agent'
+const CANONICAL_ARM = path.join(MANAGED_ROOT, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app')
+const CANONICAL_INTEL = path.join(MANAGED_ROOT, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
+const WORKTREE_BUNDLE = '/Users/rohitsabu/.claude/orchestrate/hermes-reliability-p0/worktrees/desktop-activation/apps/desktop/release/mac-arm64/Hermes.app'
+
+test('resolveUpdateTarget accepts canonical mac-arm64 bundle', () => {
+  const result = resolveUpdateTarget(MANAGED_ROOT, CANONICAL_ARM, {
+    isMac: true,
+    realpathSync: (p: string) => p
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.canonical, CANONICAL_ARM)
+})
+
+test('resolveUpdateTarget accepts canonical mac fallback bundle', () => {
+  const result = resolveUpdateTarget(MANAGED_ROOT, CANONICAL_INTEL, {
+    isMac: true,
+    realpathSync: (p: string) => p
+  })
+  assert.equal(result.ok, true)
+  assert.equal(result.canonical, CANONICAL_ARM)
+})
+
+test('resolveUpdateTarget rejects worktree path', () => {
+  // The exact bug: runningAppBundle() returns the worktree path when
+  // Hermes is launched from a dev worktree.  The updater must refuse.
+  const result = resolveUpdateTarget(MANAGED_ROOT, WORKTREE_BUNDLE, {
+    isMac: true,
+    realpathSync: (p: string) => p
+  })
+  assert.equal(result.ok, false)
+  assert.equal(result.error, 'noncanonical-install')
+})
+
+test('resolveUpdateTarget rejects artifact path', () => {
+  const result = resolveUpdateTarget(MANAGED_ROOT, '/tmp/hermes-build/Hermes.app', {
+    isMac: true,
+    realpathSync: (p: string) => p
+  })
+  assert.equal(result.ok, false)
+})
+
+test('resolveUpdateTarget rejects symlink escape', () => {
+  // realpathSync resolves the symlink to a path outside the update root.
+  const realpaths: Record<string, string> = {
+    [MANAGED_ROOT]: '/real/hermes/hermes-agent',
+    '/fake/symlink/Hermes.app': '/outside/worktree/Hermes.app'
+  }
+  const result = resolveUpdateTarget(MANAGED_ROOT, '/fake/symlink/Hermes.app', {
+    isMac: true,
+    realpathSync: (p: string) => realpaths[p] ?? p
+  })
+  assert.equal(result.ok, false)
+})
+
+test('resolveUpdateTarget returns null canonical on non-mac', () => {
+  const result = resolveUpdateTarget(MANAGED_ROOT, CANONICAL_ARM, {
+    isMac: false
+  })
+  assert.equal(result.canonical, null)
+  assert.equal(result.ok, true)
 })

--- a/apps/desktop/electron/updater-process.test.ts
+++ b/apps/desktop/electron/updater-process.test.ts
@@ -484,7 +484,7 @@ test('resolveUpdateTarget accepts canonical mac fallback bundle', () => {
     realpathSync: (p: string) => p
   })
   assert.equal(result.ok, true)
-  assert.equal(result.canonical, CANONICAL_ARM)
+  assert.equal(result.canonical, CANONICAL_INTEL)
 })
 
 test('resolveUpdateTarget rejects worktree path', () => {

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -251,8 +251,11 @@ export function resolveUpdateTarget(
   const canonicalTarget = path.join(normalizedRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app')
   const fallbackTarget = path.join(normalizedRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
 
-  if (normalizedBundle === canonicalTarget || normalizedBundle === fallbackTarget) {
+  if (normalizedBundle === canonicalTarget) {
     return { canonical: canonicalTarget, ok: true }
+  }
+  if (normalizedBundle === fallbackTarget) {
+    return { canonical: fallbackTarget, ok: true }
   }
 
   return { canonical: canonicalTarget, ok: false, error: 'noncanonical-install' }

--- a/apps/desktop/electron/updater-process.ts
+++ b/apps/desktop/electron/updater-process.ts
@@ -188,6 +188,83 @@ export function sandboxFallbackFromEnv(env: Record<string, string | undefined>, 
   return Array.isArray(launchArgs) && launchArgs.includes('--no-sandbox')
 }
 
+export interface ResolveUpdateTargetDeps {
+  isMac?: boolean
+  realpathSync?: (p: string) => string
+}
+
+export interface ResolveUpdateTargetResult {
+  /** Canonical managed bundle under updateRoot, null if not Mac. */
+  canonical: string | null
+  /** True when the running bundle is the canonical target. */
+  ok: boolean
+  /** Human-readable reason when ok is false. */
+  error?: string
+}
+
+/**
+ * Resolve the canonical update target from updateRoot and validate the
+ * running bundle against it.
+ *
+ * A packaged self-update may promote only to the normalized managed bundle
+ * under the update root.  A running worktree, artifact, symlink escape, or
+ * outside-install path must be rejected before the updater spawns — the
+ * marker write, rm, ditto, and mv must never touch a noncanonical bundle.
+ *
+ * Returns the canonical path and ok=true when the running bundle IS the
+ * canonical target (or its supported fallback).  On non-Mac platforms
+ * returns { canonical: null, ok: true } — the gate only applies to macOS
+ * .app bundles.
+ */
+export function resolveUpdateTarget(
+  updateRoot: string,
+  runningBundle: string | null,
+  deps: ResolveUpdateTargetDeps = {}
+): ResolveUpdateTargetResult {
+  const isMac = deps.isMac ?? process.platform === 'darwin'
+
+  if (!isMac) {
+    return { canonical: null, ok: true }
+  }
+
+  if (!runningBundle) {
+    return { canonical: null, ok: false, error: 'no-running-bundle' }
+  }
+
+  const realpath = deps.realpathSync ?? defaultRealpathSync
+
+  // Normalize both paths through the filesystem so symlink escapes and
+  // case-variant paths collapse to the same physical location.  An absent
+  // path is treated as a mismatch — the canonical target must exist.
+  let normalizedRoot: string
+  let normalizedBundle: string
+  try {
+    normalizedRoot = realpath(updateRoot)
+    normalizedBundle = realpath(runningBundle)
+  } catch {
+    return { canonical: null, ok: false, error: 'noncanonical-install' }
+  }
+
+  // Supported managed release bundle locations derived from the actual
+  // source topology.  The primary (Apple Silicon) and fallback (Intel)
+  // are both accepted.
+  const canonicalTarget = path.join(normalizedRoot, 'apps', 'desktop', 'release', 'mac-arm64', 'Hermes.app')
+  const fallbackTarget = path.join(normalizedRoot, 'apps', 'desktop', 'release', 'mac', 'Hermes.app')
+
+  if (normalizedBundle === canonicalTarget || normalizedBundle === fallbackTarget) {
+    return { canonical: canonicalTarget, ok: true }
+  }
+
+  return { canonical: canonicalTarget, ok: false, error: 'noncanonical-install' }
+}
+
+function defaultRealpathSync(p: string): string {
+  // fs.realpathSync.native throws ENOENT on absent paths — that is the
+  // desired fail-closed behavior for this gate.
+  const { realpathSync } = require('node:fs') as typeof import('node:fs')
+  return realpathSync.native(p)
+}
+
 export interface ResolveStagedUpdaterBinaryDeps {
   isWindows?: boolean
   fileExists?: (candidate: string) => boolean

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -362,7 +362,7 @@ mac_swap() {
   # independently callable — defense-in-depth.
   if ! mac_target_gate; then
     DONE_NOTE="Update complete, but this copy of Hermes cannot self-update — it is running from outside the managed install location. Reinstall Hermes to enable automatic updates."
-    log "refusing noncanonical relaunch target: $RELAUNCH_TARGET (expected $physical_root/apps/desktop/release/mac-arm64/Hermes.app)"
+    log "refusing noncanonical relaunch target: $RELAUNCH_TARGET"
     return
   fi
 

--- a/scripts/desktop-update/posix.sh
+++ b/scripts/desktop-update/posix.sh
@@ -39,7 +39,7 @@ ORIGINAL_ARGS=("$@")
 INSTALL_ROOT="" BRANCH="main" DESKTOP_PID=0 RELAUNCH_TARGET=""
 RELAUNCH_CWD="" SANDBOX_FALLBACK=0 RELAUNCH_ARGS=()
 NO_UI=0 NO_MARKER_CLEANUP=0 SELF_TEST_UI=0 SELF_TEST_GATE=0 SELF_TEST_MARKER=0
-SELF_TEST_TCC_HEAL=0
+SELF_TEST_TCC_HEAL=0 SELF_TEST_MAC_TARGET=0
 HANDOFF_DAEMONIZED=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -56,6 +56,7 @@ while [ $# -gt 0 ]; do
     --self-test-tcc-heal) SELF_TEST_TCC_HEAL=1; shift ;;
     --daemonized) HANDOFF_DAEMONIZED=1; shift ;;
     --self-test-marker) SELF_TEST_MARKER=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
+    --self-test-mac-target) SELF_TEST_MAC_TARGET=1; NO_UI=1; NO_MARKER_CLEANUP=1; shift ;;
     --) shift; RELAUNCH_ARGS=("$@"); shift $# ;;
     *) echo "unknown arg: $1" >&2; exit 64 ;;
   esac
@@ -332,12 +333,38 @@ linux_gate() {
   GATE=manual GATE_MSG="Update complete, but the rebuilt app can't relaunch itself (its sandbox helper needs root ownership). Reopen Hermes to finish."
 }
 
+# ── macOS canonical target gate ─────────────────────────────────────────
+# Defense-in-depth: posix.sh is independently callable.  Physically
+# normalize INSTALL_ROOT and RELAUNCH_TARGET (resolving symlinks) then
+# compare against the exact expected bundle path derived from the
+# install root.  A noncanonical target must stop before rm, ditto, or mv.
+mac_target_gate() {
+  local physical_root physical_target canonical fallback
+  physical_root="$(cd "$INSTALL_ROOT" 2>/dev/null && pwd -P)" || return 1
+  physical_target="$(cd "$RELAUNCH_TARGET" 2>/dev/null && pwd -P)" || return 1
+  canonical="$physical_root/apps/desktop/release/mac-arm64/Hermes.app"
+  fallback="$physical_root/apps/desktop/release/mac/Hermes.app"
+  if [ "$physical_target" = "$canonical" ] || [ "$physical_target" = "$fallback" ]; then
+    return 0
+  fi
+  return 1
+}
+
 mac_swap() {
   local rebuilt="" c
   for c in "$INSTALL_ROOT/apps/desktop/release/mac-arm64/Hermes.app" \
            "$INSTALL_ROOT/apps/desktop/release/mac/Hermes.app"; do
     [ -d "$c" ] && { rebuilt="$c"; break; }
   done
+
+  # Canonical target gate: refuse to mutate a noncanonical bundle.
+  # The Electron main process gates this before spawn, but posix.sh is
+  # independently callable — defense-in-depth.
+  if ! mac_target_gate; then
+    DONE_NOTE="Update complete, but this copy of Hermes cannot self-update — it is running from outside the managed install location. Reinstall Hermes to enable automatic updates."
+    log "refusing noncanonical relaunch target: $RELAUNCH_TARGET (expected $physical_root/apps/desktop/release/mac-arm64/Hermes.app)"
+    return
+  fi
 
   # Transactional swap: stage a full copy, move the old bundle aside, move
   # the copy in. Every step checked; a failed final move ROLLS BACK so the
@@ -624,6 +651,18 @@ if [ "$SELF_TEST_GATE" -eq 1 ]; then
   trap - EXIT
   linux_gate
   echo "$GATE${GATE_MSG:+:$GATE_MSG}"
+  exit 0
+fi
+
+if [ "$SELF_TEST_MAC_TARGET" -eq 1 ]; then
+  # Prints the mac target gate decision for the given
+  # --install-root/--relaunch-target and exits.
+  trap - EXIT
+  if mac_target_gate; then
+    echo "canonical"
+  else
+    echo "noncanonical"
+  fi
   exit 0
 fi
 

--- a/scripts/desktop-update/repro.sh
+++ b/scripts/desktop-update/repro.sh
@@ -180,6 +180,35 @@ case "$MODE" in
     rm -rf "$L"
     [ "$fails" -eq 0 ] && say "launch matrix: all pass" || { say "launch matrix: $fails FAILED"; exit 1; }
     ;;
+  mac-target)
+    # macOS canonical target gate matrix.  Builds fake .app directories
+    # under /tmp and asserts gate decisions — same pattern as `gate` mode.
+    # Includes a symlink alias inside the install tree that resolves to an
+    # outside bundle, proving it remains untouched.
+    M="/tmp/hermes-mac-target-test.$$"
+    CANONICAL="$M/hermes-agent/apps/desktop/release/mac-arm64/Hermes.app"
+    OUTSIDE="/tmp/hermes-mac-target-test-outside.$$/Hermes.app"
+    mkdir -p "$CANONICAL" "$OUTSIDE"
+    # Symlink escape: an alias inside the install tree pointing outside
+    mkdir -p "$M/hermes-agent/apps/desktop/release"
+    ln -sf "$OUTSIDE" "$M/hermes-agent/apps/desktop/release/escaped-link.app" 2>/dev/null || true
+
+    fails=0
+    expect() {
+      if [ "$2" = "$3" ]; then printf 'ok   %s -> %s\n' "$1" "$3"
+      else printf 'FAIL %s -> %s (want %s)\n' "$1" "$3" "$2"; fails=$((fails+1)); fi
+    }
+    decide() {
+      bash "$SCRIPT_DIR/posix.sh" --self-test-mac-target --install-root "$M/hermes-agent" "$@"
+    }
+
+    expect "canonical mac-arm64"  canonical    "$(decide --relaunch-target "$CANONICAL")"
+    expect "outside path"         noncanonical "$(decide --relaunch-target "$OUTSIDE")"
+    expect "symlink escape"       noncanonical "$(decide --relaunch-target "$M/hermes-agent/apps/desktop/release/escaped-link.app")"
+
+    rm -rf "$M" "$(dirname "$OUTSIDE")"
+    [ "$fails" -eq 0 ] && say "mac-target matrix: all pass" || { say "mac-target matrix: $fails FAILED"; exit 1; }
+    ;;
   *)
     sed -n '2,24p' "$0" | sed 's/^# \{0,1\}//'
     exit 64


### PR DESCRIPTION
# fix(desktop): restrict self-update to the canonical managed bundle

## Summary

- Only allow macOS desktop self-update replacement/relaunch when the target is the canonical `Hermes.app` inside the managed release tree.
- Reject external paths and symlink escapes instead of touching an arbitrary app bundle.
- Pass the canonical target through the Electron updater handoff and cover the gate in TypeScript and shell regression tests.

## Why

The updater must never infer that an arbitrary running app path is safe to replace. This makes the trust boundary explicit and leaves non-canonical installations on the manual-update path.

## Provenance

Prepared from carry commits `145ced456384f8c3e5f49b2d67b568ceca8d0126` and `e41e97d0271e5cf52490c60a7788cab30ad87c93`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- `npm --workspace apps/desktop run typecheck` — PASS
- `npx vitest run --project electron electron/updater-process.test.ts` — PASS, 32 tests
- `bash scripts/desktop-update/repro.sh mac-target` — PASS, canonical/outside/symlink matrix
- `pytest tests/test_desktop_update_tcc_heal.py` — PASS, 11 tests (also verifies the conflict resolution retained the pre-existing TCC-heal self-test path)
- `git diff --check origin/main..HEAD` — PASS

Full receipt: `test-output.txt`.
