### PR TITLE
fix(telegram): restore structured sends and sanitize HTML for MarkdownV2

### DIFF
--- a/hermes_cli/send_cmd.py
+++ b/hermes_cli/send_cmd.py
@@ -385,6 +385,12 @@ def cmd_send(args: argparse.Namespace) -> None:
         "target": target,
         "message": message,
     }
+    if getattr(args, "silent", False):
+        tool_args["silent"] = True
+    if getattr(args, "buttons", None):
+        tool_args["buttons"] = args.buttons
+    if getattr(args, "edit_message_id", None):
+        tool_args["edit_message_id"] = args.edit_message_id
 
     result = send_message_tool(tool_args)
     exit_code = _emit_result(
@@ -485,6 +491,32 @@ def register_send_subparser(subparsers) -> argparse.ArgumentParser:
         action="store_true",
         default=False,
         help="Suppress stdout on success (exit code only).",
+    )
+
+    parser.add_argument(
+        "--silent",
+        action="store_true",
+        default=False,
+        help="For Telegram, deliver without a push notification.",
+    )
+
+    parser.add_argument(
+        "--buttons",
+        metavar="JSON",
+        default=None,
+        help=(
+            "For Telegram, attach an inline keyboard encoded as JSON rows. "
+            "Each button needs label/text and exactly one of callback_data, "
+            "url, or copy_text."
+        ),
+    )
+
+    parser.add_argument(
+        "--edit",
+        dest="edit_message_id",
+        metavar="MESSAGE_ID",
+        default=None,
+        help="For Telegram, replace this existing text message and its buttons.",
     )
 
     parser.add_argument(

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -452,6 +452,31 @@ def _strip_mdv2(text: str) -> str:
     return cleaned
 
 
+def _sanitize_html_for_telegram(text: str) -> str:
+    """Convert HTML formatting tags to MarkdownV2 equivalents.
+
+    This is the QA8 shared-finalizer convergence seam — it runs on every
+    text chunk consumed by ``format_message`` before the MarkdownV2
+    conversion, so no producer (GA cockpit, cron digest, agent reply,
+    ``hermes send``) can leak literal HTML tags that would cause a
+    MarkdownV2 parse failure in the Telegram adapter.
+
+    Only HTML formatting tags are touched.  JSON, timestamps, hashes,
+    URLs, and all other content pass through unchanged.
+    """
+    # <b>text</b> → **text** (standard markdown bold, converted to MarkdownV2
+    # *text* by format_message step 5)
+    text = re.sub(r"<b>(.+?)</b>", r"**\1**", text, flags=re.IGNORECASE)
+    # <i>text</i> → *text* (standard markdown italic, converted to MarkdownV2
+    # _text_ by format_message step 6)
+    text = re.sub(r"<i>(.+?)</i>", r"*\1*", text, flags=re.IGNORECASE)
+    # <code>text</code> → `text` (MarkdownV2 inline code)
+    text = re.sub(r"<code>(.+?)</code>", r"`\1`", text, flags=re.IGNORECASE)
+    # Strip remaining HTML tags (keep inner content)
+    text = re.sub(r"</?[a-zA-Z][^>]*>", "", text)
+    return text
+
+
 _CHUNK_INDICATOR_ON_FENCE_RE = re.compile(
     r'(?m)^``` (?P<indicator>(?:\\)?\(\d+/\d+(?:\\)?\))$'
 )
@@ -8798,9 +8823,15 @@ class TelegramAdapter(BasePlatformAdapter):
         their contents are never modified.  Standard markdown constructs
         (headers, bold, italic, links) are translated to MarkdownV2 syntax,
         and all remaining special characters are escaped.
+
+        HTML formatting tags are converted to MarkdownV2 equivalents
+        before any other processing — this is the QA8 shared-finalizer
+        convergence seam.
         """
         if not content:
             return content
+
+        content = _sanitize_html_for_telegram(content)
 
         placeholders: dict = {}
         counter = [0]

--- a/tests/plugins/platforms/test_telegram_sanitize_html.py
+++ b/tests/plugins/platforms/test_telegram_sanitize_html.py
@@ -1,0 +1,158 @@
+"""QA8 regression: the shared Telegram finalizer (format_message) must
+convert HTML formatting tags to MarkdownV2 equivalents so no producer
+can leak literal <b>, <i>, or <code> tags that cause MarkdownV2 parse
+failures in the Telegram adapter.
+
+The hostile payload reproduces the exact malformed shape observed in
+production: GA DailyCockpitProjection text with mixed HTML <b> tags
+and Markdown backticks.  JSON, timestamps, hashes, and URLs must pass
+through unchanged (verified at the sanitizer level).
+"""
+
+from __future__ import annotations
+
+import re
+from unittest.mock import MagicMock
+
+import pytest
+
+from plugins.platforms.telegram.adapter import (
+    TelegramAdapter,
+    _sanitize_html_for_telegram,
+    _strip_mdv2,
+)
+
+
+# ── Hostile payload (matches production GA cockpit output) ─────────────
+
+_HOSTILE = (
+    "\U0001f9ed <b>Daily cockpit</b> \u2014 Monday, 29 Aug 2026\n"
+    "\n"
+    "<b>\U0001f534 Now</b>\n"
+    "\u2022 Review Q3 budget <b>URGENT</b>\n"
+    "  \u23f0 `2026-08-30T09:00:00+04:00`\n"
+    '\u2022 Call with client re: project {"id":"proj-8b7588","status":"blocked"}\n'
+    "  \u23f0 `2026-08-30T14:30:00Z`\n"
+    "\n"
+    "<b>\U0001f64b Needs you</b>\n"
+    "\u2022 Approve design mockups \u2014 <i>waiting since Thu</i>\n"
+    "  ref: a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6\n"
+    "\n"
+    "See https://example.com/dashboard for details.\n"
+    "Run with: <code>hermes cron list</code>\n"
+)
+
+# Markers that MUST appear in the MarkdownV2 output after fix.
+# format_message converts **bold** → *bold* and *italic* → _italic_.
+_MUST_CONTAIN = [
+    "*Daily cockpit*",
+    "*\U0001f534 Now*",
+    "*URGENT*",
+    "_waiting since Thu_",
+    "`hermes cron list`",
+]
+
+# HTML tags that MUST NOT appear
+_HTML_TAG = re.compile(r"</?[bi]>|</?code>", re.IGNORECASE)
+
+
+# ── Helper: minimal adapter that can call format_message ───────────────
+
+def _make_adapter() -> TelegramAdapter:
+    config = MagicMock()
+    config.extra = {}
+    config.reply_to_mode = "first"
+    adapter = object.__new__(TelegramAdapter)
+    adapter.config = config
+    adapter._app = None
+    adapter._bot = None
+    adapter._webhook_mode = False
+    adapter._reply_to_mode = "first"
+    adapter._disable_link_previews = False
+    adapter._rich_messages_enabled = False
+    adapter._rich_drafts_enabled = False
+    return adapter
+
+
+# ── Sanitizer unit tests ──────────────────────────────────────────────
+
+
+class TestSanitizeHtmlFunction:
+    """The _sanitize_html_for_telegram function converts HTML to standard
+    markdown (which format_message then converts to MarkdownV2)."""
+
+    def test_converts_bold(self):
+        assert _sanitize_html_for_telegram("<b>Hello</b>") == "**Hello**"
+
+    def test_converts_italic(self):
+        assert _sanitize_html_for_telegram("<i>world</i>") == "*world*"
+
+    def test_converts_code(self):
+        assert _sanitize_html_for_telegram("<code>cmd</code>") == "`cmd`"
+
+    def test_strips_unknown_tags_keeps_content(self):
+        assert _sanitize_html_for_telegram("<span>keep</span>") == "keep"
+
+    def test_no_html_tags_survive(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert _HTML_TAG.search(result) is None
+
+    def test_preserves_json(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert '{"id":"proj-8b7588","status":"blocked"}' in result
+
+    def test_preserves_timestamps(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert "2026-08-30T09:00:00+04:00" in result
+        assert "2026-08-30T14:30:00Z" in result
+
+    def test_preserves_hex_hashes(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert "a1b2c3d4e5f6a7b8c9d0e1f2a3b4c5d6" in result
+
+    def test_preserves_urls(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert "https://example.com/dashboard" in result
+
+    def test_preserves_backtick_code_spans(self):
+        result = _sanitize_html_for_telegram(_HOSTILE)
+        assert "`2026-08-30T09:00:00+04:00`" in result
+        assert "`2026-08-30T14:30:00Z`" in result
+
+
+# ── Product-path tests through format_message ─────────────────────────
+
+
+class TestFormatMessageThroughAdapter:
+    """GREEN: format_message converts HTML to MarkdownV2 via the sanitizer."""
+
+    def test_html_tags_converted(self):
+        adapter = _make_adapter()
+        result = adapter.format_message(_HOSTILE)
+        for marker in _MUST_CONTAIN:
+            assert marker in result, f"Expected {marker!r} in output"
+        assert _HTML_TAG.search(result) is None, (
+            f"HTML tags survived: {_HTML_TAG.findall(result)}"
+        )
+
+    def test_plain_fallback_no_html(self):
+        adapter = _make_adapter()
+        formatted = adapter.format_message(_HOSTILE)
+        plain = _strip_mdv2(formatted)
+        assert _HTML_TAG.search(plain) is None
+
+
+class TestPreimageRed:
+    """RED: format_message WITHOUT the sanitizer would leave HTML intact.
+
+    This test proves the sanitizer ran inside format_message by checking
+    that MarkdownV2 markers appear and HTML tags do not.  If the
+    sanitizer were removed, <b> tags would pass through and no *bold*
+    markers would appear.
+    """
+
+    def test_sanitizer_ran_inside_format_message(self):
+        adapter = _make_adapter()
+        result = adapter.format_message(_HOSTILE)
+        assert "*Daily cockpit*" in result
+        assert _HTML_TAG.search(result) is None

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -11,6 +11,7 @@ import logging
 import os
 import re
 import time
+from urllib.parse import urlsplit
 
 
 from agent.redact import redact_sensitive_text
@@ -211,6 +212,81 @@ async def _send_telegram_message_with_retry(bot, *, attempts: int = 3, **kwargs)
             await asyncio.sleep(delay)
 
 
+def _telegram_buttons_to_markup(buttons):
+    """Validate bounded Telegram inline-keyboard rows and build markup."""
+    if buttons is None or buttons == "":
+        return None
+    if isinstance(buttons, str):
+        if len(buttons.encode("utf-8")) > 32768:
+            raise ValueError("buttons JSON exceeds 32768 bytes")
+        try:
+            parsed = json.loads(buttons)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"buttons must be valid JSON: {exc}") from exc
+    else:
+        parsed = buttons
+
+    if not isinstance(parsed, list) or not parsed:
+        raise ValueError("buttons must be a non-empty JSON array")
+    rows = parsed if isinstance(parsed[0], list) else [parsed]
+    if len(rows) > 8:
+        raise ValueError("buttons must contain at most 8 rows")
+
+    try:
+        from telegram import CopyTextButton, InlineKeyboardButton, InlineKeyboardMarkup
+    except ImportError as exc:
+        raise ValueError("Telegram inline buttons require python-telegram-bot") from exc
+
+    keyboard = []
+    for row in rows:
+        if not isinstance(row, list) or not row or len(row) > 8:
+            raise ValueError("each button row must contain 1 to 8 buttons")
+        rendered_row = []
+        for button in row:
+            if not isinstance(button, dict):
+                raise ValueError("each button must be an object")
+            unknown = set(button) - {
+                "label", "text", "callback_data", "url", "copy_text",
+            }
+            if unknown:
+                raise ValueError(
+                    "unsupported button fields: " + ", ".join(sorted(unknown))
+                )
+            label = button.get("text") or button.get("label")
+            if not isinstance(label, str) or not label.strip() or len(label) > 64:
+                raise ValueError("each button label/text must be 1 to 64 characters")
+            actions = [
+                name for name in ("callback_data", "url", "copy_text")
+                if button.get(name) is not None
+            ]
+            if len(actions) != 1:
+                raise ValueError(
+                    "each button needs exactly one of callback_data, url, or copy_text"
+                )
+            action = actions[0]
+            value = button[action]
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"button {action} must be a non-empty string")
+            if action == "callback_data":
+                if len(value.encode("utf-8")) > 64:
+                    raise ValueError("callback_data must be 1 to 64 UTF-8 bytes")
+                rendered = InlineKeyboardButton(text=label, callback_data=value)
+            elif action == "url":
+                parsed_url = urlsplit(value)
+                if parsed_url.scheme.lower() not in {"http", "https"} or not parsed_url.netloc:
+                    raise ValueError("button url must be an absolute HTTP(S) URL")
+                rendered = InlineKeyboardButton(text=label, url=value)
+            else:
+                if len(value) > 256:
+                    raise ValueError("copy_text must be 1 to 256 characters")
+                rendered = InlineKeyboardButton(
+                    text=label, copy_text=CopyTextButton(value),
+                )
+            rendered_row.append(rendered)
+        keyboard.append(rendered_row)
+    return InlineKeyboardMarkup(keyboard)
+
+
 SEND_MESSAGE_SCHEMA = {
     "name": "send_message",
     "description": (
@@ -244,6 +320,17 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            },
+            "silent": {
+                "type": "boolean",
+                "description": "For Telegram send: disable the push notification."
+            },
+            "buttons": {
+                "description": "For Telegram send: JSON or decoded inline-keyboard rows. Each button needs label/text and exactly one of callback_data, url, or copy_text."
+            },
+            "edit_message_id": {
+                "type": "string",
+                "description": "For Telegram send: replace this existing text message and its inline keyboard."
             }
         },
         "required": []
@@ -379,6 +466,15 @@ def _handle_send(args):
     chat_id = None
     thread_id = None
 
+    structured = any(
+        args.get(name) not in (None, False, "")
+        for name in ("silent", "buttons", "edit_message_id")
+    )
+    if structured and platform_name != "telegram":
+        return tool_error(
+            "silent, buttons, and edit_message_id are supported only for Telegram"
+        )
+
     prepare_send_message_platforms()
     if target_ref:
         chat_id, thread_id, resolution_error = resolve_send_target(
@@ -443,6 +539,8 @@ def _handle_send(args):
 
     media_files, cleaned_message = BasePlatformAdapter.extract_media(message)
     media_files = BasePlatformAdapter.filter_media_delivery_paths(media_files)
+    if args.get("edit_message_id") is not None and media_files:
+        return tool_error("Telegram edit_message_id cannot be combined with media")
     mirror_text = cleaned_message.strip() or _describe_media_for_mirror(media_files)
 
     used_home_channel = False
@@ -494,6 +592,12 @@ def _handle_send(args):
             "media_files": media_files,
             "force_document": force_document_attachments,
         }
+        if structured:
+            send_kwargs.update({
+                "silent": bool(args.get("silent")),
+                "buttons": args.get("buttons"),
+                "edit_message_id": args.get("edit_message_id"),
+            })
         # Preserve the exact built-in call contract; only custom handlers need
         # the complete typed request.
         if entry is not None and entry.send_message_handler is not None:
@@ -1109,7 +1213,9 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
+                            media_files=None, force_document=False, args=None,
+                            silent=False, buttons=None, edit_message_id=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1203,6 +1309,9 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             thread_id=thread_id,
             disable_link_previews=disable_link_previews,
             force_document=force_document,
+            silent=silent,
+            buttons=buttons,
+            edit_message_id=edit_message_id,
         )
 
     # --- Discord: chunked delivery via the registry's standalone_sender_fn.
@@ -1556,7 +1665,9 @@ def _is_telegram_thread_not_found(error: Exception) -> bool:
     return "thread not found" in str(error).lower()
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None,
+                         disable_link_previews=False, force_document=False,
+                         silent=False, buttons=None, edit_message_id=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -1647,9 +1758,65 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         text_kwargs = dict(thread_kwargs)
         if disable_link_previews:
             text_kwargs["disable_web_page_preview"] = True
+        if silent:
+            text_kwargs["disable_notification"] = True
+        markup = _telegram_buttons_to_markup(buttons)
+        if markup is not None:
+            text_kwargs["reply_markup"] = markup
 
         last_msg = None
         warnings = []
+
+        if edit_message_id is not None:
+            try:
+                normalized_edit_id = int(str(edit_message_id))
+            except (TypeError, ValueError) as exc:
+                return _error(f"Telegram edit message id must be an integer: {exc}")
+            if normalized_edit_id <= 0:
+                return _error("Telegram edit message id must be positive")
+            edit_kwargs = {}
+            if disable_link_previews:
+                edit_kwargs["disable_web_page_preview"] = True
+            if markup is not None:
+                edit_kwargs["reply_markup"] = markup
+            try:
+                last_msg = await bot.edit_message_text(
+                    chat_id=int_chat_id,
+                    message_id=normalized_edit_id,
+                    text=formatted,
+                    parse_mode=send_parse_mode,
+                    **edit_kwargs,
+                )
+            except Exception as edit_error:
+                if any(
+                    marker in str(edit_error).lower()
+                    for marker in ("parse", "markdown", "html")
+                ):
+                    plain = formatted
+                    if not _has_html:
+                        try:
+                            from plugins.platforms.telegram.adapter import _strip_mdv2
+                            plain = _strip_mdv2(formatted)
+                        except Exception:
+                            pass
+                    last_msg = await bot.edit_message_text(
+                        chat_id=int_chat_id,
+                        message_id=normalized_edit_id,
+                        text=plain,
+                        parse_mode=None,
+                        **edit_kwargs,
+                    )
+                else:
+                    return _error(f"Telegram edit failed: {edit_error}")
+            if last_msg is None:
+                return {"error": "Telegram edit produced no message"}
+            return {
+                "success": True,
+                "platform": "telegram",
+                "chat_id": chat_id,
+                "message_id": str(last_msg.message_id),
+                "edited": True,
+            }
 
         # MEDIA:<path> caption: when a single captionable file is accompanied
         # by short text, attach the text to the media bubble as its native
@@ -1750,6 +1917,10 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
             try:
                 with open(media_path, "rb") as f:
                     media_kwargs = dict(thread_kwargs)
+                    if silent:
+                        media_kwargs["disable_notification"] = True
+                    if markup is not None:
+                        media_kwargs["reply_markup"] = markup
                     # Attach the MEDIA:<path> caption to the bubble itself for
                     # captionable kinds (photo/video/document). _tg_caption is
                     # only set for a single captionable file, so this never


### PR DESCRIPTION
# fix(telegram): restore structured sends and sanitize HTML for MarkdownV2

## Summary

- Restore CLI/tool support for silent sends, inline buttons, and message edits.
- Carry the structured fields through the send-message tool and Telegram proxy path.
- Convert supported Telegram HTML into safe MarkdownV2 at the adapter formatting boundary, with regression coverage for escaping and malformed input.

## Why

Structured send options should not disappear between the CLI, tool, and platform adapter. Telegram formatting also needs one defensive conversion point so HTML-shaped model output does not produce broken MarkdownV2 messages.

## Provenance

Prepared from carry commits `65f7f8353f7212a635a6e40addf72dcc748f7d62` and `56273af2061c936bb8c868626104717d98a32c4a`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- Focused send/tool/proxy/sanitizer pytest suite — PASS, 79 tests
- `git diff --check origin/main..HEAD` — PASS

Full receipt: `test-output.txt`.
