### PR TITLE
security: keep memory, state databases, and snapshots owner-only

### DIFF
--- a/hermes_cli/backup.py
+++ b/hermes_cli/backup.py
@@ -477,6 +477,21 @@ def _safe_copy_db(
     conn = None
     backup_conn = None
     try:
+        # sqlite3.connect() creates a missing destination with the process
+        # umask, which is commonly 0022 (0644).  Snapshot databases contain
+        # session and tool state, so create the inode owner-only before SQLite
+        # writes its first byte.  O_NOFOLLOW also refuses a planted symlink on
+        # platforms that support it.  Tighten an existing internal staging
+        # file as well (NamedTemporaryFile callers already create it 0600).
+        if os.name != "nt":
+            open_flags = os.O_WRONLY | os.O_CREAT
+            if hasattr(os, "O_NOFOLLOW"):
+                open_flags |= os.O_NOFOLLOW
+            secure_fd = os.open(dst, open_flags, 0o600)
+            try:
+                os.fchmod(secure_fd, 0o600)
+            finally:
+                os.close(secure_fd)
         # Disable sqlite3's implicit busy wait so backup() progress callbacks
         # control the full locked-source deadline instead of adding the
         # connection's default timeout before each callback.
@@ -1727,6 +1742,25 @@ def _quick_snapshot_root(hermes_home: Optional[Path] = None) -> Path:
     return home / _QUICK_SNAPSHOTS_DIR
 
 
+def _secure_quick_snapshot_tree(root: Path, snapshot_dir: Path) -> None:
+    """Make a staged quick snapshot owner-only before it is published.
+
+    The staging directory is private from creation, so copied source modes can
+    be normalized safely before the final atomic rename exposes the snapshot.
+    Permission failures are intentionally fatal: publishing a readable
+    recovery bundle is worse than reporting a failed snapshot.
+    """
+    if os.name == "nt":
+        return
+    os.chmod(root, 0o700)
+    os.chmod(snapshot_dir, 0o700)
+    for path in snapshot_dir.rglob("*"):
+        if path.is_dir():
+            os.chmod(path, 0o700)
+        elif path.is_file():
+            os.chmod(path, 0o600)
+
+
 def create_quick_snapshot(
     label: Optional[str] = None,
     hermes_home: Optional[Path] = None,
@@ -1803,7 +1837,10 @@ def _create_quick_snapshot_locked(
     snap_dir = root / snap_id
     staging_dir = root / f".{snap_id}.{os.getpid()}.partial"
     shutil.rmtree(staging_dir, ignore_errors=True)
-    staging_dir.mkdir(parents=True, exist_ok=False)
+    root.mkdir(parents=True, exist_ok=True, mode=0o700)
+    if os.name != "nt":
+        os.chmod(root, 0o700)
+    staging_dir.mkdir(mode=0o700, exist_ok=False)
     logger.info("quick snapshot phase=copy status=started id=%s", snap_id)
 
     manifest: Dict[str, int] = {}  # rel_path -> file size
@@ -1934,6 +1971,7 @@ def _create_quick_snapshot_locked(
     with open(staging_dir / "manifest.json", "w", encoding="utf-8") as f:
         json.dump(meta, f, indent=2)
 
+    _secure_quick_snapshot_tree(root, staging_dir)
     os.replace(staging_dir, snap_dir)
 
     # Auto-prune. Defaults preserve historical manual /snapshot behavior; callers

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -944,6 +944,43 @@ def _ensure_test_isolation(db_path: Path) -> None:
                 "its environment."
             )
 
+
+def _secure_state_db_files(db_path: Path, *, create_main: bool = False) -> None:
+    """Create/tighten a writable state database and its sidecars to 0600.
+
+    SQLite otherwise creates ``state.db``, ``-wal``, and ``-shm`` according to
+    the process umask (commonly 0644 under 0022). Use file descriptors so a
+    missing main database is private from its first byte and O_NOFOLLOW can
+    refuse a planted symlink. Read-only SessionDB attachments never call this
+    helper and remain observational.
+    """
+    if os.name == "nt":
+        return
+
+    for index, path in enumerate(
+        (
+            db_path,
+            db_path.with_name(db_path.name + "-wal"),
+            db_path.with_name(db_path.name + "-shm"),
+        )
+    ):
+        flags = os.O_RDONLY
+        if index == 0 and create_main:
+            flags = os.O_WRONLY | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        if hasattr(os, "O_CLOEXEC"):
+            flags |= os.O_CLOEXEC
+        try:
+            fd = os.open(path, flags, 0o600)
+        except FileNotFoundError:
+            continue
+        try:
+            os.fchmod(fd, 0o600)
+        finally:
+            os.close(fd)
+
+
 # ---------------------------------------------------------------------------
 # WAL-compatibility fallback
 # ---------------------------------------------------------------------------
@@ -5537,6 +5574,10 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                     if qpath is None and self.db_path.exists() and is_zeroed_state_db(self.db_path):
                         raise sqlite3.DatabaseError(msg)
 
+            # Create/tighten the main database before sqlite3.connect() so a
+            # permissive process umask can never expose a fresh profile store.
+            _secure_state_db_files(self.db_path, create_main=True)
+
             def _connect_and_init():
                 # Refuse before sqlite3.connect (under the startup lock) so we
                 # cannot mint a replacement WAL while a live writer still
@@ -5558,6 +5599,9 @@ class SessionDB(SessionSearchMixin, SessionSchemaMixin, SessionPortabilityMixin)
                 self._wal_active = (
                     apply_wal_with_fallback(self._conn, db_label="state.db") == "wal"
                 )
+                # Existing WAL/SHM files may predate the main-file hardening;
+                # normalize any sidecars that became visible during WAL setup.
+                _secure_state_db_files(self.db_path)
                 apply_database_pragmas(self._conn, db_label="state.db")
                 self._conn.execute("PRAGMA foreign_keys=ON")
                 self._fts_cjk_loaded = load_fts5_cjk_extension(self._conn)

--- a/tests/hermes_cli/test_backup_stability.py
+++ b/tests/hermes_cli/test_backup_stability.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
 import json
+import os
+import sqlite3
+import stat
 from pathlib import Path
 
 import pytest
@@ -80,6 +83,39 @@ def test_quick_snapshot_is_published_with_manifest(tmp_path, monkeypatch) -> Non
     )
     assert manifest["id"] == snapshot_id
     assert manifest["files"] == {"config.yaml": 10}
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+def test_quick_snapshot_tree_is_owner_only_under_permissive_umask(tmp_path) -> None:
+    """Recovery snapshots must never inherit world-readable default modes.
+
+    A normal 0022 umask creates SQLite databases and JSON files as 0644 and
+    directories as 0755.  Quick snapshots contain session state, credentials,
+    pairing records, and cron data, so every published file must be 0600 and
+    every directory 0700 regardless of the caller's umask or source modes.
+    """
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    with sqlite3.connect(home / "state.db") as conn:
+        conn.execute("CREATE TABLE sessions (id TEXT PRIMARY KEY)")
+
+    old_umask = os.umask(0o022)
+    try:
+        snapshot_id = create_quick_snapshot(hermes_home=home)
+    finally:
+        os.umask(old_umask)
+
+    assert snapshot_id is not None
+    root = home / "state-snapshots"
+    snapshot = root / snapshot_id
+    directories = [root, snapshot, *(p for p in snapshot.rglob("*") if p.is_dir())]
+    files = [p for p in snapshot.rglob("*") if p.is_file()]
+
+    assert directories
+    assert files
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o700 for path in directories)
+    assert all(stat.S_IMODE(path.stat().st_mode) == 0o600 for path in files)
 
 
 def test_quick_snapshot_listing_ignores_partial_directories(tmp_path) -> None:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -3,6 +3,8 @@
 import sqlite3
 import time
 import json
+import os
+import stat
 import threading
 from pathlib import Path
 from unittest import mock
@@ -110,6 +112,49 @@ def _no_fts_rebuild_throttle(monkeypatch):
 
 
 class TestConnectionLifecycle:
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_writable_state_db_is_owner_only_under_permissive_umask(self, tmp_path):
+        """state.db and any live SQLite sidecars must not inherit 0644 modes."""
+        db_path = tmp_path / "state.db"
+
+        old_umask = os.umask(0o022)
+        try:
+            session_db = SessionDB(db_path=db_path)
+        finally:
+            os.umask(old_umask)
+
+        try:
+            state_files = [
+                path
+                for path in (
+                    db_path,
+                    db_path.with_name(db_path.name + "-wal"),
+                    db_path.with_name(db_path.name + "-shm"),
+                )
+                if path.exists()
+            ]
+            assert state_files
+            assert all(
+                stat.S_IMODE(path.stat().st_mode) == 0o600
+                for path in state_files
+            )
+        finally:
+            session_db.close()
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX permission bits")
+    def test_writable_state_db_tightens_existing_loose_mode(self, tmp_path):
+        """Opening a legacy 0644 profile store repairs it in place."""
+        db_path = tmp_path / "state.db"
+        initial = SessionDB(db_path=db_path)
+        initial.close()
+        os.chmod(db_path, 0o644)
+
+        session_db = SessionDB(db_path=db_path)
+        try:
+            assert stat.S_IMODE(db_path.stat().st_mode) == 0o600
+        finally:
+            session_db.close()
+
     def test_failed_writable_open_does_not_leak_tracked_connection(
         self, tmp_path, monkeypatch
     ):

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -1,6 +1,8 @@
 """Tests for tools/memory_tool.py — MemoryStore, security scanning, and tool dispatcher."""
 
 import json
+import os
+import stat
 import pytest
 from pathlib import Path
 
@@ -105,6 +107,45 @@ def store(tmp_path, monkeypatch):
     s = MemoryStore(memory_char_limit=500, user_char_limit=300)
     s.load_from_disk()
     return s
+
+
+class TestMemoryFileLockPermissions:
+    def test_new_lock_file_is_owner_only_under_permissive_umask(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        previous_umask = os.umask(0o002)
+        try:
+            with MemoryStore._file_lock(memory_path):
+                pass
+        finally:
+            os.umask(previous_umask)
+
+        lock_path = tmp_path / "MEMORY.md.lock"
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    def test_existing_loose_lock_file_is_tightened(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        lock_path = tmp_path / "MEMORY.md.lock"
+        lock_path.write_text("", encoding="utf-8")
+        lock_path.chmod(0o664)
+
+        with MemoryStore._file_lock(memory_path):
+            pass
+
+        assert stat.S_IMODE(lock_path.stat().st_mode) == 0o600
+
+    @pytest.mark.skipif(not hasattr(os, "O_NOFOLLOW"), reason="O_NOFOLLOW unavailable")
+    def test_lock_file_symlink_is_refused(self, tmp_path):
+        memory_path = tmp_path / "MEMORY.md"
+        outside = tmp_path / "outside"
+        outside.write_text("do not touch", encoding="utf-8")
+        lock_path = tmp_path / "MEMORY.md.lock"
+        lock_path.symlink_to(outside)
+
+        with pytest.raises(OSError):
+            with MemoryStore._file_lock(memory_path):
+                pass
+
+        assert outside.read_text(encoding="utf-8") == "do not touch"
 
 
 class TestMemoryStoreAdd:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -26,6 +26,7 @@ Design:
 import copy
 import json
 import logging
+import os
 import time
 from contextlib import contextmanager
 from contextvars import ContextVar
@@ -314,7 +315,22 @@ class MemoryStore:
             yield
             return
 
-        fd = open(lock_path, "a+", encoding="utf-8")
+        flags = os.O_RDWR | os.O_CREAT
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+
+        raw_fd = os.open(lock_path, flags, 0o600)
+        try:
+            # The creation mode is filtered through the process umask and does
+            # not repair a lock left loose by an older Hermes process. Tighten
+            # the opened inode before acquiring the lock so both cases are
+            # owner-only. Operating on the fd avoids a path-swap window.
+            if hasattr(os, "fchmod"):
+                os.fchmod(raw_fd, 0o600)
+            fd = os.fdopen(raw_fd, "r+", encoding="utf-8")
+        except Exception:
+            os.close(raw_fd)
+            raise
         try:
             if fcntl:
                 fcntl.flock(fd, fcntl.LOCK_EX)


### PR DESCRIPTION
# security: keep memory, state databases, and snapshots owner-only

## Summary

- Create and repair built-in memory lock files with owner-only permissions.
- Apply owner-only permissions to state databases, SQLite sidecars, backups, and snapshots.
- Add regression tests for file-mode repair and snapshot/backup creation paths.

## Why

Session state and memory can contain private user data. Their files and coordination locks should not become group- or world-readable because of a permissive umask or a pre-existing file mode.

## Provenance

Prepared from carry commits `43ebac0febad344a36636d9b88339731101abbc0` and `e51cfa8a7a197f2d9ae64ee9b4a3c1b51ed31578`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- Focused permission/owner/snapshot/security pytest selection — PASS, 16 tests (298 deselected)
- Broader touched-file suite — 313 passed, 1 failed
- The same failure reproduces on pristine `origin/main`: `TestFTS5Search::test_search_projection_skips_context_enrichment_queries` expects one traced context query but records zero. It is unrelated to file permissions.
- `git diff --check origin/main..HEAD` — PASS

Full candidate and baseline receipts: `test-output.txt`.
