### PR TITLE
fix(gateway): reconcile profile state and harden system-service boundaries

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17384,12 +17384,17 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         f"{platform.value} with the same credential. Give each "
                         f"profile its own {platform.value} credential."
                     )
-                    logger.error(
-                        "Profile '%s' and '%s' both configure %s with the same "
-                        "credential — refusing to start the duplicate (one "
-                        "credential cannot be consumed twice). Give each profile "
-                        "its own %s credential.",
-                        owner, profile_name, platform.value, platform.value,
+                    logger.info(
+                        "[MULTIPLEX] Profile '%s' and '%s' both configure %s with "
+                        "the same credential — keeping '%s' as the live adapter "
+                        "owner and intentionally skipping the secondary '%s' "
+                        "adapter (the shared credential remains configured for "
+                        "delivery).",
+                        owner,
+                        profile_name,
+                        platform.value,
+                        owner,
+                        profile_name,
                     )
                     # A same-credential multiplex refusal is a deliberate skip,
                     # not a crash: fleets that intentionally share one token

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -17391,9 +17391,16 @@ class GatewayRunner(GatewayAuthorizationMixin, GatewayKanbanWatchersMixin, Gatew
                         "its own %s credential.",
                         owner, profile_name, platform.value, platform.value,
                     )
+                    # A same-credential multiplex refusal is a deliberate skip,
+                    # not a crash: fleets that intentionally share one token
+                    # (the owner-approved "shared adapter" topology) ride the
+                    # primary profile's adapter for cron delivery. Persist it
+                    # as a clean "disabled" state — same precedent as the
+                    # relay_disabled opt-out — instead of a red "fatal" that
+                    # paints every boot's status popover (#80451 follow-up).
                     self._update_platform_runtime_status(
                         f"{profile_name}:{platform.value}",
-                        platform_state="fatal",
+                        platform_state="disabled",
                         error_code="duplicate_credential",
                         error_message=message,
                     )

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -47,6 +47,10 @@ _gateway_lock_handle = None
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
 _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
+# Platform entries are last-known transition records, not heartbeats.  Keep a
+# short grace window for diagnostics, then discard records whose writer is no
+# longer the same live process.  A live writer is retained regardless of age.
+_PLATFORM_STATE_STALE_TTL_S = 120
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
 
@@ -1202,6 +1206,44 @@ def write_pid_file() -> None:
         raise
 
 
+def _platform_state_writer_is_live(record: Any) -> bool:
+    """Whether a platform-state record still belongs to its live writer."""
+    if not isinstance(record, dict):
+        return False
+    try:
+        writer_pid = int(record["writer_pid"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    if writer_pid <= 0 or not _pid_exists(writer_pid):
+        return False
+
+    recorded_start = record.get("writer_start_time")
+    current_start = _get_process_start_time(writer_pid)
+    if (
+        recorded_start is not None
+        and current_start is not None
+        and recorded_start != current_start
+    ):
+        return False
+    return True
+
+
+def _prune_expired_platform_states(platforms: Any) -> dict[Any, Any]:
+    """Drop expired records from dead writers while preserving live routes."""
+    if not isinstance(platforms, dict):
+        return {}
+
+    retained: dict[Any, Any] = {}
+    for name, record in platforms.items():
+        updated_at = record.get("updated_at", "") if isinstance(record, dict) else ""
+        if not _marker_is_stale(updated_at, _PLATFORM_STATE_STALE_TTL_S):
+            retained[name] = record
+            continue
+        if _platform_state_writer_is_live(record):
+            retained[name] = record
+    return retained
+
+
 def write_runtime_status(
     *,
     gateway_state: Any = _UNSET,
@@ -1223,7 +1265,7 @@ def write_runtime_status(
     payload = _read_json_file(path) or _build_runtime_status_record()
     previous_payload = copy.deepcopy(payload)
     current_record = _build_pid_record()
-    payload.setdefault("platforms", {})
+    payload["platforms"] = _prune_expired_platform_states(payload.get("platforms"))
     if clear_profile_platforms:
         # Secondary-profile adapter health is stored in the process-level
         # status file as ``<profile>:<platform>``.  A fresh gateway process
@@ -1317,8 +1359,15 @@ def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]
     profile's state file (e.g. the dashboard enumerating every profile)
     can do so without mutating ``HERMES_HOME`` in-process.  Defaults to
     the active profile's ``gateway_state.json``.
+
+    Expired platform entries from dead writers are filtered on read as well as
+    pruned on the next write.  This bounds stale status visibility even when an
+    otherwise-idle gateway emits no further transitions after startup.
     """
-    return _read_json_file(path or _get_runtime_status_path())
+    payload = _read_json_file(path or _get_runtime_status_path())
+    if payload is not None and "platforms" in payload:
+        payload["platforms"] = _prune_expired_platform_states(payload["platforms"])
+    return payload
 
 
 # Max age of a persisted ``gateway_state.json`` snapshot before its liveness

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3174,14 +3174,68 @@ def _raise_user_systemd_unavailable(
     raise UserSystemdUnavailableError(msg)
 
 
+# Absolute directories searched for privileged systemd tools when the
+# elevated system-gateway context is active (late review Finding 1).  PATH
+# is never consulted there — a unit-home ``.env`` could otherwise point at
+# an attacker-controlled ``systemctl``.
+_PRIVILEGED_TOOL_DIRS = (
+    "/usr/local/sbin",
+    "/usr/local/bin",
+    "/usr/sbin",
+    "/usr/bin",
+    "/sbin",
+    "/bin",
+)
+
+
+def _privileged_system_gateway_context() -> bool:
+    """True when this process runs as root AND adopted a system unit home.
+
+    Only the combination is privileged: the sentinel alone (forgeable by any
+    process) or root alone (e.g. a plain ``sudo hermes chat``) does not lock
+    tool resolution to absolute directories.
+    """
+    if os.environ.get("_HERMES_SYSTEM_GATEWAY_ELEVATED") != "1":
+        return False
+    if not hasattr(os, "geteuid"):
+        return False  # Windows: system gateway units are not a thing.
+    return os.geteuid() == 0
+
+
+def privileged_system_tool_path(name: str, *, system: bool = False) -> str | None:
+    """Resolve a privileged tool without honouring PATH.
+
+    In the elevated context the tool must be found in the fixed system
+    directories above.  Outside it, resolution falls back to ``shutil.which``
+    (the historical behaviour for unprivileged callers).
+    """
+    if not _privileged_system_gateway_context():
+        found = shutil.which(name)
+        return found
+    for directory in _PRIVILEGED_TOOL_DIRS:
+        candidate = f"{directory}/{name}"
+        if os.access(candidate, os.X_OK, follow_symlinks=False):
+            return candidate
+    return None
+
+
+def _privileged_system_tool(name: str, *, system: bool = False) -> str:
+    resolved = privileged_system_tool_path(name, system=system)
+    if resolved is None:
+        raise RuntimeError(f"{name} is not available on this system")
+    return resolved
+
+
 def _systemctl_cmd(system: bool = False) -> list[str]:
     if not system:
         _ensure_user_systemd_env()
-    return ["systemctl"] if system else ["systemctl", "--user"]
+    base = _privileged_system_tool("systemctl", system=system)
+    return [base] if system else [base, "--user"]
 
 
 def _journalctl_cmd(system: bool = False) -> list[str]:
-    return ["journalctl"] if system else ["journalctl", "--user"]
+    base = _privileged_system_tool("journalctl", system=system)
+    return [base] if system else [base, "--user"]
 
 
 def _run_systemctl(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -756,7 +756,74 @@ def _apply_profile_override() -> None:
             sys.argv = sys.argv[:start] + sys.argv[start + consume :]
 
 
+def _apply_system_gateway_home_override(
+    *, unit_path: Path | None = None
+) -> None:
+    """Adopt a system gateway unit's HERMES_HOME before config imports.
+
+    ``sudo`` normally strips ``HERMES_HOME`` and changes ``HOME`` to ``/root``.
+    Importing :mod:`hermes_cli.config` in that state creates an unrelated
+    ``/root/.hermes`` scaffold before the gateway command can inspect the real
+    system unit.  This deliberately small, stdlib-only pre-parser reads the
+    unit's pinned home early enough to prevent that side effect.
+
+    Explicit/profile-derived ``HERMES_HOME`` always wins.  Missing, malformed,
+    relative, and temporary unit homes fail closed without changing the
+    process environment.
+    """
+    if os.environ.get("HERMES_HOME", "").strip():
+        return
+
+    argv = sys.argv[1:]
+    if not argv or argv[0] != "gateway" or "--system" not in argv:
+        return
+
+    path = unit_path or Path("/etc/systemd/system/hermes-gateway.service")
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return
+
+    unit_home = ""
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("Environment="):
+            continue
+        body = stripped[len("Environment=") :].strip()
+        try:
+            assignments = shlex.split(body, posix=True)
+        except ValueError:
+            continue
+        for assignment in assignments:
+            if assignment.startswith("HERMES_HOME="):
+                unit_home = assignment.split("=", 1)[1].strip()
+                break
+        if unit_home:
+            break
+
+    if not unit_home:
+        return
+    candidate = Path(unit_home)
+    if not candidate.is_absolute():
+        return
+    try:
+        candidate = candidate.resolve(strict=False)
+        temporary_roots = {
+            Path(tempfile.gettempdir()).resolve(strict=False),
+            Path("/var/tmp").resolve(strict=False),
+        }
+    except OSError:
+        return
+    if candidate == Path(candidate.anchor):
+        return
+    if any(candidate == root or root in candidate.parents for root in temporary_roots):
+        return
+
+    os.environ["HERMES_HOME"] = str(candidate)
+
+
 _apply_profile_override()
+_apply_system_gateway_home_override()
 
 # Windows launcher self-heal — the ``hermes`` command users run is a COPY of
 # the venv console script, staged into the managed binary dir (the default

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -878,7 +878,7 @@ def _resolve_ordered_environment_home(sources: list[str]) -> str | None:
         for raw in text.splitlines():
             line = raw.strip()
             if line.startswith("[") and line.endswith("]"):
-                in_service = line == "[Service]"
+                in_service = line.casefold() == "[service]"
                 continue
             if not in_service or not line:
                 continue
@@ -888,9 +888,9 @@ def _resolve_ordered_environment_home(sources: list[str]) -> str | None:
             if eq < 0:
                 continue
             directive = line[:eq].strip()
-            if directive in ("EnvironmentFile", "UnsetEnvironment"):
+            if directive.casefold() in ("environmentfile", "unsetenvironment"):
                 return None
-            if directive != "Environment":
+            if directive.casefold() != "environment":
                 continue
             body = line[eq + 1 :].strip()
             if "%" in body:
@@ -937,7 +937,6 @@ def _systemd_unit_environment_home(unit_path: Path) -> str | None:
                 except (OSError, UnicodeError):
                     return None
     except OSError:
-        dropin_names = []
         return None
     return _resolve_ordered_environment_home(ordered_sources)
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -756,6 +756,192 @@ def _apply_profile_override() -> None:
             sys.argv = sys.argv[:start] + sys.argv[start + consume :]
 
 
+_SYSTEM_GATEWAY_VERBS_WITH_SYSTEM_FLAG = frozenset(
+    {"start", "stop", "restart", "status", "install", "uninstall"}
+)
+
+# Long-option prefixes that make an abbreviation like ``--s``/``--sy``
+# AMBIGUOUS per argparse prefix-matching, per verb.  Keys are verbs whose
+# subparser owns ``--system``; values are the other long options that start
+# with ``--s`` there.  Derived from hermes_cli/subcommands/gateway.py — the
+# parity test in test_system_gateway_privilege_boundary.py fails if the
+# real parser drifts from this table (a new ``--s…`` option or verb).
+_SYSTEM_GATEWAY_AMBIGUOUS_PREFIXES: dict[str, frozenset[str]] = {
+    "start": frozenset(),
+    "stop": frozenset(),
+    "restart": frozenset(),
+    "status": frozenset(),
+    "install": frozenset({"--start-now", "--start-on-login"}),
+    "uninstall": frozenset(),
+}
+
+# Sentinel set when (and only when) a root process adopted a system unit's
+# home directory.  hermes_cli.gateway refuses to honour unit-home-controlled
+# environment (PATH et al.) while this is set, closing the privileged
+# environment-injection seam (late review Finding 1).
+ELEVATED_SYSTEM_GATEWAY_SENTINEL = "_HERMES_SYSTEM_GATEWAY_ELEVATED"
+
+
+def _system_gateway_request(argv: list[str]) -> bool:
+    """True when argv is a real ``gateway <verb> --system`` invocation.
+
+    Mirrors the top-level parser's option/value scanning (the same seam
+    ``_first_positional_argv`` covers) so global flags before the subcommand
+    (``hermes --yolo gateway status --system``) and ``--`` passthrough agree
+    with argparse instead of drifting from it (late review Finding 2).
+    """
+    from hermes_cli._parser import top_level_value_flag_sets
+
+    required_value_flags, optional_value_flags = top_level_value_flag_sets()
+    value_flags = required_value_flags | optional_value_flags
+
+    saw_separator = False
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--":
+            saw_separator = True
+            i += 1
+            continue
+        if saw_separator:
+            return False  # positional passthrough: not a gateway verb
+        if tok.startswith("-"):
+            if "=" in tok:
+                i += 1
+                continue
+            if tok in value_flags and i + 1 < len(argv):
+                i += 2
+                continue
+            i += 1
+            continue
+        if tok != "gateway":
+            return False
+        verb = argv[i + 1] if i + 1 < len(argv) else None
+        if verb not in _SYSTEM_GATEWAY_VERBS_WITH_SYSTEM_FLAG:
+            return False
+        # Only tokens AFTER the verb count: ``gateway status -- --system``
+        # passes ``--system`` as an output positional, not a flag.
+        return _argv_has_system_flag(
+            argv[i + 2 :], ambiguous=_SYSTEM_GATEWAY_AMBIGUOUS_PREFIXES[verb]
+        )
+    return False
+
+
+def _argv_has_system_flag(
+    tokens: list[str], *, ambiguous: frozenset[str] = frozenset()
+) -> bool:
+    """Detect ``--system`` (or an argparse abbreviation) token.
+
+    Follows argparse's prefix matching exactly: a ``--s…`` token matches
+    ``--system`` only when it is a strict prefix of ``--system`` AND no other
+    long option of that verb's subparser starts with it (``ambiguous``).
+    With no collisions a bare ``--s`` matches (argparse accepts it); with
+    collisions (e.g. ``install``'s ``--start-now``/``--start-on-login``)
+    argparse would reject the abbreviation, so we do too.  A ``--``
+    separator ends flag scanning: everything after it is positional.
+    """
+    for tok in tokens:
+        if tok == "--":
+            return False
+        if not tok.startswith("--") or tok == "--":
+            continue
+        opt, eq, _value = tok.partition("=")
+        if eq and opt == "--system":
+            # ``--system=<x>``: store_true options reject inline values in
+            # argparse, so this is an error, not a system-scope request.
+            continue
+        if not opt.startswith("--s"):
+            continue
+        if not "system".startswith(opt[2:]):
+            continue
+        if any(other.startswith(opt) for other in ambiguous):
+            continue
+        return True
+    return False
+
+
+def _resolve_ordered_environment_home(sources: list[str]) -> str | None:
+    """Apply systemd's ordered ``Environment=`` semantics to HERMES_HOME.
+
+    Walks sources in order (base unit, then ``*.conf`` drop-ins sorted by
+    filename).  Inside ``[Service]`` only, every ``Environment=`` line is
+    shlex-split into assignments; a later ``HERMES_HOME=`` assignment wins
+    and an empty value resets (clears) it.  Returns ``None`` when the value
+    is absent/reset — and also for anything unmodellable: ``EnvironmentFile=``,
+    ``UnsetEnvironment=``, ``%``-specifiers, malformed quoting (late review
+    Finding 3's fail-closed policy).
+    """
+    resolved: str | None = None
+    saw_assignment = False
+    for text in sources:
+        in_service = False
+        for raw in text.splitlines():
+            line = raw.strip()
+            if line.startswith("[") and line.endswith("]"):
+                in_service = line == "[Service]"
+                continue
+            if not in_service or not line:
+                continue
+            if line.startswith("#") or line.startswith(";"):
+                continue
+            eq = line.find("=")
+            if eq < 0:
+                continue
+            directive = line[:eq].strip()
+            if directive in ("EnvironmentFile", "UnsetEnvironment"):
+                return None
+            if directive != "Environment":
+                continue
+            body = line[eq + 1 :].strip()
+            if "%" in body:
+                return None
+            try:
+                assignments = shlex.split(body, posix=True)
+            except ValueError:
+                return None
+            for assignment in assignments:
+                if assignment == "HERMES_HOME":
+                    # Bare key (no value): treated as a reset to empty.
+                    resolved = None
+                    saw_assignment = True
+                elif assignment.startswith("HERMES_HOME="):
+                    value = assignment.split("=", 1)[1].strip()
+                    resolved = value or None
+                    saw_assignment = True
+    if not saw_assignment:
+        return None
+    return resolved
+
+
+def _systemd_unit_environment_home(unit_path: Path) -> str | None:
+    """Read HERMES_HOME from the unit with systemd ordered semantics.
+
+    The base unit is followed by its ``<unit>.d/*.conf`` drop-ins in
+    lexicographic filename order (systemd applies drop-ins after the base,
+    later files override earlier ones).  An unreadable drop-in makes the
+    effective environment unmodellable, so the override fails closed.
+    """
+    try:
+        base_text = unit_path.read_text(encoding="utf-8")
+    except (OSError, UnicodeError):
+        return None
+    ordered_sources: list[str] = [base_text]
+    dropin_dir = unit_path.parent / (unit_path.name + ".d")
+    try:
+        if dropin_dir.is_dir():
+            for entry in sorted(dropin_dir.iterdir(), key=lambda p: p.name):
+                if entry.suffix != ".conf":
+                    continue
+                try:
+                    ordered_sources.append(entry.read_text(encoding="utf-8"))
+                except (OSError, UnicodeError):
+                    return None
+    except OSError:
+        dropin_names = []
+        return None
+    return _resolve_ordered_environment_home(ordered_sources)
+
+
 def _apply_system_gateway_home_override(
     *, unit_path: Path | None = None
 ) -> None:
@@ -770,37 +956,22 @@ def _apply_system_gateway_home_override(
     Explicit/profile-derived ``HERMES_HOME`` always wins.  Missing, malformed,
     relative, and temporary unit homes fail closed without changing the
     process environment.
+
+    Privilege boundary (late review Finding 1): when this runs as root and
+    adopts the unit home, it also sets ``ELEVATED_SYSTEM_GATEWAY_SENTINEL``.
+    The later bootstrap then skips user-owned dotenv entirely and
+    :mod:`hermes_cli.gateway` resolves privileged tools absolutely, so no
+    unit-home-controlled ``.env`` (PATH hijack) can reach privileged tools.
     """
     if os.environ.get("HERMES_HOME", "").strip():
         return
 
     argv = sys.argv[1:]
-    if not argv or argv[0] != "gateway" or "--system" not in argv:
+    if not _system_gateway_request(argv):
         return
 
     path = unit_path or Path("/etc/systemd/system/hermes-gateway.service")
-    try:
-        text = path.read_text(encoding="utf-8")
-    except (OSError, UnicodeError):
-        return
-
-    unit_home = ""
-    for line in text.splitlines():
-        stripped = line.strip()
-        if not stripped.startswith("Environment="):
-            continue
-        body = stripped[len("Environment=") :].strip()
-        try:
-            assignments = shlex.split(body, posix=True)
-        except ValueError:
-            continue
-        for assignment in assignments:
-            if assignment.startswith("HERMES_HOME="):
-                unit_home = assignment.split("=", 1)[1].strip()
-                break
-        if unit_home:
-            break
-
+    unit_home = _systemd_unit_environment_home(path)
     if not unit_home:
         return
     candidate = Path(unit_home)
@@ -811,8 +982,11 @@ def _apply_system_gateway_home_override(
         temporary_roots = {
             Path(tempfile.gettempdir()).resolve(strict=False),
             Path("/var/tmp").resolve(strict=False),
+            Path("/tmp").resolve(strict=False),
+            Path("/private/tmp").resolve(strict=False),
+            Path("/private/var/tmp").resolve(strict=False),
         }
-    except OSError:
+    except (OSError, ValueError, RuntimeError):
         return
     if candidate == Path(candidate.anchor):
         return
@@ -820,6 +994,8 @@ def _apply_system_gateway_home_override(
         return
 
     os.environ["HERMES_HOME"] = str(candidate)
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        os.environ[ELEVATED_SYSTEM_GATEWAY_SENTINEL] = "1"
 
 
 _apply_profile_override()
@@ -855,6 +1031,16 @@ if sys.platform == "win32":
 from hermes_cli.config import get_hermes_home
 from hermes_cli.env_loader import load_hermes_dotenv
 
+# Privilege boundary (late review Finding 1): when the elevated system-
+# gateway context adopted a unit home, that home's user-writable ``.env``
+# must NOT be honoured into this privileged process — a PATH line there
+# would control every later privileged tool lookup.  Skip user dotenv
+# entirely in that context; config.yaml is still read later as normal
+# (read-only config, not environment injection).
+_elevated_system_gateway = bool(
+    os.environ.get(ELEVATED_SYSTEM_GATEWAY_SENTINEL)
+)
+
 # Updating dependencies must not import optional secret-manager libraries into
 # the updater process before ``uv`` replaces the environment.  On Windows,
 # Bitwarden's cryptography import maps ``_rust.pyd`` and the parent updater then
@@ -862,10 +1048,11 @@ from hermes_cli.env_loader import load_hermes_dotenv
 # flags have already been stripped above, so the first remaining argument is
 # the authoritative argparse subcommand.  Dotenv/managed config still loads;
 # only external secret fetches are unnecessary for installation maintenance.
-load_hermes_dotenv(
-    project_env=PROJECT_ROOT / ".env",
-    load_external_secrets=sys.argv[1:2] != ["update"],
-)
+if not _elevated_system_gateway:
+    load_hermes_dotenv(
+        project_env=PROJECT_ROOT / ".env",
+        load_external_secrets=sys.argv[1:2] != ["update"],
+    )
 
 # Bridge security.redact_secrets from config.yaml → HERMES_REDACT_SECRETS env
 # var BEFORE hermes_logging imports agent.redact (which snapshots the flag at

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -650,14 +650,19 @@ def _apply_profile_override() -> None:
     # only when it already points to a specific profile directory.  The
     # distinguishing heuristic: a profile path has "profiles" as its immediate
     # parent directory name (e.g. ~/.hermes/profiles/coder or
-    # /opt/data/profiles/coder).  If HERMES_HOME points to the hermes root
-    # instead (e.g. systemd hardcodes HERMES_HOME=/root/.hermes), we must
-    # still read active_profile — the user may have switched profiles via
+    # /opt/data/profiles/coder).  The reserved ``default`` name is never a named
+    # profile: canonicalize a legacy ``profiles/default`` value back to the root
+    # without creating or using that directory.  If HERMES_HOME points to the
+    # hermes root instead (e.g. systemd hardcodes HERMES_HOME=/root/.hermes), we
+    # must still read active_profile — the user may have switched profiles via
     # `hermes profile use` and the gateway should honour that choice.
     # See issue #22502.
     hermes_home_env = os.environ.get("HERMES_HOME", "")
     if profile_name is None and hermes_home_env:
-        if Path(hermes_home_env).parent.name == "profiles":
+        profile_home = Path(hermes_home_env)
+        if profile_home.parent.name == "profiles":
+            if profile_home.name.casefold() == "default":
+                os.environ["HERMES_HOME"] = str(profile_home.parent.parent)
             return
 
     # 2. If no flag, check active_profile in the hermes root.

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -720,7 +720,7 @@ class TestSecondaryProfileConfigHandling:
 
     @pytest.mark.asyncio
     async def test_duplicate_credential_is_persisted_as_profile_disabled(
-        self, monkeypatch
+        self, monkeypatch, caplog
     ):
         """A same-credential multiplex refusal is a deliberate skip (shared-token
         fleets ride the primary adapter), so it persists as "disabled", not the
@@ -746,6 +746,7 @@ class TestSecondaryProfileConfigHandling:
             "_update_platform_runtime_status",
             lambda platform, **kwargs: writes.append((platform, kwargs)),
         )
+        caplog.set_level(logging.INFO, logger="gateway.run")
         claim = runner._adapter_credential_claim(Platform.DISCORD, adapter)
 
         connected = await runner._start_one_profile_adapters(
@@ -753,6 +754,14 @@ class TestSecondaryProfileConfigHandling:
         )
 
         assert connected == 0
+        duplicate_records = [
+            record
+            for record in caplog.records
+            if "both configure discord with the same credential" in record.getMessage()
+        ]
+        assert len(duplicate_records) == 1
+        assert duplicate_records[0].levelno == logging.INFO
+        assert not any(record.levelno >= logging.ERROR for record in duplicate_records)
         assert writes == [
             (
                 "reviewer:discord",

--- a/tests/gateway/test_multiplex_adapter_registry.py
+++ b/tests/gateway/test_multiplex_adapter_registry.py
@@ -719,9 +719,13 @@ class TestSecondaryProfileConfigHandling:
         assert adapter._runtime_status_platform_key == "reviewer:discord"
 
     @pytest.mark.asyncio
-    async def test_duplicate_credential_is_persisted_as_profile_fatal(
+    async def test_duplicate_credential_is_persisted_as_profile_disabled(
         self, monkeypatch
     ):
+        """A same-credential multiplex refusal is a deliberate skip (shared-token
+        fleets ride the primary adapter), so it persists as "disabled", not the
+        red "fatal" that status popovers render for crashes (relay_disabled
+        precedent)."""
         runner = _secondary_recovery_runner()
         config = GatewayConfig(
             multiplex_profiles=True,
@@ -753,7 +757,7 @@ class TestSecondaryProfileConfigHandling:
             (
                 "reviewer:discord",
                 {
-                    "platform_state": "fatal",
+                    "platform_state": "disabled",
                     "error_code": "duplicate_credential",
                     "error_message": (
                         "Profile 'default' and 'reviewer' both configure discord "

--- a/tests/gateway/test_stale_platform_lock_retryable.py
+++ b/tests/gateway/test_stale_platform_lock_retryable.py
@@ -19,6 +19,7 @@ A normal start or reconnect must retain the retryable conflict behavior and
 must never evict the active holder.
 """
 
+import logging
 from typing import Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -106,7 +107,7 @@ def test_explicit_replace_takeover_reacquires_lock_once(adapter):
     assert acquire.call_count == 2
 
 
-def test_lock_conflict_names_owning_profile(adapter):
+def test_lock_conflict_names_owning_profile(adapter, caplog):
     """OOF-3: cross-profile conflicts must name the owning profile, not just a PID."""
     existing = {
         "pid": 559,
@@ -115,6 +116,7 @@ def test_lock_conflict_names_owning_profile(adapter):
         "hermes_home": "/opt/data/profiles/lead-gen-outreach",
     }
 
+    caplog.set_level(logging.ERROR, logger="gateway.platforms.base")
     with patch(
         "gateway.status.acquire_scoped_lock",
         return_value=(False, existing),
@@ -134,6 +136,14 @@ def test_lock_conflict_names_owning_profile(adapter):
     )
     assert adapter._fatal_error_retryable is True
     assert adapter._fatal_error_code == "telegram-bot-token_lock"
+    conflict_records = [
+        record
+        for record in caplog.records
+        if "already in use by the 'lead-gen-outreach' profile gateway"
+        in record.getMessage()
+    ]
+    assert len(conflict_records) == 1
+    assert conflict_records[0].levelno == logging.ERROR
 
 
 def test_lock_conflict_infers_profile_from_legacy_hermes_home(adapter):

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -173,10 +173,16 @@ class TestGatewayPidState:
 class TestGatewayRuntimeStatus:
     def test_clear_profile_platforms_preserves_primary_entries(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        primary_route = {
+            "state": "connected",
+            "updated_at": "2000-01-01T00:00:00+00:00",
+            "writer_pid": os.getpid(),
+            "writer_start_time": status._get_process_start_time(os.getpid()),
+        }
         (tmp_path / "gateway_state.json").write_text(
             json.dumps({
                 "platforms": {
-                    "telegram": {"state": "connected"},
+                    "telegram": primary_route,
                     "reviewer:discord": {
                         "state": "fatal",
                         "error_code": "duplicate_credential",
@@ -189,17 +195,144 @@ class TestGatewayRuntimeStatus:
         status.write_runtime_status(clear_profile_platforms=True)
 
         payload = status.read_runtime_status()
-        assert payload["platforms"] == {"telegram": {"state": "connected"}}
+        assert payload is not None
+        assert payload["platforms"] == {"telegram": primary_route}
+
+    def test_write_prunes_expired_platform_state_from_dead_writer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: False)
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "platforms": {
+                        "feishu": {
+                            "state": "connected",
+                            "updated_at": "2000-01-01T00:00:00+00:00",
+                            "writer_pid": 424242,
+                            "writer_start_time": 1.0,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert "feishu" not in payload["platforms"]
+
+    def test_read_filters_expired_platform_state_without_waiting_for_write(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: False)
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps(
+                {
+                    "platforms": {
+                        "feishu": {
+                            "state": "connected",
+                            "updated_at": "2000-01-01T00:00:00+00:00",
+                            "writer_pid": 424242,
+                            "writer_start_time": 1.0,
+                        }
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        payload = status.read_runtime_status()
+
+        assert payload is not None
+        assert "feishu" not in payload["platforms"]
+
+    def test_read_preserves_expired_platform_state_from_live_writer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 4242)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 55.0)
+        route = {
+            "state": "connected",
+            "updated_at": "2000-01-01T00:00:00+00:00",
+            "writer_pid": 4242,
+            "writer_start_time": 55.0,
+        }
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({"platforms": {"telegram": route}}),
+            encoding="utf-8",
+        )
+
+        payload = status.read_runtime_status()
+
+        assert payload is not None
+        assert payload["platforms"]["telegram"] == route
+
+    def test_write_preserves_expired_platform_state_from_live_writer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_pid_exists", lambda pid: pid == 4242)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda _pid: 55.0)
+        route = {
+            "state": "connected",
+            "updated_at": "2000-01-01T00:00:00+00:00",
+            "writer_pid": 4242,
+            "writer_start_time": 55.0,
+        }
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({"platforms": {"telegram": route}}),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["platforms"]["telegram"] == route
+
+    def test_write_preserves_recent_platform_state_from_dead_writer(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        monkeypatch.setattr(status, "_pid_exists", lambda _pid: False)
+        route = {
+            "state": "disconnected",
+            "updated_at": status._utc_now_iso(),
+            "writer_pid": 4343,
+            "writer_start_time": 65.0,
+        }
+        (tmp_path / "gateway_state.json").write_text(
+            json.dumps({"platforms": {"discord": route}}),
+            encoding="utf-8",
+        )
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload is not None
+        assert payload["platforms"]["discord"] == route
 
     def test_clear_profile_platforms_and_write_are_one_atomic_update(
         self, tmp_path, monkeypatch
     ):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        primary_route = {
+            "state": "connected",
+            "updated_at": "2000-01-01T00:00:00+00:00",
+            "writer_pid": os.getpid(),
+            "writer_start_time": status._get_process_start_time(os.getpid()),
+        }
         (tmp_path / "gateway_state.json").write_text(
             json.dumps({
                 "platforms": {
                     "old:discord": {"state": "fatal"},
-                    "telegram": {"state": "connected"},
+                    "telegram": primary_route,
                 }
             }),
             encoding="utf-8",
@@ -211,9 +344,11 @@ class TestGatewayRuntimeStatus:
             clear_profile_platforms=True,
         )
 
-        platforms = status.read_runtime_status()["platforms"]
+        payload = status.read_runtime_status()
+        assert payload is not None
+        platforms = payload["platforms"]
         assert set(platforms) == {"telegram", "reviewer:slack"}
-        assert platforms["telegram"] == {"state": "connected"}
+        assert platforms["telegram"] == primary_route
         assert platforms["reviewer:slack"]["state"] == "connected"
 
     def test_platform_writes_are_stamped_with_writer_identity(

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -98,6 +98,44 @@ class TestApplyProfileOverrideHermesHomeGuard:
             f"Expected HERMES_HOME to end with 'coder', got: {result!r}"
         )
 
+    def test_reserved_default_profile_path_resolves_to_root_without_creating_shell(
+        self, tmp_path, monkeypatch
+    ):
+        """A legacy ``profiles/default`` environment path means the root profile.
+
+        ``default`` is reserved and must never become a named-profile directory.
+        Canonicalizing the inherited path must not create that directory either.
+        """
+        hermes_root = tmp_path / ".hermes"
+        default_shell = hermes_root / "profiles" / "default"
+
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=str(default_shell),
+            active_profile=None,
+        )
+
+        assert result == str(hermes_root)
+        assert not default_shell.exists()
+
+    def test_explicit_reserved_default_profile_resolves_to_root_without_shell(
+        self, tmp_path, monkeypatch
+    ):
+        hermes_root = tmp_path / ".hermes"
+        default_shell = hermes_root / "profiles" / "default"
+
+        result = _run_apply_profile_override(
+            tmp_path,
+            monkeypatch,
+            hermes_home=None,
+            active_profile=None,
+            argv=["hermes", "-p", "default", "gateway", "run"],
+        )
+
+        assert result == str(hermes_root)
+        assert sys.argv == ["hermes", "gateway", "run"]
+        assert not default_shell.exists()
 
     def test_sudo_explicit_profile_resolves_invoking_users_profile(self, tmp_path, monkeypatch):
         """sudo elias ... should resolve `-p elias` under SUDO_USER, not root."""

--- a/tests/hermes_cli/test_apply_profile_override.py
+++ b/tests/hermes_cli/test_apply_profile_override.py
@@ -162,6 +162,69 @@ class TestApplyProfileOverrideHermesHomeGuard:
         assert sys.argv == ["hermes", "gateway", "install", "--system"]
 
 
+class TestSystemGatewayHomeOverride:
+    """System-scope gateway commands adopt the installed unit's home early."""
+
+    def _run(self, monkeypatch, tmp_path, *, argv, unit_text, existing=None):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(unit_text, encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", argv)
+        if existing is None:
+            monkeypatch.delenv("HERMES_HOME", raising=False)
+        else:
+            monkeypatch.setenv("HERMES_HOME", existing)
+
+        from hermes_cli.main import _apply_system_gateway_home_override
+
+        _apply_system_gateway_home_override(unit_path=unit_path)
+        return os.environ.get("HERMES_HOME")
+
+    def test_adopts_installed_system_unit_home_before_config_import(
+        self, tmp_path, monkeypatch
+    ):
+        result = self._run(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--system"],
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/home/hermes/.hermes"\n',
+        )
+        assert result == "/home/hermes/.hermes"
+
+    def test_explicit_home_is_never_overridden(self, tmp_path, monkeypatch):
+        result = self._run(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--system"],
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/home/hermes/.hermes"\n',
+            existing="/srv/explicit-hermes-home",
+        )
+        assert result == "/srv/explicit-hermes-home"
+
+    def test_non_system_command_is_untouched(self, tmp_path, monkeypatch):
+        result = self._run(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status"],
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/home/hermes/.hermes"\n',
+        )
+        assert result is None
+
+    def test_relative_or_temporary_unit_home_is_refused(self, tmp_path, monkeypatch):
+        relative = self._run(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--system"],
+            unit_text='[Service]\nEnvironment="HERMES_HOME=.hermes"\n',
+        )
+        assert relative is None
+
+        temporary = self._run(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--system"],
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/tmp/transient-hermes"\n',
+        )
+        assert temporary is None
 
 
 class TestSupervisedChildIgnoresStickyProfile:

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -392,9 +392,11 @@ def test_systemd_install_checks_linger_status(monkeypatch, tmp_path, capsys):
 
     out = capsys.readouterr().out
     assert unit_path.exists()
+    # Absolute systemctl resolution (privileged-tool boundary, late review
+    # F1): commands are pinned to the system binary, not a bare PATH name.
     assert [cmd for cmd, _ in calls] == [
-        ["systemctl", "--user", "daemon-reload"],
-        ["systemctl", "--user", "enable", gateway.get_service_name()],
+        ["/usr/bin/systemctl", "--user", "daemon-reload"],
+        ["/usr/bin/systemctl", "--user", "enable", gateway.get_service_name()],
     ]
     assert helper_calls == [True]
     assert "User service installed and enabled" in out

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -784,9 +784,12 @@ class TestGatewayServiceDetection:
         )
 
         def fake_run(cmd, capture_output=True, text=True, **kwargs):
-            if cmd == ["systemctl", "--user", "is-active", gateway_cli.get_service_name()]:
+            # Absolute systemctl resolution (privileged-tool boundary, late
+            # review F1): compare on the resolved binary, not a bare name.
+            head_user = [c for c in cmd if not str(c).endswith("/systemctl")]
+            if str(cmd[0]).endswith("/systemctl") and head_user == ["--user", "is-active", gateway_cli.get_service_name()]:
                 return SimpleNamespace(returncode=0, stdout="inactive\n", stderr="")
-            if cmd == ["systemctl", "is-active", gateway_cli.get_service_name()]:
+            if str(cmd[0]).endswith("/systemctl") and head_user == ["is-active", gateway_cli.get_service_name()]:
                 return SimpleNamespace(returncode=0, stdout="active\n", stderr="")
             raise AssertionError(f"Unexpected command: {cmd}")
 
@@ -1545,7 +1548,10 @@ class TestEnsureUserSystemdEnv:
         monkeypatch.setattr(gateway_cli, "_ensure_user_systemd_env", lambda: calls.append("called"))
 
         result = gateway_cli._systemctl_cmd(system=False)
-        assert result == ["systemctl", "--user"]
+        # Resolution is absolute (privileged-tool boundary, late review F1):
+        # the binary path is pinned to the system directory, never bare PATH.
+        assert result[0].endswith("/systemctl")
+        assert result[1:] == ["--user"]
         assert calls == ["called"]
 
 

--- a/tests/hermes_cli/test_system_gateway_privilege_boundary.py
+++ b/tests/hermes_cli/test_system_gateway_privilege_boundary.py
@@ -401,6 +401,74 @@ class TestSystemdUnitParsing:
         _apply_system_gateway_home_override(unit_path=unit_path)
         assert os.environ.get("HERMES_HOME") is None
 
+    # ── P2 case-insensitive systemd directive/section matching ──────────
+
+    def test_lowercase_service_section_still_parsed(self, tmp_path, monkeypatch):
+        """systemd sections are case-insensitive; [service] must be recognised."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[service]\nEnvironment="HERMES_HOME=/srv/lower-section"\n',
+        )
+        assert result == "/srv/lower-section"
+
+    def test_lowercase_environment_directive_still_parsed(self, tmp_path, monkeypatch):
+        """systemd directives are case-insensitive; environment= must be recognised."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Service]\nenvironment="HERMES_HOME=/srv/lower-directive"\n',
+        )
+        assert result == "/srv/lower-directive"
+
+    def test_lowercase_environmentfile_fails_closed(self, tmp_path, monkeypatch):
+        """Lowercase environmentfile= must still fail closed (unmodellable)."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/base-home"\n'
+                "environmentfile=/etc/default/hermes\n"
+            ),
+        )
+        assert result is None
+
+    def test_lowercase_unsetenvironment_fails_closed(self, tmp_path, monkeypatch):
+        """Lowercase unsetenvironment= must still fail closed (unmodellable)."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/base-home"\n'
+                "unsetenvironment=HERMES_HOME\n"
+            ),
+        )
+        assert result is None
+
+    def test_mixed_case_section_and_directives(self, tmp_path, monkeypatch):
+        """Mixed case [Service] with lowercase environmentfile= still fails closed."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/base-home"\n'
+                "environmentfile=/etc/default/hermes\n"
+            ),
+        )
+        assert result is None
+
+    def test_uppercase_section_still_parsed(self, tmp_path, monkeypatch):
+        """[SERVICE] (all-caps) is legal per systemd case-insensitivity."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[SERVICE]\nEnvironment="HERMES_HOME=/srv/upper-section"\n',
+        )
+        assert result == "/srv/upper-section"
+
     def test_valid_unit_home_still_adopted(self, tmp_path, monkeypatch):
         """Control: the canonical single-assignment unit keeps working."""
         result = self._override(

--- a/tests/hermes_cli/test_system_gateway_privilege_boundary.py
+++ b/tests/hermes_cli/test_system_gateway_privilege_boundary.py
@@ -1,0 +1,665 @@
+"""Privilege-boundary regression tests for the system gateway home override.
+
+Closes the five late-review REJECT findings against commit 90ebe58c5e
+(root-home recreation guard):
+
+1.  P0 — privileged environment injection: a root process that adopted a
+    system unit home must not honour that (user-writable) home's ``.env``
+    for PATH, and must not execute PATH-resolved privileged tools.
+2.  P1 — early argument detection must agree with the real CLI: global
+    flags before the subcommand, ``--`` passthrough, argparse ``--sys``
+    abbreviation, and only gateway verbs that own ``--system``.
+3.  P1 — unit parsing must follow systemd ordered semantics (later
+    ``Environment=`` wins, empty value resets, drop-ins in filename
+    order) and fail closed on anything unmodellable.
+4.  P1 — malformed paths (embedded NUL, symlink loops) and temporary
+    roots (including fixed ``/tmp`` regardless of ``TMPDIR``) must fail
+    closed without crashing startup.
+5.  P1 — fresh-process coverage proving the import-time bootstrap picks
+    the unit home before any state creation.
+
+All privileged-tool tests execute under a *simulated* root (monkeypatched
+``os.geteuid``); no test requires real root and no test executes a real
+privileged operation.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SAFE_PATH = "/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ELEVATED_SENTINEL = "_HERMES_SYSTEM_GATEWAY_ELEVATED"
+VERBS_WITH_SYSTEM_FLAG = {
+    "start",
+    "stop",
+    "restart",
+    "status",
+    "install",
+    "uninstall",
+}
+
+
+def _pop_cli_modules() -> None:
+    """Drop cached hermes_cli modules so import-time state can be re-run."""
+    for name in ("hermes_cli.main", "hermes_cli.gateway", "hermes_cli.env_loader"):
+        sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def sudo_root_env(monkeypatch, tmp_path):
+    """Environment of a ``sudo hermes gateway <verb> --system`` process."""
+    root_home = tmp_path / "root-home"
+    root_home.mkdir()
+    monkeypatch.setenv("HOME", str(root_home))
+    monkeypatch.delenv("HERMES_HOME", raising=False)
+    monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+    monkeypatch.setenv("PATH", SAFE_PATH)
+    monkeypatch.delenv("TMPDIR", raising=False)
+    return root_home
+
+
+class TestSystemGatewayArgDetection:
+    """Finding 2 — the override must fire exactly for real CLI invocations."""
+
+    def _override(self, monkeypatch, tmp_path, argv, dropins=None):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(
+            '[Service]\nEnvironment="HERMES_HOME=/home/hermes/.hermes"\n',
+            encoding="utf-8",
+        )
+        for name, text in (dropins or {}).items():
+            d = unit_path.parent / (unit_path.name + ".d")
+            d.mkdir(exist_ok=True)
+            (d / name).write_text(text, encoding="utf-8")
+        monkeypatch.setattr(sys, "argv", argv)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+
+        from hermes_cli.main import _apply_system_gateway_home_override
+
+        _apply_system_gateway_home_override(unit_path=unit_path)
+        return os.environ.get("HERMES_HOME")
+
+    def test_global_flags_before_gateway_still_trigger(self, tmp_path, monkeypatch):
+        """`hermes --yolo gateway status --system` is a valid invocation."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "--yolo", "gateway", "status", "--system"],
+        )
+        assert result == "/home/hermes/.hermes"
+
+    def test_global_value_flag_before_gateway_still_triggers(self, tmp_path, monkeypatch):
+        """`hermes --reasoning high gateway status --system` is valid too."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "--reasoning", "high", "gateway", "status", "--system"],
+        )
+        assert result == "/home/hermes/.hermes"
+
+    def test_double_dash_separator_does_not_trigger(self, tmp_path, monkeypatch):
+        """`hermes -- gateway status --system` treats everything as positional."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "--", "gateway", "status", "--system"],
+        )
+        assert result is None
+
+    def test_argparse_abbreviation_triggers(self, tmp_path, monkeypatch):
+        """`hermes gateway status --sys` parses as `--system` (allow_abbrev)."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--sys"],
+        )
+        assert result == "/home/hermes/.hermes"
+
+    @pytest.mark.parametrize("verb", sorted(VERBS_WITH_SYSTEM_FLAG))
+    def test_verbs_owning_system_flag_trigger(self, tmp_path, monkeypatch, verb):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", verb, "--system"],
+        )
+        assert result == "/home/hermes/.hermes", verb
+
+    def test_run_does_not_own_system_flag(self, tmp_path, monkeypatch):
+        """`gateway run --system` is rejected by argparse — no override."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "run", "--system"],
+        )
+        assert result is None
+
+    def test_positional_after_double_dash_does_not_trigger(self, tmp_path, monkeypatch):
+        """`gateway status -- --system` passes --system as output positional."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "status", "--", "--system"],
+        )
+        assert result is None
+
+    def test_non_gateway_command_does_not_trigger(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "chat", "--system"],
+        )
+        assert result is None
+
+    def test_install_run_as_user_value_not_misread_as_positional(self, tmp_path, monkeypatch):
+        """`gateway install --run-as-user bob --system` is valid argparse."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            argv=["hermes", "gateway", "install", "--run-as-user", "bob", "--system"],
+        )
+        assert result == "/home/hermes/.hermes"
+
+
+class TestArgvScannerArgparseParity:
+    """The early scanner must agree with the REAL argparse on every
+    ``gateway <verb> --s…`` abbreviation (drift-proof parity).
+
+    Builds the actual gateway subparser tree and compares, for every verb
+    and every prefix of ``--system`` down to ``--s``, whether argparse
+    accepts the invocation vs whether ``_system_gateway_request`` fires.
+    Also verifies the ambiguous-prefix table matches the real parser's
+    ``--s…`` option inventory per verb.
+    """
+
+    def _real_gateway_parser(self):
+        import argparse
+
+        from hermes_cli.subcommands.gateway import build_gateway_parser
+
+        root = argparse.ArgumentParser(prog="hermes", allow_abbrev=True)
+        sub = root.add_subparsers(dest="cmd")
+        build_gateway_parser(
+            sub,
+            cmd_gateway=lambda: None,
+            cmd_proxy=lambda: None,
+            cmd_gateway_enroll=lambda: None,
+        )
+        gateway = sub.choices["gateway"]
+        return gateway
+
+    def test_scanner_matches_argparse_for_every_abbreviation(self, monkeypatch):
+        from hermes_cli import main as cli_main
+
+        gateway = self._real_gateway_parser()
+        verbs = sorted(cli_main._SYSTEM_GATEWAY_VERBS_WITH_SYSTEM_FLAG)
+        mismatches = []
+
+        for verb in verbs:
+            for abbrev in ("--system", "--syste", "--syst", "--sys", "--sy", "--s"):
+                argv_tail = ["gateway", verb, abbrev]
+                argv = ["hermes"] + argv_tail
+                parser_accepts = True
+                try:
+                    gateway.parse_args(argv_tail[1:])
+                except SystemExit:
+                    parser_accepts = False
+                scanner_fires = cli_main._system_gateway_request(argv[1:])
+                if parser_accepts != scanner_fires:
+                    mismatches.append(
+                        f"{verb} {abbrev}: argparse={parser_accepts} scanner={scanner_fires}"
+                    )
+        assert not mismatches, "\n".join(mismatches)
+
+    def test_ambiguous_prefix_table_matches_real_parser(self, monkeypatch):
+        """The static collision table must mirror the live parser tree."""
+        import argparse
+
+        from hermes_cli import main as cli_main
+
+        gateway = self._real_gateway_parser()
+        sub_action = next(
+            a
+            for a in gateway._actions
+            if isinstance(a, argparse._SubParsersAction)
+        )
+        verbs = sub_action.choices
+        table = cli_main._SYSTEM_GATEWAY_AMBIGUOUS_PREFIXES
+
+        # Every verb owning --system must be in the table…
+        owning = {
+            name
+            for name, parser in verbs.items()
+            if any("--system" in a.option_strings for a in parser._actions)
+        }
+        assert owning == set(table.keys()), (owning, set(table.keys()))
+
+        # …and the collisions listed must be exactly the other --s… options.
+        for name in owning:
+            parser = verbs[name]
+            s_options = {
+                opt
+                for a in parser._actions
+                for opt in a.option_strings
+                if opt.startswith("--s") and opt != "--system"
+            }
+            assert table[name] == s_options, (name, table[name], s_options)
+
+    def test_systemx_and_system_value_do_not_trigger(self, tmp_path, monkeypatch):
+        """`--systemx` is a different (invalid) option; `--system=x` is a
+        store_true so argparse rejects it — neither may fire the override."""
+        from hermes_cli.main import _system_gateway_request
+
+        assert (
+            _system_gateway_request(["gateway", "status", "--systemx"]) is False
+        )
+        assert (
+            _system_gateway_request(["gateway", "status", "--system=x"]) is False
+        )
+        assert _system_gateway_request(["gateway", "status", "-system"]) is False
+
+
+class TestSystemdUnitParsing:
+    """Finding 3 — systemd Environment= ordered/reset semantics, drop-ins."""
+
+    def _override(self, monkeypatch, tmp_path, unit_text, dropins=None):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(unit_text, encoding="utf-8")
+        for name, text in (dropins or {}).items():
+            d = unit_path.parent / (unit_path.name + ".d")
+            d.mkdir(exist_ok=True)
+            (d / name).write_text(text, encoding="utf-8")
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "gateway", "status", "--system"]
+        )
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+
+        from hermes_cli.main import _apply_system_gateway_home_override
+
+        _apply_system_gateway_home_override(unit_path=unit_path)
+        return os.environ.get("HERMES_HOME")
+
+    def test_later_assignment_wins(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/old-home"\n'
+                'Environment="HERMES_HOME=/srv/actual-home"\n'
+            ),
+        )
+        assert result == "/srv/actual-home"
+
+    def test_empty_assignment_resets(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/old-home"\n'
+                'Environment="HERMES_HOME="\n'
+            ),
+        )
+        assert result is None
+
+    def test_hermes_home_in_wrong_section_fails_closed(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Unit]\nEnvironment="HERMES_HOME=/srv/unit-section-home"\n',
+        )
+        assert result is None
+
+    def test_environmentfile_fails_closed(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/envfile-home"\n'
+                "EnvironmentFile=/etc/default/hermes\n"
+            ),
+        )
+        assert result is None
+
+    def test_unsetenvironment_fails_closed(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text=(
+                "[Service]\n"
+                'Environment="HERMES_HOME=/srv/base-home"\n'
+                "UnsetEnvironment=HERMES_HOME\n"
+            ),
+        )
+        assert result is None
+
+    def test_specifier_fails_closed(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Service]\nEnvironment="HERMES_HOME=%h/.hermes"\n',
+        )
+        assert result is None
+
+    def test_dropin_overrides_base_unit(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/srv/base-home"\n',
+            dropins={
+                "10-later.conf": (
+                    '[Service]\nEnvironment="HERMES_HOME=/srv/dropin-home"\n'
+                )
+            },
+        )
+        assert result == "/srv/dropin-home"
+
+    def test_dropin_ordering_is_lexicographic(self, tmp_path, monkeypatch):
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/srv/base-home"\n',
+            dropins={
+                "20-second.conf": (
+                    '[Service]\nEnvironment="HERMES_HOME=/srv/second"\n'
+                ),
+                "10-first.conf": (
+                    '[Service]\nEnvironment="HERMES_HOME=/srv/first"\n'
+                ),
+            },
+        )
+        assert result == "/srv/second"
+
+    def test_unreadable_dropin_fails_closed(self, tmp_path, monkeypatch):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(
+            '[Service]\nEnvironment="HERMES_HOME=/srv/base-home"\n', encoding="utf-8"
+        )
+        dropin = unit_path.parent / (unit_path.name + ".d") / "10-secret.conf"
+        dropin.parent.mkdir(parents=True, exist_ok=True)
+        dropin.write_text(
+            '[Service]\nEnvironment="HERMES_HOME=/srv/hidden-home"\n', encoding="utf-8"
+        )
+        dropin.chmod(0o000)
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "gateway", "status", "--system"]
+        )
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+
+        from hermes_cli.main import _apply_system_gateway_home_override
+
+        _apply_system_gateway_home_override(unit_path=unit_path)
+        assert os.environ.get("HERMES_HOME") is None
+
+    def test_valid_unit_home_still_adopted(self, tmp_path, monkeypatch):
+        """Control: the canonical single-assignment unit keeps working."""
+        result = self._override(
+            monkeypatch,
+            tmp_path,
+            unit_text='[Service]\nEnvironment="HERMES_HOME=/home/hermes/.hermes"\n',
+        )
+        assert result == "/home/hermes/.hermes"
+
+
+class TestOverridePathValidation:
+    """Finding 4 — malformed and temporary homes fail closed, never crash."""
+
+    def _override(self, monkeypatch, tmp_path, unit_home):
+        unit_path = tmp_path / "hermes-gateway.service"
+        unit_path.write_text(
+            f'[Service]\nEnvironment="HERMES_HOME={unit_home}"\n', encoding="utf-8"
+        )
+        monkeypatch.setattr(
+            sys, "argv", ["hermes", "gateway", "status", "--system"]
+        )
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+
+        from hermes_cli.main import _apply_system_gateway_home_override
+
+        _apply_system_gateway_home_override(unit_path=unit_path)
+        return os.environ.get("HERMES_HOME")
+
+    def test_embedded_nul_fails_closed(self, tmp_path, monkeypatch):
+        assert self._override(monkeypatch, tmp_path, "/home/\x00evil") is None
+
+    def test_symlink_loop_fails_closed(self, tmp_path, monkeypatch):
+        loop = tmp_path / "loop-home"
+        loop.symlink_to(loop)
+        assert self._override(monkeypatch, tmp_path, str(loop)) is None
+
+    def test_literal_tmp_refused_even_when_tmpdir_elsewhere(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("TMPDIR", str(tmp_path / "elsewhere-tmp"))
+        assert self._override(monkeypatch, tmp_path, "/tmp/transient-hermes") is None
+
+    def test_macos_private_tmp_refused(self, tmp_path, monkeypatch):
+        assert (
+            self._override(monkeypatch, tmp_path, "/private/tmp/transient-hermes")
+            is None
+        )
+
+    def test_configured_tmpdir_still_refused(self, tmp_path, monkeypatch):
+        elsewhere = tmp_path / "elsewhere-tmp"
+        elsewhere.mkdir()
+        monkeypatch.setenv("TMPDIR", str(elsewhere))
+        assert self._override(monkeypatch, tmp_path, str(elsewhere / "hermes")) is None
+
+    def test_valid_absolute_home_outside_temp_still_adopted(self, tmp_path, monkeypatch):
+        assert (
+            self._override(monkeypatch, tmp_path, "/home/hermes/.hermes")
+            == "/home/hermes/.hermes"
+        )
+
+
+class TestPrivilegedSystemToolBoundary:
+    """Finding 1 (P0) — no user-controlled env may reach privileged tools."""
+
+    @pytest.fixture
+    def hostile_unit_home(self):
+        shm = Path("/dev/shm")
+        if not shm.is_dir() or not os.access(shm, os.W_OK):
+            pytest.skip("/dev/shm not writable")
+        unit_home = shm / f"hermes-boundary-{uuid.uuid4().hex[:12]}"
+        (unit_home / "bin").mkdir(parents=True)
+        (unit_home / ".env").write_text(f"PATH={unit_home}/bin\n", encoding="utf-8")
+        marker = unit_home / "systemctl-ran"
+        fake = unit_home / "bin" / "systemctl"
+        fake.write_text(
+            "#!/usr/bin/env python3\n"
+            "import pathlib, sys\n"
+            f"pathlib.Path({str(marker)!r}).write_text(' '.join(sys.argv[1:]))\n"
+            "sys.exit(0)\n",
+            encoding="utf-8",
+        )
+        fake.chmod(0o755)
+        yield {"unit_home": unit_home, "marker": marker}
+        import shutil as _shutil
+
+        _shutil.rmtree(unit_home, ignore_errors=True)
+
+    def test_elevated_context_cannot_execute_unit_home_systemctl(
+        self, tmp_path, monkeypatch, hostile_unit_home
+    ):
+        """Privileged tool chain: override -> sentinel -> absolute systemctl.
+
+        The full import-time chain as real root is proven by the
+        TestFreshProcessBootstrap root tests; this exercises the same seam
+        in-process: a root process adopting a hostile unit home must not
+        honour that home's .env, and systemctl must resolve absolutely.
+        """
+        unit_home = hostile_unit_home["unit_home"]
+        marker = hostile_unit_home["marker"]
+
+        monkeypatch.setattr(sys, "argv", ["hermes", "gateway", "status", "--system"])
+        monkeypatch.setattr(os, "geteuid", lambda: 0, raising=False)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+        # Simulate the attacker's goal: PATH already pointing at the hijack
+        # dir BEFORE any dotenv (worst case even without the .env load).
+        monkeypatch.setenv("PATH", f"{unit_home}/bin:{SAFE_PATH}")
+
+        _pop_cli_modules()
+        try:
+            from hermes_cli.main import _apply_system_gateway_home_override
+
+            unit_file = unit_home / "hermes-gateway.service"
+            unit_file.write_text(
+                f'[Service]\nEnvironment="HERMES_HOME={unit_home}"\n',
+                encoding="utf-8",
+            )
+            _apply_system_gateway_home_override(unit_path=unit_file)
+
+            assert os.environ.get("HERMES_HOME") == str(unit_home)
+            assert os.environ.get(ELEVATED_SENTINEL) == "1"
+
+            from hermes_cli import gateway as gateway_cli
+
+            assert gateway_cli._privileged_system_gateway_context() is True
+            cmd = gateway_cli._systemctl_cmd(system=True)
+            assert cmd[0] == "/usr/bin/systemctl", cmd
+            proc = gateway_cli._run_systemctl(
+                ["--version"], system=True, capture_output=True, text=True
+            )
+            assert proc.returncode == 0, proc.stderr[-500:]
+            assert not marker.exists(), "fake systemctl from unit home executed!"
+        finally:
+            monkeypatch.setenv("PATH", SAFE_PATH)
+            os.environ.pop("HERMES_HOME", None)
+            os.environ.pop(ELEVATED_SENTINEL, None)
+            _pop_cli_modules()
+
+    def test_non_elevated_context_keeps_which_lookup(
+        self, tmp_path, monkeypatch, hostile_unit_home
+    ):
+        """Without the elevated sentinel the legacy PATH lookup still works."""
+        unit_home = hostile_unit_home["unit_home"]
+        monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.delenv(ELEVATED_SENTINEL, raising=False)
+        monkeypatch.setenv(
+            "PATH", f"{unit_home}/bin:{SAFE_PATH}"
+        )
+
+        _pop_cli_modules()
+        try:
+            from hermes_cli import gateway as gateway_cli
+
+            assert gateway_cli._privileged_system_gateway_context() is False
+            # Unprivileged callers keep PATH resolution — verify via the
+            # resolver seam rather than the host-probing helper (which may
+            # legitimately answer differently inside containers).
+            resolved = gateway_cli.privileged_system_tool_path("systemctl")
+            assert resolved == f"{unit_home}/bin/systemctl", resolved
+        finally:
+            monkeypatch.setenv("PATH", SAFE_PATH)
+            _pop_cli_modules()
+
+    def test_sentinel_without_root_cannot_lock_tools(self, monkeypatch):
+        """A forged sentinel in a non-root process must be ignored."""
+        monkeypatch.setattr(os, "geteuid", lambda: 1000, raising=False)
+        monkeypatch.setenv(ELEVATED_SENTINEL, "1")
+
+        from hermes_cli import gateway as gateway_cli
+
+        assert gateway_cli._privileged_system_gateway_context() is False
+
+
+class TestFreshProcessBootstrap:
+    """Finding 5 — import-time behaviour proven in real subprocesses.
+
+    The privileged scenario runs as real root via ``sudo`` (the live host's
+    unit carries a root-only-readable drop-in, so a non-root reader must
+    correctly fail closed — that behaviour is covered by the unit-parsing
+    tests; here we prove the actual privileged bootstrap).
+    """
+
+    CAN_RUN_AS_ROOT = os.geteuid() == 0 or subprocess.run(
+        ["sudo", "-n", "true"], capture_output=True
+    ).returncode == 0
+
+    def _bootstrap(self, tmp_path, argv_tail):
+        root_home = tmp_path / "fresh-root"
+        root_home.mkdir()
+        code = (
+            "import os, sys\n"
+            "sys.argv = ['hermes'] + sys.argv[1:]\n"
+            "import hermes_cli.main  # import-time overrides run\n"
+            "print('ENV=' + (os.environ.get('HERMES_HOME') or '-'))\n"
+            "from hermes_cli.config import get_hermes_home\n"
+            "print('EFF=' + str(get_hermes_home()))\n"
+        )
+        env = {"HOME": str(root_home), "PATH": SAFE_PATH}
+        if os.geteuid() == 0:
+            return (
+                subprocess.run(
+                    [sys.executable, "-c", code, *argv_tail],
+                    capture_output=True,
+                    text=True,
+                    timeout=180,
+                    cwd=str(REPO_ROOT),
+                    env=env,
+                ),
+                root_home,
+            )
+        if not self.CAN_RUN_AS_ROOT:
+            pytest.skip("no passwordless sudo for root-subprocess test")
+        return (
+            subprocess.run(
+                [
+                    "sudo", "-n", "-E", "--preserve-env=PATH",
+                    sys.executable, "-c", code, *argv_tail,
+                ],
+                capture_output=True,
+                text=True,
+                timeout=180,
+                cwd=str(REPO_ROOT),
+                env=env,
+            ),
+            root_home,
+        )
+
+    @staticmethod
+    def _lines(proc):
+        return dict(
+            line.split("=", 1) for line in proc.stdout.splitlines() if "=" in line
+        )
+
+    def test_yolo_prefixed_status_selects_unit_home(self, tmp_path):
+        proc, root_home = self._bootstrap(tmp_path, ["--yolo", "gateway", "status", "--system"])
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        out = self._lines(proc)
+        assert out["ENV"] == "/home/hermes/.hermes", out
+        assert out["EFF"] == "/home/hermes/.hermes", out
+        assert not (root_home / ".hermes").exists(), "root scaffold created!"
+
+    def test_run_system_does_not_adopt_unit_home(self, tmp_path):
+        proc, root_home = self._bootstrap(tmp_path, ["gateway", "run", "--system"])
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        out = self._lines(proc)
+        assert out["ENV"] == "-", out
+        assert out["EFF"] != "/home/hermes/.hermes", out
+
+    def test_double_dash_form_does_not_adopt_unit_home(self, tmp_path):
+        proc, _ = self._bootstrap(tmp_path, ["--", "gateway", "status", "--system"])
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        out = self._lines(proc)
+        assert out["ENV"] == "-", out
+
+    def test_canonical_status_adopts_unit_home(self, tmp_path):
+        proc, root_home = self._bootstrap(tmp_path, ["gateway", "status", "--system"])
+        assert proc.returncode == 0, proc.stderr[-2000:]
+        out = self._lines(proc)
+        assert out["ENV"] == "/home/hermes/.hermes", out
+        assert not (root_home / ".hermes").exists(), "root scaffold created!"


### PR DESCRIPTION
# fix(gateway): reconcile profile state and harden system-service boundaries

## Summary

- Persist same-credential multiplex refusals as disabled platform state instead of treating them as fatal startup failures.
- Reconcile profile roots and stale platform lock/status data consistently.
- Prevent system gateway commands from creating or adopting root-owned Hermes homes.
- Tighten the systemd privilege boundary, override ordering, and case-insensitive directive/section matching.
- Add extensive regression coverage for status, profile overrides, service generation, and privilege checks.

## Why

Gateway status must describe recoverable platform conflicts accurately, while system-service commands must not cross user-home ownership boundaries or generate subtly ineffective systemd overrides.

## Provenance

Prepared from carry commits `896068e4857426fceba5acc9bd717ab81076cf10`, `3e4a02e6783f9fcd579215c4e38d5faefc49ff13`, `90ebe58c5efca6938bca65cf750c016ad3021ded`, `4757424b7ba291d4cc1cad89b012559da8e5b467`, and `5bf698044ba6dc3fc872e23864b9ab95bcc18f55`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- Focused gateway/status/profile/system-service pytest suite — PASS, 331 tests; 6 skipped
- `git diff --check origin/main..HEAD` — PASS

No live gateway or system service was changed or restarted. Full receipt: `test-output.txt`.
