### PR TITLE
fix(mcp/plugins): separate application failures from transport health

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -3788,9 +3788,10 @@ class PluginManager:
         # function with the slack_bolt signature ``(ack, body, action)``.
         self._slack_action_handlers: List[tuple] = []
         # In-flight / recently-timed-out hook callbacks. Keyed by
-        # (hook_name, id(cb)) so a stuck policy hook cannot spawn a new
-        # abandoned daemon thread on every subsequent fire.
-        self._hook_running_callbacks: Dict[tuple, object] = {}
+        # (hook_name, id(cb)). Ordinary concurrent invocations are allowed;
+        # only callbacks that have actually timed out suppress later fires.
+        self._hook_running_callbacks: Dict[tuple, set[object]] = {}
+        self._hook_timed_out_callbacks: Dict[tuple, set[object]] = {}
         self._hook_timeout_suppressed_until: Dict[tuple, float] = {}
         self._hook_timeout_lock = threading.Lock()
         self._hook_timeout_suppression_seconds = _HOOK_TIMEOUT_SUPPRESSION_SECONDS
@@ -4185,6 +4186,7 @@ class PluginManager:
             self._context_engine = None
             with self._hook_timeout_lock:
                 self._hook_running_callbacks.clear()
+                self._hook_timed_out_callbacks.clear()
                 self._hook_timeout_suppressed_until.clear()
             self._discovered = False
         else:
@@ -5585,8 +5587,9 @@ class PluginManager:
         policy hook ``pre_tool_call`` are bounded by
         ``plugins.hook_callback_timeout`` (default 30s). On timeout the worker
         is abandoned (not joined) so we do not reintroduce the #6622 hang.
-        Timed-out or still-running ``pre_tool_call`` callbacks fail closed
-        with a block directive; other bounded hooks fail open (skip).
+        ``pre_tool_call`` callbacks that timed out (including workers still
+        unwinding after that timeout) fail closed with a block directive;
+        other bounded hooks fail open (skip).
 
         ``subagent_stop`` (and any hook in ``_HOOK_CALLER_THREAD_HOOKS``)
         always runs on the caller thread to preserve the documented parent-
@@ -5629,13 +5632,15 @@ class PluginManager:
                         suppressed_until = self._hook_timeout_suppressed_until.get(
                             callback_key
                         )
-                        running = callback_key in self._hook_running_callbacks
+                        timed_out_running = bool(
+                            self._hook_timed_out_callbacks.get(callback_key)
+                        )
                         if (
                             suppressed_until is not None and suppressed_until > now
-                        ) or running:
+                        ) or timed_out_running:
                             logger.warning(
-                                "Hook '%s' callback %s skipped after previous "
-                                "timeout or while still running",
+                                "Hook '%s' callback %s skipped after a previous "
+                                "timeout (worker still running or cooldown active)",
                                 hook_name,
                                 callback_name,
                             )
@@ -5644,7 +5649,9 @@ class PluginManager:
                             continue
                         if suppressed_until is not None:
                             self._hook_timeout_suppressed_until.pop(callback_key, None)
-                        self._hook_running_callbacks[callback_key] = token
+                        self._hook_running_callbacks.setdefault(
+                            callback_key, set()
+                        ).add(token)
 
                     context = contextvars.copy_context()
                     done = threading.Event()
@@ -5667,8 +5674,18 @@ class PluginManager:
                             failure["exc"] = exc
                         finally:
                             with self._hook_timeout_lock:
-                                if self._hook_running_callbacks.get(_key) is _token:
-                                    self._hook_running_callbacks.pop(_key, None)
+                                running_tokens = self._hook_running_callbacks.get(_key)
+                                if running_tokens is not None:
+                                    running_tokens.discard(_token)
+                                    if not running_tokens:
+                                        self._hook_running_callbacks.pop(_key, None)
+                                timed_out_tokens = self._hook_timed_out_callbacks.get(
+                                    _key
+                                )
+                                if timed_out_tokens is not None:
+                                    timed_out_tokens.discard(_token)
+                                    if not timed_out_tokens:
+                                        self._hook_timed_out_callbacks.pop(_key, None)
                             done.set()
 
                     thread = threading.Thread(
@@ -5680,6 +5697,13 @@ class PluginManager:
                     if not done.wait(timeout=timeout):
                         # Do not join — that would reintroduce the #6622 hang.
                         with self._hook_timeout_lock:
+                            running_tokens = self._hook_running_callbacks.get(
+                                callback_key, set()
+                            )
+                            if token in running_tokens:
+                                self._hook_timed_out_callbacks.setdefault(
+                                    callback_key, set()
+                                ).add(token)
                             self._hook_timeout_suppressed_until[callback_key] = (
                                 time.monotonic()
                                 + self._hook_timeout_suppression_seconds

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -73,9 +73,12 @@ def _attempt_track(path_str: str, task_id: str, session_id: str) -> None:
     """Best-effort auto-track. Never raises."""
     try:
         p = Path(path_str).expanduser()
+        # exists() can raise PermissionError on unreadable parents (e.g.
+        # /root/*) — treat as "not a trackable file", per the never-raises
+        # contract above. (#perf-audit-20260822)
+        if not p.exists():
+            return
     except Exception:
-        return
-    if not p.exists():
         return
     category = dg.guess_category(p)
     if category is None:

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -1070,6 +1070,40 @@ class TestForceReloadSymmetry:
             {"context": "hi"}
         ]
 
+    def test_parallel_healthy_callback_invocations_are_not_skipped(self, monkeypatch):
+        """Ordinary overlap is not a timeout and must not suppress either call."""
+        monkeypatch.setattr(
+            "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0
+        )
+
+        first_started = threading.Event()
+        release_first = threading.Event()
+        first_result = []
+
+        def callback(call_id, **_kwargs):
+            if call_id == "first":
+                first_started.set()
+                assert release_first.wait(timeout=2.0)
+            return call_id
+
+        mgr = PluginManager()
+        mgr._hooks["post_tool_call"] = [callback]
+
+        first = threading.Thread(
+            target=lambda: first_result.extend(
+                mgr.invoke_hook("post_tool_call", call_id="first")
+            )
+        )
+        first.start()
+        assert first_started.wait(timeout=1.0)
+
+        assert mgr.invoke_hook("post_tool_call", call_id="second") == ["second"]
+        release_first.set()
+        first.join(timeout=2.0)
+
+        assert not first.is_alive()
+        assert first_result == ["first"]
+
     def test_hook_exception_still_isolated_under_timeout_path(self, monkeypatch):
         monkeypatch.setattr(
             "hermes_cli.plugins._resolve_hook_callback_timeout", lambda: 1.0

--- a/tests/tools/test_mcp_circuit_breaker.py
+++ b/tests/tools/test_mcp_circuit_breaker.py
@@ -101,6 +101,48 @@ def _cleanup(mcp_tool_module, name: str) -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_application_errors_do_not_trip_transport_breaker(monkeypatch, tmp_path):
+    """A healthy MCP RPC that returns ``isError`` is an application result.
+
+    Repeating a valid application-level error (for example, requesting a
+    missing config path) must not make Hermes label the MCP server unreachable.
+    Only transport failures belong in the server circuit breaker.
+    """
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import mcp_tool
+    from tools.mcp_tool import _make_tool_handler
+
+    call_count = {"n": 0}
+
+    async def _call_tool_application_error(*a, **kw):
+        call_count["n"] += 1
+        result = MagicMock()
+        result.is_error = True
+        block = MagicMock()
+        block.text = "config path not found"
+        result.content = [block]
+        return result
+
+    _install_stub_server(mcp_tool, "srv", _call_tool_application_error)
+    mcp_tool._ensure_mcp_loop()
+
+    try:
+        handler = _make_tool_handler("srv", "config_get", 10.0)
+        attempts = mcp_tool._CIRCUIT_BREAKER_THRESHOLD + 1
+
+        for _ in range(attempts):
+            parsed = json.loads(handler({"path": "missing.path"}))
+            assert parsed.get("error") == "config path not found", parsed
+
+        assert call_count["n"] == attempts, (
+            "application errors must continue reaching the healthy MCP session"
+        )
+        assert mcp_tool._server_error_counts.get("srv", 0) == 0
+    finally:
+        _cleanup(mcp_tool, "srv")
+
+
 def test_circuit_breaker_half_opens_after_cooldown(monkeypatch, tmp_path):
     """After a tripped breaker's cooldown elapses, the *next* call must
     actually execute against the session (half-open probe). When the

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6900,15 +6900,13 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
 
         try:
             result = _call_once()
-            # Check if the MCP tool itself returned an error
-            try:
-                parsed = json.loads(result)
-                if "error" in parsed:
-                    _bump_server_error(server_name)
-                else:
-                    _reset_server_error(server_name)  # success — reset
-            except (json.JSONDecodeError, TypeError):
-                _reset_server_error(server_name)  # non-JSON = success
+            # Reaching here means the MCP RPC completed at the transport
+            # layer.  A JSON ``{"error": ...}`` payload is the normal
+            # rendering of CallToolResult.isError — an application-level
+            # result such as "config path not found", not evidence that the
+            # server is unreachable.  Only exceptions below count toward the
+            # transport circuit breaker.
+            _reset_server_error(server_name)
             return result
         except InterruptedError:
             return _interrupted_call_result()


### PR DESCRIPTION
# fix(mcp/plugins): separate application failures from transport health

## Summary

- Preserve the disk-cleanup plugin's never-raises contract when `Path.exists()` itself raises `PermissionError`.
- Keep MCP application-level tool errors from charging the transport circuit breaker.
- Distinguish plugin-run overlap from an actual execution timeout.

## Why

Expected application failures should be reported to callers without poisoning transport health, and plugin scheduling should describe the real reason a run did not proceed.

## Provenance

Prepared from carry commits `a846278ef44ba65cf1e254612e47eca7e7be3ef6`, `14461085de2fef46394c0ff238804f544eeb550e`, and `73af5e3af00aa19f3fb143d23dd5b65fb8bc23e5`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- Focused disk-cleanup/plugin/MCP-breaker pytest suite — PASS, 111 tests
- `git diff --check origin/main..HEAD` — PASS

Full receipt: `test-output.txt`.
