### PR TITLE
fix(runtime): improve quota classification and isolate updater tests

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -247,6 +247,7 @@ _USAGE_LIMIT_TRANSIENT_SIGNALS = [
     "retry",
     "resets at",
     "reset in",
+    "reset at",
     "resets in",
     "reset after",
     "available in",

--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -1644,7 +1644,9 @@ def is_container() -> bool:
     Kubernetes/k3s) were previously missed. To cover those, also check:
       * ``KUBERNETES_SERVICE_HOST`` env var — set in every Kubernetes pod.
       * ``kubepods`` / ``containerd`` / ``crio`` markers in ``/proc/1/cgroup``.
-      * the same markers in ``/proc/self/mountinfo`` (cgroup-v2 fallback).
+      * container-runtime markers on the current root mount in
+        ``/proc/self/mountinfo`` (cgroup-v2 fallback). Host-managed runtime
+        storage mounted elsewhere must not classify the host as a container.
 
     Result is cached for the process lifetime.  Import-safe — no heavy deps.
 
@@ -1673,14 +1675,28 @@ def is_container() -> bool:
     except OSError:
         pass
     # cgroup v2: /proc/1/cgroup is just "0::/" with no marker. The container
-    # runtime still shows up in the mount table (overlay rootfs, runtime mount
-    # paths), so scan mountinfo as a last resort.
+    # runtime still shows up on the process's root mount. Limit the fallback
+    # to that mount: a host may legitimately mount containerd/Kubernetes
+    # storage elsewhere for containers it manages.
     try:
         with open("/proc/self/mountinfo", "r", encoding="utf-8") as f:
-            mountinfo = f.read()
-            if any(marker in mountinfo for marker in ("kubepods", "containerd", "crio")):
-                _container_detected = True
-                return True
+            for line in f:
+                fields = line.split()
+                if (
+                    len(fields) > 4
+                    and fields[4] == "/"
+                    and any(
+                        marker in line
+                        for marker in (
+                            "kubepods",
+                            "containerd",
+                            "crio",
+                            "/var/lib/docker/",
+                        )
+                    )
+                ):
+                    _container_detected = True
+                    return True
     except OSError:
         pass
     _container_detected = False

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -413,6 +413,25 @@ class TestClassifyApiError:
         assert result.reason == FailoverReason.rate_limit
         assert result.retryable is True
 
+    def test_zai_429_reset_at_stays_rate_limit(self):
+        """Z.ai returns 'Your limit will reset at <timestamp>' (not 'resets at').
+
+        Before the 'reset at' transient signal was added, this was misclassified
+        as billing (non-retryable), preventing failover to BytePlus/Chutes.
+        Regression for hermes-health-77y.16 / commit 85ae71c473.
+        """
+        e = MockAPIError(
+            "Usage limit reached for 5 hour. Your limit will reset at"
+            " 2026-08-28 20:03:16",
+            status_code=429,
+        )
+        result = classify_api_error(e, provider="zai", model="glm-5.3")
+        assert result.reason == FailoverReason.rate_limit, (
+            "Z.ai 'reset at' must classify as rate_limit (retryable), not billing"
+        )
+        assert result.retryable is True
+        assert result.should_fallback is True
+
     def test_alibaba_rate_increased_too_quickly(self):
         """Alibaba/DashScope returns a unique throttling message.
 

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -95,6 +95,22 @@ def _setup_update_mocks(monkeypatch, tmp_path):
     monkeypatch.setattr(hermes_config, "migrate_config", lambda **kw: {"env_added": [], "config_added": []})
     monkeypatch.setattr(hermes_main, "_upgrade_pip_before_lazy_refresh", lambda *a, **kw: None)
     monkeypatch.setattr(hermes_main, "_refresh_active_lazy_features", lambda *a, **kw: True)
+    # A real update evicts cached Hermes modules after changing the checkout.
+    # In this unit test that would also evict the mocks below and reconnect the
+    # test to live host state, so keep the test's mocked module graph stable.
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
+    # Unit tests must not inherit the host's live runtime fleet.  The updater's
+    # fail-closed post-update check treats any discovered pre-update runtime as
+    # an expected restart target, which otherwise makes these tests poll the
+    # real VPS for 30 seconds and fail outside their stated autostash scope.
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[], to_dict=lambda: {}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **_kwargs: [],
+    )
 
 
 

--- a/tests/hermes_cli/test_update_head_moved_gate.py
+++ b/tests/hermes_cli/test_update_head_moved_gate.py
@@ -100,6 +100,9 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     monkeypatch.setattr(
         hermes_main, "_resume_windows_gateways_after_update", lambda *a, **k: None
     )
+    # Preserve this test's mocked module graph across the simulated checkout
+    # change; production purge behavior is covered by its dedicated tests.
+    monkeypatch.setattr(hermes_main, "_purge_stale_hermes_modules", lambda: None)
     # Short-circuit the long tail: dependency install + desktop build.
     monkeypatch.setattr(hermes_main, "_write_update_incomplete_marker", lambda: None)
     monkeypatch.setattr(hermes_main, "_clear_update_incomplete_marker", lambda: None)
@@ -118,6 +121,16 @@ def _patch_update_deps(monkeypatch, tmp_path, run_side_effect):
     )
     monkeypatch.setattr(
         hermes_gateway, "find_profile_gateway_processes", lambda *a, **k: []
+    )
+    # Keep the updater's fail-closed fleet verification inside this unit
+    # test's mocked world rather than discovering the live VPS runtimes.
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[], to_dict=lambda: {}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **_kwargs: [],
     )
 
 

--- a/tests/hermes_cli/test_update_yes_flag.py
+++ b/tests/hermes_cli/test_update_yes_flag.py
@@ -12,7 +12,42 @@ import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 from hermes_cli.main import cmd_update
+
+
+@pytest.fixture(autouse=True)
+def _isolate_update_fleet(monkeypatch):
+    """Prevent prompt tests from touching or polling the live VPS fleet."""
+    monkeypatch.setattr(
+        "hermes_cli.main._purge_stale_hermes_modules",
+        lambda: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_inventory.collect_runtime_inventory",
+        lambda: SimpleNamespace(runtimes=[], to_dict=lambda: {}),
+    )
+    monkeypatch.setattr(
+        "hermes_cli.update_receipt.collect_fleet_versions",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_gateway_pids",
+        lambda **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.supports_systemd_services",
+        lambda: False,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.gateway.find_profile_gateway_processes",
+        lambda *_args, **_kwargs: [],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.main._finish_dashboard_update_cleanup",
+        lambda *_args, **_kwargs: None,
+    )
 
 
 def _make_run_side_effect(

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -1,5 +1,6 @@
 """Tests for hermes_constants module."""
 
+import io
 import os
 from pathlib import Path
 from types import SimpleNamespace
@@ -359,6 +360,49 @@ class TestIsContainer:
         self._reset_cache(monkeypatch)
         monkeypatch.setattr(os.path, "exists", lambda p: False)
         monkeypatch.setenv("KUBERNETES_SERVICE_HOST", "10.43.0.1")
+        assert is_container() is True
+
+    def test_host_container_storage_mounts_do_not_imply_container(self, monkeypatch):
+        """Host-mounted containerd storage below /var/lib must not match root."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/\n")
+            if path == "/proc/self/mountinfo":
+                return io.StringIO(
+                    "36 25 8:1 / / rw,relatime - ext4 /dev/sda1 rw\n"
+                    "149 36 0:59 / /var/lib/docker/rootfs/overlayfs/abc rw - "
+                    "overlay overlay rw,lowerdir=/var/lib/containerd/snapshots/1/fs\n"
+                )
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open)
+        assert is_container() is False
+
+    def test_detects_containerd_root_mount_on_cgroup_v2(self, monkeypatch):
+        """A containerd-backed root mount remains a positive fallback signal."""
+        self._reset_cache(monkeypatch)
+        monkeypatch.setattr(os.path, "exists", lambda p: False)
+        monkeypatch.delenv("KUBERNETES_SERVICE_HOST", raising=False)
+
+        real_open = open
+
+        def fake_open(path, *args, **kwargs):
+            if path == "/proc/1/cgroup":
+                return io.StringIO("0::/\n")
+            if path == "/proc/self/mountinfo":
+                return io.StringIO(
+                    "36 25 0:59 / / rw - overlay overlay rw,"
+                    "lowerdir=/var/lib/containerd/snapshots/1/fs\n"
+                )
+            return real_open(path, *args, **kwargs)
+
+        monkeypatch.setattr("builtins.open", fake_open)
         assert is_container() is True
 
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -896,19 +896,33 @@ class TestFTS5Search:
         ]
         assert all("context" in row and row["context"] for row in default)
 
-    def test_search_projection_skips_context_enrichment_queries(self, db):
+    def test_search_projection_skips_context_enrichment_queries(
+        self, db, monkeypatch
+    ):
         db.create_session(session_id="s1", source="cli")
         db.append_message("s1", role="user", content="before")
         db.append_message("s1", role="assistant", content="projectionneedle")
         db.append_message("s1", role="user", content="after")
 
         statements = []
-        read_conn = db._get_read_conn() or db._conn
         traced_connections = [db._conn]
-        if read_conn is not db._conn:
-            traced_connections.append(read_conn)
-        for conn in traced_connections:
-            conn.set_trace_callback(statements.append)
+        db._conn.set_trace_callback(statements.append)
+
+        # Trace each read connection when the pool actually opens it. Calling
+        # _get_read_conn() directly here would consume a pool permit without
+        # returning that connection, while search_messages() correctly checks
+        # out a different connection; the test would then observe zero queries
+        # despite context being returned.
+        original_get_read_conn = db._get_read_conn
+
+        def traced_get_read_conn():
+            conn = original_get_read_conn()
+            if conn is not None:
+                conn.set_trace_callback(statements.append)
+                traced_connections.append(conn)
+            return conn
+
+        monkeypatch.setattr(db, "_get_read_conn", traced_get_read_conn)
 
         def context_query_count():
             normalized = (" ".join(sql.upper().split()) for sql in statements)


### PR DESCRIPTION
# fix(runtime): improve quota classification and isolate updater tests

## Summary

- Recognize provider responses containing `reset at` as transient usage-limit signals.
- Avoid treating ordinary host environments as container mounts from weak path heuristics.
- Isolate updater and state tests from live host Hermes state.
- Add regression tests for the Z.ai 429 wording, mount detection, and updater environment isolation.

## Why

These are small cross-cutting correctness fixes: retry routing needs to recognize real quota wording, environment detection should avoid false positives, and tests must never inherit live host state.

## Provenance

Prepared from carry commits `85ae71c47319cfe3f0c3b2868839e33d9be31f3a`, `303491cbfba3a5cdca3d74cab08de0c24472b9bd`, `d1b53c427f057580966e25cdb5e7d7585be4e60b`, and `81b6464a817dff056001ff5a517d1f81a940ecd4`, rebased by cherry-pick onto upstream `origin/main` at `63279301bcbdc185c1b07b98a9312eb0c862f26d`.

## Test plan

- Focused classifier/constants/updater/state pytest suite — PASS, 488 tests; 5 skipped
- `git diff --check origin/main..HEAD` — PASS

Full receipt: `test-output.txt`.
