### PR TITLE
fix(desktop): disable WSL path bridge for registry SSH/remote/cloud profiles

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -11354,6 +11354,13 @@ async function connectRegistryBackend(
 
     poolEntry.remoteBaseUrl = connection.baseUrl
 
+    // SSH backends always run on a remote host — their POSIX paths can never
+    // be opened through this machine's wsl.exe. Register the profile as
+    // bridge-inactive so file panels/dialogs don't spawn wsl.exe (visible
+    // black window on WSL-less Windows) for remote paths. The v1 path does
+    // this in ensureBackend(); the registry SSH path was missing it.
+    setWslBridgeProfileState(profileKey, false)
+
     return {
       ...connection,
       profile: profileKey,
@@ -11385,6 +11392,10 @@ async function connectRegistryBackend(
 
   await waitForHermes(connection.baseUrl, connection.token, undefined, connection.authMode, connection.headers)
   poolEntry.remoteBaseUrl = connection.baseUrl
+
+  // Remote/cloud backends live on another host too — disable the WSL path
+  // bridge for their profiles for the same reason as the SSH branch above.
+  setWslBridgeProfileState(profileKey, false)
 
   return {
     ...connection,


### PR DESCRIPTION
## Summary

Fixes #102868. When a bot profile is opened while the active connection is a **registry SSH (or remote URL / cloud) backend**, the Desktop app spawns `wsl.exe` (flashing black console window on machines where WSL has no distro; install-prompt risk on fully WSL-less machines) to resolve POSIX paths coming from the remote host.

## Root cause

Registry connections resolve their backend through `ensureRegistryBackend()` → `connectRegistryBackend()`, which **never registered the profile's WSL path bridge state**. `isWslBridgeActive(profile)` therefore fell back to its default (`?? true` in `wsl-path-bridge.ts`), so POSIX paths from the remote Linux host hit `resolveDefaultWslDistro()` and ran `execFileSync('wsl.exe', ['-l','-q'])`.

The v1 path already handles this: `ensureBackend()` calls `setWslBridgeProfileState(key, connection.mode !== 'remote')` at all three of its return sites (main.ts:11012/11037/11073), and the primary remote setup disables the bridge at main.ts:12417 (#66433).

## Fix

Mirror that guard in `connectRegistryBackend()`: SSH and remote/cloud backends always run on another host, so register the profile as bridge-inactive (`setWslBridgeProfileState(profileKey, false)`) at both remote return sites (SSH + remote/cloud).

## Validation

- `tsc --noEmit` passes.
- No unit-test carrier exists for the `main.ts` wiring layer (Electron main, heavily dependent); the change mirrors the already-tested `ensureBackend()` behavior. Manual repro: connect an SSH registry backend, open a bot profile on it → no `wsl.exe` spawn.

Related: #66433, #66447 (per-profile bridge contract tests).