### PR TITLE
fix(desktop): route preview bridge replies to the owning gateway

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { GatewayEventContext } from './types'
+
+const mocks = vi.hoisted(() => ({
+  ambientRequest: vi.fn(),
+  requestForOwnedSession: vi.fn(
+    (_sessionId: unknown, _ambient: unknown, _method: string, _params: Record<string, unknown>) =>
+      Promise.resolve({ status: 'ok' })
+  )
+}))
+
+vi.mock('@/store/gateway', () => ({
+  $gateway: {
+    get: () => ({ request: mocks.ambientRequest }),
+    listen: vi.fn(() => () => {}),
+    set: vi.fn(),
+    subscribe: vi.fn(() => () => {})
+  }
+}))
+
+vi.mock('@/store/session-states', () => ({
+  requestForOwnedSession: mocks.requestForOwnedSession
+}))
+
+vi.mock('@/app/right-sidebar/terminal/buffer', () => ({
+  readActiveTerminal: vi.fn(() => ({ text: 'visible terminal' }))
+}))
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+
+function bridgeEvent(type: string, payload: Record<string, unknown>): GatewayEventContext {
+  return {
+    event: { session_id: 'runtime-owned', type },
+    isActiveEvent: false,
+    payload,
+    sessionId: 'runtime-owned'
+  } as unknown as GatewayEventContext
+}
+
+describe('handleDesktopBridgeEvent response routing', () => {
+  beforeEach(() => {
+    mocks.ambientRequest.mockReset()
+    mocks.requestForOwnedSession.mockClear()
+  })
+
+  it('returns a preview action response through the session owner', () => {
+    const handled = handleDesktopBridgeEvent(
+      bridgeEvent('preview.act.request', { action: 'elements', request_id: 'request-1' })
+    )
+
+    expect(handled).toBe(true)
+    expect(mocks.requestForOwnedSession).toHaveBeenCalledOnce()
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[0]).toBe('runtime-owned')
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[2]).toBe('preview.act.respond')
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[3]).toEqual({
+      request_id: 'request-1',
+      text: JSON.stringify({
+        error: 'The in-app browser only takes actions in the session the user is looking at.',
+        success: false
+      })
+    })
+    expect(mocks.ambientRequest).not.toHaveBeenCalled()
+  })
+
+  it('returns a terminal read response through the session owner', () => {
+    const handled = handleDesktopBridgeEvent(
+      bridgeEvent('terminal.read.request', { count: 20, request_id: 'request-2', start: 0 })
+    )
+
+    expect(handled).toBe(true)
+    expect(mocks.requestForOwnedSession).toHaveBeenCalledOnce()
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[0]).toBe('runtime-owned')
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[2]).toBe('terminal.read.respond')
+    expect(mocks.requestForOwnedSession.mock.calls[0]?.[3]).toEqual({
+      request_id: 'request-2',
+      text: JSON.stringify({ text: 'visible terminal' })
+    })
+    expect(mocks.ambientRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -8,6 +8,7 @@ import { $gateway } from '@/store/gateway'
 import { applyDesktopLayoutPreset, revealDesktopPane } from '@/store/pane-focus'
 import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
+import { requestForOwnedSession } from '@/store/session-states'
 import { $tipsEnabled, type ActiveTip, showTip } from '@/store/tips'
 import { $toursEnabled } from '@/store/tours'
 
@@ -45,7 +46,27 @@ const loadPreviewEngine = () => {
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
 export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
-  const { event, payload, isActiveEvent } = ctx
+  const { event, payload, isActiveEvent, sessionId } = ctx
+
+  // A desktop window can hold sessions from several gateway connections. The
+  // bridge request came from the backend that owns this session, so its reply
+  // must return on that same socket. The ambient gateway follows foreground
+  // activation and can point at another connection with the same profile name;
+  // replying there leaves the real request blocked until its timeout.
+  const respond = (method: string, params: Record<string, unknown>) => {
+    const gateway = $gateway.get()
+
+    if (!gateway) {
+      return undefined
+    }
+
+    return requestForOwnedSession(
+      sessionId,
+      gateway.request.bind(gateway) as typeof gateway.request,
+      method,
+      params
+    )
+  }
 
   if (event.type === 'terminal.read.request') {
     // read_terminal tool: serialize the renderer's xterm buffer and answer
@@ -57,7 +78,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
 
-      void $gateway.get()?.request('terminal.read.respond', {
+      void respond('terminal.read.respond', {
         request_id: requestId,
         text: result ? JSON.stringify(result) : ''
       })
@@ -76,7 +97,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
       void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
+        void respond('preview.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -96,7 +117,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('preview.act.respond', {
+        respond('preview.act.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -140,7 +161,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const read = window.hermesDesktop?.readWindowBelow
 
       const answer = (result: unknown) =>
-        $gateway.get()?.request('window.read.respond', {
+        respond('window.read.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })
@@ -180,7 +201,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
 
     if (requestId) {
       const answer = (result: unknown) =>
-        $gateway.get()?.request('tour.respond', {
+        respond('tour.respond', {
           request_id: requestId,
           text: result ? JSON.stringify(result) : ''
         })


### PR DESCRIPTION
## Summary
- route blocking desktop bridge responses through the session owner instead of the ambient gateway
- cover preview action and terminal read response routing with regression tests
- fix preview, terminal, window-read, and tour timeouts when multiple SSH/registry backends expose the same profile

## Root cause
The request is emitted by the backend that owns the session, but the desktop client replied through `$gateway`, which follows whichever gateway is active in the foreground. With multiple same-named profiles on different connections, the response reached the wrong backend and the owner timed out.

## Verification
- `npm run test:ui`: 719 files, 7,169 tests passed
- `npx tsc -p . --noEmit`: passed
- `npm run lint`: passed with existing repository warnings only
- focused owner-routing suite: 93 tests passed
