### PR TITLE
fix(aux): _to_async_client drops callable API-key provider — async auxiliary calls 401 while sync succeeds

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -6732,6 +6732,35 @@ def _to_async_client(sync_client, model: str, is_vision: bool = False):
         "api_key": sync_client.api_key,
         "base_url": str(sync_client.base_url),
     }
+    # A sync client built from a per-request credential source (``key_cmd``,
+    # Azure Entra bearer providers) stores a callable in ``_api_key_provider``
+    # and leaves ``api_key`` EMPTY until the first request. OpenAI SDK 2.x
+    # (_client.py:144-147 sync / 499-504 async): passing a plain string here
+    # would silently drop that source, so every async auxiliary leg
+    # (vision, titles, compression) sends a placeholder key and 401s while the
+    # identical sync path succeeds. AsyncOpenAI accepts an *awaitable* api_key
+    # and awaits it in ``_refresh_api_key`` before each request — so bridge the
+    # sync callable into an awaitable wrapper, running it in an executor when
+    # it is a plain sync callable (key_cmd sources shell out via subprocess and
+    # must not block the event loop). Static-key clients are untouched: the
+    # guard only fires when a provider is actually present.
+    _sync_key_provider = getattr(sync_client, "_api_key_provider", None)
+    if callable(_sync_key_provider) and not isinstance(_sync_key_provider, str):
+        import asyncio as _asyncio
+
+        async def _await_key_provider():
+            # Run the sync callable itself off the loop — key_cmd sources shell
+            # out via subprocess and must not block the event loop. An
+            # awaitable-returning provider comes back as a coroutine from the
+            # executor call and is awaited here on the loop.
+            result = await _asyncio.get_running_loop().run_in_executor(
+                None, _sync_key_provider
+            )
+            if inspect.isawaitable(result):
+                return await result
+            return result
+
+        async_kwargs["api_key"] = _await_key_provider
     sync_base_url = str(sync_client.base_url)
     if base_url_host_matches(sync_base_url, "openrouter.ai"):
         async_kwargs["default_headers"] = build_or_headers()

--- a/tests/agent/test_auxiliary_client_async_key_provider.py
+++ b/tests/agent/test_auxiliary_client_async_key_provider.py
@@ -1,0 +1,126 @@
+"""Async conversion must preserve a callable API-key provider.
+
+Regression context: a sync client built from a per-request credential source
+(``key_cmd``, Azure Entra) stores a callable in ``_api_key_provider`` and
+leaves ``api_key`` empty until the first request. ``_to_async_client`` used to
+pass the still-empty ``sync_client.api_key`` to ``AsyncOpenAI``, so every async
+auxiliary leg (vision, titles, compression) sent a placeholder key and 401ed
+while the identical sync call succeeded. The invariant under test:
+
+    converting a sync client to async must preserve a callable key provider —
+    the async client must mint (not inherit) its key per request.
+"""
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME and clear module caches (mirrors sibling tests)."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text("model:\n  default: test-model\n")
+
+
+def _sync_client(base_url="https://gateway.invalid/v1", **kwargs):
+    from openai import OpenAI
+
+    return OpenAI(api_key=kwargs.pop("api_key", "sk-static"), base_url=base_url)
+
+
+class TestAsyncConversionPreservesCallableKeyProvider:
+    """The invariant: _to_async_client must not drop a callable key source."""
+
+    def test_callable_provider_survives_conversion(self):
+        from agent.auxiliary_client import _to_async_client
+
+        mints = {"count": 0}
+
+        def provider():
+            mints["count"] += 1
+            return f"minted-{mints['count']}"
+
+        sync_client = _sync_client(api_key=provider)
+        # OpenAI SDK 2.x contract: callable api_key -> _api_key_provider set,
+        # .api_key empty until first request.
+        assert sync_client._api_key_provider is not None
+        assert sync_client.api_key == ""
+
+        async_client, _model = _to_async_client(sync_client, "test-model")
+
+        assert async_client._api_key_provider is not None, (
+            "_to_async_client dropped the callable key provider — async "
+            "auxiliary calls would 401 with a placeholder key"
+        )
+        # The async client must MINT its key per request (SDK awaits the
+        # provider in _refresh_api_key), not inherit the empty string.
+        asyncio.run(async_client._refresh_api_key())
+        assert async_client.api_key == "minted-1"
+        # Repeated requests re-mint — the token source stays live.
+        asyncio.run(async_client._refresh_api_key())
+        assert async_client.api_key == "minted-2"
+
+    def test_awaitable_provider_survives_conversion(self):
+        from agent.auxiliary_client import _to_async_client
+
+        async def provider():
+            return "awaited-token"
+
+        sync_client = _sync_client(api_key=provider)
+        async_client, _model = _to_async_client(sync_client, "test-model")
+        assert async_client._api_key_provider is not None
+        asyncio.run(async_client._refresh_api_key())
+        assert async_client.api_key == "awaited-token"
+
+    def test_static_key_client_unchanged(self):
+        """No behavior change for the common static-key case."""
+        from agent.auxiliary_client import _to_async_client
+
+        sync_client = _sync_client(api_key="sk-static")
+        async_client, _model = _to_async_client(sync_client, "test-model")
+        assert async_client.api_key == "sk-static"
+        assert async_client._api_key_provider is None
+
+    def test_key_cmd_resolved_client_keeps_provider_through_async(
+        self, tmp_path, monkeypatch
+    ):
+        """End-to-end shape of the reported bug: a key_cmd named custom
+        provider resolves on the sync path and 401s on the async path.
+        The conversion must carry the minting callable across."""
+        import yaml
+
+        config_path = tmp_path / ".hermes" / "config.yaml"
+        config_path.write_text(yaml.dump({
+            "model": {"default": "test-model"},
+            "providers": {
+                "gateway": {
+                    "base_url": "https://gateway.invalid/v1",
+                    "api_mode": "chat_completions",
+                    "key_cmd": "printf minted-token",
+                },
+            },
+        }))
+
+        from agent.auxiliary_client import resolve_provider_client
+
+        sync_client, _model = resolve_provider_client(
+            "gateway", "test-model", async_mode=False
+        )
+        assert sync_client is not None
+        assert sync_client._api_key_provider is not None, (
+            "precondition: key_cmd must resolve to a callable on the sync path"
+        )
+
+        async_client, _model = resolve_provider_client(
+            "gateway", "test-model", async_mode=True
+        )
+        assert async_client is not None
+        assert async_client._api_key_provider is not None, (
+            "key_cmd provider was dropped by async conversion — async "
+            "auxiliary calls will 401"
+        )
+        asyncio.run(async_client._refresh_api_key())
+        assert async_client.api_key == "minted-token"


### PR DESCRIPTION
## Summary

`_to_async_client` (agent/auxiliary_client.py) drops a callable API-key provider when converting a sync client to `AsyncOpenAI`. Any setup whose credentials come from a per-request source — `key_cmd` (SSO/OIDC brokers, IAM, auth proxies issuing short-lived bearers) or Azure Entra bearer providers — 401s on **every async auxiliary call** (vision_analyze, title generation, compression) while the identical sync/main-turn call succeeds.

### Root cause (reproduced + verified in-process)

1. `resolve_provider_client` (agent/auxiliary_client.py) lifts `key_cmd` into a `CommandTokenSource` callable via `build_command_token_provider` and passes it to `_create_openai_client`. OpenAI SDK 2.x stores callable keys as `client._api_key_provider` with `client.api_key` left **empty until the first request** (`openai/_client.py:144-147` sync, `:499-504` async). Sync path works — `_refresh_api_key` mints per request.
2. `_to_async_client` builds `AsyncOpenAI` with `"api_key": sync_client.api_key` — the still-empty string. The callable token source is never carried over; the async client ends with `_api_key_provider = None`.
3. Every async aux leg sends the empty/placeholder key → 401.

Minimal repro (pre-fix): a `key_cmd` named custom provider resolves sync with `_api_key_provider` set, but the async-converted client has `_api_key_provider is None` and an empty `api_key`.

### Fix

In `_to_async_client`, when `getattr(sync_client, "_api_key_provider", None)` is callable, pass an **awaitable wrapper** as `api_key` instead of `sync_client.api_key`. AsyncOpenAI awaits it in `_refresh_api_key` before each request (`openai/_client.py:501-504, 678-679`). The wrapper runs the sync callable via `asyncio.get_running_loop().run_in_executor` (key_cmd sources shell out via subprocess — must not block the event loop) and awaits the result if awaitable. The guard only fires when a provider is actually present, so **static-key clients are untouched** (verified by test).

## Why config alone can't fix it

`key_cmd` config already fixes sync + scoped main-turn paths, but the async conversion discards the token source — it is unreachable from config, hence this upstream fix.

## Test plan

- New `tests/agent/test_auxiliary_client_async_key_provider.py` asserts the invariant (async conversion preserves a callable key provider) plus per-request re-minting, the awaitable-provider shape, the static-key no-change case, and the end-to-end key_cmd config → async mint path. 4 passed.
- Repro: pre-fix fails exactly as reported; post-fix passes (sync + async providers set, async mints fresh token).
- Regression: `tests/agent -k auxiliary` → 428 passed, 2 pre-existing failures in `test_auxiliary_main_first.py` that also fail identically on unmodified `main` under the same run order (test-order interference, unrelated to this change — verified in a clean worktree of `origin/main`).