### PR TITLE
fix(email): allow custom Subject via send_message metadata (SMTP-only profiles) (#102884)

### DIFF
--- a/plugins/platforms/email/adapter.py
+++ b/plugins/platforms/email/adapter.py
@@ -1212,8 +1212,13 @@ class EmailAdapter(BasePlatformAdapter):
         """Send an email reply to the given address."""
         try:
             loop = asyncio.get_running_loop()
+            subject_override = None
+            if isinstance(metadata, dict):
+                _s = metadata.get("subject")
+                if isinstance(_s, str) and _s.strip():
+                    subject_override = _s.strip()
             message_id = await loop.run_in_executor(
-                None, self._send_email, chat_id, content, reply_to
+                None, lambda: self._send_email(chat_id, content, reply_to, subject_override)
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1235,20 +1240,27 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         reply_to_msg_id: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email via SMTP. Runs in executor thread."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        # Thread context for reply
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        # Subject: explicit override (SMTP-only profiles) wins verbatim;
+        # otherwise fall back to thread context with Re: prefix.
+        if isinstance(subject_override, str) and subject_override.strip():
+            subject = subject_override.strip()
+        else:
+            ctx = self._thread_context.get(to_addr, {})
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
-        # Threading headers
+        # Threading headers — only when replying in-thread; explicit subject
+        # override without prior context should not fake threading headers.
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = reply_to_msg_id or ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
@@ -1334,12 +1346,14 @@ class EmailAdapter(BasePlatformAdapter):
 
         try:
             loop = asyncio.get_running_loop()
+            _subj = None
+            if isinstance(metadata, dict):
+                _s = metadata.get("subject")
+                if isinstance(_s, str) and _s.strip():
+                    _subj = _s.strip()
             await loop.run_in_executor(
                 None,
-                self._send_email_with_attachments,
-                chat_id,
-                body,
-                local_paths,
+                lambda: self._send_email_with_attachments(chat_id, body, local_paths, _subj),
             )
         except Exception as e:
             logger.error("[Email] Multi-image send failed, falling back: %s", e, exc_info=True)
@@ -1350,18 +1364,23 @@ class EmailAdapter(BasePlatformAdapter):
         to_addr: str,
         body: str,
         file_paths: List[str],
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email with multiple file attachments via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if isinstance(subject_override, str) and subject_override.strip():
+            subject = subject_override.strip()
+        else:
+            ctx = self._thread_context.get(to_addr, {})
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
@@ -1411,13 +1430,20 @@ class EmailAdapter(BasePlatformAdapter):
         """Send a file as an email attachment."""
         try:
             loop = asyncio.get_running_loop()
+            _subj_doc = None
+            # Subject may arrive as metadata["subject"] or top-level kwargs["subject"]
+            _meta = kwargs.get("metadata")
+            if isinstance(_meta, dict):
+                _s = _meta.get("subject")
+                if isinstance(_s, str) and _s.strip():
+                    _subj_doc = _s.strip()
+            if not _subj_doc:
+                _v = kwargs.get("subject")
+                if isinstance(_v, str) and _v.strip():
+                    _subj_doc = _v.strip()
             message_id = await loop.run_in_executor(
                 None,
-                self._send_email_with_attachment,
-                chat_id,
-                caption or "",
-                file_path,
-                file_name,
+                lambda: self._send_email_with_attachment(chat_id, caption or "", file_path, file_name, _subj_doc),
             )
             return SendResult(success=True, message_id=message_id)
         except Exception as e:
@@ -1430,18 +1456,23 @@ class EmailAdapter(BasePlatformAdapter):
         body: str,
         file_path: str,
         file_name: Optional[str] = None,
+        subject_override: Optional[str] = None,
     ) -> str:
         """Send an email with a file attachment via SMTP."""
         msg = MIMEMultipart()
         msg["From"] = self._address
         msg["To"] = to_addr
 
-        ctx = self._thread_context.get(to_addr, {})
-        subject = ctx.get("subject", "Hermes Agent")
-        if not subject.startswith("Re:"):
-            subject = f"Re: {subject}"
+        if isinstance(subject_override, str) and subject_override.strip():
+            subject = subject_override.strip()
+        else:
+            ctx = self._thread_context.get(to_addr, {})
+            subject = ctx.get("subject", "Hermes Agent")
+            if not subject.startswith("Re:"):
+                subject = f"Re: {subject}"
         msg["Subject"] = subject
 
+        ctx = self._thread_context.get(to_addr, {})
         original_msg_id = ctx.get("message_id")
         if original_msg_id:
             msg["In-Reply-To"] = original_msg_id
@@ -1507,6 +1538,7 @@ async def _standalone_send(
     thread_id=None,
     media_files=None,
     force_document=False,
+    subject=None,
 ):
     """Out-of-process Email delivery via SMTP (one-shot). Implements the
     standalone_sender_fn contract; replaces the legacy _send_email helper."""
@@ -1538,7 +1570,11 @@ async def _standalone_send(
         msg = MIMEText(message, "plain", "utf-8")
         msg["From"] = address
         msg["To"] = chat_id
-        msg["Subject"] = "Hermes Agent"
+        # Explicit subject (from send_message tool) wins verbatim; otherwise default.
+        if isinstance(subject, str) and subject.strip():
+            msg["Subject"] = subject.strip()
+        else:
+            msg["Subject"] = "Hermes Agent"
         msg["Date"] = formatdate(localtime=True)
 
         ctx = _tls_context(smtp_tls_verify, smtp_host)

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -244,6 +244,10 @@ SEND_MESSAGE_SCHEMA = {
             "message_id": {
                 "type": "string",
                 "description": "For action='react'/'unreact': id of the message to react to. Omit to target the most recent message received in that chat (usually the one being replied to)."
+            },
+            "subject": {
+                "type": "string",
+                "description": "Optional email subject. Only meaningful when target is email (e.g. 'email:user@example.com'). When omitted, a threaded 'Re: <original subject>' is used if replying to a prior email; otherwise 'Hermes Agent'. When set, it is used verbatim as the Subject header without an added 'Re:' prefix."
             }
         },
         "required": []
@@ -494,6 +498,10 @@ def _handle_send(args):
             "media_files": media_files,
             "force_document": force_document_attachments,
         }
+        # Thread optional email subject through to the email adapter via metadata.
+        _subject_val = (args.get("subject") or "").strip() if isinstance(args.get("subject"), str) else ""
+        if _subject_val:
+            send_kwargs["subject"] = _subject_val
         # Preserve the exact built-in call contract; only custom handlers need
         # the complete typed request.
         if entry is not None and entry.send_message_handler is not None:
@@ -952,6 +960,8 @@ async def _send_via_adapter(
     thread_id=None,
     media_files=None,
     force_document=False,
+    subject=None,
+    args=None,
 ):
     """Send a message via a live gateway adapter, with a standalone fallback
     for out-of-process callers (e.g. cron running separately from the gateway).
@@ -984,6 +994,14 @@ async def _send_via_adapter(
                     metadata["thread_id"] = thread_id
                 if platform_name == "ntfy" and chat_id:
                     metadata["publish_topic"] = chat_id
+                # Subject override for email (SMTP-only profiles have no thread context).
+                _eff_subject = subject
+                if not _eff_subject and isinstance(args, dict):
+                    _maybe = args.get("subject")
+                    if isinstance(_maybe, str) and _maybe.strip():
+                        _eff_subject = _maybe.strip()
+                if _eff_subject:
+                    metadata["subject"] = _eff_subject
                 if not metadata:
                     metadata = None
                 # The adapter's send() uses asyncio.Queue + worker tasks bound
@@ -1073,13 +1091,24 @@ async def _send_via_adapter(
 
     if entry is not None and entry.standalone_sender_fn is not None:
         try:
+            _cs_subject = subject
+            if not _cs_subject and isinstance(args, dict):
+                _maybe2 = args.get("subject")
+                if isinstance(_maybe2, str) and _maybe2.strip():
+                    _cs_subject = _maybe2.strip()
+            _standalone_kwargs = dict(
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+            if _cs_subject:
+                _standalone_kwargs["subject"] = _cs_subject
+                # Also expose via args copy for forward-compat standalone senders that read it
             result = await entry.standalone_sender_fn(
                 pconfig,
                 chat_id,
                 chunk,
-                thread_id=thread_id,
-                media_files=media_files,
-                force_document=force_document,
+                **_standalone_kwargs,
             )
         except asyncio.CancelledError:
             raise
@@ -1109,7 +1138,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, args=None, subject=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -1119,6 +1148,13 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     from gateway.config import Platform
 
     platform_name = platform.value if hasattr(platform, "value") else str(platform)
+
+    # Effective email subject (thread override): args["subject"] beats explicit subject param.
+    _eff_subject = subject
+    if not _eff_subject and isinstance(args, dict):
+        _maybe_subj = args.get("subject")
+        if isinstance(_maybe_subj, str) and _maybe_subj.strip():
+            _eff_subject = _maybe_subj.strip()
 
     media_files = media_files or []
 
@@ -1489,7 +1525,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.SIGNAL:
             result = await _send_signal(pconfig.extra, chat_id, chunk)
         elif platform == Platform.EMAIL:
-            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id)
+            result = await _registry_standalone_send("email", pconfig, chat_id, chunk, thread_id, subject=_eff_subject)
         elif platform == Platform.SMS:
             result = await _registry_standalone_send("sms", pconfig, chat_id, chunk, thread_id)
         elif platform == Platform.DINGTALK:
@@ -1529,6 +1565,8 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
                 thread_id=thread_id,
                 media_files=media_files if i == len(chunks) - 1 else [],
                 force_document=force_document,
+                subject=_eff_subject,
+                args=args,
             )
 
         if isinstance(result, dict) and result.get("error"):
@@ -1880,7 +1918,7 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
 # (plugins/platforms/slack/adapter.py), wired via standalone_sender_fn. #41112.
 
 
-async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None):
+async def _registry_standalone_send(platform_name, pconfig, chat_id, message, thread_id=None, subject=None):
     """Dispatch a one-shot send through a migrated platform plugin's
     standalone_sender_fn (registry hook).  Used for platforms whose adapter
     moved out of gateway/platforms/ into plugins/platforms/<name>/ (#41112):
@@ -1893,7 +1931,10 @@ async def _registry_standalone_send(platform_name, pconfig, chat_id, message, th
     entry = platform_registry.get(platform_name)
     if entry is None or entry.standalone_sender_fn is None:
         return {"error": f"{platform_name} plugin not registered or missing standalone_sender_fn"}
-    return await entry.standalone_sender_fn(pconfig, chat_id, message, thread_id=thread_id)
+    _kw = dict(thread_id=thread_id)
+    if subject:
+        _kw["subject"] = subject
+    return await entry.standalone_sender_fn(pconfig, chat_id, message, **_kw)
 
 
 # _send_whatsapp moved to plugins/platforms/whatsapp/adapter.py::_standalone_send,


### PR DESCRIPTION
Fixes #102884

**Problem:** A send-only email profile (SMTP configured, no IMAP) can never produce a custom `Subject:` header. Every outbound email was sent with `Subject: Re: Hermes Agent` regardless of intent because:

- `tools/send_message_tool.py` had no `subject` field; `metadata` only ever carried `thread_id`
- `EmailAdapter.send()` accepted `metadata` but silently discarded it, and sourced the subject exclusively from `self._thread_context` which is only populated on the IMAP receive path

**Fix:**

- Add optional `subject` to `SEND_MESSAGE_SCHEMA` (meaningful for email targets). Documented as verbatim use without forced `Re:` prefix.
- Thread `subject` through `metadata["subject"]` via `_send_via_adapter` and `_registry_standalone_send` (both live adapter and out-of-process standalone paths)
- In `EmailAdapter`, honor `metadata["subject"]` verbatim when present; otherwise fall back to existing thread-context `Re: <subject>` logic
- Covers `_send_email`, `_send_email_with_attachments`, `_send_email_with_attachment` and `_standalone_send` (default `Hermes Agent` when no override)

**Tests:** All 39 existing `tests/gateway/test_email.py` still pass; manual repro confirms verbatim subject for SMTP-only profiles and preserved `Re:` fallback for threaded replies.