### PR TITLE
fix(telegram): resolve dm_topics from top-level telegram: block in hot-reload

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -6077,7 +6077,26 @@ class TelegramAdapter(BasePlatformAdapter):
         """Re-read dm_topics from config.yaml so externally created topics work without restart."""
         try:
             from hermes_cli.config import load_config_readonly  # canonical loader: managed overlay + ${VAR}
-            dm_topics = load_config_readonly().get("platforms", {}).get("telegram", {}).get("extra", {}).get("dm_topics", [])
+            config = load_config_readonly()
+            # Resolve dm_topics with the same precedence as startup: the
+            # top-level ``telegram:`` block is primary (it reaches
+            # PlatformConfig.extra via _apply_yaml_config's telegram-extra
+            # passthrough), ``platforms.telegram`` is the nested fallback.
+            # Reading only the nested path silently cleared topic config on
+            # top-level-layout configs — one message into a non-configured
+            # topic was enough to drop skill bindings everywhere.
+            dm_topics: list = []
+            _tl = config.get("telegram")
+            if isinstance(_tl, dict):
+                _tl_extra = _tl.get("extra")
+                if isinstance(_tl_extra, dict):
+                    _tl_dm = _tl_extra.get("dm_topics")
+                    if isinstance(_tl_dm, list):
+                        dm_topics = _tl_dm
+            if not dm_topics:
+                _nested_dm = config.get("platforms", {}).get("telegram", {}).get("extra", {}).get("dm_topics", [])
+                if isinstance(_nested_dm, list):
+                    dm_topics = _nested_dm
             if not dm_topics:
                 self._dm_topics_config = []
                 self._dm_topic_chat_ids = set()

--- a/tests/gateway/test_dm_topics_reload_toplevel.py
+++ b/tests/gateway/test_dm_topics_reload_toplevel.py
@@ -1,0 +1,160 @@
+"""LOCAL PATCH 28 regression tests: _reload_dm_topics_from_config must honor
+the top-level ``telegram:`` config layout, not only ``platforms.telegram``.
+
+Poison scenario these lock in: with a top-level layout, a message into an
+ad-hoc (non-configured) topic triggers the hot-reload; the old code read only
+``platforms.telegram.extra.dm_topics`` (empty), then CLEARED
+``_dm_topics_config`` — silently dropping skill bindings for every operator
+topic until the next gateway restart.
+"""
+
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+class _FakeAdapter:
+    """Minimal stand-in exposing the reload method under test."""
+
+    def __init__(self):
+        self.name = "telegram-test"
+        self._dm_topics_config: list = []
+        self._dm_topic_chat_ids: set = set()
+        self._dm_topics: dict = {}
+        self._reload = None  # bound later from the real adapter
+
+    def reload(self):
+        assert self._reload is not None
+        return self._reload()
+
+
+TOP_LEVEL_CFG = {
+    "telegram": {
+        "extra": {
+            "dm_topics": [
+                {
+                    "chat_id": 8806247320,
+                    "topics": [
+                        {"name": "BaciScout", "thread_id": 13099,
+                         "skill": ["project-baciscout", "autonomous-project-orchestrator"]},
+                        {"name": "BaciCheck", "thread_id": 25664,
+                         "skill": ["project-bacicheck", "autonomous-project-orchestrator"]},
+                    ],
+                }
+            ]
+        }
+    }
+}
+
+NESTED_CFG = {
+    "platforms": {
+        "telegram": {
+            "extra": {
+                "dm_topics": [
+                    {
+                        "chat_id": 111,
+                        "topics": [{"name": "Nested", "thread_id": 222, "skill": "s"}],
+                    }
+                ]
+            }
+        }
+    }
+}
+
+BOTH_CFG = {
+    "telegram": {"extra": {"dm_topics": [
+        {"chat_id": 1, "topics": [{"name": "TopWins", "thread_id": 2, "skill": "top"}]},
+    ]}},
+    "platforms": {"telegram": {"extra": {"dm_topics": [
+        {"chat_id": 3, "topics": [{"name": "NestedLoses", "thread_id": 4, "skill": "nested"}]},
+    ]}}},
+}
+
+
+def _make_adapter(monkeypatch, cfg):
+    from plugins.platforms.telegram import adapter as telegram_adapter
+
+    fake = _FakeAdapter()
+    fake._reload = telegram_adapter.TelegramAdapter._reload_dm_topics_from_config.__get__(fake)
+    monkeypatch.setattr(
+        "hermes_cli.config.load_config_readonly",
+        lambda: cfg,
+    )
+    return fake
+
+
+class TestReloadDmTopicsTopLevelLayout:
+    def test_top_level_layout_is_honored_not_cleared(self, monkeypatch):
+        """The poison scenario: top-level layout must NOT clear topic config."""
+        fake = _make_adapter(monkeypatch, TOP_LEVEL_CFG)
+        # simulate state loaded at startup
+        fake._dm_topics_config = TOP_LEVEL_CFG["telegram"]["extra"]["dm_topics"]
+        fake._dm_topics = {"8806247320:BaciScout": 13099}
+
+        fake.reload()
+
+        assert fake._dm_topics_config, "topic config was cleared on top-level layout (poison bug)"
+        assert fake._dm_topic_chat_ids == {"8806247320"}
+
+    def test_top_level_layout_caches_new_thread_ids(self, monkeypatch):
+        fake = _make_adapter(monkeypatch, TOP_LEVEL_CFG)
+        fake._dm_topics = {}
+
+        fake.reload()
+
+        assert fake._dm_topics.get("8806247320:BaciCheck") == 25664
+        assert fake._dm_topics.get("8806247320:BaciScout") == 13099
+
+    def test_skill_lookup_survives_adhoc_topic_reload(self, monkeypatch):
+        """End-to-end poison repro: after reload, _get_dm_topic_info must still
+        return the skill for a cached topic (old code returned name-only)."""
+        from plugins.platforms.telegram import adapter as telegram_adapter
+
+        fake = _make_adapter(monkeypatch, TOP_LEVEL_CFG)
+        fake._dm_topics_config = TOP_LEVEL_CFG["telegram"]["extra"]["dm_topics"]
+        fake._dm_topics = {"8806247320:BaciCheck": 25664}
+
+        info = telegram_adapter.TelegramAdapter._get_dm_topic_info(
+            fake, chat_id="8806247320", thread_id="25664"
+        )
+        assert isinstance(info, dict)
+        assert info.get("skill"), (
+            "topic resolved without skill after hot-reload (poison bug): %r" % (info,)
+        )
+
+
+class TestReloadDmTopicsNestedLayout:
+    def test_nested_layout_still_works(self, monkeypatch):
+        fake = _make_adapter(monkeypatch, NESTED_CFG)
+        fake._dm_topics = {}
+
+        fake.reload()
+
+        assert "111:Nested" in fake._dm_topics
+        assert fake._dm_topic_chat_ids == {"111"}
+
+
+class TestReloadDmTopicsPrecedence:
+    def test_top_level_wins_when_both_present(self, monkeypatch):
+        fake = _make_adapter(monkeypatch, BOTH_CFG)
+        fake._dm_topics = {}
+
+        fake.reload()
+
+        assert fake._dm_topics.get("1:TopWins") == 2
+        assert "3:NestedLoses" not in fake._dm_topics
+
+
+class TestReloadDmTopicsEmpty:
+    def test_truly_empty_config_still_clears(self, monkeypatch):
+        """Legitimate clear behavior is preserved: config with NO topics
+        anywhere must still clear in-memory state."""
+        fake = _make_adapter(monkeypatch, {})
+        fake._dm_topics_config = [{"chat_id": 9, "topics": []}]
+        fake._dm_topics = {"9:Old": 99}
+
+        fake.reload()
+
+        assert fake._dm_topics_config == []
+        assert fake._dm_topic_chat_ids == set()


### PR DESCRIPTION
## Summary
- `_reload_dm_topics_from_config` read only `platforms.telegram.extra.dm_topics`. On configs using the documented top-level `telegram:` layout, that read came back empty and the empty branch **cleared `_dm_topics_config`** — silently dropping skill bindings for every operator topic until the next gateway restart.
- Any message into a non-configured (ad-hoc) topic triggers this reload, so one stray topic message poisoned all topic skill preloads.
- Startup was never affected: `dm_topics` reaches `PlatformConfig.extra` via `_apply_yaml_config`'s telegram-extra passthrough, whose `telegram_cfg` argument IS the top-level block. This PR makes the hot-reload mirror that precedence (top-level primary, `platforms.telegram` fallback) and keeps the legitimate clear when no topics are configured anywhere.

## Repro (live-verified on v0.21.0)
1. Configure dm_topics under top-level `telegram: {extra: {dm_topics: [...]}}`
2. Send any message into a topic NOT in that list (e.g. a freshly created UI topic)
3. → hot-reload fires, reads the empty nested path, clears topic config in memory
4. Next `/new` + message in a CONFIGURED topic: no `[Gateway] Auto-loaded skill(s)` line; `_get_dm_topic_info` returns `{name: ...}` without the skill key — until gateway restart

## Tests
- 6 new regression tests (`tests/gateway/test_dm_topics_reload_toplevel.py`): poison scenario (top-level layout must not clear), new-thread-id caching, `_get_dm_topic_info` skill survival after reload, nested layout still works, top-level-wins precedence, legit-empty still clears.
- Full existing `tests/gateway/test_dm_topics.py` suite green on top of latest main (20 passed combined: 6 new + 14 existing).

Fixes the whole bug class: a config reader that resolves platform settings should honor the same precedence the gateway merger establishes.
