### PR TITLE
fix(desktop): pin primary backend routing to its booted profile

### DIFF
--- a/apps/desktop/electron/main.ts
+++ b/apps/desktop/electron/main.ts
@@ -298,6 +298,7 @@ import {
   runPrimaryBackendStartup
 } from './primary-backend-startup'
 import { rehomePrimaryConnection } from './primary-connection-rehome'
+import { PrimaryProfilePin } from './primary-profile-pin'
 import {
   assertLocalProfileCanStart,
   decideProfileDeleteAction,
@@ -11169,6 +11170,8 @@ function resetHermesConnection({ soft = false } = {}) {
   backendStartFailure = null
   remoteReauthFailure = null
   remoteLiveness.clear()
+  // The next startHermes() re-reads active-profile.json for its launch profile.
+  primaryProfilePin.clear()
   const hermesProcess = backendConnectionState.invalidate()
   stopBackendChild(hermesProcess)
 
@@ -11278,11 +11281,13 @@ async function waitForBackendExit(child, timeoutMs = 5000) {
   await wait(1000)
 }
 
-// The profile the primary (window) backend runs as. readActiveDesktopProfile()
-// returns the desktop's stored preference, or null when unset (legacy launch
-// that defers to active_profile / default).
+// The profile the primary (window) backend was actually LAUNCHED as. Pinned by
+// startHermes() and cleared when the primary is torn down; while a primary is
+// live this must NOT follow active-profile.json (see primary-profile-pin.ts).
+const primaryProfilePin = new PrimaryProfilePin()
+
 function primaryProfileKey() {
-  return readActiveDesktopProfile() || 'default'
+  return primaryProfilePin.resolve(readActiveDesktopProfile)
 }
 
 // Options describing the current connection setup for `resolveProfileBackendRoute`.
@@ -12742,6 +12747,9 @@ async function startHermes() {
 
   const connectionAttempt = backendConnectionState.startAttempt()
   const primaryProfile = primaryProfileKey()
+  // Pin the routing table to the profile this primary actually boots as; a
+  // later hermes:profile:remember must not retarget requests mid-life.
+  primaryProfilePin.pin(primaryProfile)
 
   // Legacy path callers without an explicit profile belong to the primary
   // window backend. Profile-scoped callers still pass their key directly.

--- a/apps/desktop/electron/primary-profile-pin.test.ts
+++ b/apps/desktop/electron/primary-profile-pin.test.ts
@@ -1,0 +1,47 @@
+import assert from 'node:assert/strict'
+
+import { test } from 'vitest'
+
+import { PrimaryProfilePin } from './primary-profile-pin'
+
+test('with no live primary, the stored preference (or default) wins', () => {
+  const pin = new PrimaryProfilePin()
+
+  assert.equal(pin.resolve(() => null), 'default')
+  assert.equal(pin.resolve(() => '  '), 'default')
+  assert.equal(pin.resolve(() => 'claude'), 'claude')
+})
+
+test('a live primary keeps answering for its booted profile after the preference moves', () => {
+  const pin = new PrimaryProfilePin()
+  let preference: null | string = 'default'
+
+  // startHermes() boots the primary as the preference at that moment.
+  assert.equal(pin.pin(preference), 'default')
+  assert.equal(pin.resolve(() => preference), 'default')
+
+  // hermes:profile:remember rewrites active-profile.json without re-homing.
+  preference = 'claude'
+
+  // Routing must still see the running primary as "default": otherwise a
+  // request for "default" falls through to the pool and a second backend is
+  // spawned for the same HERMES_HOME.
+  assert.equal(pin.resolve(() => preference), 'default')
+})
+
+test('teardown releases the pin so the next start follows the preference', () => {
+  const pin = new PrimaryProfilePin()
+  pin.pin('default')
+  pin.clear()
+
+  assert.equal(pin.booted, null)
+  assert.equal(pin.resolve(() => 'claude'), 'claude')
+})
+
+test('pinning normalises blank input to default', () => {
+  const pin = new PrimaryProfilePin()
+
+  assert.equal(pin.pin(''), 'default')
+  assert.equal(pin.pin(undefined), 'default')
+  assert.equal(pin.pin(' grok '), 'grok')
+})

--- a/apps/desktop/electron/primary-profile-pin.ts
+++ b/apps/desktop/electron/primary-profile-pin.ts
@@ -1,0 +1,51 @@
+/**
+ * Which profile the PRIMARY (window) backend answers for.
+ *
+ * Two signals exist and they legitimately disagree mid-session:
+ *
+ *   - the stored preference (active-profile.json) — the profile Desktop should
+ *     boot into on the NEXT launch. The rail's live workspace switch rewrites
+ *     it via `hermes:profile:remember` without re-homing the primary.
+ *   - the profile the live primary child was actually spawned with.
+ *
+ * Routing (`resolveProfileBackendRoute`, `ensureBackend`, the pool) must use
+ * the second while a primary is up. Reading the preference instead made a
+ * request for the booted profile (e.g. "default") stop matching
+ * `primaryProfile`, fall through to the pool, and spawn a second backend for
+ * the same HERMES_HOME. That duplicate held a pool slot and starved every other
+ * profile into "timed out while waiting for a free slot".
+ *
+ * Pure: main.ts owns the file read and the start/teardown call sites.
+ */
+export class PrimaryProfilePin {
+  #booted: null | string = null
+
+  /** Called by startHermes() with the profile the primary is launching as. */
+  pin(profile: null | string | undefined): string {
+    const value = String(profile ?? '').trim() || 'default'
+    this.#booted = value
+
+    return value
+  }
+
+  /** Called when the primary is torn down; the next start re-reads the preference. */
+  clear(): void {
+    this.#booted = null
+  }
+
+  get booted(): null | string {
+    return this.#booted
+  }
+
+  /**
+   * The key routing should treat as "primary": the live primary's profile when
+   * one is pinned, else the stored preference, else 'default'.
+   */
+  resolve(readPreference: () => null | string | undefined): string {
+    if (this.#booted) {
+      return this.#booted
+    }
+
+    return String(readPreference() ?? '').trim() || 'default'
+  }
+}


### PR DESCRIPTION
## Symptom

After switching profiles in the Desktop rail, opening another profile fails with:

```
Error: Local backend start for "coder" timed out while waiting for a free slot.
```

`desktop.log` shows the pool is full of a **duplicate**: a second `default` backend spawned as a pool child while the primary `default` backend is still running. Every other profile then queues for `POOL_SLOT_WAIT_MS` (30s) and fails, repeatedly, until the user kills the duplicate or restarts.

```
[hermes] Profile backend "default" waiting for a free local slot (3/3 busy, 0 queued)
[hermes] Starting Hermes backend for profile "default" via Hermes at ...
[hermes] Profile backend "coder" waiting for a free local slot (3/3 busy, 1 queued)
[hermes] Hermes backend for profile "coder" failed to start: Local backend start for "coder" timed out while waiting for a free slot.
```

## Cause

`primaryProfileKey()` in `apps/desktop/electron/main.ts` re-read `active-profile.json` on every call. The rail's live workspace switch rewrites that file via `hermes:profile:remember` **without** re-homing the primary (by design, #79886). After the switch, the routing table disagrees with the running process: a request for the profile the primary actually booted as no longer matches `primaryProfile` in `resolveProfileBackendRoute`, falls through to the pool, and `spawnPoolBackend` starts a second child for the same `HERMES_HOME`.

The duplicate is keepalive-fresh so `selectPoolEvictions` correctly spares it, and it holds a `LocalBackendSpawnCoordinator` slot for the rest of the session.

## Fix

Pin the launch profile in `startHermes()` and release it in `resetHermesConnection()`, so:

- while a primary is live, routing keys off the profile it was **actually spawned with**;
- after teardown (`hermes:profile:set`, connection apply, crash recovery) the next start follows the stored preference as before.

The pin is a tiny pure module (`primary-profile-pin.ts`) with tests covering the preference-moves-mid-life case; `main.ts` only owns the file read and the two call sites.

## Verification

- `tsc -p tsconfig.electron.json --noEmit` clean, `eslint` clean
- `vitest --project electron`: new tests pass; suite otherwise unchanged (the one pre-existing failure, `managed-ssh-update` POSIX launcher, fails identically on `main` without this change)
- Rebuilt the packaged macOS app and reproduced the original flow (boot as `default`, switch rail to `claude`, open `default`/`grok`/`coder`): one backend per profile, no duplicate, no slot timeouts.
