### PR TITLE
fix(kanban): defer guarded policy denials

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -101,6 +101,10 @@ class SpawnAdmissionError(RuntimeError):
     """A configured autonomous-worker admission gate rejected a spawn."""
 
 
+class SpawnAdmissionDeferred(RuntimeError):
+    """A healthy admission gate deferred a spawn without treating it as failure."""
+
+
 def _load_configured_spawn_guard():
     """Return the optional configured guard, rejecting broken configuration."""
     from hermes_cli.config import load_config
@@ -134,7 +138,7 @@ def _spawn_with_guard(task, workspace: str, board: str | None, native_spawn):
         return call_native(task, workspace, board=board)
     try:
         return guard(task, workspace, board, call_native)
-    except SpawnAdmissionError:
+    except (SpawnAdmissionError, SpawnAdmissionDeferred):
         raise
     except Exception as exc:
         raise SpawnAdmissionError(str(exc)) from exc
@@ -9399,6 +9403,41 @@ def _record_spawn_failure(
     )
 
 
+def _record_spawn_deferred(
+    conn: sqlite3.Connection,
+    task_id: str,
+    reason: str,
+) -> None:
+    """Return a policy-deferred spawn to its source lane without failure debt."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?", (task_id,)
+        ).fetchone()
+        if row is None:
+            return
+        retry_status = _retry_status_for_run(conn, task_id, row["current_run_id"])
+        conn.execute(
+            "UPDATE tasks SET status = ?, claim_lock = NULL, claim_expires = NULL, "
+            "worker_pid = NULL WHERE id = ? AND status = 'running'",
+            (retry_status, task_id),
+        )
+        run_id = _end_run(
+            conn,
+            task_id,
+            outcome="deferred",
+            status="deferred",
+            error=reason[:500],
+            metadata={"reason": reason[:500], "retry_status": retry_status},
+        )
+        _append_event(
+            conn,
+            task_id,
+            "spawn_deferred",
+            {"reason": reason[:500], "retry_status": retry_status},
+            run_id=run_id,
+        )
+
+
 def _set_worker_pid(conn: sqlite3.Connection, task_id: str, pid: int) -> None:
     """Record the spawned child's pid + emit a ``spawned`` event.
 
@@ -10333,6 +10372,8 @@ def _dispatch_once_locked(
                 _per_profile_running[claimed.assignee] = (
                     _per_profile_running.get(claimed.assignee, 0) + 1
                 )
+        except SpawnAdmissionDeferred as exc:
+            _record_spawn_deferred(conn, claimed.id, str(exc))
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -71,6 +71,8 @@ new locking.
 from __future__ import annotations
 
 import contextlib
+import importlib
+import inspect
 import hashlib
 import json
 import os
@@ -93,6 +95,49 @@ from hermes_cli.sqlite_util import add_column_if_missing as _add_column_if_missi
 from toolsets import get_toolset_names
 
 _log = logging.getLogger(__name__)
+
+
+class SpawnAdmissionError(RuntimeError):
+    """A configured autonomous-worker admission gate rejected a spawn."""
+
+
+def _load_configured_spawn_guard():
+    """Return the optional configured guard, rejecting broken configuration."""
+    from hermes_cli.config import load_config
+    spec = (load_config().get("kanban", {}).get("spawn_guard") or "").strip()
+    if not spec:
+        return None
+    module_name, separator, attribute = spec.partition(":")
+    if not separator or not module_name or not attribute:
+        raise SpawnAdmissionError("kanban.spawn_guard must be module:callable")
+    try:
+        guard = getattr(importlib.import_module(module_name), attribute)
+    except Exception as exc:
+        raise SpawnAdmissionError("configured Kanban spawn guard unavailable") from exc
+    if not callable(guard):
+        raise SpawnAdmissionError("configured Kanban spawn guard is not callable")
+    return guard
+
+
+def _spawn_with_guard(task, workspace: str, board: str | None, native_spawn):
+    """Invoke the configured admission gate before every dispatcher spawn."""
+    def call_native(current_task, current_workspace, *, board=None):
+        try:
+            if "board" in inspect.signature(native_spawn).parameters:
+                return native_spawn(current_task, current_workspace, board=board)
+        except (TypeError, ValueError):
+            pass
+        return native_spawn(current_task, current_workspace)
+
+    guard = _load_configured_spawn_guard()
+    if guard is None:
+        return call_native(task, workspace, board=board)
+    try:
+        return guard(task, workspace, board, call_native)
+    except SpawnAdmissionError:
+        raise
+    except Exception as exc:
+        raise SpawnAdmissionError(str(exc)) from exc
 
 
 # ---------------------------------------------------------------------------
@@ -10262,18 +10307,7 @@ def _dispatch_once_locked(
         _maybe_emit_scratch_tip(conn, claimed.id, claimed.workspace_kind)
         _spawn = spawn_fn if spawn_fn is not None else _default_spawn
         try:
-            # Back-compat: older spawn_fn signatures accept only
-            # (task, workspace). Test stubs in the suite rely on that.
-            # Introspect the callable and pass `board` only when supported.
-            import inspect
-            try:
-                sig = inspect.signature(_spawn)
-                if "board" in sig.parameters:
-                    pid = _spawn(claimed, str(workspace), board=board)
-                else:
-                    pid = _spawn(claimed, str(workspace))
-            except (TypeError, ValueError):
-                pid = _spawn(claimed, str(workspace))
+            pid = _spawn_with_guard(claimed, str(workspace), board, _spawn)
             if pid:
                 _set_worker_pid(conn, claimed.id, int(pid))
             # Worker-lifecycle observer (RFC #58548): fires AFTER spawn_fn

--- a/tests/hermes_cli/test_kanban_spawn_guard.py
+++ b/tests/hermes_cli/test_kanban_spawn_guard.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from unittest.mock import Mock
+
 import pytest
 
 from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
 
 
 def test_configured_spawn_guard_wraps_custom_dispatch_spawn(monkeypatch):
@@ -38,3 +51,35 @@ def test_configured_spawn_guard_failure_never_calls_native_spawn(monkeypatch):
     with pytest.raises(kb.SpawnAdmissionError, match="governor unavailable"):
         kb._spawn_with_guard(object(), "/tmp/workspace", "board", native)
     assert called == []
+
+
+def test_guard_deferral_releases_claim_without_creating_a_phantom_worker(
+    kanban_home, all_assignees_spawnable, monkeypatch,
+):
+    """Healthy policy denial returns a task to ready without failure accounting."""
+    native_spawn = Mock(return_value=4242)
+
+    def guard(*_args, **_kwargs):
+        raise kb.SpawnAdmissionDeferred("provider reserve policy")
+
+    monkeypatch.setattr(kb, "_load_configured_spawn_guard", lambda: guard)
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="defer safely", assignee="alice")
+        result = kb.dispatch_once(conn, spawn_fn=native_spawn)
+        task = kb.get_task(conn, task_id)
+        run = kb.latest_run(conn, task_id)
+    finally:
+        conn.close()
+
+    native_spawn.assert_not_called()
+    assert result.spawned == []
+    assert task is not None
+    assert task.status == "ready"
+    assert task.claim_lock is None
+    assert task.worker_pid is None
+    assert task.current_run_id is None
+    assert task.consecutive_failures == 0
+    assert run is not None
+    assert run.outcome == "deferred"
+    assert run.error == "provider reserve policy"

--- a/tests/hermes_cli/test_kanban_spawn_guard.py
+++ b/tests/hermes_cli/test_kanban_spawn_guard.py
@@ -1,0 +1,40 @@
+"""Configured Kanban spawn guards are a fail-closed admission boundary."""
+
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+def test_configured_spawn_guard_wraps_custom_dispatch_spawn(monkeypatch):
+    calls = []
+    task = object()
+
+    def native(*args, **kwargs):
+        calls.append((args, kwargs))
+        return 4242
+
+    def guard(task, workspace, board, native_spawn):
+        assert task is not None
+        return native_spawn(task, workspace, board=board)
+
+    monkeypatch.setattr(kb, "_load_configured_spawn_guard", lambda: guard)
+    assert kb._spawn_with_guard(task, "/tmp/workspace", "board", native) == 4242
+    assert len(calls) == 1
+
+
+def test_configured_spawn_guard_failure_never_calls_native_spawn(monkeypatch):
+    called = []
+
+    def native(*args, **kwargs):
+        called.append(True)
+        return 4242
+
+    def guard(*args, **kwargs):
+        raise RuntimeError("governor unavailable")
+
+    monkeypatch.setattr(kb, "_load_configured_spawn_guard", lambda: guard)
+    with pytest.raises(kb.SpawnAdmissionError, match="governor unavailable"):
+        kb._spawn_with_guard(object(), "/tmp/workspace", "board", native)
+    assert called == []


### PR DESCRIPTION
## Problem
A guarded spawn policy denial returned `None` after native Kanban had already claimed a task. The dispatcher treated it as a spawn and left a false `running` card with no PID or heartbeat.

## Fix
- add an explicit `SpawnAdmissionDeferred` outcome
- close the claimed run as `deferred`, clear PID/claim state, restore the source lane, and avoid failure debt
- preserve real failures as the existing error path

## Tests
- targeted spawn-guard lifecycle tests: 3 passed
- verified against a live governor incident: reserve/forecast denial produced the phantom-running state this change covers