### PR TITLE
fix(mcp): accept boolean JSON Schema property schemas on tools/list

### DIFF
--- a/tests/tools/test_mcp_boolean_property_schema.py
+++ b/tests/tools/test_mcp_boolean_property_schema.py
@@ -1,0 +1,213 @@
+﻿"""Regression: boolean JSON Schema property schemas must not park MCP servers.
+
+See #101669 — mcp 2.0.0's 2025-11-25 InputSchema typed every ``properties``
+value as an object, so ``"properties": {"refresh": true}`` (legal JSON Schema
+2020-12) failed ``ListToolsResult`` validation and Hermes disabled the whole
+server. The same typing applied to OutputSchema.properties; both surfaces are
+patched and covered here.
+
+On the post-#102117 tree the compat patch lives in ``tools.mcp_tool_schema``;
+the facade ``_ensure_mcp_sdk`` still invokes it on first SDK import.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("mcp")
+pytest.importorskip("mcp_types")
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Child process proves the facade hook alone; must not import the helper by name.
+_FACADE_SEAM_SCRIPT = r"""
+from tools.mcp_tool import _ensure_mcp_sdk
+
+assert _ensure_mcp_sdk()
+
+import mcp_types.methods as mcp_methods
+from mcp.types import ListToolsResult
+
+raw = {
+    "tools": [
+        {
+            "name": "example_tool",
+            "inputSchema": {
+                "type": "object",
+                "properties": {"refresh": True, "q": {"type": "string"}},
+            },
+            "outputSchema": {
+                "type": "object",
+                "properties": {"ok": True, "blocked": False},
+            },
+        }
+    ]
+}
+mcp_methods.validate_server_result("tools/list", "2025-11-25", raw)
+result = ListToolsResult.model_validate(raw)
+assert result.tools[0].input_schema["properties"]["refresh"] is True
+assert result.tools[0].output_schema["properties"]["ok"] is True
+assert result.tools[0].output_schema["properties"]["blocked"] is False
+print("facade-seam-ok")
+"""
+
+
+def test_facade_ensure_mcp_sdk_alone_accepts_boolean_property_schemas():
+    """Only ``_ensure_mcp_sdk()`` must install wire widening (#101669).
+
+    ``tests/tools/conftest.py`` eagerly calls ``_ensure_mcp_sdk`` before each
+    in-process tools test, so a direct ``_patch_...`` call here cannot prove the
+    production facade seam. Run an isolated interpreter that never imports the
+    helper and never loads that conftest autouse fixture.
+    """
+    env = os.environ.copy()
+    env["PYTHONPATH"] = os.pathsep.join(
+        [str(_REPO_ROOT), env["PYTHONPATH"]] if env.get("PYTHONPATH") else [str(_REPO_ROOT)]
+    )
+    # Avoid inheriting pytest plugin bootstrap into the child.
+    env.pop("PYTEST_CURRENT_TEST", None)
+    env.pop("PYTEST_VERSION", None)
+
+    proc = subprocess.run(
+        [sys.executable, "-c", _FACADE_SEAM_SCRIPT],
+        cwd=_REPO_ROOT,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    assert proc.returncode == 0, (
+        f"facade-seam child failed (rc={proc.returncode})\n"
+        f"stdout:\n{proc.stdout}\nstderr:\n{proc.stderr}"
+    )
+    assert "facade-seam-ok" in proc.stdout
+
+
+def test_list_tools_result_accepts_boolean_property_schema():
+    from tools.mcp_tool import _ensure_mcp_sdk
+    from tools.mcp_tool_schema import _patch_mcp_boolean_property_schemas
+
+    assert _ensure_mcp_sdk()
+    # Idempotent if _ensure already patched; also covers calling the helper alone.
+    _patch_mcp_boolean_property_schemas()
+
+    import mcp_types.methods as mcp_methods
+
+    raw = {
+        "tools": [
+            {
+                "name": "example_tool",
+                "description": "has a boolean property schema",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "refresh": True,
+                        "q": {"type": "string"},
+                    },
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "ok": True,
+                        "blocked": False,
+                        "detail": {"type": "string"},
+                    },
+                },
+            },
+            {
+                "name": "other_tool",
+                "description": "unaffected sibling",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"x": {"type": "number"}},
+                },
+            },
+            {
+                "name": "deny_all_prop",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"never": False},
+                },
+            },
+        ]
+    }
+
+    # Negotiated pre-2026 sessions validate tools/list against the 2025-11-25
+    # surface — this is the path that used to raise dict_type and park the server.
+    mcp_methods.validate_server_result("tools/list", "2025-11-25", raw)
+
+    from mcp.types import ListToolsResult
+
+    result = ListToolsResult.model_validate(raw)
+    assert len(result.tools) == 3
+    assert result.tools[0].input_schema["properties"]["refresh"] is True
+    assert result.tools[0].output_schema["properties"]["ok"] is True
+    assert result.tools[0].output_schema["properties"]["blocked"] is False
+    assert result.tools[0].output_schema["properties"]["detail"]["type"] == "string"
+    assert result.tools[2].input_schema["properties"]["never"] is False
+
+    # Wire alias round-trip keeps boolean outputSchema properties.
+    dumped = result.model_dump(by_alias=True, mode="json")
+    out_props = dumped["tools"][0]["outputSchema"]["properties"]
+    assert out_props["ok"] is True
+    assert out_props["blocked"] is False
+    mcp_methods.validate_server_result("tools/list", "2025-11-25", dumped)
+
+
+def test_normalize_mcp_input_schema_preserves_boolean_properties():
+    from tools.mcp_tool_schema import _normalize_mcp_input_schema
+
+    out = _normalize_mcp_input_schema(
+        {
+            "type": "object",
+            "properties": {
+                "refresh": True,
+                "q": {"type": "string"},
+            },
+        }
+    )
+    assert out["properties"]["refresh"] is True
+    assert out["properties"]["q"]["type"] == "string"
+
+
+def test_boolean_property_schema_compat_patch_is_idempotent():
+    from tools.mcp_tool import _ensure_mcp_sdk
+    from tools.mcp_tool_schema import _patch_mcp_boolean_property_schemas
+
+    assert _ensure_mcp_sdk()
+    _patch_mcp_boolean_property_schemas()
+    _patch_mcp_boolean_property_schemas()
+
+    import mcp_types.methods as mcp_methods
+
+    raw = {
+        "tools": [
+            {
+                "name": "t",
+                "inputSchema": {
+                    "type": "object",
+                    "properties": {"refresh": True},
+                },
+                "outputSchema": {
+                    "type": "object",
+                    "properties": {
+                        "ok": True,
+                        "blocked": False,
+                    },
+                },
+            }
+        ]
+    }
+    mcp_methods.validate_server_result("tools/list", "2025-11-25", raw)
+
+    from mcp.types import ListToolsResult
+
+    result = ListToolsResult.model_validate(raw)
+    assert result.tools[0].input_schema["properties"]["refresh"] is True
+    assert result.tools[0].output_schema["properties"]["ok"] is True
+    assert result.tools[0].output_schema["properties"]["blocked"] is False

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -172,6 +172,12 @@ def _ensure_mcp_sdk() -> bool:
         else:
             logger.debug("mcp package not installed -- MCP tool support disabled")
         if _MCP_AVAILABLE:
+            # mcp==2.0.0's 2025-11-25 wire models reject boolean JSON Schema
+            # sub-schemas under tool properties; widen them before any
+            # tools/list validation runs (#101669). Owned by mcp_tool_schema.
+            from tools.mcp_tool_schema import _patch_mcp_boolean_property_schemas
+
+            _patch_mcp_boolean_property_schemas()
             try:
                 _JSONRPC_METHOD_NOT_FOUND = importlib.import_module("mcp.types").METHOD_NOT_FOUND
             except Exception:  # pragma: no cover — SDK without the constant

--- a/tools/mcp_tool_schema.py
+++ b/tools/mcp_tool_schema.py
@@ -220,3 +220,89 @@ def matches_name_filter(tool_name: str, patterns: set[str]) -> bool:
 _UTILITY_CAPABILITY_ATTRS = {
     "list_resources": "resources", "read_resource": "resources",
     "list_prompts": "prompts", "get_prompt": "prompts"}
+
+
+def _patch_mcp_boolean_property_schemas() -> None:
+    """Accept JSON Schema boolean sub-schemas under tool ``properties``.
+
+    JSON Schema 2020-12 allows ``true``/``false`` anywhere a schema is expected
+    (draft 2020-12 §4.3.2). The mcp 2.0.0 generated 2025-11-25 wire models
+    typed ``InputSchema.properties`` / ``OutputSchema.properties`` as
+    ``dict[str, dict[str, Any]]``, so one tool advertising
+    ``"properties": {"refresh": true}`` fails ``ListToolsResult`` validation
+    and Hermes parks the entire MCP server (#101669).
+
+    Upstream fixed this in mcp 2.1.0 (modelcontextprotocol/python-sdk#3354) by
+    widening the value type to ``dict[str, dict[str, Any] | bool]``. Hermes
+    still pins ``mcp==2.0.0``; apply the same widening at import time when the
+    installed SDK still has the strict annotation. No-op on mcp>=2.1.0.
+    """
+    try:
+        import mcp_types._v2025_11_25 as v25
+    except ImportError:
+        return
+
+    from typing import Any
+
+    widened = dict[str, dict[str, Any] | bool] | None
+    patched = False
+    for model_name in ("InputSchema", "OutputSchema"):
+        model = getattr(v25, model_name, None)
+        if model is None:
+            continue
+        field = model.model_fields.get("properties")
+        if field is None:
+            continue
+        # Already accepts bool (mcp>=2.1.0) — leave alone.
+        if "bool" in str(field.annotation):
+            continue
+        field.annotation = widened
+        patched = True
+        try:
+            model.model_rebuild(force=True)
+        except Exception:
+            logger.debug(
+                "MCP boolean-schema compat: failed to rebuild %s",
+                model_name,
+                exc_info=True,
+            )
+            return
+
+    if not patched:
+        return
+
+    # Nested models embed InputSchema/OutputSchema — rebuild consumers so the
+    # widened field is used during ListToolsResult validation.
+    for model_name in ("Tool", "ListToolsResult"):
+        model = getattr(v25, model_name, None)
+        if model is None:
+            continue
+        try:
+            model.model_rebuild(force=True)
+        except Exception:
+            logger.debug(
+                "MCP boolean-schema compat: failed to rebuild %s",
+                model_name,
+                exc_info=True,
+            )
+            return
+
+    # mcp_types.methods caches TypeAdapters on the class object; a warm cache
+    # from before the rebuild would keep rejecting boolean schemas.
+    try:
+        import mcp_types.methods as mcp_methods
+
+        cache_clear = getattr(getattr(mcp_methods, "_adapter", None), "cache_clear", None)
+        if callable(cache_clear):
+            cache_clear()
+    except Exception:
+        logger.debug(
+            "MCP boolean-schema compat: failed to clear methods._adapter cache",
+            exc_info=True,
+        )
+        return
+
+    logger.debug(
+        "MCP boolean-schema compat: widened 2025-11-25 InputSchema/"
+        "OutputSchema.properties to accept JSON Schema boolean sub-schemas"
+    )


### PR DESCRIPTION
## Summary
Related to #101669: mcp 2.0.0's 2025-11-25 `InputSchema` / `OutputSchema` reject JSON Schema boolean property sub-schemas (`true`/`false`), parking the whole MCP server on `tools/list`.

This is a **follow-up to #101810** after #102117 landed on `main`. #101810 could not be reopened because its base branch (`hermes/simplify-codebase`) was deleted when #102117 merged.

Does **not** auto-close #101669 — that issue also needs complementary per-tool isolation from #101804. Land both before closing the issue.

## Changes
- Bounded owner: widen wire models in `tools/mcp_tool_schema.py` (`_patch_mcp_boolean_property_schemas`).
- Facade hook only: `tools/mcp_tool.py` `_ensure_mcp_sdk` calls the patch on first SDK import.
- Wire regression covers boolean `true`/`false` under both **inputSchema** and **outputSchema** (plus round-trip / idempotency).
- Isolated facade-seam test: subprocess calls only `_ensure_mcp_sdk()` (no direct `_patch_...`), so the production hook is what installs widening.

## Test plan
- [x] Local: `pytest tests/tools/test_mcp_boolean_property_schema.py -q` → 4 passed (on tip rebased onto current `main`)
- [ ] Hosted CI / Docker / Nix after maintainer Approve and run

@andrexibiza — rebased onto current `main`, added facade-seam subprocess proof, and switched the issue link to non-closing `Related to #101669` (interlock with #101804). Hosted proof still needs the fork-PR workflow approval.
