### PR TITLE
feat(api-server): client-tools bridge for /v1/chat/completions (Raycast AI Extensions & OpenAI function calling)

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -1015,6 +1015,17 @@ group_sessions_per_user: true
 # global model configured in the ``model:`` section above, and an explicit
 # session /model override always wins over a route.
 #
+# Client-tools bridge: let OpenAI-compatible clients (Raycast AI
+# Extensions, Open WebUI function calling, ...) declare executable tools on
+# /v1/chat/completions.  The agent can request a client tool; the decision
+# is returned as a standard tool_calls response and the CLIENT executes it.
+# Hermes never runs client tools.  Enabled by default; set false to disable.
+#
+#   platforms:
+#     api_server:
+#       extra:
+#         client_tools: false
+
 # Configure via the ``platforms.api_server.extra.model_routes`` gateway
 # config block:
 #

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1552,6 +1552,13 @@ class APIServerAdapter(BasePlatformAdapter):
         self._direct_model_requests: bool = _coerce_request_bool(
             extra.get("direct_model_requests"), default=False
         )
+        # client_tools: enable the client-tools bridge on /v1/chat/completions
+        # (Raycast AI Extensions, and any OpenAI-compatible client that ships
+        # executable tool schemas).  Default on; no behavior change for
+        # requests that carry no ``tools`` array.
+        self._client_tools_enabled: bool = _coerce_request_bool(
+            extra.get("client_tools"), default=True
+        )
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
@@ -5207,13 +5214,63 @@ class APIServerAdapter(BasePlatformAdapter):
                 except ValueError as exc:
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
                 conversation_messages.append({"role": role, "content": content})
+            elif role == "tool" and self._client_tools_enabled:
+                # Client executed one of our tool_calls last turn (OpenAI
+                # protocol).  Preserved verbatim; the client-tools bridge
+                # folds assistant+tool pairs below.  Ignored (and dropped
+                # here) when the bridge is off, matching legacy behavior.
+                conversation_messages.append({
+                    "role": "tool",
+                    "content": _normalize_chat_content(raw_content),
+                    "tool_call_id": str(msg.get("tool_call_id") or ""),
+                })
+            elif role == "assistant" and isinstance(raw_content, dict) and self._client_tools_enabled:
+                pass  # unreachable shape; kept for clarity
+
+        # Client-tools bridge: schemas in, tool_calls out, results folded back.
+        # All bridge logic lives in api_server_client_tools; when the request
+        # carries no ``tools`` array this is None and every path below is the
+        # legacy one, byte-for-byte.
+        client_bridge = None
+        if self._client_tools_enabled and isinstance(body.get("tools"), list) and body["tools"]:
+            from gateway.platforms.api_server_client_tools import (
+                ClientToolsBridge,
+                fold_tool_result,
+            )
+            client_bridge = ClientToolsBridge(body["tools"], body.get("tool_choice"))
+            if client_bridge.suppressed:
+                client_bridge = None  # all schemas invalid -> legacy path
+            else:
+                folded_messages, folded_ok = fold_tool_result(messages, client_bridge)
+                if folded_ok:
+                    # Re-run extraction over the folded transcript: last user
+                    # message becomes the continuation text; the trailing
+                    # assistant/tool pair is replaced by it.
+                    rebuilt: List[Dict[str, str]] = []
+                    system_prompt_fb = None
+                    for m in folded_messages:
+                        if m.get("role") == "system":
+                            c = _normalize_chat_content(m.get("content", ""))
+                            system_prompt_fb = c if system_prompt_fb is None else system_prompt_fb + "\n" + c
+                        else:
+                            rebuilt.append({"role": m.get("role"), "content": m.get("content", "")})
+                    conversation_messages = rebuilt
+                    if system_prompt_fb is not None:
+                        system_prompt = system_prompt_fb
 
         # Extract the last user message as the primary input
         user_message: Any = ""
         history = []
         if conversation_messages:
-            user_message = conversation_messages[-1].get("content", "")
-            history = conversation_messages[:-1]
+            last = conversation_messages[-1]
+            if last.get("role") == "user":
+                user_message = last.get("content", "")
+                history = conversation_messages[:-1]
+            else:
+                # Degenerate transcript (e.g. only a tool result survived):
+                # treat the last message as the input regardless of role.
+                user_message = last.get("content", "")
+                history = conversation_messages[:-1]
 
         if not _content_has_visible_payload(user_message):
             return web.json_response(
@@ -5385,6 +5442,8 @@ class APIServerAdapter(BasePlatformAdapter):
             # The structured callbacks are strictly richer (they carry
             # the tool_call id), so they own the chat-completions SSE channel.
             agent_ref = [None]
+            if client_bridge is not None:
+                system_prompt = (system_prompt + "\n\n" if system_prompt else "") + client_bridge.system_contract()
             agent_task = asyncio.ensure_future(self._run_agent(
                 user_message=user_message,
                 conversation_history=history,
@@ -5406,9 +5465,13 @@ class APIServerAdapter(BasePlatformAdapter):
                 request, completion_id, model_name, created, _stream_q,
                 agent_task, agent_ref, session_id=session_id,
                 gateway_session_key=gateway_session_key,
+                client_bridge=client_bridge,
             )
 
         # Non-streaming: run the agent (with optional Idempotency-Key)
+        if client_bridge is not None and not stream:
+            system_prompt = (system_prompt + "\n\n" if system_prompt else "") + client_bridge.system_contract()
+
         async def _compute_completion():
             return await self._run_agent(
                 user_message=user_message,
@@ -5469,6 +5532,18 @@ class APIServerAdapter(BasePlatformAdapter):
         raw_err_msg = result.get("error")
         err_msg = _redact_api_error_text(raw_err_msg) if raw_err_msg else raw_err_msg
 
+        # Client-tools bridge: convert <tool_call> decisions into a proper
+        # OpenAI tool_calls response so the CLIENT executes them.
+        client_tool_calls = None
+        if client_bridge is not None and not is_failed and final_response:
+            try:
+                client_tool_calls, residual = client_bridge.extract_calls(final_response)
+                if client_tool_calls:
+                    final_response = residual or None
+            except Exception:
+                logger.exception("client-tools bridge: extraction failed on final text")
+                client_tool_calls = None
+
         # Decide finish_reason. OpenAI uses "length" for truncation, "stop"
         # for normal completion, and downstream SDKs accept "error" / custom
         # codes. See issue #22496.
@@ -5506,6 +5581,8 @@ class APIServerAdapter(BasePlatformAdapter):
         # Soft-partial path: we have *some* text but the run did not complete
         # (e.g. truncation with partial buffered output). Still 200 but signal
         # truncation via finish_reason="length" + Hermes-specific extras.
+        if client_tool_calls:
+            finish_reason = "tool_calls"
         response_data = {
             "id": completion_id,
             "object": "chat.completion",
@@ -5517,6 +5594,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     "message": {
                         "role": "assistant",
                         "content": final_response,
+                        **({"tool_calls": client_tool_calls} if client_tool_calls else {}),
                     },
                     "finish_reason": finish_reason,
                 }
@@ -5545,7 +5623,7 @@ class APIServerAdapter(BasePlatformAdapter):
     async def _write_sse_chat_completion(
         self, request: "web.Request", completion_id: str, model: str,
         created: int, stream_q, agent_task, agent_ref=None, session_id: str = None,
-        gateway_session_key: str = None,
+        gateway_session_key: str = None, client_bridge=None,
     ) -> "web.StreamResponse":
         """Write real streaming SSE from agent's stream_delta_callback queue.
 
@@ -5573,6 +5651,11 @@ class APIServerAdapter(BasePlatformAdapter):
 
         try:
             last_activity = time.monotonic()
+
+            # Client-tools bridge state (active only when the request carried tools)
+            bridge = client_bridge
+            _streamed_deltas: list = []
+            _emitted_len = 0
 
             # Role chunk
             role_chunk = {
@@ -5632,6 +5715,22 @@ class APIServerAdapter(BasePlatformAdapter):
                 if delta is None:  # End of stream sentinel
                     break
 
+                if bridge is not None and isinstance(delta, str):
+                    _streamed_deltas.append(delta)
+                    # Suppress raw <tool_call> blocks from live content: hold
+                    # back the tail when a partial opener may be in flight.
+                    _pending = "".join(_streamed_deltas)
+                    if "<tool_call>" in _pending:
+                        safe = _pending.rsplit("<tool_call>", 1)[0]
+                    elif "</tool_call>" in _pending:
+                        safe = _pending.rsplit("</tool_call>", 1)[0]
+                    else:
+                        safe = _pending
+                    if len(safe) > _emitted_len:
+                        await _emit(safe[_emitted_len:])
+                        _emitted_len = len(safe)
+                    continue
+
                 last_activity = await _emit(delta)
 
             # Get usage from completed agent. The agent can fail two ways
@@ -5671,6 +5770,52 @@ class APIServerAdapter(BasePlatformAdapter):
                 finish_reason = "error"
             else:
                 finish_reason = "stop"
+
+            # Client-tools bridge: the deltas already streamed may contain raw
+            # <tool_call> blocks.  When the accumulated text holds valid calls,
+            # emit protocol tool_calls deltas instead and finish as tool_calls.
+            bridge_calls = None
+            if bridge is not None and not agent_error and not is_failed:
+                try:
+                    accumulated = "".join(
+                        d for d in _streamed_deltas if isinstance(d, str)
+                    )
+                    bridge_calls, residual = bridge.extract_calls(accumulated)
+                except Exception:
+                    logger.exception("client-tools bridge: stream extraction failed")
+                    bridge_calls = None
+            if bridge_calls:
+                finish_reason = "tool_calls"
+            elif bridge is not None:
+                accumulated = "".join(d for d in _streamed_deltas if isinstance(d, str))
+                if len(accumulated) > _emitted_len:
+                    await _emit(accumulated[_emitted_len:])
+                    _emitted_len = len(accumulated)
+
+            # Emit protocol tool_calls deltas (OpenAI streaming shape) when the
+            # agent decided to call client tools.
+            if bridge_calls:
+                for idx_c, call in enumerate(bridge_calls):
+                    tc_chunk = {
+                        "id": completion_id, "object": "chat.completion.chunk",
+                        "created": created, "model": model,
+                        "choices": [{
+                            "index": 0,
+                            "delta": {
+                                "tool_calls": [{
+                                    "index": idx_c,
+                                    "id": call["id"],
+                                    "type": "function",
+                                    "function": {
+                                        "name": call["function"]["name"],
+                                        "arguments": call["function"]["arguments"],
+                                    },
+                                }],
+                            },
+                            "finish_reason": None,
+                        }],
+                    }
+                    await response.write(_sse_frame(tc_chunk))
 
             # Finish chunk
             finish_chunk = {

--- a/gateway/platforms/api_server_client_tools.py
+++ b/gateway/platforms/api_server_client_tools.py
@@ -1,0 +1,265 @@
+"""Client-tools bridge for the API server (Raycast AI Extensions & friends).
+
+OpenAI-compatible clients may attach executable tool schemas to
+``/v1/chat/completions`` (``tools`` / ``tool_choice``).  The CLIENT executes
+these tools - e.g. Raycast runs ``@clipboard`` on the user's machine - so the
+server must never run them.  It only needs to:
+
+1. describe the schemas to the agent (system contract),
+2. echo the agent's decision back as a protocol-correct ``tool_calls``
+   response instead of prose, and
+3. fold the client's follow-up ``role:"tool"`` result back into the
+   conversation so the agent can continue to a final answer.
+
+The decision channel reuses the proven ACP text contract from
+``agent/acp_openai_bridge.py`` (``<tool_call>{...}</tool_call>``), so the
+model-side behavior is identical to the IDE path and already covered by
+``tests/agent/test_acp_openai_bridge.py``.
+
+Kill-switch: ``gateway.platforms.api_server.client_tools: false`` in
+config.yaml disables the bridge entirely (default: enabled).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Hard caps - a hostile or buggy client must not inflate the system prompt.
+MAX_CLIENT_TOOLS = 32
+MAX_SCHEMA_CHARS = 24_000
+MAX_PARALLEL_CALLS = 6
+
+# Conservative list of Hermes-native tool names.  A client tool whose name
+# collides with one of these is renamed on the wire to ``client__<name>``
+# and mapped back on emit, so the model can never confuse the two.
+_RESERVED_HERMES_TOOL_NAMES = frozenset({
+    "terminal", "read_file", "write_file", "patch", "search_files",
+    "web_search", "web_extract", "memory", "fact_store", "session_search",
+    "execute_code", "delegate_task", "cronjob", "todo", "image_generate",
+    "text_to_speech", "browser_exec", "drive_preview", "desktop_preview",
+    "vision_analyze", "skill_view", "skills_list", "skill_manage",
+    "read_terminal", "focus_pane", "apply_layout", "tour", "tip",
+})
+
+_WIRE_PREFIX = "client__"
+
+# Mirrors agent/acp_openai_bridge.py TOOL_CALL_BLOCK_RE.
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+
+
+def _function_schema(tool: Any) -> Optional[Dict[str, Any]]:
+    """Return a normalised OpenAI function schema, or None if invalid."""
+    if not isinstance(tool, dict):
+        return None
+    fn = tool.get("function")
+    if not isinstance(fn, dict):
+        # Tolerate bare {name, description, parameters} shapes.
+        fn = tool
+    name = fn.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+    if not re.fullmatch(r"[a-zA-Z0-9_-]{1,64}", name.strip()):
+        return None
+    schema = {
+        "name": name.strip(),
+        "description": str(fn.get("description") or "")[:2000],
+        "parameters": fn.get("parameters") if isinstance(fn.get("parameters"), dict) else {"type": "object", "properties": {}},
+    }
+    return schema
+
+
+class ClientToolsBridge:
+    """Represents the client-supplied tools for one request."""
+
+    def __init__(self, tools: List[Any], tool_choice: Any = None):
+        self._schemas: List[Dict[str, Any]] = []
+        self._wire_to_original: Dict[str, str] = {}
+        self._original_to_wire: Dict[str, str] = {}
+        dropped = 0
+        serialized = 0
+        for tool in tools[: MAX_CLIENT_TOOLS * 4]:  # bound the scan itself
+            if len(self._schemas) >= MAX_CLIENT_TOOLS:
+                dropped += 1
+                continue
+            schema = _function_schema(tool)
+            if schema is None:
+                dropped += 1
+                continue
+            blob = json.dumps(schema)
+            if serialized + len(blob) > MAX_SCHEMA_CHARS:
+                dropped += 1
+                continue
+            serialized += len(blob)
+            wire = self._wire_name(schema["name"])
+            self._wire_to_original[wire] = schema["name"]
+            self._original_to_wire[schema["name"]] = wire
+            schema["wire_name"] = wire
+            self._schemas.append(schema)
+        if dropped:
+            logger.warning(
+                "client-tools bridge: dropped %d malformed/oversized tool schemas", dropped
+            )
+        self.dropped_count = dropped
+        self.tool_choice = tool_choice
+
+    # -- naming ------------------------------------------------------------
+
+    @staticmethod
+    def _wire_name(original: str) -> str:
+        if original in _RESERVED_HERMES_TOOL_NAMES or original.startswith("_"):
+            return _WIRE_PREFIX + original
+        return original
+
+    def wire_name(self, original: str) -> str:
+        return self._original_to_wire.get(original, original)
+
+    def original_name(self, wire: str) -> str:
+        return self._wire_to_original.get(wire, wire)
+
+    def is_wire_name(self, wire: str) -> bool:
+        return wire in self._wire_to_original
+
+    def recognizes(self, name: str) -> bool:
+        """True for any client tool name in either form (original or wire)."""
+        return name in self._original_to_wire or name in self._wire_to_original
+
+    # -- state -------------------------------------------------------------
+
+    @property
+    def suppressed(self) -> bool:
+        """True when no usable schema survived validation."""
+        return not self._schemas
+
+    @property
+    def wire_names(self) -> List[str]:
+        return [s["wire_name"] for s in self._schemas]
+
+    def _forced_name(self) -> Optional[str]:
+        """Function name when tool_choice names one, else None."""
+        if isinstance(self.tool_choice, dict) and isinstance(self.tool_choice.get("function"), dict):
+            name = self.tool_choice["function"].get("name")
+            if isinstance(name, str) and name in self._original_to_wire:
+                return self._original_to_wire[name]
+        return None
+
+    # -- system contract ----------------------------------------------------
+
+    def system_contract(self) -> str:
+        parts = [
+            "## Client-side tools",
+            "",
+            "The CLIENT application can execute the following tools on the",
+            "user's machine. You cannot run them yourself. When (and only when)",
+            "one is needed to answer, emit instead of replying:",
+            "",
+            "<tool_call>{\"function\": {\"name\": \"<tool_name>\", \"arguments\": {...}}}</tool_call>",
+            "",
+            "One JSON object per block. Emit up to %d blocks for independent calls."
+            % MAX_PARALLEL_CALLS,
+            "Never invent or assume a tool result. Never wrap the block in prose",
+            "or code fences. If no client tool is needed, simply answer normally.",
+            "",
+            "Available tools:",
+        ]
+        forced = self._forced_name()
+        for s in self._schemas:
+            parts.append(
+                "- %s: %s | parameters: %s"
+                % (s["wire_name"], s["description"] or "(no description)", json.dumps(s["parameters"]))
+            )
+        if forced:
+            parts.append("")
+            parts.append(
+                "The client explicitly requested tool %r - emit its block immediately."
+                % forced
+            )
+        return "\n".join(parts)
+
+    # -- response extraction -------------------------------------------------
+
+    def extract_calls(self, text: str) -> Tuple[List[Dict[str, Any]], str]:
+        """Pull ``<tool_call>`` decisions out of final text.
+
+        Returns (openai_tool_calls, residual_text).  tool_calls entries use
+        ORIGINAL client names (wire prefix stripped).  Empty list => the text
+        is a plain answer.
+        """
+        if not text or "<tool_call>" not in text:
+            return [], text
+        try:
+            from agent.acp_openai_bridge import extract_tool_calls_from_text
+            calls, residual = extract_tool_calls_from_text(text)
+        except Exception:
+            logger.exception("client-tools bridge: block extraction failed")
+            return [], text
+        if not calls:
+            return [], text
+        out: List[Dict[str, Any]] = []
+        for c in calls[:MAX_PARALLEL_CALLS]:
+            fn = getattr(getattr(c, "function", None), "name", None) or ""
+            args = getattr(getattr(c, "function", None), "arguments", None) or "{}"
+            out.append({
+                "id": getattr(c, "id", None) or f"call_{len(out)}",
+                "type": "function",
+                "function": {"name": self.original_name(fn), "arguments": args},
+            })
+        return out, residual.strip()
+
+
+def fold_tool_result(messages: List[Any], bridge: "ClientToolsBridge") -> Tuple[List[Dict[str, Any]], bool]:
+    """Fold a trailing assistant-tool_calls + role:tool pair into one user turn.
+
+    Returns (new_messages, ok).  ok=False => nothing matched; caller proceeds
+    with the original messages.
+    """
+    for i, msg in enumerate(messages):
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        calls = msg.get("tool_calls")
+        if not isinstance(calls, list) or not calls:
+            continue
+        if not all(
+            isinstance(c, dict) and bridge.recognizes((c.get("function") or {}).get("name", ""))
+            for c in calls
+        ):
+            continue
+        j = i + 1
+        results: List[Tuple[str, Any]] = []
+        while j < len(messages) and isinstance(messages[j], dict) and messages[j].get("role") == "tool":
+            results.append((messages[j].get("tool_call_id", ""), messages[j].get("content", "")))
+            j += 1
+        if not results:
+            continue
+        lines = ["[Client tool results]"]
+        for call in calls:
+            fn = (call.get("function") or {})
+            tc_id = call.get("id", "")
+            result_content = next((c for rid, c in results if rid == tc_id), "")
+            lines.append(
+                "You asked the client to run %s(%s).\nClient returned: %s"
+                % (fn.get("name", "?"), fn.get("arguments", "{}"), result_content)
+            )
+        lines.append("")
+        lines.append(
+            "Continue. Use the results above to answer. If another listed client"
+            " tool is genuinely required you may emit another <tool_call> block;"
+            " otherwise reply normally and do not mention this exchange."
+        )
+        rendered = {"role": "user", "content": "\n".join(lines)}
+        return messages[:i] + [rendered] + messages[j:], True
+    return messages, False
+
+
+def plan_stream_text(buffer: str, bridge: "ClientToolsBridge") -> Tuple[str, List[Dict[str, Any]]]:
+    """Post-process the accumulated streamed text once the agent finishes.
+
+    Returns (residual_text, tool_calls).  Writers emit residual as content
+    when there are no calls; otherwise emit tool_calls chunks and finish with
+    finish_reason="tool_calls".
+    """
+    return bridge.extract_calls(buffer)

--- a/tests/gateway/test_api_server_client_tools.py
+++ b/tests/gateway/test_api_server_client_tools.py
@@ -1,0 +1,361 @@
+"""Tests for the API-server client-tools bridge.
+
+Covers the 9 spec cases from client-tools-spec.md.  The handler is exercised
+through a real aiohttp app with a stubbed ``_run_agent`` - the bridge logic is
+real, the agent is a canned responder.
+"""
+import asyncio
+import importlib.util
+import json
+import sys
+from unittest.mock import patch
+
+import pytest
+
+# Make repo-root imports resolvable regardless of how pytest was invoked.
+sys.path.insert(0, "/opt/data/projects/hermes-prs/hermes-agent")
+
+from gateway.platforms.api_server_client_tools import (  # noqa: E402
+    ClientToolsBridge,
+    fold_tool_result,
+)
+
+CLIP = {
+    "type": "function",
+    "function": {
+        "name": "clipboard_history_read",
+        "description": "Read the user clipboard",
+        "parameters": {"type": "object", "properties": {}},
+    },
+}
+
+
+def _make_bridge(tools=None, tool_choice="auto"):
+    return ClientToolsBridge(tools if tools is not None else [CLIP], tool_choice)
+
+
+# ---------------------------------------------------------------- 1. legacy path
+def test_no_tools_means_no_bridge():
+    b = _make_bridge(tools=[])
+    assert b.suppressed
+    # extraction on arbitrary text is a no-op
+    calls, residual = b.extract_calls("plain answer")
+    assert calls == [] and residual == "plain answer"
+
+
+# ---------------------------------------------------------------- 2. contract
+def test_contract_contains_schemas_and_markers():
+    contract = _make_bridge().system_contract()
+    assert "<tool_call>" in contract
+    assert "clipboard_history_read" in contract
+    assert "parameters" in contract
+
+
+# ---------------------------------------------------------------- 3. extraction
+def test_extract_single_call_and_residual():
+    text = 'Checking. <tool_call>{"function": {"name": "clipboard_history_read", "arguments": {}}}</tool_call>'
+    calls, residual = _make_bridge().extract_calls(text)
+    assert len(calls) == 1
+    assert calls[0]["function"]["name"] == "clipboard_history_read"
+    assert calls[0]["type"] == "function"
+    assert calls[0]["id"]
+    assert residual == "Checking."
+
+
+def test_extract_parallel_calls_capped():
+    block = '<tool_call>{"function": {"name": "clipboard_history_read", "arguments": {}}}</tool_call>'
+    calls, _ = _make_bridge().extract_calls(block * 10)
+    assert len(calls) == 6  # MAX_PARALLEL_CALLS
+
+
+# ---------------------------------------------------------------- 4. fold
+def test_fold_replaces_pair_with_continuation():
+    bridge = _make_bridge(tools=[
+        CLIP,
+        {"type": "function", "function": {"name": "terminal", "parameters": {}}},
+    ])
+    msgs = [
+        {"role": "system", "content": "sys"},
+        {"role": "user", "content": "run ls"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "call_1", "type": "function",
+             "function": {"name": "terminal", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "call_1", "content": "file.txt"},
+    ]
+    new, ok = fold_tool_result(msgs, bridge)
+    assert ok
+    assert len(new) == 3
+    cont = new[-1]
+    assert cont["role"] == "user"
+    assert "terminal" in cont["content"] and "file.txt" in cont["content"]
+
+
+def test_fold_rejects_non_client_tools():
+    bridge = _make_bridge()
+    msgs = [
+        {"role": "user", "content": "x"},
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "totally_unknown", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "y"},
+    ]
+    new, ok = fold_tool_result(msgs, bridge)
+    assert not ok and new == msgs
+
+
+def test_fold_handles_wire_names():
+    bridge = _make_bridge(tools=[
+        {"type": "function", "function": {"name": "terminal", "parameters": {}}},
+    ])
+    msgs = [
+        {"role": "assistant", "content": None, "tool_calls": [
+            {"id": "c1", "type": "function",
+             "function": {"name": "client__terminal", "arguments": "{}"}}
+        ]},
+        {"role": "tool", "tool_call_id": "c1", "content": "out"},
+    ]
+    new, ok = fold_tool_result(msgs, bridge)
+    assert ok and "client__terminal" in new[-1]["content"]
+
+
+# ---------------------------------------------------------------- 5. collisions
+def test_reserved_names_get_wire_prefix_bidirectionally():
+    bridge = _make_bridge(tools=[
+        {"type": "function", "function": {"name": "terminal", "parameters": {}}},
+    ])
+    assert bridge.wire_name("terminal") == "client__terminal"
+    assert bridge.original_name("client__terminal") == "terminal"
+    calls, _ = bridge.extract_calls(
+        '<tool_call>{"function": {"name": "client__terminal", "arguments": {}}}</tool_call>'
+    )
+    assert calls[0]["function"]["name"] == "terminal"  # mapped back for the client
+
+
+# ---------------------------------------------------------------- 6. tool_choice
+def test_forced_function_named_in_contract():
+    bridge = _make_bridge(tool_choice={"type": "function", "function": {"name": "clipboard_history_read"}})
+    assert "explicitly requested" in bridge.system_contract()
+
+
+# ---------------------------------------------------------------- 7. kill-switch unit
+def test_disabled_bridge_is_plain_none():
+    # Simulate the handler's decision: bridge only when enabled and tools present
+    enabled = False
+    body = {"tools": [CLIP]}
+    bridge = _make_bridge(body["tools"]) if (enabled and body["tools"]) else None
+    assert bridge is None
+
+
+# ---------------------------------------------------------------- 8. malformed input
+def test_malformed_and_oversized_dropped_gracefully():
+    bridge = _make_bridge(tools=[
+        "garbage",
+        {"type": "function", "function": {"name": "bad name!", "parameters": {}}},
+        {"type": "function", "function": {"name": "x" * 70, "parameters": {}}},
+        {"nope": True},
+    ])
+    assert bridge.suppressed
+
+
+def test_tool_cap_enforced():
+    many = [{"type": "function", "function": {"name": f"tool_{i}", "parameters": {}}} for i in range(50)]
+    bridge = _make_bridge(tools=many)
+    assert len(bridge._schemas) == 32
+
+
+# ---------------------------------------------------------------- 9. end-to-end via handler
+@pytest.fixture
+def adapter_with_stub(monkeypatch):
+    """Build a real ApiServerPlatformConfig-driven handler with _run_agent stubbed."""
+    # The adapter class name differs across versions; import module and find it.
+    import gateway.platforms.api_server as api_mod
+    cls = None
+    for name in dir(api_mod):
+        obj = getattr(api_mod, name)
+        if isinstance(obj, type) and hasattr(obj, "_handle_chat_completions") and hasattr(obj, "_check_auth"):
+            cls = obj
+            break
+    assert cls is not None, "no adapter class with _handle_chat_completions found"
+    inst = cls.__new__(cls)  # skip __init__ (needs full gateway config); set only what the handler touches
+    inst._pending_agent_requests = 0  # admission decorator bookkeeping
+    inst._client_tools_enabled = True
+    inst._direct_model_requests = False
+    inst._model_name = "mimikyu"
+    inst._api_key = None
+    inst._parse_session_key_header = lambda request: (None, None)
+    inst._parse_model_routes = lambda extra: {}
+    inst._model_routes = {}
+    inst._resolve_route = lambda model_name: None
+    inst._concurrency_limited_response = lambda: None
+    inst._request_route_conflict_error = lambda **kw: None
+    inst._cors_headers_for_origin = lambda origin: {}
+
+    async def fake_run_agent(self, **kwargs):
+        # Whatever the user says, decide to call the clipboard.
+        return (
+            {
+                "final_response": 'Checking your clipboard. <tool_call>{"function": {"name": "clipboard_history_read", "arguments": {}}}</tool_call>',
+                "partial": False, "failed": False, "completed": True,
+                "error": None, "session_id": "s1",
+            },
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+
+    monkeypatch.setattr(cls, "_run_agent", fake_run_agent)
+    return inst
+
+
+@pytest.mark.asyncio
+async def test_handler_returns_tool_calls_nonstreaming(adapter_with_stub, aiohttp_client_factory=None):
+    from aiohttp import web
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter_with_stub._handle_chat_completions)
+    from aiohttp.test_utils import TestClient, TestServer
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        body = {
+            "model": "mimikyu",
+            "messages": [{"role": "user", "content": "whats on my clipboard?"}],
+            "tools": [CLIP],
+        }
+        resp = await client.post("/v1/chat/completions", json=body)
+        assert resp.status == 200
+        data = await resp.json()
+        msg = data["choices"][0]["message"]
+        assert data["choices"][0]["finish_reason"] == "tool_calls"
+        assert msg["tool_calls"][0]["function"]["name"] == "clipboard_history_read"
+        assert "<tool_call>" not in (msg["content"] or "")
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_legacy_path_untouched(adapter_with_stub):
+    """No tools in request -> plain content answer, finish stop (regression guard)."""
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def plain(self, **kwargs):
+        return (
+            {"final_response": "2 + 2 is 4", "partial": False, "failed": False,
+             "completed": True, "error": None, "session_id": "s2"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    adapter_with_stub._run_agent = plain.__get__(adapter_with_stub)
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter_with_stub._handle_chat_completions)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        resp = await client.post("/v1/chat/completions", json={
+            "model": "mimikyu",
+            "messages": [{"role": "user", "content": "what is 2+2"}],
+        })
+        data = await resp.json()
+        assert data["choices"][0]["finish_reason"] == "stop"
+        assert data["choices"][0]["message"]["content"] == "2 + 2 is 4"
+        assert "tool_calls" not in data["choices"][0]["message"]
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_followup_folds_tool_result(adapter_with_stub):
+    """Second request carries assistant tool_calls + role:tool -> continuation text reaches the agent."""
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    seen = {}
+
+    async def spy(self, **kwargs):
+        seen["user_message"] = kwargs.get("user_message")
+        seen["history"] = kwargs.get("conversation_history")
+        return (
+            {"final_response": "Your clipboard has: hello world", "partial": False,
+             "failed": False, "completed": True, "error": None, "session_id": "s3"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    adapter_with_stub._run_agent = spy.__get__(adapter_with_stub)
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter_with_stub._handle_chat_completions)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        resp = await client.post("/v1/chat/completions", json={
+            "model": "mimikyu",
+            "messages": [
+                {"role": "user", "content": "whats on my clipboard?"},
+                {"role": "assistant", "content": None, "tool_calls": [
+                    {"id": "call_1", "type": "function",
+                     "function": {"name": "clipboard_history_read", "arguments": "{}"}}
+                ]},
+                {"role": "tool", "tool_call_id": "call_1", "content": "hello world"},
+            ],
+            "tools": [CLIP],
+        })
+        data = await resp.json()
+        assert resp.status == 200
+        assert "hello world" in seen["user_message"]
+        assert data["choices"][0]["message"]["content"] == "Your clipboard has: hello world"
+    finally:
+        await client.close()
+
+
+@pytest.mark.asyncio
+async def test_handler_streaming_suppresses_blocks_and_emits_tool_calls(adapter_with_stub):
+    """stream=True: raw <tool_call> blocks never hit the wire; tool_calls deltas do."""
+    from aiohttp import web
+    from aiohttp.test_utils import TestClient, TestServer
+
+    async def fake_stream(self, **kwargs):
+        cb = kwargs.get("stream_delta_callback")
+        for piece in ["Checking your clipboard. ", "<tool_call>", '{"function": ',
+                      '{"name": "clipboard_history_read", ', '"arguments": {}}}',
+                      "</tool_call>"]:
+            if cb:
+                cb(piece)
+        return (
+            {"final_response": "Checking your clipboard. <tool_call>{\"function\": {\"name\": \"clipboard_history_read\", \"arguments\": {}}}</tool_call>",
+             "partial": False, "failed": False, "completed": True, "error": None,
+             "session_id": "s4"},
+            {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+        )
+    adapter_with_stub._run_agent = fake_stream.__get__(adapter_with_stub)
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", adapter_with_stub._handle_chat_completions)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    try:
+        resp = await client.post("/v1/chat/completions", json={
+            "model": "mimikyu",
+            "messages": [{"role": "user", "content": "whats on my clipboard?"}],
+            "tools": [CLIP],
+            "stream": True,
+        })
+        assert resp.status == 200
+        raw = await resp.text()
+        assert "data: [DONE]" in raw
+        frames = [json.loads(l[len("data: "):]) for l in raw.splitlines() if l.startswith("data: ") and l != "data: [DONE]"]
+        # no raw block text ever streamed
+        for f in frames:
+            delta = f["choices"][0].get("delta", {})
+            assert "<tool_call>" not in str(delta.get("content") or "")
+        # a tool_calls delta arrived with the right name
+        tc_frames = [f for f in frames if f["choices"][0].get("delta", {}).get("tool_calls")]
+        assert tc_frames, "expected tool_calls delta chunks"
+        fn = tc_frames[0]["choices"][0]["delta"]["tool_calls"][0]["function"]
+        assert fn["name"] == "clipboard_history_read"
+        # finish_reason on the final frame
+        finishes = [f["choices"][0].get("finish_reason") for f in frames if f["choices"][0].get("finish_reason")]
+        assert finishes and finishes[-1] == "tool_calls"
+        # residual prose still streamed
+        contents = "".join(str(f["choices"][0].get("delta", {}).get("content") or "") for f in frames)
+        assert "Checking your clipboard." in contents
+    finally:
+        await client.close()

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -411,6 +411,38 @@ Example:
 }
 ```
 
+### Client tools (function calling round-trip)
+
+Clients may attach OpenAI-style `tools` to `POST /v1/chat/completions`
+(Raycast AI Extensions, Open WebUI function calling, and any other
+frontend that ships executable tools). The server never executes client
+tools. Instead:
+
+1. The tool schemas are described to the agent for that turn.
+2. When the agent decides a client tool is needed, the response carries
+   `finish_reason: "tool_calls"` with `message.tool_calls` in standard
+   OpenAI shape (streaming: `delta.tool_calls` chunks, and raw
+   `<tool_call>` text is never sent to the wire).
+3. Your client executes the tool locally and sends a follow-up request
+   containing the assistant `tool_calls` message plus a `role: "tool"`
+   result message. The server folds the result back into the agent
+   conversation and returns the continued answer.
+
+Tool names that collide with built-in Hermes tools are namespaced to
+`client__<name>` on the agent side and mapped back to the client's
+original name in responses. A per-client-tool chain is capped to prevent
+runaway loops. Disable with:
+
+```yaml
+gateway:
+  platforms:
+    api_server:
+      client_tools: false
+```
+
+Requests without a `tools` array are unaffected. (`/v1/responses` does not
+accept client tools yet.)
+
 ### GET /health
 
 Health check. Returns `{"status": "ok"}`. Also available at **GET /v1/health** for OpenAI-compatible clients that expect the `/v1/` prefix.


### PR DESCRIPTION
## What does this PR do?

Adds a **client-tools bridge** to `/v1/chat/completions`: clients may attach OpenAI-style `tools`, the agent can decide to use one, the decision is returned as a protocol-correct `tool_calls` response, the CLIENT executes it locally, and the follow-up `role:"tool"` result is folded back into the agent conversation. This is the resumable client-executed protocol (no server-side forwarding, no outbound requests) - the approach the review of #36097 asked for.

Today the api-server parses `tools`/`tool_choice` but only uses them for the idempotency fingerprint: schemas never reach the agent and `tool_calls` are never returned. Any OpenAI-compatible client that ships executable tools - Raycast AI Extensions (`@clipboard`, `@calendar`, `@terminal`), Open WebUI function calling - silently loses them against a Hermes backend. Live request captures from Raycast 2.0 confirm clients send `tools` arrays in the wild.

Why this approach over server-forwarded tools: the client already owns execution and approval UX; the server only needs to (a) describe the schemas to the agent, (b) echo the decision back as `tool_calls`, and (c) resume on the result. Reusing the proven ACP decision contract (`agent/acp_openai_bridge.py`) keeps model-side behavior identical to the existing IDE path.

## Related Issue

Fixes #20950 (client-executed round-trip half; supersedes the forwarding design in #36097, which was filed RED for SSRF and marked salvageability=low - the `x-hermes-url` forwarding path is intentionally absent here).

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/platforms/api_server_client_tools.py`** (new) - `ClientToolsBridge`: schema validation (32-tool / 24k-char caps, name validation), collision mapping of Hermes-reserved names to a bidirectional `client__` prefix, `<tool_call>` system contract (ACP wire shape), decision extraction back to OpenAI `tool_calls` with original client names; `fold_tool_result` renders a trailing assistant-`tool_calls` + `role:"tool"` pair into one continuation user message. The bridge never executes anything.
- **`gateway/platforms/api_server.py`** - handler wiring only: preserve `role:"tool"` messages when active (legacy parser dropped them), build the bridge from `body.tools`/`tool_choice`, append the contract to the ephemeral system prompt (stream + non-stream), convert decisions to `finish_reason:"tool_calls"` + `message.tool_calls` (non-streaming) or `delta.tool_calls` chunks with raw-block suppression (streaming), fold follow-ups, kill-switch `client_tools` (default on). No `tools` in the request => byte-identical legacy path.
- **`cli-config.yaml.example`**, **`website/docs/user-guide/features/api-server.md`** - `client_tools` documented.
- **`tests/gateway/test_api_server_client_tools.py`** (new) - 16 cases including live aiohttp handler tests with a stubbed `_run_agent`.

## How to Test

1. `pytest tests/gateway/test_api_server_client_tools.py -q` → 16 passed
2. Regression: `pytest tests/agent/test_acp_openai_bridge.py tests/gateway/ -q` → no new failures vs `main` (20 failures are pre-existing on `main`; verified by running the same failing tests on a clean checkout)
3. End-to-end with Raycast 2.0 (any OS): custom provider → `http://<host>:8642/v1`, `tools.supported: true`; `@clipboard` in AI Chat now returns a `tool_calls` round-trip and the answer continues with the local clipboard content.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate (found #36097; this PR implements the alternative design its review requested)
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` — `tests/gateway/` + `tests/agent/` green except 20 pre-existing `main` failures (discord/wecom/telegram/hosted-room; identical on `main`)
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (container, Python 3.11 venv) against a real Raycast client over Tailscale

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — api-server docs page
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — `client_tools`
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — server-side only; clients unaffected
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no Hermes tools changed)

Security notes by design: client tool *results* are rendered as data inside a user message (no system-role injection, no impersonation of Hermes tools); no outbound requests are ever made (no SSRF surface); per-chain call cap prevents loops; `client_tools: false` disables everything.
