### PR TITLE
fix(plugin-compat): scan entry-point modules without importing parents

### DIFF
--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -28,6 +28,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterable, List, Optional, Tuple
 
+from hermes_cli.plugins_manifest import resolve_module_origin
+
 COMPAT_REMOVAL_DATE = _dt.date(2026, 9, 14)
 COMPAT_REMOVAL = COMPAT_REMOVAL_DATE.isoformat()
 ALLOW_KEY = "allow_deprecated_imports"   # under plugins: in config.yaml
@@ -96,6 +98,12 @@ def days_until_removal(today: Optional[_dt.date] = None) -> int:
 # ---------------------------------------------------------------------------------------------- scanner
 
 def _iter_py(root: Path) -> Iterable[Path]:
+    if root.is_file():
+        if root.suffix == ".py":
+            yield root
+        return
+    if not root.is_dir():
+        return
     for dp, dns, fns in os.walk(root):
         dns[:] = [d for d in dns if d not in _SKIP_DIRS and not d.startswith(".")]
         for f in fns:
@@ -149,16 +157,21 @@ def scan_source(src: str, rel: str, manifest: Dict[str, Dict[str, str]]) -> List
 
 
 def scan_plugin(plugin_dir: Optional[Path], manifest: Optional[Dict[str, Dict[str, str]]] = None) -> List[Hit]:
+    """Scan one plugin directory or one resolved Python module for compatibility hits."""
     manifest = load_manifest() if manifest is None else manifest
-    if not manifest or not plugin_dir or not Path(plugin_dir).is_dir():
+    if not manifest or not plugin_dir:
+        return []
+    root = Path(plugin_dir)
+    if not root.is_dir() and not (root.is_file() and root.suffix == ".py"):
         return []
     hits: List[Hit] = []
-    for p in _iter_py(Path(plugin_dir)):
+    for p in _iter_py(root):
         try:
             src = p.read_text(encoding="utf-8", errors="replace")
         except OSError:
             continue
-        hits += scan_source(src, str(p.relative_to(plugin_dir)), manifest)
+        rel = p.name if root.is_file() else str(p.relative_to(root))
+        hits += scan_source(src, rel, manifest)
     return hits
 
 
@@ -179,16 +192,19 @@ def _scan_root(manifest) -> Optional[Path]:
         return None
     raw = str(manifest.path)
     if getattr(manifest, "source", "") == "entrypoint":
-        import importlib.util
-        try:
-            spec = importlib.util.find_spec(raw.partition(":")[0])
-        except (ImportError, ValueError):
-            spec = None
-        origin = getattr(spec, "origin", None)
-        if not origin or origin in ("built-in", "frozen"):
+        module_name = raw.partition(":")[0].strip()
+        # Entry-point module paths are dotted Python identifiers. Validate before
+        # handing the name to the filesystem resolver: an absolute path embedded
+        # as one dotted segment would otherwise escape the package search root.
+        if not module_name or not all(part.isidentifier() for part in module_name.split(".")):
+            return None
+        origin = resolve_module_origin(module_name)
+        if not origin:
             return None
         p = Path(origin)
-        return p.parent if p.name == "__init__.py" else None
+        if p.name == "__init__.py":
+            return p.parent if p.is_file() else None
+        return p if p.is_file() and p.suffix == ".py" else None
     p = Path(raw)
     return p if p.is_dir() else None
 

--- a/tests/test_plugin_compat_notice.py
+++ b/tests/test_plugin_compat_notice.py
@@ -146,11 +146,69 @@ def test_scan_root_never_falls_back_to_cwd(tmp_path, monkeypatch):
     (tmp_path / "stray.py").write_text("from tools.web_tools import prefers_gateway\n")
     assert pc.plugin_hits(SimpleNamespace(source="directory", path=r"C:\Users\alice\plugin", name="w")) == []
     assert pc.plugin_hits(SimpleNamespace(source="entrypoint", path="no_such_pkg_xyz:register", name="e")) == []
+    namespace = tmp_path / "site" / "namespace_plugin"
+    namespace.mkdir(parents=True)
+    (namespace / "child.py").write_text("from tools.web_tools import prefers_gateway\n")
     pkg = tmp_path / "site" / "vendor_plugin"; pkg.mkdir(parents=True)
     (pkg / "__init__.py").write_text("from tools.web_tools import prefers_gateway\n")
     monkeypatch.syspath_prepend(str(tmp_path / "site"))
+    assert pc.plugin_hits(SimpleNamespace(source="entrypoint", path="namespace_plugin:register", name="n")) == []
+    assert pc.plugin_hits(SimpleNamespace(source="entrypoint", path="builtins:register", name="b")) == []
     hits = pc.plugin_hits(SimpleNamespace(source="entrypoint", path="vendor_plugin:register", name="v"))
     assert [h.file for h in hits] == ["__init__.py"]
+
+
+def test_entrypoint_scan_detects_single_file_module(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    site.mkdir()
+    (site / "single_plugin.py").write_text("from tools.web_tools import prefers_gateway\n")
+    monkeypatch.syspath_prepend(str(site))
+
+    hits = pc.plugin_hits(SimpleNamespace(
+        source="entrypoint", path="single_plugin:register", name="single",
+    ))
+
+    assert [(hit.file, hit.old) for hit in hits] == [
+        ("single_plugin.py", "tools.web_tools.prefers_gateway"),
+    ]
+
+
+def test_entrypoint_scan_resolves_dotted_module_without_importing_parent(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    parent = site / "compat_entrypoint_parent"
+    parent.mkdir(parents=True)
+    marker = tmp_path / "parent-imported"
+    (parent / "__init__.py").write_text(f"open({str(marker)!r}, 'w').write('executed')\n")
+    (parent / "child.py").write_text("from tools.web_tools import prefers_gateway\n")
+    monkeypatch.syspath_prepend(str(site))
+
+    hits = pc.plugin_hits(SimpleNamespace(
+        source="entrypoint", path="compat_entrypoint_parent.child:register", name="dotted",
+    ))
+
+    assert not marker.exists()
+    assert [(hit.file, hit.old) for hit in hits] == [
+        ("child.py", "tools.web_tools.prefers_gateway"),
+    ]
+
+
+def test_entrypoint_scan_rejects_path_shaped_module_segments(tmp_path, monkeypatch):
+    site = tmp_path / "site"
+    package = site / "legit"
+    package.mkdir(parents=True)
+    (package / "__init__.py").write_text("", encoding="utf-8")
+    outside = tmp_path / "not-the-plugin.py"
+    outside.write_text("from tools.web_tools import prefers_gateway\n", encoding="utf-8")
+    monkeypatch.syspath_prepend(str(site))
+
+    manifest = SimpleNamespace(
+        source="entrypoint",
+        path=f"legit.{outside}:register",
+        name="malformed",
+    )
+
+    assert pc._scan_root(manifest) is None
+    assert pc.plugin_hits(manifest) == []
 
 
 def test_allow_override_requires_literal_true_and_notice_reports_it(monkeypatch):


### PR DESCRIPTION
## Problem

The plugin-compat scanner added during #102117 only accepts package `__init__.py` entry points. Single-file modules and dotted child modules therefore produce no compatibility hits. Its direct `find_spec("parent.child")` call also imports `parent`, executing plugin code before the compatibility gate decides whether the plugin should load.

Malformed path-shaped module segments could additionally escape the package walk and scan an unrelated Python file.

## Fix

- Reuse the existing import-free `resolve_module_origin()` resolver.
- Scan either a package directory or one resolved Python module.
- Validate every dotted component as a Python identifier before filesystem resolution.
- Preserve the existing directory-plugin, package-entry-point, built-in, and unresolved behavior.

## Regression coverage

Tests exercise:

- single-file `module.py:register` entry points;
- dotted `package.child:register` without executing `package/__init__.py`;
- malformed/path-shaped module components;
- package entry points, unresolved modules, namespaces, and built-ins.

## Relationship to existing work

Follow-up to #102117. This completes the entry-point handling reported by @ayushnangia and builds on @teknium1's initial CWD/path fix in `957710a1194`.

This is a focused proposal for maintainer evaluation; it does not make a claim about the disposition of other compatibility follow-ups.

The separate category-loader enforcement follow-up is #102904. The two commits were also cherry-picked together in a clean integration worktree.

## Cherry-pick

```bash
git cherry-pick 838ab54f39aa18a7e027b79b2b5756591783aba0
```

## Verification

- [x] `scripts/run_tests.sh tests/test_plugin_compat_notice.py tests/hermes_cli/test_plugins.py -q` — 93 passed
- [x] Combined four-fix integration suite — 227 passed
- [x] Ruff on changed Python files
- [x] `git diff --check`

## Scope and risk

No plugin is imported by the scanner. No compatibility policy, removal date, or loader behavior changes; only source resolution and scanning are corrected.
