### PR TITLE
fix(plugin-compat): gate category-owned providers

### DIFF
--- a/hermes_cli/plugin_compat.py
+++ b/hermes_cli/plugin_compat.py
@@ -26,7 +26,8 @@ import threading
 import warnings
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, Iterable, List, Optional, Tuple
+from types import SimpleNamespace
+from typing import Any, Dict, Iterable, List, Optional, Tuple
 
 COMPAT_REMOVAL_DATE = _dt.date(2026, 9, 14)
 COMPAT_REMOVAL = COMPAT_REMOVAL_DATE.isoformat()
@@ -193,6 +194,39 @@ def _scan_root(manifest) -> Optional[Path]:
     return p if p.is_dir() else None
 
 
+def category_plugin_manifest(name: str, path: object, source: str) -> Any:
+    """Build the minimal manifest shape used by compatibility scanning and gates.
+
+    Category loaders own their discovery and deliberately do not construct a
+    general ``PluginManifest`` (doing so would couple their import paths back
+    to the manager). The compat layer only needs these three fields.
+    """
+    return SimpleNamespace(name=name, path=str(path), source=source)
+
+
+def external_plugin_disable_reason(
+    name: str, path: object, source: str, *, today: Optional[_dt.date] = None
+) -> Optional[str]:
+    """Apply the shared post-removal decision to a category-owned plugin."""
+    return disable_reason(category_plugin_manifest(name, path, source), today=today)
+
+
+def _category_compat_manifests() -> List[Any]:
+    """Return category-owned plugin references without importing plugin code."""
+    manifests: List[Any] = []
+    try:
+        from providers import _external_provider_compat_manifests
+        manifests.extend(_external_provider_compat_manifests())
+    except Exception:
+        pass
+    try:
+        from plugins.memory import _external_memory_compat_manifests
+        manifests.extend(_external_memory_compat_manifests())
+    except Exception:
+        pass
+    return manifests
+
+
 def compat_report(manifests=None, *, force: bool = False) -> Dict[str, List[Hit]]:
     """``{plugin_name: hits}`` for every ENABLED external (non-bundled) plugin with at least one hit.
 
@@ -206,6 +240,22 @@ def compat_report(manifests=None, *, force: bool = False) -> Dict[str, List[Hit]
             manifests = [lp.manifest for lp in mgr._plugins.values()]
         except Exception:
             return {}
+    manifests = list(manifests or [])
+    # The manager deliberately leaves exclusive/model-provider lifecycles to
+    # their category loaders. Ask those loaders for metadata-only references so
+    # reporting does not import the same plugin a second time.
+    known = {
+        (getattr(m, "source", ""), str(getattr(m, "path", "")))
+        for m in manifests
+    }
+    for category_manifest in _category_compat_manifests():
+        identity = (
+            getattr(category_manifest, "source", ""),
+            str(getattr(category_manifest, "path", "")),
+        )
+        if identity not in known:
+            manifests.append(category_manifest)
+            known.add(identity)
     external = [m for m in manifests if getattr(m, "source", "") != "bundled" and getattr(m, "path", None)]
     key = tuple(sorted(f"{m.name}@{m.path}" for m in external))
     with _report_lock:

--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -92,6 +92,41 @@ def _iter_provider_dirs() -> List[Tuple[str, Path]]:
     return dirs
 
 
+def _provider_source(provider_dir: Path) -> str:
+    """Return the discovery source for a provider directory without importing it."""
+    if _is_bundled(provider_dir):
+        return "bundled"
+    project_dir = _get_project_plugins_dir()
+    if project_dir is not None and (provider_dir == project_dir or project_dir in provider_dir.parents):
+        return "project"
+    return "user"
+
+
+def _external_memory_compat_manifests() -> list:
+    """Return external memory-provider references without importing provider code."""
+    from hermes_cli.plugin_compat import category_plugin_manifest
+
+    result = []
+    seen = set()
+    for name, provider_dir in _iter_provider_dirs():
+        seen.add(name)
+        if _provider_source(provider_dir) != "bundled":
+            result.append(category_plugin_manifest(name, provider_dir, _provider_source(provider_dir)))
+    for entry_point in _iter_entry_points():
+        if entry_point.name not in seen:
+            result.append(category_plugin_manifest(entry_point.name, getattr(entry_point, "value", ""), "entrypoint"))
+    return result
+
+
+def _compat_disable_reason(name: str, path: object, source: str) -> str | None:
+    """Use the compat layer's one post-removal decision for memory loading."""
+    try:
+        from hermes_cli.plugin_compat import external_plugin_disable_reason
+    except ImportError:
+        return None
+    return external_plugin_disable_reason(name, path, source)
+
+
 def _iter_entry_points():
     """Yield pip-installed memory provider entry points."""
     try:
@@ -212,6 +247,10 @@ def _load_provider_from_entry_point(entry_point, *, register_skills: bool = True
     """Import a provider entry point and extract the MemoryProvider instance: an
     instance, a subclass, a module with ``register(ctx)``, a factory / ``register``
     callable, or a namespace holding a subclass — in that order."""
+    reason = _compat_disable_reason(entry_point.name, getattr(entry_point, "value", ""), "entrypoint")
+    if reason:
+        logger.warning("Skipping entry-point memory provider %r: %s", entry_point.name, reason)
+        return None
     from agent.memory_provider import MemoryProvider
 
     loaded = entry_point.load()
@@ -246,6 +285,11 @@ def _load_provider_from_entry_point(entry_point, *, register_skills: bool = True
 
 def _load_provider_from_dir(provider_dir: Path, *, register_skills: bool = True) -> Optional["MemoryProvider"]:
     """Import a provider module; ``register(ctx)`` first, else a top-level subclass."""
+    source = _provider_source(provider_dir)
+    reason = _compat_disable_reason(provider_dir.name, provider_dir, source)
+    if reason:
+        logger.warning("Skipping %s memory provider %s: %s", source, provider_dir.name, reason)
+        return None
     name = provider_dir.name
     mod = _loader.load_plugin_module(
         _module_name(provider_dir, name), provider_dir,
@@ -374,6 +418,11 @@ def discover_plugin_cli_commands() -> List[dict]:
     active_provider = _get_active_memory_provider() if _MEMORY_PLUGINS_DIR.is_dir() else None
     plugin_dir = find_provider_dir(active_provider) if active_provider else None
     if not plugin_dir or not (plugin_dir / "cli.py").exists():
+        return []
+    source = _provider_source(plugin_dir)
+    reason = _compat_disable_reason(active_provider or "", plugin_dir, source)
+    if reason:
+        logger.warning("Skipping %s memory provider CLI %s: %s", source, active_provider, reason)
         return []
 
     module_name = _module_name(plugin_dir, active_provider) + ".cli"

--- a/providers/__init__.py
+++ b/providers/__init__.py
@@ -124,6 +124,75 @@ def _installed_plugins_dir() -> Path | None:
         return None
 
 
+def _iter_provider_entry_points() -> list:
+    """Return the shared provider entry-point group without importing targets."""
+    try:
+        import importlib.metadata as _md
+        eps = _md.entry_points()
+        if hasattr(eps, "select"):
+            return list(eps.select(group="hermes_agent.plugins"))
+        return list(eps.get("hermes_agent.plugins", []))  # type: ignore[attr-defined]
+    except Exception as exc:
+        logger.debug("entry-point provider scan skipped: %s", exc)
+        return []
+
+
+def _entry_point_enabled(name: str) -> bool:
+    """Mirror the provider scan's opt-in and deny-list gate for reporting."""
+    try:
+        from hermes_cli.plugins import _get_disabled_plugins, _get_enabled_plugins
+        enabled = _get_enabled_plugins()
+        return bool(enabled and name in enabled and name not in _get_disabled_plugins())
+    except Exception:
+        return False
+
+
+def _external_provider_compat_manifests() -> list:
+    """Return external model-provider references without importing provider code."""
+    from hermes_cli.plugin_compat import category_plugin_manifest
+    from hermes_cli.plugins_manifest import _detect_kind_from_source, _resolve_module_source
+
+    result = []
+    user_dir = _user_plugins_dir()
+    if user_dir is not None:
+        for child in sorted(user_dir.iterdir()):
+            if (
+                child.is_dir()
+                and not child.name.startswith(("_", "."))
+                and (child / "__init__.py").is_file()
+            ):
+                result.append(category_plugin_manifest(child.name, child, "user"))
+
+    installed_dir = _installed_plugins_dir()
+    if installed_dir is not None:
+        for child in sorted(installed_dir.iterdir()):
+            if (
+                child.is_dir()
+                and not child.name.startswith(("_", "."))
+                and child.name != "model-providers"
+                and (child / "__init__.py").is_file()
+                and _declares_model_provider_kind(child)
+            ):
+                result.append(category_plugin_manifest(child.name, child, "user"))
+
+    for entry_point in _iter_provider_entry_points():
+        if not _entry_point_enabled(entry_point.name):
+            continue
+        module_name = (getattr(entry_point, "value", "") or "").split(":", 1)[0].strip()
+        if _detect_kind_from_source(_resolve_module_source(module_name)) == "model-provider":
+            result.append(category_plugin_manifest(entry_point.name, getattr(entry_point, "value", ""), "entrypoint"))
+    return result
+
+
+def _compat_disable_reason(name: str, path: object, source: str) -> str | None:
+    """Use the compat layer's one post-removal decision for provider loading."""
+    try:
+        from hermes_cli.plugin_compat import external_plugin_disable_reason
+    except ImportError:
+        return None
+    return external_plugin_disable_reason(name, path, source)
+
+
 def _declares_model_provider_kind(plugin_dir: Path) -> bool:
     """Whether ``plugin_dir``'s manifest declares ``kind: model-provider``.
 
@@ -166,6 +235,10 @@ def _import_plugin_dir(plugin_dir: Path, source: str) -> None:
     """
     init_file = plugin_dir / "__init__.py"
     if not init_file.exists():
+        return
+    reason = _compat_disable_reason(plugin_dir.name, plugin_dir, source)
+    if reason:
+        logger.warning("Skipping %s provider plugin %s: %s", source, plugin_dir.name, reason)
         return
 
     # Give bundled plugins a stable import path (``plugins.model_providers.<name>``)
@@ -230,11 +303,6 @@ def _discover_entry_point_providers() -> None:
     ``register_provider()`` — a pip package cannot hijack a first-party
     provider name.
     """
-    try:
-        import importlib.metadata as _md
-    except Exception:  # pragma: no cover — importlib.metadata always present ≥3.8
-        return
-
     # Same opt-in gate as the general PluginManager: only entry points named
     # in ``plugins.enabled`` load, and ``plugins.disabled`` always wins.
     try:
@@ -247,23 +315,17 @@ def _discover_entry_point_providers() -> None:
     if not enabled:
         return
 
-    group = "hermes_agent.plugins"
-    try:
-        eps = _md.entry_points()
-        # Python 3.10+ exposes .select(); older returns a dict-like mapping.
-        if hasattr(eps, "select"):
-            group_eps = list(eps.select(group=group))
-        else:  # pragma: no cover — legacy interpreters
-            group_eps = list(eps.get(group, []))  # type: ignore[attr-defined]
-    except Exception as exc:
-        logger.debug("entry-point provider scan skipped: %s", exc)
-        return
+    group_eps = _iter_provider_entry_points()
 
     for ep in group_eps:
         if ep.name not in enabled or ep.name in disabled:
             logger.debug(
                 "entry-point provider %r skipped: not enabled in config", ep.name
             )
+            continue
+        reason = _compat_disable_reason(ep.name, getattr(ep, "value", ""), "entrypoint")
+        if reason:
+            logger.warning("Skipping entry-point provider plugin %r: %s", ep.name, reason)
             continue
         try:
             loaded = ep.load()

--- a/tests/test_category_plugin_compat.py
+++ b/tests/test_category_plugin_compat.py
@@ -1,0 +1,134 @@
+"""Category-owned provider compatibility reporting and removal gates."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import plugin_compat as pc
+
+
+OLD_IMPORT = "from tools.web_tools import prefers_gateway\n"
+
+
+def _write_category_plugins(home: Path, *, model: bool = True, memory: bool = True) -> dict[str, Path]:
+    paths: dict[str, Path] = {}
+    if model:
+        plugin = home / "plugins" / "model-providers" / "oldmodel"
+        plugin.mkdir(parents=True)
+        (plugin / "plugin.yaml").write_text(
+            "name: oldmodel\nkind: model-provider\nversion: 1.0.0\n",
+            encoding="utf-8",
+        )
+        (plugin / "__init__.py").write_text(
+            OLD_IMPORT
+            + "from pathlib import Path\n"
+            + "from providers import register_provider\n"
+            + "from providers.base import ProviderProfile\n"
+            + f"Path({str(plugin / 'LOADED')!r}).write_text('loaded')\n"
+            + "register_provider(ProviderProfile(name='oldmodel', base_url='https://oldmodel.invalid/v1'))\n",
+            encoding="utf-8",
+        )
+        paths["model"] = plugin
+    if memory:
+        plugin = home / "plugins" / "oldmemory"
+        plugin.mkdir(parents=True)
+        (plugin / "plugin.yaml").write_text(
+            "name: oldmemory\nversion: 1.0.0\n",
+            encoding="utf-8",
+        )
+        (plugin / "__init__.py").write_text(
+            OLD_IMPORT
+            + "from pathlib import Path\n"
+            + "from agent.memory_provider import MemoryProvider\n"
+            + f"Path({str(plugin / 'LOADED')!r}).write_text('loaded')\n"
+            + "class Provider(MemoryProvider):\n"
+            + "    @property\n"
+            + "    def name(self): return 'oldmemory'\n"
+            + "    def is_available(self): return True\n"
+            + "    def initialize(self, **kwargs): pass\n"
+            + "    def get_tool_schemas(self): return []\n"
+            + "def register(ctx):\n"
+            + "    ctx.register_memory_provider(Provider())\n",
+            encoding="utf-8",
+        )
+        paths["memory"] = plugin
+    return paths
+
+
+def _clear_provider_modules() -> None:
+    import providers
+
+    providers._REGISTRY.clear()
+    providers._ALIASES.clear()
+    providers._PROVIDER_LIST_CACHE = None
+    providers._discovered = False
+    for name in list(sys.modules):
+        if name.startswith("_hermes_user_provider"):
+            del sys.modules[name]
+
+
+def test_category_plugins_are_in_compat_report_after_real_discovery(tmp_path, monkeypatch):
+    """The manager's report includes model and memory category plugins it does not load itself."""
+    home = tmp_path / ".hermes"
+    paths = _write_category_plugins(home)
+    plain_model = home / "plugins" / "model-providers" / "plainmodel"
+    plain_model.mkdir(parents=True)
+    (plain_model / "__init__.py").write_text(OLD_IMPORT, encoding="utf-8")
+    installed_model = home / "plugins" / "installedmodel"
+    installed_model.mkdir()
+    (installed_model / "plugin.yaml").write_text(
+        "name: installedmodel\nkind: model-provider\nversion: 1.0.0\n",
+        encoding="utf-8",
+    )
+    (installed_model / "__init__.py").write_text(OLD_IMPORT, encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(pc, "report_file_path", lambda: home / pc.REPORT_FILE)
+
+    from hermes_cli.plugins import PluginManager
+
+    PluginManager(scope_key=str(home)).discover_and_load()
+
+    payload = json.loads((home / pc.REPORT_FILE).read_text(encoding="utf-8"))
+    assert set(payload["plugins"]) == {
+        "installedmodel", "oldmemory", "oldmodel", "plainmodel",
+    }
+    assert not (paths["model"] / "LOADED").exists()
+    assert not (paths["memory"] / "LOADED").exists()
+
+
+@pytest.mark.parametrize("category", ["model", "memory"])
+def test_category_plugins_are_skipped_after_removal_and_force_load_with_override(
+    tmp_path, monkeypatch, category
+):
+    """Real category loaders skip old imports after removal, but accept the explicit override."""
+    home = tmp_path / ".hermes"
+    paths = _write_category_plugins(home, model=category == "model", memory=category == "memory")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(pc, "removal_in_effect", lambda today=None: True)
+    monkeypatch.setattr(pc, "allow_deprecated_imports", lambda config=None: False)
+
+    if category == "model":
+        _clear_provider_modules()
+        from providers import get_provider_profile
+
+        assert get_provider_profile("oldmodel") is None
+    else:
+        import plugins.memory as memory_plugins
+
+        monkeypatch.setattr(memory_plugins, "_get_user_plugins_dir", lambda: home / "plugins")
+        assert memory_plugins.load_memory_provider("oldmemory") is None
+    assert not (paths[category] / "LOADED").exists()
+
+    monkeypatch.setattr(pc, "allow_deprecated_imports", lambda config=None: True)
+    if category == "model":
+        _clear_provider_modules()
+        from providers import get_provider_profile
+
+        assert get_provider_profile("oldmodel") is not None
+    else:
+        assert memory_plugins.load_memory_provider("oldmemory") is not None
+    assert (paths[category] / "LOADED").exists()


### PR DESCRIPTION
## Problem

#102117 added compatibility reporting and a post-removal disable decision for general Python plugins. External model providers and exclusive memory providers bypass both because their lifecycles are owned by separate category loaders.

Affected providers can disappear from the Desktop/CLI compatibility report and then fail with a plain `ImportError` after removal instead of being skipped with the documented reason.

## Fix

- Expose metadata-only references for external model and memory providers without importing them.
- Include category-owned providers in the shared compatibility report.
- Apply the same `disable_reason()` decision immediately before each real category import.
- Preserve bundled-provider behavior, model-provider precedence, entry-point opt-in/deny-list handling, and the explicit `allow_deprecated_imports: true` override.
- Cover both `$HERMES_HOME/plugins/model-providers/<name>` and flat `hermes plugins install` layouts.

## Regression coverage

Real temporary providers prove that:

- model and memory providers appear in the compatibility report without executing plugin code;
- post-removal loading is skipped;
- the explicit override restores loading;
- nested user providers, flat installed providers, and entry-point providers retain their discovery rules.

## Relationship to existing work

Follow-up to #102117 and the category-loader gap reported by @ayushnangia. The gap was acknowledged in the review thread but intentionally left for follow-up.

This PR is independently mergeable. It also composes cleanly with the entry-point scanner follow-up in #102903.

## Cherry-pick

```bash
git cherry-pick c9733c5bee51a4f8de850465f4eb2b3c72475bde
```

## Verification

- [x] Category/discovery suite — 38 passed
- [x] Combined four-fix integration suite — 227 passed
- [x] Broader provider/memory/relay/ACP run — 990 passed; 8 pre-existing optional-Hindsight dependency failures
- [x] Ruff on changed Python files
- [x] `git diff --check`

## Scope and risk

This does not alter the compatibility deadline or make plugin code a security boundary. It applies the already-documented compatibility decision consistently at the category-owned import points.
