### PR TITLE
fix(compat): restore removed public helper APIs

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -100,6 +100,17 @@ def _register_task_cwd(task_id: str, cwd: str) -> None:
         logger.debug("Failed to register ACP task cwd override", exc_info=True)
 
 
+def _clear_task_cwd(task_id: str) -> None:
+    """Remove task-specific cwd overrides for an ACP session."""
+    if not task_id:
+        return
+    try:
+        from tools.terminal_tool import clear_task_env_overrides
+        clear_task_env_overrides(task_id)
+    except Exception:
+        logger.debug("Failed to clear ACP task cwd override", exc_info=True)
+
+
 def _expand_acp_enabled_toolsets(toolsets: List[str] | None = None,
                                  mcp_server_names: List[str] | None = None) -> List[str]:
     """Return ACP toolsets plus explicit MCP server toolsets for this session."""
@@ -177,6 +188,15 @@ class SessionManager:
             state = self._sessions.get(session_id)
         return state if state is not None else self._restore(session_id)
 
+    def remove_session(self, session_id: str) -> bool:
+        """Remove a session from memory and database. Returns True if it existed."""
+        with self._lock:
+            existed = self._sessions.pop(session_id, None) is not None
+        db_existed = self._delete_persisted(session_id)
+        if existed or db_existed:
+            _clear_task_cwd(session_id)
+        return existed or db_existed
+
     def fork_session(self, session_id: str, cwd: str = ".") -> Optional[SessionState]:
         """Deep-copy a session's history into a new session."""
         cwd = _translate_acp_cwd(cwd)
@@ -243,6 +263,26 @@ class SessionManager:
         self._persist(state)
         return state
 
+    def cleanup(self) -> None:
+        """Remove all sessions (memory and database) and clear task-specific cwd overrides."""
+        with self._lock:
+            session_ids = list(self._sessions.keys())
+            self._sessions.clear()
+        for session_id in session_ids:
+            _clear_task_cwd(session_id)
+            self._delete_persisted(session_id)
+        # Also remove any DB-only ACP sessions not currently in memory.
+        db = self._get_db()
+        if db is not None:
+            try:
+                rows = db.search_sessions(source="acp", limit=10000)
+                for row in rows:
+                    sid = row["id"]
+                    _clear_task_cwd(sid)
+                    db.delete_session(sid)
+            except Exception:
+                logger.debug("Failed to cleanup ACP sessions from DB", exc_info=True)
+
     def save_session(self, session_id: str) -> None:
         """Persist a session; called by the server after prompt completion,
         history-mutating slash commands, and model switches."""
@@ -276,6 +316,17 @@ class SessionManager:
             except Exception:
                 logger.debug("SessionDB unavailable for ACP persistence", exc_info=True)
         return self._db_instance
+
+    def _delete_persisted(self, session_id: str) -> bool:
+        """Delete a session from the database. Returns True if it existed."""
+        db = self._get_db()
+        if db is None:
+            return False
+        try:
+            return db.delete_session(session_id)
+        except Exception:
+            logger.debug("Failed to delete ACP session %s from DB", session_id, exc_info=True)
+            return False
 
     def _persist(self, state: SessionState) -> None:
         """Create/update the session record, then sync the live message set."""

--- a/agent/deadline.py
+++ b/agent/deadline.py
@@ -88,6 +88,12 @@ class BoundedResult:
     timeout_s: Optional[float]
     label: str
 
+    def raise_if_timed_out(self) -> Any:
+        """Return ``value``, raising :class:`DeadlineExpired` on timeout."""
+        if self.timed_out:
+            raise DeadlineExpired(self.label, float(self.timeout_s or 0.0))
+        return self.value
+
 
 def _result(start: float, timeout_s: Optional[float], label: str, *, value: Any = None, timed_out: bool = False) -> BoundedResult:
     return BoundedResult(

--- a/agent/relay_runtime.py
+++ b/agent/relay_runtime.py
@@ -743,6 +743,10 @@ class NoopRelayRuntime:
     profile_key: str
     reason: str
 
+    @property
+    def available(self) -> bool:
+        return False
+
     def apply_tool_request_intercepts(self, *, session_id: str, tool_name: str, args: dict[str, Any]) -> dict[str, Any]:
         return args
 

--- a/agent/tool_guardrails.py
+++ b/agent/tool_guardrails.py
@@ -439,6 +439,19 @@ class ToolCallGuardrailController:
             stub = self._build_result_reference_stub(tool_name, args)
         return IdenticalCallObservation(notice=notice, stub=stub)
 
+    def observe_identical_call(
+        self,
+        tool_name: str,
+        args: Mapping[str, Any] | None,
+        result: str | None,
+    ) -> str | None:
+        """Track consecutive identical calls; return a loop-breaker notice or None.
+
+        Back-compat wrapper around :meth:`observe_call` for callers that only
+        care about the loop-breaker notice.
+        """
+        return self.observe_call(tool_name, args, result).notice
+
     def record_persisted_result(self, tool_call_id: str, file_path: str) -> None:
         """Remember the spillover path a persisted result was saved to."""
         if tool_call_id and file_path:

--- a/gateway/relay/descriptor.py
+++ b/gateway/relay/descriptor.py
@@ -54,6 +54,47 @@ class CapabilityDescriptor:
     # Assumed capability set when a legacy connector sends no supported_ops.
     LEGACY_OPS = ("send", "edit", "typing", "follow_up")
 
+    @classmethod
+    def from_platform_entry(
+        cls,
+        entry,
+        *,
+        len_unit: str = "chars",
+        supports_draft_streaming: bool = False,
+        supports_edit: bool = True,
+        supports_threads: bool = False,
+        markdown_dialect: str = "plain",
+    ) -> "CapabilityDescriptor":
+        """Project a ``gateway.platform_registry.PlatformEntry`` into a descriptor.
+
+        Demonstrates the descriptor is a *subset/projection* of what
+        ``PlatformEntry`` already encodes, not a parallel concept: ``label``,
+        ``max_message_length``, ``emoji``, ``platform_hint``, ``pii_safe`` and
+        the platform name come straight off the entry. The runtime capability
+        bits that ``PlatformEntry`` does NOT encode (length unit, draft/edit/
+        thread/markdown behavior) are supplied by the caller — in production
+        the connector fills these from the live adapter's capability methods.
+
+        ``max_message_length`` of 0 on a ``PlatformEntry`` means "no limit";
+        we map that to the stream_consumer default of 4096 so the descriptor
+        always carries a concrete chunking bound.
+        """
+        max_len = getattr(entry, "max_message_length", 0) or 4096
+        return cls(
+            contract_version=CONTRACT_VERSION,
+            platform=entry.name,
+            label=entry.label,
+            max_message_length=max_len,
+            supports_draft_streaming=supports_draft_streaming,
+            supports_edit=supports_edit,
+            supports_threads=supports_threads,
+            markdown_dialect=markdown_dialect,
+            len_unit=len_unit,
+            emoji=getattr(entry, "emoji", "\U0001f50c"),
+            platform_hint=getattr(entry, "platform_hint", ""),
+            pii_safe=getattr(entry, "pii_safe", False),
+        )
+
     def supports_op(self, op: str) -> bool:
         """Whether the connector advertises ``op`` (legacy set when none advertised).
 

--- a/gateway/turn_lease.py
+++ b/gateway/turn_lease.py
@@ -76,6 +76,9 @@ class SessionTurnLeaseRegistry:
         self._leases: Dict[str, _SessionLease] = {}
         self._max_entries = max(1, int(max_entries))
 
+    def __len__(self) -> int:
+        return len(self._leases)
+
     def _get_or_create(self, session_id: str) -> _SessionLease:
         if (lease := self._leases.get(session_id)) is None:
             self._evict_idle()

--- a/tests/acp/test_session.py
+++ b/tests/acp/test_session.py
@@ -240,6 +240,33 @@ class TestListAndCleanup:
         assert messages[0]["content"] == "original"
         assert isinstance(messages[0].get("timestamp"), (int, float))
 
+    def test_cleanup_clears_all(self, manager):
+        s1 = manager.create_session()
+        s2 = manager.create_session()
+        s1.history.append({"role": "user", "content": "one"})
+        s2.history.append({"role": "user", "content": "two"})
+        assert len(manager.list_sessions()) == 2
+        manager.cleanup()
+        assert manager.list_sessions() == []
+
+    def test_remove_session(self, manager):
+        state = manager.create_session()
+        assert manager.remove_session(state.session_id) is True
+        assert manager.get_session(state.session_id) is None
+        # Removing again returns False
+        assert manager.remove_session(state.session_id) is False
+
+    def test_cleanup_removes_db_only_rows_and_clears_task_cwds(self, tmp_path, monkeypatch):
+        db = SessionDB(tmp_path / "state.db")
+        db.create_session(session_id="db-only", source="acp", model="test")
+        cleared = []
+        monkeypatch.setattr(acp_session, "_clear_task_cwd", cleared.append)
+
+        SessionManager(agent_factory=_mock_agent, db=db).cleanup()
+
+        assert db.get_session("db-only") is None
+        assert cleared == ["db-only"]
+
 
 # ---------------------------------------------------------------------------
 # persistence — sessions survive process restarts (via SessionDB)

--- a/tests/agent/test_deadline.py
+++ b/tests/agent/test_deadline.py
@@ -170,6 +170,7 @@ class TestRunBoundedSync:
         result = run_bounded_sync(lambda: "ok", 5.0, label="t")
         assert result.timed_out is False
         assert result.value == "ok"
+        assert result.raise_if_timed_out() == "ok"
 
     def test_unbounded_when_timeout_none(self):
         result = run_bounded_sync(lambda: 7, None, label="t")
@@ -195,7 +196,9 @@ class TestRunBoundedSync:
         assert result.timed_out is True
         assert result.value is None
         assert elapsed < 5.0  # returned near the deadline, not after 30s
-        assert result.label == "wedged"
+        with pytest.raises(DeadlineExpired) as exc_info:
+            result.raise_if_timed_out()
+        assert "wedged" in str(exc_info.value)
         release.set()
 
     def test_on_timeout_callback_runs(self):

--- a/tests/agent/test_stall_guards.py
+++ b/tests/agent/test_stall_guards.py
@@ -328,6 +328,13 @@ def test_multimodal_content_never_stubbed_and_breaks_streak():
     assert c.observe_call("vision", args, _BIG, tool_call_id="c3").stub is None
 
 
+def test_observe_identical_call_backcompat_notice_still_fires():
+    c = ToolCallGuardrailController()
+    for _ in range(STALL_GUARD_IDENTICAL_CALL_THRESHOLD - 1):
+        assert c.observe_identical_call("web_search", {"q": 1}, "r") is None
+    assert c.observe_identical_call("web_search", {"q": 1}, "r") is not None
+
+
 def test_extract_persisted_path_round_trip():
     # The stub's spillover reference is parsed from the <persisted-output>
     # block that maybe_persist_tool_result builds — assert the round trip.

--- a/tests/gateway/relay/test_descriptor_from_entry.py
+++ b/tests/gateway/relay/test_descriptor_from_entry.py
@@ -1,0 +1,36 @@
+"""Descriptor <- PlatformEntry projection (relay Phase 0, Task 0.3).
+
+Proves the CapabilityDescriptor is a projection of the existing PlatformEntry,
+not a parallel concept: the entry's label/limit/emoji/hint/pii fields carry
+straight through.
+"""
+
+from gateway.platform_registry import PlatformEntry
+from gateway.relay.descriptor import CONTRACT_VERSION, CapabilityDescriptor
+
+
+def _entry(**overrides) -> PlatformEntry:
+    base = dict(
+        name="telegram",
+        label="Telegram",
+        adapter_factory=lambda cfg: None,
+        check_fn=lambda: True,
+        max_message_length=4096,
+        pii_safe=False,
+        emoji="\u2708\ufe0f",
+        platform_hint="You are on Telegram.",
+    )
+    base.update(overrides)
+    return PlatformEntry(**base)
+
+
+def test_projection_carries_platform_entry_fields():
+    d = CapabilityDescriptor.from_platform_entry(_entry(), len_unit="utf16")
+    assert d.contract_version == CONTRACT_VERSION
+    assert d.platform == "telegram"
+    assert d.label == "Telegram"
+    assert d.max_message_length == 4096
+    assert d.emoji == "\u2708\ufe0f"
+    assert d.platform_hint == "You are on Telegram."
+    assert d.pii_safe is False
+    assert d.len_unit == "utf16"

--- a/tests/gateway/test_turn_lease.py
+++ b/tests/gateway/test_turn_lease.py
@@ -462,6 +462,20 @@ def test_rebind_does_not_replace_target_during_waiter_handoff():
     _run(scenario())
 
 
+def test_registry_len_tracks_lease_entries():
+    async def scenario():
+        registry = SessionTurnLeaseRegistry()
+        assert len(registry) == 0
+        token = await registry.acquire("session", owner_key="key", generation=1, timeout=1)
+        assert token is not None
+        assert len(registry) == 1
+        assert registry.release(token) is True
+        # Released entries remain available for reuse until capacity eviction.
+        assert len(registry) == 1
+
+    _run(scenario())
+
+
 # ---------------------------------------------------------------------------
 # GatewayRunner wiring
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_relay_shared_metrics_runtime.py
+++ b/tests/hermes_cli/test_relay_shared_metrics_runtime.py
@@ -975,6 +975,7 @@ def test_core_runtime_is_fail_open_without_a_published_binding(monkeypatch, capl
     assert relay_runtime.get_runtime() is None
     host = relay_runtime.HOST_REGISTRY.for_profile()
     assert isinstance(host, relay_runtime.NoopRelayRuntime)
+    assert host.available is False
     assert host.profile_key == relay_runtime.current_profile_key()
     assert "nemo_relay" in host.reason
     assert host.apply_tool_request_intercepts(

--- a/tests/tools/test_base_environment.py
+++ b/tests/tools/test_base_environment.py
@@ -52,6 +52,15 @@ class TestBoundedOutputCollector:
         assert "[OUTPUT TRUNCATED" in rendered
 
 
+class TestLifecycleCompatibility:
+    def test_stop_alias_calls_cleanup(self):
+        env = _TestableEnv()
+        env.cleanup = MagicMock()
+
+        assert env.stop() is None
+        env.cleanup.assert_called_once_with()
+
+
 class TestWrapCommand:
     def test_basic_shape(self):
         env = _TestableEnv()

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -511,6 +511,10 @@ class BaseEnvironment(ABC):
         except Exception:
             logger.debug("terminal wait-bound kill_process_tree failed", exc_info=True)
 
+    def stop(self):
+        """Alias for cleanup (compat with older callers)."""
+        self.cleanup()
+
     # --- Shared helpers ---
     def __del__(self):
         try:


### PR DESCRIPTION
## Problem

The whole-codebase simplification removed several small public compatibility methods even though their owning classes remain importable. Existing callers receive `AttributeError` or `TypeError` after upgrading.

Affected APIs:

- `CapabilityDescriptor.from_platform_entry()`
- `SessionManager.remove_session()` / `cleanup()`
- `SessionTurnLeaseRegistry.__len__()`
- `BoundedResult.raise_if_timed_out()`
- `ToolCallGuardrailController.observe_identical_call()`
- `BaseEnvironment.stop()`
- `NoopRelayRuntime.available`

## Fix

Restore the pre-decomposition signatures and behavior as thin compatibility methods. Where implementation moved, the methods delegate to the current owner rather than duplicating new architecture.

ACP cleanup again removes in-memory and persisted sessions and clears task-CWD overrides. The Noop Relay availability surface is restored as the original property.

## Regression coverage

Restored and extended behavior tests cover each API, including ACP DB-only cleanup, descriptor projection, deadline timeout raising, loop-breaker notices, lease length, environment cleanup, and Noop Relay availability.

## Relationship to existing work

Follow-up proposal to #102117. These methods have no current in-tree callers; this PR exists so maintainers can preserve compatibility for external consumers without folding the decision back into the large refactor.

Credit to @kshitijk4poor and @itsflownium for independently identifying the compatibility removals during review.

The broken advertised-shim fixes are isolated in #102905. Both commits cherry-pick cleanly in either sequence used by the verified integration stack.

## Cherry-pick

```bash
git cherry-pick 7e0bd74d562b9e7c29f44ba1243f627921f1ed42
```

## Verification

- [x] Focused seven-file compatibility suite — 199 passed
- [x] Combined four-fix integration suite — 227 passed
- [x] Ruff on changed Python files
- [x] `git diff --check`

## Scope and risk

No new extension point or behavior is introduced. This restores only methods present before #102117; maintainers can decline this compatibility proposal independently of the three functional fixes.
