### PR TITLE
fix(hindsight): keep custom embeddings in the embedded profile env

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,7 +35,8 @@ from tools.registry import tool_error
 from .embedded import (
     _RETRIABLE_CONNECTION_MARKERS, _build_embedded_profile_env,
     _check_local_runtime, _embedded_llm_api_key, _embedded_profile_env_path,
-    _export_port_health_grace_timeout, _load_simple_env, _local_runtime_hint, _materialize_embedded_profile_env,
+    _export_port_health_grace_timeout, _install_profile_env_guard, _load_simple_env,
+    _local_runtime_hint, _materialize_embedded_profile_env,
 )
 from .settings import (
     _DEFAULT_API_URL, _DEFAULT_IDLE_TIMEOUT, _DEFAULT_LOCAL_URL, _DEFAULT_RETAIN_SOURCE,
@@ -466,7 +467,12 @@ class HindsightMemoryProvider(MemoryProvider):
                       idle_timeout=self._idle_timeout)
         if self._llm_base_url:
             kwargs["llm_base_url"] = self._llm_base_url
-        return HindsightEmbedded(**kwargs)
+        client = HindsightEmbedded(**kwargs)
+        full_env = _build_embedded_profile_env(cfg, llm_api_key=kwargs.get("llm_api_key"))
+        if hasattr(client, "config") and isinstance(getattr(client, "config", None), dict):
+            client.config.update(full_env)
+        _install_profile_env_guard(client, cfg, load_config=_load_config)
+        return client
 
     def _new_cloud_client(self):
         _ensure_client_dependency()
@@ -815,14 +821,32 @@ class HindsightMemoryProvider(MemoryProvider):
 
             client = self._get_client()
             profile = self._config.get("profile", "hermes")
-            # Profile .env out of sync with config -> rewrite and restart a running daemon.
-            if _load_simple_env(_embedded_profile_env_path(self._config)) != _build_embedded_profile_env(self._config):
-                _materialize_embedded_profile_env(self._config)
-                if client._manager.is_running(profile):
-                    _log("\n=== Config changed, restarting daemon ===\n")
+            if hasattr(client, "config") and isinstance(getattr(client, "config", None), dict):
+                client.config.update(_build_embedded_profile_env(self._config))
+            _install_profile_env_guard(client, self._config, load_config=_load_config)
+            profile_env = _embedded_profile_env_path(self._config)
+            expected_env = _build_embedded_profile_env(self._config)
+            saved = _load_simple_env(profile_env)
+            config_changed = any(saved.get(key) != value for key, value in expected_env.items())
+            if config_changed:
+                profile_env = _materialize_embedded_profile_env(self._config)
+                embeddings_mismatch = (
+                    saved.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER")
+                    != expected_env.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER")
+                    or saved.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL")
+                    != expected_env.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL")
+                )
+                if embeddings_mismatch and client._manager.is_running(profile):
+                    _log("\n=== Embeddings config changed, restarting daemon ===\n")
                     client._manager.stop(profile)
+                elif config_changed:
+                    _log(
+                        "\n=== Profile env repaired in place "
+                        f"(keys={len(_load_simple_env(profile_env))}); leaving running daemon ===\n"
+                    )
             client._ensure_started()
-            _log("\n=== Daemon started successfully ===\n")
+            repaired = _materialize_embedded_profile_env(self._config)
+            _log(f"\n=== Daemon started successfully (profile env keys={len(_load_simple_env(repaired))}) ===\n")
         except Exception as e:
             _log(f"\n=== Daemon startup failed: {e} ===\n" + traceback.format_exc())
 

--- a/plugins/memory/hindsight/embedded.py
+++ b/plugins/memory/hindsight/embedded.py
@@ -9,9 +9,10 @@ import logging
 import os
 import sys
 from pathlib import Path
-from typing import Any
+from typing import Any, Callable
 
 from agent.secret_scope import get_secret
+from hermes_constants import get_hermes_home
 
 from .settings import _DEFAULT_IDLE_TIMEOUT, _daemon_llm_provider, _parse_int_setting
 
@@ -110,27 +111,94 @@ def _embedded_profile_env_path(config: dict[str, Any]) -> Path:
     return Path.home() / ".hindsight" / "profiles" / f"{profile}.env"
 
 
+def _hermes_dotenv() -> dict[str, str]:
+    """Read $HERMES_HOME/.env from disk. A long-lived gateway process env can be stale."""
+    path = get_hermes_home() / ".env"
+    return _load_simple_env(path) if path.exists() else {}
+
+
+def _disk_secret(name: str, fallback: str = "") -> str:
+    """Prefer the on-disk Hermes .env secret over initialize-time process env."""
+    disk = _hermes_dotenv().get(name, "")
+    if disk:
+        return disk
+    return get_secret(name, fallback) or os.environ.get(name, "") or fallback
+
+
+def _put_env(env_values: dict[str, str], key: str, value: Any) -> None:
+    if value is None:
+        return
+    text = str(value)
+    if text == "":
+        return
+    env_values[key] = text
+
+
 def _embedded_llm_api_key(config: dict[str, Any]) -> str:
-    return config.get("llmApiKey") or config.get("llm_api_key") or get_secret("HINDSIGHT_LLM_API_KEY", "")
+    return config.get("llmApiKey") or config.get("llm_api_key") or _disk_secret("HINDSIGHT_LLM_API_KEY")
 
 
 def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None) -> dict[str, str]:
-    """Build the profile-scoped env that standalone hindsight-embed consumes."""
+    """Build the profile-scoped env that standalone hindsight-embed consumes.
+
+    Must forward embeddings/reranker from hindsight/config.json. An LLM-only
+    snapshot lets the daemon fall back to local BAAI/bge-small-en-v1.5 (384-d)
+    and crash on a custom-dimension bank when HindsightEmbedded.ensure_running
+    re-registers the profile.
+    """
     if llm_api_key is None:
         llm_api_key = _embedded_llm_api_key(config)
-    env_values = {
+    env_values: dict[str, str] = {
         "HINDSIGHT_API_LLM_PROVIDER": str(_daemon_llm_provider(config.get("llm_provider", ""))),
         "HINDSIGHT_API_LLM_API_KEY": str(llm_api_key or ""),
         "HINDSIGHT_API_LLM_MODEL": str(config.get("llm_model", "")),
         "HINDSIGHT_API_LOG_LEVEL": "info",
     }
-    base_url = config.get("llm_base_url") or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
-    if base_url:
-        env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(base_url)
+    base_url = (
+        config.get("llm_base_url")
+        or _hermes_dotenv().get("HINDSIGHT_API_LLM_BASE_URL")
+        or os.environ.get("HINDSIGHT_API_LLM_BASE_URL", "")
+    )
+    _put_env(env_values, "HINDSIGHT_API_LLM_BASE_URL", base_url)
+    _put_env(env_values, "HINDSIGHT_API_PORT", config.get("api_port"))
+    _put_env(env_values, "HINDSIGHT_API_LLM_TIMEOUT", config.get("llm_timeout"))
+    _put_env(env_values, "HINDSIGHT_API_LLM_REASONING_EFFORT", config.get("llm_reasoning_effort"))
+    _put_env(env_values, "HINDSIGHT_API_LLM_WIRE", config.get("llm_wire"))
     if (idle_timeout := config.get("idle_timeout")) is None:
-        idle_timeout = os.environ.get("HINDSIGHT_IDLE_TIMEOUT")
+        idle_timeout = _hermes_dotenv().get("HINDSIGHT_IDLE_TIMEOUT") or os.environ.get("HINDSIGHT_IDLE_TIMEOUT")
     if idle_timeout is not None and idle_timeout != "":
         env_values["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] = str(_parse_int_setting(idle_timeout, _DEFAULT_IDLE_TIMEOUT))
+
+    _put_env(env_values, "HINDSIGHT_API_EMBEDDINGS_PROVIDER", config.get("embeddings_provider"))
+    _put_env(env_values, "HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL", config.get("embeddings_openai_model"))
+    _put_env(env_values, "HINDSIGHT_API_EMBEDDINGS_OPENAI_BASE_URL", config.get("embeddings_openai_base_url"))
+    _put_env(env_values, "HINDSIGHT_API_EMBEDDINGS_QUERY_PREFIX", config.get("embeddings_query_prefix"))
+    _put_env(env_values, "HINDSIGHT_API_EMBEDDINGS_LOCAL_MODEL", config.get("embeddings_local_model"))
+    _put_env(
+        env_values,
+        "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY",
+        _disk_secret("HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"),
+    )
+
+    _put_env(env_values, "HINDSIGHT_API_RERANKER_PROVIDER", config.get("reranker_provider"))
+    _put_env(env_values, "HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL", config.get("reranker_siliconflow_model"))
+    _put_env(env_values, "HINDSIGHT_API_RERANKER_SILICONFLOW_BASE_URL", config.get("reranker_siliconflow_base_url"))
+    _put_env(env_values, "HINDSIGHT_API_RERANKER_SILICONFLOW_TIMEOUT", config.get("reranker_siliconflow_timeout"))
+    _put_env(
+        env_values,
+        "HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY",
+        _disk_secret("HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY"),
+    )
+    failover = config.get("reranker_failover_provider")
+    _put_env(env_values, "HINDSIGHT_API_RERANKER_1_PROVIDER", failover)
+    local_model = config.get("reranker_local_model")
+    if str(failover or "") == "local":
+        _put_env(env_values, "HINDSIGHT_API_RERANKER_1_LOCAL_MODEL", local_model)
+    if str(config.get("reranker_provider") or "") == "local":
+        _put_env(env_values, "HINDSIGHT_API_RERANKER_LOCAL_MODEL", local_model)
+    # The embedded daemon is a separate process; inherit the parent proxy.
+    _put_env(env_values, "HTTP_PROXY", os.environ.get("HTTP_PROXY") or os.environ.get("http_proxy"))
+    _put_env(env_values, "HTTPS_PROXY", os.environ.get("HTTPS_PROXY") or os.environ.get("https_proxy"))
     return env_values
 
 
@@ -166,6 +234,13 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
     profile_env = _embedded_profile_env_path(config)
     profile_env.parent.mkdir(parents=True, exist_ok=True)
     env_values = _build_embedded_profile_env(config, llm_api_key=llm_api_key)
+    # Keep unknown extra keys (HTTP_PROXY, operator-added HINDSIGHT_API_*) so a
+    # partial builder cannot wipe them on the next cold start.
+    if profile_env.exists():
+        saved = _load_simple_env(profile_env)
+        merged = dict(saved)
+        merged.update(env_values)
+        env_values = merged
     content = "".join(f"{key}={value}\n" for key, value in env_values.items())
     try:
         _secure_write_profile_env(profile_env, content)
@@ -175,3 +250,69 @@ def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: st
             profile_env.unlink()
         raise
     return profile_env
+
+
+def _install_profile_env_guard(
+    client,
+    config: dict[str, Any],
+    *,
+    load_config: Callable[[], dict[str, Any]] | None = None,
+) -> None:
+    """Keep embeddings/reranker active across official profile registration.
+
+    HindsightEmbedded.ensure_running calls _register_profile even when the
+    daemon is already up. render_config comments out every key missing from
+    that dict, so a constructor-only LLM snapshot wipes custom embeddings.
+    Last-writer rematerialize is not enough: the dict passed into
+    ensure_running must already contain the full profile env.
+    """
+    if client is None or getattr(client, "_hermes_profile_env_guard", False):
+        return
+
+    def _current_config() -> dict[str, Any]:
+        if load_config is not None:
+            try:
+                return load_config() or config
+            except Exception:
+                return config
+        return config
+
+    def _full_profile_env() -> dict[str, str]:
+        return _build_embedded_profile_env(_current_config())
+
+    manager = getattr(client, "_manager", None)
+    orig_ensure_running = getattr(manager, "ensure_running", None) if manager is not None else None
+    if callable(orig_ensure_running) and not getattr(manager, "_hermes_ensure_running_guard", False):
+        def _ensure_running_with_full_env(cfg, profile, extra_args=None):
+            target = str(_current_config().get("profile") or "hermes")
+            merged = dict(cfg or {})
+            if not profile or str(profile) == target:
+                full = _full_profile_env()
+                merged.update(full)
+                if hasattr(client, "config") and isinstance(getattr(client, "config", None), dict):
+                    client.config.update(full)
+            if extra_args is None:
+                return orig_ensure_running(merged, profile)
+            return orig_ensure_running(merged, profile, extra_args)
+
+        manager.ensure_running = _ensure_running_with_full_env
+        manager._hermes_ensure_running_guard = True
+
+    orig = getattr(client, "_ensure_started", None)
+    if callable(orig):
+        def _ensure_started_and_repair(*args, **kwargs):
+            try:
+                return orig(*args, **kwargs)
+            finally:
+                try:
+                    _materialize_embedded_profile_env(_current_config())
+                except Exception:
+                    logger.debug("Could not rematerialize Hindsight profile env", exc_info=True)
+
+        client._ensure_started = _ensure_started_and_repair
+
+    client._hermes_profile_env_guard = True
+    try:
+        _materialize_embedded_profile_env(config)
+    except Exception:
+        logger.debug("Could not rematerialize Hindsight profile env", exc_info=True)

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -34,6 +34,7 @@ from plugins.memory.hindsight import (
     _resolve_bank_id_template,
     _WRITER_SENTINEL,
 )
+from plugins.memory.hindsight.embedded import _install_profile_env_guard
 from plugins.memory.hindsight.settings import _sanitize_bank_segment
 
 
@@ -345,6 +346,150 @@ class TestConfig:
         })
 
         assert env["HINDSIGHT_EMBED_DAEMON_IDLE_TIMEOUT"] == "0"
+
+    def test_embedded_profile_env_forwards_embeddings_and_reranker(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=llm-secret\n"
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=embed-secret\n"
+            "HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY=rerank-secret\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("plugins.memory.hindsight.embedded.get_hermes_home", lambda: hermes_home)
+        monkeypatch.delenv("http_proxy", raising=False)
+        monkeypatch.delenv("HTTP_PROXY", raising=False)
+        monkeypatch.setenv("HTTP_PROXY", "http://proxy.example.test:8080")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai_compatible",
+            "llm_model": "gpt-4o-mini",
+            "llm_base_url": "https://llm.example.test/v1",
+            "llm_reasoning_effort": "medium",
+            "llm_wire": "chat",
+            "llm_timeout": 300,
+            "api_port": 9177,
+            "idle_timeout": 300,
+            "embeddings_provider": "openai",
+            "embeddings_openai_model": "qwen3-embedding-0.6b",
+            "embeddings_openai_base_url": "https://embed.example.test/v1",
+            "reranker_provider": "siliconflow",
+            "reranker_siliconflow_model": "BAAI/bge-reranker-v2-m3",
+            "reranker_siliconflow_base_url": "https://rerank.example.test/v1",
+            "reranker_siliconflow_timeout": 15,
+            "reranker_failover_provider": "local",
+            "reranker_local_model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        })
+
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_EMBEDDINGS_PROVIDER"] == "openai"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL"] == "qwen3-embedding-0.6b"
+        assert env["HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY"] == "embed-secret"
+        assert env["HINDSIGHT_API_RERANKER_PROVIDER"] == "siliconflow"
+        assert env["HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL"] == "BAAI/bge-reranker-v2-m3"
+        assert env["HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY"] == "rerank-secret"
+        assert env["HINDSIGHT_API_RERANKER_1_PROVIDER"] == "local"
+        assert env["HTTP_PROXY"] == "http://proxy.example.test:8080"
+        assert "HINDSIGHT_API_LLM_API_KEY" in env
+        assert len(env) >= 20
+
+    def test_ensure_running_guard_injects_embeddings_before_register(
+        self, tmp_path, monkeypatch
+    ):
+        """Official ensure_running/_register_profile comments keys missing from config.
+
+        Last-writer rematerialize is not enough: the dict passed into
+        ensure_running must already contain embeddings, or render_config
+        comments them out and the next cold start falls back to bge-small.
+        """
+        render_config = pytest.importorskip("hindsight_embed.env_template").render_config
+
+        hermes_home = tmp_path / "hermes-home"
+        hermes_home.mkdir()
+        (hermes_home / ".env").write_text(
+            "HINDSIGHT_LLM_API_KEY=llm-secret\n"
+            "HINDSIGHT_API_EMBEDDINGS_OPENAI_API_KEY=embed-secret\n"
+            "HINDSIGHT_API_RERANKER_SILICONFLOW_API_KEY=rerank-secret\n",
+            encoding="utf-8",
+        )
+        disk_config = {
+            "profile": "hermes",
+            "llm_provider": "openai_compatible",
+            "llm_model": "gpt-4o-mini",
+            "llm_base_url": "https://llm.example.test/v1",
+            "embeddings_provider": "openai",
+            "embeddings_openai_model": "qwen3-embedding-0.6b",
+            "embeddings_openai_base_url": "https://embed.example.test/v1",
+            "reranker_provider": "siliconflow",
+            "reranker_siliconflow_model": "BAAI/bge-reranker-v2-m3",
+            "reranker_siliconflow_base_url": "https://rerank.example.test/v1",
+            "reranker_siliconflow_timeout": 15,
+            "reranker_failover_provider": "local",
+            "reranker_local_model": "cross-encoder/ms-marco-MiniLM-L-6-v2",
+        }
+        (hermes_home / "hindsight").mkdir()
+        (hermes_home / "hindsight" / "config.json").write_text(
+            json.dumps(disk_config), encoding="utf-8"
+        )
+        monkeypatch.setattr("plugins.memory.hindsight.embedded.get_hermes_home", lambda: hermes_home)
+
+        profile_env = Path.home() / ".hindsight" / "profiles" / "hermes.env"
+        captured = []
+
+        class FakeManager:
+            def ensure_running(self, config, profile, extra_args=None):
+                captured.append(dict(config))
+                existing = _load_simple_env(profile_env) if profile_env.exists() else {}
+                api_config = {
+                    key: value
+                    for key, value in config.items()
+                    if str(key).startswith("HINDSIGHT_API_")
+                }
+                merged = {key: value for key, value in existing.items() if not str(key).islower()}
+                merged.update(api_config)
+                profile_env.parent.mkdir(parents=True, exist_ok=True)
+                profile_env.write_text(render_config(merged), encoding="utf-8")
+                return True
+
+        llm_only = {
+            "HINDSIGHT_API_LLM_PROVIDER": "openai",
+            "HINDSIGHT_API_LLM_API_KEY": "llm-secret",
+            "HINDSIGHT_API_LLM_MODEL": "gpt-4o-mini",
+            "HINDSIGHT_API_LLM_BASE_URL": "https://llm.example.test/v1",
+        }
+
+        class FakeEmbedded:
+            def __init__(self):
+                self.config = dict(llm_only)
+                self.profile = "hermes"
+                self._manager = FakeManager()
+
+            def _ensure_started(self):
+                return self._manager.ensure_running(self.config, self.profile)
+
+        client = FakeEmbedded()
+        _install_profile_env_guard(client, disk_config)
+        client._ensure_started()
+        # Official second register still uses the constructor's LLM-only dict.
+        client._manager.ensure_running(dict(llm_only), "hermes")
+
+        assert captured, "ensure_running was not called"
+        for snapshot in captured:
+            assert snapshot.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") == "openai"
+            assert snapshot.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL") == "qwen3-embedding-0.6b"
+            assert snapshot.get("HINDSIGHT_API_RERANKER_PROVIDER") == "siliconflow"
+
+        saved = _load_simple_env(profile_env)
+        assert saved.get("HINDSIGHT_API_EMBEDDINGS_PROVIDER") == "openai"
+        assert saved.get("HINDSIGHT_API_EMBEDDINGS_OPENAI_MODEL") == "qwen3-embedding-0.6b"
+        assert saved.get("HINDSIGHT_API_RERANKER_SILICONFLOW_MODEL") == "BAAI/bge-reranker-v2-m3"
+        text = profile_env.read_text(encoding="utf-8")
+        assert "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai" in text
+        assert not any(
+            line.strip().startswith("#") and "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai" in line
+            for line in text.splitlines()
+            if "HINDSIGHT_API_EMBEDDINGS_PROVIDER=openai" in line
+        )
 
 
     def test_get_client_passes_idle_timeout_to_hindsight_embedded(self, monkeypatch):


### PR DESCRIPTION
## Problem

In `local_embedded` mode the plugin constructs `HindsightEmbedded` with **LLM kwargs only** (intentional on the Hindsight side: vectorize-io/hindsight#3253). `HindsightEmbedded.ensure_running` still calls `_register_profile` even when the daemon is already healthy, and `hindsight_embed.env_template.render_config` **comments out every template key that is missing from that dict**.

`load_profile_config` skips commented lines, so the next idle-timeout cold start has no embeddings config, falls back to local `BAAI/bge-small-en-v1.5` (384-d), and crashes if the bank was built with a different dimension:

```
Cannot change embedding dimension from 1024 to 384
```

Rewriting `~/.hindsight/profiles/<profile>.env` *after* `ensure_running` is not enough: the next `ensure_running` re-registers from the LLM-only snapshot and comments the keys again.

Related open PRs (#81844, #28451, #20335, #41365) expand or preserve the materialized env file, but they do not inject embeddings into the dict that `_register_profile` receives.

## Approach

1. `_build_embedded_profile_env` forwards embeddings/reranker/port/timeouts from `hindsight/config.json` (plus secrets from `$HERMES_HOME/.env`) so those keys are **active**, not comments.
2. `_install_profile_env_guard` wraps `manager.ensure_running` and merges that full env into the config **before** official `_register_profile` / `render_config`.
3. Daemon start only recycles a running process when the embeddings provider/model actually changed — repairing extra keys in place does not bounce a healthy daemon onto the 384-d default.

## Changes

- `plugins/memory/hindsight/embedded.py` — full profile env builder, `ensure_running` guard, keep unknown extra keys on materialize.
- `plugins/memory/hindsight/__init__.py` — install the guard when creating the embedded client; inject env on daemon start.
- `tests/plugins/memory/test_hindsight_provider.py` — builder forwards embeddings/reranker; fake official LLM-only `ensure_running` + real `render_config` keeps embeddings uncommented on a second register.

## Tests

```bash
pytest tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_forwards_embeddings_and_reranker        tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_ensure_running_guard_injects_embeddings_before_register        tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_includes_idle_timeout_from_config        tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_get_client_passes_idle_timeout_to_hindsight_embedded
```

4 passed locally (including the `render_config` regression, skipped if `hindsight_embed` is not installed).

## Notes

Default local 384-d `bge-small` is unchanged. This only preserves a **custom** embedding/reranker already present in `config.json`.
