### PR TITLE
fix(bot-mode): the roster's filters survive a pane switch

### DIFF
--- a/apps/desktop/src/plugins/hermes-bots/roster-filters.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-filters.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The roster's filters are a preference, not a gesture: what you picked must
+ * still be picked after a reload. Asserts the contract (a set survives a fresh
+ * module load), not the storage key's spelling.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+async function freshModule() {
+  vi.resetModules()
+
+  return import('./roster-filters')
+}
+
+describe('roster filters', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    vi.resetModules()
+  })
+
+  it('defaults to unfiltered', async () => {
+    const m = await freshModule()
+
+    expect(m.$rosterKindFilter.get()).toBe('all')
+    expect(m.$rosterActivityFilter.get()).toBe('all')
+    expect(m.$rosterGatewayFilter.get()).toBe('all')
+  })
+
+  it('survives a reload', async () => {
+    const first = await freshModule()
+
+    first.$rosterKindFilter.set('groups')
+    first.$rosterActivityFilter.set('recent')
+    first.$rosterGatewayFilter.set('conn-42')
+
+    const reloaded = await freshModule()
+
+    expect(reloaded.$rosterKindFilter.get()).toBe('groups')
+    expect(reloaded.$rosterActivityFilter.get()).toBe('recent')
+    expect(reloaded.$rosterGatewayFilter.get()).toBe('conn-42')
+  })
+
+  it('falls back to all when a stored value is no longer a valid option', async () => {
+    const first = await freshModule()
+
+    first.$rosterKindFilter.set('groups')
+
+    // A stale key from an older build, or a hand-edited one.
+    const key = Object.keys(localStorage).find(k => k.includes('KindFilter'))
+
+    expect(key).toBeDefined()
+    localStorage.setItem(key as string, 'nonsense')
+
+    const reloaded = await freshModule()
+
+    expect(reloaded.$rosterKindFilter.get()).toBe('all')
+  })
+
+  it('reset clears all three', async () => {
+    const m = await freshModule()
+
+    m.$rosterKindFilter.set('bots')
+    m.$rosterActivityFilter.set('older')
+    m.$rosterGatewayFilter.set('conn-7')
+
+    m.resetRosterFilters()
+
+    expect(m.$rosterKindFilter.get()).toBe('all')
+    expect(m.$rosterActivityFilter.get()).toBe('all')
+    expect(m.$rosterGatewayFilter.get()).toBe('all')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/roster-filters.ts
+++ b/apps/desktop/src/plugins/hermes-bots/roster-filters.ts
@@ -1,0 +1,53 @@
+/**
+ * The roster's remembered view filters.
+ *
+ * A leaf by design: the roster pane reads and writes these, and they know
+ * nothing about it. Persisted because a filter you picked is a preference,
+ * not a gesture — core's sidebar filters (store/layout.ts) have always
+ * survived a reload, and the roster reading as the one place that forgets is
+ * the bug this fixes.
+ *
+ * The search box is deliberately NOT here: a query restored at boot renders
+ * an empty-looking roster whose cause is off-screen, which is worse than
+ * retyping it.
+ */
+
+import { Codecs, persistentAtom } from '@hermes/plugin-sdk'
+
+import type { RosterActivityFilter, RosterKindFilter } from './types'
+
+const KIND_KEY = 'hermes.desktop.botRosterKindFilter'
+const ACTIVITY_KEY = 'hermes.desktop.botRosterActivityFilter'
+const GATEWAY_KEY = 'hermes.desktop.botRosterGatewayFilter'
+
+/** Decode through the union's own values so a hand-edited or stale key falls
+ *  back to 'all' instead of poisoning the filter with an unmatchable value. */
+function oneOf<T extends string>(allowed: readonly T[], fallback: T) {
+  return {
+    decode: (raw: string): T => (allowed.includes(raw as T) ? (raw as T) : fallback),
+    encode: (value: T): null | string => value
+  }
+}
+
+export const $rosterKindFilter = persistentAtom<RosterKindFilter>(
+  KIND_KEY,
+  'all',
+  oneOf(['all', 'bots', 'groups'] as const, 'all')
+)
+
+export const $rosterActivityFilter = persistentAtom<RosterActivityFilter>(
+  ACTIVITY_KEY,
+  'all',
+  oneOf(['active', 'all', 'older', 'recent'] as const, 'all')
+)
+
+/** Gateway ids are user data, so this one stays free-form text. A gateway that
+ *  no longer exists is reconciled by the pane, which falls back to 'all'. */
+export const $rosterGatewayFilter = persistentAtom<string>(GATEWAY_KEY, 'all', Codecs.text)
+
+/** Clear all three — the pane's "reset filters" action. */
+export function resetRosterFilters() {
+  $rosterKindFilter.set('all')
+  $rosterActivityFilter.set('all')
+  $rosterGatewayFilter.set('all')
+}

--- a/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/roster-pane.tsx
@@ -66,6 +66,12 @@ import { displayName } from './labels'
 import { deleteBot, mergeServerMeta, pullServerAvatars } from './profile-ops'
 import { $activityToasts, setActivityToasts, trackInboundActivity } from './roster-actions'
 import {
+  $rosterActivityFilter,
+  $rosterGatewayFilter,
+  $rosterKindFilter,
+  resetRosterFilters
+} from './roster-filters'
+import {
   botNeedsHandleLabel,
   filterBotsByGateway,
   GatewayKindGlyph,
@@ -276,9 +282,12 @@ export function BotsPane() {
 
   const [grouping, setGrouping] = useState<null | RosterRow>(null)
   const [query, setQuery] = useState('')
-  const [rowKindFilter, setRowKindFilter] = useState<RosterKindFilter>('all')
-  const [activityFilter, setActivityFilter] = useState<RosterActivityFilter>('all')
-  const [gatewayFilter, setGatewayFilter] = useState('all')
+  const rowKindFilter = useValue($rosterKindFilter)
+  const setRowKindFilter = (value: RosterKindFilter) => $rosterKindFilter.set(value)
+  const activityFilter = useValue($rosterActivityFilter)
+  const setActivityFilter = (value: RosterActivityFilter) => $rosterActivityFilter.set(value)
+  const gatewayFilter = useValue($rosterGatewayFilter)
+  const setGatewayFilter = (value: string) => $rosterGatewayFilter.set(value)
   const [collapsedRosterSections, setCollapsedRosterSections] = useState<Set<string>>(() => new Set())
   const hiddenSectionRef = useRef<null | HTMLDivElement>(null)
   const activityToasts = useValue($activityToasts)
@@ -869,9 +878,7 @@ export function BotsPane() {
                 {activeFilterCount ? (
                   <DropdownMenuItem
                     onSelect={() => {
-                      setRowKindFilter('all')
-                      setActivityFilter('all')
-                      setGatewayFilter('all')
+                      resetRosterFilters()
                     }}
                   >
                     {b.roster.clearFilters}

--- a/apps/desktop/src/sdk/index.ts
+++ b/apps/desktop/src/sdk/index.ts
@@ -1647,6 +1647,14 @@ export { formatModifierToken } from '@/lib/keybinds/combo'
  *  a renderer that stays open for days. Only for values that can be
  *  regenerated — eviction costs a recompute or a refetch, never correctness. */
 export { LruCache } from '@/lib/lru-cache'
+/** A plugin-local atom that survives a reload. Same storage choke point core
+ *  view preferences use, so a plugin's remembered filters behave exactly like
+ *  the sidebar's — plugins must not reach for `@/lib/persisted` themselves
+ *  (the plugin fence), so the primitive is offered here. */
+export { Codecs, persistentAtom } from '@/lib/persisted'
+export type { Codec } from '@/lib/persisted'
+
+export const PANES_AREA = 'panes'
 /** The app's deterministic identity color for a name (profiles, assignees,
  *  authors), its translucent tag fill, and the curated picker swatches — so
  *  plugin-rendered identities read the same hue as everywhere else. The
@@ -1654,12 +1662,13 @@ export { LruCache } from '@/lib/lru-cache'
  *  hand-picked color still sits with the generated ones; reach for them
  *  instead of literal hex, which can't follow the theme. */
 export { PROFILE_SWATCHES, profileColor, profileColorSoft } from '@/lib/profile-color'
+export const STATUSBAR_AREAS = { left: 'statusBar.left', right: 'statusBar.right' } as const
+export const TITLEBAR_AREAS = { center: 'titleBar.center', left: 'titleBar.left', right: 'titleBar.right' } as const
+
 /** The shared client itself, for invalidation OUTSIDE React (e.g. a
  *  `ctx.socket` frame invalidating a query). Inside components keep using
  *  `useQueryClient`. */
 export { queryClient } from '@/lib/query-client'
-
-export const PANES_AREA = 'panes'
 /** Hermes' reasoning levels + their compact labels, so a plugin surfacing a
  *  thinking depth uses the same scale and spelling as the rest of the app. */
 export {
@@ -1669,9 +1678,6 @@ export {
   type ReasoningEffort,
   reasoningEffortLabel
 } from '@/lib/reasoning-effort'
-export const STATUSBAR_AREAS = { left: 'statusBar.left', right: 'statusBar.right' } as const
-export const TITLEBAR_AREAS = { center: 'titleBar.center', left: 'titleBar.left', right: 'titleBar.right' } as const
-
 /** The app's own gateway-readiness evaluation (setup.status +
  *  setup.runtime_check, reconciled) — pass `host.request`. Don't hand-roll
  *  readiness from raw RPC shapes. */


### PR DESCRIPTION
## The problem

The Bots roster keeps its kind/activity/gateway filters in component `useState`
(`plugins/hermes-bots/roster-pane.tsx`), so leaving the pane discards them. Every
return to the roster starts from `all`.

Core's own filter bar does not behave that way — `$sidebarStatusFilter`,
`$sidebarProjectFilter`, `$sidebarProfileFilter` and `$sidebarPrFilter` have always
been `persistentAtom`s under `hermes.desktop.sidebar*Filter` (`store/layout.ts`), and
`$showAllProfiles` (`store/profile.ts`) persists the same way. So the same window shows
two filter bars where only one remembers anything.

Reported by a user running a nine-bot roster who re-picked the same filters all day.
Confirmed against the running app's LevelDB: `hermes.desktop.showAllProfiles`,
`hermes.desktop.layoutTree.v` and `hermes.desktop.composer.provider` are all present —
no roster filter key exists.

## The change

Three filters move into persisted atoms in a new `roster-filters.ts`, keyed
`hermes.desktop.botRoster{Kind,Activity,Gateway}Filter`. The pane reads them through
`useValue` and the "reset filters" item calls one shared `resetRosterFilters()`.

Three decisions worth flagging, all open to correction:

**The search box stays ephemeral.** A query restored at boot renders a roster that
looks empty for a reason that is off-screen — worse than retyping it. The dropdowns are
where the complaint actually lives.

**The union filters decode through their own allowed values.** A stale key from an
older build, or a hand-edited one, falls back to `'all'` rather than poisoning the
filter with a value nothing can match. Covered by a test.

**`persistentAtom`/`Codecs` are re-exported from the SDK** rather than imported from
`@/lib/persisted` in the plugin. The plugin fence in `eslint.config.mjs` forbids the
latter, and its message prescribes exactly this remedy: *"Missing something? Add it to
the SDK."* If you would rather keep that primitive off the SDK surface, a
`host.state`-style accessor is the obvious alternative — happy to rework it.

`$showHiddenBots` in `hidden-bots.ts` is the same class of state but is commented as a
deliberate session-only toggle, so it is left untouched.

## Verification

- `roster-filters.test.ts` — 4 tests: defaults, survives a fresh module load, invalid
  stored value falls back, reset clears all three. Asserts the contract, not the key
  spelling.
- `vitest run --project ui` — **719 files, 7171 tests, all passing**
- `tsc -p . --noEmit` — clean
- `eslint src/plugins/hermes-bots/ src/sdk/index.ts` — clean, plugin fence included

## Open question

Should the keys be per-profile, given that roster contents depend on the active
profile? This PR uses global keys, matching the `hermes.desktop.sidebar*Filter`
precedent.

---

### Unrelated, but found while tracing this — a docs bug that costs users days

`website/docs/user-guide/bot-mode.md` states:

> There is also a preference to hide the canonical Bot Chats from the regular sidebar
> session list, so they only appear inside the Bots pane.

`plugins/hermes-bots/bot-state.ts:21` says the opposite:

> Bot Mode sessions are ALWAYS hidden from the global Sessions sidebar

There is no such preference; the behaviour is hard-wired.

The user above spent **four days** writing detailed context into what he believed was a
bot chat. Because Bot Mode offers two routes to the same bot — the Bots pane (hidden
canonical chat) and the profile rail (an ordinary, listed session) — and the docs
promised a toggle that would surface the former, he could not reconcile what he saw
with where his conversations actually were. They had been landing in the default
profile the whole time. Recovering that work meant reading them out of SQLite.

Worth either correcting the sentence, or implementing the preference it describes. If
the former, documenting *where* bot conversations live and how to reach them outside
the Bots pane would help — that was the genuinely hard part to reconstruct.

Happy to open this as a separate issue if you prefer it off this PR.
