### PR TITLE
session: interrupt running turn when session is deleted

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
+++ b/apps/desktop/src/app/session/hooks/use-session-actions/index.ts
@@ -2459,6 +2459,13 @@ export function useSessionActions({
 
       try {
         if (closingRuntimeId) {
+          // First interrupt the running turn so the worker thread stops
+          await requestForSessionProfile(removedOwner, requestGateway, 'session.interrupt', {
+            session_id: closingRuntimeId
+          }).catch(() => undefined)
+        }
+
+        if (closingRuntimeId) {
           await requestForSessionProfile(removedOwner, requestGateway, 'session.close', {
             session_id: closingRuntimeId
           }).catch(() => undefined)


### PR DESCRIPTION
Fixes #102895

## Problem

Deleting a desktop session while its agent turn is running did NOT
terminate the worker thread. The turn kept running (especially in
retry loops) and kept calling the model even after session deletion.

Observed behavior:
- User deletes a session while agent turn is in a retry loop
- The turn keeps running and calling the model for 10+ minutes after deletion
- Only a full app restart stops it

## Fix

`removeSession` now calls `session.interrupt` before `session.close`
to properly interrupt the running turn and destroy the worker thread.

This ensures the agent turn is properly cancelled when the session is
deleted, preventing the orphaned worker thread from continuing to call
the model.

## Tests

Manual verification:
1. Start an agent turn with multiple tool calls
2. Let it enter a retry loop (e.g., provider timeout, malformed args)
3. Delete the session in the desktop UI
4. Verify the agent turn stops and no more requests are sent to the model

Related: #80745 (TUI /stop does not interrupt running agent)