### PR TITLE
fix(ssl): don't blame certifi when CA load fails with EMFILE

### DIFF
--- a/agent/ssl_guard.py
+++ b/agent/ssl_guard.py
@@ -3,10 +3,12 @@ OpenAI/httpx turns them into an opaque ``FileNotFoundError``."""
 
 from __future__ import annotations
 
+import errno
 import logging
 import os
 import ssl
 from pathlib import Path
+from typing import NoReturn
 
 from agent.errors import SSLConfigurationError
 from utils import is_truthy_value
@@ -19,31 +21,74 @@ _REPAIR_HINT = (
     "manually: python -m pip install --force-reinstall certifi openai httpx\n"
     "If you configured a custom corporate CA bundle, fix or unset the broken CA bundle environment variable."
 )
+_FD_EXHAUSTION_HINT = (
+    "This process has run out of file descriptors (EMFILE). The CA bundle file "
+    "is probably intact — reinstalling certifi will not help.\n"
+    "Repair: restart the Hermes process that hit the limit. For Hermes Desktop "
+    "connected over SSH, quit and reopen the app (or kill the remote "
+    "`hermes serve --isolated` process so Desktop respawns it). "
+    "Long-lived backends that keep leaking fds should be restarted after "
+    "`hermes update`; raising nofile only delays the outage."
+)
 
 
-def _ssl_err(message: str) -> SSLConfigurationError:
+def is_fd_exhaustion_error(exc: BaseException) -> bool:
+    """True when *exc* (or its cause chain) is EMFILE/ENFILE / "too many open files".
+
+    ``ssl.create_default_context(cafile=...)`` needs a spare fd to open the
+    bundle. When the process is already at RLIMIT_NOFILE the OSError is wrapped
+    as "CA bundle cannot be loaded", which used to send operators at
+    ``hermes doctor --fix`` / a certifi reinstall. See #88033.
+    """
+    current: BaseException | None = exc
+    seen: set[int] = set()
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if isinstance(current, OSError) and current.errno in (errno.EMFILE, errno.ENFILE):
+            return True
+        text = str(current).lower()
+        if "too many open files" in text or "emfile" in text or "[errno 24]" in text:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
+
+
+def _ssl_err(message: str, *, fd_exhausted: bool = False) -> SSLConfigurationError:
     """Create a consistent, user-actionable SSL configuration error."""
-    return SSLConfigurationError(f"{message}\n{_REPAIR_HINT}")
+    hint = _FD_EXHAUSTION_HINT if fd_exhausted else _REPAIR_HINT
+    return SSLConfigurationError(f"{message}\n{hint}")
+
+
+def _reraise_bundle_load_error(label: str, value: str, exc: BaseException) -> NoReturn:
+    raise _ssl_err(
+        f"{label} CA bundle at {value} cannot be loaded: {exc}",
+        fd_exhausted=is_fd_exhaustion_error(exc),
+    ) from exc
 
 
 def _validate_bundle_path(label: str, value: str, *, require_substantial: bool = False) -> None:
-    path = Path(value).expanduser()
-    if not path.exists():
-        raise _ssl_err(f"{label} points to a missing CA bundle: {value}")
-    if not path.is_file():
-        raise _ssl_err(f"{label} does not point to a CA bundle file: {value}")
-    if require_substantial and path.stat().st_size < 1024:
-        raise _ssl_err(f"{label} at {value} appears corrupted (too small)")
     try:
-        ctx = ssl.create_default_context(cafile=str(path))
-    except Exception as exc:
-        raise _ssl_err(f"{label} CA bundle at {value} cannot be loaded: {exc}") from exc
-    try:
-        loaded_certs = ctx.get_ca_certs()
-    except NotImplementedError:  # truststore-backed SSLContext (Windows) lacks get_ca_certs(); loading validated it
-        return
-    if not loaded_certs:
-        raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
+        path = Path(value).expanduser()
+        if not path.exists():
+            raise _ssl_err(f"{label} points to a missing CA bundle: {value}")
+        if not path.is_file():
+            raise _ssl_err(f"{label} does not point to a CA bundle file: {value}")
+        if require_substantial and path.stat().st_size < 1024:
+            raise _ssl_err(f"{label} at {value} appears corrupted (too small)")
+        try:
+            ctx = ssl.create_default_context(cafile=str(path))
+        except Exception as exc:
+            _reraise_bundle_load_error(label, value, exc)
+        try:
+            loaded_certs = ctx.get_ca_certs()
+        except NotImplementedError:  # truststore-backed SSLContext (Windows) lacks get_ca_certs(); loading validated it
+            return
+        if not loaded_certs:
+            raise _ssl_err(f"{label} CA bundle at {value} did not load any certificates")
+    except SSLConfigurationError:
+        raise
+    except OSError as exc:
+        _reraise_bundle_load_error(label, value, exc)
 
 
 def verify_ca_bundle() -> None:
@@ -58,7 +103,7 @@ def verify_ca_bundle() -> None:
     try:
         import certifi
     except Exception as exc:
-        raise _ssl_err(f"certifi is not importable: {exc}") from exc
+        raise _ssl_err(f"certifi is not importable: {exc}", fd_exhausted=is_fd_exhaustion_error(exc)) from exc
     _validate_bundle_path("certifi", str(certifi.where()), require_substantial=True)
 
 

--- a/hermes_cli/doctor_platform.py
+++ b/hermes_cli/doctor_platform.py
@@ -182,7 +182,7 @@ def check_certificates(should_fix: bool = False, issues: "list | None" = None) -
     certifi into THIS interpreter's environment and re-verifying.
     """
     try:
-        from agent.ssl_guard import verify_ca_bundle
+        from agent.ssl_guard import is_fd_exhaustion_error, verify_ca_bundle
         from agent.errors import SSLConfigurationError
     except Exception as e:
         return check_warn("SSL certificate check skipped", str(e))
@@ -193,8 +193,17 @@ def check_certificates(should_fix: bool = False, issues: "list | None" = None) -
         return check_ok("SSL CA certificate bundle is valid")
     except SSLConfigurationError as e:
         first_error = str(e)
+        fd_exhausted = is_fd_exhaustion_error(e)
     except Exception as e:
         return check_warn("SSL certificate check skipped", str(e))
+    if fd_exhausted:
+        check_fail("SSL CA check failed: process is out of file descriptors", first_error)
+        issues.append(
+            "Restart the Hermes process that hit EMFILE (Desktop SSH: quit/reopen "
+            "the app, or kill remote `hermes serve --isolated` so Desktop respawns it). "
+            "Do not reinstall certifi — the CA bundle was not the failure."
+        )
+        return
     check_fail("SSL CA certificate bundle is broken", first_error)
     pip_cmd = f"{sys.executable} -m pip install --force-reinstall certifi"
     if not should_fix:

--- a/tests/agent/test_ssl_ca_guard.py
+++ b/tests/agent/test_ssl_ca_guard.py
@@ -1,12 +1,13 @@
 """Tests for the preventive SSL CA bundle guard."""
 
+import errno
 from pathlib import Path
 
 import certifi
 import pytest
 
 from agent.errors import SSLConfigurationError
-from agent.ssl_guard import verify_ca_bundle
+from agent.ssl_guard import is_fd_exhaustion_error, verify_ca_bundle
 
 
 def test_healthy_bundle_passes(monkeypatch):
@@ -71,3 +72,72 @@ def test_truststore_get_ca_certs_not_implemented_is_accepted(monkeypatch, tmp_pa
 
     # Must not raise on the explicit env bundle nor the certifi check.
     verify_ca_bundle()
+
+
+def _write_tiny_pem(path: Path) -> Path:
+    path.write_text(
+        "-----BEGIN CERTIFICATE-----\nfake\n-----END CERTIFICATE-----\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_emfile_loading_bundle_does_not_recommend_certifi_reinstall(monkeypatch, tmp_path):
+    """FD exhaustion while opening the CA file is not a broken certifi install.
+
+    Long-lived `hermes serve --isolated` (Desktop SSH) hits RLIMIT_NOFILE and
+    then agent init fails in ssl_guard with a message that used to tell the
+    operator to run `hermes doctor --fix`. That reinstall cannot open the
+    bundle either and hides the real leak (#88033).
+    """
+    from agent import ssl_guard
+
+    bundle = _write_tiny_pem(tmp_path / "bundle.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
+
+    def _boom(*a, **k):
+        raise OSError(errno.EMFILE, "Too many open files")
+
+    monkeypatch.setattr(ssl_guard.ssl, "create_default_context", _boom)
+    with pytest.raises(SSLConfigurationError) as exc:
+        verify_ca_bundle()
+    message = str(exc.value)
+    assert "Too many open files" in message
+    assert "force-reinstall" not in message
+    assert "hermes doctor --fix" not in message
+    assert "file descriptor" in message.lower()
+    assert "serve --isolated" in message
+    assert is_fd_exhaustion_error(exc.value)
+
+
+def test_emfile_on_stat_is_classified_as_fd_exhaustion(monkeypatch, tmp_path):
+    """exists()/stat() can also raise EMFILE before the bundle is opened."""
+    from pathlib import Path as PathType
+
+    bundle = _write_tiny_pem(tmp_path / "bundle.pem")
+    monkeypatch.setenv("SSL_CERT_FILE", str(bundle))
+
+    real_exists = PathType.exists
+
+    def _exists(self):
+        if self == bundle or self.resolve() == bundle.resolve():
+            raise OSError(errno.EMFILE, "Too many open files")
+        return real_exists(self)
+
+    monkeypatch.setattr(PathType, "exists", _exists)
+    with pytest.raises(SSLConfigurationError) as exc:
+        verify_ca_bundle()
+    assert "force-reinstall" not in str(exc.value)
+    assert is_fd_exhaustion_error(exc.value)
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        OSError(errno.EMFILE, "Too many open files"),
+        OSError(errno.ENFILE, "Too many open files in system"),
+        SSLConfigurationError("CA bundle cannot be loaded: [Errno 24] Too many open files"),
+    ],
+)
+def test_is_fd_exhaustion_error_detects_wrapped_and_raw(exc):
+    assert is_fd_exhaustion_error(exc)

--- a/tests/hermes_cli/test_certifi_repair.py
+++ b/tests/hermes_cli/test_certifi_repair.py
@@ -192,6 +192,29 @@ class TestDoctorCertificates:
         out = capsys.readouterr().out
         assert "valid" in out.lower()
 
+    def test_emfile_does_not_reinstall_certifi(self, monkeypatch, capsys):
+        """`--fix` must not pip-install certifi when the failure is EMFILE."""
+        from agent.errors import SSLConfigurationError
+
+        def fake_verify():
+            raise SSLConfigurationError(
+                "SSL_CERT_FILE CA bundle at /venv/certifi/cacert.pem cannot be loaded: "
+                "[Errno 24] Too many open files"
+            )
+
+        def _fail_run(*a, **k):
+            raise AssertionError("EMFILE must not trigger a certifi reinstall")
+
+        monkeypatch.setattr("agent.ssl_guard.verify_ca_bundle", fake_verify)
+        monkeypatch.setattr(subprocess, "run", _fail_run)
+        issues = []
+        doctor_platform.check_certificates(should_fix=True, issues=issues)
+        out = capsys.readouterr().out
+        assert "file descriptor" in out.lower()
+        assert issues
+        assert any("serve --isolated" in i for i in issues)
+        assert not any("force-reinstall certifi" in i for i in issues)
+
 
 # =========================================================================
 # 3. Startup error message stays actionable


### PR DESCRIPTION
## What does this PR do?

When a long-lived Hermes process (especially Desktop's SSH `hermes serve --isolated` backend) hits `RLIMIT_NOFILE`, agent init fails while `ssl_guard` tries to open `certifi`'s `cacert.pem`. The previous error always appended the certifi repair hint (`hermes doctor --fix` / `pip install --force-reinstall certifi`), which cannot open the bundle either and hides the real cause.

This classifies EMFILE/ENFILE (and wrapped "too many open files" / `[Errno 24]` text) and tells the operator to restart the exhausted process. `hermes doctor --fix` no longer force-reinstalls certifi on that path.

## Related Issue

Related to #88033 (the SessionDB fd leak that produces this symptom on long-lived `hermes serve`). The leak itself is already fixed on main; this PR is the remaining misdiagnosis in `ssl_guard` / doctor. Also adjacent to #97046 / #101822 (Desktop SSH backends staying stale across `hermes update`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/ssl_guard.py` — detect fd exhaustion on CA bundle open/stat; emit a restart hint instead of a certifi reinstall hint
- `hermes_cli/doctor_platform.py` — skip `--fix` certifi reinstall when the SSL error is EMFILE
- `tests/agent/test_ssl_ca_guard.py`, `tests/hermes_cli/test_certifi_repair.py` — cover both surfaces

## How to Test

1. `PYTHONPATH=. python3 -m pytest tests/agent/test_ssl_ca_guard.py tests/hermes_cli/test_certifi_repair.py -q`
2. Broken-certifi path is unchanged: a missing `SSL_CERT_FILE` still mentions `hermes doctor --fix`.
3. Simulated EMFILE on `ssl.create_default_context` must **not** mention `force-reinstall`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/agent/test_ssl_ca_guard.py tests/hermes_cli/test_certifi_repair.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 26.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Observed on a Contabo VPS Desktop SSH backend at 1024/1024 fds (~988 leftover `state.db`/`state.db-wal` handles after 18 days). Agent init printed:

```
Failed to initialize OpenAI client: SSL_CERT_FILE CA bundle at
.../certifi/cacert.pem cannot be loaded: [Errno 24] Too many open files
Repair: run hermes doctor --fix (auto-reinstalls certifi), ...
```

The bundle file was intact; `hermes doctor --fix` was the wrong action.