### PR TITLE
fix(gateway): detect launchd jobs by explicit domain

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3490,13 +3490,12 @@ def _launchd_reload_budget() -> float:
 
 
 def _launchctl_label_supervising_process(label: str) -> bool:
-    """True when launchd knows ``label`` AND runs a process for it. ``launchctl list`` exits 0 for a
-    mere registered definition (``state = not running`` on macOS 26+), so a positive PID is required."""
+    """True when an explicit launchd domain contains a live process for ``label``."""
     try:
-        result = subprocess.run(["launchctl", "list", label], check=False, timeout=10, **_CAPTURE_TEXT)
+        domain, pid = _locate_launchd_gateway_service(label)
     except (subprocess.TimeoutExpired, OSError):
         return False
-    return result.returncode == 0 and _parse_launchd_pid_from_list_output(result.stdout) is not None
+    return domain is not None and pid is not None
 
 
 def _retry_launchctl_bootstrap_until_registered(
@@ -3511,7 +3510,7 @@ def _retry_launchctl_bootstrap_until_registered(
             _launchctl_bootstrap(domain, plist_path, label, timeout=30)
             if _launchctl_label_supervising_process(label):
                 return True
-            outcome = f"exited 0 but {domain}/{label} has no supervised process (launchctl list)"
+            outcome = f"exited 0 but {domain}/{label} has no supervised process (launchctl print)"
         except subprocess.CalledProcessError as exc:
             outcome = f"failed (rc={exc.returncode}) for {domain}/{label}"
         except subprocess.TimeoutExpired:
@@ -4120,15 +4119,21 @@ def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
     label = get_launchd_label()
     try:
-        result = subprocess.run(["launchctl", "list", label], timeout=10, **_CAPTURE_TEXT)
-        service_listed = result.returncode == 0
-        list_output = result.stdout
-    except subprocess.TimeoutExpired:
-        service_listed = False
-        list_output = ""
+        launchd_domain, launchd_pid = _locate_launchd_gateway_service(label)
+    except (subprocess.TimeoutExpired, OSError):
+        launchd_domain, launchd_pid = (None, None)
 
-    # `launchctl list` exits 0 for any registered definition (even `state = not running`); only a PID proves a process.
-    launchd_pid = _parse_launchd_pid_from_list_output(list_output) if service_listed else None
+    service_listed = launchd_domain is not None
+    list_output = ""
+    if not service_listed:
+        try:
+            result = subprocess.run(["launchctl", "list", label], timeout=10, **_CAPTURE_TEXT)
+            service_listed = result.returncode == 0
+            list_output = result.stdout
+            if service_listed:
+                launchd_pid = _parse_launchd_pid_from_list_output(list_output)
+        except (subprocess.TimeoutExpired, OSError):
+            pass
 
     # Hermes PID may be a detached fallback process; when launchd IS supervising both PIDs match — don't double-count.
     from gateway.status import get_running_pid

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -616,17 +616,10 @@ class TestLaunchdServiceRecovery:
 
         def fake_run(cmd, check=False, **kwargs):
             run_calls.append(cmd)
-            if cmd[:2] == ["launchctl", "list"]:
-                # Post-bootstrap launchd reports a supervised PID; without one
-                # the success check correctly refuses to stop retrying.
-                return SimpleNamespace(
-                    returncode=0,
-                    stdout='{\n\t"PID" = 5150;\n\t"Label" = "ai.hermes.gateway";\n};',
-                    stderr="",
-                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_launchctl_label_supervising_process", lambda label: True)
 
         assert gateway_cli.refresh_launchd_plist_if_needed() is True
 
@@ -675,6 +668,32 @@ class TestLaunchdServiceRecovery:
     # ── launchd_status with active supervision ───────────────────────────
 
 
+    def test_launchd_checks_find_gui_job_from_background_context(self, tmp_path, monkeypatch, capsys):
+        """Every status path must use the explicit domain when legacy list cannot see it."""
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(os, "getuid", lambda: 501)
+
+        def fake_run(cmd, **kwargs):
+            if cmd[:2] == ["launchctl", "list"]:
+                raise AssertionError("legacy list must not run after an explicit-domain match")
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return SimpleNamespace(returncode=0, stdout="pid = 65929\n", stderr="")
+            return SimpleNamespace(returncode=113, stdout="", stderr="not found")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr("gateway.status.get_running_pid", lambda cleanup_stale=False: 65932)
+
+        assert gateway_cli._launchctl_label_supervising_process(gateway_cli.get_launchd_label())
+        assert gateway_cli._probe_launchd_service_running()
+        gateway_cli.launchd_status()
+
+        out = capsys.readouterr().out
+        assert "Gateway is supervised by launchd (PID 65929)" in out
+        assert "Gateway service is not loaded" not in out
+
+
     def test_launchd_status_reports_fallback_when_unsupported_and_pid_running(self, tmp_path, monkeypatch, capsys):
         """When the unsupported marker exists and a fallback PID is running."""
         plist_path = tmp_path / "ai.hermes.gateway.plist"
@@ -682,6 +701,8 @@ class TestLaunchdServiceRecovery:
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
 
         def fake_run(cmd, capture_output=False, text=False, timeout=None, check=False, **kwargs):
+            if isinstance(cmd, list) and cmd[:2] == ["launchctl", "print"]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="not found")
             if isinstance(cmd, list) and cmd[:2] == ["launchctl", "list"]:
                 return SimpleNamespace(
                     returncode=0,
@@ -2443,27 +2464,19 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
     PLIST = "/tmp/ai.hermes.gateway.plist"
     LABEL = "ai.hermes.gateway"
 
-    # `launchctl list <label>` output for a job launchd is actively running.
-    # Success requires a PID here, not just exit 0 — exit 0 alone also covers a
-    # registered-but-not-running definition (macOS 26+ `state = not running`).
-    RUNNING_LIST_OUTPUT = '{\n\t"PID" = 4242;\n\t"Label" = "ai.hermes.gateway";\n};'
-
     def test_returns_true_once_label_is_registered(self, monkeypatch):
-        """Success requires launchctl list to confirm a supervised process, not
-        just a zero bootstrap exit."""
-        list_results = iter([1, 0])  # first check: not registered, second: registered
+        """Success requires a supervised process, not just a zero bootstrap exit."""
+        probe_results = iter([False, True])
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "list"]:
-                rc = next(list_results)
-                return SimpleNamespace(
-                    returncode=rc,
-                    stdout=self.RUNNING_LIST_OUTPUT if rc == 0 else "",
-                    stderr="",
-                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_label_supervising_process",
+            lambda label: next(probe_results),
+        )
         monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
 
         ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
@@ -2483,17 +2496,14 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
                 if attempts["bootstrap"] == 1:
                     raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout", 30))
                 return SimpleNamespace(returncode=0, stdout="", stderr="")
-            if cmd[:2] == ["launchctl", "list"]:
-                # registered only after the second (successful) bootstrap
-                ok = attempts["bootstrap"] >= 2
-                return SimpleNamespace(
-                    returncode=0 if ok else 1,
-                    stdout=self.RUNNING_LIST_OUTPUT if ok else "",
-                    stderr="",
-                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            gateway_cli,
+            "_launchctl_label_supervising_process",
+            lambda label: attempts["bootstrap"] >= 2,
+        )
         monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
 
         ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
@@ -2505,25 +2515,21 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
     def test_registered_but_not_running_is_not_success(self, monkeypatch):
         """A definition with no PID must not end the loop.
 
-        `launchctl list` exits 0 for a registered-but-not-running job (macOS
-        26+ `state = not running`), so exit-0 alone would report success for a
-        gateway launchd is not actually running. Verified against live launchd
-        on 2026-08-05.
+        A domain may contain a registered-but-not-running job, so registration
+        alone would report success for a gateway launchd is not actually
+        running. Verified against live launchd on 2026-08-05.
         """
-        list_calls = {"n": 0}
+        probe_calls = {"n": 0}
 
         def fake_run(cmd, check=False, **kwargs):
-            if cmd[:2] == ["launchctl", "list"]:
-                list_calls["n"] += 1
-                # Registered (exit 0) but no PID line — never running.
-                return SimpleNamespace(
-                    returncode=0,
-                    stdout='{\n\t"Label" = "ai.hermes.gateway";\n};',
-                    stderr="",
-                )
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
+        def fake_probe(label):
+            probe_calls["n"] += 1
+            return False
+
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_launchctl_label_supervising_process", fake_probe)
         monkeypatch.setattr(gateway_cli.time, "sleep", lambda *_a, **_k: None)
 
         ok = gateway_cli._retry_launchctl_bootstrap_until_registered(
@@ -2531,7 +2537,7 @@ class TestRetryLaunchctlBootstrapUntilRegistered:
             deadline=gateway_cli.time.monotonic() - 1,  # already expired
         )
         assert ok is False
-        assert list_calls["n"] >= 1
+        assert probe_calls["n"] >= 1
 
 
 class TestTimeoutStopSecCoversCronFloor:


### PR DESCRIPTION
## What does this PR do?

Fixes false launchd registration and supervision failures when Hermes is invoked from a different launchd bootstrap context than the gateway service.

On macOS, legacy `launchctl list <label>` infers its domain from the caller. A Hermes CLI running from a Background context can therefore miss a healthy gateway registered in `gui/<uid>`, report it as an unmanaged detached process, and reject successful bootstrap verification.

This change reuses the existing domain-explicit `gui/<uid>` / `user/<uid>` lookup for supervision checks. `launchd_status()` retains the legacy list probe only as a compatibility fallback when neither explicit domain is accessible, preserving diagnostics for registered-but-unmanageable environments.

## Related Issue

No linked issue. Reproduced directly on macOS 26.6.2.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Use `_locate_launchd_gateway_service()` for runtime and bootstrap supervision checks.
- Make `launchd_status()` prefer explicit `launchctl print <domain>/<label>` results while preserving its legacy compatibility fallback.
- Update bootstrap retry tests for the domain-explicit supervision contract.
- Add one consolidated invariant test covering status, runtime snapshot detection, and bootstrap supervision from a Background caller when the service lives in the GUI domain.

## How to Test

1. Register `ai.hermes.gateway` in `gui/<uid>` and invoke Hermes from a Background launchd context where `launchctl list ai.hermes.gateway` returns nonzero.
2. Run `scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_update_launchd_restart_verification.py -q`.
3. Run `hermes gateway status` and verify that it reports the PID as supervised without the detached-process mismatch warning.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — scoped affected suites were run through `scripts/run_tests.sh`: 116 passed, 1 skipped
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.6.2, Python 3.11.16

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A beyond the updated helper contract
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A; no config changes
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A; no architecture or workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — macOS-only code path; no other platform behavior changes
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A; no tool schema changes

## Screenshots / Logs

The invariant test fails on unmodified `origin/main` because `_launchctl_label_supervising_process()` calls legacy `launchctl list` from the wrong context. With this commit, the scoped repository test runner reports:

```text
=== Summary: 2 files, 116 tests passed, 0 failed, 1 skipped ===
```

Live verification with the patched upstream checkout:

```text
✓ Service definition matches the current Hermes install
✓ Gateway is supervised by launchd (PID 65929)
  Auto-start at login and auto-restart on crash are available.
```
