### PR TITLE
fix(agent): keep Windows locale errors from crashing conversations

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -11,6 +11,7 @@ import httpx
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import AuthError, _read_codex_tokens, resolve_codex_runtime_credentials
 from hermes_cli.runtime_provider import resolve_runtime_provider
+from hermes_time import safe_strftime
 
 if TYPE_CHECKING:
     from typing import TypeGuard
@@ -79,7 +80,7 @@ def _format_reset(dt: Optional[datetime]) -> str:
     delta = dt - _utc_now()
     total_seconds = int(delta.total_seconds())
     if total_seconds <= 0:
-        return f"now ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
+        return f"now ({safe_strftime(local_dt, '%Y-%m-%d %H:%M %Z')})"
     hours, rem = divmod(total_seconds, 3600)
     minutes = rem // 60
     if hours >= 24:
@@ -89,7 +90,7 @@ def _format_reset(dt: Optional[datetime]) -> str:
         rel = f"in {hours}h {minutes}m"
     else:
         rel = f"in {minutes}m"
-    return f"{rel} ({local_dt.strftime('%Y-%m-%d %H:%M %Z')})"
+    return f"{rel} ({safe_strftime(local_dt, '%Y-%m-%d %H:%M %Z')})"
 
 
 def render_account_usage_lines(snapshot: Optional[AccountUsageSnapshot], *, markdown: bool = False) -> list[str]:

--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -960,7 +960,11 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
         _plugin_section_blocks(_frozen_plugin_prompt_sections(agent), "after_memory")
     )
 
-    from hermes_time import get_timezone as _hermes_tz, now as _hermes_now
+    from hermes_time import (
+        get_timezone as _hermes_tz,
+        now as _hermes_now,
+        safe_strftime,
+    )
     now = _hermes_now()
     # Date-only (not minute-precision) so the system prompt is byte-stable
     # for the full day.  Minute-precision changes invalidate prefix-cache KV
@@ -983,16 +987,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _iana = getattr(_tz, "key", None)
     if _iana:
         _zone_bits.append(_iana)
-    _abbrev = now.strftime("%Z")
+    _abbrev = safe_strftime(now, "%Z")
     if _abbrev and _abbrev != _iana:
         _zone_bits.append(_abbrev)
-    _offset = now.strftime("%z")
+    _offset = safe_strftime(now, "%z")
     if _offset:  # '-0400' -> 'UTC-04:00'
         _zone_bits.append(f"UTC{_offset[:3]}:{_offset[3:]}")
     _zone_suffix = f" ({', '.join(_zone_bits)})" if _zone_bits else ""
     _start = _session_start_like(agent, now)
     timestamp_line = (
-        f"Conversation started: {_start.strftime('%A, %B %d, %Y')}{_zone_suffix}"
+        f"Conversation started: {safe_strftime(_start, '%A, %B %d, %Y')}{_zone_suffix}"
     )
     # Second line (maintainer design, salvaging #96224's anchor): long-lived
     # sessions — Bot Mode forever-chats, messenger channels people never
@@ -1004,10 +1008,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # the added line costs no extra cache churn. Same-day sessions skip the
     # second line entirely — nothing to correct, and the single-line shape
     # stays byte-identical for the day (prefix-cache safe).
-    if now.strftime("%Y%m%d") != _start.strftime("%Y%m%d"):
+    if safe_strftime(now, "%Y%m%d") != safe_strftime(_start, "%Y%m%d"):
         timestamp_line += (
             f"\nToday's date (as of the last context rebuild): "
-            f"{now.strftime('%A, %B %d, %Y')} — trust this over the start "
+            f"{safe_strftime(now, '%A, %B %d, %Y')} — trust this over the start "
             f"date for what day it is now; query tools for exact time."
         )
     # Bot Chat sessions are effectively eternal — a birth date frozen in the

--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -11,6 +11,8 @@ import re
 from datetime import datetime
 from typing import Any, Optional, Tuple
 
+from hermes_time import safe_strftime
+
 
 # Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
 _HUMAN_TIMESTAMP_RE = re.compile(
@@ -82,7 +84,7 @@ def format_message_timestamp(ts_value: Any, tz=None) -> str:
         dt = datetime.fromtimestamp(epoch, tz=tz)
     else:
         dt = datetime.fromtimestamp(epoch).astimezone()
-    return "[" + dt.strftime("%a %Y-%m-%d %H:%M:%S %Z") + "]"
+    return "[" + safe_strftime(dt, "%a %Y-%m-%d %H:%M:%S %Z") + "]"
 
 
 def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -43,6 +43,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli._subprocess_compat import noninteractive_git_env
+from hermes_time import safe_strftime
 
 logger = logging.getLogger(__name__)
 
@@ -1249,7 +1250,9 @@ def judge_goal(
     # truth.
     clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]
     background_block = _render_background_block(background_processes)
-    current_time = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    current_time = safe_strftime(
+        datetime.now(tz=timezone.utc).astimezone(), "%Y-%m-%d %H:%M:%S %Z"
+    )
 
     if contract is not None and not contract.is_empty():
         contract_block = contract.render_block()

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -25,6 +25,7 @@ from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
+from hermes_time import safe_strftime
 from tools.tool_backend_helpers import managed_nous_tools_enabled
 
 def check_mark(ok: bool) -> str:
@@ -60,7 +61,7 @@ def _format_iso_timestamp(value) -> str:
             parsed = parsed.replace(tzinfo=timezone.utc)
     except Exception:
         return value
-    return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    return safe_strftime(parsed.astimezone(), "%Y-%m-%d %H:%M:%S %Z")
 
 
 def _format_relative_ts(ts: float) -> str:

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -15,10 +15,13 @@ crashes due to a bad timezone string.
 
 import logging
 import os
+import re
 import threading
 from datetime import datetime
-from hermes_constants import get_config_path
 from typing import Dict, Optional, Tuple
+
+from agent.message_sanitization import _sanitize_surrogates
+from hermes_constants import get_config_path
 
 logger = logging.getLogger(__name__)
 
@@ -41,6 +44,99 @@ except ImportError:
 # multiplex switches. Call reset_cache() after in-place config changes.
 _cache_lock = threading.Lock()
 _tz_cache: Dict[Tuple[str, str], Tuple[str, Optional[ZoneInfo]]] = {}
+
+_WEEKDAY_NAMES = (
+    ("Monday", "Mon"),
+    ("Tuesday", "Tue"),
+    ("Wednesday", "Wed"),
+    ("Thursday", "Thu"),
+    ("Friday", "Fri"),
+    ("Saturday", "Sat"),
+    ("Sunday", "Sun"),
+)
+_MONTH_NAMES = (
+    ("January", "Jan"),
+    ("February", "Feb"),
+    ("March", "Mar"),
+    ("April", "Apr"),
+    ("May", "May"),
+    ("June", "Jun"),
+    ("July", "Jul"),
+    ("August", "Aug"),
+    ("September", "Sep"),
+    ("October", "Oct"),
+    ("November", "Nov"),
+    ("December", "Dec"),
+)
+_LOCALE_DIRECTIVE_RE = re.compile(r"(?<!%)%(?:[EO])?([aAbBchpXxZz])")
+
+
+def _numeric_utc_offset(value: datetime) -> str:
+    offset = value.utcoffset()
+    if offset is None:
+        return ""
+    total_seconds = int(offset.total_seconds())
+    sign = "+" if total_seconds >= 0 else "-"
+    total_seconds = abs(total_seconds)
+    hours, remainder = divmod(total_seconds, 3600)
+    minutes, seconds = divmod(remainder, 60)
+    suffix = f"{seconds:02d}" if seconds else ""
+    return f"{sign}{hours:02d}{minutes:02d}{suffix}"
+
+
+def _portable_directive(value: datetime, directive: str) -> str:
+    weekday_long, weekday_short = _WEEKDAY_NAMES[value.weekday()]
+    month_long, month_short = _MONTH_NAMES[value.month - 1]
+    hour = getattr(value, "hour", 0)
+    minute = getattr(value, "minute", 0)
+    second = getattr(value, "second", 0)
+    replacements = {
+        "a": weekday_short,
+        "A": weekday_long,
+        "b": month_short,
+        "h": month_short,
+        "B": month_long,
+        "c": (
+            f"{weekday_short} {month_short} {value.day:02d} "
+            f"{hour:02d}:{minute:02d}:{second:02d} {value.year:04d}"
+        ),
+        "p": "AM" if hour < 12 else "PM",
+        "X": f"{hour:02d}:{minute:02d}:{second:02d}",
+        "x": f"{value.year:04d}-{value.month:02d}-{value.day:02d}",
+        "z": _numeric_utc_offset(value),
+    }
+    if directive == "Z":
+        try:
+            return value.tzname() or ""
+        except UnicodeEncodeError:
+            return ""
+    return replacements[directive]
+
+
+def safe_strftime(value: datetime, fmt: str) -> str:
+    """Format a datetime without leaking invalid locale surrogates.
+
+    Some Windows locale/code-page combinations raise ``UnicodeEncodeError``
+    inside ``strftime`` before Python receives a string. Retry with portable
+    replacements for locale-sensitive directives, then scrub any surrogate
+    code points returned by the platform or ``tzname()``.
+    """
+    try:
+        rendered = value.strftime(fmt)
+    except UnicodeEncodeError:
+        replacements: Dict[str, str] = {}
+
+        def replace_directive(match: re.Match[str]) -> str:
+            token = f"__HERMES_TIME_{len(replacements)}__"
+            replacements[token] = _sanitize_surrogates(
+                _portable_directive(value, match.group(1))
+            )
+            return token
+
+        rendered = value.strftime(_LOCALE_DIRECTIVE_RE.sub(replace_directive, fmt))
+        for token, replacement in replacements.items():
+            rendered = rendered.replace(token, replacement)
+    return _sanitize_surrogates(rendered)
 
 
 def _timezone_cache_identity() -> Tuple[str, str]:

--- a/tests/agent/test_system_prompt.py
+++ b/tests/agent/test_system_prompt.py
@@ -756,6 +756,28 @@ class TestConversationStartedTwoLine:
         assert "Conversation started:" in vol
         assert "as of the last context rebuild" not in vol
 
+    def test_windows_locale_strftime_error_does_not_abort_prompt(self):
+        class _UnicodeFailingDateTime(datetime):
+            def strftime(self, fmt):
+                if "%Z" in fmt:
+                    raise UnicodeEncodeError(
+                        "utf-8", "\udce9", 0, 1, "surrogates not allowed"
+                    )
+                return super().strftime(fmt)
+
+            def tzname(self):
+                return "Paris \udce9"
+
+        current = _UnicodeFailingDateTime(
+            2026, 7, 14, 13, 5, tzinfo=ZoneInfo("Europe/Paris")
+        )
+        with patch("hermes_time.now", return_value=current):
+            vol = self._volatile(self._agent("20260714_090000_fresh"))
+
+        assert "Conversation started: Tuesday, July 14, 2026" in vol
+        assert "Paris �" in vol
+        vol.encode("utf-8")
+
     def test_timeless_bot_chat_unaffected(self):
         agent = self._agent("20200110_090000_old")
         agent._bot_chat_timeless_prompt = True

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -64,6 +64,37 @@ class TestHermesTimeNow:
         assert offset_hours in {-5, -4}
 
 
+class _UnicodeFailingDateTime(datetime):
+    """Model Windows strftime failing before it can return locale text."""
+
+    def strftime(self, fmt):
+        if any(code in fmt for code in ("%A", "%B", "%Z", "%z")):
+            raise UnicodeEncodeError("utf-8", "\udce9", 0, 1, "surrogates not allowed")
+        return super().strftime(fmt)
+
+    def tzname(self):
+        return "Paris \udce9"
+
+
+class TestSafeStrftime:
+    def test_sanitizes_surrogates_returned_by_platform(self):
+        class _ReturningSurrogate:
+            def strftime(self, _fmt):
+                return "Paris \udce9"
+
+        assert hermes_time.safe_strftime(_ReturningSurrogate(), "%Z") == "Paris �"
+
+    def test_recovers_when_windows_locale_formatting_raises(self):
+        value = _UnicodeFailingDateTime(
+            2026, 7, 14, 13, 5, tzinfo=timezone(timedelta(hours=2))
+        )
+
+        rendered = hermes_time.safe_strftime(value, "%A, %B %d, %Y %H:%M %Z %z")
+
+        assert rendered == "Tuesday, July 14, 2026 13:05 Paris � +0200"
+        rendered.encode("utf-8")
+
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Prevents Windows users with affected locale/code-page combinations from losing every new or compressed conversation when Python raises `UnicodeEncodeError` while formatting local timezone text. It adds a shared formatter that retries locale-sensitive directives with portable values and removes lone surrogates before formatted timestamps enter prompts or output.

### Symptom

Starting or compressing a conversation can fail with `UnicodeEncodeError: surrogates not allowed` while the system prompt formats `%Z`.

### Impact

Affected Windows locale configurations cannot start conversations reliably, and the failure repeats whenever Hermes rebuilds the system prompt.

### Bug Cause

**Trigger:** `agent/system_prompt.py:990` / `build_system_prompt_parts()` / a Windows locale whose `strftime()` result cannot be encoded safely.

**Causal chain:**
1. A new conversation or context compression rebuilds the system prompt.
2. `datetime.strftime()` formats locale-sensitive timezone, weekday, or month directives and raises before returning a Python string.
3. Prompt construction aborts, so the desktop gateway cannot dispatch the conversation.

**Why it is wrong:** Existing surrogate sanitization only operates after a string exists, so it cannot run when the platform formatter raises internally.

**Working sibling / contrast:** Numeric-only datetime formats do not depend on localized names and continue to format normally.

**Ruled out:** API JSON serialization is not the origin of this failure because the exception occurs during prompt construction, before the request payload is built.

### Fix

Add `hermes_time.safe_strftime()` to catch the platform error, substitute portable locale-sensitive values through ASCII placeholders, and sanitize the final output. Route system prompts, gateway message timestamps, CLI status, goal-judge timestamps, and account-limit reset timestamps through the shared helper.

## Related Issue

Closes #102910

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_time.py` - add surrogate-safe datetime formatting with portable locale fallbacks.
- `agent/system_prompt.py` - protect conversation-start, rebuild-date, timezone, and offset formatting.
- `gateway/message_timestamps.py` - protect timestamps inserted into model context.
- `hermes_cli/status.py`, `hermes_cli/goals.py`, `agent/account_usage.py` - protect sibling user-facing timezone formats.
- `tests/test_timezone.py`, `tests/agent/test_system_prompt.py` - cover both pre-return formatter failures and returned lone surrogates.

## How to Test

1. Run the Windows-locale regression that makes `strftime()` raise before returning localized text.
2. Confirm the rebuilt system prompt remains UTF-8 encodable and retains its date, timezone, and UTC offset.
3. Run the related suites:

```bash
scripts/run_tests.sh tests/test_timezone.py -q
scripts/run_tests.sh tests/agent/test_system_prompt.py -q
scripts/run_tests.sh tests/gateway/test_message_timestamps.py -q
scripts/run_tests.sh tests/hermes_cli/test_goals.py -q
scripts/run_tests.sh tests/hermes_cli/test_status.py -q
scripts/run_tests.sh tests/test_account_usage.py -q
```

Result: 119 passed, 2 skipped.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [x] I've run the repo's related test suites and all selected tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] Relevant documentation updates are N/A
- [x] `cli-config.yaml.example` updates are N/A because no config keys changed
- [x] `CONTRIBUTING.md` and `AGENTS.md` updates are N/A because no workflow changed
- [x] I've considered cross-platform impact and kept the normal `strftime()` path unchanged
- [x] Tool description and schema updates are N/A

## Screenshots / Logs

N/A - automated regression tests reproduce the formatter failure directly.
