### PR TITLE
fix(desktop): @mention any bot from any chat — grant message_agent to Desktop sessions and resolve cross-connection mentions cold

### DIFF
--- a/agent/turn_context.py
+++ b/agent/turn_context.py
@@ -934,8 +934,8 @@ def build_turn_context(
         restore_or_build_system_prompt(agent, system_message, conversation_history)
     active_system_prompt = agent._cached_system_prompt
 
-    # Bot Mode DM tool — injected ONLY into a bot's canonical "Bot Chat" session (same
-    # gate as the protocol section); gate is session-stable, so cache-safe.
+    # Bot Mode DM tool — injected only into a bot's canonical "Bot Chat" session or a Desktop
+    # chat-panel session on a managed install; gate is session-stable, so cache-safe.
     try:
         from tools.bot_mode_dm import ensure_message_agent_tool
 

--- a/apps/desktop/src/plugins/hermes-bots/data.ts
+++ b/apps/desktop/src/plugins/hermes-bots/data.ts
@@ -631,82 +631,116 @@ interface UnionRoster {
   sources?: GatewaySource[]
 }
 
+/** Fetch one roster snapshot for `activeConnectionId`.
+ *
+ *  Extracted from `useRoster` so the composer surfaces can prime the same
+ *  cache entry without mounting the Bots pane — see `primeRoster`. */
+async function fetchRosterSnapshot(activeConnectionId: null | string | undefined): Promise<RosterSnapshot> {
+  // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
+  // against each bot's last local meta write, and a fetch issued before
+  // a write can only carry pre-write ui_meta. (Issue time is the
+  // conservative bound — the server answered no earlier than this.)
+  const issuedAt = Date.now()
+
+  // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
+  // come from the ACTIVE gateway's profiles.list — the canonical Bot
+  // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
+  // so the roster never sends session pointers.
+  // Refresh the alias identity index alongside the roster: alias routes
+  // (Desktop profile → remote backend root) are what let a backend row
+  // keep its configured friendly identity after activation (#89131).
+  // Best-effort and feature-detected — a failed read keeps the last
+  // good index rather than dropping identities mid-session.
+  if (typeof host.profileRoutes === 'function') {
+    const epoch = beginAliasRouteIndex()
+
+    try {
+      indexAliasRoutes(await host.profileRoutes(), epoch)
+    } catch {
+      /* keep the previous alias index */
+    }
+  }
+
+  // Owner routing is ambient in the SDK now (post-#92731): requestForBot
+  // resolves the active owner itself, no captured route needed here.
+  const activeBot = {
+    name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
+  }
+
+  const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
+  // Newer backends inject the teammate-messaging protocol into every
+  // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
+  // carry a second copy. Older gateways lack the flag: keep appending.
+  serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
+
+  // Multi-source desktops (hermes-agent #86875) also expose the union
+  // agent roster across every registered connection. Merge agents from
+  // OTHER sources in as additional rows. Feature-detected + best-effort:
+  // an older Desktop build (no host.agents) or a roster hiccup leaves
+  // the local list exactly as it was.
+  if (typeof host.agents === 'function') {
+    try {
+      const union = await host.agents()
+      const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
+      const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
+      const sources = Array.isArray(union?.sources) ? union.sources : []
+
+      return {
+        ...merged,
+        profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
+        sources,
+        fetchedAt: issuedAt
+      }
+    } catch {
+      /* older build or roster failure — single-source list stands */
+    }
+  }
+
+  return {
+    ...(local && typeof local === 'object' ? local : {}),
+    fetchedAt: issuedAt
+  }
+}
+
 export function useRoster() {
   const activeConnectionId = useValue(host.state.connectionId)
 
   return useQuery({
     queryKey: [...ROSTER_KEY, activeConnectionId],
-    queryFn: async () => {
-      // Stamp the ISSUE time on the snapshot: mergeServerMeta compares it
-      // against each bot's last local meta write, and a fetch issued before
-      // a write can only carry pre-write ui_meta. (Issue time is the
-      // conservative bound — the server answered no earlier than this.)
-      const issuedAt = Date.now()
-
-      // Rich rows (last_session, canonical_session, ui_meta, has_avatar)
-      // come from the ACTIVE gateway's profiles.list — the canonical Bot
-      // Chat is resolved server-side by NAME (the "Bot Chat" registry row),
-      // so the roster never sends session pointers.
-      // Refresh the alias identity index alongside the roster: alias routes
-      // (Desktop profile → remote backend root) are what let a backend row
-      // keep its configured friendly identity after activation (#89131).
-      // Best-effort and feature-detected — a failed read keeps the last
-      // good index rather than dropping identities mid-session.
-      if (typeof host.profileRoutes === 'function') {
-        const epoch = beginAliasRouteIndex()
-
-        try {
-          indexAliasRoutes(await host.profileRoutes(), epoch)
-        } catch {
-          /* keep the previous alias index */
-        }
-      }
-
-      // Owner routing is ambient in the SDK now (post-#92731): requestForBot
-      // resolves the active owner itself, no captured route needed here.
-      const activeBot = {
-        name: String(host.state.profile?.get?.() || 'default').trim() || 'default'
-      }
-
-      const local = await requestForBot<RosterSnapshot>(activeBot, 'profiles.list', {})
-      // Newer backends inject the teammate-messaging protocol into every
-      // session's system prompt (agent.bot_mode_protocol) — SOUL.md must not
-      // carry a second copy. Older gateways lack the flag: keep appending.
-      serverInjectsProtocol = Boolean(local?.bot_mode_protocol)
-
-      // Multi-source desktops (hermes-agent #86875) also expose the union
-      // agent roster across every registered connection. Merge agents from
-      // OTHER sources in as additional rows. Feature-detected + best-effort:
-      // an older Desktop build (no host.agents) or a roster hiccup leaves
-      // the local list exactly as it was.
-      if (typeof host.agents === 'function') {
-        try {
-          const union = await host.agents()
-          const previous: RosterRow[] = $lastRoster.get().filter(row => !row?.ghost)
-          const merged = mergeMultiSourceRoster(local, union, activeConnectionId, previous)
-          const sources = Array.isArray(union?.sources) ? union.sources : []
-
-          return {
-            ...merged,
-            profiles: (merged?.profiles || []).map(row => annotateBotSource(row, sources)),
-            sources,
-            fetchedAt: issuedAt
-          }
-        } catch {
-          /* older build or roster failure — single-source list stands */
-        }
-      }
-
-      return {
-        ...(local && typeof local === 'object' ? local : {}),
-        fetchedAt: issuedAt
-      }
-    },
+    queryFn: () => fetchRosterSnapshot(activeConnectionId),
     refetchInterval: 5000,
     staleTime: 5000,
     retry: ROSTER_QUERY_RETRY,
     retryDelay: attempt => Math.min(15000, 1000 * 2 ** attempt)
   })
+}
+
+/** Populate the roster cache for the live connection without mounting the
+ *  Bots pane.
+ *
+ *  `useRoster` is the only caller of `host.agents()`, and its only call site
+ *  is that pane. A launch that never opens it left the cache empty, so the
+ *  composer's `@` autocomplete and mention middleware — both synchronous
+ *  cache readers — could not see agents on other connections. The
+ *  middleware's cold fallback asks the ACTIVE gateway for `profiles.list`,
+ *  which cannot enumerate other connections, so cross-connection mentions
+ *  silently went unresolved while same-gateway ones worked.
+ *
+ *  One fetch per call, no polling: the pane still owns the 5s refresh while
+ *  it is open. Never throws — a failure leaves the cache empty and the
+ *  readers fall back exactly as before. */
+export async function primeRoster(): Promise<void> {
+  const connectionId = String(host.state.connectionId?.get?.() || host.activeConnectionId?.() || 'local')
+
+  try {
+    await queryClient.fetchQuery({
+      queryKey: [...ROSTER_KEY, connectionId],
+      queryFn: () => fetchRosterSnapshot(connectionId),
+      staleTime: 5000
+    })
+  } catch {
+    /* offline or older build — readers keep their existing fallbacks */
+  }
 }
 
 /** Synchronous union-roster read for the composer surfaces (autocomplete

--- a/apps/desktop/src/plugins/hermes-bots/mention-cold-roster.test.ts
+++ b/apps/desktop/src/plugins/hermes-bots/mention-cold-roster.test.ts
@@ -1,0 +1,240 @@
+/**
+ * Cross-connection @mentions must resolve in a regular chat even when the
+ * Bots pane has never been mounted this launch.
+ *
+ * `useRoster` is the only caller of `host.agents()` (the union roster across
+ * every registered connection), and its only call site is the Bots pane. A
+ * launch that never opens that pane therefore leaves the roster cache empty,
+ * and both composer surfaces read the cache synchronously. The middleware's
+ * cold-cache fallback asked the ACTIVE gateway for `profiles.list`, which by
+ * definition cannot see agents on other connections — so a cross-connection
+ * mention silently passed through unresolved while a same-gateway mention
+ * still worked.
+ *
+ * The gateway is still CONNECTING when the plugin registers, so the prime has
+ * to run on the 'open' transition; priming eagerly at registration fetches
+ * against a closed socket and leaves the cache empty (caught in a live app,
+ * not by an earlier version of this test).
+ */
+
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest'
+
+interface MentionCompletionItem {
+  display: string
+  insert: string
+  meta: string
+}
+
+interface ComposerDraft {
+  text: string
+}
+
+interface Contribution {
+  area: string
+  data: {
+    handler?: (draft: ComposerDraft) => Promise<ComposerDraft>
+    provide?: (query: string) => MentionCompletionItem[]
+  }
+  id: string
+}
+
+/** The active (local) gateway's own profiles.list — it has no knowledge of
+ *  agents living on other connections. */
+const LOCAL_PROFILES = [{ name: 'default' }, { name: 'writer' }]
+
+/** What `host.agents()` reports across every registered connection. */
+const UNION = {
+  agents: [
+    {
+      connectionId: 'local',
+      connectionKind: 'local',
+      connectionLabel: 'This device',
+      handle: 'default',
+      profile: 'default'
+    },
+    {
+      connectionId: 'local',
+      connectionKind: 'local',
+      connectionLabel: 'This device',
+      handle: 'writer',
+      profile: 'writer'
+    },
+    { connectionId: 'box', connectionKind: 'remote', connectionLabel: 'Box', handle: 'analyst', profile: 'analyst' }
+  ],
+  primaryConnectionId: 'local',
+  sources: [
+    { connectionId: 'local', kind: 'local', label: 'This device', reachable: true },
+    { connectionId: 'box', kind: 'remote', label: 'Box', reachable: true }
+  ]
+}
+
+const { cache, gatewayListeners, gatewayState, hostMock } = vi.hoisted(() => {
+  const gatewayListeners: Array<(state: string) => void> = []
+  // Registration happens while the socket is still connecting — the shape
+  // that makes an eager register-time prime a silent no-op.
+  const gatewayState = { value: 'connecting' }
+
+  return {
+    cache: new Map<string, { key: unknown[]; value: unknown }>(),
+    gatewayListeners,
+    gatewayState,
+    hostMock: {
+      agents: vi.fn(async () => UNION),
+      notify: vi.fn(),
+      profileRoutes: vi.fn(async () => []),
+      request: vi.fn(async () => ({ profiles: LOCAL_PROFILES })),
+      requestProfile: vi.fn(async () => ({ profiles: LOCAL_PROFILES })),
+      state: {
+        connectionId: { get: () => 'local', listen: () => () => undefined },
+        focusedSessionProfile: { get: () => 'default', listen: () => () => undefined },
+        focusedStoredSessionId: { get: () => null, listen: () => () => undefined },
+        gateway: {
+          get: () => gatewayState.value,
+          listen: (fn: (state: string) => void) => {
+            gatewayListeners.push(fn)
+
+            return () => undefined
+          }
+        },
+        profile: { get: () => 'default', listen: () => () => undefined }
+      }
+    }
+  }
+})
+
+vi.mock('@hermes/plugin-sdk', async () => {
+  const { atom } = await import('nanostores')
+
+  const stub: unknown = new Proxy(function stubbed() {}, {
+    apply: () => stub,
+    get: (_target, key) => (key === 'then' ? undefined : stub)
+  })
+
+  const keyOf = (key: unknown[]) => JSON.stringify(key)
+
+  // Faithful enough to TanStack Query v5 for these surfaces: getQueryData is
+  // exact-key, getQueriesData prefix-matches, fetchQuery runs the queryFn and
+  // writes the result under its key.
+  const queryClient = {
+    fetchQuery: async ({ queryKey, queryFn }: { queryFn: () => Promise<unknown>; queryKey: unknown[] }) => {
+      const value = await queryFn()
+      cache.set(keyOf(queryKey), { key: queryKey, value })
+
+      return value
+    },
+    getQueriesData: ({ queryKey }: { queryKey: unknown[] }) =>
+      [...cache.values()]
+        .filter(entry => queryKey.every((part, index) => entry.key[index] === part))
+        .map(entry => [entry.key, entry.value]),
+    getQueryData: (key: unknown[]) => cache.get(keyOf(key))?.value,
+    invalidateQueries: () => undefined,
+    setQueryData: (key: unknown[], value: unknown) => cache.set(keyOf(key), { key, value })
+  }
+
+  const known: Record<string, unknown> = {
+    atom,
+    COMPOSER_AREAS: { atCompletions: 'composer.atCompletions', middleware: 'composer.middleware' },
+    host: hostMock,
+    PALETTE_AREA: 'palette',
+    queryClient
+  }
+
+  return new Proxy(known, {
+    get: (target, key) =>
+      typeof key === 'symbol' || key in target ? target[key as string] : key === 'then' ? undefined : stub,
+    has: () => true
+  })
+})
+
+/** Register the plugin with a COLD cache and a still-connecting gateway. */
+async function coldContributions() {
+  vi.resetModules()
+  cache.clear()
+  gatewayListeners.length = 0
+  gatewayState.value = 'connecting'
+
+  const plugin = (await import('./plugin')).default
+  const registered: Contribution[] = []
+
+  try {
+    plugin.register({
+      i18n: { register: () => () => undefined },
+      onDispose: () => undefined,
+      register: (contribution: Contribution) => registered.push(contribution),
+      storage: { get: async () => undefined, remove: async () => undefined, set: async () => undefined }
+    } as never)
+  } catch {
+    /* registration walks UI surfaces this stub does not model */
+  }
+
+  return {
+    handler: registered.find(entry => entry.id === 'mention-middleware')!.data.handler!,
+    provide: registered.find(entry => entry.id === 'mention-completions')!.data.provide!
+  }
+}
+
+/** The socket finishes connecting; flush the prime it triggers. */
+async function openGateway() {
+  gatewayState.value = 'open'
+
+  for (const fn of gatewayListeners) {
+    fn('open')
+  }
+
+  await new Promise(resolve => setTimeout(resolve, 0))
+}
+
+beforeAll(async () => {
+  await import('./plugin')
+}, 120_000)
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('cross-connection @mentions with the Bots pane never mounted', () => {
+  it('identifies an agent on another connection and annotates its relay target', async () => {
+    const { handler } = await coldContributions()
+    await openGateway()
+
+    const result = await handler({ text: 'ask @analyst to check the logs' })
+
+    expect(result.text).toMatch(/@analyst = agent profile "analyst"/)
+    expect(result.text).toMatch(/message_agent target: "analyst@box"/)
+  })
+
+  it('offers cross-connection handles in the @ autocomplete', async () => {
+    const { provide } = await coldContributions()
+    await openGateway()
+
+    expect(provide('').map(item => item.insert)).toContain('@analyst')
+  })
+
+  it('still resolves a same-connection mention', async () => {
+    const { handler } = await coldContributions()
+    await openGateway()
+
+    const result = await handler({ text: 'ask @writer to draft it' })
+
+    expect(result.text).toMatch(/@writer = agent profile "writer"/)
+  })
+
+  it('resolves even if the mention arrives before the gateway-open prime', async () => {
+    // The middleware fills a cold cache itself rather than falling back to the
+    // active gateway's profiles.list, which cannot see other connections.
+    const { handler } = await coldContributions()
+
+    const result = await handler({ text: 'ask @analyst to check the logs' })
+
+    expect(result.text).toMatch(/message_agent target: "analyst@box"/)
+  })
+
+  it('leaves an unknown handle untouched', async () => {
+    const { handler } = await coldContributions()
+    await openGateway()
+
+    const result = await handler({ text: 'email someone@example.com and @nobody' })
+
+    expect(result.text).toBe('email someone@example.com and @nobody')
+  })
+})

--- a/apps/desktop/src/plugins/hermes-bots/plugin.tsx
+++ b/apps/desktop/src/plugins/hermes-bots/plugin.tsx
@@ -41,6 +41,7 @@ import {
   cachedUnionRoster,
   isActiveRosterBot,
   migrateBotMeta,
+  primeRoster,
   resolveRosterMentions
 } from './data'
 import {
@@ -114,6 +115,22 @@ export default {
       ctx.onDispose(stopFaceClock)
       ctx.onDispose(stopBotRelay)
     }
+
+    // Prime the roster cache so the composer surfaces below can resolve
+    // cross-connection @mentions without the Bots pane ever being mounted.
+    // The gateway is usually still connecting at registration, so prime on
+    // the first 'open' transition (and immediately if it is already up).
+    // One fetch per open — the pane still owns the 5s refresh while it is
+    // visible.
+    const primeOnGatewayOpen = (state: unknown) => {
+      if (String(state) === 'open') {
+        void primeRoster()
+      }
+    }
+
+    primeOnGatewayOpen(host.state.gateway?.get?.())
+
+    const unbindRosterPrime = host.state.gateway.listen(primeOnGatewayOpen)
 
     // @-mention autocomplete: typing "@rese…" in ANY composer offers the
     // roster's handles (issue #88060). Reads the roster straight from the
@@ -349,6 +366,10 @@ export default {
 
         if (typeof unbindGatewayListener === 'function') {
           unbindGatewayListener()
+        }
+
+        if (typeof unbindRosterPrime === 'function') {
+          unbindRosterPrime()
         }
 
         if (typeof unbindConnectionsChanged === 'function') {
@@ -701,7 +722,19 @@ export default {
           }
 
           const cached = cachedUnionRoster()
-          const roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+          let roster = Array.isArray(cached?.profiles) ? cached.profiles : null
+
+          if (!roster) {
+            // Cold cache (the pane has not run this launch, or the entry was
+            // evicted). Fill it the same way the pane does — a bare
+            // profiles.list here would only see the ACTIVE gateway and drop
+            // every cross-connection target on the floor.
+            await primeRoster()
+
+            const primed = cachedUnionRoster()
+            roster = Array.isArray(primed?.profiles) ? primed.profiles : null
+          }
+
           let mentionedBots = roster ? resolveRosterMentions(text, roster, live) : []
 
           if (!roster) {

--- a/tests/tools/test_bot_mode_dm.py
+++ b/tests/tools/test_bot_mode_dm.py
@@ -61,11 +61,12 @@ class _FakeDB:
 
 
 class _FakeAgent:
-    def __init__(self, home: Path, title: str = "Bot Chat"):
+    def __init__(self, home: Path, title: str = "Bot Chat", platform: str = "cli"):
         self._session_db = _FakeDB(home, title)
         self.session_id = "sess-1"
         self._session_title_hint = None
         self._bot_mode_protocol = True
+        self.platform = platform
         self.tools: list = []
         self.valid_tool_names: set = set()
 
@@ -86,17 +87,42 @@ def test_injects_only_into_bot_chat_on_managed_install(tmp_path):
     assert len(agent.tools) == 1
 
 
-@pytest.mark.parametrize(
-    "title",
-    ["", "My research chat", "Group: room-abc123", "handoff-12ab34cd"],
-)
-def test_never_injects_outside_bot_chat(tmp_path, title):
-    """CLI sessions, ordinary chats, group-room member sessions: no tool."""
+_NON_BOT_CHAT_TITLES = ["", "My research chat", "Group: room-abc123", "handoff-12ab34cd"]
+# Every session source that is not the Desktop chat panel: CLI, embedded terminal pane,
+# messaging adapters (and their group rooms), cron, kanban, subagents.
+_NON_DESKTOP_PLATFORMS = ["cli", "tui", "telegram", "discord", "cron", "kanban", "subagent"]
+
+
+@pytest.mark.parametrize("title", _NON_BOT_CHAT_TITLES)
+@pytest.mark.parametrize("platform", _NON_DESKTOP_PLATFORMS)
+def test_never_injects_outside_bot_chat(tmp_path, title, platform):
+    """Outside Bot Chat, only the Desktop chat panel qualifies — every other source: no tool."""
     home = _managed_home(tmp_path)
-    agent = _FakeAgent(home, title=title)
+    agent = _FakeAgent(home, title=title, platform=platform)
     assert bot_mode_dm.ensure_message_agent_tool(agent) is False
     assert agent.tools == []
     assert agent.valid_tool_names == set()
+
+
+@pytest.mark.parametrize("title", _NON_BOT_CHAT_TITLES)
+def test_desktop_chat_injects_outside_bot_chat(tmp_path, title):
+    """A regular Desktop chat on a managed install gets the tool: the Desktop's @mention
+    middleware tells the agent to send with message_agent from ANY chat, so the tool must
+    exist there — the gate is the session's platform, not its title."""
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title=title, platform="desktop")
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert [t["function"]["name"] for t in agent.tools] == [bot_mode_dm.MESSAGE_AGENT_TOOL_NAME]
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is True
+    assert len(agent.tools) == 1
+
+
+def test_desktop_chat_never_injects_on_unmanaged_install(tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    agent = _FakeAgent(home, title="Fresh chat", platform="desktop")
+    assert bot_mode_dm.ensure_message_agent_tool(agent) is False
+    assert agent.tools == []
 
 
 def test_never_injects_on_unmanaged_install(tmp_path):
@@ -130,14 +156,27 @@ def test_schema_never_in_global_registry():
 # ── dispatch gate (defense in depth) ─────────────────────────────────────────
 
 
-def test_tool_refuses_outside_bot_chat(tmp_path):
+@pytest.mark.parametrize("platform", _NON_DESKTOP_PLATFORMS)
+def test_tool_refuses_outside_bot_chat(tmp_path, platform):
     home = _managed_home(tmp_path)
-    agent = _FakeAgent(home, title="Ordinary chat")
+    agent = _FakeAgent(home, title="Ordinary chat", platform=platform)
     result = json.loads(
         bot_mode_dm.message_agent_tool(target="researcher", message="hi", agent=agent)
     )
     assert "error" in result
     assert "Bot Chat" in result["error"]
+
+
+def test_desktop_chat_dispatch_passes_session_gate(tmp_path):
+    """Dispatch mirrors injection: a regular Desktop chat gets past the session gate and
+    reaches target validation (the roster error proves the gate was not the refusal)."""
+    home = _managed_home(tmp_path)
+    agent = _FakeAgent(home, title="Ordinary chat", platform="desktop")
+    result = json.loads(
+        bot_mode_dm.message_agent_tool(target="nobody-here", message="hi", agent=agent)
+    )
+    assert "Bot Chat" not in result["error"]
+    assert "researcher" in result["teammates"]
 
 
 def test_tool_refuses_on_unmanaged_install(tmp_path):

--- a/tools/bot_mode_dm.py
+++ b/tools/bot_mode_dm.py
@@ -5,9 +5,10 @@ a registered peer gateway, or one on another Desktop-connected machine): the
 target is validated against the live roster, the attribution prefix is applied
 server-side, and the reply arrives later via the background-process completion
 notification (fire-and-forget). Containment: the schema is injected ONLY into a
-bot's canonical "Bot Chat" session on a Bot-Mode-managed install (same gate as
-``tools/bot_mode_probe.py``; never in the registry or any toolset), and dispatch
-re-checks that gate so a forged call returns a structured error. Transports:
+bot's canonical "Bot Chat" session or a Desktop chat-panel session (``platform ==
+"desktop"``), both on a Bot-Mode-managed install (never in the registry or any
+toolset), and dispatch re-checks that gate so a forged call returns a structured
+error. Transports:
 local → ``hermes -p <name> chat --in ~ -c "Bot Chat" --create-if-missing -Q
 --query-file <tmp>``; peer → ``hermes peer dm <peer>[/<name>] < <tmp>``; both via
 ``terminal_tool(background=True, notify_on_complete=True)``.
@@ -50,6 +51,13 @@ _LIVE_WAIT_SECONDS = 300
 _PEER_TARGET_RE = re.compile(r"^([a-z0-9][a-z0-9_-]{0,63})/([a-zA-Z0-9][a-zA-Z0-9_-]{0,63})$")
 # Same shape as ``tools.bot_relay._HANDLE_RE`` (kept local: see import note above).
 _LOCAL_TARGET_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9_-]{0,63}$")
+
+# The Desktop's @mention middleware tells the agent in ANY Desktop chat to send with
+# message_agent, so the chat panel gets the tool outside Bot Chat. ``platform`` is the
+# session's own source (``session.create {source: "desktop"}``), never a process env var:
+# the embedded terminal pane is "tui", CLI is "cli", messaging adapters carry their platform,
+# cron / kanban / subagents carry theirs — none is "desktop", so the grant stays narrow.
+DESKTOP_PLATFORM = "desktop"
 
 
 def _default_home() -> str:
@@ -110,18 +118,27 @@ def message_agent_tool_schema() -> dict:
     }
 
 
+def _session_qualifies(agent: Any) -> bool:
+    """Session half of the gate: the canonical Bot Chat, or a Desktop chat-panel session."""
+    from tools.bot_mode_probe import BOT_CHAT_TITLE
+
+    if _session_title(agent) == BOT_CHAT_TITLE:
+        return True
+    return str(getattr(agent, "platform", "") or "").strip() == DESKTOP_PLATFORM
+
+
 def message_agent_authorized(agent: Any) -> bool:
-    """The ``message_agent`` gate: a protocol-enabled agent whose session is a managed
-    Bot-Mode canonical Bot Chat. Session-stable, so it is prompt-cache safe to re-evaluate
-    on every tool-snapshot rebuild. Never raises."""
+    """The ``message_agent`` gate: a protocol-enabled agent in a qualifying session on a
+    Bot-Mode-managed install. Session-stable (title and platform are fixed at creation), so
+    it is prompt-cache safe to re-evaluate on every tool-snapshot rebuild. Never raises."""
     try:
         if not getattr(agent, "_bot_mode_protocol", True):
             return False
-        from tools.bot_mode_probe import BOT_CHAT_TITLE, is_bot_mode_managed
+        from tools.bot_mode_probe import is_bot_mode_managed
 
         # Managed-install check, NOT section non-emptiness: a SOUL.md carrying the
         # legacy protocol text gets an empty section but must still get the tool.
-        return _session_title(agent) == BOT_CHAT_TITLE and is_bot_mode_managed(_agent_home(agent))
+        return _session_qualifies(agent) and is_bot_mode_managed(_agent_home(agent))
     except Exception:  # pragma: no cover — must never break a turn
         logger.debug("message_agent_authorized failed", exc_info=True)
         return False
@@ -179,14 +196,14 @@ def message_agent_tool(target: str = "", message: str = "", task_id: Optional[st
     home = _agent_home(agent)
     try:
         from tools.bot_mode_probe import (
-            BOT_CHAT_TITLE, _handle, _hermes_root, _peers, _profile_name as _self_profile_name, _roster,
+            _handle, _hermes_root, _peers, _profile_name as _self_profile_name, _roster,
             is_bot_mode_managed,
         )
         from tools.bot_relay import BOT_CHAT_TURN_ARGS
 
-        if _session_title(agent) != BOT_CHAT_TITLE:
-            return _err("message_agent is only available in a Bot Mode 'Bot Chat' session. "
-                        "This session is not one; do not retry.")
+        if not _session_qualifies(agent):
+            return _err("message_agent is only available in a Bot Mode 'Bot Chat' session or a "
+                        "Desktop chat. This session is neither; do not retry.")
         if not is_bot_mode_managed(home):
             return _err("This install is not Bot-Mode-managed (no bot roster); "
                         "message_agent is unavailable. Do not retry.")


### PR DESCRIPTION
## Problem

Tagging a bot from a **regular** Desktop chat does nothing useful, on any gateway. Two independent gaps, one user-visible symptom:

1. **The agent never gets the tool.** Since #91915 the @mention middleware only *identifies* the bot and tells the agent to send with its `message_agent` tool — but `tools/bot_mode_dm.py` injected that tool only into a session titled exactly `"Bot Chat"`. A regular chat resolves the mention, then the agent reports "agent messaging is unavailable in this session". This is #94018 / #101556.
2. **Bots on other gateways aren't even identified.** The Bot Mode roster query (`useRoster`, `data.ts`) is the only caller of `host.agents()` — the union roster across every registered connection — and its only call site is the Bots pane. Panes mount lazily, so a launch that never opens Bots leaves the roster cache empty; the composer's `@` autocomplete offers nothing and the middleware falls back to `profiles.list` on the active gateway only. Cross-connection `@handle` stays plain text.

Either fix alone leaves the feature broken: with (2) only, a remote bot is identified and then refused; with (1) only, same-gateway works but cross-gateway mentions are silently dropped on a cold start.

## Solution

**Backend (`tools/bot_mode_dm.py`)** — the session half of the `message_agent` gate now accepts the Desktop chat panel as well as the canonical Bot Chat:

```python
def _session_qualifies(agent):
    if _session_title(agent) == BOT_CHAT_TITLE:
        return True
    return agent.platform == "desktop"
```

- Keyed on the **session's own platform** (`session.create {source: "desktop"}`), never a backend env var — so it holds for local, SSH, URL/token and cloud backends alike (root AGENTS.md: "surface capability is a property of the SESSION"). Same resolver `_load_enabled_toolsets(platform)` already uses for `desktop_ui`.
- **Session-stable**: title and platform are fixed at creation, so the tool list is byte-identical every turn — prompt-cache safe. No per-turn injection/removal.
- **Fail-closed everywhere else**: CLI, embedded TUI pane, messaging adapters (and their group rooms), cron, kanban, subagents, and unmanaged installs stay tool-free. Dispatch re-checks the same gate. The delivery path itself never depended on the title.

**Renderer (`apps/desktop/src/plugins/hermes-bots/data.ts`, `plugin.tsx`)** — extract the roster query body as `fetchRosterSnapshot` and add `primeRoster`, which fills the same cache entry via `queryClient.fetchQuery`. The plugin primes on the gateway `open` transition (priming at registration fails — the socket is still connecting); the middleware also primes on demand when it meets a cold cache. No polling added; the pane still owns the 5 s refresh while visible.

## Verification

### End-to-end, in a running Desktop against two live gateways

Isolated rig: two `hermes serve` backends in unprivileged Docker containers (`alpha` with bots `default` + `omar`, `beta` with `default` + `analyst`), a deterministic OpenAI-compatible mock model that emits a `message_agent` call when offered the tool and a literal `NO_MESSAGE_AGENT_TOOL` reply when not, and a dev Desktop with an isolated user-data dir, `alpha` as primary and `beta` registered as a second connection. Every run: cold app start, **Bots pane never opened**, fresh *regular* chat, `@handle` typed into the real composer.

| | `@` popover | model offered `message_agent` | target's Bot Chat ran the turn | reply relayed to sender |
|---|---|---|---|---|
| `main` (pre-fix gate), `@analyst` on beta | `@analyst · Bot · Analyst · Beta` | **no** → `NO_MESSAGE_AGENT_TOOL: agent messaging is unavailable in this session.` | — | — |
| this PR, `@omar` (same gateway) | `@omar · Bot · Omar` | yes → `message_agent(target="omar")` | yes — `Message from 🤖 hermes (@hermes): RIG_PING …` → `RIG_ACK …` in `profiles/omar/state.db` | yes — completion notification woke the sender's regular session |
| this PR, `@analyst` (other gateway) | `@analyst · Bot · Analyst · Beta` | yes → `message_agent(target="analyst@beta")` | yes — via the Desktop relay, rows in beta's `profiles/analyst/state.db` | yes — relay waiter completion woke the sender |

Negative control on the same rig: a `source: "cli"` session on a managed install gets the identification note and **no** tool.

Screenshots (rig app, no personal data):

| before — regular chat, `@analyst` on another gateway | after — same chat, same mention |
|---|---|
| ![before](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/pr-assets-102925/102925/pr-before.png) | ![after](https://raw.githubusercontent.com/Zeus-Deus/hermes-agent/pr-assets-102925/102925/pr-after.png) |

### Automated

- `tests/tools/test_bot_mode_dm.py` — new: desktop session injects (×4 titles), desktop dispatch passes the session gate, desktop on unmanaged install stays tool-free; the existing "never injects / refuses outside Bot Chat" cases are now parametrized over `cli, tui, telegram, discord, cron, kanban, subagent`. **5 fail on `main`, all pass with the fix.**
- `mention-cold-roster.test.ts` — 5 cases (cross-connection identification + relay-target annotation, autocomplete, same-connection unaffected, mention-before-open-event, unknown handle untouched). Fails 3/5 on `main`.
- `scripts/run_tests.sh tests/tools/ tests/agent/ tests/tui_gateway/` — green except 23 pre-existing failures in `test_daytona_environment / test_modal_snapshot_isolation / test_web_tools_config / test_image_generation / test_managed_media_gateways / test_browser_real_profile` that fail identically on a clean `upstream/main` checkout (missing optional SDKs in the environment).
- Bot Mode vitest suite: 64 files / 589 tests. `tsc -p tsconfig.json --noEmit` and `eslint src/plugins/hermes-bots/` clean.

## Notes

- Supersedes the gate half of #94114 (same design: Bot Chat **or** `platform == "desktop"` on a managed install) rebased onto current `main` — that branch predates the Sep 2 / Sep 6 `bot_mode_dm.py` refactors and no longer applies. Credit to @Shotflame for the original diagnosis.
- Not the approach of #99927 (per-turn transient injection): adding and removing a tool mid-conversation breaks the prompt-cache invariant.
- The relay-reply waiter is spawned as `python -c …` through `terminal_tool`, which the approval scanner flags as "script execution via -e/-c flag". Under `approvals.mode: smart` that is auto-approved; under `manual` the user sees an approval card for the waiter. Pre-existing behaviour of the relay path (also in Bot Chat), out of scope here.

Fixes #94018. Closes #101556.

---
Implemented by Claude Opus 5 via Hermes Agent.
