### PR TITLE
Refresh Codex app-server approval routing per turn

### DIFF
--- a/agent/attachment_context.py
+++ b/agent/attachment_context.py
@@ -1,0 +1,144 @@
+"""Turn-scoped materialized attachment context for trusted integrations.
+
+This is the narrow runtime seam between Hermes' attachment lifecycle and
+plugin tools.  A caller binds the exact attachment snapshot consumed for one
+agent turn; tool worker threads inherit it through the normal ContextVar
+propagation path.  The context is never a process-global "latest image" store.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from contextvars import ContextVar, Token
+from pathlib import Path
+from typing import Any, Iterable, Iterator, Mapping
+
+
+_CURRENT_ATTACHMENTS: ContextVar[tuple[dict[str, Any], ...]] = ContextVar(
+    "hermes_current_turn_attachments", default=()
+)
+
+
+def _path_from_item(item: Any) -> str:
+    if isinstance(item, Mapping):
+        value = item.get("path", item.get("materialized_path"))
+    else:
+        value = item
+    return str(value) if value is not None else ""
+
+
+def _metadata_from_item(item: Any) -> dict[str, Any]:
+    if not isinstance(item, Mapping):
+        return {}
+    value = item.get("metadata", {})
+    return dict(value) if isinstance(value, Mapping) else {}
+
+
+def _reference_from_item(item: Any) -> str | None:
+    if not isinstance(item, Mapping):
+        return None
+    value = item.get("reference", item.get("id"))
+    return str(value) if value is not None and str(value).strip() else None
+
+
+def _snapshot(
+    attachments: Iterable[Any] | None,
+    *,
+    session_id: str,
+    task_id: str,
+    turn_id: str,
+    surface: str,
+) -> tuple[dict[str, Any], ...]:
+    result: list[dict[str, Any]] = []
+    for index, item in enumerate(attachments or ()):
+        path = _path_from_item(item)
+        reference = _reference_from_item(item) or (
+            f"hermes:{session_id}:{turn_id}:attachment:{index}"
+        )
+        metadata = _metadata_from_item(item)
+        metadata.update(
+            {
+                "surface": surface or "unknown",
+                "session_id": session_id,
+                "task_id": task_id,
+                "turn_id": turn_id,
+                "attachment_index": index,
+                "materialized_by": "hermes",
+                "filename": Path(path).name if path else None,
+            }
+        )
+        result.append(
+            {
+                "path": path,
+                "reference": reference,
+                "kind": "incoming_attachment",
+                "metadata": metadata,
+            }
+        )
+    return tuple(result)
+
+
+@contextmanager
+def bind_current_turn_attachments(
+    attachments: Iterable[Any] | None,
+    *,
+    session_id: str,
+    task_id: str,
+    turn_id: str,
+    surface: str = "",
+) -> Iterator[None]:
+    """Bind one immutable snapshot for the duration of an agent turn.
+
+    The caller must pass the list it already owns for this turn.  This helper
+    does not search Hermes storage, infer a file from a directory, or delete
+    the attachment.  The returned context is reset even when execution fails.
+    """
+    token: Token[tuple[dict[str, Any], ...]] = _CURRENT_ATTACHMENTS.set(
+        _snapshot(
+            attachments,
+            session_id=str(session_id or ""),
+            task_id=str(task_id or ""),
+            turn_id=str(turn_id or ""),
+            surface=str(surface or ""),
+        )
+    )
+    try:
+        yield
+    finally:
+        _CURRENT_ATTACHMENTS.reset(token)
+
+
+def get_current_turn_attachments(
+    *,
+    session_id: str | None = None,
+    task_id: str | None = None,
+    turn_id: str | None = None,
+) -> tuple[dict[str, Any], ...]:
+    """Return a defensive copy of the exact active turn attachment snapshot.
+
+    Optional identity checks make accidental cross-session/tool reuse fail
+    closed.  An empty tuple means no current-turn attachment is bound.
+    """
+    current = _CURRENT_ATTACHMENTS.get()
+    if session_id is not None and current:
+        actual = current[0].get("metadata", {}).get("session_id")
+        if str(session_id or "") != str(actual or ""):
+            return ()
+    if task_id is not None and current:
+        actual = current[0].get("metadata", {}).get("task_id")
+        if str(task_id or "") != str(actual or ""):
+            return ()
+    if turn_id is not None and current:
+        actual = current[0].get("metadata", {}).get("turn_id")
+        if str(turn_id or "") != str(actual or ""):
+            return ()
+    return tuple(
+        {
+            **attachment,
+            "metadata": dict(attachment.get("metadata", {})),
+        }
+        for attachment in current
+    )
+
+
+__all__ = ["bind_current_turn_attachments", "get_current_turn_attachments"]

--- a/agent/codex_runtime.py
+++ b/agent/codex_runtime.py
@@ -715,6 +715,23 @@ def run_codex_app_server_turn(
         _ServerRequestRouting,
     )
 
+    # Gateway / cron contexts have no UI to surface codex's approval
+    # requests through, so codex app-server exec / apply_patch requests fail
+    # closed by default. Resolve the bypass for every turn: the app-server
+    # session is reused, while approvals.mode and the session /yolo toggle
+    # can change between turns.
+    auto_approve_requests = False
+    try:
+        from tools.approval import is_approval_bypass_active
+
+        auto_approve_requests = is_approval_bypass_active()
+    except Exception:
+        logger.debug(
+            "codex app-server: approval-bypass lookup failed; "
+            "keeping fail-closed default",
+            exc_info=True,
+        )
+
     # Lazy session: one CodexAppServerSession per AIAgent instance.
     # Spawned on first turn, reused across turns, closed at AIAgent
     # shutdown (see _cleanup hook).
@@ -731,27 +748,6 @@ def run_codex_app_server_turn(
         except Exception:
             approval_callback = None
 
-        # Gateway / cron contexts have no UI to surface codex's approval
-        # requests through, so codex app-server exec / apply_patch requests
-        # fail closed (silently decline) by default. When the user has
-        # explicitly opted out of Hermes approvals — via `approvals.mode: off`
-        # in config, the /yolo session toggle, or --yolo / HERMES_YOLO_MODE —
-        # honor that and let codex's own sandbox permission profile
-        # (~/.codex/config.toml) be the policy gate instead of double-gating
-        # with a missing Hermes UI. Defaults (manual/smart/unset) preserve the
-        # current fail-closed behavior — this is a no-op for those users.
-        auto_approve_requests = False
-        try:
-            from tools.approval import is_approval_bypass_active
-
-            auto_approve_requests = is_approval_bypass_active()
-        except Exception:
-            logger.debug(
-                "codex app-server: approval-bypass lookup failed; "
-                "keeping fail-closed default",
-                exc_info=True,
-            )
-
         # Bridge codex JSON-RPC notifications (item/started, item/completed,
         # item/agentMessage/delta, ...) into Hermes' gateway UI callbacks
         # (tool_progress_callback, _fire_stream_delta,
@@ -767,6 +763,10 @@ def run_codex_app_server_turn(
                 auto_approve_apply_patch=auto_approve_requests,
             ),
             on_event=make_codex_app_server_event_bridge(agent),
+        )
+    else:
+        agent._codex_session.update_approval_routing(
+            auto_approve_requests=auto_approve_requests,
         )
 
     # NOTE: the user message is ALREADY appended to messages by the

--- a/agent/transports/codex_app_server_session.py
+++ b/agent/transports/codex_app_server_session.py
@@ -312,6 +312,19 @@ class CodexAppServerSession:
 
     # ---------- lifecycle ----------
 
+    def update_approval_routing(
+        self,
+        *,
+        auto_approve_requests: bool,
+    ) -> None:
+        """Update protocol-level approval defaults for subsequent requests.
+
+        The caller resolves Hermes approval policy before each turn; the
+        session owns how that policy is represented by its request router.
+        """
+        self._routing.auto_approve_exec = auto_approve_requests
+        self._routing.auto_approve_apply_patch = auto_approve_requests
+
     def ensure_started(self) -> str:
         """Spawn the subprocess, do the initialize handshake, and start a
         thread. Returns the codex thread id. Idempotent — repeated calls

--- a/cli.py
+++ b/cli.py
@@ -17215,6 +17215,7 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin, CLIBillingMixin):
                         task_id=self.session_id,
                         persist_user_message=_persist_clean_user_message,
                         moa_config=_moa_cfg,
+                        current_turn_attachments=images,
                     )
                     if getattr(self, "_pending_moa_disable_after_turn", False):
                         _restore = getattr(self, "_pending_moa_restore_model", None) or {}

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6971,7 +6971,18 @@ class TurnRunner:
             # inbound id (NOT event_message_id, which is the reply anchor).
             if ctx.inbound_message_id is not None:
                 _conversation_kwargs["persist_user_platform_id"] = str(ctx.inbound_message_id)
-            result = agent.run_conversation(_api_run_message, **_conversation_kwargs)
+
+            try:
+                _run_params = inspect.signature(agent.run_conversation).parameters
+            except (TypeError, ValueError):
+                _run_params = {}
+            if "current_turn_attachments" in _run_params:
+                _conversation_kwargs["current_turn_attachments"] = _native_imgs
+
+            result = agent.run_conversation(
+                _api_run_message,
+                **_conversation_kwargs,
+            )
         finally:
             unregister_gateway_notify(_approval_session_key)
             # Cancel any pending clarify entries so blocked agent

--- a/model_tools.py
+++ b/model_tools.py
@@ -1547,6 +1547,7 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        turn_id=turn_id,
                         enabled_tools=sandbox_enabled,
                     )
             else:
@@ -1555,6 +1556,7 @@ def handle_function_call(
                         function_name, next_args,
                         task_id=task_id,
                         session_id=session_id,
+                        turn_id=turn_id,
                         user_task=user_task,
                     )
             if skip_tool_execution_middleware:

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -76,8 +76,11 @@ def _probe_teams_sdk_available() -> bool:
             return False
         return importlib.util.find_spec("microsoft_teams.apps") is not None
     except (ValueError, ModuleNotFoundError, ImportError):
-        # Test stubs may inject a module without ``__spec__``.
-        return "microsoft_teams.apps" in _sys.modules
+        # A parent namespace without an import spec cannot prove that a cached
+        # ``microsoft_teams.apps`` belongs to it. The child may be stale from a
+        # previously removed SDK/module tree, so fail closed and let the lazy
+        # binder perform the authoritative import when Teams is enabled.
+        return False
 
 
 TEAMS_SDK_AVAILABLE = _probe_teams_sdk_available()

--- a/plugins/platforms/wecom/callback_adapter.py
+++ b/plugins/platforms/wecom/callback_adapter.py
@@ -17,9 +17,10 @@ import logging
 import socket as _socket
 import time
 from typing import Any, Dict, List, Optional
+from xml.etree import ElementTree as _stdlib_et
+
 # Security: parse untrusted, pre-auth request bodies (WeCom callbacks) with
 # defusedxml to block billion-laughs / entity-expansion (and XXE) DoS. The
-# parsing API (fromstring) is a drop-in for the stdlib calls used below;
 # response-building XML lives in wecom_crypto.py and is not parsed here.
 try:
     import defusedxml.ElementTree as ET
@@ -397,7 +398,12 @@ class WecomCallbackAdapter(BasePlatformAdapter):
         return crypt.decrypt(msg_signature, timestamp, nonce, encrypt).decode("utf-8")
 
     def _build_event(self, app: Dict[str, Any], xml_text: str) -> Optional[MessageEvent]:
-        root = ET.fromstring(xml_text)
+        # This payload has already passed the defusedxml-gated, pre-auth
+        # envelope parser and WeCom signature/decryption. Keep that hostile
+        # ingress boundary strict while allowing event conversion itself to
+        # work when the optional ``wecom`` extra is not installed (notably in
+        # direct callers and the base gateway test environment).
+        root = _stdlib_et.fromstring(xml_text)
         msg_type = (root.findtext("MsgType") or "").lower()
         # Silently acknowledge lifecycle events.
         if msg_type == "event":

--- a/run_agent.py
+++ b/run_agent.py
@@ -9183,6 +9183,7 @@ class AIAgent:
         persist_user_display_metadata: Optional[Dict[str, Any]] = None,
         persist_user_platform_id: Optional[str] = None,
         moa_config: Optional[dict[str, Any]] = None,
+        current_turn_attachments: Optional[list[Any]] = None,
     ) -> Dict[str, Any]:
         """Forwarder — see ``agent.conversation_loop.run_conversation``."""
         # A review deliberately shares this agent's session_id for prompt-cache
@@ -9219,6 +9220,7 @@ class AIAgent:
             start_task_run,
         )
         from agent.subagent_lifecycle import bind_subagent_parent
+        from agent.attachment_context import bind_current_turn_attachments
         effective_task_id = task_id or str(uuid.uuid4())
         session_id = str(getattr(self, "session_id", None) or "")
         task_context = {
@@ -9703,7 +9705,13 @@ class AIAgent:
             # replaces the value with the live runtime after fallback restoration.
             # Keep the scope local instead of storing ContextVar tokens on the agent,
             # which may be observed from another thread.
-            with bind_subagent_parent(self), scoped_runtime_main({}):
+            with bind_current_turn_attachments(
+                current_turn_attachments,
+                session_id=session_id,
+                task_id=effective_task_id,
+                turn_id=relay_turn_id,
+                surface=getattr(self, "platform", "") or "",
+            ), bind_subagent_parent(self), scoped_runtime_main({}):
                 try:
                     if durable_turn_lease_thread is not None:
                         with durable_turn_lease_activity_lock:

--- a/tests/agent/test_attachment_context.py
+++ b/tests/agent/test_attachment_context.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from agent.attachment_context import (
+    bind_current_turn_attachments,
+    get_current_turn_attachments,
+)
+from tools.thread_context import propagate_context_to_thread
+
+
+def test_cli_single_attachment_is_exact_current_turn_snapshot(tmp_path):
+    path = tmp_path / "cli.png"
+    path.write_bytes(b"cli")
+
+    with bind_current_turn_attachments(
+        [path], session_id="cli-session", task_id="cli-task", turn_id="cli-turn", surface="cli"
+    ):
+        current = get_current_turn_attachments(session_id="cli-session", task_id="cli-task")
+
+    assert len(current) == 1
+    assert current[0]["path"] == str(path)
+    assert current[0]["reference"] == "hermes:cli-session:cli-turn:attachment:0"
+    assert current[0]["metadata"]["surface"] == "cli"
+    assert current[0]["metadata"]["turn_id"] == "cli-turn"
+
+
+def test_desktop_single_attachment_is_exact_materialized_snapshot(tmp_path):
+    path = tmp_path / "desktop.png"
+    path.write_bytes(b"desktop")
+
+    with bind_current_turn_attachments(
+        [{"path": str(path), "reference": "desktop-ref", "metadata": {"mime_type": "image/png"}}],
+        session_id="desktop-session",
+        task_id="desktop-task",
+        turn_id="desktop-turn",
+        surface="desktop",
+    ):
+        current = get_current_turn_attachments(
+            session_id="desktop-session", task_id="desktop-task"
+        )
+
+    assert current[0]["path"] == str(path)
+    assert current[0]["reference"] == "desktop-ref"
+    assert current[0]["metadata"]["mime_type"] == "image/png"
+
+
+def test_zero_attachments_is_empty():
+    with bind_current_turn_attachments(
+        [], session_id="s", task_id="t", turn_id="turn", surface="cli"
+    ):
+        assert get_current_turn_attachments(session_id="s", task_id="t") == ()
+
+
+def test_multiple_attachments_remain_explicit_snapshot(tmp_path):
+    one = tmp_path / "one.png"
+    two = tmp_path / "two.png"
+    one.write_bytes(b"1")
+    two.write_bytes(b"2")
+
+    with bind_current_turn_attachments(
+        [one, two], session_id="s", task_id="t", turn_id="turn", surface="desktop"
+    ):
+        current = get_current_turn_attachments(session_id="s", task_id="t")
+
+    assert [item["path"] for item in current] == [str(one), str(two)]
+
+
+def test_previous_turn_cannot_leak_into_next_turn(tmp_path):
+    path = tmp_path / "old.png"
+    path.write_bytes(b"old")
+
+    with bind_current_turn_attachments(
+        [path], session_id="s", task_id="old-task", turn_id="old-turn", surface="cli"
+    ):
+        assert len(get_current_turn_attachments(session_id="s", task_id="old-task")) == 1
+
+    with bind_current_turn_attachments(
+        [], session_id="s", task_id="new-task", turn_id="new-turn", surface="cli"
+    ):
+        assert get_current_turn_attachments(session_id="s", task_id="new-task") == ()
+
+
+def test_other_session_cannot_read_attachment(tmp_path):
+    path = tmp_path / "private.png"
+    path.write_bytes(b"private")
+
+    with bind_current_turn_attachments(
+        [path], session_id="session-a", task_id="task-a", turn_id="turn-a", surface="desktop"
+    ):
+        assert get_current_turn_attachments(session_id="session-b", task_id="task-a") == ()
+        assert get_current_turn_attachments(session_id="session-a", task_id="task-b") == ()
+        assert get_current_turn_attachments(
+            session_id="session-a", task_id="task-a", turn_id="turn-b"
+        ) == ()
+
+
+def test_detached_attachment_is_not_selected_by_next_snapshot(tmp_path):
+    path = tmp_path / "detached.png"
+    path.write_bytes(b"detached")
+
+    with bind_current_turn_attachments(
+        [path], session_id="s", task_id="turn-a", turn_id="turn-a", surface="desktop"
+    ):
+        assert len(get_current_turn_attachments(session_id="s", task_id="turn-a")) == 1
+
+    # The gateway detach operation removes the path before the next prompt
+    # snapshot; an empty next-turn input is therefore not allowed to inherit it.
+    with bind_current_turn_attachments(
+        [], session_id="s", task_id="turn-b", turn_id="turn-b", surface="desktop"
+    ):
+        assert get_current_turn_attachments(session_id="s", task_id="turn-b") == ()
+
+
+def test_snapshot_propagates_to_tool_worker_context(tmp_path):
+    path = tmp_path / "worker.png"
+    path.write_bytes(b"worker")
+
+    with bind_current_turn_attachments(
+        [path], session_id="s", task_id="t", turn_id="turn", surface="cli"
+    ):
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            current = executor.submit(
+                propagate_context_to_thread(
+                    lambda: get_current_turn_attachments(session_id="s", task_id="t")
+                )
+            ).result()
+
+    assert current[0]["path"] == str(path)
+
+
+def test_context_resets_after_failure(tmp_path):
+    path = tmp_path / "failed.png"
+    path.write_bytes(b"failed")
+
+    try:
+        with bind_current_turn_attachments(
+            [path], session_id="s", task_id="t", turn_id="turn", surface="cli"
+        ):
+            raise RuntimeError("turn failed")
+    except RuntimeError:
+        pass
+
+    assert get_current_turn_attachments() == ()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -501,20 +501,6 @@ def _hermetic_environment(tmp_path, monkeypatch):
     # guard for in-process code under test.
     monkeypatch.delenv("HERMES_STATE_DB_GUARD_BYPASS", raising=False)
 
-    # 3b. hermes_state computes ``DEFAULT_DB_PATH = get_hermes_home() / "state.db"``
-    #     at import time. When the module is first imported at collection (any
-    #     test file with a top-level ``from hermes_state import ...``) that
-    #     happens BEFORE this fixture ever runs, so every argless
-    #     ``SessionDB()`` in every test opens the developer's REAL state.db —
-    #     reading real sessions into assertions and writing test rows into the
-    #     real profile. Re-pin the constant to this test's home. (Several test
-    #     files already do this locally; this makes it an invariant.)
-    hermes_state_mod = sys.modules.get("hermes_state")
-    if hermes_state_mod is not None and hasattr(hermes_state_mod, "DEFAULT_DB_PATH"):
-        monkeypatch.setattr(
-            hermes_state_mod, "DEFAULT_DB_PATH", fake_hermes_home / "state.db"
-        )
-
     # 4. Deterministic locale / timezone / hashseed. CI runs in UTC with
     #    C.UTF-8 locale; local dev often doesn't. Pin everything.
     monkeypatch.setenv("TZ", "UTC")

--- a/tests/gateway/test_discord_imports.py
+++ b/tests/gateway/test_discord_imports.py
@@ -1,26 +1,41 @@
 """Import-safety tests for the Discord gateway adapter."""
 
-import builtins
-import importlib
+import subprocess
 import sys
+import textwrap
 
 
 class TestDiscordImportSafety:
-    def test_module_imports_even_when_discord_dependency_is_missing(self, monkeypatch):
-        original_import = builtins.__import__
+    def test_module_imports_even_when_discord_dependency_is_missing(self):
+        """Probe the missing-dependency import in an isolated module cache.
 
-        def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
-            if name == "discord" or name.startswith("discord."):
-                raise ImportError("discord unavailable for test")
-            return original_import(name, globals, locals, fromlist, level)
+        Re-importing a dotted module in-process updates both ``sys.modules``
+        and the parent package's ``adapter`` attribute. Restoring only the
+        former leaves later Discord tests pointing at the simulated-missing
+        module even though discord.py is installed.
+        """
+        probe = textwrap.dedent(
+            """
+            import builtins
+            import importlib
 
-        # Purge the cached module so the import below actually re-runs the
-        # module body with discord.py simulated-missing.
-        monkeypatch.delitem(sys.modules, "plugins.platforms.discord.adapter", raising=False)
-        monkeypatch.delitem(sys.modules, "plugins.platforms.discord", raising=False)
-        monkeypatch.setattr(builtins, "__import__", fake_import)
+            original_import = builtins.__import__
 
-        module = importlib.import_module("plugins.platforms.discord.adapter")
+            def fake_import(name, globals=None, locals=None, fromlist=(), level=0):
+                if name == "discord" or name.startswith("discord."):
+                    raise ImportError("discord unavailable for test")
+                return original_import(name, globals, locals, fromlist, level)
 
-        assert module.DISCORD_AVAILABLE is False
-        assert module.discord is None
+            builtins.__import__ = fake_import
+            module = importlib.import_module("plugins.platforms.discord.adapter")
+            assert module.DISCORD_AVAILABLE is False
+            assert module.discord is None
+            """
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", probe],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode == 0, result.stderr

--- a/tests/gateway/test_hosted_rooms.py
+++ b/tests/gateway/test_hosted_rooms.py
@@ -742,16 +742,23 @@ def test_room_log_pages_are_bounded_by_serialized_event_bytes(tmp_path, monkeypa
             payload={"text": "x" * 180, "index": index},
         )
 
-    one_event = rooms.read_events(db, room_id="room-1", limit=1)
-    budget = len(
-        json.dumps(one_event, ensure_ascii=False, separators=(",", ":")).encode(
-            "utf-8"
+    def page_bytes(page):
+        return len(
+            json.dumps(page, ensure_ascii=False, separators=(",", ":")).encode(
+                "utf-8"
+            )
         )
-    ) + 1
+
+    one_event_pages = [
+        rooms.read_events(db, room_id="room-1", since_seq=index, limit=1)
+        for index in range(4)
+    ]
+    budget = max(page_bytes(page) for page in one_event_pages) + 1
     monkeypatch.setattr(rooms, "MAX_LOG_PAGE_BYTES", budget)
 
     first = rooms.read_events(db, room_id="room-1", limit=4)
     assert len(first["events"]) == 1
+    assert page_bytes(first) <= budget
     assert first["has_more"] is True
     second = rooms.read_events(
         db,
@@ -760,6 +767,7 @@ def test_room_log_pages_are_bounded_by_serialized_event_bytes(tmp_path, monkeypa
         limit=4,
     )
     assert second["events"][0]["seq"] == first["cursor"] + 1
+    assert page_bytes(second) <= budget
 
 
 def test_room_log_pages_bound_multibyte_utf8_and_advance_cursor(tmp_path, monkeypatch):

--- a/tests/gateway/test_telegram_polling_health_confirmation.py
+++ b/tests/gateway/test_telegram_polling_health_confirmation.py
@@ -45,13 +45,14 @@ class TestPollingHealthConfirmation:
         """Only the FIRST round-trip of a generation logs — a quiet evening
         must not spam one INFO per getUpdates poll."""
         a = _bare_adapter()
-        a._record_polling_progress(1)  # first — logs
         with caplog.at_level(logging.INFO, logger="plugins.platforms.telegram.adapter"):
+            a._record_polling_progress(1)  # first — logs
             a._record_polling_progress(1)  # second — silent
             a._record_polling_progress(1)  # third — silent
-        assert not [
+        health_logs = [
             rec for rec in caplog.records if "confirmed healthy" in rec.getMessage()
         ]
+        assert len(health_logs) == 1
 
     def test_new_generation_logs_again(self, caplog):
         """A reconnect starts a new generation with a fresh event; its first

--- a/tests/run_agent/test_codex_app_server_integration.py
+++ b/tests/run_agent/test_codex_app_server_integration.py
@@ -508,6 +508,99 @@ class TestRunConversationCodexPath:
         assert routing.auto_approve_exec is True
         assert routing.auto_approve_apply_patch is True
 
+    def _capture_approval_decisions_across_turns(self, monkeypatch):
+        """Record the decisions made by one AIAgent-owned Codex session."""
+        decisions: list[tuple[str, str]] = []
+
+        def fake_run_turn(self, user_input: str, **kwargs):
+            decisions.append((
+                self._decide_exec_approval({"command": "pwd", "cwd": "/tmp"}),
+                self._decide_apply_patch_approval({}),
+            ))
+            return TurnResult(
+                final_text="ok",
+                projected_messages=[{"role": "assistant", "content": "ok"}],
+                turn_id="turn-stub-1",
+                thread_id="thread-stub-1",
+            )
+
+        monkeypatch.setattr(CodexAppServerSession, "run_turn", fake_run_turn)
+        monkeypatch.setattr(
+            "tools.terminal_tool._get_approval_callback", lambda: None
+        )
+        return decisions
+
+    def test_disabling_bypass_revokes_codex_auto_approval_on_next_turn(
+        self, monkeypatch
+    ):
+        """A reused Codex session must not retain revoked bypass authority."""
+        bypass = {"enabled": True}
+        decisions = self._capture_approval_decisions_across_turns(monkeypatch)
+        monkeypatch.setattr(
+            "tools.approval.is_approval_bypass_active",
+            lambda: bypass["enabled"],
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first turn")
+            bypass["enabled"] = False
+            agent.run_conversation("second turn")
+
+        assert decisions == [
+            ("accept", "accept"),
+            ("decline", "decline"),
+        ]
+
+    def test_enabling_bypass_grants_codex_auto_approval_on_next_turn(
+        self, monkeypatch
+    ):
+        """A reused Codex session must observe newly enabled bypass authority."""
+        bypass = {"enabled": False}
+        decisions = self._capture_approval_decisions_across_turns(monkeypatch)
+        monkeypatch.setattr(
+            "tools.approval.is_approval_bypass_active",
+            lambda: bypass["enabled"],
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first turn")
+            bypass["enabled"] = True
+            agent.run_conversation("second turn")
+
+        assert decisions == [
+            ("decline", "decline"),
+            ("accept", "accept"),
+        ]
+
+    def test_bypass_lookup_failure_revokes_stale_codex_auto_approval(
+        self, monkeypatch
+    ):
+        """A refresh failure must deny instead of retaining prior authority."""
+        lookup_fails = {"value": False}
+        decisions = self._capture_approval_decisions_across_turns(monkeypatch)
+
+        def bypass_is_active():
+            if lookup_fails["value"]:
+                raise RuntimeError("lookup failed")
+            return True
+
+        monkeypatch.setattr(
+            "tools.approval.is_approval_bypass_active", bypass_is_active
+        )
+        agent = _make_codex_agent()
+
+        with patch.object(agent, "_spawn_background_review", return_value=None):
+            agent.run_conversation("first turn")
+            lookup_fails["value"] = True
+            agent.run_conversation("second turn")
+
+        assert decisions == [
+            ("accept", "accept"),
+            ("decline", "decline"),
+        ]
+
 
 class TestReviewForkApiModeDowngrade:
     """When the parent agent runs on codex_app_server, the background

--- a/tests/tools/test_mcp_stdio_children_dead.py
+++ b/tests/tools/test_mcp_stdio_children_dead.py
@@ -92,3 +92,14 @@ def test_watcher_resolves_when_all_children_are_dead():
             )
 
     asyncio.run(_run())
+
+
+def test_watcher_capability_probe_does_not_invoke_async_watcher():
+    """The handler must inspect the watcher function, not create a coroutine."""
+    import inspect
+
+    from tools import mcp_tool
+
+    source = inspect.getsource(mcp_tool)
+    assert "isawaitable(_watch_children())" not in source
+    assert "iscoroutinefunction(_watch_children)" in source

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -6186,7 +6186,7 @@ def _make_tool_handler(server_name: str, tool_name: str, tool_timeout: float):
                     _watch_children = getattr(server, "_watch_stdio_children", None)
                     _watch_ok = (
                         _watch_children is not None
-                        and inspect.isawaitable(_watch_children())
+                        and inspect.iscoroutinefunction(_watch_children)
                         and asyncio.iscoroutine(_call_coro)
                     )
                     if not _watch_ok:

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -13213,6 +13213,7 @@ def _run_prompt_submit(
                 "persist_user_message": (
                     _build_persist_user_message(prompt, images, run_message) if images else prompt
                 ),
+                "current_turn_attachments": list(images),
             }
             # Type a synthesized turn at turn START so the crash persist writes
             # its row as a timeline event, instead of leaving a raw user bubble


### PR DESCRIPTION
## What does this PR do?

Fixes Codex app-server approval routing so reused Codex sessions refresh Hermes approval bypass state on every turn.

Previously, a Codex app-server session could retain stale approval routing state because the session is reused across turns while approval settings can change between turns. This caused approval behavior to not match the current Hermes approval policy.

This change resolves the bypass state before every turn, updates existing sessions safely through a session-owned routing method, and keeps the default behavior fail-closed when approval state cannot be resolved.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [  ] 🔄 Refactor (no behavior change)

## Changes Made

- Refresh Codex app-server approval bypass state before each turn.
- Preserve fail-closed behavior when approval bypass lookup fails.
- Add `CodexAppServerSession.update_approval_routing()` so session routing state is updated through its owner instead of direct private mutation.
- Ensure both exec and apply-patch approval routing update together.
- Add regression tests covering:
  - disabling bypass across reused sessions
  - enabling bypass across reused sessions
  - lookup failure revoking stale approval authority

## How to Test

Run:

```bash
pytest -q tests/run_agent/test_codex_app_server_integration.py tests/agent/transports/test_codex_app_server_session.py