### PR TITLE
Make gateway start exit non-zero in a container without s6

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5851,7 +5851,7 @@ _NO_BACKEND_MESSAGES = {
         "WSL detected but systemd is not available.",
         "Run the gateway in foreground mode instead:", *_WSL_FOREGROUND_HINT, "",
         "To enable systemd: add systemd=true to /etc/wsl.conf and run 'wsl --shutdown' from PowerShell."),
-    ("start", "container"): (0,
+    ("start", "container"): (1,
         "Service start is not applicable inside a Docker container.",
         "The gateway runs as the container's main process.", "",
         "  docker start <container>     # start a stopped container",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1805,6 +1805,32 @@ class TestDockerAwareGateway:
         assert "Docker" in out or "docker" in out
         assert "restart" in out.lower()
 
+    def test_start_in_container_exits_nonzero(self, monkeypatch, capsys):
+        """'hermes gateway start' inside a no-s6 container must not report success.
+
+        The command starts no Gateway process there (the container runtime owns the
+        lifecycle), so exit code 0 would let callers treat it as a completed start.
+        """
+        import pytest
+
+        monkeypatch.setattr(gateway_cli, "is_managed", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_container", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_dispatch_via_service_manager_if_s6", lambda *a, **k: False)
+        monkeypatch.setattr(gateway_cli, "_service_backend", lambda **k: None)
+
+        args = SimpleNamespace(gateway_command="start", system=False, all=False)
+        with pytest.raises(SystemExit) as exc_info:
+            gateway_cli.gateway_command(args)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr().out
+        assert "not applicable inside a Docker container" in out
+        assert "hermes gateway run" in out
+
 
 class TestLegacyHermesUnitDetection:
     """Tests for _find_legacy_hermes_units / has_legacy_hermes_units.


### PR DESCRIPTION
## Problem

In a WebUI single-container deployment with no systemd/s6, `hermes gateway start` exits with code 0 even though it does not start a Gateway process. Callers that treat rc=0 as terminal success (e.g. the WebUI launching the command through `subprocess.run()`) report a false successful start: a green success toast while the Gateway remains stopped and `gateway_state.json` stays `stopped`.

Fixes #102915

## Root cause

`_NO_BACKEND_MESSAGES` in `hermes_cli/gateway.py` maps `("start", "container")` to exit code 0. When no service backend matches and `is_container()` is true, `_handle_no_backend` routes there and `_no_backend_exit` calls `sys.exit(0)` — success semantics for a start that never happened.

Every other entry for a start that cannot happen exits 1:

| key | exit |
|---|---|
| `("start", "termux")` | 1 |
| `("start", "wsl")` | 1 |
| `("start", "container")` | **0** ← the odd one out |
| `("start", "unsupported")` | 1 |

## Change

- `("start", "container")`: exit code `0` → `1`. Guidance text unchanged (the message was correct, the exit code was the lie).
- Regression test `test_start_in_container_exits_nonzero` in `TestDockerAwareGateway` asserting `start` inside a container exits 1 and still prints the Docker guidance.

`install`/`uninstall` in a container stay exit 0 — those genuinely have nothing to do (no service is created there, so there is nothing to install or remove). `stop` reaches a different path and terminates the real foreground Gateway.

## Verification

- Full `tests/hermes_cli/test_gateway_service.py`: 104 passed, 1 skipped (new test included).
- `tests/hermes_cli/test_gateway_s6_dispatch.py` + `test_gateway_restart_loop.py`: 299 passed.
- `ruff check` clean on both files; no new `ruff format` complaints on the changed lines.