### PR TITLE
fix(desktop): prefetch TTS segments during playback

### DIFF
--- a/apps/desktop/src/lib/voice-client-direct.test.ts
+++ b/apps/desktop/src/lib/voice-client-direct.test.ts
@@ -226,11 +226,12 @@ describe('synthesizeSpeechClientDirect', () => {
 
   it('POSTs the openai speech shape and returns audio bytes', async () => {
     const bytes = new Uint8Array([1, 2, 3]).buffer
+    const controller = new AbortController()
 
     const fetchMock = vi.fn(async () => new Response(bytes, { status: 200 }))
     vi.stubGlobal('fetch', fetchMock)
 
-    const audio = await synthesizeSpeechClientDirect(openaiTts, 'Hello there.')
+    const audio = await synthesizeSpeechClientDirect(openaiTts, 'Hello there.', { signal: controller.signal })
 
     expect(new Uint8Array(audio)).toEqual(new Uint8Array([1, 2, 3]))
 
@@ -242,6 +243,7 @@ describe('synthesizeSpeechClientDirect', () => {
     expect(body.voice).toBe('nova')
     expect(body.input).toBe('Hello there.')
     expect(body.speed).toBeUndefined()
+    expect(init.signal).toBe(controller.signal)
   })
 
   it('speaks the elevenlabs tts shape with the voice in the path', async () => {

--- a/apps/desktop/src/lib/voice-client-direct.ts
+++ b/apps/desktop/src/lib/voice-client-direct.ts
@@ -279,7 +279,11 @@ export async function directTtsConfig(): Promise<DirectTtsConfig | null> {
 }
 
 /** Synthesize one text segment to audio bytes (mp3). Throws on provider rejection. */
-export async function synthesizeSpeechClientDirect(tts: DirectTtsConfig, text: string): Promise<ArrayBuffer> {
+export async function synthesizeSpeechClientDirect(
+  tts: DirectTtsConfig,
+  text: string,
+  options?: { signal?: AbortSignal }
+): Promise<ArrayBuffer> {
   if (tts.wire === 'openai-speech') {
     const body: Record<string, unknown> = {
       model: tts.model,
@@ -298,7 +302,8 @@ export async function synthesizeSpeechClientDirect(tts: DirectTtsConfig, text: s
         Authorization: `Bearer ${tts.api_key}`,
         'Content-Type': 'application/json'
       },
-      body: JSON.stringify(body)
+      body: JSON.stringify(body),
+      signal: options?.signal
     })
 
     if (!response.ok) {
@@ -318,7 +323,8 @@ export async function synthesizeSpeechClientDirect(tts: DirectTtsConfig, text: s
           'Content-Type': 'application/json',
           Accept: 'audio/mpeg'
         },
-        body: JSON.stringify({ text, model_id: tts.model })
+        body: JSON.stringify({ text, model_id: tts.model }),
+        signal: options?.signal
       }
     )
 

--- a/apps/desktop/src/lib/voice-playback.direct.test.ts
+++ b/apps/desktop/src/lib/voice-playback.direct.test.ts
@@ -1,0 +1,195 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { setVoicePlaybackState } from '@/store/voice-playback'
+
+import type * as VoiceClientDirect from './voice-client-direct'
+
+const mocks = vi.hoisted(() => ({
+  directTtsConfig: vi.fn(),
+  synthesizeSpeechClientDirect: vi.fn()
+}))
+
+vi.mock('@/hermes', () => ({
+  getApiRequestConnection: () => null,
+  getApiRequestProfile: () => null,
+  speakText: vi.fn()
+}))
+
+vi.mock('@/lib/voice-client-direct', async importOriginal => {
+  const actual = await importOriginal<typeof VoiceClientDirect>()
+
+  return {
+    ...actual,
+    directTtsConfig: mocks.directTtsConfig,
+    synthesizeSpeechClientDirect: mocks.synthesizeSpeechClientDirect
+  }
+})
+
+import { startSpeechStream, stopVoicePlayback } from './voice-playback'
+
+interface Deferred<T> {
+  promise: Promise<T>
+  reject: (reason?: unknown) => void
+  resolve: (value: T) => void
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (value: T) => void = () => undefined
+  let reject: (reason?: unknown) => void = () => undefined
+
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+
+  return { promise, reject, resolve }
+}
+
+class MockAudio {
+  static instances: MockAudio[] = []
+
+  readonly listeners = new Map<string, () => void>()
+  readonly load = vi.fn()
+  readonly pause = vi.fn()
+  readonly play = vi.fn(async () => undefined)
+  src: string
+
+  constructor(src: string) {
+    this.src = src
+    MockAudio.instances.push(this)
+  }
+
+  addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+    this.listeners.set(type, () => {
+      if (typeof listener === 'function') {
+        listener(new Event(type))
+      } else {
+        listener.handleEvent(new Event(type))
+      }
+    })
+  }
+
+  emit(type: string) {
+    this.listeners.get(type)?.()
+  }
+}
+
+const tts = {
+  mode: 'direct' as const,
+  wire: 'openai-speech' as const,
+  provider: 'openai',
+  base_url: 'http://127.0.0.1:7851/v1',
+  api_key: 'local-test-key',
+  model: 'local-tts',
+  voice: 'test-voice',
+  speed: null
+}
+
+const firstSentence = '这是第一段用于验证流水线预取行为的完整测试句子，长度已经超过二十四个字符。'
+const secondSentence = '这是第二段用于验证严格顺序播放的完整测试句子，长度同样超过二十四个字符。'
+const thirdSentence = '这是第三段用于验证中断后丢弃结果的完整测试句子，长度也超过二十四个字符。'
+
+async function flushPromises() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe('client-direct speech prefetch', () => {
+  let createObjectURL: ReturnType<typeof vi.fn>
+  let revokeObjectURL: ReturnType<typeof vi.fn>
+  let syntheses: Array<Deferred<ArrayBuffer>>
+
+  beforeEach(() => {
+    MockAudio.instances = []
+    syntheses = []
+    createObjectURL = vi.fn(() => `blob:voice-${createObjectURL.mock.calls.length}`)
+    revokeObjectURL = vi.fn()
+    vi.stubGlobal('Audio', MockAudio)
+    vi.stubGlobal('URL', { createObjectURL, revokeObjectURL })
+
+    mocks.directTtsConfig.mockReset()
+    mocks.synthesizeSpeechClientDirect.mockReset()
+    mocks.directTtsConfig.mockResolvedValue(tts)
+    mocks.synthesizeSpeechClientDirect.mockImplementation(() => {
+      const next = deferred<ArrayBuffer>()
+
+      syntheses.push(next)
+
+      return next.promise
+    })
+    setVoicePlaybackState({ audioElement: null, messageId: null, sequence: 0, source: null, status: 'idle' })
+  })
+
+  afterEach(() => {
+    stopVoicePlayback()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+  })
+
+  async function openSession(text: string) {
+    const session = await startSpeechStream({ messageId: 'reply-1', source: 'read-aloud' })
+    expect(session).not.toBeNull()
+    session!.append(text)
+    session!.finish()
+    await flushPromises()
+
+    return session!
+  }
+
+  it('prefetches one sentence in FIFO order and aborts in-flight work on stop', async () => {
+    const session = await openSession(`${firstSentence} ${secondSentence} ${thirdSentence}`)
+    expect(mocks.synthesizeSpeechClientDirect).toHaveBeenCalledTimes(1)
+
+    syntheses[0].resolve(new Uint8Array([1]).buffer)
+    await flushPromises()
+
+    expect(MockAudio.instances).toHaveLength(1)
+    expect(MockAudio.instances[0].play).toHaveBeenCalledTimes(1)
+    expect(mocks.synthesizeSpeechClientDirect).toHaveBeenCalledTimes(2)
+
+    syntheses[1].resolve(new Uint8Array([2]).buffer)
+    await flushPromises()
+    expect(MockAudio.instances).toHaveLength(1)
+
+    MockAudio.instances[0].emit('ended')
+    await flushPromises()
+    expect(MockAudio.instances).toHaveLength(2)
+    expect(MockAudio.instances[1].play).toHaveBeenCalledTimes(1)
+    expect(mocks.synthesizeSpeechClientDirect).toHaveBeenCalledTimes(3)
+
+    const signal = mocks.synthesizeSpeechClientDirect.mock.calls[2]?.[2]?.signal as AbortSignal
+    expect(signal.aborted).toBe(false)
+
+    stopVoicePlayback()
+    await expect(session.done).resolves.toBe('done')
+    expect(signal.aborted).toBe(true)
+    expect(MockAudio.instances[1].pause).toHaveBeenCalled()
+
+    syntheses[2].resolve(new Uint8Array([3]).buffer)
+    await flushPromises()
+    expect(MockAudio.instances).toHaveLength(2)
+  })
+
+  it('lets the current sentence finish when prefetching the next sentence fails', async () => {
+    const session = await startSpeechStream({ messageId: 'reply-1', source: 'read-aloud' })
+    expect(session).not.toBeNull()
+    session!.append(`${firstSentence} ${secondSentence} trailing`)
+    await flushPromises()
+
+    syntheses[0].resolve(new Uint8Array([1]).buffer)
+    await flushPromises()
+
+    syntheses[1].reject(new Error('provider unavailable'))
+    await flushPromises()
+    expect(MockAudio.instances[0].pause).not.toHaveBeenCalled()
+    expect(mocks.synthesizeSpeechClientDirect).toHaveBeenCalledTimes(2)
+
+    session!.append(thirdSentence)
+    await flushPromises()
+    expect(mocks.synthesizeSpeechClientDirect).toHaveBeenCalledTimes(2)
+
+    MockAudio.instances[0].emit('ended')
+    await expect(session!.done).resolves.toBe('done')
+  })
+})

--- a/apps/desktop/src/lib/voice-playback.ts
+++ b/apps/desktop/src/lib/voice-playback.ts
@@ -206,12 +206,22 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
   let buffer = ''
   let finished = false
   let settled = false
-  let started = false
-  const queue: string[] = []
+  let failed = false
+  let producedAudio = false
+  const pending: string[] = []
   let synthesizing = false
-  let playing: HTMLAudioElement | null = null
+  let ready: ArrayBuffer | null = null
+  let playing: { audio: HTMLAudioElement; url: string } | null = null
+  const abort = new AbortController()
 
   let settle: (value: 'done' | 'fallback') => void = () => undefined
+
+  const cleanupPlayback = (playback: { audio: HTMLAudioElement; url: string }) => {
+    playback.audio.pause()
+    playback.audio.src = ''
+    playback.audio.load()
+    URL.revokeObjectURL(playback.url)
+  }
 
   const done = new Promise<'done' | 'fallback'>(resolve => {
     settle = value => {
@@ -220,85 +230,110 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
       }
 
       settled = true
-      currentStop = null
+      abort.abort()
+      pending.length = 0
+      ready = null
 
       if (playing) {
-        playing.pause()
-        playing.src = ''
+        cleanupPlayback(playing)
         playing = null
+      }
+
+      if (currentStop === stop) {
+        currentStop = null
       }
 
       resolve(value)
     }
   })
 
-  currentStop = () => settle(started ? 'done' : 'fallback')
+  const stop = () => settle(producedAudio ? 'done' : 'fallback')
+  currentStop = stop
 
-  const pump = async () => {
-    if (synthesizing || settled) {
+  const startPlayback = (bytes: ArrayBuffer) => {
+    if (settled) {
       return
     }
 
+    const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/mpeg' }))
+    const audio = new Audio(url)
+    const playback = { audio, url }
+    playing = playback
+
+    const finishPlayback = () => {
+      if (playing !== playback) {
+        return
+      }
+
+      cleanupPlayback(playback)
+      playing = null
+      drive()
+    }
+
+    const failPlayback = () => {
+      if (playing !== playback) {
+        return
+      }
+
+      settle(producedAudio ? 'done' : 'fallback')
+    }
+
+    audio.addEventListener('ended', finishPlayback, { once: true })
+    audio.addEventListener('error', failPlayback, { once: true })
+
+    producedAudio = true
+    setVoicePlaybackState(currentState('speaking', options))
+    void audio.play().catch(failPlayback)
+
+    // The current segment is now playing, so use that time to prepare exactly
+    // one following segment. Playback remains strictly FIFO.
+    drive()
+  }
+
+  const startSynthesis = (sentence: string) => {
     synthesizing = true
 
-    try {
-      while (queue.length > 0 && !settled) {
-        const sentence = queue.shift()!
-
-        let bytes: ArrayBuffer
-
-        try {
-          bytes = await synthesizeSpeechClientDirect(tts, sentence)
-        } catch {
-          // Provider rejected mid-reply. Nothing played yet → let the caller
-          // fall back to the relay with the full text. Mid-playback → treat
-          // what played as the playback (replaying would stutter).
-          settle(started ? 'done' : 'fallback')
-
-          return
+    void synthesizeSpeechClientDirect(tts, sentence, { signal: abort.signal })
+      .then(bytes => {
+        if (!settled && !failed) {
+          ready = bytes
         }
-
-        if (settled) {
-          return
+      })
+      .catch(() => {
+        if (!settled && !abort.signal.aborted) {
+          failed = true
+          pending.length = 0
         }
+      })
+      .finally(() => {
+        synthesizing = false
+        drive()
+      })
+  }
 
-        if (!started) {
-          started = true
-          setVoicePlaybackState(currentState('speaking', options))
-        }
+  function drive() {
+    if (settled) {
+      return
+    }
 
-        const url = URL.createObjectURL(new Blob([bytes], { type: 'audio/mpeg' }))
+    if (!playing && ready) {
+      const bytes = ready
+      ready = null
+      startPlayback(bytes)
+    }
 
-        try {
-          await new Promise<void>((resolve, reject) => {
-            const audio = new Audio(url)
-            playing = audio
-            audio.addEventListener('ended', () => resolve(), { once: true })
-            audio.addEventListener('error', () => reject(new Error('Playback failed')), { once: true })
-            void audio.play().catch(reject)
-          })
-        } catch {
-          settle(started ? 'done' : 'fallback')
+    if (!failed && !synthesizing && ready === null && pending.length > 0) {
+      startSynthesis(pending.shift()!)
+    }
 
-          return
-        } finally {
-          playing = null
-          URL.revokeObjectURL(url)
-        }
-      }
-
-      if (finished && queue.length === 0 && !settled) {
-        settle(started ? 'done' : 'fallback')
-      }
-    } finally {
-      synthesizing = false
-
-      // Deltas that arrived while the last sentence was playing.
-      if (!settled && queue.length > 0) {
-        void pump()
-      } else if (!settled && finished && queue.length === 0) {
-        settle(started ? 'done' : 'fallback')
-      }
+    if (
+      (finished || failed) &&
+      !playing &&
+      !synthesizing &&
+      ready === null &&
+      pending.length === 0
+    ) {
+      settle(producedAudio ? 'done' : 'fallback')
     }
   }
 
@@ -313,19 +348,19 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
         const speakable = sanitizeTextForSpeech(sentence)
 
         if (speakable) {
-          queue.push(speakable)
+          pending.push(speakable)
         }
       }
 
-      void pump()
-    } else if (flush && finished && queue.length === 0 && !synthesizing) {
-      settle(started ? 'done' : 'fallback')
+      drive()
+    } else if (flush && finished) {
+      drive()
     }
   }
 
   return {
     append: text => {
-      if (text && !finished && !settled) {
+      if (text && !finished && !settled && !failed) {
         buffer += text
         ingest(false)
       }
@@ -334,6 +369,7 @@ function openClientDirectSpeechSession(tts: DirectTtsConfig, options: VoicePlayb
       if (!finished && !settled) {
         finished = true
         ingest(true)
+        drive()
       }
     },
     done


### PR DESCRIPTION
## What does this PR do?

Removes the provider-round-trip pause between client-direct TTS sentences. The previous queue did not start synthesizing the next sentence until the current `Audio` element fired `ended`; this change keeps a bounded one-segment lookahead while preserving FIFO playback.

The lookahead request is aborted on barge-in/stop. If prefetch fails after playback has started, the current sentence is allowed to finish rather than being cut off or replayed through the fallback path.

## Related Issue

N/A — I searched existing TTS playback issues and PRs and did not find a matching client-direct sentence-prefetch fix.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Reworked `apps/desktop/src/lib/voice-playback.ts` to synthesize at most one sentence ahead during playback while retaining strict FIFO ordering.
- Added `AbortSignal` forwarding for OpenAI-compatible and ElevenLabs client-direct TTS requests.
- Added regression coverage for prefetch ordering, stop cancellation/late-result discard, and mid-playback provider failure.

## How to Test

1. Before the fix, run `npm run test:ui -- src/lib/voice-playback.direct.test.ts`: the test fails because the second synthesis does not begin while the first sentence is playing.
2. Run `npm run test:ui -- src/lib/voice-playback.direct.test.ts src/lib/voice-client-direct.test.ts` (22 tests pass).
3. Run `npm run typecheck` and ESLint for the four changed files.
4. From Git Bash, run `npm run test:ui` (719 files / 7169 tests pass), then run `npm run build`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — N/A, this is a desktop-only TypeScript change with no Python files touched
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Node.js 24.20.0, npm 12.0.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A, no user-facing API or configuration changed
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — browser-standard `AbortController`, `Audio`, and object URLs only
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

Not applicable; this is an audio scheduling change. Automated tests pin the timing, FIFO, cancellation, and failure-handling invariants.