### PR TITLE
fix(telegram): give rich-message tables a blank line, not a hard break

### DIFF
--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -515,9 +515,22 @@ def _rich_normalize_linebreaks(text: str) -> str:
     Paragraph breaks (``\\n\\n``), fenced code blocks, and GFM pipe-table
     blocks are left untouched: tables render natively in the rich path and a
     hard break injected into a row separator would corrupt the table.
+
+    A pipe table additionally needs a *blank line* on each side. A table is a
+    block-level structure that cannot be opened from inside an open paragraph,
+    so prose written directly above a table (no blank line — a very common
+    model output) used to leave the paragraph open and Telegram swallowed the
+    whole table into it as literal ``| a | b |`` text. Symmetrically, prose
+    written directly below a table would be absorbed as one more table row.
+    The single boundary newline is therefore promoted to a paragraph break
+    instead of a hard break. Fenced code blocks need no such promotion: a fence
+    can interrupt a paragraph, so their boundaries are left alone.
     """
     if not text or '\n' not in text:
         return text
+
+    def _hard_breaks(prose: str) -> str:
+        return re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose)
 
     out: list[str] = []
     # Split off protected regions (fenced code OR table blocks) and only inject
@@ -525,12 +538,23 @@ def _rich_normalize_linebreaks(text: str) -> str:
     # the original single-\n regex, which sees each prose run as a whole string.
     pos = 0
     for m in _RICH_PROTECTED_REGION_RE.finditer(text):
+        region = m.group(0)
+        is_table = not region.startswith('```')
         prose = text[pos:m.start()]
-        out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', prose))
-        out.append(m.group(0))  # protected region kept verbatim
+        if is_table and prose.endswith('\n') and not prose.endswith('\n\n'):
+            # Close the paragraph above the table instead of hard-breaking it.
+            out.append(_hard_breaks(prose[:-1]))
+            out.append('\n\n')
+        else:
+            out.append(_hard_breaks(prose))
+        out.append(region)  # protected region kept verbatim
         pos = m.end()
+        if is_table and text.startswith('\n', pos) and not text.startswith('\n\n', pos):
+            # Same on the far side: keep the next prose line out of the table.
+            out.append('\n\n')
+            pos += 1
     tail = text[pos:]
-    out.append(re.sub(r'(?<!\n)\n(?!\n)', '  \n', tail))
+    out.append(_hard_breaks(tail))
     return ''.join(out)
 
 

--- a/tests/gateway/test_telegram_rich_table_boundary.py
+++ b/tests/gateway/test_telegram_rich_table_boundary.py
@@ -1,0 +1,110 @@
+"""A GFM table needs a blank line around it, not a hard break.
+
+A table written directly under a line of prose — no blank line between them —
+arrived in Telegram as a single run-on paragraph of literal ``| a | b |`` text,
+while an otherwise identical table with a blank line above it rendered
+natively.  ``sendRichMessage`` echoes the parsed block structure back, which
+shows the rule directly: a table cannot be opened from inside an open
+paragraph, and a bare newline above it is not enough either.
+
+``_rich_normalize_linebreaks`` protects the *inside* of a table block but used
+to hard-break the newline that leads into it, so the caption's paragraph stayed
+open and the table could never start a block of its own. The mirror case —
+prose written directly under the last table row — was absorbed as one more
+table row and also picked up two stray trailing spaces inside the final cell.
+
+Fenced code blocks deliberately keep their hard-break boundary: a fence *can*
+interrupt an open paragraph, so promoting that newline would only add a blank
+line nobody asked for.
+
+The ``telegram`` package is mocked by ``tests/gateway/conftest.py``, so these
+tests construct a real ``TelegramAdapter``.
+"""
+
+import pytest
+
+from plugins.platforms.telegram.adapter import TelegramAdapter
+
+
+@pytest.fixture()
+def adapter():
+    """Bare adapter instance — _rich_message_payload doesn't use self."""
+    return object.__new__(TelegramAdapter)
+
+
+def _md(adapter, content: str) -> str:
+    return adapter._rich_message_payload(content)["markdown"]
+
+
+class TestTableBoundaryPromotedToParagraphBreak:
+    """The newline between prose and a table must become a blank line."""
+
+    def test_table_under_caption_gets_blank_line(self, adapter):
+        """Caption + table with no blank line: the reported break."""
+        content = (
+            "**Knowledge base**\n"
+            "| # | What |\n"
+            "|---|---|\n"
+            "| 201 | Backlinks |\n"
+            "| 202 | Search |"
+        )
+        md = _md(adapter, content)
+        assert md.startswith("**Knowledge base**\n\n|"), md
+        # No hard break may survive on the boundary — that is what kept the
+        # caption's paragraph open and swallowed the table.
+        assert "  \n" not in md, md
+
+    def test_prose_under_table_gets_blank_line(self, adapter):
+        """Prose directly under the last row must not become a table row."""
+        content = "| # | What |\n|---|---|\n| 201 | a |\ntrailing prose"
+        md = _md(adapter, content)
+        assert md == "| # | What |\n|---|---|\n| 201 | a |\n\ntrailing prose", md
+        # The old code left "| 201 | a |  \n" — two spaces inside the last cell.
+        assert "|  \n" not in md, md
+
+    def test_every_table_in_a_multi_table_message(self, adapter):
+        """The reported message had four tables; each boundary is independent."""
+        content = (
+            "## Report\n"
+            "| a | b |\n|---|---|\n| 1 | 2 |\n"
+            "\n"
+            "**Second**\n"
+            "| c | d |\n|---|---|\n| 3 | 4 |"
+        )
+        md = _md(adapter, content)
+        assert "## Report\n\n| a | b |" in md, md
+        assert "**Second**\n\n| c | d |" in md, md
+
+    def test_existing_blank_line_is_left_alone(self, adapter):
+        """The one table that already rendered must come out byte-identical."""
+        content = "**Knowledge base**\n\n| # | What |\n|---|---|\n| 201 | Backlinks |"
+        assert _md(adapter, content) == content
+
+
+class TestBoundaryPromotionStaysNarrow:
+    """Guards against the fix reaching past table boundaries."""
+
+    def test_fence_boundary_keeps_its_hard_break(self, adapter):
+        """A fence can interrupt a paragraph — no blank line to inject."""
+        content = "Look:\n```bash\nls -la\n```\nafter"
+        md = _md(adapter, content)
+        assert md == "Look:  \n```bash\nls -la\n```  \nafter", md
+
+    def test_plain_prose_still_gets_hard_breaks(self, adapter):
+        """The original #46070 behaviour must survive untouched."""
+        assert _md(adapter, "Line 1\nLine 2\nLine 3") == "Line 1  \nLine 2  \nLine 3"
+
+    def test_fence_directly_above_table_still_gets_the_blank_line(self, adapter):
+        """The only path where the boundary is decided by the *following* region.
+
+        The closing fence is not prose, so nothing above needs a hard break —
+        but the table below still cannot open inside whatever precedes it.
+        """
+        content = "```py\nx = 1\n```\n| a | b |\n|---|---|\n| 1 | 2 |"
+        md = _md(adapter, content)
+        assert md == "```py\nx = 1\n```\n\n| a | b |\n|---|---|\n| 1 | 2 |", md
+
+    def test_table_at_message_start_needs_no_leading_blank(self, adapter):
+        """Nothing above the table — do not prepend a stray blank line."""
+        content = "| a | b |\n|---|---|\n| 1 | 2 |"
+        assert _md(adapter, content) == content


### PR DESCRIPTION
## Problem

In the Bot API 10.1 rich-message path, a GFM pipe table that is written directly under a line of prose — no blank line between them — is not rendered as a table at all. The whole block arrives as one run-on paragraph of literal `| 201 | ... |` text.

This is easy to observe from the outside, because `sendRichMessage` echoes back the *parsed* block structure. Three payloads, same table, only the boundary above it differs:

```
"Knowledge base\n| a | b |\n|---|---|\n| 1 | 2 |"       -> blocks: [paragraph]
"Knowledge base  \n| a | b |\n|---|---|\n| 1 | 2 |"     -> blocks: [paragraph]
"Knowledge base\n\n| a | b |\n|---|---|\n| 1 | 2 |"     -> blocks: [paragraph, table]
```

A table cannot be opened from inside an open paragraph: it needs a blank line, and a bare newline is not enough.

`_rich_normalize_linebreaks()` (added in #46070, table protection in a96693239) protects the *inside* of a table block, but the newline that leads *into* one is prose as far as it is concerned, so it gets a hard break (`"  \n"`) — which keeps the paragraph open and swallows the table.

The mirror case has the same root: prose written directly under the last table row is absorbed as one more table row, and the row itself picks up two stray trailing spaces inside its final cell.

Models emit a caption directly above a table often enough that this is the common case, not the corner case — in the message that prompted this, three of four tables were lost and only the one that happened to have a blank line above it rendered.

## Fix

At a boundary where a **table** region begins or ends, promote the single boundary newline to a paragraph break instead of stamping a hard break on it.

Fence boundaries are deliberately left alone: a fenced code block *can* interrupt a paragraph, so a blank line there would only add vertical space nobody asked for.

The promotion is never longer than what it replaces — `"\n"` → `"\n\n"` (+1 char) always takes the place of a site that previously emitted `"  \n"` (+2 chars) — so no payload can be pushed over the 32,768-character rich-message cap that the old code did not already push further over.

## Tests

`tests/gateway/test_telegram_rich_table_boundary.py`, 8 cases: table under a caption, prose under a table, several tables in one message, an already-blank-lined table (must stay byte-identical), a fence directly above a table, and three guards that the promotion does not reach past table boundaries (fence boundary keeps its hard break, plain prose keeps its hard breaks, a table at message start gets no leading blank line).

Reverting the change fails 4 of the 8; widening it to fence boundaries fails the fence guard. Existing `test_telegram_rich_newlines.py` and `test_telegram_rich_messages.py` pass unchanged.

## Related

#76368 touches the same function and also removes the hard break on the newline entering a table — but it leaves a bare `\n` there, which (see the parsed-block output above) still does not let the table start. The two changes are compatible in spirit; happy to rebase on top of it if it lands first, or to fold the blank-line promotion into it.
