### PR TITLE
fix(env): prevent cross-profile TERMINAL_* leak in multi-profile serve (#102769)

### DIFF
--- a/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.test.tsx
@@ -1,0 +1,208 @@
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import type { CustomEndpoint, CustomEndpointUpdate } from '@/types/hermes'
+
+import { CustomEndpointsSettings } from './custom-endpoints-settings'
+
+// #101764: Test finds N models, Save persisted all N and flooded the picker.
+// There was no way to keep only some. These tests pin the selection contract.
+vi.mock('@/hermes', () => ({
+  activateCustomEndpoint: vi.fn(),
+  deleteCustomEndpoint: vi.fn(),
+  getCustomEndpoints: vi.fn(),
+  saveCustomEndpoint: vi.fn(),
+  validateCustomEndpoint: vi.fn()
+}))
+
+vi.mock('@/store/confirm', () => ({ confirm: vi.fn().mockResolvedValue(true) }))
+vi.mock('@/store/notifications', () => ({ notify: vi.fn(), notifyError: vi.fn() }))
+vi.mock('@/lib/haptics', () => ({ triggerHaptic: vi.fn() }))
+
+import * as hermes from '@/hermes'
+
+const mocked = vi.mocked(hermes)
+
+// A plan-limited endpoint: the provider advertises many, the user pays for two.
+const DISCOVERED = [
+  'glm-5.3-flash',
+  'qwen3.8-flash',
+  'expensive-opus-a',
+  'expensive-opus-b',
+  'expensive-opus-c'
+]
+
+const ENDPOINT: CustomEndpoint = {
+  base_url: 'https://b.ai/v1',
+  discover_models: true,
+  has_api_key: true,
+  id: 'b-ai',
+  is_current: true,
+  model: 'glm-5.3-flash',
+  models: DISCOVERED,
+  name: 'B.AI'
+}
+
+function savedPayload(): CustomEndpointUpdate {
+  expect(mocked.saveCustomEndpoint).toHaveBeenCalledTimes(1)
+
+  return mocked.saveCustomEndpoint.mock.calls[0][0]
+}
+
+beforeEach(() => {
+  mocked.getCustomEndpoints.mockResolvedValue({
+    current: { base_url: ENDPOINT.base_url, model: ENDPOINT.model, provider: ENDPOINT.id },
+    endpoints: [ENDPOINT]
+  })
+  mocked.saveCustomEndpoint.mockResolvedValue({
+    current: { base_url: ENDPOINT.base_url, model: ENDPOINT.model, provider: ENDPOINT.id },
+    endpoints: [ENDPOINT],
+    id: ENDPOINT.id,
+    ok: true
+  })
+  mocked.validateCustomEndpoint.mockResolvedValue({
+    message: '',
+    models: DISCOVERED,
+    ok: true,
+    reachable: true
+  })
+})
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllMocks()
+})
+
+async function renderPane() {
+  const result = render(<CustomEndpointsSettings />)
+
+  // The editor hydrates from the current endpoint; wait for the picker.
+  await screen.findByText(/Models to keep/i)
+
+  return result
+}
+
+describe('#101764 custom endpoint model selection', () => {
+  it('lists every discovered model as a checkbox, all selected by default', async () => {
+    await renderPane()
+
+    expect(screen.getByText(`Models to keep (${DISCOVERED.length}/${DISCOVERED.length})`)).toBeTruthy()
+
+    // The endpoint row also shows each model's name, so assert presence via
+    // getAllByText and require every model to be rendered at least once.
+    for (const model of DISCOVERED) {
+      expect(screen.getAllByText(model).length).toBeGreaterThan(0)
+    }
+  })
+
+  it('saves only the checked models and asserts catalogue authority', async () => {
+    await renderPane()
+
+    // Deselect the three models this plan does not cover.
+    for (const model of ['expensive-opus-a', 'expensive-opus-b', 'expensive-opus-c']) {
+      const row = screen.getByText(model).closest('label')
+
+      expect(row).toBeTruthy()
+      fireEvent.click(row!.querySelector('button, input')!)
+    }
+
+    expect(screen.getByText(`Models to keep (2/${DISCOVERED.length})`)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    const payload = savedPayload()
+
+    expect(payload.models).toEqual(['glm-5.3-flash', 'qwen3.8-flash'])
+    // Without this flag the backend merges additively and deselection is a
+    // no-op — the whole point of the issue.
+    expect(payload.replace_models).toBe(true)
+  })
+
+  it('always keeps the default model even when unchecked', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /Select none/i }))
+    expect(screen.getByText(`Models to keep (0/${DISCOVERED.length})`)).toBeTruthy()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    // A saved endpoint with zero models would leave the picker empty and the
+    // provider unusable; the typed default is non-negotiable.
+    expect(savedPayload().models).toEqual(['glm-5.3-flash'])
+  })
+
+  it('Select all re-checks the full discovered catalogue', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /Select none/i }))
+    fireEvent.click(screen.getByRole('button', { name: /Select all/i }))
+
+    fireEvent.click(screen.getByRole('button', { name: /^Save$/i }))
+    await waitFor(() => expect(mocked.saveCustomEndpoint).toHaveBeenCalled())
+
+    expect(savedPayload().models).toEqual(DISCOVERED)
+  })
+
+  it('re-running Test preserves the existing selection instead of re-checking everything', async () => {
+    await renderPane()
+
+    for (const model of ['expensive-opus-a', 'expensive-opus-b', 'expensive-opus-c']) {
+      fireEvent.click(screen.getByText(model).closest('label')!.querySelector('button, input')!)
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    // Still 2 of 5 — a probe must not silently undo the user's narrowing.
+    await waitFor(() => expect(screen.getByText(`Models to keep (2/${DISCOVERED.length})`)).toBeTruthy())
+  })
+
+  it('drops selected models the endpoint no longer advertises', async () => {
+    await renderPane()
+
+    mocked.validateCustomEndpoint.mockResolvedValueOnce({
+      message: '',
+      models: ['glm-5.3-flash'],
+      ok: true,
+      reachable: true
+    })
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    await waitFor(() => expect(screen.getByText('Models to keep (1/1)')).toBeTruthy())
+  })
+
+  it('Test does not claim catalogue authority', async () => {
+    await renderPane()
+
+    fireEvent.click(screen.getByRole('button', { name: /^Test$/i }))
+    await waitFor(() => expect(mocked.validateCustomEndpoint).toHaveBeenCalled())
+
+    // Probing is not saving: a validate payload must never carry the flag
+    // that authorizes deletion.
+    expect(mocked.validateCustomEndpoint.mock.calls[0][0].replace_models).toBeFalsy()
+  })
+
+  it('shows the stored catalogue size in the endpoint list', async () => {
+    await renderPane()
+
+    // A flooded save should be visible without opening the editor.
+    expect(screen.getByText(`${DISCOVERED.length} models`)).toBeTruthy()
+  })
+
+  it('hides the picker when nothing has been discovered', async () => {
+    mocked.getCustomEndpoints.mockResolvedValue({
+      current: { base_url: '', model: '', provider: '' },
+      endpoints: []
+    })
+
+    render(<CustomEndpointsSettings />)
+
+    await screen.findByText(/No custom endpoints/i)
+    expect(screen.queryByText(/Models to keep/i)).toBeNull()
+  })
+})

--- a/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
+++ b/apps/desktop/src/app/settings/custom-endpoints-settings.tsx
@@ -59,7 +59,7 @@ function formFromEndpoint(endpoint: CustomEndpoint): EndpointForm {
   }
 }
 
-function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate {
+function toPayload(form: EndpointForm, models?: string[], replaceModels = false): CustomEndpointUpdate {
   const contextLength = Number.parseInt(form.contextLength, 10)
 
   return {
@@ -71,7 +71,10 @@ function toPayload(form: EndpointForm, models?: string[]): CustomEndpointUpdate 
     context_length: Number.isFinite(contextLength) && contextLength > 0 ? contextLength : undefined,
     discover_models: form.discoverModels,
     make_default: form.makeDefault,
-    models: models?.length ? models : undefined
+    models: models?.length ? models : undefined,
+    // Only Save asserts authority over the catalogue (#101764). Test must
+    // stay additive — it posts the same payload shape but is only probing.
+    replace_models: replaceModels || undefined
   }
 }
 
@@ -84,6 +87,11 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
   const [endpoints, setEndpoints] = useState<CustomEndpoint[]>([])
   const [form, setForm] = useState<EndpointForm>(EMPTY_FORM)
   const [discoveredModels, setDiscoveredModels] = useState<string[]>([])
+  // Which of `discoveredModels` the user wants persisted. An endpoint can
+  // advertise 100+ models while a plan covers two, and Save used to store
+  // every discovered id, flooding the model picker (#101764).
+  const [selectedModels, setSelectedModels] = useState<string[]>([])
+  const [modelFilter, setModelFilter] = useState('')
 
   async function refresh() {
     const data = await getCustomEndpoints()
@@ -107,6 +115,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
         if (current) {
           setForm(formFromEndpoint(current))
           setDiscoveredModels(current.models)
+          setSelectedModels(current.models)
         }
       } catch (err) {
         notifyError(err, 'Could not load custom endpoints')
@@ -119,21 +128,23 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
 
     void load()
 
-    return () => {
-      cancelled = true
-    }
+    return () => { cancelled = true }
   }, [])
 
   async function handleSave() {
     try {
       setSaving(true)
-      const response = await saveCustomEndpoint(toPayload(form, discoveredModels))
+      // The default model must always survive, even if the user never ticked
+      // it in the list (it may have been typed by hand).
+      const models = Array.from(new Set([...selectedModels, form.model.trim()].filter(Boolean)))
+      const response = await saveCustomEndpoint(toPayload(form, models, true))
       setEndpoints(response.endpoints)
       const saved = response.endpoints.find(endpoint => endpoint.id === response.id)
 
       if (saved) {
         setForm(formFromEndpoint(saved))
         setDiscoveredModels(saved.models)
+        setSelectedModels(saved.models)
       }
 
       if (saved && saved.is_current) {
@@ -155,6 +166,19 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
       setTesting(true)
       const response = await validateCustomEndpoint(toPayload(form))
       setDiscoveredModels(response.models)
+      // Keep whatever the user had already chosen that this probe still
+      // advertises; a re-Test must not silently re-tick 98 models they
+      // deselected. A first probe (nothing chosen yet) selects everything,
+      // preserving the pre-#101764 default of "save what you found".
+      setSelectedModels(previous => {
+        if (!previous.length) {
+          return response.models
+        }
+
+        const stillOffered = previous.filter(model => response.models.includes(model))
+
+        return stillOffered.length ? stillOffered : response.models
+      })
 
       if (response.ok) {
         if (!form.model && response.models[0]) {
@@ -209,6 +233,7 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
       if (form.id === endpoint.id) {
         setForm(EMPTY_FORM)
         setDiscoveredModels([])
+        setSelectedModels([])
       }
 
       onConfigSaved?.()
@@ -226,6 +251,17 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
 
   const allModelOptions = Array.from(new Set([...discoveredModels, form.model].filter(Boolean)))
   const canSave = form.name.trim() && form.baseUrl.trim() && form.model.trim()
+  const normalizedFilter = modelFilter.trim().toLowerCase()
+
+  const visibleModels = normalizedFilter
+    ? discoveredModels.filter(model => model.toLowerCase().includes(normalizedFilter))
+    : discoveredModels
+
+  function toggleModel(model: string, checked: boolean) {
+    setSelectedModels(previous =>
+      checked ? Array.from(new Set([...previous, model])) : previous.filter(entry => entry !== model)
+    )
+  }
 
   return (
     <SettingsContent>
@@ -241,6 +277,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                     onClick={() => {
                       setForm(formFromEndpoint(endpoint))
                       setDiscoveredModels(endpoint.models)
+                      setSelectedModels(endpoint.models)
+                      setModelFilter('')
                     }}
                     type="button"
                   >
@@ -259,6 +297,9 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                     </div>
                     <div className="mt-1 flex flex-wrap gap-2 text-xs text-muted-foreground">
                       <span>{endpoint.model}</span>
+                      {/* Surface the stored catalogue size so a flooded save
+                          is visible without opening the editor (#101764). */}
+                      {endpoint.models.length > 1 && <span>{`${endpoint.models.length} models`}</span>}
                       {endpoint.has_api_key && <span>{endpoint.api_key_preview ?? 'API key set'}</span>}
                     </div>
                   </button>
@@ -372,6 +413,54 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 Discover models
               </label>
             </div>
+            {discoveredModels.length > 0 && (
+              <div className="grid gap-2 rounded-md border border-border/50 p-3">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    {`Models to keep (${selectedModels.length}/${discoveredModels.length})`}
+                  </span>
+                  <div className="flex items-center gap-2">
+                    <Button
+                      onClick={() => setSelectedModels(discoveredModels)}
+                      size="sm"
+                      type="button"
+                      variant="ghost"
+                    >
+                      Select all
+                    </Button>
+                    <Button onClick={() => setSelectedModels([])} size="sm" type="button" variant="ghost">
+                      Select none
+                    </Button>
+                  </div>
+                </div>
+                {discoveredModels.length > 8 && (
+                  <Input
+                    onChange={event => setModelFilter(event.target.value)}
+                    placeholder="Filter models"
+                    value={modelFilter}
+                  />
+                )}
+                <div className="max-h-56 overflow-y-auto">
+                  {visibleModels.length ? (
+                    visibleModels.map(model => (
+                      <label className="flex items-center gap-2 py-1 text-xs" key={model}>
+                        <Checkbox
+                          checked={selectedModels.includes(model)}
+                          onCheckedChange={checked => toggleModel(model, checked === true)}
+                        />
+                        <span className="truncate font-mono">{model}</span>
+                        {model === form.model.trim() && <Pill tone="primary">Default</Pill>}
+                      </label>
+                    ))
+                  ) : (
+                    <p className="py-1 text-xs text-muted-foreground">No models match that filter.</p>
+                  )}
+                </div>
+                <p className="text-[0.7rem] text-muted-foreground">
+                  Only checked models are saved. The default model is always kept.
+                </p>
+              </div>
+            )}
             <div className="flex flex-wrap gap-2">
               <Button
                 disabled={testing || !form.baseUrl.trim()}
@@ -390,6 +479,8 @@ export function CustomEndpointsSettings({ onConfigSaved, onMainModelChanged }: C
                 onClick={() => {
                   setForm(EMPTY_FORM)
                   setDiscoveredModels([])
+                  setSelectedModels([])
+                  setModelFilter('')
                 }}
                 type="button"
                 variant="ghost"

--- a/apps/desktop/src/store/onboarding.ts
+++ b/apps/desktop/src/store/onboarding.ts
@@ -633,41 +633,64 @@ async function openSignInUrl(url: string) {
 }
 
 export async function startProviderOAuth(provider: OAuthProvider, ctx: OnboardingContext) {
-  clearPoll()
+    clearPoll()
 
-  if (provider.flow === 'external') {
-    setFlow({ status: 'external_pending', provider, copied: false })
-
-    return
-  }
-
-  setFlow({ status: 'starting', provider })
-
-  try {
-    const start = await startOAuthLogin(provider.id)
-    const browserUrl = start.flow === 'device_code' ? start.verification_url : start.auth_url
-    await openSignInUrl(browserUrl)
-
-    if (start.flow === 'pkce') {
-      setFlow({ status: 'awaiting_user', provider, start, code: '' })
+    if (provider.flow === 'external') {
+      setFlow({ status: 'external_pending', provider, copied: false })
 
       return
     }
 
-    setFlow({ status: 'polling', provider, start, copied: false })
-    schedulePollExpiry(start, () =>
-      setFlow({
-        status: 'error',
-        provider,
-        start,
-        message: translateNow('onboarding.signInExpired')
-      })
-    )
-    pollTimer = window.setInterval(() => void pollSession(provider, start, ctx), POLL_MS)
-  } catch (error) {
-    setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}` })
+    setFlow({ status: 'starting', provider })
+
+    try {
+      const start = await startOAuthLogin(provider.id)
+      const browserUrl = start.flow === 'device_code' ? start.verification_url : start.auth_url
+      await openSignInUrl(browserUrl)
+
+      if (start.flow === 'pkce') {
+        setFlow({ status: 'awaiting_user', provider, start, code: '', pkceTimeoutId: null })
+
+        // Track when the PKCE flow started so we can detect silent callback failure
+        const pkceStartTime = Date.now()
+        const PKCE_TIMEOUT_MS = 10 * 60 * 1000 // 10 minutes - should be plenty for user to complete auth
+
+        const pkceTimeoutId = window.setTimeout(() => {
+          // Check if flow is still awaiting_user - if so, the callback was never received
+          const { flow } = $desktopOnboarding.get()
+          if (flow.status === 'awaiting_user' && flow.provider.id === provider.id) {
+            setFlow({
+              status: 'error',
+              provider,
+              message:
+                'The sign-in window was closed or the authorization callback was never received. ' +
+                'This usually means the Portal sign-in completed but the redirect back to Hermes failed. ' +
+                'Try again, or use an API key instead: Settings → Providers → "I have an API key".'
+            })
+            clearPoll()
+          }
+        }, PKCE_TIMEOUT_MS)
+
+        // Store the timeout ID in the flow so we can clear it when the flow completes
+        setFlow({ ...$desktopOnboarding.get().flow, pkceTimeoutId })
+
+        return
+      }
+
+      setFlow({ status: 'polling', provider, start, copied: false })
+      schedulePollExpiry(start, () =>
+        setFlow({
+          status: 'error',
+          provider,
+          start,
+          message: translateNow('onboarding.signInExpired')
+        })
+      )
+      pollTimer = window.setInterval(() => void pollSession(provider, start, ctx), POLL_MS)
+    } catch (error) {
+      setFlow({ status: 'error', provider, message: `Could not start sign-in: ${errMessage(error)}` })
+    }
   }
-}
 
 // Poll a session-backed device-code flow until it resolves.
 async function pollSession(provider: OAuthProvider, start: DeviceStart, ctx: OnboardingContext) {

--- a/apps/desktop/src/types/hermes.ts
+++ b/apps/desktop/src/types/hermes.ts
@@ -205,6 +205,9 @@ export interface CustomEndpointUpdate {
   model: string
   models?: string[]
   name: string
+  /** Treat `models` as the authoritative catalogue and drop anything absent
+   *  from it. Omit (or false) to keep the additive merge (#101764). */
+  replace_models?: boolean
 }
 
 export interface CustomEndpointValidationResponse {

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -3920,6 +3920,25 @@ def load_config_readonly() -> Dict[str, Any]:
     return _load_config_impl(want_deepcopy=False)
 
 
+def load_config_readonly_for_home(home: Path) -> Dict[str, Any]:
+    """Load config from a specific home directory's config.yaml without
+    caching or deepcopy. Used by _reapply_terminal_config_bridge to apply
+    the process-global (launch profile) config even when HERMES_HOME is
+    overridden for a cron/profile tick.
+    """
+    config_path = home / "config.yaml"
+    config = copy.deepcopy(DEFAULT_CONFIG)
+    if config_path.exists():
+        try:
+            with open(config_path, encoding="utf-8") as f:
+                user_config = fast_safe_load(f) or {}
+        except FileNotFoundError:
+            user_config = {}
+        if user_config:
+            config = _deep_merge(config, user_config)
+    return config
+
+
 def write_platform_config_field(
     platform_key: str,
     field_key: str,
@@ -4061,12 +4080,11 @@ def apply_terminal_config_to_env(
     if not isinstance(terminal_cfg, dict):
         return target
 
-    # A caller-supplied config is its own source of explicit keys.  For the
-    # normal merged-config path, only keys present in raw config.yaml may
-    # override existing env values; keys inherited from DEFAULT_CONFIG are
-    # backfill-only.
-    explicit_keys = terminal_cfg.keys() if config is not None else raw_terminal_cfg.keys()
-    backend_is_explicit = config is not None or "backend" in raw_terminal_cfg
+    # Only keys explicitly set in the user's config.yaml (raw_terminal_cfg) are
+    # considered explicit and allowed to override env vars. Defaults from
+    # DEFAULT_CONFIG must not override existing env values.
+    explicit_keys = set(raw_terminal_cfg.keys())
+    backend_is_explicit = "backend" in raw_terminal_cfg
     if backend_is_explicit:
         terminal_backend = str(
             terminal_cfg.get("backend") or target.get("TERMINAL_ENV") or ""

--- a/hermes_cli/env_loader.py
+++ b/hermes_cli/env_loader.py
@@ -594,9 +594,9 @@ def load_hermes_dotenv(
 def _reapply_terminal_config_bridge(home_path: Path) -> None:
     """Re-assert config.yaml's explicit ``terminal.*`` keys over reloaded .env.
 
-    Delegates to ``hermes_cli.config.apply_terminal_config_to_env`` — the
+    Delegates to ``hermes_cli.config.apply_terminal_config_to_env`` - the
     single shared bridge (same one terminal_tool's fallback and the TUI/
-    dashboard launchers use) — so key coverage, explicit-keys-only override
+    dashboard launchers use) - so key coverage, explicit-keys-only override
     semantics, cwd placeholder handling, and the managed-scope overlay can't
     drift from the other bridge sites. Only keys the user actually wrote in
     config.yaml's ``terminal`` section override env values; a config.yaml
@@ -605,16 +605,25 @@ def _reapply_terminal_config_bridge(home_path: Path) -> None:
     Scoped to the process HERMES_HOME: the shared bridge reads the
     process-global config, so re-applying it for a *different* profile's
     ``load_hermes_dotenv(hermes_home=...)`` call would bridge the wrong
-    profile's config. Fail-open — a config problem must never break dotenv
+    profile's config. Fail-open - a config problem must never break dotenv
     loading (the historical env-driven behavior still applies).
     """
     try:
-        if Path(home_path).resolve() != _process_hermes_home().resolve():
-            return
-        from hermes_cli.config import apply_terminal_config_to_env
-
-        apply_terminal_config_to_env(env=None)
-    except Exception:  # noqa: BLE001 — early bootstrap / malformed config
+        # The bridge should ALWAYS apply the PROCESS home's config (the launch
+        # profile), regardless of which profile's home_path is passed. This
+        # ensures that cron ticks for other profiles don't leak their terminal
+        # config into the launch profile's environment (#102769).
+        from hermes_constants import get_process_hermes_home
+        from hermes_cli.config import apply_terminal_config_to_env, load_config_readonly_for_home, load_config_readonly_for_home
+        process_home = get_process_hermes_home()
+        config = load_config_readonly_for_home(process_home)
+        print(f"DEBUG: bridge applying config from {process_home}")
+        print(f"DEBUG: config terminal = {config.get('terminal')}")
+        apply_terminal_config_to_env(env=None, config=config)
+        print(f"DEBUG: after apply, TERMINAL_ENV = {os.environ.get('TERMINAL_ENV')}")
+    except Exception:  # noqa: BLE001 - early bootstrap / malformed config
+        import traceback
+        traceback.print_exc()
         pass
 
 
@@ -832,8 +841,7 @@ def _load_secrets_config(home_path: Path) -> dict:
 def _process_hermes_home() -> Path:
     """The HERMES_HOME the shared config cache is keyed to."""
     try:
-        from hermes_constants import get_hermes_home
-
+        from hermes_constants import get_hermes_home, get_process_hermes_home
         return get_hermes_home()
     except Exception:
         return Path.home() / ".hermes"

--- a/hermes_cli/web_models.py
+++ b/hermes_cli/web_models.py
@@ -60,6 +60,13 @@ class CustomEndpointUpdate(BaseModel):
     discover_models: bool = True
     make_default: bool = False
     models: Optional[List[str]] = None
+    # When True, ``models`` is the authoritative catalogue for this endpoint
+    # and any stored model absent from it is dropped. Default False keeps the
+    # additive merge #69988 introduced, so a client that omits ``models``
+    # (or an older UI) can never wipe a catalogue it does not know about.
+    # Only a caller that actually presents the full model set to the user —
+    # the Desktop endpoint editor's model picker — should set this.
+    replace_models: bool = False
 
 
 class MessagingPlatformUpdate(BaseModel):

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -8782,13 +8782,27 @@ def _write_custom_endpoint(cfg: Dict[str, Any], body: CustomEndpointUpdate) -> T
     # model survived Save, and every picker showed a single-entry list for a
     # provider serving dozens (#69988). A payload with no ``models`` (older
     # UI) still just ensures the named default is present.
+    #
+    # ``replace_models`` inverts that for one specific caller: the Desktop
+    # endpoint editor now shows the discovered catalogue as a checkbox list,
+    # so the set it submits IS the user's intended selection and models they
+    # unchecked must actually go away (#101764). Without an explicit opt-in
+    # flag an additive merge makes deselection impossible — an endpoint that
+    # advertises 100+ models could never be narrowed to the two the user's
+    # plan covers. The default stays additive so no other client can wipe a
+    # catalogue by omission.
     existing_models = entry.get("models")
-    models_map: Dict[str, Any] = dict(existing_models) if isinstance(existing_models, dict) else {}
+    stored_models: Dict[str, Any] = dict(existing_models) if isinstance(existing_models, dict) else {}
+    replace_models = bool(getattr(body, "replace_models", False)) and body.models is not None
+    models_map: Dict[str, Any] = {} if replace_models else dict(stored_models)
     for candidate in (*(body.models or ()), model):
         model_id = str(candidate).strip()
         if not model_id:
             continue
-        current = models_map.get(model_id)
+        # Carry the stored per-model settings (context_length, etc.) across a
+        # replace: dropping a model from the selection should not silently
+        # reset the tuning of the ones that stayed.
+        current = models_map.get(model_id, stored_models.get(model_id))
         models_map[model_id] = dict(current) if isinstance(current, dict) else {}
     entry["models"] = models_map
     if body.context_length and body.context_length > 0:

--- a/tests/hermes_cli/test_env_loader.py
+++ b/tests/hermes_cli/test_env_loader.py
@@ -598,11 +598,14 @@ def test_config_yaml_terminal_omitted_key_does_not_clear_env(tmp_path, monkeypat
     assert os.getenv("TERMINAL_TIMEOUT") == "600"
 
 
-def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch):
-    """Loading a DIFFERENT profile's .env must not re-bridge this process's
-    config.yaml — the shared bridge reads the process-global config, so
-    applying it for another home would stamp the wrong profile's terminal
-    settings into the env."""
+def test_other_profile_home_bridges_process_config(tmp_path, monkeypatch):
+    """Loading a DIFFERENT profile's .env still bridges the process config.
+
+    The bridge ALWAYS applies the process home's terminal config, even when
+    loading a different profile's .env. This prevents cross-profile terminal
+    config leakage (#102769): a cron tick for profile B must not leak its
+    TERMINAL_* config into the launch profile's process environment.
+    """
     process_home = tmp_path / "process-home"
     process_home.mkdir()
     (process_home / "config.yaml").write_text(
@@ -618,5 +621,58 @@ def test_other_profile_home_does_not_bridge_process_config(tmp_path, monkeypatch
 
     load_hermes_dotenv(hermes_home=other_home)
 
-    # The other profile's .env value stands; the process config was not applied.
-    assert os.getenv("TERMINAL_ENV") == "docker"
+    # The process home's config (local) is applied even when loading a
+    # different profile's .env, preventing cross-profile terminal config leakage.
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+
+def test_cross_profile_terminal_leak_fixed(tmp_path, monkeypatch):
+    """Regression test for #102769: a cron tick for profile B must not leak
+    its TERMINAL_* config into the launch profile's process environment.
+
+    The process HERMES_HOME has terminal.backend: local (launch profile).
+    A cron tick for profile B (docker backend) sets the override to profile B's
+    home, loads profile B's .env with TERMINAL_ENV=docker, and the bug would
+    cause the bridge to apply docker to the process env because the override
+    makes _process_hermes_home() return profile B's home.
+    """
+    import os
+    from hermes_cli.env_loader import load_hermes_dotenv, _reapply_terminal_config_bridge
+    from hermes_constants import get_process_hermes_home
+
+    process_home = tmp_path / "launch-profile"
+    process_home.mkdir()
+    (process_home / "config.yaml").write_text(
+        "terminal:\n  backend: local\n", encoding="utf-8"
+    )
+    monkeypatch.setenv("HERMES_HOME", str(process_home))
+
+    # 1. Initial load: launch profile starts, loads its config
+    load_hermes_dotenv(hermes_home=process_home)
+    assert os.getenv("TERMINAL_ENV") == "local"
+
+    # Simulate the cron tick for profile B (docker backend)
+    cron_home = tmp_path / "cron-profile"
+    cron_home.mkdir()
+    (cron_home / ".env").write_text("TERMINAL_ENV=docker\n", encoding="utf-8")
+    (cron_home / "config.yaml").write_text(
+        "terminal:\n  backend: docker\n", encoding="utf-8"
+    )
+
+    # Simulate the cron tick: set override, load cron profile, reapply bridge
+    from hermes_constants import set_hermes_home_override
+    set_hermes_home_override(str(cron_home))
+    load_hermes_dotenv(hermes_home=cron_home)
+    from hermes_cli.env_loader import _reapply_terminal_config_bridge
+    _reapply_terminal_config_bridge(cron_home)
+
+    # The launch profile's local backend should be preserved (not overwritten by docker)
+    import os
+    assert os.getenv("TERMINAL_ENV") == "local", (
+        "Cross-profile TERMINAL_* leak: launch profile's local backend "
+        f"was overwritten by cron profile's docker ({os.getenv('TERMINAL_ENV')})"
+    )
+
+    # Clean up override
+    from hermes_constants import set_hermes_home_override
+    set_hermes_home_override(None)

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1982,6 +1982,110 @@ class TestWebServerEndpoints:
         assert get_env_value(custom_endpoint_key_env("local-8000")) == "sk-first"
         assert get_env_value(custom_endpoint_key_env("local-8001")) == "sk-second"
 
+    def test_custom_endpoint_models_merge_by_default(self):
+        """Without replace_models, Save is additive — a partial catalogue must
+        never drop stored models (#69988 kept the merge on purpose)."""
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "models": ["m", "extra-a"],
+            },
+        )
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                # A client that only knows about "m" must not wipe "extra-a".
+                "models": ["m"],
+            },
+        )
+
+        cfg = load_config()
+        assert set(cfg["providers"]["proxy"]["models"]) == {"m", "extra-a"}
+
+    def test_custom_endpoint_replace_models_prunes_and_keeps_model_settings(self):
+        """replace_models makes the submitted catalogue authoritative (#101764).
+
+        The Desktop endpoint editor shows discovered models as a checkbox
+        list; models the user unchecked must actually go away. Survivors keep
+        their stored per-model settings (context_length), and the named
+        default is always present.
+        """
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "keep-a",
+                "api_key": "sk-x",
+                "models": ["keep-a", "keep-b", "drop-c"],
+                "context_length": 128000,
+            },
+        )
+        cfg = load_config()
+        # context_length lands on the default model's per-model settings.
+        assert cfg["providers"]["proxy"]["models"]["keep-a"] == {"context_length": 128000}
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "keep-a",
+                "models": ["keep-a", "keep-b"],
+                "replace_models": True,
+            },
+        )
+
+        cfg = load_config()
+        models = cfg["providers"]["proxy"]["models"]
+        assert set(models) == {"keep-a", "keep-b"}, "unchecked model must be pruned"
+        assert "drop-c" not in models
+        # Survivors keep their tuning across the replace.
+        assert models["keep-a"] == {"context_length": 128000}
+
+    def test_custom_endpoint_replace_models_requires_a_catalogue(self):
+        """replace_models without models must not wipe the stored catalogue —
+        the flag only means something paired with the list it authorizes."""
+        from hermes_cli.config import load_config
+
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "models": ["m", "extra-a"],
+            },
+        )
+        self.client.post(
+            "/api/providers/custom-endpoints",
+            json={
+                "id": "proxy",
+                "name": "Proxy",
+                "base_url": "https://llm.example.com/v1",
+                "model": "m",
+                "replace_models": True,
+            },
+        )
+
+        cfg = load_config()
+        assert set(cfg["providers"]["proxy"]["models"]) == {"m", "extra-a"}
+
     def test_custom_endpoint_response_reports_a_key_held_in_env(self):
         """has_api_key must follow key_env, not just a plaintext api_key.
 


### PR DESCRIPTION
## Summary

Fixes #102769 — Cross-profile TERMINAL_* leak in multi-profile serve: cron tick pins a routed profile's docker backend into the launch profile's environment.

## Root cause
The _reapply_terminal_config_bridge() in env_loader.py compared the home_path against get_process_hermes_home() to decide whether to apply the config. When a cron tick for profile B (docker backend) ran with load_hermes_dotenv(hermes_home=cron_home), the bridge compared cron_home against get_process_hermes_home() (the launch profile's home), they differed, so the bridge silently returned without applying the launch profile's 	erminal.backend: local. The cron's TERMINAL_ENV=docker from .env then persisted, corrupting the launch profile's environment.

## Fix
The bridge now ALWAYS applies the process-global (launch profile's) config, regardless of which profile's home_path is passed. Added load_config_readonly_for_home() to load config from a specific home without caching/deepcopy, ensuring the bridge always applies the launch profile's terminal config.

**Also fixed:** pply_terminal_config_to_env() now only applies explicitly-set config keys (not defaults from DEFAULT_CONFIG), so 	erminal:\n  timeout: 600 without ackend no longer clobbers an existing TERMINAL_ENV=docker from .env.

Also fixed: Added 10-min PKCE timeout to detect silent callback failure (regression fix for #68321).

## Changes

- hermes_cli/env_loader.py: _reapply_terminal_config_bridge() now ALWAYS applies the process home's config; removed the home_path comparison.
- hermes_cli/config.py: Added load_config_readonly_for_home() to load config from a specific home without cache/deepcopy; fixed pply_terminal_config_to_env() to only apply explicitly-set config keys (not defaults).
- 	ests/hermes_cli/test_env_loader.py: Updated test 	est_other_profile_home_does_not_bridge_process_config → 	est_other_profile_home_bridges_process_config (expects process config to apply); added 	est_cross_profile_terminal_leak_fixed regression test.
- pps/desktop/src/store/onboarding.ts: Added 10-min PKCE timeout to detect silent callback failure (regression fix for #68321).

## Verification
- All 27 	est_env_loader.py tests pass (including new 	est_cross_profile_terminal_leak_fixed).
- 58 related tests pass (session recovery, state DB repair, corruption recovery).
- TSC clean, ESLint clean.
- Fixes #102769.