### PR TITLE
fix(gateway): non-s6 container start exits non-zero with a machine-readable outcome (#102915)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5851,12 +5851,15 @@ _NO_BACKEND_MESSAGES = {
         "WSL detected but systemd is not available.",
         "Run the gateway in foreground mode instead:", *_WSL_FOREGROUND_HINT, "",
         "To enable systemd: add systemd=true to /etc/wsl.conf and run 'wsl --shutdown' from PowerShell."),
-    ("start", "container"): (0,
+    ("start", "container"): (1,
         "Service start is not applicable inside a Docker container.",
         "The gateway runs as the container's main process.", "",
         "  docker start <container>     # start a stopped container",
         "  docker restart <container>   # restart a running container", "",
-        "Or run the gateway directly: hermes gateway run"),
+        "Or run the gateway directly: hermes gateway run", "",
+        # #102915: machine-readable terminal outcome — an unstarted gateway
+        # must be distinguishable from a started one by programmatic callers.
+        "gateway_start: not_applicable"),
     ("start", "unsupported"): (1, "Not supported on this platform."),
 }
 

--- a/tests/hermes_cli/test_gateway_start_container_not_applicable.py
+++ b/tests/hermes_cli/test_gateway_start_container_not_applicable.py
@@ -1,0 +1,60 @@
+"""Regression test for #102915: ``hermes gateway start`` inside a container
+without s6 must NOT exit 0 — an unstarted gateway is not a successful start.
+
+The no-s6 container fallthrough printed Docker lifecycle guidance and exited
+0, so programmatic callers (e.g. WebUI lifecycle buttons via
+``subprocess.run``) reported a green success while no gateway was running.
+The ``("start", "container")`` entry in ``_NO_BACKEND_MESSAGES`` now exits 1
+and emits a machine-readable ``gateway_start: not_applicable`` line.
+"""
+
+import pytest
+
+import hermes_cli.gateway as gateway_mod
+from hermes_cli.gateway import _cmd_start
+
+
+def _container_args():
+    return type("Args", (), {"gateway_command": "start", "system": False, "all": False})()
+
+
+def _make_container_no_s6(monkeypatch):
+    monkeypatch.setattr(gateway_mod, "is_termux", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_service_backend", lambda: None)
+    monkeypatch.setattr(gateway_mod, "is_wsl", lambda: False)
+    monkeypatch.setattr(gateway_mod, "is_container", lambda: True)
+    monkeypatch.setattr(gateway_mod, "_running_under_s6", lambda: False)
+    monkeypatch.setattr(
+        gateway_mod, "_dispatch_via_service_manager_if_s6", lambda _action: False
+    )
+
+
+def test_start_container_without_s6_exits_nonzero_with_machine_readable_outcome(
+    monkeypatch, capsys
+):
+    _make_container_no_s6(monkeypatch)
+
+    with pytest.raises(SystemExit) as exc_info:
+        _cmd_start(_container_args())
+
+    assert exc_info.value.code != 0, (
+        "gateway start that did not start (or delegate) a gateway must not "
+        "exit 0 — callers treat rc==0 as a successful start (#102915)"
+    )
+    out = capsys.readouterr().out
+    assert "gateway_start: not_applicable" in out, (
+        "machine-readable terminal outcome lets programmatic callers tell "
+        "not_applicable apart from started/delegated"
+    )
+    # Docker lifecycle guidance is still printed for humans.
+    assert "docker start" in out
+
+
+def test_s6_container_start_dispatches_and_returns_cleanly(monkeypatch):
+    """Control: inside an s6 container the start is delegated to the service
+    slot and returns without the not-applicable exit."""
+    monkeypatch.setattr(gateway_mod, "is_termux", lambda: False)
+    monkeypatch.setattr(gateway_mod, "_dispatch_via_service_manager_if_s6", lambda _a: True)
+
+    # Must return None (no SystemExit) — delegated, not not_applicable.
+    assert _cmd_start(_container_args()) is None


### PR DESCRIPTION
## What does this PR do?

Fixes #102915: in a container without s6, `hermes gateway start` printed Docker lifecycle guidance and **exited 0** without starting (or delegating the start of) a gateway. Programmatic callers — e.g. WebUI lifecycle buttons driving the CLI via `subprocess.run` — treated rc==0 as terminal success and showed a green success toast while `gateway_state.json` stayed `stopped`.

## Related Issue

Fixes #102915

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/gateway.py`: the `("start", "container")` entry in `_NO_BACKEND_MESSAGES` now exits **1** instead of 0 (an unstarted gateway is not a successful start) and appends a machine-readable `gateway_start: not_applicable` line so programmatic callers can distinguish `not_applicable` from `started`/`delegated` without parsing prose.
- The `install`/`uninstall` container entries keep exit 0 — "not needed here" is a legitimate outcome for those, unlike a start that didn't.
- `tests/hermes_cli/test_gateway_start_container_not_applicable.py` (new): container start without s6 exits non-zero with the machine-readable line and the human guidance intact; s6 dispatch control returns cleanly.

## How to Test

`scripts/run_tests.sh tests/hermes_cli/test_gateway_start_container_not_applicable.py -q` — 2 passed.

Manual (in a non-s6 container): `hermes gateway start; echo $?` → was `0`, now `1`, with `gateway_start: not_applicable` on stdout.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (arm64), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<!-- N/A — exit-code semantics with a deterministic regression test. -->
