### PR TITLE
fix(desktop): route bridge replies to request owner

### DIFF
--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { handleDesktopBridgeEvent } from './desktop-bridge'
+import type { GatewayEventContext } from './types'
+
+const mocks = vi.hoisted(() => ({
+  ambientRequest: vi.fn(),
+  readActivePreview: vi.fn(async () => ({ text: 'page', title: 'Preview', url: 'https://example.com' })),
+  readActiveTerminal: vi.fn(() => ({ text: 'shell' })),
+  requestForOwnedSession: vi.fn(async (..._args: unknown[]) => ({ status: 'ok' }))
+}))
+
+vi.mock('@/app/chat/right-rail/preview-reader', () => ({
+  readActivePreview: mocks.readActivePreview
+}))
+vi.mock('@/app/right-sidebar/terminal/agent-terminal-stream', () => ({ writeAgentTerminalChunk: vi.fn() }))
+vi.mock('@/app/right-sidebar/terminal/buffer', () => ({ readActiveTerminal: mocks.readActiveTerminal }))
+vi.mock('@/app/right-sidebar/terminal/terminals', () => ({ closeAgentTerminalByProc: vi.fn() }))
+vi.mock('@/store/gateway', () => ({
+  $gateway: { get: () => ({ request: mocks.ambientRequest }) }
+}))
+vi.mock('@/store/pane-focus', () => ({ applyDesktopLayoutPreset: vi.fn(), revealDesktopPane: vi.fn() }))
+vi.mock('@/store/reactions-local', () => ({ recordAgentReaction: vi.fn() }))
+vi.mock('@/store/session', () => ({ setMessages: vi.fn() }))
+vi.mock('@/store/session-gone-latch', () => ({ ambientRequestFor: () => mocks.ambientRequest }))
+vi.mock('@/store/session-states', () => ({ requestForOwnedSession: mocks.requestForOwnedSession }))
+vi.mock('@/store/tips', () => ({ $tipsEnabled: { get: () => false }, showTip: vi.fn() }))
+vi.mock('@/store/tours', () => ({ $toursEnabled: { get: () => false } }))
+
+function event(type: string, requestId: string, isActiveEvent = true): GatewayEventContext {
+  return {
+    event: {
+      connectionId: 'homelab',
+      profile: 'creative-design',
+      session_id: 'runtime-creative',
+      type
+    },
+    isActiveEvent,
+    payload: { request_id: requestId },
+    sessionId: 'runtime-creative'
+  } as unknown as GatewayEventContext
+}
+
+describe('desktop bridge response routing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('routes every blocking response through the requesting session owner', async () => {
+    expect(handleDesktopBridgeEvent(event('terminal.read.request', 'terminal-1'))).toBe(true)
+    expect(handleDesktopBridgeEvent(event('preview.read.request', 'preview-read-1'))).toBe(true)
+    expect(handleDesktopBridgeEvent(event('preview.act.request', 'preview-act-1', false))).toBe(true)
+    expect(handleDesktopBridgeEvent(event('window.read.request', 'window-1'))).toBe(true)
+    expect(handleDesktopBridgeEvent(event('tour.request', 'tour-1'))).toBe(true)
+
+    await vi.waitFor(() => expect(mocks.requestForOwnedSession).toHaveBeenCalledTimes(5))
+
+    expect(mocks.requestForOwnedSession.mock.calls.map(call => [call[0], call[2]])).toEqual(
+      expect.arrayContaining([
+        ['runtime-creative', 'terminal.read.respond'],
+        ['runtime-creative', 'preview.act.respond'],
+        ['runtime-creative', 'tour.respond'],
+        ['runtime-creative', 'window.read.respond'],
+        ['runtime-creative', 'preview.read.respond']
+      ])
+    )
+    expect(mocks.ambientRequest).not.toHaveBeenCalled()
+  })
+})

--- a/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
+++ b/apps/desktop/src/app/session/hooks/use-message-stream/gateway-event/desktop-bridge.ts
@@ -8,6 +8,8 @@ import { $gateway } from '@/store/gateway'
 import { applyDesktopLayoutPreset, revealDesktopPane } from '@/store/pane-focus'
 import { recordAgentReaction } from '@/store/reactions-local'
 import { setMessages } from '@/store/session'
+import { ambientRequestFor } from '@/store/session-gone-latch'
+import { requestForOwnedSession } from '@/store/session-states'
 import { $tipsEnabled, type ActiveTip, showTip } from '@/store/tips'
 import { $toursEnabled } from '@/store/tours'
 
@@ -41,6 +43,31 @@ const loadPreviewEngine = () => {
     .then(mod => mod.actOnActivePreview as Awaited<ReturnType<typeof stable>>['actOnActivePreview'])
 }
 
+/** Answer a blocking Desktop tool on the socket that owns its session.
+ *
+ * Bot Mode and all-profiles views receive events from background profile
+ * sockets while `$gateway` still names the ambient foreground socket. Sending
+ * a `*.respond` there leaves the requesting backend blocked until timeout.
+ * Event fan-in records the exact owner before dispatch, so use the same
+ * session-owned request seam as clarify/approval responses. */
+function respondToDesktopBridgeRequest(
+  ctx: GatewayEventContext,
+  method: string,
+  requestId: string,
+  result: unknown
+): void {
+  const gateway = $gateway.get()
+
+  if (!gateway || !ctx.sessionId) {
+    return
+  }
+
+  void requestForOwnedSession(ctx.sessionId, ambientRequestFor(gateway), method, {
+    request_id: requestId,
+    text: result ? JSON.stringify(result) : ''
+  }).catch(() => undefined)
+}
+
 /** Desktop-surface bridge events: read-back requests the agent blocks on
  *  (terminal/preview/window), agent terminal streaming, pane reveal, and
  *  message reactions. */
@@ -57,10 +84,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
       const result = readActiveTerminal({ start, count })
 
-      void $gateway.get()?.request('terminal.read.respond', {
-        request_id: requestId,
-        text: result ? JSON.stringify(result) : ''
-      })
+      respondToDesktopBridgeRequest(ctx, 'terminal.read.respond', requestId, result)
     }
 
     return true
@@ -76,10 +100,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
       const count = typeof payload?.count === 'number' ? payload.count : undefined
 
       void readActivePreview({ count, start }).then(result => {
-        void $gateway.get()?.request('preview.read.respond', {
-          request_id: requestId,
-          text: result ? JSON.stringify(result) : ''
-        })
+        respondToDesktopBridgeRequest(ctx, 'preview.read.respond', requestId, result)
       })
     }
 
@@ -95,11 +116,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
-      const answer = (result: unknown) =>
-        $gateway.get()?.request('preview.act.respond', {
-          request_id: requestId,
-          text: result ? JSON.stringify(result) : ''
-        })
+      const answer = (result: unknown) => respondToDesktopBridgeRequest(ctx, 'preview.act.respond', requestId, result)
 
       if (isActiveEvent) {
         void loadPreviewEngine()
@@ -139,11 +156,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     if (requestId) {
       const read = window.hermesDesktop?.readWindowBelow
 
-      const answer = (result: unknown) =>
-        $gateway.get()?.request('window.read.respond', {
-          request_id: requestId,
-          text: result ? JSON.stringify(result) : ''
-        })
+      const answer = (result: unknown) => respondToDesktopBridgeRequest(ctx, 'window.read.respond', requestId, result)
 
       // .catch: ipcRenderer.invoke rejects on an older shell without the
       // handler or a main-side throw — without an empty answer the tool
@@ -179,11 +192,7 @@ export function handleDesktopBridgeEvent(ctx: GatewayEventContext): boolean {
     const requestId = typeof payload?.request_id === 'string' ? payload.request_id : ''
 
     if (requestId) {
-      const answer = (result: unknown) =>
-        $gateway.get()?.request('tour.respond', {
-          request_id: requestId,
-          text: result ? JSON.stringify(result) : ''
-        })
+      const answer = (result: unknown) => respondToDesktopBridgeRequest(ctx, 'tour.respond', requestId, result)
 
       if (!$toursEnabled.get()) {
         // Refused in words, not silently dropped: the agent asked for a


### PR DESCRIPTION
Fixes #94272.

## Problem

In all-profiles/Bot Mode, a profile-owned background gateway socket can receive a response-bearing Desktop bridge event while the ambient `$gateway` socket still points at the foreground profile. The renderer handled the request, but sent `*.respond` over the wrong connection, so the requesting backend waited until timeout.

## Change

Route all five response-bearing Desktop event families through the existing session-ownership seam using the event `session_id`:

- `desktop.terminal.read`
- `desktop.preview.read`
- `desktop.preview.act`
- `desktop.window.read`
- `desktop.tour`

Active-session mutation gating is unchanged. If no owner is recorded, the existing ambient fallback remains.

## Verification

- Added a regression test that dispatches all five families with a profile-owned session and proves every response uses the owner route while the ambient socket receives none.
- Target Vitest: 1 passed.
- Desktop TypeScript typecheck: passed.
- ESLint on both changed files: passed.
- Prettier check on both changed files: passed.

Co-Authored-By: OpenAI Codex <noreply@openai.com>