### PR TITLE
strftime: add safe_strftime wrapper for Windows locale surrogate issues

### DIFF
--- a/agent/system_prompt.py
+++ b/agent/system_prompt.py
@@ -29,8 +29,10 @@ import json
 import logging
 import os
 import re
+from datetime import datetime
 from typing import Any, Dict, List, Optional
 
+from agent.message_sanitization import _sanitize_surrogates
 from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY,
     EXECUTION_GUIDANCE_MODELS,
@@ -63,6 +65,30 @@ _PLUGIN_SECTION_FRAME_RE = re.compile(
     r"<!-- hermes-plugin-section-chars:(?P<chars>[0-9]{1,4}) -->\n\n",
     re.MULTILINE,
 )
+
+
+def _safe_strftime(dt: datetime, fmt: str) -> str:
+    """strftime wrapper that handles Windows locale surrogate issues.
+
+    On Windows with certain locales (e.g., fr-FR), strftime can produce
+    lone surrogate code points (U+D800\u2013U+DFFF) in locale-dependent
+    format codes like %Z, %z, %A, %B, %a, %b. These surrogates are
+    invalid in UTF-8 and crash json.dumps.
+
+    This wrapper catches UnicodeEncodeError and falls back to a format
+    string with locale-sensitive codes removed, then sanitizes any
+    remaining surrogates.
+    """
+    try:
+        return _sanitize_surrogates(dt.strftime(fmt))
+    except UnicodeEncodeError:
+        fallback = fmt
+        for code in ("%Z", "%z", "%A", "%a", "%B", "%b"):
+            fallback = fallback.replace(code, "")
+        fallback = " ".join(fallback.split())
+        if not fallback.strip():
+            return ""
+        return _sanitize_surrogates(dt.strftime(fallback))
 
 
 def _ra():
@@ -983,16 +1009,16 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     _iana = getattr(_tz, "key", None)
     if _iana:
         _zone_bits.append(_iana)
-    _abbrev = now.strftime("%Z")
+    _abbrev = _safe_strftime(now, "%Z")
     if _abbrev and _abbrev != _iana:
         _zone_bits.append(_abbrev)
-    _offset = now.strftime("%z")
+    _offset = _safe_strftime(now, "%z")
     if _offset:  # '-0400' -> 'UTC-04:00'
         _zone_bits.append(f"UTC{_offset[:3]}:{_offset[3:]}")
     _zone_suffix = f" ({', '.join(_zone_bits)})" if _zone_bits else ""
     _start = _session_start_like(agent, now)
     timestamp_line = (
-        f"Conversation started: {_start.strftime('%A, %B %d, %Y')}{_zone_suffix}"
+        f"Conversation started: {_safe_strftime(_start, '%A, %B %d, %Y')}{_zone_suffix}"
     )
     # Second line (maintainer design, salvaging #96224's anchor): long-lived
     # sessions — Bot Mode forever-chats, messenger channels people never
@@ -1004,10 +1030,10 @@ def build_system_prompt_parts(agent: Any, system_message: Optional[str] = None) 
     # the added line costs no extra cache churn. Same-day sessions skip the
     # second line entirely — nothing to correct, and the single-line shape
     # stays byte-identical for the day (prefix-cache safe).
-    if now.strftime("%Y%m%d") != _start.strftime("%Y%m%d"):
+    if _safe_strftime(now, "%Y%m%d") != _safe_strftime(_start, "%Y%m%d"):
         timestamp_line += (
             f"\nToday's date (as of the last context rebuild): "
-            f"{now.strftime('%A, %B %d, %Y')} — trust this over the start "
+            f"{_safe_strftime(now, '%A, %B %d, %Y')} — trust this over the start "
             f"date for what day it is now; query tools for exact time."
         )
     # Bot Chat sessions are effectively eternal — a birth date frozen in the

--- a/gateway/message_timestamps.py
+++ b/gateway/message_timestamps.py
@@ -11,6 +11,32 @@ import re
 from datetime import datetime
 from typing import Any, Optional, Tuple
 
+from agent.message_sanitization import _sanitize_surrogates
+
+
+def _safe_strftime(dt: datetime, fmt: str) -> str:
+    """strftime wrapper that handles Windows locale surrogate issues.
+
+    On Windows with certain locales (e.g., fr-FR), strftime can produce
+    lone surrogate code points (U+D800–U+DFFF) in locale-dependent
+    format codes like %Z, %z, %A, %B, %a, %b. These surrogates are
+    invalid in UTF-8 and crash json.dumps.
+
+    This wrapper catches UnicodeEncodeError and falls back to a format
+    string with locale-sensitive codes removed, then sanitizes any
+    remaining surrogates.
+    """
+    try:
+        return _sanitize_surrogates(dt.strftime(fmt))
+    except UnicodeEncodeError:
+        fallback = fmt
+        for code in ("%Z", "%z", "%A", "%a", "%B", "%b"):
+            fallback = fallback.replace(code, "")
+        fallback = " ".join(fallback.split())
+        if not fallback.strip():
+            return ""
+        return _sanitize_surrogates(dt.strftime(fallback))
+
 
 # Current gateway format: [Tue 2026-04-28 13:40:53 CEST]
 _HUMAN_TIMESTAMP_RE = re.compile(
@@ -82,7 +108,7 @@ def format_message_timestamp(ts_value: Any, tz=None) -> str:
         dt = datetime.fromtimestamp(epoch, tz=tz)
     else:
         dt = datetime.fromtimestamp(epoch).astimezone()
-    return "[" + dt.strftime("%a %Y-%m-%d %H:%M:%S %Z") + "]"
+    return "[" + _safe_strftime(dt, "%a %Y-%m-%d %H:%M:%S %Z") + "]"
 
 
 def strip_leading_message_timestamps(content: str, tz=None) -> Tuple[str, Optional[float]]:

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -44,6 +44,33 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_cli._subprocess_compat import noninteractive_git_env
 
+from agent.message_sanitization import _sanitize_surrogates
+
+
+def _safe_strftime(dt: datetime, fmt: str) -> str:
+    """strftime wrapper that handles Windows locale surrogate issues.
+
+    On Windows with certain locales (e.g., fr-FR), strftime can produce
+    lone surrogate code points (U+D800–U+DFFF) in locale-dependent
+    format codes like %Z, %z, %A, %B, %a, %b. These surrogates are
+    invalid in UTF-8 and crash json.dumps.
+
+    This wrapper catches UnicodeEncodeError and falls back to a format
+    string with locale-sensitive codes removed, then sanitizes any
+    remaining surrogates.
+    """
+    try:
+        return _sanitize_surrogates(dt.strftime(fmt))
+    except UnicodeEncodeError:
+        fallback = fmt
+        for code in ("%Z", "%z", "%A", "%a", "%B", "%b"):
+            fallback = fallback.replace(code, "")
+        fallback = " ".join(fallback.split())
+        if not fallback.strip():
+            return ""
+        return _sanitize_surrogates(dt.strftime(fallback))
+
+
 logger = logging.getLogger(__name__)
 
 
@@ -1249,7 +1276,7 @@ def judge_goal(
     # truth.
     clean_subgoals = [s.strip() for s in (subgoals or []) if s and s.strip()]
     background_block = _render_background_block(background_processes)
-    current_time = datetime.now(tz=timezone.utc).astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    current_time = _safe_strftime(datetime.now(tz=timezone.utc).astimezone(), "%Y-%m-%d %H:%M:%S %Z")
 
     if contract is not None and not contract.is_empty():
         contract_block = contract.render_block()

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -9,7 +9,10 @@ import sys
 import time
 import importlib.util
 import subprocess  # noqa: F401 — re-exported for tests that monkeypatch status.subprocess to guard against regressions
+from datetime import datetime
 from pathlib import Path
+
+from agent.message_sanitization import _sanitize_surrogates
 
 PROJECT_ROOT = Path(__file__).parent.parent.resolve()
 
@@ -26,6 +29,29 @@ from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_cli.vercel_auth import describe_vercel_auth
 from hermes_constants import OPENROUTER_MODELS_URL
 from tools.tool_backend_helpers import managed_nous_tools_enabled
+
+def _safe_strftime(dt: datetime, fmt: str) -> str:
+    """strftime wrapper that handles Windows locale surrogate issues.
+
+    On Windows with certain locales (e.g., fr-FR), strftime can produce
+    lone surrogate code points (U+D800–U+DFFF) in locale-dependent
+    format codes like %Z, %z, %A, %B, %a, %b. These surrogates are
+    invalid in UTF-8 and crash json.dumps.
+
+    This wrapper catches UnicodeEncodeError and falls back to a format
+    string with locale-sensitive codes removed, then sanitizes any
+    remaining surrogates.
+    """
+    try:
+        return _sanitize_surrogates(dt.strftime(fmt))
+    except UnicodeEncodeError:
+        fallback = fmt
+        for code in ("%Z", "%z", "%A", "%a", "%B", "%b"):
+            fallback = fallback.replace(code, "")
+        fallback = " ".join(fallback.split())
+        if not fallback.strip():
+            return ""
+        return _sanitize_surrogates(dt.strftime(fallback))
 
 def check_mark(ok: bool) -> str:
     if ok:
@@ -60,7 +86,7 @@ def _format_iso_timestamp(value) -> str:
             parsed = parsed.replace(tzinfo=timezone.utc)
     except Exception:
         return value
-    return parsed.astimezone().strftime("%Y-%m-%d %H:%M:%S %Z")
+    return _safe_strftime(parsed.astimezone(), "%Y-%m-%d %H:%M:%S %Z")
 
 
 def _format_relative_ts(ts: float) -> str:


### PR DESCRIPTION
Fixes #102910

## Problem

On Windows with certain locales (e.g., fr-FR), strftime can produce
lone surrogate code points (U+D800–U+DFFF) in locale-dependent
format codes like %Z, %z, %A, %B, %a, %b. These surrogates are
invalid in UTF-8 and crash json.dumps inside the OpenAI SDK.

Because the system prompt is rebuilt at every new conversation and
at every context compression, this is **recurrent**, not one-off.

## Fix

Added a `_safe_strftime` wrapper that catches UnicodeEncodeError
and falls back to a format string with locale-sensitive codes
removed, then sanitizes any remaining surrogates.

Applied to:
- agent/system_prompt.py: timestamp lines with %Z, %z, %A, %B, %d
- gateway/message_timestamps.py: format_message_timestamp with %Z
- hermes_cli/status.py: _format_iso_timestamp with %Z
- hermes_cli/goals.py: current_time with %Z

Also includes the existing _sanitize_surrogates function for
scrubbing any remaining surrogates.

## Testing

Verified that:
- Normal strftime calls work unchanged
- Locale-sensitive formats (%Z, %z, %A, %B, %a, %b) are handled
- Fallback works when UnicodeEncodeError is raised
- Existing tests pass (surrogate chokepoints, message timestamps, goals, status)
